### PR TITLE
chore(types): build via workspace-local tsc to fix fresh-install TS6046 race

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -408,6 +408,9 @@
     "packages/types": {
       "name": "@useatlas/types",
       "version": "0.1.16",
+      "devDependencies": {
+        "typescript": "^6.0.3",
+      },
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts src/proactive.ts src/catalog.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts src/proactive.ts src/catalog.ts --outdir dist --root src --target node --packages external && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepare": "bun run build"
   },
   "exports": {
@@ -129,5 +129,8 @@
   "bugs": {
     "url": "https://github.com/AtlasDevHQ/atlas/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
 }


### PR DESCRIPTION
Closes #3221

## What

`@useatlas/types`'s `prepare` (`bun run build`) tailed `bun x tsc -p tsconfig.build.json`. On a **fresh** full `bun install` (new clone / `git worktree`), `prepare` can fire before the workspace `tsc` bin is linked into `node_modules/.bin`, so `bun x tsc` resolves the **wrong** compiler and fails with:

```
tsconfig.build.json(6,25): error TS6046: Argument for '--moduleResolution' option must be: 'node', 'classic', 'node16', 'nodenext'.
error: prepare script from "@useatlas/types" exited with 2
```

## Root cause

When the local TS 6.x bin isn't linked yet at `prepare` time, `bun x tsc` falls back to the wrong compiler — either:
- the **deprecated registry `tsc` shim** it ephemerally fetches (clean machine), or
- a **global `tsc` on PATH** (this dev box has pnpm's `tsc@4.9.5`).

Both predate `moduleResolution: "bundler"` (TS 5.0+) → TS6046. Intermittent, depends on workspace link ordering. Same class as #3120.

> Note: the issue stated `typescript` was already a devDep of `@useatlas/types` — it was **not** (only in `keywords`). #3120 added it to `apps/www`, not here.

## Fix (`packages/types/package.json` only)

1. Invoke the explicit workspace-local bin **`./node_modules/.bin/tsc`** instead of `bun x tsc`. This points straight at the local devDep bin — immune to *both* the registry fetch and a PATH global shadow. (Plain `tsc` is **not** safe here: it falls through PATH to the global `tsc@4.9.5`, which also throws TS6046.)
2. Add **`typescript` `^6.0.3`** (matching root) as a direct devDep so bun links the local bin *before* `prepare` runs.

Only the TS-compile step of the `build` script changes; the `bun build` step is untouched.

## Verification

- ✅ **Cold single-pass `bun install` (scripts on)** in a fresh worktree: `prepare` builds dist, exit 0 (previously TS6046).
- ✅ **Two-step** `bun install --ignore-scripts && bun run --filter '@useatlas/types' build`: exit 0.
- ✅ **`dist/` byte-identical** to the prior `bun x tsc` output (`diff -rq` clean) — no tsconfig/target change.
- ✅ `bun.lock` regenerated (3-line diff: the new devDep edge; no version churn — typescript 6.0.3 was already in the tree as the root devDep).
- ✅ `/ci`: lint, type, syncpack (`No issues found`), template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols — all pass.
- ✅ Full `bun run test`: 552/553. The one fail (`lib/effect/__tests__/layers.test.ts` → `buildAppLayer wires ProviderKeyGuardLive`) is a **pre-existing boot-guard fast-fail race** (DpaGuard/`RESEND_API_KEY` won the parallel-merge over ProviderKeyGuard) — green 42/42 on 3 isolated re-runs, unrelated to this build-script change.

## Scope / follow-up

Kept to `@useatlas/types` only. Other packages sharing the same `bun x tsc` `prepare` race (`plugin-sdk`, `webhook-publisher`, `sdk`) tracked in **#3224**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783265628&installation_id=135337507&pr_number=3225&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3225&signature=a1fad91e7c092849cddf1672973ee70b3d0e820b1ce7565f5305bbcfdb19be56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured the build process to invoke TypeScript transpilation directly, improving build clarity and consistency.
  * Added TypeScript version `^6.0.3` as an explicit development dependency to ensure compatible and consistent builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->