### PR TITLE
feat(web): redesign /admin/connections — collapsible grouped rows + Add picker

### DIFF
--- a/packages/web/src/app/admin/connections/__tests__/curated-install-dialog.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/curated-install-dialog.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Secret-isolation coverage for the curated REST datasource install dialog.
+ *
+ * The dialog is a single long-lived instance reused across vendors (the page
+ * swaps `candidate` rather than remounting). Its only guard against a pasted
+ * credential bleeding from one vendor's install into the next is the
+ * reset-on-open effect keyed on `[open, candidate?.slug]`. A regression there
+ * (e.g. narrowing the dep array, or hoisting the field state) would silently
+ * POST a live secret — say a Stripe `sk_live_…` — against a *different*
+ * vendor's `install-form` endpoint. That's invisible to type-checking and to a
+ * casual smoke test, so it's asserted here directly.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CuratedInstallDialog, type CuratedCandidate } from "../curated-install-dialog";
+
+const STRIPE: CuratedCandidate = { slug: "stripe-data", name: "Stripe", description: null };
+const NOTION: CuratedCandidate = { slug: "notion-data", name: "Notion", description: null };
+
+const noop = () => undefined;
+
+function authInput(): HTMLInputElement {
+  return screen.getByTestId("curated-auth-value") as HTMLInputElement;
+}
+
+afterEach(cleanup);
+
+describe("CuratedInstallDialog secret isolation", () => {
+  test("clears the credential when the candidate changes (no bleed across vendors)", () => {
+    const { rerender } = render(
+      <CuratedInstallDialog candidate={STRIPE} open onOpenChange={noop} onInstalled={noop} />,
+    );
+
+    fireEvent.change(authInput(), { target: { value: "sk_live_super_secret" } });
+    expect(authInput().value).toBe("sk_live_super_secret");
+
+    // Same dialog instance, different vendor — the slug-keyed reset must wipe
+    // the previously pasted Stripe key before the Notion install form is shown.
+    rerender(
+      <CuratedInstallDialog candidate={NOTION} open onOpenChange={noop} onInstalled={noop} />,
+    );
+    expect(authInput().value).toBe("");
+  });
+
+  test("clears the credential on close-then-reopen for the same vendor", () => {
+    const { rerender } = render(
+      <CuratedInstallDialog candidate={STRIPE} open onOpenChange={noop} onInstalled={noop} />,
+    );
+
+    fireEvent.change(authInput(), { target: { value: "sk_live_x" } });
+    expect(authInput().value).toBe("sk_live_x");
+
+    // Closing then reopening the same candidate re-fires the open-gated reset,
+    // so a half-typed secret never survives a dismiss.
+    rerender(
+      <CuratedInstallDialog candidate={STRIPE} open={false} onOpenChange={noop} onInstalled={noop} />,
+    );
+    rerender(
+      <CuratedInstallDialog candidate={STRIPE} open onOpenChange={noop} onInstalled={noop} />,
+    );
+    expect(authInput().value).toBe("");
+  });
+});

--- a/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   cleanup,
+  fireEvent,
   render as rtlRender,
   type RenderResult,
   waitFor,
@@ -80,6 +81,22 @@ function render(ui: ReactElement): RenderResult {
       <AtlasProvider config={testConfig}>{ui}</AtlasProvider>
     </QueryClientProvider>,
   );
+}
+
+/**
+ * Connected datasources render as a {@link CollapsibleRow} — a one-line summary
+ * that reveals its detail sheet + action footer only when expanded. Clicks the
+ * row's toggle so the detail rows / Reconnect / Disconnect assertions can run.
+ */
+async function expandSalesforceRow(container: HTMLElement): Promise<void> {
+  const toggle = await waitFor(() => {
+    const el = container.querySelector<HTMLButtonElement>(
+      '[data-testid="salesforce-row"] button',
+    );
+    if (!el) throw new Error("salesforce row toggle not rendered yet");
+    return el;
+  });
+  fireEvent.click(toggle);
 }
 
 describe("SalesforceProviderBlock", () => {
@@ -181,8 +198,11 @@ describe("SalesforceProviderBlock", () => {
       <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
     );
 
-    // Instance URL detail row carries the post-OAuth tenant host.
+    // Connected Salesforce renders as a collapsed row whose meta line carries
+    // the post-OAuth tenant host. Expand it to reveal the detail sheet (Org ID
+    // / Refresh token) and the Disconnect action.
     await findByText("https://na139.my.salesforce.com");
+    await expandSalesforceRow(container);
     await findByText("00DAB000000ZmU8");
 
     // "Refresh token: Live" — the freshness pill maps installStatus='ok'
@@ -220,7 +240,7 @@ describe("SalesforceProviderBlock", () => {
       <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
     );
 
-    // Reconnect-needed badge surfaces on the Shell title.
+    // Reconnect-needed badge surfaces on the collapsed row's title.
     await waitFor(() => {
       const badge = container.querySelector(
         '[data-testid="salesforce-reconnect-badge"]',
@@ -228,6 +248,9 @@ describe("SalesforceProviderBlock", () => {
       if (!badge) throw new Error("reconnect badge not rendered yet");
       return badge;
     });
+
+    // Expand the row to reveal its action footer (Reconnect / Disconnect).
+    await expandSalesforceRow(container);
 
     // Reconnect link is rendered as the primary CTA (same href as
     // Connect — the OAuth callback upserts the install row in place).

--- a/packages/web/src/app/admin/connections/add-connection-picker.tsx
+++ b/packages/web/src/app/admin/connections/add-connection-picker.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { type ComponentType } from "react";
+import {
+  CreditCard,
+  GitBranch,
+  Loader2,
+  Network,
+  NotebookText,
+  Plus,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import {
+  IntegrationsCatalogResponseSchema,
+  type IntegrationsCatalogEntry,
+} from "@/ui/lib/admin-schemas";
+import { getApiUrl } from "@/lib/api-url";
+import { cn } from "@/lib/utils";
+import { DATABASE_PROVIDERS, descriptionForDbType, iconForDbType } from "./provider-meta";
+import type { CuratedCandidate } from "./curated-install-dialog";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  Add-connection picker — the single entry point for connecting a new
+ *  datasource. Replaces the old always-listed "Connect" rows (one per unused
+ *  provider) that padded the page out. Three groups:
+ *
+ *    Databases     — the SQL providers, each → the URL-form connection dialog
+ *                    pre-pointed at that dbType.
+ *    Popular APIs  — curated REST "data candidates" (Stripe, Notion, GitHub)
+ *                    read live from the integrations catalog. Form candidates
+ *                    open a one-credential dialog; OAuth candidates redirect.
+ *    Custom        — any REST API with an OpenAPI 3.x spec (freeform URL).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** The curated REST datasources we feature, in display order. Metadata is read
+ *  from the catalog at runtime; this map only carries presentation (icon) and
+ *  fixes the order. Keyed by catalog slug. */
+const CURATED: ReadonlyArray<{ slug: string; icon: LucideIcon }> = [
+  { slug: "stripe-data", icon: CreditCard },
+  { slug: "notion-data", icon: NotebookText },
+  { slug: "github-data", icon: GitBranch },
+];
+const CURATED_SLUGS = new Set(CURATED.map((c) => c.slug));
+
+function Tile({
+  icon: Icon,
+  title,
+  description,
+  onClick,
+  disabled,
+  badge,
+  testId,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  badge?: string;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      data-testid={testId}
+      className={cn(
+        "group flex items-start gap-3 rounded-xl border bg-card/40 px-3.5 py-3 text-left transition-colors",
+        "hover:border-primary/40 hover:bg-card/80",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-border disabled:hover:bg-card/40",
+      )}
+    >
+      <span className="grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground transition-colors group-hover:border-primary/30 group-hover:text-primary">
+        <Icon className="size-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold tracking-tight">{title}</span>
+          {badge ? (
+            <Badge variant="outline" className="shrink-0 text-[10px]">
+              {badge}
+            </Badge>
+          ) : null}
+        </span>
+        <span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{description}</span>
+      </span>
+    </button>
+  );
+}
+
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+      {children}
+    </h3>
+  );
+}
+
+export function AddConnectionPicker({
+  open,
+  onOpenChange,
+  demoReadOnly,
+  onPickDatabase,
+  onPickCustomRest,
+  onPickCuratedForm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  demoReadOnly: boolean;
+  onPickDatabase: (dbType: string) => void;
+  onPickCustomRest: () => void;
+  /** Form-based curated candidate (paste a key) → opens the curated dialog. */
+  onPickCuratedForm: (candidate: CuratedCandidate) => void;
+}) {
+  // Curated candidates come from the integrations catalog. NOTE: the built-in
+  // data candidates (stripe-data / notion-data / github-data) are seeded with
+  // `type: "datasource"`, which `GET /api/v1/integrations/catalog` excludes
+  // server-side (its facade narrows to `type IN ('chat','integration')`). So
+  // this fetch surfaces curated tiles only once a datasource-pillar listing is
+  // exposed (a `?pillar=datasource` mode or a dedicated endpoint) — until then
+  // the "Popular APIs" group hides itself (see `curated` below). Salesforce
+  // (legacy `type: "integration"`) is unaffected; it has its own section.
+  // Enabled only while open so the picker doesn't fetch on every page render.
+  const catalogQuery = useAdminFetch("/api/v1/integrations/catalog", {
+    schema: IntegrationsCatalogResponseSchema,
+    enabled: open,
+  });
+
+  const bySlug = new Map<string, IntegrationsCatalogEntry>(
+    (catalogQuery.data?.catalog ?? [])
+      .filter((e) => e.pillar === "datasource" && CURATED_SLUGS.has(e.slug))
+      .map((e) => [e.slug, e]),
+  );
+  // Curated candidates the operator has opted into (enabled in the catalog),
+  // in display order. Empty in deploys that haven't enabled any — the whole
+  // "Popular APIs" section then hides rather than showing a bare heading.
+  const curated = CURATED.map(({ slug, icon }) => {
+    const entry = bySlug.get(slug);
+    return entry ? { entry, icon } : null;
+  }).filter((c): c is { entry: IntegrationsCatalogEntry; icon: LucideIcon } => c !== null);
+
+  function pickDatabase(dbType: string) {
+    onOpenChange(false);
+    onPickDatabase(dbType);
+  }
+  function pickCustomRest() {
+    onOpenChange(false);
+    onPickCustomRest();
+  }
+  function pickCurated(entry: IntegrationsCatalogEntry) {
+    if (entry.installModel === "oauth") {
+      // OAuth candidates (e.g. GitHub) start the dance server-side; the
+      // callback returns the admin to /admin/connections.
+      window.location.href = `${getApiUrl()}/api/v1/integrations/${encodeURIComponent(entry.slug)}/install`;
+      return;
+    }
+    onOpenChange(false);
+    onPickCuratedForm({ slug: entry.slug, name: entry.name, description: entry.description });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] max-w-xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add a datasource</DialogTitle>
+          <DialogDescription>
+            Connect a database or a REST API. Atlas queries everything read-only; credentials are
+            encrypted at rest.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <section>
+            <GroupLabel>Databases</GroupLabel>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {DATABASE_PROVIDERS.map((p) => (
+                <Tile
+                  key={p.value}
+                  icon={iconForDbType(p.value)}
+                  title={p.label}
+                  description={descriptionForDbType(p.value)}
+                  onClick={() => pickDatabase(p.value)}
+                  disabled={demoReadOnly}
+                  testId={`add-db-${p.value}`}
+                />
+              ))}
+            </div>
+          </section>
+
+          {catalogQuery.loading ? (
+            <section>
+              <GroupLabel>Popular APIs</GroupLabel>
+              <div className="flex items-center gap-2 px-1 py-3 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                Loading curated APIs…
+              </div>
+            </section>
+          ) : curated.length > 0 ? (
+            <section>
+              <GroupLabel>Popular APIs</GroupLabel>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {curated.map(({ entry, icon }) => {
+                  const access = entry.access;
+                  const upgrade = access.kind === "upgrade";
+                  const comingSoon = entry.implementationStatus === "coming_soon";
+                  return (
+                    <Tile
+                      key={entry.slug}
+                      icon={icon}
+                      title={entry.name}
+                      description={
+                        entry.description ??
+                        `Query ${entry.name} as a read-only REST datasource.`
+                      }
+                      badge={
+                        entry.installed
+                          ? "Connected"
+                          : comingSoon
+                            ? "Soon"
+                            : access.kind === "upgrade" && access.requiredPlan
+                              ? `${access.requiredPlan} plan`
+                              : entry.installModel === "oauth"
+                                ? "OAuth"
+                                : undefined
+                      }
+                      onClick={() => pickCurated(entry)}
+                      disabled={demoReadOnly || upgrade || comingSoon}
+                      testId={`add-curated-${entry.slug}`}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          ) : null}
+
+          <section>
+            <GroupLabel>Custom</GroupLabel>
+            <Tile
+              icon={Network}
+              title="Custom REST API"
+              description="Any REST service with an OpenAPI 3.x spec — an internal service, or a vendor not listed above."
+              onClick={pickCustomRest}
+              disabled={demoReadOnly}
+              testId="add-custom-rest"
+            />
+          </section>
+
+          {demoReadOnly ? (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Plus className="size-3.5" />
+              Delete the demo connection or switch to developer mode to add a new one.
+            </p>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/admin/connections/add-connection-picker.tsx
+++ b/packages/web/src/app/admin/connections/add-connection-picker.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/ui/lib/admin-schemas";
 import { getApiUrl } from "@/lib/api-url";
 import { cn } from "@/lib/utils";
+import type { DBType } from "@/ui/lib/types";
 import { DATABASE_PROVIDERS, descriptionForDbType, iconForDbType } from "./provider-meta";
 import type { CuratedCandidate } from "./curated-install-dialog";
 
@@ -118,7 +119,7 @@ export function AddConnectionPicker({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   demoReadOnly: boolean;
-  onPickDatabase: (dbType: string) => void;
+  onPickDatabase: (dbType: DBType) => void;
   onPickCustomRest: () => void;
   /** Form-based curated candidate (paste a key) → opens the curated dialog. */
   onPickCuratedForm: (candidate: CuratedCandidate) => void;
@@ -150,7 +151,7 @@ export function AddConnectionPicker({
     return entry ? { entry, icon } : null;
   }).filter((c): c is { entry: IntegrationsCatalogEntry; icon: LucideIcon } => c !== null);
 
-  function pickDatabase(dbType: string) {
+  function pickDatabase(dbType: DBType) {
     onOpenChange(false);
     onPickDatabase(dbType);
   }

--- a/packages/web/src/app/admin/connections/curated-install-dialog.tsx
+++ b/packages/web/src/app/admin/connections/curated-install-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ExternalLink, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { InlineError } from "@/ui/components/admin/compact";
+import { getApiUrl } from "@/lib/api-url";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  Curated REST datasource install — the one-credential form for a built-in
+ *  "data candidate" (Stripe, Notion, …). The spec URL + auth kind are
+ *  pre-wired server-side; the admin only pastes the secret. POSTs the slim
+ *  `{ auth_value, display_name? }` body to the candidate's `install-form`
+ *  handler (mirrors {@link DataCandidateFormDataSchema} on the API).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CuratedCandidate {
+  slug: string;
+  name: string;
+  description: string | null;
+}
+
+/** Per-vendor copy for the single credential field. Falls back to a generic
+ *  label for any candidate not enumerated here. */
+const SECRET_FIELD: Record<string, { label: string; placeholder: string; help: string }> = {
+  "stripe-data": {
+    label: "Stripe secret key",
+    placeholder: "sk_live_…",
+    help: "Find it in Stripe Dashboard → Developers → API keys. Used read-only; encrypted at rest.",
+  },
+  "notion-data": {
+    label: "Notion integration token",
+    placeholder: "ntn_…",
+    help: "Create an internal integration at notion.so/my-integrations and share the pages you want Atlas to read.",
+  },
+};
+
+export function CuratedInstallDialog({
+  candidate,
+  open,
+  onOpenChange,
+  onInstalled,
+}: {
+  candidate: CuratedCandidate | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInstalled: () => void;
+}) {
+  const [authValue, setAuthValue] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the form whenever a different candidate opens the dialog so a
+  // previous vendor's pasted secret never leaks into the next install.
+  useEffect(() => {
+    if (open) {
+      setAuthValue("");
+      setDisplayName("");
+      setError(null);
+    }
+  }, [open, candidate?.slug]);
+
+  if (!candidate) return null;
+  const field = SECRET_FIELD[candidate.slug] ?? {
+    label: "API key / token",
+    placeholder: "",
+    help: "Used read-only; encrypted at rest.",
+  };
+
+  async function handleSubmit() {
+    if (!candidate) return;
+    setSaving(true);
+    setError(null);
+    const body: Record<string, unknown> = { auth_value: authValue };
+    if (displayName.trim()) body.display_name = displayName.trim();
+
+    try {
+      const res = await fetch(
+        `${getApiUrl()}/api/v1/integrations/${encodeURIComponent(candidate.slug)}/install-form`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        let message = `Install failed (${res.status})`;
+        try {
+          const b = (await res.json()) as {
+            message?: string;
+            fieldErrors?: Record<string, string[] | undefined>;
+            requestId?: string;
+          };
+          const firstField = b.fieldErrors ? Object.keys(b.fieldErrors)[0] : undefined;
+          const firstErr = firstField ? b.fieldErrors?.[firstField]?.[0] : undefined;
+          if (firstField && firstErr) message = `${firstField}: ${firstErr}`;
+          else if (b.message) message = b.message;
+          if (b.requestId) message = `${message} (ref: ${b.requestId.slice(0, 8)})`;
+        } catch {
+          // intentionally ignored: non-JSON body → keep the status-only message.
+        }
+        setError(message);
+        return;
+      }
+      toast.success(`${candidate.name} connected`);
+      onInstalled();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Install failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect {candidate.name}</DialogTitle>
+          <DialogDescription>
+            {candidate.description ??
+              `Query ${candidate.name} as a read-only REST datasource. The spec is pre-wired — just paste your credential.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="curated-auth-value">{field.label}</Label>
+            <Input
+              id="curated-auth-value"
+              type="password"
+              placeholder={field.placeholder}
+              value={authValue}
+              onChange={(e) => setAuthValue(e.target.value)}
+              data-testid="curated-auth-value"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">{field.help}</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="curated-display-name">Display name (optional)</Label>
+            <Input
+              id="curated-display-name"
+              placeholder={candidate.name}
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+          </div>
+
+          {error ? <InlineError>{error}</InlineError> : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={saving || authValue.trim().length === 0}
+            data-testid="curated-install-submit"
+          >
+            {saving ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <ExternalLink className="mr-1.5 size-3.5" />
+            )}
+            Connect
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/admin/connections/openapi-block.tsx
+++ b/packages/web/src/app/admin/connections/openapi-block.tsx
@@ -68,12 +68,18 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  CompactRow,
   DetailList,
   DetailRow,
   InlineError,
-  Shell,
 } from "@/ui/components/admin/compact";
+import { CollapsibleRow } from "@/ui/components/admin/collapsible-row";
+import {
+  AddDatasourceButton,
+  countLine,
+  DEMO_ADD_TOOLTIP,
+  SectionEmpty,
+  SectionHeader,
+} from "./section-header";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
@@ -277,90 +283,78 @@ function formatBreakingReasons(reasons: ReadonlyArray<{ detail: string }>, total
 
 interface OpenApiProviderBlockProps {
   readonly demoReadOnly: boolean;
-  /** Fires after an install/uninstall so the parent page can refresh too. */
+  /** Opens the Add picker (the REST install dialogs are hosted by the page). */
+  readonly onAdd: () => void;
+  /** Fires after a per-row mutation (rediscover/delete) so the page refetches. */
   readonly onChange: () => void;
 }
 
-/** Block for the OpenAPI (generic REST) datasources on `/admin/connections`. */
-export function OpenApiProviderBlock({ demoReadOnly, onChange }: OpenApiProviderBlockProps) {
+/** The "REST APIs" section on `/admin/connections` — OpenAPI/generic +
+ *  curated candidates (Stripe, Notion, …) once installed. The install flow
+ *  lives in the page's Add picker; this block renders the section + rows and
+ *  owns per-row lifecycle (rediscover / representation / disconnect). */
+export function OpenApiProviderBlock({ demoReadOnly, onAdd, onChange }: OpenApiProviderBlockProps) {
   const listQuery = useAdminFetch("/api/v1/admin/openapi-datasources", { schema: ListSchema });
   // #3044 — connection groups for the per-datasource environment picker. A
   // failure degrades to "no groups" (the picker offers only Workspace-global).
   const groupsQuery = useAdminFetch("/api/v1/me/connection-groups", {
     schema: ConnectionGroupsSchema,
   });
-  const [installOpen, setInstallOpen] = useState(false);
 
   const refresh = () => {
     listQuery.refetch();
     onChange();
   };
 
-  if (listQuery.loading) {
-    return (
-      <CompactRow
-        icon={Network}
-        title="OpenAPI (Generic REST)"
-        description="Loading…"
-        status="disconnected"
-        action={
-          <Button size="sm" variant="outline" disabled>
-            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-            Add
-          </Button>
-        }
-      />
-    );
-  }
-
-  if (listQuery.error) {
-    return (
-      <CompactRow
-        icon={Network}
-        title="OpenAPI (Generic REST)"
-        description={friendlyErrorOrNull(listQuery.error) ?? "Failed to load REST datasources."}
-        status="unhealthy"
-        action={
-          <Button size="sm" variant="outline" onClick={() => listQuery.refetch()}>
-            Retry
-          </Button>
-        }
-      />
-    );
-  }
-
   const datasources = listQuery.data?.datasources ?? [];
-  const addButton = (
-    <Button
-      size="sm"
-      variant={datasources.length === 0 ? "default" : "outline"}
-      disabled={demoReadOnly}
-      onClick={() => setInstallOpen(true)}
-      data-testid="openapi-add"
-    >
-      <Plus className="mr-1.5 size-3.5" />
-      Add REST datasource
-    </Button>
+  const addAction = (
+    <AddDatasourceButton
+      label="Add REST API"
+      onClick={onAdd}
+      demoReadOnly={demoReadOnly}
+      demoTooltip={DEMO_ADD_TOOLTIP}
+      testId="openapi-add"
+    />
   );
 
   return (
-    <div className="space-y-2">
-      {datasources.length === 0 ? (
-        <CompactRow
+    <section>
+      <SectionHeader
+        title="REST APIs"
+        count={listQuery.loading || listQuery.error ? undefined : countLine(datasources.length)}
+        action={addAction}
+      />
+
+      {listQuery.loading ? (
+        <div className="flex items-center gap-2 rounded-xl border bg-card/40 px-3.5 py-3 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          Loading REST datasources…
+        </div>
+      ) : listQuery.error ? (
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-destructive/25 bg-card/40 px-3.5 py-3">
+          <span className="text-xs text-destructive">
+            {friendlyErrorOrNull(listQuery.error) ?? "Failed to load REST datasources."}
+          </span>
+          <Button size="sm" variant="outline" onClick={() => listQuery.refetch()}>
+            Retry
+          </Button>
+        </div>
+      ) : datasources.length === 0 ? (
+        <SectionEmpty
           icon={Network}
-          title="OpenAPI (Generic REST)"
-          description="Connect any REST API with an OpenAPI 3.x spec — Twenty, Stripe, an internal service."
-          status="disconnected"
-          action={addButton}
+          title="No REST APIs connected"
+          description="Connect Stripe, Notion, or any service with an OpenAPI 3.x spec."
+          action={
+            demoReadOnly ? null : (
+              <Button size="sm" variant="outline" onClick={onAdd} data-testid="openapi-add-empty">
+                <Plus className="mr-1.5 size-3.5" />
+                Add REST API
+              </Button>
+            )
+          }
         />
       ) : (
-        <>
-          <div className="flex items-center justify-between px-1">
-            <span className="text-xs font-medium text-muted-foreground">
-              OpenAPI (Generic REST) — {datasources.length} connected
-            </span>
-            {addButton}
-          </div>
+        <div className="space-y-2">
           {datasources.map((ds) => (
             <OpenApiInstallCard
               key={ds.id}
@@ -369,18 +363,9 @@ export function OpenApiProviderBlock({ demoReadOnly, onChange }: OpenApiProvider
               onChange={refresh}
             />
           ))}
-        </>
+        </div>
       )}
-
-      <InstallDialog
-        open={installOpen}
-        onOpenChange={setInstallOpen}
-        onInstalled={() => {
-          setInstallOpen(false);
-          refresh();
-        }}
-      />
-    </div>
+    </section>
   );
 }
 
@@ -540,13 +525,17 @@ function OpenApiInstallCard({
 
   return (
     <>
-      <Shell
+      <CollapsibleRow
         icon={Network}
         title={<span className="font-mono">{ds.displayName}</span>}
         titleText={ds.displayName}
-        description={host ? `REST API · ${host}` : "REST API"}
-        status="connected"
-        statusLabel="Connected"
+        meta={host ? host : "REST API"}
+        // A standing breaking-change alert flips the row amber + "Drift" so it's
+        // visible while collapsed; a clean datasource reads as a teal "Connected".
+        status={breakingAlert ? "transitioning" : "connected"}
+        statusLabel={breakingAlert ? "Drift" : "Connected"}
+        summary={ds.snapshot ? `${ds.snapshot.operationCount} ops` : undefined}
+        dataTestId={`openapi-row-${ds.id}`}
         titleBadge={
           ds.status === "draft" ? (
             <Badge variant="outline" className="text-[10px]">
@@ -728,7 +717,7 @@ function OpenApiInstallCard({
         {rediscover.error ? (
           <InlineError>{friendlyErrorOrNull(rediscover.error) ?? "Rediscover failed."}</InlineError>
         ) : null}
-      </Shell>
+      </CollapsibleRow>
 
       <OperationsDialog
         installId={ds.id}
@@ -817,7 +806,9 @@ function OperationsDialog({
 
 // ── Install dialog ───────────────────────────────────────────────────────────
 
-function InstallDialog({
+/** The freeform "Custom REST API" install dialog (OpenAPI spec URL + auth).
+ *  Hosted by the connections page and opened from the Add picker. */
+export function RestInstallDialog({
   open,
   onOpenChange,
   onInstalled,

--- a/packages/web/src/app/admin/connections/openapi-block.tsx
+++ b/packages/web/src/app/admin/connections/openapi-block.tsx
@@ -5,7 +5,7 @@
  * (PRD #2868 slice 2, #2926). Parallel to {@link SalesforceProviderBlock}, but:
  *
  *  - **Multi-instance** — a workspace installs Twenty, Stripe, an internal
- *    service side by side. Each is its own Shell with its own actions.
+ *    service side by side. Each is its own CollapsibleRow with its own actions.
  *  - **Form install** — `POST /api/v1/integrations/openapi-generic/install-form`
  *    with the spec URL + auth (probed server-side; field errors surface inline).
  *  - **Per-install lifecycle** via `/api/v1/admin/openapi-datasources/{id}`:
@@ -523,6 +523,17 @@ function OpenApiInstallCard({
     }
   }
 
+  // The per-row PATCH/DELETE mutations report success via toast, but each is
+  // bound to a server value (the Switch/Selects below) that snaps back on a
+  // failed write — so a bare toast lets the revert read as a silent no-op once
+  // it fades. Surface a durable inline error too (rediscover already had one).
+  const settingsError =
+    setMode.error ??
+    setRefresh.error ??
+    setGroup.error ??
+    remove.error ??
+    acknowledgeDrift.error;
+
   return (
     <>
       <CollapsibleRow
@@ -716,6 +727,9 @@ function OpenApiInstallCard({
 
         {rediscover.error ? (
           <InlineError>{friendlyErrorOrNull(rediscover.error) ?? "Rediscover failed."}</InlineError>
+        ) : null}
+        {settingsError ? (
+          <InlineError>{friendlyErrorOrNull(settingsError) ?? "Update failed."}</InlineError>
         ) : null}
       </CollapsibleRow>
 

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -1218,6 +1218,14 @@ export default function ConnectionsPage() {
     }));
   })();
 
+  // "Live" mirrors the row rendering: ConnectionCard maps both `healthy` and
+  // `degraded` to a connected (teal) row via `healthToStatus`, so both count as
+  // live — otherwise a degraded row reads as connected while the rollup calls
+  // it not-live. Unhealthy / unknown are excluded. Single predicate so the hero
+  // stat and the Databases section count can't drift apart.
+  const isLive = (c: ConnectionInfo) =>
+    c.health?.status === "healthy" || c.health?.status === "degraded";
+
   // Header "X / Y live" mirrors the /admin/billing usage panel — the
   // lazy `default` fallback on self-hosted demo deploys reports
   // `billable: false` and stays out of both numerator and denominator
@@ -1225,13 +1233,13 @@ export default function ConnectionsPage() {
   // API servers that omit the field.
   const billableConnections = displayConnections.filter(isBillable);
   const stats = {
-    live: billableConnections.filter((c) => c.health?.status === "healthy").length,
+    live: billableConnections.filter(isLive).length,
     total: billableConnections.length,
   };
 
   // Databases section rollup — every row from `/admin/connections` is a SQL
   // (or legacy) database; REST APIs + Salesforce are separate sections.
-  const dbLive = displayConnections.filter((c) => c.health?.status === "healthy").length;
+  const dbLive = displayConnections.filter(isLive).length;
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-10">

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -1000,14 +1000,11 @@ export default function ConnectionsPage() {
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const { readOnly: demoReadOnly } = useDemoReadonly();
 
-  // `useQueryStates` so the segmented control reflects whichever value
-  // the URL ships with on first paint — keeps the legacy
-  // `/admin/connections/groups` redirect landing on the right view and
-  // Post-0096 cutover (#2744): the `?groupBy=environment` toggle and
-  // the environments view it routed to are gone — group membership is
-  // now visible per-connection in the edit dialog (`newGroupName` on
-  // POST/PUT). The remaining `bucketizeConnections(..., "type")` call
-  // still powers the type-grouped provider blocks.
+  // Post-0096 cutover (#2744): the `?groupBy=environment` toggle and the
+  // environments view it routed to are gone — there's no segmented control
+  // or URL-driven view state here anymore. Group membership is surfaced
+  // per-connection in the edit dialog (`newGroupName` on POST/PUT), and the
+  // page renders one flat list split into type-grouped provider sections.
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -1150,7 +1147,7 @@ export default function ConnectionsPage() {
     setEditId(null);
     setEditDetail(null);
     // Callers that don't pass a dbType (e.g. the hero CTA) get the dialog's
-    // built-in Postgres default; the provider CompactRow passes its own
+    // built-in Postgres default; the Add picker's database tile passes its own
     // dbType so the admin isn't re-routed into Postgres URL validation.
     setCreateDbType(dbType);
     setFormOpen(true);

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -6,7 +6,6 @@ import { useAtlasConfig } from "@/ui/context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { bucketizeConnections } from "./group-by";
 import {
   Select,
   SelectContent,
@@ -53,10 +52,6 @@ import {
   Droplets,
   Check,
   X,
-  Database,
-  Snowflake,
-  Cloud,
-  HardDrive,
   RefreshCw,
 } from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
@@ -80,14 +75,25 @@ import {
   type ComponentType,
 } from "react";
 import {
-  CompactRow,
   DetailList,
   DetailRow,
   InlineError,
-  SectionHeading,
-  Shell,
   type StatusKind,
 } from "@/ui/components/admin/compact";
+import { CollapsibleRow } from "@/ui/components/admin/collapsible-row";
+import { AddConnectionPicker } from "./add-connection-picker";
+import {
+  CuratedInstallDialog,
+  type CuratedCandidate,
+} from "./curated-install-dialog";
+import { RestInstallDialog } from "./openapi-block";
+import { iconForDbType, labelForDbType } from "./provider-meta";
+import {
+  AddDatasourceButton,
+  countLine,
+  SectionEmpty,
+  SectionHeader,
+} from "./section-header";
 import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/format";
 import {
@@ -920,51 +926,9 @@ function PoolStatsSection({ onError }: { onError: (msg: string) => void }) {
 }
 
 // ── Provider mapping ─────────────────────────────────────────────
-
-/** Map a dbType value to the icon used in the compact row and shell header. */
-function iconForDbType(dbType: string): ComponentType<{ className?: string }> {
-  switch (dbType) {
-    case "postgres":
-    case "mysql":
-    case "duckdb":
-      return Database;
-    case "snowflake":
-      return Snowflake;
-    case "clickhouse":
-    case "bigquery":
-      return Cloud;
-    case "salesforce":
-      return HardDrive;
-    default:
-      return Database;
-  }
-}
-
-/** Human-friendly one-line description shown under the provider name. */
-function descriptionForDbType(dbType: string): string {
-  switch (dbType) {
-    case "postgres":
-      return "Open-source OLTP — the default Atlas connection";
-    case "mysql":
-      return "MySQL / MariaDB OLTP instance";
-    case "clickhouse":
-      return "Column-store analytics warehouse";
-    case "snowflake":
-      return "Cloud data warehouse";
-    case "duckdb":
-      return "Embedded analytical SQL engine";
-    case "salesforce":
-      return "CRM objects via SOQL";
-    case "bigquery":
-      return "Google Cloud warehouse";
-    default:
-      return "Datasource connection";
-  }
-}
-
-function labelForDbType(dbType: string): string {
-  return DB_TYPES.find((t) => t.value === dbType)?.label ?? dbType;
-}
+// Icon / label / description helpers live in ./provider-meta so the page
+// (rendering connected DBs) and the Add picker (offering providers) share one
+// source of truth.
 
 /** Short human label for a connection's health.status. */
 function healthLabel(status: ConnectionHealth["status"]): string {
@@ -1058,6 +1022,17 @@ export default function ConnectionsPage() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
+
+  // Add-connection picker + the REST install dialogs it routes to. The
+  // picker replaces the old always-listed "Connect" provider rows.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [customRestOpen, setCustomRestOpen] = useState(false);
+  const [curatedCandidate, setCuratedCandidate] = useState<CuratedCandidate | null>(null);
+  // Bumped after a REST/curated install so the plugin-owned blocks
+  // (OpenAPI, Salesforce) remount and refetch their own lists — their data
+  // lives behind separate query keys from the `connections` fetch below.
+  const [datasourceRefreshKey, setDatasourceRefreshKey] = useState(0);
+  const refreshDatasources = () => setDatasourceRefreshKey((k) => k + 1);
 
   const { data: connections, loading, error, refetch } = useAdminFetch(
     "/api/v1/admin/connections",
@@ -1212,17 +1187,17 @@ export default function ConnectionsPage() {
     refetch();
   }
 
-  // Bucketize by dbType — the provider rendering walks DB_TYPES so
-  // disconnected providers can show a "Connect" CTA, and that loop
-  // needs a `dbType → connections` map shape.
-  const typeBuckets = bucketizeConnections(displayConnections, "type");
-  const byType = new Map<string, ConnectionInfo[]>(
-    typeBuckets.map((b) => [b.key, b.connections]),
-  );
-  const providerOrder: string[] = [
-    ...DB_TYPES.map((t) => t.value),
-    ...Array.from(byType.keys()).filter((k) => !DB_TYPES.some((t) => t.value === k)),
-  ];
+  // Picker routing. A database pick opens the URL-form dialog pre-pointed at
+  // that dbType; Custom REST and curated picks open their own install
+  // dialogs (which then bump `datasourceRefreshKey` on success).
+  function handlePickDatabase(dbType: string) {
+    handleAdd(dbType);
+  }
+  function handleDatasourceInstalled() {
+    setCustomRestOpen(false);
+    setCuratedCandidate(null);
+    refreshDatasources();
+  }
 
   // Derive env-dropdown choices from the connections list — one entry
   // per distinct non-null group_id. Post-cutover (#2744 / ADR-0007)
@@ -1257,8 +1232,12 @@ export default function ConnectionsPage() {
     total: billableConnections.length,
   };
 
+  // Databases section rollup — every row from `/admin/connections` is a SQL
+  // (or legacy) database; REST APIs + Salesforce are separate sections.
+  const dbLive = displayConnections.filter((c) => c.health?.status === "healthy").length;
+
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
+    <div className="mx-auto max-w-4xl px-6 py-10">
       {/* Hero */}
       <header className="mb-10 flex flex-col gap-2">
         <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
@@ -1276,8 +1255,7 @@ export default function ConnectionsPage() {
         </div>
         <div className="flex items-end justify-between gap-6">
           <p className="max-w-xl text-sm text-muted-foreground">
-            Datasources Atlas can query. Each provider below is either connected or
-            ready to connect.
+            Databases and REST APIs Atlas can query — every datasource is read-only.
           </p>
           <div className="flex items-center gap-3">
           {demoReadOnly ? (
@@ -1285,7 +1263,7 @@ export default function ConnectionsPage() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span tabIndex={0}>
-                    <Button onClick={() => handleAdd()} size="sm" disabled>
+                    <Button size="sm" disabled>
                       <Plus className="mr-2 size-4" />
                       Add connection
                     </Button>
@@ -1295,7 +1273,7 @@ export default function ConnectionsPage() {
               </Tooltip>
             </TooltipProvider>
           ) : (
-            <Button onClick={() => handleAdd()} size="sm">
+            <Button onClick={() => setPickerOpen(true)} size="sm" data-testid="add-connection-hero">
               <Plus className="mr-2 size-4" />
               Add connection
             </Button>
@@ -1305,7 +1283,7 @@ export default function ConnectionsPage() {
       </header>
 
       <ErrorBoundary>
-        <div className="space-y-6">
+        <div className="space-y-8">
           {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />}
           {!mutationError && (
             <MutationErrorSurface
@@ -1317,99 +1295,96 @@ export default function ConnectionsPage() {
 
           <PoolStatsSection onError={setMutationError} />
 
-          <AdminContentWrapper
+          {/*
+            Connections aren't draft-publishable content the way prompts or
+            entities are: CREATE in developer mode produces a draft, but UPDATE
+            and DELETE are immediate, and the demo-hide flow is a per-org
+            archived tombstone that doesn't go through publish. So we don't wrap
+            in `<PublishedContextWrapper>` — doing so traps admins in
+            dev-mode-no-drafts behind an `inert` overlay and prevents the very
+            actions (test / hide demo / drain pool) that don't require drafting.
+
+            Three category sections, each progressive-disclosure: connected
+            items collapse to a one-line row and expand in place. The Add picker
+            (hero + per-section button) is the single place new datasources are
+            connected — there are no more always-listed "Connect" provider rows.
+          */}
+          <section>
+            <SectionHeader
+              title="Databases"
+              count={loading ? undefined : countLine(displayConnections.length, dbLive)}
+              action={
+                <AddDatasourceButton
+                  label="Add database"
+                  onClick={() => setPickerOpen(true)}
+                  demoReadOnly={demoReadOnly}
+                  demoTooltip={DEMO_ADD_READONLY_TOOLTIP}
+                  testId="add-database"
+                />
+              }
+            />
+            <AdminContentWrapper
               loading={loading}
               error={error}
               feature="Connections"
               onRetry={refetch}
               loadingMessage="Loading connections..."
-              emptyIcon={Cable}
-              emptyTitle="No datasource connections"
-              emptyDescription="Add a connection to start querying your data"
-              emptyAction={{ label: "Add connection", onClick: () => handleAdd() }}
-              isEmpty={!loading && displayConnections.length === 0}
+              isEmpty={false}
             >
-              {/*
-                Connections aren't draft-publishable content the way prompts or
-                entities are: CREATE in developer mode produces a draft, but
-                UPDATE and DELETE are immediate, and the demo-hide flow is a
-                per-org archived tombstone that doesn't go through publish. So we
-                don't wrap in `<PublishedContextWrapper>` — doing so traps admins
-                in dev-mode-no-drafts behind an `inert` overlay and prevents the
-                very actions (test / hide demo / drain pool) that don't require
-                drafting in the first place.
-              */}
-              <section>
-                <SectionHeading title="Datasources" description="Providers Atlas can read from" />
+              {displayConnections.length === 0 ? (
+                <SectionEmpty
+                  icon={Cable}
+                  title="No databases connected"
+                  description="Connect Postgres, MySQL, Snowflake, and more."
+                  action={
+                    demoReadOnly ? null : (
+                      <Button size="sm" variant="outline" onClick={() => setPickerOpen(true)}>
+                        <Plus className="mr-1.5 size-3.5" />
+                        Add database
+                      </Button>
+                    )
+                  }
+                />
+              ) : (
                 <div className="space-y-2">
-                  {providerOrder.map((dbType) => {
-                    // Salesforce is plugin-managed and lives in
-                    // `workspace_plugins WHERE pillar = 'datasource'`
-                    // post-#2744 cutover — `connections.describe()`
-                    // doesn't surface it, so the generic ProviderBlock
-                    // would always render "Add connection" pointing at a
-                    // URL-form dialog that has no input shape for the
-                    // OAuth flow. Render the dedicated block, AND fall
-                    // through to render any legacy `connections` rows
-                    // with `db_type = salesforce` via `ProviderBlock`
-                    // so admins can still see + delete pre-cutover rows
-                    // (slice 7 of 1.5.3, #2745 — see PR review).
-                    if (dbType === "salesforce") {
-                      const legacyConns = byType.get(dbType) ?? [];
-                      return (
-                        <div key={dbType} className="space-y-2">
-                          <SalesforceProviderBlock
-                            demoReadOnly={demoReadOnly}
-                            onChange={handleMutationSuccess}
-                          />
-                          {legacyConns.length > 0 ? (
-                            <ProviderBlock
-                              dbType={dbType}
-                              connections={legacyConns}
-                              demoReadOnly={demoReadOnly}
-                              loadingDetail={loadingDetail}
-                              testMutation={testMutation}
-                              testStatus={testStatus}
-                              onTest={testConnection}
-                              onEdit={handleEdit}
-                              onDelete={handleDelete}
-                              onAdd={handleAdd}
-                            />
-                          ) : null}
-                        </div>
-                      );
-                    }
-                    const conns = byType.get(dbType) ?? [];
-                    return (
-                      <ProviderBlock
-                        key={dbType}
-                        dbType={dbType}
-                        connections={conns}
-                        demoReadOnly={demoReadOnly}
-                        loadingDetail={loadingDetail}
-                        testMutation={testMutation}
-                        testStatus={testStatus}
-                        onTest={testConnection}
-                        onEdit={handleEdit}
-                        onDelete={handleDelete}
-                        onAdd={handleAdd}
-                      />
-                    );
-                  })}
-                  {/*
-                    OpenAPI (generic REST) datasources (#2926). Multi-instance
-                    and plugin-resolved (not in ConnectionRegistry.describe()),
-                    so — like Salesforce — they get a dedicated block rather
-                    than a `ProviderBlock` row. Always rendered so the install
-                    affordance shows even with zero REST datasources.
-                  */}
-                  <OpenApiProviderBlock
-                    demoReadOnly={demoReadOnly}
-                    onChange={handleMutationSuccess}
-                  />
+                  {displayConnections.map((conn) => (
+                    <ConnectionCard
+                      key={conn.id}
+                      conn={conn}
+                      icon={iconForDbType(conn.dbType)}
+                      providerLabel={labelForDbType(conn.dbType)}
+                      demoReadOnly={demoReadOnly}
+                      loadingDetail={loadingDetail}
+                      testMutation={testMutation}
+                      testStatus={testStatus}
+                      onTest={testConnection}
+                      onEdit={handleEdit}
+                      onDelete={handleDelete}
+                    />
+                  ))}
                 </div>
-              </section>
+              )}
             </AdminContentWrapper>
+          </section>
+
+          {/*
+            REST APIs (OpenAPI / generic + curated candidates) and Salesforce
+            are plugin-resolved (not in ConnectionRegistry.describe()), so they
+            own their own fetch + section. Remounted on install via the
+            `datasourceRefreshKey` key so their lists repaint.
+          */}
+          <OpenApiProviderBlock
+            key={`rest-${datasourceRefreshKey}`}
+            demoReadOnly={demoReadOnly}
+            onAdd={() => setPickerOpen(true)}
+            onChange={handleMutationSuccess}
+          />
+
+          <SalesforceProviderBlock
+            key={`sf-${datasourceRefreshKey}`}
+            demoReadOnly={demoReadOnly}
+            onChange={handleMutationSuccess}
+          />
         </div>
       </ErrorBoundary>
 
@@ -1429,97 +1404,31 @@ export default function ConnectionsPage() {
         connectionId={deleteId}
         onSuccess={handleMutationSuccess}
       />
-    </div>
-  );
-}
 
-// ── Provider Block ───────────────────────────────────────────────
-
-/**
- * Renders one provider (dbType). When connections of this type exist, each
- * becomes a full IntegrationShell with a DetailList and action footer. When
- * there are none, a CompactRow prompts the admin to connect one.
- */
-function ProviderBlock({
-  dbType,
-  connections,
-  demoReadOnly,
-  loadingDetail,
-  testMutation,
-  testStatus,
-  onTest,
-  onEdit,
-  onDelete,
-  onAdd,
-}: {
-  dbType: string;
-  connections: ConnectionInfo[];
-  demoReadOnly: boolean;
-  loadingDetail: boolean;
-  testMutation: ReturnType<typeof useAdminMutation<ConnectionHealth>>;
-  testStatus: Record<string, "success" | "error">;
-  onTest: (id: string) => void;
-  onEdit: (id: string) => void;
-  onDelete: (id: string) => void;
-  /** Receives the provider's `dbType` so the create dialog can preselect it. */
-  onAdd: (dbType: string) => void;
-}) {
-  const Icon = iconForDbType(dbType);
-  const label = labelForDbType(dbType);
-  const description = descriptionForDbType(dbType);
-
-  if (connections.length === 0) {
-    return (
-      <CompactRow
-        icon={Icon}
-        title={label}
-        description={description}
-        status="disconnected"
-        action={
-          demoReadOnly ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span tabIndex={0}>
-                    <Button size="sm" variant="outline" disabled>
-                      <Plus className="mr-1.5 size-3.5" />
-                      Connect
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>{DEMO_ADD_READONLY_TOOLTIP}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
-            <Button size="sm" variant="outline" onClick={() => onAdd(dbType)}>
-              <Plus className="mr-1.5 size-3.5" />
-              Connect
-            </Button>
-          )
-        }
+      <AddConnectionPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        demoReadOnly={demoReadOnly}
+        onPickDatabase={handlePickDatabase}
+        onPickCustomRest={() => setCustomRestOpen(true)}
+        onPickCuratedForm={setCuratedCandidate}
       />
-    );
-  }
 
-  return (
-    <>
-      {connections.map((conn) => (
-        <ConnectionCard
-          key={conn.id}
-          conn={conn}
-          icon={Icon}
-          providerLabel={label}
-          providerDescription={description}
-          demoReadOnly={demoReadOnly}
-          loadingDetail={loadingDetail}
-          testMutation={testMutation}
-          testStatus={testStatus}
-          onTest={onTest}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
-      ))}
-    </>
+      <RestInstallDialog
+        open={customRestOpen}
+        onOpenChange={setCustomRestOpen}
+        onInstalled={handleDatasourceInstalled}
+      />
+
+      <CuratedInstallDialog
+        candidate={curatedCandidate}
+        open={curatedCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setCuratedCandidate(null);
+        }}
+        onInstalled={handleDatasourceInstalled}
+      />
+    </div>
   );
 }
 
@@ -1529,7 +1438,6 @@ function ConnectionCard({
   conn,
   icon,
   providerLabel,
-  providerDescription,
   demoReadOnly,
   loadingDetail,
   testMutation,
@@ -1541,7 +1449,6 @@ function ConnectionCard({
   conn: ConnectionInfo;
   icon: ComponentType<{ className?: string }>;
   providerLabel: string;
-  providerDescription: string;
   demoReadOnly: boolean;
   loadingDetail: boolean;
   testMutation: ReturnType<typeof useAdminMutation<ConnectionHealth>>;
@@ -1660,15 +1567,23 @@ function ConnectionCard({
     </>
   );
 
+  const latencySummary =
+    conn.health?.latencyMs != null ? `${conn.health.latencyMs}ms` : undefined;
+  const meta = `${providerLabel}${
+    conn.groupName ? ` · ${stripGroupPrefix(conn.groupName)}` : ""
+  }`;
+
   return (
-    <Shell
+    <CollapsibleRow
       icon={icon}
       title={<span className="font-mono">{conn.id}</span>}
       titleText={conn.id}
       titleBadge={badges}
-      description={conn.description || providerDescription}
+      meta={meta}
       status={status}
       statusLabel={pillLabel}
+      summary={latencySummary}
+      dataTestId={`connection-row-${conn.id}`}
       actions={
         <>
           {testButton}
@@ -1731,6 +1646,6 @@ function ConnectionCard({
           <DetailRow label="Last tested" value={formatDateTime(conn.health.checkedAt)} />
         ) : null}
       </DetailList>
-    </Shell>
+    </CollapsibleRow>
   );
 }

--- a/packages/web/src/app/admin/connections/provider-meta.ts
+++ b/packages/web/src/app/admin/connections/provider-meta.ts
@@ -5,21 +5,30 @@ import {
   Snowflake,
   type LucideIcon,
 } from "lucide-react";
-import { DB_TYPES } from "@/ui/lib/types";
+import { DB_TYPES, type DBType } from "@/ui/lib/types";
 
 /* ────────────────────────────────────────────────────────────────────────
  *  Provider metadata — shared by the connections page (rendering connected
  *  databases) and the Add-connection picker (offering providers to connect).
  *  Single source so an icon / blurb never drifts between the two surfaces.
+ *
+ *  The lookup functions below take `dbType: string`, not the closed `DBType`
+ *  union, on purpose: a *connected* row's dbType can be a plugin-/marketplace-
+ *  registered datasource that isn't in the URL-form `DB_TYPES` dropdown (e.g.
+ *  `bigquery`, seeded via the builtin-datasource catalog). So the extra switch
+ *  arms + `default` fallback are load-bearing for those wider runtime values,
+ *  and an exhaustiveness guard would wrongly reject them. The Add picker, by
+ *  contrast, only ever offers `DATABASE_PROVIDERS` — which is genuinely `DBType`.
  * ──────────────────────────────────────────────────────────────────────── */
 
 /** SQL database providers offered in the Add picker, in display order.
  *  Salesforce is intentionally excluded — it installs via OAuth from its own
  *  "Apps & CRM" section, not the URL-form connection dialog. */
-export const DATABASE_PROVIDERS: ReadonlyArray<{ value: string; label: string }> =
+export const DATABASE_PROVIDERS: ReadonlyArray<{ value: DBType; label: string }> =
   DB_TYPES.filter((t) => t.value !== "salesforce");
 
-/** Map a dbType to the icon used in rows and picker tiles. */
+/** Map a dbType to the icon used in rows and picker tiles. Accepts `string`
+ *  (not `DBType`) to cover plugin-registered datasources — see file header. */
 export function iconForDbType(dbType: string): LucideIcon {
   switch (dbType) {
     case "postgres":

--- a/packages/web/src/app/admin/connections/provider-meta.ts
+++ b/packages/web/src/app/admin/connections/provider-meta.ts
@@ -1,0 +1,65 @@
+import {
+  Cloud,
+  Database,
+  HardDrive,
+  Snowflake,
+  type LucideIcon,
+} from "lucide-react";
+import { DB_TYPES } from "@/ui/lib/types";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  Provider metadata — shared by the connections page (rendering connected
+ *  databases) and the Add-connection picker (offering providers to connect).
+ *  Single source so an icon / blurb never drifts between the two surfaces.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** SQL database providers offered in the Add picker, in display order.
+ *  Salesforce is intentionally excluded — it installs via OAuth from its own
+ *  "Apps & CRM" section, not the URL-form connection dialog. */
+export const DATABASE_PROVIDERS: ReadonlyArray<{ value: string; label: string }> =
+  DB_TYPES.filter((t) => t.value !== "salesforce");
+
+/** Map a dbType to the icon used in rows and picker tiles. */
+export function iconForDbType(dbType: string): LucideIcon {
+  switch (dbType) {
+    case "postgres":
+    case "mysql":
+    case "duckdb":
+      return Database;
+    case "snowflake":
+      return Snowflake;
+    case "clickhouse":
+    case "bigquery":
+      return Cloud;
+    case "salesforce":
+      return HardDrive;
+    default:
+      return Database;
+  }
+}
+
+/** Human-friendly one-line description shown under a provider name. */
+export function descriptionForDbType(dbType: string): string {
+  switch (dbType) {
+    case "postgres":
+      return "Open-source OLTP — the default Atlas connection";
+    case "mysql":
+      return "MySQL / MariaDB OLTP instance";
+    case "clickhouse":
+      return "Column-store analytics warehouse";
+    case "snowflake":
+      return "Cloud data warehouse";
+    case "duckdb":
+      return "Embedded analytical SQL engine";
+    case "salesforce":
+      return "CRM objects via SOQL";
+    case "bigquery":
+      return "Google Cloud warehouse";
+    default:
+      return "Datasource connection";
+  }
+}
+
+export function labelForDbType(dbType: string): string {
+  return DB_TYPES.find((t) => t.value === dbType)?.label ?? dbType;
+}

--- a/packages/web/src/app/admin/connections/salesforce-block.tsx
+++ b/packages/web/src/app/admin/connections/salesforce-block.tsx
@@ -146,11 +146,19 @@ export function SalesforceProviderBlock({
   const entry = catalogQuery.data?.catalog.find((e) => e.slug === SALESFORCE_SLUG);
   const installed = !!entry?.installed;
   const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
+  // A reconnect-needed install is still "connected" (the workspace_plugins row
+  // exists) but NOT live — the row below renders it as `status="unhealthy"`, so
+  // the rollup must agree or the count contradicts the row once a token expires.
+  const needsReconnect = installed && entry?.installStatus === "reconnect_needed";
 
   const header = (
     <SectionHeader
       title="Apps & CRM"
-      count={entry ? countLine(installed ? 1 : 0) : undefined}
+      count={
+        entry
+          ? countLine(installed ? 1 : 0, needsReconnect ? 0 : installed ? 1 : 0)
+          : undefined
+      }
     />
   );
 
@@ -226,8 +234,6 @@ export function SalesforceProviderBlock({
       </section>
     );
   }
-
-  const needsReconnect = installed && entry.installStatus === "reconnect_needed";
 
   // ── Disconnected branch ──────────────────────────────────────────
   if (!installed) {

--- a/packages/web/src/app/admin/connections/salesforce-block.tsx
+++ b/packages/web/src/app/admin/connections/salesforce-block.tsx
@@ -9,8 +9,8 @@
  * list (`/api/v1/admin/connections`) projects from the registry, so Salesforce
  * installs are invisible there. This component bridges the gap by reading the
  * catalog endpoint directly, finding the `salesforce` row, and rendering the
- * same provider block shape (CompactRow when disconnected, Shell when
- * connected) the SQL provider blocks use.
+ * same provider block shape (CompactRow when disconnected, CollapsibleRow when
+ * connected) the database rows use.
  *
  * Connect/Disconnect routes:
  *   - Connect    → `<a href=/api/v1/integrations/salesforce/install>` (OAuth dance,
@@ -110,9 +110,10 @@ interface SalesforceProviderBlockProps {
 
 /**
  * Provider block for the Salesforce row on `/admin/connections`. Parallel
- * to the {@link ProviderBlock} in `page.tsx` — same CompactRow / Shell
- * shape, but the install lookup goes through the catalog endpoint
- * (`/api/v1/integrations/catalog`) instead of the connections endpoint.
+ * to the `ConnectionCard` in `page.tsx` — same CompactRow (disconnected) /
+ * CollapsibleRow (connected) shape, but the install lookup goes through the
+ * catalog endpoint (`/api/v1/integrations/catalog`) instead of the
+ * connections endpoint.
  */
 export function SalesforceProviderBlock({
   demoReadOnly,
@@ -395,11 +396,11 @@ interface SalesforceActionsProps {
 }
 
 /**
- * Action footer for the connected Salesforce Shell. Mirrors the
- * `ShellActions` shape in `catalog-card.tsx`: when `needsReconnect`,
- * Reconnect is the primary CTA and Disconnect recedes to ghost;
- * otherwise Disconnect is the only routine action and Reconnect stays
- * ghost so it doesn't compete for attention.
+ * Action footer for the connected Salesforce row's expanded panel (the
+ * `CollapsibleRow` `actions` slot). When `needsReconnect`, Reconnect is the
+ * primary CTA and Disconnect recedes to ghost; otherwise Disconnect is the
+ * only routine action and Reconnect stays ghost so it doesn't compete for
+ * attention.
  */
 function SalesforceActions({
   name,

--- a/packages/web/src/app/admin/connections/salesforce-block.tsx
+++ b/packages/web/src/app/admin/connections/salesforce-block.tsx
@@ -64,8 +64,9 @@ import {
   DetailList,
   DetailRow,
   InlineError,
-  Shell,
 } from "@/ui/components/admin/compact";
+import { CollapsibleRow } from "@/ui/components/admin/collapsible-row";
+import { countLine, SectionHeader } from "./section-header";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { IntegrationsCatalogResponseSchema } from "@/ui/lib/admin-schemas";
@@ -130,177 +131,6 @@ export function SalesforceProviderBlock({
     },
   });
 
-  // Loading + error states: render a single disabled CompactRow so the
-  // page layout doesn't jump. The provider row is the smallest
-  // self-contained element on the page — surfacing a skeleton there
-  // would be noisier than a one-line "loading" state.
-  if (catalogQuery.loading) {
-    return (
-      <CompactRow
-        icon={HardDrive}
-        title="Salesforce"
-        description="Loading…"
-        status="disconnected"
-        action={
-          <Button size="sm" variant="outline" disabled>
-            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-            Connect
-          </Button>
-        }
-      />
-    );
-  }
-
-  // Fail-soft on catalog read failure: surface a disconnected block with
-  // an inline error in the action slot so the rest of the page renders.
-  // The catalog endpoint is shared with /admin/integrations — a hard
-  // failure there is already surfaced by `useAdminFetch`'s retry hook;
-  // here we just need to avoid blanking the Salesforce row entirely.
-  if (catalogQuery.error) {
-    const message =
-      friendlyErrorOrNull(catalogQuery.error) ?? "Failed to load catalog.";
-    return (
-      <CompactRow
-        icon={HardDrive}
-        title="Salesforce"
-        description={message}
-        status="unhealthy"
-        action={
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => catalogQuery.refetch()}
-          >
-            Retry
-          </Button>
-        }
-      />
-    );
-  }
-
-  const entry = catalogQuery.data?.catalog.find(
-    (e) => e.slug === SALESFORCE_SLUG,
-  );
-
-  // Salesforce row absent from the catalog → don't render anything. This
-  // happens on deploys where the catalog seeder hasn't run yet or where
-  // the row was explicitly disabled via ops. Rendering a Connect CTA
-  // that would 404 against `/api/v1/integrations/salesforce/install`
-  // would be worse than hiding the row.
-  if (!entry) return null;
-
-  // Coming-soon dominates everything else — render an inert row that
-  // signals "Atlas hasn't shipped this yet" without misleading the admin
-  // into clicking. Mirrors the CatalogCard coming-soon branch.
-  if (entry.implementationStatus === "coming_soon") {
-    return (
-      <CompactRow
-        icon={HardDrive}
-        title={entry.name}
-        description={entry.description ?? "Coming soon"}
-        status="unavailable"
-        statusLabel="Coming soon"
-        action={
-          <Button size="sm" variant="outline" disabled>
-            Coming soon
-          </Button>
-        }
-      />
-    );
-  }
-
-  const installed = entry.installed;
-  const needsReconnect = installed && entry.installStatus === "reconnect_needed";
-
-  // ── Disconnected branch ──────────────────────────────────────────
-  if (!installed) {
-    // Plan-gate the Connect CTA: when the catalog row reports
-    // `access.kind === "upgrade"`, the backend `/install` endpoint will
-    // refuse with `plan_upgrade_required` (`integrations.ts` plan-tier
-    // gate). Mirror the upgrade-gated UI from `CatalogCard` so the user
-    // sees the lock and required plan up front instead of bouncing
-    // through OAuth to a 403 redirect. The downgraded-while-installed
-    // case is handled separately by the connected branch — its
-    // Reconnect button keeps working even on a downgraded plan
-    // (matching the DELETE path's "must let downgraded customers
-    // clean up" posture in #2701).
-    if (entry.access.kind === "upgrade") {
-      const requiredPlan = entry.access.requiredPlan ?? entry.minPlan;
-      return (
-        <CompactRow
-          icon={HardDrive}
-          title={entry.name}
-          description={entry.description ?? `Premium — requires ${requiredPlan}`}
-          status="unavailable"
-          statusLabel={`Premium — requires ${requiredPlan}`}
-          action={
-            <div className="flex items-center gap-1.5">
-              <Lock
-                className="size-3.5 text-muted-foreground"
-                aria-label="Premium integration"
-                data-testid="salesforce-lock-icon"
-              />
-              <Badge
-                variant="outline"
-                className="gap-1 text-[10px]"
-                data-testid="salesforce-plan-badge"
-              >
-                <Sparkles className="size-3" />
-                Premium — requires {requiredPlan}
-              </Badge>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled
-                aria-label={`Available on ${requiredPlan} plans and above`}
-                title={`Available on ${requiredPlan} plans and above`}
-                data-testid="salesforce-locked-cta"
-              >
-                <Lock className="mr-1 size-3" />
-                Upgrade
-              </Button>
-            </div>
-          }
-        />
-      );
-    }
-
-    const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
-    return (
-      <CompactRow
-        icon={HardDrive}
-        title={entry.name}
-        description={entry.description ?? "CRM objects via SOQL"}
-        status="disconnected"
-        action={
-          demoReadOnly ? (
-            <Button size="sm" variant="outline" disabled>
-              <Plus className="mr-1.5 size-3.5" />
-              Connect
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              asChild
-              aria-label={`Connect ${entry.name}`}
-              data-testid="salesforce-connect"
-            >
-              <a href={installHref}>
-                <ExternalLink className="mr-1.5 size-3.5" />
-                Connect
-              </a>
-            </Button>
-          )
-        }
-      />
-    );
-  }
-
-  // ── Connected branch (render in Shell shape, matching SQL provider) ──
-  const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
-  const instanceUrl = readStringField(entry.installConfig, "instance_url");
-  const orgId = readStringField(entry.installConfig, "org_id");
-
   async function handleDisconnect() {
     const result = await disconnect.mutate({});
     if (result.ok) {
@@ -312,75 +142,247 @@ export function SalesforceProviderBlock({
     }
   }
 
-  return (
-    <Shell
-      icon={HardDrive}
-      title="Salesforce"
-      description={entry.description ?? "CRM objects via SOQL"}
-      status={needsReconnect ? "unhealthy" : "connected"}
-      statusLabel={needsReconnect ? "Reconnect needed" : "Live"}
-      titleBadge={
-        needsReconnect ? (
-          <Badge
-            variant="destructive"
-            className="text-[10px]"
-            data-testid="salesforce-reconnect-badge"
-          >
-            Reconnect needed
-          </Badge>
-        ) : (
-          <Badge variant="secondary" className="text-[10px]">
-            Connected
-          </Badge>
-        )
-      }
-      actions={
-        <SalesforceActions
-          name={entry.name}
-          needsReconnect={needsReconnect}
-          installHref={installHref}
-          disconnecting={disconnect.saving}
-          onDisconnect={handleDisconnect}
-        />
-      }
-    >
-      <DetailList>
-        {instanceUrl ? (
-          <DetailRow label="Instance URL" value={instanceUrl} mono truncate />
-        ) : null}
-        {orgId ? <DetailRow label="Org ID" value={orgId} mono truncate /> : null}
-        <DetailRow
-          label="Refresh token"
-          value={
-            <span
-              className={
-                needsReconnect
-                  ? "text-destructive"
-                  : "text-primary"
-              }
-            >
-              {needsReconnect ? "Reconnect required" : "Live"}
-            </span>
+  const entry = catalogQuery.data?.catalog.find((e) => e.slug === SALESFORCE_SLUG);
+  const installed = !!entry?.installed;
+  const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
+
+  const header = (
+    <SectionHeader
+      title="Apps & CRM"
+      count={entry ? countLine(installed ? 1 : 0) : undefined}
+    />
+  );
+
+  // Loading + error states: render a single disabled CompactRow under the
+  // section header so the layout doesn't jump.
+  if (catalogQuery.loading) {
+    return (
+      <section>
+        {header}
+        <CompactRow
+          icon={HardDrive}
+          title="Salesforce"
+          description="Loading…"
+          status="disconnected"
+          action={
+            <Button size="sm" variant="outline" disabled>
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              Connect
+            </Button>
           }
         />
-        {entry.installedAt ? (
-          <DetailRow
-            label="Connected"
-            value={
-              entry.installedBy
-                ? `${formatDateTime(entry.installedAt)} · by ${entry.installedBy}`
-                : formatDateTime(entry.installedAt)
+      </section>
+    );
+  }
+
+  // Fail-soft on catalog read failure: surface a disconnected row with a
+  // retry so the rest of the page renders.
+  if (catalogQuery.error) {
+    const message =
+      friendlyErrorOrNull(catalogQuery.error) ?? "Failed to load catalog.";
+    return (
+      <section>
+        {header}
+        <CompactRow
+          icon={HardDrive}
+          title="Salesforce"
+          description={message}
+          status="unhealthy"
+          action={
+            <Button size="sm" variant="outline" onClick={() => catalogQuery.refetch()}>
+              Retry
+            </Button>
+          }
+        />
+      </section>
+    );
+  }
+
+  // Salesforce row absent from the catalog → hide the whole section. This
+  // happens on deploys where the catalog seeder hasn't run yet or where the
+  // row was explicitly disabled via ops. A Connect CTA that would 404
+  // against `/api/v1/integrations/salesforce/install` is worse than nothing.
+  if (!entry) return null;
+
+  // Coming-soon dominates everything else — render an inert row that signals
+  // "Atlas hasn't shipped this yet" without misleading the admin into clicking.
+  if (entry.implementationStatus === "coming_soon") {
+    return (
+      <section>
+        {header}
+        <CompactRow
+          icon={HardDrive}
+          title={entry.name}
+          description={entry.description ?? "Coming soon"}
+          status="unavailable"
+          statusLabel="Coming soon"
+          action={
+            <Button size="sm" variant="outline" disabled>
+              Coming soon
+            </Button>
+          }
+        />
+      </section>
+    );
+  }
+
+  const needsReconnect = installed && entry.installStatus === "reconnect_needed";
+
+  // ── Disconnected branch ──────────────────────────────────────────
+  if (!installed) {
+    // Plan-gate the Connect CTA: when the catalog row reports
+    // `access.kind === "upgrade"`, the backend `/install` endpoint refuses
+    // with `plan_upgrade_required`. Mirror the lock UI so the user sees the
+    // required plan up front instead of bouncing through OAuth to a 403.
+    if (entry.access.kind === "upgrade") {
+      const requiredPlan = entry.access.requiredPlan ?? entry.minPlan;
+      return (
+        <section>
+          {header}
+          <CompactRow
+            icon={HardDrive}
+            title={entry.name}
+            description={entry.description ?? `Premium — requires ${requiredPlan}`}
+            status="unavailable"
+            statusLabel={`Premium — requires ${requiredPlan}`}
+            action={
+              <div className="flex items-center gap-1.5">
+                <Lock
+                  className="size-3.5 text-muted-foreground"
+                  aria-label="Premium integration"
+                  data-testid="salesforce-lock-icon"
+                />
+                <Badge
+                  variant="outline"
+                  className="gap-1 text-[10px]"
+                  data-testid="salesforce-plan-badge"
+                >
+                  <Sparkles className="size-3" />
+                  Premium — requires {requiredPlan}
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled
+                  aria-label={`Available on ${requiredPlan} plans and above`}
+                  title={`Available on ${requiredPlan} plans and above`}
+                  data-testid="salesforce-locked-cta"
+                >
+                  <Lock className="mr-1 size-3" />
+                  Upgrade
+                </Button>
+              </div>
             }
           />
-        ) : null}
-      </DetailList>
+        </section>
+      );
+    }
 
-      {disconnect.error ? (
-        <InlineError>
-          {friendlyErrorOrNull(disconnect.error) ?? "Disconnect failed."}
-        </InlineError>
-      ) : null}
-    </Shell>
+    return (
+      <section>
+        {header}
+        <CompactRow
+          icon={HardDrive}
+          title={entry.name}
+          description={entry.description ?? "CRM objects via SOQL"}
+          status="disconnected"
+          action={
+            demoReadOnly ? (
+              <Button size="sm" variant="outline" disabled>
+                <Plus className="mr-1.5 size-3.5" />
+                Connect
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                asChild
+                aria-label={`Connect ${entry.name}`}
+                data-testid="salesforce-connect"
+              >
+                <a href={installHref}>
+                  <ExternalLink className="mr-1.5 size-3.5" />
+                  Connect
+                </a>
+              </Button>
+            )
+          }
+        />
+      </section>
+    );
+  }
+
+  // ── Connected branch (collapsible row, matching the database rows) ──
+  const instanceUrl = readStringField(entry.installConfig, "instance_url");
+  const orgId = readStringField(entry.installConfig, "org_id");
+
+  return (
+    <section>
+      {header}
+      <CollapsibleRow
+        icon={HardDrive}
+        title="Salesforce"
+        titleText="Salesforce"
+        meta={instanceUrl ?? "CRM objects via SOQL"}
+        status={needsReconnect ? "unhealthy" : "connected"}
+        statusLabel={needsReconnect ? "Reconnect needed" : "Live"}
+        dataTestId="salesforce-row"
+        titleBadge={
+          needsReconnect ? (
+            <Badge
+              variant="destructive"
+              className="text-[10px]"
+              data-testid="salesforce-reconnect-badge"
+            >
+              Reconnect needed
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="text-[10px]">
+              Connected
+            </Badge>
+          )
+        }
+        actions={
+          <SalesforceActions
+            name={entry.name}
+            needsReconnect={needsReconnect}
+            installHref={installHref}
+            disconnecting={disconnect.saving}
+            onDisconnect={handleDisconnect}
+          />
+        }
+      >
+        <DetailList>
+          {instanceUrl ? (
+            <DetailRow label="Instance URL" value={instanceUrl} mono truncate />
+          ) : null}
+          {orgId ? <DetailRow label="Org ID" value={orgId} mono truncate /> : null}
+          <DetailRow
+            label="Refresh token"
+            value={
+              <span className={needsReconnect ? "text-destructive" : "text-primary"}>
+                {needsReconnect ? "Reconnect required" : "Live"}
+              </span>
+            }
+          />
+          {entry.installedAt ? (
+            <DetailRow
+              label="Connected"
+              value={
+                entry.installedBy
+                  ? `${formatDateTime(entry.installedAt)} · by ${entry.installedBy}`
+                  : formatDateTime(entry.installedAt)
+              }
+            />
+          ) : null}
+        </DetailList>
+
+        {disconnect.error ? (
+          <InlineError>
+            {friendlyErrorOrNull(disconnect.error) ?? "Disconnect failed."}
+          </InlineError>
+        ) : null}
+      </CollapsibleRow>
+    </section>
   );
 }
 

--- a/packages/web/src/app/admin/connections/section-header.tsx
+++ b/packages/web/src/app/admin/connections/section-header.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { type ComponentType, type ReactNode } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  Section chrome shared by the three connection categories (Databases /
+ *  REST APIs / Apps & CRM). Keeps the eyebrow heading, the count line, the
+ *  demo-gated "+ Add" button, and the per-section empty hint consistent.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Tooltip shown on a disabled "+ Add" while a demo connection holds the
+ *  workspace in read-only published mode. */
+export const DEMO_ADD_TOOLTIP =
+  "Delete the demo connection or switch to developer mode to add a new one";
+
+/** Compose a "N connected · M live" line, omitting the live clause when it
+ *  isn't meaningful (REST/Salesforce don't report a health-rollup). */
+export function countLine(connected: number, live?: number): string {
+  if (live === undefined) return `${connected} connected`;
+  return `${connected} connected · ${live} live`;
+}
+
+export function SectionHeader({
+  title,
+  count,
+  action,
+}: {
+  title: string;
+  /** The count line (use {@link countLine}); omitted while loading. */
+  count?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-end justify-between gap-4">
+      <div className="min-w-0">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {title}
+        </h2>
+        {count != null && (
+          <p className="mt-0.5 text-xs tabular-nums text-muted-foreground/80">{count}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+/** The "+ Add …" button. Disabled + tooltip-wrapped while a demo is read-only. */
+export function AddDatasourceButton({
+  label,
+  onClick,
+  demoReadOnly,
+  demoTooltip,
+  testId,
+}: {
+  label: string;
+  onClick: () => void;
+  demoReadOnly: boolean;
+  demoTooltip: string;
+  testId?: string;
+}) {
+  if (demoReadOnly) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0}>
+              <Button size="sm" variant="outline" disabled>
+                <Plus className="mr-1.5 size-3.5" />
+                {label}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{demoTooltip}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+  return (
+    <Button size="sm" variant="outline" onClick={onClick} data-testid={testId}>
+      <Plus className="mr-1.5 size-3.5" />
+      {label}
+    </Button>
+  );
+}
+
+/** Slim per-section empty state: an icon, a line of copy, and an add CTA. */
+export function SectionEmpty({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed bg-card/20 px-6 py-8 text-center">
+      <span className="grid size-9 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
+        <Icon className="size-4" />
+      </span>
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/admin/collapsible-row.tsx
+++ b/packages/web/src/ui/components/admin/collapsible-row.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useId, useState, type ComponentType, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { StatusDot, type StatusKind, STATUS_LABEL } from "./compact";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  CollapsibleRow — a dense, one-line connection/datasource row that expands
+ *  in place to reveal its detail sheet + actions.
+ *
+ *  Built for the connections surface, where a workspace can hold many
+ *  databases and REST APIs at once. The collapsed row carries everything an
+ *  admin scans for (identity, kind, health, a single headline metric); the
+ *  expanded panel carries the full DetailList + Test/Edit/Delete footer that
+ *  the old always-open {@link Shell} card showed unconditionally.
+ *
+ *  Shares the StatusKind vocabulary + status tinting with {@link Shell} so a
+ *  collapsed row and an expanded panel read as the same object. The whole
+ *  summary line is the toggle; actions live only in the expanded footer, so
+ *  the toggle never swallows an action click.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export function CollapsibleRow({
+  icon: Icon,
+  title,
+  titleText,
+  titleBadge,
+  meta,
+  status,
+  statusLabel,
+  summary,
+  defaultExpanded = false,
+  children,
+  actions,
+  dataTestId,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  /** Rendered title (often `<span className="font-mono">{id}</span>`). */
+  title: ReactNode;
+  /** Plain-text title for the aria-label when `title` is JSX. */
+  titleText?: string;
+  titleBadge?: ReactNode;
+  /** Secondary identity line shown muted after the title (e.g. "Postgres · prod"
+   *  or a REST host). Truncates. */
+  meta?: ReactNode;
+  status: StatusKind;
+  /** Override the default Live / Unhealthy / Connected pill text. */
+  statusLabel?: string;
+  /** Right-aligned headline metric shown while COLLAPSED (e.g. "12ms", "42 ops").
+   *  Hidden once expanded — the detail sheet carries the precise values. */
+  summary?: ReactNode;
+  defaultExpanded?: boolean;
+  /** Expanded detail body (typically a DetailList). */
+  children?: ReactNode;
+  /** Expanded footer actions (Test / Edit / Delete …). */
+  actions?: ReactNode;
+  dataTestId?: string;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const panelId = useId();
+  const ariaTitle = titleText ?? (typeof title === "string" ? title : "item");
+
+  const pill =
+    status === "connected" ? (
+      <span className="hidden items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary sm:flex">
+        <StatusDot kind="connected" />
+        {statusLabel ?? "Live"}
+      </span>
+    ) : status === "unhealthy" ? (
+      <span className="hidden items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-destructive sm:flex">
+        <StatusDot kind="unhealthy" />
+        {statusLabel ?? "Unhealthy"}
+      </span>
+    ) : status === "transitioning" ? (
+      <span className="hidden items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-amber-600 dark:text-amber-400 sm:flex">
+        <StatusDot kind="transitioning" />
+        {statusLabel ?? STATUS_LABEL[status]}
+      </span>
+    ) : (
+      // On a narrow screen the labelled pill collapses to just the dot so the
+      // row never wraps; the sr-only label keeps it announced.
+      <span className="flex items-center">
+        <StatusDot kind={status} />
+        <span className="sr-only">{statusLabel ?? STATUS_LABEL[status]}</span>
+      </span>
+    );
+
+  return (
+    <section
+      data-testid={dataTestId}
+      className={cn(
+        "overflow-hidden rounded-xl border bg-card/40 transition-colors",
+        expanded ? "bg-card/60" : "hover:bg-card/70 hover:border-border/80",
+        status === "connected" && expanded && "border-primary/20",
+        status === "unhealthy" && "border-destructive/25",
+        status === "transitioning" && "border-amber-500/25",
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        aria-label={`${ariaTitle}: ${statusLabel ?? STATUS_LABEL[status]}`}
+        className="flex w-full items-center gap-3 px-3.5 py-2.5 text-left"
+      >
+        <span
+          className={cn(
+            "grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40",
+            status === "connected" && "border-primary/30 text-primary",
+            status === "unhealthy" && "border-destructive/30 text-destructive",
+            status === "transitioning" &&
+              "border-amber-500/30 text-amber-600 dark:text-amber-400",
+            (status === "disconnected" ||
+              status === "unavailable" ||
+              status === "ready") &&
+              "text-muted-foreground",
+          )}
+        >
+          <Icon className="size-4" />
+        </span>
+
+        <span className="flex min-w-0 flex-1 items-baseline gap-2">
+          <span className="truncate text-sm font-semibold leading-tight tracking-tight">
+            {title}
+          </span>
+          {titleBadge}
+          {meta != null && (
+            <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">
+              {meta}
+            </span>
+          )}
+        </span>
+
+        {summary != null && !expanded && (
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+            {summary}
+          </span>
+        )}
+        {pill}
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform duration-200 ease-out",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div id={panelId} className="border-t border-border/50">
+          {children != null && (
+            <div className="space-y-3 px-4 pb-3 pt-3 text-sm">{children}</div>
+          )}
+          {actions && (
+            <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+              {actions}
+            </footer>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -30,6 +30,7 @@ export type {
   ConnectionHealth,
   ConnectionInfo,
   ConnectionDetail,
+  DBType,
   ConnectionGroup,
   ConnectionGroupStatus,
   ConnectionGroupMember,


### PR DESCRIPTION
## Summary

The connections page grew unscannable at scale (a few DBs + many REST APIs): every connected datasource rendered as a ~250px always-expanded card, every unused SQL provider took a permanent "Connect" row, and databases / REST APIs / Salesforce shared one undivided "Datasources" stack.

- **Collapse** — each connection is now a one-line row (`CollapsibleRow`) that expands in place to its detail sheet + Test/Edit/Delete. ~250px → ~48px per item.
- **Group** — three sections (**Databases / REST APIs / Apps & CRM**), each with an `N connected · M live` count. Directly fixes the "which is which" problem.
- **Add picker** — a single Add entry point (hero + per-section) opens a provider picker (database tiles + Custom REST + curated-when-available). Removes the always-listed unused-provider rows that padded the page.
- New files: `collapsible-row`, `add-connection-picker`, `curated-install-dialog`, `section-header`, `provider-meta`. Rewired `page` / `openapi-block` / `salesforce-block`.

### Note on curated APIs
The built-in REST "data candidates" (Stripe / Notion / GitHub) are wired into the picker's **Popular APIs** group, but they're seeded as `type='datasource'` which `GET /api/v1/integrations/catalog` excludes server-side. So the group stays hidden until a datasource-pillar catalog listing endpoint exists (a `?pillar=datasource` mode or a dedicated route via `PillarCatalogQuery.getByPillar`). Tracked as a follow-up — the picker degrades gracefully meanwhile.

## Test plan

- [x] `bun run lint` / `bun run type` clean
- [x] Full `bun run test` green (`@atlas/web` 190/190; suite 0 failures)
- [x] All `/ci` drift gates pass (syncpack, template, security-headers, railway-watch, schema, oauth-helper, test-discipline, twenty-resolver, published-symbols)
- [x] Verified live: collapse/expand, section counts, Add picker → DB tile → pre-pointed connection form, graceful empty states (0 console errors)
- [ ] Reviewer: confirm collapse/expand + Add picker on a populated workspace (live trial plan caps at 1 connection, so multi-item scale was reasoned from the design, not seeded)

Frontend-only; no schema/migration/dependency changes. No linked issue (ad-hoc design pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783297200&installation_id=135337507&pr_number=3230&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3230&signature=d9bf07d892b2df66902ac6033a755e2fe808c90c30ab097f0bb05fc4fc3cb5b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized Add connection picker with Popular APIs, curated REST install dialog, and custom REST flow
  * New collapsible connection rows and reusable section header/provider metadata helpers

* **UI Improvements**
  * Connections page reorganized with clearer sections, live/latency/status badges, refined reconnect/disconnect and drift handling
  * REST provider install UX delegated to add flow; inline loading/error states for APIs

* **Tests**
  * Salesforce row tests tightened for predictable expansion; added curated-install-dialog tests for secret isolation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->