### PR TITLE
test(web): de-flake drilldown-sync nuqs URL-sync test (one write per mount)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/drilldown-sync.test.tsx
@@ -7,10 +7,20 @@
  * re-renders every card with the bound value). This drives the REAL bar + REAL
  * `withOverride` through a real nuqs adapter, so the linchpin can't silently
  * break.
+ *
+ * Each test seeds the prior state via the URL and drives exactly ONE live write,
+ * then asserts — never two back-to-back writes in one mount. nuqs's update queue
+ * can drop the second of two rapid synthetic writes before the first has flushed
+ * (the compose step then sees only the first), so the original single-test
+ * drill→Reset form flaked ~17% on slow CI for exactly that reason — and was NOT
+ * locally reproducible. `withNuqsTestingAdapter`'s `resetUrlUpdateQueueOnMount`
+ * (on by default) clears the shared queue per mount, so the separate seeded
+ * mounts don't leak into each other. Mirrors the sibling cross-filter-sync
+ * .test.tsx (de-flaked the same way in #3228).
  */
 import { afterEach, describe, expect, test, mock } from "bun:test";
 import { useQueryState } from "nuqs";
-import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import { render, cleanup, fireEvent, waitFor, screen } from "@testing-library/react";
 import { DashboardParameterBar, type ParameterValues } from "@/ui/components/dashboards/dashboard-parameter-bar";
 import { DASHBOARD_PARAMS_KEY, dashboardParamsParser, withOverride } from "../search-params";
@@ -39,32 +49,31 @@ function Harness({ onChange }: { onChange: (o: ParameterValues) => void }) {
 }
 
 /**
- * A real-app round-trip adapter for the shared key. `hasMemory` makes
- * NuqsTestingAdapter retain each write in an internal synchronous ref (its
- * built-in stand-in for a real URL), so a `useQueryState` write re-renders every
- * hook subscribed to that key — the Next.js round-trip the bare adapter (frozen
- * to its initial value) doesn't reproduce. The synchronous ref also means each
- * write composes on the latest value, avoiding the optimistic-cache-vs-prop
- * desync a hand-rolled `useState`-fed adapter hits under back-to-back writes.
+ * Seeds the shared `dparams` key in the URL and drives a faithful round-trip via
+ * NuqsTestingAdapter's `hasMemory` — writes land in nuqs's own synchronous store
+ * and re-render every hook subscribed to the key (the Next.js round-trip a bare
+ * initial-frozen adapter doesn't reproduce). `resetUrlUpdateQueueOnMount` (on by
+ * default) clears the shared queue per mount, so separate seeded mounts stay
+ * independent.
  */
-function MemoryAdapter({ children }: { children: React.ReactNode }) {
-  return <NuqsTestingAdapter hasMemory>{children}</NuqsTestingAdapter>;
-}
+const seeded = (overrides: Record<string, string> = {}) =>
+  withNuqsTestingAdapter({
+    searchParams: Object.keys(overrides).length
+      ? `${DASHBOARD_PARAMS_KEY}=${encodeURIComponent(JSON.stringify(overrides))}`
+      : "",
+    hasMemory: true,
+  });
 
-describe("drilldown ↔ parameter bar URL sync", () => {
-  // One continuous lifecycle (drill → reflect → reset). Kept as a single test so
-  // the nuqs `dparams` cache — module-level and keyed by name — can't leak from a
-  // prior test's mount and make the next one non-deterministic.
-  test("a drilldown write reflects in the bar, emits the bound value, and Reset clears it", async () => {
+describe("drilldown ↔ parameter bar URL sync (#3212)", () => {
+  test("a drilldown write reflects in the bar and emits the bound override", async () => {
     const onChange = mock((_: ParameterValues) => {});
-
-    render(<Harness onChange={onChange} />, { wrapper: MemoryAdapter });
+    render(<Harness onChange={onChange} />, { wrapper: seeded() });
 
     // On mount the bar reports "no overrides" (use defaults).
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
     expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("");
 
-    // Simulate the drilldown click → page-side write of the shared key.
+    // Simulate the drilldown click → page-side write of the shared key (one write).
     fireEvent.click(screen.getByText("drill"));
 
     // The bar (same key) now reflects the drilldown value...
@@ -74,8 +83,21 @@ describe("drilldown ↔ parameter bar URL sync", () => {
     // ...and emitted the bound override — the signal the page turns into a
     // single batched re-render of every card.
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
+  });
 
-    // Reset appears once an override is present; clicking it clears to defaults.
+  test("Reset clears the active override back to defaults", async () => {
+    const onChange = mock((_: ParameterValues) => {});
+    // Seed the prior override via the URL (a reloaded / drilled-in state) so the
+    // single live write under test is the Reset itself — never two back-to-back.
+    render(<Harness onChange={onChange} />, { wrapper: seeded({ region: "us" }) });
+
+    // Mount reflects the seeded override on both the bar and the emitted map.
+    await waitFor(() => {
+      expect((screen.getByLabelText("Region") as HTMLInputElement).value).toBe("us");
+    });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ region: "us" });
+
+    // Reset appears once an override is present; clicking it clears to defaults (one write).
     fireEvent.click(screen.getByRole("button", { name: /reset/i }));
     await waitFor(() => {
       expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});


### PR DESCRIPTION
## What

De-flakes `drilldown-sync.test.tsx` — a recurring nuqs URL-sync flake (~17%) that reddens `main` CI on unrelated PRs (it just failed the docs-only #3238).

## Root cause

The single test `a drilldown write reflects in the bar… and Reset clears it` drove **two rapid composing writes in one mount** — the drill write (`region=us`) then the Reset write (`{}`). nuqs's update queue can drop the **second** of two back-to-back synthetic writes before the first flushes under a slow CI runner; the compose step then sees only the first, so the last `onChange` stays `{ region: "us" }` instead of `{}`. It is **not locally reproducible** (dev machines are too fast).

This is the same class as #3228 (which de-flaked the sibling `cross-filter-sync.test.tsx`). The old comment on this file even claimed it was "stable" because its second write is a clear — but a clear is still a second composing write, so it flaked.

## Fix

Mirror the proven #3228 pattern: **seed the prior state via the URL and drive exactly one live write per test.**

- Replace the hand-rolled `MemoryAdapter` wrapper with a `seeded(overrides)` helper using `withNuqsTestingAdapter({ searchParams, hasMemory: true })`.
- Split into two tests:
  - **drill** — seed empty → one drill write → assert bar shows `us` + emits `{ region: "us" }`.
  - **Reset** — seed `{ region: "us" }` via the URL → one Reset write → assert emits `{}` + bar clears.
- `resetUrlUpdateQueueOnMount` (on by default) clears the shared queue per mount, so the separate seeded mounts stay independent — which removes the original reason the test was kept as one two-write mount (the `dparams` module-cache leak worry).

All original assertions are preserved. Green locally across repeated runs (the structural change, not local runs, is what eliminates the CI-only flake).

## Notes

- **Test-only** — no source/behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783305119&installation_id=135337507&pr_number=3239&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3239&signature=06e54bc55610fc81c0f2089deee3fe17844ef975df6785cca2cc5eade7bbb2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite for dashboard drilldown functionality with comprehensive coverage of URL parameter handling and state management. Improved verification of parameter override synchronization and reset actions across different initialization scenarios to ensure consistent, reliable behavior. Tests now validate correct parameter state when configured through URLs and confirm proper clearing through reset actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->