### PR TITLE
chore(deps): build via workspace-local tsc in plugin-sdk/webhook-publisher/sdk (#3224)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -314,6 +314,7 @@
       "devDependencies": {
         "ai": "^6.0.193",
         "hono": "^4.12.23",
+        "typescript": "^6.0.3",
         "zod": "^4.4.3",
       },
       "peerDependencies": {
@@ -403,6 +404,7 @@
       },
       "devDependencies": {
         "@atlas/oauth-helper": "workspace:*",
+        "typescript": "^6.0.3",
       },
     },
     "packages/types": {

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -4,7 +4,7 @@
   "description": "Type definitions and helpers for authoring Atlas plugins",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepare": "bun run build",
     "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts"
   },
@@ -77,6 +77,7 @@
   "devDependencies": {
     "ai": "^6.0.193",
     "hono": "^4.12.23",
+    "typescript": "^6.0.3",
     "zod": "^4.4.3"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/client.ts src/mcp.ts --outdir dist --target node --external '@useatlas/types' && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/client.ts src/mcp.ts --outdir dist --target node --external '@useatlas/types' && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepublishOnly": "bun run build",
     "test": "bun test src/__tests__/client.test.ts src/__tests__/stream.test.ts src/__tests__/integration.test.ts src/__tests__/stream-integration.test.ts src/__tests__/fetch-starter-prompts.test.ts src/__tests__/mcp.test.ts"
   },
@@ -52,6 +52,7 @@
     "@useatlas/types": "^0.1.0"
   },
   "devDependencies": {
-    "@atlas/oauth-helper": "workspace:*"
+    "@atlas/oauth-helper": "workspace:*",
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/webhook-publisher/package.json
+++ b/packages/webhook-publisher/package.json
@@ -4,7 +4,7 @@
   "description": "Framework-free outbound webhook sender for Atlas — HMAC signing strategies + bounded retry",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/sign.ts src/deliver.ts --outdir dist --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/sign.ts src/deliver.ts --outdir dist --target node --packages external && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepare": "bun run build",
     "test": "bun test src/__tests__/sign.test.ts && bun test src/__tests__/deliver.test.ts"
   },


### PR DESCRIPTION
## What

Follow-up to #3221/#3225 (which fixed `@useatlas/types`). Three more `@useatlas/*` packages routed their TS declaration emit through `bun x tsc`, exposing them to the same fresh-install TS6046 race:

| Package | Fix |
|---|---|
| `@useatlas/plugin-sdk` | `bun x tsc` → `./node_modules/.bin/tsc` **+ add `typescript` devDep** (had none — worst case) |
| `@useatlas/webhook-publisher` | `bun x tsc` → `./node_modules/.bin/tsc` (`typescript` devDep already present) |
| `@useatlas/sdk` | `bun x tsc` → `./node_modules/.bin/tsc` **+ add `typescript` devDep** (hygiene — builds on `prepublishOnly`, not `prepare`, so no install-time race, but the local bin is still correct) |

## Why it bites

On a **full** `bun install`, a package's `prepare` can fire before the local `tsc` bin is linked into `node_modules/.bin`. `bun x tsc` then resolves the **wrong** compiler — the deprecated registry `tsc` shim on a clean machine, or a global `tsc` on `PATH` — both predating `moduleResolution: "bundler"` → intermittent `error TS6046`. Pointing straight at `./node_modules/.bin/tsc` is immune to both, and making `typescript` a direct devDep ensures bun links that local bin before `prepare` runs.

## Verification

- `bun install` → `packages/{plugin-sdk,webhook-publisher,sdk}/node_modules/.bin/tsc` all linked ✓
- `bun run build` in each package succeeds (proves `./node_modules/.bin/tsc` resolves) ✓
- `typescript` pinned to `^6.0.3`, matching the existing workspace pin (syncpack-clean) ✓
- No version bumps — devDep + build-script changes only, so no publish/ref-bump sequencing needed.

Closes #3224.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783283096&installation_id=135337507&pr_number=3229&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3229&signature=29b130b44947d90987b7842da23076558dc05cd5619609e87bcf75d57908f8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scripts across multiple packages to use local TypeScript compiler binaries. Added TypeScript as an explicit development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->