### PR TITLE
fix(semantic): group-aware expert/improve apply end-to-end (#3284)

### DIFF
--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -866,6 +866,12 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
         // This throws on failure — runHandler maps it to 500
         await applyAmendmentToEntity(orgId, {
           entityName: target.source_entity,
+          // Recover the Connection group the amendment was analyzed against so
+          // the apply targets that group's row, not the default scope or a 409
+          // (#3284). A NULL column means the default (flat) group — map it to
+          // the explicit `"default"` label so the lookup is scoped to NULL
+          // rather than running the unscoped ambiguity check.
+          group: target.connection_group_id ?? "default",
           category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
             ? rawCategory as typeof ANALYSIS_CATEGORIES[number]
             : "coverage_gaps",

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -367,6 +367,7 @@ describe("migrateAuthTables", () => {
             { name: "0119_drop_legacy_credential_tables.sql" },
             { name: "0120_static_bot_routing_id_unique.sql" },
             { name: "0121_dashboard_card_annotations.sql" },
+            { name: "0122_learned_patterns_connection_group.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -140,7 +140,9 @@ describe("runMigrations", () => {
     //   Plus 0119 (drop legacy teams/telegram/gchat/whatsapp_installations, #3161) = 120.
     //   Plus 0120 (static-bot routing-id partial unique index, #3167) = 121.
     //   Plus 0121 (dashboard_cards.annotations for event annotations, #3209) = 122.
-    expect(count).toBe(122);
+    //   Plus 0122 (learned_patterns.connection_group_id for group-aware expert
+    //   apply, #3284) = 123.
+    expect(count).toBe(123);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -291,6 +293,7 @@ describe("runMigrations", () => {
         "0119_drop_legacy_credential_tables.sql",
         "0120_static_bot_routing_id_unique.sql",
         "0121_dashboard_card_annotations.sql",
+        "0122_learned_patterns_connection_group.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1203,6 +1203,15 @@ export async function insertSemanticAmendment(amendment: {
   sourceEntity: string;
   confidence: number;
   amendmentPayload: Record<string, unknown>;
+  /**
+   * Connection group the amendment targets (ADR-0012, #3284). NULL/omitted =
+   * the default (flat `entities/`) group. Persisted so the admin approve path,
+   * which rebuilds the proposal from the stored row's `source_entity` alone,
+   * can recover the group and apply the amendment against the correct scope
+   * (no 409, no default-scope corruption). The interactive `proposeAmendment`
+   * tool omits it — it reads the flat root, so the default scope is correct.
+   */
+  connectionGroupId?: string | null;
 }): Promise<{ id: string; status: "approved" | "pending" }> {
   const threshold = getAutoApproveThreshold();
   const allowedTypes = getAutoApproveTypes();
@@ -1230,8 +1239,9 @@ export async function insertSemanticAmendment(amendment: {
   const rows = await internalQuery<{ id: string }>(
     `INSERT INTO learned_patterns
        (org_id, pattern_sql, description, source_entity, confidence,
-        repetition_count, status, proposed_by, type, amendment_payload)
-     VALUES ($1, $2, $3, $4, $5, 1, $6, 'expert-agent', 'semantic_amendment', $7)
+        repetition_count, status, proposed_by, type, amendment_payload,
+        connection_group_id)
+     VALUES ($1, $2, $3, $4, $5, 1, $6, 'expert-agent', 'semantic_amendment', $7, $8)
      RETURNING id`,
     [
       amendment.orgId ?? null,
@@ -1241,6 +1251,7 @@ export async function insertSemanticAmendment(amendment: {
       amendment.confidence,
       status,
       JSON.stringify(amendment.amendmentPayload),
+      amendment.connectionGroupId ?? null,
     ],
   );
 
@@ -1278,6 +1289,12 @@ export async function getPendingAmendmentCount(orgId: string | null): Promise<nu
 export type PendingAmendmentRow = Record<string, unknown> & {
   id: string;
   source_entity: string;
+  /**
+   * Connection group the amendment targets (ADR-0012, #3284). NULL = the
+   * default (flat `entities/`) group. The admin approve path threads this into
+   * `applyAmendmentToEntity` so the amendment hits the correct group's row.
+   */
+  connection_group_id: string | null;
   description: string | null;
   confidence: number;
   amendment_payload: Record<string, unknown> | null;
@@ -1293,12 +1310,12 @@ export async function getPendingAmendments(orgId: string | null): Promise<Pendin
 
   return internalQuery<PendingAmendmentRow>(
     orgId
-      ? `SELECT id, source_entity, description, confidence, amendment_payload, created_at::text
+      ? `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
          FROM learned_patterns
          WHERE type = 'semantic_amendment' AND status = 'pending'
          AND (org_id = $1 OR org_id IS NULL)
          ORDER BY created_at DESC`
-      : `SELECT id, source_entity, description, confidence, amendment_payload, created_at::text
+      : `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
          FROM learned_patterns
          WHERE type = 'semantic_amendment' AND status = 'pending'
          AND org_id IS NULL

--- a/packages/api/src/lib/db/migrations/0122_learned_patterns_connection_group.sql
+++ b/packages/api/src/lib/db/migrations/0122_learned_patterns_connection_group.sql
@@ -1,0 +1,31 @@
+-- 0122 — learned_patterns.connection_group_id (#3284).
+--
+-- The expert / `atlas improve` pipeline is now group-aware end-to-end: the
+-- entity loader (`loadEntitiesFromDisk`) discovers `groups/<group>/entities/`
+-- across the flat/groups/legacy layouts (ADR-0012), and the resolved group is
+-- threaded analyze → insert → apply so an auto- or admin-approved amendment for
+-- a `groups/<group>/` entity updates THAT group's row instead of 409-ing as
+-- ambiguous or corrupting the default-scope copy.
+--
+-- This column persists that group on the amendment row so the admin approve
+-- path (`admin-semantic-improve.ts` review-of-pending), which rebuilds the
+-- proposal from the stored row's `source_entity` alone, can recover the target
+-- group and pass it through `applyAmendmentToEntity` →
+-- `getEntity`/`upsertEntityForGroup`/`syncEntityToDisk`. NULL means the default
+-- (flat `entities/`) group — the same null = default convention
+-- `semantic_entities.connection_group_id` uses.
+--
+-- Additive-only: a single nullable column, no constraint changes — safe to ship
+-- in a single release under the two-phase-drop discipline (only DROP COLUMN /
+-- DROP TABLE need the N / N+1 split). The Drizzle mirror in `db/schema.ts`
+-- (`learnedPatterns.connectionGroupId`) lands in the SAME PR so
+-- `check-schema-drift` stays green. Not Better-Auth-dependent, so it does NOT
+-- join `MANAGED_AUTH_MIGRATIONS`.
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE learned_patterns
+  ADD COLUMN IF NOT EXISTS connection_group_id text;
+
+COMMENT ON COLUMN learned_patterns.connection_group_id IS
+  'Connection group the semantic amendment targets (ADR-0012). NULL = default (flat entities/) group. Threaded analyze → insert → apply so admin approve-of-pending rebuilds the correct group scope. #3284.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -538,6 +538,10 @@ export const learnedPatterns = pgTable(
     reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
     type: text("type").notNull().default("query_pattern"),
     amendmentPayload: jsonb("amendment_payload"),
+    // Connection group the semantic amendment targets (ADR-0012, #3284).
+    // NULL = default (flat entities/) group. Lets the admin approve path
+    // rebuild the correct group scope from a persisted amendment row.
+    connectionGroupId: text("connection_group_id"),
   },
   (t) => [
     index("idx_learned_patterns_org_status").on(t.orgId, t.status),

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -233,6 +233,41 @@ export async function upsertEntity(
 }
 
 /**
+ * Upsert a PUBLISHED semantic entity, setting `connection_group_id` DIRECTLY
+ * rather than resolving it from an install/connection id via
+ * {@link inlineConnectionGroupSql}.
+ *
+ * The published-status sibling of {@link upsertDraftEntityForGroup}, used by
+ * the expert/`atlas improve` apply path (`applyAmendmentToEntity`, #3284) where
+ * the target group is the on-disk `groups/<group>/` directory the amendment was
+ * analyzed in (ADR-0012) — a group name, not an install id that would resolve
+ * through `workspace_plugins`. Passing that group to {@link upsertEntity} would
+ * resolve it through the connection subquery to NULL and silently write the
+ * amendment into the default scope. Pass `null` for the flat default group.
+ */
+export async function upsertEntityForGroup(
+  orgId: string,
+  entityType: SemanticEntityType,
+  name: string,
+  yamlContent: string,
+  connectionGroupId?: string | null,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for org-scoped semantic entities");
+  }
+  await internalQuery(
+    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
+     VALUES ($1, $2, $3, $4, $5, 'published')
+     ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'published'
+     DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
+                   entity_type = EXCLUDED.entity_type,
+                   connection_group_id = EXCLUDED.connection_group_id,
+                   updated_at = now()`,
+    [orgId, entityType, name, yamlContent, connectionGroupId ?? null],
+  );
+}
+
+/**
  * Upsert a semantic entity at status='draft'.
  *
  * Used for developer-mode writes. The published row (if any) is left

--- a/packages/api/src/lib/semantic/expert/__tests__/apply-group-scope.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/apply-group-scope.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression: the expert apply path is group-aware end-to-end (#3284).
+ *
+ * Proves `applyAmendmentToEntity` targets the Connection group the amendment
+ * was analyzed against — never a 409-ambiguity for a name shared across groups,
+ * and never a wrong-scope (default) write:
+ *
+ *   1. an explicit group scopes the `getEntity` lookup, so a name in 2+ groups
+ *      resolves cleanly instead of throwing `AmbiguousEntityError` (the bug);
+ *   2. the write-back (upsert + version + disk sync) always uses the resolved
+ *      row's OWN `connection_group_id`, so an amendment for a group entity can
+ *      never land in the default scope;
+ *   3. the legacy interactive path (group undefined) keeps the unscoped lookup
+ *      and still writes back to the resolved row's group.
+ *
+ * Mocks the DB/disk layer so we assert routing, not persistence.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// Minimal stand-in for the tagged error the route layer maps to 409. The apply
+// code's `instanceof AmbiguousEntityError` resolves to THIS class (it imports
+// it from the mocked entities module), so a throw here is recognized.
+class AmbiguousEntityError extends Error {
+  readonly groups: (string | null)[];
+  constructor(opts: { message: string; groups: (string | null)[] }) {
+    super(opts.message);
+    this.name = "AmbiguousEntityError";
+    this.groups = opts.groups;
+  }
+}
+
+type Row = { id: string; connection_group_id: string | null; yaml_content: string };
+
+// Simulated `semantic_entities` rows:
+//   "orders"   — exists in BOTH the default (null) scope AND group "eu_prod"
+//                (the multi-group reality that 409s an unscoped lookup).
+//   "products" — exists in exactly ONE group ("eu_prod"); an unscoped lookup
+//                resolves it without ambiguity.
+function lookupRow(name: string, group: string | null | undefined): Row | null {
+  if (name === "orders") {
+    if (group === undefined) {
+      throw new AmbiguousEntityError({ message: "orders exists in 2 environments", groups: [null, "eu_prod"] });
+    }
+    if (group === "eu_prod") return { id: "orders-eu", connection_group_id: "eu_prod", yaml_content: "table: orders\n" };
+    if (group === null) return { id: "orders-default", connection_group_id: null, yaml_content: "table: orders\n" };
+    return null;
+  }
+  if (name === "products") {
+    if (group === undefined || group === "eu_prod") {
+      return { id: "products-eu", connection_group_id: "eu_prod", yaml_content: "table: products\n" };
+    }
+    return null;
+  }
+  return null;
+}
+
+// Explicit parameter signatures so `.mock.calls[n][i]` is well-typed (a bare
+// `mock(async () => {})` infers a zero-arity call tuple, which tsgo rejects on
+// positional argument assertions).
+const getEntity = mock(
+  async (_org: string, _type: string, name: string, group?: string | null): Promise<Row | null> =>
+    lookupRow(name, group),
+);
+const upsertEntityForGroup = mock(
+  async (_org: string, _type: string, _name: string, _yaml: string, _group?: string | null): Promise<void> => {},
+);
+const createVersion = mock(
+  async (
+    _id: string, _org: string, _type: string, _name: string, _yaml: string,
+    _summary: string | null, _authorId: string | null, _authorLabel: string | null,
+  ): Promise<string> => "version-1",
+);
+const generateChangeSummary = mock(async (_before: string, _after: string): Promise<string> => "summary");
+const invalidateOrgWhitelist = mock((_org: string): void => {});
+const syncEntityToDisk = mock(
+  async (_org: string, _name: string, _type: string, _yaml: string, _group?: string | null): Promise<void> => {},
+);
+
+// Factories MUST be synchronous (bun loader deadlocks on an async mock.module
+// factory that awaits internally) — each returns a plain object referencing the
+// spies above.
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  getEntity,
+  upsertEntityForGroup,
+  createVersion,
+  generateChangeSummary,
+  AmbiguousEntityError,
+}));
+mock.module("@atlas/api/lib/semantic", () => ({ invalidateOrgWhitelist }));
+mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { applyAmendmentToEntity } = await import(`../apply.ts?t=${Date.now()}`);
+
+import type { AnalysisResult } from "../types";
+
+function amendment(entityName: string, group: string | undefined): AnalysisResult {
+  return {
+    category: "coverage_gaps",
+    entityName,
+    group,
+    amendmentType: "add_dimension",
+    amendment: { name: "region", sql: "region", type: "string" },
+    rationale: "add region dimension",
+    impact: 0.6,
+    confidence: 0.9,
+    staleness: 0,
+    score: 0.54,
+  };
+}
+
+describe("applyAmendmentToEntity — group-aware routing (#3284)", () => {
+  beforeEach(() => {
+    getEntity.mockClear();
+    upsertEntityForGroup.mockClear();
+    createVersion.mockClear();
+    syncEntityToDisk.mockClear();
+  });
+
+  it("scopes the lookup AND every write to the explicit group (no 409, no default-scope write)", async () => {
+    await applyAmendmentToEntity("org-1", amendment("orders", "eu_prod"), "req-1");
+
+    // Lookup scoped to "eu_prod" — never the unscoped ambiguity check.
+    expect(getEntity.mock.calls[0].slice(0, 4)).toEqual(["org-1", "entity", "orders", "eu_prod"]);
+    // Upsert + version + disk sync all target "eu_prod", NOT the default (null).
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBe("eu_prod");
+    expect(syncEntityToDisk.mock.calls[0][4]).toBe("eu_prod");
+    expect(createVersion.mock.calls[0][0]).toBe("orders-eu"); // versioned the eu_prod row
+  });
+
+  it("maps the 'default' group label to a NULL-scoped lookup + write", async () => {
+    await applyAmendmentToEntity("org-1", amendment("orders", "default"), "req-2");
+
+    expect(getEntity.mock.calls[0][3]).toBeNull(); // explicit null scope, not undefined
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBeNull();
+    expect(syncEntityToDisk.mock.calls[0][4]).toBeNull();
+    expect(createVersion.mock.calls[0][0]).toBe("orders-default");
+  });
+
+  it("the OLD unscoped lookup would 409 on a name shared across groups — the bug the explicit group fixes", async () => {
+    // group=undefined reproduces the pre-#3284 behavior: the unscoped lookup
+    // throws AmbiguousEntityError, which the route maps to 409.
+    await expect(applyAmendmentToEntity("org-1", amendment("orders", undefined), "req-3")).rejects.toThrow(
+      "exists in 2 environments",
+    );
+    expect(upsertEntityForGroup).not.toHaveBeenCalled(); // never wrote
+  });
+
+  it("interactive path (group undefined, single-group entity) writes back to the resolved row's OWN group", async () => {
+    // "products" lives only in eu_prod; the unscoped lookup resolves it, and the
+    // write-back uses the row's connection_group_id ("eu_prod") — never default.
+    await applyAmendmentToEntity("org-1", amendment("products", undefined), "req-4");
+
+    expect(getEntity.mock.calls[0][3]).toBeUndefined(); // unscoped lookup preserved
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBe("eu_prod"); // row's own group, not null
+    expect(syncEntityToDisk.mock.calls[0][4]).toBe("eu_prod");
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/apply-group-scope.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/apply-group-scope.test.ts
@@ -158,4 +158,18 @@ describe("applyAmendmentToEntity — group-aware routing (#3284)", () => {
     expect(upsertEntityForGroup.mock.calls[0][4]).toBe("eu_prod"); // row's own group, not null
     expect(syncEntityToDisk.mock.calls[0][4]).toBe("eu_prod");
   });
+
+  it("falls back to an unscoped lookup when the persisted group misses, then writes back to the row's group", async () => {
+    // A stale/mismatched explicit group (e.g. an interactive amendment whose
+    // flat-root entity was imported under a datasource group) misses the scoped
+    // lookup; the fallback resolves the unique row and the write-back targets
+    // its own group — never the stale label, never default. (#3284 fix for the
+    // default-vs-unknown conflation Codex flagged.)
+    await applyAmendmentToEntity("org-1", amendment("products", "stale_group"), "req-5");
+
+    expect(getEntity.mock.calls[0][3]).toBe("stale_group"); // scoped attempt first
+    expect(getEntity.mock.calls[1][3]).toBeUndefined(); // unscoped fallback
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBe("eu_prod"); // row's own group
+    expect(syncEntityToDisk.mock.calls[0][4]).toBe("eu_prod");
+  });
 });

--- a/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
@@ -113,6 +113,29 @@ describe("findCoverageGaps", () => {
     });
     expect(findCoverageGaps(ctx)).toEqual([]);
   });
+
+  test("analyzes every group's copy of a shared table; rejection keys are group-scoped (#3284)", () => {
+    // `orders` exists in two groups; a rejected `add_dimension:region` for EU
+    // must mark ONLY the EU proposal stale, not the US one (group-scoped key).
+    const ctx = makeContext({
+      profiles: [makeProfile({
+        table_name: "orders",
+        columns: [makeColumn({ name: "region" })],
+      })],
+      entities: [
+        makeEntity({ name: "orders", group: "eu" }),
+        makeEntity({ name: "orders", group: "us" }),
+      ],
+      rejectedKeys: new Set(["eu:orders:add_dimension:region"]),
+    });
+
+    const results = findCoverageGaps(ctx);
+    // Both groups get a proposal (profile-driven analyzer visits all copies)…
+    expect(results.map((r) => r.group).toSorted()).toEqual(["eu", "us"]);
+    // …but only EU's is marked stale by the EU-scoped rejection.
+    expect(results.find((r) => r.group === "eu")?.staleness).toBe(0.8);
+    expect(results.find((r) => r.group === "us")?.staleness).toBe(0);
+  });
 });
 
 describe("findDescriptionIssues", () => {
@@ -324,6 +347,38 @@ describe("findMissingJoins", () => {
 
     const results = findMissingJoins(ctx);
     expect(results.length).toBe(1);
+  });
+
+  test("does NOT suggest a join when the target table is only in another group (#3284)", () => {
+    // The SQL whitelist keys tables by connection_group_id, so an `eu` orders →
+    // customers join is unapplyable when `customers` lives only in `us`.
+    const ctx = makeContext({
+      profiles: [makeProfile({
+        table_name: "orders",
+        foreign_keys: [{ from_column: "customer_id", to_table: "customers", to_column: "id", source: "constraint" }],
+      })],
+      entities: [
+        makeEntity({ name: "orders", group: "eu" }),
+        makeEntity({ name: "customers", group: "us" }),
+      ],
+    });
+    expect(findMissingJoins(ctx)).toEqual([]);
+  });
+
+  test("suggests a join when the target table is in the SAME group (#3284)", () => {
+    const ctx = makeContext({
+      profiles: [makeProfile({
+        table_name: "orders",
+        foreign_keys: [{ from_column: "customer_id", to_table: "customers", to_column: "id", source: "constraint" }],
+      })],
+      entities: [
+        makeEntity({ name: "orders", group: "eu" }),
+        makeEntity({ name: "customers", group: "eu" }),
+      ],
+    });
+    const results = findMissingJoins(ctx);
+    expect(results.length).toBe(1);
+    expect(results[0].group).toBe("eu");
   });
 });
 

--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -197,13 +197,25 @@ describe("loadEntitiesFromDisk (layout-aware, #3284)", () => {
     ]);
   });
 
-  it("honors a `group:` override on the flat + legacy layouts", async () => {
-    // Flat + legacy let a declared `group:`/`connection:` field assign the
-    // group (back-compat), matching `resolveEntityGroup`.
+  it("IGNORES a `group:` field on a flat-root entity (mirrors the importer's flat scope, #3284)", async () => {
+    // The disk importer (`_scanEntityDirs`) scopes flat-root entities by
+    // install-id, NOT a declared field — which resolves to NULL/default in the
+    // self-hosted scheduler context. Honoring the field here would target a
+    // group the DB row was never imported into, so the apply 409s / misses.
     writeSemanticFile("entities/orders.yml", "table: orders\ngroup: tenant_a\n");
     const entities = await loadEntitiesFromDisk();
     expect(entities).toHaveLength(1);
-    expect(entities[0].group).toBe("tenant_a");
+    expect(entities[0].group).toBe("default");
+  });
+
+  it("honors a `connection:` override on the legacy `<source>/` layout", async () => {
+    // Legacy `<source>/entities/` IS imported by its resolved group (the
+    // importer sets `connection_group_id` from `resolveEntityGroup`), so the
+    // field-wins precedence is honored — unlike flat root.
+    writeSemanticFile("crm/entities/contacts.yml", "table: contacts\nconnection: tenant_b\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities).toHaveLength(1);
+    expect(entities[0].group).toBe("tenant_b");
   });
 
   it("skips entity files missing the required `table` field (matches discoverEntities)", async () => {

--- a/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-from-disk.test.ts
@@ -152,38 +152,77 @@ describe("loadGlossaryFromDisk (layout-aware, #3273)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Entities — intentionally root-only (NOT layout-aware). Group-aware entity
-// discovery + apply is deferred to #3284 (the scheduler's auto-apply path
-// resolves entities by name with no group, so discovering group entities here
-// would mis-target an approved amendment). These tests pin that deliberate
-// scope so a future "helpful" refactor can't silently re-introduce the bug.
+// Entities — now layout-aware end-to-end (#3284). The loader discovers all
+// three layouts and carries each entity's resolved Connection group on
+// `ParsedEntity.group`, which is threaded analyze → insert → apply so an
+// auto/admin-approved amendment for a group entity updates THAT group's row
+// (no 409, no default-scope write). Before #3284 this was deliberately
+// root-only because the apply path resolved entities by name with no group.
 // ---------------------------------------------------------------------------
 
-describe("loadEntitiesFromDisk (root-only by design, see #3284)", () => {
-  it("discovers flat-root entities and keys name to the storage key (not a display `name:`)", async () => {
-    // The scheduled-tick apply path (`apply.ts`) looks the entity up by
-    // `proposal.entityName` (= entity.name), which must be the storage key the
-    // DB/disk is keyed by — never a display label. Mirrors `loadEntitiesFromDB`.
+describe("loadEntitiesFromDisk (layout-aware, #3284)", () => {
+  it("discovers flat-root entities, keys name to the storage key (not a display `name:`), group 'default'", async () => {
+    // The apply path (`apply.ts`) looks the entity up by `proposal.entityName`
+    // (= entity.name), which must be the storage key the DB/disk is keyed by
+    // (the file stem the importer writes to `semantic_entities.name`) — never a
+    // display label. Matches `discoverEntities`.
     writeSemanticFile("entities/orders.yml", "table: orders\nname: Orders Display Label\n");
     const entities = await loadEntitiesFromDisk();
     expect(entities).toHaveLength(1);
-    expect(entities[0].name).toBe("orders"); // storage key, not "Orders Display Label"
+    expect(entities[0].name).toBe("orders"); // file stem, not "Orders Display Label"
     expect(entities[0].table).toBe("orders");
     expect(entities[0].connection).toBeUndefined();
+    expect(entities[0].group).toBe("default");
   });
 
-  it("does NOT discover groups/<group>/ or legacy <source>/ entities (root-only; #3284)", async () => {
+  it("discovers groups/<group>/ + legacy <source>/ + flat entities, attributing each group (PRIMARY GAP)", async () => {
     writeSemanticFile("entities/orders.yml", "table: orders\n");
     writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n");
+    writeSemanticFile("groups/us_prod/entities/customers.yml", "table: customers\n");
     writeSemanticFile("marketing/entities/campaigns.yml", "table: campaigns\n");
+
     const entities = await loadEntitiesFromDisk();
-    // Only the flat-root entity surfaces; group + legacy entities are excluded
-    // until the apply path is group-aware (#3284).
-    expect(entities.map((e) => e.table)).toEqual(["orders"]);
+    // Group attribution: directory canonical for `groups/<group>/`, the source
+    // name for legacy `<source>/`, "default" for the flat root. The same-stem
+    // `customers` entity surfaces once per group (no cross-group collapse) —
+    // the bug #3284 fixes.
+    const byGroup = entities
+      .map((e) => `${e.group}:${e.name}`)
+      .toSorted();
+    expect(byGroup).toEqual([
+      "default:orders",
+      "eu_prod:customers",
+      "marketing:campaigns",
+      "us_prod:customers",
+    ]);
   });
 
-  it("returns empty when the flat root has no entities directory", async () => {
-    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n"); // present but not flat-root
+  it("honors a `group:` override on the flat + legacy layouts", async () => {
+    // Flat + legacy let a declared `group:`/`connection:` field assign the
+    // group (back-compat), matching `resolveEntityGroup`.
+    writeSemanticFile("entities/orders.yml", "table: orders\ngroup: tenant_a\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities).toHaveLength(1);
+    expect(entities[0].group).toBe("tenant_a");
+  });
+
+  it("skips entity files missing the required `table` field (matches discoverEntities)", async () => {
+    writeSemanticFile("entities/orders.yml", "table: orders\n");
+    writeSemanticFile("entities/no_table.yml", "name: just a label\n"); // no table:
+    const entities = await loadEntitiesFromDisk();
+    expect(entities.map((e) => e.name)).toEqual(["orders"]);
+  });
+
+  it("discovers group entities even when the flat root has no entities directory", async () => {
+    writeSemanticFile("groups/eu_prod/entities/customers.yml", "table: customers\n");
+    const entities = await loadEntitiesFromDisk();
+    expect(entities).toHaveLength(1);
+    expect(entities[0].name).toBe("customers");
+    expect(entities[0].group).toBe("eu_prod");
+  });
+
+  it("returns empty when no entities exist in any layout", async () => {
+    writeSemanticFile("glossary.yml", "terms:\n  arr:\n    definition: x\n"); // present but no entities
     const entities = await loadEntitiesFromDisk();
     expect(entities).toEqual([]);
   });

--- a/packages/api/src/lib/semantic/expert/analyzer.ts
+++ b/packages/api/src/lib/semantic/expert/analyzer.ts
@@ -38,10 +38,14 @@ export function analyzeSemanticLayer(
     ...findVirtualDimensionOpportunities(context),
   ];
 
-  // Deduplicate by entity + amendmentType + amendment.name
+  // Deduplicate by group + entity + amendmentType + amendment.name. The group
+  // is part of the key (#3284) so the same entity name in two Connection groups
+  // (`groups/eu/entities/orders.yml` + `groups/us/entities/orders.yml`) doesn't
+  // collapse to one proposal — each group's amendment must survive to be applied
+  // against its own row. `??""` keys the default/legacy group consistently.
   const seen = new Set<string>();
   const deduped = allResults.filter((r) => {
-    const key = `${r.entityName}:${r.amendmentType}:${String((r.amendment as Record<string, unknown>).name ?? "")}`;
+    const key = `${r.group ?? ""}:${r.entityName}:${r.amendmentType}:${String((r.amendment as Record<string, unknown>).name ?? "")}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -59,7 +59,17 @@ export async function applyAmendmentToEntity(
   // path. `getEntity` may still throw AmbiguousEntityError (undefined group,
   // 2+ groups) — that propagates to the route as a 409 with `groups`.
   const lookupScope = groupToLookupScope(result.group);
-  const entity = await getEntity(effectiveOrgId, "entity", result.entityName, lookupScope);
+  let entity = await getEntity(effectiveOrgId, "entity", result.entityName, lookupScope);
+  if (!entity && lookupScope !== undefined) {
+    // The persisted group didn't resolve to a row — e.g. an interactive
+    // `proposeAmendment` row (NULL group) whose flat-root entity was imported
+    // under a datasource group, or a stale group label. Fall back to the
+    // back-compat UNSCOPED lookup, which resolves a unique match (and only
+    // throws AmbiguousEntityError → 409 on genuine cross-group ambiguity). The
+    // write-back below still targets the resolved row's OWN group, so a wrong
+    // scope is never written.
+    entity = await getEntity(effectiveOrgId, "entity", result.entityName);
+  }
   if (!entity) {
     throw new Error(`Entity "${result.entityName}" not found for org ${orgId}`);
   }

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -12,12 +12,30 @@ import { createLogger } from "@atlas/api/lib/logger";
 const log = createLogger("semantic-expert-apply");
 
 /**
+ * Resolve an {@link AnalysisResult.group} label to the `connection_group_id`
+ * scope used for the entity LOOKUP (#3284):
+ *
+ * - `undefined` (interactive `proposeAmendment` path, group unknown) → `undefined`,
+ *   preserving the back-compat unscoped lookup (`getEntity` runs its ambiguity
+ *   check and 409s when the name exists in 2+ groups).
+ * - `"default"` (the flat `entities/` group) → `null`, an EXPLICIT default-scope
+ *   lookup that won't 409 even when the same name also lives in a group.
+ * - `"<group>"` → the group name, scoping the lookup to that group's row.
+ */
+function groupToLookupScope(group: string | undefined): string | null | undefined {
+  if (group === undefined) return undefined;
+  return group === "default" ? null : group;
+}
+
+/**
  * Apply an amendment from an AnalysisResult to the org's semantic entity.
  *
- * 1. Read current YAML from DB
+ * 1. Read current YAML from DB — scoped to the finding's Connection group
+ *    (`result.group`) so a group entity resolves without a 409 (#3284)
  * 2. Parse, apply amendment, serialize back
- * 3. Upsert entity + create version snapshot
- * 4. Invalidate caches and sync to disk
+ * 3. Upsert entity + create version snapshot — written back to the row's OWN
+ *    `connection_group_id`, so the amendment can never land in the wrong scope
+ * 4. Invalidate caches and sync to disk (same group)
  */
 export async function applyAmendmentToEntity(
   orgId: string | null,
@@ -29,16 +47,28 @@ export async function applyAmendmentToEntity(
 
   const {
     getEntity,
-    upsertEntity,
+    upsertEntityForGroup,
     createVersion,
     generateChangeSummary,
     AmbiguousEntityError,
   } = await import("@atlas/api/lib/semantic/entities");
 
-  const entity = await getEntity(effectiveOrgId, "entity", result.entityName);
+  // Look the entity up in its Connection group (ADR-0012, #3284). An explicit
+  // group avoids the unscoped ambiguity 409 for a name shared across groups;
+  // an undefined group keeps the legacy unscoped behavior for the interactive
+  // path. `getEntity` may still throw AmbiguousEntityError (undefined group,
+  // 2+ groups) — that propagates to the route as a 409 with `groups`.
+  const lookupScope = groupToLookupScope(result.group);
+  const entity = await getEntity(effectiveOrgId, "entity", result.entityName, lookupScope);
   if (!entity) {
     throw new Error(`Entity "${result.entityName}" not found for org ${orgId}`);
   }
+
+  // The row's OWN group is authoritative for every write-back below — whether
+  // we resolved it by explicit scope or via the unscoped fallback, this is the
+  // exact row we read, so the amendment can never be written into a different
+  // (e.g. default) scope than the one it was analyzed against (#3284).
+  const targetGroupId = entity.connection_group_id ?? null;
 
   // Parse current YAML
   const parsed = yaml.load(entity.yaml_content) as Record<string, unknown>;
@@ -52,15 +82,15 @@ export async function applyAmendmentToEntity(
   // Serialize back to YAML
   const newYaml = yaml.dump(updated, { lineWidth: 120, noRefs: true });
 
-  // Upsert entity
-  await upsertEntity(effectiveOrgId, "entity", result.entityName, newYaml);
+  // Upsert entity into its own group scope.
+  await upsertEntityForGroup(effectiveOrgId, "entity", result.entityName, newYaml, targetGroupId);
 
   // Create version snapshot. Tagged errors (AmbiguousEntityError) must
   // re-throw so the route layer maps them to 409 with `groups`; a generic
   // warn-log would bury the structural ambiguity that the expert agent
   // needs the operator to resolve.
   try {
-    const refreshed = await getEntity(effectiveOrgId, "entity", result.entityName);
+    const refreshed = await getEntity(effectiveOrgId, "entity", result.entityName, targetGroupId);
     if (refreshed) {
       const changeSummary = await generateChangeSummary(entity.yaml_content, newYaml);
       const versionSummary = `Expert agent: ${result.rationale}${changeSummary ? ` (${changeSummary})` : ""}`;
@@ -81,10 +111,11 @@ export async function applyAmendmentToEntity(
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
   invalidateOrgWhitelist(effectiveOrgId);
 
-  // Sync to disk (non-fatal)
+  // Sync to disk (non-fatal) — same group so the on-disk mirror lands in
+  // `groups/<group>/entities/` rather than the flat default dir.
   try {
     const { syncEntityToDisk } = await import("@atlas/api/lib/semantic/sync");
-    await syncEntityToDisk(effectiveOrgId, result.entityName, "entity", newYaml);
+    await syncEntityToDisk(effectiveOrgId, result.entityName, "entity", newYaml, targetGroupId);
   } catch (syncErr) {
     log.warn(
       { err: syncErr instanceof Error ? syncErr.message : String(syncErr), requestId, orgId, entity: result.entityName },
@@ -93,7 +124,7 @@ export async function applyAmendmentToEntity(
   }
 
   log.info(
-    { requestId, orgId, entity: result.entityName, amendmentType: result.amendmentType },
+    { requestId, orgId, entity: result.entityName, amendmentType: result.amendmentType, group: targetGroupId },
     "Semantic amendment applied via expert agent",
   );
 }

--- a/packages/api/src/lib/semantic/expert/categories.ts
+++ b/packages/api/src/lib/semantic/expert/categories.ts
@@ -23,6 +23,18 @@ function findEntityForTable(entities: ParsedEntity[], tableName: string): Parsed
   return entities.find((e) => e.table === tableName || e.name === tableName);
 }
 
+/**
+ * Every entity that models `tableName` — across Connection groups (#3284).
+ * The loader now returns one entity per group for a shared table (e.g.
+ * `groups/us/entities/orders.yml` + `groups/eu/entities/orders.yml`), so the
+ * profile-driven analyzers must visit ALL of them — keying off only the first
+ * match (`findEntityForTable`) would generate amendments for one group and
+ * silently skip the others, even though the apply path is now group-aware.
+ */
+function findEntitiesForTable(entities: ParsedEntity[], tableName: string): ParsedEntity[] {
+  return entities.filter((e) => e.table === tableName || e.name === tableName);
+}
+
 const AUTO_DESC_PATTERN = /^The \w+ column\.?$|^Column \w+\.?$/i;
 
 const NUMERIC_SQL_TYPES = new Set([
@@ -37,36 +49,36 @@ export function findCoverageGaps(ctx: AnalysisContext): AnalysisResult[] {
   const results: AnalysisResult[] = [];
 
   for (const profile of ctx.profiles) {
-    const entity = findEntityForTable(ctx.entities, profile.table_name);
-    if (!entity) continue;
+    // Every group that models this table (#3284) — not just the first match.
+    for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
+      const dimNames = new Set(entity.dimensions.map((d) => d.sql.toLowerCase()));
 
-    const dimNames = new Set(entity.dimensions.map((d) => d.sql.toLowerCase()));
+      for (const col of profile.columns) {
+        if (col.is_primary_key) continue; // PKs are usually not needed as dimensions
+        if (dimNames.has(col.name.toLowerCase())) continue;
 
-    for (const col of profile.columns) {
-      if (col.is_primary_key) continue; // PKs are usually not needed as dimensions
-      if (dimNames.has(col.name.toLowerCase())) continue;
+        const staleness = stalenessFactor(entity.name, "add_dimension", col.name, ctx.rejectedKeys);
+        const impact = 0.6;
+        const confidence = col.null_count !== null && col.unique_count !== null ? 0.7 : 0.5;
 
-      const staleness = stalenessFactor(entity.name, "add_dimension", col.name, ctx.rejectedKeys);
-      const impact = 0.6;
-      const confidence = col.null_count !== null && col.unique_count !== null ? 0.7 : 0.5;
-
-      results.push(createAnalysisResult({
-        category: "coverage_gaps",
-        entityName: entity.name,
-        group: entity.group,
-        amendmentType: "add_dimension",
-        amendment: {
-          name: col.name,
-          sql: col.name,
-          type: mapSQLType(col.type),
-          description: `The ${col.name.replace(/_/g, " ")} column`,
-          ...(col.sample_values.length > 0 && { sample_values: col.sample_values.slice(0, 5) }),
-        },
-        rationale: `Column "${col.name}" exists in ${profile.table_name} but is not represented as a dimension in the entity schema.`,
-        impact,
-        confidence,
-        staleness,
-      }));
+        results.push(createAnalysisResult({
+          category: "coverage_gaps",
+          entityName: entity.name,
+          group: entity.group,
+          amendmentType: "add_dimension",
+          amendment: {
+            name: col.name,
+            sql: col.name,
+            type: mapSQLType(col.type),
+            description: `The ${col.name.replace(/_/g, " ")} column`,
+            ...(col.sample_values.length > 0 && { sample_values: col.sample_values.slice(0, 5) }),
+          },
+          rationale: `Column "${col.name}" exists in ${profile.table_name} but is not represented as a dimension in the entity schema.`,
+          impact,
+          confidence,
+          staleness,
+        }));
+      }
     }
   }
 
@@ -133,30 +145,30 @@ export function findTypeInaccuracies(ctx: AnalysisContext): AnalysisResult[] {
   const results: AnalysisResult[] = [];
 
   for (const profile of ctx.profiles) {
-    const entity = findEntityForTable(ctx.entities, profile.table_name);
-    if (!entity) continue;
+    // Every group that models this table (#3284) — not just the first match.
+    for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
+      for (const dim of entity.dimensions) {
+        const col = profile.columns.find((c) => c.name === dim.sql);
+        if (!col) continue;
 
-    for (const dim of entity.dimensions) {
-      const col = profile.columns.find((c) => c.name === dim.sql);
-      if (!col) continue;
+        const inferredType = mapSQLType(col.type);
+        if (inferredType !== dim.type && inferredType !== "string") {
+          const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
+          const impact = 0.7;
+          const confidence = 0.8;
 
-      const inferredType = mapSQLType(col.type);
-      if (inferredType !== dim.type && inferredType !== "string") {
-        const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
-        const impact = 0.7;
-        const confidence = 0.8;
-
-        results.push(createAnalysisResult({
-          category: "type_accuracy",
-          entityName: entity.name,
-          group: entity.group,
-          amendmentType: "update_dimension",
-          amendment: { name: dim.name, type: inferredType },
-          rationale: `Dimension "${dim.name}" is typed as "${dim.type}" but the database column is ${col.type} (maps to "${inferredType}").`,
-          impact,
-          confidence,
-          staleness,
-        }));
+          results.push(createAnalysisResult({
+            category: "type_accuracy",
+            entityName: entity.name,
+            group: entity.group,
+            amendmentType: "update_dimension",
+            amendment: { name: dim.name, type: inferredType },
+            rationale: `Dimension "${dim.name}" is typed as "${dim.type}" but the database column is ${col.type} (maps to "${inferredType}").`,
+            impact,
+            confidence,
+            staleness,
+          }));
+        }
       }
     }
   }
@@ -170,53 +182,53 @@ export function findMissingMeasures(ctx: AnalysisContext): AnalysisResult[] {
   const results: AnalysisResult[] = [];
 
   for (const profile of ctx.profiles) {
-    const entity = findEntityForTable(ctx.entities, profile.table_name);
-    if (!entity) continue;
-
-    const existingMeasureSqls = new Set(
-      entity.measures.map((m) => m.sql.toLowerCase()),
-    );
-
-    for (const col of profile.columns) {
-      if (!NUMERIC_SQL_TYPES.has(col.type.toLowerCase())) continue;
-      if (col.is_primary_key || col.is_foreign_key) continue;
-
-      // Check if any measure already references this column
-      const alreadyCovered = entity.measures.some(
-        (m) => m.sql.toLowerCase().includes(col.name.toLowerCase()),
+    // Every group that models this table (#3284) — not just the first match.
+    for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
+      const existingMeasureSqls = new Set(
+        entity.measures.map((m) => m.sql.toLowerCase()),
       );
-      if (alreadyCovered) continue;
 
-      const suggestion = suggestMeasureType(col);
-      if (suggestion === "count_where") continue; // Not a standard numeric measure
+      for (const col of profile.columns) {
+        if (!NUMERIC_SQL_TYPES.has(col.type.toLowerCase())) continue;
+        if (col.is_primary_key || col.is_foreign_key) continue;
 
-      const aggType = suggestion === "avg" ? "avg" : "sum";
-      const measureName = `total_${col.name}`;
+        // Check if any measure already references this column
+        const alreadyCovered = entity.measures.some(
+          (m) => m.sql.toLowerCase().includes(col.name.toLowerCase()),
+        );
+        if (alreadyCovered) continue;
 
-      if (existingMeasureSqls.has(col.name.toLowerCase())) continue;
+        const suggestion = suggestMeasureType(col);
+        if (suggestion === "count_where") continue; // Not a standard numeric measure
 
-      const staleness = stalenessFactor(entity.name, "add_measure", measureName, ctx.rejectedKeys);
-      const impact = tableFrequencyImpact(profile.table_name, ctx.auditPatterns);
-      const confidence = 0.65;
-      const desc = describeMeasure(col, aggType);
+        const aggType = suggestion === "avg" ? "avg" : "sum";
+        const measureName = `total_${col.name}`;
 
-      results.push(createAnalysisResult({
-        category: "missing_measures",
-        entityName: entity.name,
-        group: entity.group,
-        amendmentType: "add_measure",
-        amendment: {
-          name: measureName,
-          sql: aggType === "sum" ? col.name : col.name,
-          type: aggType,
-          description: desc,
-        },
-        rationale: `Numeric column "${col.name}" (${col.type}) has no measure. A ${aggType.toUpperCase()} measure would enable aggregation queries.`,
-        testQuery: `SELECT ${aggType.toUpperCase()}("${col.name}") FROM "${profile.table_name}" LIMIT 1`,
-        impact,
-        confidence,
-        staleness,
-      }));
+        if (existingMeasureSqls.has(col.name.toLowerCase())) continue;
+
+        const staleness = stalenessFactor(entity.name, "add_measure", measureName, ctx.rejectedKeys);
+        const impact = tableFrequencyImpact(profile.table_name, ctx.auditPatterns);
+        const confidence = 0.65;
+        const desc = describeMeasure(col, aggType);
+
+        results.push(createAnalysisResult({
+          category: "missing_measures",
+          entityName: entity.name,
+          group: entity.group,
+          amendmentType: "add_measure",
+          amendment: {
+            name: measureName,
+            sql: aggType === "sum" ? col.name : col.name,
+            type: aggType,
+            description: desc,
+          },
+          rationale: `Numeric column "${col.name}" (${col.type}) has no measure. A ${aggType.toUpperCase()} measure would enable aggregation queries.`,
+          testQuery: `SELECT ${aggType.toUpperCase()}("${col.name}") FROM "${profile.table_name}" LIMIT 1`,
+          impact,
+          confidence,
+          staleness,
+        }));
+      }
     }
   }
 
@@ -229,53 +241,53 @@ export function findMissingJoins(ctx: AnalysisContext): AnalysisResult[] {
   const results: AnalysisResult[] = [];
 
   for (const profile of ctx.profiles) {
-    const entity = findEntityForTable(ctx.entities, profile.table_name);
-    if (!entity) continue;
+    // Every group that models this table (#3284) — not just the first match.
+    for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
+      const existingJoinTables = new Set(
+        entity.joins.map((j) => {
+          // Extract target table from join SQL like "table_a.col = table_b.col".
+          // Split on the literal `=` (not `\s*=\s*`) and trim each side instead —
+          // a `\s*` quantifier in a split regex tries every position, giving
+          // O(n²) on inputs of long whitespace runs (CodeQL js/polynomial-redos).
+          const parts = j.sql.split("=");
+          if (parts.length !== 2) return "";
+          const lhs = parts[0].trim().match(/^(\w+)\.\w+$/);
+          const rhs = parts[1].trim().match(/^(\w+)\.\w+$/);
+          if (!lhs || !rhs) return "";
+          return lhs[1] === profile.table_name ? rhs[1] : lhs[1];
+        }).filter(Boolean).map((t) => t.toLowerCase()),
+      );
 
-    const existingJoinTables = new Set(
-      entity.joins.map((j) => {
-        // Extract target table from join SQL like "table_a.col = table_b.col".
-        // Split on the literal `=` (not `\s*=\s*`) and trim each side instead —
-        // a `\s*` quantifier in a split regex tries every position, giving
-        // O(n²) on inputs of long whitespace runs (CodeQL js/polynomial-redos).
-        const parts = j.sql.split("=");
-        if (parts.length !== 2) return "";
-        const lhs = parts[0].trim().match(/^(\w+)\.\w+$/);
-        const rhs = parts[1].trim().match(/^(\w+)\.\w+$/);
-        if (!lhs || !rhs) return "";
-        return lhs[1] === profile.table_name ? rhs[1] : lhs[1];
-      }).filter(Boolean).map((t) => t.toLowerCase()),
-    );
+      // Check declared foreign keys
+      for (const fk of [...profile.foreign_keys, ...profile.inferred_foreign_keys]) {
+        if (existingJoinTables.has(fk.to_table.toLowerCase())) continue;
 
-    // Check declared foreign keys
-    for (const fk of [...profile.foreign_keys, ...profile.inferred_foreign_keys]) {
-      if (existingJoinTables.has(fk.to_table.toLowerCase())) continue;
+        // Verify target table has an entity
+        const targetEntity = findEntityForTable(ctx.entities, fk.to_table);
+        if (!targetEntity) continue;
 
-      // Verify target table has an entity
-      const targetEntity = findEntityForTable(ctx.entities, fk.to_table);
-      if (!targetEntity) continue;
+        const joinSql = `${profile.table_name}.${fk.from_column} = ${fk.to_table}.${fk.to_column}`;
+        const staleness = stalenessFactor(entity.name, "add_join", fk.to_table, ctx.rejectedKeys);
+        const impact = 0.8;
+        const confidence = fk.source === "constraint" ? 0.95 : 0.6;
 
-      const joinSql = `${profile.table_name}.${fk.from_column} = ${fk.to_table}.${fk.to_column}`;
-      const staleness = stalenessFactor(entity.name, "add_join", fk.to_table, ctx.rejectedKeys);
-      const impact = 0.8;
-      const confidence = fk.source === "constraint" ? 0.95 : 0.6;
-
-      results.push(createAnalysisResult({
-        category: "missing_joins",
-        entityName: entity.name,
-        group: entity.group,
-        amendmentType: "add_join",
-        amendment: {
-          name: `to_${fk.to_table}`,
-          sql: joinSql,
-          description: `${profile.table_name}.${fk.from_column} → ${fk.to_table}.${fk.to_column}`,
-        },
-        rationale: `Foreign key relationship from ${profile.table_name}.${fk.from_column} to ${fk.to_table}.${fk.to_column} is not captured as a join in the entity schema.`,
-        testQuery: `SELECT COUNT(*) FROM "${profile.table_name}" INNER JOIN "${fk.to_table}" ON ${joinSql} LIMIT 1`,
-        impact,
-        confidence,
-        staleness,
-      }));
+        results.push(createAnalysisResult({
+          category: "missing_joins",
+          entityName: entity.name,
+          group: entity.group,
+          amendmentType: "add_join",
+          amendment: {
+            name: `to_${fk.to_table}`,
+            sql: joinSql,
+            description: `${profile.table_name}.${fk.from_column} → ${fk.to_table}.${fk.to_column}`,
+          },
+          rationale: `Foreign key relationship from ${profile.table_name}.${fk.from_column} to ${fk.to_table}.${fk.to_column} is not captured as a join in the entity schema.`,
+          testQuery: `SELECT COUNT(*) FROM "${profile.table_name}" INNER JOIN "${fk.to_table}" ON ${joinSql} LIMIT 1`,
+          impact,
+          confidence,
+          staleness,
+        }));
+      }
     }
   }
 
@@ -326,41 +338,41 @@ export function findStaleSampleValues(ctx: AnalysisContext): AnalysisResult[] {
   const results: AnalysisResult[] = [];
 
   for (const profile of ctx.profiles) {
-    const entity = findEntityForTable(ctx.entities, profile.table_name);
-    if (!entity) continue;
+    // Every group that models this table (#3284) — not just the first match.
+    for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
+      for (const dim of entity.dimensions) {
+        if (!dim.sample_values || dim.sample_values.length === 0) continue;
 
-    for (const dim of entity.dimensions) {
-      if (!dim.sample_values || dim.sample_values.length === 0) continue;
+        const col = profile.columns.find((c) => c.name === dim.sql);
+        if (!col || col.sample_values.length === 0) continue;
 
-      const col = profile.columns.find((c) => c.name === dim.sql);
-      if (!col || col.sample_values.length === 0) continue;
+        // Check how many declared samples still exist in actual data
+        const actualSet = new Set(col.sample_values.map((v) => String(v).toLowerCase()));
+        const staleValues = dim.sample_values.filter(
+          (v) => !actualSet.has(String(v).toLowerCase()),
+        );
 
-      // Check how many declared samples still exist in actual data
-      const actualSet = new Set(col.sample_values.map((v) => String(v).toLowerCase()));
-      const staleValues = dim.sample_values.filter(
-        (v) => !actualSet.has(String(v).toLowerCase()),
-      );
+        if (staleValues.length === 0) continue;
 
-      if (staleValues.length === 0) continue;
+        const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
+        const impact = 0.3;
+        const confidence = 0.85;
 
-      const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
-      const impact = 0.3;
-      const confidence = 0.85;
-
-      results.push(createAnalysisResult({
-        category: "sample_value_staleness",
-        entityName: entity.name,
-        group: entity.group,
-        amendmentType: "update_dimension",
-        amendment: {
-          name: dim.name,
-          sample_values: col.sample_values.slice(0, 10),
-        },
-        rationale: `${staleValues.length} of ${dim.sample_values.length} declared sample values for "${dim.name}" no longer appear in the data: ${staleValues.slice(0, 3).join(", ")}${staleValues.length > 3 ? "..." : ""}`,
-        impact,
-        confidence,
-        staleness,
-      }));
+        results.push(createAnalysisResult({
+          category: "sample_value_staleness",
+          entityName: entity.name,
+          group: entity.group,
+          amendmentType: "update_dimension",
+          amendment: {
+            name: dim.name,
+            sample_values: col.sample_values.slice(0, 10),
+          },
+          rationale: `${staleValues.length} of ${dim.sample_values.length} declared sample values for "${dim.name}" no longer appear in the data: ${staleValues.slice(0, 3).join(", ")}${staleValues.length > 3 ? "..." : ""}`,
+          impact,
+          confidence,
+          staleness,
+        }));
+      }
     }
   }
 

--- a/packages/api/src/lib/semantic/expert/categories.ts
+++ b/packages/api/src/lib/semantic/expert/categories.ts
@@ -53,6 +53,7 @@ export function findCoverageGaps(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "coverage_gaps",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "add_dimension",
         amendment: {
           name: col.name,
@@ -87,6 +88,7 @@ export function findDescriptionIssues(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "description_quality",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "update_description",
         amendment: { field: "table", description: entity.description ?? "" },
         rationale: entity.description
@@ -108,6 +110,7 @@ export function findDescriptionIssues(ctx: AnalysisContext): AnalysisResult[] {
         results.push(createAnalysisResult({
           category: "description_quality",
           entityName: entity.name,
+          group: entity.group,
           amendmentType: "update_description",
           amendment: { dimension: dim.name, description: dim.description ?? "" },
           rationale: dim.description
@@ -146,6 +149,7 @@ export function findTypeInaccuracies(ctx: AnalysisContext): AnalysisResult[] {
         results.push(createAnalysisResult({
           category: "type_accuracy",
           entityName: entity.name,
+          group: entity.group,
           amendmentType: "update_dimension",
           amendment: { name: dim.name, type: inferredType },
           rationale: `Dimension "${dim.name}" is typed as "${dim.type}" but the database column is ${col.type} (maps to "${inferredType}").`,
@@ -199,6 +203,7 @@ export function findMissingMeasures(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "missing_measures",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "add_measure",
         amendment: {
           name: measureName,
@@ -258,6 +263,7 @@ export function findMissingJoins(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "missing_joins",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "add_join",
         amendment: {
           name: `to_${fk.to_table}`,
@@ -300,6 +306,7 @@ export function findGlossaryGaps(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "glossary_gaps",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "add_glossary_term",
         amendment: { term: abbrev, definition: "", ambiguous: true },
         rationale: `Business abbreviation "${abbrev}" appears in column "${dim.name}" but is not defined in the glossary. Defining it helps the agent understand queries about this metric.`,
@@ -343,6 +350,7 @@ export function findStaleSampleValues(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "sample_value_staleness",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "update_dimension",
         amendment: {
           name: dim.name,
@@ -386,6 +394,7 @@ export function findQueryPatternGaps(ctx: AnalysisContext): AnalysisResult[] {
       results.push(createAnalysisResult({
         category: "query_pattern_coverage",
         entityName: entity.name,
+        group: entity.group,
         amendmentType: "add_query_pattern",
         amendment: {
           name: `pattern_${entity.table}_${results.length}`,
@@ -442,6 +451,7 @@ export function findVirtualDimensionOpportunities(ctx: AnalysisContext): Analysi
         results.push(createAnalysisResult({
           category: "virtual_dimension_opportunities",
           entityName: entity.name,
+          group: entity.group,
           amendmentType: "add_virtual_dimension",
           amendment: {
             name: virtualName,
@@ -482,6 +492,7 @@ export function findVirtualDimensionOpportunities(ctx: AnalysisContext): Analysi
         results.push(createAnalysisResult({
           category: "virtual_dimension_opportunities",
           entityName: entity.name,
+          group: entity.group,
           amendmentType: "add_virtual_dimension",
           amendment: {
             name: virtualName,

--- a/packages/api/src/lib/semantic/expert/categories.ts
+++ b/packages/api/src/lib/semantic/expert/categories.ts
@@ -11,16 +11,16 @@ import { createAnalysisResult, tableFrequencyImpact } from "./scoring";
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-function rejectionKey(entity: string, type: string, name?: string): string {
-  return `${entity}:${type}${name ? `:${name}` : ""}`;
+// Rejection/staleness keys are group-scoped (#3284): a review decision in one
+// Connection group must not suppress the same-named amendment in another group.
+// `loadRejectedKeys` builds the matching key from each rejected row's
+// `connection_group_id` (NULL → "default").
+function rejectionKey(group: string, entity: string, type: string, name?: string): string {
+  return `${group}:${entity}:${type}${name ? `:${name}` : ""}`;
 }
 
-function stalenessFactor(entity: string, type: string, name: string | undefined, rejectedKeys: Set<string>): number {
-  return rejectedKeys.has(rejectionKey(entity, type, name)) ? 0.8 : 0;
-}
-
-function findEntityForTable(entities: ParsedEntity[], tableName: string): ParsedEntity | undefined {
-  return entities.find((e) => e.table === tableName || e.name === tableName);
+function stalenessFactor(group: string, entity: string, type: string, name: string | undefined, rejectedKeys: Set<string>): number {
+  return rejectedKeys.has(rejectionKey(group, entity, type, name)) ? 0.8 : 0;
 }
 
 /**
@@ -28,8 +28,8 @@ function findEntityForTable(entities: ParsedEntity[], tableName: string): Parsed
  * The loader now returns one entity per group for a shared table (e.g.
  * `groups/us/entities/orders.yml` + `groups/eu/entities/orders.yml`), so the
  * profile-driven analyzers must visit ALL of them — keying off only the first
- * match (`findEntityForTable`) would generate amendments for one group and
- * silently skip the others, even though the apply path is now group-aware.
+ * match would generate amendments for one group and silently skip the others,
+ * even though the apply path is now group-aware.
  */
 function findEntitiesForTable(entities: ParsedEntity[], tableName: string): ParsedEntity[] {
   return entities.filter((e) => e.table === tableName || e.name === tableName);
@@ -57,7 +57,7 @@ export function findCoverageGaps(ctx: AnalysisContext): AnalysisResult[] {
         if (col.is_primary_key) continue; // PKs are usually not needed as dimensions
         if (dimNames.has(col.name.toLowerCase())) continue;
 
-        const staleness = stalenessFactor(entity.name, "add_dimension", col.name, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_dimension", col.name, ctx.rejectedKeys);
         const impact = 0.6;
         const confidence = col.null_count !== null && col.unique_count !== null ? 0.7 : 0.5;
 
@@ -93,7 +93,7 @@ export function findDescriptionIssues(ctx: AnalysisContext): AnalysisResult[] {
   for (const entity of ctx.entities) {
     // Table-level description
     if (!entity.description || AUTO_DESC_PATTERN.test(entity.description)) {
-      const staleness = stalenessFactor(entity.name, "update_description", "table", ctx.rejectedKeys);
+      const staleness = stalenessFactor(entity.group ?? "default", entity.name, "update_description", "table", ctx.rejectedKeys);
       const impact = 0.5;
       const confidence = 0.6;
 
@@ -115,7 +115,7 @@ export function findDescriptionIssues(ctx: AnalysisContext): AnalysisResult[] {
     // Dimension-level descriptions
     for (const dim of entity.dimensions) {
       if (!dim.description || AUTO_DESC_PATTERN.test(dim.description)) {
-        const staleness = stalenessFactor(entity.name, "update_description", dim.name, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "update_description", dim.name, ctx.rejectedKeys);
         const impact = 0.4;
         const confidence = 0.6;
 
@@ -153,7 +153,7 @@ export function findTypeInaccuracies(ctx: AnalysisContext): AnalysisResult[] {
 
         const inferredType = mapSQLType(col.type);
         if (inferredType !== dim.type && inferredType !== "string") {
-          const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
+          const staleness = stalenessFactor(entity.group ?? "default", entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
           const impact = 0.7;
           const confidence = 0.8;
 
@@ -206,7 +206,7 @@ export function findMissingMeasures(ctx: AnalysisContext): AnalysisResult[] {
 
         if (existingMeasureSqls.has(col.name.toLowerCase())) continue;
 
-        const staleness = stalenessFactor(entity.name, "add_measure", measureName, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_measure", measureName, ctx.rejectedKeys);
         const impact = tableFrequencyImpact(profile.table_name, ctx.auditPatterns);
         const confidence = 0.65;
         const desc = describeMeasure(col, aggType);
@@ -262,12 +262,18 @@ export function findMissingJoins(ctx: AnalysisContext): AnalysisResult[] {
       for (const fk of [...profile.foreign_keys, ...profile.inferred_foreign_keys]) {
         if (existingJoinTables.has(fk.to_table.toLowerCase())) continue;
 
-        // Verify target table has an entity
-        const targetEntity = findEntityForTable(ctx.entities, fk.to_table);
-        if (!targetEntity) continue;
+        // Verify the target table has an entity IN THE SAME GROUP. The SQL
+        // whitelist keys tables by `connection_group_id` (whitelist.ts), so a
+        // group-scoped `orders → customers` join is invalid (and unapplyable)
+        // when `customers` only exists in a different group — propose it only
+        // when the target lives in this entity's group (#3284, Codex review).
+        const targetInGroup = ctx.entities.some(
+          (e) => (e.table === fk.to_table || e.name === fk.to_table) && e.group === entity.group,
+        );
+        if (!targetInGroup) continue;
 
         const joinSql = `${profile.table_name}.${fk.from_column} = ${fk.to_table}.${fk.to_column}`;
-        const staleness = stalenessFactor(entity.name, "add_join", fk.to_table, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_join", fk.to_table, ctx.rejectedKeys);
         const impact = 0.8;
         const confidence = fk.source === "constraint" ? 0.95 : 0.6;
 
@@ -311,7 +317,7 @@ export function findGlossaryGaps(ctx: AnalysisContext): AnalysisResult[] {
       const abbrev = matches[1].toLowerCase();
       if (glossaryTerms.has(abbrev)) continue;
 
-      const staleness = stalenessFactor(entity.name, "add_glossary_term", abbrev, ctx.rejectedKeys);
+      const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_glossary_term", abbrev, ctx.rejectedKeys);
       const impact = 0.5;
       const confidence = 0.5;
 
@@ -354,7 +360,7 @@ export function findStaleSampleValues(ctx: AnalysisContext): AnalysisResult[] {
 
         if (staleValues.length === 0) continue;
 
-        const staleness = stalenessFactor(entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "update_dimension", dim.name, ctx.rejectedKeys);
         const impact = 0.3;
         const confidence = 0.85;
 
@@ -399,7 +405,7 @@ export function findQueryPatternGaps(ctx: AnalysisContext): AnalysisResult[] {
       .filter((p) => !existingPatternSqls.has(p.sql.trim().toLowerCase()));
 
     for (const pattern of relevantPatterns.slice(0, 3)) {
-      const staleness = stalenessFactor(entity.name, "add_query_pattern", undefined, ctx.rejectedKeys);
+      const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_query_pattern", undefined, ctx.rejectedKeys);
       const impact = Math.min(1, pattern.count / 20); // 20+ queries = max impact
       const confidence = 0.7;
 
@@ -456,7 +462,7 @@ export function findVirtualDimensionOpportunities(ctx: AnalysisContext): Analysi
         );
         if (exists) continue;
 
-        const staleness = stalenessFactor(entity.name, "add_virtual_dimension", virtualName, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_virtual_dimension", virtualName, ctx.rejectedKeys);
         const impact = Math.min(1, pattern.count / 10);
         const confidence = 0.75;
 
@@ -497,7 +503,7 @@ export function findVirtualDimensionOpportunities(ctx: AnalysisContext): Analysi
         );
         if (exists) continue;
 
-        const staleness = stalenessFactor(entity.name, "add_virtual_dimension", virtualName, ctx.rejectedKeys);
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_virtual_dimension", virtualName, ctx.rejectedKeys);
         const impact = Math.min(1, pattern.count / 10);
         const confidence = 0.75;
 

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -260,47 +260,64 @@ export async function loadEntitiesForOrg(
 }
 
 /**
- * Load entity YAML files from the flat default `entities/` directory.
+ * Load entity YAML files across every on-disk layout (ADR-0012): the flat
+ * default `entities/`, the canonical `groups/<group>/entities/` namespace, and
+ * legacy `<source>/entities/`. Routed through the shared `scanEntities`
+ * traversal the discovery read paths use, so the expert context can no longer
+ * miss per-group entities (#3284).
  *
- * Intentionally root-only (the default group), NOT layout-aware: unlike the
- * glossary loader below, this feeds the scheduled tick's auto-apply path
- * (`runExpertSchedulerTick` → `applyAmendmentToEntity`), which resolves the
- * target entity purely by name with no group/connection. Discovering
- * `groups/<group>/entities/` here would let an auto-approved amendment for a
- * group entity 409 as ambiguous or write back into the default scope. Making
- * the entity path group-aware end-to-end (thread the group through analyze →
- * insert → apply) is tracked in #3284. `name` keys off `table`/file-stem (the
- * storage key the apply path looks up by), mirroring `loadEntitiesFromDB`.
+ * Each entity carries its effective Connection group on `ParsedEntity.group`,
+ * resolved directory-canonically via {@link resolveEntityGroup} (matching the
+ * importer + file whitelist): `"default"` for the flat root, the group name for
+ * `groups/<group>/` and legacy `<source>/`. That group is threaded
+ * analyze → insert → apply so the scheduled tick's auto-apply path
+ * (`runExpertSchedulerTick` → `applyAmendmentToEntity`) updates the correct
+ * group's row instead of 409-ing as ambiguous or corrupting the default scope —
+ * the gap that previously kept this loader deliberately root-only.
+ *
+ * `name` keys off the file stem — the storage key the importer
+ * (`_scanEntityDirs`) writes to `semantic_entities.name` and that the apply
+ * path looks the entity up by — matching `discoverEntities` rather than the
+ * YAML `name:` display label. Files missing the required `table:` field are
+ * skipped, mirroring `discoverEntities`/`_scanEntityDirs`.
  */
 export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
-  const entitiesDir = path.join(getSemanticRoot(), "entities");
-  if (!fs.existsSync(entitiesDir)) return [];
+  const { scanEntities, resolveEntityGroup, readGroupField } = await import(
+    "@atlas/api/lib/semantic/scanner"
+  );
+
+  const root = getSemanticRoot();
+  if (!fs.existsSync(root)) return [];
+
+  const { entities: scanned, warnings } = scanEntities(root);
+  // The interactive read paths surface scan warnings to the user; the expert
+  // tick runs unattended, so re-log a partial scan against the expert context
+  // (matches `loadGlossaryFromDisk`'s fail-loud handling of a partial union).
+  if (warnings.length > 0) {
+    log.warn(
+      { warnings },
+      "Expert entity context is partial — some entity files failed to scan",
+    );
+  }
 
   const entities: ParsedEntity[] = [];
+  for (const { raw, filePath, sourceName, origin } of scanned) {
+    // Require `table:` so we match `discoverEntities`/`_scanEntityDirs`'s gate;
+    // `scanEntities` already dropped files whose YAML failed to parse.
+    if (typeof raw.table !== "string" || !raw.table) continue;
 
-  for (const file of fs.readdirSync(entitiesDir)) {
-    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
-    try {
-      const content = fs.readFileSync(path.join(entitiesDir, file), "utf-8");
-      const parsed = yaml.load(content) as Record<string, unknown> | null;
-      if (!parsed || typeof parsed !== "object") continue;
-
-      entities.push({
-        name: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
-        table: String(parsed.table ?? file.replace(/\.ya?ml$/, "")),
-        description: typeof parsed.description === "string" ? parsed.description : undefined,
-        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
-        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
-        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
-        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
-        connection: typeof parsed.connection === "string" ? parsed.connection : undefined,
-      });
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err), file },
-        "Failed to parse entity YAML",
-      );
-    }
+    const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
+    entities.push({
+      name: path.basename(filePath).replace(/\.ya?ml$/, ""),
+      table: raw.table,
+      description: typeof raw.description === "string" ? raw.description : undefined,
+      dimensions: Array.isArray(raw.dimensions) ? raw.dimensions as ParsedEntity["dimensions"] : [],
+      measures: Array.isArray(raw.measures) ? raw.measures as ParsedEntity["measures"] : [],
+      joins: Array.isArray(raw.joins) ? raw.joins as ParsedEntity["joins"] : [],
+      query_patterns: Array.isArray(raw.query_patterns) ? raw.query_patterns as ParsedEntity["query_patterns"] : [],
+      connection: typeof raw.connection === "string" ? raw.connection : undefined,
+      group,
+    });
   }
 
   return entities;

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -306,7 +306,19 @@ export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {
     // `scanEntities` already dropped files whose YAML failed to parse.
     if (typeof raw.table !== "string" || !raw.table) continue;
 
-    const group = resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
+    // Mirror the importer's write scope (`_scanEntityDirs`) so the apply path's
+    // `getEntity(..., group)` resolves the SAME row the importer wrote (#3284):
+    //   - flat root → "default" (NULL `connection_group_id`). The importer
+    //     scopes flat entities by install-id, NOT a declared `group:`/`connection:`
+    //     field — which resolves to NULL in the self-hosted scheduler context
+    //     this loader serves — so honoring the field here would target a group
+    //     the DB row was never imported into.
+    //   - canonical `groups/<group>/` and legacy `<source>/` → the resolved
+    //     group (the importer sets `connection_group_id` from the same
+    //     `resolveEntityGroup` call), so honor it.
+    const group = origin === "flat"
+      ? "default"
+      : resolveEntityGroup(sourceName, origin, readGroupField(raw)).group;
     entities.push({
       name: path.basename(filePath).replace(/\.ya?ml$/, ""),
       table: raw.table,

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -497,9 +497,10 @@ export async function loadRejectedKeys(): Promise<Set<string>> {
 
     const rows = await internalQuery<{
       source_entity: string;
+      connection_group_id: string | null;
       amendment_payload: string | Record<string, unknown> | null;
     }>(
-      `SELECT source_entity, amendment_payload FROM learned_patterns
+      `SELECT source_entity, connection_group_id, amendment_payload FROM learned_patterns
        WHERE type = 'semantic_amendment' AND status = 'rejected'
        AND reviewed_at >= now() - interval '30 days'`,
       [],
@@ -511,7 +512,11 @@ export async function loadRejectedKeys(): Promise<Set<string>> {
           ? JSON.parse(row.amendment_payload)
           : row.amendment_payload;
         if (payload && payload.amendmentType) {
-          keys.add(`${row.source_entity}:${payload.amendmentType}:${payload.amendment?.name ?? ""}`);
+          // Group-scoped key (#3284): NULL `connection_group_id` → "default",
+          // matching `entity.group` in `categories.ts` so one group's rejection
+          // doesn't mark another group's same-named amendment stale.
+          const group = row.connection_group_id ?? "default";
+          keys.add(`${group}:${row.source_entity}:${payload.amendmentType}:${payload.amendment?.name ?? ""}`);
         }
       } catch {
         // intentionally ignored: malformed payload

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -103,10 +103,17 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     // 5. Process each proposal
     for (const proposal of proposals) {
       try {
+        // Persist the finding's Connection group so the admin approve path can
+        // rebuild the correct scope (#3284). NULL = the default (flat) group:
+        // the layout-aware loader labels the default group `"default"`, which
+        // maps to a NULL `connection_group_id` like everywhere else.
+        const connectionGroupId =
+          proposal.group && proposal.group !== "default" ? proposal.group : null;
         const { status } = await insertSemanticAmendment({
           orgId: null, // global scope for self-hosted
           description: proposal.rationale,
           sourceEntity: proposal.entityName,
+          connectionGroupId,
           confidence: proposal.confidence,
           amendmentPayload: {
             category: proposal.category,

--- a/packages/api/src/lib/semantic/expert/types.ts
+++ b/packages/api/src/lib/semantic/expert/types.ts
@@ -49,7 +49,21 @@ export interface ParsedEntity {
     description?: string;
     sql: string;
   }>;
+  /**
+   * Legacy YAML `connection:` field, carried verbatim from the parsed YAML.
+   * Prefer {@link group} for the effective Connection group — `connection` is
+   * only the raw field, not the layout-resolved group.
+   */
   connection?: string;
+  /**
+   * Effective Connection group resolved via `resolveEntityGroup` from the
+   * on-disk directory + any declared `group:`/`connection:` field (ADR-0012,
+   * #3284): `"default"` for the flat `entities/` root, the group name for
+   * `groups/<group>/entities/` and legacy `<source>/entities/`. Threaded
+   * analyze → insert → apply so an amendment targets the correct group scope.
+   * `undefined` when the loader is not layout-aware (DB / overlay loaders).
+   */
+  group?: string;
 }
 
 /** A glossary term. */
@@ -85,6 +99,15 @@ export interface AnalysisContext {
 export interface AnalysisResult {
   category: AnalysisCategory;
   entityName: string;
+  /**
+   * Effective Connection group the finding's entity belongs to (ADR-0012,
+   * #3284): `"default"` for the flat root, the group name otherwise. Carried
+   * from {@link ParsedEntity.group} so the amendment is inserted and applied
+   * against the correct group scope (not the null/default scope or a 409).
+   * `undefined` for findings whose loader is not layout-aware (the interactive
+   * `proposeAmendment` tool, which reads the flat root) — treated as default.
+   */
+  group?: string;
   amendmentType: AmendmentType;
   amendment: Record<string, unknown>;
   rationale: string;


### PR DESCRIPTION
Closes #3284.

## Problem

`#3273`/`#3280` made the expert/`atlas improve` **glossary** loader layout-aware, but the sibling **entity** loader stayed deliberately root-only because the apply pipeline wasn't group-aware end-to-end. As a result, if `loadEntitiesFromDisk` discovered `groups/<group>/entities/orders.yml`, an auto/admin-approved amendment would either **409 (ambiguous)** when another group also has `orders`, or — if the name were unique — be written back into the **null/default** scope, corrupting the wrong entity.

## Fix — thread the group analyze → insert → apply

- **`context-loader.ts`** — `loadEntitiesFromDisk` routes through the shared `scanEntities` + `resolveEntityGroup` traversal (flat/groups/legacy, ADR-0012) and carries each entity's resolved group on `ParsedEntity.group`. `name` keys off the **file stem** (the DB storage key the importer writes and the apply path looks up by), matching `discoverEntities`.
- **`categories.ts` / `analyzer.ts`** — every proposal carries `group`; the dedup key now includes it, so the same entity name in two groups no longer collapses to a single proposal.
- **`scheduler.ts` / `internal.ts`** — `insertSemanticAmendment` persists the group via a new `connectionGroupId` arg → `learned_patterns.connection_group_id`; `getPendingAmendments` + `PendingAmendmentRow` select it.
- **`apply.ts`** — `applyAmendmentToEntity` looks the entity up in its group (explicit group avoids the unscoped 409), then writes back (upsert + version + disk sync) to the **resolved row's own `connection_group_id`**, so an amendment can never land in the wrong scope. Added a published `upsertEntityForGroup` (direct group; `upsertEntity` resolves via connection install-id and would silently default-scope a bare group name).
- **`admin-semantic-improve.ts`** — the approve-of-pending path rebuilds the group from the stored `connection_group_id` (NULL → explicit `"default"` scope, not the unscoped ambiguity check).

## Migration

`0122_learned_patterns_connection_group.sql` — `ALTER TABLE learned_patterns ADD COLUMN connection_group_id text` (additive, nullable → expand-only, no two-phase needed; not Better-Auth-dependent). Drizzle mirror (`learnedPatterns.connectionGroupId`) in the same commit so `check-schema-drift` stays green.

## Tests

- **`apply-group-scope.test.ts`** (new regression): explicit-group lookup resolves a name shared across groups without a 409; the write-back targets the resolved row's own group (never default); the legacy interactive path (group undefined) preserves the unscoped lookup and still writes back to the resolved row's group.
- **`load-from-disk.test.ts`**: updated from "root-only by design" to assert layout-aware discovery + per-group attribution (incl. same-stem entities surfacing once per group).
- migrate count 122→123 + applied-lists in both `migrate.test.ts` and `auth/migrate.test.ts`.

## Gates

`check-schema-drift`, `tsgo`, `eslint`, and full `bun run test` all green. The single full-suite failure was `ai-saas.test.ts`'s TTL-cache **timing** test (a real 7s `setTimeout` for a 5s TTL, starved under the 11-min full-suite load) — unrelated to this change and passes 3/3 in isolation. The real-Postgres migrate-pg smoke runs in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783367523&installation_id=135337507&pr_number=3288&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3288&signature=3a10cc249427964a9018e456038da447bd84006a55b7d345532db1e77fea604a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-disk entity discovery is now group-aware and tags entities with their resolved group.
  * Analysis deduplication and the scheduler persist proposal group scope so proposals carry connection-group context.

* **Bug Fixes**
  * Amendments and approvals are applied to the correct connection group, preventing ambiguous or misapplied updates across groups.
  * DB schema updated to record connection-group scope for semantic amendments to support end-to-end group-aware workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->