### PR TITLE
fix(semantic): treat "main" schema as unqualified in generateMetricYAML (#3244)

### DIFF
--- a/packages/api/src/lib/semantic/__tests__/generate-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/generate-engine.test.ts
@@ -121,3 +121,38 @@ describe("shared generate engine (direct ../generate path)", () => {
     expect(isView(orders)).toBe(false);
   });
 });
+
+describe("generateMetricYAML schema qualification (issue #3244)", () => {
+  // Every metric's SQL uses `FROM <table>`; pull the table ref out of each clause.
+  function fromTables(metricYaml: string): string[] {
+    const parsed = yaml.load(metricYaml) as { metrics: { sql: string }[] };
+    return parsed.metrics
+      .map((m) => m.sql.match(/FROM\s+(\S+)/)?.[1])
+      .filter((t): t is string => Boolean(t));
+  }
+
+  it('treats schema="public" as unqualified (FROM orders)', () => {
+    const out = generateMetricYAML(orders, "public");
+    expect(out).not.toBeNull();
+    const tables = fromTables(out!);
+    expect(tables.length).toBeGreaterThan(0);
+    expect(tables.every((t) => t === "orders")).toBe(true);
+  });
+
+  it('treats schema="main" (DuckDB/SQLite) as unqualified, matching generateEntityYAML', () => {
+    const out = generateMetricYAML(orders, "main");
+    expect(out).not.toBeNull();
+    const tables = fromTables(out!);
+    expect(tables.length).toBeGreaterThan(0);
+    expect(tables.every((t) => t === "orders")).toBe(true);
+    expect(out!).not.toContain("main.orders");
+  });
+
+  it("qualifies a custom schema (FROM analytics.orders)", () => {
+    const out = generateMetricYAML(orders, "analytics");
+    expect(out).not.toBeNull();
+    const tables = fromTables(out!);
+    expect(tables.length).toBeGreaterThan(0);
+    expect(tables.every((t) => t === "analytics.orders")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -540,7 +540,7 @@ export function generateMetricYAML(profile: TableProfile, schema: string = "publ
 
   const pkCol = profile.columns.find((c) => c.is_primary_key);
   const enumCols = profile.columns.filter((c) => c.is_enum_like);
-  const qualifiedTable = schema !== "public" ? `${schema}.${profile.table_name}` : profile.table_name;
+  const qualifiedTable = schema !== "public" && schema !== "main" ? `${schema}.${profile.table_name}` : profile.table_name;
 
   const metrics: Record<string, unknown>[] = [];
 


### PR DESCRIPTION
## What

`generateMetricYAML` only special-cased the `"public"` schema as unqualified, while `generateEntityYAML` treats **both** `"public"` and `"main"` as unqualified. For DuckDB/SQLite (schema = `"main"`, see `cli/src/commands/init.ts` DuckDB path passing `duckSchema = "main"`), the **entity** YAML emitted an unqualified `orders` while the **metric** YAML emitted `main.orders` — inconsistent and broken generated metric SQL.

One-line fix at `packages/api/src/lib/semantic/generate/yaml.ts:543` brings `generateMetricYAML` into parity with `generateEntityYAML` (`yaml.ts:27`):

```diff
-const qualifiedTable = schema !== "public" ? `${schema}.${profile.table_name}` : profile.table_name;
+const qualifiedTable = schema !== "public" && schema !== "main" ? `${schema}.${profile.table_name}` : profile.table_name;
```

## Why standalone

This is a **behavior change** — it alters generated DuckDB/SQLite metric SQL. It was deliberately *not* folded into the #3233 parity refactor (which moved this code verbatim from `lib/profiler.ts`). Surfaced by CodeRabbit on PR #3242.

## Tests

Added a `generateMetricYAML` schema-qualification block to `generate-engine.test.ts` pinning all three branches:
- `schema="public"` → unqualified (`FROM orders`)
- `schema="main"` (DuckDB/SQLite) → unqualified, asserts no `main.orders` — **was failing before the fix (TDD red)**
- `schema="analytics"` (custom) → qualified (`FROM analytics.orders`)

## Verification

- `bun test src/lib/semantic/__tests__/generate-engine.test.ts` — 9 pass
- Profiler facade suites (`profiler*.test.ts`, `enrich-engine.test.ts`, `wizard.test.ts`) — all green (they exercise the same code via the `@atlas/api/lib/profiler` re-export)
- Full `/ci`: lint, type, full test suite, syncpack, template drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols — all pass

Closes #3244

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783349136&installation_id=135337507&pr_number=3249&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3249&signature=31faa53d605b61fc8892c5160777f26736fb6ddf3005a2126b40c00c9870d634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric query generation to properly treat the main schema as unqualified on DuckDB and SQLite databases, eliminating unnecessary schema prefixes in generated metric table references for better compatibility.

* **Tests**
  * Added comprehensive test suite to validate schema qualification behavior for metric generation, covering public, main, and custom analytics schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->