### PR TITLE
fix(api): wire prod OTel export + span-name consistency cleanup (#3175, #3183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -380,7 +380,8 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 
 # === Observability ===
 # ATLAS_LOG_LEVEL=info                              # debug | info | warn | error
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 # OTLP HTTP (traces exported only when set)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 # OTLP HTTP — traces + metrics exported only when set (one endpoint drives both)
+# OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <token>"  # Auth header(s) your collector requires (e.g. Honeycomb/Grafana Cloud). Set per-service in prod.
 
 # === Runtime ===
 # ATLAS_MIGRATION_RETRIES=5                       # Retry count for internal DB migrations at startup (default: 5, 0 = disabled)

--- a/.env.example
+++ b/.env.example
@@ -381,7 +381,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # === Observability ===
 # ATLAS_LOG_LEVEL=info                              # debug | info | warn | error
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 # OTLP HTTP — traces + metrics exported only when set (one endpoint drives both)
-# OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <token>"  # Auth header(s) your collector requires (e.g. Honeycomb/Grafana Cloud). Set per-service in prod.
+# OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer%20<token>"  # Auth header(s) your collector requires (W3C Baggage format — percent-encode spaces, e.g. %20). Set per-service in prod.
 
 # === Runtime ===
 # ATLAS_MIGRATION_RETRIES=5                       # Retry count for internal DB migrations at startup (default: 5, 0 = disabled)

--- a/apps/docs/content/docs/platform-ops/observability.mdx
+++ b/apps/docs/content/docs/platform-ops/observability.mdx
@@ -24,9 +24,9 @@ Set `OTEL_EXPORTER_OTLP_ENDPOINT` to your collector's OTLP HTTP endpoint:
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
-The API server initializes the OpenTelemetry Node.js SDK on startup, registering a trace exporter that sends spans to `{OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`. The API is identified as `atlas-api`; the web frontend as `atlas`. Both use the package version from `package.json`.
+The API server initializes the OpenTelemetry Node.js SDK on startup, registering **both** a trace exporter (spans → `{OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`) and a periodic metric exporter (metrics → `{OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`, 60s cadence). The API is identified as `atlas-api`; the web frontend as `atlas`. Both use the package version from `package.json`. The single endpoint variable drives traces and [metrics](#metrics) together — there is no separate metrics endpoint to set.
 
-When the environment variable is absent, no SDK is initialized and all trace calls are no-ops — zero overhead.
+When the environment variable is absent, no SDK is initialized and all trace **and** metric calls are no-ops — zero overhead. This is the default for self-hosted and development. See [Production deployment](#production-deployment-railway--saas) for wiring an exporter in a hosted environment.
 
 ### What Gets Traced
 
@@ -59,6 +59,14 @@ HTTP Request (http.request)
 
 Each span records success/failure status and captures exceptions on error, making it straightforward to trace agent step failures back to specific tool calls.
 
+<Callout title="Agent per-step spans">
+When OTel is active, the agent loop also enables the Vercel AI SDK's telemetry, so each `streamText` step emits `ai.streamText` / `ai.streamText.doStream` child spans **under** `atlas.agent`. These carry per-step structure — finish reason, token split, tool-call count — so a multi-step run no longer collapses into a single span. Prompt and completion **content is deliberately not recorded** on these spans (same stance as `atlas.sql.execute`, which omits SQL text); they carry structural metadata only.
+</Callout>
+
+<Callout title="MCP span vs. counter leaf names">
+The MCP dispatch **span** is `atlas.mcp.tool.run` and the MCP dispatch **counter** is [`atlas.mcp.tool.calls`](#metrics) — the different leaf names (`.run` vs. `.calls`) are intentional, not a typo. `.run` names the per-dispatch execution span (one per tool call, with timing and nesting); `.calls` names the monotonic count of those dispatches split by outcome. They describe the same event from the trace and metric sides and are meant to be joined, not reconciled to one name. The span is emitted from `packages/mcp` (the MCP server), the counter from `@atlas/api`.
+</Callout>
+
 ### Metrics
 
 Atlas also publishes a small set of OTel metrics through the `@atlas/api` Meter for time-series the trace waterfall doesn't naturally cover:
@@ -70,7 +78,7 @@ Atlas also publishes a small set of OTel metrics through the `@atlas/api` Meter 
 | `atlas.mcp.tool.latency` | Histogram (`ms`) | Same as `atlas.mcp.tool.calls` | Raw per-dispatch latency observations — derive p50/p95/p99 in your collector. Bucket boundaries stay defaulted so dashboards aren't pinned to one set of cutoffs |
 | `atlas.mcp.activations` | Counter | `workspace.id`, `transport`, `deploy.mode` | Fires once per workspace per MCP process on the first observed tool call. Process-local dedup only — restarts and SSE replicas re-fire for the same workspace. For a true "unique workspaces" view, configure your collector to group by `workspace.id` × first-seen day |
 
-Counters use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered — wire one through your OTel collector configuration to feed dashboards and alerting.
+Counters and gauges use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` registers one automatically — the same SDK init that wires trace export also attaches a `PeriodicExportingMetricReader` (60s) pointed at `{endpoint}/v1/metrics`, so these series feed your collector with no extra configuration. When the endpoint is unset they stay no-ops, exactly like spans.
 
 ### Collector Setup
 
@@ -122,6 +130,29 @@ OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=your-api-key"
 <Callout>
 Atlas uses `@opentelemetry/exporter-trace-otlp-http` for trace export. Standard OpenTelemetry environment variables like `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_RESOURCE_ATTRIBUTES` are respected by the underlying SDK.
 </Callout>
+
+### Production deployment (Railway / SaaS)
+
+OpenTelemetry export is **opt-in** and off by default — including in the hosted Atlas SaaS. The instrumentation (every span and metric in the tables above) is always present in the code, but it feeds a no-op tracer/meter until `OTEL_EXPORTER_OTLP_ENDPOINT` is set. **An unset endpoint in production is expected, not a bug:** the process still boots cleanly and stays observable through the compensating controls below.
+
+To turn on traces + metrics in a hosted deployment:
+
+1. **Stand up an OTLP-HTTP collector** — Grafana Cloud / Tempo, Honeycomb, Datadog Agent, Axiom, SigNoz, or self-hosted Jaeger (see the setups above). You need a URL that accepts OTLP over HTTP and, usually, an auth header.
+
+2. **Set the endpoint (and headers) per service.** On Railway the Atlas API runs as **three regional services** sharing one image — `api`, `api-eu`, `api-apac`. Set the variables on **each** one:
+
+   ```bash
+   OTEL_EXPORTER_OTLP_ENDPOINT=https://your-collector:4318
+   OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <token>"   # whatever your collector requires
+   ```
+
+<Callout type="warn" title="Set the endpoint on every regional service">
+Railway **shared-scope** variables and `${{ service.VAR }}` references do **not** auto-inherit onto the per-service runtime — a shared `OTEL_EXPORTER_OTLP_ENDPOINT` resolves to an empty string at runtime. Set the OTel variables as explicit **per-service** overrides on `api`, `api-eu`, **and** `api-apac`, or two of the three regions will silently keep dropping telemetry.
+</Callout>
+
+3. **Verify export.** After redeploy, confirm a span arrives in your collector (filter service `atlas-api`) and that a metric series such as `atlas.mcp.tool.calls` or `atlas.abuse.escalations` appears. Both ride the single endpoint — see [Metrics](#metrics).
+
+If you choose **not** to wire a collector, that is a valid posture: Atlas in production remains observable via **structured pino logs** (shipped to the platform's log stream — Railway, etc.), **abuse events** persisted to `abuse_events` and surfaced in the admin console, and **external uptime monitoring** (Atlas SaaS uses OpenStatus). OTel traces/metrics add request-level waterfalls and time-series dashboards on top of that; they do not replace it.
 
 ### Graceful Shutdown
 

--- a/apps/docs/content/docs/platform-ops/observability.mdx
+++ b/apps/docs/content/docs/platform-ops/observability.mdx
@@ -78,7 +78,11 @@ Atlas also publishes a small set of OTel metrics through the `@atlas/api` Meter 
 | `atlas.mcp.tool.latency` | Histogram (`ms`) | Same as `atlas.mcp.tool.calls` | Raw per-dispatch latency observations — derive p50/p95/p99 in your collector. Bucket boundaries stay defaulted so dashboards aren't pinned to one set of cutoffs |
 | `atlas.mcp.activations` | Counter | `workspace.id`, `transport`, `deploy.mode` | Fires once per workspace per MCP process on the first observed tool call. Process-local dedup only — restarts and SSE replicas re-fire for the same workspace. For a true "unique workspaces" view, configure your collector to group by `workspace.id` × first-seen day |
 
-Counters and gauges use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` registers one automatically — the same SDK init that wires trace export also attaches a `PeriodicExportingMetricReader` (60s) pointed at `{endpoint}/v1/metrics`, so these series feed your collector with no extra configuration. When the endpoint is unset they stay no-ops, exactly like spans.
+Counters and gauges use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered. In the **API server process**, setting `OTEL_EXPORTER_OTLP_ENDPOINT` registers one automatically — the same SDK init that wires trace export also attaches a `PeriodicExportingMetricReader` (60s) pointed at `{endpoint}/v1/metrics`, so these series export with no extra configuration. When the endpoint is unset they stay no-ops, exactly like spans.
+
+<Callout title="Standalone MCP server is a separate process">
+The `atlas.mcp.*` instruments (and the `atlas.mcp.tool.run` span) export automatically only where the OTel SDK is initialized — the **API server process**, which also serves the hosted/SaaS MCP in-process. The **standalone** MCP server (`packages/mcp`, run over stdio or its own SSE transport) is a separate process that does **not** currently initialize the SDK, so its MCP instruments stay no-ops there regardless of `OTEL_EXPORTER_OTLP_ENDPOINT`. Wiring the SDK into the standalone MCP entry point is tracked in [#3199](https://github.com/AtlasDevHQ/atlas/issues/3199).
+</Callout>
 
 ### Collector Setup
 
@@ -143,7 +147,9 @@ To turn on traces + metrics in a hosted deployment:
 
    ```bash
    OTEL_EXPORTER_OTLP_ENDPOINT=https://your-collector:4318
-   OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <token>"   # whatever your collector requires
+   # OTEL_EXPORTER_OTLP_HEADERS follows the W3C Baggage format — percent-encode
+   # spaces in the value (the space between "Bearer" and the token → %20):
+   OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer%20<token>"   # whatever your collector requires
    ```
 
 <Callout type="warn" title="Set the endpoint on every regional service">

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -10,6 +10,19 @@
  *   - ATLAS_REGION_US_DB_URL (defaults to DATABASE_URL)
  *   - ATLAS_REGION_EU_DB_URL
  *   - ATLAS_REGION_APAC_DB_URL
+ *
+ * Observability export (optional, OFF by default). OpenTelemetry traces +
+ * metrics export only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; it gates the
+ * SDK init in `lib/telemetry.ts` (no endpoint → no-op tracer/meter, clean boot).
+ * These are per-service runtime vars, NOT application config, so they live in
+ * Railway like the region DB URLs above — and like those they must be set as
+ * explicit per-service overrides on each regional service (`api`, `api-eu`,
+ * `api-apac`); a shared-scope var resolves empty at runtime and silently drops
+ * telemetry for the regions that didn't get the override:
+ *   - OTEL_EXPORTER_OTLP_ENDPOINT  (OTLP-HTTP collector base URL)
+ *   - OTEL_EXPORTER_OTLP_HEADERS   (collector auth header(s), if required)
+ * See apps/docs/content/docs/platform-ops/observability.mdx → "Production
+ * deployment (Railway / SaaS)".
  */
 
 import { defineConfig } from "./packages/api/src/lib/config";

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1206,6 +1206,22 @@ export async function runAgent({
       temperature: 0.2,
       maxOutputTokens: 4096,
       stopWhen: stepCountIs(maxStepsOverride ?? getAgentMaxSteps()),
+      // Per-step AI-SDK telemetry (#3183 L-2): emit `ai.streamText` /
+      // `ai.streamText.doStream` child spans under the enclosing `atlas.agent`
+      // span so a multi-step run no longer collapses into one span — each step's
+      // finish reason, token split, and tool-call count become visible. Gated on
+      // the OTLP endpoint so it's a true no-op (zero AI-SDK span overhead) when
+      // OTel is off, matching every other span site. `recordInputs`/`recordOutputs`
+      // are OFF by intent: spans carry structural metadata only, never prompt or
+      // completion text — same security stance as `atlas.sql.execute` (which
+      // excludes SQL content). Prompts here would otherwise attach user questions
+      // + semantic-layer context + tool args to the trace.
+      experimental_telemetry: {
+        isEnabled: Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT),
+        functionId: "atlas.agent",
+        recordInputs: false,
+        recordOutputs: false,
+      },
       // totalMs: 180s for self-hosted (full agent loop budget).
       // On Vercel, maxDuration caps the serverless function at 300s (Pro plan).
       timeout: { totalMs: 180_000, stepMs: 30_000, chunkMs: 5_000 },

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -174,9 +174,9 @@ function withFiberDeathLog<A, E, R>(
 // fiber that raises an error log when no tick is observed in > 2× the
 // interval. A per-tick span would be redundant with that, so #2987 leaves
 // them on heartbeat + watchdog. Self-spanning module fibers
-// (`byot_catalog_refresh`, `openapi_install_rediscover`, the scheduler engine
-// `tick`/`task.run`) define their span inside their own module and so never
-// appear in either record here.
+// (`byot_catalog_refresh`, `openapi_install_rediscover`, `openapi_spec_refresh`,
+// the scheduler engine `tick`/`task.run`) define their span inside their own
+// module and so never appear in either record here.
 //
 // Span names follow the existing `atlas.<area>.<op>` dotted convention
 // (cf. `atlas.sql.execute`, `atlas.scheduler.task.run`, and the

--- a/packages/api/src/lib/scheduler/openapi-spec-refresh.ts
+++ b/packages/api/src/lib/scheduler/openapi-spec-refresh.ts
@@ -32,6 +32,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { withSpan } from "@atlas/api/lib/tracing";
 import {
   refreshSharedSpecsCycle,
   type SharedRefreshCycleResult,
@@ -71,9 +72,42 @@ export function getSharedSpecRefreshIntervalMs(): number {
  * Run a single refresh cycle over the shared cache's working set. Never throws —
  * `refreshSharedSpecsCycle` isolates per-catalog failures (logged + counted) so a
  * down upstream can't stall the others or kill the scheduler loop.
+ *
+ * Span + heartbeat (#3183 L-1): the cycle was the only periodic refresh fiber
+ * without a per-tick span — its siblings `byot-catalog-refresh.ts` and
+ * `openapi-install-rediscover.ts` both emit one, so a wedged spec-refresh fiber
+ * was invisible until a catalog drift surfaced. Wrap the cycle in
+ * `atlas.scheduler.openapi_spec_refresh` (presence/absence against the cadence is
+ * the liveness signal) and emit a per-cycle `log.info` heartbeat so a hung tick
+ * is visible in logs too, not just traces. This is a `setInterval` scheduler with
+ * a Promise-native cycle, so it uses the Promise `withSpan` (not the Effect
+ * `withEffectSpan` the byot/rediscover cycles use); it self-spans here and so
+ * never slots into `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts`.
  */
 export async function runOpenApiSpecRefreshCycle(): Promise<SharedRefreshCycleResult> {
-  return refreshSharedSpecsCycle({ specUrlFor: specUrlForCatalog });
+  return withSpan(
+    "atlas.scheduler.openapi_spec_refresh",
+    {},
+    async () => {
+      log.info("Shared OpenAPI spec refresh cycle starting");
+      const result = await refreshSharedSpecsCycle({ specUrlFor: specUrlForCatalog });
+      // `refreshSharedSpecsCycle` already emits a detailed "cycle complete" log
+      // (with per-catalog counts) when the working set is non-empty. Emit our own
+      // completion heartbeat for the empty-cache case — the common shape on a
+      // fresh pod or low-traffic region — so the cadence is unbroken there too
+      // and the two paths each leave exactly one start + one complete log.
+      if (result.inspected === 0) {
+        log.info("Shared OpenAPI spec refresh cycle complete — empty working set (no cached specs to refresh)");
+      }
+      return result;
+    },
+    (result) => ({
+      "atlas.openapi_spec_refresh.inspected": result.inspected,
+      "atlas.openapi_spec_refresh.updated": result.updated,
+      "atlas.openapi_spec_refresh.not_modified": result.notModified,
+      "atlas.openapi_spec_refresh.failed": result.failed,
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two v0.0.9 production-hardening observability findings, landed as one "make prod observable, make span names consistent" unit. Both touch the telemetry layer, span-emitting sites, and `observability.mdx`.

Closes #3175
Closes #3183

## #3175 — prod OTel export was a silent no-op (HIGH)

**Diagnosis (`/diagnose`):** The OTel SDK only initializes when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. `TelemetryLive` (merged into `buildAppLayer`, boots eagerly) gates the `lib/telemetry.ts` dynamic import on that env var; `telemetry.ts` wires **both** a trace exporter (`/v1/traces`) and a `PeriodicExportingMetricReader` (`/v1/metrics`, 60s). The var is **unset on all three prod api services**, so every span (`atlas.agent`, `atlas.sql.execute`, `atlas.scheduler.*`, …) and metric (`atlas.mcp.*`, `atlas.abuse.*`, `atlas.*_outbox.*`, …) fed a no-op exporter and was dropped.

This is a **deploy/operator gap, not a code defect** — the gate is correct and no-op-safe (verified: boot stays clean when the var is unset; self-hosted/dev are unaffected). The fix here is to make the code side correct + documented and tee up the operator wiring:

- **`observability.mdx`** — new **Production deployment (Railway / SaaS)** section: per-service `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_EXPORTER_OTLP_HEADERS` on `api`/`api-eu`/`api-apac`, the shared-scope-refs-don't-inherit warning, verify steps, and the explicit decision that OTel is **opt-in** — when unset, prod stays observable via pino→Railway logs + `abuse_events` + OpenStatus, and the no-op exporter is expected, not a bug.
- Corrected the **Metrics** section (the metric reader auto-registers when the endpoint is set — no separate config) and the enable paragraph (traces **and** metrics ride the one endpoint).
- **`deploy/api/atlas.config.ts`** header comment + **`.env.example`** now document the optional per-service OTEL vars.

> [!IMPORTANT]
> **Remaining HITL step (operator):** This PR does **not** set the live Railway variable — that needs a collector endpoint (Grafana Cloud / Honeycomb / Datadog / etc.) and the secret. To turn on prod telemetry, set `OTEL_EXPORTER_OTLP_ENDPOINT` (+ `OTEL_EXPORTER_OTLP_HEADERS`) as **per-service** overrides on `api`, `api-eu`, **and** `api-apac`, then confirm a span/metric arrives. Until then prod runs on the documented self-host-only posture (pino + OpenStatus + abuse_events), which is a valid choice.

## #3183 — observability consistency cleanup (LOW)

- **L-1** — `scheduler/openapi-spec-refresh.ts` was the only periodic refresh fiber with no per-tick span. Wrapped the cycle in `atlas.scheduler.openapi_spec_refresh` (Promise `withSpan`, since it's a `setInterval` Promise-native cycle — not the Effect `withEffectSpan` the byot/rediscover cycles use) + a per-cycle `log.info` heartbeat (incl. the empty-cache case) so a wedged fiber shows as absence against its cadence. Updated the `layers.ts` self-spanning-fiber inventory comment.
- **L-2** — `agent.ts` `streamText` now sets `experimental_telemetry: { isEnabled, functionId: "atlas.agent", recordInputs: false, recordOutputs: false }`, gated on the OTLP endpoint (zero overhead when off). Multi-step runs now emit `ai.streamText` child spans under `atlas.agent` (finish reason / token split / tool-call count). **Content recording is off by design** — structural metadata only, never prompt/completion text (same security stance as `atlas.sql.execute`).
- **L-3** — Verified the real MCP dispatch span in `packages/mcp/src/telemetry.ts` is `atlas.mcp.tool.run`, which already **matches** the doc. The apparent "drift" was the `.run` (span) vs `.calls` (counter) leaf-name difference — intentional, different signal types. Added a clarifying note so neither gets "fixed" to match the other.

## Testing / gates

All six `/ci` gates green: `bun run lint`, `bun run type`, **full** `bun run test` (0 failures), `bun x syncpack lint`, template-drift, railway-watch (the `deploy/api/` edit is a header comment — no COPY source added). Affected API suite 71/71.

## Coordination note

Shares `effect/layers.ts` (TelemetryLive region + a comment) and `deploy/api/*` with a parallel boot-guard session. This PR owns the `TelemetryLive` region and the OTLP env documentation; the boot-guard session owns `buildAppLayer` guard sequencing + the region map. Regions differ — trivial rebase if it merges second.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783193344&installation_id=135337507&pr_number=3195&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3195&signature=ae7219c4cf6a34c72b83cda37a7df760cdaf61ae9d737d70ae35ee9afccbd5e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-step telemetry for agent execution emits child spans (without recording prompt/completion content)
  * Added tracing spans around OpenAPI refresh cycles and heartbeat logging for empty runs

* **Documentation**
  * Clarified OpenTelemetry startup: single OTLP HTTP endpoint exports traces+metrics; metrics are no-ops until a MeterProvider is registered
  * Added guidance for per-service OTEL config, auth/header examples, deployment verification, and non-OTEL fallbacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->