### PR TITLE
fix(semantic): render note & possible_mappings in glossary index (#3277)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -330,6 +330,75 @@ describe("buildSemanticIndex", () => {
     expect(index).toContain("users.status");
   });
 
+  it("renders note and possible_mappings independently across object-form terms (#3277)", () => {
+    const root = ensureDir(`glossary-independent-${testCounter}`);
+    mkdirSync(join(root, "entities"), { recursive: true });
+    writeFileSync(
+      join(root, "entities", "orders.yml"),
+      makeEntity("orders", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+
+    // The two render branches are independent ternaries — exercise each on its
+    // own: note-only, possible_mappings-only, and an empty mappings array.
+    writeFileSync(
+      join(root, "glossary.yml"),
+      [
+        "terms:",
+        "  note_only:",
+        "    status: ambiguous",
+        '    note: "Guidance with no candidate columns."',
+        "  mappings_only:",
+        "    status: ambiguous",
+        "    possible_mappings: [orders.id, orders.total]",
+        "  empty_mappings:",
+        "    status: ambiguous",
+        "    possible_mappings: []",
+      ].join("\n") + "\n",
+    );
+
+    const index = buildSemanticIndex(root);
+    const lineOf = (term: string) =>
+      index.split("\n").find((l) => l.includes(`**${term}**`)) ?? "";
+
+    // note-only → renders the note, no "(maps to:" suffix.
+    expect(lineOf("note_only")).toContain("→ Guidance with no candidate columns.");
+    expect(lineOf("note_only")).not.toContain("maps to:");
+
+    // possible_mappings-only → renders the mappings, no note arrow.
+    expect(lineOf("mappings_only")).toContain("(maps to: orders.id, orders.total)");
+    expect(lineOf("mappings_only")).not.toContain("→");
+
+    // empty possible_mappings array → the `.length > 0` guard suppresses the suffix.
+    expect(lineOf("empty_mappings")).not.toContain("maps to:");
+  });
+
+  it("filters non-string possible_mappings entries (#3277)", () => {
+    const root = ensureDir(`glossary-filter-${testCounter}`);
+    mkdirSync(join(root, "entities"), { recursive: true });
+    writeFileSync(
+      join(root, "entities", "orders.yml"),
+      makeEntity("orders", { dimensions: [{ name: "id", type: "integer" }] }),
+    );
+
+    // Hand-written YAML can carry non-string entries (e.g. a bare number); the
+    // formatter drops them rather than rendering a coerced value, and preserves
+    // the order of the surviving strings.
+    writeFileSync(
+      join(root, "glossary.yml"),
+      [
+        "terms:",
+        "  status:",
+        "    status: ambiguous",
+        "    possible_mappings: [orders.status, 42, users.status]",
+      ].join("\n") + "\n",
+    );
+
+    const index = buildSemanticIndex(root);
+
+    expect(index).toContain("(maps to: orders.status, users.status)");
+    expect(index).not.toContain("42");
+  });
+
   it("discovers groups/<group>/metrics, glossary, and catalog in the index (#3240)", () => {
     const root = ensureDir(`group-discovery-${testCounter}`);
     mkdirSync(join(root, "entities"), { recursive: true });

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -380,23 +380,32 @@ describe("buildSemanticIndex", () => {
       makeEntity("orders", { dimensions: [{ name: "id", type: "integer" }] }),
     );
 
-    // Hand-written YAML can carry non-string entries (e.g. a bare number); the
-    // formatter drops them rather than rendering a coerced value, and preserves
-    // the order of the surviving strings.
+    // Hand-written YAML can carry non-string or blank entries; the formatter
+    // drops them, preserves the order of the survivors, and emits no clause at
+    // all when nothing survives (never a bare "(maps to: )").
     writeFileSync(
       join(root, "glossary.yml"),
       [
         "terms:",
-        "  status:",
+        "  mixed:",
         "    status: ambiguous",
         "    possible_mappings: [orders.status, 42, users.status]",
+        "  all_invalid:",
+        "    status: ambiguous",
+        "    possible_mappings: [1, 2, 3]",
       ].join("\n") + "\n",
     );
 
     const index = buildSemanticIndex(root);
+    const lineOf = (term: string) =>
+      index.split("\n").find((l) => l.includes(`**${term}**`)) ?? "";
 
-    expect(index).toContain("(maps to: orders.status, users.status)");
-    expect(index).not.toContain("42");
+    // Survivors render in order; the non-string entry is dropped.
+    expect(lineOf("mixed")).toContain("(maps to: orders.status, users.status)");
+    expect(lineOf("mixed")).not.toContain("42");
+
+    // No surviving strings → no "maps to" clause (not an empty one).
+    expect(lineOf("all_invalid")).not.toContain("maps to:");
   });
 
   it("discovers groups/<group>/metrics, glossary, and catalog in the index (#3240)", () => {

--- a/packages/api/src/lib/__tests__/semantic-index.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-index.test.ts
@@ -290,6 +290,44 @@ describe("buildSemanticIndex", () => {
     expect(index).toContain("**size**");
     expect(index).toContain("[AMBIGUOUS]");
     expect(index).toContain("Ask the user which size they mean");
+    // Array-form terms without note/possible_mappings carry no mapping noise.
+    expect(index).not.toContain("maps to:");
+  });
+
+  it("renders note and possible_mappings for object-form ambiguous terms (#3277)", () => {
+    const root = ensureDir(`glossary-mappings-${testCounter}`);
+    mkdirSync(join(root, "entities"), { recursive: true });
+
+    writeFileSync(
+      join(root, "entities", "orders.yml"),
+      makeEntity("orders", {
+        dimensions: [{ name: "id", type: "integer" }],
+      }),
+    );
+
+    // Object-form glossary — the term carries its disambiguation guidance in
+    // `note` + `possible_mappings` (the shape the lookup layer uses), not in
+    // `definition`/`disambiguation`. The prompt index must surface both.
+    writeFileSync(
+      join(root, "glossary.yml"),
+      [
+        "terms:",
+        "  status:",
+        "    status: ambiguous",
+        '    note: "Appears in multiple tables — ASK the user."',
+        "    possible_mappings: [orders.status, users.status]",
+      ].join("\n") + "\n",
+    );
+
+    const index = buildSemanticIndex(root);
+
+    expect(index).toContain("### Glossary");
+    expect(index).toContain("**status**");
+    expect(index).toContain("[AMBIGUOUS]");
+    // The "ask the user" guidance and the candidate columns both surface.
+    expect(index).toContain("Appears in multiple tables — ASK the user.");
+    expect(index).toContain("orders.status");
+    expect(index).toContain("users.status");
   });
 
   it("discovers groups/<group>/metrics, glossary, and catalog in the index (#3240)", () => {

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -428,9 +428,16 @@ function formatGlossaryTerm(term: GlossaryTerm): string {
   // these fields are spread untyped from yaml.load, so the static `string[]`
   // type can't be trusted here (mirrors parseGlossaryTerm in lookups.ts).
   const note = term.note ? ` → ${term.note}` : "";
+  const mappingCandidates = Array.isArray(term.possible_mappings)
+    ? term.possible_mappings.filter(
+        (m): m is string => typeof m === "string" && m.trim().length > 0,
+      )
+    : [];
+  // Gate on the filtered candidates, not the raw array — an all-non-string or
+  // all-blank `possible_mappings` must emit no clause, never a bare "(maps to: )".
   const mappings =
-    Array.isArray(term.possible_mappings) && term.possible_mappings.length > 0
-      ? ` (maps to: ${term.possible_mappings.filter((m) => typeof m === "string").join(", ")})`
+    mappingCandidates.length > 0
+      ? ` (maps to: ${mappingCandidates.join(", ")})`
       : "";
   const group = term.group ? ` [${term.group}]` : "";
   return `- **${name}**${status}${def}${disambig}${note}${mappings}${group}`;

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -421,9 +421,12 @@ function formatGlossaryTerm(term: GlossaryTerm): string {
   const disambig = term.disambiguation
     ? ` → ${term.disambiguation}`
     : "";
-  // Object-form ambiguous terms carry their guidance in `note`/`possible_mappings`
-  // rather than `disambiguation`; surface both so the index matches what the
-  // searchGlossary tool returns (#3277).
+  // Object-form glossaries carry their disambiguation guidance in
+  // `note`/`possible_mappings` rather than `disambiguation`; surface both so the
+  // index carries the same disambiguation fields the searchGlossary tool returns
+  // (#3277). The runtime Array.isArray + string filter guards malformed input:
+  // these fields are spread untyped from yaml.load, so the static `string[]`
+  // type can't be trusted here (mirrors parseGlossaryTerm in lookups.ts).
   const note = term.note ? ` → ${term.note}` : "";
   const mappings =
     Array.isArray(term.possible_mappings) && term.possible_mappings.length > 0

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -95,6 +95,19 @@ interface GlossaryTerm {
   definition?: string;
   status?: string;
   disambiguation?: string;
+  /**
+   * Free-text disambiguation guidance (e.g. "Appears in multiple tables — ASK
+   * the user."). Object-form glossaries carry their "ask the user" guidance
+   * here rather than in `disambiguation`; the lookup layer (`GlossaryTermLookup`)
+   * mirrors this field. See #3277.
+   */
+  note?: string;
+  /**
+   * Candidate column mappings for an ambiguous term (e.g.
+   * `["orders.status", "users.status"]`), used to spell out the choices the
+   * agent should ask the user about. Mirrors `GlossaryTermLookup`. See #3277.
+   */
+  possible_mappings?: string[];
   /** Display group — set only for the canonical `groups/<group>/` namespace (see {@link ParsedMetric.group}). */
   group?: string;
 }
@@ -408,8 +421,16 @@ function formatGlossaryTerm(term: GlossaryTerm): string {
   const disambig = term.disambiguation
     ? ` → ${term.disambiguation}`
     : "";
+  // Object-form ambiguous terms carry their guidance in `note`/`possible_mappings`
+  // rather than `disambiguation`; surface both so the index matches what the
+  // searchGlossary tool returns (#3277).
+  const note = term.note ? ` → ${term.note}` : "";
+  const mappings =
+    Array.isArray(term.possible_mappings) && term.possible_mappings.length > 0
+      ? ` (maps to: ${term.possible_mappings.filter((m) => typeof m === "string").join(", ")})`
+      : "";
   const group = term.group ? ` [${term.group}]` : "";
-  return `- **${name}**${status}${def}${disambig}${group}`;
+  return `- **${name}**${status}${def}${disambig}${note}${mappings}${group}`;
 }
 
 // --- Loaders ---


### PR DESCRIPTION
## Summary

Fixes #3277. The boot-time semantic index's `formatGlossaryTerm`
(`packages/api/src/lib/semantic/search.ts`) rendered only `definition` and
`disambiguation` (plus `[AMBIGUOUS]`), silently dropping `note` and
`possible_mappings` — the fields **object-form** glossaries use to carry the
actual "ask the user" disambiguation guidance (the same shape the lookup layer's
`GlossaryTermLookup` carries).

So an ambiguous term like:

```yaml
terms:
  status:
    status: ambiguous
    note: "Appears in multiple tables — ASK the user."
    possible_mappings: [orders.status, users.status]
```

rendered in the agent prompt index as just `**status** **[AMBIGUOUS]**` — without
the mappings or the guidance. (The agent still got full context via the
`searchGlossary` MCP tool, so this was a prompt-index richness gap, not a total
loss — but the index should carry it too.)

Pre-existing for all layouts; made more visible by #3240 (PR #3258 review, Codex)
now that object-form group glossaries are discovered.

## Fix

- Extend the `GlossaryTerm` type + `formatGlossaryTerm` in `search.ts` to render
  `note` (` → note`) and `possible_mappings` (` (maps to: a, b)`) when present.
- Array-form terms (and terms lacking those fields) render **unchanged**.

Now renders:

```
- **status** **[AMBIGUOUS]** → Appears in multiple tables — ASK the user. (maps to: orders.status, users.status)
- **revenue**: Total income from sales
```

## Acceptance criteria

- [x] An object-form ambiguous term with `note`/`possible_mappings` renders that guidance in the index
- [x] Array-form terms unchanged when those fields are absent (existing test + new `not.toContain("maps to:")` guard)
- [x] Test covers ambiguous-term rendering with mappings (`renders note and possible_mappings for object-form ambiguous terms (#3277)`)

## Scope

api-only; independent of all other in-flight work. Edits confined to `search.ts`
(`GlossaryTerm` type) + its test — `lookups.ts` / `expert/context-loader.ts` /
`mcp/semantic-tools.ts` untouched (owned by other sessions).

## Testing

`/ci` — all gates green: lint, type, test (full suite, 0 failures), syncpack,
template-drift, security-headers, railway-watch, schema-drift, oauth-helper,
test-discipline, twenty-resolver, published-symbols.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783358159&installation_id=135337507&pr_number=3278&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3278&signature=1db13aefdddb89aaf4be63491a5e685fd848f4b4c81e3076a7b8f1d952d18c49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Glossary entries can include guidance notes and candidate column mappings to clarify ambiguous terms.

* **Tests**
  * Expanded test coverage to ensure guidance notes display correctly, mapping lists only show valid candidates, and no empty "maps to:" clause is shown when mappings are absent or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->