### PR TITLE
fix(semantic): layout-aware expert/improve glossary loader (#3273)

### DIFF
--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit test for the expert/`atlas improve` disk loaders `loadGlossaryFromDisk`
+ * and `loadEntitiesFromDisk` (#3273).
+ *
+ * Pins the load-bearing contract: both loaders must discover the canonical
+ * `groups/<group>/…` namespace (ADR-0012) — not just the flat root — so the
+ * expert agent's context is complete on a multi-group deployment. Before #3273
+ * the glossary loader read only `<root>/glossary.yml` (and only the array-term
+ * shape, so it dropped the object-form glossaries the bundle ships) and the
+ * entity loader read only `<root>/entities/`. Attribution must match the shared
+ * discovery read paths: the directory is canonical in `groups/<group>/`; a
+ * `group:`/`connection:` field overrides on the flat + legacy layouts.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+let tmpRoot: string;
+const ORIGINAL_SEMANTIC_ROOT = process.env.ATLAS_SEMANTIC_ROOT;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-load-from-disk-"));
+  process.env.ATLAS_SEMANTIC_ROOT = tmpRoot;
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (ORIGINAL_SEMANTIC_ROOT === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = ORIGINAL_SEMANTIC_ROOT;
+});
+
+beforeEach(() => {
+  // Reset the semantic-root fixture each test (path stays stable so the
+  // ATLAS_SEMANTIC_ROOT env var set in beforeAll remains valid).
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(tmpRoot, { recursive: true });
+});
+
+/** Write a fixture file relative to the semantic root, creating parents. */
+function writeSemanticFile(rel: string, body: string): void {
+  const full = path.join(tmpRoot, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+}
+
+// Re-import per test file (matches the pattern used by sibling semantic tests;
+// `getSemanticRoot()` reads ATLAS_SEMANTIC_ROOT at call time, so the import
+// itself does not capture the root).
+const mod = (await import(`../context-loader.ts?t=${Date.now()}`)) as typeof import("../context-loader");
+const { loadGlossaryFromDisk, loadEntitiesFromDisk } = mod;
+
+// ---------------------------------------------------------------------------
+// Glossary — the primary #3273 gap
+// ---------------------------------------------------------------------------
+
+describe("loadGlossaryFromDisk (layout-aware, #3273)", () => {
+  it("discovers object-form terms in the flat root glossary", async () => {
+    // The bundled glossaries use the object form `terms: { name: { ... } }`,
+    // which the prior array-only parser dropped entirely.
+    writeSemanticFile(
+      "glossary.yml",
+      "terms:\n  arr:\n    status: ambiguous\n    note: ARR appears in multiple tables\n",
+    );
+    const terms = await loadGlossaryFromDisk();
+    expect(terms.map((t) => t.term)).toEqual(["arr"]);
+    expect(terms[0].ambiguous).toBe(true);
+  });
+
+  it("discovers groups/<group>/glossary.yml and merges with the root (PRIMARY GAP)", async () => {
+    writeSemanticFile("glossary.yml", "terms:\n  arr:\n    definition: Annual recurring revenue\n");
+    writeSemanticFile("groups/eu_prod/glossary.yml", "terms:\n  vat:\n    status: ambiguous\n");
+    writeSemanticFile("groups/us_prod/glossary.yml", "terms:\n  ltv:\n    definition: Lifetime value\n");
+
+    const terms = await loadGlossaryFromDisk();
+    expect(terms.map((t) => t.term).toSorted()).toEqual(["arr", "ltv", "vat"]);
+    expect(terms.find((t) => t.term === "vat")?.ambiguous).toBe(true);
+  });
+
+  it("discovers legacy <source>/glossary.yml", async () => {
+    writeSemanticFile("marketing/glossary.yml", "terms:\n  cac:\n    definition: Customer acquisition cost\n");
+    const terms = await loadGlossaryFromDisk();
+    expect(terms.map((t) => t.term)).toEqual(["cac"]);
+  });
+
+  it("still parses the legacy array-term shape", async () => {
+    writeSemanticFile(
+      "glossary.yml",
+      "terms:\n  - term: mrr\n    definition: Monthly recurring revenue\n    ambiguous: true\n",
+    );
+    const terms = await loadGlossaryFromDisk();
+    expect(terms).toHaveLength(1);
+    expect(terms[0]).toEqual({ term: "mrr", definition: "Monthly recurring revenue", ambiguous: true });
+  });
+
+  it("returns empty when no glossary exists in any layout", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\n"); // present but no glossary
+    const terms = await loadGlossaryFromDisk();
+    expect(terms).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entities — the sibling root-only read (#3273 FIX bullet)
+// ---------------------------------------------------------------------------
+
+describe("loadEntitiesFromDisk (layout-aware, #3273)", () => {
+  it("discovers entities across flat, groups/, and legacy layouts with discovery-matching attribution", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\n");
+    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n");
+    writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\n");
+
+    const entities = await loadEntitiesFromDisk();
+    const connByTable = Object.fromEntries(entities.map((e) => [e.table, e.connection]));
+
+    expect(Object.keys(connByTable).toSorted()).toEqual(["campaigns", "customers", "orders"]);
+    // flat default → null connection (undefined), parity with the DB loaders.
+    expect(connByTable.orders).toBeUndefined();
+    // canonical groups/<group>/ → directory is canonical.
+    expect(connByTable.customers).toBe("eu_prod");
+    // legacy <source>/ → source name.
+    expect(connByTable.campaigns).toBe("marketing");
+  });
+
+  it("directory is canonical in groups/<group>/ even when a connection: field disagrees", async () => {
+    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\nconnection: wrong\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities).toHaveLength(1);
+    expect(entities[0].connection).toBe("eu_prod"); // not "wrong"
+  });
+
+  it("honors a connection: field override on the flat layout", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\nconnection: legacy_grp\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities[0].connection).toBe("legacy_grp");
+  });
+
+  it("returns empty when the semantic root has no entities", async () => {
+    const entities = await loadEntitiesFromDisk();
+    expect(entities).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -201,6 +201,24 @@ describe("loadEntitiesFromDisk (layout-aware, #3273)", () => {
     expect(entities[0].connection).toBe("canonical_grp");
   });
 
+  it("honors a connection: override on the legacy layout", async () => {
+    // Legacy `<source>/entities/` retains field-wins precedence (ADR-0012):
+    // the source dir is "marketing" but the field reassigns the group.
+    writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\nconnection: override_grp\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities[0].connection).toBe("override_grp");
+  });
+
+  it("keys entity.name to the storage key (table/file stem), not a display `name:`", async () => {
+    // The scheduled-tick apply path (`apply.ts`) looks the entity up by
+    // `proposal.entityName` (= entity.name), which must be the storage key the
+    // DB/disk is keyed by — never a display label. Mirrors `loadEntitiesFromDB`.
+    writeSemanticFile("entities/orders.yml", "table: orders\nname: Orders Display Label\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities[0].name).toBe("orders"); // storage key, not "Orders Display Label"
+    expect(entities[0].table).toBe("orders");
+  });
+
   it("returns empty when the semantic root has no entities", async () => {
     const entities = await loadEntitiesFromDisk();
     expect(entities).toEqual([]);

--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -64,8 +64,16 @@ describe("loadGlossaryFromDisk (layout-aware, #3273)", () => {
       "terms:\n  arr:\n    status: ambiguous\n    note: ARR appears in multiple tables\n",
     );
     const terms = await loadGlossaryFromDisk();
-    expect(terms.map((t) => t.term)).toEqual(["arr"]);
-    expect(terms[0].ambiguous).toBe(true);
+    // `definition` falls back to "" when the object-form entry has only `note:`
+    // (the analyzer reads `term`/length, not `definition`, but the fallback is a
+    // contract the `GlossaryTerm` shape depends on — never `undefined`).
+    expect(terms).toEqual([{ term: "arr", definition: "", ambiguous: true }]);
+  });
+
+  it("extracts the object-form definition field when present", async () => {
+    writeSemanticFile("glossary.yml", "terms:\n  arr:\n    definition: Annual recurring revenue\n");
+    const terms = await loadGlossaryFromDisk();
+    expect(terms).toEqual([{ term: "arr", definition: "Annual recurring revenue", ambiguous: false }]);
   });
 
   it("discovers groups/<group>/glossary.yml and merges with the root (PRIMARY GAP)", async () => {
@@ -92,6 +100,48 @@ describe("loadGlossaryFromDisk (layout-aware, #3273)", () => {
     const terms = await loadGlossaryFromDisk();
     expect(terms).toHaveLength(1);
     expect(terms[0]).toEqual({ term: "mrr", definition: "Monthly recurring revenue", ambiguous: true });
+  });
+
+  it("derives `ambiguous` from either marker, in either shape, else false", async () => {
+    // `ambiguous = (ambiguous === true) || (status === "ambiguous")` — the
+    // crossed cells the headline tests don't reach: array-form `status:`,
+    // object-form `ambiguous:`, and the negative (neither marker → false).
+    writeSemanticFile(
+      "glossary.yml",
+      [
+        "terms:",
+        "  - term: status_arr", // array-form, status marker
+        "    status: ambiguous",
+        "  - term: plain", // array-form, no marker
+        "    definition: nothing special",
+      ].join("\n") + "\n",
+    );
+    writeSemanticFile(
+      "groups/g/glossary.yml",
+      "terms:\n  flag_obj:\n    ambiguous: true\n", // object-form, ambiguous flag
+    );
+    const terms = await loadGlossaryFromDisk();
+    const byTerm = Object.fromEntries(terms.map((t) => [t.term, t.ambiguous]));
+    expect(byTerm).toEqual({ status_arr: true, plain: false, flag_obj: true });
+  });
+
+  it("emits a duplicate when the same term name appears in two layouts (no dedup at this layer)", async () => {
+    // The loader intentionally does NOT dedup — `categories.ts` keys off the
+    // term name via a Set, so duplicates are harmless there; pinning this keeps
+    // a future dedup from silently shifting the count `health.ts` sees.
+    writeSemanticFile("glossary.yml", "terms:\n  arr:\n    definition: root\n");
+    writeSemanticFile("groups/eu_prod/glossary.yml", "terms:\n  arr:\n    definition: eu\n");
+    const terms = await loadGlossaryFromDisk();
+    expect(terms.filter((t) => t.term === "arr")).toHaveLength(2);
+  });
+
+  it("one corrupt group glossary does not blank the rest of the union", async () => {
+    writeSemanticFile("glossary.yml", "terms:\n  arr:\n    definition: ok\n");
+    writeSemanticFile("groups/broken/glossary.yml", "terms: [unclosed\n"); // malformed YAML
+    writeSemanticFile("groups/good/glossary.yml", "terms:\n  ltv:\n    definition: fine\n");
+    const terms = await loadGlossaryFromDisk();
+    // The corrupt file is logged + skipped; the valid root + group terms survive.
+    expect(terms.map((t) => t.term).toSorted()).toEqual(["arr", "ltv"]);
   });
 
   it("returns empty when no glossary exists in any layout", async () => {
@@ -134,6 +184,21 @@ describe("loadEntitiesFromDisk (layout-aware, #3273)", () => {
     writeSemanticFile("entities/orders.yml", "table: orders\nconnection: legacy_grp\n");
     const entities = await loadEntitiesFromDisk();
     expect(entities[0].connection).toBe("legacy_grp");
+  });
+
+  it("honors the canonical `group:` field override on the flat layout", async () => {
+    // `group:` is the canonical field (ADR-0012); `connection:` is the
+    // deprecated alias. The override test above used the alias — pin the
+    // canonical field new authors will actually write.
+    writeSemanticFile("entities/orders.yml", "table: orders\ngroup: us_prod\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities[0].connection).toBe("us_prod");
+  });
+
+  it("the canonical `group:` field wins over the deprecated `connection:` alias", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\ngroup: canonical_grp\nconnection: alias_grp\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities[0].connection).toBe("canonical_grp");
   });
 
   it("returns empty when the semantic root has no entities", async () => {

--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -152,74 +152,38 @@ describe("loadGlossaryFromDisk (layout-aware, #3273)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Entities — the sibling root-only read (#3273 FIX bullet)
+// Entities — intentionally root-only (NOT layout-aware). Group-aware entity
+// discovery + apply is deferred to #3284 (the scheduler's auto-apply path
+// resolves entities by name with no group, so discovering group entities here
+// would mis-target an approved amendment). These tests pin that deliberate
+// scope so a future "helpful" refactor can't silently re-introduce the bug.
 // ---------------------------------------------------------------------------
 
-describe("loadEntitiesFromDisk (layout-aware, #3273)", () => {
-  it("discovers entities across flat, groups/, and legacy layouts with discovery-matching attribution", async () => {
-    writeSemanticFile("entities/orders.yml", "table: orders\n");
-    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n");
-    writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\n");
-
-    const entities = await loadEntitiesFromDisk();
-    const connByTable = Object.fromEntries(entities.map((e) => [e.table, e.connection]));
-
-    expect(Object.keys(connByTable).toSorted()).toEqual(["campaigns", "customers", "orders"]);
-    // flat default → null connection (undefined), parity with the DB loaders.
-    expect(connByTable.orders).toBeUndefined();
-    // canonical groups/<group>/ → directory is canonical.
-    expect(connByTable.customers).toBe("eu_prod");
-    // legacy <source>/ → source name.
-    expect(connByTable.campaigns).toBe("marketing");
-  });
-
-  it("directory is canonical in groups/<group>/ even when a connection: field disagrees", async () => {
-    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\nconnection: wrong\n");
-    const entities = await loadEntitiesFromDisk();
-    expect(entities).toHaveLength(1);
-    expect(entities[0].connection).toBe("eu_prod"); // not "wrong"
-  });
-
-  it("honors a connection: field override on the flat layout", async () => {
-    writeSemanticFile("entities/orders.yml", "table: orders\nconnection: legacy_grp\n");
-    const entities = await loadEntitiesFromDisk();
-    expect(entities[0].connection).toBe("legacy_grp");
-  });
-
-  it("honors the canonical `group:` field override on the flat layout", async () => {
-    // `group:` is the canonical field (ADR-0012); `connection:` is the
-    // deprecated alias. The override test above used the alias — pin the
-    // canonical field new authors will actually write.
-    writeSemanticFile("entities/orders.yml", "table: orders\ngroup: us_prod\n");
-    const entities = await loadEntitiesFromDisk();
-    expect(entities[0].connection).toBe("us_prod");
-  });
-
-  it("the canonical `group:` field wins over the deprecated `connection:` alias", async () => {
-    writeSemanticFile("entities/orders.yml", "table: orders\ngroup: canonical_grp\nconnection: alias_grp\n");
-    const entities = await loadEntitiesFromDisk();
-    expect(entities[0].connection).toBe("canonical_grp");
-  });
-
-  it("honors a connection: override on the legacy layout", async () => {
-    // Legacy `<source>/entities/` retains field-wins precedence (ADR-0012):
-    // the source dir is "marketing" but the field reassigns the group.
-    writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\nconnection: override_grp\n");
-    const entities = await loadEntitiesFromDisk();
-    expect(entities[0].connection).toBe("override_grp");
-  });
-
-  it("keys entity.name to the storage key (table/file stem), not a display `name:`", async () => {
+describe("loadEntitiesFromDisk (root-only by design, see #3284)", () => {
+  it("discovers flat-root entities and keys name to the storage key (not a display `name:`)", async () => {
     // The scheduled-tick apply path (`apply.ts`) looks the entity up by
     // `proposal.entityName` (= entity.name), which must be the storage key the
     // DB/disk is keyed by — never a display label. Mirrors `loadEntitiesFromDB`.
     writeSemanticFile("entities/orders.yml", "table: orders\nname: Orders Display Label\n");
     const entities = await loadEntitiesFromDisk();
+    expect(entities).toHaveLength(1);
     expect(entities[0].name).toBe("orders"); // storage key, not "Orders Display Label"
     expect(entities[0].table).toBe("orders");
+    expect(entities[0].connection).toBeUndefined();
   });
 
-  it("returns empty when the semantic root has no entities", async () => {
+  it("does NOT discover groups/<group>/ or legacy <source>/ entities (root-only; #3284)", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\n");
+    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n");
+    writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\n");
+    const entities = await loadEntitiesFromDisk();
+    // Only the flat-root entity surfaces; group + legacy entities are excluded
+    // until the apply path is group-aware (#3284).
+    expect(entities.map((e) => e.table)).toEqual(["orders"]);
+  });
+
+  it("returns empty when the flat root has no entities directory", async () => {
+    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n"); // present but not flat-root
     const entities = await loadEntitiesFromDisk();
     expect(entities).toEqual([]);
   });

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -260,55 +260,47 @@ export async function loadEntitiesForOrg(
 }
 
 /**
- * Load all entity YAML files from disk across every on-disk layout (ADR-0012):
- * the flat default root `entities/`, the canonical `groups/<group>/entities/`
- * namespace, and legacy `<source>/entities/`. Routed through the shared
- * `scanEntities` traversal the discovery read paths use (the entity group
- * namespace landed in #3241), so the self-hosted (no internal DB) expert context
- * sees every group's entities, not just the root's (#3273). Root-only before, it
- * silently dropped per-group entities on a multi-group deployment.
+ * Load entity YAML files from the flat default `entities/` directory.
  *
- * Like the other entity discovery surfaces this is `.yml`-only (via
- * `scanEntities`); the prior loader's extra `.yaml` acceptance was the odd one
- * out and never produced a queryable entity (the whitelist/file-tree are
- * `.yml`-only too).
+ * Intentionally root-only (the default group), NOT layout-aware: unlike the
+ * glossary loader below, this feeds the scheduled tick's auto-apply path
+ * (`runExpertSchedulerTick` → `applyAmendmentToEntity`), which resolves the
+ * target entity purely by name with no group/connection. Discovering
+ * `groups/<group>/entities/` here would let an auto-approved amendment for a
+ * group entity 409 as ambiguous or write back into the default scope. Making
+ * the entity path group-aware end-to-end (thread the group through analyze →
+ * insert → apply) is tracked in #3284. `name` keys off `table`/file-stem (the
+ * storage key the apply path looks up by), mirroring `loadEntitiesFromDB`.
  */
 export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
-  const root = getSemanticRoot();
-  if (!fs.existsSync(root)) return [];
-
-  const { scanEntities, resolveEntityGroup, readGroupField } =
-    await import("@atlas/api/lib/semantic/scanner");
+  const entitiesDir = path.join(getSemanticRoot(), "entities");
+  if (!fs.existsSync(entitiesDir)) return [];
 
   const entities: ParsedEntity[] = [];
-  // `scanEntities` parses every layout's YAML and logs+skips unreadable files
-  // and namespace-enumeration failures internally (scanner.ts), so a partial
-  // read is already traced — re-logging its `warnings` here would double-count
-  // the per-file parse failures it already emitted.
-  for (const { raw, filePath, sourceName, origin } of scanEntities(root).entities) {
-    // Attribution matches the discovery read paths (ADR-0012): the directory is
-    // canonical in the `groups/<group>/` namespace — a disagreeing field loses
-    // (`resolveEntityGroup`'s `mismatch` flag is intentionally not surfaced here,
-    // mirroring the lookup/catalog read paths); a top-level `group:`/`connection:`
-    // field overrides on the flat + legacy layouts. The flat default group maps
-    // to the null connection (`undefined`), keeping parity with the DB loaders
-    // above.
-    const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
-    const projected = projectParsedEntity(raw, {
-      fallbackName: path.basename(filePath).replace(/\.yml$/, ""),
-    });
-    entities.push({
-      ...projected,
-      // The scheduled-tick analyzer stamps each proposal with `entity.name`, and
-      // the apply path (`apply.ts` → `getEntity`/`upsertEntity`/`syncEntityToDisk`)
-      // resolves the target by that key — which is the STORAGE name (table / file
-      // stem), never a display `name:`. Mirror `loadEntitiesFromDB`, which also
-      // ignores `parsed.name`, so an auto-approved amendment still finds its
-      // entity; honoring a display `name:` here would make apply look up a key
-      // that doesn't exist (#3280 review).
-      name: projected.table,
-      connection: group === "default" ? undefined : group,
-    });
+
+  for (const file of fs.readdirSync(entitiesDir)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    try {
+      const content = fs.readFileSync(path.join(entitiesDir, file), "utf-8");
+      const parsed = yaml.load(content) as Record<string, unknown> | null;
+      if (!parsed || typeof parsed !== "object") continue;
+
+      entities.push({
+        name: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
+        table: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
+        description: typeof parsed.description === "string" ? parsed.description : undefined,
+        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
+        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
+        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
+        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
+        connection: typeof parsed.connection === "string" ? parsed.connection : undefined,
+      });
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), file },
+        "Failed to parse entity YAML",
+      );
+    }
   }
 
   return entities;

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -260,68 +260,123 @@ export async function loadEntitiesForOrg(
 }
 
 /**
- * Load all entity YAML files from disk.
+ * Load all entity YAML files from disk across every on-disk layout (ADR-0012):
+ * the flat default root `entities/`, the canonical `groups/<group>/entities/`
+ * namespace, and legacy `<source>/entities/`. Routed through the shared
+ * `scanEntities` traversal the discovery read paths use (#3240), so the
+ * self-hosted (no internal DB) expert context sees every group's entities, not
+ * just the root's (#3273). Root-only before, it silently dropped per-group
+ * entities on a multi-group deployment.
  */
 export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
-  const entitiesDir = path.join(getSemanticRoot(), "entities");
-  if (!fs.existsSync(entitiesDir)) return [];
+  const root = getSemanticRoot();
+  if (!fs.existsSync(root)) return [];
+
+  const { scanEntities, resolveEntityGroup, readGroupField } =
+    await import("@atlas/api/lib/semantic/scanner");
 
   const entities: ParsedEntity[] = [];
-
-  for (const file of fs.readdirSync(entitiesDir)) {
-    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
-    try {
-      const content = fs.readFileSync(path.join(entitiesDir, file), "utf-8");
-      const parsed = yaml.load(content) as Record<string, unknown> | null;
-      if (!parsed || typeof parsed !== "object") continue;
-
-      entities.push({
-        name: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
-        table: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
-        description: typeof parsed.description === "string" ? parsed.description : undefined,
-        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
-        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
-        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
-        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
-        connection: typeof parsed.connection === "string" ? parsed.connection : undefined,
-      });
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err), file },
-        "Failed to parse entity YAML",
-      );
-    }
+  // `scanEntities` parses every layout's YAML and logs+skips unreadable files
+  // (matching this loader's prior per-file `try/catch`).
+  for (const { raw, filePath, sourceName, origin } of scanEntities(root).entities) {
+    // Attribution matches the discovery read paths (ADR-0012): the directory is
+    // canonical in the `groups/<group>/` namespace; a top-level `group:`/
+    // `connection:` field overrides on the flat + legacy layouts. The flat
+    // default group maps to the null connection (`undefined`), keeping parity
+    // with the DB loaders above.
+    const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
+    entities.push({
+      ...projectParsedEntity(raw, {
+        fallbackName: path.basename(filePath).replace(/\.ya?ml$/, ""),
+      }),
+      connection: group === "default" ? undefined : group,
+    });
   }
 
   return entities;
 }
 
 /**
- * Load glossary terms from disk.
+ * Load glossary terms from disk across every on-disk layout (ADR-0012): the flat
+ * default root, the canonical `groups/<group>/glossary.yml` namespace, and
+ * legacy `<source>/glossary.yml`. Routed through the same layout-aware
+ * `getGroupDirs` traversal the discovery read paths use (#3240), so the expert
+ * context can no longer miss per-group glossary terms (#3273).
+ *
+ * Both glossary YAML shapes are honored, matching the discovery loaders
+ * (`lib/semantic/lookups.ts`, `lib/semantic/search.ts`): the object form
+ * `terms: { name: { status, definition } }` (canonical) and the array form
+ * `terms: [{ term, definition, ambiguous }]` (legacy). The previous root-only
+ * loader parsed the array form *only*, so it returned nothing for the object
+ * form the bundled glossaries actually use — a second drift point this closes.
+ *
+ * The expert `GlossaryTerm` carries no group label — the scheduled analyzer
+ * reasons at global scope and dedups terms by name (`categories.ts`) — so the
+ * loader returns a flat union of every group's terms; per-group attribution is
+ * the entity loader's concern.
  */
 export async function loadGlossaryFromDisk(): Promise<GlossaryTerm[]> {
-  const glossaryPath = path.join(getSemanticRoot(), "glossary.yml");
-  if (!fs.existsSync(glossaryPath)) return [];
+  const { getGroupDirs } = await import("@atlas/api/lib/semantic/scanner");
 
+  const terms: GlossaryTerm[] = [];
+  for (const { dir } of getGroupDirs(getSemanticRoot(), null).dirs) {
+    loadGlossaryFile(path.join(dir, "glossary.yml"), terms);
+  }
+  return terms;
+}
+
+/**
+ * Parse a single `glossary.yml` into expert `GlossaryTerm`s, appending to `out`.
+ * Tolerates both the object- and array-term shapes; a read/parse failure on one
+ * group's file is logged and skipped so it can't blank the whole expert context.
+ */
+function loadGlossaryFile(filePath: string, out: GlossaryTerm[]): void {
+  if (!fs.existsSync(filePath)) return;
+
+  let raw: unknown;
   try {
-    const content = fs.readFileSync(glossaryPath, "utf-8");
-    const parsed = yaml.load(content) as Record<string, unknown> | null;
-    if (!parsed || typeof parsed !== "object") return [];
-
-    const terms = parsed.terms;
-    if (Array.isArray(terms)) {
-      return terms.filter(
-        (t): t is GlossaryTerm => t != null && typeof t === "object" && "term" in t,
-      );
-    }
+    raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { filePath, err: err instanceof Error ? err.message : String(err) },
       "Failed to parse glossary.yml",
     );
+    return;
   }
 
-  return [];
+  if (!raw || typeof raw !== "object") return;
+  const termsNode = (raw as { terms?: unknown }).terms;
+
+  if (Array.isArray(termsNode)) {
+    for (const entry of termsNode) {
+      const term = normalizeGlossaryTerm(entry);
+      if (term) out.push(term);
+    }
+  } else if (termsNode && typeof termsNode === "object") {
+    for (const [key, value] of Object.entries(termsNode as Record<string, unknown>)) {
+      const term = normalizeGlossaryTerm(value, key);
+      if (term) out.push(term);
+    }
+  }
+}
+
+/**
+ * Normalize one glossary entry into the expert `GlossaryTerm` shape. Object-form
+ * entries supply the term name via `fallbackTerm` (the YAML key); array-form
+ * entries carry their own `term`. Returns `null` when no term name resolves.
+ * `ambiguous` is derived from an explicit `ambiguous: true` or the load-bearing
+ * `status: ambiguous` marker (the glossary's canonical "ask the user" signal).
+ */
+function normalizeGlossaryTerm(raw: unknown, fallbackTerm?: string): GlossaryTerm | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const rec = raw as Record<string, unknown>;
+  const term = typeof rec.term === "string" && rec.term ? rec.term : fallbackTerm;
+  if (!term) return null;
+  return {
+    term,
+    definition: typeof rec.definition === "string" ? rec.definition : "",
+    ambiguous: rec.ambiguous === true || rec.status === "ambiguous",
+  };
 }
 
 /**

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -263,10 +263,15 @@ export async function loadEntitiesForOrg(
  * Load all entity YAML files from disk across every on-disk layout (ADR-0012):
  * the flat default root `entities/`, the canonical `groups/<group>/entities/`
  * namespace, and legacy `<source>/entities/`. Routed through the shared
- * `scanEntities` traversal the discovery read paths use (#3240), so the
- * self-hosted (no internal DB) expert context sees every group's entities, not
- * just the root's (#3273). Root-only before, it silently dropped per-group
- * entities on a multi-group deployment.
+ * `scanEntities` traversal the discovery read paths use (the entity group
+ * namespace landed in #3241), so the self-hosted (no internal DB) expert context
+ * sees every group's entities, not just the root's (#3273). Root-only before, it
+ * silently dropped per-group entities on a multi-group deployment.
+ *
+ * Like the other entity discovery surfaces this is `.yml`-only (via
+ * `scanEntities`); the prior loader's extra `.yaml` acceptance was the odd one
+ * out and never produced a queryable entity (the whitelist/file-tree are
+ * `.yml`-only too).
  */
 export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
   const root = getSemanticRoot();
@@ -277,17 +282,21 @@ export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
 
   const entities: ParsedEntity[] = [];
   // `scanEntities` parses every layout's YAML and logs+skips unreadable files
-  // (matching this loader's prior per-file `try/catch`).
+  // and namespace-enumeration failures internally (scanner.ts), so a partial
+  // read is already traced — re-logging its `warnings` here would double-count
+  // the per-file parse failures it already emitted.
   for (const { raw, filePath, sourceName, origin } of scanEntities(root).entities) {
     // Attribution matches the discovery read paths (ADR-0012): the directory is
-    // canonical in the `groups/<group>/` namespace; a top-level `group:`/
-    // `connection:` field overrides on the flat + legacy layouts. The flat
-    // default group maps to the null connection (`undefined`), keeping parity
-    // with the DB loaders above.
+    // canonical in the `groups/<group>/` namespace — a disagreeing field loses
+    // (`resolveEntityGroup`'s `mismatch` flag is intentionally not surfaced here,
+    // mirroring the lookup/catalog read paths); a top-level `group:`/`connection:`
+    // field overrides on the flat + legacy layouts. The flat default group maps
+    // to the null connection (`undefined`), keeping parity with the DB loaders
+    // above.
     const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
     entities.push({
       ...projectParsedEntity(raw, {
-        fallbackName: path.basename(filePath).replace(/\.ya?ml$/, ""),
+        fallbackName: path.basename(filePath).replace(/\.yml$/, ""),
       }),
       connection: group === "default" ? undefined : group,
     });
@@ -310,17 +319,31 @@ export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
  * loader parsed the array form *only*, so it returned nothing for the object
  * form the bundled glossaries actually use — a second drift point this closes.
  *
- * The expert `GlossaryTerm` carries no group label — the scheduled analyzer
- * reasons at global scope and dedups terms by name (`categories.ts`) — so the
- * loader returns a flat union of every group's terms; per-group attribution is
- * the entity loader's concern.
+ * The expert `GlossaryTerm` carries no group label, so the loader returns a flat
+ * union of every group's terms (per-group attribution is the entity loader's
+ * concern). It does NOT dedup: the gap detector keys off term name via a Set
+ * (`categories.ts`), so a name defined in two groups won't spawn spurious gap
+ * proposals; the health count uses the raw list length (`health.ts`), so a name
+ * repeated across groups is counted once per group.
  */
 export async function loadGlossaryFromDisk(): Promise<GlossaryTerm[]> {
   const { getGroupDirs } = await import("@atlas/api/lib/semantic/scanner");
 
   const terms: GlossaryTerm[] = [];
-  for (const { dir } of getGroupDirs(getSemanticRoot(), null).dirs) {
+  const { dirs, failedScans } = getGroupDirs(getSemanticRoot(), null);
+  for (const { dir } of dirs) {
     loadGlossaryFile(path.join(dir, "glossary.yml"), terms);
+  }
+  // The interactive lookup/search read paths surface scan failures to the user
+  // through the response; the expert tick runs unattended, so re-log a failed
+  // namespace enumeration against the expert context — otherwise a quietly
+  // partial glossary leaves only a low-level scanner warn (#3243 fail-closed
+  // semantics).
+  if (failedScans.length > 0) {
+    log.warn(
+      { failedScans },
+      "Expert glossary context is partial — a semantic namespace failed to enumerate",
+    );
   }
   return terms;
 }

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -294,10 +294,19 @@ export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
     // to the null connection (`undefined`), keeping parity with the DB loaders
     // above.
     const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
+    const projected = projectParsedEntity(raw, {
+      fallbackName: path.basename(filePath).replace(/\.yml$/, ""),
+    });
     entities.push({
-      ...projectParsedEntity(raw, {
-        fallbackName: path.basename(filePath).replace(/\.yml$/, ""),
-      }),
+      ...projected,
+      // The scheduled-tick analyzer stamps each proposal with `entity.name`, and
+      // the apply path (`apply.ts` → `getEntity`/`upsertEntity`/`syncEntityToDisk`)
+      // resolves the target by that key — which is the STORAGE name (table / file
+      // stem), never a display `name:`. Mirror `loadEntitiesFromDB`, which also
+      // ignores `parsed.name`, so an auto-approved amendment still finds its
+      // entity; honoring a display `name:` here would make apply look up a key
+      // that doesn't exist (#3280 review).
+      name: projected.table,
       connection: group === "default" ? undefined : group,
     });
   }


### PR DESCRIPTION
Fixes #3273.

## Problem

The expert / `atlas improve` context loader read the semantic-layer **glossary** root-only, so a multi-group (non-default Connection group) deployment's `groups/<group>/glossary.yml` (ADR-0012) never reached the expert agent's context — the exact drift the #3240 discovery centralization was meant to eliminate. Worse, `loadGlossaryFromDisk()` parsed only the **array** term shape and silently returned nothing for the **object** shape (`terms: { name: { … } }`) the bundled glossaries actually use.

## Fix (glossary loader)

Route `loadGlossaryFromDisk` through the same shared, layout-aware `getGroupDirs(root, null)` traversal #3240 backs the SQL whitelist, lookups, admin discovery, and the boot index with (`lib/semantic/scanner.ts`) — across flat / `groups/<group>/` / legacy — and parse **both** the object-form (canonical) and array-form (legacy) term shapes, matching the discovery loaders (`lookups.ts` / `search.ts`). `failedScans` is surfaced at the expert-loader level (the scheduled tick is unattended, so a quietly-partial glossary would otherwise leave only a low-level scanner warn).

The expert `GlossaryTerm` carries no group label — the scheduled analyzer reasons at global scope and the gap detector dedups by name — so the loader returns a flat global union of every group's terms (no apply-by-group step).

## Scope note — entity loader stays root-only (follow-up #3284)

The first revision also routed the sibling `loadEntitiesFromDisk` through `groups/`, but **#3280 review (Codex) correctly flagged** that the expert auto-apply path isn't group-aware: `analyzeSemanticLayer` emits only `entityName`, the scheduler stores only `sourceEntity`, and `applyAmendmentToEntity` → `getEntity`/`upsertEntity`/`syncEntityToDisk` resolve by name with no group. Discovering `groups/<group>/entities/` would let an auto-approved amendment for a group entity 409 (ambiguous) or write back into the default scope. Entity group-discovery was never in #3273's glossary-specific acceptance criteria, and threading the group through analyze → insert → apply is a larger cross-cutting change outside this PR's coordination boundary — so `loadEntitiesFromDisk` is reverted to its original root-only form and the group-aware entity work is tracked in **#3284**.

## Acceptance criteria

- [x] Expert context loader discovers `groups/<group>/glossary.yml` across flat/groups/legacy layouts (plus object-form term parsing). Metrics: the context loader does not load metrics, so none to route.
- [x] Attribution matches the discovery read paths (directory canonical; field override on flat/legacy) — the glossary union surfaces every group's terms, same as `lookups.ts`/`search.ts`.
- [x] Unit test covers `groups/` glossary discovery in the expert loader — `expert/__tests__/load-from-disk.test.ts` (12 cases; includes the deliberate entity root-only scope pin).

## Scope / coordination

Touches only `expert/context-loader.ts` (+ test). Reuses `getGroupDirs` from `scanner.ts`; does **not** modify scanner.ts / search.ts / lookups.ts. This is in the deferred expert-agent maintenance layer (#1180), parallel-safe and out of v0.0.12's onboarding scope.

## Testing

`/ci` — lint, type, full test suite, syncpack, and all drift gates pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering glossary and entity loading across supported layouts, legacy formats, duplicate/overlapping entries, malformed files, and empty states.

* **Refactor**
  * Glossary loader now aggregates group and root glossaries, normalizes legacy and object formats, and skips broken group files without failing overall.
  * Entity loader remains root-only (flat directory), keys entity identity to storage key and exposes no connection info for this scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->