### PR TITLE
fix(semantic): dbType-aware "main" schema qualification (#3252)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -14318,6 +14318,9 @@
                   "schema": {
                     "type": "string"
                   },
+                  "dbType": {
+                    "type": "string"
+                  },
                   "profiles": {
                     "type": "array",
                     "items": {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -197,6 +197,11 @@ const SaveRequestSchema = z.object({
   connectionId: z.string().min(1),
   entities: z.array(z.object({ tableName: z.string(), yaml: z.string() })).min(1),
   schema: z.string().optional(),
+  // Datasource dbType for the server-side metric branch (raw `profiles`
+  // submissions). Drives dbType-aware `main` qualification so metric `FROM`
+  // matches the pre-generated entity `table:` (issue #3252). Omitted by the
+  // wizard frontend, which never sends `profiles`; defaults to "postgres".
+  dbType: z.string().optional(),
   profiles: z.array(TableProfileSchema).optional(),
 });
 
@@ -799,10 +804,16 @@ wizard.openapi(saveRoute, async (c) => {
       // sends pre-generated entity YAML via { connectionId, entities }; this
       // branch is for callers (e.g. future CLI integrations) that submit
       // raw TableProfile[] for server-side generation.
-      const { schema: bodySchema, profiles: profileData } = body;
+      const { schema: bodySchema, dbType: bodyDbType, profiles: profileData } = body;
       if (profileData && profileData.length > 0) {
         const profiles = profileData;
         const resolvedSchema = bodySchema ?? "public";
+        // Keep metric `FROM` qualification in lockstep with the entity
+        // `table:` the frontend already generated (issue #3252). Defaults to
+        // "postgres" — the only dbType where a custom schema named `main` is
+        // reachable; "main" stays unqualified for DuckDB/SQLite callers that
+        // pass dbType explicitly.
+        const resolvedDbType = bodyDbType ?? "postgres";
 
         const catalogYaml = generateCatalogYAML(profiles);
         const catalogPath = path.join(outputBase, "catalog.yml");
@@ -816,7 +827,7 @@ wizard.openapi(saveRoute, async (c) => {
 
         for (const profile of profiles) {
           if (!profile.table_name || !SAFE_TABLE_NAME.test(profile.table_name)) continue;
-          const metricYaml = generateMetricYAML(profile, resolvedSchema);
+          const metricYaml = generateMetricYAML(profile, resolvedSchema, resolvedDbType);
           if (metricYaml) {
             const safeMetricName = path.basename(profile.table_name);
             const filePath = path.join(metricsDir, `${safeMetricName}.yml`);

--- a/packages/api/src/lib/semantic/__tests__/generate-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/generate-engine.test.ts
@@ -122,37 +122,75 @@ describe("shared generate engine (direct ../generate path)", () => {
   });
 });
 
-describe("generateMetricYAML schema qualification (issue #3244)", () => {
-  // Every metric's SQL uses `FROM <table>`; pull the table ref out of each clause.
-  function fromTables(metricYaml: string): string[] {
-    const parsed = yaml.load(metricYaml) as { metrics: { sql: string }[] };
-    return parsed.metrics
-      .map((m) => m.sql.match(/FROM\s+(\S+)/)?.[1])
-      .filter((t): t is string => Boolean(t));
-  }
+// Every metric's SQL uses `FROM <table>`; pull the table ref out of each clause.
+function metricFromTables(metricYaml: string): string[] {
+  const parsed = yaml.load(metricYaml) as { metrics: { sql: string }[] };
+  return parsed.metrics
+    .map((m) => m.sql.match(/FROM\s+(\S+)/)?.[1])
+    .filter((t): t is string => Boolean(t));
+}
 
+describe("generateMetricYAML schema qualification (issue #3244)", () => {
   it('treats schema="public" as unqualified (FROM orders)', () => {
-    const out = generateMetricYAML(orders, "public");
+    const out = generateMetricYAML(orders, "public", "postgres");
     expect(out).not.toBeNull();
-    const tables = fromTables(out!);
+    const tables = metricFromTables(out!);
     expect(tables.length).toBeGreaterThan(0);
     expect(tables.every((t) => t === "orders")).toBe(true);
   });
 
-  it('treats schema="main" (DuckDB/SQLite) as unqualified, matching generateEntityYAML', () => {
-    const out = generateMetricYAML(orders, "main");
+  it('treats schema="main" as unqualified for DuckDB/SQLite, matching generateEntityYAML', () => {
+    const out = generateMetricYAML(orders, "main", "duckdb");
     expect(out).not.toBeNull();
-    const tables = fromTables(out!);
+    const tables = metricFromTables(out!);
     expect(tables.length).toBeGreaterThan(0);
     expect(tables.every((t) => t === "orders")).toBe(true);
     expect(out!).not.toContain("main.orders");
   });
 
   it("qualifies a custom schema (FROM analytics.orders)", () => {
-    const out = generateMetricYAML(orders, "analytics");
+    const out = generateMetricYAML(orders, "analytics", "postgres");
     expect(out).not.toBeNull();
-    const tables = fromTables(out!);
+    const tables = metricFromTables(out!);
     expect(tables.length).toBeGreaterThan(0);
     expect(tables.every((t) => t === "analytics.orders")).toBe(true);
   });
+});
+
+// #3252: `main` is the DuckDB/SQLite default schema (correct to unqualify
+// there), but `--schema` is Postgres-only, so a Postgres datasource can be
+// profiled with a *custom* schema literally named `main` — which MUST stay
+// qualified or resolution silently falls back to `search_path`. The entity
+// `table:` field and metric `FROM` must AGREE in every case, because the SQL
+// whitelist is built from `entity.table` — a divergent metric ref fails
+// table-whitelist validation. So both generators are checked in lockstep.
+describe("dbType-aware 'main' qualification (issue #3252)", () => {
+  function entityTable(entityYaml: string): string {
+    const parsed = yaml.load(entityYaml) as { table: string };
+    return parsed.table;
+  }
+
+  const cases: { name: string; dbType: string; schema: string; expected: string }[] = [
+    { name: "DuckDB main → unqualified", dbType: "duckdb", schema: "main", expected: "orders" },
+    { name: "Postgres custom main → qualified", dbType: "postgres", schema: "main", expected: "main.orders" },
+    { name: "Postgres public → unqualified", dbType: "postgres", schema: "public", expected: "orders" },
+    { name: "Postgres custom analytics → qualified", dbType: "postgres", schema: "analytics", expected: "analytics.orders" },
+  ];
+
+  for (const { name, dbType, schema, expected } of cases) {
+    it(`${name} — entity table: and metric FROM agree`, () => {
+      const entity = generateEntityYAML(orders, [orders], dbType, schema);
+      const metric = generateMetricYAML(orders, schema, dbType);
+      expect(metric).not.toBeNull();
+
+      const table = entityTable(entity);
+      const fromTables = metricFromTables(metric!);
+
+      expect(table).toBe(expected);
+      expect(fromTables.length).toBeGreaterThan(0);
+      expect(fromTables.every((t) => t === expected)).toBe(true);
+      // Entity `table:` and every metric `FROM` reference the same qualifier.
+      expect(fromTables.every((t) => t === table)).toBe(true);
+    });
+  }
 });

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -16,6 +16,29 @@ import { mapSQLType, isViewLike, singularize, entityName } from "../../profiler-
 import { suggestMeasureType, describeMeasure } from "../../profiler-patterns";
 import { isView, isMatView, mapSalesforceFieldType } from "./analyze";
 
+/**
+ * Decide the `table:` / `FROM` qualifier for a profiled table.
+ *
+ * `public` is the PostgreSQL default schema and is always left unqualified.
+ * `main` is the DuckDB/SQLite default schema, so it is unqualified *only*
+ * there — but `--schema` is Postgres-only, so a PostgreSQL datasource can be
+ * profiled with a custom schema literally named `main`, which MUST stay
+ * qualified or resolution silently falls back to the connection's
+ * `search_path` rather than the explicit schema (issue #3252). Every other
+ * schema is qualified.
+ *
+ * `generateEntityYAML` (entity `table:`) and `generateMetricYAML` (metric
+ * `FROM`) call this in lockstep: the SQL whitelist is built from
+ * `entity.table`, so a divergent metric ref would fail table-whitelist
+ * validation.
+ */
+function qualifyTableName(tableName: string, schema: string, dbType: DBType): string {
+  const schemaIsDefault =
+    schema === "public" ||
+    (schema === "main" && (dbType === "duckdb" || dbType === "sqlite"));
+  return schemaIsDefault ? tableName : `${schema}.${tableName}`;
+}
+
 export function generateEntityYAML(
   profile: TableProfile,
   allProfiles: TableProfile[],
@@ -24,7 +47,7 @@ export function generateEntityYAML(
   source?: string,
 ): string {
   const name = entityName(profile.table_name);
-  const qualifiedTable = schema !== "public" && schema !== "main" ? `${schema}.${profile.table_name}` : profile.table_name;
+  const qualifiedTable = qualifyTableName(profile.table_name, schema, dbType);
 
   // Build dimensions
   const dimensions: Record<string, unknown>[] = profile.columns.map((col) => {
@@ -525,7 +548,16 @@ export function generateCatalogYAML(profiles: TableProfile[]): string {
   return yaml.dump(catalog, { lineWidth: 120, noRefs: true });
 }
 
-export function generateMetricYAML(profile: TableProfile, schema: string = "public"): string | null {
+// `dbType` is appended after `schema` (rather than placed before it as in
+// generateEntityYAML) to preserve the existing `(profile, schema)` callers; it
+// is required for dbType-aware `main` qualification (issue #3252) and defaults
+// to "postgres" — the primary datasource and the only dbType for which a custom
+// schema named `main` is reachable.
+export function generateMetricYAML(
+  profile: TableProfile,
+  schema: string = "public",
+  dbType: DBType = "postgres",
+): string | null {
   if (isViewLike(profile)) return null;
 
   const numericCols = profile.columns.filter(
@@ -540,7 +572,7 @@ export function generateMetricYAML(profile: TableProfile, schema: string = "publ
 
   const pkCol = profile.columns.find((c) => c.is_primary_key);
   const enumCols = profile.columns.filter((c) => c.is_enum_like);
-  const qualifiedTable = schema !== "public" && schema !== "main" ? `${schema}.${profile.table_name}` : profile.table_name;
+  const qualifiedTable = qualifyTableName(profile.table_name, schema, dbType);
 
   const metrics: Record<string, unknown>[] = [];
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -607,7 +607,7 @@ async function profileDatasource(
 
   // Generate metric files per table
   for (const profile of profiles) {
-    const metricYaml = generateMetricYAML(profile, schemaArg);
+    const metricYaml = generateMetricYAML(profile, schemaArg, dbType);
     if (metricYaml) {
       const filePath = path.join(
         metricsOutDir,
@@ -908,7 +908,7 @@ export async function handleInit(args: string[]): Promise<void> {
     console.log(`  wrote ${glossaryPath}`);
 
     for (const profile of profiles) {
-      const metricYaml = generateMetricYAML(profile, duckSchema);
+      const metricYaml = generateMetricYAML(profile, duckSchema, "duckdb" as DBType);
       if (metricYaml) {
         const filePath = path.join(
           metricsOutDir,


### PR DESCRIPTION
Closes #3252.

## Problem

The mechanical generators treated the literal schema name `main` as **globally unqualified**, independent of `dbType`:

```ts
const qualifiedTable =
  schema !== "public" && schema !== "main" ? `${schema}.${table}` : table;
```

`main` is the DuckDB/SQLite default schema (correct to unqualify there), but `--schema` is **Postgres-only**, so a Postgres datasource can legitimately be profiled with a *custom* schema named `main`. In that case both the entity `table:` field and the generated metric SQL dropped the qualifier (`orders` instead of `main.orders`), making resolution depend on the connection's `search_path` rather than the explicit schema.

Surfaced by Codex (P2) on PR #3249. Not a regression from #3244 — that PR only brought `generateMetricYAML` into parity with `generateEntityYAML` for `main`. This refines that parity to be `dbType`-aware.

## Fix

- New shared `qualifyTableName(tableName, schema, dbType)` helper in `generate/yaml.ts`: `public` always unqualified; `main` unqualified **only** for `duckdb`/`sqlite`; everything else qualified.
- Both `generateEntityYAML` (already received `dbType`) and `generateMetricYAML` (gains a **trailing optional** `dbType`, default `"postgres"`) call it **in lockstep** — entity `table:` and metric `FROM` must agree, because the SQL whitelist is built from `entity.table` (a divergent metric ref would fail table-whitelist validation).
- `dbType` threaded through all call sites:
  - `cli/init.ts` — Postgres (`schemaArg`, `dbType`) + DuckDB (`duckSchema`, `"duckdb"`) paths.
  - `routes/wizard.ts` — `SaveRequestSchema` gains optional `dbType` (the wizard frontend never sends `profiles`, so this is the forward-looking raw-profile metric branch); defaults to `"postgres"`.

`dbType` is appended *after* `schema` on `generateMetricYAML` (rather than before, as on `generateEntityYAML`) specifically to preserve the existing `(profile, schema)` callers — only the one #3244 `main` test changes (intentionally, to assert the new `dbType`-aware behavior).

## Tests

`generate-engine.test.ts` covers all four cases and asserts the entity `table:` and metric `FROM` **agree** in each:

| dbType | schema | result |
|--------|--------|--------|
| duckdb | main | `orders` (unqualified) |
| postgres | main | `main.orders` (qualified) |
| postgres | public | `orders` (unqualified) |
| postgres | analytics | `analytics.orders` (qualified) |

## Verification

`/ci` — lint, type, full `bun run test` (556 API + all other suites, 0 failures), syncpack, template/security-headers/railway-watch/schema/oauth-helper/test-discipline/twenty-resolver/published-symbols drift — **all pass**.

## Scope

Generation qualification only. No unrelated generator behavior changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352510&installation_id=135337507&pr_number=3257&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3257&signature=437a61e3ef53c4c00c9053a2d849bafa226f8a87b535223b6cf92bdf97224fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API and tooling now accept an optional dbType so generated artifacts respect the target database.

* **Bug Fixes**
  * Metric SQL and entity metadata are kept consistent across PostgreSQL, DuckDB, and SQLite (including handling of a `main` default schema).

* **Tests**
  * Added/updated tests to verify DB-type-aware table qualification behavior.

* **Documentation**
  * OpenAPI schema updated to include the new dbType property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->