### PR TITLE
fix(semantic): group-scoped semantic correctness — #3285, #3275, #3281

### DIFF
--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -498,7 +498,9 @@ describe("POST /api/v1/wizard/generate", () => {
     expect(entities.length).toBe(1);
     expect(entities[0].tableName).toBe("users");
     expect(entities[0].yaml).toContain("name: Users");
-    // Default connection → NULL default group → no group field emitted.
+    // Default connection → NULL default group → no group field emitted
+    // (neither the canonical `group:` nor the deprecated `connection:` alias).
+    expect(entities[0].yaml).not.toContain("group:");
     expect(entities[0].yaml).not.toContain("connection:");
   });
 
@@ -512,7 +514,10 @@ describe("POST /api/v1/wizard/generate", () => {
     expect(res.status).toBe(200);
     const data = await json(res);
     const entities = data.entities as { tableName: string; yaml: string }[];
-    expect(entities[0].yaml).toContain("connection: warehouse");
+    // #3285: the canonical `group:` field (ADR-0012), not the deprecated
+    // `connection:` alias the generator used to emit.
+    expect(entities[0].yaml).toContain("group: warehouse");
+    expect(entities[0].yaml).not.toContain("connection:");
   });
 
   it("degrades to no group field when group resolution fails (preview is best-effort)", async () => {
@@ -529,6 +534,8 @@ describe("POST /api/v1/wizard/generate", () => {
     const data = await json(res);
     const entities = data.entities as { tableName: string; yaml: string }[];
     expect(entities[0].tableName).toBe("users");
+    // Degraded preview falls back to no group field at all (#3285).
+    expect(entities[0].yaml).not.toContain("group:");
     expect(entities[0].yaml).not.toContain("connection:");
   });
 

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -629,7 +629,7 @@ export function registerSemanticEditorRoutes(
       // Sync to disk — non-fatal; DB is authoritative
       try {
         const { syncEntityToDisk } = await import("@atlas/api/lib/semantic/sync");
-        await syncEntityToDisk(orgId, name, "entity", yamlContent);
+        await syncEntityToDisk(orgId, name, "entity", yamlContent, body.connectionId);
       } catch (syncErr) {
         log.warn(
           { err: syncErr instanceof Error ? syncErr.message : String(syncErr), requestId, orgId, name },
@@ -714,7 +714,7 @@ export function registerSemanticEditorRoutes(
       // Sync deletion to disk — non-fatal; DB is authoritative
       try {
         const { syncEntityDeleteFromDisk } = await import("@atlas/api/lib/semantic/sync");
-        await syncEntityDeleteFromDisk(orgId, name, "entity");
+        await syncEntityDeleteFromDisk(orgId, name, "entity", existing.connection_group_id ?? null);
       } catch (syncErr) {
         log.warn(
           { err: syncErr instanceof Error ? syncErr.message : String(syncErr), requestId, orgId, name },
@@ -967,7 +967,7 @@ export function registerSemanticEditorRoutes(
       // Sync to disk — non-fatal
       try {
         const { syncEntityToDisk } = await import("@atlas/api/lib/semantic/sync");
-        await syncEntityToDisk(orgId, name, "entity", targetVersion.yaml_content);
+        await syncEntityToDisk(orgId, name, "entity", targetVersion.yaml_content, currentEntity?.connection_group_id ?? null);
       } catch (syncErr) {
         log.warn(
           { err: syncErr instanceof Error ? syncErr.message : String(syncErr), requestId, orgId, name },

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -626,10 +626,15 @@ export function registerSemanticEditorRoutes(
       const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
       invalidateOrgWhitelist(orgId);
 
-      // Sync to disk — non-fatal; DB is authoritative
+      // Sync to disk — non-fatal; DB is authoritative. Key the disk write by
+      // the PERSISTED group scope (re-fetched), not the raw request
+      // `body.connectionId`, so editor writes land in the same group namespace
+      // the delete/rollback paths use — a raw request id can differ from the
+      // resolved group key (CodeRabbit, #3275).
       try {
         const { syncEntityToDisk } = await import("@atlas/api/lib/semantic/sync");
-        await syncEntityToDisk(orgId, name, "entity", yamlContent, body.connectionId);
+        const persisted = await getEntity(orgId, "entity", name, scope);
+        await syncEntityToDisk(orgId, name, "entity", yamlContent, persisted?.connection_group_id ?? null);
       } catch (syncErr) {
         log.warn(
           { err: syncErr instanceof Error ? syncErr.message : String(syncErr), requestId, orgId, name },

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -2118,7 +2118,7 @@ admin.openapi(putOrgEntityRoute, async (c) => runHandler(c, "save org semantic e
   // All YAML uploads stage as drafts regardless of `atlasMode` (#2177).
   await upsertDraftEntity(orgId, entityType, name, body.yamlContent, body.connectionId);
   invalidateOrgWhitelist(orgId);
-  await syncEntityToDisk(orgId, name, entityType, body.yamlContent);
+  await syncEntityToDisk(orgId, name, entityType, body.yamlContent, body.connectionId);
 
   log.info({ requestId, orgId, name, entityType }, "Org semantic entity upserted");
 
@@ -2185,7 +2185,7 @@ admin.openapi(deleteOrgEntityRoute, async (c) => runHandler(c, "delete org seman
     return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);
   }
   invalidateOrgWhitelist(orgId);
-  await syncEntityDeleteFromDisk(orgId, name, entityType);
+  await syncEntityDeleteFromDisk(orgId, name, entityType, existing.connection_group_id ?? null);
 
   log.info({ requestId, orgId, name, entityType }, "Org semantic entity deleted");
 

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -834,7 +834,7 @@ wizard.openapi(saveRoute, async (c) => {
         // entities are split rather than just a log line.
         if (hasInternalDB()) {
           const syncResult = yield* Effect.tryPromise({
-            try: () => syncEntityToDisk(orgId, entity.tableName, "entity", entity.yaml),
+            try: () => syncEntityToDisk(orgId, entity.tableName, "entity", entity.yaml, connectionGroupId),
             catch: (err) => err instanceof Error ? err : new Error(String(err)),
           }).pipe(Effect.catchAll((err) => {
             log.warn(

--- a/packages/api/src/lib/__tests__/profiler-edge-cases.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-edge-cases.test.ts
@@ -240,11 +240,13 @@ describe("generateEntityYAML edge cases", () => {
     expect(yaml).toContain("TO_CHAR(created_at");
   });
 
-  it("includes source connection in YAML when specified", () => {
+  it("includes the canonical group field in YAML when a group is specified", () => {
+    // #3285: canonical `group:` (ADR-0012), not the deprecated `connection:` alias.
     const profile = makeProfile();
     const yaml = generateEntityYAML(profile, [profile], "postgres", "public", "analytics-db");
 
-    expect(yaml).toContain("connection: analytics-db");
+    expect(yaml).toContain("group: analytics-db");
+    expect(yaml).not.toContain("connection:");
   });
 
   it("skips measures for views", () => {

--- a/packages/api/src/lib/__tests__/profiler.test.ts
+++ b/packages/api/src/lib/__tests__/profiler.test.ts
@@ -324,10 +324,13 @@ describe("generateEntityYAML", () => {
     expect(yaml).toContain("Primary key");
   });
 
-  it("includes connection source when provided", () => {
+  it("includes the canonical group field when a group is provided", () => {
+    // #3285: the generator emits `group:` (ADR-0012), not the deprecated
+    // `connection:` alias.
     const profile = makeTestProfile("users", { withPk: true });
     const yaml = generateEntityYAML(profile, [profile], "postgres", "public", "warehouse");
-    expect(yaml).toContain("connection: warehouse");
+    expect(yaml).toContain("group: warehouse");
+    expect(yaml).not.toContain("connection:");
   });
 });
 

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -370,6 +370,88 @@ describe("syncAllEntitiesToDisk", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Group-namespace DB→disk mirror (#3275, ADR-0012)
+// ---------------------------------------------------------------------------
+
+describe("syncAllEntitiesToDisk — group namespace (#3275)", () => {
+  it("writes same-stem entities from different groups without collision", async () => {
+    const orgId = testOrgId();
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow(orgId, "orders", "entity", "table: orders\ndescription: US orders\n", "us"),
+        makeEntityRow(orgId, "orders", "entity", "table: orders\ndescription: EU orders\n", "eu"),
+        makeEntityRow(orgId, "users", "entity", "table: users\ndescription: Default users\n"),
+      ]),
+    );
+
+    const synced = await syncAllEntitiesToDisk(orgId);
+    expect(synced).toBe(3);
+
+    const root = getSemanticRoot(orgId);
+    const usPath = path.join(root, "groups", "us", "entities", "orders.yml");
+    const euPath = path.join(root, "groups", "eu", "entities", "orders.yml");
+    // Both group files exist — neither overwrote the other. The pre-fix bug
+    // wrote both to a flat entities/orders.yml, silently losing one group.
+    expect(fs.existsSync(usPath)).toBe(true);
+    expect(fs.existsSync(euPath)).toBe(true);
+    expect(fs.readFileSync(usPath, "utf-8")).toContain("US orders");
+    expect(fs.readFileSync(euPath, "utf-8")).toContain("EU orders");
+    // The default group stays flat at the root; no flat collision.
+    expect(fs.existsSync(path.join(root, "entities", "users.yml"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "entities", "orders.yml"))).toBe(false);
+  });
+
+  it("routes group metrics under groups/<group>/metrics/", async () => {
+    const orgId = testOrgId();
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow(orgId, "revenue", "metric", "id: revenue\nsql: SELECT 1\n", "us"),
+      ]),
+    );
+    await syncAllEntitiesToDisk(orgId);
+    const root = getSemanticRoot(orgId);
+    expect(fs.existsSync(path.join(root, "groups", "us", "metrics", "revenue.yml"))).toBe(true);
+  });
+
+  it("cleans a stale group entity removed from the DB", async () => {
+    const orgId = testOrgId();
+    const root = getSemanticRoot(orgId);
+    const staleGroupFile = path.join(root, "groups", "eu", "entities", "orders.yml");
+    fs.mkdirSync(path.dirname(staleGroupFile), { recursive: true });
+    fs.writeFileSync(staleGroupFile, "table: orders\n");
+    expect(fs.existsSync(staleGroupFile)).toBe(true);
+
+    // DB now only has the US group's orders.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow(orgId, "orders", "entity", "table: orders\ndescription: US\n", "us"),
+      ]),
+    );
+    await syncAllEntitiesToDisk(orgId);
+
+    // The EU group's stale file is removed; the US group's file is written.
+    expect(fs.existsSync(staleGroupFile)).toBe(false);
+    expect(fs.existsSync(path.join(root, "groups", "us", "entities", "orders.yml"))).toBe(true);
+  });
+
+  it("skips a row whose group is an unsafe path segment", async () => {
+    const orgId = testOrgId();
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow(orgId, "orders", "entity", "table: orders\n", "../escape"),
+        makeEntityRow(orgId, "users", "entity", "table: users\n", "us"),
+      ]),
+    );
+    const synced = await syncAllEntitiesToDisk(orgId);
+    // Only the safe row is written; the traversal row is skipped, not escaped.
+    expect(synced).toBe(1);
+    const root = getSemanticRoot(orgId);
+    expect(fs.existsSync(path.join(root, "groups", "us", "entities", "users.yml"))).toBe(true);
+    expect(fs.existsSync(path.join(path.dirname(root), "escape"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cleanupOrgDirectory
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/semantic/__tests__/group-namespace-generation.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/group-namespace-generation.test.ts
@@ -109,6 +109,13 @@ describe("group-namespace generation (#3234, ADR-0012)", () => {
     expect(orders).toBeDefined();
     expect(orders!.sourceName).toBe("warehouse");
     expect(orders!.origin).toBe("group");
+
+    // #3285: the generator emits the canonical `group:` field, not the
+    // deprecated `connection:` alias (ADR-0012). Pin it on the parsed output —
+    // the round-trip above passes either way because the directory is canonical
+    // for `groups/` origin, so it can't catch a deprecated-field regression.
+    expect(orders!.raw.group).toBe("warehouse");
+    expect(orders!.raw.connection).toBeUndefined();
   });
 
   it("writes the default group flat at the root with no groups/ directory", () => {
@@ -136,6 +143,11 @@ describe("group-namespace generation (#3234, ADR-0012)", () => {
     const orders = entities.find((e) => e.raw.table === "orders");
     expect(orders!.sourceName).toBe("default");
     expect(orders!.origin).toBe("flat");
+
+    // #3285: the default group emits no group field at all (flat root), so a
+    // standalone DB gains neither `group:` nor the deprecated `connection:`.
+    expect(orders!.raw.group).toBeUndefined();
+    expect(orders!.raw.connection).toBeUndefined();
   });
 
   it("keeps multiple groups isolated on disk and distinctly attributed", () => {

--- a/packages/api/src/lib/semantic/admin-source.ts
+++ b/packages/api/src/lib/semantic/admin-source.ts
@@ -266,15 +266,18 @@ function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
   // expects the file stem — so `name` must be the file stem, not the
   // table. `displayName` keeps the existing UX label.
   //
-  // Per-source disk dirs (`semantic/<source>/entities/<stem>.yml`) can
-  // hold the same file stem under different sources — the merge dedup
-  // is `(name, connectionId)`, so leaving `connectionId: null` for
-  // every disk row would collapse them. Treating `source` as a virtual
-  // group keeps both rows in the list and surfaces the source label as
-  // the file-tree env badge (which is what the admin actually wants to
-  // see for multi-source self-hosted layouts). "default" stays null so
-  // single-source orgs keep the unchanged badge-free rendering.
-  const groupAsSource = e.source !== "default" ? e.source : null;
+  // Group-scoped disk dirs can hold the same file stem under different
+  // groups — the merge dedup is `(name, connectionId)`, so leaving
+  // `connectionId: null` for every disk row would collapse them. Scope by
+  // the resolved `e.group` (ADR-0012, #3275), NOT the raw `e.source`: for a
+  // canonical `groups/<g>/` entity the directory is authoritative, and the
+  // flat default root with a `group:`/`connection:` field resolves to that
+  // field's group — using `e.source` would scope it to "default" and disagree
+  // with the drift reader / whitelist, which both key off the resolved group.
+  // This mirrors the DB path (`parseRowToAdminSummary`): source =
+  // group-or-"default", connectionId = group-or-null. "default" stays null so
+  // single-group orgs keep the unchanged badge-free rendering.
+  const resolvedGroup = e.group !== "default" ? e.group : null;
   return {
     name: e.name,
     displayName: e.displayName,
@@ -283,12 +286,12 @@ function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
     columnCount: e.columnCount,
     joinCount: e.joinCount,
     measureCount: e.measureCount,
-    source: e.source,
+    source: e.group,
     connection: e.connection,
     type: e.type,
     status: "published",
     sourceKind: "disk",
-    connectionId: groupAsSource,
+    connectionId: resolvedGroup,
     updatedAt: null,
   };
 }

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -404,7 +404,7 @@ export function generateEntityYAML(
     name,
     type: entityType,
     table: qualifiedTable,
-    ...(source ? { connection: source } : {}),
+    ...(source ? { group: source } : {}),
     grain: isMatView(profile)
       ? `one row per result from ${profile.table_name} materialized view`
       : isViewLike(profile)

--- a/packages/api/src/lib/semantic/reconcile.ts
+++ b/packages/api/src/lib/semantic/reconcile.ts
@@ -79,10 +79,11 @@ async function safeSyncToDisk(
   orgId: string,
   name: string,
   yamlContent: string,
+  connectionGroupId?: string | null,
 ): Promise<void> {
   try {
     const { syncEntityToDisk } = await import("./sync");
-    await syncEntityToDisk(orgId, name, "entity", yamlContent);
+    await syncEntityToDisk(orgId, name, "entity", yamlContent, connectionGroupId);
   } catch (err) {
     log.warn(
       { err: errorMessage(err), orgId, name },
@@ -91,10 +92,14 @@ async function safeSyncToDisk(
   }
 }
 
-async function safeSyncDeleteFromDisk(orgId: string, name: string): Promise<void> {
+async function safeSyncDeleteFromDisk(
+  orgId: string,
+  name: string,
+  connectionGroupId?: string | null,
+): Promise<void> {
   try {
     const { syncEntityDeleteFromDisk } = await import("./sync");
-    await syncEntityDeleteFromDisk(orgId, name, "entity");
+    await syncEntityDeleteFromDisk(orgId, name, "entity", connectionGroupId);
   } catch (err) {
     log.warn(
       { err: errorMessage(err), orgId, name },
@@ -144,7 +149,7 @@ async function reconcileSyncYaml(input: ReconcileInput): Promise<ReconcileResult
 
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
   invalidateOrgWhitelist(input.orgId);
-  await safeSyncToDisk(input.orgId, input.name, updatedYaml);
+  await safeSyncToDisk(input.orgId, input.name, updatedYaml, input.connection);
 
   log.info(
     { orgId: input.orgId, name: input.name, table },
@@ -179,7 +184,7 @@ async function reconcileRemove(input: ReconcileInput): Promise<ReconcileResult> 
 
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
   invalidateOrgWhitelist(input.orgId);
-  await safeSyncDeleteFromDisk(input.orgId, input.name);
+  await safeSyncDeleteFromDisk(input.orgId, input.name, groupId);
 
   log.info({ orgId: input.orgId, name: input.name }, "Removed entity via reconcile");
 
@@ -210,7 +215,7 @@ async function reconcileCreateFromDb(input: ReconcileInput): Promise<ReconcileRe
   await upsertDraftEntity(input.orgId, "entity", input.name, starterYaml, input.connection);
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
   invalidateOrgWhitelist(input.orgId);
-  await safeSyncToDisk(input.orgId, input.name, starterYaml);
+  await safeSyncToDisk(input.orgId, input.name, starterYaml, input.connection);
 
   log.info(
     { orgId: input.orgId, name: input.name, columns: columns.length },

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -19,6 +19,7 @@ import * as path from "path";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getSemanticRoot as getBaseSemanticRoot } from "./files";
+import { GROUPS_DIR } from "./scanner";
 
 const log = createLogger("semantic-sync");
 
@@ -104,12 +105,58 @@ function safeName(name: string): string {
   return path.basename(name).replace(/[^a-zA-Z0-9_.-]/g, "_");
 }
 
-/** Resolve the full file path for an entity on disk. */
-function entityFilePath(orgId: string, name: string, type: SemanticEntityType): string {
-  const root = getSemanticRoot(orgId);
+/**
+ * True when `value` is safe as a single path segment — no separators or `..`
+ * traversal that could escape the semantic root. Mirrors the generator's
+ * `assertSafePathSegment` (profiler.ts) but returns a boolean so the
+ * best-effort DB→disk writers can skip an unsafe row rather than aborting the
+ * whole rebuild.
+ */
+function isSafePathSegment(value: string): boolean {
+  return (
+    value === path.basename(value) &&
+    value !== "." &&
+    value !== ".." &&
+    !value.includes("/") &&
+    !value.includes("\\")
+  );
+}
+
+/**
+ * Resolve an entity's path within `root`, honoring its Connection group
+ * (ADR-0012, #3275). A non-default group is laid into the canonical
+ * `groups/<group>/<subdir>/` namespace so same-stem entities in different
+ * groups don't collide on a flat `<subdir>/<name>.yml` (whichever wrote last
+ * used to win, silently dropping the other group's YAML from the explore view).
+ * The default group (`null` / `undefined` / `"default"`) stays flat at the
+ * root, unchanged.
+ *
+ * Returns `null` when the group is an unsafe path segment — the caller skips
+ * the row rather than letting a crafted group escape `root`.
+ */
+function entityPathInRoot(
+  root: string,
+  name: string,
+  type: SemanticEntityType,
+  connectionGroupId?: string | null,
+): string | null {
   const subdir = entityTypeDir(type);
   const fileName = `${safeName(name)}.yml`;
-  return subdir ? path.join(root, subdir, fileName) : path.join(root, fileName);
+  const group =
+    connectionGroupId && connectionGroupId !== "default" ? connectionGroupId : null;
+  if (group && !isSafePathSegment(group)) return null;
+  const base = group ? path.join(root, GROUPS_DIR, group) : root;
+  return subdir ? path.join(base, subdir, fileName) : path.join(base, fileName);
+}
+
+/** Resolve the full file path for an entity on disk (group-aware, #3275). */
+function entityFilePath(
+  orgId: string,
+  name: string,
+  type: SemanticEntityType,
+  connectionGroupId?: string | null,
+): string | null {
+  return entityPathInRoot(getSemanticRoot(orgId), name, type, connectionGroupId);
 }
 
 // ---------------------------------------------------------------------------
@@ -125,8 +172,16 @@ export async function syncEntityToDisk(
   name: string,
   type: SemanticEntityType,
   yamlContent: string,
+  connectionGroupId?: string | null,
 ): Promise<void> {
-  const filePath = entityFilePath(orgId, name, type);
+  const filePath = entityFilePath(orgId, name, type, connectionGroupId);
+  if (filePath === null) {
+    log.error(
+      { orgId, name, type, connectionGroupId },
+      "Refusing to sync entity to disk — group is an unsafe path segment",
+    );
+    return;
+  }
   try {
     await atomicWriteFile(filePath, yamlContent);
     log.debug({ orgId, name, type, filePath }, "Synced entity to disk");
@@ -148,8 +203,16 @@ export async function syncEntityDeleteFromDisk(
   orgId: string,
   name: string,
   type: SemanticEntityType,
+  connectionGroupId?: string | null,
 ): Promise<void> {
-  const filePath = entityFilePath(orgId, name, type);
+  const filePath = entityFilePath(orgId, name, type, connectionGroupId);
+  if (filePath === null) {
+    log.error(
+      { orgId, name, type, connectionGroupId },
+      "Refusing to delete entity from disk — group is an unsafe path segment",
+    );
+    return;
+  }
   try {
     await fs.promises.unlink(filePath);
     log.debug({ orgId, name, type, filePath }, "Deleted entity from disk");
@@ -224,7 +287,19 @@ async function _doSyncAllEntitiesToDisk(orgId: string): Promise<number> {
 
   let synced = 0;
   for (const row of rows) {
-    const filePath = entityFilePath(orgId, row.name, row.entity_type as SemanticEntityType);
+    const filePath = entityPathInRoot(
+      root,
+      row.name,
+      row.entity_type as SemanticEntityType,
+      row.connection_group_id,
+    );
+    if (filePath === null) {
+      log.error(
+        { orgId, name: row.name, type: row.entity_type, group: row.connection_group_id },
+        "Skipping entity during full sync — group is an unsafe path segment",
+      );
+      continue;
+    }
     expectedFiles.add(filePath);
     try {
       await atomicWriteFile(filePath, row.yaml_content);
@@ -261,6 +336,24 @@ async function _cleanStaleFiles(root: string, expectedFiles: Set<string>): Promi
     path.join(root, "metrics"),
     root, // for glossary.yml, catalog.yml
   ];
+
+  // Group namespace (ADR-0012, #3275): each groups/<group>/ holds its own
+  // entities/ + metrics/ subdirs plus a group-level glossary.yml/catalog.yml.
+  // Scan them too, else a group entity removed from the DB would linger on
+  // disk and keep shadowing the explore view after the rebuild.
+  const groupsRoot = path.join(root, GROUPS_DIR);
+  try {
+    const groupEntries = await fs.promises.readdir(groupsRoot, { withFileTypes: true });
+    for (const entry of groupEntries) {
+      if (!entry.isDirectory()) continue;
+      const groupDir = path.join(groupsRoot, entry.name);
+      dirs.push(path.join(groupDir, "entities"), path.join(groupDir, "metrics"), groupDir);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn({ groupsRoot, err: errorMessage(err) }, "Failed to scan groups/ namespace for stale files");
+    }
+  }
 
   for (const dir of dirs) {
     try {
@@ -431,9 +524,20 @@ async function _buildOrgModeRoot(
   let written = 0;
   let failed = 0;
   for (const row of rows) {
-    const subdir = entityTypeDir(row.entity_type as SemanticEntityType);
-    const fileName = `${safeName(row.name)}.yml`;
-    const filePath = subdir ? path.join(root, subdir, fileName) : path.join(root, fileName);
+    const filePath = entityPathInRoot(
+      root,
+      row.name,
+      row.entity_type as SemanticEntityType,
+      row.connection_group_id,
+    );
+    if (filePath === null) {
+      failed++;
+      log.error(
+        { orgId, mode, name: row.name, type: row.entity_type, group: row.connection_group_id },
+        "Skipping mode-specific entity file — group is an unsafe path segment",
+      );
+      continue;
+    }
     expectedFiles.add(filePath);
     try {
       await atomicWriteFile(filePath, row.yaml_content);

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -743,20 +743,34 @@ export async function getOrgSemanticIndex(orgId: string): Promise<string> {
   const { getSemanticRoot, syncAllEntitiesToDisk } = await import("@atlas/api/lib/semantic/sync");
   const orgRoot = getSemanticRoot(orgId);
 
-  // Ensure the org directory exists on disk (may be first access after boot)
-  const entitiesDir = path.join(orgRoot, "entities");
+  // Detect whether any entity YAML is already on disk — the flat `entities/`
+  // dir OR a group namespace `groups/<group>/entities/` (ADR-0012, #3275). A
+  // multi-group org can have an empty flat dir with every entity under
+  // `groups/`, so checking only the flat dir would force a full DB→disk
+  // rebuild on every cache-cold build. `getEntityDirs` is the same
+  // layout-aware traversal the loader uses.
   let hasFiles = false;
   let syncFailed = false;
   try {
-    const entries = fs.readdirSync(entitiesDir);
-    hasFiles = entries.some((e) => e.endsWith(".yml"));
+    const { dirs } = getEntityDirs(orgRoot);
+    hasFiles = dirs.some(({ dir }) => {
+      try {
+        return fs.readdirSync(dir).some((e) => e.endsWith(".yml"));
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          log.warn(
+            { orgId, dir, err: err instanceof Error ? err.message : String(err) },
+            "Unexpected error reading org entity directory",
+          );
+        }
+        return false;
+      }
+    });
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      log.warn(
-        { orgId, err: err instanceof Error ? err.message : String(err) },
-        "Unexpected error reading org entities directory",
-      );
-    }
+    log.warn(
+      { orgId, err: err instanceof Error ? err.message : String(err) },
+      "Unexpected error scanning org entity directories",
+    );
   }
 
   if (!hasFiles) {

--- a/packages/cli/bin/__tests__/multi-source.test.ts
+++ b/packages/cli/bin/__tests__/multi-source.test.ts
@@ -60,9 +60,9 @@ describe("outputDirForDatasource", () => {
   });
 });
 
-// --- Entity YAML connection: field ---
+// --- Entity YAML group: field (#3285, ADR-0012) ---
 
-describe("entity YAML connection field", () => {
+describe("entity YAML group field", () => {
   const profile = makeProfile({
     table_name: "orders",
     columns: [
@@ -72,20 +72,22 @@ describe("entity YAML connection field", () => {
     primary_key_columns: ["id"],
   });
 
-  test("default source omits connection: field", () => {
-    // source=undefined → no connection field
+  test("default source omits the group field", () => {
+    // source=undefined → no group field (neither canonical nor deprecated alias)
     const yaml = generateEntityYAML(profile, [profile], "postgres", "public", undefined);
+    expect(yaml).not.toContain("group:");
     expect(yaml).not.toContain("connection:");
   });
 
-  test("named source includes connection: field", () => {
+  test("named source emits the canonical group: field", () => {
     const yaml = generateEntityYAML(profile, [profile], "postgres", "public", "warehouse");
-    expect(yaml).toContain("connection: warehouse");
+    expect(yaml).toContain("group: warehouse");
+    expect(yaml).not.toContain("connection:");
   });
 
   test("different named source", () => {
     const yaml = generateEntityYAML(profile, [profile], "postgres", "public", "analytics");
-    expect(yaml).toContain("connection: analytics");
+    expect(yaml).toContain("group: analytics");
   });
 });
 

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -148,6 +148,28 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
   },
 }));
 
+// #3281 — group-member routing for runMetric. Test topology: group "analytics"
+// has members "analytics" (the group id) + "analytics_eu"; group "warehouse"
+// has "warehouse" + "warehouse_eu"; everything else is ungrouped (1×1 fallback,
+// groupId undefined). Lets the member-routing tests resolve a member id to its
+// group without a real internal DB.
+mock.module("@atlas/api/lib/env-routing/lookup", () => ({
+  loadGroupRoutingContext: mock(async (_orgId: string | undefined, connectionId: string) => {
+    const topology: Record<string, string> = {
+      analytics: "analytics",
+      analytics_eu: "analytics",
+      warehouse: "warehouse",
+      warehouse_eu: "warehouse",
+    };
+    const groupId = topology[connectionId];
+    if (groupId) {
+      const members = Object.keys(topology).filter((c) => topology[c] === groupId);
+      return { groupId, members, primaryMember: members[0], currentMember: connectionId };
+    }
+    return { members: [connectionId], primaryMember: connectionId, currentMember: connectionId };
+  }),
+}));
+
 // Imports must come AFTER mock.module() registrations.
 const { registerSemanticTools } = await import("../semantic-tools.js");
 
@@ -781,6 +803,41 @@ describe("MCP semantic tools", () => {
     const result = await client.callTool({
       name: "runMetric",
       arguments: { id: "orders_count", connectionId: "analytics" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("validation_failed");
+    expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
+  });
+
+  // --- runMetric multi-member-group routing (#3281) ---
+  // A multi-member group registers each member under its own install id, none
+  // equal to the group id. runMetric must accept a member connectionId (route
+  // to that member) while still rejecting a connection outside the group.
+
+  it("runMetric forwards a member connectionId of the metric's group, routing to that member (#3281)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      // "analytics_eu" is a member of group "analytics" but not the group id.
+      arguments: { id: "analytics_orders_count", connectionId: "analytics_eu" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const callArgs = (mockExecuteSQLExecute.mock.calls[0] as unknown[])[0] as {
+      connectionId?: string;
+    };
+    // Routes to the specific member, not the group id — the whole point of #3281.
+    expect(callArgs.connectionId).toBe("analytics_eu");
+  });
+
+  it("runMetric rejects a connectionId that is a member of a DIFFERENT group (#3281)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      // "warehouse_eu" is a real grouped member, but of "warehouse", not "analytics".
+      arguments: { id: "analytics_orders_count", connectionId: "warehouse_eu" },
     });
 
     expect(result.isError).toBe(true);

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -35,6 +35,7 @@ import {
   findMetricById,
 } from "@atlas/api/lib/semantic/lookups";
 import { executeSQL } from "@atlas/api/lib/tools/sql";
+import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
 import {
   DESCRIBE_ENTITY_ERROR_CODES,
   DESCRIBE_ENTITY_TOOL_DESCRIPTION,
@@ -453,18 +454,37 @@ export function registerSemanticTools(
               // Reject an explicit connectionId that targets a different group:
               // running the metric's authoritative SQL against the wrong
               // datasource is the silently-wrong-results failure mode #3274
-              // exists to prevent. An explicit match (including the literal
-              // `"default"` for a default-group metric) is honored as-is.
+              // exists to prevent. An explicit match against the group id itself
+              // (including the literal `"default"` for a default-group metric)
+              // is honored as-is.
               if (connectionId !== undefined && connectionId !== metricConnectionId) {
-                return toEnvelopeResult(
-                  envelope(
-                    "validation_failed",
-                    `Metric "${metric.id}" belongs to the "${metric.source}" group, but connectionId "${connectionId}" targets a different datasource. Running it there would query the wrong data.`,
-                    {
-                      hint: `Omit connectionId to run "${metric.id}" against its own group, or pass connectionId "${metricConnectionId}".`,
-                    },
-                  ),
-                );
+                // #3281 — the connectionId isn't the group id itself, but for a
+                // multi-member group it may be a legitimate MEMBER: a group
+                // `prod` with members `us-prod`/`eu-prod` registers each member
+                // under its own install id, none equal to the group id. Resolve
+                // the passed connection's group and accept iff it matches the
+                // metric's group, then route to that specific member.
+                //
+                // A default-source (ungrouped) metric has no members: its
+                // canonical SQL is defined only against the default connection,
+                // so any explicit non-default connectionId is rejected. Running
+                // a canonical metric against an arbitrary sibling connection is
+                // intentionally out of scope — model it as a grouped metric and
+                // pass a member id instead (decision recorded for #3281).
+                const isGroupMember =
+                  metric.source !== DEFAULT_SEMANTIC_GROUP &&
+                  (await loadGroupRoutingContext(workspaceId, connectionId)).groupId === metric.source;
+                if (!isGroupMember) {
+                  return toEnvelopeResult(
+                    envelope(
+                      "validation_failed",
+                      `Metric "${metric.id}" belongs to the "${metric.source}" group, but connectionId "${connectionId}" targets a different datasource. Running it there would query the wrong data.`,
+                      {
+                        hint: `Omit connectionId to run "${metric.id}" against its own group, or pass the group id "${metricConnectionId}" or one of its member connections.`,
+                      },
+                    ),
+                  );
+                }
               }
               const targetConnectionId = connectionId ?? groupConnectionId;
 


### PR DESCRIPTION
Drains three review-surfaced correctness follow-ups from the v0.0.12 group-scoped semantic work (ADR-0012), fixed inline rather than deferred. Each is an independent, tested fix; all of `bun run type` (api + mcp) and the affected suites are green.

## #3285 — generator emits the canonical `group:` field
`generateEntityYAML` wrote `connection: <group>` for non-default groups — the spelling ADR-0012 deprecates. The directory-canonical loader masked it (the generate→load round-trip passes either way), so freshly-generated files slow-rotted toward the deprecated alias. Now emits `group:`; the default group still emits no field. Pinned directly on parsed output (the round-trip can't catch it).

## #3275 — group-aware DB→disk semantic mirror
The DB→disk writers wrote every entity to a flat `entities/<name>.yml`, ignoring `connection_group_id`. Two groups with the same file stem (`users` in `g_prod_us` **and** `g_prod_eu`) mapped to one path; last-writer-wins silently dropped a group's YAML from the explore view after reconciliation.
- `entityPathInRoot()` lays group rows into `groups/<group>/<subdir>/`; default stays flat; unsafe group segments are skipped (not escaped)
- both rebuild loops (full + per-mode) and `_cleanStaleFiles` are group-aware
- `syncEntityToDisk`/`Delete` take an optional group, threaded through wizard / admin / admin-semantic / reconcile callers
- `getOrgSemanticIndex` `hasFiles` check is layout-aware (`getEntityDirs`) so a multi-group org with an empty flat dir doesn't rebuild every call
- `diskToAdminSummary` scopes by the resolved `e.group`, matching the drift reader
- regression: two groups, same stem, round-trip without loss

## #3281 — runMetric accepts member connections of multi-member groups
The #3274 group-mismatch check used strict equality against the group id, so a legitimate member of a multi-member group (group `prod` with members `us-prod`/`eu-prod`) was rejected as a wrong-datasource target. Now resolves the passed connection's group via `loadGroupRoutingContext` and accepts iff it matches the metric's group, routing to that member. A connection outside the group still `validation_fails`. Default-source metrics keep rejecting non-default connectionIds (intentional — recorded for #3281).

## Not in this PR
**#3284** (expert/improve group-aware apply) is the remaining v0.0.12 follow-up. It needs a `connection_group_id` column on the amendments table (the `getPendingAmendments`→apply path reconstructs the target from `source_entity` alone) plus end-to-end threading — a migration-bearing slice that belongs in its own PR for the schema-drift + pg-smoke gates. Landing next.

Closes #3285
Closes #3275
Closes #3281

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783363332&installation_id=135337507&pr_number=3286&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3286&signature=83a38d9aacd5c5257e4032ed54f168b2713a074207bd3ce29058a6e7b808fa34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics can route to individual group-member datasources (in addition to group IDs).

* **Improvements**
  * YAML output now emits the canonical `group:` field instead of the deprecated `connection:` alias.
  * Disk sync and delete operations preserve per-group scoping, improving on-disk organization and preventing cross-group collisions.
  * Safer disk handling: path-traversal checks skip/log unsafe groups and stale grouped files are cleaned up.

* **Tests**
  * Updated/added tests to validate `group:` behavior, multi-group mirroring, and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->