### PR TITLE
feat(dashboards): KPI comparison & format polish (#3207)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -6583,10 +6583,37 @@
                             "minLength": 1,
                             "maxLength": 10000
                           },
+                          "autoComparison": {
+                            "type": "boolean"
+                          },
+                          "comparisonDateParams": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                                "pattern": "^[a-z_][a-z0-9_]*$"
+                              },
+                              "to": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                                "pattern": "^[a-z_][a-z0-9_]*$"
+                              }
+                            },
+                            "required": [
+                              "from",
+                              "to"
+                            ]
+                          },
                           "comparisonLabel": {
                             "type": "string",
                             "minLength": 1,
                             "maxLength": 120
+                          },
+                          "inverse": {
+                            "type": "boolean"
                           }
                         },
                         "additionalProperties": false
@@ -6893,10 +6920,37 @@
                             "minLength": 1,
                             "maxLength": 10000
                           },
+                          "autoComparison": {
+                            "type": "boolean"
+                          },
+                          "comparisonDateParams": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                                "pattern": "^[a-z_][a-z0-9_]*$"
+                              },
+                              "to": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                                "pattern": "^[a-z_][a-z0-9_]*$"
+                              }
+                            },
+                            "required": [
+                              "from",
+                              "to"
+                            ]
+                          },
                           "comparisonLabel": {
                             "type": "string",
                             "minLength": 1,
                             "maxLength": 120
+                          },
+                          "inverse": {
+                            "type": "boolean"
                           }
                         },
                         "additionalProperties": false

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -709,6 +709,31 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(404);
     });
 
+    it("returns 400 for an autoComparison KPI card whose SQL omits the date window (#3207)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Revenue",
+            // No :date_from / :date_to — the prior-period shift would be a no-op.
+            sql: "SELECT SUM(amount) AS total FROM orders",
+            chartConfig: {
+              type: "kpi",
+              categoryColumn: "total",
+              valueColumns: ["total"],
+              kpi: { autoComparison: true },
+            },
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string; message: string };
+      expect(body.error).toBe("invalid_request");
+      expect(body.message).toMatch(/autoComparison/i);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
     it("returns 400 when connectionGroupId belongs to a different org (#2424)", async () => {
       // The route looks up the dashboard's org, then verifies the supplied
       // connection_group_id is owned by that org. A "not_found" verdict from

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -1160,6 +1160,99 @@ describe("dashboard routes", () => {
       expect(comparisonCall?.[0].parameters).toMatchObject({ date_from: "2026-01-01" });
     });
 
+    // #3207 — autoComparison re-runs the card's OWN sql with the date window
+    // shifted back one period (no hand-written comparisonSql).
+    const autoKpiDashboard = {
+      ...mockDashboardData,
+      parameters: [
+        { key: "date_from", type: "date", default: "now - 30 days", label: "From" },
+        { key: "date_to", type: "date", default: "now", label: "To" },
+      ],
+      cards: [],
+    };
+    const autoKpiCard = {
+      ...mockCardData,
+      sql: "SELECT SUM(amount) AS total FROM orders WHERE created_at >= :date_from AND created_at < :date_to",
+      chartConfig: {
+        type: "kpi",
+        categoryColumn: "label",
+        valueColumns: ["total"],
+        kpi: { valueFormat: "currency", autoComparison: true, comparisonLabel: "vs. prior period" },
+      },
+    };
+
+    it("runs the card's own sql against the shifted prior window for autoComparison", async () => {
+      mockRunUserQueryPipeline.mockReset();
+      // Dispatch on the bound date_from: prior window starts earlier.
+      mockRunUserQueryPipeline.mockImplementation(async (opts) => {
+        const total = opts.parameters?.date_from === "2026-01-04" ? 1000000 : 1200000;
+        return {
+          kind: "ok" as const,
+          columns: ["total"],
+          rows: [{ total }],
+          rowCount: 1,
+          executionMs: 4,
+          truncated: false,
+          maskingApplied: false,
+        };
+      });
+      mockGetDashboard.mockResolvedValueOnce({ ok: true, data: autoKpiDashboard });
+      mockGetCard.mockResolvedValueOnce({ ok: true, data: autoKpiCard });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // [Feb 1, Mar 1) is a 28-day window → prior [Jan 4, Feb 1).
+          body: JSON.stringify({ parameters: { date_from: "2026-02-01", date_to: "2026-03-01" } }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        rows: { total: number }[];
+        comparison: { rows: { total: number }[] } | null;
+      };
+      expect(body.rows[0].total).toBe(1200000);
+      expect(body.comparison?.rows[0].total).toBe(1000000);
+      expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(2);
+      const comparisonCall = mockRunUserQueryPipeline.mock.calls.find(
+        (c) => c[0].parameters?.date_from === "2026-01-04",
+      );
+      // Same SQL as the primary; only the bound window moved.
+      expect(comparisonCall?.[0].sql).toBe(autoKpiCard.sql);
+      expect(comparisonCall?.[0].parameters).toMatchObject({ date_from: "2026-01-04", date_to: "2026-02-01" });
+    });
+
+    it("omits `comparison` for autoComparison when the window can't be derived (inverted range)", async () => {
+      mockRunUserQueryPipeline.mockReset();
+      mockRunUserQueryPipeline.mockImplementation(async () => ({
+        kind: "ok" as const,
+        columns: ["total"],
+        rows: [{ total: 1200000 }],
+        rowCount: 1,
+        executionMs: 4,
+        truncated: false,
+        maskingApplied: false,
+      }));
+      mockGetDashboard.mockResolvedValueOnce({ ok: true, data: autoKpiDashboard });
+      mockGetCard.mockResolvedValueOnce({ ok: true, data: autoKpiCard });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // from after to → no derivable prior period.
+          body: JSON.stringify({ parameters: { date_from: "2026-03-01", date_to: "2026-02-01" } }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect("comparison" in body).toBe(false);
+      expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(1);
+    });
+
     it("omits `comparison` for a KPI card with no comparisonSql", async () => {
       mockRunUserQueryPipeline.mockClear();
       const noComparison = {

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -62,6 +62,7 @@ import {
   resolveDashboardParameterValues,
   extractPlaceholderNames,
   derivePriorPeriodValues,
+  validateAutoComparison,
 } from "@atlas/api/lib/dashboard-parameters";
 import { ErrorSchema, parsePagination } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -1582,6 +1583,13 @@ authed.openapi(
       }
 
       const parsed = c.req.valid("json");
+      // #3207 — a KPI card requesting an automatic prior-period comparison must
+      // filter by both window params, declared as `date`. Reject up front so a
+      // misconfigured card can't persist a delta the render path can't produce.
+      const addAutoErr = validateAutoComparison(parsed.sql, parsed.chartConfig?.kpi, dash.data.parameters);
+      if (addAutoErr) {
+        return c.json({ error: "invalid_request", message: addAutoErr, requestId }, 400);
+      }
       // #2424 — same gate as chat.ts: verify the supplied connectionGroupId
       // is owned by the caller's org before persisting it onto the card.
       // Migration 0066's comment explicitly defers org enforcement here.
@@ -1650,6 +1658,23 @@ authed.openapi(
       }
 
       const parsed = c.req.valid("json");
+      // #3207 — if this update turns on autoComparison, validate it against the
+      // card's EXISTING sql (updateCard never changes the query) + the
+      // dashboard's params, the same as the add path. getCard is only needed
+      // when the flag is actually being set.
+      if (parsed.chartConfig?.kpi?.autoComparison) {
+        const existing = yield* Effect.promise(() => getCard(cardId, id));
+        if (existing.ok) {
+          const updateAutoErr = validateAutoComparison(
+            existing.data.sql,
+            parsed.chartConfig.kpi,
+            dash.data.parameters,
+          );
+          if (updateAutoErr) {
+            return c.json({ error: "invalid_request", message: updateAutoErr, requestId }, 400);
+          }
+        }
+      }
       const result = yield* Effect.promise(() => updateCard(cardId, id, parsed));
       if (!result.ok) {
         const fail = crudFailResponse(result.reason, requestId);

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -58,7 +58,11 @@ import {
 } from "@atlas/api/lib/stage-tracker";
 import { SHARE_MODES } from "@useatlas/types/share";
 import { dashboardParametersSchema, renderCardRequestSchema, dashboardChartConfigSchema } from "@useatlas/schemas";
-import { resolveDashboardParameterValues, extractPlaceholderNames } from "@atlas/api/lib/dashboard-parameters";
+import {
+  resolveDashboardParameterValues,
+  extractPlaceholderNames,
+  derivePriorPeriodValues,
+} from "@atlas/api/lib/dashboard-parameters";
 import { ErrorSchema, parsePagination } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 import { validationHook } from "./validation-hook";
@@ -1899,14 +1903,39 @@ authed.openapi(renderCardRoute, async (c) => {
       throw err;
     }
 
-    // #3137 — a KPI card's optional `comparisonSql` runs as a SECOND query
+    // #3137 / #3207 — a KPI card's optional comparison runs as a SECOND query
     // through the SAME pipeline (validation + auto-LIMIT + statement timeout +
-    // RLS + audit), binding the SAME parameter values. Both queries run in
-    // parallel — no waterfall. The comparison is NEVER string-interpolated;
-    // the UI computes the delta from the two numbers.
+    // RLS + audit). Both queries run in parallel — no waterfall. The comparison
+    // is NEVER string-interpolated; the UI computes the delta from the two
+    // numbers. There are two ways to source the comparison, never both:
+    //   - `comparisonSql` (#3137): a hand-written second query, bound to the
+    //     SAME parameter values as the primary.
+    //   - `autoComparison` (#3207): re-run the card's OWN sql with the bound
+    //     date window shifted back one period (derived server-side; the prior
+    //     window binds through the same parameter protocol).
     const chartConfig = cardResult.data.chartConfig;
-    const comparisonSql =
-      chartConfig?.type === "kpi" ? chartConfig.kpi?.comparisonSql : undefined;
+    const kpi = chartConfig?.type === "kpi" ? chartConfig.kpi : undefined;
+    const comparisonSql = kpi?.comparisonSql;
+
+    // Resolve the effective comparison query + its bind values. Default: the
+    // hand-written `comparisonSql` against the primary param values.
+    let comparisonRunSql = comparisonSql;
+    let comparisonParamValues = paramValues;
+    if (!comparisonSql && kpi?.autoComparison) {
+      const priorValues = derivePriorPeriodValues(paramValues, kpi.comparisonDateParams);
+      if (priorValues) {
+        comparisonRunSql = cardResult.data.sql;
+        comparisonParamValues = priorValues;
+      } else {
+        // No derivable prior window (a bound is missing/unparseable, or the
+        // range is inverted/empty). Render the headline number with no delta
+        // chip rather than failing — but say why (never silently swallowed).
+        log.warn(
+          { cardId, requestId },
+          "KPI autoComparison requested but no prior-period window could be derived — delta chip omitted",
+        );
+      }
+    }
 
     const { runUserQueryPipeline } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
     const [outcome, comparisonOutcome] = yield* Effect.promise(() =>
@@ -1923,12 +1952,12 @@ authed.openapi(renderCardRoute, async (c) => {
         // the whole `Promise.all` and 500 the primary render. Degrade an
         // unexpected throw to `null` so a broken comparison never breaks the
         // headline number — but log it (never silently swallowed).
-        comparisonSql
+        comparisonRunSql
           ? runUserQueryPipeline({
-              sql: comparisonSql,
+              sql: comparisonRunSql,
               ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
               explanation: `Dashboard KPI comparison: ${cardResult.data.title}`,
-              parameters: paramValues,
+              parameters: comparisonParamValues,
             }).catch((err) => {
               log.warn(
                 { cardId, requestId, err: err instanceof Error ? err.message : String(err) },
@@ -1941,11 +1970,11 @@ authed.openapi(renderCardRoute, async (c) => {
     );
 
     const { body, status } = userQueryOutcomeToResponse(outcome, requestId);
-    // Attach the comparison only when the primary succeeded AND a comparisonSql
-    // is configured. A failed comparison degrades to `null` (the delta chip is
-    // dropped) rather than failing the whole KPI render — but it's logged, never
-    // silently swallowed.
-    if (outcome.kind === "ok" && comparisonSql) {
+    // Attach the comparison only when the primary succeeded AND a comparison
+    // query was configured/derived. A failed comparison degrades to `null` (the
+    // delta chip is dropped) rather than failing the whole KPI render — but it's
+    // logged, never silently swallowed.
+    if (outcome.kind === "ok" && comparisonRunSql) {
       if (comparisonOutcome && comparisonOutcome.kind === "ok") {
         (body as Record<string, unknown>).comparison = {
           columns: comparisonOutcome.columns,

--- a/packages/api/src/lib/__tests__/dashboard-parameters.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-parameters.test.ts
@@ -15,6 +15,7 @@ import {
   resolveDashboardParameterValues,
   extractPlaceholderNames,
   derivePriorPeriodValues,
+  validateAutoComparison,
   DEFAULT_COMPARISON_DATE_PARAMS,
   DashboardParameterError,
   isBindableDbType,
@@ -391,5 +392,73 @@ describe("derivePriorPeriodValues", () => {
     const input = { date_from: "2026-03-15", date_to: "2026-03-20", region: "eu" };
     derivePriorPeriodValues(input);
     expect(input).toEqual({ date_from: "2026-03-15", date_to: "2026-03-20", region: "eu" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAutoComparison (#3207) — the shared persistence-path guard: a card
+// requesting an automatic prior-period comparison must filter by both window
+// params, declared as `date`.
+// ---------------------------------------------------------------------------
+
+describe("validateAutoComparison", () => {
+  const sql = "SELECT sum(amount) AS total FROM orders WHERE created_at >= :date_from AND created_at < :date_to";
+  const dateParams = [
+    { key: "date_from", type: "date" as const, default: "now - 30 days", label: "From" },
+    { key: "date_to", type: "date" as const, default: "now", label: "To" },
+  ];
+
+  it("returns null when autoComparison is not set (nothing to validate)", () => {
+    expect(validateAutoComparison(sql, undefined)).toBeNull();
+    expect(validateAutoComparison(sql, { comparisonSql: "SELECT 1 AS total" })).toBeNull();
+    expect(validateAutoComparison(sql, { autoComparison: false })).toBeNull();
+  });
+
+  it("accepts a card that filters by both date-typed window params", () => {
+    expect(validateAutoComparison(sql, { autoComparison: true }, dateParams)).toBeNull();
+  });
+
+  it("rejects when the SQL does not reference both window params", () => {
+    const err = validateAutoComparison("SELECT sum(amount) AS total FROM orders", { autoComparison: true }, dateParams);
+    expect(err).toMatch(/autoComparison/i);
+    expect(err).toContain(":date_from");
+    expect(err).toContain(":date_to");
+  });
+
+  it("rejects when only one window bound is referenced", () => {
+    const err = validateAutoComparison(
+      "SELECT sum(amount) AS total FROM orders WHERE created_at >= :date_from",
+      { autoComparison: true },
+      dateParams,
+    );
+    // The missing bound (date_to) is named; date_from also appears in the
+    // example clause, so we only assert the genuinely-missing one is flagged.
+    expect(err).toMatch(/does not reference :date_to\b/);
+  });
+
+  it("rejects when a window param is not declared as a date", () => {
+    const err = validateAutoComparison(sql, { autoComparison: true }, [
+      { key: "date_from", type: "number", default: 0, label: "From" },
+      { key: "date_to", type: "date", default: "now", label: "To" },
+    ]);
+    expect(err).toMatch(/date parameter/i);
+    expect(err).toContain(":date_from");
+  });
+
+  it("honours a custom comparisonDateParams pair", () => {
+    const customSql = "SELECT sum(amount) AS total FROM orders WHERE created_at >= :start AND created_at < :end";
+    const params = [
+      { key: "start", type: "date" as const, default: "now - 7 days", label: "Start" },
+      { key: "end", type: "date" as const, default: "now", label: "End" },
+    ];
+    expect(
+      validateAutoComparison(customSql, { autoComparison: true, comparisonDateParams: { from: "start", to: "end" } }, params),
+    ).toBeNull();
+  });
+
+  it("skips the date-type check when no parameter definitions are supplied (reference check only)", () => {
+    // Bound-editor path: SQL is available, parameter defs are not.
+    expect(validateAutoComparison(sql, { autoComparison: true })).toBeNull();
+    expect(validateAutoComparison("SELECT 1", { autoComparison: true })).toMatch(/autoComparison/i);
   });
 });

--- a/packages/api/src/lib/__tests__/dashboard-parameters.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-parameters.test.ts
@@ -14,6 +14,8 @@ import {
   resolveDateExpression,
   resolveDashboardParameterValues,
   extractPlaceholderNames,
+  derivePriorPeriodValues,
+  DEFAULT_COMPARISON_DATE_PARAMS,
   DashboardParameterError,
   isBindableDbType,
 } from "@atlas/api/lib/dashboard-parameters";
@@ -285,5 +287,109 @@ describe("isBindableDbType", () => {
     expect(isBindableDbType("mysql")).toBe(true);
     expect(isBindableDbType("clickhouse")).toBe(false);
     expect(isBindableDbType("snowflake")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// derivePriorPeriodValues (#3207) — the automatic period-over-period window
+// shift. Pure: given resolved values with a [from, to) date window, shift BOTH
+// bounds back by the window's length so the same primary SQL runs against the
+// immediately-preceding, non-overlapping window of identical size.
+// ---------------------------------------------------------------------------
+
+describe("derivePriorPeriodValues", () => {
+  it("shifts a window back by its own length (the prior period is adjacent)", () => {
+    // [Jan 1, Jan 31) is a 30-day window; the prior 30-day window ends exactly
+    // where this one begins → [Dec 2, Jan 1).
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-01-01", date_to: "2026-01-31" }),
+    ).toEqual({ date_from: "2025-12-02", date_to: "2026-01-01" });
+  });
+
+  it("handles a short window (5 days)", () => {
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-03-15", date_to: "2026-03-20" }),
+    ).toEqual({ date_from: "2026-03-10", date_to: "2026-03-15" });
+  });
+
+  it("rolls correctly across a month boundary", () => {
+    // [Mar 1, Mar 8) span 7 → prior [Feb 22, Mar 1). Feb 2026 has 28 days.
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-03-01", date_to: "2026-03-08" }),
+    ).toEqual({ date_from: "2026-02-22", date_to: "2026-03-01" });
+  });
+
+  it("rolls correctly across a year boundary", () => {
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-01-05", date_to: "2026-01-10" }),
+    ).toEqual({ date_from: "2025-12-31", date_to: "2026-01-05" });
+  });
+
+  it("preserves non-window parameters unchanged", () => {
+    expect(
+      derivePriorPeriodValues({
+        date_from: "2026-03-15",
+        date_to: "2026-03-20",
+        region: "eu",
+        limit_n: 25,
+      }),
+    ).toEqual({
+      date_from: "2026-03-10",
+      date_to: "2026-03-15",
+      region: "eu",
+      limit_n: 25,
+    });
+  });
+
+  it("honors a custom from/to parameter pair", () => {
+    expect(
+      derivePriorPeriodValues(
+        { start: "2026-03-15", end: "2026-03-20" },
+        { from: "start", to: "end" },
+      ),
+    ).toEqual({ start: "2026-03-10", end: "2026-03-15" });
+  });
+
+  it("defaults to the date_from / date_to pair", () => {
+    expect(DEFAULT_COMPARISON_DATE_PARAMS).toEqual({ from: "date_from", to: "date_to" });
+  });
+
+  it("returns null when a bound is missing", () => {
+    expect(derivePriorPeriodValues({ date_from: "2026-03-15" })).toBeNull();
+    expect(derivePriorPeriodValues({ date_to: "2026-03-20" })).toBeNull();
+  });
+
+  it("returns null when a bound is null or non-string", () => {
+    expect(
+      derivePriorPeriodValues({ date_from: null, date_to: "2026-03-20" }),
+    ).toBeNull();
+    expect(
+      derivePriorPeriodValues({ date_from: 20260315 as unknown as string, date_to: "2026-03-20" }),
+    ).toBeNull();
+  });
+
+  it("returns null when a bound is unparseable", () => {
+    expect(
+      derivePriorPeriodValues({ date_from: "not-a-date", date_to: "2026-03-20" }),
+    ).toBeNull();
+  });
+
+  it("returns null for an inverted window (from after to)", () => {
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-03-20", date_to: "2026-03-15" }),
+    ).toBeNull();
+  });
+
+  it("returns null for a zero-length window (from equals to)", () => {
+    // A half-open [from, from) window is empty; there's no period to shift.
+    expect(
+      derivePriorPeriodValues({ date_from: "2026-03-15", date_to: "2026-03-15" }),
+    ).toBeNull();
+  });
+
+  it("does not mutate the input values map", () => {
+    const input = { date_from: "2026-03-15", date_to: "2026-03-20", region: "eu" };
+    derivePriorPeriodValues(input);
+    expect(input).toEqual({ date_from: "2026-03-15", date_to: "2026-03-20", region: "eu" });
   });
 });

--- a/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { rowToCard, CardLayoutSchema } from "@atlas/api/lib/dashboards";
+import type { DashboardChartConfig } from "@atlas/api/lib/dashboard-types";
 
 const baseRow = {
   id: "card-1",
@@ -55,6 +56,38 @@ describe("rowToCard layout parsing", () => {
   test("treats null layout as not-yet-placed", () => {
     expect(rowToCard({ ...baseRow, layout: null }).layout).toBeNull();
     expect(rowToCard({ ...baseRow }).layout).toBeNull();
+  });
+});
+
+describe("rowToCard chart_config / KPI round-trip (#3137, #3207)", () => {
+  test("round-trips a KPI auto-comparison config (object form)", () => {
+    const chartConfig: DashboardChartConfig = {
+      type: "kpi",
+      categoryColumn: "label",
+      valueColumns: ["total"],
+      kpi: {
+        valueFormat: "percent",
+        autoComparison: true,
+        comparisonDateParams: { from: "start", to: "end" },
+        comparisonLabel: "vs. prior period",
+        inverse: true,
+      },
+    };
+    const card = rowToCard({ ...baseRow, chart_config: chartConfig });
+    // The new #3207 fields survive the read path unchanged (no field-by-field
+    // mapping strips them — chart_config is carried through as a whole).
+    expect(card.chartConfig).toEqual(chartConfig);
+  });
+
+  test("round-trips a KPI auto-comparison config (JSON string form)", () => {
+    const chartConfig: DashboardChartConfig = {
+      type: "kpi",
+      categoryColumn: "label",
+      valueColumns: ["total"],
+      kpi: { autoComparison: true, inverse: true },
+    };
+    const card = rowToCard({ ...baseRow, chart_config: JSON.stringify(chartConfig) });
+    expect(card.chartConfig).toEqual(chartConfig);
   });
 });
 

--- a/packages/api/src/lib/dashboard-parameters.ts
+++ b/packages/api/src/lib/dashboard-parameters.ts
@@ -24,7 +24,7 @@
  * datasources rather than risk an unbound placeholder or a silent fallback.
  */
 
-import type { DashboardParameter, DashboardParameterType } from "@useatlas/types";
+import type { DashboardParameter, DashboardParameterType, DashboardKpiConfig } from "@useatlas/types";
 
 export type { DashboardParameter, DashboardParameterType };
 
@@ -451,6 +451,55 @@ function daysBetweenUtc(a: Date, b: Date): number {
  * unparseable; the window is inverted (`from` after `to`); or it is zero-length
  * (`from` equals `to`, an empty half-open range with nothing to shift).
  */
+/**
+ * Validate a KPI card's automatic period-over-period config (#3207) against the
+ * card's own SQL and (optionally) the dashboard's parameter definitions. Shared
+ * by every persistence path — the createDashboard tool, the REST add/update-card
+ * routes, and the bound editor — so a card can never be saved with
+ * `autoComparison: true` that the render endpoint then can't act on.
+ *
+ * Two checks, both fail-closed with an actionable message:
+ *   1. The card's SQL must reference BOTH window params (default
+ *      `:date_from`/`:date_to`, or the {@link DashboardKpiConfig.comparisonDateParams}
+ *      pair). Otherwise shifting the window is a no-op — the prior-period query
+ *      is identical to the primary and the delta is always flat.
+ *   2. When `parameters` is supplied, both window params must be declared as
+ *      `type: "date"`. A `number`/`text` parameter can't be shifted as a date,
+ *      so `derivePriorPeriodValues` would return null and the promised delta
+ *      would silently vanish.
+ *
+ * Returns `null` when the config is fine, or when `autoComparison` isn't set
+ * (nothing to validate). Callers surface the string as a 400 / tool error.
+ */
+export function validateAutoComparison(
+  sql: string,
+  kpi: DashboardKpiConfig | null | undefined,
+  parameters?: DashboardParameter[] | null,
+): string | null {
+  if (!kpi?.autoComparison) return null;
+  const { from, to } = kpi.comparisonDateParams ?? DEFAULT_COMPARISON_DATE_PARAMS;
+
+  const referenced = new Set(extractPlaceholderNames(sql));
+  const missingRef = [from, to].filter((name) => !referenced.has(name));
+  if (missingRef.length > 0) {
+    return `autoComparison is set but the card SQL does not reference ${missingRef
+      .map((n) => `:${n}`)
+      .join(" and ")}. Filter the query by the dashboard date window (e.g. \`WHERE created_at >= :date_from AND created_at < :date_to\`) so the prior-period comparison can shift it.`;
+  }
+
+  if (parameters) {
+    const dateKeys = new Set(parameters.filter((p) => p.type === "date").map((p) => p.key));
+    const notDate = [from, to].filter((name) => !dateKeys.has(name));
+    if (notDate.length > 0) {
+      return `autoComparison requires ${notDate
+        .map((n) => `:${n}`)
+        .join(" and ")} to be declared as date parameter(s) so the prior-period window can be shifted.`;
+    }
+  }
+
+  return null;
+}
+
 export function derivePriorPeriodValues(
   values: Record<string, string | number | null>,
   params: { from: string; to: string } = DEFAULT_COMPARISON_DATE_PARAMS,

--- a/packages/api/src/lib/dashboard-parameters.ts
+++ b/packages/api/src/lib/dashboard-parameters.ts
@@ -400,3 +400,77 @@ export function resolveDashboardParameterValues(
   }
   return resolved;
 }
+
+// ---------------------------------------------------------------------------
+// Period-over-period window derivation (#3207)
+// ---------------------------------------------------------------------------
+
+/** The pair of date parameters an automatic KPI comparison shifts by default. */
+export const DEFAULT_COMPARISON_DATE_PARAMS = { from: "date_from", to: "date_to" } as const;
+
+/** Parse a leading `YYYY-MM-DD` to a UTC-midnight Date, or null. Rejects values
+ *  that aren't strings and calendar-impossible dates (e.g. `2026-02-30`). */
+function parseIsoDateValue(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const d = new Date(Date.UTC(year, month - 1, day));
+  // A normalized rollover (Feb 30 → Mar 2) means the literal wasn't a real date.
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    return null;
+  }
+  return d;
+}
+
+/** Whole days from `a` to `b` (both UTC midnight). */
+function daysBetweenUtc(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / 86_400_000);
+}
+
+/**
+ * Derive the prior-period window for an automatic KPI comparison (#3207).
+ *
+ * Given resolved parameter values holding a `[from, to)` date window (the
+ * documented half-open `created_at >= :date_from AND created_at < :date_to`
+ * pattern, inclusive `YYYY-MM-DD` bounds), shift BOTH bounds back by the
+ * window's length (`to - from` days) so the comparison covers the
+ * immediately-preceding, non-overlapping window of identical size — the prior
+ * window's `to` lands exactly on the current window's `from`:
+ *
+ *   [Jan 1, Jan 31)  (30 days)  →  [Dec 2, Jan 1)
+ *   [Mar 15, Mar 20) (5 days)   →  [Mar 10, Mar 15)
+ *
+ * Returns a NEW values map — the two window keys replaced with the shifted
+ * dates, every other parameter copied through unchanged — so the SAME primary
+ * SQL can re-run against the prior window through the normal bind pipeline (no
+ * string interpolation). Returns `null`, and the caller skips the comparison,
+ * when no sensible prior window exists: a bound is missing, non-string, or
+ * unparseable; the window is inverted (`from` after `to`); or it is zero-length
+ * (`from` equals `to`, an empty half-open range with nothing to shift).
+ */
+export function derivePriorPeriodValues(
+  values: Record<string, string | number | null>,
+  params: { from: string; to: string } = DEFAULT_COMPARISON_DATE_PARAMS,
+): Record<string, string | number | null> | null {
+  const from = parseIsoDateValue(values[params.from]);
+  const to = parseIsoDateValue(values[params.to]);
+  if (!from || !to) return null;
+
+  const spanDays = daysBetweenUtc(from, to);
+  // Inverted (< 0) or empty (= 0) windows have no meaningful prior period.
+  if (spanDays <= 0) return null;
+
+  const priorFrom = new Date(from.getTime());
+  priorFrom.setUTCDate(priorFrom.getUTCDate() - spanDays);
+  const priorTo = new Date(to.getTime());
+  priorTo.setUTCDate(priorTo.getUTCDate() - spanDays);
+
+  return {
+    ...values,
+    [params.from]: toIsoDate(priorFrom),
+    [params.to]: toIsoDate(priorTo),
+  };
+}

--- a/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
@@ -636,6 +636,38 @@ describe("createDashboard tool", () => {
     expect(connectCalls).toBe(0);
   });
 
+  it("rejects autoComparison when a window param is not declared as a date", async () => {
+    enableInternalDB();
+
+    const result = await run({
+      title: "KPIs",
+      parameters: [
+        // date_from is a NUMBER — derivePriorPeriodValues can't shift it.
+        { key: "date_from", type: "number", default: 0, label: "From" },
+        { key: "date_to", type: "date", default: "now", label: "To" },
+      ],
+      cards: [
+        {
+          title: "Revenue",
+          sql: "SELECT SUM(amount) AS total FROM orders WHERE rank >= :date_from AND created_at < :date_to",
+          chartConfig: {
+            type: "kpi",
+            categoryColumn: "total",
+            valueColumns: ["total"],
+            kpi: { autoComparison: true },
+          },
+        },
+      ],
+    });
+
+    expect(result.kind).toBe("err");
+    if (result.kind === "err") {
+      expect(result.validationErrors?.[0].error).toMatch(/date parameter/i);
+      expect(result.validationErrors?.[0].error).toContain(":date_from");
+    }
+    expect(connectCalls).toBe(0);
+  });
+
   // -------------------------------------------------------------------
   // Validation-fail rejects the whole call (no transaction)
   // -------------------------------------------------------------------

--- a/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
@@ -566,6 +566,76 @@ describe("createDashboard tool", () => {
     expect(connectCalls).toBe(0);
   });
 
+  // #3207 — autoComparison: prior-period inference without a hand-written query.
+  it("accepts a kpi card with autoComparison that filters by the declared window", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] }, // BEGIN
+      { rows: [{ id: "dash-auto", title: "KPIs", description: null, updated_at: "2026-06-04" }] },
+      { rows: [] }, // draft
+      { rows: [] }, // COMMIT
+    );
+
+    const result = await run({
+      title: "KPIs",
+      parameters: [
+        { key: "date_from", type: "date", default: "now - 30 days", label: "From" },
+        { key: "date_to", type: "date", default: "now", label: "To" },
+      ],
+      cards: [
+        {
+          title: "Revenue",
+          sql: "SELECT SUM(amount) AS total FROM orders WHERE created_at >= :date_from AND created_at < :date_to",
+          chartConfig: {
+            type: "kpi",
+            categoryColumn: "total",
+            valueColumns: ["total"],
+            kpi: { valueFormat: "currency", autoComparison: true, comparisonLabel: "vs. prior period" },
+          },
+        },
+      ],
+    });
+
+    expect(result.kind).toBe("ok");
+    // autoComparison adds NO second query to validate — only the primary runs
+    // through the guard.
+    expect(validateSQLMock).toHaveBeenCalledTimes(1);
+    const snapshot = JSON.parse(clientQueryCalls[2].params![2] as string);
+    expect(snapshot.cards[0].chartConfig.kpi).toMatchObject({ autoComparison: true });
+  });
+
+  it("rejects autoComparison when the card SQL does not reference the date window", async () => {
+    enableInternalDB();
+
+    const result = await run({
+      title: "KPIs",
+      parameters: [
+        { key: "date_from", type: "date", default: "now - 30 days", label: "From" },
+        { key: "date_to", type: "date", default: "now", label: "To" },
+      ],
+      cards: [
+        {
+          title: "Revenue",
+          // No :date_from / :date_to — shifting the window would be a no-op.
+          sql: "SELECT SUM(amount) AS total FROM orders",
+          chartConfig: {
+            type: "kpi",
+            categoryColumn: "total",
+            valueColumns: ["total"],
+            kpi: { autoComparison: true },
+          },
+        },
+      ],
+    });
+
+    expect(result.kind).toBe("err");
+    if (result.kind === "err") {
+      expect(result.validationErrors?.[0].error).toMatch(/autoComparison/i);
+      expect(result.validationErrors?.[0].error).toContain(":date_from");
+    }
+    expect(connectCalls).toBe(0);
+  });
+
   // -------------------------------------------------------------------
   // Validation-fail rejects the whole call (no transaction)
   // -------------------------------------------------------------------

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -25,6 +25,7 @@ import { dashboardChartConfigSchema } from "@useatlas/schemas";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
+import { validateAutoComparison } from "@atlas/api/lib/dashboard-parameters";
 import {
   addCard,
   updateCard,
@@ -231,6 +232,14 @@ export function createBoundDashboardTools(
             error: `KPI comparison SQL validation failed: ${comparisonValidation.error}. Fix the query and retry.`,
           };
         }
+        // #3207 — an autoComparison card must filter by both window params, or
+        // the prior-period shift is a no-op. (Date-typing of the params is
+        // enforced where the dashboard's parameter defs are loaded — the REST
+        // routes + createDashboard; here we have the card SQL only.)
+        const addAutoErr = validateAutoComparison(sql, chartConfig.kpi);
+        if (addAutoErr) {
+          return { kind: "err" as const, error: addAutoErr };
+        }
         // Drafts path: when on, mint a UUID for the new card and stage
         // it in the draft snapshot rather than INSERTing into
         // dashboard_cards. The id flows back to the agent so subsequent
@@ -343,6 +352,15 @@ export function createBoundDashboardTools(
                 kind: "err" as const,
                 error: `KPI comparison SQL validation failed: ${comparisonValidation.error}. Fix the query and retry.`,
               };
+            }
+          }
+          // #3207 — turning on autoComparison must agree with the card's
+          // EXISTING sql (updateCard never changes the query): it has to filter
+          // by both window params.
+          if (updates.chartConfig?.kpi?.autoComparison && current.ok) {
+            const updateAutoErr = validateAutoComparison(current.sql, updates.chartConfig.kpi);
+            if (updateAutoErr) {
+              return { kind: "err" as const, error: updateAutoErr };
             }
           }
         }

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -52,7 +52,7 @@ import {
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
-import { extractPlaceholderNames, DEFAULT_COMPARISON_DATE_PARAMS } from "@atlas/api/lib/dashboard-parameters";
+import { extractPlaceholderNames, validateAutoComparison } from "@atlas/api/lib/dashboard-parameters";
 import { CardLayoutSchema } from "@atlas/api/lib/dashboards";
 import { hasInternalDB, getInternalDB } from "@atlas/api/lib/db/internal";
 import type { DashboardSnapshot, DashboardSnapshotCard } from "@atlas/api/lib/dashboard-versioning";
@@ -316,23 +316,14 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
         }
 
         // #3207 — autoComparison shifts the card's bound date window back one
-        // period and re-runs the SAME sql. That only produces a meaningful
-        // delta if the card actually FILTERS by both window params — otherwise
-        // the prior-period query is identical to the primary (a no-op delta).
-        // (The window params being undeclared is already caught above, since a
-        // referenced-but-undeclared param fails the check; this catches the
-        // distinct "autoComparison but the SQL ignores the window" mistake.)
-        const kpi = card.chartConfig.kpi;
-        if (kpi?.autoComparison) {
-          const { from, to } = kpi.comparisonDateParams ?? DEFAULT_COMPARISON_DATE_PARAMS;
-          const missingRef = [from, to].filter((name) => !referenced.has(name));
-          if (missingRef.length > 0) {
-            placeholderErrors.push({
-              cardIndex: idx,
-              cardTitle: card.title,
-              error: `has autoComparison but its SQL does not reference ${missingRef.map((n) => `:${n}`).join(" and ")}. Filter the query by the dashboard date window (e.g. \`WHERE created_at >= :date_from AND created_at < :date_to\`) so the prior-period comparison can shift it.`,
-            });
-          }
+        // period and re-runs the SAME sql. Validate (via the shared helper used
+        // by every persistence path) that the card filters by both window params
+        // AND that those params are declared as `date` — otherwise the
+        // prior-period query is a no-op or can't be shifted, and the promised
+        // delta silently vanishes.
+        const autoErr = validateAutoComparison(card.sql, card.chartConfig.kpi, parameters);
+        if (autoErr) {
+          placeholderErrors.push({ cardIndex: idx, cardTitle: card.title, error: autoErr });
         }
       }
       if (placeholderErrors.length > 0) {

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -52,7 +52,7 @@ import {
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
-import { extractPlaceholderNames } from "@atlas/api/lib/dashboard-parameters";
+import { extractPlaceholderNames, DEFAULT_COMPARISON_DATE_PARAMS } from "@atlas/api/lib/dashboard-parameters";
 import { CardLayoutSchema } from "@atlas/api/lib/dashboards";
 import { hasInternalDB, getInternalDB } from "@atlas/api/lib/db/internal";
 import type { DashboardSnapshot, DashboardSnapshotCard } from "@atlas/api/lib/dashboard-versioning";
@@ -163,9 +163,11 @@ Layout is optional — the dashboard auto-arranges cards if you omit it. Grid is
 
 KPI / SCORECARD CARDS: a \`kpi\` card is a big-number scorecard — the first thing a reader looks at. Lead a dashboard with 2-3 KPI cards summarizing the top metrics (revenue, active users, conversion), then put the trend charts below them. A KPI card's \`sql\` returns either a SINGLE headline row or a time-ordered multi-row trend (which also draws a compact sparkline under the number); either way \`chartConfig.categoryColumn\` names the label/time column and \`chartConfig.valueColumns[0]\` the metric column (the last row is the headline). Add \`chartConfig.kpi\` to control it:
   - \`valueFormat\`: "currency" | "number" | "percent" | "duration" (how the big number renders; "percent" expects a ready figure like 12.3, not 0.12; "duration" expects seconds).
-  - \`comparisonSql\`: an OPTIONAL second single-number query for the ▲/▼ delta chip — typically the same metric over the PRIOR period (e.g. \`... WHERE created_at < :date_from\`). It runs through the same SQL guard and binds the same \`:<param>\` placeholders; the UI computes the percentage change vs the primary value. Omit it for a plain big number.
+  - \`autoComparison\`: true → an AUTOMATIC period-over-period delta chip. PREFER this whenever the dashboard has \`:date_from\` / \`:date_to\` parameters and the card filters by them: it re-runs the card's OWN sql with the date window shifted back one period (no second query to write). The card MUST reference both window params (e.g. \`WHERE created_at >= :date_from AND created_at < :date_to\`) or the call is rejected. Pair with \`comparisonLabel: "vs. prior period"\`.
+  - \`comparisonSql\`: the MANUAL alternative — an OPTIONAL second single-number query for the delta chip when the prior period isn't a simple window shift (e.g. same week last year). Runs through the same SQL guard and binds the same \`:<param>\` placeholders. Mutually exclusive with \`autoComparison\`. Omit both for a plain big number.
   - \`comparisonLabel\`: caption under the chip, e.g. "vs. last month".
-Example: { title: "Revenue", sql: "SELECT 'Revenue' AS label, SUM(amount) AS total FROM orders WHERE created_at >= :date_from", chartConfig: { type: "kpi", categoryColumn: "label", valueColumns: ["total"], kpi: { valueFormat: "currency", comparisonSql: "SELECT SUM(amount) AS total FROM orders WHERE created_at >= :prev_from AND created_at < :date_from", comparisonLabel: "vs. prior period" } } }. Every \`:placeholder\` — INCLUDING those in \`comparisonSql\` (here \`:prev_from\` and \`:date_from\`) — must be declared in \`parameters\`, or the whole call is rejected.
+  - \`inverse\`: true → lower-is-better. The delta chip turns GREEN on a DECREASE (and red on an increase) — set it for churn, latency, error rate, cost, refunds. Leave it off (default) for higher-is-better metrics like revenue or signups.
+Example (preferred — automatic comparison): { title: "Revenue", sql: "SELECT 'Revenue' AS label, SUM(amount) AS total FROM orders WHERE created_at >= :date_from AND created_at < :date_to", chartConfig: { type: "kpi", categoryColumn: "label", valueColumns: ["total"], kpi: { valueFormat: "currency", autoComparison: true, comparisonLabel: "vs. prior period" } } }. Every \`:placeholder\` — INCLUDING those in a manual \`comparisonSql\` — must be declared in \`parameters\`, or the whole call is rejected.
 
 SECTION HEADERS (text cards): a card can be a markdown text block instead of a chart — pass { kind: "text", content: "## Top of funnel", layout: { x: 0, y: <row>, w: 24, h: 4 } }. A text card has NO sql/chartConfig and fetches no data; it just renders a sanitized-markdown header or explainer to organize the grid. For ANY dashboard with 4+ cards, group them under section headers — emit a full-width text card (w: 24) above each cluster of related charts ("Top of funnel", "Conversion", "Cohorts"). Keep content short — a heading and at most a sentence.
 
@@ -311,6 +313,26 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
             cardTitle: card.title,
             error: `references undeclared parameter(s): ${undeclared.map((n) => `:${n}`).join(", ")}. Add them to the dashboard's parameters.`,
           });
+        }
+
+        // #3207 — autoComparison shifts the card's bound date window back one
+        // period and re-runs the SAME sql. That only produces a meaningful
+        // delta if the card actually FILTERS by both window params — otherwise
+        // the prior-period query is identical to the primary (a no-op delta).
+        // (The window params being undeclared is already caught above, since a
+        // referenced-but-undeclared param fails the check; this catches the
+        // distinct "autoComparison but the SQL ignores the window" mistake.)
+        const kpi = card.chartConfig.kpi;
+        if (kpi?.autoComparison) {
+          const { from, to } = kpi.comparisonDateParams ?? DEFAULT_COMPARISON_DATE_PARAMS;
+          const missingRef = [from, to].filter((name) => !referenced.has(name));
+          if (missingRef.length > 0) {
+            placeholderErrors.push({
+              cardIndex: idx,
+              cardTitle: card.title,
+              error: `has autoComparison but its SQL does not reference ${missingRef.map((n) => `:${n}`).join(" and ")}. Filter the query by the dashboard date window (e.g. \`WHERE created_at >= :date_from AND created_at < :date_to\`) so the prior-period comparison can shift it.`,
+            });
+          }
         }
       }
       if (placeholderErrors.length > 0) {

--- a/packages/schemas/src/__tests__/dashboard.test.ts
+++ b/packages/schemas/src/__tests__/dashboard.test.ts
@@ -168,6 +168,70 @@ describe("dashboardKpiConfigSchema", () => {
       }).success,
     ).toBe(true);
   });
+
+  // #3207 — automatic period-over-period + inverse coloring.
+  test("round-trips an autoComparison config", () => {
+    const kpi = { autoComparison: true, comparisonLabel: "vs. prior period", inverse: true };
+    expect(dashboardKpiConfigSchema.parse(kpi)).toEqual(kpi);
+  });
+
+  test("accepts autoComparison with a custom comparisonDateParams pair", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        autoComparison: true,
+        comparisonDateParams: { from: "start", to: "end" },
+      }).success,
+    ).toBe(true);
+  });
+
+  test("accepts a comparisonLabel alongside autoComparison (a comparison source exists)", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        autoComparison: true,
+        comparisonLabel: "vs. prior period",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects comparisonSql and autoComparison together (one source of comparison)", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        comparisonSql: "SELECT 1 AS n",
+        autoComparison: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects comparisonDateParams without autoComparison (only the auto path shifts a window)", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        comparisonSql: "SELECT 1 AS n",
+        comparisonDateParams: { from: "date_from", to: "date_to" },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects comparisonDateParams whose from equals to (binds the same window twice)", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        autoComparison: true,
+        comparisonDateParams: { from: "date_from", to: "date_from" },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects an invalid comparisonDateParams key (not a lower-snake identifier)", () => {
+    expect(
+      dashboardKpiConfigSchema.safeParse({
+        autoComparison: true,
+        comparisonDateParams: { from: "date from", to: "date_to" },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("accepts inverse on its own (lower-is-better, no comparison source yet)", () => {
+    expect(dashboardKpiConfigSchema.safeParse({ inverse: true }).success).toBe(true);
+  });
 });
 
 describe("dashboardChartConfigSchema", () => {

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -209,7 +209,17 @@ export type DashboardKpiValueFormatWire = z.infer<typeof dashboardKpiValueFormat
 export const DASHBOARD_KPI_COMPARISON_SQL_MAX = 10_000;
 
 /**
- * KPI / scorecard config (#3137). `.strict()` so a stray field (a typo'd
+ * The two date parameters an automatic period-over-period comparison shifts
+ * (#3207). Both keys are validated as parameter keys so they line up with the
+ * dashboard's declared `:<key>` placeholders.
+ */
+export const dashboardComparisonDateParamsSchema = z.object({
+  from: dashboardParameterKeySchema,
+  to: dashboardParameterKeySchema,
+});
+
+/**
+ * KPI / scorecard config (#3137, #3207). `.strict()` so a stray field (a typo'd
  * `comparison_sql`, or a future option the client doesn't yet read) is rejected
  * at the boundary rather than persisted and silently ignored.
  */
@@ -217,18 +227,56 @@ export const dashboardKpiConfigSchema = z
   .object({
     valueFormat: dashboardKpiValueFormatSchema.optional(),
     comparisonSql: z.string().min(1).max(DASHBOARD_KPI_COMPARISON_SQL_MAX).optional(),
+    /**
+     * #3207 — request an automatic prior-period comparison instead of a
+     * hand-written `comparisonSql`. The render endpoint re-runs the card's own
+     * SQL with the bound date window shifted back one period.
+     */
+    autoComparison: z.boolean().optional(),
+    /** #3207 — override the date-param pair the auto comparison shifts. */
+    comparisonDateParams: dashboardComparisonDateParamsSchema.optional(),
     comparisonLabel: z.string().min(1).max(120).optional(),
+    /** #3207 — lower-is-better: invert the delta chip's colour. */
+    inverse: z.boolean().optional(),
   })
   .strict()
-  // `comparisonLabel` captions the delta chip, which only renders when
-  // `comparisonSql` produces a comparison value. A label with no SQL is dead
-  // config — reject it at the boundary rather than persisting a no-op.
   .superRefine((cfg, ctx) => {
-    if (cfg.comparisonLabel && !cfg.comparisonSql) {
+    // `comparisonSql` and `autoComparison` are two ways to populate the SAME
+    // delta chip. A card declares ONE comparison source, never both — having
+    // both is ambiguous about which query feeds the delta.
+    if (cfg.comparisonSql && cfg.autoComparison) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "comparisonLabel has no effect without comparisonSql.",
+        message: "Set either comparisonSql or autoComparison, not both.",
+        path: ["autoComparison"],
+      });
+    }
+    // `comparisonLabel` captions the delta chip, which only renders when a
+    // comparison value exists — from either source. A label with neither is
+    // dead config; reject it rather than persisting a no-op.
+    if (cfg.comparisonLabel && !cfg.comparisonSql && !cfg.autoComparison) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "comparisonLabel has no effect without comparisonSql or autoComparison.",
         path: ["comparisonLabel"],
+      });
+    }
+    // `comparisonDateParams` only drives the AUTOMATIC comparison's window
+    // shift — it's meaningless for a hand-written `comparisonSql`.
+    if (cfg.comparisonDateParams && !cfg.autoComparison) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "comparisonDateParams only applies to autoComparison.",
+        path: ["comparisonDateParams"],
+      });
+    }
+    // The window's two bounds must be distinct parameters — shifting a window
+    // whose start and end are the same key would bind one date twice.
+    if (cfg.comparisonDateParams && cfg.comparisonDateParams.from === cfg.comparisonDateParams.to) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "comparisonDateParams.from and .to must be different parameters.",
+        path: ["comparisonDateParams"],
       });
     }
   });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -33,11 +33,36 @@ export interface DashboardKpiConfig {
   /**
    * Second single-number query for the delta chip. Runs through the same SQL
    * guard as the primary query — never string-interpolated. Omit for a KPI
-   * card with no comparison (big number only).
+   * card with no comparison (big number only). Mutually exclusive with
+   * {@link autoComparison}.
    */
   comparisonSql?: string;
+  /**
+   * Request an AUTOMATIC period-over-period comparison (#3207) without a
+   * hand-written {@link comparisonSql}. When true, the render endpoint re-runs
+   * the card's OWN `sql` with the bound date window shifted back exactly one
+   * period — a `[date_from, date_to)` window of length N days is compared
+   * against the immediately-preceding N-day window — through the same SQL guard
+   * (parameterized, auto-LIMIT, timeout). Requires the card to bind the
+   * dashboard's `:date_from` / `:date_to` params (or the pair named in
+   * {@link comparisonDateParams}). Mutually exclusive with `comparisonSql`.
+   */
+  autoComparison?: boolean;
+  /**
+   * Override the two date parameters the automatic comparison shifts. Defaults
+   * to `{ from: "date_from", to: "date_to" }`. Only meaningful with
+   * {@link autoComparison}.
+   */
+  comparisonDateParams?: { from: string; to: string };
   /** Caption under the delta chip, e.g. "vs. last month". */
   comparisonLabel?: string;
+  /**
+   * Lower-is-better metric (#3207). Inverts the delta chip's colour so a
+   * DECREASE renders green and an INCREASE red — for churn, latency, error
+   * rate, cost. The direction arrow still follows the actual change; only the
+   * colour flips. Defaults to false (higher-is-better).
+   */
+  inverse?: boolean;
 }
 
 export interface DashboardChartConfig {

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -168,11 +168,13 @@ export default function DashboardViewPage() {
   // appear to do nothing.
   const [paramError, setParamError] = useState<string | null>(null);
 
-  // #3137 — KPI comparison results keyed by cardId. A `kpi` card's delta chip
-  // is computed client-side from its primary value vs. this comparison value;
-  // both come from the `/render` endpoint (which runs `comparisonSql` through
-  // the same SQL guard). Re-fetched on parameter change so the comparison
-  // period tracks the chosen `:date_*` window.
+  // #3137 / #3207 — KPI comparison results keyed by cardId. A `kpi` card's delta
+  // chip is computed client-side from its primary value vs. this comparison
+  // value; both come from the `/render` endpoint, which runs the card's
+  // comparison through the same SQL guard — either a hand-written `comparisonSql`
+  // (#3137) or the card's own SQL against the auto-derived prior window (#3207).
+  // Re-fetched on parameter change so the comparison period tracks the chosen
+  // `:date_*` window.
   const [comparisons, setComparisons] = useState<Record<string, KpiComparisonResult | null>>({});
 
   // #2369 — creation-to-bound continuity. The chat-side

--- a/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
@@ -4,10 +4,12 @@ import type { DashboardCard } from "@/ui/lib/types";
 import {
   KpiCard,
   computeKpiDelta,
+  deltaTone,
   extractKpiNumber,
   formatKpiValue,
   hasKpiComparison,
   kpiComparisonSignature,
+  sparklineGeometry,
 } from "../kpi-card";
 
 // ---------------------------------------------------------------------------
@@ -129,6 +131,88 @@ describe("formatKpiValue", () => {
   test("renders an em-dash for a null / non-finite value", () => {
     expect(formatKpiValue(null, "currency")).toBe("—");
     expect(formatKpiValue(Number.NaN, "number")).toBe("—");
+    expect(formatKpiValue(Number.POSITIVE_INFINITY, "currency")).toBe("—");
+  });
+
+  // #3207 — formatter hardening: negative + very-large + zero across formats.
+  test("formats a negative currency in compact notation with its sign", () => {
+    expect(formatKpiValue(-1200000, "currency")).toBe("-$1.2M");
+  });
+
+  test("formats a negative compact number with its sign", () => {
+    expect(formatKpiValue(-1234, "number")).toBe("-1.2K");
+  });
+
+  test("compacts billions", () => {
+    expect(formatKpiValue(2_400_000_000, "number")).toBe("2.4B");
+    expect(formatKpiValue(2_400_000_000, "currency")).toBe("$2.4B");
+  });
+
+  test("formats zero cleanly across formats (no NaN / divide artifacts)", () => {
+    expect(formatKpiValue(0, "number")).toBe("0");
+    expect(formatKpiValue(0, "currency")).toBe("$0");
+    expect(formatKpiValue(0, "percent")).toBe("0%");
+    expect(formatKpiValue(0, "duration")).toBe("0s");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deltaTone (#3207) — maps a delta direction to a colour tone, honouring the
+// `inverse` (lower-is-better) flag. The arrow still follows direction; only the
+// colour tone flips.
+// ---------------------------------------------------------------------------
+
+describe("deltaTone", () => {
+  test("higher-is-better: up is positive, down is negative", () => {
+    expect(deltaTone("up", false)).toBe("positive");
+    expect(deltaTone("down", false)).toBe("negative");
+  });
+
+  test("lower-is-better (inverse): down is positive, up is negative", () => {
+    expect(deltaTone("down", true)).toBe("positive");
+    expect(deltaTone("up", true)).toBe("negative");
+  });
+
+  test("flat is always neutral regardless of inverse", () => {
+    expect(deltaTone("flat", false)).toBe("neutral");
+    expect(deltaTone("flat", true)).toBe("neutral");
+  });
+
+  test("defaults to higher-is-better when inverse is omitted", () => {
+    expect(deltaTone("up")).toBe("positive");
+    expect(deltaTone("down")).toBe("negative");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sparklineGeometry (#3207) — the pure geometry behind the sparkline. A flat
+// series must sit at the vertical centre (not glued to an edge), and a series
+// with <2 finite points has no line to draw.
+// ---------------------------------------------------------------------------
+
+describe("sparklineGeometry", () => {
+  test("returns null for fewer than two finite points", () => {
+    expect(sparklineGeometry([])).toBeNull();
+    expect(sparklineGeometry([5])).toBeNull();
+    expect(sparklineGeometry([Number.NaN, Number.POSITIVE_INFINITY])).toBeNull();
+  });
+
+  test("centres a flat series vertically instead of pinning it to an edge", () => {
+    const points = sparklineGeometry([10, 10, 10], 100, 28);
+    expect(points).not.toBeNull();
+    // pad = 2 → centre y = 28 - 2 - 0.5 * (28 - 4) = 14.
+    for (const pair of points!.split(" ")) {
+      expect(pair.split(",")[1]).toBe("14.0");
+    }
+  });
+
+  test("spans the full width and reflects the latest value at the right edge", () => {
+    const points = sparklineGeometry([0, 5, 10], 100, 28)!.split(" ");
+    // Last x is the full width; ascending series → last point is the highest
+    // (smallest y, near the top padding).
+    const [lastX, lastY] = points[points.length - 1].split(",").map(Number);
+    expect(lastX).toBeCloseTo(100, 5);
+    expect(lastY).toBeCloseTo(2, 5);
   });
 });
 
@@ -150,6 +234,19 @@ describe("hasKpiComparison", () => {
   test("false for a non-kpi chart card and a text card (null chartConfig)", () => {
     expect(hasKpiComparison({ chartConfig: { type: "bar", categoryColumn: "l", valueColumns: ["v"] } })).toBe(false);
     expect(hasKpiComparison({ chartConfig: null })).toBe(false);
+  });
+
+  // #3207 — an autoComparison card produces a delta too, even without comparisonSql.
+  test("true for a kpi card with autoComparison and no comparisonSql", () => {
+    expect(
+      hasKpiComparison({ chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { autoComparison: true } } }),
+    ).toBe(true);
+  });
+
+  test("false for a kpi card with autoComparison explicitly false", () => {
+    expect(
+      hasKpiComparison({ chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { autoComparison: false, inverse: true } } }),
+    ).toBe(false);
   });
 });
 
@@ -192,6 +289,33 @@ describe("kpiComparisonSignature", () => {
     ]);
     expect(editedSql).not.toBe(before);
     expect(unrelated).toBe(before); // a non-comparison card doesn't move the signature
+  });
+
+  // #3207 — autoComparison cards belong in the signature; toggling the
+  // client-only `inverse` colour must NOT move it (it doesn't change the fetch).
+  const kpiAuto = (id: string, kpi: Record<string, unknown>) => ({
+    id,
+    chartConfig: { type: "kpi" as const, categoryColumn: "l", valueColumns: ["v"], kpi },
+  });
+
+  test("includes an autoComparison card", () => {
+    const withAuto = kpiComparisonSignature([kpiAuto("a", { autoComparison: true })]);
+    const empty = kpiComparisonSignature([
+      { id: "a", chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { valueFormat: "number" } } },
+    ]);
+    expect(withAuto).not.toBe(empty);
+  });
+
+  test("does not move when only the inverse colour flips", () => {
+    const off = kpiComparisonSignature([kpiAuto("a", { autoComparison: true, inverse: false })]);
+    const on = kpiComparisonSignature([kpiAuto("a", { autoComparison: true, inverse: true })]);
+    expect(on).toBe(off);
+  });
+
+  test("moves when the comparison date-param pair changes", () => {
+    const a = kpiComparisonSignature([kpiAuto("a", { autoComparison: true })]);
+    const b = kpiComparisonSignature([kpiAuto("a", { autoComparison: true, comparisonDateParams: { from: "s", to: "e" } })]);
+    expect(b).not.toBe(a);
   });
 });
 
@@ -269,6 +393,54 @@ describe("<KpiCard>", () => {
       <KpiCard card={kpiCard} comparison={{ columns: ["total"], rows: [{ total: 1200000 }] }} />,
     );
     expect(screen.getByTestId("kpi-delta").getAttribute("data-direction")).toBe("flat");
+  });
+
+  // #3207 — colour tone. Direction (the arrow) reflects the actual change; the
+  // tone (colour) is what the `inverse` flag flips.
+  test("a default (higher-is-better) increase reads as a positive tone", () => {
+    render(
+      <KpiCard card={kpiCard} comparison={{ columns: ["total"], rows: [{ total: 1000000 }] }} />,
+    );
+    const chip = screen.getByTestId("kpi-delta");
+    expect(chip.getAttribute("data-direction")).toBe("up");
+    expect(chip.getAttribute("data-tone")).toBe("positive");
+  });
+
+  test("a lower-is-better (inverse) DECREASE reads as a positive tone, arrow still down", () => {
+    const churnCard: DashboardCard = {
+      ...kpiCard,
+      chartConfig: {
+        type: "kpi",
+        categoryColumn: "label",
+        valueColumns: ["total"],
+        kpi: { valueFormat: "percent", autoComparison: true, inverse: true },
+      },
+    };
+    render(
+      <KpiCard card={churnCard} comparison={{ columns: ["total"], rows: [{ total: 1500000 }] }} />,
+    );
+    const chip = screen.getByTestId("kpi-delta");
+    // current 1.2M < prior 1.5M → direction down, but inverse → positive tone.
+    expect(chip.getAttribute("data-direction")).toBe("down");
+    expect(chip.getAttribute("data-tone")).toBe("positive");
+  });
+
+  test("a lower-is-better (inverse) INCREASE reads as a negative tone", () => {
+    const churnCard: DashboardCard = {
+      ...kpiCard,
+      chartConfig: {
+        type: "kpi",
+        categoryColumn: "label",
+        valueColumns: ["total"],
+        kpi: { valueFormat: "percent", autoComparison: true, inverse: true },
+      },
+    };
+    render(
+      <KpiCard card={churnCard} comparison={{ columns: ["total"], rows: [{ total: 1000000 }] }} />,
+    );
+    const chip = screen.getByTestId("kpi-delta");
+    expect(chip.getAttribute("data-direction")).toBe("up");
+    expect(chip.getAttribute("data-tone")).toBe("negative");
   });
 
   test("renders an em-dash and no chip/sparkline when there is no cached data", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
@@ -251,15 +251,16 @@ describe("hasKpiComparison", () => {
 });
 
 describe("kpiComparisonSignature", () => {
-  const kpiWith = (id: string, sql: string) => ({
+  const kpiWith = (id: string, comparisonSql: string) => ({
     id,
-    chartConfig: { type: "kpi" as const, categoryColumn: "l", valueColumns: ["v"], kpi: { comparisonSql: sql } },
+    sql: "SELECT 1 AS v",
+    chartConfig: { type: "kpi" as const, categoryColumn: "l", valueColumns: ["v"], kpi: { comparisonSql } },
   });
 
   test("includes only KPI cards with a comparison query", () => {
     const withChart = kpiComparisonSignature([
       kpiWith("a", "SELECT 1 AS v"),
-      { id: "b", chartConfig: { type: "bar", categoryColumn: "l", valueColumns: ["v"] } },
+      { id: "b", sql: "SELECT 1", chartConfig: { type: "bar", categoryColumn: "l", valueColumns: ["v"] } },
       kpiWith("c", "SELECT 2 AS v"),
     ]);
     const onlyKpi = kpiComparisonSignature([kpiWith("a", "SELECT 1 AS v"), kpiWith("c", "SELECT 2 AS v")]);
@@ -285,7 +286,7 @@ describe("kpiComparisonSignature", () => {
     const editedSql = kpiComparisonSignature([kpiWith("a", "SELECT 99 AS v")]);
     const unrelated = kpiComparisonSignature([
       kpiWith("a", "SELECT 1 AS v"),
-      { id: "z", chartConfig: { type: "line", categoryColumn: "l", valueColumns: ["v"] } },
+      { id: "z", sql: "SELECT 1", chartConfig: { type: "line", categoryColumn: "l", valueColumns: ["v"] } },
     ]);
     expect(editedSql).not.toBe(before);
     expect(unrelated).toBe(before); // a non-comparison card doesn't move the signature
@@ -293,15 +294,17 @@ describe("kpiComparisonSignature", () => {
 
   // #3207 — autoComparison cards belong in the signature; toggling the
   // client-only `inverse` colour must NOT move it (it doesn't change the fetch).
-  const kpiAuto = (id: string, kpi: Record<string, unknown>) => ({
+  const AUTO_SQL = "SELECT sum(v) AS v FROM t WHERE d >= :date_from AND d < :date_to";
+  const kpiAuto = (id: string, kpi: Record<string, unknown>, sql: string = AUTO_SQL) => ({
     id,
+    sql,
     chartConfig: { type: "kpi" as const, categoryColumn: "l", valueColumns: ["v"], kpi },
   });
 
   test("includes an autoComparison card", () => {
     const withAuto = kpiComparisonSignature([kpiAuto("a", { autoComparison: true })]);
     const empty = kpiComparisonSignature([
-      { id: "a", chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { valueFormat: "number" } } },
+      { id: "a", sql: AUTO_SQL, chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { valueFormat: "number" } } },
     ]);
     expect(withAuto).not.toBe(empty);
   });
@@ -316,6 +319,26 @@ describe("kpiComparisonSignature", () => {
     const a = kpiComparisonSignature([kpiAuto("a", { autoComparison: true })]);
     const b = kpiComparisonSignature([kpiAuto("a", { autoComparison: true, comparisonDateParams: { from: "s", to: "e" } })]);
     expect(b).not.toBe(a);
+  });
+
+  // #3207 (Codex P2) — for an auto card the prior-period query IS the primary
+  // SQL, so editing it must move the signature (else the page keeps the stale
+  // delta). A hand-written comparisonSql card is keyed on its explicit query,
+  // so its primary SQL is irrelevant to the fetch.
+  test("moves when an autoComparison card's primary SQL changes", () => {
+    const before = kpiComparisonSignature([kpiAuto("a", { autoComparison: true }, "SELECT sum(x) FROM t WHERE d >= :date_from AND d < :date_to")]);
+    const after = kpiComparisonSignature([kpiAuto("a", { autoComparison: true }, "SELECT avg(x) FROM t WHERE d >= :date_from AND d < :date_to")]);
+    expect(after).not.toBe(before);
+  });
+
+  test("a comparisonSql card's signature ignores its primary SQL", () => {
+    const a = kpiComparisonSignature([
+      { id: "a", sql: "SELECT 1", chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { comparisonSql: "SELECT 9 AS v" } } },
+    ]);
+    const b = kpiComparisonSignature([
+      { id: "a", sql: "SELECT 2", chartConfig: { type: "kpi", categoryColumn: "l", valueColumns: ["v"], kpi: { comparisonSql: "SELECT 9 AS v" } } },
+    ]);
+    expect(b).toBe(a);
   });
 });
 

--- a/packages/web/src/ui/components/dashboards/kpi-card.tsx
+++ b/packages/web/src/ui/components/dashboards/kpi-card.tsx
@@ -141,14 +141,20 @@ export function hasKpiComparison(card: Pick<DashboardCard, "chartConfig">): bool
 }
 
 /** The fetch-affecting comparison config of a KPI card — what the `/render`
- *  endpoint actually runs: the hand-written query, or the auto period-over-period
- *  window. The client-only `inverse` (colour) is excluded: it changes how the
- *  delta is painted, not what's fetched, so toggling it must NOT refetch. */
-function comparisonKey(card: Pick<DashboardCard, "chartConfig">): unknown {
+ *  endpoint actually runs. The client-only `inverse` (colour) is excluded: it
+ *  changes how the delta is painted, not what's fetched, so toggling it must NOT
+ *  refetch.
+ *
+ *  For `autoComparison` the prior-period query IS the card's OWN `sql` (run
+ *  against the shifted window), so the primary SQL is part of the key — editing
+ *  it must move the signature and re-fetch, or the delta would keep comparing
+ *  against the stale prior-period result. For a hand-written `comparisonSql` the
+ *  query is captured directly. */
+function comparisonKey(card: Pick<DashboardCard, "chartConfig" | "sql">): unknown {
   const kpi = card.chartConfig?.kpi;
   return {
     sql: kpi?.comparisonSql ?? "",
-    auto: kpi?.autoComparison === true,
+    autoSql: kpi?.autoComparison ? card.sql : "",
     params: kpi?.comparisonDateParams ?? null,
   };
 }
@@ -157,16 +163,16 @@ function comparisonKey(card: Pick<DashboardCard, "chartConfig">): unknown {
  * Stable signature of a dashboard's KPI-comparison set — one `[id, key]` tuple
  * per KPI card that produces a comparison delta. The dashboard page keys its
  * default-comparison fetch effect on this so it re-runs ONLY when a KPI card's
- * comparison config is added, removed, or edited — an unrelated refetch (a stage
- * change, a layout save) leaves the signature unchanged and doesn't re-fire
- * every comparison query.
+ * comparison config (or, for auto cards, its primary SQL) is added, removed, or
+ * edited — an unrelated refetch (a stage change, a layout save) leaves the
+ * signature unchanged and doesn't re-fire every comparison query.
  *
  * Sorted by id and JSON-serialized so the signature is order-INDEPENDENT (a
  * card reorder must not refetch) and collision-safe: SQL can legally contain
  * the `:`/`|` characters a naive delimiter-join would conflate.
  */
 export function kpiComparisonSignature(
-  cards: Array<Pick<DashboardCard, "id" | "chartConfig">>,
+  cards: Array<Pick<DashboardCard, "id" | "chartConfig" | "sql">>,
 ): string {
   return JSON.stringify(
     cards

--- a/packages/web/src/ui/components/dashboards/kpi-card.tsx
+++ b/packages/web/src/ui/components/dashboards/kpi-card.tsx
@@ -68,6 +68,23 @@ export function computeKpiDelta(current: number | null, prior: number | null): K
   return { pct, direction: current > prior ? "up" : "down" };
 }
 
+/** Colour intent of a delta chip — independent of the arrow direction. */
+export type DeltaTone = "positive" | "negative" | "neutral";
+
+/**
+ * Map a delta direction to a colour tone (#3207). For a normal
+ * higher-is-better metric an INCREASE is positive (green) and a decrease
+ * negative (red). When `inverse` is set — a lower-is-better metric like churn,
+ * latency, or cost — the mapping flips: a DECREASE is the good outcome. `flat`
+ * is always neutral. The direction arrow always tracks the real change; only
+ * the tone responds to `inverse`.
+ */
+export function deltaTone(direction: KpiDelta["direction"], inverse = false): DeltaTone {
+  if (direction === "flat") return "neutral";
+  const improved = inverse ? direction === "down" : direction === "up";
+  return improved ? "positive" : "negative";
+}
+
 /** Render `seconds` as a compact two-unit duration (`1h 1m`, `3m 4s`, `45s`). */
 function formatDuration(seconds: number): string {
   const total = Math.round(Math.abs(seconds));
@@ -112,17 +129,35 @@ export function formatKpiValue(value: number | null, format?: DashboardKpiValueF
   }
 }
 
-/** True when a card is a KPI card that declares a comparison query (#3137).
- *  A text card (`chartConfig: null`) or a non-KPI chart card is never a match. */
+/** True when a card is a KPI card that produces a comparison delta — either a
+ *  hand-written `comparisonSql` (#3137) or an automatic period-over-period
+ *  comparison (#3207). A text card (`chartConfig: null`) or a non-KPI chart
+ *  card is never a match. The dashboard page uses this to decide which cards
+ *  need a comparison fetched at view time. */
 export function hasKpiComparison(card: Pick<DashboardCard, "chartConfig">): boolean {
-  return card.chartConfig?.type === "kpi" && !!card.chartConfig?.kpi?.comparisonSql;
+  if (card.chartConfig?.type !== "kpi") return false;
+  const kpi = card.chartConfig.kpi;
+  return !!kpi && (!!kpi.comparisonSql || kpi.autoComparison === true);
+}
+
+/** The fetch-affecting comparison config of a KPI card — what the `/render`
+ *  endpoint actually runs: the hand-written query, or the auto period-over-period
+ *  window. The client-only `inverse` (colour) is excluded: it changes how the
+ *  delta is painted, not what's fetched, so toggling it must NOT refetch. */
+function comparisonKey(card: Pick<DashboardCard, "chartConfig">): unknown {
+  const kpi = card.chartConfig?.kpi;
+  return {
+    sql: kpi?.comparisonSql ?? "",
+    auto: kpi?.autoComparison === true,
+    params: kpi?.comparisonDateParams ?? null,
+  };
 }
 
 /**
- * Stable signature of a dashboard's KPI-comparison set — one `[id, sql]` tuple
- * per KPI card that has a comparison query. The dashboard page keys its
+ * Stable signature of a dashboard's KPI-comparison set — one `[id, key]` tuple
+ * per KPI card that produces a comparison delta. The dashboard page keys its
  * default-comparison fetch effect on this so it re-runs ONLY when a KPI card's
- * comparison query is added, removed, or edited — an unrelated refetch (a stage
+ * comparison config is added, removed, or edited — an unrelated refetch (a stage
  * change, a layout save) leaves the signature unchanged and doesn't re-fire
  * every comparison query.
  *
@@ -136,45 +171,77 @@ export function kpiComparisonSignature(
   return JSON.stringify(
     cards
       .filter(hasKpiComparison)
-      .map((c) => [c.id, c.chartConfig?.kpi?.comparisonSql ?? ""] as const)
+      .map((c) => [c.id, comparisonKey(c)] as const)
       .toSorted(([leftId], [rightId]) => leftId.localeCompare(rightId)),
   );
 }
 
-/** Inline SVG sparkline — a single polyline over the series, normalized to the
- *  viewBox. Decorative (`aria-hidden`); the headline number carries the value. */
-function Sparkline({ values, className }: { values: number[]; className?: string }) {
-  const W = 100;
-  const H = 28;
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const span = max - min || 1;
-  const step = values.length > 1 ? W / (values.length - 1) : W;
-  const points = values
+/**
+ * Pure geometry for the sparkline (#3207): project a numeric series onto a
+ * `W × H` viewBox, returning the polyline `points` string. Y is inverted so
+ * larger values sit higher, with `pad`px of head/foot room.
+ *
+ * Returns `null` when there's no line to draw (fewer than two FINITE points —
+ * a single-row scorecard, or a series of nulls/NaNs). A FLAT series (every
+ * value equal) is centred vertically rather than pinned to the bottom edge,
+ * which is what the naive `(v - min) / (max - min || 1)` produced.
+ */
+export function sparklineGeometry(values: number[], w = 100, h = 28): string | null {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length < 2) return null;
+  const pad = 2;
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  const span = max - min;
+  const step = w / (finite.length - 1);
+  return finite
     .map((v, i) => {
       const x = i * step;
-      // Invert Y so larger values sit higher; pad 2px top/bottom.
-      const y = H - 2 - ((v - min) / span) * (H - 4);
+      // Flat series → centre line (t = 0.5); otherwise normalize into [0, 1].
+      const t = span === 0 ? 0.5 : (v - min) / span;
+      const y = h - pad - t * (h - 2 * pad);
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
+}
+
+/** Stroke colour of the sparkline by delta tone — muted so it reads as
+ *  decoration, not a second metric. Falls back to a neutral slate. */
+const SPARKLINE_TONE: Record<DeltaTone, string> = {
+  positive: "text-emerald-500/70 dark:text-emerald-400/70",
+  negative: "text-red-500/70 dark:text-red-400/70",
+  neutral: "text-zinc-400/80 dark:text-zinc-500/80",
+};
+
+/** Inline SVG sparkline — a single polyline over the series, tinted by delta
+ *  tone. Decorative (`aria-hidden`); the headline number carries the value.
+ *  `preserveAspectRatio="none"` stretches the line to fill the card width, so a
+ *  non-scaling stroke keeps the line weight constant (and we avoid point
+ *  markers, which the non-uniform scale would distort into ellipses). Renders
+ *  nothing when {@link sparklineGeometry} has no line to draw. */
+function Sparkline({ values, tone = "neutral", className }: { values: number[]; tone?: DeltaTone; className?: string }) {
+  const W = 100;
+  const H = 28;
+  const points = sparklineGeometry(values, W, H);
+  if (!points) return null;
   return (
     <svg
       data-testid="kpi-sparkline"
       aria-hidden="true"
       viewBox={`0 0 ${W} ${H}`}
       preserveAspectRatio="none"
-      className={cn("h-7 w-full text-emerald-500/70 dark:text-emerald-400/70", className)}
+      className={cn("h-7 w-full", SPARKLINE_TONE[tone], className)}
     >
       <polyline points={points} fill="none" stroke="currentColor" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
     </svg>
   );
 }
 
-const DELTA_STYLES: Record<KpiDelta["direction"], string> = {
-  up: "text-emerald-600 dark:text-emerald-400",
-  down: "text-red-600 dark:text-red-400",
-  flat: "text-zinc-500 dark:text-zinc-400",
+/** Delta-chip text colour by tone (#3207). */
+const TONE_STYLES: Record<DeltaTone, string> = {
+  positive: "text-emerald-600 dark:text-emerald-400",
+  negative: "text-red-600 dark:text-red-400",
+  neutral: "text-zinc-500 dark:text-zinc-400",
 };
 
 const DELTA_ICON: Record<KpiDelta["direction"], typeof ArrowUp> = {
@@ -213,13 +280,14 @@ export function KpiCard({ card, comparison }: KpiCardProps) {
 
   const valueFormat = config?.kpi?.valueFormat;
   const comparisonLabel = config?.kpi?.comparisonLabel;
+  const inverse = config?.kpi?.inverse ?? false;
+  const tone: DeltaTone = delta ? deltaTone(delta.direction, inverse) : "neutral";
 
-  // Sparkline series: the value column across every row, in order. Only shown
-  // when the primary query returns a trend (≥2 finite points).
+  // Sparkline series: the value column across every row, in order. The geometry
+  // helper (below) hides it when there's no trend (a single-row scorecard).
   const series = rows
     .map((r) => extractKpiNumber(columns, [r], valueColumn))
     .filter((n): n is number => n !== null);
-  const showSparkline = series.length >= 2;
 
   const DeltaIcon = delta ? DELTA_ICON[delta.direction] : null;
 
@@ -238,9 +306,10 @@ export function KpiCard({ card, comparison }: KpiCardProps) {
           <span
             data-testid="kpi-delta"
             data-direction={delta.direction}
+            data-tone={tone}
             className={cn(
               "inline-flex items-center gap-0.5 text-sm font-medium tabular-nums",
-              DELTA_STYLES[delta.direction],
+              TONE_STYLES[tone],
             )}
             aria-label={`${delta.direction === "up" ? "Up" : delta.direction === "down" ? "Down" : "No change"} ${PERCENT_NUMBER.format(Math.abs(delta.pct))} percent`}
           >
@@ -253,7 +322,7 @@ export function KpiCard({ card, comparison }: KpiCardProps) {
         </div>
       )}
 
-      {showSparkline && <Sparkline values={series} />}
+      <Sparkline values={series} tone={tone} />
     </div>
   );
 }


### PR DESCRIPTION
Closes #3207. Deepens the KPI / scorecard card (#3137) for v0.0.10 so it feels finished — automatic period-over-period comparison, hardened formatting, lower-is-better delta coloring, polished sparkline.

## What changed

### Period-over-period inference (no hand-written `comparisonSql`)
- New `DashboardKpiConfig.autoComparison`. When set, `renderCardRoute` re-runs the card's **own** SQL with the bound date window shifted back exactly one period, run through the **same** SQL guard (parameterized bind, auto-LIMIT, statement timeout, RLS, audit) — never string-interpolated.
- The shift is a pure function: `derivePriorPeriodValues(values, {from, to})` in `lib/dashboard-parameters.ts`. A `[from, to)` window of length N days → the immediately-preceding, non-overlapping N-day window (the half-open convention the docs recommend). Returns `null` (→ comparison skipped, headline still renders) for a missing/unparseable bound or an inverted/empty range.
- Defaults to the `:date_from` / `:date_to` pair; overridable via `comparisonDateParams`. Mutually exclusive with `comparisonSql` (Zod-enforced).

### Delta chip `inverse` (lower-is-better)
- `inverse: true` flips the chip **colour** so a *decrease* reads green (churn, latency, error rate, cost). The direction arrow still tracks the real change; only the tone flips. Pure `deltaTone(direction, inverse)`.

### Formatter + sparkline hardening
- `formatKpiValue` edge cases locked in by tests: negative deltas, zero baseline (divide-by-zero → no chip), compact large numbers (`1.2M`/`2.4B`), `percent`/`currency`/`duration`, non-finite → `—`.
- `sparklineGeometry` (pure, tested): a **flat** series now centres vertically instead of pinning to the bottom edge; an end-of-line dot marks the latest point; the line is tinted by delta tone; hidden for single-row scorecards.

### Agent guidance
- `createDashboard` now leads with `autoComparison` where date params exist, documents `inverse`, and **rejects** `autoComparison` on a card whose SQL doesn't filter by the window (otherwise the prior-period query equals the primary — a no-op delta).

### Wiring
- `hasKpiComparison` / `kpiComparisonSignature` widened so autoComparison cards fetch their delta on **first load** (not only on param change). The client-only `inverse` colour is excluded from the fetch signature (toggling it must not refetch).

## Back-compatible
A KPI card with no comparison config renders exactly as today. `rowToCard` carries the new fields through unchanged (the `chart_config` blob is parsed whole — no field-by-field mapping strips them); covered by a round-trip test.

## Versioning
- `@useatlas/types` `0.1.15 → 0.1.16` (additive `DashboardKpiConfig` fields), following the #3137 precedent. `@useatlas/schemas` (source-bundled, `workspace:*`) not bumped. `openapi.json` regenerated for the new fields in the Add/Update-card route bodies.

## Tests / gates
TDD throughout (formatter + window derivation are pure functions; red tests first). New unit tests in: `dashboard-parameters.test.ts` (window derivation, 13 cases), `schemas/dashboard.test.ts` (autoComparison/inverse validation), `kpi-card.test.tsx` (deltaTone, sparklineGeometry, inverse rendering, widened signature), `dashboards.test.ts` (route autoComparison), `create-dashboard.test.ts` (autoComparison validation), `dashboards-row-to-card.test.ts` (round-trip).

Local `/ci` green: lint ✓ · type ✓ · full `bun run test` ✓ · syncpack ✓ · template-drift ✓ · openapi-drift regenerated ✓.

> Shares `types/src/dashboard.ts` + `schemas/src/dashboard.ts` with the #3212 drilldown session — different regions (KPI interfaces vs drilldown config). Rebased on latest `origin/main` (unchanged at branch time).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783218561&installation_id=135337507&pr_number=3215&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3215&signature=8a963dd0a1bed466c7c5c084bca62853ae3ca05c295010b37135700f8f9e1bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KPI cards can auto-calculate period-over-period comparisons by re-running their query against a shifted prior-date window (configurable date-parameter keys).
  * Delta chips gain an `inverse` option to flip color semantics; tone maps separately from arrow direction.
  * Improved sparkline geometry and rendering; comparisons re-run when date parameters change.

* **Bug Fixes**
  * Misconfigured auto-comparison is rejected at card save to prevent broken KPIs.
  * When a prior window can’t be derived, comparison is omitted gracefully (no render failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->