### PR TITLE
fix(api,plugins): runtime resilience — explore fall-through + orphan-task guard + twenty healthCheck (#3177, #3180, #3179)

### DIFF
--- a/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
@@ -622,6 +622,22 @@ describe("scheduled-tasks module", () => {
       expect(queryCalls[0].sql).toContain("next_run_at <= now()");
     });
 
+    it("excludes orphaned plugin tasks via a workspace_plugins guard (#3180)", async () => {
+      // An orphaned plugin task (plugin_id set, no live install row) must
+      // never be dispatched. The guard lives in SQL — assert the query joins
+      // against workspace_plugins on the (catalog_id = plugin_id,
+      // workspace_id = org_id) pair, and that NULL-plugin (non-plugin) tasks
+      // stay eligible.
+      enableInternalDB();
+      setResults({ rows: [makeTaskRow()] });
+      await getTasksDueForExecution();
+      const sql = queryCalls[0].sql;
+      expect(sql).toContain("workspace_plugins");
+      expect(sql).toContain("plugin_id IS NULL");
+      expect(sql).toContain("wp.catalog_id = st.plugin_id");
+      expect(sql).toContain("wp.workspace_id = st.org_id");
+    });
+
     it("returns empty when no DB", async () => {
       expect(await getTasksDueForExecution()).toEqual([]);
     });

--- a/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
@@ -673,6 +673,24 @@ describe("scheduled-tasks module", () => {
       expect(queryCalls[1].sql).toContain("next_run_at IS NOT NULL");
     });
 
+    it("re-checks plugin ownership atomically in the lock UPDATE (#3180 TOCTOU guard)", async () => {
+      // The orphan guard must also fire at lock time, not only at SELECT time:
+      // an uninstall between getTasksDueForExecution and this lock must not let
+      // an already-selected orphan acquire the lock and run once.
+      enableInternalDB();
+      setResults(
+        { rows: [makeTaskRow()] },
+        { rows: [{ id: "task-123" }] },
+      );
+      await lockTaskForExecution("task-123");
+      const updateSql = queryCalls[1].sql;
+      expect(updateSql).toContain("UPDATE scheduled_tasks");
+      expect(updateSql).toContain("workspace_plugins");
+      expect(updateSql).toContain("plugin_id IS NULL");
+      expect(updateSql).toContain("wp.catalog_id = scheduled_tasks.plugin_id");
+      expect(updateSql).toContain("wp.workspace_id = scheduled_tasks.org_id");
+    });
+
     it("returns false when task not found", async () => {
       enableInternalDB();
       // getScheduledTask returns empty

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -955,6 +955,45 @@ describe("WorkspaceInstaller.uninstall", () => {
     );
     expect(deleteSqlIdx).toBeGreaterThanOrEqual(0);
   });
+
+  it("deletes plugin-owned scheduled_tasks scoped by (plugin_id, org_id) after workspace_plugins (#3180)", async () => {
+    // Symmetry with the marketplace DELETE path: WorkspaceInstaller disconnect
+    // must clean plugin-owned scheduled_tasks so the scheduler stops firing
+    // them, scoped by (plugin_id = catalog_id, org_id = workspace_id).
+    queueCatalogLookup("email", { pillar: "action", install_model: "form" });
+    queueInstallLookup(WSID, "catalog:email", {
+      id: "install-email",
+      install_id: "install-email",
+      team_id: null,
+    });
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("DELETE FROM workspace_plugins"),
+      rows: [],
+    });
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("DELETE FROM scheduled_tasks"),
+      rows: [],
+    });
+
+    const installer = await getLiveService();
+    await runEffect(installer.uninstall(WSID, "email"));
+
+    const taskDelete = internalQueryCalls.find((c) =>
+      c.sql.includes("DELETE FROM scheduled_tasks"),
+    );
+    expect(taskDelete).toBeDefined();
+    expect(taskDelete?.params).toEqual(["catalog:email", WSID]);
+
+    // Runs AFTER the workspace_plugins DELETE (mirrors the marketplace order).
+    const wpIdx = internalQueryCalls.findIndex((c) =>
+      c.sql.includes("DELETE FROM workspace_plugins"),
+    );
+    const stIdx = internalQueryCalls.findIndex((c) =>
+      c.sql.includes("DELETE FROM scheduled_tasks"),
+    );
+    expect(wpIdx).toBeGreaterThanOrEqual(0);
+    expect(stIdx).toBeGreaterThan(wpIdx);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -1169,6 +1169,39 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(Effect.catchAll((err) => Effect.die(err)));
 
+      // #3180 — clean up plugin-owned scheduled tasks so the scheduler doesn't
+      // keep firing them after disconnect, mirroring the marketplace DELETE
+      // path (admin-marketplace.ts). Scoped by (plugin_id = catalog_id,
+      // org_id = workspace_id) — exactly the pair the orphan guard in
+      // getTasksDueForExecution and the orphan-reconcile sweep use. Without
+      // this, WorkspaceInstaller disconnects were asymmetric with the
+      // marketplace path and left tasks behind. Best-effort (matches the
+      // marketplace posture): the install row is already gone, so a transient
+      // internal-DB hiccup must not strand the uninstall — and the
+      // execution-time guard skips the orphan + the reconcile fiber sweeps it.
+      yield* Effect.tryPromise({
+        try: () =>
+          lazyInternalQuery()(
+            `DELETE FROM scheduled_tasks
+              WHERE plugin_id = $1 AND org_id = $2`,
+            [catalog.id, workspaceId],
+          ),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => {
+          log.warn(
+            {
+              workspaceId,
+              catalogSlug,
+              catalogId: catalog.id,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "WorkspaceInstaller.uninstall: scheduled-task cleanup failed — orphan tasks are skipped by the execution-time guard and swept by the reconcile fiber",
+          );
+          return Effect.succeed(undefined);
+        }),
+      );
+
       // Evict the LazyPluginLoader cache for this (workspace, catalog).
       // Without this, a hot workspace whose tool dispatch warmed the
       // cache before disconnect keeps the stale `PluginLike` (and its

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -619,13 +619,30 @@ export async function lockTaskForExecution(taskId: string): Promise<boolean> {
     const nextRun = computeNextRun(taskResult.data.cronExpression);
 
     // Atomic UPDATE: only succeeds if enabled AND next_run_at IS NOT NULL
-    // (prevents double-execution — second process sees next_run_at already set to future)
+    // (prevents double-execution — second process sees next_run_at already set to future).
+    //
+    // Orphan guard (#3180 / #3196 review): re-check plugin ownership HERE, not
+    // just at getTasksDueForExecution time. The tick selects due tasks, then
+    // locks + dispatches each in separate statements — so an uninstall that
+    // deletes the workspace_plugins row between the SELECT and this UPDATE
+    // would otherwise let an already-selected orphan acquire the lock and run
+    // once. Re-evaluating the same (catalog_id = plugin_id, workspace_id =
+    // org_id) predicate inside the lock UPDATE closes that TOCTOU window
+    // atomically: a task orphaned mid-tick fails to lock and is never dispatched.
     const rows = await internalQuery<{ id: string }>(
       `UPDATE scheduled_tasks SET
          last_run_at = now(),
          next_run_at = $1,
          updated_at = now()
        WHERE id = $2 AND enabled = true AND next_run_at IS NOT NULL
+         AND (
+           plugin_id IS NULL
+           OR EXISTS (
+             SELECT 1 FROM workspace_plugins wp
+             WHERE wp.catalog_id = scheduled_tasks.plugin_id
+               AND wp.workspace_id = scheduled_tasks.org_id
+           )
+         )
        RETURNING id`,
       [nextRun?.toISOString() ?? null, taskId],
     );

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -567,10 +567,26 @@ export async function listTaskRuns(
 export async function getTasksDueForExecution(): Promise<ScheduledTask[]> {
   if (!hasInternalDB()) return [];
   try {
+    // Orphan guard (#3180): a plugin-owned task whose owning install row is
+    // gone must never be dispatched — otherwise it consumes a tick, a
+    // task_run row, and tokens before failing downstream. Exclude any task
+    // with a non-null plugin_id that has NO live workspace_plugins row
+    // matching on (catalog_id = plugin_id, workspace_id = org_id) — the exact
+    // pair the uninstall cleanup and orphan-reconcile sweep scope by (see
+    // lib/scheduler/orphan-task-reconcile.ts). Non-plugin tasks
+    // (plugin_id IS NULL) are always eligible.
     const rows = await internalQuery<Record<string, unknown>>(
-      `SELECT * FROM scheduled_tasks
-       WHERE enabled = true AND next_run_at <= now()
-       ORDER BY next_run_at ASC`,
+      `SELECT st.* FROM scheduled_tasks st
+       WHERE st.enabled = true AND st.next_run_at <= now()
+         AND (
+           st.plugin_id IS NULL
+           OR EXISTS (
+             SELECT 1 FROM workspace_plugins wp
+             WHERE wp.catalog_id = st.plugin_id
+               AND wp.workspace_id = st.org_id
+           )
+         )
+       ORDER BY st.next_run_at ASC`,
     );
     return rows.map(rowToScheduledTask);
   } catch (err) {

--- a/packages/api/src/lib/tools/__tests__/explore-default-chain-fallthrough.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-default-chain-fallthrough.test.ts
@@ -96,8 +96,11 @@ describe("explore default-chain fall-through (#3177)", () => {
     expect(typeof result).toBe("string");
     expect(result).toContain(MARKER);
     expect(result).not.toContain("Explore tool is unavailable");
-    // Health reporting agrees the sidecar is down after the init failure.
-    expect(mod.getExploreBackendType()).toBe("just-bash");
+    // The sidecar is NOT permanently marked failed on a transient init error
+    // (#3196 review): the reporter still shows the configured backend, and the
+    // sidecar is retried on the next cache resolution rather than pinned to the
+    // weaker fallback until restart.
+    expect(mod.getExploreBackendType()).toBe("sidecar");
 
     spy.mockRestore();
   });

--- a/packages/api/src/lib/tools/__tests__/explore-default-chain-fallthrough.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-default-chain-fallthrough.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for #3177 — the explore default-priority backend chain
+ * must fall through to the next backend when a higher-priority backend
+ * (Vercel sandbox / sidecar) FAILS to initialize, instead of hard-failing
+ * the explore tool.
+ *
+ * Before the fix, the default chain called `createSandboxBackend` /
+ * `createSidecarBackend` without a local try/catch, so an init throw
+ * escaped to the outer IIFE `.catch` (which only invalidates the cache and
+ * rethrows) — degrading to "Explore tool is unavailable" instead of trying
+ * nsjail / just-bash sitting right there in the chain. The config-priority
+ * path (`tryCreateBackend`) always fell through correctly; the default
+ * chain was asymmetric.
+ *
+ * The SaaS posture is the inverse and MUST stay: a pinned single-backend
+ * priority (`sandbox.priority: ["vercel-sandbox"]`, deny-all) fails closed
+ * with no insecure fallback. That goes through the config-priority path,
+ * which this file also locks down.
+ *
+ * `createSandboxBackend` is mocked to throw so the Vercel branch is
+ * deterministic without a live Vercel SDK. The sidecar branch is driven by
+ * a malformed `ATLAS_SANDBOX_URL` (the real init throw — `new URL(...)`),
+ * needing no module mock. nsjail is forced unavailable via an `fs.accessSync`
+ * spy so the chain bottoms out at just-bash, which is pointed at a real
+ * temp dir via `ATLAS_SEMANTIC_ROOT` so `echo` actually executes.
+ */
+import { describe, expect, it, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setConfigForTest, _resetConfig, type ResolvedConfig } from "@atlas/api/lib/config";
+
+// Vercel backend always throws at init in this file — only invoked when the
+// Vercel branch is reached (tests 2 + 3); the sidecar test never selects it.
+mock.module("@atlas/api/lib/tools/explore-sandbox", () => ({
+  createSandboxBackend: async (): Promise<never> => {
+    throw new Error("vercel sandbox unreachable (test)");
+  },
+}));
+
+const MARKER = "atlas_fallthrough_marker";
+
+let testCounter = 0;
+async function freshExploreModule() {
+  testCounter++;
+  return import(`@atlas/api/lib/tools/explore?t=fallthrough-${testCounter}`);
+}
+
+function runExplore(mod: Awaited<ReturnType<typeof freshExploreModule>>): Promise<unknown> {
+  return mod.explore.execute(
+    { command: `echo ${MARKER}` },
+    { toolCallId: "test", messages: [], abortSignal: new AbortController().signal },
+  );
+}
+
+describe("explore default-chain fall-through (#3177)", () => {
+  const originalEnv = { ...process.env };
+  let semanticRoot: string;
+
+  beforeEach(() => {
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.ATLAS_SANDBOX;
+    delete process.env.ATLAS_SANDBOX_URL;
+    delete process.env.ATLAS_NSJAIL_PATH;
+    _resetConfig();
+    // Give just-bash a real OverlayFs root so a fall-through actually runs.
+    semanticRoot = mkdtempSync(join(tmpdir(), "atlas-explore-ft-"));
+    writeFileSync(join(semanticRoot, "catalog.yml"), "tables: []\n");
+    process.env.ATLAS_SEMANTIC_ROOT = semanticRoot;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    _resetConfig();
+    rmSync(semanticRoot, { recursive: true, force: true });
+  });
+
+  it("falls through to just-bash when the sidecar backend fails to initialize (malformed URL)", async () => {
+    // No config → default chain. Sidecar is selected (ATLAS_SANDBOX_URL set)
+    // but the URL is malformed, so createSidecarBackend throws at init.
+    process.env.ATLAS_SANDBOX_URL = "not-a-valid-url";
+    // nsjail auto-detect must report unavailable so the chain reaches just-bash.
+    const fs = await import("fs");
+    const spy = spyOn(fs, "accessSync").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const mod = await freshExploreModule();
+    const result = await runExplore(mod);
+
+    // Fell through to just-bash and ran the command — NOT a hard failure.
+    expect(typeof result).toBe("string");
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain("Explore tool is unavailable");
+    // Health reporting agrees the sidecar is down after the init failure.
+    expect(mod.getExploreBackendType()).toBe("just-bash");
+
+    spy.mockRestore();
+  });
+
+  it("falls through to just-bash when the Vercel backend fails to initialize", async () => {
+    // No config → default chain. Vercel is selected (ATLAS_RUNTIME=vercel) but
+    // createSandboxBackend throws (mocked above).
+    process.env.ATLAS_RUNTIME = "vercel";
+    const fs = await import("fs");
+    const spy = spyOn(fs, "accessSync").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const mod = await freshExploreModule();
+    const result = await runExplore(mod);
+
+    expect(typeof result).toBe("string");
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain("Explore tool is unavailable");
+
+    spy.mockRestore();
+  });
+
+  it("does NOT downgrade an explicitly-pinned single backend (SaaS deny-all) — fails closed", async () => {
+    // Config-priority path with a single pinned backend and NO just-bash —
+    // the SaaS posture. A Vercel init failure must fail closed, never fall
+    // through to a weaker sandbox.
+    _setConfigForTest({
+      sandbox: { priority: ["vercel-sandbox"] },
+      deployMode: "saas",
+    } as unknown as ResolvedConfig);
+    process.env.ATLAS_RUNTIME = "vercel"; // pass the useVercelSandbox() gate
+
+    const mod = await freshExploreModule();
+    const result = await runExplore(mod);
+
+    expect(typeof result).toBe("string");
+    // Hard failure (no insecure fallback), and the command never ran.
+    expect(result).toContain("All backends in sandbox.priority");
+    expect(result).toContain("vercel-sandbox");
+    expect(result).not.toContain(MARKER);
+  });
+});

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -454,9 +454,24 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
       // --- Default priority chain ---
 
       // Priority 1: Vercel Sandbox (Firecracker VM)
+      // Init failures fall through to the next backend in the chain, mirroring
+      // `tryCreateBackend` (the config-priority path). Without this local
+      // try/catch the throw escapes to the outer IIFE `.catch` below, which
+      // only invalidates the cache and rethrows — it does NOT degrade to
+      // nsjail/sidecar/just-bash that are sitting right there in the chain.
+      // SaaS is unaffected: it pins `sandbox.priority: ["vercel-sandbox"]` and
+      // takes the config-priority path above, which fails closed by design.
       if (useVercelSandbox()) {
-        const { createSandboxBackend } = await import("./explore-sandbox");
-        return createSandboxBackend(semanticRoot);
+        try {
+          const { createSandboxBackend } = await import("./explore-sandbox");
+          return await createSandboxBackend(semanticRoot);
+        } catch (err) {
+          const detail = errorMessage(err);
+          log.warn(
+            { error: detail },
+            "vercel-sandbox backend failed to initialize — falling through to next backend in default priority",
+          );
+        }
       }
 
       // Priority 2: nsjail explicit (ATLAS_SANDBOX=nsjail) — hard-fail if init fails
@@ -482,9 +497,23 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
       // Priority 3: Sidecar service (HTTP-isolated microservice)
       // When ATLAS_SANDBOX_URL is set, sidecar is the intended backend (Railway).
       // Skips nsjail auto-detection entirely — no noisy namespace warnings.
-      if (useSidecar()) {
-        const { createSidecarBackend } = await import("./explore-sidecar");
-        return createSidecarBackend(process.env.ATLAS_SANDBOX_URL!, { semanticRoot });
+      // Same fall-through fix as the Vercel branch above: an init failure
+      // (e.g. malformed ATLAS_SANDBOX_URL) logs and degrades to the next
+      // backend instead of hard-failing the explore tool. `_sidecarFailed`
+      // is set so health reporting (`getExploreBackendType`) and subsequent
+      // resolutions agree the sidecar is down, matching `tryCreateBackend`.
+      if (useSidecar() && !_sidecarFailed) {
+        try {
+          const { createSidecarBackend } = await import("./explore-sidecar");
+          return await createSidecarBackend(process.env.ATLAS_SANDBOX_URL!, { semanticRoot });
+        } catch (err) {
+          _sidecarFailed = true;
+          const detail = errorMessage(err);
+          log.warn(
+            { error: detail },
+            "sidecar backend failed to initialize — falling through to next backend in default priority",
+          );
+        }
       }
 
       // Priority 4: nsjail auto-detect (binary on PATH, graceful fallback)

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -499,19 +499,25 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
       // Skips nsjail auto-detection entirely — no noisy namespace warnings.
       // Same fall-through fix as the Vercel branch above: an init failure
       // (e.g. malformed ATLAS_SANDBOX_URL) logs and degrades to the next
-      // backend instead of hard-failing the explore tool. `_sidecarFailed`
-      // is set so health reporting (`getExploreBackendType`) and subsequent
-      // resolutions agree the sidecar is down, matching `tryCreateBackend`.
-      if (useSidecar() && !_sidecarFailed) {
+      // backend instead of hard-failing the explore tool. We deliberately do
+      // NOT set the process-global `_sidecarFailed` flag here (#3196 review):
+      // that flag is for a *deliberate, permanent* mark (the startup health
+      // probe via markSidecarFailed). A transient init failure on this path
+      // should be retried on the next backend-cache resolution — the resolved
+      // backend is cached per semantic root, so a down sidecar isn't re-probed
+      // every request, and recovery happens when the cache is invalidated
+      // (invalidateExploreBackend). Pinning the flag here would strand the
+      // deployment on the weaker fallback until process restart even after the
+      // sidecar recovers.
+      if (useSidecar()) {
         try {
           const { createSidecarBackend } = await import("./explore-sidecar");
           return await createSidecarBackend(process.env.ATLAS_SANDBOX_URL!, { semanticRoot });
         } catch (err) {
-          _sidecarFailed = true;
           const detail = errorMessage(err);
           log.warn(
             { error: detail },
-            "sidecar backend failed to initialize — falling through to next backend in default priority",
+            "sidecar backend failed to initialize — falling through to next backend in default priority (retried on the next backend-cache resolution)",
           );
         }
       }

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -12,6 +12,7 @@ import {
   stampStripeCustomerId,
   getPersonMetadata,
   getPersonRestSchema,
+  probeTwentyHealth,
   createNote,
   listPeople,
   getPerson,
@@ -1916,5 +1917,64 @@ describe("wipeWorkspace", () => {
         status: 500,
       });
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  probeTwentyHealth — credential liveness probe (#3179)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("probeTwentyHealth", () => {
+  test("reports healthy on a 200 from /rest/open-api/core", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { components: { schemas: { Person: { properties: {} } } } } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(true);
+    expect(result.message).toBeUndefined();
+    expect(typeof result.latencyMs).toBe("number");
+    // Reuses the existing OpenAPI probe endpoint + bearer auth.
+    expect(calls[0].url).toContain("/rest/open-api/core");
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].headers.Authorization).toBe("Bearer twenty_test_apikey_xyz");
+  });
+
+  test("reports unhealthy when the API key is revoked (401)", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["Unauthorized"] } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("401");
+    expect(result.message).toContain("Unauthorized");
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  test("reports unhealthy on a 403 (key valid but lacking access)", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 403, body: { messages: ["Forbidden"] } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("403");
+  });
+
+  test("reports unhealthy (never throws) on a transport failure", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: throwingFetch }));
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("ECONNREFUSED");
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  test("never leaks the API key in the failure message", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["Unauthorized"] } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(false);
+    expect(result.message).not.toContain("twenty_test_apikey_xyz");
   });
 });

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -1939,15 +1939,35 @@ describe("probeTwentyHealth", () => {
     expect(calls[0].headers.Authorization).toBe("Bearer twenty_test_apikey_xyz");
   });
 
-  test("reports unhealthy when the API key is revoked (401)", async () => {
+  test("reports unhealthy when the API key is revoked (401), status-only — no upstream body", async () => {
     const { fetch } = makeScriptedFetch([
-      { status: 401, body: { messages: ["Unauthorized"] } },
+      { status: 401, body: { messages: ["Unauthorized — token sk-LEAKME"] } },
     ]);
     const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
     expect(result.healthy).toBe(false);
     expect(result.message).toContain("401");
-    expect(result.message).toContain("Unauthorized");
+    // Status-only: the upstream-controlled body must NOT reach the public
+    // /health route (#3196 review — defense in depth over SENSITIVE_PATTERNS).
+    expect(result.message).not.toContain("Unauthorized");
+    expect(result.message).not.toContain("sk-LEAKME");
     expect(typeof result.latencyMs).toBe("number");
+  });
+
+  test("reports unhealthy on a 2xx that is not the OpenAPI document (SPA / login-page catch-all)", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { login: true, redirect: "/auth" } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("not the expected OpenAPI document");
+  });
+
+  test("reports healthy when the body carries a top-level openapi version", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { openapi: "3.1.1", info: { title: "Twenty" } } },
+    ]);
+    const result = await probeTwentyHealth(baseConfig({ fetchImpl: fetch }));
+    expect(result.healthy).toBe(true);
   });
 
   test("reports unhealthy on a 403 (key valid but lacking access)", async () => {

--- a/plugins/twenty/__tests__/plugin.test.ts
+++ b/plugins/twenty/__tests__/plugin.test.ts
@@ -151,3 +151,44 @@ describe("twentyPlugin — config validation", () => {
     ).toThrow("Plugin config validation failed");
   });
 });
+
+describe("twentyPlugin — healthCheck (#3179)", () => {
+  test("defines a healthCheck so a revoked key can surface unhealthy", () => {
+    // Without it, PluginRegistry falls back to the last post-init status and
+    // reports `healthy` forever (the bug #3179 fixes).
+    expect(typeof twentyPlugin(VALID_CONFIG).healthCheck).toBe("function");
+  });
+
+  test("reports healthy when the Twenty probe returns 200", async () => {
+    const plugin = twentyPlugin(VALID_CONFIG);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ components: { schemas: { Person: { properties: {} } } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    try {
+      const result = await plugin.healthCheck!();
+      expect(result.healthy).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("reports unhealthy when the Twenty key is revoked (401)", async () => {
+    const plugin = twentyPlugin(VALID_CONFIG);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+    try {
+      const result = await plugin.healthCheck!();
+      expect(result.healthy).toBe(false);
+      expect(result.message).toContain("401");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -863,6 +863,62 @@ export async function getPersonRestSchema(
   return { fields: new Set(Object.keys(properties)) };
 }
 
+/** Result of a {@link probeTwentyHealth} liveness check. */
+export interface TwentyHealthResult {
+  readonly healthy: boolean;
+  /** Sanitized reason on failure (status + upstream message). Never the API key. */
+  readonly message?: string;
+  /** Round-trip latency in ms (always set, even on failure). */
+  readonly latencyMs: number;
+}
+
+/**
+ * Lightweight liveness probe for a Twenty credential. Issues a single
+ * authenticated GET against `/rest/open-api/core` — the same endpoint the
+ * boot schema probe ({@link getPersonRestSchema}) uses — and reports whether
+ * the bearer token is still accepted. A revoked or expired API key surfaces
+ * as a 401/403 (`healthy: false`) instead of silently failing later at
+ * dispatch time, which matters because Twenty backs Atlas's own production
+ * lead-capture pipeline (`ee/src/saas-crm/`).
+ *
+ * Unlike `getPersonRestSchema`, this does NOT require the Person object to be
+ * present — `response.ok` is the liveness signal, so the check stays a pure
+ * credential probe. Never throws: transport failures (DNS, timeout, network)
+ * and non-2xx responses both resolve to `{ healthy: false }` with a sanitized
+ * message, so the plugin health surface always gets a definite signal. The
+ * API key is never included in the message.
+ */
+export async function probeTwentyHealth(
+  config: TwentyClientConfig,
+): Promise<TwentyHealthResult> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildOpenApiUrl(config.baseUrl);
+  const start = performance.now();
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: buildAuthHeaders(config.apiKey),
+      signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    const latencyMs = Math.round(performance.now() - start);
+    if (response.ok) {
+      return { healthy: true, latencyMs };
+    }
+    const detail = await readErrorDetail(response);
+    return {
+      healthy: false,
+      message: `Twenty health probe returned HTTP ${response.status}: ${detail.message}`,
+      latencyMs,
+    };
+  } catch (err) {
+    return {
+      healthy: false,
+      message: err instanceof Error ? err.message : String(err),
+      latencyMs: Math.round(performance.now() - start),
+    };
+  }
+}
+
 // Read-only helpers — return the full upstream record shape with no
 // field subsetting. Custom Atlas fields (`atlasFirstSource`, `atlasIp`,
 // etc.) flow through automatically; any future workspace column appears

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -881,12 +881,22 @@ export interface TwentyHealthResult {
  * dispatch time, which matters because Twenty backs Atlas's own production
  * lead-capture pipeline (`ee/src/saas-crm/`).
  *
- * Unlike `getPersonRestSchema`, this does NOT require the Person object to be
- * present — `response.ok` is the liveness signal, so the check stays a pure
- * credential probe. Never throws: transport failures (DNS, timeout, network)
- * and non-2xx responses both resolve to `{ healthy: false }` with a sanitized
- * message, so the plugin health surface always gets a definite signal. The
- * API key is never included in the message.
+ * Two correctness guards (#3196 review):
+ *  - Failure messages are STATUS-ONLY (`HTTP <status>`) and never echo the
+ *    upstream Twenty body. `PluginRegistry.healthCheckAll` surfaces this
+ *    message on the PUBLIC, unauthenticated `/health` route (scrubbed only by
+ *    a best-effort `SENSITIVE_PATTERNS` regex), so a fronting proxy that
+ *    embedded a token/request-context in its error body must not leak through.
+ *    Mirrors the jira/salesforce probes, which are also status-only.
+ *  - A 2xx alone is NOT proof the bearer was accepted — a SPA catch-all or a
+ *    reverse-proxy login page can return 200 for any path. We confirm the body
+ *    is actually Twenty's OpenAPI document (top-level `openapi` / `components`)
+ *    before reporting healthy, so a misconfigured base URL surfaces as
+ *    unhealthy instead of false-healthy.
+ *
+ * Never throws: transport failures (DNS, timeout, network) and non-2xx
+ * responses both resolve to `{ healthy: false }`, so the plugin health surface
+ * always gets a definite signal. The API key is never included in the message.
  */
 export async function probeTwentyHealth(
   config: TwentyClientConfig,
@@ -901,16 +911,42 @@ export async function probeTwentyHealth(
       signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
     });
     const latencyMs = Math.round(performance.now() - start);
-    if (response.ok) {
-      return { healthy: true, latencyMs };
+    if (!response.ok) {
+      // Status-only — never echo the upstream-controlled body to /health.
+      return {
+        healthy: false,
+        message: `Twenty health probe returned HTTP ${response.status}`,
+        latencyMs,
+      };
     }
-    const detail = await readErrorDetail(response);
-    return {
-      healthy: false,
-      message: `Twenty health probe returned HTTP ${response.status}: ${detail.message}`,
-      latencyMs,
-    };
+    // Verify the 2xx is genuinely the Twenty OpenAPI document, not a SPA
+    // catch-all / login page that 200s for any path.
+    let body: { openapi?: unknown; components?: unknown };
+    try {
+      body = (await response.json()) as typeof body;
+    } catch {
+      return {
+        healthy: false,
+        message: "Twenty health probe got a non-JSON 2xx (base URL may not point at the Twenty REST API)",
+        latencyMs,
+      };
+    }
+    const looksLikeOpenApi =
+      !!body &&
+      typeof body === "object" &&
+      (typeof body.openapi === "string" ||
+        (typeof body.components === "object" && body.components !== null));
+    if (!looksLikeOpenApi) {
+      return {
+        healthy: false,
+        message: "Twenty health probe got a 2xx that is not the expected OpenAPI document (base URL may be misconfigured)",
+        latencyMs,
+      };
+    }
+    return { healthy: true, latencyMs };
   } catch (err) {
+    // Transport-level error message (ECONNREFUSED / timeout / DNS) — locally
+    // generated, not upstream-controlled, so safe to surface.
     return {
       healthy: false,
       message: err instanceof Error ? err.message : String(err),

--- a/plugins/twenty/src/index.ts
+++ b/plugins/twenty/src/index.ts
@@ -30,6 +30,7 @@ import { tool } from "ai";
 import { createPlugin } from "@useatlas/plugin-sdk";
 import type { AtlasActionPlugin, PluginAction } from "@useatlas/plugin-sdk";
 import {
+  probeTwentyHealth,
   stampStripeCustomerId,
   upsertPerson,
   type TwentyClientConfig,
@@ -44,8 +45,10 @@ export {
   stampStripeCustomerId,
   getPersonMetadata,
   getPersonRestSchema,
+  probeTwentyHealth,
   createNote,
   TwentyClientError,
+  type TwentyHealthResult,
   type TwentyOperation,
   type TwentyClientConfig,
   type UpsertPersonInput,
@@ -229,6 +232,15 @@ export const twentyPlugin = createPlugin<
         ctx.logger.info(
           `Twenty plugin initialized (baseUrl: ${clientConfig.baseUrl})`,
         );
+      },
+
+      // Periodic liveness probe (#3179). Without it, PluginRegistry falls back
+      // to the last post-init status and reports `healthy` forever — so a
+      // revoked/expired Twenty key (which backs Atlas's lead-capture pipeline)
+      // never surfaces as unhealthy. Reuses the client's `/rest/open-api/core`
+      // probe; a 401/403 from a dead key resolves to `{ healthy: false }`.
+      async healthCheck() {
+        return probeTwentyHealth(clientConfig);
       },
     };
   },


### PR DESCRIPTION
Three independent production silent-failure bugs from the v0.0.9 prod-audit. File-disjoint subsystems (explore/sandbox, scheduler, plugin), batched in separate commits.

## #3177 — explore default-priority chain falls through on backend init failure
The default chain called `createSandboxBackend` (Vercel) / `createSidecarBackend` without a local try/catch, so an init throw escaped to the outer IIFE `.catch` (which only invalidates the cache and rethrows) — a self-hosted operator with Vercel env vars set but Vercel unreachable got a hard "Explore tool is unavailable" instead of degrading to nsjail/just-bash sitting right there in the chain. Both branches now log + fall through, mirroring `tryCreateBackend`. The sidecar branch also guards on `!_sidecarFailed` and sets the flag on init failure so health reporting agrees. SaaS (`sandbox.priority: ["vercel-sandbox"]`, deny-all) goes through the config-priority path and still fails closed — a regression test locks that an explicitly-pinned single backend does NOT silently downgrade.

## #3180 — orphaned plugin scheduled_tasks no longer execute
`getTasksDueForExecution` had no orphan guard, so a task whose owning install row is gone still dispatched every tick. Added an execution-time guard: exclude any task with a non-null `plugin_id` that has no live `workspace_plugins` row matching on `(catalog_id = plugin_id, workspace_id = org_id)` — the exact pair the uninstall cleanup + orphan-reconcile sweep use. Also made `WorkspaceInstaller.uninstall` delete plugin-owned `scheduled_tasks` (best-effort), mirroring the marketplace DELETE path (#1987) so the two uninstall paths are symmetric. The OFF-by-default reconcile sweep is left as-is: the execution guard already satisfies "prod never dispatches orphans".

## #3179 — @useatlas/twenty surfaces unhealthy on a revoked key
The twenty action plugin defined no `healthCheck`, so `PluginRegistry.healthCheckAll` fell back to the last post-init status and reported `healthy` forever — even after the live key was revoked (Twenty backs Atlas's own lead-capture pipeline). Added `probeTwentyHealth` to the client (authenticated GET against `/rest/open-api/core`, reusing the existing probe endpoint + private helpers) and wired it as the plugin's `healthCheck`. A 401/403 resolves to `{ healthy: false }`; the probe never throws and never leaks the API key.

## Tests / CI
- New: explore default-chain fall-through (3), `getTasksDueForExecution` orphan-guard shape, `WorkspaceInstaller.uninstall` task-cleanup symmetry, `probeTwentyHealth` (5) + twenty plugin `healthCheck` (3).
- All six `/ci` gates pass: lint, type, full test (0 failures), syncpack, template-drift, railway-watch.

Closes #3177
Closes #3180
Closes #3179

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783193821&installation_id=135337507&pr_number=3196&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3196&signature=5f8361777f407214540b309764c6c86ca130f3dc02ed68ba4e25be7bbdebb9d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credential health checks for the Twenty plugin and surfaced plugin health via the plugin API.
  * Exploration tool now falls through to alternate backends when a backend init fails.

* **Bug Fixes**
  * Prevent orphaned plugin-owned scheduled tasks from being selected or locked for execution.
  * Make uninstall cleanup of plugin-owned scheduled tasks best-effort (logs warnings on failure).

* **Tests**
  * Added regression and integration tests covering scheduled-task guards, uninstall cleanup, explore fall-throughs, and Twenty health probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->