### PR TITLE
ci(publish): enable @useatlas/elasticsearch CI publishing (#3272)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
       - 'duckdb-v*'
       - 'mysql-v*'
       - 'salesforce-v*'
-      # - 'elasticsearch-v*'  # TODO(#3272): uncomment once the npm trusted publisher is configured for @useatlas/elasticsearch
+      - 'elasticsearch-v*'
       # Plugins — sandbox
       - 'e2b-v*'
       - 'daytona-v*'
@@ -124,13 +124,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/salesforce-v')
         run: cd plugins/salesforce && npm publish --access public --provenance
 
-      # TODO(#3272): uncomment after configuring the npm trusted publisher (OIDC) for
-      # @useatlas/elasticsearch. v0.0.1 was published manually to bootstrap the package
-      # name; later versions publish here on an `elasticsearch-v*` tag (also uncomment
-      # the matching trigger in the `on.push.tags` list above).
-      # - name: Publish @useatlas/elasticsearch
-      #   if: startsWith(github.ref, 'refs/tags/elasticsearch-v')
-      #   run: cd plugins/elasticsearch && npm publish --access public --provenance
+      - name: Publish @useatlas/elasticsearch
+        if: startsWith(github.ref, 'refs/tags/elasticsearch-v')
+        run: cd plugins/elasticsearch && npm publish --access public --provenance
 
       # Sandbox
       - name: Publish @useatlas/e2b


### PR DESCRIPTION
## What
The npm **OIDC trusted publisher** for `@useatlas/elasticsearch` is now configured, so this uncomments the staged `elasticsearch-v*` trigger + `Publish @useatlas/elasticsearch` step in `.github/workflows/publish.yml` (staged commented-out in #3291).

## Effect
Future releases publish via CI on an `elasticsearch-v*` tag with `--provenance` (token-less, OIDC), consistent with every other `@useatlas/*` plugin. `@useatlas/elasticsearch@0.0.1` was the manual bootstrap publish; the **first CI-driven publish will be the next version bump** (0.0.1 already exists on the registry, so re-tagging 0.0.1 would no-op/fail by design).

Part of #3272. Diff is 4 lines added / 8 removed (comment removal + activation); YAML validated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783382462&installation_id=135337507&pr_number=3292&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3292&signature=7ce89223c2fd39cf712f0c4f9b040f03d20cf778df53a92aaedd352e8f289fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated publishing for the Elasticsearch plugin via version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->