### PR TITLE
fix(api,docs,cli): v0.0.9 standalone cleanup — matchError label + migration/CLI/2FA docs (#3186, #3187, #3191, #3192)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,12 +167,13 @@ bun run atlas -- seed workspace --workspace <id|slug> --group prod \
 ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
 # One-shot: enqueue every demo_leads row into crm_outbox for dispatch to Twenty:
 bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo]
-# Local-only E2E check of the demo→Twenty lead pipeline (below Turnstile, via the outbox):
+# E2E check of the demo→Twenty lead pipeline (below Turnstile, via the outbox);
+# run ad-hoc by an operator AND as the post-deploy staging-smoke gate:
 bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] [--twenty-base-url <url>] \
   [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
 ```
 
-`ops wipe` is the only subcommand that wipes the tenant DB: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. `ops smoke-crm` is a local-only (never-in-CI) end-to-end verification of the demo→Twenty lead-capture pipeline; its optional `--wipe-twenty` phase clears the Twenty workspace and is double-gated by `ATLAS_SMOKE_WIPE_OK=1`. One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
+`ops wipe` is the only subcommand that wipes the tenant DB: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. `ops smoke-crm` is an end-to-end verification of the demo→Twenty lead-capture pipeline — run ad-hoc by an operator and as the post-deploy Staging Smoke gate (`.github/workflows/staging-smoke.yml`), though not per-PR CI; its optional `--wipe-twenty` phase clears the Twenty workspace and is double-gated by `ATLAS_SMOKE_WIPE_OK=1`. One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Guidance for Claude Code when working in this repository.
 ### Database & Migrations
 - [ ] **Drizzle schema mirrors every migration** — A new `db/migrations/####_*.sql` that creates/alters a table needs a matching `db/schema.ts` update **in the same PR** — mirror types, composite PKs, indexes, CHECK constraints. `scripts/check-schema-drift.sh` (in `/ci`) fails on missing mirrors; without it, the next `drizzle-kit generate` emits a `DROP TABLE` that wipes the table on deploy
 - [ ] **DROP TABLE migrations tracked separately** — `check-schema-drift.sh` excludes tables explicitly dropped by migrations (e.g. `mcp_tokens`, dropped by 0047). When you drop a table, remove its `pgTable` from `schema.ts` in the same commit
+- [ ] **Two-phase drop discipline for `DROP TABLE`/`DROP COLUMN`** — stop reading/writing the object in release N, drop it in release N+1, so the N-1↔N deploy-overlap window can never `relation/column does not exist`. Rationale + expand-contract checklist: [packages/api/src/lib/db/migrations/README.md](packages/api/src/lib/db/migrations/README.md)
 - [ ] **Real-Postgres migration smoke runs in CI** — `migrate-pg.test.ts` runs every migration against `TEST_DATABASE_URL`; Better-Auth-dependent migrations must join `MANAGED_AUTH_MIGRATIONS` in `db/internal.ts`. See [docs/development/testing.md](docs/development/testing.md)
 
 ### Effect.ts (packages/api only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,12 @@ bun run atlas -- seed workspace --workspace <id|slug> --group prod \
 ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
 # One-shot: enqueue every demo_leads row into crm_outbox for dispatch to Twenty:
 bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo]
+# Local-only E2E check of the demo→Twenty lead pipeline (below Turnstile, via the outbox):
+bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] [--twenty-base-url <url>] \
+  [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
 ```
 
-`ops wipe` is the only destructive subcommand: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
+`ops wipe` is the only subcommand that wipes the tenant DB: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. `ops smoke-crm` is a local-only (never-in-CI) end-to-end verification of the demo→Twenty lead-capture pipeline; its optional `--wipe-twenty` phase clears the Twenty workspace and is double-gated by `ATLAS_SMOKE_WIPE_OK=1`. One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
 
 ## Architecture
 

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -865,14 +865,14 @@ bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--personas <path>` | — | Required. Fixture file declaring the personas to inject and the expected Persons/Notes. |
-| `--wipe-twenty` | off | Clear the Twenty workspace before the run. **Destructive** — double-gated by `ATLAS_SMOKE_WIPE_OK=1` (the run aborts if the flag is passed without the env var). |
+| `--wipe-twenty` | off | **Best-effort** delete of existing Persons/Notes/Companies before the run (bounded to `SMOKE_MAX_RECORDS_PER_TYPE` = 1,000 per object type; per-record delete failures are logged and the run continues, so it is not a guaranteed full clear). **Destructive** — double-gated by `ATLAS_SMOKE_WIPE_OK=1` (the run aborts if the flag is passed without the env var). |
 | `--twenty-base-url <url>` | `TWENTY_BASE_URL` or `https://api.twenty.com` | Twenty REST base URL. |
 | `--twenty-api-key <key>` | `TWENTY_API_KEY` | Twenty API key. Required — pass the flag or set the env var. |
 | `--timeout-seconds <n>` | `60` | How long to poll `crm_outbox` for all enqueued rows to reach `done`/`dead` before failing. |
 | `--database-url <url>` | `ATLAS_TEAM_PG_URL` / `DATABASE_URL` | Explicit tenant-DB URL (same resolution as `ops wipe`). |
 
 <Callout type="warn" title="Every run writes to Twenty; --wipe-twenty also deletes">
-A smoke run is **never read-only**: it enqueues the fixture personas and the flusher creates/updates Persons + Notes in the target Twenty workspace, leaving fixture records behind. Point it at a staging/test Twenty workspace, **never production**. `--wipe-twenty` additionally **deletes** workspace data before the run and is gated by `ATLAS_SMOKE_WIPE_OK=1` exactly as `ops wipe` is gated by `ATLAS_WIPE_OK=1`; omitting it only skips that *delete* phase — it does not make the run non-mutating.
+A smoke run is **never read-only**: it enqueues the fixture personas and the flusher creates/updates Persons + Notes in the target Twenty workspace, leaving fixture records behind. Point it at a staging/test Twenty workspace, **never production**. `--wipe-twenty` additionally does a best-effort **delete** of existing records before the run (bounded, continues on per-record errors — see the flag table) and is gated by `ATLAS_SMOKE_WIPE_OK=1` exactly as `ops wipe` is gated by `ATLAS_WIPE_OK=1`; omitting it only skips that *delete* phase — it does not make the run non-mutating.
 </Callout>
 
 **Exit codes:** `0` = clean (observed matches expected); `1` = argument/fixture parse error; `2` = outbox drain timed out; `3` = diff dirty (dispatcher misbehaved or Twenty unreachable); `4` = wipe phase failed; `5` = infrastructure failure (tenant DB unreachable, enqueue insert failed, or poll query errored).

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -853,6 +853,30 @@ bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source
 
 Already-run on prod against `demo_leads`; safe to re-run if a new region comes online. See the SaaS lead pipeline in [Twenty CRM integration](/integrations/twenty).
 
+### ops smoke-crm
+
+End-to-end verification of the demo → Twenty CRM lead-capture pipeline. It injects fixture personas **below** the form/Turnstile layer (straight into `crm_outbox` via `enqueue`), waits for the lead-outbox flusher to drain, then lists Twenty over REST and diffs the resulting Persons + Notes against what the fixture declared. It is a **local-only** operator check — it makes live Twenty network calls and never runs in CI.
+
+```bash
+bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] \
+  [--twenty-base-url <url>] [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--personas <path>` | — | Required. Fixture file declaring the personas to inject and the expected Persons/Notes. |
+| `--wipe-twenty` | off | Clear the Twenty workspace before the run. **Destructive** — double-gated by `ATLAS_SMOKE_WIPE_OK=1` (the run aborts if the flag is passed without the env var). |
+| `--twenty-base-url <url>` | `TWENTY_BASE_URL` or `https://api.twenty.com` | Twenty REST base URL. |
+| `--twenty-api-key <key>` | `TWENTY_API_KEY` | Twenty API key. Required — pass the flag or set the env var. |
+| `--timeout-seconds <n>` | `60` | How long to poll `crm_outbox` for all enqueued rows to reach `done`/`dead` before failing. |
+| `--database-url <url>` | `ATLAS_TEAM_PG_URL` / `DATABASE_URL` | Explicit tenant-DB URL (same resolution as `ops wipe`). |
+
+<Callout type="warn" title="Destructive when --wipe-twenty is set">
+`--wipe-twenty` deletes data in the target Twenty workspace. It is gated by `ATLAS_SMOKE_WIPE_OK=1` exactly as `ops wipe` is gated by `ATLAS_WIPE_OK=1`. A smoke run without `--wipe-twenty` skips the wipe phase entirely and is non-destructive.
+</Callout>
+
+**Exit codes:** `0` = clean (observed matches expected); `1` = argument/fixture parse error; `2` = outbox drain timed out; `3` = diff dirty (dispatcher misbehaved or Twenty unreachable); `4` = wipe phase failed; `5` = infrastructure failure (tenant DB unreachable, enqueue insert failed, or poll query errored).
+
 ---
 
 ## See Also

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -855,7 +855,7 @@ Already-run on prod against `demo_leads`; safe to re-run if a new region comes o
 
 ### ops smoke-crm
 
-End-to-end verification of the demo → Twenty CRM lead-capture pipeline. It injects fixture personas **below** the form/Turnstile layer (straight into `crm_outbox` via `enqueue`), waits for the lead-outbox flusher to drain, then lists Twenty over REST and diffs the resulting Persons + Notes against what the fixture declared. It is a **local-only** operator check — it makes live Twenty network calls and never runs in CI.
+End-to-end verification of the demo → Twenty CRM lead-capture pipeline. It injects fixture personas **below** the form/Turnstile layer (straight into `crm_outbox` via `enqueue`), waits for the lead-outbox flusher to drain, then lists Twenty over REST and diffs the resulting Persons + Notes against what the fixture declared. Because it makes live Twenty network calls it is **not** part of per-PR CI, but it is not local-only either: an operator runs it ad-hoc, **and** it is the post-deploy **Staging Smoke** gate (`.github/workflows/staging-smoke.yml`), which fires after a staging deploy to prove the flusher path is alive against the staging DB + Twenty. Changing or removing this subcommand will break that gate.
 
 ```bash
 bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] \

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -871,8 +871,8 @@ bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] \
 | `--timeout-seconds <n>` | `60` | How long to poll `crm_outbox` for all enqueued rows to reach `done`/`dead` before failing. |
 | `--database-url <url>` | `ATLAS_TEAM_PG_URL` / `DATABASE_URL` | Explicit tenant-DB URL (same resolution as `ops wipe`). |
 
-<Callout type="warn" title="Destructive when --wipe-twenty is set">
-`--wipe-twenty` deletes data in the target Twenty workspace. It is gated by `ATLAS_SMOKE_WIPE_OK=1` exactly as `ops wipe` is gated by `ATLAS_WIPE_OK=1`. A smoke run without `--wipe-twenty` skips the wipe phase entirely and is non-destructive.
+<Callout type="warn" title="Every run writes to Twenty; --wipe-twenty also deletes">
+A smoke run is **never read-only**: it enqueues the fixture personas and the flusher creates/updates Persons + Notes in the target Twenty workspace, leaving fixture records behind. Point it at a staging/test Twenty workspace, **never production**. `--wipe-twenty` additionally **deletes** workspace data before the run and is gated by `ATLAS_SMOKE_WIPE_OK=1` exactly as `ops wipe` is gated by `ATLAS_WIPE_OK=1`; omitting it only skips that *delete* phase — it does not make the run non-mutating.
 </Callout>
 
 **Exit codes:** `0` = clean (observed matches expected); `1` = argument/fixture parse error; `2` = outbox drain timed out; `3` = diff dirty (dispatcher misbehaved or Twenty unreachable); `4` = wipe phase failed; `5` = infrastructure failure (tenant DB unreachable, enqueue insert failed, or poll query errored).

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -120,6 +120,31 @@ in one step and routes straight to the workspace. See
 [Passkeys → Signing In With a Passkey](./passkeys#signing-in-with-a-passkey)
 for the login-page surface.
 
+## Tracking Adoption (Admin Console)
+
+You don't have to write SQL to see whether your co-admins have actually
+enrolled. The **My Security** page (**Admin → My Security**,
+`/admin/account-security`) opens with a **Security posture** panel — three
+traffic-light tiles that aggregate MFA and trust-device adoption across the
+workspace's admins:
+
+- **MFA enrollment** — how many **admin/owner** members have a second factor
+  (an authenticator app *or* a passkey). Green at 100%, amber when partial
+  (e.g. *"3 of 5 admins enrolled"*), red when none are enrolled, and muted
+  when the workspace has no co-admins yet.
+- **Backup codes available** — a proxy tile: enrolling TOTP means Better Auth
+  issued backup codes, so this reflects authenticator-app coverage rather than
+  a per-user code count.
+- **Trust-device adoption** — informational; counts the active *Trust this
+  device for 30 days* grants held by admin/owner members.
+
+The panel is **read-only** and scoped to your active workspace. It counts
+admin-role members only — admin/owner accounts are the API-gated, highest-value
+logins (see [Scope](#scope)). It is backed by
+`GET /api/v1/admin/security/metrics` and requires the internal database, so it
+is unavailable in datasource-only deployments. Cross-workspace operators get a
+fleet-wide roll-up of the same enrollment metrics at `/platform/security`.
+
 ## Operator Reference
 
 ### What's stored

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -130,8 +130,10 @@ workspace's admins:
 
 - **All admins have MFA** — how many **admin/owner** members have a second factor
   (an authenticator app *or* a passkey). Green at 100%, amber when partial
-  (the tile reads *"3 of 5 admins enrolled"*), red when none are enrolled, and
-  muted when the workspace has no co-admins yet.
+  (the tile reads *"3 of 5 admins enrolled"*), red when none are enrolled. The
+  count includes the owner, so a normal workspace shows green/amber/red; the
+  muted *"No admins yet"* state appears only in the edge case of zero
+  admin/owner members.
 - **Backup codes available** — a proxy tile: enrolling TOTP means Better Auth
   issued backup codes, so this reflects authenticator-app coverage rather than
   a per-user code count.

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -128,10 +128,10 @@ enrolled. The **My Security** page (**Admin → My Security**,
 traffic-light tiles that aggregate MFA and trust-device adoption across the
 workspace's admins:
 
-- **MFA enrollment** — how many **admin/owner** members have a second factor
+- **All admins have MFA** — how many **admin/owner** members have a second factor
   (an authenticator app *or* a passkey). Green at 100%, amber when partial
-  (e.g. *"3 of 5 admins enrolled"*), red when none are enrolled, and muted
-  when the workspace has no co-admins yet.
+  (the tile reads *"3 of 5 admins enrolled"*), red when none are enrolled, and
+  muted when the workspace has no co-admins yet.
 - **Backup codes available** — a proxy tile: enrolling TOTP means Better Auth
   issued backup codes, so this reflects authenticator-app coverage rather than
   a per-user code count.

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -279,19 +279,11 @@ function classifyChatError(err: unknown, requestId?: string): ChatErrorClassific
     };
   }
   // Pattern-matched fallback for non-APICallError exceptions. In this route
-  // we know an unreachable host is the LLM, not the analytics datasource —
-  // re-route the generic `internal_error` matchError default accordingly.
-  const errMessage = err instanceof Error ? err.message : String(err);
-  const matched = matchError(err);
+  // an unreachable host is the LLM, not the analytics datasource, so we pass
+  // `subsystem: "provider"` — `matchError` then labels a connection failure
+  // `provider_unreachable` directly (no post-hoc re-routing needed here).
+  const matched = matchError(err, { subsystem: "provider" });
   if (matched) {
-    const isConnectionError = /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(errMessage);
-    if (matched.code === "internal_error" && isConnectionError) {
-      return {
-        code: "provider_unreachable",
-        message:
-          "Could not reach the LLM provider. Check your network connection and provider status.",
-      };
-    }
     if (matched.code === "provider_unreachable") {
       return {
         code: "provider_unreachable",

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -597,7 +597,12 @@ demo.openapi(demoChatRoute, async (c) => {
           return c.json({ error: "provider_error", message: `LLM provider error (HTTP ${status}).`, retryable: true, requestId }, 502);
         }
 
-        const matched = matchError(err);
+        // Like the chat route, the demo runs the agent loop — an exception
+        // reaching here is the LLM provider, not the datasource (executeSQL
+        // errors are caught as tool results). Pass `subsystem: "provider"` so
+        // an unreachable host is labeled `provider_unreachable`, not the
+        // datasource-framed `internal_error`.
+        const matched = matchError(err, { subsystem: "provider" });
         if (matched) {
           const httpStatus = matched.code === "rate_limited" ? 429 : 500;
           if (matched.code === "rate_limited") {

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -604,7 +604,18 @@ demo.openapi(demoChatRoute, async (c) => {
         // datasource-framed `internal_error`.
         const matched = matchError(err, { subsystem: "provider" });
         if (matched) {
-          const httpStatus = matched.code === "rate_limited" ? 429 : 500;
+          // Honor the canonical code→HTTP contract (mirror of
+          // CLASSIFIER_STATUS_MAP in chat.ts + reference/error-codes.mdx): a
+          // provider outage must surface as 503/504, not a misleading 500.
+          // matchError returns one of rate_limited / provider_unreachable /
+          // provider_timeout / internal_error here.
+          const STATUS_BY_CODE: Record<string, 429 | 500 | 503 | 504> = {
+            rate_limited: 429,
+            provider_unreachable: 503,
+            provider_timeout: 504,
+            internal_error: 500,
+          };
+          const httpStatus = STATUS_BY_CODE[matched.code] ?? 500;
           if (matched.code === "rate_limited") {
             log.warn({ err: errObj, category: matched.code, requestId }, "Matched error: %s", matched.code);
           } else {

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -602,6 +602,12 @@ demo.openapi(demoChatRoute, async (c) => {
         // errors are caught as tool results). Pass `subsystem: "provider"` so
         // an unreachable host is labeled `provider_unreachable`, not the
         // datasource-framed `internal_error`.
+        //
+        // NOTE: this only covers errors thrown *before* the stream is returned
+        // (runAgent throwing synchronously). A provider error raised mid-stream
+        // hits the `createUIMessageStream` onError above, which still returns a
+        // generic string — classifying that path (as chat.ts does) is tracked
+        // by #3202.
         const matched = matchError(err, { subsystem: "provider" });
         if (matched) {
           // Honor the canonical code→HTTP contract (mirror of

--- a/packages/api/src/lib/db/migrations/README.md
+++ b/packages/api/src/lib/db/migrations/README.md
@@ -7,8 +7,13 @@ request handlers *inside the same container*. Better Auth-owned tables follow
 the `MANAGED_AUTH_MIGRATIONS` ordering in `db/internal.ts`.
 
 Companion one-shot backfill scripts live in [`scripts/`](./scripts/README.md).
-Every `CREATE TABLE`/`ALTER TABLE` must be mirrored in `db/schema.ts` in the
-same PR — `scripts/check-schema-drift.sh` (in `/ci`) fails otherwise.
+Every schema change must be mirrored in `db/schema.ts` in the same PR. Note the
+guard's reach: `scripts/check-schema-drift.sh` (in `/ci`) only checks that each
+`CREATE TABLE` has a matching `pgTable` (table-level existence) and that dropped
+tables are removed from `schema.ts`. It does **not** inspect `ALTER TABLE` —
+added/changed columns, types, constraints, and indexes are **not** caught, so an
+unmirrored `ALTER TABLE` passes `/ci` green and a later `drizzle-kit generate`
+can then emit a migration that reverts it. Mirror column-level changes by hand.
 
 ## Two-phase drop discipline (expand–contract)
 
@@ -61,11 +66,14 @@ stays green (the same reason `mcp_tokens`, dropped by 0047, is excluded).
 ### Motivating examples
 
 - **`0119_drop_legacy_credential_tables.sql`** — `DROP TABLE ... CASCADE` of the
-  four legacy static-bot install tables. Safe **only** because the read paths
-  were removed earlier in the same release train (#3154): the inbound resolvers
-  already read exclusively from `workspace_plugins`. Had an N-1 pod still read
-  `teams_installations` during overlap, it would have 500'd. This is the
-  borderline case the rule is meant to make deliberate rather than incidental.
+  four legacy static-bot install tables, in the **same release** that removed
+  their readers (#3154). This is exactly the pattern the rule discourages:
+  although the inbound resolvers had already moved to `workspace_plugins`, a
+  draining N-1 pod still runs the *old* readers during overlap and would 500 on
+  `teams_installations`. Moving the readers was necessary but **not** sufficient —
+  it was acceptable only under the pre-launch exception below (no real overlap
+  traffic), and the migration header flags it as a deliberate exception. Once a
+  customer is live, this same drop would have needed the two-phase split.
 - **`0118_drop_user_admin_role.sql`** — unbounded `UPDATE member/user` scans plus
   the column retirement. A no-op on current data, but the advisory-lock hold
   grows with table size, so at scale the migration itself becomes the stall — a

--- a/packages/api/src/lib/db/migrations/README.md
+++ b/packages/api/src/lib/db/migrations/README.md
@@ -7,13 +7,20 @@ request handlers *inside the same container*. Better Auth-owned tables follow
 the `MANAGED_AUTH_MIGRATIONS` ordering in `db/internal.ts`.
 
 Companion one-shot backfill scripts live in [`scripts/`](./scripts/README.md).
-Every schema change must be mirrored in `db/schema.ts` in the same PR. Note the
-guard's reach: `scripts/check-schema-drift.sh` (in `/ci`) only checks that each
-`CREATE TABLE` has a matching `pgTable` (table-level existence) and that dropped
-tables are removed from `schema.ts`. It does **not** inspect `ALTER TABLE` —
-added/changed columns, types, constraints, and indexes are **not** caught, so an
-unmirrored `ALTER TABLE` passes `/ci` green and a later `drizzle-kit generate`
-can then emit a migration that reverts it. Mirror column-level changes by hand.
+Every schema change must be mirrored in `db/schema.ts` in the same PR. Note how
+narrow the guard's reach is: `scripts/check-schema-drift.sh` (in `/ci`) does a
+single forward check — every `CREATE TABLE` name must have a matching `pgTable`
+(table-level existence). That's all it enforces. It does **not**:
+- inspect `ALTER TABLE` — added/changed columns, types, constraints, indexes are
+  **not** compared, so an unmirrored `ALTER TABLE` passes `/ci` green and a later
+  `drizzle-kit generate` can emit a migration that reverts it;
+- verify that a *dropped* table's `pgTable` was removed — `DROP TABLE` names are
+  only subtracted from the expected set (to avoid a false-positive), never
+  reverse-checked, so a leftover `pgTable` for a dropped table also passes green
+  and can have `drizzle-kit generate` re-`CREATE` it.
+
+So mirror column-level changes and dropped-table removals **by hand** — a green
+drift check does not confirm either.
 
 ## Two-phase drop discipline (expand–contract)
 
@@ -54,14 +61,17 @@ still-running pod (N or N-1) reads the object.
 For a **`DROP COLUMN`**, the same split applies: stop writing the column in N
 (let it go `NULL`/default), drop it in N+1.
 
-### How the schema-drift guard already encodes this
+### How the schema-drift guard relates to drops
 
 `scripts/check-schema-drift.sh` computes *expected tables = created MINUS
 dropped*: every `DROP TABLE [IF EXISTS] <name>` subtracts that table from the set
-it expects to find in `schema.ts`. So the guard's contract is already
-"a dropped table must also be removed from `schema.ts`" — pair your drop
-migration with the matching `schema.ts` deletion in one commit and the check
-stays green (the same reason `mcp_tokens`, dropped by 0047, is excluded).
+it expects to find in `schema.ts`. That subtraction only stops a *false
+positive* — once a table is dropped, the forward check no longer demands a
+`pgTable` for it (the same reason `mcp_tokens`, dropped by 0047, is excluded). It
+does **not** verify you removed the stale `pgTable`; that remains your job (see
+the guard-reach note at the top). Pair your drop migration with the matching
+`schema.ts` deletion in the same commit so a later `drizzle-kit generate` can't
+re-`CREATE` the table.
 
 ### Motivating examples
 
@@ -72,8 +82,10 @@ stays green (the same reason `mcp_tokens`, dropped by 0047, is excluded).
   draining N-1 pod still runs the *old* readers during overlap and would 500 on
   `teams_installations`. Moving the readers was necessary but **not** sufficient —
   it was acceptable only under the pre-launch exception below (no real overlap
-  traffic), and the migration header flags it as a deliberate exception. Once a
-  customer is live, this same drop would have needed the two-phase split.
+  traffic). Once a customer is live, this same drop would have needed the
+  two-phase split. (The `0119` header documents *why the tables are unused*, not
+  the overlap reasoning — capturing that deploy-safety rationale in the header is
+  exactly the discipline this doc is asking future drops to add.)
 - **`0118_drop_user_admin_role.sql`** — unbounded `UPDATE member/user` scans plus
   the column retirement. A no-op on current data, but the advisory-lock hold
   grows with table size, so at scale the migration itself becomes the stall — a
@@ -82,6 +94,7 @@ stays green (the same reason `mcp_tokens`, dropped by 0047, is excluded).
 ### When a one-release drop is still fine
 
 Pre-launch (no customers) the overlap window carries no real traffic, so a
-same-release "remove reads + drop" is acceptable today — but write it as a
-*deliberate* exception in the migration header (as `0119` does), not a default.
-Once live, default to the two-phase split.
+same-release "remove reads + drop" is acceptable today — but call it out as a
+*deliberate* exception in the migration header (state that the overlap is
+empty because there are no customers yet), not a default. Once live, default to
+the two-phase split.

--- a/packages/api/src/lib/db/migrations/README.md
+++ b/packages/api/src/lib/db/migrations/README.md
@@ -1,0 +1,79 @@
+# `migrations/` — numbered SQL migrations
+
+Hand-written, append-only SQL migrations named `NNNN_<short_slug>.sql`. They
+run **in-process at boot**, under a `pg_advisory_lock`, **before** `Bun.serve`
+starts accepting traffic (`migrate.ts`), so a migration never races live
+request handlers *inside the same container*. Better Auth-owned tables follow
+the `MANAGED_AUTH_MIGRATIONS` ordering in `db/internal.ts`.
+
+Companion one-shot backfill scripts live in [`scripts/`](./scripts/README.md).
+Every `CREATE TABLE`/`ALTER TABLE` must be mirrored in `db/schema.ts` in the
+same PR — `scripts/check-schema-drift.sh` (in `/ci`) fails otherwise.
+
+## Two-phase drop discipline (expand–contract)
+
+> **Rule:** a column or table is *stopped being read and written* in release N,
+> and *dropped* in release N+1. Never drop in the same release that removes the
+> last reader, once a paying customer is live.
+
+### Why — the N-1 ↔ N deploy-overlap window
+
+Migrations are safe *within* a container, but a deploy is not atomic across
+containers. Railway deploys are **replace-not-rolling** (`numReplicas: 1`), yet
+there is still a brief overlap where the **old (N-1)** container is draining and
+still serving requests while the **new (N)** container has *already* migrated the
+**shared regional database**. During that window:
+
+- a `DROP TABLE` / `DROP COLUMN` applied by N means an N-1 request that still
+  reads the dropped object hits `relation does not exist` /
+  `column does not exist` — a hard 500 for real traffic.
+
+Because the schema is shared and the migration lands the instant N boots, the
+*old code* is the thing that breaks, not the new code. Splitting the change into
+two releases closes the window: by the time the drop ships in N+1, no
+still-running pod (N or N-1) reads the object.
+
+### The two phases
+
+1. **Release N — contract reads/writes (no DDL on the doomed object).**
+   Remove every code path that reads or writes the column/table. Stop writing it
+   first; backfill any successor column if needed. The object still exists, so
+   any lingering N-1 pod from the *previous* deploy keeps working.
+2. **Release N+1 — drop the object.**
+   Now that no shipped code (and no in-flight pod) touches it, `DROP TABLE` /
+   `DROP COLUMN` is safe. Remove the `pgTable`/column from `db/schema.ts` in the
+   **same commit** as the drop migration (`check-schema-drift.sh` excludes
+   explicitly-dropped tables from the expected set, so a tracked drop won't
+   surface as false-positive drift — see below).
+
+For a **`DROP COLUMN`**, the same split applies: stop writing the column in N
+(let it go `NULL`/default), drop it in N+1.
+
+### How the schema-drift guard already encodes this
+
+`scripts/check-schema-drift.sh` computes *expected tables = created MINUS
+dropped*: every `DROP TABLE [IF EXISTS] <name>` subtracts that table from the set
+it expects to find in `schema.ts`. So the guard's contract is already
+"a dropped table must also be removed from `schema.ts`" — pair your drop
+migration with the matching `schema.ts` deletion in one commit and the check
+stays green (the same reason `mcp_tokens`, dropped by 0047, is excluded).
+
+### Motivating examples
+
+- **`0119_drop_legacy_credential_tables.sql`** — `DROP TABLE ... CASCADE` of the
+  four legacy static-bot install tables. Safe **only** because the read paths
+  were removed earlier in the same release train (#3154): the inbound resolvers
+  already read exclusively from `workspace_plugins`. Had an N-1 pod still read
+  `teams_installations` during overlap, it would have 500'd. This is the
+  borderline case the rule is meant to make deliberate rather than incidental.
+- **`0118_drop_user_admin_role.sql`** — unbounded `UPDATE member/user` scans plus
+  the column retirement. A no-op on current data, but the advisory-lock hold
+  grows with table size, so at scale the migration itself becomes the stall — a
+  second reason to keep doomed-object changes small and staged.
+
+### When a one-release drop is still fine
+
+Pre-launch (no customers) the overlap window carries no real traffic, so a
+same-release "remove reads + drop" is acceptable today — but write it as a
+*deliberate* exception in the migration header (as `0119` does), not a default.
+Once live, default to the two-phase split.

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -739,7 +739,7 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       {
         name: "smoke-crm",
         description:
-          "End-to-end CRM lead-capture verification — inject fixture personas below Turnstile via the outbox, wait for the flusher to drain, then diff the resulting Twenty Persons/Notes against the fixture. Local-only (never runs in CI). Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1), --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60), --database-url <url>.",
+          "End-to-end CRM lead-capture verification — inject fixture personas below Turnstile via the outbox, wait for the flusher to drain, then diff the resulting Twenty Persons/Notes against the fixture. Makes live Twenty calls: run ad-hoc by an operator and as the post-deploy staging-smoke gate, not per-PR CI. Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1), --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60), --database-url <url>.",
       },
     ],
     flags: [

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -724,19 +724,34 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
   ops: {
     description:
       "Operator-only tools that touch tenant data. Destructive subcommands require an explicit double-confirm flag.",
-    usage: "ops <wipe> [options]",
+    usage: "ops <wipe|backfill-crm-leads|smoke-crm> [options]",
     subcommands: [
       {
         name: "wipe",
         description:
           "TRUNCATE every public table in the tenant DB (excluding migration bookkeeping) with RESTART IDENTITY CASCADE. Requires ATLAS_WIPE_OK=1 + --confirm. No backup is taken — wrap with pg_dump yourself.",
       },
+      {
+        name: "backfill-crm-leads",
+        description:
+          "Enqueue every existing demo_leads row into crm_outbox so the flusher dispatches them to Twenty as Persons. Re-runs are safe (dedupe by primary email). Flags: --dry-run, --batch-size N (default 500), --source demo, --database-url <url>.",
+      },
+      {
+        name: "smoke-crm",
+        description:
+          "End-to-end CRM lead-capture verification — inject fixture personas below Turnstile via the outbox, wait for the flusher to drain, then diff the resulting Twenty Persons/Notes against the fixture. Local-only (never runs in CI). Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1), --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60), --database-url <url>.",
+      },
     ],
     flags: [
       {
         flag: "--confirm",
         description:
-          "Required to proceed past the double-confirm gate. Pair with ATLAS_WIPE_OK=1 in the env.",
+          "wipe: required to proceed past the double-confirm gate. Pair with ATLAS_WIPE_OK=1 in the env.",
+      },
+      {
+        flag: "--wipe-twenty",
+        description:
+          "smoke-crm: clear the Twenty workspace before the run. Destructive — double-gated by ATLAS_SMOKE_WIPE_OK=1.",
       },
       {
         flag: "--database-url <url>",
@@ -747,6 +762,9 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
     examples: [
       "ATLAS_WIPE_OK=1 atlas ops wipe --confirm",
       "ATLAS_WIPE_OK=1 atlas ops wipe --confirm --database-url $US_DB_URL",
+      "atlas ops backfill-crm-leads --dry-run",
+      "atlas ops smoke-crm --personas ./fixtures/personas.yml",
+      "ATLAS_SMOKE_WIPE_OK=1 atlas ops smoke-crm --personas ./fixtures/personas.yml --wipe-twenty",
     ],
   },
 };

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -8,10 +8,13 @@
  *
  * Scope (per issue #2866):
  *   - Below Turnstile only — no form-layer scripting (manual A5/A6).
- *   - Live-network only locally; this CLI never runs in CI.
+ *   - Live-network: talks to a real Twenty workspace. NOT part of per-PR CI,
+ *     but it IS run automatically as the post-deploy Staging Smoke gate
+ *     (`.github/workflows/staging-smoke.yml`, added in staging slice #2898)
+ *     against the staging DB + Twenty — and ad-hoc by an operator locally.
  *   - Unit tests cover fixture parsing + diff reporting; the live Twenty
- *     round-trip and the inline `/rest/noteTargets` join run only on a
- *     local invocation against a real workspace.
+ *     round-trip and the inline `/rest/noteTargets` join run only against a
+ *     real workspace (local invocation or the staging-smoke job).
  *
  * Flow:
  *   1. Parse args + fixture.

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -13,8 +13,10 @@
  *   smoke-crm              End-to-end CRM lead-capture verification: inject fixture
  *                          personas below Turnstile via the outbox, wait for the
  *                          flusher to drain, then diff the resulting Twenty Persons/
- *                          Notes against the fixture. Local-only (never runs in CI).
- *                          Optional `--wipe-twenty` is double-gated by
+ *                          Notes against the fixture. Makes live Twenty calls:
+ *                          run ad-hoc by an operator and as the post-deploy
+ *                          staging-smoke gate, not per-PR CI. Optional
+ *                          `--wipe-twenty` is double-gated by
  *                          `ATLAS_SMOKE_WIPE_OK=1`. See ./ops-smoke-crm.ts.
  *
  * Wipe replaces internal/wipe-prod.sh's per-DB logic; the script's

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -10,6 +10,12 @@
  *                          so the lead-outbox flusher dispatches them to Twenty as
  *                          Persons. Re-runs are safe — `TwentyClient.upsertPerson`
  *                          dedupes by primary email. See #2736.
+ *   smoke-crm              End-to-end CRM lead-capture verification: inject fixture
+ *                          personas below Turnstile via the outbox, wait for the
+ *                          flusher to drain, then diff the resulting Twenty Persons/
+ *                          Notes against the fixture. Local-only (never runs in CI).
+ *                          Optional `--wipe-twenty` is double-gated by
+ *                          `ATLAS_SMOKE_WIPE_OK=1`. See ./ops-smoke-crm.ts.
  *
  * Wipe replaces internal/wipe-prod.sh's per-DB logic; the script's
  * Railway-credential fetching and 3-region orchestration are operator concerns

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -98,6 +98,51 @@ describe("matchError", () => {
     expect(result.message).not.toContain("postgresql://");
   });
 
+  // --- Provider-vs-datasource disambiguation (#3186) ---
+  //
+  // ECONNREFUSED/ENOTFOUND are identical whether the unreachable host is the
+  // analytics datasource or the LLM provider. Callers pass `subsystem` to
+  // disambiguate; without it we default to datasource framing (the historical
+  // behavior every DB-connectivity caller relies on).
+
+  test("ECONNREFUSED with subsystem:datasource is internal_error (the default)", () => {
+    const err = new Error("connect ECONNREFUSED 10.0.0.1:5432");
+    const explicit = matchError(err, { subsystem: "datasource" }) as MatchedError;
+    const defaulted = matchError(err) as MatchedError;
+    expect(explicit.code).toBe("internal_error");
+    expect(explicit.message).toContain("Database unreachable");
+    // Omitting subsystem must match passing datasource explicitly.
+    expect(defaulted.code).toBe(explicit.code);
+    expect(defaulted.message).toBe(explicit.message);
+  });
+
+  test("ECONNREFUSED with subsystem:provider is provider_unreachable", () => {
+    const err = new Error("connect ECONNREFUSED 10.0.0.1:443");
+    const result = matchError(err, { subsystem: "provider" }) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.code).toBe("provider_unreachable");
+    // Provider framing must not leak the database-host phrasing.
+    expect(result.message).not.toContain("Database unreachable");
+    expect(result.message).toMatch(/provider/i);
+  });
+
+  test("ENOTFOUND with subsystem:provider is provider_unreachable", () => {
+    const err = new Error("getaddrinfo ENOTFOUND api.openai.com");
+    const result = matchError(err, { subsystem: "provider" }) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.code).toBe("provider_unreachable");
+    expect(result.message).not.toContain("Could not resolve hostname");
+    expect(result.message).toMatch(/provider/i);
+  });
+
+  test("ENOTFOUND with subsystem:datasource keeps the DNS-resolution message", () => {
+    const err = new Error("getaddrinfo ENOTFOUND db.example.com");
+    const result = matchError(err, { subsystem: "datasource" }) as MatchedError;
+    expect(result.code).toBe("internal_error");
+    expect(result.message).toContain("Could not resolve hostname");
+    expect(result.message).toContain("db.example.com");
+  });
+
   // --- Timeout ---
 
   test("matches timeout errors with default seconds", () => {

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -291,14 +291,26 @@ export function parseContextWarning(value: unknown): ChatContextWarning | null {
 /**
  * Result from `matchError()` — a pattern-matched, user-safe error.
  *
- * `code` is a suggested `ChatErrorCode`. Callers may override it based
- * on context (e.g. ECONNREFUSED in the chat route is `provider_unreachable`,
- * but in startup it's `internal_error`).
+ * `code` is the resolved `ChatErrorCode`. A bare connection failure
+ * (ECONNREFUSED/ENOTFOUND) is ambiguous — the unreachable host could be the
+ * analytics datasource or the LLM provider — so callers pass `subsystem` to
+ * `matchError()` and the returned `code`/`message` are already correct for
+ * that context (no post-hoc re-labeling needed).
  */
 export interface MatchedError {
   code: ChatErrorCode;
   message: string;
 }
+
+/**
+ * Which dependency a caller was talking to when the error was raised.
+ *
+ * Disambiguates connection failures whose error text is identical regardless
+ * of the unreachable host: `"provider"` → the LLM/AI provider, `"datasource"`
+ * → the analytics database. Defaults to `"datasource"` to preserve the
+ * historical framing every DB-connectivity caller relies on.
+ */
+export type ErrorSubsystem = "provider" | "datasource";
 
 /**
  * Extract a hostname from an error message (e.g. "connect ECONNREFUSED 127.0.0.1:5432").
@@ -325,12 +337,18 @@ function extractHostFromError(msg: string): string {
  * @param error  - The caught error (any type).
  * @param opts.timeoutSeconds - Configured query/request timeout, included in
  *   timeout messages so users know the limit. Defaults to 30.
+ * @param opts.subsystem - Which dependency the caller was talking to, used to
+ *   label connection failures (ECONNREFUSED/ENOTFOUND) correctly. Defaults to
+ *   `"datasource"`. Provider-facing callers (the chat/demo agent routes) pass
+ *   `"provider"` so an unreachable LLM host maps to `provider_unreachable`
+ *   instead of the datasource-framed `internal_error`.
  */
 export function matchError(
   error: unknown,
-  opts?: { timeoutSeconds?: number },
+  opts?: { timeoutSeconds?: number; subsystem?: ErrorSubsystem },
 ): MatchedError | null {
   const msg = error instanceof Error ? error.message : String(error);
+  const subsystem = opts?.subsystem ?? "datasource";
 
   // Pool exhaustion — too many active database connections (transient)
   if (/too many (clients already|connections)|connection pool exhausted|remaining connection slots are reserved/i.test(msg)) {
@@ -340,22 +358,30 @@ export function matchError(
     };
   }
 
-  // ECONNREFUSED — database or service unreachable
-  if (/ECONNREFUSED/i.test(msg)) {
+  // ECONNREFUSED (refused) / ENOTFOUND (DNS) — a connection failure whose
+  // error text is identical whether the unreachable host is the analytics
+  // datasource or the LLM provider. `subsystem` is the disambiguator: a
+  // provider-facing caller gets `provider_unreachable`; everyone else keeps
+  // the historical datasource framing.
+  const isConnRefused = /ECONNREFUSED/i.test(msg);
+  if (isConnRefused || /ENOTFOUND/i.test(msg)) {
+    if (subsystem === "provider") {
+      return {
+        code: "provider_unreachable",
+        message:
+          "Could not reach the LLM provider. Check your network connection and provider status.",
+      };
+    }
     const host = extractHostFromError(msg);
-    return {
-      code: "internal_error",
-      message: `Database unreachable at ${host} — check that the database is running and accessible`,
-    };
-  }
-
-  // ENOTFOUND — DNS resolution failure
-  if (/ENOTFOUND/i.test(msg)) {
-    const host = extractHostFromError(msg);
-    return {
-      code: "internal_error",
-      message: `Could not resolve hostname "${host}" — check your connection URL`,
-    };
+    return isConnRefused
+      ? {
+          code: "internal_error",
+          message: `Database unreachable at ${host} — check that the database is running and accessible`,
+        }
+      : {
+          code: "internal_error",
+          message: `Could not resolve hostname "${host}" — check your connection URL`,
+        };
   }
 
   // SSL / TLS errors — match specific error contexts, not bare keywords


### PR DESCRIPTION
Four small, independent v0.0.9 production-hardening findings, each as its own commit. They touch four disjoint subsystems (error types, migration docs, CLI, security docs) — no shared files with each other or with the other in-flight v0.0.9 sessions.

Closes #3186
Closes #3187
Closes #3191
Closes #3192

---

### #3186 — `matchError` provider-vs-datasource label (refactor + test)

A bare `ECONNREFUSED`/`ENOTFOUND` is identical whether the unreachable host is the analytics datasource or the LLM provider. `matchError` hard-coded the datasource framing (`internal_error` + "Database unreachable at <host>"), so **every caller except the chat route** — which carried a compensating override — mislabeled an unreachable *provider* as a *datasource* failure. The demo route was the live example.

- `matchError` gains an `subsystem: "provider" | "datasource"` hint (default `datasource`). Provider callers now get `provider_unreachable` directly; datasource/DB callers (`startup.ts`, `connection.ts`) keep the historical framing unchanged.
- `chat.ts` passes `subsystem: "provider"` and the now-redundant `internal_error`+connection re-route branch is removed. The `provider_unreachable` reframe branch still runs, so **chat-route output is byte-identical** (76 chat tests green; the ECONNREFUSED→`provider_unreachable` 503 + fetch-failed frame contracts both hold).
- `demo.ts` passes `subsystem: "provider"`, fixing its latent mislabel.
- New unit tests pin **both** the provider and datasource unreachable cases (plus the "omitting subsystem == datasource" default).
- Full suite run because this is a cross-package `@useatlas/types` change — no other caller relied on the old (wrong) label.

### #3187 — two-phase DROP discipline doc

Migrations run safely in-process before `Bun.serve`, but a Railway replace-not-rolling deploy still has a brief N-1↔N overlap where the draining old container serves traffic against the shared DB the new container already migrated — a `DROP TABLE/COLUMN` there makes the old code hit `relation/column does not exist`.

New `packages/api/src/lib/db/migrations/README.md` documents the expand-contract rule (stop reading/writing in release N, drop in N+1), grounded in how `check-schema-drift.sh` already subtracts explicitly-dropped tables, with `0119` (CASCADE drop, safe only because reads were removed same-train via #3154) and `0118` (unbounded UPDATE scan) as the motivating examples. Cross-linked from the CLAUDE.md Database & Migrations checklist.

### #3191 — `ops smoke-crm` documentation

**Decision: DOCUMENT** (not keep-internal). `ops smoke-crm` is a real operator command — fully implemented and dispatched, with a complete flag surface and an `ATLAS_SMOKE_WIPE_OK` double-gate mirroring its sibling `ops wipe`. Its siblings (`ops wipe`, `ops backfill-crm-leads`) are already documented and the `handleOps` fallback usage string already lists it; trimming the siblings (the WONTFIX option) would lose useful docs, so consistency argues for documenting it.

Brought every under-documenting surface in line:
- `cli.mdx` — new `### ops smoke-crm` section (purpose, flag table, `--wipe-twenty` destructive callout, exit codes 0–5).
- `help.ts` `SUBCOMMAND_HELP.ops` — was listing only `wipe`; now lists all three subcommands, fixes the usage string, adds the `--wipe-twenty` gate flag + examples.
- `ops.ts` JSDoc header — adds `smoke-crm` to the Subcommands list.
- CLAUDE.md operator block — adds the invocation + gate note, keeping the declared SSOT aligned with `cli.mdx`.

### #3192 — Account Security adoption-metrics page doc

The admin **My Security** page (`/admin/account-security`) opens with a Security-posture panel sourced from `/api/v1/admin/security/metrics`, but no narrative guide pointed to it. Added a "Tracking Adoption (Admin Console)" section to `security/two-factor-auth.mdx` describing the three traffic-light tiles **accurately from source** (`SecurityPosturePanel` + `admin-security-metrics.ts`): MFA enrollment among admin/owner members (TOTP or passkey), the backup-codes-available proxy tile, and trust-device adoption (active 30-day grants). Notes it is read-only, workspace-scoped, internal-DB-gated, with a pointer to the `/platform/security` fleet roll-up.

---

### CI
All six pre-PR gates pass locally: `lint`, `type`, full `test` (548/548 `@atlas/api` files + all other packages, 0 fail), `syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh`.

### Disjointness
Does **not** touch the files owned by the parallel sessions/rounds: `effect/errors.ts`, `effect/hono.ts`, `error-codes.mdx`, `environment-variables.mdx`, `observability.mdx`, `agent.ts`. #3186 edits `packages/types/src/errors.ts` (`matchError`), a different file from the new tagged error in `effect/errors.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783193839&installation_id=135337507&pr_number=3197&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3197&signature=9886c7f719612ba0b3332f3f92aabf21634f8cae2080b24526cd40842cc2fd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end CRM smoke command usable locally or as a post-deploy staging smoke gate, with persona-driven verification and an optional double‑gated destructive wipe.

* **Documentation**
  * Admin → My Security posture panel (MFA/backup-code/trust-device metrics) docs.
  * Expanded migrations guidance with a two‑phase drop discipline and operational notes.
  * CLI reference and help/examples for CRM ops commands and invocation flags.

* **Improvements**
  * More precise provider vs datasource error classification and mapped HTTP statuses for provider failures.

* **Tests**
  * Unit tests covering provider vs datasource error disambiguation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->