### PR TITLE
fix(api): provider guard & error-path correctness — boot-guard family (#3200, #3203, #3202, #3181)

### DIFF
--- a/packages/api/src/__tests__/demo-error-classification.test.ts
+++ b/packages/api/src/__tests__/demo-error-classification.test.ts
@@ -36,6 +36,19 @@ describe("classifyDemoError (#3202)", () => {
     expect(cls.code).toBe("internal_error");
     expect(cls.message).toContain(REQUEST_ID.slice(0, 8));
   });
+
+  it("unwraps a connection failure buried on the error's cause (#3206)", () => {
+    // The AI SDK wraps a transport failure in an outer error whose top-level
+    // message has no ECONNREFUSED — the detail lives on `.cause`.
+    const err = new Error("Cannot connect to API", {
+      cause: new Error("connect ECONNREFUSED 10.0.0.5:443"),
+    });
+    expect(classifyDemoError(err, REQUEST_ID).code).toBe("provider_unreachable");
+  });
+
+  it("maps a 'fetch failed' transport error to provider_unreachable (#3206)", () => {
+    expect(classifyDemoError(new Error("fetch failed"), REQUEST_ID).code).toBe("provider_unreachable");
+  });
 });
 
 describe("buildDemoMidStreamErrorFrame (#3202)", () => {

--- a/packages/api/src/__tests__/demo-error-classification.test.ts
+++ b/packages/api/src/__tests__/demo-error-classification.test.ts
@@ -1,0 +1,65 @@
+/**
+ * #3202 — the demo route must classify provider errors raised WHILE the stream is
+ * consumed (the `createUIMessageStream` `onError` path), not only the synchronous
+ * catch. `runAgent()` returns the streamText result before the stream is read, so
+ * an ECONNREFUSED/ENOTFOUND raised mid-generation never reaches the catch — it
+ * lands in `onError`, which used to return a generic string (a 200 with no
+ * structured error frame). These tests pin the shared classifier + the mid-stream
+ * frame builder so a provider outage carries the same `code` / `retryable` /
+ * `requestId` contract whether it surfaces before or after the first byte.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+// demo.ts reads env at module load (it imports the agent loop). Set a datasource
+// so the import graph resolves without warnings.
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+import { classifyDemoError, buildDemoMidStreamErrorFrame } from "@atlas/api/api/routes/demo";
+
+const REQUEST_ID = "req-12345678-aaaa-bbbb";
+
+describe("classifyDemoError (#3202)", () => {
+  it("labels a mid-stream connection failure (ECONNREFUSED) as provider_unreachable", () => {
+    const err = new Error("connect ECONNREFUSED 127.0.0.1:443");
+    const cls = classifyDemoError(err, REQUEST_ID);
+    expect(cls.code).toBe("provider_unreachable");
+  });
+
+  it("labels a DNS failure (ENOTFOUND) as provider_unreachable", () => {
+    const err = new Error("getaddrinfo ENOTFOUND api.anthropic.com");
+    expect(classifyDemoError(err, REQUEST_ID).code).toBe("provider_unreachable");
+  });
+
+  it("falls back to internal_error (with a quotable ref) for an unrelated error", () => {
+    const cls = classifyDemoError(new Error("something odd"), REQUEST_ID);
+    expect(cls.code).toBe("internal_error");
+    expect(cls.message).toContain(REQUEST_ID.slice(0, 8));
+  });
+});
+
+describe("buildDemoMidStreamErrorFrame (#3202)", () => {
+  it("emits a structured frame (code + message + retryable + requestId) for a mid-stream outage", () => {
+    const err = new Error("connect ECONNREFUSED 10.0.0.5:443");
+    const frame = buildDemoMidStreamErrorFrame(err, REQUEST_ID);
+    const parsed = JSON.parse(frame) as {
+      error: string;
+      message: string;
+      retryable: boolean;
+      requestId: string;
+    };
+    expect(parsed.error).toBe("provider_unreachable");
+    expect(typeof parsed.message).toBe("string");
+    expect(parsed.message.length).toBeGreaterThan(0);
+    // provider_unreachable is transient — the client should be told it can retry.
+    expect(parsed.retryable).toBe(true);
+    expect(parsed.requestId).toBe(REQUEST_ID);
+  });
+
+  it("is no longer a generic, unstructured string", () => {
+    const frame = buildDemoMidStreamErrorFrame(new Error("connect ECONNREFUSED 1.2.3.4:443"), REQUEST_ID);
+    // Must be valid JSON (the structured frame), not the old prose sentence.
+    expect(() => JSON.parse(frame)).not.toThrow();
+    expect(frame).not.toContain("Try sending your message again");
+  });
+});

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -621,6 +621,7 @@ demo.openapi(demoChatRoute, async (c) => {
             clearStreamWriter(requestId);
           },
           onError: (error) => {
+            clearStreamWriter(requestId);
             // #3202 — a provider error raised WHILE the stream is consumed (e.g.
             // ECONNREFUSED/ENOTFOUND mid-generation) lands here, not the sync
             // catch below (runAgent returns the streamText result before the

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -60,6 +60,110 @@ const log = createLogger("demo");
 const DemoErrorSchema = z.record(z.string(), z.unknown());
 
 // ---------------------------------------------------------------------------
+// Error classification (#3197 + #3202)
+// ---------------------------------------------------------------------------
+
+/** Codes the demo classifier emits — a subset of `ChatErrorCode`. */
+type DemoErrorCode =
+  | "provider_model_not_found"
+  | "provider_auth_error"
+  | "provider_rate_limit"
+  | "provider_timeout"
+  | "provider_error"
+  | "provider_unreachable"
+  | "rate_limited"
+  | "internal_error";
+
+/** 1:1 code→HTTP status for the synchronous catch path. Mirror of chat.ts's
+ * `CLASSIFIER_STATUS_MAP` + reference/error-codes.mdx — a provider outage must
+ * surface as 503/504, not a misleading 500. */
+const DEMO_STATUS_BY_CODE = {
+  provider_model_not_found: 400,
+  provider_auth_error: 503,
+  provider_rate_limit: 503,
+  provider_timeout: 504,
+  provider_error: 502,
+  provider_unreachable: 503,
+  rate_limited: 429,
+  internal_error: 500,
+} as const satisfies Record<DemoErrorCode, 400 | 429 | 500 | 502 | 503 | 504>;
+
+interface DemoErrorClassification {
+  readonly code: DemoErrorCode;
+  readonly message: string;
+}
+
+/**
+ * Classify a demo agent-loop error. Single source of truth for the demo surface,
+ * invoked by BOTH the synchronous catch (which builds the JSON HTTP response) and
+ * the mid-stream `createUIMessageStream` `onError` path (which serializes the SSE
+ * error frame). One classifier guarantees a provider outage carries the same
+ * `code` whether it surfaces before the stream is returned (runAgent throwing) or
+ * WHILE the stream is consumed (#3202) — exactly the gap chat.ts's
+ * `classifyChatError` already closes for the main chat route.
+ *
+ * The agent loop's exceptions are the LLM provider (executeSQL errors are caught
+ * as tool results), so the non-SDK-typed fallback passes `subsystem: "provider"`
+ * — `matchError` then labels a connection failure (ECONNREFUSED/ENOTFOUND)
+ * `provider_unreachable` rather than the datasource-framed `internal_error`.
+ */
+export function classifyDemoError(err: unknown, requestId: string): DemoErrorClassification {
+  const message = err instanceof Error ? err.message : String(err);
+  if (GatewayModelNotFoundError.isInstance(err)) {
+    return { code: "provider_model_not_found", message: "Model not found on the AI Gateway." };
+  }
+  if (NoSuchModelError.isInstance(err)) {
+    return { code: "provider_model_not_found", message: "The configured model was not found." };
+  }
+  if (LoadAPIKeyError.isInstance(err)) {
+    return { code: "provider_auth_error", message: "LLM provider API key could not be loaded." };
+  }
+  if (APICallError.isInstance(err)) {
+    const status = err.statusCode;
+    if (status === 401 || status === 403) {
+      return { code: "provider_auth_error", message: "LLM provider authentication failed." };
+    }
+    if (status === 429) {
+      return { code: "provider_rate_limit", message: "LLM provider rate limit reached." };
+    }
+    if (status === 408 || /timeout/i.test(message)) {
+      return { code: "provider_timeout", message: "The request timed out." };
+    }
+    return { code: "provider_error", message: `LLM provider error (HTTP ${status}).` };
+  }
+  const matched = matchError(err, { subsystem: "provider" });
+  if (
+    matched &&
+    (matched.code === "provider_unreachable" ||
+      matched.code === "provider_timeout" ||
+      matched.code === "rate_limited")
+  ) {
+    return { code: matched.code, message: matched.message };
+  }
+  return {
+    code: "internal_error",
+    message: `An unexpected error occurred. Quote ref ${requestId.slice(0, 8)} when reporting.`,
+  };
+}
+
+/**
+ * Serialize a demo classification into the SSE error frame the AI SDK carries as
+ * `errorText`. Same `{ error, message, retryable, requestId }` shape as the
+ * synchronous JSON response (and chat.ts's `buildMidStreamErrorFrame`), so a
+ * provider outage raised mid-stream is no longer indistinguishable from a normal
+ * response error — the client gets a structured frame either way (#3202).
+ */
+export function buildDemoMidStreamErrorFrame(err: unknown, requestId: string): string {
+  const cls = classifyDemoError(err, requestId);
+  return JSON.stringify({
+    error: cls.code,
+    message: cls.message,
+    retryable: isRetryableError(cls.code),
+    requestId,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
 
@@ -517,12 +621,21 @@ demo.openapi(demoChatRoute, async (c) => {
             clearStreamWriter(requestId);
           },
           onError: (error) => {
-            clearStreamWriter(requestId);
-            log.error(
-              { err: error instanceof Error ? error : new Error(String(error)), requestId },
-              "Demo stream error",
+            // #3202 — a provider error raised WHILE the stream is consumed (e.g.
+            // ECONNREFUSED/ENOTFOUND mid-generation) lands here, not the sync
+            // catch below (runAgent returns the streamText result before the
+            // stream is read). Classify it the same way so the client gets a
+            // structured `provider_unreachable`/503-equivalent frame rather than
+            // a generic string — matching chat.ts's mid-stream contract.
+            const cls = classifyDemoError(error, requestId);
+            const logFn = cls.code === "rate_limited" || cls.code === "provider_rate_limit" ? log.warn : log.error;
+            logFn.call(
+              log,
+              { err: error instanceof Error ? error : new Error(String(error)), category: cls.code, requestId },
+              "Demo stream error (mid-stream): %s",
+              cls.code,
             );
-            return `An error occurred while generating a response (ref: ${requestId.slice(0, 8)}). Try sending your message again.`;
+            return buildDemoMidStreamErrorFrame(error, requestId);
           },
         });
 
@@ -548,100 +661,26 @@ demo.openapi(demoChatRoute, async (c) => {
         // Streaming response bypasses OpenAPI typed returns via HTTPException + res
         throw new HTTPException(200, { res: streamResponse });
       } catch (err) {
-        // Re-throw HTTPException (stream response) — handled by global onError
+        // Re-throw HTTPException (stream response) — handled by global onError.
         if (err instanceof HTTPException) throw err;
 
-        // Error handling mirrors main chat route
+        // Early-throw path: runAgent threw synchronously, before the stream was
+        // returned. Classified by the same `classifyDemoError` the mid-stream
+        // onError uses (#3202), so the response is identical whether the failure
+        // surfaces before or after the first byte. Provider outages map to
+        // 503/504 via DEMO_STATUS_BY_CODE, not a misleading 500 (#3197).
         const errObj = err instanceof Error ? err : new Error(String(err));
-        const message = errObj.message;
-
-        if (GatewayModelNotFoundError.isInstance(err)) {
-          log.error({ err: errObj, category: "provider_model_not_found" }, "Gateway model not found");
-          return c.json(
-            { error: "provider_model_not_found", message: "Model not found on the AI Gateway.", retryable: false, requestId },
-            400,
-          );
+        const cls = classifyDemoError(err, requestId);
+        const httpStatus = DEMO_STATUS_BY_CODE[cls.code];
+        const retryable = isRetryableError(cls.code);
+        if (cls.code === "rate_limited" || cls.code === "provider_rate_limit") {
+          log.warn({ err: errObj, category: cls.code, statusCode: httpStatus, requestId }, "Demo error: %s", cls.code);
+        } else {
+          log.error({ err: errObj, category: cls.code, statusCode: httpStatus, requestId }, "Demo error: %s", cls.code);
         }
-
-        if (NoSuchModelError.isInstance(err)) {
-          log.error({ err: errObj, category: "provider_model_not_found" }, "Model not found");
-          return c.json(
-            { error: "provider_model_not_found", message: "The configured model was not found.", retryable: false, requestId },
-            400,
-          );
-        }
-
-        if (LoadAPIKeyError.isInstance(err)) {
-          log.error({ err: errObj, category: "provider_auth_error" }, "API key not loaded");
-          return c.json(
-            { error: "provider_auth_error", message: "LLM provider API key could not be loaded.", retryable: false, requestId },
-            503,
-          );
-        }
-
-        if (APICallError.isInstance(err)) {
-          const status = err.statusCode;
-          if (status === 401 || status === 403) {
-            log.error({ err: errObj, category: "provider_auth_error", statusCode: status, requestId }, "Provider auth error");
-            return c.json({ error: "provider_auth_error", message: "LLM provider authentication failed.", retryable: false, requestId }, 503);
-          }
-          if (status === 429) {
-            log.warn({ err: errObj, category: "provider_rate_limit", statusCode: status, requestId }, "Provider rate limit");
-            return c.json({ error: "provider_rate_limit", message: "LLM provider rate limit reached.", retryable: true, requestId }, 503);
-          }
-          if (status === 408 || /timeout/i.test(message)) {
-            log.error({ err: errObj, category: "provider_timeout", statusCode: status, requestId }, "Provider timeout");
-            return c.json({ error: "provider_timeout", message: "The request timed out.", retryable: true, requestId }, 504);
-          }
-          log.error({ err: errObj, category: "provider_error", statusCode: status, requestId }, "Provider error (HTTP %s)", String(status));
-          return c.json({ error: "provider_error", message: `LLM provider error (HTTP ${status}).`, retryable: true, requestId }, 502);
-        }
-
-        // Like the chat route, the demo runs the agent loop — an exception
-        // reaching here is the LLM provider, not the datasource (executeSQL
-        // errors are caught as tool results). Pass `subsystem: "provider"` so
-        // an unreachable host is labeled `provider_unreachable`, not the
-        // datasource-framed `internal_error`.
-        //
-        // NOTE: this only covers errors thrown *before* the stream is returned
-        // (runAgent throwing synchronously). A provider error raised mid-stream
-        // hits the `createUIMessageStream` onError above, which still returns a
-        // generic string — classifying that path (as chat.ts does) is tracked
-        // by #3202.
-        const matched = matchError(err, { subsystem: "provider" });
-        if (matched) {
-          // Honor the canonical code→HTTP contract (mirror of
-          // CLASSIFIER_STATUS_MAP in chat.ts + reference/error-codes.mdx): a
-          // provider outage must surface as 503/504, not a misleading 500.
-          // matchError returns one of rate_limited / provider_unreachable /
-          // provider_timeout / internal_error here.
-          const STATUS_BY_CODE: Record<string, 429 | 500 | 503 | 504> = {
-            rate_limited: 429,
-            provider_unreachable: 503,
-            provider_timeout: 504,
-            internal_error: 500,
-          };
-          const httpStatus = STATUS_BY_CODE[matched.code] ?? 500;
-          if (matched.code === "rate_limited") {
-            log.warn({ err: errObj, category: matched.code, requestId }, "Matched error: %s", matched.code);
-          } else {
-            log.error({ err: errObj, category: matched.code, requestId }, "Matched error: %s", matched.code);
-          }
-          return c.json(
-            { error: matched.code, message: matched.message, retryable: isRetryableError(matched.code), requestId },
-            httpStatus as 500,
-          );
-        }
-
-        log.error({ err: errObj, category: "internal_error" }, "Unclassified demo error");
         return c.json(
-          {
-            error: "internal_error",
-            message: `An unexpected error occurred. Quote ref ${requestId.slice(0, 8)} when reporting.`,
-            retryable: false,
-            requestId,
-          },
-          500,
+          { error: cls.code, message: cls.message, retryable, requestId },
+          httpStatus as 500,
         );
       }
     },

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -94,6 +94,24 @@ interface DemoErrorClassification {
 }
 
 /**
+ * Flatten an error + its `cause` chain into one string. `matchError` inspects
+ * only `error.message`, but the AI SDK wraps a transport failure (ECONNREFUSED /
+ * ENOTFOUND / "fetch failed") in an `APICallError` whose connection detail lives
+ * on `.cause`, not the top-level message — so without this a mid-stream provider
+ * outage would miss the `provider_unreachable` match (#3202/#3206 Codex).
+ */
+function flattenErrorMessage(err: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = err;
+  for (let depth = 0; current instanceof Error && depth < 5; depth++) {
+    parts.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  if (typeof current === "string" && current.length > 0) parts.push(current);
+  return parts.join(" | ");
+}
+
+/**
  * Classify a demo agent-loop error. Single source of truth for the demo surface,
  * invoked by BOTH the synchronous catch (which builds the JSON HTTP response) and
  * the mid-stream `createUIMessageStream` `onError` path (which serializes the SSE
@@ -129,9 +147,17 @@ export function classifyDemoError(err: unknown, requestId: string): DemoErrorCla
     if (status === 408 || /timeout/i.test(message)) {
       return { code: "provider_timeout", message: "The request timed out." };
     }
-    return { code: "provider_error", message: `LLM provider error (HTTP ${status}).` };
+    if (typeof status === "number") {
+      return { code: "provider_error", message: `LLM provider error (HTTP ${status}).` };
+    }
+    // No HTTP status → the SDK wrapped a transport/connection failure (e.g.
+    // ECONNREFUSED/ENOTFOUND/"fetch failed" on `.cause`). Fall through to the
+    // connection-aware matchError below so it maps to provider_unreachable
+    // rather than a misleading `provider_error (HTTP undefined)` (#3206 Codex).
   }
-  const matched = matchError(err, { subsystem: "provider" });
+  // Inspect the message AND the cause chain so a connection failure the SDK
+  // buried on `APICallError.cause` still maps to provider_unreachable.
+  const matched = matchError(new Error(flattenErrorMessage(err)), { subsystem: "provider" });
   if (
     matched &&
     (matched.code === "provider_unreachable" ||

--- a/packages/api/src/lib/__tests__/agent-error-recovery-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-error-recovery-prompt.test.ts
@@ -1,0 +1,44 @@
+/**
+ * #3181 — the agent's "Error Recovery" prompt block must distinguish an
+ * infrastructure outage (datasource unreachable / pool exhausted) from a fixable
+ * query error. On an outage the agent should STOP and report, not burn its retry
+ * + step budget reformulating SQL it cannot fix.
+ *
+ * Prompt-text contract test: build the system prompt for a plain-string provider
+ * (openai — no cache-control wrapping) and assert the Error Recovery block now
+ * carries the stop-and-report guidance referencing the tool's outage vocabulary
+ * (`lib/tools/sql.ts` returns "Database unreachable at <host>" / pool-exhausted).
+ */
+
+import { describe, it, expect } from "bun:test";
+
+// agent.ts reads env at module load; keep this set before the import below.
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+import { buildSystemParam } from "@atlas/api/lib/agent";
+
+function systemText(): string {
+  // openai is a non-cache provider → buildSystemParam returns a plain string.
+  const system = buildSystemParam("openai");
+  return typeof system === "string" ? system : String(system.content);
+}
+
+describe("agent Error Recovery prompt — infrastructure outage guidance (#3181)", () => {
+  it("keeps the Error Recovery block", () => {
+    expect(systemText()).toContain("Error Recovery");
+  });
+
+  it("recognizes datasource-unreachable / pool-exhausted as an outage, not a query error", () => {
+    const text = systemText();
+    expect(text).toMatch(/unreachable/i);
+    expect(text).toMatch(/connection pool|pool is exhausted|pool is/i);
+  });
+
+  it("instructs the agent to stop and report rather than retry/modify the SQL", () => {
+    const text = systemText();
+    // The outage branch must tell the agent NOT to retry, and to surface the
+    // outage to the user as temporarily unavailable.
+    expect(text).toMatch(/do not retry|don't retry|not retry at all/i);
+    expect(text).toMatch(/temporarily unavailable/i);
+  });
+});

--- a/packages/api/src/lib/__tests__/provider-config-mock.ts
+++ b/packages/api/src/lib/__tests__/provider-config-mock.ts
@@ -39,8 +39,12 @@ export function mockGetMissingProviderConfig(provider: string): string[] {
       return isEnvSet("OPENAI_API_KEY") ? [] : ["OPENAI_API_KEY"];
     case "gateway":
       return isEnvSet("AI_GATEWAY_API_KEY") ? [] : ["AI_GATEWAY_API_KEY"];
-    case "openai-compatible":
-      return isEnvSet("OPENAI_COMPATIBLE_BASE_URL") ? [] : ["OPENAI_COMPATIBLE_BASE_URL"];
+    case "openai-compatible": {
+      const missing: string[] = [];
+      if (!isEnvSet("OPENAI_COMPATIBLE_BASE_URL")) missing.push("OPENAI_COMPATIBLE_BASE_URL");
+      if (!isEnvSet("ATLAS_MODEL")) missing.push("ATLAS_MODEL");
+      return missing;
+    }
     case "bedrock": {
       const pair = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
       if (!pair.some(isEnvSet)) return []; // credential-provider chain

--- a/packages/api/src/lib/__tests__/provider-config-mock.ts
+++ b/packages/api/src/lib/__tests__/provider-config-mock.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared `@atlas/api/lib/providers` mock fragment for the `startup.test.ts`
+ * family (#3200).
+ *
+ * `startup.ts` mocks the whole `providers` module to keep the heavy `@ai-sdk/*`
+ * static imports out of the diagnostics tests. Once `checkProviderApiKey` moved
+ * to the set-based `getMissingProviderConfig` SSOT, every one of those mocks
+ * needs a faithful stand-in for it (and `isSupportedProvider`). Centralising the
+ * stand-in here keeps the four mock blocks from each hand-copying — and silently
+ * drifting from — the real provider-config semantics (Bedrock all-or-none,
+ * openai-compatible base URL). Mirror of `lib/providers.ts`; not a test itself
+ * (plain `.ts`, so the isolated runner skips it).
+ */
+
+const SUPPORTED_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "bedrock",
+  "ollama",
+  "openai-compatible",
+  "gateway",
+] as const;
+
+export function mockIsSupportedProvider(value: string): boolean {
+  return (SUPPORTED_PROVIDERS as readonly string[]).includes(value);
+}
+
+function isEnvSet(key: string): boolean {
+  const value = process.env[key];
+  return value !== undefined && value !== "";
+}
+
+/** Mirror of `providers.ts:getMissingProviderConfig` (#3200). */
+export function mockGetMissingProviderConfig(provider: string): string[] {
+  switch (provider) {
+    case "anthropic":
+      return isEnvSet("ANTHROPIC_API_KEY") ? [] : ["ANTHROPIC_API_KEY"];
+    case "openai":
+      return isEnvSet("OPENAI_API_KEY") ? [] : ["OPENAI_API_KEY"];
+    case "gateway":
+      return isEnvSet("AI_GATEWAY_API_KEY") ? [] : ["AI_GATEWAY_API_KEY"];
+    case "openai-compatible":
+      return isEnvSet("OPENAI_COMPATIBLE_BASE_URL") ? [] : ["OPENAI_COMPATIBLE_BASE_URL"];
+    case "bedrock": {
+      const pair = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+      if (!pair.some(isEnvSet)) return []; // credential-provider chain
+      return pair.filter((key) => !isEnvSet(key));
+    }
+    case "ollama":
+      return [];
+    default:
+      return [];
+  }
+}

--- a/packages/api/src/lib/__tests__/startup-actions.test.ts
+++ b/packages/api/src/lib/__tests__/startup-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
 
 // ---------------------------------------------------------------------------
 // Mock heavy I/O modules so validateEnvironment() skips DB/filesystem checks
@@ -20,8 +21,11 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
-  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
-  // imports it, so mock.module must provide it (mock-all-exports).
+  // Required-config SSOT (#3200) — startup.ts's checkProviderApiKey consumes the
+  // set-based check; shared fixture mirrors real providers.ts semantics.
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  // PROVIDER_KEY_MAP retained for the display/signup-URL mirror (#3178).
   PROVIDER_KEY_MAP: {
     anthropic: "ANTHROPIC_API_KEY",
     openai: "OPENAI_API_KEY",

--- a/packages/api/src/lib/__tests__/startup-first-run.test.ts
+++ b/packages/api/src/lib/__tests__/startup-first-run.test.ts
@@ -121,7 +121,7 @@ const MANAGED_VARS = [
   "ATLAS_AUTH_AUDIENCE", "ATLAS_SANDBOX", "ATLAS_SANDBOX_URL",
   "ATLAS_RUNTIME", "VERCEL", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
   "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "OPENAI_COMPATIBLE_BASE_URL",
-  "AI_GATEWAY_API_KEY", "ATLAS_DEMO_DATA",
+  "ATLAS_MODEL", "AI_GATEWAY_API_KEY", "ATLAS_DEMO_DATA",
 ] as const;
 
 const saved: Record<string, string | undefined> = {};
@@ -217,22 +217,40 @@ describe("first-run: missing LLM provider API key", () => {
     expect(errors.find((e) => e.code === "MISSING_API_KEY")).toBeUndefined();
   });
 
-  // #3200 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL, which
-  // has no PROVIDER_KEY_MAP entry; the old single-key check skipped it entirely.
-  it("flags the missing base URL for openai-compatible (#3200)", async () => {
+  // #3200/#3206 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL
+  // (no PROVIDER_KEY_MAP entry) and needs ATLAS_MODEL (no default model); the old
+  // single-key check skipped the provider entirely.
+  it("flags the missing base URL and model for openai-compatible (#3200/#3206)", async () => {
     process.env.ATLAS_PROVIDER = "openai-compatible";
     delete process.env.OPENAI_COMPATIBLE_BASE_URL;
+    delete process.env.ATLAS_MODEL;
 
     const errors = await validateEnvironment();
     const err = errors.find((e) => e.code === "MISSING_API_KEY");
     expect(err).toBeDefined();
     expect(err!.message).toContain("OPENAI_COMPATIBLE_BASE_URL");
+    expect(err!.message).toContain("ATLAS_MODEL");
   });
 
   it("no error when using ollama (no key required)", async () => {
     process.env.ATLAS_PROVIDER = "ollama";
 
     const errors = await validateEnvironment();
+    expect(errors.find((e) => e.code === "MISSING_API_KEY")).toBeUndefined();
+  });
+
+  // #3206 (CodeRabbit) — a typo'd / unsupported provider must surface a
+  // diagnostic so /health flags it; resolveSelection() would otherwise throw on
+  // every request while /health stays green.
+  it("flags an unsupported ATLAS_PROVIDER with an INVALID_CONFIG diagnostic (#3206)", async () => {
+    process.env.ATLAS_PROVIDER = "anthropc"; // typo
+
+    const errors = await validateEnvironment();
+    const err = errors.find((e) => e.code === "INVALID_CONFIG");
+    expect(err).toBeDefined();
+    expect(err!.message).toContain("anthropc");
+    expect(err!.message).toContain("not a supported provider");
+    // ...and no misleading MISSING_API_KEY for the unknown provider.
     expect(errors.find((e) => e.code === "MISSING_API_KEY")).toBeUndefined();
   });
 

--- a/packages/api/src/lib/__tests__/startup-first-run.test.ts
+++ b/packages/api/src/lib/__tests__/startup-first-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
 
 // ---------------------------------------------------------------------------
 // Control variables for mocks — mutated per-test in beforeEach
@@ -36,8 +37,12 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
-  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
-  // imports it, so mock.module must provide it (mock-all-exports).
+  // Required-config SSOT (#3200) — startup.ts's checkProviderApiKey consumes
+  // the set-based check (not PROVIDER_KEY_MAP); shared fixture mirrors the real
+  // providers.ts semantics (Bedrock all-or-none, openai-compatible base URL).
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  // PROVIDER_KEY_MAP retained for the display/signup-URL mirror (#3178).
   PROVIDER_KEY_MAP: {
     anthropic: "ANTHROPIC_API_KEY",
     openai: "OPENAI_API_KEY",
@@ -115,7 +120,8 @@ const MANAGED_VARS = [
   "BETTER_AUTH_TRUSTED_ORIGINS", "ATLAS_AUTH_JWKS_URL", "ATLAS_AUTH_ISSUER",
   "ATLAS_AUTH_AUDIENCE", "ATLAS_SANDBOX", "ATLAS_SANDBOX_URL",
   "ATLAS_RUNTIME", "VERCEL", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
-  "AWS_ACCESS_KEY_ID", "AI_GATEWAY_API_KEY", "ATLAS_DEMO_DATA",
+  "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "OPENAI_COMPATIBLE_BASE_URL",
+  "AI_GATEWAY_API_KEY", "ATLAS_DEMO_DATA",
 ] as const;
 
 const saved: Record<string, string | undefined> = {};
@@ -185,15 +191,42 @@ describe("first-run: missing LLM provider API key", () => {
     expect(err!.message).toContain("vercel.com");
   });
 
-  it("includes env var name without signup URL for bedrock", async () => {
+  // #3200 — Bedrock models the static-credentials pair as all-or-none: only one
+  // key set is a partial config that boots green then throws at first chat. The
+  // diagnostic now flags the missing partner (here AWS_SECRET_ACCESS_KEY).
+  it("flags the missing partner key for partial bedrock static creds (#3200)", async () => {
     process.env.ATLAS_PROVIDER = "bedrock";
-    delete process.env.AWS_ACCESS_KEY_ID;
+    process.env.AWS_ACCESS_KEY_ID = "AKIA-test";
+    delete process.env.AWS_SECRET_ACCESS_KEY;
 
     const errors = await validateEnvironment();
     const err = errors.find((e) => e.code === "MISSING_API_KEY");
     expect(err).toBeDefined();
-    expect(err!.message).toContain("AWS_ACCESS_KEY_ID");
+    expect(err!.message).toContain("AWS_SECRET_ACCESS_KEY");
     expect(err!.message).toContain(".env");
+  });
+
+  // #3200 — Bedrock with NEITHER static key set must NOT false-fail: that's the
+  // AWS credential-provider chain (instance profile / SSO / web-identity).
+  it("no error for bedrock with no static creds (credential-provider chain, #3200)", async () => {
+    process.env.ATLAS_PROVIDER = "bedrock";
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+
+    const errors = await validateEnvironment();
+    expect(errors.find((e) => e.code === "MISSING_API_KEY")).toBeUndefined();
+  });
+
+  // #3200 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL, which
+  // has no PROVIDER_KEY_MAP entry; the old single-key check skipped it entirely.
+  it("flags the missing base URL for openai-compatible (#3200)", async () => {
+    process.env.ATLAS_PROVIDER = "openai-compatible";
+    delete process.env.OPENAI_COMPATIBLE_BASE_URL;
+
+    const errors = await validateEnvironment();
+    const err = errors.find((e) => e.code === "MISSING_API_KEY");
+    expect(err).toBeDefined();
+    expect(err!.message).toContain("OPENAI_COMPATIBLE_BASE_URL");
   });
 
   it("no error when using ollama (no key required)", async () => {

--- a/packages/api/src/lib/__tests__/startup-schema.test.ts
+++ b/packages/api/src/lib/__tests__/startup-schema.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
 
 // ---------------------------------------------------------------------------
 // Control variables for mocks
@@ -41,8 +42,11 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
-  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
-  // imports it, so mock.module must provide it (mock-all-exports).
+  // Required-config SSOT (#3200) — startup.ts's checkProviderApiKey consumes the
+  // set-based check; shared fixture mirrors real providers.ts semantics.
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  // PROVIDER_KEY_MAP retained for the display/signup-URL mirror (#3178).
   PROVIDER_KEY_MAP: {
     anthropic: "ANTHROPIC_API_KEY",
     openai: "OPENAI_API_KEY",

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock, type Mock } from "bun:test";
 import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
 
 // ---------------------------------------------------------------------------
 // Mock heavy I/O modules so validateEnvironment() skips DB/filesystem checks
@@ -22,8 +23,11 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
-  // PROVIDER_KEY_MAP moved here from startup.ts (#3178). startup.ts
-  // imports it, so mock.module must provide it (mock-all-exports).
+  // Required-config SSOT (#3200) — startup.ts's checkProviderApiKey consumes the
+  // set-based check; shared fixture mirrors real providers.ts semantics.
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  // PROVIDER_KEY_MAP retained for the display/signup-URL mirror (#3178).
   PROVIDER_KEY_MAP: {
     anthropic: "ANTHROPIC_API_KEY",
     openai: "OPENAI_API_KEY",

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -117,13 +117,14 @@ Before writing SQL, check if the user's question contains terms from the glossar
 - If the glossary provides a default interpretation, mention it: "By 'revenue' I'll use companies.revenue (annual company revenue). Would you prefer subscription MRR from accounts.monthly_value?"
 
 ## Error Recovery
-When a SQL query fails, read the error carefully before retrying:
+When a SQL query fails, read the error carefully before retrying. First decide whether it is an **infrastructure outage** or a **query problem** — they call for opposite responses:
+- **Infrastructure / connection outage** — If the error says the database or datasource is **unreachable** (e.g., "Database unreachable at ..."), the **connection pool is exhausted**, or the datasource is **temporarily unavailable**, this is an outage, NOT a query you can fix. Do **NOT** retry or modify the SQL — rewriting it wastes steps on something outside your control. Stop and tell the user the data source is temporarily unavailable and to try again shortly.
 - **Column not found** — The error often suggests the correct name (e.g., "column 'revnue' does not exist — did you mean 'revenue'?"). Go back to the entity schema to verify the exact column name.
 - **Table not found** — Re-read catalog.yml to find the correct table name. The table may use a different name than you expected.
 - **Syntax error** — Check the error position hint. Common issues: missing commas, unmatched parentheses, incorrect JOIN syntax.
 - **Type mismatch** — You may need to CAST a column (e.g., CAST(value AS numeric)). Check the column type in the entity schema.
 - **Timeout** — Simplify the query: remove unnecessary JOINs, add WHERE filters to reduce the dataset, or break into smaller queries.
-- Never retry the exact same SQL. Always fix the identified issue first.
+- Never retry the exact same SQL. Always fix the identified issue first (and for an infrastructure outage, do not retry at all — report it).
 - Max 2 retries per question — if the query still fails, explain the issue to the user.
 
 ## Suggested Follow-ups

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -652,6 +652,7 @@ describe("ProviderKeyGuardLive", () => {
     "AWS_ACCESS_KEY_ID",
     "AWS_SECRET_ACCESS_KEY",
     "OPENAI_COMPATIBLE_BASE_URL",
+    "ATLAS_MODEL",
   ] as const;
   function withProviderEnv<T>(overrides: Record<string, string>, run: () => Promise<T>): Promise<T> {
     const saved: Record<string, string | undefined> = {};
@@ -771,11 +772,11 @@ describe("ProviderKeyGuardLive", () => {
     });
   });
 
-  // #3200 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL, which
-  // has no PROVIDER_KEY_MAP entry. The old single-key guard skipped it entirely,
-  // so boot stayed green and buildModel() threw on the first chat. The set-based
-  // check now requires the base URL.
-  test("fails boot in SaaS for openai-compatible with no OPENAI_COMPATIBLE_BASE_URL (#3200)", async () => {
+  // #3200 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL (no
+  // PROVIDER_KEY_MAP entry) AND needs ATLAS_MODEL (it has no default model, so
+  // resolveSelection() throws without one — #3206 Codex). The old single-key
+  // guard skipped it entirely; the set-based check now requires both.
+  test("fails boot in SaaS for openai-compatible with neither base URL nor model (#3200)", async () => {
     await withCleanEnv(() =>
       withProviderEnv({}, async () => {
         process.env.ATLAS_PROVIDER = "openai-compatible";
@@ -784,18 +785,39 @@ describe("ProviderKeyGuardLive", () => {
         const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
         expect(failure).toBeInstanceOf(ProviderKeyMissingError);
         expect((failure as TProviderKeyMissingError).provider).toBe("openai-compatible");
-        expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["OPENAI_COMPATIBLE_BASE_URL"]);
+        expect((failure as TProviderKeyMissingError).missingKeys).toEqual([
+          "OPENAI_COMPATIBLE_BASE_URL",
+          "ATLAS_MODEL",
+        ]);
       }),
     );
   });
 
-  test("succeeds in SaaS for openai-compatible once OPENAI_COMPATIBLE_BASE_URL is set (#3200)", async () => {
+  // Base URL set but no model → still incomplete (openai-compatible has no
+  // default model). Pins the ATLAS_MODEL half of the required set.
+  test("fails boot in SaaS for openai-compatible with base URL but no ATLAS_MODEL (#3206)", async () => {
     await withCleanEnv(() =>
       withProviderEnv({ OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8000/v1" }, async () => {
         process.env.ATLAS_PROVIDER = "openai-compatible";
         const exit = await runGuard();
-        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+        expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["ATLAS_MODEL"]);
       }),
+    );
+  });
+
+  test("succeeds in SaaS for openai-compatible once base URL AND model are set (#3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv(
+        { OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8000/v1", ATLAS_MODEL: "my-model" },
+        async () => {
+          process.env.ATLAS_PROVIDER = "openai-compatible";
+          const exit = await runGuard();
+          expect(Exit.isSuccess(exit)).toBe(true);
+        },
+      ),
     );
   });
 

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -34,11 +34,33 @@ mock.module("@atlas/api/lib/logger", () => ({
   getRequestContext: () => undefined,
 }));
 
+// Controls what the (dynamic-imported) settings module returns to
+// `ProviderKeyGuardLive` for the proactive (settings-backed) provider (#3203).
+// Defaults to `undefined` so the settings-backed provider resolves identically
+// to the env provider — no divergence — keeping every pre-#3203 case unaffected.
+// Individual tests set it (and reset to undefined in `finally`) to exercise the
+// settings-only-misconfig path. Full export surface mocked per mock-all-exports.
+let mockSettingProvider: string | undefined;
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string) => (key === "ATLAS_PROVIDER" ? mockSettingProvider : undefined),
+  getSetting: () => undefined,
+  getSettingLive: async () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getAllSettingOverrides: async () => [],
+  loadSettings: async () => 0,
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  refreshSettingsTick: async () => {},
+  _resetSettingsCache: () => {},
+}));
+
 // Type-only imports for the tagged error classes and the `Config` Tag
 // type — needed because the runtime values are pulled in via dynamic
 // `await import(...)` after the logger mock is installed, which gives
 // us values but not types.
-import type { Config as TConfig, ConfigShape } from "../layers";
+import type { Config as TConfig, ConfigShape, Settings as TSettings, SettingsShape } from "../layers";
 import type {
   EnterpriseRequiredError as TEnterpriseRequiredError,
   EncryptionKeyMissingError as TEncryptionKeyMissingError,
@@ -62,6 +84,7 @@ const {
   RateLimitGuardLive,
   RateLimitRequiredError,
   ProviderKeyGuardLive,
+  ProactiveProviderKeyGuardLive,
   ProviderKeyMissingError,
   ProviderUnsupportedError,
   RegionGuardLive,
@@ -69,7 +92,7 @@ const {
   ChatAdapterEnvGuardLive,
   ChatAdapterEnvMissingError,
 } = await import("../saas-guards");
-const { Config } = await import("../layers");
+const { Config, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
 
 // ── Test helpers ────────────────────────────────────────────────────
@@ -80,6 +103,13 @@ function makeTestConfigLayer(
   return Layer.succeed(Config, {
     config: config as unknown as ConfigShape["config"],
   });
+}
+
+// `ProviderKeyGuardLive` depends on `Settings` for ordering (#3203) — provide a
+// stub Tag so the guard's `yield* Settings` resolves without running the real
+// `SettingsLive` (the settings VALUES come from the mocked module above).
+function makeTestSettingsLayer(): Layer.Layer<TSettings> {
+  return Layer.succeed(Settings, { loaded: 0 } satisfies SettingsShape);
 }
 
 // Source of truth lives in `effect/saas-env.ts :: SAAS_ENV_KEYS` (#2226).
@@ -612,12 +642,64 @@ describe("ProviderKeyGuardLive", () => {
     });
   }
 
-  function runGuard(): Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>> {
+  // Non-SAAS_ENV_KEYS provider env vars that `withCleanEnv` does NOT clear —
+  // `getMissingProviderConfig` reads them dynamically (same pattern as the
+  // ANTHROPIC_API_KEY carve-out). Cleared + overridden here so a dev machine's
+  // stray AWS creds can't make a "fails when partial" case pass for the wrong
+  // reason.
+  const NON_SAAS_PROVIDER_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "OPENAI_COMPATIBLE_BASE_URL",
+  ] as const;
+  function withProviderEnv<T>(overrides: Record<string, string>, run: () => Promise<T>): Promise<T> {
+    const saved: Record<string, string | undefined> = {};
+    for (const key of NON_SAAS_PROVIDER_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    for (const [k, v] of Object.entries(overrides)) process.env[k] = v;
+    return run().finally(() => {
+      for (const key of NON_SAAS_PROVIDER_KEYS) {
+        if (saved[key] !== undefined) process.env[key] = saved[key];
+        else delete process.env[key];
+      }
+    });
+  }
+
+  // Drive what the mocked settings module returns for the proactive
+  // (settings-backed) provider resolution (#3203); reset in `finally`.
+  function withSettingProvider<T>(provider: string | undefined, run: () => Promise<T>): Promise<T> {
+    const saved = mockSettingProvider;
+    mockSettingProvider = provider;
+    return run().finally(() => {
+      mockSettingProvider = saved;
+    });
+  }
+
+  // The env-only main-chat guard (#3178/#3200) — Config-only.
+  function runGuard(
+    deployMode: "saas" | "self-hosted" = "saas",
+  ): Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>> {
     return Effect.runPromiseExit(
       Effect.void.pipe(
         Effect.provide(
-          ProviderKeyGuardLive.pipe(
-            Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+          ProviderKeyGuardLive.pipe(Layer.provide(makeTestConfigLayer({ deployMode }))),
+        ),
+      ),
+    ) as Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>>;
+  }
+
+  // The settings-backed proactive guard (#3203) — Config + Settings.
+  function runProactiveGuard(
+    deployMode: "saas" | "self-hosted" = "saas",
+  ): Promise<Exit.Exit<void, TProviderKeyMissingError | TProviderUnsupportedError>> {
+    return Effect.runPromiseExit(
+      Effect.void.pipe(
+        Effect.provide(
+          ProactiveProviderKeyGuardLive.pipe(
+            Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode }), makeTestSettingsLayer())),
           ),
         ),
       ),
@@ -637,7 +719,8 @@ describe("ProviderKeyGuardLive", () => {
       expect(failure).toBeInstanceOf(ProviderKeyMissingError);
       expect((failure as TProviderKeyMissingError)._tag).toBe("ProviderKeyMissingError");
       expect((failure as TProviderKeyMissingError).provider).toBe("gateway");
-      expect((failure as TProviderKeyMissingError).requiredKey).toBe("AI_GATEWAY_API_KEY");
+      expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["AI_GATEWAY_API_KEY"]);
+      expect((failure as TProviderKeyMissingError).source).toBe("main-chat (env)");
       expect((failure as TProviderKeyMissingError).message).toContain("#3178");
     });
   });
@@ -651,7 +734,7 @@ describe("ProviderKeyGuardLive", () => {
         const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
         expect(failure).toBeInstanceOf(ProviderKeyMissingError);
         expect((failure as TProviderKeyMissingError).provider).toBe("anthropic");
-        expect((failure as TProviderKeyMissingError).requiredKey).toBe("ANTHROPIC_API_KEY");
+        expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["ANTHROPIC_API_KEY"]);
       }),
     );
   });
@@ -678,8 +761,8 @@ describe("ProviderKeyGuardLive", () => {
     });
   });
 
-  // ollama runs locally and needs no key — PROVIDER_KEY_MAP maps it to "",
-  // which the guard treats as "no key required" and skips.
+  // ollama runs locally and needs no key — getMissingProviderConfig returns []
+  // for it, which the guard treats as "fully configured" and skips.
   test("succeeds in SaaS with ATLAS_PROVIDER=ollama (no key required)", async () => {
     await withCleanEnv(async () => {
       process.env.ATLAS_PROVIDER = "ollama";
@@ -688,22 +771,80 @@ describe("ProviderKeyGuardLive", () => {
     });
   });
 
-  // openai-compatible authenticates via a base URL, not a fixed key var, so
-  // PROVIDER_KEY_MAP has no entry — but it IS a supported provider, so the guard
-  // skips the key check rather than treating it as unknown.
-  test("succeeds in SaaS for a valid keyless provider (openai-compatible)", async () => {
-    await withCleanEnv(async () => {
-      process.env.ATLAS_PROVIDER = "openai-compatible";
-      const exit = await runGuard();
-      expect(Exit.isSuccess(exit)).toBe(true);
-    });
+  // #3200 — openai-compatible authenticates via OPENAI_COMPATIBLE_BASE_URL, which
+  // has no PROVIDER_KEY_MAP entry. The old single-key guard skipped it entirely,
+  // so boot stayed green and buildModel() threw on the first chat. The set-based
+  // check now requires the base URL.
+  test("fails boot in SaaS for openai-compatible with no OPENAI_COMPATIBLE_BASE_URL (#3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({}, async () => {
+        process.env.ATLAS_PROVIDER = "openai-compatible";
+        const exit = await runGuard();
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+        expect((failure as TProviderKeyMissingError).provider).toBe("openai-compatible");
+        expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["OPENAI_COMPATIBLE_BASE_URL"]);
+      }),
+    );
+  });
+
+  test("succeeds in SaaS for openai-compatible once OPENAI_COMPATIBLE_BASE_URL is set (#3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({ OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8000/v1" }, async () => {
+        process.env.ATLAS_PROVIDER = "openai-compatible";
+        const exit = await runGuard();
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  // #3200 — Bedrock's static-credentials path needs BOTH the access key AND the
+  // secret. The old single-key guard passed on AWS_ACCESS_KEY_ID alone, then the
+  // first chat threw. The set-based check flags the missing partner.
+  test("fails boot in SaaS for bedrock with only AWS_ACCESS_KEY_ID set (#3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({ AWS_ACCESS_KEY_ID: "AKIA-test" }, async () => {
+        process.env.ATLAS_PROVIDER = "bedrock";
+        const exit = await runGuard();
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+        expect((failure as TProviderKeyMissingError).provider).toBe("bedrock");
+        expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["AWS_SECRET_ACCESS_KEY"]);
+      }),
+    );
+  });
+
+  // #3200 — Bedrock with BOTH static keys present is fully configured.
+  test("succeeds in SaaS for bedrock with both static credentials set (#3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({ AWS_ACCESS_KEY_ID: "AKIA-test", AWS_SECRET_ACCESS_KEY: "secret-test" }, async () => {
+        process.env.ATLAS_PROVIDER = "bedrock";
+        const exit = await runGuard();
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  // #3200 — Bedrock with NEITHER static key set must NOT false-fail: that's the
+  // AWS credential-provider chain (EC2/ECS instance profile, SSO, web-identity),
+  // a legitimate keyless deploy. The all-or-none rule requires nothing here.
+  test("succeeds in SaaS for bedrock with no static creds (credential-provider chain, #3200)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({}, async () => {
+        process.env.ATLAS_PROVIDER = "bedrock";
+        const exit = await runGuard();
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
   });
 
   // #3198 Codex (round 4) — a typo / unsupported ATLAS_PROVIDER would make
   // resolveSelection() throw on every chat at first I/O while boot/health stay
   // green. Fail boot with the distinct ProviderUnsupportedError instead of
-  // skipping (an unknown provider also yields PROVIDER_KEY_MAP[x] === undefined,
-  // so it must be distinguished from a valid keyless provider).
+  // skipping (an unknown provider also yields an empty missing-config set, so it
+  // must be distinguished from a valid keyless provider).
   test("fails boot in SaaS when ATLAS_PROVIDER is an unsupported value (#3198)", async () => {
     await withCleanEnv(async () => {
       process.env.ATLAS_PROVIDER = "anthrop"; // typo
@@ -713,25 +854,74 @@ describe("ProviderKeyGuardLive", () => {
       expect(failure).toBeInstanceOf(ProviderUnsupportedError);
       expect((failure as TProviderUnsupportedError)._tag).toBe("ProviderUnsupportedError");
       expect((failure as TProviderUnsupportedError).provider).toBe("anthrop");
+      expect((failure as TProviderUnsupportedError).source).toBe("main-chat (env)");
       expect((failure as TProviderUnsupportedError).message).toContain("#3178");
     });
   });
 
+  // ── #3203 — settings-backed proactive provider (ProactiveProviderKeyGuardLive) ──
+  //
+  // The SaaS proactive runtime resolves its provider via
+  // getSettingAuto("ATLAS_PROVIDER") (DB setting → env → default), NOT the
+  // env-only path the main chat uses. A persisted provider whose key is absent
+  // passes ProviderKeyGuardLive's env-only check yet fails every proactive answer
+  // at model init — so the sibling guard validates the settings resolution too.
+
+  test("fails boot when the settings-backed proactive provider is missing its key (#3203)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({}, () =>
+        // Env path resolves to gateway (with its key set) → passes. The DB-backed
+        // ATLAS_PROVIDER=anthropic has no ANTHROPIC_API_KEY → proactive would fail.
+        withSettingProvider("anthropic", async () => {
+          process.env.ATLAS_DEPLOY_MODE = "saas"; // env → gateway default
+          process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+          const exit = await runProactiveGuard();
+          expect(Exit.isFailure(exit)).toBe(true);
+          const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+          expect(failure).toBeInstanceOf(ProviderKeyMissingError);
+          expect((failure as TProviderKeyMissingError).provider).toBe("anthropic");
+          expect((failure as TProviderKeyMissingError).missingKeys).toEqual(["ANTHROPIC_API_KEY"]);
+          expect((failure as TProviderKeyMissingError).source).toBe("proactive (settings)");
+        }),
+      ),
+    );
+  });
+
+  test("proactive guard no-ops when env and settings resolve to the same provider (#3203 no false-fail)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({}, () =>
+        // Both paths resolve to gateway (key set) — the proactive guard must
+        // short-circuit the no-divergence case rather than double-validate.
+        withSettingProvider("gateway", async () => {
+          process.env.ATLAS_DEPLOY_MODE = "saas";
+          process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+          const exit = await runProactiveGuard();
+          expect(Exit.isSuccess(exit)).toBe(true);
+        }),
+      ),
+    );
+  });
+
+  test("proactive guard short-circuits on self-hosted (#3203)", async () => {
+    await withCleanEnv(() =>
+      withProviderEnv({}, () =>
+        withSettingProvider("anthropic", async () => {
+          process.env.ATLAS_PROVIDER = "ollama";
+          const exit = await runProactiveGuard("self-hosted");
+          expect(Exit.isSuccess(exit)).toBe(true);
+        }),
+      ),
+    );
+  });
+
   // The self-hosted counterpart of the test pair the issue calls for:
-  // a keyless dev loop must still boot (it keeps the per-request 503).
+  // a keyless dev loop must still boot (it keeps the per-request 503). The guard
+  // short-circuits on deployMode before touching providers/settings.
   test("succeeds on self-hosted with no provider key (per-request 503 preserved)", async () => {
     await withCleanEnv(() =>
       withoutAnthropicKey(async () => {
         process.env.ATLAS_PROVIDER = "anthropic";
-        const exit = await Effect.runPromiseExit(
-          Effect.void.pipe(
-            Effect.provide(
-              ProviderKeyGuardLive.pipe(
-                Layer.provide(makeTestConfigLayer({ deployMode: "self-hosted" })),
-              ),
-            ),
-          ),
-        );
+        const exit = await runGuard("self-hosted");
         expect(Exit.isSuccess(exit)).toBe(true);
       }),
     );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -52,6 +52,7 @@ import {
   InternalDbGuardLive,
   RateLimitGuardLive,
   ProviderKeyGuardLive,
+  ProactiveProviderKeyGuardLive,
   RegionGuardLive,
   PluginConfigGuardLive,
   ChatAdapterEnvGuardLive,
@@ -2825,12 +2826,19 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const encryptionKeyGuardLayer = EncryptionKeyGuardLive.pipe(Layer.provide(configLayer));
   const internalDbGuardLayer = InternalDbGuardLive.pipe(Layer.provide(configLayer));
   const rateLimitGuardLayer = RateLimitGuardLive.pipe(Layer.provide(configLayer));
-  // #3178 — fails boot when the configured provider's API key is missing in
-  // SaaS (boot-green-then-503 otherwise). Depends only on `Config`; it resolves
-  // the provider env-only (matching getModel()/resolveProvider, the path the
-  // main chat uses — #3198) and reads its key from env, so it runs as a peer of
-  // the other env-checking guards.
+  // #3178/#3200 — fails boot when the env-only MAIN-CHAT provider's required
+  // config is incomplete in SaaS (boot-green-then-503 otherwise). Validates
+  // required env as a SET (`getMissingProviderConfig`). `Config`-only and reads
+  // env directly, so it fails fast as a peer of the other env-checking guards.
   const providerKeyGuardLayer = ProviderKeyGuardLive.pipe(Layer.provide(configLayer));
+  // #3203 — sibling guard for the settings-backed PROACTIVE provider. Depends on
+  // `Config` + `Settings` (like `DpaGuardLive`): the `Settings` edge sequences it
+  // after `loadSettings()` warms the cache so `getSettingAuto("ATLAS_PROVIDER")`
+  // sees DB overrides. Kept separate from the env guard above so that guard stays
+  // `Config`-only and fast-failing.
+  const proactiveProviderKeyGuardLayer = ProactiveProviderKeyGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, settingsLayer)),
+  );
   // #2672 — walks the chat catalog and fails boot when an oauth+enabled
   // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
   // only on `Config` and reads env directly, so it runs in parallel with
@@ -2876,6 +2884,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     internalDbGuardLayer,
     rateLimitGuardLayer,
     providerKeyGuardLayer,
+    proactiveProviderKeyGuardLayer,
     regionGuardLayer,
     pluginConfigGuardLayer,
     chatAdapterEnvGuardLayer,

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -43,12 +43,13 @@
  *      so a platform admin can't re-open the hole at runtime via
  *      `setSetting`.
  *
- *   4b. {@link ProviderKeyGuardLive} (#3178) — the configured LLM provider
- *      (`ATLAS_PROVIDER` or the gateway default) has no API key set. Without
- *      it the api boots green and every chat 503s with `MISSING_API_KEY` at
- *      first I/O. Resolves the provider exactly as the runtime does and reads
- *      the required key (via `PROVIDER_KEY_MAP`) at boot. Self-hosted keeps the
- *      per-request 503 so keyless dev loops still boot.
+ *   4b. {@link ProviderKeyGuardLive} (#3178 + #3200 + #3203) — a configured LLM
+ *      provider's required config is incomplete. Without it the api boots green
+ *      and chat/proactive 503s at first I/O. Validates per-provider required env
+ *      as a SET (`getMissingProviderConfig` — Bedrock access key + secret,
+ *      openai-compatible base URL; #3200), for BOTH the env-only main-chat
+ *      provider AND the settings-backed proactive provider (#3203). Self-hosted
+ *      keeps the per-request 503 so keyless dev loops still boot.
  *
  *   5. {@link RegionGuardLive} (#1988 C7) — claimed `ATLAS_API_REGION`
  *      missing from `config.residency.regions` or pointing at a
@@ -86,7 +87,7 @@
 
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { Config } from "./layers";
+import { Config, Settings } from "./layers";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const log = createLogger("effect:saas-guards");
@@ -171,17 +172,31 @@ export class RateLimitRequiredError extends Data.TaggedError("RateLimitRequiredE
  * `validateEnvironment`'s per-request `MISSING_API_KEY` diagnostic — the exact
  * "broken at first I/O" class the guard family exists to prevent (#3178).
  *
- * `provider` is the resolved provider string and `requiredKey` the env var that
- * was expected (e.g. `anthropic` / `ANTHROPIC_API_KEY`), both exposed so the
- * operator-actionable boot log names the missing key without re-parsing
- * `message`. Self-hosted is unaffected — operators may run keyless dev loops
- * and keep the per-request 503.
+ * `provider` is the resolved provider string and `missingKeys` the full SET of
+ * required env vars that were absent (#3200) — e.g. `bedrock` /
+ * `["AWS_SECRET_ACCESS_KEY"]` when only the access key was set, or `anthropic` /
+ * `["ANTHROPIC_API_KEY"]`. Both exposed so the operator-actionable boot log
+ * names every missing key without re-parsing `message`. `source` records which
+ * resolution surfaced the misconfig — the env-only main-chat path or the
+ * settings-backed proactive path (#3203) — so a settings-only divergence is
+ * self-describing in the log. Self-hosted is unaffected — operators may run
+ * keyless dev loops and keep the per-request 503.
  */
 export class ProviderKeyMissingError extends Data.TaggedError("ProviderKeyMissingError")<{
   readonly message: string;
   readonly provider: string;
-  readonly requiredKey: string;
+  readonly missingKeys: readonly string[];
+  readonly source: ProviderResolutionSource;
 }> {}
+
+/**
+ * Which provider resolution surfaced a provider misconfig. The boot guard
+ * validates two: the env-only provider the main chat uses (`getModel()` →
+ * `resolveProvider()`), and the settings-backed provider the SaaS proactive
+ * runtime uses (`getSettingAuto("ATLAS_PROVIDER")` via `getProactiveAiRuntime`,
+ * #3203). Carried on the tagged errors so the boot log names the surface.
+ */
+export type ProviderResolutionSource = "main-chat (env)" | "proactive (settings)";
 
 /**
  * SaaS region booted with `ATLAS_PROVIDER` set to a value that isn't a
@@ -190,11 +205,14 @@ export class ProviderKeyMissingError extends Data.TaggedError("ProviderKeyMissin
  * boots green and then 503s every chat — the same boot-green-then-broken class
  * `ProviderKeyMissingError` catches, but for the provider *name* rather than its
  * key. Distinct error so the operator log names "unsupported provider" (not a
- * missing key). Self-hosted keeps the per-request throw (#3198).
+ * missing key). `source` records which resolution tripped it (env main-chat vs
+ * settings-backed proactive, #3203). Self-hosted keeps the per-request throw
+ * (#3198).
  */
 export class ProviderUnsupportedError extends Data.TaggedError("ProviderUnsupportedError")<{
   readonly message: string;
   readonly provider: string;
+  readonly source: ProviderResolutionSource;
 }> {}
 
 /**
@@ -544,109 +562,165 @@ export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Conf
 );
 
 // ══════════════════════════════════════════════════════════════════════
-// ██  ProviderKeyGuardLive (#3178)
+// ██  ProviderKeyGuardLive (#3178/#3200) + ProactiveProviderKeyGuardLive (#3203)
 // ══════════════════════════════════════════════════════════════════════
 
+/** Lazy-import the provider-config SSOT, walling off `providers.ts`'s heavy
+ * `@ai-sdk/*` static graph from this module (same pattern as
+ * `EncryptionKeyGuardLive`). A rejected import → defect via `Effect.orDie`:
+ * `providers.ts` is core and always loadable at boot, so a rejection means the
+ * api can't run anyway, and silently skipping would reopen the boot-green-then
+ * -503 hole these guards close. */
+const importProviderConfig = () =>
+  Effect.tryPromise({
+    try: () => import("@atlas/api/lib/providers"),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(Effect.orDie);
+
 /**
- * Fail boot in SaaS when the configured LLM provider's API key is missing.
+ * Validate one resolved provider string against its required config. Returns a
+ * tagged-error Effect to fail boot, or `Effect.void` when complete. `source`
+ * names which resolution this is (env main-chat vs settings-backed proactive)
+ * for the operator-actionable boot log.
  *
- * Resolves the provider EXACTLY as the main chat path does. `/api/v1/chat`
- * (`chat.ts`) calls `runAgent()` without an injected model, which reaches
- * `getModel()` / `getProviderType()` → `resolveProvider()` →
- * `resolveSelection()` (no args) → `process.env.ATLAS_PROVIDER ??
- * getDefaultProvider()` (`lib/providers.ts`). That is **env-only** — it does
- * NOT consult `getSettingAuto`/persisted admin settings. The settings-aware
- * `resolveModelFromSettings` / `AtlasAiModel` path (which folds the persisted
- * `ATLAS_PROVIDER` setting) is reached only via `runAgentEffect`, which no
- * production route calls. Matching `getModel` keeps the guard asserting on the
- * SAME provider + key a real chat will use, and stays in lockstep with the
- * per-request diagnostic `startup.ts:checkProviderApiKey` (also env-only).
- * (A persisted-only `ATLAS_PROVIDER` therefore does NOT change what a real
- * chat resolves, so an env-only guard cannot false-fail it — and `setSetting`
- * can't mutate `process.env`, so the boot decision can't be bypassed at
- * runtime either. See #3198.)
+ *   - not in the supported set → a typo / unsupported vendor: fail boot with
+ *     {@link ProviderUnsupportedError} (`resolveSelection()` would otherwise throw
+ *     on every chat/proactive answer — boot-green-then-broken). Checked first so a
+ *     typo isn't mistaken for a keyless provider (both yield an empty set).
+ *   - otherwise → `getMissingProviderConfig(provider)` (the required-config SET
+ *     SSOT in `lib/providers.ts`, #3200) returns the env vars that must be present
+ *     but aren't. `[]` → satisfied (`ollama` needs none; a Bedrock
+ *     credential-provider-chain deploy needs no static keys). Non-empty → fail
+ *     with {@link ProviderKeyMissingError} carrying the full set.
+ */
+function validateResolvedProvider(
+  provider: string,
+  source: ProviderResolutionSource,
+  isSupportedProvider: (value: string) => boolean,
+  getMissingProviderConfig: (provider: string) => string[],
+): Effect.Effect<void, ProviderKeyMissingError | ProviderUnsupportedError> {
+  if (!isSupportedProvider(provider)) {
+    return Effect.fail(
+      new ProviderUnsupportedError({
+        provider,
+        source,
+        message:
+          `SaaS region booted with the ${source} provider resolved to "${provider}", which is not a ` +
+          `supported provider — model initialization (resolveSelection) would throw at first I/O while ` +
+          `boot and /health stay green. Set ATLAS_PROVIDER to one of: anthropic, openai, bedrock, ollama, ` +
+          `openai-compatible, gateway (or unset it to use the SaaS gateway default). See ${PROVIDER_KEY_ISSUE_REF}.`,
+      }),
+    );
+  }
+
+  const missingKeys = getMissingProviderConfig(provider);
+  if (missingKeys.length === 0) return Effect.void;
+
+  return Effect.fail(
+    new ProviderKeyMissingError({
+      provider,
+      missingKeys,
+      source,
+      message:
+        `SaaS region booted with the ${source} provider "${provider}" but its required config is ` +
+        `incomplete — missing: [${missingKeys.join(", ")}]. The api would boot green, /health would ` +
+        `stay green, and every ${source === "proactive (settings)" ? "proactive answer" : "chat/query"} ` +
+        `would fail at first I/O. Set the missing env var(s) on every region's api service before ` +
+        `booting (or point ATLAS_PROVIDER at a fully-configured provider). See ${PROVIDER_KEY_ISSUE_REF}.`,
+    }),
+  );
+}
+
+/**
+ * Fail boot in SaaS when the MAIN-CHAT provider's required config is incomplete.
  *
- * The required key is looked up via the shared `PROVIDER_KEY_MAP` (SSOT in
- * `lib/providers.ts`):
+ * `/api/v1/chat` (`chat.ts`) calls `runAgent()` without an injected model →
+ * `getModel()` / `getProviderType()` → `resolveProvider()` → `resolveSelection()`
+ * (no args) → `process.env.ATLAS_PROVIDER ?? getDefaultProvider()`. **Env-only** —
+ * it does NOT consult persisted admin settings. Without this guard the api boots
+ * green, `/health` stays green, and every chat/query 503s at first I/O.
  *
- *   - provider not in the supported set → a typo / unsupported vendor: fail boot
- *     with {@link ProviderUnsupportedError} (in SaaS, `resolveSelection()` would
- *     otherwise throw on every chat — boot-green-then-broken). `isSupportedProvider`
- *     distinguishes this from a valid-but-keyless provider below.
- *   - valid provider, `PROVIDER_KEY_MAP[provider] === undefined` → keyless
- *     (e.g. `openai-compatible`, which authenticates via a base URL): skip the
- *     key check. (Fuller per-provider required-config validation — Bedrock
- *     secret/region, openai-compatible base URL — is tracked in #3200.)
- *   - `""` → `ollama`: skip (runs locally, no key).
- *   - otherwise → read the key straight from `process.env` (dynamic key, same
- *     pattern as `ChatAdapterEnvGuardLive`) and fail boot when unset/empty.
+ * Validates the env provider's required config as a SET via
+ * {@link validateResolvedProvider} (#3200 — Bedrock access key + secret,
+ * openai-compatible base URL). The settings-backed proactive provider is a
+ * separate resolution, validated by {@link ProactiveProviderKeyGuardLive} (#3203).
  *
- * Self-hosted is intentionally unaffected: an operator running a keyless dev
- * loop keeps the existing per-request 503 from `validateEnvironment` rather
- * than a hard boot failure.
- *
- * `getDefaultProvider` + `PROVIDER_KEY_MAP` are pulled via dynamic `import()`
- * to keep `providers.ts` (which statically imports the `@ai-sdk/*` packages)
- * out of `saas-guards.ts`'s static graph — same lazy-import wall-off as
- * `EncryptionKeyGuardLive`. A rejected import is promoted to a defect via
- * `Effect.orDie` (rather than silently skipping the check): `providers.ts` is
- * core and always loadable at boot, so a rejection means the api can't run
- * anyway, and a silent skip would reintroduce the boot-green-then-503 hole
- * this guard closes.
+ * Depends ONLY on `Config` (reads env directly) so it fails as fast as the other
+ * env-only guards — it does NOT wait on `loadSettings`, which keeps its
+ * `buildAppLayer` wiring canary deterministic (a main-chat misconfig must beat
+ * the `Settings`-gated sibling guards to the boot Layer's failure channel).
+ * Self-hosted is intentionally unaffected: a keyless dev loop keeps the existing
+ * per-request 503 from `validateEnvironment` rather than a hard boot failure.
  */
 export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError | ProviderUnsupportedError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
-    const { getDefaultProvider, PROVIDER_KEY_MAP, isSupportedProvider } = yield* Effect.tryPromise({
-      try: () => import("@atlas/api/lib/providers"),
+    const { getDefaultProvider, isSupportedProvider, getMissingProviderConfig } = yield* importProviderConfig();
+    const envProvider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    yield* validateResolvedProvider(
+      envProvider,
+      "main-chat (env)",
+      isSupportedProvider,
+      getMissingProviderConfig,
+    );
+  }),
+);
+
+/**
+ * Fail boot in SaaS when the SETTINGS-BACKED PROACTIVE provider's required config
+ * is incomplete (#3203).
+ *
+ * The SaaS proactive listener (Slack classifier + answer adapters) resolves its
+ * model via `getProactiveAiRuntime()` (`deploy/api/atlas.config.ts`), whose
+ * `AtlasAiModelLive` calls `resolveModelFromSettings()` →
+ * `getModelForConfig(getSettingAuto("ATLAS_PROVIDER"))` → `resolveSelection()` —
+ * i.e. `getSettingAuto("ATLAS_PROVIDER") ?? process.env.ATLAS_PROVIDER ??
+ * getDefaultProvider()`. A DB-persisted `ATLAS_PROVIDER` whose key is absent
+ * passes {@link ProviderKeyGuardLive}'s env-only check (the main chat still
+ * resolves to the env/gateway provider) yet fails every proactive answer at model
+ * init despite green boot/health. `ATLAS_PROVIDER` is `requiresRestart: true`, so
+ * a post-boot settings change only takes effect on the next boot — which re-runs
+ * this guard — making the boot-time check authoritative without a revalidation
+ * fiber. (And `setSetting` can't mutate `process.env`, so the boot decision can't
+ * be bypassed at runtime.)
+ *
+ * Split from {@link ProviderKeyGuardLive} rather than folded in because validating
+ * the settings-backed provider needs the settings cache: it depends on `Settings`
+ * (like `DpaGuardLive`) so `yield* Settings` sequences it after `loadSettings()`
+ * warms the in-process cache — without that ordering `getSettingAuto` would miss a
+ * DB override and fall back to env. Keeping this as a separate `Settings`-gated
+ * layer leaves the env guard above `Config`-only and fast-failing.
+ *
+ * Only validates when the settings provider DIVERGES from the env provider — the
+ * common case (no DB override) resolves identically and is already covered by
+ * {@link ProviderKeyGuardLive}, so re-validating would double-report. `settings.ts`
+ * is lazy-imported for the same wall-off reason as `providers.ts`.
+ */
+export const ProactiveProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError | ProviderUnsupportedError, Config | Settings> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+    yield* Settings; // sequence after loadSettings warms the in-process cache
+
+    const { getDefaultProvider, isSupportedProvider, getMissingProviderConfig } = yield* importProviderConfig();
+    const { getSettingAuto } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/settings"),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.orDie);
 
-    // Env-only, matching getModel() → resolveProvider() → resolveSelection()
-    // (the path chat.ts/runAgent actually uses); getDefaultProvider() supplies
-    // the SaaS gateway default when ATLAS_PROVIDER is unset.
-    const provider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    const envProvider = readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    const settingsProvider =
+      getSettingAuto("ATLAS_PROVIDER") ?? readSaasEnv().ATLAS_PROVIDER ?? getDefaultProvider();
+    if (settingsProvider === envProvider) return; // covered by ProviderKeyGuardLive
 
-    // Unsupported provider (typo / unknown vendor): `resolveSelection()` would
-    // throw on every chat in SaaS, so fail boot instead of skipping. Checked
-    // BEFORE the key lookup so a typo isn't mistaken for a valid keyless
-    // provider (both give `PROVIDER_KEY_MAP[provider] === undefined`).
-    if (!isSupportedProvider(provider)) {
-      return yield* Effect.fail(
-        new ProviderUnsupportedError({
-          provider,
-          message:
-            `SaaS region booted with ATLAS_PROVIDER="${provider}", which is not a supported provider — ` +
-            `model initialization (resolveSelection) would throw on every chat/query at first I/O while ` +
-            `boot and /health stay green. Set ATLAS_PROVIDER to one of: anthropic, openai, bedrock, ollama, ` +
-            `openai-compatible, gateway (or unset it to use the SaaS gateway default). See ${PROVIDER_KEY_ISSUE_REF}.`,
-        }),
-      );
-    }
-
-    const requiredKey = PROVIDER_KEY_MAP[provider];
-
-    // Valid provider with no mapped key → keyless (`ollama` → `""`,
-    // `openai-compatible` → `undefined`): skip the key check. (#3200 tracks
-    // openai-compatible's base-URL validation.)
-    if (!requiredKey) return;
-
-    const value = process.env[requiredKey];
-    if (value === undefined || value === "") {
-      yield* Effect.fail(
-        new ProviderKeyMissingError({
-          provider,
-          requiredKey,
-          message:
-            `SaaS region booted with provider "${provider}" but ${requiredKey} is not set — the api ` +
-            `would boot green, /health would stay green, and every chat/query would 503 with ` +
-            `MISSING_API_KEY at first I/O. Set ${requiredKey} on every region's api service before ` +
-            `booting (or set ATLAS_PROVIDER to a provider whose key is configured). See ${PROVIDER_KEY_ISSUE_REF}.`,
-        }),
-      );
-    }
+    yield* validateResolvedProvider(
+      settingsProvider,
+      "proactive (settings)",
+      isSupportedProvider,
+      getMissingProviderConfig,
+    );
   }),
 );
 

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -163,10 +163,19 @@ export function getMissingProviderConfig(provider: string): string[] {
       return isProviderEnvSet("OPENAI_API_KEY") ? [] : ["OPENAI_API_KEY"];
     case "gateway":
       return isProviderEnvSet("AI_GATEWAY_API_KEY") ? [] : ["AI_GATEWAY_API_KEY"];
-    case "openai-compatible":
-      return isProviderEnvSet("OPENAI_COMPATIBLE_BASE_URL")
-        ? []
-        : ["OPENAI_COMPATIBLE_BASE_URL"];
+    case "openai-compatible": {
+      // Needs its base URL AND a model id: openai-compatible is the only
+      // provider with no `PROVIDER_DEFAULTS` model, so `resolveSelection()`
+      // throws "ATLAS_MODEL is required" without one — the same
+      // boot-green-then-first-I/O failure the guard exists to prevent. The
+      // model is resolved from `ATLAS_MODEL` on the env path this check covers
+      // (resolveSelection: `modelOverride ?? process.env.ATLAS_MODEL ??
+      // PROVIDER_DEFAULTS[provider]`).
+      const missing: string[] = [];
+      if (!isProviderEnvSet("OPENAI_COMPATIBLE_BASE_URL")) missing.push("OPENAI_COMPATIBLE_BASE_URL");
+      if (!isProviderEnvSet("ATLAS_MODEL")) missing.push("ATLAS_MODEL");
+      return missing;
+    }
     case "bedrock":
       return missingBedrockStaticCreds();
     case "ollama":

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -95,6 +95,12 @@ export function getDefaultProvider(): ConfigProvider {
  * - `openai-compatible` is intentionally absent: it authenticates via a base
  *   URL, not a fixed key var, so neither the diagnostic nor the guard asserts
  *   a key for it (lookup is `undefined` → skipped).
+ *
+ * This map answers "which single *primary* key" — kept for display / signup-URL
+ * lookups. The authoritative "is this provider fully configured" check is
+ * {@link getMissingProviderConfig}, which models each provider's required env as
+ * a SET (Bedrock needs an access key AND a secret; openai-compatible needs its
+ * base URL) so a partial config can't boot green then fail the first chat (#3200).
  */
 export const PROVIDER_KEY_MAP: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
@@ -103,6 +109,73 @@ export const PROVIDER_KEY_MAP: Record<string, string> = {
   ollama: "", // Ollama runs locally, no API key required
   gateway: "AI_GATEWAY_API_KEY",
 };
+
+/** An env var is "set" only when present AND non-empty (mirrors the truthy
+ * `!process.env[key]` check the per-request diagnostic has always used). */
+function isProviderEnvSet(key: string): boolean {
+  const value = process.env[key];
+  return value !== undefined && value !== "";
+}
+
+/**
+ * Bedrock static-credentials all-or-none rule (#3200).
+ *
+ * The static-credentials path needs BOTH `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`. But a naive "require both" would false-fail the
+ * deploys that set NEITHER and instead rely on the AWS credential-provider
+ * chain (EC2/ECS instance profile, SSO, `~/.aws/credentials`, web-identity).
+ * So the pair is treated as all-or-none: if NEITHER is set, require nothing
+ * (chain-backed deploy); if EITHER is set, the deploy is using static creds and
+ * the partner is required — a half-configured pair throws at first model init.
+ *
+ * Region is intentionally NOT asserted — it has its own chain fallbacks
+ * (`AWS_REGION` / `AWS_DEFAULT_REGION` / instance metadata), so a missing region
+ * env var is not necessarily a misconfig.
+ */
+function missingBedrockStaticCreds(): string[] {
+  const pair = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"] as const;
+  const anySet = pair.some(isProviderEnvSet);
+  if (!anySet) return []; // credential-provider chain — nothing statically required
+  return pair.filter((key) => !isProviderEnvSet(key));
+}
+
+/**
+ * Required-config SSOT (#3200): the env vars that MUST be set for `provider` to
+ * initialize but currently are not — `[]` when the provider's required config is
+ * complete, when it needs none (`ollama`), or for an unknown provider (the
+ * unsupported-provider decision is the caller's, via {@link isSupportedProvider}).
+ *
+ * Consumed by BOTH `ProviderKeyGuardLive` (the SaaS boot guard) and
+ * `startup.ts:checkProviderApiKey` (the per-request 503 diagnostic) so the two
+ * agree on exactly what "configured" means for every provider — including the
+ * multi-key providers a single `PROVIDER_KEY_MAP` lookup silently passed:
+ *
+ *   - `bedrock` — `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (all-or-none;
+ *     see {@link missingBedrockStaticCreds}).
+ *   - `openai-compatible` — `OPENAI_COMPATIBLE_BASE_URL` (no `PROVIDER_KEY_MAP`
+ *     entry; `buildModel()` throws without it).
+ */
+export function getMissingProviderConfig(provider: string): string[] {
+  switch (provider) {
+    case "anthropic":
+      return isProviderEnvSet("ANTHROPIC_API_KEY") ? [] : ["ANTHROPIC_API_KEY"];
+    case "openai":
+      return isProviderEnvSet("OPENAI_API_KEY") ? [] : ["OPENAI_API_KEY"];
+    case "gateway":
+      return isProviderEnvSet("AI_GATEWAY_API_KEY") ? [] : ["AI_GATEWAY_API_KEY"];
+    case "openai-compatible":
+      return isProviderEnvSet("OPENAI_COMPATIBLE_BASE_URL")
+        ? []
+        : ["OPENAI_COMPATIBLE_BASE_URL"];
+    case "bedrock":
+      return missingBedrockStaticCreds();
+    case "ollama":
+      return []; // runs locally, no key
+    default:
+      // Unknown provider — not this function's concern (see isSupportedProvider).
+      return [];
+  }
+}
 
 /** Anthropic-family model ids contain "anthropic" or "claude". */
 function isAnthropicFamilyModelId(modelId: string): boolean {

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -172,10 +172,22 @@ function checkDatasourceUrlPresence(
 function checkProviderApiKey(errors: DiagnosticError[]): void {
   const provider = process.env.ATLAS_PROVIDER ?? getDefaultProvider();
 
-  // Unknown provider — providers.ts will throw a descriptive error at model
-  // init, so we don't duplicate that check here (and `getMissingProviderConfig`
-  // returns `[]` for it, which would otherwise read as "fully configured").
-  if (!isSupportedProvider(provider)) return;
+  // Unknown provider (typo / unsupported vendor): `resolveSelection()` throws at
+  // model init on every chat/query, so without a diagnostic `/health` would stay
+  // green while the agent is dead. Surface it (#3206 CodeRabbit) — the SaaS boot
+  // guard already hard-fails this via `ProviderUnsupportedError`; self-hosted
+  // keeps booting but the diagnostic flags the misconfig. `getMissingProviderConfig`
+  // returns `[]` for an unknown provider, so the set check below cannot catch it.
+  if (!isSupportedProvider(provider)) {
+    errors.push({
+      code: "INVALID_CONFIG",
+      message:
+        `ATLAS_PROVIDER="${provider}" is not a supported provider — model initialization will fail on ` +
+        `every chat/query. Set ATLAS_PROVIDER to one of: anthropic, openai, bedrock, ollama, ` +
+        `openai-compatible, gateway.`,
+    });
+    return;
+  }
 
   // Required-config as a SET (#3200): Bedrock needs an access key AND a secret
   // (all-or-none with the AWS credential-provider chain); openai-compatible

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { matchError } from "@useatlas/types";
 import { detectDBType, resolveDatasourceUrl } from "./db/connection";
 import { maskConnectionUrl } from "./security";
-import { getDefaultProvider, PROVIDER_KEY_MAP } from "./providers";
+import { getDefaultProvider, getMissingProviderConfig, isSupportedProvider } from "./providers";
 import { detectAuthMode, getAuthModeSource } from "./auth/detect";
 import { resolvePasskeyRpId } from "./auth/rpid";
 import { getWebOrigin } from "./web-origin";
@@ -34,9 +34,10 @@ export interface DiagnosticError {
   message: string;
 }
 
-// PROVIDER_KEY_MAP moved to ./providers (#3178) so the SaaS boot guard
-// (`ProviderKeyGuardLive`) can share it without importing this module's
-// heavy request-path graph. Imported above.
+// The provider required-config SSOT lives in ./providers (#3178/#3200) so the
+// SaaS boot guard (`ProviderKeyGuardLive`) and this per-request diagnostic agree
+// on what "configured" means without this module's heavy request-path graph.
+// Imported above: `getMissingProviderConfig` (set-based) + `isSupportedProvider`.
 
 const PROVIDER_SIGNUP_URL: Record<string, string> = {
   anthropic: "https://console.anthropic.com/settings/keys",
@@ -170,19 +171,28 @@ function checkDatasourceUrlPresence(
 
 function checkProviderApiKey(errors: DiagnosticError[]): void {
   const provider = process.env.ATLAS_PROVIDER ?? getDefaultProvider();
-  const requiredKey = PROVIDER_KEY_MAP[provider];
 
-  if (requiredKey === undefined) {
-    // Unknown provider — providers.ts will throw a descriptive error at model init,
-    // so we don't duplicate that check here.
-  } else if (requiredKey && !process.env[requiredKey]) {
-    let message = `${requiredKey} is not set. Atlas needs an API key for the "${provider}" provider. Set it in your .env file.`;
-    const signupUrl = PROVIDER_SIGNUP_URL[provider];
-    if (signupUrl) {
-      message += ` Get one at ${signupUrl}`;
-    }
-    errors.push({ code: "MISSING_API_KEY", message });
+  // Unknown provider — providers.ts will throw a descriptive error at model
+  // init, so we don't duplicate that check here (and `getMissingProviderConfig`
+  // returns `[]` for it, which would otherwise read as "fully configured").
+  if (!isSupportedProvider(provider)) return;
+
+  // Required-config as a SET (#3200): Bedrock needs an access key AND a secret
+  // (all-or-none with the AWS credential-provider chain); openai-compatible
+  // needs its base URL. A single-key check passed these then 503'd at first chat.
+  const missing = getMissingProviderConfig(provider);
+  if (missing.length === 0) return;
+
+  const isPlural = missing.length > 1;
+  let message =
+    `${missing.join(", ")} ${isPlural ? "are" : "is"} not set. ` +
+    `Atlas needs ${isPlural ? "these" : "this"} for the "${provider}" provider. ` +
+    `Set ${isPlural ? "them" : "it"} in your .env file.`;
+  const signupUrl = PROVIDER_SIGNUP_URL[provider];
+  if (signupUrl) {
+    message += ` Get an API key at ${signupUrl}`;
   }
+  errors.push({ code: "MISSING_API_KEY", message });
 }
 
 function checkSemanticLayerPresence(errors: DiagnosticError[]): void {


### PR DESCRIPTION
Completes the v0.0.9 **boot-guard family** hardening — four tightly-coupled provider / infra-error correctness fixes. Convergence PR: empties the milestone, doesn't grow it.

Closes #3200, #3203, #3202, #3181.

## What & why

### #3200 — validate per-provider required-config as a SET, not a single key
`PROVIDER_KEY_MAP` mapped each provider to **one** key, so a partial config booted green then 503'd on the first chat. New `getMissingProviderConfig()` SSOT in `lib/providers.ts` models the **full required set**:
- **Bedrock** → `AWS_ACCESS_KEY_ID` **and** `AWS_SECRET_ACCESS_KEY`, treated **all-or-none** so instance-profile / SSO / web-identity deploys (which set neither static key and rely on the AWS credential-provider chain) don't false-fail; one-of-two set → the partner is required.
- **openai-compatible** → `OPENAI_COMPATIBLE_BASE_URL` (no `PROVIDER_KEY_MAP` entry; `buildModel()` threw without it).

Threaded through **both** `ProviderKeyGuardLive` (SaaS boot) and `startup.ts:checkProviderApiKey` (per-request 503). `ProviderKeyMissingError` now carries the full `missingKeys[]` set + a `source` discriminator.

### #3203 — also validate the settings-backed proactive provider
The main chat resolves the provider **env-only**; the SaaS proactive path resolves via `getProactiveAiRuntime()` → `getSettingAuto("ATLAS_PROVIDER")` (DB → env → default). A DB-persisted provider whose key is absent passed the env-only guard yet failed every proactive answer despite green boot. New sibling **`ProactiveProviderKeyGuardLive`** (`Config + Settings`, like `DpaGuardLive`) validates the settings resolution at boot **when it diverges** from the env provider. `ATLAS_PROVIDER` is `requiresRestart: true`, so the boot-time check is authoritative (a restart re-runs the guard) — no revalidation fiber needed. Kept **split** from the env guard so that one stays `Config`-only and fast-failing, which keeps its `buildAppLayer` wiring canary deterministic.

### #3202 — classify provider errors raised mid-stream in the demo route
`runAgent()` returns the `streamText` result **before** the stream is consumed, so an `ECONNREFUSED`/`ENOTFOUND` raised while reading lands in `createUIMessageStream`'s `onError` — never the sync catch — and used to return a generic 200 string. Extracted `classifyDemoError` as the **single** classifier for both transports (mirrors `chat.ts:classifyChatError`); `onError` now emits a structured `{ error, message, retryable, requestId }` frame so `provider_unreachable` → 503-equivalent is distinguishable from a normal response error before or after the first byte.

### #3181 — agent Error Recovery prompt distinguishes outage from query error
The recovery block only coached query errors, so on an infra error ("Database unreachable at …", pool exhausted) the agent burned retries "fixing" SQL up to the step cap. Added explicit guidance: on an infrastructure/connection outage, **STOP and report** — do not retry or modify the SQL.

## ⚠ Newly-required provider env vars (for the docs sweep)
This PR makes two vars required where they previously weren't validated — **not** documented here to avoid a parallel merge conflict on `.env.example` / `environment-variables.mdx`. Please pick these up in the docs sweep, **#3189**:
- `AWS_SECRET_ACCESS_KEY` — required alongside `AWS_ACCESS_KEY_ID` for Bedrock static-credentials deploys (all-or-none; chain-backed deploys still need neither).
- `OPENAI_COMPATIBLE_BASE_URL` — required for the `openai-compatible` provider.

## Tests
- `saas-guards.test.ts`: Bedrock partial/none/both, openai-compatible base-URL present/absent, env↔settings divergence (proactive guard), no-false-fail when identical, self-hosted short-circuit.
- `startup-first-run.test.ts`: Bedrock partial → flags missing partner; Bedrock none → no error (credential chain); openai-compatible → flags base URL. Shared `provider-config-mock.ts` mirrors the SSOT across the 4 startup mocks.
- `demo-error-classification.test.ts`: mid-stream `ECONNREFUSED`/`ENOTFOUND` → `provider_unreachable` frame (retryable + requestId); internal_error fallback; no longer a generic string.
- `agent-error-recovery-prompt.test.ts`: recovery block carries the stop-and-report infra-outage guidance.

## Gates
Local `/ci` green: `lint`, `type` (tsgo, full), `test` (93 affected api files + the touched web/route tests), `syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783207706&installation_id=135337507&pr_number=3206&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3206&signature=fe026dcafddd7191fc3df0d6ba613b10d080004ecbe758a37c948741f4df1bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added proactive SaaS provider boot validation, a shared provider-config resolver, and more rigorous startup provider checks.

* **Bug Fixes**
  * Standardized demo-mode error classification and returned structured JSON error frames for mid-stream failures.
  * Agent prompt improved to distinguish infrastructure outages from query errors and avoid unsafe retries.

* **Tests**
  * Expanded test coverage for demo error handling, provider-config diagnostics, and startup/provider guard behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->