### PR TITLE
feat(semantic): generate into the Connection-group namespace — init + wizard (#3234)

### DIFF
--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ bun run atlas -- init [options]
 |------|-------------|
 | `--tables <t1,t2>` | Profile only specific tables/views (comma-separated) |
 | `--schema <name>` | PostgreSQL schema name (default: `public`) |
-| `--source <name>` | Write to `semantic/{name}/` subdirectory (per-source layout). Mutually exclusive with `--connection` |
+| `--source <name>` | Deprecated alias for selecting the output group — writes to `semantic/groups/{name}/` (group-of-one). Mutually exclusive with `--connection` |
 | `--connection <name>` | Profile a named datasource from `atlas.config.ts`. Mutually exclusive with `--source` |
 | `--csv <file1.csv,...>` | Load CSV files via DuckDB (no DB server needed). Requires `@duckdb/node-api` |
 | `--parquet <f1.parquet,...>` | Load Parquet files via DuckDB. Requires `@duckdb/node-api` |
@@ -66,7 +66,7 @@ bun run atlas -- init --connection warehouse
 # Profile CSV files directly (no database needed)
 bun run atlas -- init --csv sales.csv,products.csv
 
-# Legacy per-source layout (writes to semantic/warehouse/)
+# Select the output group explicitly (writes to semantic/groups/warehouse/)
 bun run atlas -- init --source warehouse
 
 # Org-scoped: writes to semantic/.orgs/org-123/ and imports to DB
@@ -81,7 +81,7 @@ bun run atlas -- init --org org-123 --no-import
 `--connection` and `--source` cannot be used together. Here's how they differ:
 
 - **No flag** — Profiles the default datasource (`ATLAS_DATASOURCE_URL`) and writes output to the flat-root default group at `semantic/entities/`.
-- **`--source <name>`** — Writes output to the **legacy** per-source layout `semantic/<name>/entities/`. Deprecated alias for the group namespace ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md)) — still recognized for back-compat. Does not change which datasource is profiled.
+- **`--source <name>`** — A **deprecated alias** for selecting the output group ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md)). Writes output to the canonical `semantic/groups/<name>/entities/` namespace (group-of-one). Does not change which datasource is profiled. The pre-ADR-0012 flat `semantic/<name>/entities/` layout from older runs is still read by the loader for back-compat.
 - **`--connection <name>`** — Profiles a named datasource defined in `atlas.config.ts` (e.g. `datasources.warehouse`) and writes output to that connection's group under the canonical `semantic/groups/<name>/` namespace (the default datasource stays flat at `semantic/`).
 
 If more than 20% of tables fail to profile, `init` exits with an error — this usually indicates a systemic issue like wrong credentials or missing permissions. Use `--force` to override this threshold.

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ bun run atlas -- init [options]
 |------|-------------|
 | `--tables <t1,t2>` | Profile only specific tables/views (comma-separated) |
 | `--schema <name>` | PostgreSQL schema name (default: `public`) |
-| `--source <name>` | Deprecated alias for selecting the output group — writes to `semantic/groups/{name}/` (group-of-one). Mutually exclusive with `--connection` |
+| `--source <name>` | Deprecated. Writes to the legacy per-source layout `semantic/{name}/`. Mutually exclusive with `--connection` |
 | `--connection <name>` | Profile a named datasource from `atlas.config.ts`. Mutually exclusive with `--source` |
 | `--csv <file1.csv,...>` | Load CSV files via DuckDB (no DB server needed). Requires `@duckdb/node-api` |
 | `--parquet <f1.parquet,...>` | Load Parquet files via DuckDB. Requires `@duckdb/node-api` |
@@ -66,7 +66,7 @@ bun run atlas -- init --connection warehouse
 # Profile CSV files directly (no database needed)
 bun run atlas -- init --csv sales.csv,products.csv
 
-# Select the output group explicitly (writes to semantic/groups/warehouse/)
+# Legacy per-source layout (writes to semantic/warehouse/)
 bun run atlas -- init --source warehouse
 
 # Org-scoped: writes to semantic/.orgs/org-123/ and imports to DB
@@ -81,7 +81,7 @@ bun run atlas -- init --org org-123 --no-import
 `--connection` and `--source` cannot be used together. Here's how they differ:
 
 - **No flag** — Profiles the default datasource (`ATLAS_DATASOURCE_URL`) and writes output to the flat-root default group at `semantic/entities/`.
-- **`--source <name>`** — A **deprecated alias** for selecting the output group ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md)). Writes output to the canonical `semantic/groups/<name>/entities/` namespace (group-of-one). Does not change which datasource is profiled. The pre-ADR-0012 flat `semantic/<name>/entities/` layout from older runs is still read by the loader for back-compat.
+- **`--source <name>`** — **Deprecated.** Writes output to the legacy per-source layout `semantic/<name>/entities/` ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md) — the loader still reads this layout for back-compat, but new layers should use the `groups/` namespace via `--connection`). Does not change which datasource is profiled.
 - **`--connection <name>`** — Profiles a named datasource defined in `atlas.config.ts` (e.g. `datasources.warehouse`) and writes output to that connection's group under the canonical `semantic/groups/<name>/` namespace (the default datasource stays flat at `semantic/`).
 
 If more than 20% of tables fail to profile, `init` exits with an error — this usually indicates a systemic issue like wrong credentials or missing permissions. Use `--force` to override this threshold.

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -66,7 +66,7 @@ bun run atlas -- init --connection warehouse
 # Profile CSV files directly (no database needed)
 bun run atlas -- init --csv sales.csv,products.csv
 
-# Per-source layout (writes to semantic/warehouse/)
+# Legacy per-source layout (writes to semantic/warehouse/)
 bun run atlas -- init --source warehouse
 
 # Org-scoped: writes to semantic/.orgs/org-123/ and imports to DB
@@ -80,9 +80,9 @@ bun run atlas -- init --org org-123 --no-import
 
 `--connection` and `--source` cannot be used together. Here's how they differ:
 
-- **No flag** — Profiles the default datasource (`ATLAS_DATASOURCE_URL`) and writes output to `semantic/entities/`.
-- **`--source <name>`** — Writes output to `semantic/<name>/entities/` (for multi-source layouts where you organize by source). Does not change which datasource is profiled.
-- **`--connection <name>`** — Profiles a named datasource defined in `atlas.config.ts` (e.g. `datasources.warehouse`) and automatically writes output to the matching `semantic/<name>/` subdirectory.
+- **No flag** — Profiles the default datasource (`ATLAS_DATASOURCE_URL`) and writes output to the flat-root default group at `semantic/entities/`.
+- **`--source <name>`** — Writes output to the **legacy** per-source layout `semantic/<name>/entities/`. Deprecated alias for the group namespace ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md)) — still recognized for back-compat. Does not change which datasource is profiled.
+- **`--connection <name>`** — Profiles a named datasource defined in `atlas.config.ts` (e.g. `datasources.warehouse`) and writes output to that connection's group under the canonical `semantic/groups/<name>/` namespace (the default datasource stays flat at `semantic/`).
 
 If more than 20% of tables fail to profile, `init` exits with an error — this usually indicates a systemic issue like wrong credentials or missing permissions. Use `--force` to override this threshold.
 

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -188,27 +188,29 @@ export default defineConfig({
 });
 ```
 
-### Per-datasource semantic layers
+### Per-group semantic layers
 
-Each named datasource can have its own semantic layer directory at `semantic/{sourceId}/entities/`. The CLI's `--connection` flag writes to the matching subdirectory automatically:
+The semantic layer is scoped by **Connection group** ([ADR-0012](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0012-group-scoped-semantic-layer-directories.md)). The default datasource is the flat-root **default group**; each non-default datasource is a group-of-one whose entities live under the dedicated `semantic/groups/<group>/` namespace. The CLI's `--connection` flag writes to the matching group directory automatically:
 
 ```bash
-# Profile the "warehouse" datasource → writes to semantic/warehouse/entities/
+# Profile the "warehouse" datasource → writes to semantic/groups/warehouse/entities/
 bun run atlas -- init --connection warehouse
 ```
 
 ```
 semantic/
-├── entities/            # Default datasource entities
+├── entities/                  # Default group (flat root)
 │   └── users.yml
-├── warehouse/
-│   └── entities/        # "warehouse" datasource entities
-│       └── inventory.yml
 ├── metrics/
-└── glossary.yml
+├── glossary.yml
+└── groups/
+    └── warehouse/             # "warehouse" group
+        ├── entities/
+        │   └── inventory.yml
+        └── metrics/
 ```
 
-Atlas discovers per-source subdirectories automatically and maps entities to connections by directory name.
+Atlas discovers the `groups/<group>/` namespace automatically and maps entities to connection groups by directory name. The legacy per-source layout (`semantic/<source>/entities/`, e.g. from the deprecated `--source` flag) is still recognized for back-compat.
 
 ---
 

--- a/docs/design/semantic-onboarding.md
+++ b/docs/design/semantic-onboarding.md
@@ -36,7 +36,7 @@ Entities bind to a **Connection group** — a standalone DB is simply a group-of
 
 - The unit is surfaced as **`group`** everywhere: YAML `group:`, the view's grouping, the CLI's target.
 - The three historical aliases — the YAML `connection:` field, the CLI `--source` flag, the admin/API `source` — are **deprecated and unified** to `group`. (See [CONTEXT.md § Semantic layer scoping](../../CONTEXT.md) and [ADR-0012](../adr/0012-group-scoped-semantic-layer-directories.md).)
-- *As implemented (#3234):* **generation honors this unit** — both `atlas init` and the wizard write into the group the connection belongs to (see § F), so the scope key is consistent end-to-end from generation through load and query.
+- *As implemented (#3234):* **generation honors this unit** — generation writes into a group namespace rather than scoping by raw `connectionId` (see § F). The wizard resolves the connection's *actual* Connection group (members of a group share one set of entities); the file-based CLI treats each connection name as a group-of-one. Either way the scope key is consistent end-to-end from generation through load and query.
 
 ### B. On-disk representation (self-host / file-based)
 

--- a/docs/design/semantic-onboarding.md
+++ b/docs/design/semantic-onboarding.md
@@ -36,6 +36,7 @@ Entities bind to a **Connection group** — a standalone DB is simply a group-of
 
 - The unit is surfaced as **`group`** everywhere: YAML `group:`, the view's grouping, the CLI's target.
 - The three historical aliases — the YAML `connection:` field, the CLI `--source` flag, the admin/API `source` — are **deprecated and unified** to `group`. (See [CONTEXT.md § Semantic layer scoping](../../CONTEXT.md) and [ADR-0012](../adr/0012-group-scoped-semantic-layer-directories.md).)
+- *As implemented (#3234):* **generation honors this unit** — both `atlas init` and the wizard write into the group the connection belongs to (see § F), so the scope key is consistent end-to-end from generation through load and query.
 
 ### B. On-disk representation (self-host / file-based)
 
@@ -108,13 +109,15 @@ All three doors call the same group-scoped generation flow (Phase 1 → optional
 
 This is what makes the flow **DB-count-agnostic**: the 1st-DB-after-skip and the Nth-DB are the same code path.
 
+*As implemented (#3234):* whichever door launches the flow, the generated entities land in the **correct Connection group** — the shared group-routing in § F means a new-group connection seeds its own `groups/<group>/` namespace while a member added to a populated group reuses the existing group's entities (no second copy). This is the substrate the two-phase generate UI (#3236) and the entry points (#3237) build on.
+
 ### F. Shared engine (CLI ↔ web parity)
 
 Today the generator runs in two places and enrichment in a third (CLI-only). Consolidate:
 
 - Move the mechanical generator + the enrichment logic out of `packages/cli/bin/enrich.ts` into shared **`packages/api/src/lib/semantic/…`** (respecting CLAUDE.md: `lib/` sits above `api/routes/`; `lib/` must not import from `api/routes/`).
 - Both front-ends call the same engine: the `wizard.ts` routes (web) and `atlas init` / a new enrich surface (CLI). One behavior, two doors — no drift between "what the CLI produces" and "what the wizard produces."
-- Fix `wizard.ts` to scope by **group**, not `connectionId` (`wizard.ts:565`).
+- *As implemented (#3234):* both front-ends write into the canonical group namespace via the shared `outputDirForGroup(group, orgId)` helper (`lib/profiler.ts`) — the default group flat at the root, a non-default group under `groups/<group>/`, exactly what the #3232 loader reads back. `atlas init --connection <c>` treats `<c>` as a group-of-one; the wizard `/generate` + `/save` routes resolve the connection's actual Connection group via `resolveGroupIdForConnection` (`lib/semantic/entities.ts`), so saved rows carry the right `connection_group_id` (DB-backed) and land in `groups/<group>/` (file-based) — replacing the old `connectionId` scoping. Adding a member to an already-populated group resolves to the same group and upserts the shared rows rather than duplicating them.
 
 ### G. Relationship to the Semantic Expert Agent
 

--- a/packages/api/src/api/__tests__/admin-archive-restore.test.ts
+++ b/packages/api/src/api/__tests__/admin-archive-restore.test.ts
@@ -120,6 +120,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   upsertDraftEntity: mock(() => Promise.resolve()),
   upsertTombstone: mock(() => Promise.resolve()),
   deleteDraftEntity: mock(() => Promise.resolve(false)),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -154,6 +154,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   applyTombstones: mock(() => Promise.resolve(0)),
   promoteDraftEntities: mock(() => Promise.resolve(0)),
   DEMO_CONNECTION_ID: "__demo__",

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -115,6 +115,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   upsertDraftEntity: mock(() => Promise.resolve()),
   upsertTombstone: mock(() => Promise.resolve()),
   deleteDraftEntity: mock(() => Promise.resolve(false)),

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -181,6 +181,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   applyTombstones: mock(() => Promise.resolve(0)),
   promoteDraftEntities: mock(() => Promise.resolve(0)),
   DEMO_CONNECTION_ID: "__demo__",

--- a/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
@@ -135,13 +135,17 @@ mock.module("@atlas/api/lib/semantic/sync", () => ({
 // the route on the 201 path so the audit assertions can run.
 const mockBulkUpsertEntities: Mock<(
   orgId: string,
-  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string }>,
+  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
 ) => Promise<number>> = mock(async (_orgId, entities) => entities.length);
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
   bulkUpsertEntities: mockBulkUpsertEntities,
+  // #3234: the wizard resolves the connection's group before saving.
+  resolveGroupIdForConnection: mock(async (_orgId: string, connectionId?: string | null) =>
+    !connectionId || connectionId === "default" ? null : connectionId,
+  ),
   upsertEntity: async () => {},
   upsertDraftEntity: async () => {},
   upsertTombstone: async () => {},
@@ -195,6 +199,11 @@ mock.module("@atlas/api/lib/profiler", () => ({
   generateMetricYAML: () => "metrics: []\n",
   outputDirForDatasource: (sourceId: string, orgId: string) =>
     `/tmp/test-semantic/.orgs/${orgId}/${sourceId}`,
+  // #3234 / ADR-0012: default group → flat root; non-default → groups/<group>/.
+  outputDirForGroup: (group: string | null | undefined, orgId?: string) => {
+    const base = orgId ? `/tmp/test-semantic/.orgs/${orgId}` : "/tmp/test-semantic";
+    return !group || group === "default" ? base : `${base}/groups/${group}`;
+  },
 }));
 
 const { app } = await import("../index");

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -244,6 +244,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   // Publish / archive helpers (#1429, #1437) — not exercised here but
   // required for admin route loading since admin-publish.ts and
   // admin-archive.ts import them.

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -406,6 +406,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteDraftEntityForGroup: mockDeleteDraftEntityAdmin,
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   createVersion: mockCreateVersion,
   listVersions: mockListVersions,
   getVersion: mockGetVersion,

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -215,6 +215,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteDraftEntityForGroup: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   createVersion: mock(() => Promise.resolve(null)),
   listVersions: mock(() => Promise.resolve([])),
   getVersion: mock(() => Promise.resolve(null)),

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -109,15 +109,24 @@ mock.module("@atlas/api/lib/semantic", () => ({
 
 const mockBulkUpsertEntities: Mock<(
   orgId: string,
-  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string }>,
+  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
 ) => Promise<number>> = mock(async (_orgId, entities) => entities.length);
+
+// Connection → Connection group resolver (#3234). The wizard scopes saved
+// entities by group: the default/unknown connection → NULL default group
+// (flat root), a non-default connection → its group (group-of-one stand-in
+// here = the connectionId itself). Tests override per-case for member-share.
+const mockResolveGroupId: Mock<(orgId: string, connectionId?: string | null) => Promise<string | null>> = mock(
+  async (_orgId, connectionId) => (!connectionId || connectionId === "default" ? null : connectionId),
+);
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   // Constants the wizard route imports statically
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
-  // Function under test in this suite
+  // Functions under test in this suite
   bulkUpsertEntities: mockBulkUpsertEntities,
+  resolveGroupIdForConnection: mockResolveGroupId,
   // Other named exports — the mock.module() loader requires every export
   // from the real module to be present, otherwise other test files in the
   // same isolated process throw `Export named 'X' not found`.
@@ -204,6 +213,7 @@ import {
   generateGlossaryYAML as _genGlossaryReal,
   generateMetricYAML as _genMetricReal,
   outputDirForDatasource as _outputDirReal,
+  outputDirForGroup as _outputDirGroupReal,
   mapSQLType as _mapSQLTypeReal,
   mapSalesforceFieldType as _mapSfReal,
   singularize as _singReal,
@@ -290,6 +300,7 @@ mock.module("@atlas/api/lib/profiler", () => ({
   generateGlossaryYAML: _genGlossaryReal,
   generateMetricYAML: _genMetricReal,
   outputDirForDatasource: _outputDirReal,
+  outputDirForGroup: _outputDirGroupReal,
   mapSQLType: _mapSQLTypeReal,
   mapSalesforceFieldType: _mapSfReal,
   singularize: _singReal,
@@ -377,6 +388,11 @@ beforeEach(() => {
   mockResetWhitelists.mockReset();
   mockSyncEntityToDisk.mockReset();
   mockSyncEntityToDisk.mockImplementation(async () => {});
+
+  mockResolveGroupId.mockReset();
+  mockResolveGroupId.mockImplementation(
+    async (_orgId, connectionId) => (!connectionId || connectionId === "default" ? null : connectionId),
+  );
 
   mockListPostgresObjects.mockReset();
   mockListPostgresObjects.mockImplementation(async () => [
@@ -672,19 +688,61 @@ describe("POST /api/v1/wizard/save", () => {
     const [orgIdArg, entitiesArg] = mockBulkUpsertEntities.mock.calls[0];
     expect(orgIdArg).toBe("org-1");
     expect(entitiesArg).toHaveLength(2);
+    // Rows are scoped by the Connection group (#3234), not the raw
+    // connectionId — "warehouse" resolves to its group (group-of-one here).
     expect(entitiesArg[0]).toMatchObject({
       entityType: "entity",
       name: "users",
       yamlContent: "table: users\n",
-      connectionId: "warehouse",
+      connectionGroupId: "warehouse",
     });
     expect(entitiesArg[1]).toMatchObject({
       entityType: "entity",
       name: "orders",
-      connectionId: "warehouse",
+      connectionGroupId: "warehouse",
     });
 
     expect(mockInvalidateOrgWhitelist).toHaveBeenCalledWith("org-1");
+  });
+
+  it("routes two members of the same group to one shared group key (no duplicate on member-add)", async () => {
+    // Adding a MEMBER to an already-populated group must not create a second
+    // copy of its entities (#3234). Both member connections resolve to the
+    // SAME connection_group_id, so saving via either upserts the shared
+    // group rows (the DB ON CONFLICT keys on connection_group_id) rather
+    // than inserting a duplicate. This pins the wizard half: both members
+    // route the same (name, group) key into bulkUpsertEntities.
+    mockResolveGroupId.mockReset();
+    mockResolveGroupId.mockImplementation(async () => "prod-group"); // every member → same group
+    mockBulkUpsertEntities.mockClear();
+    mockMkdirSync.mockReset();
+
+    const save = (conn: string) =>
+      postJson("/api/v1/wizard/save", {
+        connectionId: conn,
+        entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      });
+
+    const first = await save("us-prod");
+    const second = await save("eu-prod"); // member added to the already-populated group
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(mockBulkUpsertEntities).toHaveBeenCalledTimes(2);
+
+    const firstEntities = mockBulkUpsertEntities.mock.calls[0][1];
+    const secondEntities = mockBulkUpsertEntities.mock.calls[1][1];
+    // Same (name, group) key on both members → upsert, never a second row.
+    expect(firstEntities[0]).toMatchObject({ name: "orders", connectionGroupId: "prod-group" });
+    expect(secondEntities[0]).toMatchObject({ name: "orders", connectionGroupId: "prod-group" });
+
+    // Both members write into the SAME on-disk group namespace, not a
+    // per-connection dir — so the disk layer doesn't duplicate either.
+    const path = await import("path");
+    const mkdirPaths = mockMkdirSync.mock.calls.map(([dir]) => String(dir));
+    expect(mkdirPaths.every((p) => !p.includes(path.join("groups", "us-prod")))).toBe(true);
+    expect(mkdirPaths.every((p) => !p.includes(path.join("groups", "eu-prod")))).toBe(true);
+    expect(mkdirPaths.some((p) => p.includes(path.join("groups", "prod-group")))).toBe(true);
   });
 
   it("returns 500 db_persist_failed when bulkUpsertEntities throws", async () => {
@@ -1082,7 +1140,7 @@ describe("wizard __demo__ end-to-end", () => {
     expect(entities[0].tableName).toBe("users");
   });
 
-  it("save → persists the demo entities under the __demo__ output dir (not default/)", async () => {
+  it("save → persists the demo entities under the __demo__ group namespace (not default/)", async () => {
     registerDemoInRegistry();
     const res = await postJson("/api/v1/wizard/save", {
       connectionId: "__demo__",
@@ -1094,12 +1152,15 @@ describe("wizard __demo__ end-to-end", () => {
     expect(data.connectionId).toBe("__demo__");
     expect(data.orgId).toBe("org-1");
 
-    // Pin the sourceId branch in wizard.ts: __demo__ must NOT collapse
-    // into the `default` output dir (`semantic/.orgs/{orgId}/`) — it
-    // gets its own scope (`semantic/.orgs/{orgId}/__demo__/`) so a
-    // demo wipe doesn't blow away an org's real semantic layer.
+    // Pin the group-scoping branch in wizard.ts: __demo__ resolves to its
+    // own Connection group, so it must NOT collapse into the `default`
+    // output dir (`semantic/.orgs/{orgId}/`). Under ADR-0012 (#3234) it
+    // lands in the canonical groups/<group>/ namespace
+    // (`semantic/.orgs/{orgId}/groups/__demo__/`) so a demo wipe doesn't
+    // blow away an org's real semantic layer.
+    const path = await import("path");
     const mkdirPaths = mockMkdirSync.mock.calls.map(([dir]) => String(dir));
-    expect(mkdirPaths.some((p) => p.includes("__demo__"))).toBe(true);
+    expect(mkdirPaths.some((p) => p.includes(path.join("groups", "__demo__")))).toBe(true);
   });
 
   it("profile → falls back to ATLAS_DATASOURCE_URL when DB lookup misses __demo__", async () => {

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -498,6 +498,38 @@ describe("POST /api/v1/wizard/generate", () => {
     expect(entities.length).toBe(1);
     expect(entities[0].tableName).toBe("users");
     expect(entities[0].yaml).toContain("name: Users");
+    // Default connection → NULL default group → no group field emitted.
+    expect(entities[0].yaml).not.toContain("connection:");
+  });
+
+  it("scopes generated YAML by the connection's group (non-default connection)", async () => {
+    // A non-default connection resolves to its group, which is baked into the
+    // preview YAML so it matches the groups/<group>/ dir /save writes into.
+    const res = await postJson("/api/v1/wizard/generate", {
+      connectionId: "warehouse",
+      tables: ["users"],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    const entities = data.entities as { tableName: string; yaml: string }[];
+    expect(entities[0].yaml).toContain("connection: warehouse");
+  });
+
+  it("degrades to no group field when group resolution fails (preview is best-effort)", async () => {
+    // /generate is a preview — a group-lookup hiccup must not fail the whole
+    // generate; it falls back to no group field rather than 500ing.
+    mockResolveGroupId.mockReset();
+    mockResolveGroupId.mockRejectedValueOnce(new Error("internal DB unreachable"));
+
+    const res = await postJson("/api/v1/wizard/generate", {
+      connectionId: "warehouse",
+      tables: ["users"],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    const entities = data.entities as { tableName: string; yaml: string }[];
+    expect(entities[0].tableName).toBe("users");
+    expect(entities[0].yaml).not.toContain("connection:");
   });
 
   it("returns 500 with generate_failed when profiling throws", async () => {
@@ -743,6 +775,29 @@ describe("POST /api/v1/wizard/save", () => {
     expect(mkdirPaths.every((p) => !p.includes(path.join("groups", "us-prod")))).toBe(true);
     expect(mkdirPaths.every((p) => !p.includes(path.join("groups", "eu-prod")))).toBe(true);
     expect(mkdirPaths.some((p) => p.includes(path.join("groups", "prod-group")))).toBe(true);
+  });
+
+  it("fails closed with 500 save_failed when group resolution throws (no misscoped write)", async () => {
+    // The resolved group keys both the DB rows and the on-disk groups/<group>/
+    // dir. If resolution throws, we must abort BEFORE any write rather than
+    // silently fall through to the default group and misscope the entities.
+    mockResolveGroupId.mockReset();
+    mockResolveGroupId.mockRejectedValueOnce(new Error("internal DB unreachable"));
+    mockBulkUpsertEntities.mockClear();
+    mockWriteFileSync.mockClear();
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "warehouse",
+      entities: [{ tableName: "users", yaml: "table: users\n" }],
+    });
+
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("save_failed");
+    expect(data.requestId).toBeDefined();
+    // Fail-closed: neither the DB nor the disk was touched.
+    expect(mockBulkUpsertEntities).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
   it("returns 500 db_persist_failed when bulkUpsertEntities throws", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -24,7 +24,11 @@ import { validationHook } from "./validation-hook";
 import { connections, detectDBType } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, decryptSecret } from "@atlas/api/lib/db/internal";
 import { _resetWhitelists, invalidateOrgWhitelist } from "@atlas/api/lib/semantic";
-import { DEMO_CONNECTION_ID, bulkUpsertEntities } from "@atlas/api/lib/semantic/entities";
+import {
+  DEMO_CONNECTION_ID,
+  bulkUpsertEntities,
+  resolveGroupIdForConnection,
+} from "@atlas/api/lib/semantic/entities";
 import { syncEntityToDisk } from "@atlas/api/lib/semantic/sync";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { adminAuth, requestContext, type AuthEnv } from "./middleware";
@@ -39,7 +43,7 @@ import {
   listMySQLObjects,
   profilePostgres,
   profileMySQL,
-  outputDirForDatasource,
+  outputDirForGroup,
 } from "@atlas/api/lib/profiler";
 // Mechanical generation runs through the shared semantic engine (issue #3233)
 // so the wizard and the CLI emit identical YAML.
@@ -570,8 +574,27 @@ wizard.openapi(generateRoute, async (c) => {
         // Run heuristics (returns new array — no mutation)
         const analyzedProfiles = analyzeTableProfiles(result.profiles);
 
-        // Generate entity YAML for each profile
-        const sourceId = connectionId === "default" ? undefined : connectionId;
+        // Scope the generated YAML by the Connection group the connection
+        // belongs to (ADR-0012 / #3234), not the raw connectionId — so the
+        // emitted group field matches the groups/<group>/ directory the
+        // matching /save writes into. A standalone datasource is a
+        // group-of-one; the default/unknown connection resolves to the NULL
+        // default group, which emits no group field (flat root). Best-effort:
+        // /generate is a preview, so a group-lookup hiccup degrades to no
+        // group field rather than failing the whole generate (/save resolves
+        // the group authoritatively and fails closed there).
+        let connectionGroupId: string | null = null;
+        if (user?.activeOrganizationId) {
+          try {
+            connectionGroupId = await resolveGroupIdForConnection(user.activeOrganizationId, connectionId);
+          } catch (err) {
+            log.warn(
+              { err: err instanceof Error ? err.message : String(err), requestId, connectionId },
+              "Wizard generate: connection-group resolution failed — previewing without a group field",
+            );
+          }
+        }
+        const sourceId = connectionGroupId ?? undefined;
         const entities = analyzedProfiles.map((profile) => ({
           tableName: profile.table_name,
           objectType: profile.object_type,
@@ -712,6 +735,31 @@ wizard.openapi(saveRoute, async (c) => {
       }
     }
   
+    // Scope every saved entity by the Connection group the connection belongs
+    // to (ADR-0012 / #3234), not the raw connectionId. A standalone datasource
+    // is a group-of-one; the default/unknown connection resolves to the NULL
+    // default group (flat root). Both the DB rows (connection_group_id) and the
+    // on-disk groups/<group>/ namespace key on this, so adding a MEMBER to an
+    // already-populated group upserts the shared group rows instead of writing a
+    // second copy. Resolved up front so a lookup failure fails the whole save
+    // (no partial write to the wrong group) rather than silently misscoping.
+    const groupResult = yield* Effect.tryPromise({
+      try: () => resolveGroupIdForConnection(orgId, connectionId),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.either);
+    if (groupResult._tag === "Left") {
+      log.error(
+        { err: groupResult.left, requestId, orgId, connectionId },
+        "Wizard save: failed to resolve connection group",
+      );
+      return c.json({
+        error: "save_failed",
+        message: "Failed to resolve the connection group. Check server logs for details.",
+        requestId,
+      }, 500);
+    }
+    const connectionGroupId = groupResult.right;
+
     try {
       // Disk + DB are not transactional. Run DB first so a failure leaves
       // the disk untouched — disk-orphan recovery is harder than DB-only
@@ -720,7 +768,7 @@ wizard.openapi(saveRoute, async (c) => {
         entityType: "entity" as const,
         name: path.basename(e.tableName),
         yamlContent: e.yaml,
-        connectionId,
+        connectionGroupId,
       }));
       if (hasInternalDB()) {
         const upserted = yield* Effect.tryPromise({
@@ -761,9 +809,10 @@ wizard.openapi(saveRoute, async (c) => {
         invalidateOrgWhitelist(orgId);
       }
 
-      // Disk writes happen after DB success. Output dir is org-scoped.
-      const sourceId = connectionId === "default" ? "default" : connectionId;
-      const outputBase = outputDirForDatasource(sourceId, orgId);
+      // Disk writes happen after DB success. Output dir is org-scoped and
+      // group-scoped: the canonical groups/<group>/ namespace (ADR-0012), or
+      // the flat default root for the NULL default group.
+      const outputBase = outputDirForGroup(connectionGroupId, orgId);
       const entitiesDir = path.join(outputBase, "entities");
       const metricsDir = path.join(outputBase, "metrics");
 

--- a/packages/api/src/lib/__tests__/profiler.test.ts
+++ b/packages/api/src/lib/__tests__/profiler.test.ts
@@ -469,6 +469,14 @@ describe("outputDirForGroup", () => {
     expect(() => outputDirForGroup("a/b")).toThrow();
     expect(() => outputDirForGroup("..")).toThrow();
   });
+
+  it("rejects an orgId containing path separators or traversal (both helpers)", () => {
+    // orgId becomes a path segment under .orgs/ — an --org/ATLAS_ORG_ID value
+    // like "../../outside" must not escape the semantic root.
+    expect(() => outputDirForGroup(undefined, "../../outside")).toThrow();
+    expect(() => outputDirForGroup("warehouse", "a/b")).toThrow();
+    expect(() => outputDirForDatasource("warehouse", "..")).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/__tests__/profiler.test.ts
+++ b/packages/api/src/lib/__tests__/profiler.test.ts
@@ -20,6 +20,7 @@ import {
   generateGlossaryYAML,
   generateMetricYAML,
   outputDirForDatasource,
+  outputDirForGroup,
   type TableProfile,
   type ProfilingResult,
 } from "../profiler";
@@ -423,6 +424,50 @@ describe("outputDirForDatasource", () => {
   it("returns semantic/.orgs/{orgId}/{id}/ for non-default with orgId", () => {
     const result = outputDirForDatasource("warehouse", "org-123");
     expect(result).toContain(path.join(".orgs", "org-123", "warehouse"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// outputDirForGroup — canonical ADR-0012 groups/ namespace (#3234)
+// ---------------------------------------------------------------------------
+
+describe("outputDirForGroup", () => {
+  it("returns the flat semantic/ root for the default group", () => {
+    expect(outputDirForGroup(undefined)).toMatch(/semantic$/);
+    expect(outputDirForGroup(null)).toMatch(/semantic$/);
+    expect(outputDirForGroup("default")).toMatch(/semantic$/);
+  });
+
+  it("returns semantic/groups/<group>/ for a non-default group", () => {
+    const result = outputDirForGroup("warehouse");
+    expect(result).toMatch(/semantic[/\\]groups[/\\]warehouse$/);
+  });
+
+  it("nests the default group flat under .orgs/<orgId>/", () => {
+    const result = outputDirForGroup(undefined, "org-123");
+    expect(result).toContain(path.join(".orgs", "org-123"));
+    expect(result).not.toContain(path.join("org-123", "groups"));
+  });
+
+  it("nests a non-default group under .orgs/<orgId>/groups/<group>/", () => {
+    const result = outputDirForGroup("warehouse", "org-123");
+    expect(result).toContain(path.join(".orgs", "org-123", "groups", "warehouse"));
+  });
+
+  it("produces the canonical groups/<group> suffix the #3232 loader reads", () => {
+    // The CLI/wizard write to outputDirForGroup; the loader (getEntityDirs)
+    // reads groups/<group>/. This pins the two halves agree: a non-default
+    // group dir is exactly groups/<group> relative to the default root.
+    const rel = path.relative(outputDirForGroup(undefined), outputDirForGroup("warehouse"));
+    expect(rel).toBe(path.join("groups", "warehouse"));
+    // The default group adds zero nesting (round-trips to the flat root).
+    expect(path.relative(outputDirForGroup(undefined), outputDirForGroup("default"))).toBe("");
+  });
+
+  it("rejects group names containing path separators or traversal", () => {
+    expect(() => outputDirForGroup("../escape")).toThrow();
+    expect(() => outputDirForGroup("a/b")).toThrow();
+    expect(() => outputDirForGroup("..")).toThrow();
   });
 });
 

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -164,8 +164,8 @@ export function outputDirForDatasource(id: string, orgId?: string): string {
  *   setups gain no nesting.
  * - A **non-default group** `<g>` lives under the dedicated
  *   `groups/<g>/` namespace — exactly what the #3232 loader
- *   ({@link getEntityDirs}) reads back as group `<g>`, so generation and
- *   loading can't drift on the layout (#3234).
+ *   (`getEntityDirs` in `./semantic/scanner`) reads back as group `<g>`, so
+ *   generation and loading can't drift on the layout (#3234).
  *
  * Unlike the deprecated {@link outputDirForDatasource} (a bare
  * `semantic/<id>/` dir), this writes the blessed `groups/` parent.

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -143,7 +143,12 @@ const SEMANTIC_DIR = path.resolve("semantic");
 
 /** Root for a (possibly org-scoped) semantic layer. */
 function semanticBaseDir(orgId?: string): string {
-  return orgId ? path.join(SEMANTIC_DIR, ".orgs", orgId) : SEMANTIC_DIR;
+  if (!orgId) return SEMANTIC_DIR;
+  // orgId becomes a path segment under `.orgs/`; a value like `../../outside`
+  // (e.g. from --org / ATLAS_ORG_ID) would escape the semantic root. Same guard
+  // sync.ts:getSemanticRoot already applies on the read side.
+  assertSafePathSegment(orgId, "org");
+  return path.join(SEMANTIC_DIR, ".orgs", orgId);
 }
 
 /**
@@ -177,18 +182,18 @@ export function outputDirForDatasource(id: string, orgId?: string): string {
 export function outputDirForGroup(group: string | null | undefined, orgId?: string): string {
   const base = semanticBaseDir(orgId);
   if (!group || group === "default") return base;
-  assertSafeGroupSegment(group);
+  assertSafePathSegment(group, "group");
   return path.join(base, GROUPS_DIR, group);
 }
 
 /**
- * Reject group names that would escape (or rename) the per-group directory.
- * A group becomes a single path segment under `groups/`, so separators and
- * `..` traversal are not allowed.
+ * Reject a group/org name that would escape (or rename) its directory. The
+ * value becomes a single path segment, so separators and `..` traversal are
+ * not allowed.
  */
-function assertSafeGroupSegment(group: string): void {
-  if (group !== path.basename(group) || group === "." || group === ".." || group.includes("/") || group.includes("\\")) {
-    throw new Error(`Invalid semantic group name: "${group}". Group names cannot contain path separators or "..".`);
+function assertSafePathSegment(value: string, kind: "group" | "org"): void {
+  if (value !== path.basename(value) || value === "." || value === ".." || value.includes("/") || value.includes("\\")) {
+    throw new Error(`Invalid semantic ${kind} name: "${value}". ${kind === "group" ? "Group" : "Org"} names cannot contain path separators or "..".`);
   }
 }
 

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -137,12 +137,59 @@ export {
 // ---------------------------------------------------------------------------
 
 import * as path from "path";
+import { GROUPS_DIR } from "./semantic/scanner";
 
 const SEMANTIC_DIR = path.resolve("semantic");
 
+/** Root for a (possibly org-scoped) semantic layer. */
+function semanticBaseDir(orgId?: string): string {
+  return orgId ? path.join(SEMANTIC_DIR, ".orgs", orgId) : SEMANTIC_DIR;
+}
+
+/**
+ * @deprecated Writes the pre-ADR-0012 per-source `semantic/<id>/` layout.
+ * New generation routes through {@link outputDirForGroup} (the canonical
+ * `groups/<group>/` namespace). Retained for back-compat consumers.
+ */
 export function outputDirForDatasource(id: string, orgId?: string): string {
-  const base = orgId ? path.join(SEMANTIC_DIR, ".orgs", orgId) : SEMANTIC_DIR;
+  const base = semanticBaseDir(orgId);
   return id === "default" ? base : path.join(base, id);
+}
+
+/**
+ * Canonical ADR-0012 output base for a Connection group's semantic layer.
+ *
+ * - The **default group** (`undefined` / `null` / `"default"`, i.e.
+ *   `connection_group_id = NULL`) stays **flat at the root** so single-DB
+ *   setups gain no nesting.
+ * - A **non-default group** `<g>` lives under the dedicated
+ *   `groups/<g>/` namespace — exactly what the #3232 loader
+ *   ({@link getEntityDirs}) reads back as group `<g>`, so generation and
+ *   loading can't drift on the layout (#3234).
+ *
+ * Unlike the deprecated {@link outputDirForDatasource} (a bare
+ * `semantic/<id>/` dir), this writes the blessed `groups/` parent.
+ *
+ * @throws if `group` contains a path separator or `..` traversal — group
+ *   names become a directory segment, so an unsafe value could escape the
+ *   semantic root.
+ */
+export function outputDirForGroup(group: string | null | undefined, orgId?: string): string {
+  const base = semanticBaseDir(orgId);
+  if (!group || group === "default") return base;
+  assertSafeGroupSegment(group);
+  return path.join(base, GROUPS_DIR, group);
+}
+
+/**
+ * Reject group names that would escape (or rename) the per-group directory.
+ * A group becomes a single path segment under `groups/`, so separators and
+ * `..` traversal are not allowed.
+ */
+function assertSafeGroupSegment(group: string): void {
+  if (group !== path.basename(group) || group === "." || group === ".." || group.includes("/") || group.includes("\\")) {
+    throw new Error(`Invalid semantic group name: "${group}". Group names cannot contain path separators or "..".`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/__tests__/group-namespace-generation.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/group-namespace-generation.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for group-namespace generation — the WRITE side of ADR-0012 (#3234).
+ *
+ * `atlas init` and the wizard write a generated semantic layer via
+ * `outputDirForGroup`. These tests pin that the canonical `groups/<group>/`
+ * layout it produces is exactly what the #3232 loader
+ * (`getEntityDirs` / `scanEntities`) reads back under the same group — i.e.
+ * generate → load round-trips, the default group stays flat (no `groups/`
+ * dir), and a non-default group is attributed to its directory.
+ *
+ * The logger is mocked (sync factory) so scanner warnings can't crash the
+ * loader — see docs/development/testing.md.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { resolve, join, relative } from "path";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import type { TableProfile } from "../../profiler";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }),
+  getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+}));
+
+const { outputDirForGroup, generateEntityYAML } = await import("../../profiler");
+const { getEntityDirs, scanEntities } = await import("../scanner");
+
+const tmpBase = resolve(__dirname, ".tmp-group-namespace-gen-test");
+let counter = 0;
+
+function freshRoot(): string {
+  counter++;
+  const r = join(tmpBase, `t-${counter}`);
+  mkdirSync(r, { recursive: true });
+  return r;
+}
+
+/**
+ * The path (relative to the default flat root) that `outputDirForGroup`
+ * lays a group's layer into — the literal directory the CLI/wizard write.
+ * Deriving the test layout from the production helper makes this a true
+ * round-trip rather than a hand-built fixture that could drift.
+ */
+function groupSubpath(group: string | undefined): string {
+  return relative(outputDirForGroup(undefined), outputDirForGroup(group));
+}
+
+function profile(table: string): TableProfile {
+  return {
+    table_name: table,
+    object_type: "table",
+    row_count: 100,
+    columns: [
+      {
+        name: "id",
+        type: "integer",
+        nullable: false,
+        unique_count: 100,
+        null_count: 0,
+        sample_values: [],
+        is_primary_key: true,
+        is_foreign_key: false,
+        fk_target_table: null,
+        fk_target_column: null,
+        is_enum_like: false,
+        profiler_notes: [],
+      },
+    ],
+    primary_key_columns: ["id"],
+    foreign_keys: [],
+    inferred_foreign_keys: [],
+    profiler_notes: [],
+    table_flags: { possibly_abandoned: false, possibly_denormalized: false },
+  };
+}
+
+beforeEach(() => {
+  if (existsSync(tmpBase)) rmSync(tmpBase, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  if (existsSync(tmpBase)) rmSync(tmpBase, { recursive: true, force: true });
+});
+
+describe("group-namespace generation (#3234, ADR-0012)", () => {
+  it("writes a non-default group into groups/<group>/ that the loader reads back under that group", () => {
+    const root = freshRoot();
+    // The CLI/wizard write to outputDirForGroup("warehouse", …) — derive the
+    // same on-disk layout under a temp root.
+    const sub = groupSubpath("warehouse");
+    expect(sub).toBe(join("groups", "warehouse"));
+
+    const entitiesDir = join(root, sub, "entities");
+    mkdirSync(entitiesDir, { recursive: true });
+    writeFileSync(
+      join(entitiesDir, "orders.yml"),
+      generateEntityYAML(profile("orders"), [profile("orders")], "postgres", "public", "warehouse"),
+    );
+
+    // Loader (read side, #3232) attributes the dir to group "warehouse".
+    const { dirs } = getEntityDirs(root);
+    const warehouse = dirs.find((d) => d.sourceName === "warehouse");
+    expect(warehouse).toBeDefined();
+    expect(warehouse!.origin).toBe("group");
+
+    const { entities, warnings } = scanEntities(root);
+    expect(warnings).toHaveLength(0);
+    const orders = entities.find((e) => e.raw.table === "orders");
+    expect(orders).toBeDefined();
+    expect(orders!.sourceName).toBe("warehouse");
+    expect(orders!.origin).toBe("group");
+  });
+
+  it("writes the default group flat at the root with no groups/ directory", () => {
+    const root = freshRoot();
+    // The default group adds zero nesting — flat root, the standalone-DB case.
+    expect(groupSubpath(undefined)).toBe("");
+    expect(groupSubpath("default")).toBe("");
+
+    const entitiesDir = join(root, "entities");
+    mkdirSync(entitiesDir, { recursive: true });
+    writeFileSync(
+      join(entitiesDir, "orders.yml"),
+      generateEntityYAML(profile("orders"), [profile("orders")], "postgres", "public", undefined),
+    );
+
+    // AC: a standalone DB generates a flat default-group layout (no groups/).
+    expect(existsSync(join(root, "groups"))).toBe(false);
+
+    const { dirs } = getEntityDirs(root);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0].sourceName).toBe("default");
+    expect(dirs[0].origin).toBe("flat");
+
+    const { entities } = scanEntities(root);
+    const orders = entities.find((e) => e.raw.table === "orders");
+    expect(orders!.sourceName).toBe("default");
+    expect(orders!.origin).toBe("flat");
+  });
+
+  it("keeps multiple groups isolated on disk and distinctly attributed", () => {
+    const root = freshRoot();
+    for (const group of ["warehouse", "crm"]) {
+      const dir = join(root, groupSubpath(group), "entities");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `${group}_events.yml`),
+        generateEntityYAML(profile(`${group}_events`), [profile(`${group}_events`)], "postgres", "public", group),
+      );
+    }
+
+    const { dirs } = getEntityDirs(root);
+    expect(dirs.filter((d) => d.origin === "group").map((d) => d.sourceName).sort()).toEqual(["crm", "warehouse"]);
+
+    const { entities } = scanEntities(root);
+    const bySource = Object.fromEntries(entities.map((e) => [e.raw.table, e.sourceName]));
+    expect(bySource["warehouse_events"]).toBe("warehouse");
+    expect(bySource["crm_events"]).toBe("crm");
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -133,8 +133,14 @@ export async function listConnectionGroupMembers(
  * keep its current "no scope" behavior; the caller is expected to have
  * already verified `hasInternalDB()` before invoking write paths that
  * actually need the resolution.
+ *
+ * Exported for the onboarding write paths (the wizard `/generate` + `/save`
+ * routes, #3234) which scope generated entities by the Connection group the
+ * connection belongs to — group-of-one for a standalone datasource, NULL for
+ * the default/unknown connection — so adding a member to a populated group
+ * updates the shared group rows rather than duplicating them.
  */
-async function resolveGroupIdForConnection(
+export async function resolveGroupIdForConnection(
   orgId: string,
   connectionId: string | null | undefined,
 ): Promise<string | null> {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -20,7 +20,7 @@ import {
   isView,
   isMatView,
   isViewLike,
-  outputDirForDatasource,
+  outputDirForGroup,
   listPostgresObjects,
   listMySQLObjects,
 } from "@atlas/api/lib/profiler";
@@ -556,8 +556,12 @@ async function profileDatasource(
     );
   }
 
-  // Compute output directories
-  const outputBase = outputDirForDatasource(id, orgId);
+  // Compute output directories. The semantic layer is Connection-group-scoped
+  // (ADR-0012): the default datasource is the flat-root default group, and a
+  // file-based standalone datasource is a group-of-one whose group is its id —
+  // so its entities land in the canonical `semantic/groups/<id>/` namespace the
+  // #3232 loader reads back, not the legacy `semantic/<id>/` layout (#3234).
+  const outputBase = outputDirForGroup(id, orgId);
   const entitiesOutDir = path.join(outputBase, "entities");
   const metricsOutDir = path.join(outputBase, "metrics");
 
@@ -669,10 +673,10 @@ async function profileDatasource(
   }
 
   const relativeOutput = orgId
-    ? `./semantic/.orgs/${orgId}/`
+    ? `./semantic/.orgs/${orgId}/${id === "default" ? "" : `groups/${id}/`}`
     : id === "default"
       ? "./semantic/"
-      : `./semantic/${id}/`;
+      : `./semantic/groups/${id}/`;
   console.log(`
 Done! Semantic layer written to ${relativeOutput} in ${formatDuration(profilingElapsed)}
 
@@ -690,11 +694,9 @@ Next steps:
   // Create initial snapshot after generation
   try {
     const { createSnapshot } = await import("../../lib/migrate");
-    const semanticRoot = orgId
-      ? path.join(SEMANTIC_DIR, ".orgs", orgId)
-      : id === "default"
-        ? SEMANTIC_DIR
-        : path.join(SEMANTIC_DIR, id);
+    // Snapshot the group's own directory — the same canonical
+    // `groups/<group>/` (or flat-root default) base we just wrote to.
+    const semanticRoot = outputBase;
     const entry = createSnapshot(semanticRoot, {
       message: `Initial snapshot from atlas init${demoDataset ? " (demo)" : ""}`,
       trigger: "init",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -768,7 +768,7 @@ export async function handleInit(args: string[]): Promise<void> {
       "  --connection profiles a named datasource from atlas.config.ts",
     );
     console.error(
-      "  --source is the legacy flag for per-source output directory",
+      "  --source is the deprecated flag for selecting the output group (writes semantic/groups/<name>/)",
     );
     process.exit(1);
   }
@@ -793,10 +793,10 @@ export async function handleInit(args: string[]): Promise<void> {
         files.push({ path: f.trim(), format: "parquet" });
     }
 
-    // Compute output directories
-    const outputBase = sourceArg
-      ? path.join(SEMANTIC_DIR, sourceArg)
-      : SEMANTIC_DIR;
+    // Compute output directories. Like the DB path, `--source <name>` is a
+    // group-of-one and writes the canonical `semantic/groups/<name>/` namespace
+    // (ADR-0012 / #3234); no `--source` → the flat-root default group.
+    const outputBase = outputDirForGroup(sourceArg);
     const entitiesOutDir = path.join(outputBase, "entities");
     const metricsOutDir = path.join(outputBase, "metrics");
     const dbPath = path.join(outputBase, ".atlas.duckdb");
@@ -923,7 +923,7 @@ export async function handleInit(args: string[]): Promise<void> {
 
     const duckDbUrl = `duckdb://${dbPath}`;
     const relativeOutput = sourceArg
-      ? `./semantic/${sourceArg}/`
+      ? `./semantic/groups/${sourceArg}/`
       : "./semantic/";
     console.log(`
 Done! Your semantic layer is at ${relativeOutput}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -21,6 +21,7 @@ import {
   isMatView,
   isViewLike,
   outputDirForGroup,
+  outputDirForDatasource,
   listPostgresObjects,
   listMySQLObjects,
 } from "@atlas/api/lib/profiler";
@@ -201,6 +202,13 @@ export async function handleIndex(args: string[]): Promise<void> {
 
 interface ProfileDatasourceOpts {
   id: string; // "default", "warehouse", etc.
+  // On-disk layout (ADR-0012 / #3234):
+  //   "group"      — canonical groups/<id>/ namespace (named/config datasources,
+  //                  --connection, default). The path forward.
+  //   "datasource" — legacy semantic/<id>/ layout, kept for the deprecated
+  //                  --source flag's back-compat (its existing output is the
+  //                  "legacy <source>/ layout" ADR-0012 migrates from).
+  outputLayout: "group" | "datasource";
   url: string;
   dbType: DBType;
   schema: string; // resolved schema for this datasource
@@ -223,6 +231,7 @@ async function profileDatasource(
 ): Promise<void> {
   const {
     id,
+    outputLayout,
     url: connStr,
     dbType,
     filterTables,
@@ -557,11 +566,15 @@ async function profileDatasource(
   }
 
   // Compute output directories. The semantic layer is Connection-group-scoped
-  // (ADR-0012): the default datasource is the flat-root default group, and a
-  // file-based standalone datasource is a group-of-one whose group is its id —
-  // so its entities land in the canonical `semantic/groups/<id>/` namespace the
-  // #3232 loader reads back, not the legacy `semantic/<id>/` layout (#3234).
-  const outputBase = outputDirForGroup(id, orgId);
+  // (ADR-0012): named/config datasources + --connection write the canonical
+  // `semantic/groups/<id>/` namespace the #3232 loader reads back (a standalone
+  // datasource is a group-of-one; "default" stays flat at the root). The
+  // deprecated `--source` flag keeps the legacy `semantic/<id>/` layout for
+  // back-compat (#3234).
+  const outputBase =
+    outputLayout === "datasource"
+      ? outputDirForDatasource(id, orgId)
+      : outputDirForGroup(id, orgId);
   const entitiesOutDir = path.join(outputBase, "entities");
   const metricsOutDir = path.join(outputBase, "metrics");
 
@@ -672,11 +685,10 @@ async function profileDatasource(
     }
   }
 
-  const relativeOutput = orgId
-    ? `./semantic/.orgs/${orgId}/${id === "default" ? "" : `groups/${id}/`}`
-    : id === "default"
-      ? "./semantic/"
-      : `./semantic/groups/${id}/`;
+  // Derived from outputBase so it stays correct across both layouts (group vs
+  // legacy datasource) and the org-scoped nesting — single source of truth.
+  const relSuffix = path.relative(SEMANTIC_DIR, outputBase);
+  const relativeOutput = relSuffix ? `./semantic/${relSuffix}/` : "./semantic/";
   console.log(`
 Done! Semantic layer written to ${relativeOutput} in ${formatDuration(profilingElapsed)}
 
@@ -768,7 +780,7 @@ export async function handleInit(args: string[]): Promise<void> {
       "  --connection profiles a named datasource from atlas.config.ts",
     );
     console.error(
-      "  --source is the deprecated flag for selecting the output group (writes semantic/groups/<name>/)",
+      "  --source is the deprecated flag for the legacy per-source output directory (semantic/<name>/)",
     );
     process.exit(1);
   }
@@ -793,10 +805,11 @@ export async function handleInit(args: string[]): Promise<void> {
         files.push({ path: f.trim(), format: "parquet" });
     }
 
-    // Compute output directories. Like the DB path, `--source <name>` is a
-    // group-of-one and writes the canonical `semantic/groups/<name>/` namespace
-    // (ADR-0012 / #3234); no `--source` → the flat-root default group.
-    const outputBase = outputDirForGroup(sourceArg);
+    // Compute output directories. CSV/Parquet ingestion is only reachable via
+    // the deprecated `--source` flag (or no flag), so it keeps the legacy
+    // `semantic/<name>/` layout for back-compat (`--connection`, which writes
+    // the canonical groups/<group>/ namespace, isn't valid for file sources).
+    const outputBase = outputDirForDatasource(sourceArg ?? "default");
     const entitiesOutDir = path.join(outputBase, "entities");
     const metricsOutDir = path.join(outputBase, "metrics");
     const dbPath = path.join(outputBase, ".atlas.duckdb");
@@ -923,7 +936,7 @@ export async function handleInit(args: string[]): Promise<void> {
 
     const duckDbUrl = `duckdb://${dbPath}`;
     const relativeOutput = sourceArg
-      ? `./semantic/groups/${sourceArg}/`
+      ? `./semantic/${sourceArg}/`
       : "./semantic/";
     console.log(`
 Done! Your semantic layer is at ${relativeOutput}
@@ -1153,6 +1166,11 @@ Next steps:
   const isMultiSource = datasources.length > 1;
   const errors: { id: string; error: string }[] = [];
 
+  // The deprecated `--source` flag keeps the legacy `semantic/<id>/` layout for
+  // back-compat; every other path (--connection, config datasources, default)
+  // writes the canonical groups/<id>/ namespace (ADR-0012 / #3234).
+  const outputLayout: "group" | "datasource" = sourceArg ? "datasource" : "group";
+
   for (const ds of datasources) {
     let dbType: DBType;
     try {
@@ -1179,6 +1197,7 @@ Next steps:
     try {
       await profileDatasource({
         id: ds.id,
+        outputLayout,
         url: ds.url,
         dbType,
         schema: ds.schema,


### PR DESCRIPTION
## What

Make semantic-layer **generation** write into the correct **Connection-group namespace** (ADR-0012) — the critical-path slice of v0.0.12. Generation previously scoped by the raw `connectionId` and wrote the legacy `semantic/<source>/` layout; it now keys on the **Connection group** the connection belongs to and writes the canonical `semantic/groups/<group>/` namespace the #3232 loader reads back.

Closes #3234. Unblocks #3236 and #3237.

## How

- **New primitive `outputDirForGroup(group, orgId)`** (`packages/api/src/lib/profiler.ts`) — the single group-routing helper both front-ends use. Default group → flat root; non-default group → `groups/<group>/` (exactly what `getEntityDirs` reads as group `<group>`). Path-safety guard rejects separators/`..` in the group segment. The legacy `outputDirForDatasource` is kept (deprecated) for back-compat consumers.
- **CLI** (`packages/cli/src/commands/init.ts`) — `atlas init --connection <c>` writes to `semantic/groups/<c>/` (a file-based standalone datasource is a group-of-one; the default datasource stays flat). `relativeOutput` display + the init snapshot path follow the same base.
- **Wizard** (`packages/api/src/api/routes/wizard.ts`) — `/generate` + `/save` resolve the connection's actual Connection group via `resolveGroupIdForConnection` (now exported from `lib/semantic/entities.ts`):
  - DB-backed: rows carry the right `connection_group_id` (via `bulkUpsertEntities` `connectionGroupId`, routing through `upsertDraftEntityForGroup`).
  - File-based: disk files land under `groups/<group>/` via `outputDirForGroup`.
  - `/save` resolves the group up front and **fails closed** on a lookup error (no misscoped write); `/generate` is best-effort (preview degrades to no group field rather than 500ing).
  - Adding a **member** to an already-populated group resolves to the **same** group key, so it upserts the shared group rows instead of writing a second copy.

The disk→DB import path (`_scanEntityDirs`, #3245) was already group-aware, so the round-trip is consistent end-to-end.

## Acceptance criteria

- [x] `atlas init --connection <c>` writes into the group `<c>` belongs to (`semantic/groups/<group>/…`; flat root for default group).
- [x] Wizard save persists entities under the Connection group, not `connectionId`; SaaS rows get the right `connection_group_id`.
- [x] Generated layout round-trips through the #3232 loader (generate → load under the same group).
- [x] A standalone DB still generates a flat default-group layout (no `groups/` dir).
- [x] Tests: generate-into-group (file + DB), default-group flat, no-duplicate-on-member-add.

## Tests

- `packages/api/src/lib/semantic/__tests__/group-namespace-generation.test.ts` (new) — generate→load round-trip into `groups/<group>/`, default-group flat (no `groups/` dir), multi-group isolation, using the real `outputDirForGroup` + `generateEntityYAML` + loader.
- `profiler.test.ts` — `outputDirForGroup` unit coverage (default-flat, groups/, org-scoped, canonical-suffix-matches-loader, path-traversal rejection).
- `wizard.test.ts` — DB rows keyed by `connectionGroupId`; demo lands in `groups/__demo__/`; **member-add no-duplicate** (two members → one shared group key).
- Updated the entities-mock in the app-loading admin/wizard tests for the new `resolveGroupIdForConnection` export.

## Docs

- `docs/design/semantic-onboarding.md` §§ A/E/F — annotated with the shipped write-path behavior.
- `apps/docs/content/docs/reference/config.mdx` + `cli.mdx` — `--connection` output is now `semantic/groups/<group>/` (the `--source` flag documented as the legacy/back-compat alias).

## CI

Local `/ci` green: lint, type, full test (api 558/558 + others, 0 failures), syncpack, template/security-header/railway/schema/oauth/test-discipline/twenty-resolver drift, published-symbols — all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783359306&installation_id=135337507&pr_number=3282&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3282&signature=c929e3e53b74f409da0850d65e414f5d0435992ff4fe93607b8eed421bd4787b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference, config, and onboarding docs to describe connection-group-scoped semantic directories and flag behavior.

* **New Features**
  * Semantic layer now organized by connection groups: default stays flat; non-default groups placed under semantic/groups/<group>/.
  * CLI init messaging and examples updated to show group-scoped output and clarify --connection vs deprecated --source.
  * Onboarding (wizard generate/save) and persistence now route entities by connection group so shared-group connections use a single namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->