### PR TITLE
docs: fix verified accuracy drift surfaced by /docs-audit (v0.0.9)

### DIFF
--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -118,7 +118,7 @@ Connect Microsoft Teams to enable `@atlas` mentions and channel conversations.
 
 There are two ways to connect Teams:
 
-1. **Platform OAuth (recommended)** — Set `TEAMS_APP_ID` and `TEAMS_APP_PASSWORD` environment variables (plus `TEAMS_TENANT_ID` for a single-tenant Azure Bot). The admin UI **Connect to Teams** button appears once `TEAMS_APP_ID` is detected, and initiates the Azure AD admin-consent flow. The callback captures the Azure-verified tenant id and persists a per-workspace `workspace_plugins` row through the chat-integration cap (#3142) — over-cap installs get an upgrade prompt. See the [Microsoft Teams integration guide](/docs/integrations/teams) for the full per-workspace flow (manifest distribution + admin consent).
+1. **Platform OAuth (recommended)** — Set `TEAMS_APP_ID` and `TEAMS_APP_PASSWORD` environment variables (plus `TEAMS_TENANT_ID` for a single-tenant Azure Bot). The admin UI **Connect to Teams** button appears once `TEAMS_APP_ID` is detected, and initiates the Azure AD admin-consent flow. The callback captures the Azure-verified tenant id and persists a per-workspace `workspace_plugins` row through the chat-integration cap (#3142) — over-cap installs get an upgrade prompt. See the [Microsoft Teams integration guide](/integrations/teams) for the full per-workspace flow (manifest distribution + admin consent).
 
 2. **App credentials (BYOT)** — If platform env vars are not set but an internal database is available (`DATABASE_URL`), the card shows a credentials form. Create an [Azure Bot](https://dev.botframework.com/bots/new), copy the App ID and App Password, and enter them on the Integrations page. Credentials are validated via Azure AD client credentials token acquisition.
 

--- a/apps/docs/content/docs/guides/starter-prompt-moderation.mdx
+++ b/apps/docs/content/docs/guides/starter-prompt-moderation.mdx
@@ -104,7 +104,7 @@ Pending and hidden rows never leave the admin boundary. Draft rows — edits que
 
 ## API
 
-The admin UI is a thin layer over four endpoints. Each requires `role = 'admin'`.
+The admin UI is a thin layer over four endpoints. Each requires a workspace admin role — the effective `member.role` of `admin` or `owner` (platform admins also pass). Tenant admin-ness is single-sourced on `member.role`, not the raw Better Auth `user.role` (#2890).
 
 | Endpoint                                               | Effect                                                                              |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------- |

--- a/apps/docs/content/docs/integrations/twenty.mdx
+++ b/apps/docs/content/docs/integrations/twenty.mdx
@@ -161,7 +161,7 @@ operator at the missing env var.
 
 ## Reference
 
-- [Plugin SDK docs](/plugins/sdk)
+- [Plugin SDK docs](/plugins/authoring-guide)
 - [Twenty REST API](https://twenty.com/developers/section/rest-api)
 - [Twenty metadata API](https://twenty.com/developers/section/api-and-webhooks/metadata-api)
 - [Encryption key rotation](/platform-ops/encryption-key-rotation)

--- a/apps/docs/content/docs/platform-ops/sla-monitoring.mdx
+++ b/apps/docs/content/docs/platform-ops/sla-monitoring.mdx
@@ -83,7 +83,7 @@ permanent and not retried.
 Set `ATLAS_SLA_WEBHOOK_SECRET` to HMAC-sign every alert delivery so your
 receiver can confirm it originated from Atlas. When the secret is set, two
 headers ride alongside the body — the same `timestamped` convention as the
-[sub-processor feed](/docs/integrations/sub-processor-feed):
+[sub-processor feed](/integrations/sub-processor-feed):
 
 | Header | Value |
 |--------|-------|

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Complete reference for the Atlas CLI — init, diff, migrate, import, export, migrate-import, index, learn, improve, query, doctor, validate, mcp, eval, canonical-eval, smoke, completions, and operator subcommands (proactive / seed / ops).
+description: Complete reference for the Atlas CLI — init, diff, migrate, import, export, migrate-import, index, learn, improve, query, doctor, validate, mcp, eval, canonical-eval, smoke, plugin, benchmark, completions, and operator subcommands (proactive / seed / ops).
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -301,7 +301,7 @@ bun run atlas -- canonical-eval [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--schema <name>` | `ecommerce` | Canonical-eval schema (only `ecommerce` ships today; stays open-ended for future seeds) |
-| `--questions <path>` | `eval/canonical-questions/questions.json` | Path to the canonical questions fixture |
+| `--questions <path>` | `eval/canonical-questions/questions.yml` | Path to the canonical questions fixture |
 | `--llm` | — | Run the full agent loop and assert on the snapshot SQL. Mutually exclusive with `--mcp-llm` |
 | `--mcp-llm` | — | Dispatch through the real MCP route via an LLM. Mutually exclusive with `--llm` |
 | `--baseline <path>` | `eval/canonical-questions/mcp-llm-baseline.json` | Per-question latency baseline file for `--mcp-llm` mode |

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -310,7 +310,7 @@ For multi-tenant deployments, each organization can get its own isolated connect
 export default defineConfig({
   pool: {
     perOrg: {
-      maxConnections: 10,     // Max connections per org (default: 10)
+      maxConnections: 5,      // Max connections per org (default: 5)
       idleTimeoutMs: 30000,   // Idle timeout in ms (default: 30000)
       maxOrgs: 50,            // Max org pools before LRU eviction (default: 50)
       warmupProbes: 2,        // Warmup probes when pool created (default: 2)
@@ -322,7 +322,7 @@ export default defineConfig({
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `perOrg.maxConnections` | `number` | `10` | Max connections per pool per org (dev-tier floor — `POOL_DEV_FLOOR_MAX_CONNECTIONS` in `packages/api/src/lib/config.ts`) |
+| `perOrg.maxConnections` | `number` | `5` | Max connections per pool per org (`DEFAULT_ORG_POOL_MAX_CONNECTIONS` in `packages/api/src/lib/config.ts`, held in lockstep with the runtime registry default) |
 | `perOrg.idleTimeoutMs` | `number` | `30000` | Idle timeout in ms for per-org pool connections |
 | `perOrg.maxOrgs` | `number` | `50` | Max org pool sets before LRU eviction |
 | `perOrg.warmupProbes` | `number` | `2` | Warmup probes when an org pool is first created. `0` disables warmup |
@@ -572,7 +572,7 @@ export default defineConfig({
     },
     "jira:create": {
       approval: "manual",
-      requiredRole: "analyst",
+      requiredRole: "admin",
     },
   },
 });
@@ -587,7 +587,7 @@ export default defineConfig({
 | `defaults.maxPerConversation` | `number` | Max actions per conversation |
 | `[actionType].enabled` | `boolean` | Enable/disable this action |
 | `[actionType].approval` | `string` | Override approval mode for this action |
-| `[actionType].requiredRole` | `string` | Minimum role to approve: `viewer`, `analyst`, `admin` |
+| `[actionType].requiredRole` | `string` | Minimum role to approve: `member`, `admin`, `owner`, or `platform_admin` |
 | `[actionType].timeout` | `number` | Execution timeout in ms. Overrides `defaults.timeout` for this action type |
 | `[actionType].credentials` | `object` | Required env vars (`{ VAR_NAME: { env: "VAR_NAME" } }`) |
 | `[actionType].rateLimit` | `number` | Max executions per minute for this action type |

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -76,7 +76,7 @@ The `ChatErrorCode` catalog above is scoped to the chat-stream endpoint — the 
 |------|-------------|---------|-----|-----------|
 | `demo_readonly` | 403 | Write against the `__demo__` connection while in published mode | Switch to developer mode to manage demo content. See [Developer Mode](/guides/developer-mode) | No |
 | `workspace_migrating` | 409 | Write attempted while the workspace's data is being moved to a new region | Transient — retry once the migration completes (typically minutes). See [Data Residency](/platform-ops/data-residency) | Yes |
-| `misdirected_request` | 421 | Request reached a regional API that doesn't hold this workspace's data | Use the `correctApiUrl` field in the response body to retarget. The SDK can be initialized with the correct regional URL once and cached. See [Regional API](/platform-ops/regional-api) | No |
+| `misdirected_request` | 421 | Request reached a regional API that doesn't hold this workspace's data | Use the `correctApiUrl` field in the response body to retarget. The SDK can be initialized with the correct regional URL once and cached. See [Regional API routing](/platform-ops/data-residency#misrouting-detection) | No |
 
 ### Starter-prompt favorites
 
@@ -158,7 +158,7 @@ The scheduler runs proactive prompts and report deliveries on workspace cron sch
 
 ### Governance & Enterprise
 
-These cover the always-403 governance gates and the 503 fallback raised when an enterprise feature is enabled but its EE Layer failed to bind. See [Enterprise & SaaS Gating](/platform-ops/enterprise) for the broader feature-flag model.
+These cover the always-403 governance gates and the 503 fallback raised when an enterprise feature is enabled but its EE Layer failed to bind. See [Enterprise & SaaS Gating](/architecture/enterprise) for the broader feature-flag model.
 
 | Code | `_tag` | HTTP Status | Trigger | Fix | Retryable |
 |------|--------|-------------|---------|-----|-----------|


### PR DESCRIPTION
## What

Inline, source-verified accuracy corrections from a `/docs-audit` pass against code reality (toward **v0.0.9 — Production Hardening**, #61). Principle for this PR: **correct wrong info inline; file missing content as issues.** No content additions here — every change is a 1-line correction of something the docs got wrong.

### Corrections (7 files, 12 lines)

| File | Fix | Source of truth |
|------|-----|-----------------|
| `reference/config.mdx` | `perOrg.maxConnections` default `10` → `5`; drop nonexistent `POOL_DEV_FLOOR_MAX_CONNECTIONS`, name the real `DEFAULT_ORG_POOL_MAX_CONNECTIONS` | `config.ts:225` (`= 5`, #2943) |
| `reference/config.mdx` | `requiredRole` valid values → `member`/`admin`/`owner`/`platform_admin`; example `"analyst"` (would fail Zod) → `"admin"` | `ATLAS_ROLES`, `config.ts:106,112` |
| `guides/starter-prompt-moderation.mdx` | "`role = 'admin'`" → effective `member.role` of `admin`/`owner` (platform admins also pass), single-sourced on `member.role` | post-#2890 `effective-role.ts` / `adminAuth` |
| `reference/cli.mdx` | `canonical-eval --questions` default `.json` → `.yml`; add `plugin`/`benchmark` to frontmatter | `canonical-eval.ts:553` |
| `guides/integrations.mdx` | dead link `/docs/integrations/teams` → `/integrations/teams` | target exists |
| `platform-ops/sla-monitoring.mdx` | dead link `/docs/integrations/sub-processor-feed` → `/integrations/sub-processor-feed` | target exists |
| `reference/error-codes.mdx` | dead link `/platform-ops/regional-api` → `/platform-ops/data-residency#misrouting-detection`; `/platform-ops/enterprise` → `/architecture/enterprise` | targets/anchor exist |
| `integrations/twenty.mdx` | dead link `/plugins/sdk` (folder, no index) → `/plugins/authoring-guide` | matches `index.mdx:101` convention |

### Verified accurate — no change needed
- The four static-bot chat platform pages (telegram / teams / whatsapp / gchat) match catalog reality: telegram/teams/whatsapp seed `available` in `deploy/api/atlas.config.ts`; **gchat correctly says "Coming Soon"** because its install route returns 409 in both deploy modes until the Marketplace-webhook binding lands (#3154).

## Non-trivial gaps filed as issues (not in this PR)
- #3189 — env-variables.mdx + .env.example missing integration-credential & operator env vars
- #3190 — error-codes.mdx missing 11 mapped tagged errors
- #3191 — CLI reference omits `ops smoke-crm` (decision needed)
- #3192 — 2FA/admin guide should mention the Account Security adoption-metrics page

## Test plan
- `next build` of `apps/docs` passes (605+ pages prerendered, clean compile). Docs-only MDX prose/link edits — no TypeScript/schema/test surface touched; full `/ci` gates are unaffected and run as required PR checks.
- All retargeted link destinations + the `#misrouting-detection` anchor were verified to exist on disk.

Milestone: v0.0.9 — Production Hardening.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185678&installation_id=135337507&pr_number=3193&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3193&signature=cf32fd46d877b794e229784efc6b89b3c5f11ca1a2fe2de5bbf8232e8d97db54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed documentation links across integration, platform operations, and reference guides
  * Clarified workspace admin role requirements for admin UI access
  * Updated default pool connection settings and action configuration role options
  * Improved CLI command reference documentation with updated fixture paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->