### PR TITLE
docs(www): privacy security blurb states no SOC 2/ISO cert held yet

### DIFF
--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -161,7 +161,7 @@ const SECTIONS: LegalSectionData[] = [
     id: "security",
     title: "Security",
     legal: [
-      "Atlas maintains a security program aligned with ISO 27001 and SOC 2 Type II controls. Highlights: TLS 1.2+ in transit, AES-256-GCM at rest with versioned key rotation, least-privilege IAM, encrypted internal-database storage of all integration credentials and connection strings, automated vulnerability scanning of container images and dependencies, and TOTP two-factor authentication required for every administrator account on managed-mode sessions. Per-customer KMS keys are on the public roadmap and negotiable on enterprise contracts.",
+      "Atlas maintains a security program aligned with ISO 27001 and SOC 2 Type II controls. Highlights: TLS 1.2+ in transit, AES-256-GCM at rest with versioned key rotation, least-privilege IAM, encrypted internal-database storage of all integration credentials and connection strings, automated vulnerability scanning of container images and dependencies, and TOTP two-factor authentication required for every administrator account on managed-mode sessions. Per-customer KMS keys are on the public roadmap and negotiable on enterprise contracts. Atlas does not currently hold a SOC 2 Type II report or ISO 27001 certificate; formal certification is on the roadmap.",
       "Suspected security incidents may be reported to security@useatlas.dev. Our disclosure policy is published at useatlas.dev/.well-known/security.txt (RFC 9116). Encrypted reports may use the PGP key at useatlas.dev/.well-known/atlas-security.asc (fingerprint: B00E 2A64 12E9 3CDF 9624 29CF 3970 0A61 1481 92C7).",
     ],
     plain:


### PR DESCRIPTION
## What

Appends the explicit "Atlas does not currently hold a SOC 2 Type II report or ISO 27001 certificate; formal certification is on the roadmap" disclaimer to the `/privacy` **Security** legal blurb (`apps/www/src/app/privacy/page.tsx:164`).

## Why

`www-audit` (v0.0.9) finding **C-1**. The privacy Security legal text claimed a security program *"aligned with ISO 27001 and SOC 2 Type II controls"* but — unlike the DPA page (`dpa/page.tsx:109,113`) and its own plain-language summary (`privacy/page.tsx:168`, *"Working toward formal SOC 2 Type II + ISO 27001 certifications"*) — omitted the explicit "we don't hold either cert yet" disclaimer.

Not a false claim ("aligned with controls" is a legitimate posture statement), but an **inconsistency on a legal/procurement surface**: a buyer skimming only the legal copy could infer a certification Atlas does not hold. Atlas holds no third-party security certification today; #1928 tracks the certification *program*.

This brings the privacy legal text in line with the DPA and its own plain-language line.

## Scope / verification

- One-line copy append to a string literal on a legal page. No logic change.
- Root `lint` (`eslint packages/ ee/`) and `type` gates structurally exclude `apps/www`; www is type-checked by its Next build. Ran `tsgo --noEmit -p apps/www/tsconfig.json` → clean.

## Audit result

The full `www-audit` pass was otherwise clean — pricing matches `plans.ts` exactly, sub-processor table accurate, `security.txt` RFC-9116 compliant, no `/sla` breakage, domains/regions correct, install snippets current. Remaining non-trivial finding (blog orphaned from nav/footer) filed separately toward v0.0.9.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185203&installation_id=135337507&pr_number=3173&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3173&signature=ec99e809834397590706a3d9a8e8213dbbaad84f7203c2dc93277d1fe7140fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the Security section of legal documentation to clarify current security certification status and communicate that formal certifications are planned for the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->