### PR TITLE
fix(integrations): close static-bot routing-id concurrent-install race (#3167)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2390,3 +2390,23 @@ The admin form is a shared, type-aware `<ConfigSchemaFields>` renderer (extracte
 **Deferred (tracked):** platform `/users` cross-tenant role change under per-org scoping (#3157); making the last-admin guards atomic — a pre-existing TOCTOU (#3158).
 
 **Category:** Model-collapse / seam-cleaning — two overlapping role surfaces with an undefined-semantics middle state reduced to one source of truth (`member.role`) + one cross-tenant escape hatch (`platform_admin`), deleting a duplicate resolver and closing every raw-`user.role` authorization seam as a class.
+
+---
+
+## 83. Static-bot routing-id uniqueness moves from a racy pre-check to a DB-enforced invariant + one conflict-recognition seam (#3167)
+
+**Date:** 2026-06-04
+**Issue:** #3167
+**PR:** #3170
+
+**Problem:** #3154/#3163 (win #81's spine) gave each of the five static-bot install handlers a cross-workspace ownership PRE-CHECK — a read-only `SELECT … WHERE config->>'<routing_id>' = $1 AND workspace_id <> $2` (`assert*UnboundElsewhere`). But that check was **not transactionally fused** with the cap-gate UPSERT: `checkChatIntegrationLimitAndInstall`'s advisory lock is keyed by `workspace_id`, and `workspace_plugins_singleton` is unique only on `(workspace_id, catalog_id)`. So two *different* workspaces installing the *same* routing id concurrently could both observe no row and both UPSERT — collapsing the inbound resolvers in `executeQuery.ts` onto their `rows.length > 1` fail-closed for **both**, an availability/griefing outage. The "uniqueness" invariant lived only as a best-effort read in five places, with no authority that actually held it under concurrency.
+
+**Solution:** Make the database the authority. Migration `0120` adds a partial UNIQUE index on the per-platform routing key — a single `CASE` keyed on `catalog_id` (`chat_id`/`guild_id`/`tenant_id`/`phone_number_id`/`workspace_id`), scoped `WHERE enabled = true AND pillar = 'chat'`, with a leading `catalog_id` column that namespaces the value per platform. The carve-outs are expressed in the index itself, not in scattered conditionals: `NULLIF(config->>'workspace_id', 'my_customer')` plus the CASE falling through to `NULL` for Slack/unmapped catalogs means "exempt" == "the expression is NULL" (DISTINCT in a unique index), one mechanism for all three carve-outs (alias, Slack, disabled-via-partial-WHERE). The losing concurrent writer now hits a `23505`, recognized by **one** shared seam — `isRoutingIdUniqueViolation(err)` in `routing-id-conflict.ts`, a tight predicate keyed on SQLSTATE + the exact index name — which each handler maps back to the *same* actionable "already connected elsewhere" error its pre-check returns (extracted into a per-handler `*_ROUTING_CONFLICT_MESSAGE` constant so both paths are identical).
+
+**Impact:**
+- **The uniqueness invariant has a single authority that holds under concurrency** (the index), instead of five racy reads that could all pass simultaneously. The pre-checks remain as a cheap fast-path with a friendly pre-write error, but correctness no longer depends on them winning the race.
+- **One conflict-recognition seam, not five ad-hoc casts** — `isRoutingIdUniqueViolation` is the only place that inspects a pg error's `code`/`constraint` for this concern; a 23505 on any *other* index re-throws untouched, so a real 500 is never relabelled as a cross-workspace conflict.
+- **Carve-outs are declarative** — `my_customer`, Slack, and disabled installs are all "NULL in the index" rather than three separate special cases in code; adding a platform is one CASE arm in the migration + its schema.ts mirror (kept in lockstep, drift-guarded by the indexdef assertion in `migrate-pg.test.ts`).
+- **No new lock contention** — the fix is a DB constraint, not a wider/longer advisory lock, so it adds zero coordination cost to the install hot path.
+
+**Category:** Invariant-relocation / seam-cleaning — a correctness property that lived as a best-effort read in five handlers is moved to the one place that can actually enforce it (a partial unique index), with a single shared predicate translating the DB's enforcement back into the domain's existing error vocabulary.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56727,6 +56727,31 @@
               }
             }
           },
+          "409": {
+            "description": "A routing identifier in the config (static-bot chat_id / guild_id / tenant_id / phone_number_id / gchat workspace_id) is already connected to a different workspace (#3167)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "422": {
             "description": "Strict-mode plugin secrets check rejected the write (catalog schema corrupt or per-key secret/passthrough drift)",
             "content": {

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -1959,6 +1959,54 @@ describe("audit emission — Workspace marketplace", () => {
       expect(entry.metadata!.error).toContain("config update failed");
     });
 
+    it("maps a routing-id unique violation (23505) to 409 with the cross-workspace conflict message (#3167)", async () => {
+      // Editing a static-bot install's routing field via the generic config
+      // PUT can collide with another workspace's id; the migration-0120 partial
+      // unique index raises 23505. The handler must surface the actionable
+      // "already connected elsewhere" 409, not a generic 500 — and still log
+      // the failure audit (tapError fires before the catch).
+      setQueryResult("FROM workspace_plugins wp", [{ config: {}, config_schema: null }]);
+      setQueryResult(
+        "UPDATE workspace_plugins",
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      );
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: { chat_id: "-100999" } }),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("routing_conflict");
+      expect(body.message).toMatch(/already connected to a different Atlas workspace/i);
+      // Failure audit still emitted by the tapError before the catch.
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      expect(mockLogAdminAction.mock.calls[0]![0].status).toBe("failure");
+    });
+
+    it("re-throws a 23505 on a DIFFERENT index as a 500 — not relabelled as a routing conflict (#3167)", async () => {
+      setQueryResult("FROM workspace_plugins wp", [{ config: {}, config_schema: null }]);
+      setQueryResult(
+        "UPDATE workspace_plugins",
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_id_unique",
+        }),
+      );
+
+      const res = await buildWorkspaceApp().request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: { key: "val" } }),
+      });
+      expect(res.status).toBe(500);
+    });
+
     it("does not emit audit when installation not found (404)", async () => {
       // The pre-SELECT for secret restoration finds no row, short-circuits
       // to 404 before UPDATE runs.

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -30,6 +30,7 @@ import {
   isPlanEligible as planRankEligible,
   parsePlanTier,
 } from "@atlas/api/lib/integrations/install/plan-rank";
+import { isRoutingIdUniqueViolation } from "@atlas/api/lib/integrations/install/routing-id-conflict";
 import {
   ErrorSchema,
   AuthErrorSchema,
@@ -677,6 +678,7 @@ const updateConfigRoute = createRoute({
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Installation not found", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "A routing identifier in the config (static-bot chat_id / guild_id / tenant_id / phone_number_id / gchat workspace_id) is already connected to a different workspace (#3167)", content: { "application/json": { schema: ErrorSchema } } },
     422: { description: "Strict-mode plugin secrets check rejected the write (catalog schema corrupt or per-key secret/passthrough drift)", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -1235,29 +1237,53 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
       const sanitizedConfig = restoreMaskedSecrets(body.config, originalConfig, schema);
       const encryptedForPersist = encryptSecretFields(sanitizedConfig, schema);
 
-      const rows = yield* queryEffect<WorkspacePluginRow>(
-        `UPDATE workspace_plugins SET config = $1
-         WHERE id = $2 AND workspace_id = $3
-         RETURNING *, (SELECT name FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS name,
-                     (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug,
-                     (SELECT type FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS type,
-                     (SELECT description FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS description`,
-        [JSON.stringify(encryptedForPersist), id, orgId],
-      ).pipe(Effect.tapError((err) => Effect.sync(() => {
-        logAdminAction({
-          actionType: ADMIN_ACTIONS.plugin.configUpdate,
-          targetType: "plugin",
-          targetId: id,
-          scope: "workspace",
-          status: "failure",
-          metadata: {
-            pluginId: id,
-            orgId,
-            keysChanged,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        });
-      })));
+      // `try/catch` around `yield* queryEffect(...)` so a routing-id unique
+      // violation (#3167) maps to the same actionable conflict the install
+      // handlers surface, instead of a generic 500. A static-bot install's
+      // routing field (chat_id / guild_id / tenant_id / phone_number_id /
+      // gchat workspace_id) lives in `config`, so this generic PUT can repoint
+      // it onto an id already claimed by another workspace — the migration-0120
+      // partial unique index then raises 23505 (wrapped by @effect/sql, which
+      // is why the cross-workspace check walks the `.cause` chain). The
+      // `tapError` failure audit fires before the throw; any non-routing error
+      // is re-thrown to the existing 500 path. (try/catch is the failure-branch
+      // pattern that works under both real Effect and the route test shim.)
+      let rows: WorkspacePluginRow[];
+      try {
+        rows = yield* queryEffect<WorkspacePluginRow>(
+          `UPDATE workspace_plugins SET config = $1
+           WHERE id = $2 AND workspace_id = $3
+           RETURNING *, (SELECT name FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS name,
+                       (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug,
+                       (SELECT type FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS type,
+                       (SELECT description FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS description`,
+          [JSON.stringify(encryptedForPersist), id, orgId],
+        ).pipe(Effect.tapError((err) => Effect.sync(() => {
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.plugin.configUpdate,
+            targetType: "plugin",
+            targetId: id,
+            scope: "workspace",
+            status: "failure",
+            metadata: {
+              pluginId: id,
+              orgId,
+              keysChanged,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          });
+        })));
+      } catch (err) {
+        if (isRoutingIdUniqueViolation(err)) {
+          return c.json({
+            error: "routing_conflict",
+            message:
+              "This routing identifier is already connected to a different Atlas workspace. Each one can be linked to only one workspace — disconnect it there first.",
+            requestId,
+          }, 409);
+        }
+        throw err;
+      }
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Installation "${id}" not found in this workspace.`, requestId }, 404);

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -365,6 +365,7 @@ describe("migrateAuthTables", () => {
             { name: "0117_dashboard_text_cards.sql" },
             { name: "0118_drop_user_admin_role.sql" },
             { name: "0119_drop_legacy_credential_tables.sql" },
+            { name: "0120_static_bot_routing_id_unique.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1573,7 +1573,7 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // ─────────────────────────────────────────────────────────────────────
   describe("0120 static-bot routing-id uniqueness (#3167)", () => {
     // Chat catalog rows aren't seeded by migrations (catalog-seeder runs at
-    // boot, not here), so seed the three platforms these tests exercise.
+    // boot, not here), so seed every static-bot platform these tests exercise.
     // ON CONFLICT DO NOTHING keeps it idempotent across this schema.
     beforeAll(async () => {
       await pool.query(
@@ -1581,10 +1581,31 @@ describeIfPg("migrate-pg (real Postgres)", () => {
          VALUES
            ('catalog:telegram', 'Telegram',    'telegram', 'chat', 'chat', 'static-bot'),
            ('catalog:discord',  'Discord',     'discord',  'chat', 'chat', 'static-bot'),
+           ('catalog:teams',    'Microsoft Teams', 'teams', 'chat', 'chat', 'static-bot'),
+           ('catalog:whatsapp', 'WhatsApp',    'whatsapp', 'chat', 'chat', 'static-bot'),
            ('catalog:gchat',    'Google Chat', 'gchat',    'chat', 'chat', 'static-bot')
          ON CONFLICT (id) DO NOTHING`,
       );
     });
+
+    // One entry per static-bot CASE arm in the migration. Driving the
+    // rejection test off this list proves all five arms end-to-end against
+    // real Postgres — a wrong JSONB key in any arm (the CASE is the single
+    // source of the per-platform routing-key contract) would fail here. The
+    // `sample` values are deliberately NOT `my_customer` so gchat exercises
+    // the constrained (non-NULLIF) path; the alias carve-out is a separate test.
+    const PLATFORM_ROUTING_KEYS: ReadonlyArray<{
+      platform: string;
+      catalogId: string;
+      key: string;
+      sample: (stamp: string) => string;
+    }> = [
+      { platform: "Telegram", catalogId: "catalog:telegram", key: "chat_id", sample: (s) => `-1001${s.slice(0, 9)}` },
+      { platform: "Discord", catalogId: "catalog:discord", key: "guild_id", sample: (s) => `12${s.slice(0, 16)}` },
+      { platform: "Teams", catalogId: "catalog:teams", key: "tenant_id", sample: (s) => `tenant-${s}` },
+      { platform: "WhatsApp", catalogId: "catalog:whatsapp", key: "phone_number_id", sample: (s) => `10${s.slice(0, 12)}` },
+      { platform: "gchat", catalogId: "catalog:gchat", key: "workspace_id", sample: (s) => `C0${s.slice(0, 7)}` },
+    ];
 
     /** Insert one chat install row. Throws on a routing-id unique violation. */
     async function installChat(opts: {
@@ -1608,33 +1629,38 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       );
     }
 
-    it("rejects a second workspace binding the same Telegram chat_id with 23505 on the routing index (#3167)", async () => {
-      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-      const chatId = `-1001${stamp.replace(/\D/g, "").slice(0, 9)}`;
-      await installChat({
-        id: `wp-a-${stamp}`,
-        workspaceId: `wsA-${stamp}`,
-        catalogId: "catalog:telegram",
-        config: { chat_id: chatId },
-      });
-
-      let err: { code?: string; constraint?: string } | null = null;
-      try {
+    // One rejection test per platform — exercises every CASE arm end-to-end.
+    // (A loop, not it.each, so the assertion runs against real Postgres for
+    // each arm with the platform name in the test title.)
+    for (const p of PLATFORM_ROUTING_KEYS) {
+      it(`rejects a second workspace binding the same ${p.platform} ${p.key} with 23505 on the routing index (#3167)`, async () => {
+        const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+        const routingId = p.sample(stamp);
         await installChat({
-          id: `wp-b-${stamp}`,
-          workspaceId: `wsB-${stamp}`,
-          catalogId: "catalog:telegram",
-          config: { chat_id: chatId },
+          id: `wp-a-${p.platform}-${stamp}`,
+          workspaceId: `wsA-${p.platform}-${stamp}`,
+          catalogId: p.catalogId,
+          config: { [p.key]: routingId },
         });
-      } catch (e) {
-        err = e as { code?: string; constraint?: string };
-      }
-      expect(err?.code).toBe("23505");
-      // The handlers' `isRoutingIdUniqueViolation` keys on this exact name —
-      // a rename here without updating the helper would silently regress the
-      // error mapping back to a raw 500.
-      expect(err?.constraint).toBe("workspace_plugins_chat_routing_id_unique");
-    }, PG_TEST_TIMEOUT_MS);
+
+        let err: { code?: string; constraint?: string } | null = null;
+        try {
+          await installChat({
+            id: `wp-b-${p.platform}-${stamp}`,
+            workspaceId: `wsB-${p.platform}-${stamp}`,
+            catalogId: p.catalogId,
+            config: { [p.key]: routingId },
+          });
+        } catch (e) {
+          err = e as { code?: string; constraint?: string };
+        }
+        expect(err?.code).toBe("23505");
+        // The handlers' `isRoutingIdUniqueViolation` keys on this exact name —
+        // a rename here without updating the helper would silently regress the
+        // error mapping back to a raw 500.
+        expect(err?.constraint).toBe("workspace_plugins_chat_routing_id_unique");
+      }, PG_TEST_TIMEOUT_MS);
+    }
 
     it("allows a same-workspace reconnect UPSERT of its own chat_id — idempotent, no conflict (#3167)", async () => {
       const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
@@ -1691,27 +1717,9 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       expect(rows[0]?.c).toBe(2);
     }, PG_TEST_TIMEOUT_MS);
 
-    it("still rejects two workspaces sharing a REAL gchat customer id with 23505 (#3167)", async () => {
-      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-      const customerId = `C0${stamp.replace(/\D/g, "").slice(0, 7)}`;
-      await installChat({
-        id: `wp-gc-a-${stamp}`,
-        workspaceId: `wsGcA-${stamp}`,
-        catalogId: "catalog:gchat",
-        config: { workspace_id: customerId },
-      });
-      await expect(
-        installChat({
-          id: `wp-gc-b-${stamp}`,
-          workspaceId: `wsGcB-${stamp}`,
-          catalogId: "catalog:gchat",
-          config: { workspace_id: customerId },
-        }),
-      ).rejects.toMatchObject({
-        code: "23505",
-        constraint: "workspace_plugins_chat_routing_id_unique",
-      });
-    }, PG_TEST_TIMEOUT_MS);
+    // (The gchat arm of the rejection loop above already proves a REAL
+    // customer id — i.e. not `my_customer` — is constrained, the positive
+    // counterpart to the `my_customer` exemption test below.)
 
     it("does NOT collide the same routing value across two different platforms (#3167)", async () => {
       const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
@@ -1766,15 +1774,80 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       expect(rows[0]?.c).toBe(2);
     }, PG_TEST_TIMEOUT_MS);
 
-    it("creates the partial unique index by name — drift guard (#3167)", async () => {
-      const { rows } = await pool.query<{ indexname: string }>(
-        `SELECT indexname FROM pg_indexes
+    it("scopes the index to pillar = 'chat' — an action-pillar row with a routing-key-shaped config does NOT collide (#3167)", async () => {
+      // Isolates the `pillar = 'chat'` half of the partial predicate (the
+      // disabled test above covers the `enabled = true` half). A row on the
+      // SAME catalog whose CASE arm matches (so it's only the pillar clause
+      // keeping it out of the index) must not conflict with an enabled chat
+      // row sharing the routing value. The denormalized `pillar = 'action'`
+      // on a telegram catalog row can't arise from the real install path, but
+      // it's the minimal way to exercise the pillar clause in isolation — if
+      // the migration dropped `pillar = 'chat'`, this would 23505.
+      const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+      const chatId = `-100888${stamp.slice(0, 6)}`;
+      await installChat({
+        id: `wp-chat-${stamp}`,
+        workspaceId: `wsChat-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { chat_id: chatId },
+      });
+      // Raw insert with pillar = 'action' (installChat hardcodes 'chat').
+      await pool.query(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, 'catalog:telegram', $1, 'action', $3::jsonb, true, NOW())`,
+        [`wp-action-${stamp}`, `wsAction-${stamp}`, JSON.stringify({ chat_id: chatId })],
+      );
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins
+          WHERE catalog_id = 'catalog:telegram' AND config->>'chat_id' = $1`,
+        [chatId],
+      );
+      expect(rows[0]?.c).toBe(2);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("exempts a chat install whose routing key is absent — CASE yields NULL, which is DISTINCT (#3167)", async () => {
+      // Same NULL-distinctness mechanism the `my_customer` carve-out relies on:
+      // a telegram row with no `chat_id` produces a NULL index key, so two such
+      // rows never conflict. Documents this as intentional (not an accident).
+      const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+      await installChat({
+        id: `wp-nokey-a-${stamp}`,
+        workspaceId: `wsNoKeyA-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { display_name: "no-routing-key-a" },
+      });
+      await installChat({
+        id: `wp-nokey-b-${stamp}`,
+        workspaceId: `wsNoKeyB-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { display_name: "no-routing-key-b" },
+      });
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins WHERE id LIKE $1`,
+        [`wp-nokey-%-${stamp}`],
+      );
+      expect(rows[0]?.c).toBe(2);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("creates the partial unique index with the expected predicate + CASE definition — drift guard (#3167)", async () => {
+      const { rows } = await pool.query<{ indexname: string; indexdef: string }>(
+        `SELECT indexname, indexdef FROM pg_indexes
           WHERE schemaname = current_schema() AND tablename = 'workspace_plugins'
           ORDER BY indexname`,
       );
-      expect(rows.map((r) => r.indexname)).toContain(
-        "workspace_plugins_chat_routing_id_unique",
-      );
+      const idx = rows.find((r) => r.indexname === "workspace_plugins_chat_routing_id_unique");
+      expect(idx).toBeDefined();
+      const def = idx?.indexdef ?? "";
+      // Pin the load-bearing pieces so a migration edit that drops the partial
+      // predicate, the NULLIF carve-out, or a platform's routing key fails here
+      // even when no behavioral test happens to exercise that exact arm.
+      expect(def).toMatch(/UNIQUE INDEX/i);
+      expect(def).toMatch(/WHERE .*enabled.*AND.*pillar = 'chat'/is);
+      expect(def).toMatch(/NULLIF/i);
+      for (const key of ["chat_id", "guild_id", "tenant_id", "phone_number_id", "workspace_id"]) {
+        expect(def).toContain(key);
+      }
     }, PG_TEST_TIMEOUT_MS);
   });
 });

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1549,6 +1549,234 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       expect(rows[0]?.pillar).toBe("action");
     }, PG_TEST_TIMEOUT_MS);
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // 0120 — static-bot routing-id partial unique index (#3167)
+  //
+  // Closes the concurrent-install race: two DIFFERENT workspaces binding
+  // the SAME routing id (Telegram chat_id / Discord guild_id / Teams
+  // tenant_id / WhatsApp phone_number_id / gchat workspace_id) can no longer
+  // both persist. The losing writer hits a 23505 on
+  // `workspace_plugins_chat_routing_id_unique`, which the handlers map to the
+  // actionable "already connected elsewhere" error
+  // (`isRoutingIdUniqueViolation` keys on that exact index name).
+  //
+  // Carve-outs proved here mirror the migration's intent:
+  //   - gchat `my_customer` self-install alias is exempt (NULLIF → NULL,
+  //     DISTINCT in the index);
+  //   - the SAME routing value under two different platforms does NOT collide
+  //     (the leading `catalog_id` column scopes per platform);
+  //   - a disabled install frees its routing id for reuse (partial WHERE
+  //     enabled = true);
+  //   - a same-workspace reconnect UPSERT is idempotent (lands on its own
+  //     singleton row, routing value unchanged).
+  // ─────────────────────────────────────────────────────────────────────
+  describe("0120 static-bot routing-id uniqueness (#3167)", () => {
+    // Chat catalog rows aren't seeded by migrations (catalog-seeder runs at
+    // boot, not here), so seed the three platforms these tests exercise.
+    // ON CONFLICT DO NOTHING keeps it idempotent across this schema.
+    beforeAll(async () => {
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES
+           ('catalog:telegram', 'Telegram',    'telegram', 'chat', 'chat', 'static-bot'),
+           ('catalog:discord',  'Discord',     'discord',  'chat', 'chat', 'static-bot'),
+           ('catalog:gchat',    'Google Chat', 'gchat',    'chat', 'chat', 'static-bot')
+         ON CONFLICT (id) DO NOTHING`,
+      );
+    });
+
+    /** Insert one chat install row. Throws on a routing-id unique violation. */
+    async function installChat(opts: {
+      id: string;
+      workspaceId: string;
+      catalogId: string;
+      config: Record<string, string>;
+      enabled?: boolean;
+    }): Promise<void> {
+      await pool.query(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, $5, NOW())`,
+        [
+          opts.id,
+          opts.workspaceId,
+          opts.catalogId,
+          JSON.stringify(opts.config),
+          opts.enabled ?? true,
+        ],
+      );
+    }
+
+    it("rejects a second workspace binding the same Telegram chat_id with 23505 on the routing index (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const chatId = `-1001${stamp.replace(/\D/g, "").slice(0, 9)}`;
+      await installChat({
+        id: `wp-a-${stamp}`,
+        workspaceId: `wsA-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { chat_id: chatId },
+      });
+
+      let err: { code?: string; constraint?: string } | null = null;
+      try {
+        await installChat({
+          id: `wp-b-${stamp}`,
+          workspaceId: `wsB-${stamp}`,
+          catalogId: "catalog:telegram",
+          config: { chat_id: chatId },
+        });
+      } catch (e) {
+        err = e as { code?: string; constraint?: string };
+      }
+      expect(err?.code).toBe("23505");
+      // The handlers' `isRoutingIdUniqueViolation` keys on this exact name —
+      // a rename here without updating the helper would silently regress the
+      // error mapping back to a raw 500.
+      expect(err?.constraint).toBe("workspace_plugins_chat_routing_id_unique");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("allows a same-workspace reconnect UPSERT of its own chat_id — idempotent, no conflict (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const ws = `wsRecon-${stamp}`;
+      const chatId = `-100555${stamp.replace(/\D/g, "").slice(0, 6)}`;
+      await installChat({
+        id: `wp-r1-${stamp}`,
+        workspaceId: ws,
+        catalogId: "catalog:telegram",
+        config: { chat_id: chatId },
+      });
+      // Mirror the handler UPSERT exactly: ON CONFLICT on the singleton index
+      // lands on the existing row; the routing value is unchanged, so the
+      // routing index sees no NEW conflicting entry against another row.
+      await pool.query(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, 'catalog:telegram', $1, 'chat', $3::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE SET config = EXCLUDED.config, enabled = true`,
+        [`wp-r2-${stamp}`, ws, JSON.stringify({ chat_id: chatId, display_name: "renamed" })],
+      );
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins
+          WHERE workspace_id = $1 AND catalog_id = 'catalog:telegram'`,
+        [ws],
+      );
+      expect(rows[0]?.c).toBe(1);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("exempts the gchat 'my_customer' self-install alias — two workspaces store it without conflict (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      await installChat({
+        id: `wp-mc-a-${stamp}`,
+        workspaceId: `wsMcA-${stamp}`,
+        catalogId: "catalog:gchat",
+        config: { workspace_id: "my_customer" },
+      });
+      // NULLIF(config->>'workspace_id', 'my_customer') => NULL, which is
+      // DISTINCT in the index, so a second self-install must NOT conflict.
+      await installChat({
+        id: `wp-mc-b-${stamp}`,
+        workspaceId: `wsMcB-${stamp}`,
+        catalogId: "catalog:gchat",
+        config: { workspace_id: "my_customer" },
+      });
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins
+          WHERE catalog_id = 'catalog:gchat'
+            AND config->>'workspace_id' = 'my_customer'
+            AND id LIKE $1`,
+        [`wp-mc-%-${stamp}`],
+      );
+      expect(rows[0]?.c).toBe(2);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("still rejects two workspaces sharing a REAL gchat customer id with 23505 (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const customerId = `C0${stamp.replace(/\D/g, "").slice(0, 7)}`;
+      await installChat({
+        id: `wp-gc-a-${stamp}`,
+        workspaceId: `wsGcA-${stamp}`,
+        catalogId: "catalog:gchat",
+        config: { workspace_id: customerId },
+      });
+      await expect(
+        installChat({
+          id: `wp-gc-b-${stamp}`,
+          workspaceId: `wsGcB-${stamp}`,
+          catalogId: "catalog:gchat",
+          config: { workspace_id: customerId },
+        }),
+      ).rejects.toMatchObject({
+        code: "23505",
+        constraint: "workspace_plugins_chat_routing_id_unique",
+      });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("does NOT collide the same routing value across two different platforms (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const shared = `1234567${stamp.replace(/\D/g, "").slice(0, 8)}`;
+      await installChat({
+        id: `wp-tg-${stamp}`,
+        workspaceId: `wsTg-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { chat_id: shared },
+      });
+      // Discord guild_id with the identical string — different catalog_id, so
+      // (catalog_id, value) differs and there is no conflict. The leading
+      // catalog_id column is what keeps routing values namespaced per platform.
+      await installChat({
+        id: `wp-dc-${stamp}`,
+        workspaceId: `wsDc-${stamp}`,
+        catalogId: "catalog:discord",
+        config: { guild_id: shared },
+      });
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins WHERE id IN ($1, $2)`,
+        [`wp-tg-${stamp}`, `wp-dc-${stamp}`],
+      );
+      expect(rows[0]?.c).toBe(2);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("a disabled install frees its routing id — another workspace may then claim it (#3167)", async () => {
+      const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const chatId = `-100777${stamp.replace(/\D/g, "").slice(0, 6)}`;
+      // Disabled row sits OUTSIDE the partial index (WHERE enabled = true).
+      await installChat({
+        id: `wp-dis-${stamp}`,
+        workspaceId: `wsDis-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { chat_id: chatId },
+        enabled: false,
+      });
+      // Enabled install in a different workspace with the same chat_id — no
+      // conflict, because the disabled row isn't in the index.
+      await installChat({
+        id: `wp-en-${stamp}`,
+        workspaceId: `wsEn-${stamp}`,
+        catalogId: "catalog:telegram",
+        config: { chat_id: chatId },
+        enabled: true,
+      });
+      const { rows } = await pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM workspace_plugins
+          WHERE catalog_id = 'catalog:telegram' AND config->>'chat_id' = $1`,
+        [chatId],
+      );
+      expect(rows[0]?.c).toBe(2);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("creates the partial unique index by name — drift guard (#3167)", async () => {
+      const { rows } = await pool.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes
+          WHERE schemaname = current_schema() AND tablename = 'workspace_plugins'
+          ORDER BY indexname`,
+      );
+      expect(rows.map((r) => r.indexname)).toContain(
+        "workspace_plugins_chat_routing_id_unique",
+      );
+    }, PG_TEST_TIMEOUT_MS);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -138,7 +138,8 @@ describe("runMigrations", () => {
     //   Plus 0117 (dashboard_cards.content for text/section cards, #3138) = 118.
     //   Plus 0118 (clear user.role='admin' + member backfill, #2890) = 119.
     //   Plus 0119 (drop legacy teams/telegram/gchat/whatsapp_installations, #3161) = 120.
-    expect(count).toBe(120);
+    //   Plus 0120 (static-bot routing-id partial unique index, #3167) = 121.
+    expect(count).toBe(121);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -287,6 +288,7 @@ describe("runMigrations", () => {
         "0117_dashboard_text_cards.sql",
         "0118_drop_user_admin_role.sql",
         "0119_drop_legacy_credential_tables.sql",
+        "0120_static_bot_routing_id_unique.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0120_static_bot_routing_id_unique.sql
+++ b/packages/api/src/lib/db/migrations/0120_static_bot_routing_id_unique.sql
@@ -43,7 +43,8 @@
 --     the CASE, so the expression is NULL and the row is exempt. Slack
 --     routes on `team_id` via its own path and is intentionally untouched
 --     here. A new static-bot platform must add its key to BOTH this CASE
---     and the `WORKSPACE_PLUGINS_CHAT_ROUTING_ID` mirror in schema.ts.
+--     and the matching `uniqueIndex("workspace_plugins_chat_routing_id_unique")`
+--     CASE expression in db/schema.ts (kept in lockstep).
 --   * disabled installs — `WHERE enabled = true` matches the pre-check's
 --     `enabled = true` filter, so a disconnected (disabled) row frees its
 --     routing id for another workspace exactly as the pre-check intends.

--- a/packages/api/src/lib/db/migrations/0120_static_bot_routing_id_unique.sql
+++ b/packages/api/src/lib/db/migrations/0120_static_bot_routing_id_unique.sql
@@ -1,0 +1,77 @@
+-- 0120_static_bot_routing_id_unique.sql
+--
+-- #3167 — close the static-bot routing-id concurrent-install race.
+--
+-- Background. The five static-bot install handlers (Telegram, Discord,
+-- Teams, WhatsApp, Google Chat) each run a cross-workspace ownership
+-- PRE-CHECK before persisting — a read-only
+-- `SELECT … WHERE config->>'<routing_id>' = $1 AND workspace_id <> $2`
+-- (`assert*UnboundElsewhere`, #3154/#3163). That pre-check is NOT
+-- transactionally fused with the cap-gate UPSERT: the gate's advisory
+-- lock (`checkChatIntegrationLimitAndInstall`) is keyed by `workspace_id`,
+-- and `workspace_plugins_singleton` is unique only on
+-- `(workspace_id, catalog_id)`. So two DIFFERENT workspaces installing the
+-- SAME routing id concurrently can both observe no conflicting row and
+-- both UPSERT. The read-side resolvers in `lib/chat-plugin/executeQuery.ts`
+-- then fail-close on `rows.length > 1` for BOTH workspaces — no data leak,
+-- but an availability/griefing outage until an admin disconnects one side.
+--
+-- Fix. A partial UNIQUE index on the per-platform routing key, scoped to
+-- enabled chat-pillar installs. The DB now rejects the second concurrent
+-- writer with a `unique_violation` (23505); the handlers catch it and
+-- surface the SAME actionable "already connected elsewhere" error their
+-- pre-check returns (see `routing-id-conflict.ts` + the per-handler catch
+-- branches). DB-enforced uniqueness needs no extra lock contention.
+--
+-- Why a CASE expression rather than five indexes: every platform stores
+-- its routing id under a different JSONB key (Telegram `chat_id`, Discord
+-- `guild_id`, Teams `tenant_id`, WhatsApp `phone_number_id`, gchat
+-- `workspace_id`). One expression index keyed on `catalog_id` maps each
+-- catalog to its key and keeps the routing-key contract in a single place
+-- that mirrors the per-handler `*InstallConfig` shapes. The leading
+-- `catalog_id` column scopes routing values per platform, so a Telegram
+-- `chat_id` of "123" never collides with a Discord `guild_id` of "123".
+--
+-- Carve-outs (all expressed as the CASE yielding NULL — Postgres treats
+-- NULLs as DISTINCT in a unique index by default, so NULL-keyed rows never
+-- conflict with each other):
+--   * gchat `my_customer` — a caller-relative self-install alias, not a
+--     global customer id. `NULLIF(config->>'workspace_id', 'my_customer')`
+--     drops it out of the constraint so every admin's "my own tenant"
+--     self-install stays allowed.
+--   * Slack (and any future chat catalog not in the CASE) — has no key in
+--     the CASE, so the expression is NULL and the row is exempt. Slack
+--     routes on `team_id` via its own path and is intentionally untouched
+--     here. A new static-bot platform must add its key to BOTH this CASE
+--     and the `WORKSPACE_PLUGINS_CHAT_ROUTING_ID` mirror in schema.ts.
+--   * disabled installs — `WHERE enabled = true` matches the pre-check's
+--     `enabled = true` filter, so a disconnected (disabled) row frees its
+--     routing id for another workspace exactly as the pre-check intends.
+--
+-- Existing-duplicate assumption. Pre-#3154 two workspaces could bind the
+-- same routing id; any such pair is ALREADY non-functional because the
+-- read-side resolver fail-closes on `rows.length > 1`. The static-bot
+-- install path is brand-new (#2994 umbrella, #3141–#3144) and Atlas is
+-- pre-launch with no live multi-tenant chat installs, so no enabled-row
+-- routing-id duplicates are expected. If one did exist this `CREATE UNIQUE
+-- INDEX` would fail loudly at deploy (correct fail-closed behaviour) —
+-- naming the conflicting index — rather than silently shipping a broken
+-- guard. Plain (non-CONCURRENTLY) creation: the migration runner wraps
+-- every file in a single transaction under an advisory lock, and
+-- CONCURRENTLY cannot run inside a transaction block.
+--
+-- Plain CREATE UNIQUE INDEX (no Better Auth tables touched) → no
+-- MANAGED_AUTH_MIGRATIONS entry. Idempotent via IF NOT EXISTS.
+
+CREATE UNIQUE INDEX IF NOT EXISTS workspace_plugins_chat_routing_id_unique
+  ON workspace_plugins (
+    catalog_id,
+    (CASE catalog_id
+       WHEN 'catalog:telegram' THEN config->>'chat_id'
+       WHEN 'catalog:discord'  THEN config->>'guild_id'
+       WHEN 'catalog:teams'    THEN config->>'tenant_id'
+       WHEN 'catalog:whatsapp' THEN config->>'phone_number_id'
+       WHEN 'catalog:gchat'    THEN NULLIF(config->>'workspace_id', 'my_customer')
+     END)
+  )
+  WHERE enabled = true AND pillar = 'chat';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1547,6 +1547,38 @@ export const workspacePlugins = pgTable(
     uniqueIndex("workspace_plugins_singleton")
       .on(t.workspaceId, t.catalogId)
       .where(sql`pillar IN ('chat', 'action')`),
+    // 0120 / #3167 — closes the static-bot routing-id concurrent-install
+    // race. The five static-bot handlers' cross-workspace pre-checks
+    // (`assert*UnboundElsewhere`) aren't transactionally fused with the
+    // per-workspace-locked cap-gate UPSERT, so two DIFFERENT workspaces
+    // could both bind the SAME routing id and collapse the read-side
+    // resolver onto its `rows.length > 1` fail-closed. This partial unique
+    // index is the DB-enforced backstop: one routing key per platform.
+    //   - Leading `catalog_id` scopes the routing value per platform, so a
+    //     Telegram chat_id "123" never collides with a Discord guild_id "123".
+    //   - The CASE maps each catalog to its JSONB routing key (mirrors the
+    //     per-handler `*InstallConfig` shapes). A NULL result (Slack, any
+    //     future unmapped chat catalog, or gchat's `my_customer` self-install
+    //     alias via NULLIF) is DISTINCT in the index → exempt from the
+    //     constraint. Adding a static-bot platform means extending BOTH this
+    //     CASE and the migration 0120 expression in lockstep.
+    //   - `WHERE enabled = true` matches the pre-check filter, so a
+    //     disconnected (disabled) install frees its routing id for reuse.
+    // The handlers catch the 23505 this raises and surface the same
+    // "already connected elsewhere" error as the pre-check (see
+    // `lib/integrations/install/routing-id-conflict.ts`).
+    uniqueIndex("workspace_plugins_chat_routing_id_unique")
+      .on(
+        t.catalogId,
+        sql`(CASE catalog_id
+       WHEN 'catalog:telegram' THEN config->>'chat_id'
+       WHEN 'catalog:discord'  THEN config->>'guild_id'
+       WHEN 'catalog:teams'    THEN config->>'tenant_id'
+       WHEN 'catalog:whatsapp' THEN config->>'phone_number_id'
+       WHEN 'catalog:gchat'    THEN NULLIF(config->>'workspace_id', 'my_customer')
+     END)`,
+      )
+      .where(sql`enabled = true AND pillar = 'chat'`),
     index("idx_workspace_plugins_workspace").on(t.workspaceId),
     index("idx_workspace_plugins_catalog").on(t.catalogId),
     index("idx_workspace_plugins_status").on(t.workspaceId, t.status),

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -250,6 +250,43 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — cross-workspace guar
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(/db down/);
     expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
+
+  it("maps a concurrent routing-id unique violation (23505) from the cap gate to the actionable conflict error (#3167)", async () => {
+    // Pre-check passes (no existing bind), but a concurrent install in another
+    // workspace claimed the guild_id first. The migration-0120 partial unique
+    // index rejects our UPSERT with a 23505 naming
+    // `workspace_plugins_chat_routing_id_unique`. The handler must surface the
+    // SAME error its pre-check returns, not leak a raw 500.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      ),
+    );
+    const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
+    await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+  });
+
+  it("re-throws a 23505 on a DIFFERENT index untouched — not relabelled as a cross-workspace conflict (#3167)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "workspace_plugins_id_unique"'),
+          { code: "23505", constraint: "workspace_plugins_id_unique" },
+        ),
+      ),
+    );
+    const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
+    await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
+      /duplicate key value/i,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/gchat-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/gchat-static-bot-handler.test.ts
@@ -388,6 +388,43 @@ describe("GchatStaticBotInstallHandler.confirmInstall — cross-workspace guard"
     );
     expect(guardCall).toBeUndefined();
   });
+
+  it("maps a concurrent routing-id unique violation (23505) from the cap gate to the actionable conflict error (#3167)", async () => {
+    // Pre-check passes (no existing bind), but a concurrent install in another
+    // workspace claimed the customer id first. The migration-0120 partial
+    // unique index rejects our UPSERT with a 23505 naming
+    // `workspace_plugins_chat_routing_id_unique`. The handler must surface the
+    // SAME error its pre-check returns, not leak a raw 500.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      ),
+    );
+    const handler = buildHandler();
+    await expect(handler.confirmInstall(wsid, VALID_WORKSPACE_ID)).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+  });
+
+  it("re-throws a 23505 on a DIFFERENT index untouched — not relabelled as a cross-workspace conflict (#3167)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "workspace_plugins_id_unique"'),
+          { code: "23505", constraint: "workspace_plugins_id_unique" },
+        ),
+      ),
+    );
+    const handler = buildHandler();
+    await expect(handler.confirmInstall(wsid, VALID_WORKSPACE_ID)).rejects.toThrow(
+      /duplicate key value/i,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for {@link isRoutingIdUniqueViolation} (#3167) — the predicate the
+ * five static-bot handlers use to recognise a lost concurrent-install race
+ * (a Postgres 23505 on the migration-0120 routing-id partial unique index)
+ * and re-surface it as the actionable "already connected elsewhere" error.
+ *
+ * The predicate must be TIGHT: a 23505 on any OTHER index, a non-23505 error,
+ * or a non-object value (network/driver failures) must NOT be classified as a
+ * routing-id conflict — otherwise an unrelated failure would be silently
+ * relabelled with a misleading cross-workspace message.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  CHAT_ROUTING_ID_UNIQUE_INDEX,
+  isRoutingIdUniqueViolation,
+} from "../routing-id-conflict";
+
+/** Build a pg-DatabaseError-shaped object. */
+function pgError(code: string, constraint?: string): Error {
+  return Object.assign(new Error("duplicate key value violates unique constraint"), {
+    code,
+    ...(constraint !== undefined ? { constraint } : {}),
+  });
+}
+
+describe("isRoutingIdUniqueViolation (#3167)", () => {
+  it("matches a 23505 on the routing-id index", () => {
+    expect(isRoutingIdUniqueViolation(pgError("23505", CHAT_ROUTING_ID_UNIQUE_INDEX))).toBe(true);
+  });
+
+  it("does NOT match a 23505 on a different index (singleton / id index)", () => {
+    expect(isRoutingIdUniqueViolation(pgError("23505", "workspace_plugins_singleton"))).toBe(false);
+    expect(isRoutingIdUniqueViolation(pgError("23505", "workspace_plugins_id_unique"))).toBe(false);
+  });
+
+  it("does NOT match a 23505 with no constraint name", () => {
+    expect(isRoutingIdUniqueViolation(pgError("23505"))).toBe(false);
+  });
+
+  it("does NOT match a different SQLSTATE on the routing-id index", () => {
+    // e.g. 23514 check_violation, 23503 fk_violation — different failure class.
+    expect(isRoutingIdUniqueViolation(pgError("23514", CHAT_ROUTING_ID_UNIQUE_INDEX))).toBe(false);
+  });
+
+  it("does NOT match non-object / nullish / plain-Error values", () => {
+    expect(isRoutingIdUniqueViolation(null)).toBe(false);
+    expect(isRoutingIdUniqueViolation(undefined)).toBe(false);
+    expect(isRoutingIdUniqueViolation("23505")).toBe(false);
+    expect(isRoutingIdUniqueViolation(new Error("network down"))).toBe(false);
+  });
+
+  it("pins the index name the migration + schema mirror create", () => {
+    // A rename in migration 0120 / schema.ts without updating this constant
+    // would silently regress every handler's conflict mapping back to a 500.
+    expect(CHAT_ROUTING_ID_UNIQUE_INDEX).toBe("workspace_plugins_chat_routing_id_unique");
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
@@ -50,6 +50,37 @@ describe("isRoutingIdUniqueViolation (#3167)", () => {
     expect(isRoutingIdUniqueViolation(new Error("network down"))).toBe(false);
   });
 
+  // The no-org install path (`internalQuery`) and the marketplace config
+  // UPDATE (`queryEffect`) both run through `@effect/sql`, which wraps the pg
+  // DatabaseError in `SqlError.cause` with no top-level `code`. The predicate
+  // must follow `.cause` to catch those (Codex review on #3170).
+  it("matches when the pg error is wrapped in an @effect/sql SqlError.cause", () => {
+    const sqlError = Object.assign(new Error("statement failed"), {
+      _tag: "SqlError",
+      cause: pgError("23505", CHAT_ROUTING_ID_UNIQUE_INDEX),
+    });
+    expect(isRoutingIdUniqueViolation(sqlError)).toBe(true);
+  });
+
+  it("matches a pg error nested several .cause links deep", () => {
+    const deep = { cause: { cause: pgError("23505", CHAT_ROUTING_ID_UNIQUE_INDEX) } };
+    expect(isRoutingIdUniqueViolation(deep)).toBe(true);
+  });
+
+  it("does NOT match a wrapped 23505 on a DIFFERENT index", () => {
+    const sqlError = Object.assign(new Error("statement failed"), {
+      _tag: "SqlError",
+      cause: pgError("23505", "workspace_plugins_singleton"),
+    });
+    expect(isRoutingIdUniqueViolation(sqlError)).toBe(false);
+  });
+
+  it("terminates on a self-referential / cyclic cause chain (no infinite loop)", () => {
+    const cyclic: { code: string; cause?: unknown } = { code: "08006" };
+    cyclic.cause = cyclic;
+    expect(isRoutingIdUniqueViolation(cyclic)).toBe(false);
+  });
+
   it("pins the index name the migration + schema mirror create", () => {
     // A rename in migration 0120 / schema.ts without updating this constant
     // would silently regress every handler's conflict mapping back to a 500.

--- a/packages/api/src/lib/integrations/install/__tests__/teams-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/teams-static-bot-handler.test.ts
@@ -358,6 +358,41 @@ describe("TeamsStaticBotInstallHandler.confirmInstall — cross-workspace guard"
     await expect(handler.confirmInstall(wsid, SAMPLE_TENANT)).rejects.toThrow(/db down/);
     expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
+
+  it("maps a concurrent routing-id unique violation (23505) from the cap gate to the actionable conflict error (#3167)", async () => {
+    // Pre-check passes (no existing bind), but a concurrent install in another
+    // workspace consented the tenant_id first. The migration-0120 partial
+    // unique index rejects our UPSERT with a 23505 naming
+    // `workspace_plugins_chat_routing_id_unique`. The handler must surface the
+    // SAME error its pre-check returns, not leak a raw 500.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      ),
+    );
+    const handler = new TeamsStaticBotInstallHandler({ appId: "id", appPassword: "pwd" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_TENANT)).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+  });
+
+  it("re-throws a 23505 on a DIFFERENT index untouched — not relabelled as a cross-workspace conflict (#3167)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "workspace_plugins_id_unique"'),
+          { code: "23505", constraint: "workspace_plugins_id_unique" },
+        ),
+      ),
+    );
+    const handler = new TeamsStaticBotInstallHandler({ appId: "id", appPassword: "pwd" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_TENANT)).rejects.toThrow(/duplicate key value/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
@@ -286,6 +286,41 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — cross-workspace gua
     expect(result.installRecord.catalogId).toBe(TELEGRAM_SLUG);
     expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
+
+  it("maps a concurrent routing-id unique violation (23505) from the cap gate to the actionable conflict error (#3167)", async () => {
+    // Pre-check passes (no existing bind), but a concurrent install in another
+    // workspace claimed the chat_id first. The migration-0120 partial unique
+    // index rejects our UPSERT with a 23505 naming
+    // `workspace_plugins_chat_routing_id_unique`. The handler must surface the
+    // SAME error its pre-check returns, not leak a raw 500.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      ),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+    await expect(handler.confirmInstall(wsid, "-100999")).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+  });
+
+  it("re-throws a 23505 on a DIFFERENT index untouched — not relabelled as a cross-workspace conflict (#3167)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "workspace_plugins_id_unique"'),
+          { code: "23505", constraint: "workspace_plugins_id_unique" },
+        ),
+      ),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+    await expect(handler.confirmInstall(wsid, "-100999")).rejects.toThrow(/duplicate key value/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
@@ -495,6 +495,43 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — cross-workspace gua
     expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
     expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
+
+  it("maps a concurrent routing-id unique violation (23505) from the cap gate to the actionable conflict error (#3167)", async () => {
+    // Pre-check passes (no existing bind), but a concurrent install in another
+    // workspace claimed the phone_number_id first. The migration-0120 partial
+    // unique index rejects our UPSERT with a 23505 naming
+    // `workspace_plugins_chat_routing_id_unique`. The handler must surface the
+    // SAME error its pre-check returns, not leak a raw 500.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "workspace_plugins_chat_routing_id_unique",
+        }),
+      ),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+  });
+
+  it("re-throws a 23505 on a DIFFERENT index untouched — not relabelled as a cross-workspace conflict (#3167)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.reject(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "workspace_plugins_id_unique"'),
+          { code: "23505", constraint: "workspace_plugins_id_unique" },
+        ),
+      ),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /duplicate key value/i,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -284,13 +284,15 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
     // a failed verification never leaves a half-installed row behind.
     const apiGuildName = await this.verifyReachability(routingIdentifier);
 
-    // ── 2b. Cross-workspace ownership guard (#3154) ─────────────────
+    // ── 2b. Cross-workspace ownership guard (#3154 / #3167) ─────────
     // Reachability proves the operator bot is in the guild, NOT that THIS
     // workspace owns it — guild ids are non-secret. Reject a guild_id already
     // bound to a *different* workspace so a second workspace can't claim it and
     // collapse the read-side resolver onto a `rows.length > 1` fail-closed
     // (which would disable both). A reconnect by the same workspace is excluded
-    // by the `workspace_id <> $3` filter.
+    // by the `workspace_id <> $3` filter. The simultaneous-race residual is
+    // closed by the migration-0120 partial unique index, whose 23505 the
+    // cap-gate catch below maps to the same error (#3167).
     await assertGuildIdUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 2c. Plan cap + install row — atomic (#2953, #3001) ─────────

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -48,6 +48,7 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.discord");
 
@@ -64,19 +65,32 @@ export const DISCORD_SLUG: CatalogId = "discord";
 export const DISCORD_CATALOG_ID = "catalog:discord";
 
 /**
- * Cross-workspace ownership guard (#3154). The OAuth bot-install redirect
- * proves an admin of the guild authorized the operator bot, but a guild id is
- * non-secret (it leaks in every Discord message envelope and is copyable by
- * any member via Developer Mode). So reject a guild_id already bound to a
- * *different* workspace before persisting — otherwise a second workspace can
- * claim the same guild and the read-side resolver in `executeQuery.ts`
- * fail-closes on `rows.length > 1`, disabling BOTH workspaces (a
- * griefing / availability vector). The `workspace_id <> $3` filter excludes
- * the installing workspace so a reconnect (same workspace re-binding its own
- * guild) is never blocked. Read-only pre-check: it narrows the cross-tenant
- * window but isn't transactionally fused with the cap gate's INSERT, so the
- * simultaneous-race case remains (acceptable — first writer wins, the loser's
- * read-side fail-closed is recoverable by disconnecting one side).
+ * Surfaced when a guild_id is already bound to a different workspace — by the
+ * pre-check below AND by `confirmInstall`'s catch when the migration-0120
+ * partial unique index rejects a concurrent claim. Single source so both paths
+ * return identical, actionable text (#3167).
+ */
+const DISCORD_ROUTING_CONFLICT_MESSAGE =
+  "This Discord server is already connected to a different Atlas workspace. Each server can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.";
+
+/**
+ * Cross-workspace ownership guard (#3154 / #3167). The OAuth bot-install
+ * redirect proves an admin of the guild authorized the operator bot, but a
+ * guild id is non-secret (it leaks in every Discord message envelope and is
+ * copyable by any member via Developer Mode). So reject a guild_id already
+ * bound to a *different* workspace before persisting — otherwise a second
+ * workspace can claim the same guild and the read-side resolver in
+ * `executeQuery.ts` fail-closes on `rows.length > 1`, disabling BOTH
+ * workspaces (a griefing / availability vector). The `workspace_id <> $3`
+ * filter excludes the installing workspace so a reconnect (same workspace
+ * re-binding its own guild) is never blocked.
+ *
+ * This read-only pre-check catches the common case cheaply. The
+ * simultaneous-race case (two workspaces binding a never-before-seen guild_id
+ * at the same instant) is now closed by the partial unique index from
+ * migration 0120 (#3167): the losing writer's UPSERT fails with a 23505 that
+ * `confirmInstall`'s catch maps back to {@link DISCORD_ROUTING_CONFLICT_MESSAGE},
+ * so both paths return the same error.
  */
 async function assertGuildIdUnboundElsewhere(
   guildId: string,
@@ -98,8 +112,7 @@ async function assertGuildIdUnboundElsewhere(
       "Discord install rejected — guild_id already bound to a different workspace",
     );
     throw new DiscordGuildIdInvalidError({
-      message:
-        "This Discord server is already connected to a different Atlas workspace. Each server can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.",
+      message: DISCORD_ROUTING_CONFLICT_MESSAGE,
     });
   }
 }
@@ -327,6 +340,19 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
         },
       );
     } catch (err) {
+      if (isRoutingIdUniqueViolation(err)) {
+        // Another workspace claimed this guild_id between our pre-check and
+        // our UPSERT; the migration-0120 partial unique index rejected us
+        // (#3167). Surface the same actionable error the pre-check returns
+        // rather than a raw 500 — first writer wins, we lost the race.
+        log.warn(
+          { workspaceId },
+          "Discord install rejected — guild_id claimed by another workspace concurrently (unique index)",
+        );
+        throw new DiscordGuildIdInvalidError({
+          message: DISCORD_ROUTING_CONFLICT_MESSAGE,
+        });
+      }
       log.error(
         {
           workspaceId,

--- a/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
@@ -76,6 +76,7 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.gchat");
 
@@ -92,25 +93,42 @@ export const GCHAT_SLUG: CatalogId = "gchat";
 export const GCHAT_CATALOG_ID = "catalog:gchat";
 
 /**
- * Cross-workspace ownership guard (#3154). The Pub/Sub round-trip proves the
- * customer-supplied service account can publish, but the Google Workspace
- * customer id (`workspace_id`) is a non-secret routing identifier — it rides
- * in every inbound Google Chat event envelope. Reject a `workspace_id` already
- * bound to a *different* Atlas workspace before persisting, otherwise a second
- * workspace can claim it and the read-side resolver in `executeQuery.ts`
+ * Surfaced when a Google Workspace customer id is already bound to a different
+ * workspace — by the pre-check below AND by `confirmInstall`'s catch when the
+ * migration-0120 partial unique index rejects a concurrent claim. Single
+ * source so both paths return identical, actionable text (#3167).
+ */
+const GCHAT_ROUTING_CONFLICT_MESSAGE =
+  "This Google Workspace is already connected to a different Atlas workspace. Each Google Workspace customer id can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.";
+
+/**
+ * Cross-workspace ownership guard (#3154 / #3167). The Pub/Sub round-trip
+ * proves the customer-supplied service account can publish, but the Google
+ * Workspace customer id (`workspace_id`) is a non-secret routing identifier —
+ * it rides in every inbound Google Chat event envelope. Reject a `workspace_id`
+ * already bound to a *different* Atlas workspace before persisting, otherwise a
+ * second workspace can claim it and the read-side resolver in `executeQuery.ts`
  * fail-closes on `rows.length > 1`, disabling BOTH workspaces. The
  * `workspace_id <> $3` filter (the installing Atlas workspace) excludes a
- * reconnect of the same workspace. Read-only pre-check — narrows the
- * cross-tenant window without being transactionally fused to the cap-gate
- * INSERT (first writer wins; the loser's fail-closed is recoverable).
+ * reconnect of the same workspace.
  *
- * The literal `my_customer` self-install alias is exempt: it is a
- * caller-relative reference (each Google Workspace admin's "my own tenant"),
- * NOT a globally unique customer id, so comparing it across workspaces would
- * falsely block every later self-install. Two different tenants legitimately
- * storing `my_customer` is a separate (pre-existing) non-routability concern —
- * the inbound resolver matches the *real* customer id from the event envelope,
- * never the literal alias — and is out of scope for this guard.
+ * This read-only pre-check catches the common case cheaply. The
+ * simultaneous-race case (two workspaces binding a never-before-seen customer
+ * id at the same instant) is now closed by the partial unique index from
+ * migration 0120 (#3167): the losing writer's UPSERT fails with a 23505 that
+ * `confirmInstall`'s catch maps back to {@link GCHAT_ROUTING_CONFLICT_MESSAGE},
+ * so both paths return the same error.
+ *
+ * The literal `my_customer` self-install alias is exempt — in BOTH layers. It
+ * is a caller-relative reference (each Google Workspace admin's "my own
+ * tenant"), NOT a globally unique customer id, so comparing it across
+ * workspaces would falsely block every later self-install. The pre-check
+ * short-circuits it below; the migration-0120 index excludes it via
+ * `NULLIF(config->>'workspace_id', 'my_customer')` (NULL keys are DISTINCT, so
+ * never conflict). Two different tenants legitimately storing `my_customer` is
+ * a separate (pre-existing) non-routability concern — the inbound resolver
+ * matches the *real* customer id from the event envelope, never the literal
+ * alias — and is out of scope for this guard.
  */
 async function assertWorkspaceIdUnboundElsewhere(
   gchatWorkspaceId: string,
@@ -133,8 +151,7 @@ async function assertWorkspaceIdUnboundElsewhere(
       "Google Chat install rejected — workspace_id already bound to a different workspace",
     );
     throw new GchatWorkspaceIdInvalidError({
-      message:
-        "This Google Workspace is already connected to a different Atlas workspace. Each Google Workspace customer id can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.",
+      message: GCHAT_ROUTING_CONFLICT_MESSAGE,
     });
   }
 }
@@ -476,6 +493,19 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
         },
       );
     } catch (err) {
+      if (isRoutingIdUniqueViolation(err)) {
+        // Another workspace claimed this customer id between our pre-check and
+        // our UPSERT; the migration-0120 partial unique index rejected us
+        // (#3167). Surface the same actionable error the pre-check returns
+        // rather than a raw 500 — first writer wins, we lost the race.
+        log.warn(
+          { workspaceId },
+          "Google Chat install rejected — workspace_id claimed by another workspace concurrently (unique index)",
+        );
+        throw new GchatWorkspaceIdInvalidError({
+          message: GCHAT_ROUTING_CONFLICT_MESSAGE,
+        });
+      }
       log.error(
         {
           workspaceId,

--- a/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
@@ -450,13 +450,15 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
     // so a failed verification never leaves a half-installed row behind.
     await this.verifyReachability(routingIdentifier);
 
-    // ── 2b. Cross-workspace ownership guard (#3154) ─────────────────
+    // ── 2b. Cross-workspace ownership guard (#3154 / #3167) ─────────
     // The Pub/Sub round-trip proves the SA can publish, NOT that THIS
     // workspace owns the customer id (which is non-secret). Reject a
     // workspace_id already bound to a *different* workspace so a second
     // workspace can't claim it and collapse the read-side resolver onto a
     // `rows.length > 1` fail-closed. A reconnect is excluded by `workspace_id
-    // <> $3`.
+    // <> $3`. The simultaneous-race residual is closed by the migration-0120
+    // partial unique index, whose 23505 the cap-gate catch below maps to the
+    // same error (#3167).
     await assertWorkspaceIdUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Plan cap + install row — atomic (#3143, #3001) ──────────

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -1,0 +1,57 @@
+/**
+ * Routing-id concurrent-install conflict detection (#3167).
+ *
+ * The five static-bot install handlers (Telegram, Discord, Teams,
+ * WhatsApp, Google Chat) each run a cross-workspace ownership PRE-CHECK
+ * (`assert*UnboundElsewhere`) before persisting their routing identifier.
+ * That pre-check narrows — but does not eliminate — the window where two
+ * DIFFERENT workspaces bind the SAME routing id concurrently: it isn't
+ * transactionally fused with the cap-gate UPSERT (whose advisory lock is
+ * keyed by `workspace_id`, and whose `workspace_plugins_singleton` index
+ * is unique only on `(workspace_id, catalog_id)`).
+ *
+ * Migration 0120 closes that race with a partial unique index
+ * ({@link CHAT_ROUTING_ID_UNIQUE_INDEX}) on the per-platform routing key.
+ * The losing concurrent writer's UPSERT then fails with a Postgres
+ * `unique_violation` (SQLSTATE 23505) naming that index. This helper
+ * recognises exactly that error so each handler can re-surface the SAME
+ * actionable "already connected elsewhere" message its pre-check returns —
+ * rather than leaking a raw 500.
+ *
+ * The constraint-name check is deliberately tight: a 23505 on any OTHER
+ * index (the `workspace_plugins_id_unique` id index, the singleton index)
+ * is a genuinely different failure and must NOT be relabelled as a
+ * cross-workspace routing conflict.
+ */
+
+/**
+ * Name of the partial unique index created by migration 0120 and mirrored
+ * in `db/schema.ts`. Postgres reports it as the `constraint` field on the
+ * `unique_violation` error when a concurrent install loses the race.
+ */
+export const CHAT_ROUTING_ID_UNIQUE_INDEX = "workspace_plugins_chat_routing_id_unique";
+
+/** Postgres SQLSTATE for `unique_violation`. */
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Shape of the fields we read off a `pg` `DatabaseError`. `code` carries
+ * the SQLSTATE; `constraint` carries the violated index/constraint name on
+ * a unique violation. Both are optional because the value reaching a
+ * `catch` is `unknown` — a network/driver error won't have them.
+ */
+interface PgErrorLike {
+  readonly code?: unknown;
+  readonly constraint?: unknown;
+}
+
+/**
+ * True iff `err` is a Postgres unique-violation raised by the static-bot
+ * routing-id index ({@link CHAT_ROUTING_ID_UNIQUE_INDEX}) — i.e. a second
+ * workspace lost the concurrent-install race for the same routing id.
+ */
+export function isRoutingIdUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as PgErrorLike;
+  return e.code === PG_UNIQUE_VIOLATION && e.constraint === CHAT_ROUTING_ID_UNIQUE_INDEX;
+}

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -35,23 +35,50 @@ export const CHAT_ROUTING_ID_UNIQUE_INDEX = "workspace_plugins_chat_routing_id_u
 const PG_UNIQUE_VIOLATION = "23505";
 
 /**
- * Shape of the fields we read off a `pg` `DatabaseError`. `code` carries
- * the SQLSTATE; `constraint` carries the violated index/constraint name on
- * a unique violation. Both are optional because the value reaching a
- * `catch` is `unknown` — a network/driver error won't have them.
+ * Max `.cause` links to follow. The pg error is at most a couple of links
+ * deep (`SqlError.cause` → pg `DatabaseError`); the cap is a backstop against
+ * a cyclic `cause` chain rather than a real depth requirement.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * Shape of the fields we read off an error link. `code` carries the SQLSTATE;
+ * `constraint` carries the violated index/constraint name on a unique
+ * violation; `cause` is the next link to inspect. All optional because the
+ * value reaching a `catch` is `unknown` — a network/driver error won't have
+ * them.
  */
 interface PgErrorLike {
   readonly code?: unknown;
   readonly constraint?: unknown;
+  readonly cause?: unknown;
 }
 
 /**
- * True iff `err` is a Postgres unique-violation raised by the static-bot
- * routing-id index ({@link CHAT_ROUTING_ID_UNIQUE_INDEX}) — i.e. a second
- * workspace lost the concurrent-install race for the same routing id.
+ * True iff `err` (or any link in its `.cause` chain) is a Postgres
+ * unique-violation raised by the static-bot routing-id index
+ * ({@link CHAT_ROUTING_ID_UNIQUE_INDEX}) — i.e. a second workspace lost the
+ * concurrent-install race for the same routing id.
+ *
+ * The chain walk matters: the pg `DatabaseError` surfaces with top-level
+ * `code`/`constraint` on the raw-pool transaction path (the common with-org
+ * install via `getInternalDB().connect()`), but the no-org direct-insert path
+ * and the generic marketplace config UPDATE both go through `@effect/sql`
+ * (`internalQuery` / `queryEffect` → `_sqlClient.unsafe`), which wraps the pg
+ * error inside a `SqlError.cause` with NO top-level `code`. Inspecting each
+ * link catches the 23505 regardless of how deeply the driver/Effect layer
+ * wrapped it.
  */
 export function isRoutingIdUniqueViolation(err: unknown): boolean {
-  if (typeof err !== "object" || err === null) return false;
-  const e = err as PgErrorLike;
-  return e.code === PG_UNIQUE_VIOLATION && e.constraint === CHAT_ROUTING_ID_UNIQUE_INDEX;
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (typeof current !== "object" || current === null) return false;
+    const e = current as PgErrorLike;
+    if (e.code === PG_UNIQUE_VIOLATION && e.constraint === CHAT_ROUTING_ID_UNIQUE_INDEX) {
+      return true;
+    }
+    if (e.cause === current) return false; // self-referential guard
+    current = e.cause;
+  }
+  return false;
 }

--- a/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
@@ -268,13 +268,15 @@ export class TeamsStaticBotInstallHandler implements StaticBotInstallHandler {
     // row behind.
     await this.verifyReachability(normalizedTenantId);
 
-    // ── 2b. Cross-workspace ownership guard (#3154) ─────────────────
+    // ── 2b. Cross-workspace ownership guard (#3154 / #3167) ─────────
     // Even though admin-consent proves tenant ownership, the tenant GUID is
     // non-secret and two Atlas workspaces in the same Microsoft tenant could
     // both consent it — binding it twice collapses the read-side resolver onto
     // a `rows.length > 1` fail-closed (disabling both). Reject a tenant_id
     // already bound to a *different* workspace; a reconnect is excluded by
-    // `workspace_id <> $3`.
+    // `workspace_id <> $3`. The simultaneous-race residual is closed by the
+    // migration-0120 partial unique index, whose 23505 the cap-gate catch
+    // below maps to the same error (#3167).
     await assertTenantIdUnboundElsewhere(normalizedTenantId, workspaceId);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─

--- a/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
@@ -65,6 +65,7 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.teams");
 
@@ -81,17 +82,33 @@ export const TEAMS_SLUG: CatalogId = "teams";
 export const TEAMS_CATALOG_ID = "catalog:teams";
 
 /**
- * Cross-workspace ownership guard (#3154). Teams captures its tenant_id through
- * the Azure AD admin-consent callback, so the id is ownership-proven for the
- * consenting admin — but the tenant GUID is non-secret (it rides in every Bot
- * Framework activity envelope's `channelData.tenant.id`), and two distinct
- * Atlas workspaces controlled from the same Microsoft tenant could both
- * legitimately consent it. Binding the same tenant_id to two workspaces
+ * Surfaced when a tenant_id is already bound to a different workspace — by the
+ * pre-check below AND by `confirmInstall`'s catch when the migration-0120
+ * partial unique index rejects a concurrent claim. Single source so both paths
+ * return identical, actionable text (#3167).
+ */
+const TEAMS_ROUTING_CONFLICT_MESSAGE =
+  "This Microsoft Teams tenant is already connected to a different Atlas workspace. Each tenant can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.";
+
+/**
+ * Cross-workspace ownership guard (#3154 / #3167). Teams captures its tenant_id
+ * through the Azure AD admin-consent callback, so the id is ownership-proven
+ * for the consenting admin — but the tenant GUID is non-secret (it rides in
+ * every Bot Framework activity envelope's `channelData.tenant.id`), and two
+ * distinct Atlas workspaces controlled from the same Microsoft tenant could
+ * both legitimately consent it. Binding the same tenant_id to two workspaces
  * collapses the read-side resolver in `executeQuery.ts` onto a
  * `rows.length > 1` fail-closed, disabling BOTH. So this is a
  * uniqueness/availability guard (first binder wins): reject a tenant_id already
  * bound to a *different* workspace. The `workspace_id <> $3` filter excludes a
  * reconnect of the same workspace.
+ *
+ * This read-only pre-check catches the common case cheaply. The
+ * simultaneous-race case (two workspaces consenting a never-before-seen
+ * tenant_id at the same instant) is now closed by the partial unique index
+ * from migration 0120 (#3167): the losing writer's UPSERT fails with a 23505
+ * that `confirmInstall`'s catch maps back to {@link TEAMS_ROUTING_CONFLICT_MESSAGE},
+ * so both paths return the same error.
  */
 async function assertTenantIdUnboundElsewhere(
   tenantId: string,
@@ -113,8 +130,7 @@ async function assertTenantIdUnboundElsewhere(
       "Teams install rejected — tenant_id already bound to a different workspace",
     );
     throw new TeamsTenantIdInvalidError({
-      message:
-        "This Microsoft Teams tenant is already connected to a different Atlas workspace. Each tenant can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.",
+      message: TEAMS_ROUTING_CONFLICT_MESSAGE,
     });
   }
 }
@@ -307,6 +323,19 @@ export class TeamsStaticBotInstallHandler implements StaticBotInstallHandler {
         },
       );
     } catch (err) {
+      if (isRoutingIdUniqueViolation(err)) {
+        // Another workspace consented this tenant_id between our pre-check and
+        // our UPSERT; the migration-0120 partial unique index rejected us
+        // (#3167). Surface the same actionable error the pre-check returns
+        // rather than a raw 500 — first binder wins, we lost the race.
+        log.warn(
+          { workspaceId },
+          "Teams install rejected — tenant_id claimed by another workspace concurrently (unique index)",
+        );
+        throw new TeamsTenantIdInvalidError({
+          message: TEAMS_ROUTING_CONFLICT_MESSAGE,
+        });
+      }
       log.error(
         {
           workspaceId,

--- a/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
@@ -224,15 +224,17 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
     // so a failed verification never leaves a half-installed row behind.
     await this.verifyReachability(routingIdentifier);
 
-    // ── 2b. Cross-workspace ownership guard (#3141 / Codex #3153) ────
+    // ── 2b. Cross-workspace ownership guard (#3141 / Codex #3153 / #3167) ─
     // `getChat` proves the operator bot is a member of the chat, NOT that
     // THIS workspace owns it — and chat_ids leak in every message envelope.
     // Reject a chat_id already bound to a *different* workspace so a member
     // of the chat can't bind it to their own workspace and intercept the
     // chat's messages (a reconnect by the same workspace is excluded by the
-    // `workspace_id <> $3` filter). This narrows the cross-tenant window; the
-    // residual (two workspaces racing a never-before-bound id) is tracked,
-    // with the full ownership-proof flow, in #3154.
+    // `workspace_id <> $3` filter). This pre-check catches the common case
+    // cheaply; the simultaneous-race residual (two workspaces racing a
+    // never-before-bound id) is closed by the migration-0120 partial unique
+    // index, whose 23505 the cap-gate catch below maps to the same error
+    // (#3167).
     await assertChatIdUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Plan cap + install row — atomic (#3141, #3001) ──────────

--- a/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
@@ -57,6 +57,7 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.telegram");
 
@@ -75,15 +76,29 @@ export const TELEGRAM_SLUG: CatalogId = "telegram";
 export const TELEGRAM_CATALOG_ID = "catalog:telegram";
 
 /**
- * Cross-workspace ownership guard (#3141 / Codex #3153). `getChat` proves the
- * operator bot is a member of the chat, not that the installing workspace owns
- * it — and chat_ids are non-secret (they leak in every message envelope). So
- * reject a chat_id already bound to a *different* workspace before persisting.
- * The `workspace_id <> $3` filter excludes the installing workspace, so a
- * reconnect (same workspace re-binding its own chat) is never blocked.
- * Read-only pre-check: it narrows the cross-tenant window but isn't
- * transactionally fused with the cap gate's INSERT, so the simultaneous-race
- * case remains — tracked, with the full ownership-proof flow, in #3154.
+ * Surfaced when a chat_id is already bound to a different workspace — by the
+ * pre-check below AND by `confirmInstall`'s catch when the migration-0120
+ * partial unique index rejects a concurrent claim. Single source so both paths
+ * return identical, actionable text (#3167).
+ */
+const TELEGRAM_ROUTING_CONFLICT_MESSAGE =
+  "This Telegram chat is already connected to a different Atlas workspace. Each chat can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.";
+
+/**
+ * Cross-workspace ownership guard (#3141 / Codex #3153 / #3167). `getChat`
+ * proves the operator bot is a member of the chat, not that the installing
+ * workspace owns it — and chat_ids are non-secret (they leak in every message
+ * envelope). So reject a chat_id already bound to a *different* workspace
+ * before persisting. The `workspace_id <> $3` filter excludes the installing
+ * workspace, so a reconnect (same workspace re-binding its own chat) is never
+ * blocked.
+ *
+ * This read-only pre-check catches the common case cheaply. The
+ * simultaneous-race case (two workspaces binding a never-before-seen chat_id
+ * at the same instant) is now closed by the partial unique index from
+ * migration 0120 (#3167): the losing writer's UPSERT fails with a 23505 that
+ * `confirmInstall`'s catch maps back to {@link TELEGRAM_ROUTING_CONFLICT_MESSAGE},
+ * so both paths return the same error.
  */
 async function assertChatIdUnboundElsewhere(
   chatId: string,
@@ -105,8 +120,7 @@ async function assertChatIdUnboundElsewhere(
       "Telegram install rejected — chat_id already bound to a different workspace",
     );
     throw new TelegramChatIdInvalidError({
-      message:
-        "This Telegram chat is already connected to a different Atlas workspace. Each chat can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.",
+      message: TELEGRAM_ROUTING_CONFLICT_MESSAGE,
     });
   }
 }
@@ -254,6 +268,19 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
         },
       );
     } catch (err) {
+      if (isRoutingIdUniqueViolation(err)) {
+        // Another workspace claimed this chat_id between our pre-check and
+        // our UPSERT; the migration-0120 partial unique index rejected us
+        // (#3167). Surface the same actionable error the pre-check returns
+        // rather than a raw 500 — first writer wins, we lost the race.
+        log.warn(
+          { workspaceId },
+          "Telegram install rejected — chat_id claimed by another workspace concurrently (unique index)",
+        );
+        throw new TelegramChatIdInvalidError({
+          message: TELEGRAM_ROUTING_CONFLICT_MESSAGE,
+        });
+      }
       log.error(
         {
           workspaceId,

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -356,16 +356,18 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     // omitting the label entirely.
     const apiFallback = await this.verifyReachability(routingIdentifier);
 
-    // ── 2b. Cross-workspace ownership guard (#3144 / Codex #3153) ────
+    // ── 2b. Cross-workspace ownership guard (#3144 / Codex #3153 / #3167) ─
     // The operator's Meta token can read any phone_number_id shared into
     // its WhatsApp Business Account, so reachability proves the number is
     // in the operator's account — NOT that THIS workspace controls it.
     // Reject a phone_number_id already bound to a *different* workspace so
     // one customer can't claim another's number and intercept its inbound
     // messages (a reconnect by the same workspace is excluded by the
-    // `workspace_id <> $3` filter). This narrows the cross-tenant window;
-    // the residual (two workspaces racing a never-before-bound id, and the
-    // full operator-approval/ownership-proof flow) is tracked in #3154.
+    // `workspace_id <> $3` filter). This pre-check catches the common case
+    // cheaply; the simultaneous-race residual (two workspaces racing a
+    // never-before-bound id) is closed by the migration-0120 partial unique
+    // index, whose 23505 the cap-gate catch below maps to the same error
+    // (#3167).
     await assertPhoneNumberUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -78,6 +78,7 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.whatsapp");
 
@@ -93,16 +94,28 @@ export const WHATSAPP_SLUG: CatalogId = "whatsapp";
 export const WHATSAPP_CATALOG_ID = "catalog:whatsapp";
 
 /**
- * Cross-workspace ownership guard (#3144 / Codex #3153). Reachability proves
- * the phone_number_id is in the operator's WhatsApp Business Account, not that
- * the installing workspace controls it — so reject an id already bound to a
- * *different* workspace before persisting. The `workspace_id <> $3` filter
+ * Surfaced when a phone_number_id is already bound to a different workspace —
+ * by the pre-check below AND by `confirmInstall`'s catch when the
+ * migration-0120 partial unique index rejects a concurrent claim. Single
+ * source so both paths return identical, actionable text (#3167).
+ */
+const WHATSAPP_ROUTING_CONFLICT_MESSAGE =
+  "This WhatsApp number is already connected to a different Atlas workspace. Each phone number can be linked to only one workspace — disconnect it there first, or contact your operator if you believe this is an error.";
+
+/**
+ * Cross-workspace ownership guard (#3144 / Codex #3153 / #3167). Reachability
+ * proves the phone_number_id is in the operator's WhatsApp Business Account,
+ * not that the installing workspace controls it — so reject an id already bound
+ * to a *different* workspace before persisting. The `workspace_id <> $3` filter
  * excludes the installing workspace, so a reconnect (same workspace re-binding
- * its own id) is never blocked. Read-only pre-check: it narrows the
- * cross-tenant window but isn't transactionally fused with the cap gate's
- * INSERT, so the simultaneous-race case (two workspaces binding a
- * never-before-seen id at once) remains — tracked, with the full
- * ownership-proof flow, in #3154.
+ * its own id) is never blocked.
+ *
+ * This read-only pre-check catches the common case cheaply. The
+ * simultaneous-race case (two workspaces binding a never-before-seen
+ * phone_number_id at the same instant) is now closed by the partial unique
+ * index from migration 0120 (#3167): the losing writer's UPSERT fails with a
+ * 23505 that `confirmInstall`'s catch maps back to
+ * {@link WHATSAPP_ROUTING_CONFLICT_MESSAGE}, so both paths return the same error.
  */
 async function assertPhoneNumberUnboundElsewhere(
   phoneNumberId: string,
@@ -124,8 +137,7 @@ async function assertPhoneNumberUnboundElsewhere(
       "WhatsApp install rejected — phone_number_id already bound to a different workspace",
     );
     throw new WhatsAppPhoneNumberIdInvalidError({
-      message:
-        "This WhatsApp number is already connected to a different Atlas workspace. Each phone number can be linked to only one workspace — disconnect it there first, or contact your operator if you believe this is an error.",
+      message: WHATSAPP_ROUTING_CONFLICT_MESSAGE,
     });
   }
 }
@@ -403,6 +415,19 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
         },
       );
     } catch (err) {
+      if (isRoutingIdUniqueViolation(err)) {
+        // Another workspace claimed this phone_number_id between our pre-check
+        // and our UPSERT; the migration-0120 partial unique index rejected us
+        // (#3167). Surface the same actionable error the pre-check returns
+        // rather than a raw 500 — first writer wins, we lost the race.
+        log.warn(
+          { workspaceId },
+          "WhatsApp install rejected — phone_number_id claimed by another workspace concurrently (unique index)",
+        );
+        throw new WhatsAppPhoneNumberIdInvalidError({
+          message: WHATSAPP_ROUTING_CONFLICT_MESSAGE,
+        });
+      }
       log.error(
         {
           workspaceId,


### PR DESCRIPTION
Closes #3167.

## Problem

The five static-bot install handlers (Telegram/Discord/Teams/WhatsApp/gchat) gained a cross-workspace ownership **pre-check** (`assert*UnboundElsewhere`) in #3154/#3163, but it is **not transactionally fused** with the cap-gate UPSERT:

- the advisory lock in `checkChatIntegrationLimitAndInstall` is keyed by `workspace_id`, and
- `workspace_plugins_singleton` is unique only on `(workspace_id, catalog_id)`.

So two **different** workspaces installing the **same** routing id concurrently can both observe no conflicting row and both UPSERT. The read-side resolvers in `lib/chat-plugin/executeQuery.ts` then fail-close on `rows.length > 1` for **both** workspaces — no data leak, but an availability/griefing outage until an admin disconnects one side.

## Fix — option (a): partial unique index (DB-enforced, no lock contention)

`db/migrations/0120_static_bot_routing_id_unique.sql` adds a **partial UNIQUE index** on the per-platform routing key, scoped `WHERE enabled = true AND pillar = 'chat'`:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS workspace_plugins_chat_routing_id_unique
  ON workspace_plugins (
    catalog_id,
    (CASE catalog_id
       WHEN 'catalog:telegram' THEN config->>'chat_id'
       WHEN 'catalog:discord'  THEN config->>'guild_id'
       WHEN 'catalog:teams'    THEN config->>'tenant_id'
       WHEN 'catalog:whatsapp' THEN config->>'phone_number_id'
       WHEN 'catalog:gchat'    THEN NULLIF(config->>'workspace_id', 'my_customer')
     END)
  )
  WHERE enabled = true AND pillar = 'chat';
```

- One CASE expression keyed on `catalog_id` maps each catalog to its JSONB routing key (mirrors the per-handler `*InstallConfig` shapes — one place to extend when a platform is added).
- The leading `catalog_id` column scopes routing values **per platform**, so a Telegram `chat_id` of `"123"` never collides with a Discord `guild_id` of `"123"`.
- The losing concurrent writer's UPSERT hits a `23505`, which each handler maps — via the shared `isRoutingIdUniqueViolation` helper (`lib/integrations/install/routing-id-conflict.ts`) — to the **same** actionable "already connected elsewhere" error its pre-check returns (extracted into a per-handler message constant so both paths are identical).

### Carve-outs (all expressed as the CASE yielding `NULL`, which is DISTINCT in a unique index)

- **gchat `my_customer`** self-install alias stays exempt via `NULLIF(..., 'my_customer')` — it's caller-relative, not a global id.
- **Slack** (and any future unmapped chat catalog) has no CASE branch → NULL → exempt. Slack routes on `team_id` via its own path.
- **disabled installs** are outside the partial index (`WHERE enabled = true`), so a disconnected install frees its routing id for reuse — matching the pre-check's `enabled = true` filter.

## Schema + migration discipline

- `db/schema.ts` mirrors the index in the same change (`check-schema-drift` passes).
- New migration → updated the hardcoded-count assertions in `db/__tests__/migrate.test.ts` (120 → 121 + the applied-list) **and** the applied-list in `auth/__tests__/migrate.test.ts`. (`--affected` wouldn't surface these — no TS-graph edge.)
- **Not** Better-Auth-dependent → **not** added to `MANAGED_AUTH_MIGRATIONS`.
- **Existing-duplicate assumption** (documented in the migration header): pre-#3154 two workspaces could bind the same routing id, but the read-side resolver already fail-closes on any such enabled-row duplicate, so they're non-functional. Atlas is pre-launch with no live multi-tenant static-bot installs, so none are expected. If one did exist, the plain (non-CONCURRENTLY) `CREATE UNIQUE INDEX` fails loudly at deploy naming the index — the correct fail-closed behaviour. Plain creation is required because the migration runner wraps each file in a transaction and `CONCURRENTLY` can't run inside one.

## Tests

- **`migrate-pg.test.ts`** (real Postgres): migration applies + idempotency; a second workspace binding the same Telegram `chat_id` → `23505` on `workspace_plugins_chat_routing_id_unique`; same-workspace reconnect UPSERT idempotent; `my_customer` exempt (two workspaces, no conflict); real gchat customer id still rejected; same value across two platforms does NOT collide; disabled install frees its id; index-exists drift guard. **66/66 pass locally.**
- **Per-handler unit tests** (×5): the gate's `23505` on the routing index maps to the platform-specific "already connected elsewhere" error; a `23505` on a *different* index is re-thrown untouched (not relabelled).
- **`routing-id-conflict.test.ts`**: tight predicate coverage (right index → true; other index / other SQLSTATE / non-object → false; pins the index name).

## CI

`/ci` green locally: lint, type, full test suite, syncpack, template drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols — all pass.

This is architecture-labeled; the install seam deepens slightly (DB-enforced routing-key uniqueness + a single shared conflict-detection helper) — architecture-wins entry to follow if reviewers agree it qualifies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783178302&installation_id=135337507&pr_number=3170&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3170&signature=c7127e4fc2793d3186025f10ec9aa02209cd6d1af646a542f786a70beab60531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DB-enforced uniqueness prevents the same chat account from being connected to multiple workspaces (Discord, GChat, Teams, Telegram, WhatsApp). Admin update flow now returns a clear routing_conflict (HTTP 409).

* **Bug Fixes**
  * Closes race where simultaneous installs could bypass ownership checks by failing at persistence time.

* **Tests**
  * Added extensive end-to-end and unit tests covering routing-ID uniqueness and conflict handling.

* **Documentation**
  * Added architecture note describing enforcement and conflict-mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->