### PR TITLE
fix(dashboards): attach CORS headers to raw export/screenshot Responses

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -2500,6 +2500,35 @@ describe("dashboard routes", () => {
       expect(response.headers.get("x-atlas-export-partial")).toBe("1");
     });
 
+    it("attaches CORS expose-headers to the raw export response (readable cross-origin)", async () => {
+      // A handler-returned raw Response does NOT inherit the middleware's
+      // `c.header()` CORS headers, so the route must spread them on. Without
+      // this, a cross-origin deploy can't read the file, and the browser never
+      // exposes X-Atlas-Export-Partial / Content-Disposition to JS (#3222).
+      mockExportDashboard.mockResolvedValueOnce({
+        ok: true,
+        format: "pdf",
+        bytes: Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d]),
+        contentType: "application/pdf",
+        filename: "demo-20260604-120000.pdf",
+        title: "Demo",
+        partial: false,
+        durationMs: 30,
+      });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/export`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Origin: "https://app.example.com" },
+          body: JSON.stringify({ format: "pdf" }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const expose = response.headers.get("access-control-expose-headers") ?? "";
+      expect(expose).toContain("X-Atlas-Export-Partial");
+      expect(expose).toContain("Content-Disposition");
+    });
+
     it("returns 404 when the dashboard is not in the caller's org", async () => {
       mockExportDashboard.mockResolvedValueOnce({
         ok: false,

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -2308,6 +2308,24 @@ describe("dashboard routes", () => {
       expect(bytes[1]).toBe(0x50);
     });
 
+    it("attaches CORS headers to the raw screenshot response (readable cross-origin)", async () => {
+      // A handler-returned raw Response does NOT inherit the middleware's
+      // `c.header()` CORS headers, so the route must spread them on. Without
+      // Access-Control-Allow-Origin a cross-origin browser blocks the image
+      // download entirely (the screenshot's own X-Atlas-* headers aren't in
+      // the expose list, so Allow-Origin is the load-bearing one here) (#3222).
+      mockScreenshotDashboard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/screenshot`, {
+          headers: { Origin: "https://app.example.com" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).not.toBeNull();
+      expect(response.headers.get("access-control-expose-headers")).not.toBeNull();
+    });
+
     it("returns 404 when the dashboard is not in the caller's org", async () => {
       mockScreenshotDashboard.mockResolvedValueOnce({
         ok: false,

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -2624,6 +2624,13 @@ authed.openapi(screenshotDashboardRoute, async (c) => {
     return new Response(new Uint8Array(result.png), {
       status: 200,
       headers: {
+        // A raw `Response` returned from the handler does NOT inherit the
+        // `c.header()`-set CORS headers from the `/api/*` middleware (Hono
+        // doesn't merge prepared headers onto a handler-returned Response),
+        // so spread them on explicitly — otherwise a cross-origin deploy
+        // (app.* → api.*) can't read the image. Same pattern as the CSV
+        // export branch and the chat/demo streaming responses (#3222).
+        ...corsResponseHeaders(c.req.header("Origin") ?? ""),
         "Content-Type": "image/png",
         "Content-Length": String(result.png.length),
         // Short caller-side cache; the server-side LRU is the primary
@@ -2730,6 +2737,14 @@ authed.openapi(exportDashboardRoute, async (c) => {
     return new Response(new Uint8Array(result.bytes), {
       status: 200,
       headers: {
+        // A raw `Response` returned from the handler does NOT inherit the
+        // `c.header()`-set CORS headers from the `/api/*` middleware (Hono
+        // doesn't merge prepared headers onto a handler-returned Response),
+        // so spread them on explicitly — otherwise a cross-origin deploy
+        // (app.* → api.*) can't read the file, and `X-Atlas-Export-Partial`
+        // / `Content-Disposition` aren't exposed to JS. Same pattern as the
+        // CSV export branch and the chat/demo streaming responses (#3222).
+        ...corsResponseHeaders(c.req.header("Origin") ?? ""),
         "Content-Type": result.contentType,
         "Content-Length": String(result.bytes.length),
         // Filename is an ASCII slug + UTC stamp (see buildExportFilename), so a


### PR DESCRIPTION
## Summary

The whole-dashboard **export** (`POST /api/v1/dashboards/:id/export`, #3211) and **screenshot** handlers return a raw `new Response(...)` directly from the OpenAPI handler. Hono 4.x does **not** merge the `/api/*` middleware's `c.header()`-set CORS headers onto a handler-returned raw `Response`.

On a **cross-origin** SaaS deploy (`app.useatlas.dev` → `api.useatlas.dev`, where the web client sends `credentials: "include"`):
- `Access-Control-Allow-Origin` is absent → the browser blocks the whole download.
- `X-Atlas-Export-Partial` / `Content-Disposition` aren't in the exposed set, so the partial-render warning never fires and the filename falls back.

It only works today on a same-origin deploy (`isCrossOrigin === false`).

## Fix

Spread `corsResponseHeaders(c.req.header("Origin") ?? "")` into each raw Response's headers — exactly the pattern the per-card CSV branch (#3210 / PR #3220) and the chat/demo streaming responses (`routes/chat.ts:1492`, `demo.ts:678`) already use. (`X-Atlas-Export-Partial` and `Content-Disposition` are already in the `Access-Control-Expose-Headers` allowlist in `lib/cors.ts` — the gap was purely that the raw Response didn't carry the CORS headers.)

- `routes/dashboards.ts` screenshot handler (~L2624) — spread CORS headers onto the PNG Response.
- `routes/dashboards.ts` export handler (~L2730) — spread CORS headers onto the PNG/PDF Response.

## Test

New regression test in `dashboards.test.ts` mirrors the existing CSV CORS test: POSTs the export route with an `Origin` header and asserts `Access-Control-Expose-Headers` is present and includes `X-Atlas-Export-Partial` and `Content-Disposition`.

## Acceptance criteria

- [x] Both raw `Response`s spread `corsResponseHeaders(c.req.header("Origin") ?? "")`.
- [x] Regression test asserts `Access-Control-Expose-Headers` (incl. `X-Atlas-Export-Partial`, `Content-Disposition`) is present on the export response when an `Origin` is sent.

## CI

Local `/ci` — lint, type, full test (553 api files, `Failed: 0`), syncpack, template drift, security-headers drift, railway-watch, schema drift, oauth-helper drift, test discipline, twenty-resolver, published-symbols — all pass.

No user-facing API contract change (pure cross-origin header fix) → no docs update.

Closes #3222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783266660&installation_id=135337507&pr_number=3226&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3226&signature=e949c6f9daf7ef519e3a027be8dd909aa584e0d65c8a2afc2fbe74d0f5250009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard screenshot and export responses now include proper CORS headers, allowing cross-origin clients to retrieve binary artifacts and associated response metadata.

* **Tests**
  * Added test coverage to verify CORS headers are present for dashboard screenshot and export responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->