### PR TITLE
feat(plugins): @useatlas/elasticsearch SQL query surface (#3262)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -608,7 +608,7 @@
     },
     "plugins/elasticsearch": {
       "name": "@useatlas/elasticsearch",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
         "ai": "^6.0.193",

--- a/plugins/elasticsearch/README.md
+++ b/plugins/elasticsearch/README.md
@@ -5,11 +5,12 @@ that connects an Elasticsearch (and, in a later slice, OpenSearch) cluster as a
 read-only Atlas datasource over a thin `fetch`-based HTTP client — no official
 SDK dependency.
 
-> **Status — connection foundation only.** This release ships the connection
-> layer: `elasticsearch://` URL + **API-key** auth parsing, an authenticated
-> cluster-info/ping health check, and ConnectionRegistry registration. The query
-> surfaces (SQL via `executeSQL` and a dedicated Query DSL tool), the remaining
-> auth modes (Basic / Cloud ID / AWS SigV4), the OpenSearch engine, and
+> **Status — connection + SQL query surface.** This release ships the connection
+> layer (`elasticsearch://` URL + **API-key** auth, an authenticated
+> cluster-info/ping health check, ConnectionRegistry registration) **and** the
+> SQL query surface: tabular/aggregate questions over a single index, answered
+> through the standard `executeSQL` tool. The dedicated Query DSL tool, the
+> remaining auth modes (Basic / Cloud ID / AWS SigV4), the OpenSearch engine, and
 > `atlas init` mapping profiling arrive in later slices. See the
 > [PRD (#3259)](https://github.com/AtlasDevHQ/atlas/issues/3259).
 
@@ -53,15 +54,62 @@ masks it in the admin UI. It is not returned in plaintext: connection/health
 errors are scrubbed (the literal key is redacted and messages tripping auth
 markers are collapsed) before they reach the agent, the user, or logs.
 
+## SQL query surface
+
+Ask a tabular or aggregate question over a single Elasticsearch index in chat and
+the agent answers it through the standard `executeSQL` tool — the same tool, the
+same 4-layer validation pipeline, as any SQL datasource. Under the hood the
+connection's `query()` POSTs your statement to the cluster SQL API
+(`POST /_sql?format=json`), follows the response `cursor` across pages up to the
+row cap, and normalizes ES SQL's `{ columns:[{name,type}], rows:[[…]] }` into the
+Atlas `{ columns, rows }` shape.
+
+```text
+"How many orders per status?"
+  → SELECT status, COUNT(*) AS n FROM orders GROUP BY status
+  → a table of statuses and counts
+```
+
+### Supported SQL subset
+
+ES SQL **is** standard SQL, so it rides the unmodified Atlas pipeline. The plugin
+declares `parserDialect: "PostgresQL"` (no custom validator) — verified against
+`node-sql-parser` 5.4.0, PostgreSQL mode cleanly parses the documented subset and
+PostgreSQL's double-quoted identifier quoting matches ES SQL's index-name quoting
+(MySQL mode would expect backticks).
+
+| Supported                                                                 | Notes |
+| ------------------------------------------------------------------------- | ----- |
+| `SELECT` projection / `SELECT *`                                          | Read-only — the pipeline rejects everything that isn't a single `SELECT`. |
+| `FROM <index>` (one index per query)                                      | Each index is a table. Quote names with `-`, `.`, `:` in double quotes: `FROM "logs-2024.01.01"`. **No JOINs across indices.** |
+| `WHERE` with `=`,`<`,`>`,`IN`,`BETWEEN`,`LIKE`,`IS NULL`                  | Standard predicates. |
+| `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`                                  | `LIMIT` is auto-appended by Atlas (`ATLAS_ROW_LIMIT`, default 1000) if you omit it. |
+| `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `COUNT(DISTINCT …)`                   | Aggregates. |
+| Nested fields by dotted path (`geo.dest`)                                  | Addressed like a column. |
+
+Beyond the base DML/DDL guard, the connection adds ES-specific
+`forbiddenPatterns` that block the catalog/schema-disclosure verbs `SHOW …` and
+`DESCRIBE …` (they enumerate every index/field and so bypass the index
+whitelist). These are anchored to the statement start, so a field literally named
+`show` or `description` mid-query is unaffected, and `ORDER BY … DESC` is fine.
+
+> **Row cap.** The authoritative cap is the `LIMIT` Atlas appends
+> (`ATLAS_ROW_LIMIT`). The connector also enforces a defensive client-side
+> ceiling (10,000 rows) as a runaway-cursor backstop; if it ever truncates, it
+> logs a warning rather than silently dropping rows.
+
 ## Security
 
-- **Read-only.** This foundation slice performs only an authenticated
-  cluster-info/ping round-trip. Query surfaces (added later) are read-only by
-  design.
-- **Secret-scrubbed errors.** Connection/health errors are scrubbed before they
-  reach the agent, the user, or logs: the literal API key is redacted and
-  messages that trip auth-context markers are collapsed to a generic message
-  (the detail stays in server logs).
+- **Read-only.** Only `SELECT` reaches the cluster. The SQL surface goes through
+  Atlas's standard 4-layer validation (regex DML/DDL guard → AST single-`SELECT`
+  parse → index whitelist → auto-`LIMIT` + statement timeout), plus the
+  ES-specific `SHOW`/`DESCRIBE` guard above. The plugin sets **no** custom
+  validator, so this pipeline applies unchanged.
+- **Secret-scrubbed errors.** Connection, health, and query errors are scrubbed
+  before they reach the agent, the user, or logs: the literal API key is redacted
+  and messages that trip auth-context markers are collapsed to a generic message
+  (the detail stays in server logs). Query errors still surface the actionable ES
+  reason (e.g. `Unknown column [foo]`) so the agent can self-correct.
 
 ## License
 

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -928,6 +928,74 @@ describe("createElasticsearchClient.sqlQuery", () => {
     client.close();
     await expect(client.sqlQuery({ query: "SELECT 1" })).rejects.toThrow(/closed/);
   });
+
+  test("a failed cursor close is non-fatal — still returns the truncated rows, warns, logs at debug", async () => {
+    // The whole point of the best-effort /_sql/close is that its failure must NOT
+    // fail the user's already-successful (truncated) query. Also locks the
+    // "truncation is logged, never silent" contract.
+    const warns: unknown[][] = [];
+    const debugs: unknown[][] = [];
+    const logger = {
+      info: (...a: unknown[]) => void a,
+      warn: (...a: unknown[]) => void warns.push(a),
+      error: (...a: unknown[]) => void a,
+      debug: (...a: unknown[]) => void debugs.push(a),
+    };
+    const fetchImpl = mock(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/_sql/close")) {
+        throw new Error("close request boom");
+      }
+      const payload = JSON.parse(String(init.body));
+      if (payload.query) {
+        return fetchResponse({
+          columns: [{ name: "id", type: "long" }],
+          rows: [[1], [2]],
+          cursor: "live-cursor",
+        });
+      }
+      return fetchResponse({ rows: [[3], [4]], cursor: "live-cursor" });
+    });
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch, logger },
+    );
+    const result = await client.sqlQuery({ query: "SELECT id FROM flights", maxRows: 3 });
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    // Truncation warned (never silent) and the close failure logged at debug.
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns[0][0]).toEqual({ maxRows: 3 });
+    expect(debugs.length).toBeGreaterThan(0);
+  });
+
+  test("caps on the first page (zero loop iterations) and still closes the cursor", async () => {
+    // Distinct control-flow path: the first page alone meets maxRows AND carries a
+    // cursor, so the `while` body never runs — but the cap-on-entry close must
+    // still fire and NO cursor-continuation page may be fetched.
+    let cursorPageFetched = false;
+    let closeCalled = false;
+    const fetchImpl = mock(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/_sql/close")) {
+        closeCalled = true;
+        return fetchResponse({ succeeded: true });
+      }
+      const payload = JSON.parse(String(init.body));
+      if (payload.query) {
+        return fetchResponse({
+          columns: [{ name: "id", type: "long" }],
+          rows: [[1], [2], [3]],
+          cursor: "live-cursor",
+        });
+      }
+      cursorPageFetched = true; // must not happen
+      return fetchResponse({ rows: [[4]] });
+    });
+    const client = makeClient(fetchImpl);
+    const result = await client.sqlQuery({ query: "SELECT id FROM flights", maxRows: 2 });
+
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(cursorPageFetched).toBe(false);
+    expect(closeCalled).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -11,7 +11,12 @@ import {
   createElasticsearchConnection,
   scrubElasticsearchError,
   SENSITIVE_PATTERNS,
+  normalizeSqlPages,
+  extractEsSqlErrorMessage,
+  ELASTICSEARCH_FORBIDDEN_PATTERNS,
+  ELASTICSEARCH_PARSER_DIALECT,
 } from "../src/index";
+import type { ElasticsearchSqlResponse } from "../src/index";
 
 const VALID_URL = "elasticsearch://localhost:9200?ssl=false";
 const API_KEY = "VnVhQ2ZHY0JDZGJrU=test-key";
@@ -384,9 +389,29 @@ describe("createElasticsearchConnection", () => {
     expect(typeof conn.close).toBe("function");
   });
 
-  test("query() throws — the query surface is not in this slice", async () => {
-    const conn = createElasticsearchConnection({ url: VALID_URL, apiKey: API_KEY });
-    await expect(conn.query("SELECT 1")).rejects.toThrow(/#3262|not available/i);
+  test("query() POSTs ES SQL to /_sql and returns normalized { columns, rows }", async () => {
+    const fetchImpl = mock(async () =>
+      fetchResponse({
+        columns: [
+          { name: "origin", type: "text" },
+          { name: "cnt", type: "long" },
+        ],
+        rows: [
+          ["SFO", 42],
+          ["JFK", 31],
+        ],
+      }),
+    );
+    const conn = createElasticsearchConnection(
+      { url: VALID_URL, apiKey: API_KEY },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const result = await conn.query("SELECT origin, COUNT(*) AS cnt FROM flights GROUP BY origin");
+    expect(result.columns).toEqual(["origin", "cnt"]);
+    expect(result.rows).toEqual([
+      { origin: "SFO", cnt: 42 },
+      { origin: "JFK", cnt: 31 },
+    ]);
   });
 
   test("ping() round-trips through the injected fetch", async () => {
@@ -611,5 +636,347 @@ describe("teardown", () => {
   test("teardown is a no-op when no connection was created", async () => {
     const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
     await plugin.teardown!(); // should not throw
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSqlPages — PURE: ES SQL pages → Atlas { columns, rows }
+// ---------------------------------------------------------------------------
+
+describe("normalizeSqlPages", () => {
+  test("normalizes a single page of scalar columns to keyed rows", () => {
+    const page: ElasticsearchSqlResponse = {
+      columns: [
+        { name: "origin", type: "text" },
+        { name: "delay", type: "long" },
+      ],
+      rows: [
+        ["SFO", 12],
+        ["JFK", 7],
+      ],
+    };
+    const result = normalizeSqlPages([page]);
+    expect(result.columns).toEqual(["origin", "delay"]);
+    expect(result.rows).toEqual([
+      { origin: "SFO", delay: 12 },
+      { origin: "JFK", delay: 7 },
+    ]);
+  });
+
+  test("folds multiple cursor pages — columns come from the first page only", () => {
+    // ES returns `columns` only on the first page; cursor-continuation pages
+    // carry `rows` (and possibly another `cursor`) but omit `columns`.
+    const first: ElasticsearchSqlResponse = {
+      columns: [
+        { name: "carrier", type: "keyword" },
+        { name: "n", type: "long" },
+      ],
+      rows: [["AA", 1]],
+      cursor: "cursor-1",
+    };
+    const second: ElasticsearchSqlResponse = {
+      rows: [["DL", 2]],
+      cursor: "cursor-2",
+    };
+    const third: ElasticsearchSqlResponse = {
+      rows: [["UA", 3]],
+    };
+    const result = normalizeSqlPages([first, second, third]);
+    expect(result.columns).toEqual(["carrier", "n"]);
+    expect(result.rows).toEqual([
+      { carrier: "AA", n: 1 },
+      { carrier: "DL", n: 2 },
+      { carrier: "UA", n: 3 },
+    ]);
+  });
+
+  test("handles an empty result — columns present, zero rows", () => {
+    const page: ElasticsearchSqlResponse = {
+      columns: [{ name: "origin", type: "text" }],
+      rows: [],
+    };
+    const result = normalizeSqlPages([page]);
+    expect(result.columns).toEqual(["origin"]);
+    expect(result.rows).toEqual([]);
+  });
+
+  test("returns empty columns and rows for a degenerate empty page set", () => {
+    expect(normalizeSqlPages([])).toEqual({ columns: [], rows: [] });
+    expect(normalizeSqlPages([{}])).toEqual({ columns: [], rows: [] });
+  });
+
+  test("preserves falsy scalar values (0, false, empty string) and null", () => {
+    const page: ElasticsearchSqlResponse = {
+      columns: [
+        { name: "count", type: "long" },
+        { name: "active", type: "boolean" },
+        { name: "note", type: "text" },
+        { name: "missing", type: "text" },
+      ],
+      rows: [[0, false, "", null]],
+    };
+    const result = normalizeSqlPages([page]);
+    expect(result.rows).toEqual([{ count: 0, active: false, note: "", missing: null }]);
+  });
+
+  test("caps accumulated rows at maxRows across pages", () => {
+    const first: ElasticsearchSqlResponse = {
+      columns: [{ name: "id", type: "long" }],
+      rows: [[1], [2], [3]],
+      cursor: "c1",
+    };
+    const second: ElasticsearchSqlResponse = { rows: [[4], [5]] };
+    const result = normalizeSqlPages([first, second], 4);
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+  });
+
+  test("fills missing trailing cells with null when a row is short", () => {
+    const page: ElasticsearchSqlResponse = {
+      columns: [
+        { name: "a", type: "long" },
+        { name: "b", type: "long" },
+      ],
+      rows: [[1]],
+    };
+    const result = normalizeSqlPages([page]);
+    expect(result.rows).toEqual([{ a: 1, b: null }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractEsSqlErrorMessage — PURE: ES error body → actionable message
+// ---------------------------------------------------------------------------
+
+describe("extractEsSqlErrorMessage", () => {
+  test("extracts type + reason from a structured ES error body", () => {
+    const body = {
+      error: {
+        type: "verification_exception",
+        reason: "Found 1 problem\nline 1:8: Unknown column [foo]",
+      },
+      status: 400,
+    };
+    const msg = extractEsSqlErrorMessage(body, 400, "Bad Request");
+    expect(msg).toContain("verification_exception");
+    expect(msg).toContain("Unknown column [foo]");
+  });
+
+  test("uses reason alone when type is absent", () => {
+    const body = { error: { reason: "index_not_found_exception" } };
+    expect(extractEsSqlErrorMessage(body, 404, "Not Found")).toBe(
+      "index_not_found_exception",
+    );
+  });
+
+  test("accepts a string error field", () => {
+    const body = { error: "something broke" };
+    expect(extractEsSqlErrorMessage(body, 500, "Internal Server Error")).toBe(
+      "something broke",
+    );
+  });
+
+  test("falls back to the HTTP status line when the body has no error", () => {
+    expect(extractEsSqlErrorMessage({}, 503, "Service Unavailable")).toMatch(
+      /HTTP 503 Service Unavailable/,
+    );
+    expect(extractEsSqlErrorMessage(undefined, 502, "Bad Gateway")).toMatch(
+      /HTTP 502 Bad Gateway/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// client.sqlQuery — POSTs to /_sql, follows cursors, scrubs errors
+// ---------------------------------------------------------------------------
+
+describe("createElasticsearchClient.sqlQuery", () => {
+  function makeClient(fetchImpl: unknown) {
+    return createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as typeof fetch },
+    );
+  }
+
+  test("POSTs the query to /_sql with ApiKey auth + JSON body", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+    const fetchImpl = mock(async (url: string, init: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return fetchResponse({
+        columns: [{ name: "n", type: "long" }],
+        rows: [[5]],
+      });
+    });
+    const client = makeClient(fetchImpl);
+    const result = await client.sqlQuery({ query: "SELECT COUNT(*) AS n FROM flights" });
+
+    expect(capturedUrl).toBe("http://localhost:9200/_sql?format=json");
+    expect(capturedInit?.method).toBe("POST");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`ApiKey ${API_KEY}`);
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(String(capturedInit?.body));
+    expect(body.query).toBe("SELECT COUNT(*) AS n FROM flights");
+    expect(typeof body.fetch_size).toBe("number");
+    expect(result.rows).toEqual([{ n: 5 }]);
+  });
+
+  test("follows the cursor across pages and concatenates rows", async () => {
+    const bodies: unknown[] = [];
+    const fetchImpl = mock(async (_url: string, init: RequestInit) => {
+      const payload = JSON.parse(String(init.body));
+      bodies.push(payload);
+      if (payload.query) {
+        return fetchResponse({
+          columns: [{ name: "id", type: "long" }],
+          rows: [[1], [2]],
+          cursor: "cursor-abc",
+        });
+      }
+      if (payload.cursor === "cursor-abc") {
+        return fetchResponse({ rows: [[3]], cursor: "cursor-def" });
+      }
+      return fetchResponse({ rows: [[4]] });
+    });
+    const client = makeClient(fetchImpl);
+    const result = await client.sqlQuery({ query: "SELECT id FROM flights" });
+
+    expect(result.columns).toEqual(["id"]);
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+    // 1 query page + 2 cursor pages
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(bodies[1]).toEqual({ cursor: "cursor-abc" });
+    expect(bodies[2]).toEqual({ cursor: "cursor-def" });
+  });
+
+  test("stops at maxRows and best-effort closes a still-open cursor", async () => {
+    let closeCalled = false;
+    let closeCursor: string | undefined;
+    const fetchImpl = mock(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/_sql/close")) {
+        closeCalled = true;
+        closeCursor = JSON.parse(String(init.body)).cursor;
+        return fetchResponse({ succeeded: true });
+      }
+      const payload = JSON.parse(String(init.body));
+      if (payload.query) {
+        return fetchResponse({
+          columns: [{ name: "id", type: "long" }],
+          rows: [[1], [2]],
+          cursor: "live-cursor",
+        });
+      }
+      return fetchResponse({ rows: [[3], [4]], cursor: "live-cursor" });
+    });
+    const client = makeClient(fetchImpl);
+    const result = await client.sqlQuery({ query: "SELECT id FROM flights", maxRows: 3 });
+
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(closeCalled).toBe(true);
+    expect(closeCursor).toBe("live-cursor");
+  });
+
+  test("throws an actionable, scrubbed error on a non-2xx response", async () => {
+    const fetchImpl = mock(async () =>
+      fetchResponse(
+        { error: { type: "verification_exception", reason: "Unknown column [nope]" }, status: 400 },
+        { ok: false, status: 400, statusText: "Bad Request" },
+      ),
+    );
+    const client = makeClient(fetchImpl);
+    await expect(client.sqlQuery({ query: "SELECT nope FROM flights" })).rejects.toThrow(
+      /Unknown column \[nope\]/,
+    );
+  });
+
+  test("never leaks the API key even if the server echoes it in an error", async () => {
+    const fetchImpl = mock(async () =>
+      fetchResponse(
+        { error: { type: "security_exception", reason: `bad ApiKey ${API_KEY}` } },
+        { ok: false, status: 403, statusText: "Forbidden" },
+      ),
+    );
+    const client = makeClient(fetchImpl);
+    let message = "";
+    try {
+      await client.sqlQuery({ query: "SELECT * FROM flights" });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).not.toContain(API_KEY);
+  });
+
+  test("rejects with a timeout error when the request exceeds timeoutMs", async () => {
+    const fetchImpl = mock(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(Object.assign(new Error("The operation was aborted"), { name: "AbortError" })),
+          );
+        }),
+    );
+    const client = makeClient(fetchImpl);
+    await expect(
+      client.sqlQuery({ query: "SELECT * FROM flights", timeoutMs: 10 }),
+    ).rejects.toThrow(/timed out after 10ms/);
+  });
+
+  test("sqlQuery after close rejects", async () => {
+    const fetchImpl = mock(async () => fetchResponse({ columns: [], rows: [] }));
+    const client = makeClient(fetchImpl);
+    client.close();
+    await expect(client.sqlQuery({ query: "SELECT 1" })).rejects.toThrow(/closed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQL surface wiring — parserDialect + forbiddenPatterns + dialect, no validate
+// ---------------------------------------------------------------------------
+
+describe("SQL surface wiring", () => {
+  test("declares the PostgresQL parser dialect on the connection", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    expect(plugin.connection.parserDialect).toBe("PostgresQL");
+    expect(ELASTICSEARCH_PARSER_DIALECT).toBe("PostgresQL");
+  });
+
+  test("sets NO custom validate — the standard 4-layer SQL pipeline applies", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    expect(plugin.connection.validate).toBeUndefined();
+  });
+
+  test("declares ES-specific forbiddenPatterns on the connection", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    expect(Array.isArray(plugin.connection.forbiddenPatterns)).toBe(true);
+    expect(plugin.connection.forbiddenPatterns!.length).toBeGreaterThan(0);
+  });
+
+  test("forbiddenPatterns block ES catalog/schema disclosure verbs", () => {
+    const matches = (sql: string) =>
+      ELASTICSEARCH_FORBIDDEN_PATTERNS.some((p) => p.test(sql));
+    expect(matches("SHOW TABLES")).toBe(true);
+    expect(matches("SHOW COLUMNS IN flights")).toBe(true);
+    expect(matches("SHOW FUNCTIONS")).toBe(true);
+    expect(matches("DESCRIBE flights")).toBe(true);
+    expect(matches("  show catalogs")).toBe(true);
+  });
+
+  test("forbiddenPatterns do NOT false-positive on legitimate SELECTs", () => {
+    const matches = (sql: string) =>
+      ELASTICSEARCH_FORBIDDEN_PATTERNS.some((p) => p.test(sql));
+    // ORDER BY ... DESC must not trip the guard.
+    expect(matches("SELECT origin FROM flights ORDER BY delay DESC LIMIT 10")).toBe(false);
+    // A field literally named `show` or `description` mid-query is fine.
+    expect(matches("SELECT show, description FROM tv_shows LIMIT 5")).toBe(false);
+  });
+
+  test("provides ES SQL dialect guidance for the agent system prompt", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    expect(typeof plugin.dialect).toBe("string");
+    expect(plugin.dialect!).toMatch(/Elasticsearch SQL/i);
+    expect(plugin.dialect!).toMatch(/executeSQL/);
+    // Single-index guidance (no JOINs across indices in the SQL surface).
+    expect(plugin.dialect!.toLowerCase()).toContain("index");
   });
 });

--- a/plugins/elasticsearch/package.json
+++ b/plugins/elasticsearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/elasticsearch",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Atlas Elasticsearch / OpenSearch datasource plugin",
   "type": "module",
   "main": "./src/index.ts",

--- a/plugins/elasticsearch/src/connection.ts
+++ b/plugins/elasticsearch/src/connection.ts
@@ -1,25 +1,34 @@
 /**
  * Elasticsearch connection foundation for the datasource plugin.
  *
- * Three deep, independently testable modules live here:
+ * Deep, independently testable modules live here:
  *   1. Config/URL + auth parser — `parseElasticsearchUrl` (URL → engine +
  *      endpoint) and `resolveElasticsearchConfig` ({ url, apiKey } → resolved
  *      config + auth descriptor). Mirrors `parseSalesforceURL`.
  *   2. Thin `fetch`-based HTTP client — `createElasticsearchClient`. No official
  *      SDK (`@elastic/elasticsearch` / `@opensearch-project/opensearch`); it
- *      talks to the cluster's read endpoints directly. This slice exposes only an
- *      authenticated cluster-info/ping round-trip; query surfaces arrive later.
- *   3. Error scrubbing — `scrubElasticsearchError` strips the API key and other
- *      sensitive markers before a message reaches the agent, the user, or logs.
+ *      talks to the cluster's read endpoints directly. Exposes `ping()`
+ *      (cluster-info round-trip) and `sqlQuery()` (the SQL query surface, #3262).
+ *   3. SQL surface — `sqlQuery()` POSTs to the cluster SQL API (`POST /_sql`),
+ *      follows `cursor` pagination up to a row cap, and `normalizeSqlPages` (a
+ *      PURE folder) maps ES SQL `{ columns:[{name,type}], rows:[[...]] }` pages
+ *      into Atlas `{ columns, rows }`. ES SQL is real SQL, so it rides the host's
+ *      standard 4-layer `executeSQL` pipeline — this module ships only the
+ *      `parserDialect` + `forbiddenPatterns` it configures (no custom validate).
+ *   4. Error scrubbing — `scrubElasticsearchError` strips the API key and other
+ *      sensitive markers before a message reaches the agent, the user, or logs;
+ *      `extractEsSqlErrorMessage` surfaces the actionable ES error reason first.
  *
- * This slice (#3261) handles `elasticsearch://` URLs with API-key auth only.
- * Basic / Cloud ID / AWS SigV4 auth and the OpenSearch engine are later slices.
+ * This slice handles `elasticsearch://` URLs with API-key auth only. Basic /
+ * Cloud ID / AWS SigV4 auth, the OpenSearch engine, and the Query DSL tool
+ * (#3267) are later slices.
  */
 
 import type {
   PluginDBConnection,
   PluginQueryResult,
   PluginLogger,
+  ParserDialect,
 } from "@useatlas/plugin-sdk";
 
 // ---------------------------------------------------------------------------
@@ -78,6 +87,158 @@ export interface ClusterInfo {
   version?: string;
   /** Distribution flavor (`version.distribution`), e.g. `elasticsearch`/`opensearch`. */
   distribution?: string;
+}
+
+// ---------------------------------------------------------------------------
+// SQL query surface (#3262)
+// ---------------------------------------------------------------------------
+
+/** A column descriptor from an ES SQL response (`{ name, type }`). */
+export interface ElasticsearchSqlColumn {
+  name: string;
+  /** ES type (`text`, `long`, `keyword`, …). Not consumed by Atlas yet. */
+  type?: string;
+}
+
+/**
+ * One page of the ES SQL API response. The first page carries `columns`; every
+ * page carries `rows` (positional arrays aligned to the column order) and, when
+ * more pages remain, a `cursor` to fetch the next one.
+ */
+export interface ElasticsearchSqlResponse {
+  columns?: ElasticsearchSqlColumn[];
+  rows?: unknown[][];
+  cursor?: string;
+}
+
+/** Options for a single (possibly multi-page) SQL query. */
+export interface ElasticsearchSqlQueryOptions {
+  /**
+   * The ES SQL statement. By the time it reaches here the host's `executeSQL`
+   * pipeline has already validated it (SELECT-only, index whitelist) and
+   * appended its auto-LIMIT — that LIMIT is the authoritative row cap.
+   */
+  query: string;
+  /** Total deadline for the whole multi-page fetch, in ms. Defaults to 30000. */
+  timeoutMs?: number;
+  /** ES `fetch_size` (rows per page). Defaults to {@link DEFAULT_FETCH_SIZE}. */
+  fetchSize?: number;
+  /**
+   * Defensive client-side ceiling on accumulated rows. The SQL's auto-LIMIT is
+   * the real cap; this only backstops a pathological cursor. Defaults to
+   * {@link DEFAULT_MAX_ROWS}. Truncation is logged, never silent.
+   */
+  maxRows?: number;
+}
+
+/** Default ES `fetch_size` (rows per page) when the caller doesn't set one. */
+export const DEFAULT_FETCH_SIZE = 1000;
+
+/**
+ * Defensive ceiling on rows accumulated across cursor pages. The host appends a
+ * `LIMIT` (default `ATLAS_ROW_LIMIT` = 1000) before the query reaches us, so in
+ * normal operation the cursor terminates well below this — it exists only to
+ * cap a runaway cursor. Comfortably above the typical limit so it never silently
+ * truncates legitimately-LIMITed results; if it ever does fire, we log a warning.
+ */
+export const DEFAULT_MAX_ROWS = 10000;
+
+/**
+ * node-sql-parser dialect for the ES SQL surface. ES SQL is standard SQL and the
+ * full documented subset (SELECT / WHERE / GROUP BY / HAVING / ORDER BY / LIMIT
+ * over a single index-as-table, plus COUNT/SUM/AVG/MIN/MAX and COUNT(DISTINCT))
+ * parses cleanly under PostgreSQL mode. PostgreSQL is chosen over MySQL because
+ * ES SQL quotes identifiers (index names with `-`, `.`, etc.) with double quotes
+ * — `SELECT * FROM "logs-2024.01.01"` — matching PostgreSQL, whereas MySQL mode
+ * expects backticks. (Verified against node-sql-parser 5.4.0.)
+ */
+export const ELASTICSEARCH_PARSER_DIALECT: ParserDialect = "PostgresQL";
+
+/**
+ * ES-specific forbidden patterns layered on top of the host's base DML/DDL guard.
+ *
+ * The `/_sql` endpoint is query-only (no INSERT/UPDATE/DELETE exist in ES SQL),
+ * so the base guard already covers mutations. What ES SQL adds are catalog- and
+ * schema-disclosure verbs — `SHOW TABLES|COLUMNS|FUNCTIONS|CATALOGS`, `DESCRIBE`
+ * — which enumerate every index/field and so bypass the index whitelist. They
+ * are already rejected downstream (the AST layer parses `SHOW` as a non-`select`
+ * node and `DESCRIBE <x>` fails to parse), but blocking them here gives a clear
+ * "forbidden operation" error and a defense-in-depth net independent of parser
+ * behavior.
+ *
+ * Anchored to the statement start (`^\s*`) on purpose: a SELECT never begins
+ * with these verbs, so anchoring blocks the standalone commands without ever
+ * false-positiving on a field literally named `show`/`description`. Bare `DESC`
+ * is deliberately NOT blocked — it is the `ORDER BY … DESC` sort direction.
+ */
+export const ELASTICSEARCH_FORBIDDEN_PATTERNS: RegExp[] = [
+  /^\s*SHOW\b/i,
+  /^\s*DESCRIBE\b/i,
+];
+
+/**
+ * PURE: fold a sequence of ES SQL response pages into Atlas `{ columns, rows }`.
+ *
+ * Column names are taken from the first page that declares them (cursor pages
+ * omit `columns`). Each positional row array is zipped against those names into
+ * a record. Falsy scalars (`0`, `false`, `""`) are preserved; a missing trailing
+ * cell becomes `null`. Accumulation stops once `maxRows` records are collected.
+ *
+ * Side-effect free and HTTP-free so it can be unit-tested in isolation — the
+ * cursor-following fetch loop lives in {@link createElasticsearchClient}.
+ */
+export function normalizeSqlPages(
+  pages: ElasticsearchSqlResponse[],
+  maxRows: number = Number.POSITIVE_INFINITY,
+): PluginQueryResult {
+  const columnDefs =
+    pages.find((p) => Array.isArray(p.columns) && p.columns.length > 0)?.columns ?? [];
+  const columns = columnDefs.map((c) => c.name);
+
+  const rows: Record<string, unknown>[] = [];
+  for (const page of pages) {
+    for (const rowArr of page.rows ?? []) {
+      if (rows.length >= maxRows) return { columns, rows };
+      const record: Record<string, unknown> = {};
+      for (let i = 0; i < columns.length; i++) {
+        const value = rowArr[i];
+        // `?? null` only replaces null/undefined — 0, false, "" survive.
+        record[columns[i]] = value ?? null;
+      }
+      rows.push(record);
+    }
+  }
+  return { columns, rows };
+}
+
+/**
+ * PURE: extract an actionable message from an ES SQL error response body.
+ *
+ * ES returns structured errors — `{ error: { type, reason }, status }` — whose
+ * `reason` (e.g. "Unknown column [foo]") lets the agent self-correct. Prefer
+ * `type: reason`, then `reason`, then `type`, then a string `error`, and finally
+ * fall back to the HTTP status line. The caller scrubs the result through
+ * {@link scrubElasticsearchError} before it leaves the process.
+ */
+export function extractEsSqlErrorMessage(
+  body: unknown,
+  status: number,
+  statusText: string,
+): string {
+  const fallback = `Elasticsearch SQL request failed: HTTP ${status} ${statusText}`;
+  if (body && typeof body === "object" && "error" in body) {
+    const error = (body as { error: unknown }).error;
+    if (typeof error === "string" && error.trim()) return error;
+    if (error && typeof error === "object") {
+      const e = error as { type?: unknown; reason?: unknown };
+      const reason = typeof e.reason === "string" && e.reason.trim() ? e.reason : undefined;
+      const type = typeof e.type === "string" && e.type.trim() ? e.type : undefined;
+      if (reason && type) return `${type}: ${reason}`;
+      if (reason) return reason;
+      if (type) return type;
+    }
+  }
+  return fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -245,6 +406,12 @@ export function resolveElasticsearchConfig(
 export interface ElasticsearchClient {
   /** Authenticated cluster-info round-trip (`GET /`). Resolves cluster metadata. */
   ping(timeoutMs?: number): Promise<ClusterInfo>;
+  /**
+   * Run an ES SQL statement via `POST /_sql`, following `cursor` pagination up to
+   * the row cap, and return the normalized `{ columns, rows }`. Errors are
+   * secret-scrubbed before they reach the caller.
+   */
+  sqlQuery(opts: ElasticsearchSqlQueryOptions): Promise<PluginQueryResult>;
   /** Release the client — aborts any in-flight request and rejects future calls. */
   close(): void;
 }
@@ -326,6 +493,108 @@ export function createElasticsearchClient(
       }
     },
 
+    async sqlQuery(opts: ElasticsearchSqlQueryOptions): Promise<PluginQueryResult> {
+      if (closed) {
+        throw new Error("Elasticsearch client is closed");
+      }
+
+      const {
+        query,
+        timeoutMs = 30000,
+        fetchSize = DEFAULT_FETCH_SIZE,
+        maxRows = DEFAULT_MAX_ROWS,
+      } = opts;
+
+      const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+      const controller = new AbortController();
+      inFlight.add(controller);
+      // One deadline for the whole multi-page fetch — the statement timeout
+      // bounds total wall-clock across every cursor page, not each page.
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      const headers = {
+        Authorization: `ApiKey ${auth.apiKey}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+
+      /** POST a payload to `/_sql` and return the parsed page (throws on non-2xx). */
+      const postSql = async (
+        payload: Record<string, unknown>,
+      ): Promise<ElasticsearchSqlResponse> => {
+        const res = await fetchImpl(`${endpoint}/_sql?format=json`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          // Read the body for the actionable ES error reason; fall back to the
+          // status line if it isn't JSON. The message is scrubbed in the catch.
+          let body: unknown;
+          try {
+            body = await res.json();
+          } catch {
+            // intentionally ignored: a non-JSON error body just falls back to
+            // the HTTP status line via extractEsSqlErrorMessage.
+            body = undefined;
+          }
+          throw new Error(extractEsSqlErrorMessage(body, res.status, res.statusText));
+        }
+        return (await res.json()) as ElasticsearchSqlResponse;
+      };
+
+      try {
+        const pages: ElasticsearchSqlResponse[] = [];
+        let rowCount = 0;
+
+        let page = await postSql({ query, fetch_size: fetchSize });
+        pages.push(page);
+        rowCount += page.rows?.length ?? 0;
+
+        while (page.cursor && rowCount < maxRows) {
+          page = await postSql({ cursor: page.cursor });
+          pages.push(page);
+          rowCount += page.rows?.length ?? 0;
+        }
+
+        // Stopped early on the row cap with a live cursor: log (never silent) and
+        // best-effort release the server-side cursor so it doesn't linger.
+        if (page.cursor && rowCount >= maxRows) {
+          options?.logger?.warn(
+            { maxRows },
+            `Elasticsearch SQL result truncated at the client row cap (${maxRows}); a LIMIT below ${maxRows} avoids truncation.`,
+          );
+          try {
+            await fetchImpl(`${endpoint}/_sql/close`, {
+              method: "POST",
+              headers,
+              body: JSON.stringify({ cursor: page.cursor }),
+              signal: controller.signal,
+            });
+          } catch (closeErr) {
+            options?.logger?.debug(
+              { err: closeErr instanceof Error ? closeErr.message : String(closeErr) },
+              "Failed to close Elasticsearch SQL cursor (non-fatal)",
+            );
+          }
+        }
+
+        return normalizeSqlPages(pages, maxRows);
+      } catch (err) {
+        if (controller.signal.aborted && !closed) {
+          throw new Error(
+            `Elasticsearch SQL query timed out after ${timeoutMs}ms`,
+          );
+        }
+        // Scrub before surfacing — see the ping() rationale above (no cause chain).
+        throw new Error(scrubElasticsearchError(err, auth.apiKey));
+      } finally {
+        clearTimeout(timer);
+        inFlight.delete(controller);
+      }
+    },
+
     close(): void {
       closed = true;
       for (const controller of inFlight) {
@@ -342,8 +611,8 @@ export function createElasticsearchClient(
 
 /**
  * A {@link PluginDBConnection} for Elasticsearch, extended with `ping()` for the
- * health check. `query()` is intentionally unimplemented in this slice — the SQL
- * surface (`executeSQL`) arrives in #3262 and the Query DSL tool in #3267.
+ * health check. `query()` runs ES SQL via the cluster SQL API (#3262); the Query
+ * DSL tool arrives in #3267.
  */
 export interface ElasticsearchConnection extends PluginDBConnection {
   ping(timeoutMs?: number): Promise<ClusterInfo>;
@@ -363,10 +632,11 @@ export function createElasticsearchConnection(
   const client = createElasticsearchClient(resolved, options);
 
   return {
-    async query(_sql: string, _timeoutMs?: number): Promise<PluginQueryResult> {
-      throw new Error(
-        "Elasticsearch query surface is not available yet — it arrives in a later slice (#3262).",
-      );
+    async query(sql: string, timeoutMs?: number): Promise<PluginQueryResult> {
+      // ES SQL is real SQL: the host's `executeSQL` pipeline has already run the
+      // 4-layer validation (SELECT-only, index whitelist) and appended its
+      // auto-LIMIT before calling here. We just execute + normalize the result.
+      return client.sqlQuery({ query: sql, timeoutMs });
     },
 
     async ping(timeoutMs?: number): Promise<ClusterInfo> {

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -39,8 +39,27 @@ import {
   parseElasticsearchUrl,
   extractHost,
   scrubElasticsearchError,
+  ELASTICSEARCH_PARSER_DIALECT,
+  ELASTICSEARCH_FORBIDDEN_PATTERNS,
 } from "./connection";
 import type { ElasticsearchConnection, ElasticsearchPluginConfig } from "./connection";
+
+/**
+ * ES SQL dialect guidance injected into the agent system prompt (under
+ * "## Additional SQL Dialect Notes"). ES SQL is standard SQL over a single
+ * index-as-table via the `executeSQL` tool — these notes steer the agent away
+ * from the few places it diverges (no cross-index JOINs, double-quote index
+ * names with special characters).
+ */
+const ELASTICSEARCH_DIALECT_GUIDE = [
+  "This datasource is Elasticsearch SQL (the cluster `/_sql` API), queried with the `executeSQL` tool.",
+  "- Each Elasticsearch index is a table — `SELECT ... FROM <index>`. One index per query: there are NO JOINs across indices.",
+  "- Quote index names containing `-`, `.`, or `:` with double quotes, e.g. `SELECT * FROM \"logs-2024.01.01\"`.",
+  "- Supported: WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, and the aggregates COUNT, SUM, AVG, MIN, MAX (incl. COUNT(DISTINCT ...)).",
+  "- Standard predicates work: =, <, >, IN (...), BETWEEN, LIKE, IS NULL.",
+  "- A nested field is addressed by its dotted path (e.g. `geo.dest`).",
+  "- Read-only: only SELECT is allowed. SHOW/DESCRIBE and any DML/DDL are rejected.",
+].join("\n");
 
 const ElasticsearchConfigSchema = z.object({
   /** Elasticsearch connection URL (elasticsearch://host:9200). */
@@ -109,11 +128,18 @@ export function buildElasticsearchPlugin(
     connection: {
       create: () => getOrCreateConnection(),
       dbType: "elasticsearch",
-      // No custom `validate` and no `parserDialect`/`forbiddenPatterns` yet —
-      // the query surfaces (and their validation) arrive in #3262.
+      // ES SQL is real SQL, so there is intentionally NO custom `validate`: the
+      // host's standard 4-layer pipeline (regex guard → AST parse → index/table
+      // whitelist → auto-LIMIT + timeout) applies unchanged. We only tell it
+      // which grammar to parse with and add ES-specific guards on top of the
+      // base DML/DDL regex.
+      parserDialect: ELASTICSEARCH_PARSER_DIALECT,
+      forbiddenPatterns: ELASTICSEARCH_FORBIDDEN_PATTERNS,
     },
 
     entities: [],
+
+    dialect: ELASTICSEARCH_DIALECT_GUIDE,
 
     /**
      * Serializable config schema for the admin install form + the secret
@@ -214,6 +240,12 @@ export {
   createElasticsearchConnection,
   scrubElasticsearchError,
   SENSITIVE_PATTERNS,
+  normalizeSqlPages,
+  extractEsSqlErrorMessage,
+  ELASTICSEARCH_PARSER_DIALECT,
+  ELASTICSEARCH_FORBIDDEN_PATTERNS,
+  DEFAULT_FETCH_SIZE,
+  DEFAULT_MAX_ROWS,
 } from "./connection";
 export type {
   ElasticsearchEngine,
@@ -226,4 +258,7 @@ export type {
   ElasticsearchClient,
   ElasticsearchClientOptions,
   ClusterInfo,
+  ElasticsearchSqlColumn,
+  ElasticsearchSqlResponse,
+  ElasticsearchSqlQueryOptions,
 } from "./connection";


### PR DESCRIPTION
## What & why

First **query surface** for the `@useatlas/elasticsearch` datasource (#3262, milestone v0.0.13): tabular/aggregate questions over a single Elasticsearch index, answered through the existing `executeSQL` tool. Builds on the connection foundation (#3261), which shipped the thin fetch client with `ping()` only and a `query()` that threw "arrives in a later slice (#3262)" — this implements that.

## Decision checkpoint — node-sql-parser accepts the ES SQL subset

Per the issue's required decision checkpoint, I probed `node-sql-parser` 5.4.0 against a representative ES SQL subset **before** writing the adapter.

**Result: `node-sql-parser` (PostgreSQL mode) cleanly parses the full documented subset — no custom `validate()` fallback needed.** All 14 representative queries parsed as `select` and `tableList` extracted the index name correctly, including double-quoted index names with special chars (`"logs-2024.01.01"`):

- `SELECT *` / projection / `WHERE` (`=`,`<`,`>`,`IN`,`BETWEEN`,`LIKE`,`IS NULL`)
- `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `DISTINCT`
- aggregates `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `COUNT(DISTINCT …)`

**Why `PostgresQL` over `MySQL`:** ES SQL quotes identifiers (index names with `-`/`.`/`:`) with **double quotes** — matching PostgreSQL — whereas MySQL mode expects backticks. DML (`DELETE`/`UPDATE`/`INSERT`/`DROP`) parses as its non-`select` type and is rejected by the pipeline's SELECT-only AST check (and the regex guard first).

So the connection declares `parserDialect: "PostgresQL"` + ES-specific `forbiddenPatterns` and sets **no** custom `validate()` — the host's standard 4-layer pipeline (regex guard → AST single-`SELECT` parse → index whitelist → auto-`LIMIT` + statement timeout) applies unchanged. Supported subset is documented in the plugin README and a code comment on `ELASTICSEARCH_PARSER_DIALECT`.

## Changes

- **`connection.query()`** → `POST /_sql?format=json`, follows the response `cursor` across pages up to a defensive client-side row cap (10,000; the host's auto-`LIMIT` is the authoritative cap), best-effort `POST /_sql/close` on early stop (logged, never silent).
- **`normalizeSqlPages` (PURE)** — folds ES SQL `{columns:[{name,type}], rows:[[…]]}` pages into Atlas `{columns, rows}`. Columns from the first page (cursor pages omit them); falsy scalars (`0`/`false`/`""`) preserved; short rows null-filled. Unit-tested in isolation (scalar, multi-page cursor, empty, truncation, null-fill).
- **`extractEsSqlErrorMessage` (PURE)** — surfaces the actionable ES error reason (e.g. `Unknown column [foo]`) so the agent can self-correct; everything still runs through `scrubElasticsearchError` (literal key redacted, auth-marker messages collapsed) before reaching agent/user/logs.
- **ES-specific `forbiddenPatterns`** — anchored `/^\s*SHOW\b/i` + `/^\s*DESCRIBE\b/i` block the catalog/schema-disclosure verbs that bypass the index whitelist. Anchoring to statement-start means no false positives on a field named `show`/`description`, and `ORDER BY … DESC` is unaffected. Layered on top of the base DML/DDL guard.
- **Agent system prompt** — ES SQL `dialect` guidance via the plugin `.dialect` field (one index per query, no cross-index JOINs, double-quote special-char index names, supported clauses/aggregates).
- Bumps `@useatlas/elasticsearch` `0.0.1` → `0.0.2` (+ `bun.lock` sync). No consumers, so no ref-bump follow-up needed.

## Tests & gates

- `plugins/elasticsearch/__tests__/elasticsearch.test.ts`: **80 pass** (added 24, built TDD red→green from the pure normalizer). Covers normalizer, error extractor, `sqlQuery` (POST shape, cursor pagination, maxRows + cursor close, scrubbed errors, timeout, closed), and SQL-surface wiring (parserDialect/forbiddenPatterns/dialect/no-validate).
- Full `/ci` green: lint, type, test (full suite), syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols.

## End-to-end acceptance

Configure the plugin → ask a tabular/aggregate question over a single index in chat (e.g. "orders per status") → agent issues `SELECT status, COUNT(*) … GROUP BY status` via `executeSQL` → correct table.

Closes #3262.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783385143&installation_id=135337507&pr_number=3293&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3293&signature=e9982bd3e0809adbf3445675a5a61c433dc516f44b7ef363acf8b42ce2782ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQL query execution for Elasticsearch with cursor-based pagination, client-side row caps, and truncation warnings
  * Enforced read-only SQL subset and blocked catalog-disclosure patterns (e.g., SHOW/DESCRIBE)

* **Documentation**
  * Expanded README detailing the SQL query surface, validation pipeline, and error-handling/scrubbing behavior

* **Tests**
  * Expanded test coverage for SQL normalization, pagination, error extraction, security guards, and client behavior

* **Chores**
  * Bumped plugin package version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->