### PR TITLE
fix(api,mcp): cache /health plugin probes + init OTel in standalone MCP (#3201, #3199)

### DIFF
--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -180,6 +180,9 @@ mock.module("@atlas/api/lib/plugins/registry", () => ({
   plugins: {
     describe: () => pluginDescribeImpl(),
     healthCheckAll: () => pluginHealthCheckAllImpl(),
+    // #3201 — the route calls the cached variant; drive it from the same
+    // per-scenario impl so existing health tests exercise the real code path.
+    healthCheckAllCached: () => pluginHealthCheckAllImpl(),
     getAll: () => [],
     getAllHealthy: () => [],
     getByType: () => [],

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -361,7 +361,14 @@ health.openapi(healthRoute, async (c) => {
       const { plugins } = await import("@atlas/api/lib/plugins/registry");
       const registered = plugins.describe();
       if (registered.length > 0) {
-        const probe = await plugins.healthCheckAll();
+        // #3201 — `/health` is public + unauthenticated, so a monitor poll
+        // loop / request burst would otherwise fan out one live upstream
+        // probe per credential-backed plugin on every request. The *Cached
+        // variant serves a short-TTL liveness snapshot (configurable via
+        // ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS) so repeated hits probe each
+        // upstream at most once per window. An unhealthy plugin still
+        // surfaces — failing results are cached verbatim, not masked.
+        const probe = await plugins.healthCheckAllCached();
         const items = registered.map((p) => {
           const result = probe.get(p.id);
           // /health is public, no auth (file header) — every operator-facing
@@ -396,16 +403,19 @@ health.openapi(healthRoute, async (c) => {
         };
       }
     } catch (err) {
-      // healthCheckAll() at the registry level throwing is operator-significant
-      // — the per-plugin try/catch in PluginRegistry.healthCheckAll already
-      // catches individual probe failures, so reaching this branch implies
-      // module load failure, registry corruption, or an iterator bug. log.error
-      // (not warn) so the structured-log scraper paged on errors picks it up.
-      // /health still returns — the dashboard is most needed when things are
-      // broken. The hardcoded message is safe (no plugin-supplied content).
+      // healthCheckAllCached() at the registry level throwing is
+      // operator-significant — the per-plugin try/catch in
+      // PluginRegistry.healthCheckAll already catches individual probe
+      // failures, so reaching this branch implies module load failure,
+      // registry corruption, or an iterator bug. A rejected probe is not
+      // cached, so the next request re-probes rather than serving a stale
+      // failure. log.error (not warn) so the structured-log scraper paged on
+      // errors picks it up. /health still returns — the dashboard is most
+      // needed when things are broken. The hardcoded message is safe (no
+      // plugin-supplied content).
       log.error(
         { err: err instanceof Error ? err : new Error(String(err)) },
-        "Plugin healthCheckAll() failed at the registry level — surfacing plugins component as degraded",
+        "Plugin healthCheckAllCached() failed at the registry level — surfacing plugins component as degraded",
       );
       pluginAggregateDegraded = true;
       pluginsComponent = {

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -253,10 +253,9 @@ export const TelemetryLive: Layer.Layer<Telemetry> = Layer.scoped(
     if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
       const result = yield* Effect.tryPromise({
         try: async () => {
-          const { shutdownTelemetry } = await import(
-            "@atlas/api/lib/telemetry"
-          );
-          return shutdownTelemetry;
+          const { initTelemetry } = await import("@atlas/api/lib/telemetry");
+          // Defaults service.name to "atlas-api" (or OTEL_SERVICE_NAME).
+          return await initTelemetry();
         },
         catch: (err) => (err instanceof Error ? err.message : String(err)),
       }).pipe(

--- a/packages/api/src/lib/plugins/__tests__/registry.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 
 // Capture spans recorded by the registry (#1979) without spinning up an
 // in-memory exporter. Must be registered before importing PluginRegistry
@@ -17,7 +17,7 @@ mock.module("@atlas/api/lib/tracing", () => ({
   withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
 }));
 
-const { PluginRegistry } = await import("../registry");
+const { PluginRegistry, getPluginHealthCacheTtlMs } = await import("../registry");
 type PluginRegistryT = InstanceType<typeof PluginRegistry>;
 import type { PluginLike, PluginContextLike } from "../registry";
 
@@ -242,6 +242,181 @@ describe("PluginRegistry", () => {
 
       await registry.healthCheckAll();
       expect(registry.getStatus("test-plugin")).toBe("unhealthy");
+    });
+  });
+
+  // --- healthCheckAllCached (#3201) ---
+
+  describe("healthCheckAllCached", () => {
+    // Build a plugin whose healthCheck increments a shared counter so tests
+    // can assert how many times the upstream probe actually ran.
+    function countingPlugin(
+      counter: { calls: number },
+      result: () => Promise<{ healthy: boolean; message?: string }> = async () => ({
+        healthy: true,
+      }),
+    ): PluginLike {
+      return makePlugin({
+        healthCheck: async () => {
+          counter.calls++;
+          return result();
+        },
+      });
+    }
+
+    test("repeated calls within the TTL probe upstream at most once", async () => {
+      const counter = { calls: 0 };
+      registry.register(countingPlugin(counter));
+      await registry.initializeAll(minimalCtx);
+
+      // Large TTL — the second sequential call must hit the cache.
+      const a = await registry.healthCheckAllCached(60_000);
+      const b = await registry.healthCheckAllCached(60_000);
+
+      expect(counter.calls).toBe(1);
+      expect(b.get("test-plugin")?.healthy).toBe(true);
+      // Same snapshot object returned from the cache.
+      expect(b).toBe(a);
+    });
+
+    test("re-probes once the TTL has elapsed", async () => {
+      const counter = { calls: 0 };
+      registry.register(countingPlugin(counter));
+      await registry.initializeAll(minimalCtx);
+
+      // ttl=0 → every sequential call is considered stale and re-probes.
+      await registry.healthCheckAllCached(0);
+      await registry.healthCheckAllCached(0);
+
+      expect(counter.calls).toBe(2);
+    });
+
+    test("coalesces concurrent callers onto a single in-flight probe", async () => {
+      const counter = { calls: 0 };
+      registry.register(
+        countingPlugin(
+          counter,
+          () =>
+            // Defer resolution a tick so both callers observe the in-flight probe.
+            new Promise((resolve) =>
+              setTimeout(() => resolve({ healthy: true }), 5),
+            ),
+        ),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      const [a, b] = await Promise.all([
+        registry.healthCheckAllCached(60_000),
+        registry.healthCheckAllCached(60_000),
+      ]);
+
+      expect(counter.calls).toBe(1);
+      expect(a).toBe(b);
+    });
+
+    test("caches an unhealthy result verbatim — the cache never masks it", async () => {
+      const counter = { calls: 0 };
+      registry.register(
+        countingPlugin(counter, async () => ({
+          healthy: false,
+          message: "upstream down",
+        })),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      const first = await registry.healthCheckAllCached(60_000);
+      const second = await registry.healthCheckAllCached(60_000);
+
+      expect(counter.calls).toBe(1);
+      for (const snapshot of [first, second]) {
+        const entry = snapshot.get("test-plugin");
+        expect(entry?.healthy).toBe(false);
+        expect(entry?.status).toBe("unhealthy");
+        expect(entry?.message).toBe("upstream down");
+      }
+    });
+
+    test("does not cache a rejected probe — the next call re-probes", async () => {
+      const counter = { calls: 0 };
+      registry.register(countingPlugin(counter)); // always healthy
+      await registry.initializeAll(minimalCtx);
+
+      // healthCheckAll catches per-plugin failures, so it never rejects from a
+      // plugin probe. The rejection path is a registry-level failure (module
+      // load, iterator bug). Force it to reject once, then delegate to the
+      // real implementation.
+      const realHealthCheckAll = registry.healthCheckAll.bind(registry);
+      let threw = false;
+      registry.healthCheckAll = async () => {
+        if (!threw) {
+          threw = true;
+          throw new Error("registry-level failure");
+        }
+        return realHealthCheckAll();
+      };
+
+      await expect(registry.healthCheckAllCached(60_000)).rejects.toThrow(
+        "registry-level failure",
+      );
+      // Rejection was not cached: the retry probes live and resolves healthy.
+      const retry = await registry.healthCheckAllCached(60_000);
+      expect(retry.get("test-plugin")?.healthy).toBe(true);
+      expect(counter.calls).toBe(1); // probe ran once, on the successful retry
+    });
+
+    test("_reset clears the cached snapshot", async () => {
+      const counter = { calls: 0 };
+      registry.register(countingPlugin(counter));
+      await registry.initializeAll(minimalCtx);
+
+      await registry.healthCheckAllCached(60_000);
+      expect(counter.calls).toBe(1);
+
+      registry._reset();
+      // After reset there are no plugins; re-register and probe again.
+      registry.register(countingPlugin(counter));
+      await registry.initializeAll(minimalCtx);
+      await registry.healthCheckAllCached(60_000);
+
+      // A fresh probe ran post-reset (cache did not survive the reset).
+      expect(counter.calls).toBe(2);
+    });
+  });
+
+  // --- getPluginHealthCacheTtlMs (#3201) ---
+
+  describe("getPluginHealthCacheTtlMs", () => {
+    const ENV = "ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS";
+    const orig = process.env[ENV];
+
+    afterEach(() => {
+      if (orig === undefined) delete process.env[ENV];
+      else process.env[ENV] = orig;
+    });
+
+    test("defaults to 15000ms when unset", () => {
+      delete process.env[ENV];
+      expect(getPluginHealthCacheTtlMs()).toBe(15_000);
+    });
+
+    test("honours a valid override", () => {
+      process.env[ENV] = "30000";
+      expect(getPluginHealthCacheTtlMs()).toBe(30_000);
+    });
+
+    test("allows 0 to disable caching", () => {
+      process.env[ENV] = "0";
+      expect(getPluginHealthCacheTtlMs()).toBe(0);
+    });
+
+    test("falls back to the default on a non-numeric value", () => {
+      process.env[ENV] = "not-a-number";
+      expect(getPluginHealthCacheTtlMs()).toBe(15_000);
+    });
+
+    test("falls back to the default on a negative value", () => {
+      process.env[ENV] = "-1";
+      expect(getPluginHealthCacheTtlMs()).toBe(15_000);
     });
   });
 

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -12,6 +12,50 @@ import { withSpan } from "@atlas/api/lib/tracing";
 const log = createLogger("plugins");
 
 // ---------------------------------------------------------------------------
+// Cached-liveness TTL for /health (#3201)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default TTL (ms) for the cached plugin-liveness snapshot served to `/health`.
+ *
+ * `/health` is public + unauthenticated and probes every credential-backed
+ * plugin on each request (jira → /myself, salesforce connection probe, email
+ * → Resend /domains, twenty → /rest/open-api/core). A monitor poll loop or a
+ * request burst would otherwise amplify into N live upstream calls per request.
+ * A short TTL collapses repeats onto a single probe while staying fresh enough
+ * to surface a newly-unhealthy plugin within ~15s.
+ */
+const DEFAULT_PLUGIN_HEALTH_CACHE_TTL_MS = 15_000;
+
+/** Upper bound — caps accidental over-staleness from a fat-fingered env value. */
+const MAX_PLUGIN_HEALTH_CACHE_TTL_MS = 300_000;
+
+let lastWarnedHealthTtl: string | undefined;
+
+/**
+ * Resolve the plugin-liveness cache TTL (ms) from
+ * `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`. Falls back to the 15s default on an
+ * absent / unparseable / out-of-range value. `0` is valid and disables
+ * caching (every call re-probes upstream).
+ */
+export function getPluginHealthCacheTtlMs(): number {
+  const raw = process.env.ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS;
+  if (raw === undefined || raw === "") return DEFAULT_PLUGIN_HEALTH_CACHE_TTL_MS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0 || n > MAX_PLUGIN_HEALTH_CACHE_TTL_MS) {
+    if (raw !== lastWarnedHealthTtl) {
+      log.warn(
+        { value: raw },
+        `Invalid ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS; using default ${DEFAULT_PLUGIN_HEALTH_CACHE_TTL_MS}ms`,
+      );
+      lastWarnedHealthTtl = raw;
+    }
+    return DEFAULT_PLUGIN_HEALTH_CACHE_TTL_MS;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
 // Structural interfaces (no import from @useatlas/plugin-sdk)
 // ---------------------------------------------------------------------------
 
@@ -23,6 +67,12 @@ export interface PluginHealthResult {
 
 export type PluginType = "datasource" | "context" | "interaction" | "action" | "sandbox";
 export type PluginStatus = "registered" | "initializing" | "healthy" | "unhealthy" | "teardown";
+
+/** Per-plugin liveness keyed by plugin id — the shape `healthCheckAll` returns. */
+export type PluginHealthSnapshot = Map<
+  string,
+  PluginHealthResult & { status: PluginStatus }
+>;
 
 /**
  * Serializable config field description for admin UI form generation.
@@ -95,6 +145,17 @@ export class PluginRegistry {
   private idSet = new Set<string>();
   private initialized = false;
 
+  // ── Cached plugin liveness for /health (#3201) ─────────────────────────
+  // The public, unauthenticated `/health` route calls `healthCheckAllCached`
+  // (not `healthCheckAll`) so a monitor poll loop / request burst collapses
+  // onto a single upstream probe per TTL window instead of fanning out N
+  // external calls per request. The route's cheap in-process checks (DB
+  // SELECT 1, etc.) stay live — only the credential-backed plugin probes are
+  // cached here.
+  private healthSnapshot: { at: number; result: PluginHealthSnapshot } | null =
+    null;
+  private healthSnapshotInFlight: Promise<PluginHealthSnapshot> | null = null;
+
   // `register` is intentionally not span-wrapped: synchronous, sub-millisecond
   // array push. A span here would dwarf its own measurement and clutter every
   // plugin boot trace. `init` / `teardown` / `healthCheckAll` are wrapped
@@ -165,13 +226,17 @@ export class PluginRegistry {
   /**
    * Run health checks on all registered plugins. Returns a map of plugin id
    * to health result with current status. Catches exceptions from probes.
+   *
+   * Always probes live — every credential-backed plugin's upstream is hit.
+   * The unauthenticated `/health` route must call `healthCheckAllCached`
+   * instead so repeated polls don't amplify into N external calls per request.
    */
-  async healthCheckAll(): Promise<Map<string, PluginHealthResult & { status: PluginStatus }>> {
+  async healthCheckAll(): Promise<PluginHealthSnapshot> {
     return withSpan(
       "atlas.plugin.healthCheckAll",
       { "atlas.plugin_count": this.entries.length },
       async () => {
-        const results = new Map<string, PluginHealthResult & { status: PluginStatus }>();
+        const results: PluginHealthSnapshot = new Map();
 
         for (const entry of this.entries) {
           if (!entry.plugin.healthCheck) {
@@ -195,6 +260,46 @@ export class PluginRegistry {
         return results;
       },
     );
+  }
+
+  /**
+   * Like {@link healthCheckAll}, but serves a cached snapshot while the
+   * previous probe is younger than `ttlMs` (default
+   * `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`, 15s). Built for the public,
+   * unauthenticated `/health` route: it bounds upstream fan-out so a monitor
+   * poll loop or request burst triggers each credential-backed plugin probe
+   * at most once per TTL window.
+   *
+   * - Concurrent callers during an in-flight probe share that probe rather
+   *   than each spawning their own (request coalescing).
+   * - Unhealthy results are cached verbatim — caching never converts a failing
+   *   probe into a healthy one, so an unhealthy plugin still surfaces.
+   * - A probe that rejects is NOT cached: the rejection propagates (so the
+   *   caller can surface `degraded`) and the next call re-probes. Any prior
+   *   snapshot is left untouched rather than being clobbered by the failure.
+   * - `ttlMs === 0` disables caching (every call re-probes).
+   */
+  async healthCheckAllCached(
+    ttlMs: number = getPluginHealthCacheTtlMs(),
+  ): Promise<PluginHealthSnapshot> {
+    const snapshot = this.healthSnapshot;
+    if (snapshot && Date.now() - snapshot.at < ttlMs) {
+      return snapshot.result;
+    }
+    if (this.healthSnapshotInFlight) {
+      return this.healthSnapshotInFlight;
+    }
+
+    const inFlight = this.healthCheckAll()
+      .then((result) => {
+        this.healthSnapshot = { at: Date.now(), result };
+        return result;
+      })
+      .finally(() => {
+        this.healthSnapshotInFlight = null;
+      });
+    this.healthSnapshotInFlight = inFlight;
+    return inFlight;
   }
 
   /**
@@ -311,6 +416,8 @@ export class PluginRegistry {
     this.entries = [];
     this.idSet.clear();
     this.initialized = false;
+    this.healthSnapshot = null;
+    this.healthSnapshotInFlight = null;
   }
 }
 

--- a/packages/api/src/lib/telemetry.ts
+++ b/packages/api/src/lib/telemetry.ts
@@ -1,61 +1,120 @@
 /**
- * OpenTelemetry SDK initialization for the Atlas API server.
+ * OpenTelemetry SDK bootstrap (traces + metrics).
  *
- * Separated from tracing.ts (span helpers) so the SDK is only loaded when
- * OTEL_EXPORTER_OTLP_ENDPOINT is set. Without this import, @opentelemetry/api
- * returns no-op tracers — zero overhead.
+ * Shared by the API server (via `TelemetryLive` in `lib/effect/layers.ts`) and
+ * the standalone MCP process (via `@atlas/mcp`'s `startMcpTelemetry`, #3199).
  *
- * Import this module once during server startup:
- *   if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) await import("@atlas/api/lib/telemetry");
+ * Only ever reached when OTEL_EXPORTER_OTLP_ENDPOINT is set — every caller
+ * gates the dynamic `import()` of this module on the endpoint being present.
+ * Importing the module is cheap (no side effects); the heavy
+ * `@opentelemetry/sdk-node` graph is pulled in lazily inside `initTelemetry()`.
+ * Without an init call, `@opentelemetry/api` returns no-op tracers/meters —
+ * zero overhead.
+ *
+ * Keeping the `@opentelemetry/sdk-node` import dynamic (and out of any module's
+ * STATIC graph) is load-bearing: Next.js's App Router tracer follows static
+ * imports, so a request-path consumer that statically reached this module
+ * would fail the create-atlas standalone scaffold build trying to resolve
+ * `@opentelemetry/sdk-node` (see the notes in `lib/config.ts` /
+ * `lib/effect/saas-guards.ts`).
+ *
+ * @example
+ *   if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+ *     const { initTelemetry } = await import("@atlas/api/lib/telemetry");
+ *     const shutdown = await initTelemetry();
+ *     // ... later, during graceful shutdown:
+ *     await shutdown();
+ *   }
  */
 
-const { NodeSDK } = await import("@opentelemetry/sdk-node");
-const { OTLPTraceExporter } = await import(
-  "@opentelemetry/exporter-trace-otlp-http"
-);
-const { OTLPMetricExporter } = await import(
-  "@opentelemetry/exporter-metrics-otlp-http"
-);
-const { PeriodicExportingMetricReader } = await import(
-  "@opentelemetry/sdk-metrics"
-);
-const { resourceFromAttributes } = await import("@opentelemetry/resources");
-const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = await import(
-  "@opentelemetry/semantic-conventions"
-);
+import type { NodeSDK } from "@opentelemetry/sdk-node";
 
-const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+export interface InitTelemetryOptions {
+  /**
+   * Resource `service.name`. Defaults to `OTEL_SERVICE_NAME`, then
+   * `"atlas-api"`. The standalone MCP process passes `"atlas-mcp"` so its
+   * spans/metrics are attributed to the MCP service rather than the API.
+   */
+  serviceName?: string;
+}
 
-const resource = resourceFromAttributes({
-  [ATTR_SERVICE_NAME]: "atlas-api",
-  [ATTR_SERVICE_VERSION]: process.env.npm_package_version ?? "0.0.0",
-});
-
-const traceExporter = new OTLPTraceExporter({
-  url: `${endpoint}/v1/traces`,
-});
-
-// Metric reader — without this, every meter defined in metrics.ts
-// (atlas.abuse.*, atlas.mcp.*, atlas.oauth.*, atlas.rate_limit.*,
-// atlas.crm_outbox.*) feeds a no-op meter and is silently dropped even
-// when OTEL_EXPORTER_OTLP_ENDPOINT is set. Export to the same collector
-// as traces on a 60s cadence so dashboards/alerts built on those counters
-// actually receive data.
-const metricReader = new PeriodicExportingMetricReader({
-  exporter: new OTLPMetricExporter({
-    url: `${endpoint}/v1/metrics`,
-  }),
-  exportIntervalMillis: 60_000,
-});
-
-const sdk = new NodeSDK({ resource, traceExporter, metricReader });
-sdk.start();
+// Process-global singleton. The OTel NodeSDK installs global tracer/meter
+// providers, so a second `start()` would double-register. An idempotent init
+// lets multiple boot paths in one process (e.g. the API Effect layer, or a
+// future in-process embed) call it without racing.
+let sdk: NodeSDK | null = null;
 
 /**
- * Flush pending spans and shut down the SDK.
- * Called from the server's graceful shutdown sequence — not a standalone
- * SIGTERM handler, to avoid racing with process.exit().
+ * Start the OTel NodeSDK exporting traces + metrics to
+ * `OTEL_EXPORTER_OTLP_ENDPOINT`. Idempotent — a second call is a no-op and
+ * returns the same shutdown handle. Returns a shutdown function that flushes
+ * pending spans/metrics and tears the SDK down.
+ *
+ * Callers are responsible for gating on the endpoint being set (so the heavy
+ * SDK graph is never imported when telemetry is disabled).
+ */
+export async function initTelemetry(
+  opts: InitTelemetryOptions = {},
+): Promise<() => Promise<void>> {
+  if (sdk) return shutdownTelemetry;
+
+  const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+  const { NodeSDK } = await import("@opentelemetry/sdk-node");
+  const { OTLPTraceExporter } = await import(
+    "@opentelemetry/exporter-trace-otlp-http"
+  );
+  const { OTLPMetricExporter } = await import(
+    "@opentelemetry/exporter-metrics-otlp-http"
+  );
+  const { PeriodicExportingMetricReader } = await import(
+    "@opentelemetry/sdk-metrics"
+  );
+  const { resourceFromAttributes } = await import("@opentelemetry/resources");
+  const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = await import(
+    "@opentelemetry/semantic-conventions"
+  );
+
+  const serviceName =
+    opts.serviceName ?? process.env.OTEL_SERVICE_NAME ?? "atlas-api";
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_VERSION]: process.env.npm_package_version ?? "0.0.0",
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${endpoint}/v1/traces`,
+  });
+
+  // Metric reader — without this, every meter defined in metrics.ts
+  // (atlas.abuse.*, atlas.mcp.*, atlas.oauth.*, atlas.rate_limit.*,
+  // atlas.crm_outbox.*) feeds a no-op meter and is silently dropped even
+  // when OTEL_EXPORTER_OTLP_ENDPOINT is set. Export to the same collector
+  // as traces on a 60s cadence so dashboards/alerts built on those counters
+  // actually receive data.
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({
+      url: `${endpoint}/v1/metrics`,
+    }),
+    exportIntervalMillis: 60_000,
+  });
+
+  sdk = new NodeSDK({ resource, traceExporter, metricReader });
+  sdk.start();
+
+  return shutdownTelemetry;
+}
+
+/**
+ * Flush pending spans/metrics and shut down the SDK. Idempotent — a no-op if
+ * the SDK was never started. Called from each process's graceful-shutdown
+ * sequence (the API Effect finalizer; the MCP SIGINT/SIGTERM handlers) — not a
+ * standalone SIGTERM handler, to avoid racing with `process.exit()`.
  */
 export async function shutdownTelemetry(): Promise<void> {
-  await sdk.shutdown();
+  if (!sdk) return;
+  const current = sdk;
+  sdk = null;
+  await current.shutdown();
 }

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -169,6 +169,24 @@ export {
 // Re-export handleActionApproval from extracted query module
 export { handleActionApproval } from "../src/commands/query";
 
+/**
+ * Flush + tear down OTel on graceful shutdown of the `atlas mcp` server.
+ * Best-effort — a telemetry shutdown failure must not block process exit.
+ * No-op when telemetry was never started (`shutdown` is null). (#3199)
+ */
+async function shutdownMcpTelemetry(
+  shutdown: (() => Promise<void>) | null,
+): Promise<void> {
+  if (!shutdown) return;
+  try {
+    await shutdown();
+  } catch (err) {
+    console.error(
+      `[atlas] Error shutting down OpenTelemetry: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 // --- Main ---
 
 async function main() {
@@ -281,6 +299,14 @@ async function main() {
     }
 
     try {
+      // #3199 — the CLI `atlas mcp` command is a standalone MCP process too;
+      // initialize OTel (no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set) so
+      // its atlas.mcp.* signals export, mirroring packages/mcp's bin/serve.ts.
+      const { startMcpTelemetry } = await import(
+        "@atlas/mcp/telemetry-bootstrap"
+      );
+      const shutdownTelemetry = await startMcpTelemetry();
+
       const { createAtlasMcpServer } = await import(
         "@atlas/mcp/server"
       );
@@ -306,6 +332,7 @@ async function main() {
               `[atlas] Error closing SSE server: ${err instanceof Error ? err.message : String(err)}`,
             );
           }
+          await shutdownMcpTelemetry(shutdownTelemetry);
           process.exit(0);
         };
         process.on("SIGINT", shutdown);
@@ -316,6 +343,24 @@ async function main() {
           "@modelcontextprotocol/sdk/server/stdio.js"
         );
         await server.connect(new StdioServerTransport());
+
+        let shuttingDown = false;
+        const shutdown = async () => {
+          if (shuttingDown) return;
+          shuttingDown = true;
+          try {
+            await server.close();
+          } catch (err) {
+            console.error(
+              `[atlas] Error closing server: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          await shutdownMcpTelemetry(shutdownTelemetry);
+          process.exit(0);
+        };
+        process.on("SIGINT", shutdown);
+        process.on("SIGTERM", shutdown);
+
         console.error("[atlas] MCP server running on stdio");
       }
     } catch (err) {

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -169,24 +169,6 @@ export {
 // Re-export handleActionApproval from extracted query module
 export { handleActionApproval } from "../src/commands/query";
 
-/**
- * Flush + tear down OTel on graceful shutdown of the `atlas mcp` server.
- * Best-effort — a telemetry shutdown failure must not block process exit.
- * No-op when telemetry was never started (`shutdown` is null). (#3199)
- */
-async function shutdownMcpTelemetry(
-  shutdown: (() => Promise<void>) | null,
-): Promise<void> {
-  if (!shutdown) return;
-  try {
-    await shutdown();
-  } catch (err) {
-    console.error(
-      `[atlas] Error shutting down OpenTelemetry: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
 // --- Main ---
 
 async function main() {
@@ -299,14 +281,6 @@ async function main() {
     }
 
     try {
-      // #3199 — the CLI `atlas mcp` command is a standalone MCP process too;
-      // initialize OTel (no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set) so
-      // its atlas.mcp.* signals export, mirroring packages/mcp's bin/serve.ts.
-      const { startMcpTelemetry } = await import(
-        "@atlas/mcp/telemetry-bootstrap"
-      );
-      const shutdownTelemetry = await startMcpTelemetry();
-
       const { createAtlasMcpServer } = await import(
         "@atlas/mcp/server"
       );
@@ -332,7 +306,6 @@ async function main() {
               `[atlas] Error closing SSE server: ${err instanceof Error ? err.message : String(err)}`,
             );
           }
-          await shutdownMcpTelemetry(shutdownTelemetry);
           process.exit(0);
         };
         process.on("SIGINT", shutdown);
@@ -343,24 +316,6 @@ async function main() {
           "@modelcontextprotocol/sdk/server/stdio.js"
         );
         await server.connect(new StdioServerTransport());
-
-        let shuttingDown = false;
-        const shutdown = async () => {
-          if (shuttingDown) return;
-          shuttingDown = true;
-          try {
-            await server.close();
-          } catch (err) {
-            console.error(
-              `[atlas] Error closing server: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-          await shutdownMcpTelemetry(shutdownTelemetry);
-          process.exit(0);
-        };
-        process.on("SIGINT", shutdown);
-        process.on("SIGTERM", shutdown);
-
         console.error("[atlas] MCP server running on stdio");
       }
     } catch (err) {

--- a/packages/mcp/bin/serve.ts
+++ b/packages/mcp/bin/serve.ts
@@ -29,6 +29,7 @@
 
 import { createAtlasMcpServer } from "../src/server.js";
 import { resolveMcpActor } from "../src/actor.js";
+import { startMcpTelemetry } from "../src/telemetry-bootstrap.js";
 import { initializeConfig } from "@atlas/api/lib/config";
 
 function parseArgs(argv: string[]) {
@@ -66,6 +67,11 @@ function parseArgs(argv: string[]) {
 async function main() {
   const { transport, port, corsOrigin } = parseArgs(process.argv);
 
+  // #3199 — initialize OTel in the standalone MCP process so atlas.mcp.*
+  // traces/metrics actually export. No-op (returns null) unless
+  // OTEL_EXPORTER_OTLP_ENDPOINT is set; covers both stdio and sse transports.
+  const shutdownTelemetry = await startMcpTelemetry();
+
   if (transport === "sse") {
     // #1858: resolve the actor once at boot and share it across all SSE
     // sessions. The doc contract says "fails loud at boot if mis-configured"
@@ -90,6 +96,7 @@ async function main() {
       } catch (err) {
         console.error(`[atlas-mcp] Error closing SSE server: ${err instanceof Error ? err.message : String(err)}`);
       }
+      await shutdownMcpTelemetry(shutdownTelemetry);
       process.exit(0);
     };
 
@@ -117,6 +124,7 @@ async function main() {
     } catch (err) {
       console.error(`[atlas-mcp] Error closing server: ${err instanceof Error ? err.message : String(err)}`);
     }
+    await shutdownMcpTelemetry(shutdownTelemetry);
     process.exit(0);
   };
 
@@ -125,6 +133,24 @@ async function main() {
 
   // Log to stderr so it doesn't interfere with JSON-RPC on stdout
   console.error("[atlas-mcp] Server running on stdio");
+}
+
+/**
+ * Flush + tear down OTel on graceful shutdown. Best-effort: a telemetry
+ * shutdown failure must not block process exit. No-op when telemetry was
+ * never started (`shutdown` is null).
+ */
+async function shutdownMcpTelemetry(
+  shutdown: (() => Promise<void>) | null,
+): Promise<void> {
+  if (!shutdown) return;
+  try {
+    await shutdown();
+  } catch (err) {
+    console.error(
+      `[atlas-mcp] Error shutting down OpenTelemetry: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 main().catch((err) => {

--- a/packages/mcp/bin/serve.ts
+++ b/packages/mcp/bin/serve.ts
@@ -27,10 +27,15 @@
  *   # Connect via: http://localhost:8080/mcp
  */
 
-import { createAtlasMcpServer } from "../src/server.js";
-import { resolveMcpActor } from "../src/actor.js";
+// NOTE: only telemetry-bootstrap is imported statically here. The MCP server
+// modules (server.ts → tools/prompts → @atlas/api/lib/metrics) are imported
+// *dynamically* inside main(), AFTER startMcpTelemetry(), because
+// @opentelemetry/api@1.x has no ProxyMeter: a meter obtained before
+// sdk.start() is a permanent no-op, so any module that creates atlas.mcp.*
+// instruments must load only after the SDK is running, or its counters never
+// export (#3199). The API server gets this ordering for free via Next.js's
+// instrumentation.ts register() hook; the standalone process must enforce it.
 import { startMcpTelemetry } from "../src/telemetry-bootstrap.js";
-import { initializeConfig } from "@atlas/api/lib/config";
 
 function parseArgs(argv: string[]) {
   const args = argv.slice(2);
@@ -67,10 +72,14 @@ function parseArgs(argv: string[]) {
 async function main() {
   const { transport, port, corsOrigin } = parseArgs(process.argv);
 
-  // #3199 — initialize OTel in the standalone MCP process so atlas.mcp.*
-  // traces/metrics actually export. No-op (returns null) unless
-  // OTEL_EXPORTER_OTLP_ENDPOINT is set; covers both stdio and sse transports.
+  // #3199 — initialize OTel FIRST (before importing any MCP server module so
+  // atlas.mcp.* instruments bind to the real meter, see the import note above).
+  // No-op (returns null) unless OTEL_EXPORTER_OTLP_ENDPOINT is set; covers both
+  // stdio and sse transports.
   const shutdownTelemetry = await startMcpTelemetry();
+
+  // Dynamic import — must come after startMcpTelemetry() (see import note).
+  const { createAtlasMcpServer } = await import("../src/server.js");
 
   if (transport === "sse") {
     // #1858: resolve the actor once at boot and share it across all SSE
@@ -78,6 +87,8 @@ async function main() {
     // — resolving lazily per-session would push the failure to the first
     // request and let the server start in a known-broken state. Initialize
     // config first since `resolveMcpActor` touches the internal DB.
+    const { initializeConfig } = await import("@atlas/api/lib/config");
+    const { resolveMcpActor } = await import("../src/actor.js");
     await initializeConfig();
     const actor = await resolveMcpActor();
 
@@ -130,6 +141,14 @@ async function main() {
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+
+  // An MCP host can end a stdio session by closing stdin rather than sending a
+  // signal. When OTel is on, the periodic metric-reader timer keeps the event
+  // loop alive, so the process would hang after the transport ends. Tear down
+  // on stdin EOF/close too (the shuttingDown guard makes the double path safe).
+  // (#3199, Codex P2)
+  process.stdin.once("end", () => void shutdown());
+  process.stdin.once("close", () => void shutdown());
 
   // Log to stderr so it doesn't interfere with JSON-RPC on stdout
   console.error("[atlas-mcp] Server running on stdio");

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./server": "./src/server.ts",
     "./sse": "./src/sse.ts",
+    "./telemetry-bootstrap": "./src/telemetry-bootstrap.ts",
     "./hosted": "./src/hosted.ts",
     "./prompts/listing": "./src/prompts/listing.ts",
     "./eval/auth": "./src/eval/auth.ts",

--- a/packages/mcp/src/__tests__/telemetry-bootstrap.test.ts
+++ b/packages/mcp/src/__tests__/telemetry-bootstrap.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the standalone MCP OTel bootstrap (#3199).
+ *
+ * Asserts the entry-point seam: OTel initializes (with service.name
+ * "atlas-mcp") when OTEL_EXPORTER_OTLP_ENDPOINT is set, and no-ops cleanly
+ * when it is unset — without pulling in the real @opentelemetry/sdk-node.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// Shared shutdown handle the mocked initTelemetry hands back.
+const mockShutdown = mock(async () => {});
+
+// Indirection so individual tests can swap the init behaviour (success vs
+// throw) without depending on mockImplementationOnce semantics.
+let initImpl: (opts?: { serviceName?: string }) => Promise<() => Promise<void>> =
+  async () => mockShutdown;
+
+const mockInitTelemetry = mock((opts?: { serviceName?: string }) =>
+  initImpl(opts),
+);
+
+// Sync factory (bun:test async mock.module factories deadlock the loader).
+// Mock ALL exports of the real module per CLAUDE.md.
+mock.module("@atlas/api/lib/telemetry", () => ({
+  initTelemetry: mockInitTelemetry,
+  shutdownTelemetry: mockShutdown,
+}));
+
+const { startMcpTelemetry, MCP_OTEL_SERVICE_NAME } = await import(
+  "../telemetry-bootstrap"
+);
+
+const ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const ORIG_ENDPOINT = process.env[ENDPOINT];
+
+describe("startMcpTelemetry", () => {
+  beforeEach(() => {
+    mockInitTelemetry.mockClear();
+    mockShutdown.mockClear();
+    initImpl = async () => mockShutdown;
+  });
+
+  afterEach(() => {
+    if (ORIG_ENDPOINT === undefined) delete process.env[ENDPOINT];
+    else process.env[ENDPOINT] = ORIG_ENDPOINT;
+  });
+
+  test("no-ops (returns null, never inits) when the OTLP endpoint is unset", async () => {
+    delete process.env[ENDPOINT];
+
+    const shutdown = await startMcpTelemetry();
+
+    expect(shutdown).toBeNull();
+    expect(mockInitTelemetry).not.toHaveBeenCalled();
+  });
+
+  test("initializes OTel as service 'atlas-mcp' when the endpoint is set", async () => {
+    process.env[ENDPOINT] = "http://collector:4318";
+
+    const shutdown = await startMcpTelemetry();
+
+    expect(mockInitTelemetry).toHaveBeenCalledTimes(1);
+    expect(mockInitTelemetry).toHaveBeenCalledWith({
+      serviceName: "atlas-mcp",
+    });
+    // Returns the SDK shutdown handle so the entry point can flush on exit.
+    expect(shutdown).toBe(mockShutdown);
+  });
+
+  test("returns null (best-effort) when initialization throws", async () => {
+    process.env[ENDPOINT] = "http://collector:4318";
+    initImpl = async () => {
+      throw new Error("exporter import failed");
+    };
+
+    // Must not throw — telemetry failure can't stop the MCP server booting.
+    const shutdown = await startMcpTelemetry();
+
+    expect(shutdown).toBeNull();
+    expect(mockInitTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("MCP service name constant is 'atlas-mcp'", () => {
+    expect(MCP_OTEL_SERVICE_NAME).toBe("atlas-mcp");
+  });
+});

--- a/packages/mcp/src/telemetry-bootstrap.ts
+++ b/packages/mcp/src/telemetry-bootstrap.ts
@@ -1,0 +1,54 @@
+/**
+ * OTel bootstrap for the standalone MCP process (#3199).
+ *
+ * The OTel SDK (NodeSDK: traces + metrics) is initialized in the API server
+ * via `@atlas/api/lib/telemetry`. The standalone MCP process — `bin/serve.ts`
+ * and the CLI's `atlas mcp` command — runs in its own process and imports none
+ * of that, so every `atlas.mcp.*` instrument (`src/telemetry.ts`) feeds a
+ * no-op meter and its spans/counters are silently dropped. This wires the same
+ * bootstrap into the MCP process.
+ *
+ * Gating mirrors the API exactly: a no-op unless `OTEL_EXPORTER_OTLP_ENDPOINT`
+ * is set. The dynamic import keeps `@opentelemetry/sdk-node` (resolved through
+ * the `@atlas/api` workspace dependency) off the import path entirely when
+ * telemetry is disabled.
+ *
+ * Telemetry lifecycle is owned by the PROCESS entry, not the SSE library: the
+ * NodeSDK installs global providers, so the entry point inits once at boot and
+ * shuts down on SIGINT/SIGTERM. `startSseServer` / `createAtlasMcpServer` stay
+ * free of process-global state so they remain safe to embed (and to call from
+ * tests).
+ */
+
+/** Resource `service.name` for spans/metrics emitted by the MCP process. */
+export const MCP_OTEL_SERVICE_NAME = "atlas-mcp";
+
+/**
+ * Initialize OpenTelemetry for the standalone MCP process when
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+ *
+ * @returns a shutdown function (flush + tear down the SDK) when telemetry was
+ *   started, or `null` when it is disabled or initialization failed. Callers
+ *   invoke the returned function during graceful shutdown and skip it on
+ *   `null`.
+ */
+export async function startMcpTelemetry(): Promise<
+  (() => Promise<void>) | null
+> {
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) return null;
+
+  try {
+    const { initTelemetry } = await import("@atlas/api/lib/telemetry");
+    return await initTelemetry({ serviceName: MCP_OTEL_SERVICE_NAME });
+  } catch (err) {
+    // Telemetry is best-effort — a failed exporter import or SDK start must
+    // not stop the MCP server from serving. Log to stderr (the MCP package's
+    // logging convention — stdout carries JSON-RPC on the stdio transport).
+    process.stderr.write(
+      `[atlas-mcp] Failed to initialize OpenTelemetry: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
Hardens Atlas's production health + telemetry surfaces (v0.0.9). Two independent fixes, one PR.

## #3201 — cache credential-backed plugin liveness on `/health` (refactor, area: api)

`/health` is **public + unauthenticated** and called `PluginRegistry.healthCheckAll()` on *every* request, fanning out one live upstream probe per credential-backed plugin (jira → `/myself`, salesforce connection probe, email → Resend `/domains`, twenty → `/rest/open-api/core`). A monitor poll loop or request burst amplified into **N external calls per request**.

- New `PluginRegistry.healthCheckAllCached(ttlMs?)` — serves a short-TTL liveness snapshot and **coalesces concurrent callers** onto a single in-flight probe. The route switches to it; the existing `healthCheckAll()` (and its tests) are untouched.
- TTL configurable via **`ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`** (default **15000ms**; `0` disables caching; invalid/out-of-range → default with a one-time warn).
- The cheap in-process checks in the route (datasource `SELECT 1`, internal DB `SELECT 1`) stay **live** — only the credential-backed plugin probes are cached.
- Correctness: unhealthy results are cached **verbatim** (the cache never converts a failing probe to healthy); a **rejected** registry-level probe is **not** cached — the rejection propagates (route → `degraded`) and the next call re-probes, leaving any prior snapshot untouched.

## #3199 — initialize the OTel SDK in the standalone MCP process (feature, area: mcp)

The OTel SDK (traces + metrics) was initialized only in the API process via `TelemetryLive` → `lib/telemetry.ts`. The **standalone MCP process** (`packages/mcp/bin/serve.ts`, both stdio and SSE) imported none of it, so every `atlas.mcp.*` instrument fed a **no-op meter**.

- `lib/telemetry.ts` refactored from an import-side-effect module into an idempotent **`initTelemetry({ serviceName })`** (default `atlas-api`, or `OTEL_SERVICE_NAME`). The single API call site (`lib/effect/layers.ts`) now calls it; behavior unchanged.
- New **`@atlas/mcp/telemetry-bootstrap`** exporting `startMcpTelemetry()` — service name **`atlas-mcp`**, gated on `OTEL_EXPORTER_OTLP_ENDPOINT` (returns `null` + no-ops when unset; best-effort on init failure so the server still boots).
- Wired into `bin/serve.ts` with clean **SIGINT/SIGTERM + stdin-close** shutdown that flushes + tears down the SDK (the periodic metric-reader timer must not keep the process alive after the host disconnects).
- **Meter-init ordering** (caught in review): `@opentelemetry/api@1.x` has a `ProxyTracer` but **no ProxyMeter**, so a meter obtained before `sdk.start()` is a permanent no-op. The MCP server modules (which create `atlas.mcp.*` instruments at import time) are therefore imported **dynamically, after `startMcpTelemetry()`**. The `@opentelemetry/sdk-node` import stays dynamic + endpoint-gated so it never enters the request-path static graph (Next.js App Router tracer / create-atlas scaffold build).

> **Scope note:** an earlier revision also wired the CLI `atlas mcp` command, but it was **reverted** — guaranteeing meter-init ordering in the multi-command CLI entry (whose top-level static imports may load `metrics.ts` before the command runs) needs more care than #3199's scope. The CLI keeps its pre-PR behavior (no OTel, no regression); a focused follow-up can address it.

## Acceptance

- [x] N rapid `/health` requests within the TTL trigger each credential-backed upstream probe at most once; unhealthy state still surfaces (not masked).
- [x] Cache TTL configurable via env with a sane default (`ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`, 15s).
- [x] Standalone MCP initializes OTel traces+metrics when `OTEL_EXPORTER_OTLP_ENDPOINT` is set (and the meter binds to the real provider, not a no-op); no-ops cleanly when unset; shuts down on signal **and** stdin-close without leaking the metric-reader timer.
- [x] `/ci` green locally: lint, type (`tsgo`), tests (api full **549** + mcp **18** + cli **29**), syncpack, template-drift (762 files), railway-watch (new `packages/mcp` file covered).

## Docs

New env var **`ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`** — env-var doc rows (`env-variables.mdx` / `.env.example`) are owned by docs-sweep session **#3189**, so they're intentionally **not** edited here to avoid a parallel conflict.

## Tests

- `registry.test.ts` — cached path probes once within TTL, re-probes after TTL, coalesces concurrent callers, caches unhealthy verbatim, doesn't cache a rejection, `_reset` clears the cache; plus `getPluginHealthCacheTtlMs` env parsing.
- `telemetry-bootstrap.test.ts` — inits as `atlas-mcp` when the endpoint is set, no-ops (returns null, never inits) when unset, best-effort `null` on init failure.

Closes #3201
Closes #3199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin health checks now support configurable caching with TTL controls
  * OpenTelemetry initialization refactored for lazy loading and idempotent behavior

* **Bug Fixes**
  * MCP server now properly initializes and shuts down telemetry
  * Fixed hanging on stdin closure in stdio MCP sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->