### PR TITLE
docs(roadmap): check off shipped v0.0.10 slices (#3208, #3210, #3213)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -23,12 +23,12 @@ The codebase is Hono + Next.js + TypeScript + Effect.ts + Vercel AI SDK + bun, o
 **`v0.0.10` — Dashboard Primitives & Polish** ([milestone #60](https://github.com/AtlasDevHQ/atlas/milestone/60)) is the next tag, taking the dashboard surface from "saved query gallery" toward Looker/Mode-class. Its first slice already shipped under v0.0.9 — the KPI / scorecard card ([#3137](https://github.com/AtlasDevHQ/atlas/issues/3137)). The remaining seven slices (kicked off 2026-06-04) are the "Lower tier — track but defer" list from the [#2267](https://github.com/AtlasDevHQ/atlas/issues/2267) design pass, now firmed into issues:
 
 - [x] KPI comparison & format polish — period-over-period delta + value formats + sparkline ([#3207](https://github.com/AtlasDevHQ/atlas/issues/3207) → [#3215](https://github.com/AtlasDevHQ/atlas/pull/3215))
-- [ ] Goal lines & thresholds on chart + KPI cards ([#3208](https://github.com/AtlasDevHQ/atlas/issues/3208))
+- [x] Goal lines & thresholds on chart + KPI cards ([#3208](https://github.com/AtlasDevHQ/atlas/issues/3208) → [#3218](https://github.com/AtlasDevHQ/atlas/pull/3218))
 - [ ] Event annotations on time-series cards (`annotations` JSONB, migration 0121) ([#3209](https://github.com/AtlasDevHQ/atlas/issues/3209))
-- [ ] Per-card CSV export ([#3210](https://github.com/AtlasDevHQ/atlas/issues/3210))
+- [x] Per-card CSV export ([#3210](https://github.com/AtlasDevHQ/atlas/issues/3210) → [#3220](https://github.com/AtlasDevHQ/atlas/pull/3220))
 - [x] Whole-dashboard PDF / image export ([#3211](https://github.com/AtlasDevHQ/atlas/issues/3211) → [#3214](https://github.com/AtlasDevHQ/atlas/pull/3214))
 - [x] Drilldown foundation — click a data point → set a dashboard parameter → refetch ([#3212](https://github.com/AtlasDevHQ/atlas/issues/3212) → [#3216](https://github.com/AtlasDevHQ/atlas/pull/3216))
-- [ ] Cross-filtering — card-to-card filters + chips + clear-all ([#3213](https://github.com/AtlasDevHQ/atlas/issues/3213), depends on #3212)
+- [x] Cross-filtering — card-to-card filters + chips + clear-all ([#3213](https://github.com/AtlasDevHQ/atlas/issues/3213) → [#3219](https://github.com/AtlasDevHQ/atlas/pull/3219), depends on #3212)
 
 Drilldown ships as the full cross-filter feature (split foundation → UI); #3208 and #3209 soft-couple on `result-chart.tsx` `<ReferenceLine>` rendering (second to land rebases). All others are independently parallelizable.
 


### PR DESCRIPTION
Checks off the three v0.0.10 dashboard slices that just merged to main:

- Goal lines & thresholds — #3208 → #3218
- Per-card CSV export — #3210 → #3220
- Cross-filtering — #3213 → #3219

Only #3209 (event annotations) remains open in the v0.0.10 slice set (no PR yet). Docs-only; no code or tests touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783263705&installation_id=135337507&pr_number=3223&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3223&signature=587b1a8ca1db3834e2d02befd7e0e6c3b73166dbfaabbad7ea4a235357194de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project roadmap documentation with completion status for dashboard features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->