### PR TITLE
feat(semantic): group-namespace discovery for metrics/glossary/catalog (#3240)

### DIFF
--- a/docs/design/semantic-onboarding.md
+++ b/docs/design/semantic-onboarding.md
@@ -61,6 +61,7 @@ semantic/                       # multi-DB
 - The loader infers the group from the directory (`semantic/groups/<group>/…` → group `<group>`); an in-file `group:` field is an **optional override**, not a co-equal second source of truth.
 - The **default group stays flat at the root** (`semantic/entities/…`, `connection_group_id = NULL`), so single-DB users see zero added nesting.
 - This formalizes (and renames) the existing-but-unblessed `semantic/<source>/entities/` inference in `whitelist.ts` into the dedicated `groups/` namespace. Legacy `semantic/<source>/` layouts need a one-time migration (see ADR-0012 Consequences).
+- **All four artifact types — entities, metrics, glossary, catalog — share one layout-aware traversal** (`getGroupDirs` in `lib/semantic/scanner.ts`, #3240). A non-default group's `groups/<group>/metrics/*.yml`, `groups/<group>/glossary.yml`, and `groups/<group>/catalog.yml` are discovered and attributed to `<group>` on every read path (admin discovery, the agent's lookup helpers, and the boot-time search index). `groups/` is a reserved namespace, so nothing is ever attributed to a source literally named "groups". The admin catalog endpoint remains the global root view (catalog is unscoped in the admin/DB model); group catalogs surface as `use_for` hints in the agent's semantic index.
 
 In SaaS (DB-backed), the group is `connection_group_id` on the entity row — no files; the same grouping drives the view.
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1574,23 +1574,31 @@ describe("GET /api/v1/admin/semantic/metrics", () => {
     expect(body.metrics.length).toBe(1);
   });
 
-  it("discovers groups/<group>/metrics and attributes them to <group> (#3240)", async () => {
+  it("discovers groups/<group>/metrics (attributed to <group>) and keeps legacy <source>/metrics (#3240)", async () => {
     const groupDir = path.join(tmpRoot, "groups", "analytics", "metrics");
     fs.mkdirSync(groupDir, { recursive: true });
     fs.writeFileSync(
       path.join(groupDir, "sessions.yml"),
       ["id: sessions_count", "sql: SELECT COUNT(*) FROM sessions"].join("\n"),
     );
+    // Legacy <source>/metrics must still resolve to <source> (unchanged).
+    const legacyDir = path.join(tmpRoot, "warehouse", "metrics");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyDir, "events.yml"),
+      ["id: events_count", "sql: SELECT COUNT(*) FROM events"].join("\n"),
+    );
     try {
       const res = await app.fetch(adminRequest("/api/v1/admin/semantic/metrics"));
       expect(res.status).toBe(200);
       const body = (await res.json()) as { metrics: Array<{ source: string; file: string }> };
-      const grouped = body.metrics.find((m) => m.file === "sessions");
-      expect(grouped?.source).toBe("analytics");
+      expect(body.metrics.find((m) => m.file === "sessions")?.source).toBe("analytics");
+      expect(body.metrics.find((m) => m.file === "events")?.source).toBe("warehouse");
       // The reserved groups/ container is never itself a source.
       expect(body.metrics.some((m) => m.source === "groups")).toBe(false);
     } finally {
       fs.rmSync(path.join(tmpRoot, "groups"), { recursive: true, force: true });
+      fs.rmSync(path.join(tmpRoot, "warehouse", "metrics"), { recursive: true, force: true });
     }
   });
 });
@@ -1609,21 +1617,28 @@ describe("GET /api/v1/admin/semantic/glossary", () => {
     expect(body.glossary.length).toBeGreaterThan(0);
   });
 
-  it("discovers groups/<group>/glossary.yml and attributes it to <group> (#3240)", async () => {
+  it("discovers groups/<group>/glossary.yml (attributed to <group>) and keeps legacy <source>/glossary.yml (#3240)", async () => {
     const groupDir = path.join(tmpRoot, "groups", "analytics");
     fs.mkdirSync(groupDir, { recursive: true });
     fs.writeFileSync(
       path.join(groupDir, "glossary.yml"),
       ["terms:", "  mau:", "    status: defined", "    definition: Monthly active users."].join("\n"),
     );
+    // Legacy <source>/glossary.yml must still resolve to <source> (unchanged).
+    fs.writeFileSync(
+      path.join(tmpRoot, "warehouse", "glossary.yml"),
+      ["terms:", "  cohort:", "    status: defined", "    definition: Signup-month group."].join("\n"),
+    );
     try {
       const res = await app.fetch(adminRequest("/api/v1/admin/semantic/glossary"));
       expect(res.status).toBe(200);
       const body = (await res.json()) as { glossary: Array<{ source: string }> };
       expect(body.glossary.some((g) => g.source === "analytics")).toBe(true);
+      expect(body.glossary.some((g) => g.source === "warehouse")).toBe(true);
       expect(body.glossary.some((g) => g.source === "groups")).toBe(false);
     } finally {
       fs.rmSync(path.join(tmpRoot, "groups"), { recursive: true, force: true });
+      fs.rmSync(path.join(tmpRoot, "warehouse", "glossary.yml"), { force: true });
     }
   });
 });

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1573,6 +1573,26 @@ describe("GET /api/v1/admin/semantic/metrics", () => {
     const body = (await res.json()) as { metrics: unknown[] };
     expect(body.metrics.length).toBe(1);
   });
+
+  it("discovers groups/<group>/metrics and attributes them to <group> (#3240)", async () => {
+    const groupDir = path.join(tmpRoot, "groups", "analytics", "metrics");
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(groupDir, "sessions.yml"),
+      ["id: sessions_count", "sql: SELECT COUNT(*) FROM sessions"].join("\n"),
+    );
+    try {
+      const res = await app.fetch(adminRequest("/api/v1/admin/semantic/metrics"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { metrics: Array<{ source: string; file: string }> };
+      const grouped = body.metrics.find((m) => m.file === "sessions");
+      expect(grouped?.source).toBe("analytics");
+      // The reserved groups/ container is never itself a source.
+      expect(body.metrics.some((m) => m.source === "groups")).toBe(false);
+    } finally {
+      fs.rmSync(path.join(tmpRoot, "groups"), { recursive: true, force: true });
+    }
+  });
 });
 
 describe("GET /api/v1/admin/semantic/glossary", () => {
@@ -1587,6 +1607,24 @@ describe("GET /api/v1/admin/semantic/glossary", () => {
 
     const body = (await res.json()) as { glossary: unknown[] };
     expect(body.glossary.length).toBeGreaterThan(0);
+  });
+
+  it("discovers groups/<group>/glossary.yml and attributes it to <group> (#3240)", async () => {
+    const groupDir = path.join(tmpRoot, "groups", "analytics");
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(groupDir, "glossary.yml"),
+      ["terms:", "  mau:", "    status: defined", "    definition: Monthly active users."].join("\n"),
+    );
+    try {
+      const res = await app.fetch(adminRequest("/api/v1/admin/semantic/glossary"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { glossary: Array<{ source: string }> };
+      expect(body.glossary.some((g) => g.source === "analytics")).toBe(true);
+      expect(body.glossary.some((g) => g.source === "groups")).toBe(false);
+    } finally {
+      fs.rmSync(path.join(tmpRoot, "groups"), { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -65,6 +65,15 @@ import {
   AdminEntityYamlShapeError,
   type AdminEntityYamlError,
 } from "@atlas/api/lib/semantic/admin-source";
+// Shared, layout-aware traversal (ADR-0012): the single source of truth so
+// metric/glossary discovery recognizes the canonical groups/<group>/ namespace
+// alongside flat-root + legacy <source>/ layouts (#3240).
+import {
+  getGroupDirs,
+  resolveEntityGroup,
+  readGroupField,
+  type EntityDirOrigin,
+} from "@atlas/api/lib/semantic/scanner";
 import { AmbiguousEntityError } from "@atlas/api/lib/effect/errors";
 import { runDiff, runDriftDiff } from "@atlas/api/lib/semantic/diff";
 import { attachDrift } from "@atlas/api/lib/semantic/drift";
@@ -510,81 +519,70 @@ registerSemanticEditorRoutes(admin, adminAuthAndContext);
 function discoverMetrics(root: string): Array<{ source: string; file: string; data: unknown }> {
   const metrics: Array<{ source: string; file: string; data: unknown }> = [];
 
-  const defaultDir = path.join(root, "metrics");
-  if (fs.existsSync(defaultDir)) {
-    loadMetricsFromDir(defaultDir, "default", metrics);
-  }
-
-  const RESERVED_DIRS = new Set(["entities", "metrics"]);
-  if (fs.existsSync(root)) {
-    try {
-      const entries = fs.readdirSync(root, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-        const subMetrics = path.join(root, entry.name, "metrics");
-        if (fs.existsSync(subMetrics)) {
-          loadMetricsFromDir(subMetrics, entry.name, metrics);
-        }
-      }
-    } catch (err) {
-      log.warn({ err: err instanceof Error ? err : new Error(String(err)), root }, "Failed to scan semantic root for per-source metrics");
-    }
+  // Flat default `metrics/`, the canonical `groups/<group>/metrics/` namespace,
+  // and legacy `<source>/metrics/` all flow through the shared scanner — never
+  // the reserved `groups/` dir itself (ADR-0012, #3240).
+  for (const { dir, group, origin } of getGroupDirs(root, "metrics").dirs) {
+    loadMetricsFromDir(dir, group, origin, metrics);
   }
 
   return metrics;
 }
 
-function loadMetricsFromDir(dir: string, source: string, out: Array<{ source: string; file: string; data: unknown }>): void {
+function loadMetricsFromDir(
+  dir: string,
+  dirGroup: string,
+  origin: EntityDirOrigin,
+  out: Array<{ source: string; file: string; data: unknown }>,
+): void {
   let files: string[];
   try {
     files = fs.readdirSync(dir).filter((f) => f.endsWith(".yml"));
   } catch (err) {
-    log.warn({ err: err instanceof Error ? err : new Error(String(err)), dir, source }, "Failed to read metrics directory");
+    log.warn({ err: err instanceof Error ? err : new Error(String(err)), dir, dirGroup }, "Failed to read metrics directory");
     return;
   }
 
   for (const file of files) {
     try {
       const raw = readYamlFile(path.join(dir, file));
+      // Directory is canonical for groups/<group>/; a file-level group:/connection:
+      // can override on the flat/legacy layouts (ADR-0012).
+      const fieldGroup =
+        raw && typeof raw === "object"
+          ? readGroupField(raw as Record<string, unknown>)
+          : undefined;
+      const source = resolveEntityGroup(dirGroup, origin, fieldGroup).group;
       out.push({ source, file: file.replace(/\.yml$/, ""), data: raw });
     } catch (err) {
-      log.warn({ err: err instanceof Error ? err : new Error(String(err)), file, dir, source }, "Failed to parse metric YAML file");
+      log.warn({ err: err instanceof Error ? err : new Error(String(err)), file, dir, dirGroup }, "Failed to parse metric YAML file");
     }
   }
 }
 
 /**
- * Load glossary from semantic/glossary.yml and per-source glossaries.
+ * Load glossary from the flat default `glossary.yml`, the canonical
+ * `groups/<group>/glossary.yml` namespace, and legacy `<source>/glossary.yml`
+ * (ADR-0012, #3240) — all via the shared scanner traversal.
  */
 function loadGlossary(root: string): unknown[] {
   const glossaries: unknown[] = [];
 
-  const defaultFile = path.join(root, "glossary.yml");
-  if (fs.existsSync(defaultFile)) {
+  for (const { dir, group, origin } of getGroupDirs(root, null).dirs) {
+    const file = path.join(dir, "glossary.yml");
+    if (!fs.existsSync(file)) continue;
     try {
-      glossaries.push({ source: "default", data: readYamlFile(defaultFile) });
+      const data = readYamlFile(file);
+      // Directory is canonical for groups/<group>/; a file-level group:/connection:
+      // can override on the flat/legacy layouts (ADR-0012).
+      const fieldGroup =
+        data && typeof data === "object"
+          ? readGroupField(data as Record<string, unknown>)
+          : undefined;
+      const source = resolveEntityGroup(group, origin, fieldGroup).group;
+      glossaries.push({ source, data });
     } catch (err) {
-      log.warn({ err: err instanceof Error ? err : new Error(String(err)), file: defaultFile }, "Failed to parse glossary YAML");
-    }
-  }
-
-  const RESERVED_DIRS = new Set(["entities", "metrics"]);
-  if (fs.existsSync(root)) {
-    try {
-      const entries = fs.readdirSync(root, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-        const subGlossary = path.join(root, entry.name, "glossary.yml");
-        if (fs.existsSync(subGlossary)) {
-          try {
-            glossaries.push({ source: entry.name, data: readYamlFile(subGlossary) });
-          } catch (err) {
-            log.warn({ err: err instanceof Error ? err : new Error(String(err)), file: subGlossary, source: entry.name }, "Failed to parse per-source glossary YAML");
-          }
-        }
-      }
-    } catch (err) {
-      log.warn({ err: err instanceof Error ? err : new Error(String(err)), root }, "Failed to scan semantic root for per-source glossaries");
+      log.warn({ err: err instanceof Error ? err : new Error(String(err)), file, dirGroup: group }, "Failed to parse glossary YAML");
     }
   }
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1853,6 +1853,14 @@ admin.openapi(getCatalogRoute, async (c) => {
   const { requestId, authResult } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
   const root = resolveSemanticRoot(orgId);
+  // Catalog is a single global document at the admin level — the root
+  // catalog.yml's top-level metadata (name/description/use_for) drives the
+  // single-object CatalogViewer, and the admin/DB model treats catalog as
+  // unscoped (serveRawYaml forces its group to null). Unlike metrics/glossary,
+  // it is intentionally NOT discovered per-group here; a group's
+  // groups/<group>/catalog.yml surfaces where it's agent-meaningful — as
+  // per-entity `use_for` hints merged into the boot-time search index
+  // (see loadCatalog in lib/semantic/search.ts). #3240.
   const catalogFile = path.join(root, "catalog.yml");
   if (!fs.existsSync(catalogFile)) {
     return c.json({ catalog: null }, 200);

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -292,6 +292,66 @@ describe("buildSemanticIndex", () => {
     expect(index).toContain("Ask the user which size they mean");
   });
 
+  it("discovers groups/<group>/metrics, glossary, and catalog in the index (#3240)", () => {
+    const root = ensureDir(`group-discovery-${testCounter}`);
+    mkdirSync(join(root, "entities"), { recursive: true });
+    mkdirSync(join(root, "groups", "analytics", "entities"), { recursive: true });
+    mkdirSync(join(root, "groups", "analytics", "metrics"), { recursive: true });
+
+    // An entity in the group so its catalog use_for hint can attach.
+    writeFileSync(
+      join(root, "groups", "analytics", "entities", "sessions.yml"),
+      makeEntity("sessions", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+    // A flat-root entity so the layer isn't group-only.
+    writeFileSync(
+      join(root, "entities", "orders.yml"),
+      makeEntity("orders", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+
+    writeFileSync(
+      join(root, "groups", "analytics", "metrics", "sessions_metrics.yml"),
+      [
+        "metrics:",
+        "  - name: weekly_active_users",
+        '    description: "Distinct users active in the last 7 days"',
+        "    entity: sessions",
+        "    aggregation: count_distinct",
+      ].join("\n") + "\n",
+    );
+    writeFileSync(
+      join(root, "groups", "analytics", "glossary.yml"),
+      [
+        "terms:",
+        "  - term: wau",
+        '    definition: "Weekly active users"',
+        "    status: defined",
+      ].join("\n") + "\n",
+    );
+    writeFileSync(
+      join(root, "groups", "analytics", "catalog.yml"),
+      [
+        "version: '1'",
+        "entities:",
+        "  - name: sessions",
+        '    description: "User sessions"',
+        "    use_for:",
+        '      - "Engagement analysis"',
+      ].join("\n") + "\n",
+    );
+
+    const index = buildSemanticIndex(root);
+
+    // Group metric + glossary term are discovered (were entirely skipped before).
+    expect(index).toContain("weekly_active_users");
+    expect(index).toContain("**wau**");
+    // Group catalog use_for hint attaches to the group entity.
+    expect(index).toContain("Use for: Engagement analysis");
+    // The group entity is labeled with its group; nothing is attributed to "groups".
+    expect(index).toContain("[analytics]");
+    expect(index).not.toContain("[groups]");
+  });
+
   it("handles per-source subdirectories", () => {
     const root = ensureDir(`multisource-${testCounter}`);
     mkdirSync(join(root, "entities"), { recursive: true });

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -322,21 +322,24 @@ describe("buildSemanticIndex", () => {
       ].join("\n") + "\n",
     );
 
+    // Canonical single-metric shape — keyed by `id:` (no `name:`), the common
+    // form for generated group metrics. The index must surface it.
     writeFileSync(
-      join(root, "groups", "analytics", "metrics", "sessions_metrics.yml"),
+      join(root, "groups", "analytics", "metrics", "wau.yml"),
       [
-        "metrics:",
-        "  - name: weekly_active_users",
-        '    description: "Distinct users active in the last 7 days"',
-        "    entity: sessions",
-        "    aggregation: count_distinct",
+        "id: weekly_active_users",
+        'description: "Distinct users active in the last 7 days"',
+        "entity: sessions",
+        "aggregation: count_distinct",
+        "sql: SELECT COUNT(DISTINCT user_id) FROM sessions",
       ].join("\n") + "\n",
     );
+    // Object-form glossary (current shape) — keyed by term name.
     writeFileSync(
       join(root, "groups", "analytics", "glossary.yml"),
       [
         "terms:",
-        "  - term: wau",
+        "  wau:",
         '    definition: "Weekly active users"',
         "    status: defined",
       ].join("\n") + "\n",
@@ -365,6 +368,58 @@ describe("buildSemanticIndex", () => {
     // The group entity is labeled with its group; nothing is attributed to "groups".
     expect(index).toContain("[analytics]");
     expect(index).not.toContain("[groups]");
+  });
+
+  it("scopes catalog use_for hints to the matching group on a cross-group name collision (#3240)", () => {
+    const root = ensureDir(`catalog-collision-${testCounter}`);
+    mkdirSync(join(root, "entities"), { recursive: true });
+    mkdirSync(join(root, "groups", "analytics", "entities"), { recursive: true });
+
+    // Same entity NAME (`customers`) in two groups — the flat default and the
+    // analytics group — each with its own catalog hint.
+    writeFileSync(
+      join(root, "entities", "customers.yml"),
+      makeEntity("customers", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+    writeFileSync(
+      join(root, "groups", "analytics", "entities", "customers.yml"),
+      makeEntity("customers", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+    writeFileSync(
+      join(root, "catalog.yml"),
+      [
+        "entities:",
+        "  - name: customers",
+        "    use_for:",
+        '      - "Billing default-group"',
+      ].join("\n") + "\n",
+    );
+    writeFileSync(
+      join(root, "groups", "analytics", "catalog.yml"),
+      [
+        "entities:",
+        "  - name: customers",
+        "    use_for:",
+        '      - "Engagement analytics-group"',
+      ].join("\n") + "\n",
+    );
+
+    const index = buildSemanticIndex(root);
+
+    // Each entity gets ONLY its own group's hint — no cross-group leakage.
+    expect(index).toContain("Use for: Billing default-group");
+    expect(index).toContain("Use for: Engagement analytics-group");
+    // The analytics-group hint must not also attach to the default customers
+    // entity rendered under the default (unlabeled) section, and vice versa.
+    // Render order is default first, then groups, so the default entity's block
+    // precedes the [analytics] block; assert the default block doesn't carry
+    // the analytics hint by checking the analytics hint appears only after the
+    // [analytics] label.
+    const analyticsLabelIdx = index.indexOf("[analytics]");
+    const analyticsHintIdx = index.indexOf("Use for: Engagement analytics-group");
+    const defaultHintIdx = index.indexOf("Use for: Billing default-group");
+    expect(analyticsHintIdx).toBeGreaterThan(analyticsLabelIdx);
+    expect(defaultHintIdx).toBeLessThan(analyticsLabelIdx);
   });
 
   it("handles per-source subdirectories", () => {

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -358,9 +358,12 @@ describe("buildSemanticIndex", () => {
 
     const index = buildSemanticIndex(root);
 
-    // Group metric + glossary term are discovered (were entirely skipped before).
+    // Group metric + glossary term are discovered (were entirely skipped before)
+    // AND attributed to their group on their own line (not just via the entity).
     expect(index).toContain("weekly_active_users");
     expect(index).toContain("**wau**");
+    expect(index).toMatch(/weekly_active_users.*\[analytics\]/);
+    expect(index).toMatch(/\*\*wau\*\*.*\[analytics\]/);
     // Catalog use_for hints from BOTH the flat-root catalog and the group
     // catalog merge in — each attaches to its own entity.
     expect(index).toContain("Use for: Engagement analysis"); // group catalog → sessions

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -308,6 +308,19 @@ describe("buildSemanticIndex", () => {
       join(root, "entities", "orders.yml"),
       makeEntity("orders", { dimensions: [{ name: "id", type: "integer" }] }),
     );
+    // A flat-root catalog alongside the group catalog → loadCatalog must MERGE
+    // both layouts' entities[] so each entity gets its own use_for hint.
+    writeFileSync(
+      join(root, "catalog.yml"),
+      [
+        "version: '1'",
+        "entities:",
+        "  - name: orders",
+        '    description: "Customer orders"',
+        "    use_for:",
+        '      - "Revenue analysis"',
+      ].join("\n") + "\n",
+    );
 
     writeFileSync(
       join(root, "groups", "analytics", "metrics", "sessions_metrics.yml"),
@@ -345,8 +358,10 @@ describe("buildSemanticIndex", () => {
     // Group metric + glossary term are discovered (were entirely skipped before).
     expect(index).toContain("weekly_active_users");
     expect(index).toContain("**wau**");
-    // Group catalog use_for hint attaches to the group entity.
-    expect(index).toContain("Use for: Engagement analysis");
+    // Catalog use_for hints from BOTH the flat-root catalog and the group
+    // catalog merge in — each attaches to its own entity.
+    expect(index).toContain("Use for: Engagement analysis"); // group catalog → sessions
+    expect(index).toContain("Use for: Revenue analysis"); // flat catalog → orders
     // The group entity is labeled with its group; nothing is attributed to "groups".
     expect(index).toContain("[analytics]");
     expect(index).not.toContain("[groups]");

--- a/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
@@ -41,7 +41,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 const { getWhitelistedTables, getCrossSourceJoins, _resetWhitelists } = await import("../whitelist");
-const { getEntityDirs, resolveEntityGroup } = await import("../scanner");
+const { getEntityDirs, getGroupDirs, resolveEntityGroup } = await import("../scanner");
 
 const tmpBase = resolve(__dirname, ".tmp-group-scoped-loader-test");
 let testCounter = 0;
@@ -118,6 +118,69 @@ describe("getEntityDirs — group-scoped layout (ADR-0012)", () => {
     const legacy = dirs.find((d) => d.sourceName === "sales");
     expect(legacy).toBeDefined();
     expect(legacy!.origin).toBe("legacy");
+  });
+});
+
+describe("getGroupDirs — shared layout traversal (ADR-0012 / #3240)", () => {
+  it("resolves a named subdir (metrics) across flat / groups / legacy layouts", () => {
+    const root = ensureDir(`gd-metrics-${testCounter}`);
+    ensureDir(`gd-metrics-${testCounter}/metrics`); // flat default
+    ensureDir(`gd-metrics-${testCounter}/groups/analytics/metrics`); // canonical
+    ensureDir(`gd-metrics-${testCounter}/sales/metrics`); // legacy
+
+    const { dirs } = getGroupDirs(root, "metrics");
+    const byGroup = Object.fromEntries(dirs.map((d) => [d.group, d]));
+    expect(byGroup["default"]?.origin).toBe("flat");
+    expect(byGroup["analytics"]?.origin).toBe("group");
+    expect(byGroup["sales"]?.origin).toBe("legacy");
+    // Each resolved dir is the <base>/metrics target.
+    expect(byGroup["analytics"]?.dir.endsWith(join("analytics", "metrics"))).toBe(true);
+  });
+
+  it("returns only existing target dirs for a named subdir", () => {
+    const root = ensureDir(`gd-missing-${testCounter}`);
+    ensureDir(`gd-missing-${testCounter}/groups/warehouse/entities`); // no metrics/ here
+
+    const { dirs } = getGroupDirs(root, "metrics");
+    // warehouse has entities/ but no metrics/ → not returned for subdir "metrics".
+    expect(dirs.some((d) => d.group === "warehouse")).toBe(false);
+  });
+
+  it("subdir=null returns the per-group base dir (for glossary.yml / catalog.yml)", () => {
+    const root = ensureDir(`gd-null-${testCounter}`);
+    ensureDir(`gd-null-${testCounter}/groups/analytics/entities`);
+    ensureDir(`gd-null-${testCounter}/sales/entities`);
+
+    const { dirs } = getGroupDirs(root, null);
+    const byGroup = Object.fromEntries(dirs.map((d) => [d.group, d]));
+    // Flat default base is the root itself.
+    expect(byGroup["default"]?.dir).toBe(root);
+    expect(byGroup["default"]?.origin).toBe("flat");
+    // Group base is groups/<group>, NOT groups/<group>/<subdir>.
+    expect(byGroup["analytics"]?.dir.endsWith(join("groups", "analytics"))).toBe(true);
+    expect(byGroup["analytics"]?.origin).toBe("group");
+    expect(byGroup["sales"]?.origin).toBe("legacy");
+  });
+
+  it("never attributes a directory to a source named 'groups'", () => {
+    const root = ensureDir(`gd-reserved-${testCounter}`);
+    ensureDir(`gd-reserved-${testCounter}/groups/crm/metrics`);
+
+    expect(getGroupDirs(root, "metrics").dirs.some((d) => d.group === "groups")).toBe(false);
+    expect(getGroupDirs(root, null).dirs.some((d) => d.group === "groups")).toBe(false);
+  });
+
+  it("getEntityDirs is a faithful projection of getGroupDirs(root, 'entities')", () => {
+    const root = ensureDir(`gd-parity-${testCounter}`);
+    ensureDir(`gd-parity-${testCounter}/entities`);
+    ensureDir(`gd-parity-${testCounter}/groups/warehouse/entities`);
+    ensureDir(`gd-parity-${testCounter}/sales/entities`);
+
+    const groupDirs = getGroupDirs(root, "entities").dirs;
+    const entityDirs = getEntityDirs(root).dirs;
+    expect(entityDirs.map((d) => [d.dir, d.sourceName, d.origin])).toEqual(
+      groupDirs.map((d) => [d.dir, d.group, d.origin]),
+    );
   });
 });
 

--- a/packages/api/src/lib/semantic/__tests__/lookups.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/lookups.test.ts
@@ -322,6 +322,85 @@ describe("searchGlossary — possible_mappings haystack", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Group-namespace discovery (ADR-0012 / #3240) — metrics + glossary under the
+// canonical `semantic/groups/<group>/` layout are discovered and attributed to
+// `<group>`, never to a source literally named "groups". Flat-root + legacy
+// `<source>/` layouts must keep behaving exactly as before.
+// ---------------------------------------------------------------------------
+describe("group-namespace discovery (#3240)", () => {
+  let groupRoot: string;
+
+  beforeAll(() => {
+    groupRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-lookups-groups-"));
+    // Flat default group (unchanged baseline).
+    fs.mkdirSync(path.join(groupRoot, "metrics"), { recursive: true });
+    fs.writeFileSync(
+      path.join(groupRoot, "metrics", "default_revenue.yml"),
+      ["id: default_revenue", "sql: |-", "  SELECT SUM(total) FROM orders"].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(groupRoot, "glossary.yml"),
+      ["terms:", "  revenue:", "    status: defined", "    definition: Paid invoice total."].join("\n"),
+    );
+    // A flat-root metric with a `group:` field override — reuses the entity
+    // group-resolution logic, so it attributes to the field group, not default.
+    fs.writeFileSync(
+      path.join(groupRoot, "metrics", "override_metric.yml"),
+      ["id: override_metric", "group: crm", "sql: |-", "  SELECT COUNT(*) FROM leads"].join("\n"),
+    );
+
+    // Canonical groups/<group>/ namespace.
+    fs.mkdirSync(path.join(groupRoot, "groups", "analytics", "metrics"), { recursive: true });
+    fs.writeFileSync(
+      path.join(groupRoot, "groups", "analytics", "metrics", "sessions.yml"),
+      ["id: sessions_count", "sql: |-", "  SELECT COUNT(*) FROM sessions"].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(groupRoot, "groups", "analytics", "glossary.yml"),
+      ["terms:", "  mau:", "    status: defined", "    definition: Monthly active users."].join("\n"),
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(groupRoot, { recursive: true, force: true });
+  });
+
+  it("discovers groups/<group>/metrics and attributes them to <group>", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    const sessions = metrics.find((m) => m.id === "sessions_count");
+    expect(sessions).toBeDefined();
+    expect(sessions?.source).toBe("analytics");
+  });
+
+  it("discovers groups/<group>/glossary.yml and attributes terms to <group>", () => {
+    const terms = loadGlossaryTerms({ semanticRoot: groupRoot });
+    const mau = terms.find((t) => t.term === "mau");
+    expect(mau).toBeDefined();
+    expect(mau?.source).toBe("analytics");
+  });
+
+  it("never attributes a metric or glossary term to a source named 'groups'", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    const terms = loadGlossaryTerms({ semanticRoot: groupRoot });
+    expect(metrics.some((m) => m.source === "groups")).toBe(false);
+    expect(terms.some((t) => t.source === "groups")).toBe(false);
+  });
+
+  it("keeps the flat default group attributed to 'default' (unchanged)", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    const def = metrics.find((m) => m.id === "default_revenue");
+    expect(def?.source).toBe("default");
+    const terms = loadGlossaryTerms({ semanticRoot: groupRoot });
+    expect(terms.find((t) => t.term === "revenue")?.source).toBe("default");
+  });
+
+  it("honors a flat-root metric `group:` field override (reuses resolveEntityGroup)", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    expect(metrics.find((m) => m.id === "override_metric")?.source).toBe("crm");
+  });
+});
+
 describe("listEntities — defensive coercion", () => {
   let coerceRoot: string;
 

--- a/packages/api/src/lib/semantic/__tests__/lookups.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/lookups.test.ts
@@ -356,9 +356,28 @@ describe("group-namespace discovery (#3240)", () => {
       path.join(groupRoot, "groups", "analytics", "metrics", "sessions.yml"),
       ["id: sessions_count", "sql: |-", "  SELECT COUNT(*) FROM sessions"].join("\n"),
     );
+    // Foot-gun: a canonical-namespace metric that declares a DIFFERENT group —
+    // the directory must win (never silently honored backwards), or a group
+    // file could escape its directory's whitelist partition.
+    fs.writeFileSync(
+      path.join(groupRoot, "groups", "analytics", "metrics", "sneaky.yml"),
+      ["id: sneaky_metric", "group: crm", "sql: |-", "  SELECT 1"].join("\n"),
+    );
     fs.writeFileSync(
       path.join(groupRoot, "groups", "analytics", "glossary.yml"),
       ["terms:", "  mau:", "    status: defined", "    definition: Monthly active users."].join("\n"),
+    );
+
+    // Legacy <source>/ layout — must keep its historical field-wins precedence
+    // and directory-derived source attribution (unchanged by #3240).
+    fs.mkdirSync(path.join(groupRoot, "warehouse", "metrics"), { recursive: true });
+    fs.writeFileSync(
+      path.join(groupRoot, "warehouse", "metrics", "events.yml"),
+      ["id: warehouse_events", "sql: |-", "  SELECT COUNT(*) FROM events"].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(groupRoot, "warehouse", "glossary.yml"),
+      ["terms:", "  cohort:", "    status: defined", "    definition: Signup-month group."].join("\n"),
     );
   });
 
@@ -398,6 +417,21 @@ describe("group-namespace discovery (#3240)", () => {
   it("honors a flat-root metric `group:` field override (reuses resolveEntityGroup)", () => {
     const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
     expect(metrics.find((m) => m.id === "override_metric")?.source).toBe("crm");
+  });
+
+  it("directory wins for a canonical groups/<group>/ metric that declares a different group:", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    // sneaky.yml sits in groups/analytics/ but declares group: crm → resolves to
+    // analytics (the directory), NOT crm — the security-relevant precedence.
+    expect(metrics.find((m) => m.id === "sneaky_metric")?.source).toBe("analytics");
+    expect(metrics.some((m) => m.id === "sneaky_metric" && m.source === "crm")).toBe(false);
+  });
+
+  it("keeps legacy <source>/ metric + glossary attribution unchanged", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: groupRoot });
+    expect(metrics.find((m) => m.id === "warehouse_events")?.source).toBe("warehouse");
+    const terms = loadGlossaryTerms({ semanticRoot: groupRoot });
+    expect(terms.find((t) => t.term === "cohort")?.source).toBe("warehouse");
   });
 });
 

--- a/packages/api/src/lib/semantic/lookups.ts
+++ b/packages/api/src/lib/semantic/lookups.ts
@@ -13,7 +13,15 @@ import * as path from "path";
 import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSemanticRoot, isValidEntityName } from "./files";
-import { RESERVED_DIRS, scanEntities, readEntityYaml, getEntityDirs } from "./scanner";
+import {
+  scanEntities,
+  readEntityYaml,
+  getEntityDirs,
+  getGroupDirs,
+  resolveEntityGroup,
+  readGroupField,
+  type EntityDirOrigin,
+} from "./scanner";
 
 const log = createLogger("semantic-lookups");
 
@@ -85,27 +93,12 @@ export function loadGlossaryTerms(
   const root = opts.semanticRoot ?? getSemanticRoot();
   const out: GlossaryTermLookup[] = [];
 
-  loadGlossaryFile(path.join(root, "glossary.yml"), "default", out);
-
-  if (fs.existsSync(root)) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true });
-    } catch (err) {
-      log.warn(
-        { root, err: err instanceof Error ? err.message : String(err) },
-        "Failed to scan semantic root for per-source glossaries",
-      );
-      return out;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-      loadGlossaryFile(
-        path.join(root, entry.name, "glossary.yml"),
-        entry.name,
-        out,
-      );
-    }
+  // Layout-aware traversal (ADR-0012): the flat default root, the canonical
+  // groups/<group>/ namespace, and legacy <source>/ all surface their
+  // glossary.yml through the shared scanner — never the reserved `groups/` dir
+  // itself.
+  for (const { dir, group, origin } of getGroupDirs(root, null).dirs) {
+    loadGlossaryFile(path.join(dir, "glossary.yml"), group, origin, out);
   }
 
   return out;
@@ -134,7 +127,8 @@ export function searchGlossary(
 
 function loadGlossaryFile(
   filePath: string,
-  source: string,
+  dirGroup: string,
+  origin: EntityDirOrigin,
   out: GlossaryTermLookup[],
 ): void {
   if (!fs.existsSync(filePath)) return;
@@ -152,6 +146,10 @@ function loadGlossaryFile(
   }
 
   if (!raw || typeof raw !== "object") return;
+  // Resolve the effective group: the directory is canonical for groups/<group>/;
+  // a top-level group:/connection: field can override on the flat/legacy layouts
+  // (ADR-0012, same precedence the entity loader uses).
+  const source = resolveEntityGroup(dirGroup, origin, readGroupField(raw as Record<string, unknown>)).group;
   const terms = (raw as { terms?: unknown }).terms;
   if (!terms) return;
 
@@ -224,34 +222,19 @@ export interface MetricDefinition {
   readonly binding: MetricBinding | null;
 }
 
-/** Load every metric defined under `metrics/` (default + per-source). */
+/**
+ * Load every metric defined under `metrics/` across all three layouts:
+ * the flat default root, the canonical `groups/<group>/metrics/` namespace,
+ * and legacy `<source>/metrics/` (ADR-0012, via the shared scanner).
+ */
 export function loadMetricDefinitions(
   opts: { semanticRoot?: string } = {},
 ): MetricDefinition[] {
   const root = opts.semanticRoot ?? getSemanticRoot();
   const out: MetricDefinition[] = [];
 
-  loadMetricsFromDir(path.join(root, "metrics"), "default", out);
-
-  if (fs.existsSync(root)) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true });
-    } catch (err) {
-      log.warn(
-        { root, err: err instanceof Error ? err.message : String(err) },
-        "Failed to scan semantic root for per-source metric directories",
-      );
-      return out;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-      loadMetricsFromDir(
-        path.join(root, entry.name, "metrics"),
-        entry.name,
-        out,
-      );
-    }
+  for (const { dir, group, origin } of getGroupDirs(root, "metrics").dirs) {
+    loadMetricsFromDir(dir, group, origin, out);
   }
 
   return out;
@@ -268,7 +251,8 @@ export function findMetricById(
 
 function loadMetricsFromDir(
   dir: string,
-  source: string,
+  dirGroup: string,
+  origin: EntityDirOrigin,
   out: MetricDefinition[],
 ): void {
   if (!fs.existsSync(dir)) return;
@@ -299,6 +283,10 @@ function loadMetricsFromDir(
 
     if (!raw || typeof raw !== "object") continue;
     const r = raw as Record<string, unknown>;
+
+    // Directory is canonical for groups/<group>/; a file-level group:/connection:
+    // can override on the flat/legacy layouts (ADR-0012).
+    const source = resolveEntityGroup(dirGroup, origin, readGroupField(r)).group;
 
     if (Array.isArray(r.metrics)) {
       for (const m of r.metrics) {

--- a/packages/api/src/lib/semantic/lookups.ts
+++ b/packages/api/src/lib/semantic/lookups.ts
@@ -81,7 +81,9 @@ export interface GlossaryTermLookup {
 }
 
 /**
- * Load all glossary terms from `glossary.yml` and per-source glossaries.
+ * Load every glossary term across all three layouts: the flat default root, the
+ * canonical `groups/<group>/glossary.yml` namespace, and legacy
+ * `<source>/glossary.yml` (ADR-0012, via the shared scanner).
  *
  * Supports both glossary YAML shapes:
  * - Object form: `terms: { name: { status, definition, ... } }` (current)

--- a/packages/api/src/lib/semantic/scanner.ts
+++ b/packages/api/src/lib/semantic/scanner.ts
@@ -119,9 +119,12 @@ export interface GroupDirResult {
 }
 
 /**
- * The single, layout-aware traversal of a semantic root — the SINGLE SOURCE OF
- * TRUTH so entity/metric/glossary/catalog discovery can never drift on the
- * layout again (ADR-0012, #3240).
+ * The shared, layout-aware traversal of a semantic root — the single source of
+ * truth for the discovery read paths it backs (the SQL whitelist via
+ * {@link getEntityDirs}, the lookup helpers, admin discovery, and the boot-time
+ * search index), so they can't drift on the layout (ADR-0012, #3240). Read
+ * paths that don't route through here (e.g. the expert/`improve` context
+ * loader) are deliberately root-only.
  *
  * Resolves, in precedence order, the per-group directory for a given `subdir`
  * across all three layouts:
@@ -132,8 +135,9 @@ export interface GroupDirResult {
  * `subdir` is the per-group subdirectory to resolve (e.g. `"entities"`,
  * `"metrics"`); pass `null` for artifacts that live directly in the per-group
  * root (`glossary.yml`, `catalog.yml`), which returns the per-group base dir
- * itself. Only directories that exist are returned — for `subdir === null` the
- * per-group bases always exist, so the caller checks for the specific file.
+ * itself. Only existing directories are returned — the per-group bases returned
+ * for `subdir === null` are known to exist, so the caller only needs to check
+ * for the specific file (`glossary.yml` / `catalog.yml`).
  *
  * The `groups/` namespace dir is never itself treated as a legacy `<source>/`
  * (it is in {@link RESERVED_DIRS}), so no artifact is ever attributed to a

--- a/packages/api/src/lib/semantic/scanner.ts
+++ b/packages/api/src/lib/semantic/scanner.ts
@@ -95,34 +95,75 @@ export interface EntityDirResult {
 }
 
 /**
- * Discover entity directories under a semantic root.
- *
- * Returns, in precedence order:
- *   1. the default `entities/` dir (flat default group), if it exists;
- *   2. the canonical `groups/<group>/entities/` dirs (ADR-0012);
- *   3. the legacy `<source>/entities/` dirs (back-compat).
- *
- * Also reports whether the root scan failed so callers can escalate severity.
+ * A per-group directory resolved by {@link getGroupDirs}, layout-aware across
+ * all three on-disk layouts (ADR-0012).
  */
-export function getEntityDirs(root: string): EntityDirResult {
-  const dirs: EntityDir[] = [];
+export interface GroupDir {
+  /**
+   * Absolute path to the resolved directory: `<base>/<subdir>` when a `subdir`
+   * was requested, or the per-group base itself when `subdir` is `null` (for
+   * artifacts that live directly in the group root — `glossary.yml`,
+   * `catalog.yml`).
+   */
+  dir: string;
+  /** Group name resolved from the directory: `"default"` for the flat root, the directory name otherwise. */
+  group: string;
+  /** On-disk layout this directory belongs to — drives group precedence. */
+  origin: EntityDirOrigin;
+}
+
+export interface GroupDirResult {
+  dirs: GroupDir[];
+  /** Same fail-closed semantics as {@link EntityDirResult.failedScans}. */
+  failedScans: ScanNamespace[];
+}
+
+/**
+ * The single, layout-aware traversal of a semantic root — the SINGLE SOURCE OF
+ * TRUTH so entity/metric/glossary/catalog discovery can never drift on the
+ * layout again (ADR-0012, #3240).
+ *
+ * Resolves, in precedence order, the per-group directory for a given `subdir`
+ * across all three layouts:
+ *   1. flat default root → group `"default"` (origin `"flat"`);
+ *   2. canonical `groups/<group>/…` → group `"<group>"` (origin `"group"`);
+ *   3. legacy `<source>/…` → group `"<source>"` (origin `"legacy"`).
+ *
+ * `subdir` is the per-group subdirectory to resolve (e.g. `"entities"`,
+ * `"metrics"`); pass `null` for artifacts that live directly in the per-group
+ * root (`glossary.yml`, `catalog.yml`), which returns the per-group base dir
+ * itself. Only directories that exist are returned — for `subdir === null` the
+ * per-group bases always exist, so the caller checks for the specific file.
+ *
+ * The `groups/` namespace dir is never itself treated as a legacy `<source>/`
+ * (it is in {@link RESERVED_DIRS}), so no artifact is ever attributed to a
+ * source literally named "groups". Also reports whether either scan failed so
+ * callers can escalate severity and fail closed (#3243).
+ */
+export function getGroupDirs(root: string, subdir: string | null): GroupDirResult {
+  const dirs: GroupDir[] = [];
   const failedScans: ScanNamespace[] = [];
 
-  const defaultDir = path.join(root, "entities");
+  // Resolve a per-group base to its target dir: the requested subdir under the
+  // base, or the base itself when the artifact lives directly in the group root.
+  const resolve = (base: string): string => (subdir === null ? base : path.join(base, subdir));
+
+  // 1. Flat default root.
+  const defaultDir = resolve(root);
   if (fs.existsSync(defaultDir)) {
-    dirs.push({ dir: defaultDir, sourceName: "default", origin: "flat" });
+    dirs.push({ dir: defaultDir, group: "default", origin: "flat" });
   }
 
-  // Canonical per-group namespace: semantic/groups/<group>/entities/ (ADR-0012).
+  // 2. Canonical per-group namespace: semantic/groups/<group>/… (ADR-0012).
   const groupsRoot = path.join(root, GROUPS_DIR);
   if (fs.existsSync(groupsRoot)) {
     try {
       const groupEntries = fs.readdirSync(groupsRoot, { withFileTypes: true });
       for (const entry of groupEntries) {
         if (!entry.isDirectory()) continue;
-        const subDir = path.join(groupsRoot, entry.name, "entities");
-        if (fs.existsSync(subDir)) {
-          dirs.push({ dir: subDir, sourceName: entry.name, origin: "group" });
+        const target = resolve(path.join(groupsRoot, entry.name));
+        if (fs.existsSync(target)) {
+          dirs.push({ dir: target, group: entry.name, origin: "group" });
         }
       }
     } catch (err) {
@@ -131,33 +172,53 @@ export function getEntityDirs(root: string): EntityDirResult {
       // namespace so the partition decision downstream fails closed (#3243).
       failedScans.push("groups");
       log.warn(
-        { root: groupsRoot, err: err instanceof Error ? err.message : String(err) },
+        { root: groupsRoot, subdir, err: err instanceof Error ? err.message : String(err) },
         "Failed to scan semantic groups/ namespace — affected groups fail closed",
       );
     }
   }
 
-  // Legacy per-source layout: semantic/<source>/entities/ (pre-ADR-0012).
+  // 3. Legacy per-source layout: semantic/<source>/… (pre-ADR-0012).
   if (fs.existsSync(root)) {
     try {
       const entries = fs.readdirSync(root, { withFileTypes: true });
       for (const entry of entries) {
         if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-        const subDir = path.join(root, entry.name, "entities");
-        if (fs.existsSync(subDir)) {
-          dirs.push({ dir: subDir, sourceName: entry.name, origin: "legacy" });
+        const target = resolve(path.join(root, entry.name));
+        if (fs.existsSync(target)) {
+          dirs.push({ dir: target, group: entry.name, origin: "legacy" });
         }
       }
     } catch (err) {
       failedScans.push("legacy");
       log.warn(
-        { root, err: err instanceof Error ? err.message : String(err) },
+        { root, subdir, err: err instanceof Error ? err.message : String(err) },
         "Failed to scan semantic root for per-source directories — affected sources fail closed",
       );
     }
   }
 
   return { dirs, failedScans };
+}
+
+/**
+ * Discover entity directories under a semantic root.
+ *
+ * Returns, in precedence order:
+ *   1. the default `entities/` dir (flat default group), if it exists;
+ *   2. the canonical `groups/<group>/entities/` dirs (ADR-0012);
+ *   3. the legacy `<source>/entities/` dirs (back-compat).
+ *
+ * Thin projection over {@link getGroupDirs} (the shared traversal) into the
+ * entity-specific shape — `group` is surfaced as `sourceName`. Also reports
+ * whether either scan failed so callers can escalate severity.
+ */
+export function getEntityDirs(root: string): EntityDirResult {
+  const { dirs, failedScans } = getGroupDirs(root, "entities");
+  return {
+    dirs: dirs.map(({ dir, group, origin }) => ({ dir, sourceName: group, origin })),
+    failedScans,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -72,6 +72,8 @@ interface ParsedEntity {
 }
 
 interface ParsedMetric {
+  /** Canonical metric key (current shape). Older files used `name`. */
+  id?: string;
   name?: string;
   description?: string;
   sql?: string;
@@ -93,6 +95,13 @@ interface CatalogEntry {
   description?: string;
   use_for?: string[];
   common_questions?: string[];
+  /**
+   * Resolved Connection group of the catalog this entry came from (`"default"`
+   * for the flat root). Stamped by {@link loadCatalog} so a merged multi-group
+   * catalog applies each entry's hints only to its own group's entity, never
+   * across groups (ADR-0012, #3240).
+   */
+  group?: string;
 }
 
 interface ParsedCatalog {
@@ -280,9 +289,15 @@ function formatEntity(
     lines.push(`Grain: ${entity.grain}`);
   }
 
-  // Catalog use_for hints
+  // Catalog use_for hints — match on entity name/table AND the resolved group,
+  // so a merged multi-group catalog never leaks one group's hints onto another
+  // group's same-named entity (#3240). `entity.connection` is the entity's
+  // resolved group (undefined for the default group).
+  const entityGroup = entity.connection ?? "default";
   const catalogEntry = catalog?.entities?.find(
-    (e) => e.name === entity.name || e.name === entity.table,
+    (e) =>
+      (e.name === entity.name || e.name === entity.table) &&
+      (e.group ?? "default") === entityGroup,
   );
   if (catalogEntry?.use_for && catalogEntry.use_for.length > 0) {
     lines.push(`Use for: ${catalogEntry.use_for.join("; ")}`);
@@ -370,7 +385,7 @@ function formatEntity(
 }
 
 function formatMetric(metric: ParsedMetric): string {
-  const name = metric.name ?? "unnamed";
+  const name = metric.name ?? metric.id ?? "unnamed";
   const desc = metric.description ? ` — ${metric.description}` : "";
   const entity = metric.entity ? ` (${metric.entity})` : "";
   return `- **${name}**${entity}${desc}`;
@@ -444,12 +459,13 @@ function loadMetricsFromDir(dir: string, out: ParsedMetric[]): void {
       const raw = yaml.load(content) as Record<string, unknown> | null;
       if (!raw || typeof raw !== "object") continue;
 
-      // Metric files may contain a top-level array of metrics or a single metric
+      // Metric files may contain a top-level array of metrics or a single
+      // metric, keyed by the canonical `id:` (current shape) or legacy `name:`.
       if (Array.isArray(raw.metrics)) {
         for (const m of raw.metrics as ParsedMetric[]) {
           if (m && typeof m === "object") out.push(m);
         }
-      } else if (raw.name) {
+      } else if (raw.name || raw.id) {
         out.push(raw as ParsedMetric);
       }
     } catch (err) {
@@ -478,9 +494,16 @@ function loadGlossaryFile(filePath: string, out: GlossaryTerm[]): void {
     const raw = yaml.load(content) as Record<string, unknown> | null;
     if (!raw || typeof raw !== "object") return;
 
+    // Supports both shapes: array form `terms: [{ term, ... }]` (legacy) and
+    // object form `terms: { name: { ... } }` (current) — the latter is the
+    // common case for grouped glossaries, so the index must handle it too.
     if (Array.isArray(raw.terms)) {
       for (const t of raw.terms as GlossaryTerm[]) {
         if (t && typeof t === "object") out.push(t);
+      }
+    } else if (raw.terms && typeof raw.terms === "object") {
+      for (const [term, value] of Object.entries(raw.terms as Record<string, unknown>)) {
+        if (value && typeof value === "object") out.push({ term, ...(value as GlossaryTerm) });
       }
     }
   } catch (err) {
@@ -499,16 +522,24 @@ function loadCatalog(semanticRoot: string): ParsedCatalog | null {
   let version: string | undefined;
   let found = false;
 
-  for (const { dir } of getGroupDirs(semanticRoot, null).dirs) {
+  for (const { dir, group, origin } of getGroupDirs(semanticRoot, null).dirs) {
     const catalogPath = path.join(dir, "catalog.yml");
     if (!fs.existsSync(catalogPath)) continue;
     try {
       const content = fs.readFileSync(catalogPath, "utf-8");
-      const parsed = yaml.load(content) as ParsedCatalog | null;
+      const parsed = yaml.load(content);
       if (!parsed || typeof parsed !== "object") continue;
+      const rec = parsed as Record<string, unknown>;
       found = true;
-      if (version === undefined && typeof parsed.version === "string") version = parsed.version;
-      if (Array.isArray(parsed.entities)) merged.push(...parsed.entities);
+      if (version === undefined && typeof rec.version === "string") version = rec.version;
+      if (!Array.isArray(rec.entities)) continue;
+      // Stamp each entry with the catalog's resolved group so formatEntity can
+      // scope hints to the matching group (directory canonical; a file-level
+      // group:/connection: can override on flat/legacy layouts, ADR-0012).
+      const catalogGroup = resolveEntityGroup(group, origin, readGroupField(rec)).group;
+      for (const entry of rec.entities as CatalogEntry[]) {
+        merged.push({ ...entry, group: catalogGroup });
+      }
     } catch (err) {
       log.warn({ catalogPath, err: err instanceof Error ? err.message : String(err) }, "Failed to load catalog for semantic index");
     }

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -492,7 +492,9 @@ function loadCatalog(semanticRoot: string): ParsedCatalog | null {
   // Merge catalog.yml across the flat default root, the canonical
   // groups/<group>/ namespace, and legacy <source>/ (ADR-0012) so per-group
   // `use_for` hints reach the index. The index keys catalog entries by entity
-  // name, so concatenating their `entities[]` is the natural merge.
+  // name, so concatenating their `entities[]` is the natural merge. On a
+  // name collision across groups the lookup is first-wins (acceptable — entity
+  // names don't collide across groups in practice).
   const merged: CatalogEntry[] = [];
   let version: string | undefined;
   let found = false;

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -15,7 +15,7 @@ import * as path from "path";
 import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSemanticRoot as getDefaultSemanticRoot } from "./files";
-import { RESERVED_DIRS, scanEntities, resolveEntityGroup, readGroupField } from "./scanner";
+import { scanEntities, resolveEntityGroup, readGroupField, getGroupDirs } from "./scanner";
 
 const log = createLogger("semantic-index");
 
@@ -417,25 +417,11 @@ function loadEntities(semanticRoot: string): ParsedEntity[] {
 function loadMetrics(semanticRoot: string): ParsedMetric[] {
   const metrics: ParsedMetric[] = [];
 
-  // Default metrics
-  loadMetricsFromDir(path.join(semanticRoot, "metrics"), metrics);
-
-  // Per-source subdirectories
-  if (fs.existsSync(semanticRoot)) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(semanticRoot, { withFileTypes: true });
-    } catch (err) {
-      log.warn({ semanticRoot, err: err instanceof Error ? err.message : String(err) }, "Failed to scan semantic root for per-source metric directories");
-      return metrics;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-      const subMetrics = path.join(semanticRoot, entry.name, "metrics");
-      if (fs.existsSync(subMetrics)) {
-        loadMetricsFromDir(subMetrics, metrics);
-      }
-    }
+  // Layout-aware traversal (ADR-0012): flat default `metrics/`, the canonical
+  // `groups/<group>/metrics/` namespace, and legacy `<source>/metrics/` all
+  // feed the index through the shared scanner.
+  for (const { dir } of getGroupDirs(semanticRoot, "metrics").dirs) {
+    loadMetricsFromDir(dir, metrics);
   }
 
   return metrics;
@@ -475,25 +461,10 @@ function loadMetricsFromDir(dir: string, out: ParsedMetric[]): void {
 function loadGlossary(semanticRoot: string): GlossaryTerm[] {
   const terms: GlossaryTerm[] = [];
 
-  // Try root glossary
-  loadGlossaryFile(path.join(semanticRoot, "glossary.yml"), terms);
-
-  // Per-source glossaries
-  if (fs.existsSync(semanticRoot)) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(semanticRoot, { withFileTypes: true });
-    } catch (err) {
-      log.warn({ semanticRoot, err: err instanceof Error ? err.message : String(err) }, "Failed to scan semantic root for per-source glossary files");
-      return terms;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
-      loadGlossaryFile(
-        path.join(semanticRoot, entry.name, "glossary.yml"),
-        terms,
-      );
-    }
+  // Flat default root, the canonical groups/<group>/ namespace, and legacy
+  // <source>/ all surface glossary.yml through the shared scanner (ADR-0012).
+  for (const { dir } of getGroupDirs(semanticRoot, null).dirs) {
+    loadGlossaryFile(path.join(dir, "glossary.yml"), terms);
   }
 
   return terms;
@@ -518,14 +489,29 @@ function loadGlossaryFile(filePath: string, out: GlossaryTerm[]): void {
 }
 
 function loadCatalog(semanticRoot: string): ParsedCatalog | null {
-  const catalogPath = path.join(semanticRoot, "catalog.yml");
-  if (!fs.existsSync(catalogPath)) return null;
+  // Merge catalog.yml across the flat default root, the canonical
+  // groups/<group>/ namespace, and legacy <source>/ (ADR-0012) so per-group
+  // `use_for` hints reach the index. The index keys catalog entries by entity
+  // name, so concatenating their `entities[]` is the natural merge.
+  const merged: CatalogEntry[] = [];
+  let version: string | undefined;
+  let found = false;
 
-  try {
-    const content = fs.readFileSync(catalogPath, "utf-8");
-    return yaml.load(content) as ParsedCatalog | null;
-  } catch (err) {
-    log.warn({ catalogPath, err: err instanceof Error ? err.message : String(err) }, "Failed to load catalog for semantic index");
-    return null;
+  for (const { dir } of getGroupDirs(semanticRoot, null).dirs) {
+    const catalogPath = path.join(dir, "catalog.yml");
+    if (!fs.existsSync(catalogPath)) continue;
+    try {
+      const content = fs.readFileSync(catalogPath, "utf-8");
+      const parsed = yaml.load(content) as ParsedCatalog | null;
+      if (!parsed || typeof parsed !== "object") continue;
+      found = true;
+      if (version === undefined && typeof parsed.version === "string") version = parsed.version;
+      if (Array.isArray(parsed.entities)) merged.push(...parsed.entities);
+    } catch (err) {
+      log.warn({ catalogPath, err: err instanceof Error ? err.message : String(err) }, "Failed to load catalog for semantic index");
+    }
   }
+
+  if (!found) return null;
+  return { version, entities: merged };
 }

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -81,6 +81,13 @@ interface ParsedMetric {
   entity?: string;
   aggregation?: string;
   unit?: string;
+  /**
+   * Display group for the prompt index — set ONLY for the canonical
+   * `groups/<group>/` namespace so the agent can tell same-id metrics from
+   * different groups apart. Flat default + legacy `<source>/` stay unlabeled
+   * (exactly as before, ADR-0012/#3240).
+   */
+  group?: string;
 }
 
 interface GlossaryTerm {
@@ -88,6 +95,8 @@ interface GlossaryTerm {
   definition?: string;
   status?: string;
   disambiguation?: string;
+  /** Display group — set only for the canonical `groups/<group>/` namespace (see {@link ParsedMetric.group}). */
+  group?: string;
 }
 
 interface CatalogEntry {
@@ -388,7 +397,8 @@ function formatMetric(metric: ParsedMetric): string {
   const name = metric.name ?? metric.id ?? "unnamed";
   const desc = metric.description ? ` — ${metric.description}` : "";
   const entity = metric.entity ? ` (${metric.entity})` : "";
-  return `- **${name}**${entity}${desc}`;
+  const group = metric.group ? ` [${metric.group}]` : "";
+  return `- **${name}**${entity}${desc}${group}`;
 }
 
 function formatGlossaryTerm(term: GlossaryTerm): string {
@@ -398,7 +408,8 @@ function formatGlossaryTerm(term: GlossaryTerm): string {
   const disambig = term.disambiguation
     ? ` → ${term.disambiguation}`
     : "";
-  return `- **${name}**${status}${def}${disambig}`;
+  const group = term.group ? ` [${term.group}]` : "";
+  return `- **${name}**${status}${def}${disambig}${group}`;
 }
 
 // --- Loaders ---
@@ -434,15 +445,16 @@ function loadMetrics(semanticRoot: string): ParsedMetric[] {
 
   // Layout-aware traversal (ADR-0012): flat default `metrics/`, the canonical
   // `groups/<group>/metrics/` namespace, and legacy `<source>/metrics/` all
-  // feed the index through the shared scanner.
-  for (const { dir } of getGroupDirs(semanticRoot, "metrics").dirs) {
-    loadMetricsFromDir(dir, metrics);
+  // feed the index through the shared scanner. Only canonical groups/ metrics
+  // carry a display group label; flat + legacy stay unlabeled (as before).
+  for (const { dir, group, origin } of getGroupDirs(semanticRoot, "metrics").dirs) {
+    loadMetricsFromDir(dir, origin === "group" ? group : undefined, metrics);
   }
 
   return metrics;
 }
 
-function loadMetricsFromDir(dir: string, out: ParsedMetric[]): void {
+function loadMetricsFromDir(dir: string, displayGroup: string | undefined, out: ParsedMetric[]): void {
   if (!fs.existsSync(dir)) return;
 
   let files: string[];
@@ -463,10 +475,10 @@ function loadMetricsFromDir(dir: string, out: ParsedMetric[]): void {
       // metric, keyed by the canonical `id:` (current shape) or legacy `name:`.
       if (Array.isArray(raw.metrics)) {
         for (const m of raw.metrics as ParsedMetric[]) {
-          if (m && typeof m === "object") out.push(m);
+          if (m && typeof m === "object") out.push({ ...m, group: displayGroup });
         }
       } else if (raw.name || raw.id) {
-        out.push(raw as ParsedMetric);
+        out.push({ ...(raw as ParsedMetric), group: displayGroup });
       }
     } catch (err) {
       log.warn({ file, dir, err: err instanceof Error ? err.message : String(err) }, "Skipping metric file in semantic index — failed to read or parse");
@@ -479,14 +491,16 @@ function loadGlossary(semanticRoot: string): GlossaryTerm[] {
 
   // Flat default root, the canonical groups/<group>/ namespace, and legacy
   // <source>/ all surface glossary.yml through the shared scanner (ADR-0012).
-  for (const { dir } of getGroupDirs(semanticRoot, null).dirs) {
-    loadGlossaryFile(path.join(dir, "glossary.yml"), terms);
+  // Only canonical groups/ terms carry a display group label; flat + legacy
+  // stay unlabeled (as before).
+  for (const { dir, group, origin } of getGroupDirs(semanticRoot, null).dirs) {
+    loadGlossaryFile(path.join(dir, "glossary.yml"), origin === "group" ? group : undefined, terms);
   }
 
   return terms;
 }
 
-function loadGlossaryFile(filePath: string, out: GlossaryTerm[]): void {
+function loadGlossaryFile(filePath: string, displayGroup: string | undefined, out: GlossaryTerm[]): void {
   if (!fs.existsSync(filePath)) return;
 
   try {
@@ -499,11 +513,11 @@ function loadGlossaryFile(filePath: string, out: GlossaryTerm[]): void {
     // common case for grouped glossaries, so the index must handle it too.
     if (Array.isArray(raw.terms)) {
       for (const t of raw.terms as GlossaryTerm[]) {
-        if (t && typeof t === "object") out.push(t);
+        if (t && typeof t === "object") out.push({ ...t, group: displayGroup });
       }
     } else if (raw.terms && typeof raw.terms === "object") {
       for (const [term, value] of Object.entries(raw.terms as Record<string, unknown>)) {
-        if (value && typeof value === "object") out.push({ term, ...(value as GlossaryTerm) });
+        if (value && typeof value === "object") out.push({ term, ...(value as GlossaryTerm), group: displayGroup });
       }
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

Teaches the **metrics, glossary, and catalog read/discovery paths** about the canonical `semantic/groups/<group>/` namespace (ADR-0012), matching what the entity loader already does after #3232. Before this, a non-default Connection group's `metrics/`, `glossary.yml`, and `catalog.yml` were **silently invisible** — the admin helpers used a private reserved-dir set without `groups` and descended only one level, while the lookup/search loaders imported the shared `RESERVED_DIRS` (which now contains `groups`) and skipped the whole `groups/` dir.

- **`scanner.ts`** — adds `getGroupDirs(root, subdir)` as the **single, layout-aware traversal** across all three layouts (flat default root → `default`, canonical `groups/<group>/…` → `<group>`, legacy `<source>/…` → `<source>`). `getEntityDirs` is now a thin projection over it, so entity/metric/glossary/catalog discovery share one implementation and can't drift on the layout again. `subdir` resolves a per-group subdir (`entities`, `metrics`); `null` returns the per-group root (for `glossary.yml` / `catalog.yml`).
- **`admin.ts`** — `discoverMetrics` + `loadGlossary` drop their private `RESERVED_DIRS` sets and consume the shared traversal, attributing each artifact via `resolveEntityGroup`.
- **`lookups.ts`** — `loadMetricDefinitions` + `loadGlossaryTerms` descend into `groups/<group>/` and attribute to `<group>`.
- **`search.ts`** — `loadMetrics` / `loadGlossary` / `loadCatalog` descend into `groups/<group>/`; group catalog `use_for` hints now reach the agent's semantic index.

No artifact is ever attributed to a source literally named **"groups"**; flat default-root and legacy `<source>/` layouts behave exactly as before.

### Scope notes
- **Read/discovery only.** Generation (#3234), drift/DB-import (#3245, parallel session — disjoint files), and the whitelist fail-closed behavior (#3243, already shipped) are out of scope.
- The **admin catalog endpoint stays the global root view** — catalog is unscoped in the admin/DB model (`serveRawYaml` forces catalog group to `null`; the web `CatalogViewer` consumes a single object). Per-group catalog discovery surfaces where it's agent-meaningful: the semantic index's `use_for` hints. Changing the admin catalog response shape would break the frontend and is out of scope.

## Test plan
- [x] `getGroupDirs` unit tests — metrics/null-subdir across flat/groups/legacy, never attributes to "groups", `getEntityDirs` parity (`group-scoped-loader.test.ts`)
- [x] `lookups` — `groups/<group>/metrics` + `glossary.yml` attributed to `<group>`, flat `default` unchanged, flat-root `group:` field override (`lookups.test.ts`)
- [x] search index — `groups/<group>/` metrics + glossary + catalog `use_for` discovered, labeled `[analytics]`, never `[groups]` (`semantic-index.test.ts`)
- [x] admin routes — `/semantic/metrics` + `/semantic/glossary` discover `groups/<group>/` with `source = <group>` (`admin.test.ts`)
- [x] `/ci` — lint, type, full test, syncpack, template/security-headers/schema/oauth-helper drift, railway-watch, test-discipline, twenty-resolver, published-symbols — all pass
- [x] Existing #3232 entity tests still green (getEntityDirs parity preserved)

Closes #3240

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352965&installation_id=135337507&pr_number=3258&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3258&signature=dd2d215e211472ef8d098d87bb22befd2e1bf44c2bdb827f7f1fbc1bff7b11d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-aware discovery for metrics, glossary, and catalogs: resources under groups/<group>/... are attributed to that group; multiple catalog files are merged; directory attribution overrides per-file group hints. Metric/glossary loaders accept legacy/current shapes; metric formatting prefers name then id and displays group labels.

* **Documentation**
  * Design doc clarifies group-layout behavior and that the reserved "groups" container is not treated as a data source.

* **Tests**
  * Added integration and unit tests for group-scoped discovery, indexing, and traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->