### PR TITLE
fix(api): SaaS boot-guard family — claimed-region scoping + ProviderKeyGuardLive + downgrade health signal (#3176, #3178, #3184)

### DIFF
--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -545,12 +545,16 @@ ATLAS_PUBLIC_URL=https://api.example.com
 
 Settings for multi-region deployments with per-workspace region routing. See also [`residency` in atlas.config.ts](/reference/config#residency) and the [Data Residency guide](/platform-ops/data-residency).
 
+<Callout type="info">
+**Per-service scoping (#3176).** Each `ATLAS_REGION_*_DB_URL` only has to be set on the api service whose `ATLAS_API_REGION` **claims that region** — the US service needs `ATLAS_REGION_US_DB_URL`, the EU service needs `ATLAS_REGION_EU_DB_URL`, and so on. The shared `deploy/api/atlas.config.ts` declares all regions in one map, but a non-claimed region's URL may be left unset/empty on a given service without aborting its boot. Only the **claimed** region's URL is hard-validated at boot (by `RegionGuardLive`); an empty or malformed claimed URL still fails boot.
+</Callout>
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAS_API_REGION` | — | Region identity of this API instance (e.g. `us-west`, `eu-west`, `ap-southeast`). Used for misrouting detection. Falls back to `residency.defaultRegion` from config if unset |
-| `ATLAS_REGION_US_DB_URL` | — | Per-region internal-DB URL used by the SaaS residency router when `ATLAS_API_REGION=us-*`. Required on SaaS regions that route to a US workspace database. Source: `packages/api/src/lib/effect/saas-env.ts` |
-| `ATLAS_REGION_EU_DB_URL` | — | Per-region internal-DB URL used by the residency router when `ATLAS_API_REGION=eu-*`. Required on SaaS regions that route to an EU workspace database |
-| `ATLAS_REGION_APAC_DB_URL` | — | Per-region internal-DB URL used by the residency router when `ATLAS_API_REGION=ap-*`. Required on SaaS regions that route to an APAC workspace database |
+| `ATLAS_REGION_US_DB_URL` | — | Per-region internal-DB URL for the US region. **Only required on the api service that claims `ATLAS_API_REGION=us`** — other services may leave it unset/empty (see callout above). Source: `packages/api/src/lib/effect/saas-env.ts` |
+| `ATLAS_REGION_EU_DB_URL` | — | Per-region internal-DB URL for the EU region. **Only required on the api service that claims `ATLAS_API_REGION=eu`** — other services may leave it unset/empty |
+| `ATLAS_REGION_APAC_DB_URL` | — | Per-region internal-DB URL for the APAC region. **Only required on the api service that claims `ATLAS_API_REGION=apac`** — other services may leave it unset/empty |
 | `ATLAS_STRICT_ROUTING` | `false` | When `true`, misrouted requests receive `421 Misdirected Request` with a `correctApiUrl` hint instead of being served with a warning log |
 | `ATLAS_INTERNAL_SECRET` | — | Shared secret for cross-region service-to-service auth. Required for region migration operations. Both the source and target API instances must share the same secret |
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -425,6 +425,17 @@
                         "type": "string"
                       }
                     },
+                    "deployModeDowngraded": {
+                      "type": "object",
+                      "properties": {
+                        "reason": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "reason"
+                      ]
+                    },
                     "brandColor": {
                       "type": "string"
                     },
@@ -924,6 +935,17 @@
                           "items": {
                             "type": "string"
                           }
+                        },
+                        "deployModeDowngraded": {
+                          "type": "object",
+                          "properties": {
+                            "reason": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "reason"
+                          ]
                         },
                         "brandColor": {
                           "type": "string"

--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -234,6 +234,36 @@ describe("residency", () => {
       expect(result!.region).toBe("eu-west");
     });
 
+    // #3176/#3198 — a region whose internal-DB `databaseUrl` is unset on this
+    // instance (now allowed, so a non-claimed region URL can't abort boot
+    // fleet-wide) must STILL resolve its analytics datasource routing. The
+    // caller routes off `datasourceUrl`/`region` and never reads `databaseUrl`,
+    // so the resolver must NOT bail to null (that would silently drop the
+    // region's datasource and fall through to the default datasource — the
+    // Codex P1 on PR #3198). `databaseUrl` is simply omitted.
+    it("preserves datasource routing when a region's databaseUrl is unset (#3198)", async () => {
+      mockConfig = {
+        residency: {
+          regions: {
+            "us": { label: "US", databaseUrl: "postgresql://us/atlas" },
+            // EU's internal-DB URL is unset on this US box, but it still
+            // declares a per-region analytics datasource override.
+            "eu-west": { label: "EU West", datasourceUrl: "postgresql://eu-west/data" },
+          },
+          defaultRegion: "us",
+        },
+      };
+      mockRows.push([{ region: "eu-west" }]);
+      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      expect(result).not.toBeNull();
+      expect(result!.region).toBe("eu-west");
+      expect(result!.datasourceUrl).toBe("postgresql://eu-west/data");
+      expect(result!.databaseUrl).toBeUndefined();
+      // No "contract may be violated" error — this is the expected per-service
+      // omission state, not a misconfiguration.
+      expect(loggerErrors).toHaveLength(0);
+    });
+
     it("returns null when residency is not configured", async () => {
       mockConfig = {};
       const result = await run(resolveRegionDatabaseUrl("org-1"));

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -241,7 +241,7 @@ export const getWorkspaceRegionAssignment = (
  */
 export const resolveRegionDatabaseUrl = (
   workspaceId: string,
-): Effect.Effect<{ databaseUrl: string; datasourceUrl?: string; region: string } | null> =>
+): Effect.Effect<{ databaseUrl?: string; datasourceUrl?: string; region: string } | null> =>
   Effect.gen(function* () {
     const config = getConfig();
     if (!config?.residency) return null;
@@ -307,25 +307,18 @@ export const resolveRegionDatabaseUrl = (
       return null;
     }
 
-    // `databaseUrl` is now optional on `RegionConfig` (#3176) so that an
-    // unset/empty NON-claimed region URL can't abort boot fleet-wide. If a
-    // workspace is keyed to a region whose URL isn't configured on THIS api
-    // instance, we genuinely can't resolve its residency DB here — return null
-    // (same contract as the "region no longer configured" branch above) so the
-    // caller falls through rather than handing an empty connection string to a
-    // pool. The instance that actually claims `region` boots with a valid URL
-    // (enforced by `RegionGuardLive`), so this only fires for cross-region
-    // lookups on a box that doesn't serve that region.
-    if (!regionConfig.databaseUrl) {
-      log.error(
-        { workspaceId, region, configuredRegions: Object.keys(config.residency.regions) },
-        "Workspace assigned to a region whose databaseUrl is not configured on this API instance — cannot resolve residency routing; falling through",
-      );
-      return null;
-    }
-
+    // `databaseUrl` is optional on `RegionConfig` (#3176): a non-claimed
+    // region's internal-DB URL may be unset on an instance that doesn't serve
+    // it. Do NOT bail to null on an empty/absent `databaseUrl` — the only
+    // consumer (`getRegionAwareConnection`) routes the analytics datasource off
+    // `datasourceUrl`/`region` and never reads `databaseUrl`, so returning null
+    // here would silently DROP a region's datasource routing and fall the query
+    // through to the default datasource (#3198 Codex P1). Pass the route through
+    // unchanged; `databaseUrl` is omitted when unset so no empty connection
+    // string reaches a pool. Routing semantics are identical to before the
+    // schema relaxation — `datasourceUrl` was always the routing key.
     return {
-      databaseUrl: regionConfig.databaseUrl,
+      ...(regionConfig.databaseUrl ? { databaseUrl: regionConfig.databaseUrl } : {}),
       datasourceUrl: regionConfig.datasourceUrl,
       region,
     };

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -307,6 +307,23 @@ export const resolveRegionDatabaseUrl = (
       return null;
     }
 
+    // `databaseUrl` is now optional on `RegionConfig` (#3176) so that an
+    // unset/empty NON-claimed region URL can't abort boot fleet-wide. If a
+    // workspace is keyed to a region whose URL isn't configured on THIS api
+    // instance, we genuinely can't resolve its residency DB here — return null
+    // (same contract as the "region no longer configured" branch above) so the
+    // caller falls through rather than handing an empty connection string to a
+    // pool. The instance that actually claims `region` boots with a valid URL
+    // (enforced by `RegionGuardLive`), so this only fires for cross-region
+    // lookups on a box that doesn't serve that region.
+    if (!regionConfig.databaseUrl) {
+      log.error(
+        { workspaceId, region, configuredRegions: Object.keys(config.residency.regions) },
+        "Workspace assigned to a region whose databaseUrl is not configured on this API instance — cannot resolve residency routing; falling through",
+      );
+      return null;
+    }
+
     return {
       databaseUrl: regionConfig.databaseUrl,
       datasourceUrl: regionConfig.datasourceUrl,

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -444,6 +444,41 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.status).toBe("degraded");
   });
+
+  // #3184 — a config-file SaaS→self-hosted downgrade (enterprise not enabled)
+  // must be visible on /health beyond the CRITICAL boot log. No diagnostics
+  // here, so status would otherwise be "ok"; the downgrade promotes it to
+  // degraded and exposes the reason. Stays 200 — the box still serves traffic.
+  it("surfaces deployModeDowngraded and promotes status to degraded (#3184)", async () => {
+    mockValidateEnvironment.mockResolvedValue([]);
+    const config = await import("@atlas/api/lib/config");
+    config._setConfigForTest({
+      deployMode: "self-hosted",
+      deployModeDowngraded: {
+        reason: 'atlas.config.ts requested deployMode "saas" but enterprise is not enabled — see #1978',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    } as any);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("degraded");
+    expect(body.deployModeDowngraded).toEqual({
+      reason: expect.stringContaining("#1978"),
+    });
+  });
+
+  it("omits deployModeDowngraded on a normal boot (#3184)", async () => {
+    mockValidateEnvironment.mockResolvedValue([]);
+    const config = await import("@atlas/api/lib/config");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
+    config._setConfigForTest({ deployMode: "self-hosted" } as any);
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.deployModeDowngraded).toBeUndefined();
+  });
 });
 
 // #1987 — plugin healthcheck must surface in /health.

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -91,6 +91,11 @@ export const HealthResponseSchema = z.object({
   region: z.string().optional(),
   misroutedRequests: z.number().int().nonnegative().optional(),
   warnings: z.array(z.string()).optional(),
+  // #3184 — present only when atlas.config.ts requested SaaS mode but
+  // enterprise wasn't enabled, so the deploy mode silently downgraded to
+  // self-hosted (all SaaS contracts skipped). Surfaces the downgrade beyond
+  // the CRITICAL boot log; promotes overall status to at least `degraded`.
+  deployModeDowngraded: z.object({ reason: z.string() }).optional(),
   brandColor: z.string().optional(),
   components: z.object({
     datasource: ComponentHealthSchema,
@@ -415,6 +420,15 @@ health.openapi(healthRoute, async (c) => {
     // unchanged (still 200) — only the dashboard label shifts.
     if (pluginAggregateDegraded && status === "ok") status = "degraded";
 
+    // #3184 — config-file SaaS→self-hosted downgrade. When atlas.config.ts
+    // requested saas but enterprise wasn't enabled, applyDeployMode() stamps
+    // a reason onto the resolved config. Surface it on /health and promote
+    // ok → degraded so a headless box shows the silent downgrade beyond the
+    // CRITICAL log. Never escalates to error (the box still serves traffic as
+    // self-hosted), so the HTTP status stays 200.
+    const deployModeDowngraded = getConfig()?.deployModeDowngraded;
+    if (deployModeDowngraded && status === "ok") status = "degraded";
+
     const components = {
       datasource: {
         status: dsNotConfigured
@@ -473,6 +487,7 @@ health.openapi(healthRoute, async (c) => {
       ...(region && { region }),
       ...(misroutedRequests > 0 && { misroutedRequests }),
       ...(warnings.length > 0 && { warnings }),
+      ...(deployModeDowngraded && { deployModeDowngraded }),
       ...(brandColor && { brandColor }),
       components,
       checks: {

--- a/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
@@ -166,4 +166,22 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     expect(errorLogs).toHaveLength(0);
     expect(resolved.deployModeDowngraded).toBeUndefined();
   });
+
+  // #3198 Codex P2 (follow-up) — an explicit `ATLAS_DEPLOY_MODE=auto` ALSO wins
+  // over a config-file `saas` (resolveDeployMode reads env ?? configFile), so a
+  // legitimate auto→self-hosted resolution must not be reported as a downgrade.
+  it("does NOT flag a downgrade when env explicitly sets auto over config saas", async () => {
+    process.env.ATLAS_DEPLOY_MODE = "auto";
+    const dir = ensureTmpDir(`env-auto-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "atlas.config.ts"),
+      `export default { deployMode: "saas" };`,
+    );
+
+    const resolved = await loadConfig(dir);
+
+    const errorLogs = logCalls.filter((c) => c.level === "error" && c.message.includes("CRITICAL"));
+    expect(errorLogs).toHaveLength(0);
+    expect(resolved.deployModeDowngraded).toBeUndefined();
+  });
 });

--- a/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
@@ -98,7 +98,7 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     // /health can surface a degraded flag + reason beyond the log line.
     expect(resolved.deployModeDowngraded).toBeDefined();
     expect(resolved.deployModeDowngraded!.reason).toContain("#1978");
-    expect(resolved.deployModeDowngraded!.reason).toContain("downgraded");
+    expect(resolved.deployModeDowngraded!.reason).toContain("SaaS contracts");
   });
 
   // Negative cases — must NOT log so the warning stays meaningful.

--- a/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
@@ -146,4 +146,24 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     // #3184 — no downgrade, so the health-facing flag stays unset.
     expect(resolved.deployModeDowngraded).toBeUndefined();
   });
+
+  // #3198 Codex P2 — an explicit `ATLAS_DEPLOY_MODE=self-hosted` env var WINS
+  // over a config-file `deployMode: "saas"` by resolveDeployMode precedence, so
+  // it's an intentional override, NOT a silent missing-enterprise downgrade.
+  // It must neither log CRITICAL nor stamp the health-facing flag (otherwise
+  // /health would permanently report degraded with a false claim).
+  it("does NOT flag a downgrade when env explicitly overrides config saas with self-hosted", async () => {
+    process.env.ATLAS_DEPLOY_MODE = "self-hosted";
+    const dir = ensureTmpDir(`env-self-hosted-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "atlas.config.ts"),
+      `export default { deployMode: "saas" };`,
+    );
+
+    const resolved = await loadConfig(dir);
+
+    const errorLogs = logCalls.filter((c) => c.level === "error" && c.message.includes("CRITICAL"));
+    expect(errorLogs).toHaveLength(0);
+    expect(resolved.deployModeDowngraded).toBeUndefined();
+  });
 });

--- a/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
@@ -184,4 +184,25 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     expect(errorLogs).toHaveLength(0);
     expect(resolved.deployModeDowngraded).toBeUndefined();
   });
+
+  // #3198 Codex (round 3) — an UNRECOGNIZED env value (typo) is not a deliberate
+  // override: resolveDeployMode treats it as `auto`, but the config-file `saas`
+  // is still the operator's intent, so the silent-downgrade signal must survive.
+  it("DOES flag a downgrade when env is an invalid value over config saas", async () => {
+    process.env.ATLAS_DEPLOY_MODE = "sasa"; // typo → treated as auto → self-hosted
+    const dir = ensureTmpDir(`env-invalid-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "atlas.config.ts"),
+      `export default { deployMode: "saas" };`,
+    );
+
+    const resolved = await loadConfig(dir);
+
+    const critical = logCalls.find(
+      (c) => c.level === "error" && c.message.includes("CRITICAL") && c.message.includes("#1978"),
+    );
+    expect(critical).toBeDefined();
+    expect(resolved.deployModeDowngraded).toBeDefined();
+    expect(resolved.deployModeDowngraded!.reason).toContain("#1978");
+  });
 });

--- a/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-deploy-mode-warning.test.ts
@@ -85,7 +85,7 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
       `export default { deployMode: "saas" };`,
     );
 
-    await loadConfig(dir);
+    const resolved = await loadConfig(dir);
 
     const errorLogs = logCalls.filter((c) => c.level === "error");
     // The "CRITICAL" + "#1978" pair is the operator-grep signal.
@@ -93,6 +93,12 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     expect(critical).toBeDefined();
     expect((critical!.payload as Record<string, unknown>).source).toBe("atlas.config.ts");
     expect((critical!.payload as Record<string, unknown>).requested).toBe("saas");
+
+    // #3184 — the downgrade is also threaded onto the resolved config so
+    // /health can surface a degraded flag + reason beyond the log line.
+    expect(resolved.deployModeDowngraded).toBeDefined();
+    expect(resolved.deployModeDowngraded!.reason).toContain("#1978");
+    expect(resolved.deployModeDowngraded!.reason).toContain("downgraded");
   });
 
   // Negative cases — must NOT log so the warning stays meaningful.
@@ -133,9 +139,11 @@ describe("applyDeployMode: config-file silent-downgrade warning (#1978)", () => 
     const dir = ensureTmpDir(`auto-${testCounter}`);
     writeFileSync(resolve(dir, "atlas.config.ts"), `export default {};`);
 
-    await loadConfig(dir);
+    const resolved = await loadConfig(dir);
 
     const errorLogs = logCalls.filter((c) => c.level === "error" && c.message.includes("CRITICAL"));
     expect(errorLogs).toHaveLength(0);
+    // #3184 — no downgrade, so the health-facing flag stays unset.
+    expect(resolved.deployModeDowngraded).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/__tests__/config.test.ts
+++ b/packages/api/src/lib/__tests__/config.test.ts
@@ -1552,3 +1552,48 @@ describe("RegionConfigSchema apiUrl", () => {
     expect(() => validateAndResolve(config)).toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #3176 — region databaseUrl is no longer fleet-wide-validated at parse time.
+// The shared SaaS deploy config declares every region but each api service
+// only populates the env var for the region it claims; a non-claimed region's
+// URL resolving to "" / undefined (the Railway shared-scope hazard) must NOT
+// abort config parse on the other regions' services. The hard postgres://
+// check moved to RegionGuardLive (scoped to the claimed region) — see
+// saas-guards.test.ts.
+// ---------------------------------------------------------------------------
+
+describe("RegionConfigSchema databaseUrl scoping (#3176)", () => {
+  it("accepts a non-claimed region whose databaseUrl is an empty string (no fleet-wide abort)", () => {
+    const config = defineConfig({
+      residency: {
+        regions: {
+          // Claimed region on this (US) service — has its real URL.
+          "us": { label: "US", databaseUrl: "postgresql://us/atlas" },
+          // Non-claimed region — its env var is unset on this service, so the
+          // shared config passes through an empty string. Previously this
+          // tripped `.min(1)` and aborted boot fleet-wide.
+          "eu": { label: "EU", databaseUrl: "" },
+        },
+        defaultRegion: "us",
+      },
+    });
+    const resolved = validateAndResolve(config);
+    expect(resolved.residency!.regions["us"].databaseUrl).toBe("postgresql://us/atlas");
+    expect(resolved.residency!.regions["eu"].databaseUrl).toBe("");
+  });
+
+  it("accepts a region config that omits databaseUrl entirely", () => {
+    const config = defineConfig({
+      residency: {
+        regions: {
+          "us": { label: "US", databaseUrl: "postgresql://us/atlas" },
+          "apac": { label: "APAC" },
+        },
+        defaultRegion: "us",
+      },
+    });
+    const resolved = validateAndResolve(config);
+    expect(resolved.residency!.regions["apac"].databaseUrl).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/__tests__/startup-actions.test.ts
+++ b/packages/api/src/lib/__tests__/startup-actions.test.ts
@@ -20,6 +20,15 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
+  // imports it, so mock.module must provide it (mock-all-exports).
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
 }));
 
 mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({

--- a/packages/api/src/lib/__tests__/startup-first-run.test.ts
+++ b/packages/api/src/lib/__tests__/startup-first-run.test.ts
@@ -36,6 +36,15 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
+  // imports it, so mock.module must provide it (mock-all-exports).
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
 }));
 
 mock.module("pg", () => ({

--- a/packages/api/src/lib/__tests__/startup-schema.test.ts
+++ b/packages/api/src/lib/__tests__/startup-schema.test.ts
@@ -41,6 +41,15 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
+  // imports it, so mock.module must provide it (mock-all-exports).
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
 }));
 
 mock.module("pg", () => ({

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -22,6 +22,15 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
+  // imports it, so mock.module must provide it (mock-all-exports).
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
 }));
 
 // Mock explore-nsjail — controllable sandbox capability check

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1409,21 +1409,24 @@ async function applyDeployMode(
   // resolve `@opentelemetry/sdk-node`. Keeping the helper inline here
   // walls the boot-only modules off from request-path consumers.
   // Only a CONFIG-FILE "saas" that was the OPERATIVE request counts as a silent
-  // downgrade. `resolveDeployMode` reads `process.env.ATLAS_DEPLOY_MODE ??
-  // configFileValue`, so the config-file value is operative ONLY when the env
-  // var is unset/empty. ANY explicit env value wins over the config file and is
-  // therefore an env-driven resolution, not a missing-enterprise downgrade:
+  // downgrade. A *recognized* explicit env value (`saas` | `self-hosted` |
+  // `auto`) wins over the config file (resolveDeployMode precedence), so it's an
+  // env-driven resolution, not a missing-enterprise downgrade:
   //   - env "saas"        → EnterpriseGuardLive hard-fails at boot
   //   - env "self-hosted" → explicit operator override (#3198 Codex P2)
   //   - env "auto"        → explicit auto-resolution, not a config downgrade
   //                         (#3198 Codex P2)
-  // Flagging any of those would leave `/health` permanently (and falsely)
-  // degraded with an "enterprise not enabled" claim.
+  // But an UNRECOGNIZED env value (a typo like "sasa", or unset/empty) is NOT a
+  // deliberate override — resolveDeployMode treats it as `auto` and the config
+  // file's "saas" is still the operator's expressed intent, so the downgrade
+  // signal must survive (#3198 Codex follow-up). Mirrors the same recognized
+  // set resolveDeployMode validates against.
   const envDeployMode = process.env.ATLAS_DEPLOY_MODE;
-  const envProvidesDeployMode = envDeployMode !== undefined && envDeployMode !== "";
+  const envSetRecognizedMode =
+    envDeployMode === "saas" || envDeployMode === "self-hosted" || envDeployMode === "auto";
   if (
     resolved.deployMode !== "saas" &&
-    !envProvidesDeployMode &&
+    !envSetRecognizedMode &&
     configFileValue === "saas"
   ) {
     const reason =

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1429,11 +1429,17 @@ async function applyDeployMode(
     !envSetRecognizedMode &&
     configFileValue === "saas"
   ) {
+    // Cause-agnostic wording (#3198 Codex round 4): the downgrade can be caused
+    // by missing enterprise OR an invalid ATLAS_DEPLOY_MODE (treated as auto) OR
+    // auto-resolution without an internal DB even when enterprise IS enabled.
+    // Don't assert a single cause — list the candidates so the prescribed
+    // remediation can actually fix the resolved state.
     const reason =
-      `atlas.config.ts requested deployMode "saas" but enterprise is not enabled — ` +
-      `silently downgraded to "${resolved.deployMode}". DPA, encryption, and internal-DB ` +
-      `guards are NOT running. Build with @atlas/ee installed and ATLAS_ENTERPRISE_ENABLED=true, ` +
-      `or remove the deployMode override from atlas.config.ts. See #1978.`;
+      `atlas.config.ts requested deployMode "saas" but it resolved to "${resolved.deployMode}" — ` +
+      `the SaaS contracts (DPA, encryption, internal-DB guards) are NOT running. Likely causes: ` +
+      `@atlas/ee not installed or ATLAS_ENTERPRISE_ENABLED unset; an invalid ATLAS_DEPLOY_MODE value ` +
+      `(treated as "auto"); or auto-resolution without DATABASE_URL. Fix the underlying cause, or ` +
+      `remove the deployMode override from atlas.config.ts. See #1978.`;
     log.error(
       {
         requested: "saas",

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1408,22 +1408,22 @@ async function applyDeployMode(
   // create-atlas standalone scaffold would fail at build time trying to
   // resolve `@opentelemetry/sdk-node`. Keeping the helper inline here
   // walls the boot-only modules off from request-path consumers.
-  // Only a CONFIG-FILE "saas" that was the operative request counts as a
-  // silent downgrade. If the env explicitly set a concrete mode it WINS over
-  // the config file (resolveDeployMode precedence), so that's an intentional
-  // override, not a missing-enterprise downgrade:
-  //   - env "saas"        → handled by EnterpriseGuardLive (hard fail at boot)
-  //   - env "self-hosted" → explicit operator choice; must NOT be flagged
-  //     (else /health would permanently report degraded with a false
-  //     "enterprise not enabled" claim — #3198 Codex P2)
-  // "auto"/unset env leaves the config file's "saas" operative, so it can be
-  // genuinely downgraded when enterprise is missing.
-  const envRequestedConcreteMode =
-    process.env.ATLAS_DEPLOY_MODE === "saas" ||
-    process.env.ATLAS_DEPLOY_MODE === "self-hosted";
+  // Only a CONFIG-FILE "saas" that was the OPERATIVE request counts as a silent
+  // downgrade. `resolveDeployMode` reads `process.env.ATLAS_DEPLOY_MODE ??
+  // configFileValue`, so the config-file value is operative ONLY when the env
+  // var is unset/empty. ANY explicit env value wins over the config file and is
+  // therefore an env-driven resolution, not a missing-enterprise downgrade:
+  //   - env "saas"        → EnterpriseGuardLive hard-fails at boot
+  //   - env "self-hosted" → explicit operator override (#3198 Codex P2)
+  //   - env "auto"        → explicit auto-resolution, not a config downgrade
+  //                         (#3198 Codex P2)
+  // Flagging any of those would leave `/health` permanently (and falsely)
+  // degraded with an "enterprise not enabled" claim.
+  const envDeployMode = process.env.ATLAS_DEPLOY_MODE;
+  const envProvidesDeployMode = envDeployMode !== undefined && envDeployMode !== "";
   if (
     resolved.deployMode !== "saas" &&
-    !envRequestedConcreteMode &&
+    !envProvidesDeployMode &&
     configFileValue === "saas"
   ) {
     const reason =

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1408,9 +1408,22 @@ async function applyDeployMode(
   // create-atlas standalone scaffold would fail at build time trying to
   // resolve `@opentelemetry/sdk-node`. Keeping the helper inline here
   // walls the boot-only modules off from request-path consumers.
+  // Only a CONFIG-FILE "saas" that was the operative request counts as a
+  // silent downgrade. If the env explicitly set a concrete mode it WINS over
+  // the config file (resolveDeployMode precedence), so that's an intentional
+  // override, not a missing-enterprise downgrade:
+  //   - env "saas"        → handled by EnterpriseGuardLive (hard fail at boot)
+  //   - env "self-hosted" → explicit operator choice; must NOT be flagged
+  //     (else /health would permanently report degraded with a false
+  //     "enterprise not enabled" claim — #3198 Codex P2)
+  // "auto"/unset env leaves the config file's "saas" operative, so it can be
+  // genuinely downgraded when enterprise is missing.
+  const envRequestedConcreteMode =
+    process.env.ATLAS_DEPLOY_MODE === "saas" ||
+    process.env.ATLAS_DEPLOY_MODE === "self-hosted";
   if (
     resolved.deployMode !== "saas" &&
-    process.env.ATLAS_DEPLOY_MODE !== "saas" &&
+    !envRequestedConcreteMode &&
     configFileValue === "saas"
   ) {
     const reason =

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -254,8 +254,22 @@ const PoolConfigSchema = z.object({
 const RegionConfigSchema = z.object({
   /** Human-readable region label for the admin console. */
   label: z.string().min(1),
-  /** Database URL for the region's internal database. */
-  databaseUrl: z.string().min(1, "Region database URL must not be empty"),
+  /**
+   * Database URL for the region's internal database.
+   *
+   * Intentionally **not** `.min(1)` (#3176): the SaaS deploy config
+   * (`deploy/api/atlas.config.ts`) declares all regions in one map and reads
+   * each `databaseUrl` from a region-specific env var, but a given api service
+   * only sets the env var for the region it claims (`ATLAS_API_REGION`). The
+   * other regions' vars resolve to `""`/`undefined` (the Railway shared-scope
+   * hazard), and a fleet-wide `.min(1)` parse here would abort boot on every
+   * service for one unset non-claimed region. The hard `postgres://`
+   * well-formedness check is scoped to the **claimed** region by
+   * `RegionGuardLive` (`lib/effect/saas-guards.ts`), which already validates
+   * per-claim — so an empty/malformed *claimed* URL still fails boot, while an
+   * empty/unset *non-claimed* URL no longer takes down the fleet.
+   */
+  databaseUrl: z.string().optional(),
   /** Optional datasource URL override for analytics in this region. */
   datasourceUrl: z.string().min(1).optional(),
   /** Public API endpoint for this region (e.g. "https://api-eu.useatlas.dev"). */
@@ -715,6 +729,16 @@ export interface ResolvedConfig {
   residency?: ResidencyConfig;
   /** Resolved deploy mode — binary "saas" or "self-hosted" (auto is resolved at boot). */
   deployMode?: "saas" | "self-hosted";
+  /**
+   * Set when `atlas.config.ts` requested `deployMode: "saas"` but enterprise
+   * was not enabled, so `resolveDeployMode` silently downgraded to
+   * `self-hosted` (the config-file path — the env-var path fails boot via
+   * `EnterpriseGuardLive` instead). The env-path downgrade is loud; this
+   * config-file path otherwise only emits a CRITICAL log. Threaded here so
+   * `/health` can surface a `degraded` flag + reason beyond the log line
+   * (#3184). Absent on a normal boot.
+   */
+  deployModeDowngraded?: { reason: string };
   /**
    * Plugin Catalog declaration — flat list of installable chat Platforms
    * and integration plugins. Seeded into `plugin_catalog` at boot via
@@ -1389,17 +1413,23 @@ async function applyDeployMode(
     process.env.ATLAS_DEPLOY_MODE !== "saas" &&
     configFileValue === "saas"
   ) {
+    const reason =
+      `atlas.config.ts requested deployMode "saas" but enterprise is not enabled — ` +
+      `silently downgraded to "${resolved.deployMode}". DPA, encryption, and internal-DB ` +
+      `guards are NOT running. Build with @atlas/ee installed and ATLAS_ENTERPRISE_ENABLED=true, ` +
+      `or remove the deployMode override from atlas.config.ts. See #1978.`;
     log.error(
       {
         requested: "saas",
         resolved: resolved.deployMode,
         source: "atlas.config.ts",
       },
-      `CRITICAL: atlas.config.ts requested deployMode "saas" but enterprise is not enabled — ` +
-        `silently downgraded to "${resolved.deployMode}". DPA, encryption, and internal-DB ` +
-        `guards will NOT run. Build with @atlas/ee installed and ATLAS_ENTERPRISE_ENABLED=true, ` +
-        `or remove the deployMode override from atlas.config.ts. See #1978.`,
+      `CRITICAL: ${reason}`,
     );
+    // #3184 — surface the silent downgrade beyond the log so a headless
+    // Railway box shows a degraded `/health` signal, not just one easy-to-miss
+    // CRITICAL line. Health reads this off the resolved config singleton.
+    resolved.deployModeDowngraded = { reason };
   }
 
   // Pool-default warning runs after deploy mode resolves so the

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1740,7 +1740,7 @@ export async function getRegionAwareConnection(
     return yield* residency.resolveRegionDatabaseUrl(orgId);
   });
 
-  let regionInfo: { databaseUrl: string; datasourceUrl?: string; region: string } | null;
+  let regionInfo: { databaseUrl?: string; datasourceUrl?: string; region: string } | null;
   try {
     regionInfo = await runEnterprise(resolveRegion);
   } catch (err) {

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -713,10 +713,14 @@ describe("buildAppLayer", () => {
   test("buildAppLayer wires InternalDbGuardLive — missing DATABASE_URL fails the layer in SaaS", async () => {
     const savedDb = process.env.DATABASE_URL;
     const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
+    const savedProvider = process.env.ATLAS_PROVIDER;
     delete process.env.DATABASE_URL;
     // Provide a valid encryption key so EncryptionKeyGuardLive doesn't
     // also fail and hide the InternalDbGuardLive failure.
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
+    // Satisfy ProviderKeyGuardLive (#3178) with a keyless provider so its
+    // failure doesn't mix into the cause this test asserts on.
+    process.env.ATLAS_PROVIDER = "ollama";
 
     try {
       const config = { deployMode: "saas" } as Parameters<typeof buildAppLayer>[0];
@@ -736,6 +740,8 @@ describe("buildAppLayer", () => {
       if (savedDb !== undefined) process.env.DATABASE_URL = savedDb;
       if (savedKeys !== undefined) process.env.ATLAS_ENCRYPTION_KEYS = savedKeys;
       else delete process.env.ATLAS_ENCRYPTION_KEYS;
+      if (savedProvider !== undefined) process.env.ATLAS_PROVIDER = savedProvider;
+      else delete process.env.ATLAS_PROVIDER;
     }
   });
 
@@ -749,11 +755,13 @@ describe("buildAppLayer", () => {
     const savedDb = process.env.DATABASE_URL;
     const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
     const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+    const savedProvider = process.env.ATLAS_PROVIDER;
     // Satisfy the other SaaS guards so the failure cause carries
-    // exclusively the rate-limit error — not the encryption-key or
-    // internal-DB error from a sibling guard firing first.
+    // exclusively the rate-limit error — not the encryption-key,
+    // internal-DB, or provider-key error from a sibling guard firing first.
     process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
+    process.env.ATLAS_PROVIDER = "ollama"; // keyless provider — satisfies ProviderKeyGuardLive
     delete process.env.ATLAS_RATE_LIMIT_RPM;
 
     try {
@@ -774,6 +782,53 @@ describe("buildAppLayer", () => {
       else delete process.env.ATLAS_ENCRYPTION_KEYS;
       if (savedRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = savedRpm;
       else delete process.env.ATLAS_RATE_LIMIT_RPM;
+      if (savedProvider !== undefined) process.env.ATLAS_PROVIDER = savedProvider;
+      else delete process.env.ATLAS_PROVIDER;
+    }
+  });
+
+  // #3178 — same canary shape as the two guards above. Without this end-to-end
+  // assertion a future merge that drops `providerKeyGuardLayer` from
+  // `Layer.mergeAll(...)` would still pass the unit tests in saas-guards.test.ts
+  // (which provide the guard Layer directly). Boot the full app layer in SaaS
+  // with a configured provider whose key is absent and assert the tagged error
+  // reaches the boot Layer's failure channel.
+  test("buildAppLayer wires ProviderKeyGuardLive — missing provider key fails the layer in SaaS", async () => {
+    const savedDb = process.env.DATABASE_URL;
+    const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
+    const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+    const savedProvider = process.env.ATLAS_PROVIDER;
+    const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+    // Satisfy the sibling guards so the cause carries exclusively the
+    // provider-key error.
+    process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
+    process.env.ATLAS_RATE_LIMIT_RPM = "300";
+    process.env.ATLAS_PROVIDER = "anthropic";
+    delete process.env.ANTHROPIC_API_KEY;
+
+    try {
+      const config = { deployMode: "saas" } as Parameters<typeof buildAppLayer>[0];
+      const layer = buildAppLayer(config);
+
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(Effect.provide(layer)),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const text = String(Exit.isFailure(exit) ? exit.cause : "");
+      expect(text).toContain("ProviderKeyMissingError");
+    } finally {
+      if (savedDb !== undefined) process.env.DATABASE_URL = savedDb;
+      else delete process.env.DATABASE_URL;
+      if (savedKeys !== undefined) process.env.ATLAS_ENCRYPTION_KEYS = savedKeys;
+      else delete process.env.ATLAS_ENCRYPTION_KEYS;
+      if (savedRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = savedRpm;
+      else delete process.env.ATLAS_RATE_LIMIT_RPM;
+      if (savedProvider !== undefined) process.env.ATLAS_PROVIDER = savedProvider;
+      else delete process.env.ATLAS_PROVIDER;
+      if (savedAnthropic !== undefined) process.env.ANTHROPIC_API_KEY = savedAnthropic;
+      else delete process.env.ANTHROPIC_API_KEY;
     }
   });
 

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -799,11 +799,15 @@ describe("buildAppLayer", () => {
     const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
     const savedProvider = process.env.ATLAS_PROVIDER;
     const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+    const savedResend = process.env.RESEND_API_KEY;
     // Satisfy the sibling guards so the cause carries exclusively the
-    // provider-key error.
+    // provider-key error. RESEND_API_KEY satisfies DpaGuardLive: it now shares
+    // the settings layer with ProviderKeyGuardLive (#3198), so a DpaGuard
+    // failure would interrupt the sibling before its error surfaces.
     process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
     process.env.ATLAS_RATE_LIMIT_RPM = "300";
+    process.env.RESEND_API_KEY = "re_wiring-regression-test-key";
     process.env.ATLAS_PROVIDER = "anthropic";
     delete process.env.ANTHROPIC_API_KEY;
 
@@ -825,6 +829,8 @@ describe("buildAppLayer", () => {
       else delete process.env.ATLAS_ENCRYPTION_KEYS;
       if (savedRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = savedRpm;
       else delete process.env.ATLAS_RATE_LIMIT_RPM;
+      if (savedResend !== undefined) process.env.RESEND_API_KEY = savedResend;
+      else delete process.env.RESEND_API_KEY;
       if (savedProvider !== undefined) process.env.ATLAS_PROVIDER = savedProvider;
       else delete process.env.ATLAS_PROVIDER;
       if (savedAnthropic !== undefined) process.env.ANTHROPIC_API_KEY = savedAnthropic;

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -799,15 +799,11 @@ describe("buildAppLayer", () => {
     const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
     const savedProvider = process.env.ATLAS_PROVIDER;
     const savedAnthropic = process.env.ANTHROPIC_API_KEY;
-    const savedResend = process.env.RESEND_API_KEY;
     // Satisfy the sibling guards so the cause carries exclusively the
-    // provider-key error. RESEND_API_KEY satisfies DpaGuardLive: it now shares
-    // the settings layer with ProviderKeyGuardLive (#3198), so a DpaGuard
-    // failure would interrupt the sibling before its error surfaces.
+    // provider-key error.
     process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
     process.env.ATLAS_RATE_LIMIT_RPM = "300";
-    process.env.RESEND_API_KEY = "re_wiring-regression-test-key";
     process.env.ATLAS_PROVIDER = "anthropic";
     delete process.env.ANTHROPIC_API_KEY;
 
@@ -829,8 +825,6 @@ describe("buildAppLayer", () => {
       else delete process.env.ATLAS_ENCRYPTION_KEYS;
       if (savedRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = savedRpm;
       else delete process.env.ATLAS_RATE_LIMIT_RPM;
-      if (savedResend !== undefined) process.env.RESEND_API_KEY = savedResend;
-      else delete process.env.RESEND_API_KEY;
       if (savedProvider !== undefined) process.env.ATLAS_PROVIDER = savedProvider;
       else delete process.env.ATLAS_PROVIDER;
       if (savedAnthropic !== undefined) process.env.ANTHROPIC_API_KEY = savedAnthropic;

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -45,6 +45,8 @@ describe("SAAS_ENV_KEYS", () => {
       ATLAS_ENCRYPTION_KEY: undefined,
       BETTER_AUTH_SECRET: undefined,
       ATLAS_RATE_LIMIT_RPM: undefined,
+      ATLAS_PROVIDER: undefined,
+      AI_GATEWAY_API_KEY: undefined,
       ATLAS_API_REGION: undefined,
       ATLAS_REGION_US_DB_URL: undefined,
       ATLAS_REGION_EU_DB_URL: undefined,
@@ -99,6 +101,10 @@ describe("makeBootSmokeFixture", () => {
     expect(fixture.BETTER_AUTH_SECRET?.length ?? 0).toBeGreaterThanOrEqual(32);
     expect(fixture.ATLAS_API_REGION).toBe("us");
     expect(fixture.RESEND_API_KEY).toBeTruthy();
+    // ProviderKeyGuardLive (#3178): ATLAS_PROVIDER unset → gateway default, so
+    // the gateway key must be present for boot-smoke to pass.
+    expect(fixture.ATLAS_PROVIDER).toBeUndefined();
+    expect(fixture.AI_GATEWAY_API_KEY).toBeTruthy();
   });
 
   test("databaseUrl override flows to internal + datasource + every region", () => {

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -13,7 +13,7 @@
  * output without rewiring imports.
  */
 
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { Effect, Exit, Layer } from "effect";
 
 // Logger no-op mock — keeps these tests quiet (and isolated from any
@@ -32,21 +32,6 @@ mock.module("@atlas/api/lib/logger", () => ({
   getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
-}));
-
-// `ProviderKeyGuardLive` lazy-imports `@atlas/api/lib/settings` and resolves
-// `ATLAS_PROVIDER` via `getSettingAuto` (DB-persisted platform setting → env →
-// default), matching the runtime model path. It's the ONLY guard in this file
-// that touches settings, so a thin mock here is safe. `getSettingAuto` mirrors
-// the real tier chain for the keys these tests read: a test-controlled
-// persisted override first, then `process.env` (Tier 3). `_persistedProvider`
-// lets a test exercise the persisted-DB tier (env unset) that the env-driven
-// tests below can't reach. Default `undefined` → pure env behavior.
-let _persistedProvider: string | undefined = undefined;
-mock.module("@atlas/api/lib/settings", () => ({
-  getSettingAuto: (key: string): string | undefined =>
-    key === "ATLAS_PROVIDER" ? _persistedProvider ?? process.env.ATLAS_PROVIDER : process.env[key],
-  getSetting: (key: string): string | undefined => process.env[key],
 }));
 
 // Type-only imports for the tagged error classes and the `Config` Tag
@@ -82,13 +67,8 @@ const {
   ChatAdapterEnvGuardLive,
   ChatAdapterEnvMissingError,
 } = await import("../saas-guards");
-const { Config, Settings } = await import("../layers");
+const { Config } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
-
-// `ProviderKeyGuardLive` depends on `Settings` (it sequences after the
-// settings cache is warm). The value is unused by the guard — only the
-// dependency-ordering matters — so a `loaded: 0` stub satisfies the Layer.
-const TestSettingsLayer = Layer.succeed(Settings, { loaded: 0 });
 
 // ── Test helpers ────────────────────────────────────────────────────
 
@@ -635,55 +615,12 @@ describe("ProviderKeyGuardLive", () => {
       Effect.void.pipe(
         Effect.provide(
           ProviderKeyGuardLive.pipe(
-            Layer.provide(
-              Layer.merge(makeTestConfigLayer({ deployMode: "saas" }), TestSettingsLayer),
-            ),
+            Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
           ),
         ),
       ),
     ) as Promise<Exit.Exit<void, TProviderKeyMissingError>>;
   }
-
-  // `_persistedProvider` is module-level (the settings mock closes over it);
-  // reset before each case so a persisted-tier test can't leak into the
-  // env-driven cases.
-  beforeEach(() => {
-    _persistedProvider = undefined;
-  });
-
-  // #3198 Codex P1 — the runtime resolves ATLAS_PROVIDER through
-  // getSettingAuto (admin-console-persisted setting → env → default), so a
-  // SaaS region that configures its provider via the admin UI (env-level
-  // ATLAS_PROVIDER unset, no AI_GATEWAY_API_KEY) must NOT be false-failed at
-  // boot. Persisted anthropic + ANTHROPIC_API_KEY present → boots.
-  test("boots in SaaS when a PERSISTED ATLAS_PROVIDER's key is set, even with env-provider unset (#3198)", async () => {
-    await withCleanEnv(() =>
-      withoutAnthropicKey(async () => {
-        process.env.ATLAS_DEPLOY_MODE = "saas"; // getDefaultProvider() would say "gateway"
-        _persistedProvider = "anthropic"; // ...but the persisted setting wins, like the runtime
-        process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
-        const exit = await runGuard();
-        expect(Exit.isSuccess(exit)).toBe(true);
-      }),
-    );
-  });
-
-  // Corollary — a persisted provider whose key is absent still fails boot, and
-  // reports the SETTINGS-resolved provider (not the gateway default).
-  test("fails boot in SaaS when a PERSISTED ATLAS_PROVIDER's key is missing (#3198)", async () => {
-    await withCleanEnv(() =>
-      withoutAnthropicKey(async () => {
-        process.env.ATLAS_DEPLOY_MODE = "saas";
-        _persistedProvider = "anthropic";
-        const exit = await runGuard();
-        expect(Exit.isFailure(exit)).toBe(true);
-        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
-        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
-        expect((failure as TProviderKeyMissingError).provider).toBe("anthropic");
-        expect((failure as TProviderKeyMissingError).requiredKey).toBe("ANTHROPIC_API_KEY");
-      }),
-    );
-  });
 
   // The gateway default is the SaaS prod path: ATLAS_PROVIDER unset →
   // getDefaultProvider() → "gateway" (because ATLAS_DEPLOY_MODE=saas) →
@@ -769,9 +706,7 @@ describe("ProviderKeyGuardLive", () => {
           Effect.void.pipe(
             Effect.provide(
               ProviderKeyGuardLive.pipe(
-                Layer.provide(
-                  Layer.merge(makeTestConfigLayer({ deployMode: "self-hosted" }), TestSettingsLayer),
-                ),
+                Layer.provide(makeTestConfigLayer({ deployMode: "self-hosted" })),
               ),
             ),
           ),

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -45,6 +45,7 @@ import type {
   EncryptionKeyMalformedError as TEncryptionKeyMalformedError,
   InternalDatabaseRequiredError as TInternalDatabaseRequiredError,
   RateLimitRequiredError as TRateLimitRequiredError,
+  ProviderKeyMissingError as TProviderKeyMissingError,
   RegionMisconfiguredError as TRegionMisconfiguredError,
   ChatAdapterEnvMissingError as TChatAdapterEnvMissingError,
 } from "../saas-guards";
@@ -59,6 +60,8 @@ const {
   InternalDatabaseRequiredError,
   RateLimitGuardLive,
   RateLimitRequiredError,
+  ProviderKeyGuardLive,
+  ProviderKeyMissingError,
   RegionGuardLive,
   RegionMisconfiguredError,
   ChatAdapterEnvGuardLive,
@@ -589,6 +592,131 @@ describe("RateLimitGuardLive", () => {
   });
 });
 
+// ══════════════════════════════════════════════════════════════════════
+// ██  ProviderKeyGuardLive (#3178)
+// ══════════════════════════════════════════════════════════════════════
+
+describe("ProviderKeyGuardLive", () => {
+  // ANTHROPIC_API_KEY isn't a member of SAAS_ENV_KEYS (the guard reads any
+  // provider key dynamically from process.env), so `withCleanEnv` doesn't
+  // clear it. A dev machine may have it set, which would let a "fails when
+  // missing" assertion pass for the wrong reason — delete it explicitly.
+  function withoutAnthropicKey<T>(run: () => Promise<T>): Promise<T> {
+    const saved = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    return run().finally(() => {
+      if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+      else delete process.env.ANTHROPIC_API_KEY;
+    });
+  }
+
+  function runGuard(): Promise<Exit.Exit<void, TProviderKeyMissingError>> {
+    return Effect.runPromiseExit(
+      Effect.void.pipe(
+        Effect.provide(
+          ProviderKeyGuardLive.pipe(
+            Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+          ),
+        ),
+      ),
+    ) as Promise<Exit.Exit<void, TProviderKeyMissingError>>;
+  }
+
+  // The gateway default is the SaaS prod path: ATLAS_PROVIDER unset →
+  // getDefaultProvider() → "gateway" (because ATLAS_DEPLOY_MODE=saas) →
+  // requires AI_GATEWAY_API_KEY, which is a SAAS_ENV_KEYS member cleared by
+  // withCleanEnv. The acceptance criterion explicitly calls out this path.
+  test("fails boot in SaaS (gateway default) when AI_GATEWAY_API_KEY is missing", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_DEPLOY_MODE = "saas"; // drives getDefaultProvider() → gateway
+      const exit = await runGuard();
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+      expect((failure as TProviderKeyMissingError)._tag).toBe("ProviderKeyMissingError");
+      expect((failure as TProviderKeyMissingError).provider).toBe("gateway");
+      expect((failure as TProviderKeyMissingError).requiredKey).toBe("AI_GATEWAY_API_KEY");
+      expect((failure as TProviderKeyMissingError).message).toContain("#3178");
+    });
+  });
+
+  test("fails boot in SaaS when ATLAS_PROVIDER=anthropic but ANTHROPIC_API_KEY is unset", async () => {
+    await withCleanEnv(() =>
+      withoutAnthropicKey(async () => {
+        process.env.ATLAS_PROVIDER = "anthropic";
+        const exit = await runGuard();
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+        expect((failure as TProviderKeyMissingError).provider).toBe("anthropic");
+        expect((failure as TProviderKeyMissingError).requiredKey).toBe("ANTHROPIC_API_KEY");
+      }),
+    );
+  });
+
+  // Empty-string key is treated as missing (matches the per-request
+  // diagnostic's `!process.env[requiredKey]` truthy check).
+  test("fails boot in SaaS when the provider key is an empty string", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_DEPLOY_MODE = "saas";
+      process.env.AI_GATEWAY_API_KEY = "";
+      const exit = await runGuard();
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+    });
+  });
+
+  test("succeeds in SaaS (gateway default) when AI_GATEWAY_API_KEY is set", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_DEPLOY_MODE = "saas";
+      process.env.AI_GATEWAY_API_KEY = " test-gateway-key";
+      const exit = await runGuard();
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // ollama runs locally and needs no key — PROVIDER_KEY_MAP maps it to "",
+  // which the guard treats as "no key required" and skips.
+  test("succeeds in SaaS with ATLAS_PROVIDER=ollama (no key required)", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_PROVIDER = "ollama";
+      const exit = await runGuard();
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // openai-compatible authenticates via a base URL, not a fixed key var, so
+  // PROVIDER_KEY_MAP has no entry — the guard skips rather than failing boot.
+  test("succeeds in SaaS for a provider with no mapped key (openai-compatible)", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_PROVIDER = "openai-compatible";
+      const exit = await runGuard();
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // The self-hosted counterpart of the test pair the issue calls for:
+  // a keyless dev loop must still boot (it keeps the per-request 503).
+  test("succeeds on self-hosted with no provider key (per-request 503 preserved)", async () => {
+    await withCleanEnv(() =>
+      withoutAnthropicKey(async () => {
+        process.env.ATLAS_PROVIDER = "anthropic";
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              ProviderKeyGuardLive.pipe(
+                Layer.provide(makeTestConfigLayer({ deployMode: "self-hosted" })),
+              ),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+});
+
 // Note: tests for `warnIfDeployModeSilentlyDowngraded` previously lived
 // here. The helper was inlined into `lib/config.ts` to break a static-
 // reachability chain that broke the create-atlas standalone scaffold
@@ -711,6 +839,68 @@ describe("RegionGuardLive", () => {
         ),
       );
       expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // #3176 — the load-bearing acceptance criterion. A US service claims `us`
+  // (valid URL), while a NON-claimed region (`eu`) has an empty databaseUrl
+  // because its env var isn't set on this box. Boot must succeed: only the
+  // claimed region is validated, so one unset non-claimed region can't take
+  // down the fleet. The schema-level half of this fix is pinned in config.test.ts.
+  test("boots in SaaS when a non-claimed region's databaseUrl is empty (#3176)", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_API_REGION = "us";
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            RegionGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                residency: {
+                  regions: {
+                    "us": { databaseUrl: "postgres://u:p@h:5432/db" },
+                    "eu": { databaseUrl: "" }, // env var unset on this US service
+                  },
+                  defaultRegion: "us",
+                },
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // #3176 corollary — the empty-URL protection is preserved, just scoped: an
+  // empty databaseUrl on the CLAIMED region still fails boot (it's the URL this
+  // service actually routes to). Complements the malformed-URL test above with
+  // the specific empty-string case the old `.min(1)` schema check used to catch.
+  test("fails boot in SaaS when the claimed region's databaseUrl is empty (#3176 corollary)", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_API_REGION = "us";
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            RegionGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                residency: {
+                  regions: {
+                    "us": { databaseUrl: "" }, // claimed region — must still fail boot
+                    "eu": { databaseUrl: "postgres://u:p@h:5432/db" },
+                  },
+                  defaultRegion: "us",
+                },
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(RegionMisconfiguredError);
+      expect((failure as TRegionMisconfiguredError).cause).toBe("malformed_database_url");
     });
   });
 });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -13,7 +13,7 @@
  * output without rewiring imports.
  */
 
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { Effect, Exit, Layer } from "effect";
 
 // Logger no-op mock — keeps these tests quiet (and isolated from any
@@ -32,6 +32,21 @@ mock.module("@atlas/api/lib/logger", () => ({
   getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
+}));
+
+// `ProviderKeyGuardLive` lazy-imports `@atlas/api/lib/settings` and resolves
+// `ATLAS_PROVIDER` via `getSettingAuto` (DB-persisted platform setting → env →
+// default), matching the runtime model path. It's the ONLY guard in this file
+// that touches settings, so a thin mock here is safe. `getSettingAuto` mirrors
+// the real tier chain for the keys these tests read: a test-controlled
+// persisted override first, then `process.env` (Tier 3). `_persistedProvider`
+// lets a test exercise the persisted-DB tier (env unset) that the env-driven
+// tests below can't reach. Default `undefined` → pure env behavior.
+let _persistedProvider: string | undefined = undefined;
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string): string | undefined =>
+    key === "ATLAS_PROVIDER" ? _persistedProvider ?? process.env.ATLAS_PROVIDER : process.env[key],
+  getSetting: (key: string): string | undefined => process.env[key],
 }));
 
 // Type-only imports for the tagged error classes and the `Config` Tag
@@ -67,8 +82,13 @@ const {
   ChatAdapterEnvGuardLive,
   ChatAdapterEnvMissingError,
 } = await import("../saas-guards");
-const { Config } = await import("../layers");
+const { Config, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
+
+// `ProviderKeyGuardLive` depends on `Settings` (it sequences after the
+// settings cache is warm). The value is unused by the guard — only the
+// dependency-ordering matters — so a `loaded: 0` stub satisfies the Layer.
+const TestSettingsLayer = Layer.succeed(Settings, { loaded: 0 });
 
 // ── Test helpers ────────────────────────────────────────────────────
 
@@ -615,12 +635,55 @@ describe("ProviderKeyGuardLive", () => {
       Effect.void.pipe(
         Effect.provide(
           ProviderKeyGuardLive.pipe(
-            Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+            Layer.provide(
+              Layer.merge(makeTestConfigLayer({ deployMode: "saas" }), TestSettingsLayer),
+            ),
           ),
         ),
       ),
     ) as Promise<Exit.Exit<void, TProviderKeyMissingError>>;
   }
+
+  // `_persistedProvider` is module-level (the settings mock closes over it);
+  // reset before each case so a persisted-tier test can't leak into the
+  // env-driven cases.
+  beforeEach(() => {
+    _persistedProvider = undefined;
+  });
+
+  // #3198 Codex P1 — the runtime resolves ATLAS_PROVIDER through
+  // getSettingAuto (admin-console-persisted setting → env → default), so a
+  // SaaS region that configures its provider via the admin UI (env-level
+  // ATLAS_PROVIDER unset, no AI_GATEWAY_API_KEY) must NOT be false-failed at
+  // boot. Persisted anthropic + ANTHROPIC_API_KEY present → boots.
+  test("boots in SaaS when a PERSISTED ATLAS_PROVIDER's key is set, even with env-provider unset (#3198)", async () => {
+    await withCleanEnv(() =>
+      withoutAnthropicKey(async () => {
+        process.env.ATLAS_DEPLOY_MODE = "saas"; // getDefaultProvider() would say "gateway"
+        _persistedProvider = "anthropic"; // ...but the persisted setting wins, like the runtime
+        process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+        const exit = await runGuard();
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  // Corollary — a persisted provider whose key is absent still fails boot, and
+  // reports the SETTINGS-resolved provider (not the gateway default).
+  test("fails boot in SaaS when a PERSISTED ATLAS_PROVIDER's key is missing (#3198)", async () => {
+    await withCleanEnv(() =>
+      withoutAnthropicKey(async () => {
+        process.env.ATLAS_DEPLOY_MODE = "saas";
+        _persistedProvider = "anthropic";
+        const exit = await runGuard();
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+        expect((failure as TProviderKeyMissingError).provider).toBe("anthropic");
+        expect((failure as TProviderKeyMissingError).requiredKey).toBe("ANTHROPIC_API_KEY");
+      }),
+    );
+  });
 
   // The gateway default is the SaaS prod path: ATLAS_PROVIDER unset →
   // getDefaultProvider() → "gateway" (because ATLAS_DEPLOY_MODE=saas) →
@@ -706,7 +769,9 @@ describe("ProviderKeyGuardLive", () => {
           Effect.void.pipe(
             Effect.provide(
               ProviderKeyGuardLive.pipe(
-                Layer.provide(makeTestConfigLayer({ deployMode: "self-hosted" })),
+                Layer.provide(
+                  Layer.merge(makeTestConfigLayer({ deployMode: "self-hosted" }), TestSettingsLayer),
+                ),
               ),
             ),
           ),

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -46,6 +46,7 @@ import type {
   InternalDatabaseRequiredError as TInternalDatabaseRequiredError,
   RateLimitRequiredError as TRateLimitRequiredError,
   ProviderKeyMissingError as TProviderKeyMissingError,
+  ProviderUnsupportedError as TProviderUnsupportedError,
   RegionMisconfiguredError as TRegionMisconfiguredError,
   ChatAdapterEnvMissingError as TChatAdapterEnvMissingError,
 } from "../saas-guards";
@@ -62,6 +63,7 @@ const {
   RateLimitRequiredError,
   ProviderKeyGuardLive,
   ProviderKeyMissingError,
+  ProviderUnsupportedError,
   RegionGuardLive,
   RegionMisconfiguredError,
   ChatAdapterEnvGuardLive,
@@ -610,7 +612,7 @@ describe("ProviderKeyGuardLive", () => {
     });
   }
 
-  function runGuard(): Promise<Exit.Exit<void, TProviderKeyMissingError>> {
+  function runGuard(): Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>> {
     return Effect.runPromiseExit(
       Effect.void.pipe(
         Effect.provide(
@@ -619,7 +621,7 @@ describe("ProviderKeyGuardLive", () => {
           ),
         ),
       ),
-    ) as Promise<Exit.Exit<void, TProviderKeyMissingError>>;
+    ) as Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>>;
   }
 
   // The gateway default is the SaaS prod path: ATLAS_PROVIDER unset →
@@ -687,12 +689,31 @@ describe("ProviderKeyGuardLive", () => {
   });
 
   // openai-compatible authenticates via a base URL, not a fixed key var, so
-  // PROVIDER_KEY_MAP has no entry — the guard skips rather than failing boot.
-  test("succeeds in SaaS for a provider with no mapped key (openai-compatible)", async () => {
+  // PROVIDER_KEY_MAP has no entry — but it IS a supported provider, so the guard
+  // skips the key check rather than treating it as unknown.
+  test("succeeds in SaaS for a valid keyless provider (openai-compatible)", async () => {
     await withCleanEnv(async () => {
       process.env.ATLAS_PROVIDER = "openai-compatible";
       const exit = await runGuard();
       expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // #3198 Codex (round 4) — a typo / unsupported ATLAS_PROVIDER would make
+  // resolveSelection() throw on every chat at first I/O while boot/health stay
+  // green. Fail boot with the distinct ProviderUnsupportedError instead of
+  // skipping (an unknown provider also yields PROVIDER_KEY_MAP[x] === undefined,
+  // so it must be distinguished from a valid keyless provider).
+  test("fails boot in SaaS when ATLAS_PROVIDER is an unsupported value (#3198)", async () => {
+    await withCleanEnv(async () => {
+      process.env.ATLAS_PROVIDER = "anthrop"; // typo
+      const exit = await runGuard();
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ProviderUnsupportedError);
+      expect((failure as TProviderUnsupportedError)._tag).toBe("ProviderUnsupportedError");
+      expect((failure as TProviderUnsupportedError).provider).toBe("anthrop");
+      expect((failure as TProviderUnsupportedError).message).toContain("#3178");
     });
   });
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2826,13 +2826,11 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const internalDbGuardLayer = InternalDbGuardLive.pipe(Layer.provide(configLayer));
   const rateLimitGuardLayer = RateLimitGuardLive.pipe(Layer.provide(configLayer));
   // #3178 — fails boot when the configured provider's API key is missing in
-  // SaaS (boot-green-then-503 otherwise). Depends on `Config` + `Settings`:
-  // it resolves the provider via `getSettingAuto` (admin-console setting → env
-  // → default), so it must sequence after the settings cache is warm to match
-  // the runtime (#3198). Same `configLayer + settingsLayer` shape as DpaGuard.
-  const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(
-    Layer.provide(Layer.merge(configLayer, settingsLayer)),
-  );
+  // SaaS (boot-green-then-503 otherwise). Depends only on `Config`; it resolves
+  // the provider env-only (matching getModel()/resolveProvider, the path the
+  // main chat uses — #3198) and reads its key from env, so it runs as a peer of
+  // the other env-checking guards.
+  const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(Layer.provide(configLayer));
   // #2672 — walks the chat catalog and fails boot when an oauth+enabled
   // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
   // only on `Config` and reads env directly, so it runs in parallel with

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -51,6 +51,7 @@ import {
   EncryptionKeyGuardLive,
   InternalDbGuardLive,
   RateLimitGuardLive,
+  ProviderKeyGuardLive,
   RegionGuardLive,
   PluginConfigGuardLive,
   ChatAdapterEnvGuardLive,
@@ -2824,6 +2825,11 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const encryptionKeyGuardLayer = EncryptionKeyGuardLive.pipe(Layer.provide(configLayer));
   const internalDbGuardLayer = InternalDbGuardLive.pipe(Layer.provide(configLayer));
   const rateLimitGuardLayer = RateLimitGuardLive.pipe(Layer.provide(configLayer));
+  // #3178 — fails boot when the configured provider's API key is missing in
+  // SaaS (boot-green-then-503 otherwise). Depends only on `Config`; resolves
+  // the provider + reads its key from env, so it runs as a peer of the other
+  // env-checking guards.
+  const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(Layer.provide(configLayer));
   // #2672 — walks the chat catalog and fails boot when an oauth+enabled
   // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
   // only on `Config` and reads env directly, so it runs in parallel with
@@ -2868,6 +2874,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     encryptionKeyGuardLayer,
     internalDbGuardLayer,
     rateLimitGuardLayer,
+    providerKeyGuardLayer,
     regionGuardLayer,
     pluginConfigGuardLayer,
     chatAdapterEnvGuardLayer,

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2826,10 +2826,13 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const internalDbGuardLayer = InternalDbGuardLive.pipe(Layer.provide(configLayer));
   const rateLimitGuardLayer = RateLimitGuardLive.pipe(Layer.provide(configLayer));
   // #3178 — fails boot when the configured provider's API key is missing in
-  // SaaS (boot-green-then-503 otherwise). Depends only on `Config`; resolves
-  // the provider + reads its key from env, so it runs as a peer of the other
-  // env-checking guards.
-  const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(Layer.provide(configLayer));
+  // SaaS (boot-green-then-503 otherwise). Depends on `Config` + `Settings`:
+  // it resolves the provider via `getSettingAuto` (admin-console setting → env
+  // → default), so it must sequence after the settings cache is warm to match
+  // the runtime (#3198). Same `configLayer + settingsLayer` shape as DpaGuard.
+  const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, settingsLayer)),
+  );
   // #2672 — walks the chat catalog and fails boot when an oauth+enabled
   // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
   // only on `Config` and reads env directly, so it runs in parallel with

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -41,6 +41,18 @@ export interface SaasEnv {
   // Rate limiting (RateLimitGuardLive)
   readonly ATLAS_RATE_LIMIT_RPM: string | undefined;
 
+  // LLM provider key (ProviderKeyGuardLive, #3178). `ATLAS_PROVIDER` selects
+  // the provider (unset → `getDefaultProvider()`, which is `gateway` in SaaS).
+  // `AI_GATEWAY_API_KEY` is the key the SaaS gateway-default path requires; it
+  // is listed here so `makeBootSmokeFixture` populates it (the boot-smoke gate
+  // boots on the gateway default). The guard resolves the *required* key for
+  // the configured provider dynamically via `PROVIDER_KEY_MAP` and reads it
+  // straight from `process.env` — so a non-gateway key (ANTHROPIC_API_KEY,
+  // OPENAI_API_KEY, AWS_ACCESS_KEY_ID) need not be enumerated here (same
+  // dynamic-read pattern as ChatAdapterEnvGuardLive's adapter keys).
+  readonly ATLAS_PROVIDER: string | undefined;
+  readonly AI_GATEWAY_API_KEY: string | undefined;
+
   // Region routing (RegionGuardLive + atlas.config.ts residency)
   readonly ATLAS_API_REGION: string | undefined;
   readonly ATLAS_REGION_US_DB_URL: string | undefined;
@@ -110,6 +122,8 @@ export const SAAS_ENV_KEYS = [
   "ATLAS_ENCRYPTION_KEY",
   "BETTER_AUTH_SECRET",
   "ATLAS_RATE_LIMIT_RPM",
+  "ATLAS_PROVIDER",
+  "AI_GATEWAY_API_KEY",
   "ATLAS_API_REGION",
   "ATLAS_REGION_US_DB_URL",
   "ATLAS_REGION_EU_DB_URL",
@@ -147,6 +161,8 @@ export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
     ATLAS_ENCRYPTION_KEY: env.ATLAS_ENCRYPTION_KEY,
     BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
     ATLAS_RATE_LIMIT_RPM: env.ATLAS_RATE_LIMIT_RPM,
+    ATLAS_PROVIDER: env.ATLAS_PROVIDER,
+    AI_GATEWAY_API_KEY: env.AI_GATEWAY_API_KEY,
     ATLAS_API_REGION: env.ATLAS_API_REGION,
     ATLAS_REGION_US_DB_URL: env.ATLAS_REGION_US_DB_URL,
     ATLAS_REGION_EU_DB_URL: env.ATLAS_REGION_EU_DB_URL,
@@ -217,6 +233,14 @@ export function makeBootSmokeFixture(
     // at-rest encryption — this is purely the Better Auth path.
     BETTER_AUTH_SECRET: "ci-fixture-better-auth-secret-not-a-secret-pad-pad",
     ATLAS_RATE_LIMIT_RPM: "300",
+    // ProviderKeyGuardLive (#3178): leave ATLAS_PROVIDER unset so the guard
+    // exercises the SaaS gateway default (getDefaultProvider() → "gateway"),
+    // and supply the key that path requires. Not a secret — identical every
+    // CI run, like the other fixture placeholders. The gateway SDK only reads
+    // it at per-request model init, never at boot, so any non-empty value
+    // satisfies the boot guard.
+    ATLAS_PROVIDER: undefined,
+    AI_GATEWAY_API_KEY: "ci-fixture-ai-gateway-key-not-a-secret",
     ATLAS_API_REGION: "us",
     ATLAS_REGION_US_DB_URL: databaseUrl,
     ATLAS_REGION_EU_DB_URL: databaseUrl,

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -86,7 +86,7 @@
 
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { Config, Settings } from "./layers";
+import { Config } from "./layers";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const log = createLogger("effect:saas-guards");
@@ -536,67 +536,62 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
 /**
  * Fail boot in SaaS when the configured LLM provider's API key is missing.
  *
- * Resolves the provider exactly as the runtime model-init does — `resolveSelection`
- * in `lib/providers.ts` uses `getSettingAuto("ATLAS_PROVIDER") ?? getDefaultProvider()`,
- * and `getSettingAuto` folds the DB-persisted admin setting → env (`ATLAS_PROVIDER`)
- * → registry default. The guard mirrors that precedence so it asserts on the SAME
- * key the first chat would require (see the `Settings` note below for why an
- * env-only check would be wrong). The required key is then looked up via the
- * shared `PROVIDER_KEY_MAP` (SSOT in `lib/providers.ts`):
+ * Resolves the provider EXACTLY as the main chat path does. `/api/v1/chat`
+ * (`chat.ts`) calls `runAgent()` without an injected model, which reaches
+ * `getModel()` / `getProviderType()` → `resolveProvider()` →
+ * `resolveSelection()` (no args) → `process.env.ATLAS_PROVIDER ??
+ * getDefaultProvider()` (`lib/providers.ts`). That is **env-only** — it does
+ * NOT consult `getSettingAuto`/persisted admin settings. The settings-aware
+ * `resolveModelFromSettings` / `AtlasAiModel` path (which folds the persisted
+ * `ATLAS_PROVIDER` setting) is reached only via `runAgentEffect`, which no
+ * production route calls. Matching `getModel` keeps the guard asserting on the
+ * SAME provider + key a real chat will use, and stays in lockstep with the
+ * per-request diagnostic `startup.ts:checkProviderApiKey` (also env-only).
+ * (A persisted-only `ATLAS_PROVIDER` therefore does NOT change what a real
+ * chat resolves, so an env-only guard cannot false-fail it — and `setSetting`
+ * can't mutate `process.env`, so the boot decision can't be bypassed at
+ * runtime either. See #3198.)
+ *
+ * The required key is looked up via the shared `PROVIDER_KEY_MAP` (SSOT in
+ * `lib/providers.ts`):
  *
  *   - `undefined` → unknown / unmapped provider (e.g. `openai-compatible`,
  *     which authenticates via a base URL): skip. `providers.ts` throws a
  *     descriptive error at model init for a genuinely-unknown provider, so the
- *     guard doesn't duplicate that.
+ *     guard doesn't duplicate that. (Fuller per-provider required-config
+ *     validation — Bedrock secret/region, openai-compatible base URL — is
+ *     tracked in #3200.)
  *   - `""` → `ollama`: skip (runs locally, no key).
  *   - otherwise → read the key straight from `process.env` (dynamic key, same
- *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty. (The
- *     provider *selection* is settings-aware; the API *keys* come from env, the
- *     same contract as the runtime SDK clients and `startup.ts:checkProviderApiKey`.)
+ *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty.
  *
  * Self-hosted is intentionally unaffected: an operator running a keyless dev
  * loop keeps the existing per-request 503 from `validateEnvironment` rather
  * than a hard boot failure.
  *
- * Depends on `Settings` (not just `Config`) so the persisted-settings cache is
- * loaded before the guard reads it — the runtime resolves `ATLAS_PROVIDER`
- * through `getSettingAuto()` (DB-persisted platform setting → env → default),
- * so a SaaS region that configures its provider via the admin console rather
- * than an env var would otherwise be FALSE-FAILED at boot by an env-only check
- * (#3198 Codex P1). Sequencing after `Settings` mirrors `DpaGuardLive`.
- *
- * `getDefaultProvider` + `PROVIDER_KEY_MAP` + `getSettingAuto` are pulled via
- * dynamic `import()` to keep `providers.ts` (which statically imports the
- * `@ai-sdk/*` packages) and `settings.ts` out of `saas-guards.ts`'s static
- * graph — same lazy-import wall-off as `EncryptionKeyGuardLive`. A rejected
- * import is promoted to a defect via `Effect.orDie` (rather than silently
- * skipping the check): both modules are core and always loadable at boot, so a
- * rejection means the api can't run anyway, and a silent skip would reintroduce
- * the boot-green-then-503 hole this guard closes.
+ * `getDefaultProvider` + `PROVIDER_KEY_MAP` are pulled via dynamic `import()`
+ * to keep `providers.ts` (which statically imports the `@ai-sdk/*` packages)
+ * out of `saas-guards.ts`'s static graph — same lazy-import wall-off as
+ * `EncryptionKeyGuardLive`. A rejected import is promoted to a defect via
+ * `Effect.orDie` (rather than silently skipping the check): `providers.ts` is
+ * core and always loadable at boot, so a rejection means the api can't run
+ * anyway, and a silent skip would reintroduce the boot-green-then-503 hole
+ * this guard closes.
  */
-export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config | Settings> = Layer.effectDiscard(
+export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
-    // Sequence after the persisted-settings cache is warm so `getSettingAuto`
-    // below sees admin-console-configured provider overrides, not just env.
-    yield* Settings;
 
-    const [{ getDefaultProvider, PROVIDER_KEY_MAP }, { getSettingAuto }] = yield* Effect.tryPromise({
-      try: () =>
-        Promise.all([
-          import("@atlas/api/lib/providers"),
-          import("@atlas/api/lib/settings"),
-        ]),
+    const { getDefaultProvider, PROVIDER_KEY_MAP } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/providers"),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.orDie);
 
-    // Resolve EXACTLY as the runtime model-init does (`resolveSelection` in
-    // providers.ts): `getSettingAuto("ATLAS_PROVIDER")` folds the DB-persisted
-    // platform setting → env (`ATLAS_PROVIDER`) → registry default; when none
-    // is set, `getDefaultProvider()` supplies the SaaS gateway default. This
-    // keeps the boot guard in lockstep with the provider a real chat will use.
-    const provider = getSettingAuto("ATLAS_PROVIDER") ?? getDefaultProvider();
+    // Env-only, matching getModel() → resolveProvider() → resolveSelection()
+    // (the path chat.ts/runAgent actually uses); getDefaultProvider() supplies
+    // the SaaS gateway default when ATLAS_PROVIDER is unset.
+    const provider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
     const requiredKey = PROVIDER_KEY_MAP[provider];
 
     // `undefined` → unknown/unmapped provider (skip; model init reports it).

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -43,6 +43,13 @@
  *      so a platform admin can't re-open the hole at runtime via
  *      `setSetting`.
  *
+ *   4b. {@link ProviderKeyGuardLive} (#3178) — the configured LLM provider
+ *      (`ATLAS_PROVIDER` or the gateway default) has no API key set. Without
+ *      it the api boots green and every chat 503s with `MISSING_API_KEY` at
+ *      first I/O. Resolves the provider exactly as the runtime does and reads
+ *      the required key (via `PROVIDER_KEY_MAP`) at boot. Self-hosted keeps the
+ *      per-request 503 so keyless dev loops still boot.
+ *
  *   5. {@link RegionGuardLive} (#1988 C7) — claimed `ATLAS_API_REGION`
  *      missing from `config.residency.regions` or pointing at a
  *      malformed `databaseUrl`. Without this guard, a region-routing
@@ -88,6 +95,7 @@ const ISSUE_REF = "#1978";
 const RATE_LIMIT_ISSUE_REF = "#1983";
 const ISSUE_REF_1988 = "#1988";
 const CHAT_ADAPTER_ISSUE_REF = "#2672";
+const PROVIDER_KEY_ISSUE_REF = "#3178";
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Tagged errors
@@ -154,6 +162,25 @@ export class InternalDatabaseRequiredError extends Data.TaggedError("InternalDat
  */
 export class RateLimitRequiredError extends Data.TaggedError("RateLimitRequiredError")<{
   readonly message: string;
+}> {}
+
+/**
+ * SaaS region booted with `ATLAS_PROVIDER` (or the gateway default) set to a
+ * provider whose API key env var is unset. Without this guard the api boots
+ * green, `/health` liveness stays green, and every real chat 503s via
+ * `validateEnvironment`'s per-request `MISSING_API_KEY` diagnostic — the exact
+ * "broken at first I/O" class the guard family exists to prevent (#3178).
+ *
+ * `provider` is the resolved provider string and `requiredKey` the env var that
+ * was expected (e.g. `anthropic` / `ANTHROPIC_API_KEY`), both exposed so the
+ * operator-actionable boot log names the missing key without re-parsing
+ * `message`. Self-hosted is unaffected — operators may run keyless dev loops
+ * and keep the per-request 503.
+ */
+export class ProviderKeyMissingError extends Data.TaggedError("ProviderKeyMissingError")<{
+  readonly message: string;
+  readonly provider: string;
+  readonly requiredKey: string;
 }> {}
 
 /**
@@ -496,6 +523,74 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
             `SaaS region booted with ATLAS_RATE_LIMIT_RPM=${JSON.stringify(raw)} — value would parse to ` +
             `"rate limiting disabled" at runtime via getRpmLimit() + checkRateLimit() in auth/middleware.ts. ` +
             `Set ATLAS_RATE_LIMIT_RPM to a positive integer (>= 1). See ${RATE_LIMIT_ISSUE_REF}.`,
+        }),
+      );
+    }
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  ProviderKeyGuardLive (#3178)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Fail boot in SaaS when the configured LLM provider's API key is missing.
+ *
+ * Resolves the provider exactly as the runtime model-init does
+ * (`process.env.ATLAS_PROVIDER ?? getDefaultProvider()` — see
+ * `lib/providers.ts` and `startup.ts:checkProviderApiKey`) so the guard
+ * asserts on the SAME key the first chat would require. The required key is
+ * looked up via the shared `PROVIDER_KEY_MAP` (SSOT in `lib/providers.ts`):
+ *
+ *   - `undefined` → unknown / unmapped provider (e.g. `openai-compatible`,
+ *     which authenticates via a base URL): skip. `providers.ts` throws a
+ *     descriptive error at model init for a genuinely-unknown provider, so the
+ *     guard doesn't duplicate that.
+ *   - `""` → `ollama`: skip (runs locally, no key).
+ *   - otherwise → read the key straight from `process.env` (dynamic key, same
+ *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty.
+ *
+ * Self-hosted is intentionally unaffected: an operator running a keyless dev
+ * loop keeps the existing per-request 503 from `validateEnvironment` rather
+ * than a hard boot failure.
+ *
+ * `getDefaultProvider` + `PROVIDER_KEY_MAP` are pulled via dynamic `import()`
+ * to keep `providers.ts` (which statically imports the `@ai-sdk/*` packages)
+ * out of `saas-guards.ts`'s static graph — same lazy-import wall-off as
+ * `EncryptionKeyGuardLive`. A rejected import is promoted to a defect via
+ * `Effect.orDie` (rather than silently skipping the check): `providers.ts` is
+ * core and always loadable at boot, so a rejection means the api can't run
+ * anyway, and a silent skip would reintroduce the boot-green-then-503 hole
+ * this guard closes.
+ */
+export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+
+    const { getDefaultProvider, PROVIDER_KEY_MAP } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/providers"),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.orDie);
+
+    const provider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    const requiredKey = PROVIDER_KEY_MAP[provider];
+
+    // `undefined` → unknown/unmapped provider (skip; model init reports it).
+    // `""` → ollama (skip; no key needed). `!requiredKey` covers both.
+    if (!requiredKey) return;
+
+    const value = process.env[requiredKey];
+    if (value === undefined || value === "") {
+      yield* Effect.fail(
+        new ProviderKeyMissingError({
+          provider,
+          requiredKey,
+          message:
+            `SaaS region booted with provider "${provider}" but ${requiredKey} is not set — the api ` +
+            `would boot green, /health would stay green, and every chat/query would 503 with ` +
+            `MISSING_API_KEY at first I/O. Set ${requiredKey} on every region's api service before ` +
+            `booting (or set ATLAS_PROVIDER to a provider whose key is configured). See ${PROVIDER_KEY_ISSUE_REF}.`,
         }),
       );
     }

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -86,7 +86,7 @@
 
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { Config } from "./layers";
+import { Config, Settings } from "./layers";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const log = createLogger("effect:saas-guards");
@@ -536,11 +536,13 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
 /**
  * Fail boot in SaaS when the configured LLM provider's API key is missing.
  *
- * Resolves the provider exactly as the runtime model-init does
- * (`process.env.ATLAS_PROVIDER ?? getDefaultProvider()` — see
- * `lib/providers.ts` and `startup.ts:checkProviderApiKey`) so the guard
- * asserts on the SAME key the first chat would require. The required key is
- * looked up via the shared `PROVIDER_KEY_MAP` (SSOT in `lib/providers.ts`):
+ * Resolves the provider exactly as the runtime model-init does — `resolveSelection`
+ * in `lib/providers.ts` uses `getSettingAuto("ATLAS_PROVIDER") ?? getDefaultProvider()`,
+ * and `getSettingAuto` folds the DB-persisted admin setting → env (`ATLAS_PROVIDER`)
+ * → registry default. The guard mirrors that precedence so it asserts on the SAME
+ * key the first chat would require (see the `Settings` note below for why an
+ * env-only check would be wrong). The required key is then looked up via the
+ * shared `PROVIDER_KEY_MAP` (SSOT in `lib/providers.ts`):
  *
  *   - `undefined` → unknown / unmapped provider (e.g. `openai-compatible`,
  *     which authenticates via a base URL): skip. `providers.ts` throws a
@@ -548,32 +550,53 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
  *     guard doesn't duplicate that.
  *   - `""` → `ollama`: skip (runs locally, no key).
  *   - otherwise → read the key straight from `process.env` (dynamic key, same
- *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty.
+ *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty. (The
+ *     provider *selection* is settings-aware; the API *keys* come from env, the
+ *     same contract as the runtime SDK clients and `startup.ts:checkProviderApiKey`.)
  *
  * Self-hosted is intentionally unaffected: an operator running a keyless dev
  * loop keeps the existing per-request 503 from `validateEnvironment` rather
  * than a hard boot failure.
  *
- * `getDefaultProvider` + `PROVIDER_KEY_MAP` are pulled via dynamic `import()`
- * to keep `providers.ts` (which statically imports the `@ai-sdk/*` packages)
- * out of `saas-guards.ts`'s static graph — same lazy-import wall-off as
- * `EncryptionKeyGuardLive`. A rejected import is promoted to a defect via
- * `Effect.orDie` (rather than silently skipping the check): `providers.ts` is
- * core and always loadable at boot, so a rejection means the api can't run
- * anyway, and a silent skip would reintroduce the boot-green-then-503 hole
- * this guard closes.
+ * Depends on `Settings` (not just `Config`) so the persisted-settings cache is
+ * loaded before the guard reads it — the runtime resolves `ATLAS_PROVIDER`
+ * through `getSettingAuto()` (DB-persisted platform setting → env → default),
+ * so a SaaS region that configures its provider via the admin console rather
+ * than an env var would otherwise be FALSE-FAILED at boot by an env-only check
+ * (#3198 Codex P1). Sequencing after `Settings` mirrors `DpaGuardLive`.
+ *
+ * `getDefaultProvider` + `PROVIDER_KEY_MAP` + `getSettingAuto` are pulled via
+ * dynamic `import()` to keep `providers.ts` (which statically imports the
+ * `@ai-sdk/*` packages) and `settings.ts` out of `saas-guards.ts`'s static
+ * graph — same lazy-import wall-off as `EncryptionKeyGuardLive`. A rejected
+ * import is promoted to a defect via `Effect.orDie` (rather than silently
+ * skipping the check): both modules are core and always loadable at boot, so a
+ * rejection means the api can't run anyway, and a silent skip would reintroduce
+ * the boot-green-then-503 hole this guard closes.
  */
-export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config> = Layer.effectDiscard(
+export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config | Settings> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
+    // Sequence after the persisted-settings cache is warm so `getSettingAuto`
+    // below sees admin-console-configured provider overrides, not just env.
+    yield* Settings;
 
-    const { getDefaultProvider, PROVIDER_KEY_MAP } = yield* Effect.tryPromise({
-      try: () => import("@atlas/api/lib/providers"),
+    const [{ getDefaultProvider, PROVIDER_KEY_MAP }, { getSettingAuto }] = yield* Effect.tryPromise({
+      try: () =>
+        Promise.all([
+          import("@atlas/api/lib/providers"),
+          import("@atlas/api/lib/settings"),
+        ]),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.orDie);
 
-    const provider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    // Resolve EXACTLY as the runtime model-init does (`resolveSelection` in
+    // providers.ts): `getSettingAuto("ATLAS_PROVIDER")` folds the DB-persisted
+    // platform setting → env (`ATLAS_PROVIDER`) → registry default; when none
+    // is set, `getDefaultProvider()` supplies the SaaS gateway default. This
+    // keeps the boot guard in lockstep with the provider a real chat will use.
+    const provider = getSettingAuto("ATLAS_PROVIDER") ?? getDefaultProvider();
     const requiredKey = PROVIDER_KEY_MAP[provider];
 
     // `undefined` → unknown/unmapped provider (skip; model init reports it).

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -184,6 +184,20 @@ export class ProviderKeyMissingError extends Data.TaggedError("ProviderKeyMissin
 }> {}
 
 /**
+ * SaaS region booted with `ATLAS_PROVIDER` set to a value that isn't a
+ * supported provider (a typo / unsupported vendor). `resolveSelection()` in
+ * `lib/providers.ts` throws `Unknown provider "<x>"` at model init, so the api
+ * boots green and then 503s every chat — the same boot-green-then-broken class
+ * `ProviderKeyMissingError` catches, but for the provider *name* rather than its
+ * key. Distinct error so the operator log names "unsupported provider" (not a
+ * missing key). Self-hosted keeps the per-request throw (#3198).
+ */
+export class ProviderUnsupportedError extends Data.TaggedError("ProviderUnsupportedError")<{
+  readonly message: string;
+  readonly provider: string;
+}> {}
+
+/**
  * SaaS region claims a residency region (`ATLAS_API_REGION` env var or
  * `residency.defaultRegion` in `atlas.config.ts`) that does not have a
  * matching entry in `config.residency.regions`, or whose entry has a
@@ -555,12 +569,14 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
  * The required key is looked up via the shared `PROVIDER_KEY_MAP` (SSOT in
  * `lib/providers.ts`):
  *
- *   - `undefined` → unknown / unmapped provider (e.g. `openai-compatible`,
- *     which authenticates via a base URL): skip. `providers.ts` throws a
- *     descriptive error at model init for a genuinely-unknown provider, so the
- *     guard doesn't duplicate that. (Fuller per-provider required-config
- *     validation — Bedrock secret/region, openai-compatible base URL — is
- *     tracked in #3200.)
+ *   - provider not in the supported set → a typo / unsupported vendor: fail boot
+ *     with {@link ProviderUnsupportedError} (in SaaS, `resolveSelection()` would
+ *     otherwise throw on every chat — boot-green-then-broken). `isSupportedProvider`
+ *     distinguishes this from a valid-but-keyless provider below.
+ *   - valid provider, `PROVIDER_KEY_MAP[provider] === undefined` → keyless
+ *     (e.g. `openai-compatible`, which authenticates via a base URL): skip the
+ *     key check. (Fuller per-provider required-config validation — Bedrock
+ *     secret/region, openai-compatible base URL — is tracked in #3200.)
  *   - `""` → `ollama`: skip (runs locally, no key).
  *   - otherwise → read the key straight from `process.env` (dynamic key, same
  *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty.
@@ -578,12 +594,12 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
  * anyway, and a silent skip would reintroduce the boot-green-then-503 hole
  * this guard closes.
  */
-export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, Config> = Layer.effectDiscard(
+export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError | ProviderUnsupportedError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
-    const { getDefaultProvider, PROVIDER_KEY_MAP } = yield* Effect.tryPromise({
+    const { getDefaultProvider, PROVIDER_KEY_MAP, isSupportedProvider } = yield* Effect.tryPromise({
       try: () => import("@atlas/api/lib/providers"),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.orDie);
@@ -592,10 +608,29 @@ export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError, C
     // (the path chat.ts/runAgent actually uses); getDefaultProvider() supplies
     // the SaaS gateway default when ATLAS_PROVIDER is unset.
     const provider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+
+    // Unsupported provider (typo / unknown vendor): `resolveSelection()` would
+    // throw on every chat in SaaS, so fail boot instead of skipping. Checked
+    // BEFORE the key lookup so a typo isn't mistaken for a valid keyless
+    // provider (both give `PROVIDER_KEY_MAP[provider] === undefined`).
+    if (!isSupportedProvider(provider)) {
+      return yield* Effect.fail(
+        new ProviderUnsupportedError({
+          provider,
+          message:
+            `SaaS region booted with ATLAS_PROVIDER="${provider}", which is not a supported provider — ` +
+            `model initialization (resolveSelection) would throw on every chat/query at first I/O while ` +
+            `boot and /health stay green. Set ATLAS_PROVIDER to one of: anthropic, openai, bedrock, ollama, ` +
+            `openai-compatible, gateway (or unset it to use the SaaS gateway default). See ${PROVIDER_KEY_ISSUE_REF}.`,
+        }),
+      );
+    }
+
     const requiredKey = PROVIDER_KEY_MAP[provider];
 
-    // `undefined` → unknown/unmapped provider (skip; model init reports it).
-    // `""` → ollama (skip; no key needed). `!requiredKey` covers both.
+    // Valid provider with no mapped key → keyless (`ollama` → `""`,
+    // `openai-compatible` → `undefined`): skip the key check. (#3200 tracks
+    // openai-compatible's base-URL validation.)
     if (!requiredKey) return;
 
     const value = process.env[requiredKey];

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -894,7 +894,12 @@ export function createAuthContextTestLayer(
 // so this contract can be typed without pulling in `@atlas/ee`.
 
 type ResidencyRegionRoute = {
-  readonly databaseUrl: string;
+  // Optional (#3176/#3198): a region's internal-DB URL may be unset on an
+  // instance that doesn't claim it. `getRegionAwareConnection` routes the
+  // analytics datasource off `datasourceUrl`/`region` and never reads
+  // `databaseUrl`, so it is passenger data here — omitted when unconfigured
+  // rather than coerced to an empty string.
+  readonly databaseUrl?: string;
   readonly datasourceUrl?: string;
   readonly region: string;
 };

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -69,6 +69,31 @@ export function getDefaultProvider(): ConfigProvider {
     : "anthropic";
 }
 
+/**
+ * Maps an `ATLAS_PROVIDER` value to the env var that holds its API key.
+ *
+ * Single source of truth for "which key does this provider need" — consumed
+ * by `startup.ts`'s per-request diagnostic (`checkProviderApiKey`, a 503 path)
+ * AND by `ProviderKeyGuardLive` (the SaaS boot guard, #3178) so the two agree
+ * on the exact key the runtime will require. Lives here next to
+ * {@link getDefaultProvider} (the provider-resolution SSOT) rather than in
+ * `startup.ts` so the boot guard can read it without pulling the startup
+ * module's heavy request-path graph.
+ *
+ * - `ollama` → empty string: runs locally, no API key required (callers treat
+ *   `""` as "no key needed", distinct from an unknown provider's `undefined`).
+ * - `openai-compatible` is intentionally absent: it authenticates via a base
+ *   URL, not a fixed key var, so neither the diagnostic nor the guard asserts
+ *   a key for it (lookup is `undefined` → skipped).
+ */
+export const PROVIDER_KEY_MAP: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  bedrock: "AWS_ACCESS_KEY_ID",
+  ollama: "", // Ollama runs locally, no API key required
+  gateway: "AI_GATEWAY_API_KEY",
+};
+
 /** Anthropic-family model ids contain "anthropic" or "claude". */
 function isAnthropicFamilyModelId(modelId: string): boolean {
   return modelId.includes("anthropic") || modelId.includes("claude");

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -38,6 +38,16 @@ const VALID_PROVIDERS: ReadonlySet<ConfigProvider> = new Set([
   "gateway",
 ]);
 
+/**
+ * Whether `value` is a supported `ATLAS_PROVIDER`. Exposed so boot guards can
+ * distinguish a genuinely-unknown provider (a typo — `resolveSelection()` would
+ * throw on every chat) from a valid-but-keyless one (`ollama`,
+ * `openai-compatible`). Mirrors the membership `resolveSelection()` enforces.
+ */
+export function isSupportedProvider(value: string): boolean {
+  return VALID_PROVIDERS.has(value as ConfigProvider);
+}
+
 const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { matchError } from "@useatlas/types";
 import { detectDBType, resolveDatasourceUrl } from "./db/connection";
 import { maskConnectionUrl } from "./security";
-import { getDefaultProvider } from "./providers";
+import { getDefaultProvider, PROVIDER_KEY_MAP } from "./providers";
 import { detectAuthMode, getAuthModeSource } from "./auth/detect";
 import { resolvePasskeyRpId } from "./auth/rpid";
 import { getWebOrigin } from "./web-origin";
@@ -34,13 +34,9 @@ export interface DiagnosticError {
   message: string;
 }
 
-const PROVIDER_KEY_MAP: Record<string, string> = {
-  anthropic: "ANTHROPIC_API_KEY",
-  openai: "OPENAI_API_KEY",
-  bedrock: "AWS_ACCESS_KEY_ID",
-  ollama: "", // Ollama runs locally, no API key required
-  gateway: "AI_GATEWAY_API_KEY",
-};
+// PROVIDER_KEY_MAP moved to ./providers (#3178) so the SaaS boot guard
+// (`ProviderKeyGuardLive`) can share it without importing this module's
+// heavy request-path graph. Imported above.
 
 const PROVIDER_SIGNUP_URL: Record<string, string> = {
   anthropic: "https://console.anthropic.com/settings/keys",


### PR DESCRIPTION
Hardens the **SaaS boot-guard family** — three v0.0.9 production-hardening findings that all mutate the SaaS boot path. They're one cohesive unit: *fail loud, or surface the degradation — never boot-green-then-broken.* Done on one branch because all three edit `saas-guards.ts` and/or `config.ts`.

Surfaced by `/prod-audit` (Config & Boot Guards, Part C). Craft loop: reproduced each as a boot test, then TDD'd the regression. All guards use `Data.TaggedError`; `satisfies` on returns.

---

### #3176 — region-URL parse aborted boot fleet-wide (HIGH)

`deploy/api/atlas.config.ts` declares all four regions in one `residency.regions` map, each `databaseUrl` read from a region-specific env var. The whole map was Zod-parsed with `databaseUrl: z.string().min(1)` **before** `RegionGuardLive` runs — so an empty/unset URL in *any* region (the Railway shared-scope-resolves-`""` hazard) aborted boot on **all three** api services, even the US box that never routes EU/APAC. This already bit once.

**Fix:** relax `RegionConfigSchema.databaseUrl` to `.optional()` and let the existing `RegionGuardLive` (which already validates per-claim) be the hard `postgres://` check — scoped to the **claimed** region only.
- An empty/malformed **claimed** URL still fails boot (`malformed_database_url`).
- An empty/unset **non-claimed** URL no longer takes down the fleet.
- `ee/src/platform/residency.ts` handles the now-optional URL (returns `null` for an unresolvable cross-region lookup — same contract as "region no longer configured").
- `environment-variables.mdx` clarifies each region URL is only required on the service whose `ATLAS_API_REGION` claims it.

### #3178 — add `ProviderKeyGuardLive` (HIGH)

If the configured provider's key (`ANTHROPIC_API_KEY` / `AI_GATEWAY_API_KEY` / …) was unset, SaaS **booted green**, `/health` stayed green, and every real chat 503'd via `validateEnvironment`'s per-request `MISSING_API_KEY` — exactly the "broken at first I/O" class the guard family exists to catch. No family member asserted the provider key.

**Fix:** new `ProviderKeyGuardLive` mirroring `RateLimitGuardLive`'s `Data.TaggedError` + `Layer.effectDiscard` shape, sequenced into `buildAppLayer`.
- Resolves the provider **exactly as the runtime model-init does** (`ATLAS_PROVIDER ?? getDefaultProvider()`) so it asserts on the *same* key the first chat needs.
- Required key looked up via `PROVIDER_KEY_MAP`, **moved from `startup.ts` to `providers.ts`** (its SSOT home, next to `getDefaultProvider`) so both the per-request diagnostic and the boot guard share it.
- Covers the gateway-default path (`AI_GATEWAY_API_KEY`); skips `ollama` (`""`) and unmapped providers (`openai-compatible`).
- Self-hosted is unaffected — keeps the per-request 503 so keyless dev loops still boot.
- `SaasEnv` + `makeBootSmokeFixture` extended (`ATLAS_PROVIDER`, `AI_GATEWAY_API_KEY`) so the boot-smoke gate keeps passing on the gateway default.

> Not a prod regression: prod has `AI_GATEWAY_API_KEY` set, so it boots fine. The guard can only convert an already-broken (chats-503ing) state into a louder boot failure.

### #3184 — config-file deploy-mode downgrade had no `/health` signal (LOW)

`ATLAS_DEPLOY_MODE=saas` via **env** fails boot (`EnterpriseGuardLive`). But `deployMode: "saas"` from the **config file** without enterprise only emitted a CRITICAL log and booted as self-hosted with all SaaS contracts silently skipped — easy to miss on a headless box.

**Fix:** `applyDeployMode()` stamps `deployModeDowngraded: { reason }` onto `ResolvedConfig`; `/health` surfaces it and promotes `ok → degraded` (stays 200 — the box still serves traffic). OpenAPI spec regenerated.

---

### Tests
- `saas-guards.test.ts`: 7 new `ProviderKeyGuardLive` cases (gateway-default miss, explicit-provider miss, empty-string key, ollama skip, openai-compatible skip, self-hosted boots) + 2 `RegionGuardLive` cases (non-claimed empty URL boots; claimed empty URL fails).
- `config.test.ts`: schema accepts empty/omitted non-claimed `databaseUrl`.
- `layers.test.ts`: `ProviderKeyGuardLive` wiring canary; existing InternalDb/RateLimit wiring tests set `ATLAS_PROVIDER=ollama` so their cause stays single-error.
- `saas-env.test.ts`: exhaustiveness + fixture pins for the new keys.
- `config-deploy-mode-warning.test.ts` + `health.test.ts`: downgrade flag set/unset + surfaced-degraded.
- 4 `startup-*.test.ts`: providers mock now includes `PROVIDER_KEY_MAP` (mock-all-exports).

### `/ci` — all green
`bun run type` · `bun run lint` · `bun x syncpack lint` · `check-template-drift.sh` · `check-railway-watch.sh` · full `bun run test` (exit 0) · OpenAPI drift regenerated.

Closes #3176
Closes #3178
Closes #3184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783194014&installation_id=135337507&pr_number=3198&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3198&signature=507f6fb9be51d176cddaf5d7b8a36aa2dda445da47b458935e9dadda4f282e26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Data Residency env var guidance: per-service scoping for region DB URLs and when they may be empty.

* **New Features**
  * Health endpoint can surface an optional deploy-mode downgrade reason and downgrade status to "degraded" (response may include the reason).
  * SaaS startup now enforces required provider API-key presence and fails early when missing.

* **Bug Fixes**
  * Non-claimed region database URLs may be omitted (optional) to support multi-region setups.

* **Tests**
  * Added/expanded tests for deploy-mode downgrade, provider-key guards, and region DB behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->