### PR TITLE
feat(dashboards): click-to-drilldown foundation (#3212)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -6590,6 +6590,21 @@
                           }
                         },
                         "additionalProperties": false
+                      },
+                      "drilldown": {
+                        "type": "object",
+                        "properties": {
+                          "targetParam": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "pattern": "^[a-z_][a-z0-9_]*$"
+                          }
+                        },
+                        "required": [
+                          "targetParam"
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -6899,6 +6914,21 @@
                             "maxLength": 120
                           }
                         },
+                        "additionalProperties": false
+                      },
+                      "drilldown": {
+                        "type": "object",
+                        "properties": {
+                          "targetParam": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "pattern": "^[a-z_][a-z0-9_]*$"
+                          }
+                        },
+                        "required": [
+                          "targetParam"
+                        ],
                         "additionalProperties": false
                       }
                     },

--- a/packages/schemas/src/__tests__/dashboard.test.ts
+++ b/packages/schemas/src/__tests__/dashboard.test.ts
@@ -9,6 +9,7 @@ import {
   dashboardChartTypeSchema,
   dashboardKpiConfigSchema,
   dashboardChartConfigSchema,
+  dashboardDrilldownConfigSchema,
 } from "../dashboard";
 
 describe("dashboardParameterSchema", () => {
@@ -194,6 +195,56 @@ describe("dashboardChartConfigSchema", () => {
   test("rejects a config missing valueColumns", () => {
     expect(
       dashboardChartConfigSchema.safeParse({ type: "kpi", categoryColumn: "label", valueColumns: [] }).success,
+    ).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Click-to-drilldown (#3212)
+  // ---------------------------------------------------------------------------
+
+  test("round-trips a chart config with a drilldown target", () => {
+    const config = {
+      type: "bar" as const,
+      categoryColumn: "region",
+      valueColumns: ["revenue"],
+      drilldown: { targetParam: "region" },
+    };
+    expect(dashboardChartConfigSchema.parse(config)).toEqual(config);
+  });
+
+  test("a chart config without drilldown stays back-compatible (field absent)", () => {
+    const config = { type: "bar" as const, categoryColumn: "stage", valueColumns: ["amount"] };
+    const parsed = dashboardChartConfigSchema.parse(config);
+    expect(parsed).toEqual(config);
+    expect("drilldown" in parsed).toBe(false);
+  });
+
+  test("rejects a drilldown target that isn't a lower-snake parameter key", () => {
+    expect(
+      dashboardChartConfigSchema.safeParse({
+        type: "bar",
+        categoryColumn: "region",
+        valueColumns: ["revenue"],
+        drilldown: { targetParam: "Region Filter" },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("dashboardDrilldownConfigSchema", () => {
+  test("accepts a valid parameter-key target", () => {
+    expect(dashboardDrilldownConfigSchema.safeParse({ targetParam: "region" }).success).toBe(true);
+    expect(dashboardDrilldownConfigSchema.safeParse({ targetParam: "date_from" }).success).toBe(true);
+  });
+
+  test("rejects a non-identifier target (would not match the :placeholder scanner)", () => {
+    expect(dashboardDrilldownConfigSchema.safeParse({ targetParam: "9region" }).success).toBe(false);
+    expect(dashboardDrilldownConfigSchema.safeParse({ targetParam: "" }).success).toBe(false);
+  });
+
+  test("rejects unknown keys (strict — no stray config rides along)", () => {
+    expect(
+      dashboardDrilldownConfigSchema.safeParse({ targetParam: "region", crossFilter: true }).success,
     ).toBe(false);
   });
 });

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -235,16 +235,32 @@ export const dashboardKpiConfigSchema = z
 export type DashboardKpiConfigWire = z.infer<typeof dashboardKpiConfigSchema>;
 
 /**
+ * Click-to-drilldown config (#3212). `.strict()` so a stray field is rejected
+ * at the boundary rather than persisted and silently ignored — same discipline
+ * as `dashboardKpiConfigSchema`. `targetParam` reuses the parameter-key schema:
+ * it names a declared {@link dashboardParameterSchema} `key`, so it must be the
+ * same lower-snake identifier the `:placeholder` scanner matches.
+ */
+export const dashboardDrilldownConfigSchema = z
+  .object({
+    targetParam: dashboardParameterKeySchema,
+  })
+  .strict();
+export type DashboardDrilldownConfigWire = z.infer<typeof dashboardDrilldownConfigSchema>;
+
+/**
  * Full chart-config schema. `kpi` is optional and only meaningful when
  * `type === "kpi"`; the agent surface + REST routes carry it through as-is.
  * `categoryColumn` allows the empty string (a `table`/`kpi` card may not set a
  * label) — `valueColumns` must hold at least one column so a card always has a
- * metric to plot.
+ * metric to plot. `drilldown` is optional + back-compatible (#3212); absent →
+ * the card is inert on click.
  */
 export const dashboardChartConfigSchema = z.object({
   type: dashboardChartTypeSchema,
   categoryColumn: z.string(),
   valueColumns: z.array(z.string().min(1)).min(1),
   kpi: dashboardKpiConfigSchema.optional(),
+  drilldown: dashboardDrilldownConfigSchema.optional(),
 });
 export type DashboardChartConfigWire = z.infer<typeof dashboardChartConfigSchema>;

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -40,12 +40,41 @@ export interface DashboardKpiConfig {
   comparisonLabel?: string;
 }
 
+/**
+ * Click-to-drilldown target (#3212 — drilldown foundation). When set, clicking
+ * a data point (bar / line / area / pie slice, or a table row) on this card
+ * sets the named dashboard parameter to the clicked CATEGORY value and refetches
+ * every card through the render path (server-side parameterized binding — never
+ * string-interpolated). The clicked value is the chart's category-axis value
+ * for chart views, or the row's `categoryColumn` cell for the table view.
+ *
+ * Optional + back-compatible: a card with no `drilldown` is inert on click (no
+ * regression to existing view/interaction). The cross-filter UX (filter chips,
+ * card-A-filters-B..N) is the follow-up (#3213) — this is the plumbing layer.
+ *
+ * Wire-type mirror of `dashboardDrilldownConfigSchema` in `@useatlas/schemas`.
+ */
+export interface DashboardDrilldownConfig {
+  /**
+   * Key of the dashboard parameter a click populates. References a declared
+   * {@link DashboardParameter.key} (same lower-snake identifier constraint).
+   * A target that names no declared parameter is ignored at click time — the
+   * render endpoint binds declared parameters only.
+   */
+  targetParam: string;
+}
+
 export interface DashboardChartConfig {
   type: ChartType;
   categoryColumn: string;
   valueColumns: string[];
   /** Present only when `type === "kpi"` (#3137). */
   kpi?: DashboardKpiConfig;
+  /**
+   * Click-to-drilldown target (#3212). Absent → the card is inert on click.
+   * See {@link DashboardDrilldownConfig}.
+   */
+  drilldown?: DashboardDrilldownConfig;
 }
 
 /**

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Dashboard card render batch (#2267 parameters, #3212 drilldown).
+ *
+ * This is the seam a drilldown click ultimately drives: setting a parameter
+ * re-renders every card with the bound value. Pins that one POST per chart card
+ * is issued to `/render`, carries the override map under `parameters` (bound
+ * server-side, never interpolated), and that text cards are skipped.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  renderDashboardCard,
+  renderDashboardCards,
+  type CardRenderContext,
+} from "../dashboard-card-render";
+import type { DashboardCard } from "@/ui/lib/types";
+
+const CTX: CardRenderContext = {
+  apiUrl: "https://api.test",
+  dashboardId: "dash-1",
+  isCrossOrigin: true,
+};
+
+const baseCard: DashboardCard = {
+  id: "card-1",
+  dashboardId: "dash-1",
+  position: 0,
+  title: "Revenue by region",
+  kind: "chart",
+  sql: "SELECT region, SUM(amount) AS revenue FROM orders WHERE region = :region GROUP BY 1",
+  chartConfig: {
+    type: "bar",
+    categoryColumn: "region",
+    valueColumns: ["revenue"],
+    drilldown: { targetParam: "region" },
+  },
+  content: null,
+  cachedColumns: ["region", "revenue"],
+  cachedRows: [{ region: "us", revenue: 100 }],
+  cachedAt: "2026-06-04T00:00:00Z",
+  connectionGroupId: null,
+  layout: { x: 0, y: 0, w: 12, h: 8 },
+  createdAt: "2026-06-04T00:00:00Z",
+  updatedAt: "2026-06-04T00:00:00Z",
+};
+
+const textCard: DashboardCard = {
+  ...baseCard,
+  id: "card-text",
+  kind: "text",
+  sql: "",
+  chartConfig: null,
+  content: "## Section",
+};
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+const errResponse = (status: number, body: unknown) =>
+  ({ ok: false, status, json: async () => body }) as unknown as Response;
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("renderDashboardCard", () => {
+  test("POSTs to the card's /render with the override map bound under `parameters`", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return okResponse({ columns: ["region", "revenue"], rows: [{ region: "us", revenue: 100 }] });
+    }) as unknown as typeof fetch;
+
+    const entry = await renderDashboardCard(baseCard, { region: "us" }, CTX);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.test/api/v1/dashboards/dash-1/cards/card-1/render");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].init.credentials).toBe("include"); // isCrossOrigin → include
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ parameters: { region: "us" } });
+    expect(entry).toEqual({
+      cardId: "card-1",
+      ok: true,
+      columns: ["region", "revenue"],
+      rows: [{ region: "us", revenue: 100 }],
+      comparison: undefined,
+    });
+  });
+
+  test("maps a non-OK response to ok:false with the backend message (never throws)", async () => {
+    globalThis.fetch = mock(async () =>
+      errResponse(409, { error: "approval_required", message: "Approval required." }),
+    ) as unknown as typeof fetch;
+
+    const entry = await renderDashboardCard(baseCard, { region: "us" }, CTX);
+    expect(entry).toEqual({ cardId: "card-1", ok: false, error: "Approval required." });
+  });
+
+  test("maps a network throw to ok:false rather than rejecting", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    const entry = await renderDashboardCard(baseCard, { region: "us" }, CTX);
+    expect(entry).toEqual({ cardId: "card-1", ok: false, error: "network down" });
+  });
+});
+
+describe("renderDashboardCards (batch)", () => {
+  test("issues exactly one render per chart card with the bound value, and skips text cards", async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+      return okResponse({ columns: ["region", "revenue"], rows: [] });
+    }) as unknown as typeof fetch;
+
+    const cardB: DashboardCard = { ...baseCard, id: "card-2" };
+    const entries = await renderDashboardCards([baseCard, textCard, cardB], { region: "eu" }, CTX);
+
+    // Text card skipped — only the two chart cards are rendered.
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://api.test/api/v1/dashboards/dash-1/cards/card-1/render",
+      "https://api.test/api/v1/dashboards/dash-1/cards/card-2/render",
+    ]);
+    // Every card binds the identical override map.
+    for (const call of calls) {
+      expect(call.body).toEqual({ parameters: { region: "eu" } });
+    }
+    expect(entries.map((e) => e.cardId)).toEqual(["card-1", "card-2"]);
+    expect(entries.every((e) => e.ok)).toBe(true);
+  });
+
+  test("does not fetch at all when every card is a text card", async () => {
+    const fetchMock = mock(async () => okResponse({ columns: [], rows: [] }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const entries = await renderDashboardCards([textCard], { region: "us" }, CTX);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Drilldown ↔ parameter-bar URL sync (#3212).
+ *
+ * The whole feature rests on the page and the parameter bar sharing ONE nuqs
+ * key: a drilldown click writes the override (page side), and the bar — reading
+ * the same key — reflects it AND emits it via `onChange` (the trigger that
+ * re-renders every card with the bound value). This drives the REAL bar + REAL
+ * `withOverride` through a real nuqs adapter, so the linchpin can't silently
+ * break.
+ */
+import { afterEach, describe, expect, test, mock } from "bun:test";
+import { useState } from "react";
+import { useQueryState } from "nuqs";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { render, cleanup, fireEvent, waitFor, screen } from "@testing-library/react";
+import { DashboardParameterBar, type ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
+import { DASHBOARD_PARAMS_KEY, dashboardParamsParser, withOverride } from "../search-params";
+import type { DashboardParameter } from "@/ui/lib/types";
+
+afterEach(cleanup);
+
+const REGION: DashboardParameter = { key: "region", type: "text", default: null, label: "Region" };
+
+/**
+ * Mirrors the page wiring: a page-side `useQueryState` on the shared key (the
+ * drilldown writer) rendered alongside the bar (which subscribes to the same
+ * key). The button stands in for a chart/table click resolved to
+ * `onDrilldown("region", "us")`.
+ */
+function Harness({ onChange }: { onChange: (o: ParameterValues) => void }) {
+  const [raw, setRaw] = useQueryState(DASHBOARD_PARAMS_KEY, dashboardParamsParser);
+  return (
+    <>
+      <button type="button" onClick={() => void setRaw(withOverride(raw, "region", "us"))}>
+        drill
+      </button>
+      <DashboardParameterBar parameters={[REGION]} onChange={onChange} />
+    </>
+  );
+}
+
+/**
+ * A self-updating testing adapter: it feeds its captured URL updates straight
+ * back in as `searchParams`. That reproduces the real-app round-trip — in
+ * Next.js a `useQueryState` write updates the URL, which re-renders every hook
+ * subscribed to that key — which the bare testing adapter doesn't do on its own.
+ */
+function SyncingAdapter({ children }: { children: React.ReactNode }) {
+  const [search, setSearch] = useState(() => new URLSearchParams());
+  return (
+    <NuqsTestingAdapter searchParams={search} onUrlUpdate={(e) => setSearch(e.searchParams)}>
+      {children}
+    </NuqsTestingAdapter>
+  );
+}
+
+describe("drilldown ↔ parameter bar URL sync", () => {
+  test("a drilldown write lands in the shared key; the bar reflects it and emits the bound value", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+
+    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
+
+    // On mount the bar reports "no overrides" (use defaults).
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
+    expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("");
+
+    // Simulate the drilldown click → page-side write of the shared key.
+    fireEvent.click(screen.getByText("drill"));
+
+    // The bar (same key) now reflects the drilldown value...
+    await waitFor(() => {
+      expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
+    });
+    // ...and emitted the bound override — the signal the page turns into a
+    // single batched re-render of every card.
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
+  });
+
+  test("the bar can clear a drilldown-set value (Reset)", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
+
+    fireEvent.click(screen.getByText("drill"));
+    await waitFor(() => {
+      expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
+    });
+
+    // Reset appears once an override is present; clicking it clears back to defaults.
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+    await waitFor(() => {
+      expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
+    });
+    expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("");
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
@@ -55,7 +55,10 @@ function SyncingAdapter({ children }: { children: React.ReactNode }) {
 }
 
 describe("drilldown ↔ parameter bar URL sync", () => {
-  test("a drilldown write lands in the shared key; the bar reflects it and emits the bound value", async () => {
+  // One continuous lifecycle (drill → reflect → reset). Kept as a single test so
+  // the nuqs `dparams` cache — module-level and keyed by name — can't leak from a
+  // prior test's mount and make the next one non-deterministic.
+  test("a drilldown write reflects in the bar, emits the bound value, and Reset clears it", async () => {
     const onChange = mock((_: ParameterValues) => {});
 
     render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
@@ -74,18 +77,8 @@ describe("drilldown ↔ parameter bar URL sync", () => {
     // ...and emitted the bound override — the signal the page turns into a
     // single batched re-render of every card.
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
-  });
 
-  test("the bar can clear a drilldown-set value (Reset)", async () => {
-    const onChange = mock((_: ParameterValues) => {});
-    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
-
-    fireEvent.click(screen.getByText("drill"));
-    await waitFor(() => {
-      expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
-    });
-
-    // Reset appears once an override is present; clicking it clears back to defaults.
+    // Reset appears once an override is present; clicking it clears to defaults.
     fireEvent.click(screen.getByRole("button", { name: /reset/i }));
     await waitFor(() => {
       expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/search-params.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/search-params.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Dashboard parameter URL-state helpers (#2267 parameters, #3212 drilldown).
+ *
+ * The parameter bar and click-to-drilldown share ONE `dparams` URL key, so these
+ * pure (de)serialize helpers are the single source of truth for how the override
+ * map round-trips through the URL — bookmarked/shared links and drilldown both
+ * depend on it. Covers parse robustness, the "no overrides clears the param"
+ * contract, and the drilldown merge/clear path.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseOverrides, serializeOverrides, withOverride } from "../search-params";
+
+describe("parseOverrides", () => {
+  test("returns an empty map for null / empty / malformed input", () => {
+    expect(parseOverrides(null)).toEqual({});
+    expect(parseOverrides("")).toEqual({});
+    expect(parseOverrides("not json")).toEqual({});
+  });
+
+  test("ignores non-object JSON (arrays, primitives)", () => {
+    expect(parseOverrides("[1,2]")).toEqual({});
+    expect(parseOverrides("123")).toEqual({});
+    expect(parseOverrides('"region"')).toEqual({});
+  });
+
+  test("parses a well-formed override object", () => {
+    expect(parseOverrides('{"region":"us","limit_n":5}')).toEqual({ region: "us", limit_n: 5 });
+  });
+});
+
+describe("serializeOverrides", () => {
+  test("returns null for an empty map (clears the URL param)", () => {
+    expect(serializeOverrides({})).toBeNull();
+  });
+
+  test("drops null and empty-string entries", () => {
+    expect(serializeOverrides({ region: null, segment: "", limit_n: 5 })).toBe('{"limit_n":5}');
+  });
+
+  test("returns null when every entry is dropped", () => {
+    expect(serializeOverrides({ region: null, segment: "" })).toBeNull();
+  });
+
+  test("serializes a populated map", () => {
+    expect(serializeOverrides({ region: "us" })).toBe('{"region":"us"}');
+  });
+});
+
+describe("withOverride (drilldown merge)", () => {
+  test("sets a value into an empty (null) URL state", () => {
+    expect(withOverride(null, "region", "us")).toBe('{"region":"us"}');
+  });
+
+  test("merges into existing overrides without clobbering them", () => {
+    const next = withOverride('{"region":"us"}', "date_from", "2026-01-01");
+    expect(parseOverrides(next)).toEqual({ region: "us", date_from: "2026-01-01" });
+  });
+
+  test("overwrites the same key on a repeat drilldown", () => {
+    const next = withOverride('{"region":"us"}', "region", "eu");
+    expect(parseOverrides(next)).toEqual({ region: "eu" });
+  });
+
+  test("clearing one of several keys keeps the rest", () => {
+    const next = withOverride('{"region":"us","date_from":"2026-01-01"}', "region", null);
+    expect(parseOverrides(next)).toEqual({ date_from: "2026-01-01" });
+  });
+
+  test("clearing the only key collapses to null (no dangling param)", () => {
+    expect(withOverride('{"region":"us"}', "region", null)).toBeNull();
+  });
+
+  test("round-trips through parse → serialize", () => {
+    const raw = withOverride(withOverride(null, "region", "us"), "limit_n", 10);
+    expect(serializeOverrides(parseOverrides(raw))).toBe(raw);
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/search-params.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/search-params.test.ts
@@ -8,7 +8,12 @@
  * contract, and the drilldown merge/clear path.
  */
 import { describe, expect, test } from "bun:test";
-import { parseOverrides, serializeOverrides, withOverride } from "../search-params";
+import {
+  parseOverrides,
+  serializeOverrides,
+  withOverride,
+  normalizeDrilldownValue,
+} from "../search-params";
 
 describe("parseOverrides", () => {
   test("returns an empty map for null / empty / malformed input", () => {
@@ -73,5 +78,26 @@ describe("withOverride (drilldown merge)", () => {
   test("round-trips through parse → serialize", () => {
     const raw = withOverride(withOverride(null, "region", "us"), "limit_n", 10);
     expect(serializeOverrides(parseOverrides(raw))).toBe(raw);
+  });
+});
+
+describe("normalizeDrilldownValue", () => {
+  test("slices a date param's ISO timestamp category to YYYY-MM-DD (DatePicker shape)", () => {
+    expect(normalizeDrilldownValue("date", "2026-06-04T12:00:00Z")).toBe("2026-06-04");
+    expect(normalizeDrilldownValue("date", "2026-06-04 12:00:00")).toBe("2026-06-04");
+  });
+
+  test("leaves a plain YYYY-MM-DD date untouched", () => {
+    expect(normalizeDrilldownValue("date", "2026-06-04")).toBe("2026-06-04");
+  });
+
+  test("leaves non-ISO date labels (month/quarter) untouched", () => {
+    expect(normalizeDrilldownValue("date", "Jun 2026")).toBe("Jun 2026");
+    expect(normalizeDrilldownValue("date", "Q1 2026")).toBe("Q1 2026");
+  });
+
+  test("passes text/number param values through unchanged", () => {
+    expect(normalizeDrilldownValue("text", "2026-06-04T12:00:00Z")).toBe("2026-06-04T12:00:00Z");
+    expect(normalizeDrilldownValue("number", "42")).toBe("42");
   });
 });

--- a/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
@@ -81,7 +81,16 @@ export async function renderDashboardCard(
       comparison: json.comparison,
     };
   } catch (err) {
-    return { cardId: card.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    // The error is surfaced to the user via the returned entry (paramError on
+    // the grid), but log it too so the underlying network/parse failure stays
+    // visible in diagnostics rather than only as a UI banner.
+    const message = err instanceof Error ? err.message : String(err);
+    console.debug("[dashboard] card render failed", {
+      cardId: card.id,
+      dashboardId: ctx.dashboardId,
+      error: message,
+    });
+    return { cardId: card.id, ok: false, error: message };
   }
 }
 

--- a/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
@@ -1,0 +1,101 @@
+/**
+ * Dashboard card render batch (#2267 parameters, #3212 drilldown).
+ *
+ * Issues the view-time, parameter-aware `/render` for each CHART card with the
+ * supplied override map bound server-side (#3136 — parameterized query, never
+ * string-interpolated). Text / section-block cards are skipped (they have no
+ * SQL; the render endpoint would short-circuit them anyway). One POST per card,
+ * the same bound override map across all of them.
+ *
+ * Extracted from the dashboard view page so the batch — the thing that actually
+ * refetches every card with the bound value — is unit-testable without mounting
+ * the page. The page wraps this in its stale-batch sequence guards and folds the
+ * entries into grid/comparison/error state.
+ */
+import type { DashboardCard, KpiComparisonResult } from "@/ui/lib/types";
+import type { ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
+
+export interface CardRenderContext {
+  apiUrl: string;
+  dashboardId: string;
+  isCrossOrigin: boolean;
+}
+
+export type CardRenderEntry =
+  | {
+      cardId: string;
+      ok: true;
+      columns: string[];
+      rows: Record<string, unknown>[];
+      /** #3137 — present (possibly null) only for KPI cards; drives the delta chip. */
+      comparison?: KpiComparisonResult | null;
+    }
+  | { cardId: string; ok: false; error: string };
+
+/** Render ONE card's SQL with the override values bound server-side. Never
+ *  throws — every failure (non-OK status, network error) maps to an `ok: false`
+ *  entry so a single bad card can't reject the whole batch. */
+export async function renderDashboardCard(
+  card: DashboardCard,
+  overrides: ParameterValues,
+  ctx: CardRenderContext,
+): Promise<CardRenderEntry> {
+  try {
+    const res = await fetch(`${ctx.apiUrl}/api/v1/dashboards/${ctx.dashboardId}/cards/${card.id}/render`, {
+      method: "POST",
+      credentials: ctx.isCrossOrigin ? "include" : "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parameters: overrides }),
+    });
+    if (!res.ok) {
+      // Surface the backend reason (approval required, connection unavailable,
+      // invalid parameters, …) instead of dropping it.
+      let message = `Request failed (${res.status})`;
+      try {
+        const body = (await res.json()) as { message?: string; error?: string };
+        message = body.message ?? body.error ?? message;
+      } catch (parseError) {
+        // Non-JSON error body — keep the status-based message, but surface the
+        // parse failure for debugging rather than dropping it.
+        console.debug("[dashboard] failed to parse render error body", {
+          cardId: card.id,
+          status: res.status,
+          parseError: parseError instanceof Error ? parseError.message : String(parseError),
+        });
+      }
+      return { cardId: card.id, ok: false, error: message };
+    }
+    const json = (await res.json()) as {
+      columns: string[];
+      rows: Record<string, unknown>[];
+      comparison?: KpiComparisonResult | null;
+    };
+    return {
+      cardId: card.id,
+      ok: true,
+      columns: json.columns,
+      rows: json.rows,
+      // Left undefined for a non-KPI card (the render endpoint omits the field);
+      // a KPI card carries the block or `null`. Callers record only the KPI
+      // cards, whose value is the comparison block or `null`.
+      comparison: json.comparison,
+    };
+  } catch (err) {
+    return { cardId: card.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Render every CHART card in one batch (text cards skipped). The override map is
+ * bound identically across cards. Resolves once all renders settle — each entry
+ * carries its own ok/err so partial failures are reported per card, not as a
+ * whole-batch rejection.
+ */
+export function renderDashboardCards(
+  cards: DashboardCard[],
+  overrides: ParameterValues,
+  ctx: CardRenderContext,
+): Promise<CardRenderEntry[]> {
+  const chartCards = cards.filter((c) => c.kind !== "text");
+  return Promise.all(chartCards.map((card) => renderDashboardCard(card, overrides, ctx)));
+}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -28,7 +28,7 @@ import { DashboardShareDialog } from "./share-dialog";
 import { DashboardGrid } from "@/ui/components/dashboards/dashboard-grid";
 import { DashboardTopBar } from "@/ui/components/dashboards/dashboard-topbar";
 import { DashboardParameterBar, type ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
-import { DASHBOARD_PARAMS_KEY, dashboardParamsParser, withOverride } from "./search-params";
+import { DASHBOARD_PARAMS_KEY, dashboardParamsParser, withOverride, normalizeDrilldownValue } from "./search-params";
 import { renderDashboardCards } from "./dashboard-card-render";
 import { DraftStatusBanner } from "@/ui/components/dashboards/draft-status-banner";
 import { PublishDiffModal } from "@/ui/components/dashboards/publish-diff-modal";
@@ -580,13 +580,18 @@ export default function DashboardViewPage() {
     // Ignore a target that names no declared parameter — the render endpoint
     // binds declared parameters only, so an unknown key would set dead URL
     // state that no card reads. (A misconfigured card, not an expected path.)
-    if (!dashboard.parameters.some((p) => p.key === targetParam)) {
+    const param = dashboard.parameters.find((p) => p.key === targetParam);
+    if (!param) {
       console.debug("[dashboard] drilldown target is not a declared parameter; ignoring", {
         targetParam,
       });
       return;
     }
-    void setDparamsRaw(withOverride(dparamsRaw, targetParam, value));
+    // Normalize for the target type — e.g. a `date` param's DatePicker only
+    // reads YYYY-MM-DD, so a timestamp category must be sliced or the bar shows
+    // a blank date even though the filter applied.
+    const normalized = normalizeDrilldownValue(param.type, value);
+    void setDparamsRaw(withOverride(dparamsRaw, targetParam, normalized));
   }
 
   // #3137 — fetch KPI comparison values against the parameter DEFAULTS. Used on

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import Link from "next/link";
 import { MessagesSquare, Plus, Sparkles, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,8 @@ import { DashboardShareDialog } from "./share-dialog";
 import { DashboardGrid } from "@/ui/components/dashboards/dashboard-grid";
 import { DashboardTopBar } from "@/ui/components/dashboards/dashboard-topbar";
 import { DashboardParameterBar, type ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
+import { DASHBOARD_PARAMS_KEY, dashboardParamsParser, withOverride } from "./search-params";
+import { renderDashboardCards } from "./dashboard-card-render";
 import { DraftStatusBanner } from "@/ui/components/dashboards/draft-status-banner";
 import { PublishDiffModal } from "@/ui/components/dashboards/publish-diff-modal";
 import { diffDashboards, type DashboardDiff } from "@/ui/components/dashboards/dashboard-diff";
@@ -155,6 +158,13 @@ export default function DashboardViewPage() {
   // of that pattern cascaded into React #185 once refetches started landing
   // fast enough during multi-drag sessions.
   const [optimisticLayouts, setOptimisticLayouts] = useState<Record<string, DashboardCardLayout>>({});
+
+  // #3212 — page-level handle on the SAME `dparams` URL key the parameter bar
+  // owns. Click-to-drilldown WRITES here; the bar — subscribed to the same nuqs
+  // key — observes the change and fires the single batched re-render via its
+  // onChange effect (so the bar stays the sole render trigger). Read access lets
+  // us merge a drilldown value into the current override map.
+  const [dparamsRaw, setDparamsRaw] = useQueryState(DASHBOARD_PARAMS_KEY, dashboardParamsParser);
 
   // #2267 — parameter bar state. `paramResults` holds ephemeral, per-viewer
   // rendered rows keyed by cardId (NOT persisted to the card cache); when set,
@@ -516,78 +526,17 @@ export default function DashboardViewPage() {
     // concurrently in-flight loadDefaultComparisons (from mount or a prior
     // reset) can't land afterward and overwrite this batch's delta chips.
     const cSeq = ++comparisonReqSeq.current;
-    // #3138: text / section-block cards have no SQL — the /render endpoint
-    // short-circuits them to an empty result, and the tile ignores cached
-    // data, so skip them client-side rather than firing a redundant request
-    // per text card on every parameter change.
-    const cards = dashboard.cards.filter((c) => c.kind !== "text");
     setParamLoading(true);
     setParamError(null);
     try {
-      type RenderEntry =
-        | {
-            cardId: string;
-            ok: true;
-            columns: string[];
-            rows: Record<string, unknown>[];
-            // #3137 — present (possibly null) only for KPI cards; drives the delta chip.
-            comparison?: KpiComparisonResult | null;
-          }
-        | { cardId: string; ok: false; error: string };
-      const entries = await Promise.all(
-        cards.map(async (card): Promise<RenderEntry> => {
-          try {
-            const res = await fetch(
-              `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render`,
-              {
-                method: "POST",
-                credentials: isCrossOrigin ? "include" : "same-origin",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ parameters: overrides }),
-              },
-            );
-            if (!res.ok) {
-              // Surface the backend reason (approval required, connection
-              // unavailable, invalid parameters, …) instead of dropping it.
-              let message = `Request failed (${res.status})`;
-              try {
-                const body = (await res.json()) as { message?: string; error?: string };
-                message = body.message ?? body.error ?? message;
-              } catch (parseError) {
-                // Non-JSON error body — keep the status-based message, but
-                // surface the parse failure for debugging rather than dropping it.
-                console.debug("[dashboard] failed to parse render error body", {
-                  cardId: card.id,
-                  status: res.status,
-                  parseError: parseError instanceof Error ? parseError.message : String(parseError),
-                });
-              }
-              return { cardId: card.id, ok: false, error: message };
-            }
-            const json = (await res.json()) as {
-              columns: string[];
-              rows: Record<string, unknown>[];
-              comparison?: KpiComparisonResult | null;
-            };
-            return {
-              cardId: card.id,
-              ok: true,
-              columns: json.columns,
-              rows: json.rows,
-              // Left undefined for a non-KPI card (the render endpoint omits the
-              // field); a KPI card carries the block or `null`. The map-build
-              // below uses this to record comparisons for KPI cards only.
-              comparison: json.comparison,
-            };
-          } catch (err) {
-            return {
-              cardId: card.id,
-              ok: false,
-              error: err instanceof Error ? err.message : String(err),
-            };
-          }
-        }),
-      );
+      // #3138: text cards are skipped inside renderDashboardCards (no SQL).
+      // One POST per chart card, binding `overrides` server-side (#3212 drilldown
+      // and #2267 manual changes flow through the same batch).
+      const entries = await renderDashboardCards(dashboard.cards, overrides, {
+        apiUrl,
+        dashboardId: id,
+        isCrossOrigin,
+      });
       // A newer change superseded this batch — discard its results.
       if (seq !== paramReqSeq.current) return;
       const next: Record<string, { columns: string[]; rows: Record<string, unknown>[] }> = {};
@@ -618,6 +567,26 @@ export default function DashboardViewPage() {
     } finally {
       if (seq === paramReqSeq.current) setParamLoading(false);
     }
+  }
+
+  // #3212 — click-to-drilldown. Sets the card's drilldown target parameter to
+  // the clicked category value by merging it into the shared `dparams` URL key.
+  // We don't refetch here: writing the key updates the parameter bar (which
+  // reflects the value and lets the user clear/override it) and the bar's
+  // onChange effect issues the single batched /render of every card with the
+  // bound value — server-side parameterized, never string-interpolated.
+  function handleDrilldown(targetParam: string, value: string) {
+    if (!dashboard) return;
+    // Ignore a target that names no declared parameter — the render endpoint
+    // binds declared parameters only, so an unknown key would set dead URL
+    // state that no card reads. (A misconfigured card, not an expected path.)
+    if (!dashboard.parameters.some((p) => p.key === targetParam)) {
+      console.debug("[dashboard] drilldown target is not a declared parameter; ignoring", {
+        targetParam,
+      });
+      return;
+    }
+    void setDparamsRaw(withOverride(dparamsRaw, targetParam, value));
   }
 
   // #3137 — fetch KPI comparison values against the parameter DEFAULTS. Used on
@@ -888,6 +857,7 @@ export default function DashboardViewPage() {
                   refreshingId={refreshingCardId}
                   stages={stages}
                   comparisons={comparisons}
+                  onDrilldown={handleDrilldown}
                   onLayoutChange={handleLayoutChange}
                   onRefresh={handleRefreshCard}
                   onDuplicate={handleDuplicate}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
@@ -1,0 +1,70 @@
+/**
+ * Dashboard view URL state (#2267 parameters, #3212 drilldown).
+ *
+ * The dashboard parameter override map lives in ONE nuqs query key so the
+ * parameter bar (manual control changes) and click-to-drilldown (set a
+ * parameter by clicking a data point) read + write the SAME state. A drilldown
+ * value therefore shows up in the bar (where it can be cleared/overridden),
+ * survives reload, and is shareable — consistent with the conversation-scope
+ * URL pattern.
+ *
+ * The override map is JSON-encoded into a single string param rather than one
+ * param per key: the parameter set is dynamic (defined per dashboard), so a
+ * fixed nuqs schema can't enumerate the keys ahead of time.
+ *
+ * SECURITY: these values are bound server-side through the `/render` endpoint's
+ * parameterized query path (`@atlas/api/lib/dashboard-parameters`) — never
+ * interpolated into SQL text. Unknown keys (e.g. a drilldown target that names
+ * no declared parameter) are ignored by the resolver.
+ */
+import { parseAsString } from "nuqs";
+import type { ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
+
+/** URL query key holding the JSON-encoded dashboard parameter override map. */
+export const DASHBOARD_PARAMS_KEY = "dparams";
+
+/** nuqs parser for {@link DASHBOARD_PARAMS_KEY}. Shared by the page (drilldown
+ *  writes) and the parameter bar (manual changes) so both subscribe to the
+ *  same key. */
+export const dashboardParamsParser = parseAsString;
+
+/** Parse the URL-encoded override map defensively (drop anything unusable). */
+export function parseOverrides(raw: string | null): ParameterValues {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as ParameterValues;
+    }
+  } catch {
+    // Malformed URL state — fall back to defaults rather than throwing.
+  }
+  return {};
+}
+
+/**
+ * Serialize an override map for the URL. Drops `null`/empty-string entries so
+ * the URL stays clean, and returns `null` when nothing remains — nuqs clears
+ * the param entirely for `null`, so "no overrides" serialises to no query state.
+ */
+export function serializeOverrides(overrides: ParameterValues): string | null {
+  const cleaned: ParameterValues = {};
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === null || v === "") continue;
+    cleaned[k] = v;
+  }
+  return Object.keys(cleaned).length === 0 ? null : JSON.stringify(cleaned);
+}
+
+/**
+ * Merge a single drilldown value into the current (raw) override map and return
+ * the serialized URL value (#3212). A `null`/empty value clears that key. The
+ * result is suitable to hand straight to the nuqs setter.
+ */
+export function withOverride(
+  raw: string | null,
+  key: string,
+  value: string | number | null,
+): string | null {
+  return serializeOverrides({ ...parseOverrides(raw), [key]: value });
+}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
@@ -37,7 +37,7 @@ export function parseOverrides(raw: string | null): ParameterValues {
       return parsed as ParameterValues;
     }
   } catch {
-    // Malformed URL state — fall back to defaults rather than throwing.
+    // intentionally ignored: malformed URL state — fall back to defaults rather than throwing.
   }
   return {};
 }

--- a/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
@@ -68,3 +68,21 @@ export function withOverride(
 ): string | null {
   return serializeOverrides({ ...parseOverrides(raw), [key]: value });
 }
+
+/**
+ * Normalize a clicked category value for its target parameter's type (#3212).
+ *
+ * A `date` parameter's control (DatePicker) only renders `YYYY-MM-DD`, so a
+ * timestamp category like `2026-06-04T12:00:00Z` (or `2026-06-04 12:00:00`)
+ * would filter correctly server-side but show a BLANK date in the bar — the
+ * drilldown would look like it did nothing. Slice the date portion off an ISO
+ * timestamp so the bar reflects the active value. Non-timestamp values (plain
+ * `YYYY-MM-DD`, month/quarter labels, text, numbers) pass through unchanged.
+ */
+export function normalizeDrilldownValue(paramType: string, value: string): string {
+  if (paramType === "date") {
+    const match = /^(\d{4}-\d{2}-\d{2})[T ]/.exec(value);
+    if (match) return match[1];
+  }
+  return value;
+}

--- a/packages/web/src/ui/__tests__/chart-detection.test.ts
+++ b/packages/web/src/ui/__tests__/chart-detection.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { classifyColumn, detectCharts, transformData, type ChartRecommendation, type ClassifiedColumn } from "../components/chart/chart-detection";
+import {
+  classifyColumn,
+  detectCharts,
+  transformData,
+  categoryFromChartClick,
+  categoryFromPieClick,
+  type ChartRecommendation,
+  type ClassifiedColumn,
+} from "../components/chart/chart-detection";
 
 /* ------------------------------------------------------------------ */
 /*  classifyColumn                                                      */
@@ -560,5 +568,40 @@ describe("transformData", () => {
     expect(data[0].score).toBe(100);
     expect(data[1].score).toBe(0);
     expect(data[1].name).toBe("Bob");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Click-to-drilldown value extractors (#3212)                         */
+/* ------------------------------------------------------------------ */
+
+describe("categoryFromChartClick", () => {
+  test("returns the active category label of the clicked tick", () => {
+    expect(categoryFromChartClick({ activeLabel: "Discovery" } as never)).toBe("Discovery");
+  });
+
+  test("coerces a numeric/date activeLabel to a string", () => {
+    expect(categoryFromChartClick({ activeLabel: 2026 } as never)).toBe("2026");
+  });
+
+  test("returns null when the click lands off any category", () => {
+    expect(categoryFromChartClick(null)).toBeNull();
+    expect(categoryFromChartClick(undefined)).toBeNull();
+    expect(categoryFromChartClick({ activeLabel: undefined } as never)).toBeNull();
+    expect(categoryFromChartClick({ activeLabel: "" } as never)).toBeNull();
+  });
+});
+
+describe("categoryFromPieClick", () => {
+  test("reads the category column off the sector's original-row payload", () => {
+    const sector = { payload: { region: "EMEA", revenue: 1200 } };
+    expect(categoryFromPieClick(sector, "region")).toBe("EMEA");
+  });
+
+  test("returns null when the payload is missing or the cell is empty", () => {
+    expect(categoryFromPieClick(null, "region")).toBeNull();
+    expect(categoryFromPieClick({}, "region")).toBeNull();
+    expect(categoryFromPieClick({ payload: { region: "" } }, "region")).toBeNull();
+    expect(categoryFromPieClick({ payload: { region: null } }, "region")).toBeNull();
   });
 });

--- a/packages/web/src/ui/__tests__/data-table.test.tsx
+++ b/packages/web/src/ui/__tests__/data-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
 import { DataTable } from "../components/chat/data-table";
 
@@ -121,5 +121,37 @@ describe("DataTable", () => {
     expect(container.querySelector("table")).toBeNull();
     expect(container.textContent).toContain("Query returned no results");
     expect(container.textContent).toContain("Try adjusting your query filters or criteria");
+  });
+
+  // -------------------------------------------------------------------------
+  // Row click-to-drilldown (#3212) — opt-in via onRowClick
+  // -------------------------------------------------------------------------
+
+  test("rows are inert (no button role) when onRowClick is omitted", () => {
+    const { container } = render(<DataTable columns={columns} rows={rows} />);
+    expect(container.querySelectorAll("tbody tr[role='button']").length).toBe(0);
+  });
+
+  test("clicking a row forwards the row object when onRowClick is provided", () => {
+    const onRowClick = mock((_row: Record<string, unknown> | unknown[]) => {});
+    const { container } = render(
+      <DataTable columns={columns} rows={rows} onRowClick={onRowClick} />,
+    );
+    const firstRow = container.querySelector("tbody tr");
+    expect(firstRow?.getAttribute("role")).toBe("button");
+    fireEvent.click(firstRow!);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0]?.[0]).toEqual(rows[0]);
+  });
+
+  test("Enter/Space on a focused row activates it (keyboard a11y)", () => {
+    const onRowClick = mock((_row: Record<string, unknown> | unknown[]) => {});
+    const { container } = render(
+      <DataTable columns={columns} rows={rows} onRowClick={onRowClick} />,
+    );
+    const firstRow = container.querySelector("tbody tr")!;
+    fireEvent.keyDown(firstRow, { key: "Enter" });
+    fireEvent.keyDown(firstRow, { key: " " });
+    expect(onRowClick).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/src/ui/components/chart/chart-detection.ts
+++ b/packages/web/src/ui/components/chart/chart-detection.ts
@@ -1,5 +1,10 @@
 /* Chart detection — pure functions, zero React deps. Kept framework-agnostic for direct unit testing. */
 
+// `MouseHandlerDataParam` is a recharts TYPE only (erased at runtime) — importing
+// it here keeps this module free of any recharts runtime dependency, so the
+// click extractors below stay unit-testable without evaluating recharts in jsdom.
+import type { MouseHandlerDataParam } from "recharts";
+
 type ColumnType = "numeric" | "date" | "categorical" | "unknown";
 
 export type ClassifiedColumn = {
@@ -110,6 +115,40 @@ export function classifyColumn(header: string, values: string[]): ColumnType {
   if (unique.size < 50) return "categorical";
 
   return "unknown";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Click-to-drilldown value extractors (#3212)                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Pull the clicked category-axis value out of a Recharts categorical chart
+ * click (bar / line / area). `activeLabel` is the category/domain value at the
+ * clicked tick; `null` means the click landed off any category (empty plot
+ * area). Pure — the recharts click itself is not reproducible in jsdom, so this
+ * is the unit-tested seam.
+ */
+export function categoryFromChartClick(
+  state: MouseHandlerDataParam | null | undefined,
+): string | null {
+  const label = state?.activeLabel;
+  if (label == null || label === "") return null;
+  return String(label);
+}
+
+/**
+ * Pull the clicked slice's category value out of a Recharts Pie click. The
+ * sector carries the original {@link RechartsRow} on `payload`, keyed by header,
+ * so we read the category column off it. Pure + unit-tested.
+ */
+export function categoryFromPieClick(
+  data: { payload?: unknown } | null | undefined,
+  categoryKey: string,
+): string | null {
+  const payload = (data?.payload ?? null) as Record<string, unknown> | null;
+  const value = payload?.[categoryKey];
+  if (value == null || value === "") return null;
+  return String(value);
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -22,9 +22,12 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
+import type { MouseHandlerDataParam } from "recharts";
 import {
   detectCharts,
   transformData,
+  categoryFromChartClick,
+  categoryFromPieClick,
   CHART_COLORS_LIGHT,
   CHART_COLORS_DARK,
   type ChartRecommendation,
@@ -32,6 +35,31 @@ import {
   type RechartsRow,
   type ChartDetectionResult,
 } from "./chart-detection";
+
+/* ------------------------------------------------------------------ */
+/*  Click-to-drilldown (#3212)                                          */
+/*  Pure value extractors live in chart-detection.ts (zero React deps,  */
+/*  unit-testable without importing recharts into jsdom).               */
+/* ------------------------------------------------------------------ */
+
+/** Build a categorical-chart `onClick` that forwards the clicked category value,
+ *  or `undefined` when drilldown is off (so recharts attaches no handler). */
+function chartClickHandler(
+  onCategoryClick: ((value: string) => void) | undefined,
+): ((state: MouseHandlerDataParam) => void) | undefined {
+  if (!onCategoryClick) return undefined;
+  return (state) => {
+    const value = categoryFromChartClick(state);
+    if (value != null) onCategoryClick(value);
+  };
+}
+
+/** Pointer cursor on the chart wrapper signals a card is drillable. */
+function drilldownCursor(
+  onCategoryClick: ((value: string) => void) | undefined,
+): React.CSSProperties | undefined {
+  return onCategoryClick ? { cursor: "pointer" } : undefined;
+}
 
 /* ------------------------------------------------------------------ */
 /*  Theme helpers                                                       */
@@ -120,20 +148,23 @@ function BarChartView({
   data,
   rec,
   dark,
+  onCategoryClick,
 }: {
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
+  const onClick = chartClickHandler(onCategoryClick);
 
   return (
-    <div className="aspect-[4/3] sm:aspect-[16/9]">
+    <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }}>
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }} onClick={onClick}>
           <CartesianGrid strokeDasharray="3 3" stroke={t.grid} />
           <XAxis
             dataKey={catKey}
@@ -167,20 +198,23 @@ function LineChartView({
   data,
   rec,
   dark,
+  onCategoryClick,
 }: {
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
+  const onClick = chartClickHandler(onCategoryClick);
 
   return (
-    <div className="aspect-[4/3] sm:aspect-[16/9]">
+    <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }}>
+        <LineChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }} onClick={onClick}>
           <CartesianGrid strokeDasharray="3 3" stroke={t.grid} />
           <XAxis
             dataKey={catKey}
@@ -217,10 +251,12 @@ function PieChartView({
   data,
   rec,
   dark,
+  onCategoryClick,
 }: {
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
@@ -238,8 +274,15 @@ function PieChartView({
     );
   }
 
+  const onPieClick = onCategoryClick
+    ? (sector: { payload?: unknown }) => {
+        const value = categoryFromPieClick(sector, catKey);
+        if (value != null) onCategoryClick(value);
+      }
+    : undefined;
+
   return (
-    <div className="aspect-[4/3] sm:aspect-[16/9]">
+    <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Pie
@@ -250,6 +293,7 @@ function PieChartView({
             cy="50%"
             innerRadius={40}
             outerRadius={100}
+            onClick={onPieClick}
             label={({ name, value }: { name?: string; value?: number }) =>
               `${truncateLabel(String(name ?? ""), 10)} ${total > 0 && value != null ? ((value / total) * 100).toFixed(0) : 0}%`
             }
@@ -275,21 +319,24 @@ function AreaChartView({
   data,
   rec,
   dark,
+  onCategoryClick,
 }: {
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   const chartId = useId();
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
+  const onClick = chartClickHandler(onCategoryClick);
 
   return (
-    <div className="aspect-[4/3] sm:aspect-[16/9]">
+    <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
       <ResponsiveContainer width="100%" height="100%">
-        <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }}>
+        <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }} onClick={onClick}>
           <defs>
             {valKeys.map((key, i) => (
               <linearGradient key={key} id={`area-grad-${chartId}-${i}`} x1="0" y1="0" x2="0" y2="1">
@@ -337,20 +384,23 @@ function StackedBarChartView({
   data,
   rec,
   dark,
+  onCategoryClick,
 }: {
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
+  const onClick = chartClickHandler(onCategoryClick);
 
   return (
-    <div className="aspect-[4/3] sm:aspect-[16/9]">
+    <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }}>
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }} onClick={onClick}>
           <CartesianGrid strokeDasharray="3 3" stroke={t.grid} />
           <XAxis
             dataKey={catKey}
@@ -495,25 +545,29 @@ function ChartRenderer({
   defaultData,
   defaultRec,
   dark,
+  onCategoryClick,
 }: {
   rows: string[][];
   rec: ChartRecommendation;
   defaultData: RechartsRow[];
   defaultRec: ChartRecommendation;
   dark: boolean;
+  onCategoryClick?: (value: string) => void;
 }) {
   // Re-transform data when switching chart type (category axis may differ)
   const chartData = rec === defaultRec ? defaultData : transformData(rows, rec);
   const type = rec.type;
 
+  // Scatter is intentionally not drillable (#3212): both axes are numeric — it
+  // has no category to bind a parameter to. Every other view forwards clicks.
   return (
     <div className="p-2">
-      {type === "bar" ? <BarChartView data={chartData} rec={rec} dark={dark} />
-        : type === "line" ? <LineChartView data={chartData} rec={rec} dark={dark} />
-        : type === "area" ? <AreaChartView data={chartData} rec={rec} dark={dark} />
-        : type === "stacked-bar" ? <StackedBarChartView data={chartData} rec={rec} dark={dark} />
+      {type === "bar" ? <BarChartView data={chartData} rec={rec} dark={dark} onCategoryClick={onCategoryClick} />
+        : type === "line" ? <LineChartView data={chartData} rec={rec} dark={dark} onCategoryClick={onCategoryClick} />
+        : type === "area" ? <AreaChartView data={chartData} rec={rec} dark={dark} onCategoryClick={onCategoryClick} />
+        : type === "stacked-bar" ? <StackedBarChartView data={chartData} rec={rec} dark={dark} onCategoryClick={onCategoryClick} />
         : type === "scatter" ? <ScatterChartView data={chartData} rec={rec} dark={dark} />
-        : <PieChartView data={chartData} rec={rec} dark={dark} />}
+        : <PieChartView data={chartData} rec={rec} dark={dark} onCategoryClick={onCategoryClick} />}
     </div>
   );
 }
@@ -527,11 +581,18 @@ export function ResultChart({
   rows,
   dark,
   detectionResult,
+  onCategoryClick,
 }: {
   headers: string[];
   rows: string[][];
   dark: boolean;
   detectionResult?: ChartDetectionResult;
+  /**
+   * #3212 — click-to-drilldown. When provided, clicking a bar / line / area
+   * point or pie slice forwards the clicked category-axis value. Omitted on
+   * the chat surface and on non-drillable dashboard cards (no-op click).
+   */
+  onCategoryClick?: (value: string) => void;
 }) {
   const result = useMemo(
     () => detectionResult ?? detectCharts(headers, rows),
@@ -569,6 +630,7 @@ export function ResultChart({
           defaultData={result.data}
           defaultRec={result.recommendations[0]}
           dark={dark}
+          onCategoryClick={onCategoryClick}
         />
       </ErrorBoundary>
     </div>

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -42,21 +42,25 @@ import {
 /*  unit-testable without importing recharts into jsdom).               */
 /* ------------------------------------------------------------------ */
 
-/** Build a categorical-chart `onClick` that forwards the clicked category value,
- *  or `undefined` when drilldown is off (so recharts attaches no handler). */
+/** Build a categorical-chart `onClick` that forwards the clicked category value
+ *  plus the chart's category-axis column (`categoryKey`, the detected header),
+ *  or `undefined` when drilldown is off (so recharts attaches no handler). The
+ *  consumer gates on `categoryKey` so a parameter is only ever set from the
+ *  card's configured drilldown column (#3212). */
 function chartClickHandler(
-  onCategoryClick: ((value: string) => void) | undefined,
+  onCategoryClick: ((value: string, categoryKey: string) => void) | undefined,
+  categoryKey: string,
 ): ((state: MouseHandlerDataParam) => void) | undefined {
   if (!onCategoryClick) return undefined;
   return (state) => {
     const value = categoryFromChartClick(state);
-    if (value != null) onCategoryClick(value);
+    if (value != null) onCategoryClick(value, categoryKey);
   };
 }
 
 /** Pointer cursor on the chart wrapper signals a card is drillable. */
 function drilldownCursor(
-  onCategoryClick: ((value: string) => void) | undefined,
+  onCategoryClick: ((value: string, categoryKey: string) => void) | undefined,
 ): React.CSSProperties | undefined {
   return onCategoryClick ? { cursor: "pointer" } : undefined;
 }
@@ -153,13 +157,13 @@ function BarChartView({
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
-  const onClick = chartClickHandler(onCategoryClick);
+  const onClick = chartClickHandler(onCategoryClick, catKey);
 
   return (
     <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
@@ -203,13 +207,13 @@ function LineChartView({
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
-  const onClick = chartClickHandler(onCategoryClick);
+  const onClick = chartClickHandler(onCategoryClick, catKey);
 
   return (
     <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
@@ -256,7 +260,7 @@ function PieChartView({
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
@@ -277,7 +281,7 @@ function PieChartView({
   const onPieClick = onCategoryClick
     ? (sector: { payload?: unknown }) => {
         const value = categoryFromPieClick(sector, catKey);
-        if (value != null) onCategoryClick(value);
+        if (value != null) onCategoryClick(value, catKey);
       }
     : undefined;
 
@@ -324,14 +328,14 @@ function AreaChartView({
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const chartId = useId();
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
-  const onClick = chartClickHandler(onCategoryClick);
+  const onClick = chartClickHandler(onCategoryClick, catKey);
 
   return (
     <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
@@ -389,13 +393,13 @@ function StackedBarChartView({
   data: RechartsRow[];
   rec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
   const valKeys = rec.valueColumns.map((c) => c.header);
-  const onClick = chartClickHandler(onCategoryClick);
+  const onClick = chartClickHandler(onCategoryClick, catKey);
 
   return (
     <div className="aspect-[4/3] sm:aspect-[16/9]" style={drilldownCursor(onCategoryClick)}>
@@ -552,7 +556,7 @@ function ChartRenderer({
   defaultData: RechartsRow[];
   defaultRec: ChartRecommendation;
   dark: boolean;
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   // Re-transform data when switching chart type (category axis may differ)
   const chartData = rec === defaultRec ? defaultData : transformData(rows, rec);
@@ -589,10 +593,12 @@ export function ResultChart({
   detectionResult?: ChartDetectionResult;
   /**
    * #3212 — click-to-drilldown. When provided, clicking a bar / line / area
-   * point or pie slice forwards the clicked category-axis value. Omitted on
-   * the chat surface and on non-drillable dashboard cards (no-op click).
+   * point or pie slice forwards the clicked category-axis value AND the chart's
+   * category-axis column header (so the consumer can confirm it matches the
+   * card's configured drilldown column before binding). Omitted on the chat
+   * surface and on non-drillable dashboard cards (no-op click).
    */
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const result = useMemo(
     () => detectionResult ?? detectCharts(headers, rows),

--- a/packages/web/src/ui/components/chat/data-table.tsx
+++ b/packages/web/src/ui/components/chat/data-table.tsx
@@ -4,15 +4,24 @@ import { useState, type ComponentProps } from "react";
 import { formatCell } from "../../lib/helpers";
 import { ErrorBoundary } from "../error-boundary";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function DataTableInner({
   columns,
   rows,
   maxRows = 10,
+  onRowClick,
 }: {
   columns: string[];
   rows: (Record<string, unknown> | unknown[])[];
   maxRows?: number;
+  /**
+   * #3212 — click-to-drilldown. When provided, each row becomes an activatable
+   * button (pointer cursor + Enter/Space) that forwards the clicked row object.
+   * Omitted on the chat surface (rows stay inert), so this is opt-in and
+   * back-compatible. The consumer decides which column's value to read.
+   */
+  onRowClick?: (row: Record<string, unknown> | unknown[]) => void;
 }) {
   const [sortCol, setSortCol] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
@@ -103,18 +112,38 @@ function DataTableInner({
           </tr>
         </thead>
         <tbody>
-          {display.map((row, i) => (
-            <tr
-              key={i}
-              className={i % 2 === 0 ? "bg-zinc-100/60 dark:bg-zinc-900/60" : "bg-zinc-50/30 dark:bg-zinc-900/30"}
-            >
-              {columns.map((_, j) => (
-                <td key={j} className="whitespace-nowrap px-3 py-1.5 text-zinc-700 dark:text-zinc-300">
-                  {formatCell(cell(row, j))}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {display.map((row, i) => {
+            const clickable = onRowClick !== undefined;
+            return (
+              <tr
+                key={i}
+                className={cn(
+                  i % 2 === 0 ? "bg-zinc-100/60 dark:bg-zinc-900/60" : "bg-zinc-50/30 dark:bg-zinc-900/30",
+                  clickable &&
+                    "cursor-pointer transition-colors hover:bg-blue-100/60 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:hover:bg-blue-950/30",
+                )}
+                role={clickable ? "button" : undefined}
+                tabIndex={clickable ? 0 : undefined}
+                onClick={clickable ? () => onRowClick?.(row) : undefined}
+                onKeyDown={
+                  clickable
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRowClick?.(row);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                {columns.map((_, j) => (
+                  <td key={j} className="whitespace-nowrap px-3 py-1.5 text-zinc-700 dark:text-zinc-300">
+                    {formatCell(cell(row, j))}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       </div>

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -1,12 +1,18 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { DashboardCard } from "@/ui/lib/types";
 
 // Stub the dynamic ResultChart import so jsdom doesn't try to evaluate
 // recharts. Bypass next/dynamic entirely so the sentinel renders synchronously
-// — the dynamic loader otherwise suspends past the test's render() call.
+// — the dynamic loader otherwise suspends past the test's render() call. The
+// stub forwards `onCategoryClick` (#3212) so a click can exercise the tile→chart
+// drilldown plumbing without a real recharts chart.
 mock.module("@/ui/components/chart/result-chart", () => ({
-  ResultChart: () => <div data-testid="result-chart">chart</div>,
+  ResultChart: ({ onCategoryClick }: { onCategoryClick?: (value: string) => void }) => (
+    <button type="button" data-testid="result-chart" onClick={() => onCategoryClick?.("Discovery")}>
+      chart
+    </button>
+  ),
 }));
 mock.module("next/dynamic", () => ({
   default: (loader: () => Promise<{ default: React.ComponentType }>) => {
@@ -237,5 +243,86 @@ describe("DashboardTile — KPI cards", () => {
     expect(screen.getByRole("button", { name: "Refresh tile" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fullscreen" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Tile actions" })).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Click-to-drilldown (#3212)
+// ---------------------------------------------------------------------------
+
+// A table-type card renders the DataTable view immediately (no chart mount /
+// recharts), so the table drilldown path is exercisable synchronously.
+const tableCard: DashboardCard = {
+  ...baseCard,
+  id: "card-table",
+  chartConfig: { type: "table", categoryColumn: "stage", valueColumns: ["amount"] },
+};
+
+const tableDrillCard: DashboardCard = {
+  ...tableCard,
+  chartConfig: { ...tableCard.chartConfig!, drilldown: { targetParam: "stage" } },
+};
+
+const barDrillCard: DashboardCard = {
+  ...baseCard,
+  id: "card-bar-drill",
+  chartConfig: { type: "bar", categoryColumn: "stage", valueColumns: ["amount"], drilldown: { targetParam: "stage" } },
+};
+
+describe("DashboardTile — drilldown (#3212)", () => {
+  afterEach(cleanup);
+
+  test("clicking a table row on a drilldown card fires onDrilldown(targetParam, categoryValue)", () => {
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    const { container } = render(
+      <DashboardTile {...baseProps} card={tableDrillCard} onDrilldown={onDrilldown} />,
+    );
+    const firstRow = container.querySelector("tbody tr");
+    expect(firstRow?.getAttribute("role")).toBe("button");
+    fireEvent.click(firstRow!);
+    expect(onDrilldown).toHaveBeenCalledTimes(1);
+    // categoryColumn is "stage"; first cached row's stage is "Discovery".
+    expect(onDrilldown.mock.calls[0]).toEqual(["stage", "Discovery"]);
+  });
+
+  test("a card without a drilldown target is inert on row click (no regression)", () => {
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    const { container } = render(
+      <DashboardTile {...baseProps} card={tableCard} onDrilldown={onDrilldown} />,
+    );
+    const firstRow = container.querySelector("tbody tr");
+    expect(firstRow?.getAttribute("role")).toBeNull();
+    fireEvent.click(firstRow!);
+    expect(onDrilldown).not.toHaveBeenCalled();
+  });
+
+  test("clicking a chart data point on a drilldown card fires onDrilldown with the clicked category", async () => {
+    const restore = setBoundingRect(600, 300);
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    render(<DashboardTile {...baseProps} card={barDrillCard} onDrilldown={onDrilldown} />);
+    // Flush the readiness gate + dynamic ResultChart load.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The stubbed ResultChart forwards onCategoryClick("Discovery") on click.
+    fireEvent.click(screen.getByTestId("result-chart"));
+    expect(onDrilldown).toHaveBeenCalledTimes(1);
+    expect(onDrilldown.mock.calls[0]).toEqual(["stage", "Discovery"]);
+    restore();
+  });
+
+  test("drilldown is disabled while editing (chart body is a drag surface)", async () => {
+    const restore = setBoundingRect(600, 300);
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    render(<DashboardTile {...baseProps} card={barDrillCard} editing={true} onDrilldown={onDrilldown} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // onCategoryClick is undefined while editing → the stub's click is a no-op.
+    fireEvent.click(screen.getByTestId("result-chart"));
+    expect(onDrilldown).not.toHaveBeenCalled();
+    restore();
   });
 });

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -8,10 +8,21 @@ import type { DashboardCard } from "@/ui/lib/types";
 // stub forwards `onCategoryClick` (#3212) so a click can exercise the tile→chart
 // drilldown plumbing without a real recharts chart.
 mock.module("@/ui/components/chart/result-chart", () => ({
-  ResultChart: ({ onCategoryClick }: { onCategoryClick?: (value: string) => void }) => (
-    <button type="button" data-testid="result-chart" onClick={() => onCategoryClick?.("Discovery")}>
-      chart
-    </button>
+  ResultChart: ({ onCategoryClick }: { onCategoryClick?: (value: string, categoryKey: string) => void }) => (
+    <>
+      {/* Fires with the card's configured category column ("stage") — matches. */}
+      <button type="button" data-testid="result-chart" onClick={() => onCategoryClick?.("Discovery", "stage")}>
+        chart
+      </button>
+      {/* Fires with a DIFFERENT detected column — the tile must reject this. */}
+      <button
+        type="button"
+        data-testid="result-chart-other-col"
+        onClick={() => onCategoryClick?.("Discovery", "other_col")}
+      >
+        chart-other
+      </button>
+    </>
   ),
 }));
 mock.module("next/dynamic", () => ({
@@ -305,10 +316,25 @@ describe("DashboardTile — drilldown (#3212)", () => {
     await act(async () => {
       await Promise.resolve();
     });
-    // The stubbed ResultChart forwards onCategoryClick("Discovery") on click.
+    // The stubbed ResultChart forwards onCategoryClick("Discovery", "stage").
     fireEvent.click(screen.getByTestId("result-chart"));
     expect(onDrilldown).toHaveBeenCalledTimes(1);
     expect(onDrilldown.mock.calls[0]).toEqual(["stage", "Discovery"]);
+    restore();
+  });
+
+  test("a chart click from a column other than the configured categoryColumn is rejected", async () => {
+    const restore = setBoundingRect(600, 300);
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    // Card's drilldown column is "stage"; the stub's second button fires with
+    // "other_col" (a divergent detected axis) — the tile must not bind it.
+    render(<DashboardTile {...baseProps} card={barDrillCard} onDrilldown={onDrilldown} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId("result-chart-other-col"));
+    expect(onDrilldown).not.toHaveBeenCalled();
     restore();
   });
 

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -32,6 +32,12 @@ interface DashboardGridProps {
    * `kpi` tile so it can render the delta chip. Non-KPI cards ignore it.
    */
   comparisons?: Record<string, KpiComparisonResult | null>;
+  /**
+   * #3212 — click-to-drilldown. Forwarded to each tile; called with a card's
+   * drilldown target parameter key + the clicked category value. Undefined →
+   * cards are inert on click.
+   */
+  onDrilldown?: (targetParam: string, value: string) => void;
   onLayoutChange: (cardId: string, layout: DashboardCardLayout) => void;
   onRefresh: (cardId: string) => void;
   onDuplicate: (cardId: string) => void;
@@ -45,6 +51,7 @@ export function DashboardGrid({
   refreshingId,
   stages,
   comparisons,
+  onDrilldown,
   onLayoutChange,
   onRefresh,
   onDuplicate,
@@ -146,6 +153,7 @@ export function DashboardGrid({
                 isRefreshing={refreshingId === card.id}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
+                onDrilldown={onDrilldown}
                 onFullscreen={(id) => setFullscreenId((prev) => (prev === id ? null : id))}
                 onRefresh={onRefresh}
                 onDuplicate={onDuplicate}
@@ -193,6 +201,7 @@ export function DashboardGrid({
                 isRefreshing={refreshingId === card.id}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
+                onDrilldown={onDrilldown}
                 onFullscreen={(id) => setFullscreenId((prev) => (prev === id ? null : id))}
                 onRefresh={onRefresh}
                 onDuplicate={onDuplicate}

--- a/packages/web/src/ui/components/dashboards/dashboard-parameter-bar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-parameter-bar.tsx
@@ -14,13 +14,23 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { parseAsString, useQueryState } from "nuqs";
+import { useQueryState } from "nuqs";
 import { RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/date-picker";
 import type { DashboardParameter } from "@/ui/lib/types";
+// The override map is shared with click-to-drilldown (#3212) — both read/write
+// the same nuqs key via these helpers, so the key + (de)serialization stay
+// single-sourced. (App-local URL helpers; ui→app is the same direction as
+// `view-all-modal` importing `select-recent`.)
+import {
+  DASHBOARD_PARAMS_KEY,
+  dashboardParamsParser,
+  parseOverrides,
+  serializeOverrides,
+} from "@/app/(workspace)/dashboards/[id]/search-params";
 
 export type ParameterValues = Record<string, string | number | null>;
 
@@ -34,20 +44,6 @@ interface DashboardParameterBarProps {
   onChange: (overrides: ParameterValues) => void;
   /** True while card renders triggered by a change are in flight. */
   loading?: boolean;
-}
-
-/** Parse the URL-encoded override map defensively (drop anything unusable). */
-function parseOverrides(raw: string | null): ParameterValues {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as ParameterValues;
-    }
-  } catch {
-    // Malformed URL state — fall back to defaults rather than throwing.
-  }
-  return {};
 }
 
 /** Local `YYYY-MM-DD` formatting (matches the server's ISO date bind shape). */
@@ -66,7 +62,7 @@ function fromIsoDate(s: string | number | null | undefined): Date | undefined {
 }
 
 export function DashboardParameterBar({ parameters, onChange, loading }: DashboardParameterBarProps) {
-  const [raw, setRaw] = useQueryState("dparams", parseAsString);
+  const [raw, setRaw] = useQueryState(DASHBOARD_PARAMS_KEY, dashboardParamsParser);
   const overrides = useMemo(() => parseOverrides(raw), [raw]);
 
   // Notify the page whenever the committed override map changes (incl. mount).
@@ -78,16 +74,9 @@ export function DashboardParameterBar({ parameters, onChange, loading }: Dashboa
   }, [serialized]);
 
   const commit = useCallback(
-    (next: ParameterValues) => {
-      // Drop null/empty entries so the URL stays clean and "no overrides"
-      // serialises to nothing.
-      const cleaned: ParameterValues = {};
-      for (const [k, v] of Object.entries(next)) {
-        if (v === null || v === "") continue;
-        cleaned[k] = v;
-      }
-      void setRaw(Object.keys(cleaned).length === 0 ? null : JSON.stringify(cleaned));
-    },
+    // `serializeOverrides` drops null/empty entries (clean URL) and returns null
+    // when nothing remains, so "no overrides" clears the param.
+    (next: ParameterValues) => void setRaw(serializeOverrides(next)),
     [setRaw],
   );
 

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -143,7 +143,16 @@ function ChartTile({
   const drillEnabled = !editing && !isKpi;
   const onCategoryClick =
     drillEnabled && drilldownParam !== null && onDrilldown
-      ? (value: string) => onDrilldown(drilldownParam, value)
+      ? (value: string, categoryKey: string) => {
+          // Only bind when the clicked chart axis IS the card's configured
+          // drilldown column. ResultChart re-detects the chart from the data, so
+          // a divergent category axis would otherwise set the parameter from the
+          // wrong column; gating keeps the chart path consistent with the table
+          // path (which reads `categoryColumn` directly). (#3212, Codex review.)
+          if (categoryColumn && categoryKey === categoryColumn) {
+            onDrilldown(drilldownParam, value);
+          }
+        }
       : undefined;
   const onRowClick =
     drillEnabled && drilldownParam !== null && onDrilldown && categoryColumn
@@ -476,7 +485,7 @@ function ChartSlot({
   stringRows: string[][];
   dark: boolean;
   /** #3212 — forwarded to ResultChart; undefined → chart is inert on click. */
-  onCategoryClick?: (value: string) => void;
+  onCategoryClick?: (value: string, categoryKey: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -63,11 +63,34 @@ interface DashboardTileProps {
    * Ignored by non-KPI tiles.
    */
   comparison?: KpiComparisonResult | null;
+  /**
+   * #3212 — click-to-drilldown. Called with the card's drilldown target
+   * parameter key + the clicked category value when a data point (bar / line /
+   * area / pie slice, or a table row) is clicked on a card that declares
+   * `chartConfig.drilldown`. Omitted / unset → the card is inert on click.
+   */
+  onDrilldown?: (targetParam: string, value: string) => void;
   onFullscreen: (cardId: string) => void;
   onRefresh: (cardId: string) => void;
   onDuplicate: (cardId: string) => void;
   onDelete: (card: DashboardCard) => void;
   onUpdateTitle: (cardId: string, title: string) => void;
+}
+
+/**
+ * #3212 — pull the drilldown value out of a clicked table row: the cell in the
+ * card's configured `categoryColumn`. Returns null when the column is unset or
+ * the cell is empty (the row is then inert), so a table card without a usable
+ * category column can't fire a no-op drilldown.
+ */
+function drilldownValueFromRow(
+  row: Record<string, unknown> | unknown[],
+  categoryColumn: string,
+): string | null {
+  if (!categoryColumn || Array.isArray(row)) return null;
+  const value = row[categoryColumn];
+  if (value == null || value === "") return null;
+  return String(value);
 }
 
 /**
@@ -87,6 +110,7 @@ function ChartTile({
   isRefreshing,
   stage,
   comparison,
+  onDrilldown,
   onFullscreen,
   onRefresh,
   onDuplicate,
@@ -107,6 +131,27 @@ function ChartTile({
   const rows = (card.cachedRows ?? []) as Record<string, unknown>[];
   const hasData = columns.length > 0 && rows.length > 0;
   const stringRows = hasData ? toStringRows(columns, rows) : [];
+
+  // #3212 — click-to-drilldown. A card that declares `chartConfig.drilldown`
+  // forwards the clicked category value to its target parameter. Disabled while
+  // editing (the chart body is a drag surface then) and on KPI cards (a single
+  // number has no category to drill into). The inline `drilldownParam !== null`
+  // and `onDrilldown` checks narrow both — `const` narrowing flows into the
+  // handler closures, so no non-null assertions are needed.
+  const drilldownParam = card.chartConfig?.drilldown?.targetParam ?? null;
+  const categoryColumn = card.chartConfig?.categoryColumn ?? "";
+  const drillEnabled = !editing && !isKpi;
+  const onCategoryClick =
+    drillEnabled && drilldownParam !== null && onDrilldown
+      ? (value: string) => onDrilldown(drilldownParam, value)
+      : undefined;
+  const onRowClick =
+    drillEnabled && drilldownParam !== null && onDrilldown && categoryColumn
+      ? (row: Record<string, unknown> | unknown[]) => {
+          const value = drilldownValueFromRow(row, categoryColumn);
+          if (value != null) onDrilldown(drilldownParam, value);
+        }
+      : undefined;
 
   function commitTitle() {
     const next = titleDraft.trim();
@@ -288,10 +333,11 @@ function ChartTile({
               columns={columns}
               stringRows={stringRows}
               dark={dark}
+              onCategoryClick={onCategoryClick}
             />
           ) : (
             <div className="min-h-0 flex-1 overflow-auto">
-              <DataTable columns={columns} rows={rows} />
+              <DataTable columns={columns} rows={rows} onRowClick={onRowClick} />
             </div>
           )
         ) : (
@@ -423,11 +469,14 @@ function ChartSlot({
   columns,
   stringRows,
   dark,
+  onCategoryClick,
 }: {
   cardId: string;
   columns: string[];
   stringRows: string[][];
   dark: boolean;
+  /** #3212 — forwarded to ResultChart; undefined → chart is inert on click. */
+  onCategoryClick?: (value: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
@@ -466,6 +515,7 @@ function ChartSlot({
           headers={columns}
           rows={stringRows}
           dark={dark}
+          onCategoryClick={onCategoryClick}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #3212. First slice of full click-to-drilldown / cross-filtering (#2267). Wires chart/table interactions so clicking a data point on a card that declares a **drilldown target parameter** sets that parameter and refetches every card through the existing render path. This is the **plumbing layer** — the cross-filter UX (filter chips, card-A-filters-B..N) lands in the follow-up #3213.

## What changed

**Config (types + schemas)** — optional, back-compatible `chartConfig.drilldown.targetParam`:
- `DashboardDrilldownConfig` in `@useatlas/types`; `dashboardDrilldownConfigSchema` (`.strict()`, reuses the parameter-key schema) in `@useatlas/schemas`. Absent → the card is inert on click.

**Click surfacing**
- `result-chart.tsx`: `onCategoryClick` wired on bar / line / area / stacked-bar (chart-level `activeLabel`) and pie (`Pie.onClick`); pointer cursor when drillable. Scatter stays inert (both axes numeric — no category). The pure click-value extractors (`categoryFromChartClick` / `categoryFromPieClick`) live in `chart-detection.ts` so they're unit-testable without evaluating recharts in jsdom.
- `data-table.tsx`: opt-in `onRowClick` (pointer + `role=button` + Enter/Space); omitted on the chat surface, so rows stay inert there.
- `dashboard-tile.tsx` / `dashboard-grid.tsx`: thread `onDrilldown`; disabled while editing (the chart body is a drag surface) and on KPI cards.

**State + refetch (`page.tsx`)**
- A drilldown click writes the clicked value into the **same `dparams` nuqs key the parameter bar owns**, so the bar reflects it (and the user can clear/override it there) and the bar's `onChange` fires the **single batched** `/render` of every card with the bound value — **server-side parameterized binding, never string-interpolated** (reuses the #3136 substitution path).
- Drilldown state lives in the URL via `nuqs` → shareable + survives reload, consistent with the conversation-scope pattern. URL helpers centralized in a new `search-params.ts`; the render batch extracted to a testable `dashboard-card-render.ts`.
- A drilldown target that names no declared parameter is ignored (the render endpoint binds declared params only).

## Acceptance criteria (#3212)
- [x] Clicking a bar/slice/row on a drilldown card sets the parameter and refetches all cards via `/render` (server-side parameterized binding — no string interpolation).
- [x] The parameter bar reflects the drilldown-set value; the user can clear/override it there.
- [x] Cards without a drilldown target are inert on click (no regression).
- [x] Drilldown state lives in URL/`nuqs` — shareable + survives reload.
- [x] Tests: click → param set → batched render with the right bound value; non-drilldown cards unaffected; URL round-trip.

## Tests
- `schemas/…/dashboard.test.ts` — drilldown config round-trip + validation (strict, key format).
- `…/[id]/__tests__/search-params.test.ts` — URL parse/serialize/merge/clear round-trip.
- `ui/__tests__/chart-detection.test.ts` — chart + pie click → category value extraction.
- `ui/__tests__/data-table.test.tsx` — row click forwards the row; inert without `onRowClick`.
- `…/dashboard-tile.test.tsx` — chart/table click → `onDrilldown(targetParam, value)`; inert without config; disabled while editing.
- `…/[id]/__tests__/dashboard-card-render.test.ts` — one POST per chart card with the bound value; text cards skipped.
- `…/[id]/__tests__/drilldown-sync.test.tsx` — page↔bar nuqs round-trip (bar reflects + emits the bound value; Reset clears).

## Gates
`/ci` green locally: lint ✓ · type ✓ · web tests (182 isolated) + schemas (32) + API dashboard (13) ✓ · syncpack ✓ · template-drift ✓ · railway-watch ✓.

No docs page exists for dashboards yet; no changelog entry added (closeout handles roadmap).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783218753&installation_id=135337507&pr_number=3216&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3216&signature=63cd1e7c95745f193e88559a22367a1a424c973a8b70793063cf637f6b778bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-to-drilldown on dashboard charts and tables (category/row clicks set dashboard parameters); pointer cursor and keyboard activation added; drilldown disabled while editing. Drilldown config is optional/back-compatible and date values are normalized for the parameter bar.
  * Dashboard state now syncs drilldown overrides with the URL.
  * Batched, resilient dashboard card rendering with per-card success/error results.

* **Tests**
  * New tests for rendering, drilldown sync, URL parse/serialize, click extraction, and table/chart activation.

* **Documentation**
  * API schema updated to include drilldown configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->