### PR TITLE
fix(api): fail-closed semantic whitelist on directory-scan failure (#3243)

### DIFF
--- a/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
@@ -14,9 +14,10 @@
  * observable — see `docs/development/testing.md` and the existing
  * `config-deploy-mode-warning.test.ts` for the pattern.
  */
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { resolve, join } from "path";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import * as fs from "fs";
 
 type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
 const logCalls: LogCall[] = [];
@@ -297,6 +298,139 @@ describe("getWhitelistedTables — group partitioning (ADR-0012)", () => {
     const warehouseTables = getWhitelistedTables("warehouse", undefined, root);
     expect(warehouseTables.has("orders")).toBe(false);
     expect(warehouseTables.size).toBe(0);
+  });
+});
+
+describe("fail-closed on directory scan failure (#3243)", () => {
+  // Simulate a real FS error (EACCES) on a single readdir path — distinct from
+  // "directory absent", which `existsSync` already guards. The dir EXISTS but
+  // cannot be enumerated, so its groups silently drop out of the whitelist
+  // unless we fail closed. We delegate every non-target readdir to the real fs
+  // so directory setup and the default `entities/` read still work.
+  // `spyOn(fs, …)` patches the shared `fs` namespace that scanner.ts calls
+  // through (same pattern as explore-backend.test.ts).
+  function throwReaddirOn(targetPath: string, code = "EACCES"): ReturnType<typeof spyOn> {
+    const realReaddir = fs.readdirSync.bind(fs) as (p: fs.PathLike, o?: unknown) => unknown;
+    return spyOn(fs, "readdirSync").mockImplementation(((p: fs.PathLike, options?: unknown) => {
+      if (typeof p === "string" && p === targetPath) {
+        throw Object.assign(new Error(`${code}: simulated scan failure`), { code });
+      }
+      return realReaddir(p, options);
+    }) as unknown as typeof fs.readdirSync);
+  }
+
+  it("getEntityDirs reports failedScans:['groups'] when the groups/ scan throws", () => {
+    const root = ensureDir(`scanfail-groups-${testCounter}`);
+    ensureDir(`scanfail-groups-${testCounter}/entities`);
+    ensureDir(`scanfail-groups-${testCounter}/groups`); // exists → readdir attempted
+    const spy = throwReaddirOn(join(root, "groups"));
+    try {
+      const { failedScans } = getEntityDirs(root);
+      expect(failedScans).toContain("groups");
+      expect(failedScans).not.toContain("legacy");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("getEntityDirs reports failedScans:['legacy'] when the legacy root scan throws", () => {
+    const root = ensureDir(`scanfail-legacy-${testCounter}`);
+    ensureDir(`scanfail-legacy-${testCounter}/entities`);
+    // No groups/ dir → groups scan skipped; the root (legacy) readdir throws.
+    const spy = throwReaddirOn(root);
+    try {
+      const { failedScans } = getEntityDirs(root);
+      expect(failedScans).toContain("legacy");
+      expect(failedScans).not.toContain("groups");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("a failed groups/ scan fails CLOSED — affected group gets an EMPTY set, not default's tables", () => {
+    const root = ensureDir(`scanfail-closed-${testCounter}`);
+    const entities = ensureDir(`scanfail-closed-${testCounter}/entities`);
+    ensureDir(`scanfail-closed-${testCounter}/groups`);
+    writeEntity(entities, "orders.yml", entity("orders"));
+    const spy = throwReaddirOn(join(root, "groups"));
+    try {
+      // default is unaffected by a groups/ scan failure → still serves its tables.
+      expect(getWhitelistedTables("default", undefined, root).has("orders")).toBe(true);
+      // The group whose scan failed must NOT inherit default's tables.
+      const warehouse = getWhitelistedTables("warehouse", undefined, root);
+      expect(warehouse.has("orders")).toBe(false);
+      expect(warehouse.size).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("a failed scan does NOT drop to shared-default mode", () => {
+    // Pre-fix: with only `default` surviving, hasNonDefaultConnection=false →
+    // shared mode → EVERY connection validates against default's tables. The
+    // scan-failure signal must keep us out of shared mode (fail-toward-widening).
+    const root = ensureDir(`scanfail-noshare-${testCounter}`);
+    const entities = ensureDir(`scanfail-noshare-${testCounter}/entities`);
+    ensureDir(`scanfail-noshare-${testCounter}/groups`);
+    writeEntity(entities, "orders.yml", entity("orders"));
+    const spy = throwReaddirOn(join(root, "groups"));
+    try {
+      // An arbitrary non-default connection must NOT see default's `orders`.
+      expect(getWhitelistedTables("anything", undefined, root).has("orders")).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("the escalated error names WHICH scan failed and is distinct from the no-entities warning", () => {
+    const root = ensureDir(`scanfail-log-${testCounter}`);
+    const entities = ensureDir(`scanfail-log-${testCounter}/entities`);
+    ensureDir(`scanfail-log-${testCounter}/groups`);
+    writeEntity(entities, "orders.yml", entity("orders"));
+    const spy = throwReaddirOn(join(root, "groups"));
+    try {
+      getWhitelistedTables("warehouse", undefined, root);
+      // Names the failed namespace in the escalated (error-level) log payload.
+      const named = logCalls.some(
+        (c) =>
+          c.level === "error" &&
+          Array.isArray((c.payload as { failedScans?: unknown }).failedScans) &&
+          (c.payload as { failedScans: string[] }).failedScans.includes("groups"),
+      );
+      expect(named).toBe(true);
+      // Distinguishes "scan failed (incomplete)" from "no entities configured":
+      // the empty `warehouse` whitelist is logged as a scan failure, NOT the
+      // benign "No entities configured" warning.
+      const scanFailedMsg = logCalls.some(
+        (c) => /scan failed/i.test(c.message) && /(load incomplete|failing closed)/i.test(c.message),
+      );
+      expect(scanFailedMsg).toBe(true);
+      const noEntitiesMsg = logCalls.some((c) =>
+        /No entities configured for connection/i.test(c.message),
+      );
+      expect(noEntitiesMsg).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("a successful scan with a genuinely empty group keeps the benign 'no entities configured' message", () => {
+    // No scan failure: an absent group must keep today's behavior (benign warn,
+    // not a scan-failure error) — the two operator situations stay distinct.
+    const root = ensureDir(`noscanfail-${testCounter}`);
+    const entities = ensureDir(`noscanfail-${testCounter}/entities`);
+    ensureDir(`noscanfail-${testCounter}/groups/warehouse/entities`); // empty, real dir
+    writeEntity(entities, "orders.yml", entity("orders"));
+
+    // `crm` has no directory → empty set, but no scan failed.
+    const crm = getWhitelistedTables("crm", undefined, root);
+    expect(crm.size).toBe(0);
+    const noEntitiesMsg = logCalls.some(
+      (c) => c.level === "warn" && /No entities configured for connection/i.test(c.message),
+    );
+    expect(noEntitiesMsg).toBe(true);
+    const scanFailedErr = logCalls.some((c) => c.level === "error" && /scan failed/i.test(c.message));
+    expect(scanFailedErr).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/semantic/scanner.ts
+++ b/packages/api/src/lib/semantic/scanner.ts
@@ -63,14 +63,35 @@ export interface EntityDir {
   origin: EntityDirOrigin;
 }
 
+/**
+ * On-disk namespace whose directory scan can fail independently of the others:
+ *
+ * - `groups` — the canonical `groups/<group>/` namespace (ADR-0012);
+ * - `legacy` — the pre-ADR-0012 per-source `<source>/` root scan.
+ *
+ * Naming the namespace (instead of collapsing both catch sites into one
+ * boolean) lets the escalated error say WHICH scan failed, and lets consumers
+ * reason about which groups may be missing (#3243).
+ */
+export type ScanNamespace = "groups" | "legacy";
+
 export interface EntityDirResult {
   dirs: EntityDir[];
   /**
-   * True when a directory scan failed — either the canonical `groups/`
-   * namespace or the legacy `<source>/` root — so some group/source dirs may
-   * be missing. Consumers escalate this to an error-level log.
+   * Namespaces whose directory scan FAILED with an unexpected FS error
+   * (EACCES, ENOTDIR on a symlinked/non-dir path, EMFILE/ENFILE under fd
+   * pressure, EIO/stalled network mount) — all distinct from "directory
+   * absent", which is guarded by `existsSync` and is NOT a failure. Empty when
+   * every scan that ran succeeded.
+   *
+   * A non-empty list means some group/source dirs may be missing, so the
+   * partition decision downstream is unreliable: consumers MUST fail closed
+   * (resolve the requested group to its own — possibly empty — set) rather than
+   * infer "no non-default group exists" and drop to the shared-default
+   * whitelist, which would validate a connection against the WRONG group
+   * (#3243). Consumers escalate this to an error-level log.
    */
-  rootScanFailed: boolean;
+  failedScans: ScanNamespace[];
 }
 
 /**
@@ -85,7 +106,7 @@ export interface EntityDirResult {
  */
 export function getEntityDirs(root: string): EntityDirResult {
   const dirs: EntityDir[] = [];
-  let rootScanFailed = false;
+  const failedScans: ScanNamespace[] = [];
 
   const defaultDir = path.join(root, "entities");
   if (fs.existsSync(defaultDir)) {
@@ -105,10 +126,13 @@ export function getEntityDirs(root: string): EntityDirResult {
         }
       }
     } catch (err) {
-      rootScanFailed = true;
+      // The dir EXISTS (existsSync above) but could not be enumerated — a real
+      // FS failure (EACCES/ENOTDIR/EMFILE/EIO), not "absent". Record the failed
+      // namespace so the partition decision downstream fails closed (#3243).
+      failedScans.push("groups");
       log.warn(
         { root: groupsRoot, err: err instanceof Error ? err.message : String(err) },
-        "Failed to scan semantic groups/ namespace",
+        "Failed to scan semantic groups/ namespace — affected groups fail closed",
       );
     }
   }
@@ -125,15 +149,15 @@ export function getEntityDirs(root: string): EntityDirResult {
         }
       }
     } catch (err) {
-      rootScanFailed = true;
+      failedScans.push("legacy");
       log.warn(
         { root, err: err instanceof Error ? err.message : String(err) },
-        "Failed to scan semantic root for per-source directories",
+        "Failed to scan semantic root for per-source directories — affected sources fail closed",
       );
     }
   }
 
-  return { dirs, rootScanFailed };
+  return { dirs, failedScans };
 }
 
 // ---------------------------------------------------------------------------
@@ -248,9 +272,9 @@ export function scanEntities(root: string): ScanResult {
   const entities: ScannedEntity[] = [];
   const warnings: string[] = [];
 
-  const { dirs, rootScanFailed } = getEntityDirs(root);
-  if (rootScanFailed) {
-    warnings.push("Failed to read semantic root directory");
+  const { dirs, failedScans } = getEntityDirs(root);
+  if (failedScans.length > 0) {
+    warnings.push(`Failed to read semantic directory namespace(s): ${failedScans.join(", ")}`);
   }
 
   for (const { dir, sourceName, origin } of dirs) {

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -29,7 +29,7 @@ import { z } from "zod";
 import { getSemanticRoot as getDefaultSemanticRoot } from "./files";
 import { createLogger } from "@atlas/api/lib/logger";
 import { invalidateSemanticIndex } from "./search";
-import { getEntityDirs, readGroupField, resolveEntityGroup, type EntityDirOrigin } from "./scanner";
+import { getEntityDirs, readGroupField, resolveEntityGroup, type EntityDirOrigin, type ScanNamespace } from "./scanner";
 import { invalidateOrgModeRoots } from "./sync";
 
 const log = createLogger("semantic");
@@ -60,6 +60,13 @@ export interface CrossSourceJoin {
 
 const _whitelists = new Map<string, Set<string>>();
 let _tablesByConnection: Map<string, Set<string>> | null = null;
+/**
+ * Namespaces whose directory scan failed during the cached load (#3243).
+ * Cached alongside `_tablesByConnection` so the fail-closed decision in
+ * {@link getWhitelistedTables} stays consistent with the table map it was
+ * built from. Reset by `_resetWhitelists`.
+ */
+let _scanFailedNamespaces: ScanNamespace[] = [];
 let _crossSourceJoins: CrossSourceJoin[] | null = null;
 
 /**
@@ -217,24 +224,38 @@ function loadEntitiesFromDir(
  * @param semanticRoot - Semantic layer root directory (scans subdirectories).
  * @param entitiesDir - Override for a single flat entities directory (DI for tests).
  */
+interface LoadedTables {
+  byConnection: Map<string, Set<string>>;
+  /**
+   * Namespaces whose directory scan failed during this load (see
+   * {@link ScanNamespace}). A non-empty list means the partition decision is
+   * unreliable and affected groups must fail closed — never drop to
+   * shared-default mode (#3243).
+   */
+  failedScans: ScanNamespace[];
+}
+
 function loadTablesByConnection(
   semanticRoot?: string,
   entitiesDir?: string,
   crossJoins?: CrossSourceJoin[],
-): Map<string, Set<string>> {
+): LoadedTables {
   const byConnection = new Map<string, Set<string>>();
 
   // Legacy flat-directory path (existing tests use this) — the default group.
   if (entitiesDir) {
     loadEntitiesFromDir(entitiesDir, "default", "flat", byConnection, crossJoins);
-    return byConnection;
+    return { byConnection, failedScans: [] };
   }
 
   const root = semanticRoot ?? getDefaultSemanticRoot();
 
-  const { dirs, rootScanFailed } = getEntityDirs(root);
-  if (rootScanFailed) {
-    log.error({ root }, "Failed to scan semantic root — per-group whitelist entries may be missing");
+  const { dirs, failedScans } = getEntityDirs(root);
+  if (failedScans.length > 0) {
+    log.error(
+      { root, failedScans },
+      "Failed to scan semantic namespace(s) — per-group whitelist entries may be missing; affected groups fail closed (not dropped to shared-default)",
+    );
   }
 
   for (const { dir, sourceName, origin } of dirs) {
@@ -256,16 +277,64 @@ function loadTablesByConnection(
     log.info({ groups: Array.from(byConnection.keys()) }, "Partitioned table whitelist mode");
   }
 
-  return byConnection;
+  return { byConnection, failedScans };
 }
 
-function getTablesByConnection(semanticRoot?: string, entitiesDir?: string): Map<string, Set<string>> {
+function getTablesByConnection(semanticRoot?: string, entitiesDir?: string): LoadedTables {
   if (!_tablesByConnection) {
     const crossJoins: CrossSourceJoin[] = [];
-    _tablesByConnection = loadTablesByConnection(semanticRoot, entitiesDir, crossJoins);
+    const { byConnection, failedScans } = loadTablesByConnection(semanticRoot, entitiesDir, crossJoins);
+    _tablesByConnection = byConnection;
+    _scanFailedNamespaces = failedScans;
     _crossSourceJoins = crossJoins;
   }
-  return _tablesByConnection;
+  return { byConnection: _tablesByConnection, failedScans: _scanFailedNamespaces };
+}
+
+/**
+ * Resolve the whitelist for one Connection group from a loaded by-connection
+ * map, applying the fail-closed rule on scan failure (#3243).
+ *
+ * Partition mode (each group sees only its own tables) is normally inferred
+ * from the presence of a non-default group. That inference is only trustworthy
+ * when every directory scan SUCCEEDED — a failed `groups/`/legacy scan can hide
+ * the very group that would have flipped the decision. So when any scan failed
+ * we never drop to shared-default mode: the requested group resolves to its own
+ * (possibly empty) set and fails closed, rather than silently inheriting the
+ * default group's tables (a fail-toward-widening, validating against the WRONG
+ * group). The empty-whitelist log distinguishes "scan failed (incomplete)" from
+ * "no entities configured" — different operator situations.
+ */
+function resolveGroupTables(
+  byConnection: Map<string, Set<string>>,
+  connectionId: string,
+  failedScans: ScanNamespace[],
+): Set<string> {
+  const scanFailed = failedScans.length > 0;
+  const hasNonDefaultConnection = Array.from(byConnection.keys()).some((k) => k !== "default");
+
+  // Shared-default (single-DB back-compat) ONLY when no non-default group
+  // exists AND every scan succeeded. A failed scan makes "no non-default group"
+  // untrustworthy, so we must not widen the lookup to the default whitelist.
+  if (!hasNonDefaultConnection && !scanFailed) {
+    return new Set(byConnection.get("default") ?? []);
+  }
+
+  const tables = new Set(byConnection.get(connectionId) ?? []);
+  if (tables.size === 0) {
+    if (scanFailed) {
+      log.error(
+        { connectionId, failedScans, knownConnections: Array.from(byConnection.keys()) },
+        "Semantic layer scan failed — whitelist load incomplete; failing closed (all queries for this connection rejected). This is a scan failure, not an unconfigured group.",
+      );
+    } else {
+      log.warn(
+        { connectionId, knownConnections: Array.from(byConnection.keys()) },
+        "No entities configured for connection — whitelist is empty; all queries will be rejected",
+      );
+    }
+  }
+  return tables;
 }
 
 /**
@@ -293,21 +362,8 @@ export function getWhitelistedTables(
 ): Set<string> {
   // When using custom paths (tests), bypass the global cache
   if (entitiesDir || semanticRoot) {
-    const byConnection = loadTablesByConnection(semanticRoot, entitiesDir);
-    const hasNonDefaultConnection = Array.from(byConnection.keys()).some((k) => k !== "default");
-
-    let tables: Set<string>;
-    if (!hasNonDefaultConnection) {
-      tables = new Set(byConnection.get("default") ?? []);
-    } else {
-      tables = new Set(byConnection.get(connectionId) ?? []);
-      if (tables.size === 0) {
-        log.warn(
-          { connectionId, knownConnections: Array.from(byConnection.keys()) },
-          "No entities found for connection — whitelist is empty; all queries will be rejected",
-        );
-      }
-    }
+    const { byConnection, failedScans } = loadTablesByConnection(semanticRoot, entitiesDir);
+    const tables = resolveGroupTables(byConnection, connectionId, failedScans);
     // Merge plugin-provided entities even in custom-path mode
     const pluginTables = _pluginEntities.get(connectionId);
     if (pluginTables && pluginTables.size > 0) {
@@ -319,25 +375,11 @@ export function getWhitelistedTables(
   const cached = _whitelists.get(connectionId);
   if (cached) return cached;
 
-  const byConnection = getTablesByConnection();
-
-  // Backward compat: if no non-default group exists (no `group:`/`connection:`
-  // field and no `groups/`/legacy subdirectories), all connections share the
-  // full set (pre-v0.7 single-DB behavior).
-  const hasNonDefaultConnection = Array.from(byConnection.keys()).some((k) => k !== "default");
-
-  let tables: Set<string>;
-  if (!hasNonDefaultConnection) {
-    tables = new Set(byConnection.get("default") ?? []);
-  } else {
-    tables = new Set(byConnection.get(connectionId) ?? []);
-    if (tables.size === 0) {
-      log.warn(
-        { connectionId, knownConnections: Array.from(byConnection.keys()) },
-        "No entities found for connection — whitelist is empty; all queries will be rejected",
-      );
-    }
-  }
+  // Resolve from the cached load, failing closed when a directory scan failed:
+  // a swallowed FS error must never drop the partition decision to shared-default
+  // mode (back-compat single-DB sharing applies only when every scan succeeded).
+  const { byConnection, failedScans } = getTablesByConnection();
+  const tables = resolveGroupTables(byConnection, connectionId, failedScans);
 
   // Merge plugin-provided entities for this connection
   const pluginTables = _pluginEntities.get(connectionId);
@@ -371,6 +413,7 @@ export function getCrossSourceJoins(semanticRoot?: string): readonly CrossSource
 export function _resetWhitelists(): void {
   _whitelists.clear();
   _tablesByConnection = null;
+  _scanFailedNamespaces = [];
   _crossSourceJoins = null;
   invalidateSemanticIndex();
 }

--- a/packages/api/src/lib/tools/__tests__/sql-connection-whitelist.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-connection-whitelist.test.ts
@@ -22,6 +22,11 @@ mock.module("@atlas/api/lib/semantic", () => ({
         return new Set(["events", "analytics.events"]);
       case "nonexistent":
         return new Set(); // empty — unknown connection
+      case "scanfail":
+        // A REGISTERED connection whose semantic directory scan FAILED, so its
+        // whitelist came back empty (fail-closed, #3243). It must reject all
+        // queries — never validate against the default group's tables.
+        return new Set();
       default:
         return new Set(["orders", "users", "companies"]);
     }
@@ -87,6 +92,16 @@ describe("per-connection whitelist enforcement", () => {
 
   it("rejects schema-qualified table not in warehouse whitelist", async () => {
     const result = await validateSQL("SELECT * FROM public.orders", "warehouse");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("not in the allowed list");
+  });
+
+  it("fails closed: a registered connection whose scan failed (empty whitelist) rejects queries — not validated against default (#3243)", async () => {
+    // `orders` IS in the default whitelist. The "scanfail" connection is
+    // registered (getDBType returns postgres, no throw) but its whitelist is
+    // empty because its semantic scan failed and fell back closed. The query
+    // must be REJECTED — proving it did not silently validate against default.
+    const result = await validateSQL("SELECT * FROM orders", "scanfail");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });


### PR DESCRIPTION
Closes #3243.

## Problem

The table whitelist is a SELECT-only **security boundary**. When `fs.readdirSync` throws inside `getEntityDirs` (EACCES, ENOTDIR on a symlinked dir, EMFILE/ENFILE under fd pressure, EIO/stalled network mount — all **distinct** from "directory absent", which `existsSync` already guards), the catch set `rootScanFailed = true` and the affected group's entities silently dropped out of `byConnection`. Two bad downstream effects in `whitelist.ts`:

1. **Mis-attributed empty whitelist.** The log blamed the connection ("No entities found for connection") rather than the scan failure — an operator concludes the group was never configured when its YAMLs exist on disk but were locked out by a transient/permission error.
2. **Silent drop to shared-default mode (the security-relevant one).** Partition mode is keyed on `hasNonDefaultConnection`. If the scan that *would* have produced the non-default group fails and only `default` remains, the system fell into shared-whitelist mode — a connection that should be restricted to (or rejected by) the `warehouse` group's whitelist instead validated against `default`. A swallowed FS error changing which whitelist a connection is validated against is **fail-toward-widening**.

> It still fails closed *at enforcement* (`tools/sql.ts` rejects unlisted tables), so it cannot widen *beyond* default — but validating against the *wrong* (default) group instead of an empty/correct one is the bug.

## Fix

- **`scanner.ts`** — replace the single `rootScanFailed` boolean with a typed `failedScans: ScanNamespace[]` (`"groups" | "legacy"`). Both catch sites push their namespace, so the escalated error can name **which** scan failed. Kept well-typed and minimal so the queued #3240/#3245 scanner work can build on it without churn.
- **`whitelist.ts`** — thread `failedScans` out of `loadTablesByConnection` / `getTablesByConnection` into a new shared `resolveGroupTables` helper (de-duplicates the live + cached decision paths). When **any** scan failed, never drop to shared-default mode: the requested group resolves to its own (possibly empty) set and **fails closed**. The empty-whitelist log now distinguishes **"scan failed (incomplete)"** (error, names the namespace) from **"no entities configured"** (warn) — different operator situations. The scan-failure signal is cached alongside `_tablesByConnection` so the decision stays consistent with the map it was built from.

`default` is unaffected by a `groups/` scan failure (it still serves its own tables); only the groups whose scan failed fail closed.

## Tests

- **`group-scoped-loader.test.ts`** — simulate a real FS error (EACCES) via `spyOn(fs, "readdirSync")` (the established pattern from `explore-backend.test.ts`; distinct from "absent"). Asserts: (a) the affected group fails **closed** (empty set, **not** default's tables); (b) does **not** drop to shared-default mode; (c) the escalated error **names** the failed namespace and is distinct from the no-entities warning; (d) `getEntityDirs` reports `failedScans` correctly for both `groups` and `legacy`; (e) a *successful* scan with a genuinely empty group keeps today's benign warning (no behavior change when scans succeed).
- **`sql-connection-whitelist.test.ts`** — a **registered** connection whose scan failed (empty whitelist) has its query **REJECTED**, proving the enforcement layer does not validate it against `default`.

RED confirmed before merge: with the fail-closed guard reverted to the old "drop to default" behavior, exactly the 3 fail-closed behavioral tests fail (the group inherits `default`'s `orders`, drops to shared mode, emits the wrong log); the scanner-threading and benign-no-entities tests correctly still pass.

## Acceptance criteria

- [x] A failed directory scan does not silently drop to shared-default mode; affected groups fail-closed.
- [x] The empty-whitelist log distinguishes "scan failed (incomplete)" from "no entities configured".
- [x] Escalated error names which scan (groups/ vs legacy) failed.
- [x] Tests simulate a scan failure (FS error) and assert fail-closed + accurate messaging.

## CI

Local gates all green: lint, type (full monorepo), full test suite, syncpack, template/security-headers/railway/schema/oauth-helper drift, test-discipline, twenty-resolver, published-symbols.

This is an **architecture-labeled** fix (module-boundary hardening); an architecture-wins entry will be recorded after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783349600&installation_id=135337507&pr_number=3251&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3251&signature=bd69dd2dff842c58d8bcd4615ccd753e2a8c0cab561c2c7d1714cb311472ab48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of semantic directory scan failures with more granular error tracking and a fail-closed security strategy that restricts database access when scans encounter filesystem errors, preventing potential exposure of unvetted tables.
  * Enhanced error logging to clearly identify which scan operations failed during directory traversal.

* **Tests**
  * Added comprehensive tests verifying fail-closed behavior and error reporting when directory scans encounter permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->