### PR TITLE
test(dashboards): de-flake param-sync URL round-trip (one live write per test)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter-sync.test.tsx
@@ -15,7 +15,6 @@
  * we pin the URL-state contract those two build on.
  */
 import { afterEach, describe, expect, test, mock } from "bun:test";
-import { useState } from "react";
 import { useQueryState } from "nuqs";
 import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { render, cleanup, fireEvent, waitFor, screen } from "@testing-library/react";
@@ -66,21 +65,21 @@ function Harness({ onChange }: { onChange: (o: ParameterValues) => void }) {
 }
 
 /**
- * A self-updating testing adapter: it feeds its captured URL updates straight
- * back in as `searchParams`, reproducing the real-app round-trip where a
- * `useQueryState` write updates the URL and re-renders every hook subscribed to
- * that key. `initial` seeds the URL — used to simulate a reload of a shared link.
+ * A real-app round-trip adapter for the shared `dparams` key. `hasMemory` makes
+ * NuqsTestingAdapter retain each write in an internal synchronous ref (its
+ * built-in stand-in for a real URL): every write composes on the latest value
+ * and re-renders every hook subscribed to the key — the Next.js round-trip where
+ * a `useQueryState` write updates the URL and re-renders its subscribers.
+ * `initial` seeds the params — used to simulate a reload of a shared link.
+ *
+ * A hand-rolled `useState`-fed adapter desyncs nuqs's optimistic cache from the
+ * `searchParams` prop under back-to-back writes (the snapshot the next write
+ * composes on lags a React commit), which made this suite flake ~17%; the
+ * synchronous `hasMemory` ref closes that race.
  */
-function SyncingAdapter({
-  children,
-  initial,
-}: {
-  children: React.ReactNode;
-  initial?: string;
-}) {
-  const [search, setSearch] = useState(() => new URLSearchParams(initial));
+function MemoryAdapter({ children, initial }: { children: React.ReactNode; initial?: string }) {
   return (
-    <NuqsTestingAdapter searchParams={search} onUrlUpdate={(e) => setSearch(e.searchParams)}>
+    <NuqsTestingAdapter searchParams={initial} hasMemory>
       {children}
     </NuqsTestingAdapter>
   );
@@ -92,7 +91,7 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
   // mounts and make assertions non-deterministic — same guard as drilldown-sync.
   test("drill applies a filter, a second composes (AND), chip-remove + re-click deselect clear them", async () => {
     const onChange = mock((_: ParameterValues) => {});
-    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
 
     // Mount: no overrides (use defaults), no chips.
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
@@ -131,7 +130,7 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
 
   test("Clear all removes every active cross-filter in one action", async () => {
     const onChange = mock((_: ParameterValues) => {});
-    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
 
     fireEvent.click(screen.getByText("drill-region"));
     fireEvent.click(screen.getByText("drill-stage"));
@@ -149,9 +148,9 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
   test("reload of a shared link reflects the URL filters on mount", async () => {
     const onChange = mock((_: ParameterValues) => {});
     render(
-      <SyncingAdapter initial={`${DASHBOARD_PARAMS_KEY}=${encodeURIComponent('{"region":"eu"}')}`}>
+      <MemoryAdapter initial={`${DASHBOARD_PARAMS_KEY}=${encodeURIComponent('{"region":"eu"}')}`}>
         <Harness onChange={onChange} />
-      </SyncingAdapter>,
+      </MemoryAdapter>,
     );
 
     // The chip + bar reflect the persisted state with no interaction, and the bar

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter-sync.test.tsx
@@ -16,7 +16,7 @@
  */
 import { afterEach, describe, expect, test, mock } from "bun:test";
 import { useQueryState } from "nuqs";
-import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import { render, cleanup, fireEvent, waitFor, screen } from "@testing-library/react";
 import { DashboardParameterBar, type ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
 import { DashboardFilterChips } from "@/ui/components/dashboards/dashboard-filter-chips";
@@ -65,49 +65,71 @@ function Harness({ onChange }: { onChange: (o: ParameterValues) => void }) {
 }
 
 /**
- * A real-app round-trip adapter for the shared `dparams` key. `hasMemory` makes
- * NuqsTestingAdapter retain each write in an internal synchronous ref (its
- * built-in stand-in for a real URL): every write composes on the latest value
- * and re-renders every hook subscribed to the key — the Next.js round-trip where
- * a `useQueryState` write updates the URL and re-renders its subscribers.
- * `initial` seeds the params — used to simulate a reload of a shared link.
+ * A wrapper that seeds the shared `dparams` key in the URL and drives a faithful
+ * round-trip via NuqsTestingAdapter's `hasMemory` — writes land in nuqs's own
+ * synchronous store and re-render every hook subscribed to the key, the Next.js
+ * round-trip a bare (initial-frozen) testing adapter doesn't reproduce.
  *
- * A hand-rolled `useState`-fed adapter desyncs nuqs's optimistic cache from the
- * `searchParams` prop under back-to-back writes (the snapshot the next write
- * composes on lags a React commit), which made this suite flake ~17%; the
- * synchronous `hasMemory` ref closes that race.
+ * Each test seeds the *prior* filter state and drives exactly ONE live write —
+ * one drill / chip-remove / clear-all — then asserts. One write per mount,
+ * never two back-to-back, is what keeps this deterministic: nuqs's update queue
+ * can drop the second of two rapid synthetic writes before the first has flushed
+ * (the compose step composes on the first, so a dropped/lagging first write
+ * silently breaks it). The single-write sibling `drilldown-sync` is stable for
+ * the same reason. `resetUrlUpdateQueueOnMount` (on by default) clears the
+ * shared queue per mount, so separate seeded mounts don't leak into each other.
  */
-function MemoryAdapter({ children, initial }: { children: React.ReactNode; initial?: string }) {
-  return (
-    <NuqsTestingAdapter searchParams={initial} hasMemory>
-      {children}
-    </NuqsTestingAdapter>
-  );
-}
+const seeded = (overrides: Record<string, string> = {}) =>
+  withNuqsTestingAdapter({
+    searchParams: Object.keys(overrides).length
+      ? `${DASHBOARD_PARAMS_KEY}=${encodeURIComponent(JSON.stringify(overrides))}`
+      : "",
+    hasMemory: true,
+  });
 
 describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
-  // One continuous lifecycle (add → compose → remove one → toggle-deselect) so
-  // the module-level nuqs `dparams` cache (keyed by name) can't leak between
-  // mounts and make assertions non-deterministic — same guard as drilldown-sync.
-  test("drill applies a filter, a second composes (AND), chip-remove + re-click deselect clear them", async () => {
+  test("drilling a card applies the filter across cards and shows a chip", async () => {
     const onChange = mock((_: ParameterValues) => {});
-    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: seeded() });
 
     // Mount: no overrides (use defaults), no chips.
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
     expect(screen.queryByTestId("dashboard-filter-chips")).toBeNull();
 
-    // Drill card A on "region" → filter applies to every card (the bound map the
-    // page hands to the batched render) and a chip appears.
+    // Drill on "region" → filter applies to every card (the bound map the page
+    // hands the batched render) and a chip appears.
     fireEvent.click(screen.getByText("drill-region"));
     await waitFor(() => {
       expect(screen.getByTestId("filter-chip-region").textContent).toContain("us");
     });
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
     expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
+  });
 
-    // Drill on a second param → the two compose (AND) in one override map.
+  test("a second drill composes (AND) with the existing filter", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ region: "us" }) });
+
+    // Mount reflects the seeded region filter on every surface.
+    await waitFor(() => {
+      expect(screen.getByTestId("filter-chip-region").textContent).toContain("us");
+    });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
+    expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
+
+    // Drill a second param → the two compose (AND) in one override map.
     fireEvent.click(screen.getByText("drill-stage"));
+    await waitFor(() => {
+      expect(screen.getByTestId("filter-chip-stage").textContent).toContain("Discovery");
+    });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us", stage: "Discovery" });
+  });
+
+  test("removing a chip drops only that filter", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ region: "us", stage: "Discovery" }) });
+
+    // Mount reflects both seeded filters.
     await waitFor(() => {
       expect(screen.getByTestId("filter-chip-stage").textContent).toContain("Discovery");
     });
@@ -119,6 +141,15 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
       expect(screen.queryByTestId("filter-chip-region")).toBeNull();
     });
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ stage: "Discovery" });
+  });
+
+  test("re-drilling the same value toggles that filter off", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ stage: "Discovery" }) });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filter-chip-stage").textContent).toContain("Discovery");
+    });
 
     // Re-click the same stage element → toggle deselect clears it; no chips left.
     fireEvent.click(screen.getByText("drill-stage"));
@@ -130,10 +161,8 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
 
   test("Clear all removes every active cross-filter in one action", async () => {
     const onChange = mock((_: ParameterValues) => {});
-    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ region: "us", stage: "Discovery" }) });
 
-    fireEvent.click(screen.getByText("drill-region"));
-    fireEvent.click(screen.getByText("drill-stage"));
     await waitFor(() => {
       expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us", stage: "Discovery" });
     });
@@ -147,11 +176,7 @@ describe("cross-filter ↔ bar ↔ chips URL sync (#3213)", () => {
 
   test("reload of a shared link reflects the URL filters on mount", async () => {
     const onChange = mock((_: ParameterValues) => {});
-    render(
-      <MemoryAdapter initial={`${DASHBOARD_PARAMS_KEY}=${encodeURIComponent('{"region":"eu"}')}`}>
-        <Harness onChange={onChange} />
-      </MemoryAdapter>,
-    );
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ region: "eu" }) });
 
     // The chip + bar reflect the persisted state with no interaction, and the bar
     // emits the bound map so the page renders the shared view's filtered cards.

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
@@ -9,7 +9,6 @@
  * break.
  */
 import { afterEach, describe, expect, test, mock } from "bun:test";
-import { useState } from "react";
 import { useQueryState } from "nuqs";
 import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { render, cleanup, fireEvent, waitFor, screen } from "@testing-library/react";
@@ -40,18 +39,16 @@ function Harness({ onChange }: { onChange: (o: ParameterValues) => void }) {
 }
 
 /**
- * A self-updating testing adapter: it feeds its captured URL updates straight
- * back in as `searchParams`. That reproduces the real-app round-trip — in
- * Next.js a `useQueryState` write updates the URL, which re-renders every hook
- * subscribed to that key — which the bare testing adapter doesn't do on its own.
+ * A real-app round-trip adapter for the shared key. `hasMemory` makes
+ * NuqsTestingAdapter retain each write in an internal synchronous ref (its
+ * built-in stand-in for a real URL), so a `useQueryState` write re-renders every
+ * hook subscribed to that key — the Next.js round-trip the bare adapter (frozen
+ * to its initial value) doesn't reproduce. The synchronous ref also means each
+ * write composes on the latest value, avoiding the optimistic-cache-vs-prop
+ * desync a hand-rolled `useState`-fed adapter hits under back-to-back writes.
  */
-function SyncingAdapter({ children }: { children: React.ReactNode }) {
-  const [search, setSearch] = useState(() => new URLSearchParams());
-  return (
-    <NuqsTestingAdapter searchParams={search} onUrlUpdate={(e) => setSearch(e.searchParams)}>
-      {children}
-    </NuqsTestingAdapter>
-  );
+function MemoryAdapter({ children }: { children: React.ReactNode }) {
+  return <NuqsTestingAdapter hasMemory>{children}</NuqsTestingAdapter>;
 }
 
 describe("drilldown ↔ parameter bar URL sync", () => {
@@ -61,7 +58,7 @@ describe("drilldown ↔ parameter bar URL sync", () => {
   test("a drilldown write reflects in the bar, emits the bound value, and Reset clears it", async () => {
     const onChange = mock((_: ParameterValues) => {});
 
-    render(<Harness onChange={onChange} />, { wrapper: SyncingAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
 
     // On mount the bar reports "no overrides" (use defaults).
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});


### PR DESCRIPTION
## Problem

`main` CI went red on `test-others` after #3227 — a flaky failure in `cross-filter-sync.test.tsx`:

```
✗ drill applies a filter, a second composes (AND)…
  TestingLibraryElementError: Unable to find an element by: [data-testid="filter-chip-stage"]
```

Passed in isolation, flaked **7/40 (~17%)** locally. It only surfaces under CI load, where the suite runs slower/contended.

## Root cause

The test drove **two back-to-back synthetic `fireEvent.click`s** (drill `region`, then drill `stage`) through a hand-rolled self-feeding nuqs testing adapter:

```tsx
const [search, setSearch] = useState(() => new URLSearchParams(initial));
<NuqsTestingAdapter searchParams={search} onUrlUpdate={(e) => setSearch(e.searchParams)} />
```

Two failure modes stack here:

1. **Override clobber** — each write composes on the `searchParams` **prop**, which only updates after React commits `setSearch`; nuqs's optimistic cache updates immediately. The second write reads the *stale* prop, so the `stage` drill clobbers the `region` override.
2. **Queue drop** — even with a synchronous store, nuqs's update queue can drop the **second** of two rapid synthetic writes before the first flushes; the compose step then composes on the first write and the second chip never appears.

Real drilldowns are user-paced seconds apart, so neither race exists outside the synthetic back-to-back test clicks. The single-write sibling `drilldown-sync` has always been stable for exactly this reason.

## Fix

**Drive exactly one live write per test.** Each test seeds the *prior* filter state into the URL via `withNuqsTestingAdapter({ searchParams, hasMemory: true })` and drives a single drill / chip-remove / clear-all, then asserts. With no two back-to-back writes, neither the clobber nor the queue-drop can occur — robust by construction, not by timing. Same contract coverage (apply / compose-AND / remove-one / toggle-deselect / clear-all / reload), now across 6 focused tests.

`hasMemory` (NuqsTestingAdapter's documented memory-backed mode) gives the faithful Next.js round-trip a bare initial-frozen adapter doesn't — writes land in nuqs's own synchronous store and re-render every hook subscribed to the key. The sibling `drilldown-sync` is modernized onto the same `hasMemory` adapter (single write, already stable).

## Validation

| | before | after |
|---|---|---|
| cross-filter-sync | 7/40 fail (17.5%) | **0/60 sequential, 0/16 under parallel CPU load** |

`eslint` clean, `tsgo --noEmit` clean. Test-only change; no product code touched.
