### PR TITLE
feat(web): in-product entry points to generate a group's semantic layer (#3237)

### DIFF
--- a/docs/design/semantic-onboarding.md
+++ b/docs/design/semantic-onboarding.md
@@ -125,6 +125,8 @@ This is what makes the flow **DB-count-agnostic**: the 1st-DB-after-skip and the
 
 *As implemented (#3234):* whichever door launches the flow, the generated entities land in the **correct Connection group** — the shared group-routing in § F means a new-group connection seeds its own `groups/<group>/` namespace while a member added to a populated group reuses the existing group's entities (no second copy). This is the substrate the two-phase generate UI (#3236) and the entry points (#3237) build on.
 
+*As implemented (#3237):* both new doors deep-link into the one wizard flow rather than re-implementing it — `wizardGenerateHref(connectionId)` builds `/wizard?connectionId=…&step=2`, jumping straight to the table picker; the `/wizard/generate`+`/wizard/save` routes resolve the group server-side (above), so the door can stay group-unaware. **Door 1** (`wizard-generate-entry.ts` + `admin/connections/generate-prompt.ts`): after a create that forms a new group — `__create__` (named) or `__none__` (auto-singleton, the single-DB/first-DB-after-skip path) — an inline AlertDialog offers "Generate"; joining an existing group stays silent (`createsNewGroup`). **Door 2** (`/admin/semantic` empty state): a "Generate semantic layer" CTA scoped to the sole connection when there's exactly one (`generateLaunchConnectionId`), and the catalog/glossary/metrics empty states now point at the flow instead of "Run `atlas init`".
+
 ### F. Shared engine (CLI ↔ web parity)
 
 Today the generator runs in two places and enrichment in a third (CLI-only). Consolidate:
@@ -154,6 +156,6 @@ Tracer-bullet slices, roughly in dependency order:
 3. **`wizard.ts` group scoping** — replace `connectionId` scoping with group; save into the group's namespace.
 4. **Two-phase generate UI** — mechanical baseline auto + Enrich all / select / ignore (pre-seeded) + streamed results.
 5. **Grouped-tree view** — `/admin/semantic` grouped by Connection group with datasource-type/member labels.
-6. **Entry points** — inline-on-add prompt in `/admin/connections` (new-group trigger) + per-group "Generate" empty state replacing "run `atlas init`".
+6. **Entry points** — inline-on-add prompt in `/admin/connections` (new-group trigger) + per-group "Generate" empty state replacing "run `atlas init`". *(shipped — #3237; see § E "As implemented")*
 </content>
 </invoke>

--- a/packages/web/src/app/admin/connections/generate-prompt.test.ts
+++ b/packages/web/src/app/admin/connections/generate-prompt.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Door 1 (#3237) decision logic: the inline "Generate semantic layer" prompt
+ * fires only when a created connection forms a *new* Connection group, never
+ * when it joins an already-populated one (acceptance criteria 1 & 2).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  ENV_SENTINEL_NONE,
+  ENV_SENTINEL_CREATE,
+  createsNewGroup,
+  newGroupLabel,
+} from "./generate-prompt";
+
+describe("connections/generate-prompt", () => {
+  describe("createsNewGroup", () => {
+    it("fires for a brand-new named group (__create__)", () => {
+      expect(createsNewGroup(ENV_SENTINEL_CREATE)).toBe(true);
+    });
+
+    it("fires for an ungrouped connection (__none__ → auto-singleton)", () => {
+      // The common single-DB / first-DB-after-skip path: an ungrouped add
+      // becomes its own group of one, which has no schema yet → prompt.
+      expect(createsNewGroup(ENV_SENTINEL_NONE)).toBe(true);
+    });
+
+    it("does NOT fire when joining an existing populated group", () => {
+      expect(createsNewGroup("prod")).toBe(false);
+      expect(createsNewGroup("g_warehouse")).toBe(false);
+    });
+  });
+
+  describe("newGroupLabel", () => {
+    it("uses the typed name for a new named group", () => {
+      expect(newGroupLabel(ENV_SENTINEL_CREATE, "  Production ", "wh")).toBe("Production");
+    });
+
+    it("falls back to the connection id when the new name is blank", () => {
+      expect(newGroupLabel(ENV_SENTINEL_CREATE, "   ", "warehouse")).toBe("warehouse");
+    });
+
+    it("labels an auto-singleton by its connection id", () => {
+      expect(newGroupLabel(ENV_SENTINEL_NONE, "", "warehouse")).toBe("warehouse");
+    });
+  });
+});

--- a/packages/web/src/app/admin/connections/generate-prompt.test.ts
+++ b/packages/web/src/app/admin/connections/generate-prompt.test.ts
@@ -9,6 +9,7 @@ import {
   ENV_SENTINEL_NONE,
   ENV_SENTINEL_CREATE,
   createsNewGroup,
+  shouldPromptGenerate,
   newGroupLabel,
 } from "./generate-prompt";
 
@@ -27,6 +28,23 @@ describe("connections/generate-prompt", () => {
     it("does NOT fire when joining an existing populated group", () => {
       expect(createsNewGroup("prod")).toBe(false);
       expect(createsNewGroup("g_warehouse")).toBe(false);
+    });
+  });
+
+  describe("shouldPromptGenerate", () => {
+    it("prompts on a create that forms a new group", () => {
+      expect(shouldPromptGenerate(false, ENV_SENTINEL_CREATE)).toBe(true);
+      expect(shouldPromptGenerate(false, ENV_SENTINEL_NONE)).toBe(true);
+    });
+
+    it("does not prompt on a create that joins an existing group", () => {
+      expect(shouldPromptGenerate(false, "prod")).toBe(false);
+    });
+
+    it("never prompts on edit, regardless of Environment selection", () => {
+      expect(shouldPromptGenerate(true, ENV_SENTINEL_CREATE)).toBe(false);
+      expect(shouldPromptGenerate(true, ENV_SENTINEL_NONE)).toBe(false);
+      expect(shouldPromptGenerate(true, "prod")).toBe(false);
     });
   });
 

--- a/packages/web/src/app/admin/connections/generate-prompt.ts
+++ b/packages/web/src/app/admin/connections/generate-prompt.ts
@@ -3,10 +3,12 @@
  * (issue #3237 door 1, docs/design/semantic-onboarding.md § E).
  *
  * Adding a SQL connection that forms a **new** Connection group offers to
- * generate a semantic layer for it. Adding a **member to an already-populated
- * group** does NOT re-prompt — that group already has its schema. The whole
- * decision is knowable from the create form's Environment selection, so it
- * lives here as pure functions rather than as another API round-trip.
+ * generate a semantic layer for it. A connection that **joins an existing
+ * group** does NOT re-prompt — generation is offered once, when the group is
+ * first formed (`/admin/semantic`'s empty state is the always-available way
+ * back in for a group whose generation was skipped). The whole decision is
+ * knowable from the create form's Environment selection, so it lives here as
+ * pure functions rather than as another API round-trip.
  */
 
 // Sentinel values for the Environment combobox, shared with the connection
@@ -26,10 +28,20 @@ export const ENV_SENTINEL_CREATE = "__create__";
  *  - `__create__` → a brand-new named group → new.
  *  - `__none__`   → server mints an auto `g_<id>` singleton → new (this is the
  *                   common single-DB / first-DB-after-skip path).
- *  - any existing group id → joining a populated group → NOT new.
+ *  - any existing group id → joining an existing group → NOT new.
  */
 export function createsNewGroup(envSelection: string): boolean {
   return envSelection === ENV_SENTINEL_NONE || envSelection === ENV_SENTINEL_CREATE;
+}
+
+/**
+ * Whether a connection-form submission should fire the generate prompt (door 1):
+ * only on **create** (never edit) and only when it forms a new group. Folding
+ * the `isEdit` gate in here keeps the "never prompt on edit" rule on the
+ * unit-tested surface alongside the Environment decision.
+ */
+export function shouldPromptGenerate(isEdit: boolean, envSelection: string): boolean {
+  return !isEdit && createsNewGroup(envSelection);
 }
 
 /**

--- a/packages/web/src/app/admin/connections/generate-prompt.ts
+++ b/packages/web/src/app/admin/connections/generate-prompt.ts
@@ -1,0 +1,51 @@
+/**
+ * Decision logic for the inline-on-add "Generate semantic layer" prompt
+ * (issue #3237 door 1, docs/design/semantic-onboarding.md § E).
+ *
+ * Adding a SQL connection that forms a **new** Connection group offers to
+ * generate a semantic layer for it. Adding a **member to an already-populated
+ * group** does NOT re-prompt — that group already has its schema. The whole
+ * decision is knowable from the create form's Environment selection, so it
+ * lives here as pure functions rather than as another API round-trip.
+ */
+
+// Sentinel values for the Environment combobox, shared with the connection
+// form (`page.tsx` imports these so there's one source of truth):
+//   - `__none__`   → the connection lands ungrouped; the server mints an auto
+//                    `g_<id>` singleton group (the migration-0062 invariant).
+//   - `__create__` → swaps the combobox for a text input bound to a brand-new
+//                    named group.
+// Any other value is an existing group id the connection is joining.
+export const ENV_SENTINEL_NONE = "__none__";
+export const ENV_SENTINEL_CREATE = "__create__";
+
+/**
+ * Whether creating a connection with this Environment selection forms a *new*
+ * Connection group. Only a new group should trigger the generate prompt:
+ *
+ *  - `__create__` → a brand-new named group → new.
+ *  - `__none__`   → server mints an auto `g_<id>` singleton → new (this is the
+ *                   common single-DB / first-DB-after-skip path).
+ *  - any existing group id → joining a populated group → NOT new.
+ */
+export function createsNewGroup(envSelection: string): boolean {
+  return envSelection === ENV_SENTINEL_NONE || envSelection === ENV_SENTINEL_CREATE;
+}
+
+/**
+ * Human label for the group a newly-created connection formed, for the prompt
+ * copy ("Generate semantic layer for `<label>`?"). A named group uses its
+ * typed name; an auto-singleton (`__none__`) has no user-facing group name yet,
+ * so we label it by the connection id — which *is* the group, of one.
+ */
+export function newGroupLabel(
+  envSelection: string,
+  newGroupName: string,
+  connectionId: string,
+): string {
+  if (envSelection === ENV_SENTINEL_CREATE) {
+    const trimmed = newGroupName.trim();
+    if (trimmed) return trimmed;
+  }
+  return connectionId;
+}

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -38,7 +38,7 @@ import { DEMO_CONNECTION_ID } from "./columns";
 import {
   ENV_SENTINEL_NONE,
   ENV_SENTINEL_CREATE,
-  createsNewGroup,
+  shouldPromptGenerate,
   newGroupLabel,
 } from "./generate-prompt";
 import { wizardGenerateHref } from "../../wizard/wizard-generate-entry";
@@ -349,9 +349,9 @@ function ConnectionFormDialog({
     if (result.ok) {
       // A create that forms a new group is the one moment to offer generation
       // (#3237). Fire before closing so the parent's prompt opens as the form
-      // dismisses; member-adds and edits stay silent — they reuse the group's
-      // existing schema, with /admin/semantic's empty state as the way back in.
-      if (!isEdit && onCreatedNewGroup && createsNewGroup(values.envSelection)) {
+      // dismisses; member-adds and edits stay silent (`shouldPromptGenerate`),
+      // with /admin/semantic's empty state as the always-available way back in.
+      if (onCreatedNewGroup && shouldPromptGenerate(isEdit, values.envSelection)) {
         onCreatedNewGroup({
           connectionId: values.id,
           groupLabel: newGroupLabel(values.envSelection, values.newGroupName, values.id),
@@ -1439,8 +1439,11 @@ export default function ConnectionsPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
+              {/* groupLabel is already display-ready (the typed group name, or
+                  the connection id for an auto-singleton) — never a synthetic
+                  `g_<id>`, so no stripGroupPrefix. */}
               Generate a semantic layer for{" "}
-              <span className="font-mono">{genPrompt ? stripGroupPrefix(genPrompt.groupLabel) : ""}</span>?
+              <span className="font-mono">{genPrompt?.groupLabel ?? ""}</span>?
             </AlertDialogTitle>
             <AlertDialogDescription>
               Atlas profiles this database and builds editable YAML so the agent

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -35,6 +35,13 @@ import {
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
 import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { DEMO_CONNECTION_ID } from "./columns";
+import {
+  ENV_SENTINEL_NONE,
+  ENV_SENTINEL_CREATE,
+  createsNewGroup,
+  newGroupLabel,
+} from "./generate-prompt";
+import { wizardGenerateHref } from "../../wizard/wizard-generate-entry";
 import { stripGroupPrefix, isAutoBackfilledSingleton, isEmptyBackfillOrphan } from "@/ui/lib/strip-group-prefix";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -117,12 +124,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 // surfaces in tests because the API returns a 400 with the same message.
 const ENV_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$/;
 
-// Sentinel values used by the Environment combobox. `__create__` swaps the
-// combobox row for an inline text input bound to `newGroupName`; `__none__`
-// means the connection lands ungrouped (auto `g_<id>` singleton — the
-// migration-0062 invariant the single-DB user never has to think about).
-const ENV_SENTINEL_NONE = "__none__";
-const ENV_SENTINEL_CREATE = "__create__";
+// `ENV_SENTINEL_NONE` / `ENV_SENTINEL_CREATE` (the Environment combobox
+// sentinels) live in ./generate-prompt — shared with the new-group detection
+// for the inline "Generate semantic layer" prompt (#3237) so there's one
+// source of truth.
 
 const envSelectionSchema = z.string();
 
@@ -219,6 +224,13 @@ interface ConnectionFormProps {
    * cache and the dialog's combobox renders pre-selected on first open. */
   envGroups: ReadonlyArray<EnvGroup>;
   onSuccess: () => void;
+  /**
+   * Called after a successful **create** that formed a *new* Connection group
+   * (#3237 door 1). The parent surfaces an inline "Generate semantic layer?"
+   * prompt. Not called on edit, or when the connection joined an existing
+   * populated group.
+   */
+  onCreatedNewGroup?: (info: { connectionId: string; groupLabel: string }) => void;
 }
 
 function ConnectionFormDialog({
@@ -229,6 +241,7 @@ function ConnectionFormDialog({
   initialDbType,
   envGroups,
   onSuccess,
+  onCreatedNewGroup,
 }: ConnectionFormProps) {
   const isEdit = !!editId;
   const [showUrl, setShowUrl] = useState(false);
@@ -334,6 +347,16 @@ function ConnectionFormDialog({
     setSubmitError(null);
     const result = await saveMutation.mutate({ path, method, body });
     if (result.ok) {
+      // A create that forms a new group is the one moment to offer generation
+      // (#3237). Fire before closing so the parent's prompt opens as the form
+      // dismisses; member-adds and edits stay silent — they reuse the group's
+      // existing schema, with /admin/semantic's empty state as the way back in.
+      if (!isEdit && onCreatedNewGroup && createsNewGroup(values.envSelection)) {
+        onCreatedNewGroup({
+          connectionId: values.id,
+          groupLabel: newGroupLabel(values.envSelection, values.newGroupName, values.id),
+        });
+      }
       onOpenChange(false);
     } else {
       setSubmitError(result.error);
@@ -1019,6 +1042,10 @@ export default function ConnectionsPage() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
+  // Inline "Generate semantic layer?" prompt shown after a create that forms a
+  // new Connection group (#3237 door 1). Holds the connection to scope the
+  // generate flow to; `null` when no prompt is pending.
+  const [genPrompt, setGenPrompt] = useState<{ connectionId: string; groupLabel: string } | null>(null);
 
   // Add-connection picker + the REST install dialogs it routes to. The
   // picker replaces the old always-listed "Connect" provider rows.
@@ -1401,7 +1428,42 @@ export default function ConnectionsPage() {
         initialDbType={createDbType}
         envGroups={envGroups}
         onSuccess={handleMutationSuccess}
+        onCreatedNewGroup={setGenPrompt}
       />
+
+      {/* Inline-on-add → generate (#3237 door 1). Both onboarding doors route
+          through `wizardGenerateHref` so they launch the one shared flow; the
+          generate/save routes resolve the connection's group server-side, so
+          the entities land in this new group. */}
+      <AlertDialog open={genPrompt !== null} onOpenChange={(open) => { if (!open) setGenPrompt(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Generate a semantic layer for{" "}
+              <span className="font-mono">{genPrompt ? stripGroupPrefix(genPrompt.groupLabel) : ""}</span>?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Atlas profiles this database and builds editable YAML so the agent
+              understands your schema and can write SQL on it. You can fine-tune
+              or skip enrichment along the way — and do this any time later from
+              the semantic layer page.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Not now</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const target = genPrompt;
+                setGenPrompt(null);
+                if (target) router.push(wizardGenerateHref(target.connectionId));
+              }}
+            >
+              <Plus className="mr-1.5 size-3.5" />
+              Generate
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <DeleteConnectionDialog
         open={deleteOpen}

--- a/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
+++ b/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Door 2 (#3237): the /admin/semantic empty state offers an in-product
+ * "Generate semantic layer" entry — replacing the old "Run `atlas init`"
+ * terminal instruction — that launches the shared wizard flow. With exactly
+ * one connection the CTA deep-links to that connection's table picker so the
+ * generated entities land in its Connection group.
+ *
+ * Pins:
+ *   1. empty + one connection → Generate CTA links to /wizard?connectionId=…&step=2
+ *   2. empty + zero connections → Generate CTA links to the bare /wizard picker
+ *   3. populated workspace → Generate CTA absent
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+
+mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/semantic",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+mock.module("@/ui/context", () => ({
+  useAtlasConfig: () => ({
+    apiUrl: "http://localhost",
+    isCrossOrigin: false,
+    authClient: { useSession: () => ({ data: null }) },
+  }),
+}));
+
+mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null }),
+}));
+
+mock.module("@/ui/hooks/use-demo-readonly", () => ({
+  useDemoReadonly: () => ({ readOnly: false, demoIndustry: null }),
+  demoIndustryLabel: () => null,
+}));
+
+mock.module("@/ui/hooks/use-dev-mode-no-drafts", () => ({
+  useDevModeNoDrafts: () => false,
+}));
+
+mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: mock(async () => ({ ok: true as const, data: null })),
+    saving: false,
+    error: null,
+    clearError: () => {},
+    reset: () => {},
+  }),
+}));
+
+mock.module("@/ui/components/admin/semantic-health-widget", () => ({
+  SemanticHealthWidget: () => null,
+}));
+mock.module("@/ui/components/admin/semantic-file-tree", () => ({
+  SemanticFileTree: () => createElement("div", { "data-testid": "semantic-file-tree" }),
+}));
+mock.module("@/ui/components/admin/entity-version-history", () => ({
+  EntityVersionHistory: () => null,
+}));
+mock.module("@/ui/components/admin/entity-editor-dialog", () => ({
+  EntityEditorDialog: () => null,
+  formValuesToEntityBody: () => ({}),
+}));
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockSemanticApi(opts: {
+  entities: Array<{ name: string; columnCount?: number }>;
+  connections: Array<{ id: string; dbType: string }>;
+}) {
+  globalThis.fetch = mock((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/api/v1/admin/semantic/entities")) {
+      return Promise.resolve(jsonResponse({ entities: opts.entities }));
+    }
+    if (url.includes("/api/v1/admin/semantic/glossary")) {
+      return Promise.resolve(jsonResponse({ glossary: [] }));
+    }
+    if (url.includes("/api/v1/admin/semantic/metrics")) {
+      return Promise.resolve(jsonResponse({ metrics: [] }));
+    }
+    if (url.includes("/api/v1/admin/semantic/catalog")) {
+      return Promise.resolve(jsonResponse({ catalog: null }));
+    }
+    if (url.includes("/api/v1/admin/connections")) {
+      return Promise.resolve(jsonResponse({ connections: opts.connections }));
+    }
+    return Promise.resolve(jsonResponse({}));
+  }) as unknown as typeof fetch;
+}
+
+const SemanticPage = (await import("../page")).default;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(
+    NuqsAdapter,
+    null,
+    createElement(QueryClientProvider, { client }, children),
+  );
+}
+
+function findGenerateCta(): HTMLAnchorElement | null {
+  return document.querySelector<HTMLAnchorElement>('[data-testid="semantic-generate-cta"]');
+}
+
+describe("/admin/semantic — Generate empty state (#3237)", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("empty + one connection: CTA deep-links to that connection's table picker", async () => {
+    mockSemanticApi({
+      entities: [],
+      connections: [{ id: "warehouse", dbType: "postgres" }],
+    });
+
+    await act(async () => {
+      render(createElement(SemanticPage), { wrapper });
+    });
+
+    const cta = await waitFor(() => {
+      const el = findGenerateCta();
+      if (!el) throw new Error("Generate CTA not rendered");
+      return el;
+    });
+
+    expect(cta.getAttribute("href")).toBe("/wizard?connectionId=warehouse&step=2");
+    expect(cta.textContent).toContain("Generate semantic layer");
+  });
+
+  test("empty + zero connections: CTA routes to the bare wizard picker", async () => {
+    mockSemanticApi({ entities: [], connections: [] });
+
+    await act(async () => {
+      render(createElement(SemanticPage), { wrapper });
+    });
+
+    const cta = await waitFor(() => {
+      const el = findGenerateCta();
+      if (!el) throw new Error("Generate CTA not rendered");
+      return el;
+    });
+
+    expect(cta.getAttribute("href")).toBe("/wizard");
+  });
+
+  test("populated workspace: no Generate CTA, no 'atlas init' instruction", async () => {
+    mockSemanticApi({
+      entities: [{ name: "companies", columnCount: 3 }],
+      connections: [{ id: "warehouse", dbType: "postgres" }],
+    });
+
+    await act(async () => {
+      render(createElement(SemanticPage), { wrapper });
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="semantic-file-tree"]')).not.toBeNull();
+    });
+
+    expect(findGenerateCta()).toBeNull();
+  });
+});

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -44,6 +44,10 @@ import {
   type SemanticGroupMeta,
 } from "@/ui/components/admin/semantic-file-tree";
 import { stripGroupPrefix } from "@/ui/lib/strip-group-prefix";
+import {
+  wizardGenerateHref,
+  generateLaunchConnectionId,
+} from "../../wizard/wizard-generate-entry";
 import { ConnectionsResponseSchema } from "@/ui/lib/admin-schemas";
 import { type ConnectionInfo } from "@/ui/lib/types";
 import { normalizeDrift } from "./normalize-drift";
@@ -119,14 +123,32 @@ interface CatalogMeta {
 
 // ── Content viewers ───────────────────────────────────────────────
 
+/**
+ * Empty-state hint shared by the catalog / glossary / metrics viewers (#3237):
+ * point at the in-product generate flow instead of "Run `atlas init`" (a
+ * terminal). The manual-YAML fallback stays for power users editing files
+ * directly.
+ */
+function GenerateHint({ manualPath }: { manualPath: string }) {
+  return (
+    <p className="mt-1 text-xs">
+      <Link
+        href={wizardGenerateHref()}
+        className="font-medium text-primary underline-offset-2 hover:underline"
+      >
+        Generate the semantic layer
+      </Link>{" "}
+      from your database, or create{" "}
+      <code className="rounded bg-muted px-1 py-0.5">{manualPath}</code> manually.
+    </p>
+  );
+}
+
 function CatalogViewer({ catalog }: { catalog: CatalogMeta | null }) {
   if (!catalog) {
     return (
       <EmptyState icon={FileText} message="No catalog metadata found">
-        <p className="mt-1 text-xs">
-          Run <code className="rounded bg-muted px-1 py-0.5">atlas init</code> to generate a catalog,
-          or create <code className="rounded bg-muted px-1 py-0.5">semantic/catalog.yml</code> manually.
-        </p>
+        <GenerateHint manualPath="semantic/catalog.yml" />
       </EmptyState>
     );
   }
@@ -172,10 +194,7 @@ function GlossaryViewer({ glossary }: { glossary: GlossaryTerm[] }) {
   if (glossary.length === 0) {
     return (
       <EmptyState icon={BookOpen} message="No glossary terms found">
-        <p className="mt-1 text-xs">
-          Run <code className="rounded bg-muted px-1 py-0.5">atlas init</code> to generate a glossary,
-          or create <code className="rounded bg-muted px-1 py-0.5">semantic/glossary.yml</code> manually.
-        </p>
+        <GenerateHint manualPath="semantic/glossary.yml" />
       </EmptyState>
     );
   }
@@ -216,10 +235,7 @@ function MetricsViewer({ metrics }: { metrics: MetricEntry[] }) {
   if (metrics.length === 0) {
     return (
       <EmptyState icon={BarChart3} message="No metrics found">
-        <p className="mt-1 text-xs">
-          Run <code className="rounded bg-muted px-1 py-0.5">atlas init</code> to generate metrics,
-          or add YAML files to <code className="rounded bg-muted px-1 py-0.5">semantic/metrics/</code>.
-        </p>
+        <GenerateHint manualPath="semantic/metrics/" />
       </EmptyState>
     );
   }
@@ -914,18 +930,31 @@ export default function SemanticPage() {
         <div className="p-6" data-testid="semantic-empty-state">
           <EmptyState
             icon={BookOpen}
-            title="No semantic entities yet"
-            description="Atlas reads semantic/entities/*.yml from the deployment image. Use this to populate the editor from disk."
+            title="No semantic layer yet"
+            description="Generate one from a connected database — Atlas profiles your schema and builds editable YAML the agent can query."
           >
-            <Button
-              variant="link"
-              size="xs"
-              onClick={runImport}
-              disabled={importing}
-              className="mt-3"
-            >
-              {importing ? "Syncing..." : "Sync from disk"}
-            </Button>
+            {/* Door 2 (#3237): lead with the in-product generate flow, scoped
+                to the sole connection when there's exactly one. "Sync from
+                disk" stays as the recovery path for image-shipped YAML. */}
+            <div className="mt-3 flex flex-col items-center gap-2">
+              <Button asChild size="sm" className="gap-1.5">
+                <Link
+                  href={wizardGenerateHref(generateLaunchConnectionId(connections))}
+                  data-testid="semantic-generate-cta"
+                >
+                  <Sparkles className="size-4" />
+                  Generate semantic layer
+                </Link>
+              </Button>
+              <Button
+                variant="link"
+                size="xs"
+                onClick={runImport}
+                disabled={importing}
+              >
+                {importing ? "Syncing..." : "Sync from disk"}
+              </Button>
+            </div>
           </EmptyState>
         </div>
       ) : (

--- a/packages/web/src/app/wizard/wizard-generate-entry.test.ts
+++ b/packages/web/src/app/wizard/wizard-generate-entry.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The two onboarding doors (#3237) must launch the *same* generate flow — that
+ * invariant is enforced by both building their href through `wizardGenerateHref`.
+ * These tests pin the href shape and the empty-state connection-selection rule.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { ConnectionInfo } from "@/ui/lib/types";
+import { DEMO_CONNECTION_ID } from "../admin/connections/columns";
+import {
+  wizardGenerateHref,
+  generateLaunchConnectionId,
+} from "./wizard-generate-entry";
+
+const conn = (id: string, extras: Partial<ConnectionInfo> = {}): ConnectionInfo => ({
+  id,
+  dbType: "postgres",
+  ...extras,
+});
+
+describe("wizard-generate-entry", () => {
+  describe("wizardGenerateHref", () => {
+    it("deep-links to the table picker (step 2) when a connection is given", () => {
+      expect(wizardGenerateHref("warehouse")).toBe(
+        "/wizard?connectionId=warehouse&step=2",
+      );
+    });
+
+    it("routes to the bare wizard (datasource picker) with no connection", () => {
+      expect(wizardGenerateHref()).toBe("/wizard");
+      expect(wizardGenerateHref(null)).toBe("/wizard");
+      expect(wizardGenerateHref("")).toBe("/wizard");
+    });
+
+    it("URL-encodes the connection id", () => {
+      // Connection ids are slug-validated, but encoding keeps the door honest
+      // if that ever loosens — a raw `&`/space must not corrupt the query.
+      expect(wizardGenerateHref("a b&step=9")).toBe(
+        "/wizard?connectionId=a%20b%26step%3D9&step=2",
+      );
+    });
+  });
+
+  describe("generateLaunchConnectionId", () => {
+    it("returns the sole real connection's id", () => {
+      expect(generateLaunchConnectionId([conn("warehouse")])).toBe("warehouse");
+    });
+
+    it("returns null with zero connections (route to the picker)", () => {
+      expect(generateLaunchConnectionId([])).toBeNull();
+    });
+
+    it("returns null with multiple connections (let the user choose)", () => {
+      expect(generateLaunchConnectionId([conn("us-prod"), conn("eu-prod")])).toBeNull();
+    });
+
+    it("excludes the demo connection from the count", () => {
+      // Demo + one real → deep-link to the real one.
+      expect(
+        generateLaunchConnectionId([conn(DEMO_CONNECTION_ID), conn("warehouse")]),
+      ).toBe("warehouse");
+      // Demo only → nothing of the user's to scope to.
+      expect(generateLaunchConnectionId([conn(DEMO_CONNECTION_ID)])).toBeNull();
+    });
+  });
+});

--- a/packages/web/src/app/wizard/wizard-generate-entry.ts
+++ b/packages/web/src/app/wizard/wizard-generate-entry.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared entry-point helpers for the semantic-layer generate flow (issue #3237,
+ * docs/design/semantic-onboarding.md § E).
+ *
+ * There is exactly **one** generate flow — the wizard's table-pick → two-phase
+ * review → save (#3236). The onboarding wizard, the inline-on-add prompt in
+ * `/admin/connections`, and the per-group empty state in `/admin/semantic` are
+ * all just *doors* into it. Centralizing the deep-link here is what makes
+ * "one flow, many doors" true by construction: every door builds its href the
+ * same way, so they can't drift into separate flows.
+ *
+ * Deliberately UI- and fetch-free so the routing/selection logic is unit-
+ * testable without a React render.
+ */
+
+import type { ConnectionInfo } from "@/ui/lib/types";
+import { DEMO_CONNECTION_ID } from "../admin/connections/columns";
+
+/** Wizard step number for the table picker (step 2). The datasource picker is
+ * step 1; deep-linking past it skips a redundant "which connection?" prompt
+ * when the caller already knows the connection. Mirrors `wizard-steps.ts`. */
+const WIZARD_TABLES_STEP = 2;
+
+/**
+ * Build the deep-link into the shared generate flow.
+ *
+ * With a `connectionId` we jump straight to the table picker (step 2) for that
+ * connection — the `/wizard/generate` + `/wizard/save` routes resolve the
+ * connection's Connection group server-side (#3234), so the generated entities
+ * land in the right group regardless of which door launched the flow.
+ *
+ * With no connection we route to the wizard's datasource picker (step 1) and
+ * let the user choose.
+ */
+export function wizardGenerateHref(connectionId?: string | null): string {
+  if (connectionId) {
+    return `/wizard?connectionId=${encodeURIComponent(connectionId)}&step=${WIZARD_TABLES_STEP}`;
+  }
+  return "/wizard";
+}
+
+/**
+ * Pick a connection to pre-select when launching the generate flow from the
+ * `/admin/semantic` empty state (door 2). With exactly one real connection we
+ * deep-link straight to its table picker; with zero or many we return `null`
+ * so the caller routes to the datasource picker and lets the user choose.
+ *
+ * The demo connection is excluded — generating against the shared demo dataset
+ * isn't the onboarding intent, and on a demo-only workspace there's nothing of
+ * the user's own to scope to.
+ */
+export function generateLaunchConnectionId(
+  connections: readonly ConnectionInfo[],
+): string | null {
+  const real = connections.filter((c) => c.id !== DEMO_CONNECTION_ID);
+  return real.length === 1 ? real[0].id : null;
+}

--- a/packages/web/src/app/wizard/wizard-generate-entry.ts
+++ b/packages/web/src/app/wizard/wizard-generate-entry.ts
@@ -4,10 +4,10 @@
  *
  * There is exactly **one** generate flow — the wizard's table-pick → two-phase
  * review → save (#3236). The onboarding wizard, the inline-on-add prompt in
- * `/admin/connections`, and the per-group empty state in `/admin/semantic` are
- * all just *doors* into it. Centralizing the deep-link here is what makes
- * "one flow, many doors" true by construction: every door builds its href the
- * same way, so they can't drift into separate flows.
+ * `/admin/connections`, and the empty state in `/admin/semantic` are all just
+ * *doors* into it. Centralizing the deep-link here is what makes "one flow,
+ * many doors" true by construction: every door builds its href the same way,
+ * so they can't drift into separate flows.
  *
  * Deliberately UI- and fetch-free so the routing/selection logic is unit-
  * testable without a React render.
@@ -15,11 +15,14 @@
 
 import type { ConnectionInfo } from "@/ui/lib/types";
 import { DEMO_CONNECTION_ID } from "../admin/connections/columns";
+import { WIZARD_STEPS } from "./wizard-steps";
 
-/** Wizard step number for the table picker (step 2). The datasource picker is
- * step 1; deep-linking past it skips a redundant "which connection?" prompt
- * when the caller already knows the connection. Mirrors `wizard-steps.ts`. */
-const WIZARD_TABLES_STEP = 2;
+/** Wizard step number (1-based) for the table picker. Deep-linking past the
+ * datasource picker (step 1) skips a redundant "which connection?" prompt when
+ * the caller already knows the connection. Derived from `WIZARD_STEPS` rather
+ * than hardcoded so inserting/reordering a step can't silently point the
+ * deep-link at the wrong screen. */
+const WIZARD_TABLES_STEP = WIZARD_STEPS.findIndex((s) => s.id === "tables") + 1;
 
 /**
  * Build the deep-link into the shared generate flow.


### PR DESCRIPTION
Closes #3237 — the last open slice of **v0.0.12 — Semantic Layer Onboarding** ([milestone #62](https://github.com/AtlasDevHQ/atlas/milestone/62)).

## What & why

Adding a database had no in-product road to a semantic layer: `/admin/connections` offered nothing, and `/admin/semantic` empty states told you to "Run `atlas init`" (a terminal). This adds **two doors into the one shared generate flow** (#3236) — identical whether it's your 1st database (added after skipping signup) or your Nth.

### Door 1 — inline-on-add (push)
Creating a SQL connection that forms a **new** Connection group surfaces an inline "Generate semantic layer for `<group>`?" prompt in `/admin/connections`:
- `__create__` (a brand-new named group) **or** `__none__` (ungrouped → server mints an auto-singleton; the common single-DB / first-DB-after-skip path) → **prompt fires**.
- Joining an **already-populated** group → **silent** (it reuses that group's existing schema; `/admin/semantic`'s empty state is the way back in).

### Door 2 — per-group empty state (pull)
`/admin/semantic` leads with a "Generate semantic layer" CTA (scoped to the sole connection when there's exactly one, else routes to the datasource picker), and the catalog / glossary / metrics empty states now point at the generate flow instead of "Run `atlas init`".

## One flow, many doors
Both doors deep-link into the existing wizard via `wizardGenerateHref(connectionId)` → `/wizard?connectionId=…&step=2` rather than re-implementing the two-phase generate UI. The `/wizard/generate` + `/wizard/save` routes resolve the connection's Connection group **server-side** (#3234), so the door stays group-unaware and entities always land in the right group. DB-count-agnostic by construction.

## Tests
Decision logic lives in pure, unit-tested helpers (the codebase's established pattern):
- `wizard-generate-entry.test.ts` — href shape + empty-state connection selection (**both doors → same flow**).
- `generate-prompt.test.ts` — `createsNewGroup` / `newGroupLabel` (**new-group fires, member-add does not**).
- `generate-empty-state.test.tsx` — `/admin/semantic` **Generate CTA** present/scoped when empty, absent when populated.

127/127 web tests across wizard + connections + semantic pass; `bun run type` + `eslint` clean.

## Acceptance criteria
- [x] New-group create shows an inline Generate entry that launches the flow
- [x] Member-add to a populated group does **not** prompt
- [x] `/admin/semantic` empty state offers Generate, no longer says "run `atlas init`"
- [x] Both doors launch the same flow and land entities in the correct group
- [x] First-DB-after-skip reaches generation via these doors, no special-casing
- [x] Tests: new-group fires / populated does not / empty-state Generate / both doors → same flow

Design + implementation notes: `docs/design/semantic-onboarding.md` § E (updated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783372815&installation_id=135337507&pr_number=3290&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3290&signature=4eb64909220494f965b2c6d21be6da4297b321cc745502396d0b28edf1186474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline "Generate semantic layer" prompt when creating a new connection group
  * Added "Generate semantic layer" call-to-action on the semantic empty-state page
  * Both entry points deep-link into a unified in-product wizard flow

* **Tests**
  * Added comprehensive tests covering the new entry points, URL/deep-link behavior, and prompt display logic

* **Documentation**
  * Updated design doc to reflect the implemented onboarding entry-point behavior and build sequence note
<!-- end of auto-generated comment: release notes by coderabbit.ai -->