### PR TITLE
fix(api): traverse semantic/groups/<group>/ in drift snapshots & DB import (#3245)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -833,6 +833,10 @@ describe("importFromDisk — group namespace traversal (#3245)", () => {
     expect(result.imported).toBe(1);
     // The surviving row is the canonical one, not the stale legacy YAML.
     expect(orders[0].yamlContent).toContain("orders_canonical");
+    // The dropped legacy duplicate is still counted, so the summary is truthful
+    // about how many files were scanned (2), not silently undercounted (1).
+    expect(result.skipped).toBe(1);
+    expect(result.total).toBe(2);
   });
 
   it("reports a per-file error for a grouped entity missing the table field", async () => {

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -16,7 +16,7 @@
  * Uses mock.module() to mock the DB layer.
  */
 
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -33,6 +33,7 @@ const mockBulkUpsertEntities = mock((_orgId: string, entities: unknown[]): Promi
 );
 const mockHasInternalDB = mock((): boolean => true);
 const mockInternalQuery = mock((): Promise<Array<{ org_id: string }>> => Promise.resolve([]));
+const mockCountEntities = mock((_orgId: string): Promise<number> => Promise.resolve(0));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntityRows: mockListEntities,
@@ -41,7 +42,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   getEntity: mock(() => Promise.resolve(null)),
   upsertEntity: mock(() => Promise.resolve()),
   deleteEntity: mock(() => Promise.resolve(false)),
-  countEntities: mock(() => Promise.resolve(0)),
+  countEntities: mockCountEntities,
   bulkUpsertEntities: mockBulkUpsertEntities,
 }));
 
@@ -532,6 +533,42 @@ describe("reconcileAllOrgs", () => {
     const sales = ents.find((e) => e.name === "sales");
     expect(sales).toBeDefined();
     expect(sales!.connectionGroupId).toBe("prod");
+  });
+
+  it("first-boot: a namespace scan failure fails closed — does not silently skip the org (#3243/#3245)", async () => {
+    // getEntityDirs records a failed groups/ scan in `failedScans` and returns
+    // a dir list that is silently short. The auto-import detection must NOT
+    // treat that as "org is empty" and `continue` — it must fail closed and
+    // still consult the DB / attempt the import. Verified by asserting
+    // countEntities was consulted for the org (the buggy fail-open path
+    // `continue`s before reaching it).
+    const orgId = testOrgId();
+    const root = getSemanticRoot(orgId);
+    // groups/ exists (so getEntityDirs attempts to enumerate it) but its scan
+    // throws; no flat entities/ dir → without the fail-closed guard the org
+    // looks empty.
+    fs.mkdirSync(path.join(root, "groups"), { recursive: true });
+
+    const groupsPath = path.join(root, "groups");
+    const realReaddirSync = fs.readdirSync.bind(fs) as (p: fs.PathLike, o?: unknown) => unknown;
+    const spy = spyOn(fs, "readdirSync").mockImplementation(((p: fs.PathLike, options?: unknown) => {
+      if (typeof p === "string" && p === groupsPath) {
+        throw Object.assign(new Error("EACCES: simulated scan failure"), { code: "EACCES" });
+      }
+      return realReaddirSync(p, options);
+    }) as unknown as typeof fs.readdirSync);
+
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockImplementationOnce(() => Promise.resolve([])); // no DB orgs → auto-import branch
+    mockCountEntities.mockClear();
+
+    try {
+      await reconcileAllOrgs();
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(mockCountEntities.mock.calls.some((c) => c[0] === orgId)).toBe(true);
   });
 
   it("end-to-end: rename apikey → ApiKey in DB, then reconcile + list shows only ApiKey", async () => {

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -110,7 +110,7 @@ function makeEntityRow(
   name: string,
   entityType: string,
   yamlContent: string,
-  connectionId?: string,
+  connectionGroupId?: string | null,
 ): SemanticEntityRow {
   return {
     id: `id-${name}`,
@@ -118,7 +118,7 @@ function makeEntityRow(
     entity_type: entityType as SemanticEntityRow["entity_type"],
     name,
     yaml_content: yamlContent,
-    connection_id: connectionId ?? null,
+    connection_group_id: connectionGroupId ?? null,
     status: "published" as const,
     created_at: "2026-01-01",
     updated_at: "2026-01-01",
@@ -717,7 +717,7 @@ describe("importFromDisk — group namespace traversal (#3245)", () => {
   const entityYaml = (table: string, extra = "") => `${extra}table: ${table}\n`;
 
   /** Entities handed to bulkUpsertEntities during the most recent import. */
-  type Collected = { entityType: string; name: string; connectionId?: string; connectionGroupId?: string | null };
+  type Collected = { entityType: string; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null };
   function lastUpsertedEntities(): Collected[] {
     const calls = mockBulkUpsertEntities.mock.calls;
     expect(calls.length).toBeGreaterThan(0);
@@ -814,6 +814,25 @@ describe("importFromDisk — group namespace traversal (#3245)", () => {
     expect(flat!.connectionGroupId).toBeUndefined();
     expect(grouped!.connectionGroupId).toBe("prod");
     expect(grouped!.connectionId).toBeUndefined();
+  });
+
+  it("lets the canonical groups/ entity win over a same-group legacy duplicate (Codex review)", async () => {
+    // Mid-migration overlap: both canonical groups/prod/ and legacy prod/ hold
+    // an `orders` entity for group "prod". getEntityDirs orders canonical first,
+    // so only the canonical one is imported — the legacy duplicate must not
+    // upsert last into the shared (org, type, name, group) row and clobber it.
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("orders_canonical"), "orders.yml", "groups", "prod");
+    writeEntityFile(root, entityYaml("orders_legacy"), "orders.yml", "prod");
+
+    const result = await importFromDisk("org-1", { sourceDir: root });
+
+    const upserted = lastUpsertedEntities();
+    const orders = upserted.filter((e) => e.name === "orders" && e.connectionGroupId === "prod");
+    expect(orders).toHaveLength(1); // de-duped, not two rows
+    expect(result.imported).toBe(1);
+    // The surviving row is the canonical one, not the stale legacy YAML.
+    expect(orders[0].yamlContent).toContain("orders_canonical");
   });
 
   it("reports a per-file error for a grouped entity missing the table field", async () => {

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -507,6 +507,33 @@ describe("reconcileAllOrgs", () => {
     expect((calledEntities as unknown[]).length).toBeGreaterThan(0);
   });
 
+  it("first-boot: no DB orgs + ONLY grouped disk entities → triggers auto-import (#3245)", async () => {
+    // A purely-grouped org (groups/<group>/entities/ with no flat entities/)
+    // must still be detected for first-boot auto-import — the flat-only
+    // detection skipped it, so its grouped entities never reached the DB.
+    const orgId = testOrgId();
+    const root = getSemanticRoot(orgId);
+    fs.mkdirSync(path.join(root, "groups", "prod", "entities"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "groups", "prod", "entities", "sales.yml"),
+      "table: sales\nname: sales\n",
+    );
+
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockImplementationOnce(() => Promise.resolve([]));
+    mockBulkUpsertEntities.mockClear();
+
+    await reconcileAllOrgs();
+
+    expect(mockBulkUpsertEntities).toHaveBeenCalled();
+    const [calledOrgId, calledEntities] = mockBulkUpsertEntities.mock.calls[0] ?? [];
+    expect(calledOrgId).toBe(orgId);
+    const ents = calledEntities as Array<{ name: string; connectionGroupId?: string | null }>;
+    const sales = ents.find((e) => e.name === "sales");
+    expect(sales).toBeDefined();
+    expect(sales!.connectionGroupId).toBe("prod");
+  });
+
   it("end-to-end: rename apikey → ApiKey in DB, then reconcile + list shows only ApiKey", async () => {
     // The two coupled changes in #2561 (admin reads DB-only when DB is
     // present, sync GC removes orphan files) together produce the
@@ -627,5 +654,138 @@ describe("importFromDisk", () => {
     expect(result.imported).toBe(1);
     // The mock bulkUpsertEntities doesn't check connectionId,
     // but we verify it doesn't error
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importFromDisk — group-scoped layout traversal (#3245, ADR-0012)
+// ---------------------------------------------------------------------------
+
+describe("importFromDisk — group namespace traversal (#3245)", () => {
+  /** Source roots created during these tests — cleaned up in afterEach. */
+  const sourceDirs: string[] = [];
+
+  function makeSourceRoot(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-import-groups-"));
+    sourceDirs.push(dir);
+    return dir;
+  }
+
+  function writeEntityFile(root: string, content: string, file: string, ...segments: string[]) {
+    const dir = path.join(root, ...segments, "entities");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, file), content);
+  }
+
+  const entityYaml = (table: string, extra = "") => `${extra}table: ${table}\n`;
+
+  /** Entities handed to bulkUpsertEntities during the most recent import. */
+  type Collected = { entityType: string; name: string; connectionId?: string; connectionGroupId?: string | null };
+  function lastUpsertedEntities(): Collected[] {
+    const calls = mockBulkUpsertEntities.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][1] as unknown as Collected[];
+  }
+
+  beforeEach(() => {
+    mockBulkUpsertEntities.mockClear();
+  });
+
+  afterEach(() => {
+    for (const dir of sourceDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+    sourceDirs.length = 0;
+  });
+
+  it("discovers grouped entities and imports them under their directory group", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("sales"), "sales.yml", "groups", "prod");
+
+    const result = await importFromDisk("org-1", { sourceDir: root });
+
+    expect(result.imported).toBe(1);
+    const ent = lastUpsertedEntities().find((e) => e.name === "sales");
+    expect(ent).toBeDefined();
+    expect(ent!.connectionGroupId).toBe("prod");
+  });
+
+  it("scopes each group's entities to its own directory group", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("orders_us"), "orders.yml", "groups", "us");
+    writeEntityFile(root, entityYaml("orders_eu"), "orders.yml", "groups", "eu");
+
+    await importFromDisk("org-1", { sourceDir: root });
+
+    const upserted = lastUpsertedEntities();
+    const groups = upserted
+      .filter((e) => e.entityType === "entity")
+      .map((e) => e.connectionGroupId)
+      .sort();
+    expect(groups).toEqual(["eu", "us"]);
+  });
+
+  it("honors the directory group when a grouped entity's field disagrees (ADR-0012)", async () => {
+    const root = makeSourceRoot();
+    // `connection:` field claims a different group than the directory.
+    writeEntityFile(root, entityYaml("sales", "connection: staging\n"), "sales.yml", "groups", "prod");
+
+    await importFromDisk("org-1", { sourceDir: root });
+
+    const ent = lastUpsertedEntities().find((e) => e.name === "sales");
+    expect(ent!.connectionGroupId).toBe("prod");
+  });
+
+  it("imports legacy <source>/entities/ under the source group (connectionGroupId)", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("events"), "events.yml", "warehouse");
+
+    const result = await importFromDisk("org-1", { sourceDir: root });
+
+    expect(result.imported).toBe(1);
+    const ent = lastUpsertedEntities().find((e) => e.name === "events");
+    expect(ent!.connectionGroupId).toBe("warehouse");
+  });
+
+  it("keeps flat default entities on the install-id path (connectionId, no group)", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("users"), "users.yml");
+
+    await importFromDisk("org-1", { sourceDir: root, connectionId: "__demo__" });
+
+    const ent = lastUpsertedEntities().find((e) => e.name === "users");
+    expect(ent!.connectionId).toBe("__demo__");
+    expect(ent!.connectionGroupId).toBeUndefined();
+  });
+
+  it("imports flat + grouped entities together, each scoped correctly", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, entityYaml("users"), "users.yml"); // flat default
+    writeEntityFile(root, entityYaml("sales"), "sales.yml", "groups", "prod"); // grouped
+
+    const result = await importFromDisk("org-1", { sourceDir: root, connectionId: "wh" });
+
+    expect(result.imported).toBe(2);
+    const upserted = lastUpsertedEntities();
+    const flat = upserted.find((e) => e.name === "users");
+    const grouped = upserted.find((e) => e.name === "sales");
+    expect(flat!.connectionId).toBe("wh");
+    expect(flat!.connectionGroupId).toBeUndefined();
+    expect(grouped!.connectionGroupId).toBe("prod");
+    expect(grouped!.connectionId).toBeUndefined();
+  });
+
+  it("reports a per-file error for a grouped entity missing the table field", async () => {
+    const root = makeSourceRoot();
+    writeEntityFile(root, "description: no table\n", "bad.yml", "groups", "prod");
+
+    const result = await importFromDisk("org-1", { sourceDir: root });
+
+    expect(result.imported).toBe(0);
+    expect(result.errors.some((e) => e.file === "bad.yml" && e.reason.includes("table"))).toBe(true);
   });
 });

--- a/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
@@ -34,6 +34,7 @@ const diskSummary = (over: Partial<EntitySummary> & Pick<EntitySummary, "table">
   connection: over.connection ?? null,
   type: over.type ?? null,
   source: over.source ?? "default",
+  filePath: over.filePath ?? `/semantic/entities/${over.name ?? over.table}.yml`,
 });
 
 describe("parseRowToAdminSummary", () => {

--- a/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
@@ -34,6 +34,7 @@ const diskSummary = (over: Partial<EntitySummary> & Pick<EntitySummary, "table">
   connection: over.connection ?? null,
   type: over.type ?? null,
   source: over.source ?? "default",
+  group: over.group ?? over.source ?? "default",
   filePath: over.filePath ?? `/semantic/entities/${over.name ?? over.table}.yml`,
 });
 

--- a/packages/api/src/lib/semantic/__tests__/diff-group-snapshots.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/diff-group-snapshots.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `getYAMLSnapshots` group-namespace traversal (#3245, ADR-0012).
+ *
+ * The drift YAML-snapshot reader used to reconstruct each entity's path as the
+ * LEGACY `<root>/<source>/entities/<table>.yml`, which:
+ *   - silently skipped the canonical `groups/<group>/entities/` namespace
+ *     (`existsSync` failed → entity dropped → drift drawer empty for groups), and
+ *   - rebuilt the filename from `table` instead of the file stem (`name`), so a
+ *     YAML whose filename differed from its `table` never resolved.
+ *
+ * These tests exercise the real `getYAMLSnapshots` against a temp semantic root
+ * (no DB, no mocked modules — it reads disk via `ATLAS_SEMANTIC_ROOT`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { resolve, join } from "path";
+import { getYAMLSnapshots } from "../diff";
+
+const tmp = resolve(import.meta.dir, ".tmp-diff-group-snapshots");
+let prevRoot: string | undefined;
+
+beforeEach(() => {
+  prevRoot = process.env.ATLAS_SEMANTIC_ROOT;
+  process.env.ATLAS_SEMANTIC_ROOT = tmp;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  if (prevRoot === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = prevRoot;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Write an entity YAML under `<tmp>/<...segments>/entities/<file>`. */
+function writeEntity(file: string, content: string, ...segments: string[]) {
+  const dir = join(tmp, ...segments, "entities");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, file), content);
+}
+
+const entity = (table: string, extra = "") =>
+  `${extra}table: ${table}\ndimensions:\n  - name: id\n    type: number\n  - name: created_at\n    type: date\n`;
+
+describe("getYAMLSnapshots — group-scoped layout (#3245)", () => {
+  it("resolves grouped entities from groups/<group>/entities/", () => {
+    writeEntity("sales.yml", entity("sales"), "groups", "prod");
+
+    const { snapshots, warnings } = getYAMLSnapshots("prod");
+
+    expect(snapshots.has("sales")).toBe(true);
+    expect(snapshots.get("sales")!.columns.get("id")).toBe("number");
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("resolves a grouped entity via its file stem (name), not its table", () => {
+    // File stem `sales_entity` ≠ `table: fact_sales`. The legacy path
+    // reconstruction keyed on `table`, so this never resolved.
+    writeEntity(
+      "sales_entity.yml",
+      entity("fact_sales", "name: sales_entity\n"),
+      "groups",
+      "prod",
+    );
+
+    const { snapshots } = getYAMLSnapshots("prod");
+
+    expect(snapshots.has("fact_sales")).toBe(true);
+  });
+
+  it("scopes grouped entities to their own group (does not leak across groups)", () => {
+    writeEntity("orders.yml", entity("orders_us"), "groups", "us");
+    writeEntity("orders.yml", entity("orders_eu"), "groups", "eu");
+
+    const us = getYAMLSnapshots("us");
+    const eu = getYAMLSnapshots("eu");
+
+    expect(us.snapshots.has("orders_us")).toBe(true);
+    expect(us.snapshots.has("orders_eu")).toBe(false);
+    expect(eu.snapshots.has("orders_eu")).toBe(true);
+    expect(eu.snapshots.has("orders_us")).toBe(false);
+  });
+
+  it("leaves the flat default layout unchanged", () => {
+    writeEntity("users.yml", entity("users"));
+
+    const { snapshots } = getYAMLSnapshots("default");
+
+    expect(snapshots.has("users")).toBe(true);
+  });
+
+  it("leaves the legacy <source>/entities/ layout unchanged", () => {
+    writeEntity("orders.yml", entity("orders"), "warehouse");
+
+    const { snapshots } = getYAMLSnapshots("warehouse");
+
+    expect(snapshots.has("orders")).toBe(true);
+  });
+
+  it("includes a grouped entity in the computed diff, mirroring flat entities", async () => {
+    writeEntity("sales.yml", entity("sales"), "groups", "prod");
+    const { computeDiff } = await import("../diff");
+
+    const { snapshots } = getYAMLSnapshots("prod");
+    const dbSide = new Map(snapshots); // identical → unchanged, not skipped
+    const diff = computeDiff(dbSide, snapshots);
+
+    expect(diff.unchangedCount).toBe(1);
+    expect(diff.removedTables).not.toContain("sales");
+  });
+});

--- a/packages/api/src/lib/semantic/__tests__/diff-group-snapshots.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/diff-group-snapshots.test.ts
@@ -81,6 +81,20 @@ describe("getYAMLSnapshots — group-scoped layout (#3245)", () => {
     expect(eu.snapshots.has("orders_us")).toBe(false);
   });
 
+  it("scopes a grouped entity by its directory, not a disagreeing connection field (ADR-0012)", () => {
+    // A canonical groups/<group>/ entity whose `connection:` field disagrees
+    // with its directory must scope to the DIRECTORY (matching the importer +
+    // whitelist), not the field — otherwise the drift view diverges from the
+    // imported whitelist for the same files (#3245).
+    writeEntity("sales.yml", entity("sales", "connection: staging\n"), "groups", "prod");
+
+    const prod = getYAMLSnapshots("prod");
+    const staging = getYAMLSnapshots("staging");
+
+    expect(prod.snapshots.has("sales")).toBe(true); // directory wins
+    expect(staging.snapshots.has("sales")).toBe(false); // field does NOT win
+  });
+
   it("leaves the flat default layout unchanged", () => {
     writeEntity("users.yml", entity("users"));
 

--- a/packages/api/src/lib/semantic/diff.ts
+++ b/packages/api/src/lib/semantic/diff.ts
@@ -300,13 +300,13 @@ export function getYAMLSnapshots(
   }
 
   for (const entity of entities) {
-    // Match entities to the requested connection:
-    // - entities with connection=null/undefined belong to "default"
-    // - entities with an explicit connection belong to that connection
-    const entityConnection = entity.connection ?? entity.source ?? "default";
-    // "default" source means flat layout → default connection
-    const effectiveConnection = entityConnection === "default" ? "default" : entityConnection;
-    if (effectiveConnection !== connectionId) continue;
+    // Match entities to the requested connection by their resolved Connection
+    // group (directory-canonical per ADR-0012), NOT the raw `connection`/`source`
+    // fields. A canonical `groups/<group>/` entity carrying a stale `connection:`
+    // field would otherwise be scoped to the field's group here while the
+    // importer + whitelist scope it to its directory — diverging the drift view
+    // from the imported whitelist for the same files (#3245).
+    if (entity.group !== connectionId) continue;
 
     // Locate the entity's YAML via the layout-aware path the scanner already
     // discovered. Reconstructing `<root>/<source>/entities/<table>.yml` (the

--- a/packages/api/src/lib/semantic/diff.ts
+++ b/packages/api/src/lib/semantic/diff.ts
@@ -6,7 +6,6 @@
  */
 
 import * as fs from "fs";
-import * as path from "path";
 import type { SemanticTableDiff, SemanticDiffResponse } from "@useatlas/types";
 import type { AtlasMode } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -309,11 +308,12 @@ export function getYAMLSnapshots(
     const effectiveConnection = entityConnection === "default" ? "default" : entityConnection;
     if (effectiveConnection !== connectionId) continue;
 
-    // Resolve entity file path
-    const entitiesDir = entity.source === "default"
-      ? path.join(root, "entities")
-      : path.join(root, entity.source, "entities");
-    const filePath = path.join(entitiesDir, `${entity.table}.yml`);
+    // Locate the entity's YAML via the layout-aware path the scanner already
+    // discovered. Reconstructing `<root>/<source>/entities/<table>.yml` (the
+    // legacy layout, keyed on `table`) silently skipped the canonical
+    // `groups/<group>/entities/<name>.yml` namespace and broke whenever a
+    // YAML's filename (`name`) differed from its `table` (#3245, ADR-0012).
+    const filePath = entity.filePath;
 
     if (!fs.existsSync(filePath)) continue;
 
@@ -323,7 +323,7 @@ export function getYAMLSnapshots(
       const snapshot = parseEntityYAML(doc);
       snapshots.set(snapshot.table, snapshot);
     } catch (err) {
-      const msg = `Failed to parse ${entity.table}.yml: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = `Failed to parse ${entity.name}.yml: ${err instanceof Error ? err.message : String(err)}`;
       log.warn({ err: err instanceof Error ? err : new Error(String(err)), filePath }, msg);
       warnings.push(msg);
     }

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -256,6 +256,41 @@ export async function upsertDraftEntity(
 }
 
 /**
+ * Upsert a draft entity, setting `connection_group_id` DIRECTLY rather than
+ * resolving it from an install/connection id via {@link inlineConnectionGroupSql}.
+ *
+ * Used by the disk → DB importer for the canonical `groups/<group>/entities/`
+ * namespace (and legacy `<source>/entities/`), where the directory *is* the
+ * group (ADR-0012) — the group is the on-disk directory name, not an install
+ * id that would resolve through `workspace_plugins`. Mirrors
+ * {@link upsertTombstoneForGroup}, which already keys on a direct
+ * `connection_group_id`. The flat default `entities/` dir keeps using
+ * {@link upsertDraftEntity} so demo/wizard install-id resolution is unchanged
+ * (#3245).
+ */
+export async function upsertDraftEntityForGroup(
+  orgId: string,
+  entityType: SemanticEntityType,
+  name: string,
+  yamlContent: string,
+  connectionGroupId?: string | null,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for org-scoped semantic entities");
+  }
+  await internalQuery(
+    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
+     VALUES ($1, $2, $3, $4, $5, 'draft')
+     ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'draft'
+     DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
+                   entity_type = EXCLUDED.entity_type,
+                   connection_group_id = EXCLUDED.connection_group_id,
+                   updated_at = now()`,
+    [orgId, entityType, name, yamlContent, connectionGroupId ?? null],
+  );
+}
+
+/**
  * Insert a draft_delete tombstone for an entity.
  *
  * Used for developer-mode deletes where a published row exists — the
@@ -1464,7 +1499,7 @@ export async function restoreSingleConnection(
  */
 export async function bulkUpsertEntities(
   orgId: string,
-  entities: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string }>,
+  entities: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
 ): Promise<number> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
@@ -1474,7 +1509,14 @@ export async function bulkUpsertEntities(
   let upserted = 0;
   for (const e of entities) {
     try {
-      await upsertDraftEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId);
+      // A group-scoped row (canonical `groups/<group>/` or legacy `<source>/`)
+      // carries its group directly; the flat default dir keeps resolving the
+      // connection/install id through `inlineConnectionGroupSql` (#3245).
+      if (e.connectionGroupId !== undefined) {
+        await upsertDraftEntityForGroup(orgId, e.entityType, e.name, e.yamlContent, e.connectionGroupId);
+      } else {
+        await upsertDraftEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId);
+      }
       upserted++;
     } catch (err) {
       // log.error (not log.warn) because a row-level upsert failure means

--- a/packages/api/src/lib/semantic/files.ts
+++ b/packages/api/src/lib/semantic/files.ts
@@ -88,10 +88,12 @@ export interface EntitySummary {
    * (a disagreeing `group:`/`connection:` field is ignored and warned on by
    * the whitelist), while the flat default root and legacy `<source>/` layout
    * let the field assign the group. This is the SAME key the file-based
-   * whitelist and importer scope by, so consumers (e.g. the drift snapshot
-   * reader) match entities to a connection by group here rather than the raw
-   * `connection`/`source` fields, which let a stale field win over the
-   * directory (#3245).
+   * whitelist scopes by (and the importer's group/legacy path), so consumers
+   * (e.g. the drift snapshot reader) match entities to a connection by group
+   * here rather than the raw `connection`/`source` fields, which let a stale
+   * field win over the directory (#3245). NOTE: the importer's flat default
+   * path still scopes by install id, not this group, so for flat entities this
+   * resolves the group but the DB row's scope comes from the install lookup.
    */
   group: string;
   /**

--- a/packages/api/src/lib/semantic/files.ts
+++ b/packages/api/src/lib/semantic/files.ts
@@ -8,7 +8,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
-import { scanEntities, getEntityDirs } from "./scanner";
+import { scanEntities, getEntityDirs, resolveEntityGroup, readGroupField } from "./scanner";
 
 // ---------------------------------------------------------------------------
 // Semantic layer root
@@ -83,6 +83,18 @@ export interface EntitySummary {
   type: string | null;
   source: string;
   /**
+   * Effective Connection group resolved via {@link resolveEntityGroup}
+   * (ADR-0012): the canonical `groups/<group>/` directory is authoritative
+   * (a disagreeing `group:`/`connection:` field is ignored and warned on by
+   * the whitelist), while the flat default root and legacy `<source>/` layout
+   * let the field assign the group. This is the SAME key the file-based
+   * whitelist and importer scope by, so consumers (e.g. the drift snapshot
+   * reader) match entities to a connection by group here rather than the raw
+   * `connection`/`source` fields, which let a stale field win over the
+   * directory (#3245).
+   */
+  group: string;
+  /**
    * Absolute path to the entity's YAML file as discovered by the scanner.
    * Threaded out of `scanEntities` so consumers (e.g. the drift snapshot
    * reader) can locate the file from the layout-aware traversal instead of
@@ -110,7 +122,7 @@ export function discoverEntities(root: string): DiscoverEntitiesResult {
   const { entities: scanned, warnings } = scanEntities(root);
   const entities: EntitySummary[] = [];
 
-  for (const { sourceName, raw, filePath } of scanned) {
+  for (const { sourceName, origin, raw, filePath } of scanned) {
     if (!raw.table) {
       warnings.push(`Entity file missing required 'table' field: ${path.relative(root, filePath)}`);
       continue;
@@ -125,6 +137,10 @@ export function discoverEntities(root: string): DiscoverEntitiesResult {
     const fileStem = path.basename(filePath, ".yml");
     const displayName =
       typeof raw.name === "string" && raw.name ? raw.name : String(raw.table);
+    // Resolve the effective group directory-canonically (ADR-0012) so it
+    // matches the importer + file-based whitelist; the raw `connection`/`source`
+    // fields are kept for display/back-compat but must not drive scoping.
+    const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
     entities.push({
       name: fileStem,
       displayName,
@@ -136,6 +152,7 @@ export function discoverEntities(root: string): DiscoverEntitiesResult {
       connection: typeof raw.connection === "string" ? raw.connection : null,
       type: typeof raw.type === "string" ? raw.type : null,
       source: sourceName,
+      group,
       filePath,
     });
   }

--- a/packages/api/src/lib/semantic/files.ts
+++ b/packages/api/src/lib/semantic/files.ts
@@ -82,6 +82,15 @@ export interface EntitySummary {
   connection: string | null;
   type: string | null;
   source: string;
+  /**
+   * Absolute path to the entity's YAML file as discovered by the scanner.
+   * Threaded out of `scanEntities` so consumers (e.g. the drift snapshot
+   * reader) can locate the file from the layout-aware traversal instead of
+   * reconstructing a path from `source`/`table` — which silently skipped
+   * the canonical `groups/<group>/entities/` namespace and broke whenever a
+   * YAML's filename differed from its `table` (#3245, ADR-0012).
+   */
+  filePath: string;
 }
 
 /**
@@ -127,6 +136,7 @@ export function discoverEntities(root: string): DiscoverEntitiesResult {
       connection: typeof raw.connection === "string" ? raw.connection : null,
       type: typeof raw.type === "string" ? raw.type : null,
       source: sourceName,
+      filePath,
     });
   }
 

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -819,8 +819,9 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
     // the import and its grouped entities would stay missing from the DB
     // whitelist (#3245, ADR-0012).
     const orgRoot = path.join(orgsDir, orgId);
+    const { dirs, failedScans } = getEntityDirs(orgRoot);
     let hasDiskEntities = false;
-    for (const { dir } of getEntityDirs(orgRoot).dirs) {
+    for (const { dir } of dirs) {
       try {
         if ((await fs.promises.readdir(dir)).some((e) => e.endsWith(".yml"))) {
           hasDiskEntities = true;
@@ -837,7 +838,19 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
       }
     }
 
-    if (!hasDiskEntities) continue;
+    // Fail closed (#3243): a failed groups/ or legacy namespace scan returns a
+    // dir list that is silently short, so a `hasDiskEntities === false` verdict
+    // is unreliable — the org may be populated but unscannable. Don't treat it
+    // as empty; attempt the import (which re-scans and surfaces the failure)
+    // rather than silently skipping a possibly-populated org.
+    if (failedScans.length > 0) {
+      log.error(
+        { orgId, failedScans },
+        "Auto-import: semantic namespace scan failed — cannot confirm org is empty; attempting import (fail closed)",
+      );
+    } else if (!hasDiskEntities) {
+      continue;
+    }
     const dbCount = await countEntities(orgId);
     if (dbCount > 0) continue; // already imported
 

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -481,6 +481,21 @@ interface ImportResult {
 }
 
 /**
+ * A row staged for `bulkUpsertEntities`. Exactly one of `connectionId` /
+ * `connectionGroupId` carries the scope: flat default + metrics/glossary use
+ * `connectionId` (resolved to a group via the install-id lookup), while
+ * group-scoped entities (`groups/<group>/`, legacy `<source>/`) carry their
+ * directory group directly in `connectionGroupId` (#3245, ADR-0012).
+ */
+type CollectedEntity = {
+  entityType: SemanticEntityType;
+  name: string;
+  yamlContent: string;
+  connectionId?: string;
+  connectionGroupId?: string | null;
+};
+
+/**
  * Import YAML files from an org's disk directory into the DB.
  *
  * Scans `{orgRoot}/entities/*.yml`, `metrics/*.yml`, and
@@ -501,13 +516,17 @@ export async function importFromDisk(
 
   const root = options?.sourceDir ?? getSemanticRoot(orgId);
   const errors: ImportError[] = [];
-  const entities: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string }> = [];
+  const entities: CollectedEntity[] = [];
 
-  // Scan entities/*.yml
-  const entitiesDir = path.join(root, "entities");
-  await _scanYamlDir(entitiesDir, "entity", entities, errors, yaml, options?.connectionId);
+  // Scan entities across the full group-scoped layout (ADR-0012): the flat
+  // default `entities/`, the canonical `groups/<group>/entities/` namespace,
+  // and legacy `<source>/entities/`. Hardcoding `root/entities` skipped grouped
+  // entities entirely, so the DB-backed whitelist/admin view was empty for
+  // those groups even though the file-based whitelist read them (#3245).
+  await _scanEntityDirs(root, entities, errors, yaml, options?.connectionId);
 
-  // Scan metrics/*.yml
+  // Scan metrics/*.yml — metrics group-namespace traversal is out of scope
+  // here (#3240), so metrics stay flat + scoped by the install id.
   const metricsDir = path.join(root, "metrics");
   await _scanYamlDir(metricsDir, "metric", entities, errors, yaml, options?.connectionId);
 
@@ -572,7 +591,7 @@ export async function importFromDisk(
 async function _scanYamlDir(
   dir: string,
   entityType: SemanticEntityType,
-  out: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string }>,
+  out: CollectedEntity[],
   errors: ImportError[],
   yaml: typeof import("js-yaml"),
   connectionId?: string,
@@ -604,6 +623,86 @@ async function _scanYamlDir(
       out.push({ entityType, name, yamlContent: content, connectionId });
     } catch (err) {
       errors.push({ file, reason: errorMessage(err) });
+    }
+  }
+}
+
+/**
+ * Scan every entity directory under a semantic root — the flat default
+ * `entities/`, the canonical `groups/<group>/entities/` namespace, and legacy
+ * `<source>/entities/` (ADR-0012) — collecting valid entity rows for import.
+ *
+ * Uses the same shared traversal (`getEntityDirs`) as the file-based whitelist
+ * and entity loader so the DB-backed whitelist can't drift from the on-disk
+ * one. The directory's group (resolved via {@link resolveEntityGroup}, with the
+ * canonical directory authoritative and a disagreeing `group:`/`connection:`
+ * field flagged) is carried into `connection_group_id` for group/legacy dirs.
+ *
+ * The flat default dir keeps the legacy install-id resolution path: its rows
+ * carry `defaultConnectionId` (e.g. demo's `__demo__`) so existing demo/wizard
+ * scoping is unchanged (#3245).
+ */
+async function _scanEntityDirs(
+  root: string,
+  out: CollectedEntity[],
+  errors: ImportError[],
+  yaml: typeof import("js-yaml"),
+  defaultConnectionId?: string,
+): Promise<void> {
+  const { getEntityDirs, resolveEntityGroup, readGroupField } = await import("./scanner");
+  const { dirs, failedScans } = getEntityDirs(root);
+  if (failedScans.length > 0) {
+    // Surface a partial-scan failure as a per-namespace import error rather
+    // than silently importing a subset — a failed groups/ scan means some
+    // grouped entities may be missing from the DB whitelist.
+    errors.push({
+      file: root,
+      reason: `Failed to scan semantic directory namespace(s): ${failedScans.join(", ")}`,
+    });
+  }
+
+  for (const { dir, sourceName, origin } of dirs) {
+    let files: string[];
+    try {
+      files = (await fs.promises.readdir(dir)).filter((f) => f.endsWith(".yml"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue; // dir vanished — fine
+      errors.push({ file: dir, reason: errorMessage(err) });
+      continue;
+    }
+
+    for (const file of files) {
+      const filePath = path.join(dir, file);
+      const name = file.replace(/\.yml$/, "");
+      try {
+        const content = await fs.promises.readFile(filePath, "utf-8");
+        const parsed = yaml.load(content);
+
+        if (!parsed || typeof parsed !== "object" || !("table" in (parsed as Record<string, unknown>))) {
+          errors.push({ file, reason: "Entity YAML must contain a 'table' field" });
+          continue;
+        }
+
+        if (origin === "flat") {
+          // Flat default group — preserve the install-id resolution path so
+          // demo/wizard scoping is unchanged.
+          out.push({ entityType: "entity", name, yamlContent: content, connectionId: defaultConnectionId });
+        } else {
+          // Group-scoped (canonical `groups/<group>/` or legacy `<source>/`):
+          // the directory is the group, set connection_group_id directly.
+          const fieldGroup = readGroupField(parsed as { group?: unknown; connection?: unknown });
+          const { group, mismatch } = resolveEntityGroup(sourceName, origin, fieldGroup);
+          if (mismatch) {
+            log.warn(
+              { file, dir, directoryGroup: sourceName, declaredGroup: fieldGroup },
+              "Import: entity declares a group that differs from its directory — honoring the directory (ADR-0012)",
+            );
+          }
+          out.push({ entityType: "entity", name, yamlContent: content, connectionGroupId: group });
+        }
+      } catch (err) {
+        errors.push({ file, reason: errorMessage(err) });
+      }
     }
   }
 }
@@ -711,23 +810,34 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
   }
 
   const { countEntities } = await import("@atlas/api/lib/semantic/entities");
+  const { getEntityDirs } = await import("./scanner");
 
   for (const orgId of orgDirs) {
-    const entitiesDir = path.join(orgsDir, orgId, "entities");
-    let entries: string[];
-    try {
-      entries = await fs.promises.readdir(entitiesDir);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        log.warn(
-          { orgId, err: errorMessage(err) },
-          "Cannot read entities dir for auto-import — skipping org",
-        );
+    // Detect importable disk files across the full group-scoped layout, not
+    // just the flat `entities/` dir — otherwise a purely-grouped org
+    // (`groups/<group>/entities/` with no flat entities) would never trigger
+    // the import and its grouped entities would stay missing from the DB
+    // whitelist (#3245, ADR-0012).
+    const orgRoot = path.join(orgsDir, orgId);
+    let hasDiskEntities = false;
+    for (const { dir } of getEntityDirs(orgRoot).dirs) {
+      try {
+        if ((await fs.promises.readdir(dir)).some((e) => e.endsWith(".yml"))) {
+          hasDiskEntities = true;
+          break;
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          log.warn(
+            { orgId, dir, err: errorMessage(err) },
+            "Cannot read entities dir for auto-import — skipping dir",
+          );
+        }
+        // ENOENT or read failure on one dir — keep checking the others.
       }
-      continue;
     }
 
-    if (!entries.some((e) => e.endsWith(".yml"))) continue;
+    if (!hasDiskEntities) continue;
     const dbCount = await countEntities(orgId);
     if (dbCount > 0) continue; // already imported
 

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -525,7 +525,7 @@ export async function importFromDisk(
   // and legacy `<source>/entities/`. Hardcoding `root/entities` skipped grouped
   // entities entirely, so the DB-backed whitelist/admin view was empty for
   // those groups even though the file-based whitelist read them (#3245).
-  await _scanEntityDirs(root, entities, errors, yaml, options?.connectionId);
+  const { duplicateSkips } = await _scanEntityDirs(root, entities, errors, yaml, options?.connectionId);
 
   // Scan metrics/*.yml — metrics group-namespace traversal is out of scope
   // here (#3240), so metrics stay flat + scoped by the install id.
@@ -554,10 +554,14 @@ export async function importFromDisk(
     // ENOENT is fine — glossary is optional
   }
 
-  const total = entities.length + errors.length;
+  // `total` and `skipped` count every file the scan considered, including
+  // lower-precedence duplicates dropped by `_scanEntityDirs` — otherwise a
+  // canonical+legacy overlap would report `{ imported: 1, skipped: 0, total: 1 }`
+  // despite two YAML files being scanned (CodeRabbit review).
+  const total = entities.length + errors.length + duplicateSkips;
 
   if (entities.length === 0) {
-    return { imported: 0, skipped: errors.length, errors, total };
+    return { imported: 0, skipped: errors.length + duplicateSkips, errors, total };
   }
 
   let imported: number;
@@ -576,14 +580,15 @@ export async function importFromDisk(
     );
   }
 
+  const skipped = errors.length + dbFailures + duplicateSkips;
   log.info(
-    { orgId, imported, skipped: errors.length + dbFailures, total },
+    { orgId, imported, skipped, duplicateSkips, total },
     "Imported semantic entities from disk to DB",
   );
 
   return {
     imported,
-    skipped: errors.length + dbFailures,
+    skipped,
     errors,
     total,
   };
@@ -650,7 +655,8 @@ async function _scanEntityDirs(
   errors: ImportError[],
   yaml: typeof import("js-yaml"),
   defaultConnectionId?: string,
-): Promise<void> {
+): Promise<{ duplicateSkips: number }> {
+  let duplicateSkips = 0;
   const { getEntityDirs, resolveEntityGroup, readGroupField } = await import("./scanner");
   const { dirs, failedScans } = getEntityDirs(root);
   if (failedScans.length > 0) {
@@ -713,6 +719,7 @@ async function _scanEntityDirs(
           // stem, so the key can't be forged by a crafted name.
           const groupKey = `${group}\0${name}`;
           if (seenGroupKeys.has(groupKey)) {
+            duplicateSkips++;
             log.warn(
               { file, dir, group, name, origin },
               "Import: duplicate entity for the same group already collected from a higher-precedence directory — skipping (ADR-0012: canonical groups/ wins over legacy)",
@@ -727,6 +734,8 @@ async function _scanEntityDirs(
       }
     }
   }
+
+  return { duplicateSkips };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -481,11 +481,13 @@ interface ImportResult {
 }
 
 /**
- * A row staged for `bulkUpsertEntities`. Exactly one of `connectionId` /
- * `connectionGroupId` carries the scope: flat default + metrics/glossary use
- * `connectionId` (resolved to a group via the install-id lookup), while
- * group-scoped entities (`groups/<group>/`, legacy `<source>/`) carry their
- * directory group directly in `connectionGroupId` (#3245, ADR-0012).
+ * A row staged for `bulkUpsertEntities`. At most one of `connectionId` /
+ * `connectionGroupId` is set (never both); the PRESENCE of `connectionGroupId`
+ * (even `null`) is what routes a row to the direct-group upsert. Flat default +
+ * metrics/glossary carry `connectionId` (resolved to a group via the install-id
+ * lookup) — frequently `undefined` for self-hosted, which resolves to the NULL
+ * default group. Group-scoped entities (`groups/<group>/`, legacy `<source>/`)
+ * carry their directory group directly in `connectionGroupId` (#3245, ADR-0012).
  */
 type CollectedEntity = {
   entityType: SemanticEntityType;
@@ -661,6 +663,15 @@ async function _scanEntityDirs(
     });
   }
 
+  // Track (group, name) pairs already collected from a group/legacy dir.
+  // `getEntityDirs` orders canonical `groups/<group>/` BEFORE legacy
+  // `<source>/`, so the canonical entry is seen first and a same-name/same-group
+  // legacy duplicate (mid-migration overlap) is skipped — otherwise the stale
+  // legacy YAML would upsert LAST into the shared
+  // `(org, type, name, connection_group_id)` draft row and overwrite the
+  // canonical file that should win (ADR-0012: directory canonical). Codex review.
+  const seenGroupKeys = new Set<string>();
+
   for (const { dir, sourceName, origin } of dirs) {
     let files: string[];
     try {
@@ -698,6 +709,17 @@ async function _scanEntityDirs(
               "Import: entity declares a group that differs from its directory — honoring the directory (ADR-0012)",
             );
           }
+          // Use NUL as the separator — it can't appear in a group name or file
+          // stem, so the key can't be forged by a crafted name.
+          const groupKey = `${group}\0${name}`;
+          if (seenGroupKeys.has(groupKey)) {
+            log.warn(
+              { file, dir, group, name, origin },
+              "Import: duplicate entity for the same group already collected from a higher-precedence directory — skipping (ADR-0012: canonical groups/ wins over legacy)",
+            );
+            continue;
+          }
+          seenGroupKeys.add(groupKey);
           out.push({ entityType: "entity", name, yamlContent: content, connectionGroupId: group });
         }
       } catch (err) {


### PR DESCRIPTION
Closes #3245.

## Problem

After #3232, entity discovery returns group-scoped entities tagged with their group as `source`, but two entity-traversing paths still assumed the flat/legacy layout and silently skipped the canonical `semantic/groups/<group>/entities/` namespace (ADR-0012):

1. **Drift snapshots** (`getYAMLSnapshots`) reconstructed each entity's path as the **legacy** `<root>/<source>/entities/<table>.yml`. For grouped entities that path doesn't exist → `existsSync` fails → entity silently skipped → the drift drawer / reconcile YAML side was **empty for grouped entities**. It also rebuilt the filename from `table` rather than the file stem (`name`), so a YAML whose filename differed from its `table` never resolved.
2. **DB import** (`importFromDisk`) scanned only `<root>/entities/*.yml`, never walking `<root>/groups/*/entities`. SaaS workspaces initialized from the canonical layout skipped grouped entities on import → the admin DB view + org whitelist were **empty for those groups** even though the file-based whitelist read them.

## Fix

**Drift** — thread the scanner-discovered file path through `discoverEntities` (`EntitySummary.filePath`) and locate each entity via that layout-aware path instead of reconstructing it. Resolution now uses the file stem (`name`), not `table`.

**Import** — reuse the shared `getEntityDirs` traversal (the same SSOT as the file-based whitelist + entity loader, so the layouts can't drift again) and carry each directory's group — resolved via `resolveEntityGroup`, directory-canonical with a disagreeing field flagged — into `connection_group_id`. Because the group is the on-disk directory name (not an install id resolvable through `workspace_plugins`), grouped/legacy rows are written via a new `upsertDraftEntityForGroup` that sets `connection_group_id` directly (mirroring the existing `upsertTombstoneForGroup`). The flat default dir keeps the install-id resolution path, so **demo/wizard scoping is unchanged**. First-boot auto-import detection (`_autoImportOrgsFromDisk`) is also made group-aware so a purely-grouped org still triggers import.

Entities only — metrics/glossary/catalog traversal (#3240) and group-namespace generation (#3234) are untouched (out of scope).

## Acceptance criteria

- [x] Drift snapshots resolve grouped entities from `groups/<group>/entities/` and include them in the diff
- [x] Drift resolution uses the file stem (`name`), not `table` (name/table divergence resolves)
- [x] `importFromDisk` discovers grouped entities + imports under correct group scope (DB-backed grouped whitelist/admin view matches the file-based whitelist)
- [x] Flat default + legacy `<source>/` layouts unchanged
- [x] Tests cover both paths (drift + import) for the `groups/` layout + unchanged flat/legacy

## Tests

- New `diff-group-snapshots.test.ts` — 6 tests: grouped resolution, name≠table via stem, per-group scoping (no cross-group leak), flat + legacy unchanged, grouped entity surfaces in `computeDiff`.
- `semantic-sync.test.ts` — 8 new tests: grouped import under directory group, per-group scoping, directory-wins on field mismatch, legacy `<source>/` under source group, flat stays on the install-id path, mixed flat+grouped, missing-`table` per-file error, and purely-grouped first-boot auto-import.

## Verification

Diagnosed with a reproduction (grouped entities → 0 drift snapshots pre-fix), then fixed and added regression tests. All `/ci` gates pass locally: lint, type, **full `bun run test` (api 557 files + others, 0 failures)**, syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols.

> Generated with Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352989&installation_id=135337507&pr_number=3260&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3260&signature=cd4391dd1376c84f523d0b98b3806a034b2e2cd419ba91ef4c30f893a97528c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-scoped entity discovery and imports: directory-based groups are preserved and draft upserts can be keyed to groups.

* **Bug Fixes**
  * Prevents cross-group leakage; grouped-only orgs import on first boot.
  * Import now “fails closed” on partial namespace scan errors and deduplicates canonical group entries over legacy duplicates.

* **Tests**
  * Added regression and snapshot tests covering grouped, flat, legacy, mixed layouts, precedence, counts, and per-file error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->