### PR TITLE
fix(semantic): group-aware disk detail in getAdminEntity (#3275)

### DIFF
--- a/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { resolve, join } from "path";
 import {
+  AdminEntityYamlParseError,
+  getAdminEntity,
   mergeAdminEntities,
   parseRowToAdminSummary,
   type AdminEntitySummary,
@@ -443,5 +447,103 @@ describe("mergeAdminEntities", () => {
       "users|g_prod_eu",
       "users|g_prod_us",
     ]);
+  });
+});
+
+// ── getAdminEntity disk branch: group-aware detail (#3275 / PR #3286) ────
+//
+// The pure-YAML (no internal DB) disk branch must resolve DETAIL by
+// (name, group) through the SAME discovery (`discoverEntities`) the LIST
+// path uses, so the two can't drift: after #3275 kept same-stem rows
+// distinct per group in the list, a stem-only `findEntityFile` detail read
+// could still open whichever group it scanned first. A stem-only lookup
+// spanning more than one group is now rejected (mirrors the DB
+// unique-or-409 contract).
+//
+// Harness: point `ATLAS_SEMANTIC_ROOT` at a temp dir and call without an
+// `orgId`. The `orgId && hasInternalDB()` guard short-circuits on the
+// absent `orgId`, so the disk branch runs deterministically — no need to
+// mock the (heavy, 60-export) `db/internal` module just to force
+// `hasInternalDB() === false`.
+describe("getAdminEntity — group-aware disk detail (#3275)", () => {
+  const tmp = resolve(import.meta.dir, ".tmp-admin-source-disk");
+  let prevRoot: string | undefined;
+
+  beforeEach(() => {
+    prevRoot = process.env.ATLAS_SEMANTIC_ROOT;
+    process.env.ATLAS_SEMANTIC_ROOT = tmp;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (prevRoot === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+    else process.env.ATLAS_SEMANTIC_ROOT = prevRoot;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /** Write `<tmp>/groups/<group>/entities/<stem>.yml` with a given table. */
+  function writeGroupEntity(group: string, stem: string, table: string): void {
+    const dir = join(tmp, "groups", group, "entities");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${stem}.yml`), `table: ${table}\n`);
+  }
+
+  /** Write a raw (possibly malformed) YAML body to the flat `entities/` dir. */
+  function writeFlatEntity(stem: string, body: string): void {
+    const dir = join(tmp, "entities");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${stem}.yml`), body);
+  }
+
+  it("resolves the requested group when the same stem exists in two groups", async () => {
+    writeGroupEntity("us", "orders", "orders_us");
+    writeGroupEntity("eu", "orders", "orders_eu");
+
+    const us = await getAdminEntity({ name: "orders", connectionGroupId: "us" });
+    expect(us).not.toBeNull();
+    expect(us?.source).toBe("disk");
+    expect(us?.entity.table).toBe("orders_us");
+
+    // Same stem, other group → the OTHER file, proving detail no longer
+    // opens whichever same-stem match is scanned first.
+    const eu = await getAdminEntity({ name: "orders", connectionGroupId: "eu" });
+    expect(eu?.entity.table).toBe("orders_eu");
+  });
+
+  it("returns null for an ambiguous stem-only lookup across groups", async () => {
+    writeGroupEntity("us", "orders", "orders_us");
+    writeGroupEntity("eu", "orders", "orders_eu");
+
+    // `connectionGroupId` omitted + >1 group match → reject (DB 409 mirror).
+    const detail = await getAdminEntity({ name: "orders" });
+    expect(detail).toBeNull();
+  });
+
+  it("returns the single match for a stem that exists in only one group", async () => {
+    writeGroupEntity("us", "products", "products");
+
+    // Single match → resolvable even without `connectionGroupId`.
+    const detail = await getAdminEntity({ name: "products" });
+    expect(detail).not.toBeNull();
+    expect(detail?.source).toBe("disk");
+    expect(detail?.entity.table).toBe("products");
+  });
+
+  it("surfaces a malformed authored file as a parse error, not a silent 404", async () => {
+    // `discoverEntities` parses every file and drops the unparseable ones,
+    // so a stem-only resolver built on it would 404 a broken file and hide
+    // the authoring error. The raw-existence fallback must still reach
+    // `parseEntityYaml` so the route can return its contracted 500.
+    writeFlatEntity("broken", "table: broken\ndimensions: [invalid: yaml: structure\n");
+
+    await expect(getAdminEntity({ name: "broken" })).rejects.toBeInstanceOf(
+      AdminEntityYamlParseError,
+    );
+  });
+
+  it("returns null for a genuinely absent entity", async () => {
+    writeGroupEntity("us", "orders", "orders_us");
+
+    expect(await getAdminEntity({ name: "nonexistent" })).toBeNull();
   });
 });

--- a/packages/api/src/lib/semantic/admin-source.ts
+++ b/packages/api/src/lib/semantic/admin-source.ts
@@ -473,17 +473,53 @@ export async function getAdminEntity(opts: GetAdminEntityOptions): Promise<Admin
   }
 
   // No internal DB → pure-YAML self-hosted. The disk root holds the
-  // authored YAML.
+  // authored YAML. Resolve DETAIL by (name, group) through the SAME
+  // discovery (`discoverEntities`) the LIST path uses, so the two can't
+  // drift: `findEntityFile` resolved by file stem alone and, after #3275
+  // kept same-stem rows distinct per group in the LIST, the DETAIL read
+  // could still open whichever stem match was scanned first — the wrong
+  // group.
   const diskRoot = resolveSemanticRoot(orgId);
-  const filePath = findEntityFile(diskRoot, name);
-  if (!filePath) return null;
+  const stemMatches = discoverEntities(diskRoot).entities.filter((e) => e.name === name);
+
+  let filePath: string | null;
+  if (stemMatches.length === 0) {
+    // `discoverEntities` parses every file and drops the unparseable / no-
+    // `table` ones, so an authored-but-broken file would vanish here and
+    // 404 — hiding a real authoring error behind "not found". Fall back to
+    // a raw stem existence check (group-agnostic: a broken file's group is
+    // unknowable) and let `parseEntityYaml` below surface it as the 500 the
+    // route contracts for malformed YAML. A genuinely absent file still
+    // returns null → 404.
+    filePath = findEntityFile(diskRoot, name);
+    if (!filePath) return null;
+  } else {
+    let chosen: EntitySummary | undefined;
+    if (connectionGroupId === undefined) {
+      // Mirror the DB unique-or-409 contract: a stem-only lookup spanning
+      // more than one group is ambiguous — reject rather than silently pick.
+      if (stemMatches.length > 1) {
+        log.warn(
+          { requestId, name, groups: stemMatches.map((e) => e.group) },
+          "getAdminEntity: ambiguous stem-only disk lookup across groups — pass connectionGroupId to disambiguate",
+        );
+        return null;
+      }
+      chosen = stemMatches[0];
+    } else {
+      const wantGroup = connectionGroupId === null ? "default" : connectionGroupId;
+      chosen = stemMatches.find((e) => e.group === wantGroup);
+    }
+    if (!chosen) return null;
+    filePath = chosen.filePath;
+  }
 
   // Intentional 403→404 downgrade if the path escapes the root: don't
   // leak whether a path-traversal probe hit a real file. The route's
   // upstream `isValidEntityName` check returns 400 for obvious probes,
   // so this branch is pure defense-in-depth (symlinks, future bugs in
-  // `findEntityFile`). `requestId` is preserved end-to-end via the
-  // 404 response so log correlation still works.
+  // disk path resolution). `requestId` is preserved end-to-end via the
+  // 404 response so log correlation works.
   const resolved = path.resolve(filePath);
   if (!resolved.startsWith(path.resolve(diskRoot))) {
     log.error({ requestId, name, resolved, root: diskRoot }, "getAdminEntity: resolved path escaped semantic root");


### PR DESCRIPTION
Follow-up to **PR #3286** addressing CodeRabbit's second finding (the PR merged before this was pushed). No new issue — fixing inline per repo convention. References #3275.

## Problem

`getAdminEntity()`'s pure-YAML (no internal DB) disk branch resolved by file stem only via `findEntityFile(diskRoot, name)`, ignoring `connectionGroupId`. After #3275 made the **list** keep same-stem rows distinct per Connection group, the **detail** lookup could still open whichever stem match was scanned first — the wrong group. Detail and list could drift.

## Fix

The disk read now resolves by `(name, group)` through the **same discovery the list path uses** (`discoverEntities`), so detail and list can't disagree:

- `connectionGroupId` given → match the file whose resolved `group` equals it (`null` → `"default"`).
- `connectionGroupId` omitted + more than one group match → **reject** (returns `null` → 404), mirroring the DB `getEntity` unique-or-409 contract instead of silently picking one.
- single match → return it.

## Deviation from the suggested diff (kept `findEntityFile`)

CodeRabbit's suggestion removed the now-"unused" `findEntityFile` import. I kept it: `discoverEntities` **parses** every file and silently drops the unparseable / no-`table` ones, so resolving solely through it would turn the existing **"malformed authored YAML → 500"** route contract (`GET /api/v1/semantic/entities/:name`, covered by `semantic.test.ts`) into a misleading **404**. So when discovery yields *zero* parseable matches, the branch falls back to a raw stem existence check and lets `parseEntityYaml` surface the parse/shape error as the contracted 500. A genuinely absent file still returns `null` → 404. Without this, `semantic.test.ts > returns 500 for malformed YAML` regresses.

## Tests

Added a disk-fixture harness to `admin-source.test.ts` (`ATLAS_SEMANTIC_ROOT` → temp dir, no `orgId` so the disk branch runs deterministically without mocking the heavy `db/internal`):

- same stem in two groups → `connectionGroupId:"us"` returns the US file, `:"eu"` the EU file;
- stem-only lookup across two groups → `null` (ambiguous, DB-409 mirror);
- single-group stem → resolvable without `connectionGroupId`;
- malformed authored file → throws `AdminEntityYamlParseError` (the 500 contract, via the fallback);
- genuinely absent entity → `null`.

## Gates

`bun run test` (full) + `bun run type` + `bun run lint` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783367085&installation_id=135337507&pr_number=3287&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3287&signature=0f966d941ba49cb5c0d8ab0d01e928d487f6950f8d19085e65593afa9b74a52f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced entity resolution to properly handle entities across multiple groups and prevent silent failures from ambiguous lookups.
  * Improved error reporting for malformed entity configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->