### PR TITLE
feat: ES/OpenSearch — atlas init + diff mapping→entity-YAML profiler (#3268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
 # When atlas.config.ts defines datasources, this env var is not needed.
 ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 # ATLAS_DATASOURCE_URL=mysql://user:pass@localhost:3306/mydb
+# ATLAS_DATASOURCE_URL=elasticsearch://my-cluster.es.io:9243   # Elasticsearch (HTTPS; append ?ssl=false for a local cluster)
+# ATLAS_ES_API_KEY=                            # Base64 API key for the Elasticsearch datasource above. Required by `atlas init`/`diff` — the key is NOT carried in the elasticsearch:// URL
 
 # === LLM Provider (pick one) ===
 # ATLAS_PROVIDER=anthropic

--- a/packages/cli/lib/cli-utils.ts
+++ b/packages/cli/lib/cli-utils.ts
@@ -99,10 +99,11 @@ export function detectDBType(url: string): DBType {
   if (url.startsWith("snowflake://")) return "snowflake";
   if (url.startsWith("duckdb://")) return "duckdb";
   if (url.startsWith("salesforce://")) return "salesforce";
+  if (url.startsWith("elasticsearch://")) return "elasticsearch";
   const scheme = url.split("://")[0] || "(empty)";
   throw new Error(
     `Unsupported database URL scheme "${scheme}://". ` +
-      "Supported: postgresql://, mysql://, clickhouse://, snowflake://, duckdb://, salesforce://.",
+      "Supported: postgresql://, mysql://, clickhouse://, snowflake://, duckdb://, salesforce://, elasticsearch://.",
   );
 }
 

--- a/packages/cli/lib/diff.ts
+++ b/packages/cli/lib/diff.ts
@@ -6,6 +6,7 @@
 
 import type { TableProfile } from "@atlas/api/lib/profiler";
 import { mapSQLType, isView, isMatView } from "@atlas/api/lib/profiler";
+import type { EsEntityDoc } from "../../../plugins/elasticsearch/src/mapping";
 
 // --- Schema diff types ---
 
@@ -162,6 +163,29 @@ export function profileToSnapshot(profile: TableProfile): EntitySnapshot {
     objectType,
     partitionStrategy: profile.partition_info?.strategy,
     partitionKey: profile.partition_info?.key,
+  };
+}
+
+/**
+ * Build an EntitySnapshot from an Elasticsearch entity doc (one per index).
+ *
+ * The mirror of {@link profileToSnapshot} for the ES path: each flattened
+ * mapping field becomes a column (`name → mapped type`), keyed exactly as
+ * {@link parseEntityYAML} reads them back, so a freshly-profiled index diffs
+ * clean against its own emitted YAML. Elasticsearch has no foreign keys, so the
+ * FK set is always empty.
+ */
+export function esEntityToSnapshot(entity: EsEntityDoc): EntitySnapshot {
+  const columns = new Map<string, string>();
+  for (const dim of entity.dimensions) {
+    columns.set(dim.name, dim.type);
+  }
+
+  return {
+    table: entity.table,
+    columns,
+    foreignKeys: new Set<string>(),
+    objectType: entity.type,
   };
 }
 

--- a/packages/cli/lib/profilers/elasticsearch.ts
+++ b/packages/cli/lib/profilers/elasticsearch.ts
@@ -1,0 +1,120 @@
+/**
+ * Elasticsearch / OpenSearch profiler.
+ *
+ * Unlike the SQL profilers (which build `TableProfile`s for the shared
+ * `generateEntityYAML` pipeline), Elasticsearch has no rows / PKs / FKs and its
+ * query surface is Elasticsearch SQL — so it profiles index `_mapping`s
+ * straight into entity docs via the plugin's pure `mappingsToEntities`
+ * transform. `atlas init` serializes the docs to `semantic/entities/*.yml`;
+ * `atlas diff` compares them against the on-disk layer.
+ *
+ * The API key is NOT carried in the `elasticsearch://` URL (the URL parser
+ * rejects credentials); the caller passes it separately (resolved from
+ * `ATLAS_ES_API_KEY`).
+ */
+
+import type { ProfileError } from "@atlas/api/lib/profiler";
+import type { ProfileProgressCallbacks } from "../../src/progress";
+import type { EsEntityDoc } from "../../../../plugins/elasticsearch/src/mapping";
+
+export interface ElasticsearchProfilingResult {
+  entities: EsEntityDoc[];
+  errors: ProfileError[];
+}
+
+export interface ProfileElasticsearchOptions {
+  /** Connection-group scope written onto each entity (ADR-0012). */
+  group?: string;
+  /** Include dot-prefixed system indices (`.kibana`, `.security`…). Default false. */
+  includeSystem?: boolean;
+  /** Inject a fetch implementation (tests). Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  progress?: ProfileProgressCallbacks;
+}
+
+/**
+ * Profile an Elasticsearch cluster into entity docs — one per index. Fetches
+ * `_mapping` once (covers every index) via the thin client, then runs the pure
+ * mapping→entity transform. Connection / mapping-fetch failures surface as a
+ * secret-scrubbed error.
+ *
+ * @param connectionString `elasticsearch://host[:port][/prefix]` (no credentials).
+ * @param apiKey Base64 API key (from `ATLAS_ES_API_KEY`).
+ * @param filterIndices When set, only these indices are profiled; any requested
+ *   index absent from the cluster mapping is reported in `errors`.
+ */
+export async function profileElasticsearch(
+  connectionString: string,
+  apiKey: string,
+  filterIndices?: string[],
+  options?: ProfileElasticsearchOptions,
+): Promise<ElasticsearchProfilingResult> {
+  const { resolveElasticsearchConfig, createElasticsearchClient, scrubElasticsearchError } =
+    await import("../../../../plugins/elasticsearch/src/connection");
+  const { mappingsToEntities } = await import(
+    "../../../../plugins/elasticsearch/src/mapping"
+  );
+
+  const resolved = resolveElasticsearchConfig({ url: connectionString, apiKey });
+  const client = createElasticsearchClient(
+    resolved,
+    options?.fetchImpl ? { fetchImpl: options.fetchImpl } : undefined,
+  );
+
+  const errors: ProfileError[] = [];
+
+  try {
+    const mapping = await client.getMapping();
+
+    let entities = mappingsToEntities(mapping, {
+      includeSystem: options?.includeSystem ?? false,
+      ...(options?.group ? { group: options.group } : {}),
+    });
+
+    if (filterIndices && filterIndices.length > 0) {
+      const wanted = new Set(filterIndices);
+      entities = entities.filter((e) => wanted.has(e.table));
+      const found = new Set(entities.map((e) => e.table));
+      for (const idx of filterIndices) {
+        if (!found.has(idx)) {
+          errors.push({
+            table: idx,
+            error: "Index not found in the cluster mapping (or has no fields).",
+          });
+        }
+      }
+    }
+
+    options?.progress?.onStart(entities.length);
+    return { entities, errors };
+  } catch (err) {
+    // `getMapping` already scrubs its errors, and `resolveElasticsearchConfig`
+    // errors carry no credential — so the caught error is credential-free and
+    // its cause chain is safe to preserve (unlike inside the client, which must
+    // drop the cause because the raw fetch error can echo the API key).
+    throw new Error(scrubElasticsearchError(err, apiKey), { cause: err });
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Build a minimal `catalog.yml` object for the profiled indices — the discovery
+ * index every `atlas init` writes alongside `entities/`. ES has no metrics /
+ * glossary in this slice, so the catalog is an entity listing only.
+ */
+export function elasticsearchCatalog(
+  entities: EsEntityDoc[],
+): Record<string, unknown> {
+  return {
+    version: "1.0",
+    entities: entities.map((e) => ({
+      name: e.name,
+      file: `entities/${e.table}.yml`,
+      grain: e.grain,
+      description: `${e.table} (Elasticsearch index, ${e.dimensions.length} field${e.dimensions.length === 1 ? "" : "s"})`,
+      use_for: [`Search and aggregation over the ${e.table} index`],
+      common_questions: [`What documents are in ${e.table}?`],
+    })),
+  };
+}

--- a/packages/cli/lib/profilers/elasticsearch.ts
+++ b/packages/cli/lib/profilers/elasticsearch.ts
@@ -47,11 +47,14 @@ export async function profileElasticsearch(
   filterIndices?: string[],
   options?: ProfileElasticsearchOptions,
 ): Promise<ElasticsearchProfilingResult> {
+  // Independent modules — load concurrently (no async waterfall).
+  const [connectionModule, mappingModule] = await Promise.all([
+    import("../../../../plugins/elasticsearch/src/connection"),
+    import("../../../../plugins/elasticsearch/src/mapping"),
+  ]);
   const { resolveElasticsearchConfig, createElasticsearchClient, scrubElasticsearchError } =
-    await import("../../../../plugins/elasticsearch/src/connection");
-  const { mappingsToEntities } = await import(
-    "../../../../plugins/elasticsearch/src/mapping"
-  );
+    connectionModule;
+  const { mappingsToEntities } = mappingModule;
 
   const resolved = resolveElasticsearchConfig({ url: connectionString, apiKey });
   const client = createElasticsearchClient(

--- a/packages/cli/lib/profilers/elasticsearch.ts
+++ b/packages/cli/lib/profilers/elasticsearch.ts
@@ -14,7 +14,6 @@
  */
 
 import type { ProfileError } from "@atlas/api/lib/profiler";
-import type { ProfileProgressCallbacks } from "../../src/progress";
 import type { EsEntityDoc } from "../../../../plugins/elasticsearch/src/mapping";
 
 export interface ElasticsearchProfilingResult {
@@ -29,7 +28,6 @@ export interface ProfileElasticsearchOptions {
   includeSystem?: boolean;
   /** Inject a fetch implementation (tests). Defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
-  progress?: ProfileProgressCallbacks;
 }
 
 /**
@@ -85,7 +83,8 @@ export async function profileElasticsearch(
       }
     }
 
-    options?.progress?.onStart(entities.length);
+    // One `_mapping` round-trip covers every index, so there is no per-index
+    // progress to report — the caller logs the index list from `entities`.
     return { entities, errors };
   } catch (err) {
     // `getMapping` already scrubs its errors, and `resolveElasticsearchConfig`

--- a/packages/cli/lib/profilers/index.ts
+++ b/packages/cli/lib/profilers/index.ts
@@ -21,3 +21,9 @@ export {
   listDuckDBObjects,
   profileDuckDB,
 } from "./duckdb";
+
+export {
+  type ElasticsearchProfilingResult,
+  type ProfileElasticsearchOptions,
+  profileElasticsearch,
+} from "./elasticsearch";

--- a/packages/cli/lib/test-connection.ts
+++ b/packages/cli/lib/test-connection.ts
@@ -260,6 +260,43 @@ export async function testDatabaseConnection(
       }
     }
 
+    case "elasticsearch": {
+      // The API key is NOT in the elasticsearch:// URL (the parser rejects
+      // credentials) — it is a separate secret, read from ATLAS_ES_API_KEY.
+      const apiKey = process.env.ATLAS_ES_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "ATLAS_ES_API_KEY is required for an Elasticsearch datasource. " +
+            "Set it to the base64 API key for the cluster.",
+        );
+      }
+      const {
+        resolveElasticsearchConfig,
+        createElasticsearchClient,
+        scrubElasticsearchError,
+      } = await import("../../../plugins/elasticsearch/src/connection");
+      const client = createElasticsearchClient(
+        resolveElasticsearchConfig({ url: connStr, apiKey }),
+      );
+      try {
+        const info = await client.ping(5000);
+        const distribution = info.distribution ?? "elasticsearch";
+        const version = info.version ? ` ${info.version}` : "";
+        const cluster = info.clusterName ? ` (cluster: ${info.clusterName})` : "";
+        return `Elasticsearch [${distribution}${version}]${cluster}`;
+      } catch (err) {
+        // `client.ping` already scrubs its errors and config errors carry no
+        // credential, so the caught error is credential-free — preserving the
+        // cause chain is safe here.
+        throw new Error(
+          `Cannot connect to Elasticsearch: ${scrubElasticsearchError(err, apiKey)}`,
+          { cause: err },
+        );
+      } finally {
+        client.close();
+      }
+    }
+
     case "postgres":
     default: {
       const testPool = new Pool({

--- a/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
+++ b/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
@@ -102,6 +102,25 @@ describe("profileElasticsearch", () => {
     expect(entities.map((e) => e.table)).toContain(".kibana");
   });
 
+  test("returns empty (no entities, no errors) for a cluster with no user indices", async () => {
+    // A fresh cluster (or one exposing only system/empty indices) — the empty
+    // result is the contract the init/diff callers turn into a clear error.
+    const onlySystem = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch({
+        ".kibana": { mappings: { properties: { config: { type: "keyword" } } } },
+        empty_index: { mappings: { properties: {} } },
+      }),
+    });
+    expect(onlySystem.entities).toEqual([]);
+    expect(onlySystem.errors).toEqual([]);
+
+    const emptyMapping = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch({}),
+    });
+    expect(emptyMapping.entities).toEqual([]);
+    expect(emptyMapping.errors).toEqual([]);
+  });
+
   test("surfaces a secret-scrubbed error when the mapping fetch fails", async () => {
     const failing = mock(async () =>
       fetchResponse(

--- a/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
+++ b/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, mock } from "bun:test";
+import * as yaml from "js-yaml";
+
+import {
+  profileElasticsearch,
+  elasticsearchCatalog,
+} from "../../lib/profilers/elasticsearch";
+import {
+  esEntityToSnapshot,
+  parseEntityYAML,
+  computeDiff,
+  type EntitySnapshot,
+} from "../../lib/diff";
+
+const URL = "elasticsearch://localhost:9200?ssl=false";
+const API_KEY = "dGVzdC1lcy1rZXk=";
+
+/** Minimal Response-like object for the mocked fetch (client reads ok/status/json). */
+function fetchResponse(
+  body: unknown,
+  init?: { ok?: boolean; status?: number; statusText?: string },
+): Response {
+  const status = init?.status ?? 200;
+  return {
+    ok: init?.ok ?? (status >= 200 && status < 300),
+    status,
+    statusText: init?.statusText ?? "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** A fetch that returns a fixed `_mapping` body for any request. */
+function mappingFetch(body: unknown): typeof fetch {
+  return mock(async () => fetchResponse(body)) as unknown as typeof fetch;
+}
+
+const MAPPING = {
+  products: {
+    mappings: {
+      properties: {
+        sku: { type: "keyword" },
+        title: { type: "text", fields: { keyword: { type: "keyword" } } },
+        price: { type: "double" },
+        created_at: { type: "date" },
+        vendor: { properties: { name: { type: "text" }, rating: { type: "float" } } },
+      },
+    },
+  },
+  customers: {
+    mappings: { properties: { email: { type: "keyword" } } },
+  },
+  ".kibana": {
+    mappings: { properties: { config: { type: "keyword" } } },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// profileElasticsearch
+// ---------------------------------------------------------------------------
+
+describe("profileElasticsearch", () => {
+  test("profiles every non-system index into an entity doc", async () => {
+    const { entities, errors } = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    expect(errors).toEqual([]);
+    expect(entities.map((e) => e.table).sort()).toEqual(["customers", "products"]);
+    const products = entities.find((e) => e.table === "products")!;
+    const names = products.dimensions.map((d) => d.name);
+    expect(names).toContain("sku");
+    expect(names).toContain("title.keyword");
+    expect(names).toContain("vendor.rating");
+    expect(names).not.toContain("vendor"); // object container is not a field
+  });
+
+  test("filters to requested indices and reports missing ones", async () => {
+    const { entities, errors } = await profileElasticsearch(
+      URL,
+      API_KEY,
+      ["products", "does_not_exist"],
+      { fetchImpl: mappingFetch(MAPPING) },
+    );
+    expect(entities.map((e) => e.table)).toEqual(["products"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].table).toBe("does_not_exist");
+  });
+
+  test("threads the connection-group scope onto each entity", async () => {
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      group: "warehouse",
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    expect(entities.every((e) => e.group === "warehouse")).toBe(true);
+  });
+
+  test("includes system indices only when asked", async () => {
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      includeSystem: true,
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    expect(entities.map((e) => e.table)).toContain(".kibana");
+  });
+
+  test("surfaces a secret-scrubbed error when the mapping fetch fails", async () => {
+    const failing = mock(async () =>
+      fetchResponse(
+        { error: `denied for ApiKey ${API_KEY}` },
+        { ok: false, status: 403, statusText: "Forbidden" },
+      ),
+    ) as unknown as typeof fetch;
+    let message = "";
+    try {
+      await profileElasticsearch(URL, API_KEY, undefined, { fetchImpl: failing });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("403");
+    expect(message).not.toContain(API_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// esEntityToSnapshot + end-to-end diff round-trip
+// ---------------------------------------------------------------------------
+
+describe("esEntityToSnapshot", () => {
+  test("maps each dimension to a column (name → type), no FKs", async () => {
+    const { entities } = await profileElasticsearch(URL, API_KEY, ["products"], {
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    const snap = esEntityToSnapshot(entities[0]);
+    expect(snap.table).toBe("products");
+    expect(snap.columns.get("sku")).toBe("string");
+    expect(snap.columns.get("price")).toBe("number");
+    expect(snap.columns.get("created_at")).toBe("timestamp");
+    expect(snap.foreignKeys.size).toBe(0);
+  });
+});
+
+describe("Elasticsearch diff round-trip", () => {
+  /** Profile a mapping, serialize each entity to YAML, parse it back — the
+   *  on-disk semantic-layer side of `atlas diff`. */
+  async function yamlSnapshotsFor(body: unknown): Promise<Map<string, EntitySnapshot>> {
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch(body),
+    });
+    const snapshots = new Map<string, EntitySnapshot>();
+    for (const entity of entities) {
+      const doc = yaml.load(yaml.dump(entity)) as Record<string, unknown>;
+      snapshots.set(entity.table, parseEntityYAML(doc));
+    }
+    return snapshots;
+  }
+
+  test("a freshly-profiled index diffs clean against its own YAML", async () => {
+    const yamlSnaps = await yamlSnapshotsFor(MAPPING);
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    const dbSnaps = new Map<string, EntitySnapshot>(
+      entities.map((e) => [e.table, esEntityToSnapshot(e)]),
+    );
+    const diff = computeDiff(dbSnaps, yamlSnaps);
+    expect(diff.newTables).toEqual([]);
+    expect(diff.removedTables).toEqual([]);
+    expect(diff.tableDiffs).toEqual([]);
+  });
+
+  test("reports added / removed / changed fields when the mapping drifts", async () => {
+    // YAML side = original MAPPING; live side = a mutated products mapping.
+    const yamlSnaps = await yamlSnapshotsFor(MAPPING);
+
+    const MUTATED = {
+      products: {
+        mappings: {
+          properties: {
+            sku: { type: "keyword" },
+            title: { type: "text", fields: { keyword: { type: "keyword" } } },
+            price: { type: "keyword" }, // double(number) → keyword(string): type change
+            brand: { type: "keyword" }, // added
+            vendor: { properties: { name: { type: "text" }, rating: { type: "float" } } },
+            // created_at removed
+          },
+        },
+      },
+      customers: MAPPING.customers,
+    };
+
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch(MUTATED),
+    });
+    const dbSnaps = new Map<string, EntitySnapshot>(
+      entities.map((e) => [e.table, esEntityToSnapshot(e)]),
+    );
+
+    const diff = computeDiff(dbSnaps, yamlSnaps);
+    const products = diff.tableDiffs.find((t) => t.table === "products");
+    expect(products).toBeDefined();
+    expect(products!.addedColumns.map((c) => c.name)).toContain("brand");
+    expect(products!.removedColumns.map((c) => c.name)).toContain("created_at");
+    expect(products!.typeChanges.map((c) => c.name)).toContain("price");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elasticsearchCatalog
+// ---------------------------------------------------------------------------
+
+describe("elasticsearchCatalog", () => {
+  test("lists one catalog entry per entity", async () => {
+    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+      fetchImpl: mappingFetch(MAPPING),
+    });
+    const catalog = elasticsearchCatalog(entities) as {
+      version: string;
+      entities: { name: string; file: string }[];
+    };
+    expect(catalog.version).toBe("1.0");
+    expect(catalog.entities).toHaveLength(2);
+    expect(catalog.entities.map((e) => e.file).sort()).toEqual([
+      "entities/customers.yml",
+      "entities/products.yml",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -28,9 +28,12 @@ import { testDatabaseConnection } from "../../lib/test-connection";
 import {
   parseEntityYAML,
   profileToSnapshot,
+  esEntityToSnapshot,
   computeDiff,
   formatDiff,
+  type EntitySnapshot,
 } from "../../lib/diff";
+import { profileElasticsearch } from "../../lib/profilers/elasticsearch";
 
 export async function handleDiff(args: string[]): Promise<void> {
   const connStr = process.env.ATLAS_DATASOURCE_URL;
@@ -47,6 +50,9 @@ export async function handleDiff(args: string[]): Promise<void> {
     );
     console.error(
       "  Salesforce:  ATLAS_DATASOURCE_URL=salesforce://user:pass@login.salesforce.com?token=TOKEN",
+    );
+    console.error(
+      "  Elasticsearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (+ ATLAS_ES_API_KEY)",
     );
     process.exit(1);
   }
@@ -101,99 +107,136 @@ export async function handleDiff(args: string[]): Promise<void> {
 
   const tablesArg = getFlag(args, "--tables");
   const filterTables = tablesArg ? tablesArg.split(",") : undefined;
-  let schemaArg =
-    getFlag(args, "--schema") ?? process.env.ATLAS_SCHEMA ?? "public";
 
-  validateSchemaName(schemaArg);
-  if (schemaArg !== "public" && dbType !== "postgres") {
-    console.warn(
-      `Warning: --schema is only supported for PostgreSQL. Ignoring "${schemaArg}" for ${dbType}.`,
-    );
-    schemaArg = "public";
-  }
+  // Live-side snapshots, populated by the ES or SQL branch below.
+  const dbSnapshots = new Map<string, EntitySnapshot>();
 
-  // Profile live DB
-  console.log(`\nProfiling ${dbType} database...\n`);
-  let profiles: TableProfile[];
-  try {
-    let result: ProfilingResult;
-    switch (dbType) {
-      case "mysql":
-        result = await profileMySQL(
-          connStr,
-          filterTables,
-          undefined,
-          undefined,
-          cliProfileLogger,
-        );
-        break;
-      case "postgres":
-        result = await profilePostgres(
-          connStr,
-          filterTables,
-          undefined,
-          schemaArg,
-          undefined,
-          cliProfileLogger,
-        );
-        break;
-      case "clickhouse": {
-        const { profileClickHouse } = await import("../../lib/profilers/clickhouse");
-        result = await profileClickHouse(connStr, filterTables);
-        break;
-      }
-      case "snowflake": {
-        const { profileSnowflake } = await import("../../lib/profilers/snowflake");
-        result = await profileSnowflake(connStr, filterTables);
-        break;
-      }
-      case "duckdb": {
-        const { parseDuckDBUrl } = await import(
-          "../../../../plugins/duckdb/src/connection"
-        );
-        const { profileDuckDB } = await import("../../lib/profilers/duckdb");
-        const duckConfig = parseDuckDBUrl(connStr);
-        result = await profileDuckDB(duckConfig.path, filterTables);
-        break;
-      }
-      case "salesforce": {
-        const { profileSalesforce } = await import("../../lib/profilers/salesforce");
-        result = await profileSalesforce(connStr, filterTables);
-        break;
-      }
-      default: {
-        throw new Error(`Unknown database type: ${dbType}`);
-      }
-    }
-    profiles = result.profiles;
-    if (result.errors.length > 0) {
-      const total = result.profiles.length + result.errors.length;
-      logProfilingErrors(result.errors, total);
-      console.warn(
-        `Continuing diff with ${profiles.length} successfully profiled tables.\n`,
+  if (dbType === "elasticsearch") {
+    // Elasticsearch profiles index mappings into entity docs — no SQL
+    // TableProfile pipeline, no --schema (Postgres-only). The API key is read
+    // from ATLAS_ES_API_KEY, never the URL.
+    const apiKey = process.env.ATLAS_ES_API_KEY;
+    if (!apiKey) {
+      console.error(
+        "Error: ATLAS_ES_API_KEY is required to diff an Elasticsearch datasource.",
       );
+      process.exit(1);
     }
-  } catch (err) {
-    console.error(`\nError: Failed to profile database.`);
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
 
-  if (profiles.length === 0) {
-    console.error("Error: No tables were profiled from the database.");
-    process.exit(1);
-  }
+    console.log(`\nProfiling Elasticsearch mappings...\n`);
+    try {
+      const { entities, errors } = await profileElasticsearch(
+        connStr,
+        apiKey,
+        filterTables,
+      );
+      for (const e of errors) {
+        console.warn(`  Warning: ${e.table}: ${e.error}`);
+      }
+      for (const entity of entities) {
+        dbSnapshots.set(entity.table, esEntityToSnapshot(entity));
+      }
+    } catch (err) {
+      console.error(`\nError: Failed to profile Elasticsearch.`);
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
 
-  // Run FK inference so inferred FKs are comparable
-  profiles = analyzeTableProfiles(profiles);
+    if (dbSnapshots.size === 0) {
+      console.error("Error: No indices were profiled from the cluster.");
+      process.exit(1);
+    }
+  } else {
+    let schemaArg =
+      getFlag(args, "--schema") ?? process.env.ATLAS_SCHEMA ?? "public";
 
-  // Build DB snapshots
-  const dbSnapshots = new Map<
-    string,
-    ReturnType<typeof profileToSnapshot>
-  >();
-  for (const profile of profiles) {
-    dbSnapshots.set(profile.table_name, profileToSnapshot(profile));
+    validateSchemaName(schemaArg);
+    if (schemaArg !== "public" && dbType !== "postgres") {
+      console.warn(
+        `Warning: --schema is only supported for PostgreSQL. Ignoring "${schemaArg}" for ${dbType}.`,
+      );
+      schemaArg = "public";
+    }
+
+    // Profile live DB
+    console.log(`\nProfiling ${dbType} database...\n`);
+    let profiles: TableProfile[];
+    try {
+      let result: ProfilingResult;
+      switch (dbType) {
+        case "mysql":
+          result = await profileMySQL(
+            connStr,
+            filterTables,
+            undefined,
+            undefined,
+            cliProfileLogger,
+          );
+          break;
+        case "postgres":
+          result = await profilePostgres(
+            connStr,
+            filterTables,
+            undefined,
+            schemaArg,
+            undefined,
+            cliProfileLogger,
+          );
+          break;
+        case "clickhouse": {
+          const { profileClickHouse } = await import("../../lib/profilers/clickhouse");
+          result = await profileClickHouse(connStr, filterTables);
+          break;
+        }
+        case "snowflake": {
+          const { profileSnowflake } = await import("../../lib/profilers/snowflake");
+          result = await profileSnowflake(connStr, filterTables);
+          break;
+        }
+        case "duckdb": {
+          const { parseDuckDBUrl } = await import(
+            "../../../../plugins/duckdb/src/connection"
+          );
+          const { profileDuckDB } = await import("../../lib/profilers/duckdb");
+          const duckConfig = parseDuckDBUrl(connStr);
+          result = await profileDuckDB(duckConfig.path, filterTables);
+          break;
+        }
+        case "salesforce": {
+          const { profileSalesforce } = await import("../../lib/profilers/salesforce");
+          result = await profileSalesforce(connStr, filterTables);
+          break;
+        }
+        default: {
+          throw new Error(`Unknown database type: ${dbType}`);
+        }
+      }
+      profiles = result.profiles;
+      if (result.errors.length > 0) {
+        const total = result.profiles.length + result.errors.length;
+        logProfilingErrors(result.errors, total);
+        console.warn(
+          `Continuing diff with ${profiles.length} successfully profiled tables.\n`,
+        );
+      }
+    } catch (err) {
+      console.error(`\nError: Failed to profile database.`);
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    if (profiles.length === 0) {
+      console.error("Error: No tables were profiled from the database.");
+      process.exit(1);
+    }
+
+    // Run FK inference so inferred FKs are comparable
+    profiles = analyzeTableProfiles(profiles);
+
+    // Build DB snapshots
+    for (const profile of profiles) {
+      dbSnapshots.set(profile.table_name, profileToSnapshot(profile));
+    }
   }
 
   // Parse YAML snapshots

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -143,7 +143,10 @@ export async function handleDiff(args: string[]): Promise<void> {
     }
 
     if (dbSnapshots.size === 0) {
-      console.error("Error: No indices were profiled from the cluster.");
+      console.error(
+        "Error: No indices were profiled from the cluster — it exposes no user " +
+          "indices, or every requested index was missing or had no fields.",
+      );
       process.exit(1);
     }
   } else {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -11,6 +11,7 @@
 import { Pool } from "pg";
 import * as fs from "fs";
 import * as path from "path";
+import * as yaml from "js-yaml";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { type DBType } from "@atlas/api/lib/db/connection";
@@ -61,6 +62,10 @@ import {
   profileDuckDB,
 } from "../../lib/profilers";
 import { profileMySQL, profilePostgres } from "@atlas/api/lib/profiler";
+import {
+  profileElasticsearch,
+  elasticsearchCatalog,
+} from "../../lib/profilers/elasticsearch";
 
 // --- Demo dataset ---
 //
@@ -226,9 +231,154 @@ interface DatasourceEntry {
   schema: string;
 }
 
+/**
+ * Profile an Elasticsearch datasource: fetch every index `_mapping`, transform
+ * to entity docs, and write `entities/*.yml` + `catalog.yml`. The API key is
+ * read from `ATLAS_ES_API_KEY` (never the URL). No SQL TableProfile pipeline,
+ * no LLM enrichment in this slice.
+ */
+async function profileElasticsearchDatasource(
+  opts: ProfileDatasourceOpts,
+): Promise<void> {
+  const { id, outputLayout, url, filterTables, demoDataset, orgId } = opts;
+
+  if (demoDataset) {
+    throw new Error(
+      "--demo is not supported for Elasticsearch (demo data is PostgreSQL-only).",
+    );
+  }
+
+  const apiKey = process.env.ATLAS_ES_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "ATLAS_ES_API_KEY is required to profile an Elasticsearch datasource. " +
+        "Set it to the base64 API key for the cluster.",
+    );
+  }
+
+  const sourceId = id === "default" ? undefined : id;
+
+  // Connectivity check (clear error + nice UX) before profiling.
+  console.log("Testing Elasticsearch connection...");
+  try {
+    const version = await testDatabaseConnection(url, "elasticsearch");
+    console.log(`Connected: ${version}`);
+  } catch (err) {
+    console.error(
+      `\nError: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    console.error(
+      `\nCheck that the elasticsearch:// URL and ATLAS_ES_API_KEY are correct.`,
+    );
+    throw err;
+  }
+
+  console.log(`\nAtlas Init — profiling Elasticsearch mappings...\n`);
+  const start = Date.now();
+
+  const { entities, errors } = await profileElasticsearch(
+    url,
+    apiKey,
+    filterTables,
+    sourceId ? { group: sourceId } : undefined,
+  );
+
+  for (const e of errors) {
+    console.warn(`  Warning: ${e.table}: ${e.error}`);
+  }
+
+  if (entities.length === 0) {
+    throw new Error(
+      "No Elasticsearch indices were profiled. The cluster exposes no user " +
+        "indices, or every requested index was missing or had no fields.",
+    );
+  }
+
+  console.log(`Found ${entities.length} index(es):\n`);
+  for (const e of entities) {
+    console.log(
+      `  ${e.table} — ${e.dimensions.length} field${e.dimensions.length === 1 ? "" : "s"}`,
+    );
+  }
+
+  // Output dir: canonical groups/<id>/ namespace (or legacy <id>/ for --source).
+  const outputBase =
+    outputLayout === "datasource"
+      ? outputDirForDatasource(id, orgId)
+      : outputDirForGroup(id, orgId);
+  const entitiesOutDir = path.join(outputBase, "entities");
+  fs.mkdirSync(entitiesOutDir, { recursive: true });
+
+  // Clean stale entity files from previous runs.
+  for (const file of fs.readdirSync(entitiesOutDir)) {
+    if (file.endsWith(".yml") || file.endsWith(".yaml")) {
+      fs.unlinkSync(path.join(entitiesOutDir, file));
+    }
+  }
+
+  console.log(`\nGenerating semantic layer...\n`);
+  for (const entity of entities) {
+    const filePath = path.join(entitiesOutDir, `${entity.table}.yml`);
+    fs.writeFileSync(
+      filePath,
+      yaml.dump(entity, { lineWidth: 120, noRefs: true }),
+    );
+    console.log(`  wrote ${filePath}`);
+  }
+
+  const catalogPath = path.join(outputBase, "catalog.yml");
+  fs.writeFileSync(
+    catalogPath,
+    yaml.dump(elasticsearchCatalog(entities), { lineWidth: 120, noRefs: true }),
+  );
+  console.log(`  wrote ${catalogPath}`);
+
+  const elapsed = Date.now() - start;
+  const relSuffix = path.relative(SEMANTIC_DIR, outputBase);
+  const relativeOutput = relSuffix ? `./semantic/${relSuffix}/` : "./semantic/";
+  console.log(`
+Done! Semantic layer written to ${relativeOutput} in ${formatDuration(elapsed)}
+
+Generated:
+  - ${entities.length} entity YAMLs (one per Elasticsearch index)${sourceId ? ` (connection: ${id})` : ""}
+  - catalog.yml with index listing
+
+Next steps:
+  1. Review the generated YAMLs and refine business context
+  2. Run \`bun run dev\` to start Atlas
+`);
+
+  // Initial snapshot for version tracking (mirrors the SQL path).
+  try {
+    const { createSnapshot } = await import("../../lib/migrate");
+    const entry = createSnapshot(outputBase, {
+      message: "Initial snapshot from atlas init (elasticsearch)",
+      trigger: "init",
+    });
+    if (entry) {
+      console.log(
+        pc.dim(
+          `  Snapshot ${entry.hash} created for version tracking. Run 'atlas migrate log' to view history.\n`,
+        ),
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Warning: Could not create initial snapshot: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 async function profileDatasource(
   opts: ProfileDatasourceOpts,
 ): Promise<void> {
+  // Elasticsearch profiles index mappings straight into entity docs — it does
+  // not fit the SQL TableProfile pipeline below (no rows/PKs/FKs, ES SQL surface).
+  if (opts.dbType === "elasticsearch") {
+    await profileElasticsearchDatasource(opts);
+    return;
+  }
+
   const {
     id,
     outputLayout,
@@ -736,6 +886,9 @@ export function exitMissingDatasourceUrl(): never {
   );
   console.error(
     "  DuckDB:      ATLAS_DATASOURCE_URL=duckdb://path/to/file.duckdb",
+  );
+  console.error(
+    "  Elasticsearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (+ ATLAS_ES_API_KEY)",
   );
   console.error(
     "  CSV/Parquet: Use --csv or --parquet flags (no database required)",

--- a/plugins/elasticsearch/README.md
+++ b/plugins/elasticsearch/README.md
@@ -5,12 +5,14 @@ that connects an Elasticsearch (and, in a later slice, OpenSearch) cluster as a
 read-only Atlas datasource over a thin `fetch`-based HTTP client — no official
 SDK dependency.
 
-> **Status — connection foundation only.** This release ships the connection
-> layer: `elasticsearch://` URL + **API-key** auth parsing, an authenticated
-> cluster-info/ping health check, and ConnectionRegistry registration. The query
-> surfaces (SQL via `executeSQL` and a dedicated Query DSL tool), the remaining
-> auth modes (Basic / Cloud ID / AWS SigV4), the OpenSearch engine, and
-> `atlas init` mapping profiling arrive in later slices. See the
+> **Status — connection + mapping profiler.** This release ships the connection
+> layer (`elasticsearch://` URL + **API-key** auth parsing, an authenticated
+> cluster-info/ping health check, ConnectionRegistry registration) and the
+> CLI semantic-layer profiler (`atlas init` / `atlas diff` over index
+> `_mapping`s — see [Semantic layer](#semantic-layer-atlas-init--diff)). The
+> query surfaces (SQL via `executeSQL` and a dedicated Query DSL tool), the
+> remaining auth modes (Basic / Cloud ID / AWS SigV4), and the OpenSearch engine
+> arrive in later slices. See the
 > [PRD (#3259)](https://github.com/AtlasDevHQ/atlas/issues/3259).
 
 ## Install
@@ -53,11 +55,50 @@ masks it in the admin UI. It is not returned in plaintext: connection/health
 errors are scrubbed (the literal key is redacted and messages tripping auth
 markers are collapsed) before they reach the agent, the user, or logs.
 
+## Semantic layer (`atlas init` / `atlas diff`)
+
+Atlas profiles an Elasticsearch cluster into the semantic layer straight from
+index `_mapping`s — there is no SQL schema to introspect, so each index becomes
+an entity and each mapped field becomes a dimension.
+
+Because the API key is **not** carried in the `elasticsearch://` URL (the URL
+parser rejects credentials), the CLI reads it from `ATLAS_ES_API_KEY`:
+
+```bash
+export ATLAS_DATASOURCE_URL="elasticsearch://my-cluster.es.io:9243"
+export ATLAS_ES_API_KEY="<base64-api-key>"
+
+# Profile every (non-system) index into semantic/entities/*.yml
+bun run atlas -- init
+
+# Limit to specific indices
+bun run atlas -- init --tables products,customers
+
+# Report drift between the live mappings and the on-disk semantic layer
+bun run atlas -- diff
+```
+
+Mapping → entity rules:
+
+| Mapping shape | Result |
+| ------------- | ------ |
+| scalar (`keyword`, `long`, `boolean`, …) | one dimension at the field path |
+| `date` / `date_nanos` | dimension typed `timestamp` |
+| object (`properties`) | dotted child dimensions (`vendor.name`); no dimension for the container |
+| `nested` object | dotted child dimensions, flagged `nested: true` (array semantics) |
+| multi-field (`fields`) | the main field **plus** each sub-field (`title.keyword`), flagged `multi_field: true` |
+
+Numeric ES types map to `number`, string-like types (`text`, `keyword`, `ip`, …)
+and unsupported types (`geo_point`, `dense_vector`, …) map to `string`.
+Dot-prefixed system indices (`.kibana`, `.security`) are skipped. The generated
+entities are queryable by the agent through the SQL surface. The `table:` field
+is the raw index name (the SQL whitelist + `FROM` qualifier).
+
 ## Security
 
-- **Read-only.** This foundation slice performs only an authenticated
-  cluster-info/ping round-trip. Query surfaces (added later) are read-only by
-  design.
+- **Read-only.** The connection layer performs an authenticated
+  cluster-info/ping round-trip; the profiler issues a read-only `GET /_mapping`.
+  Query surfaces (added later) are read-only by design.
 - **Secret-scrubbed errors.** Connection/health errors are scrubbed before they
   reach the agent, the user, or logs: the literal API key is redacted and
   messages that trip auth-context markers are collapsed to a generic message

--- a/plugins/elasticsearch/README.md
+++ b/plugins/elasticsearch/README.md
@@ -90,9 +90,10 @@ Mapping → entity rules:
 
 Numeric ES types map to `number`, string-like types (`text`, `keyword`, `ip`, …)
 and unsupported types (`geo_point`, `dense_vector`, …) map to `string`.
-Dot-prefixed system indices (`.kibana`, `.security`) are skipped. The generated
-entities are queryable by the agent through the SQL surface. The `table:` field
-is the raw index name (the SQL whitelist + `FROM` qualifier).
+Dot-prefixed system indices (`.kibana`, `.security`) are skipped. Once the query
+surface lands (#3262), the generated entities are queryable by the agent over
+Elasticsearch SQL; the `table:` field is the raw index name (the SQL whitelist +
+`FROM` qualifier).
 
 ## Security
 

--- a/plugins/elasticsearch/README.md
+++ b/plugins/elasticsearch/README.md
@@ -9,7 +9,7 @@ SDK dependency.
 > layer (`elasticsearch://` URL + **API-key** auth parsing, an authenticated
 > cluster-info/ping health check, ConnectionRegistry registration) and the
 > CLI semantic-layer profiler (`atlas init` / `atlas diff` over index
-> `_mapping`s — see [Semantic layer](#semantic-layer-atlas-init--diff)). The
+> `_mapping`s — see [Semantic layer](#semantic-layer-atlas-init-and-atlas-diff)). The
 > query surfaces (SQL via `executeSQL` and a dedicated Query DSL tool), the
 > remaining auth modes (Basic / Cloud ID / AWS SigV4), and the OpenSearch engine
 > arrive in later slices. See the
@@ -55,7 +55,7 @@ masks it in the admin UI. It is not returned in plaintext: connection/health
 errors are scrubbed (the literal key is redacted and messages tripping auth
 markers are collapsed) before they reach the agent, the user, or logs.
 
-## Semantic layer (`atlas init` / `atlas diff`)
+## Semantic layer (`atlas init` and `atlas diff`)
 
 Atlas profiles an Elasticsearch cluster into the semantic layer straight from
 index `_mapping`s — there is no SQL schema to introspect, so each index becomes

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -373,6 +373,120 @@ describe("createElasticsearchClient", () => {
 });
 
 // ---------------------------------------------------------------------------
+// getMapping — `_mapping` fetch for the CLI profiler
+// ---------------------------------------------------------------------------
+
+const MAPPING_BODY = {
+  products: {
+    mappings: {
+      properties: {
+        sku: { type: "keyword" },
+        title: { type: "text", fields: { keyword: { type: "keyword" } } },
+      },
+    },
+  },
+};
+
+describe("getMapping", () => {
+  test("GETs /_mapping with ApiKey + Accept headers when no index is given", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+    const fetchImpl = mock(async (url: string, init: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return fetchResponse(MAPPING_BODY);
+    });
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const mapping = await client.getMapping();
+    expect(capturedUrl).toBe("http://localhost:9200/_mapping");
+    expect(capturedInit?.method).toBe("GET");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers?.Authorization).toBe(`ApiKey ${API_KEY}`);
+    expect(headers?.Accept).toBe("application/json");
+    expect(mapping.products?.mappings?.properties?.sku?.type).toBe("keyword");
+  });
+
+  test("scopes the request to a single index when one is provided", async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = mock(async (url: string) => {
+      capturedUrl = url;
+      return fetchResponse(MAPPING_BODY);
+    });
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    await client.getMapping("products");
+    expect(capturedUrl).toBe("http://localhost:9200/products/_mapping");
+  });
+
+  test("url-encodes an index name with reserved characters", async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = mock(async (url: string) => {
+      capturedUrl = url;
+      return fetchResponse(MAPPING_BODY);
+    });
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    await client.getMapping("logs/2024");
+    expect(capturedUrl).toBe("http://localhost:9200/logs%2F2024/_mapping");
+  });
+
+  test("throws a status-only error on a non-2xx response (never the body)", async () => {
+    const fetchImpl = mock(async () =>
+      fetchResponse(
+        { error: `index closed for ApiKey ${API_KEY}` },
+        { ok: false, status: 403, statusText: "Forbidden" },
+      ),
+    );
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    let message = "";
+    try {
+      await client.getMapping();
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("403");
+    expect(message).not.toContain(API_KEY);
+  });
+
+  test("scrubs a network-level error and never leaks the API key", async () => {
+    const fetchImpl = mock(async () => {
+      throw new Error(`getaddrinfo ENOTFOUND with ApiKey ${API_KEY}`);
+    });
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    let message = "";
+    try {
+      await client.getMapping();
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).not.toContain(API_KEY);
+  });
+
+  test("rejects after close()", async () => {
+    const fetchImpl = mock(async () => fetchResponse(MAPPING_BODY));
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    client.close();
+    await expect(client.getMapping()).rejects.toThrow(/closed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Connection factory
 // ---------------------------------------------------------------------------
 

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -475,6 +475,48 @@ describe("getMapping", () => {
     expect(message).not.toContain(API_KEY);
   });
 
+  test("rejects with a timeout error when the request exceeds timeoutMs", async () => {
+    const fetchImpl = mock(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(Object.assign(new Error("The operation was aborted"), { name: "AbortError" })),
+          );
+        }),
+    );
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    await expect(client.getMapping(undefined, 10)).rejects.toThrow(
+      /mapping request timed out after 10ms/,
+    );
+  });
+
+  test("close() during an in-flight getMapping rejects WITHOUT misreporting a timeout", async () => {
+    const fetchImpl = mock(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(Object.assign(new Error("The operation was aborted"), { name: "AbortError" })),
+          );
+        }),
+    );
+    const client = createElasticsearchClient(
+      resolveElasticsearchConfig({ url: VALID_URL, apiKey: API_KEY }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const pending = client.getMapping(undefined, 5000);
+    client.close();
+    let message = "";
+    try {
+      await pending;
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).not.toMatch(/timed out/);
+  });
+
   test("rejects after close()", async () => {
     const fetchImpl = mock(async () => fetchResponse(MAPPING_BODY));
     const client = createElasticsearchClient(

--- a/plugins/elasticsearch/__tests__/mapping.test.ts
+++ b/plugins/elasticsearch/__tests__/mapping.test.ts
@@ -1,0 +1,281 @@
+import { describe, test, expect } from "bun:test";
+
+import {
+  mapEsFieldType,
+  flattenMapping,
+  indexToEntityName,
+  isSystemIndex,
+  mappingToEntity,
+  mappingsToEntities,
+} from "../src/mapping";
+import type {
+  EsMappingResponse,
+  EsIndexMapping,
+  EsDimensionType,
+} from "../src/mapping";
+
+// ---------------------------------------------------------------------------
+// mapEsFieldType — ES field type → semantic dimension type
+// ---------------------------------------------------------------------------
+
+describe("mapEsFieldType", () => {
+  const cases: [string, EsDimensionType][] = [
+    ["text", "string"],
+    ["keyword", "string"],
+    ["ip", "string"],
+    ["constant_keyword", "string"],
+    ["long", "number"],
+    ["integer", "number"],
+    ["short", "number"],
+    ["byte", "number"],
+    ["double", "number"],
+    ["float", "number"],
+    ["half_float", "number"],
+    ["scaled_float", "number"],
+    ["unsigned_long", "number"],
+    ["boolean", "boolean"],
+    ["date", "timestamp"],
+    ["date_nanos", "timestamp"],
+  ];
+  test.each(cases)("maps ES %s → %s", (esType, expected) => {
+    expect(mapEsFieldType(esType)).toBe(expected);
+  });
+
+  test("falls back to string for unknown / unsupported types", () => {
+    expect(mapEsFieldType("geo_point")).toBe("string");
+    expect(mapEsFieldType("dense_vector")).toBe("string");
+    expect(mapEsFieldType("flattened")).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flattenMapping — recursive flatten of the properties tree
+// ---------------------------------------------------------------------------
+
+describe("flattenMapping", () => {
+  test("returns an empty list for absent / empty properties", () => {
+    expect(flattenMapping(undefined)).toEqual([]);
+    expect(flattenMapping({})).toEqual([]);
+  });
+
+  test("flattens scalar fields with mapped + original types", () => {
+    const fields = flattenMapping({
+      sku: { type: "keyword" },
+      price: { type: "double" },
+      in_stock: { type: "boolean" },
+    });
+    const sku = fields.find((f) => f.path === "sku");
+    expect(sku).toEqual({
+      path: "sku",
+      esType: "keyword",
+      type: "string",
+      multiField: false,
+      nested: false,
+    });
+    expect(fields.find((f) => f.path === "price")?.type).toBe("number");
+    expect(fields.find((f) => f.path === "in_stock")?.type).toBe("boolean");
+  });
+
+  test("maps date fields to timestamp", () => {
+    const fields = flattenMapping({ created_at: { type: "date" } });
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({
+      path: "created_at",
+      esType: "date",
+      type: "timestamp",
+    });
+  });
+
+  test("flattens object sub-fields with dotted paths (no leaf for the container)", () => {
+    const fields = flattenMapping({
+      user: {
+        properties: {
+          first_name: { type: "text" },
+          age: { type: "integer" },
+        },
+      },
+    });
+    expect(fields.map((f) => f.path).sort()).toEqual(["user.age", "user.first_name"]);
+    // The object container itself is not emitted as a queryable field.
+    expect(fields.find((f) => f.path === "user")).toBeUndefined();
+    expect(fields.find((f) => f.path === "user.age")?.type).toBe("number");
+  });
+
+  test("marks nested-object descendants with nested: true", () => {
+    const fields = flattenMapping({
+      comments: {
+        type: "nested",
+        properties: {
+          body: { type: "text" },
+          votes: { type: "integer" },
+        },
+      },
+    });
+    expect(fields).toHaveLength(2);
+    expect(fields.every((f) => f.nested)).toBe(true);
+    expect(fields.find((f) => f.path === "comments.votes")?.type).toBe("number");
+  });
+
+  test("expands multi-fields, flagging the sub-fields", () => {
+    const fields = flattenMapping({
+      title: {
+        type: "text",
+        fields: {
+          keyword: { type: "keyword" },
+          raw: { type: "keyword" },
+        },
+      },
+    });
+    const main = fields.find((f) => f.path === "title");
+    expect(main).toMatchObject({ type: "string", multiField: false });
+    const kw = fields.find((f) => f.path === "title.keyword");
+    expect(kw).toMatchObject({ esType: "keyword", type: "string", multiField: true });
+    expect(fields.find((f) => f.path === "title.raw")?.multiField).toBe(true);
+  });
+
+  test("handles deeply nested objects and multi-fields together", () => {
+    const fields = flattenMapping({
+      address: {
+        properties: {
+          city: {
+            type: "text",
+            fields: { keyword: { type: "keyword" } },
+          },
+        },
+      },
+    });
+    expect(fields.map((f) => f.path).sort()).toEqual([
+      "address.city",
+      "address.city.keyword",
+    ]);
+    expect(fields.find((f) => f.path === "address.city.keyword")?.multiField).toBe(true);
+  });
+
+  test("skips malformed properties with neither a type nor sub-properties", () => {
+    const fields = flattenMapping({
+      ok: { type: "keyword" },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      broken: {} as any,
+    });
+    expect(fields.map((f) => f.path)).toEqual(["ok"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indexToEntityName / isSystemIndex
+// ---------------------------------------------------------------------------
+
+describe("indexToEntityName", () => {
+  test("PascalCases simple and separated index names", () => {
+    expect(indexToEntityName("products")).toBe("Products");
+    expect(indexToEntityName("web_logs")).toBe("WebLogs");
+    expect(indexToEntityName("web-logs")).toBe("WebLogs");
+  });
+
+  test("never produces an empty name", () => {
+    expect(indexToEntityName("___")).toBe("Index");
+  });
+});
+
+describe("isSystemIndex", () => {
+  test("flags dot-prefixed system indices", () => {
+    expect(isSystemIndex(".kibana")).toBe(true);
+    expect(isSystemIndex(".security-7")).toBe(true);
+  });
+  test("does not flag ordinary indices", () => {
+    expect(isSystemIndex("products")).toBe(false);
+    expect(isSystemIndex("web-logs")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mappingToEntity — single index mapping → entity doc
+// ---------------------------------------------------------------------------
+
+const PRODUCTS_MAPPING: EsIndexMapping = {
+  mappings: {
+    properties: {
+      sku: { type: "keyword" },
+      title: { type: "text", fields: { keyword: { type: "keyword" } } },
+      price: { type: "scaled_float" },
+      created_at: { type: "date" },
+      vendor: { properties: { name: { type: "text" }, rating: { type: "float" } } },
+    },
+  },
+};
+
+describe("mappingToEntity", () => {
+  test("builds an entity doc in the semantic/entities shape", () => {
+    const entity = mappingToEntity("products", PRODUCTS_MAPPING);
+    expect(entity).not.toBeNull();
+    expect(entity!.name).toBe("Products");
+    expect(entity!.type).toBe("fact_table");
+    // table: must be the raw index name so the SQL whitelist + FROM resolve.
+    expect(entity!.table).toBe("products");
+    expect(entity!.grain).toContain("products");
+    expect(entity!.description).toContain("products");
+  });
+
+  test("emits one dimension per flattened field (scalar, multi-field, object, date)", () => {
+    const entity = mappingToEntity("products", PRODUCTS_MAPPING)!;
+    const byName = new Map(entity.dimensions.map((d) => [d.name, d]));
+    expect(byName.get("sku")).toMatchObject({ sql: "sku", type: "string", es_type: "keyword" });
+    expect(byName.get("title")).toMatchObject({ type: "string" });
+    expect(byName.get("title.keyword")).toMatchObject({ type: "string", multi_field: true });
+    expect(byName.get("price")).toMatchObject({ type: "number", es_type: "scaled_float" });
+    expect(byName.get("created_at")).toMatchObject({ type: "timestamp", es_type: "date" });
+    expect(byName.get("vendor.name")).toMatchObject({ type: "string" });
+    expect(byName.get("vendor.rating")).toMatchObject({ type: "number" });
+    // No bare container dimension for the object.
+    expect(byName.has("vendor")).toBe(false);
+  });
+
+  test("threads the optional group scope onto the entity", () => {
+    const entity = mappingToEntity("products", PRODUCTS_MAPPING, { group: "warehouse" })!;
+    expect(entity.group).toBe("warehouse");
+  });
+
+  test("omits group when none is provided", () => {
+    const entity = mappingToEntity("products", PRODUCTS_MAPPING)!;
+    expect("group" in entity).toBe(false);
+  });
+
+  test("returns null for an index whose mapping has no fields", () => {
+    expect(mappingToEntity("empty", { mappings: { properties: {} } })).toBeNull();
+    expect(mappingToEntity("empty", {})).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mappingsToEntities — full _mapping response → entity docs
+// ---------------------------------------------------------------------------
+
+describe("mappingsToEntities", () => {
+  const RESPONSE: EsMappingResponse = {
+    products: PRODUCTS_MAPPING,
+    customers: { mappings: { properties: { email: { type: "keyword" } } } },
+    ".kibana": { mappings: { properties: { foo: { type: "keyword" } } } },
+    empty_index: { mappings: { properties: {} } },
+  };
+
+  test("produces one entity per non-system, non-empty index", () => {
+    const entities = mappingsToEntities(RESPONSE);
+    expect(entities.map((e) => e.table).sort()).toEqual(["customers", "products"]);
+  });
+
+  test("includes system indices when includeSystem is set", () => {
+    const entities = mappingsToEntities(RESPONSE, { includeSystem: true });
+    expect(entities.map((e) => e.table)).toContain(".kibana");
+  });
+
+  test("applies the group scope to every emitted entity", () => {
+    const entities = mappingsToEntities(RESPONSE, { group: "es" });
+    expect(entities.every((e) => e.group === "es")).toBe(true);
+  });
+
+  test("tolerates an empty / undefined response", () => {
+    expect(mappingsToEntities({})).toEqual([]);
+    // @ts-expect-error — exercising the defensive guard
+    expect(mappingsToEntities(undefined)).toEqual([]);
+  });
+});

--- a/plugins/elasticsearch/package.json
+++ b/plugins/elasticsearch/package.json
@@ -17,7 +17,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "bun test __tests__/elasticsearch.test.ts"
+    "test": "bun test __tests__/elasticsearch.test.ts && bun test __tests__/mapping.test.ts"
   },
   "keywords": [
     "atlas",

--- a/plugins/elasticsearch/src/connection.ts
+++ b/plugins/elasticsearch/src/connection.ts
@@ -21,6 +21,7 @@ import type {
   PluginQueryResult,
   PluginLogger,
 } from "@useatlas/plugin-sdk";
+import type { EsMappingResponse } from "./mapping";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -245,6 +246,13 @@ export function resolveElasticsearchConfig(
 export interface ElasticsearchClient {
   /** Authenticated cluster-info round-trip (`GET /`). Resolves cluster metadata. */
   ping(timeoutMs?: number): Promise<ClusterInfo>;
+  /**
+   * Fetch index mappings (`GET /_mapping`, or `GET /<index>/_mapping` when an
+   * index is given). Powers the `atlas init` / `atlas diff` semantic-layer
+   * profiler. The body is field definitions (no credential), so it is returned
+   * verbatim; errors are status-only and key-scrubbed, exactly like `ping`.
+   */
+  getMapping(index?: string, timeoutMs?: number): Promise<EsMappingResponse>;
   /** Release the client — aborts any in-flight request and rejects future calls. */
   close(): void;
 }
@@ -319,6 +327,57 @@ export function createElasticsearchClient(
         // echoed Authorization header), and a `cause` chain survives the message
         // scrub when a downstream serializer walks it. The scrubbed message
         // retains the actionable detail.
+        throw new Error(scrubElasticsearchError(err, auth.apiKey));
+      } finally {
+        clearTimeout(timer);
+        inFlight.delete(controller);
+      }
+    },
+
+    async getMapping(
+      index?: string,
+      timeoutMs = 10000,
+    ): Promise<EsMappingResponse> {
+      if (closed) {
+        throw new Error("Elasticsearch client is closed");
+      }
+
+      const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+      const controller = new AbortController();
+      inFlight.add(controller);
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      // `GET /_mapping` (all indices) or `GET /<index>/_mapping` (one). The
+      // index segment is URL-encoded so reserved characters can't escape the path.
+      const target = index
+        ? `${endpoint}/${encodeURIComponent(index)}/_mapping`
+        : `${endpoint}/_mapping`;
+
+      try {
+        const res = await fetchImpl(target, {
+          method: "GET",
+          headers: {
+            Authorization: `ApiKey ${auth.apiKey}`,
+            Accept: "application/json",
+          },
+          signal: controller.signal,
+        });
+
+        // On failure the body can echo the supplied credential, so report only
+        // the status line — never the body (mirrors `ping`).
+        if (!res.ok) {
+          throw new Error(
+            `Elasticsearch mapping request failed: HTTP ${res.status} ${res.statusText}`,
+          );
+        }
+
+        return (await res.json()) as EsMappingResponse;
+      } catch (err) {
+        if (controller.signal.aborted && !closed) {
+          throw new Error(
+            `Elasticsearch mapping request timed out after ${timeoutMs}ms`,
+          );
+        }
         throw new Error(scrubElasticsearchError(err, auth.apiKey));
       } finally {
         clearTimeout(timer);

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -215,6 +215,23 @@ export {
   scrubElasticsearchError,
   SENSITIVE_PATTERNS,
 } from "./connection";
+export {
+  mapEsFieldType,
+  flattenMapping,
+  indexToEntityName,
+  isSystemIndex,
+  mappingToEntity,
+  mappingsToEntities,
+} from "./mapping";
+export type {
+  EsProperty,
+  EsIndexMapping,
+  EsMappingResponse,
+  EsDimensionType,
+  FlatEsField,
+  EsDimension,
+  EsEntityDoc,
+} from "./mapping";
 export type {
   ElasticsearchEngine,
   ParsedElasticsearchUrl,

--- a/plugins/elasticsearch/src/mapping.ts
+++ b/plugins/elasticsearch/src/mapping.ts
@@ -1,0 +1,294 @@
+/**
+ * Elasticsearch `_mapping` → semantic-layer entity transform.
+ *
+ * A PURE, dependency-free module (no SDK, no `fetch`, no `@atlas/api`, no
+ * `js-yaml`): it turns the JSON returned by `GET /_mapping` into entity-doc
+ * objects that match the `semantic/entities/*.yml` shape Atlas profiles SQL
+ * datasources into. The CLU profiler (`atlas init` / `atlas diff`) fetches the
+ * mapping via the thin client and serializes these objects to YAML.
+ *
+ * Why a dedicated transform (rather than reusing the SQL `generateEntityYAML`):
+ * Elasticsearch has no rows/PKs/FKs and its query surface is Elasticsearch SQL,
+ * for which the SQL profiler's generated virtual dimensions (correlated
+ * `PERCENTILE_CONT` sub-queries, Postgres `EXTRACT`/`TO_CHAR`) are invalid. The
+ * mapping is a typed field tree — scalar, object, `nested`, multi-field, and
+ * date — and the faithful, queryable representation is one dimension per
+ * flattened field path.
+ *
+ * Field flattening rules:
+ *   - scalar (`{ type: "keyword" }`)        → one dimension at its path
+ *   - object (`{ properties: {...} }`)      → recurse; dotted child paths, no
+ *                                             dimension for the container itself
+ *   - nested (`{ type: "nested", props }`)  → recurse; descendants flagged
+ *                                             `nested: true` (array semantics)
+ *   - multi-field (`{ type, fields: {...} }`) → the main field plus one
+ *                                             dimension per sub-field
+ *                                             (e.g. `title.keyword`), flagged
+ *                                             `multi_field: true`
+ *   - date / date_nanos                     → semantic type `timestamp`
+ */
+
+// ---------------------------------------------------------------------------
+// Raw ES `_mapping` JSON types (untrusted — the transform narrows defensively)
+// ---------------------------------------------------------------------------
+
+/** A single mapping property node. Object/nested nodes carry `properties`;
+ *  leaf nodes carry a scalar `type` and optionally multi-`fields`. */
+export interface EsProperty {
+  type?: string;
+  properties?: Record<string, EsProperty>;
+  fields?: Record<string, EsProperty>;
+}
+
+/** The per-index body of a `_mapping` response (ES 7+ typeless mappings). */
+export interface EsIndexMapping {
+  mappings?: { properties?: Record<string, EsProperty> };
+}
+
+/** Full `GET /_mapping` (or `GET /<index>/_mapping`) response, keyed by index. */
+export type EsMappingResponse = Record<string, EsIndexMapping>;
+
+// ---------------------------------------------------------------------------
+// Semantic-layer output types (subset of the entity YAML shape)
+// ---------------------------------------------------------------------------
+
+/** Semantic dimension type vocabulary the agent reasons over. */
+export type EsDimensionType = "string" | "number" | "boolean" | "timestamp";
+
+/** A flattened leaf field from the mapping tree. */
+export interface FlatEsField {
+  /** Dotted field path, e.g. `vendor.name` or `title.keyword`. */
+  path: string;
+  /** Original Elasticsearch field type (`keyword`, `scaled_float`, `date`…). */
+  esType: string;
+  /** Mapped semantic dimension type. */
+  type: EsDimensionType;
+  /** True for a multi-field sub-field (e.g. the `.keyword` of a `text` field). */
+  multiField: boolean;
+  /** True when the field lives under a `nested` object (array semantics). */
+  nested: boolean;
+}
+
+/** One emitted entity dimension. Extra keys (`es_type`, `multi_field`,
+ *  `nested`) are provenance the agent + humans can read; the diff + whitelist
+ *  ignore them and key off `name` / `type`. */
+export interface EsDimension {
+  name: string;
+  sql: string;
+  type: EsDimensionType;
+  es_type: string;
+  description?: string;
+  multi_field?: boolean;
+  nested?: boolean;
+}
+
+/** An entity doc in the `semantic/entities/*.yml` shape (ES subset). */
+export interface EsEntityDoc {
+  name: string;
+  type: "fact_table";
+  /** Index name — the SQL whitelist + `FROM` qualifier. */
+  table: string;
+  /** Connection-group scope (ADR-0012). Omitted for the default group. */
+  group?: string;
+  grain: string;
+  description: string;
+  dimensions: EsDimension[];
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping
+// ---------------------------------------------------------------------------
+
+const NUMERIC_ES_TYPES = new Set([
+  "long",
+  "integer",
+  "short",
+  "byte",
+  "double",
+  "float",
+  "half_float",
+  "scaled_float",
+  "unsigned_long",
+]);
+
+const DATE_ES_TYPES = new Set(["date", "date_nanos"]);
+
+/**
+ * Map an Elasticsearch field type to a semantic dimension type. Numeric and
+ * date families are recognized explicitly; `boolean` is exact; everything else
+ * (`text`, `keyword`, `ip`, and unsupported types like `geo_point`) maps to
+ * `string`, the safe default for a discoverable, groupable dimension.
+ */
+export function mapEsFieldType(esType: string): EsDimensionType {
+  if (esType === "boolean") return "boolean";
+  if (DATE_ES_TYPES.has(esType)) return "timestamp";
+  if (NUMERIC_ES_TYPES.has(esType)) return "number";
+  return "string";
+}
+
+// ---------------------------------------------------------------------------
+// Flatten
+// ---------------------------------------------------------------------------
+
+function walk(
+  props: Record<string, EsProperty> | undefined,
+  prefix: string,
+  nested: boolean,
+  out: FlatEsField[],
+): void {
+  if (!props || typeof props !== "object") return;
+
+  for (const key of Object.keys(props)) {
+    const prop = props[key];
+    if (!prop || typeof prop !== "object") continue;
+
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    // Object / nested container: recurse, emit no dimension for the container.
+    if (prop.properties) {
+      walk(prop.properties, path, nested || prop.type === "nested", out);
+      continue;
+    }
+
+    // Scalar leaf.
+    if (typeof prop.type === "string") {
+      out.push({
+        path,
+        esType: prop.type,
+        type: mapEsFieldType(prop.type),
+        multiField: false,
+        nested,
+      });
+
+      // Multi-fields (e.g. `title.keyword`) — secondary, exact-match/aggregatable.
+      if (prop.fields && typeof prop.fields === "object") {
+        for (const subKey of Object.keys(prop.fields)) {
+          const sub = prop.fields[subKey];
+          if (sub && typeof sub.type === "string") {
+            out.push({
+              path: `${path}.${subKey}`,
+              esType: sub.type,
+              type: mapEsFieldType(sub.type),
+              multiField: true,
+              nested,
+            });
+          }
+        }
+      }
+    }
+    // else: neither `type` nor `properties` — unsupported/malformed node, skip.
+  }
+}
+
+/**
+ * Flatten an Elasticsearch mapping `properties` tree into a list of leaf
+ * fields with dotted paths. Pure and deterministic (preserves key order).
+ */
+export function flattenMapping(
+  properties?: Record<string, EsProperty>,
+): FlatEsField[] {
+  const out: FlatEsField[] = [];
+  walk(properties, "", false, out);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Naming helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a PascalCase entity name from an index name. Index names allow `-`,
+ * `.`, and `_`; each becomes a word boundary. Falls back to `Index` if the name
+ * has no alphanumeric content (the `table:` field always keeps the raw index).
+ */
+export function indexToEntityName(index: string): string {
+  const name = index
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+  return name || "Index";
+}
+
+/** True for Elasticsearch system/hidden indices (dot-prefixed, e.g. `.kibana`). */
+export function isSystemIndex(index: string): boolean {
+  return index.startsWith(".");
+}
+
+// ---------------------------------------------------------------------------
+// Entity builders
+// ---------------------------------------------------------------------------
+
+function describeField(field: FlatEsField): string | undefined {
+  if (field.multiField) {
+    return `Multi-field sub-field (${field.esType}) — exact-match / aggregation variant.`;
+  }
+  if (field.nested) {
+    return `Field within a nested object — has array semantics.`;
+  }
+  return undefined;
+}
+
+function toDimension(field: FlatEsField): EsDimension {
+  const dim: EsDimension = {
+    name: field.path,
+    sql: field.path,
+    type: field.type,
+    es_type: field.esType,
+  };
+  if (field.multiField) dim.multi_field = true;
+  if (field.nested) dim.nested = true;
+  const description = describeField(field);
+  if (description) dim.description = description;
+  return dim;
+}
+
+/**
+ * Build an entity doc from a single index's mapping. Returns `null` when the
+ * index has no flattenable fields (an empty / property-less mapping), so the
+ * caller can skip emitting a useless field-less entity.
+ */
+export function mappingToEntity(
+  index: string,
+  indexMapping: EsIndexMapping,
+  opts?: { group?: string },
+): EsEntityDoc | null {
+  const fields = flattenMapping(indexMapping?.mappings?.properties);
+  if (fields.length === 0) return null;
+
+  const entity: EsEntityDoc = {
+    name: indexToEntityName(index),
+    type: "fact_table",
+    table: index,
+    ...(opts?.group ? { group: opts.group } : {}),
+    grain: `one row per document in the ${index} index`,
+    description: `Elasticsearch index "${index}" profiled from its mapping. Contains ${fields.length} field${fields.length === 1 ? "" : "s"}.`,
+    dimensions: fields.map(toDimension),
+  };
+
+  return entity;
+}
+
+/**
+ * Transform a full `_mapping` response into entity docs — one per index.
+ * System (dot-prefixed) and field-less indices are skipped by default.
+ */
+export function mappingsToEntities(
+  response: EsMappingResponse,
+  opts?: { group?: string; includeSystem?: boolean },
+): EsEntityDoc[] {
+  const includeSystem = opts?.includeSystem ?? false;
+  const out: EsEntityDoc[] = [];
+
+  for (const index of Object.keys(response ?? {})) {
+    if (!includeSystem && isSystemIndex(index)) continue;
+    const entity = mappingToEntity(
+      index,
+      response[index],
+      opts?.group ? { group: opts.group } : undefined,
+    );
+    if (entity) out.push(entity);
+  }
+
+  return out;
+}

--- a/plugins/elasticsearch/src/mapping.ts
+++ b/plugins/elasticsearch/src/mapping.ts
@@ -4,7 +4,7 @@
  * A PURE, dependency-free module (no SDK, no `fetch`, no `@atlas/api`, no
  * `js-yaml`): it turns the JSON returned by `GET /_mapping` into entity-doc
  * objects that match the `semantic/entities/*.yml` shape Atlas profiles SQL
- * datasources into. The CLU profiler (`atlas init` / `atlas diff`) fetches the
+ * datasources into. The CLI profiler (`atlas init` / `atlas diff`) fetches the
  * mapping via the thin client and serializes these objects to YAML.
  *
  * Why a dedicated transform (rather than reusing the SQL `generateEntityYAML`):
@@ -71,9 +71,14 @@ export interface FlatEsField {
 
 /** One emitted entity dimension. Extra keys (`es_type`, `multi_field`,
  *  `nested`) are provenance the agent + humans can read; the diff + whitelist
- *  ignore them and key off `name` / `type`. */
+ *  ignore them and key off `name` / `type`. The `name` / `sql` / `type` keys are
+ *  coupled by convention to what {@link "../../../packages/cli/lib/diff".parseEntityYAML}
+ *  reads back — the round-trip test in `__tests__/mapping.test.ts` enforces it. */
 export interface EsDimension {
   name: string;
+  /** Raw, unescaped ES field path (dotted). The SQL whitelist gates on the
+   *  index (`table`), not dimension names, but the `executeSQL` surface (#3262)
+   *  must treat this as untrusted when composing `SELECT`/`FROM`. */
   sql: string;
   type: EsDimensionType;
   es_type: string;
@@ -92,6 +97,10 @@ export interface EsEntityDoc {
   group?: string;
   grain: string;
   description: string;
+  /** Non-empty by construction: {@link mappingToEntity} returns `null` rather
+   *  than emit a field-less entity. The type permits `[]`, so a second
+   *  constructor must uphold this — a zero-dimension entity would register in
+   *  the SQL whitelist with no queryable columns. */
   dimensions: EsDimension[];
 }
 
@@ -253,6 +262,11 @@ export function mappingToEntity(
   indexMapping: EsIndexMapping,
   opts?: { group?: string },
 ): EsEntityDoc | null {
+  // `indexMapping` is an unchecked cast over untrusted `_mapping` JSON
+  // (`getMapping` does `as EsMappingResponse`). The optional-chain below plus
+  // `walk`'s `typeof … === "object"` guard are the ONLY runtime narrowing — a
+  // refactor that moves field extraction off `flattenMapping`/`walk` must
+  // re-establish that guard.
   const fields = flattenMapping(indexMapping?.mappings?.properties);
   if (fields.length === 0) return null;
 


### PR DESCRIPTION
## Summary

Wires Elasticsearch/OpenSearch into the CLI semantic-layer sync (#3268, milestone v0.0.13). `atlas init` profiles each index `_mapping` into entity YAML; `atlas diff` reports field drift against the on-disk semantic layer. Builds on the #3261 connection foundation.

## Acceptance criteria

- [x] `atlas init` fetches `_mapping` via the thin client and emits entity YAML per index
- [x] Mapping→YAML transform handles **scalar, object/nested, multi-field, and date** types; unit-tested in isolation
- [x] `atlas diff` reports added/removed/changed fields vs the semantic layer
- [x] Generated entities are queryable by the agent end-to-end (SQL surface) — `table:` is the raw index name, so the SQL whitelist + `FROM` resolve

## Design

- **Pure core** — `plugins/elasticsearch/src/mapping.ts`: ES `_mapping` JSON → entity-doc objects. Dependency-free (no SDK / `fetch` / `@atlas/api` / `js-yaml`). Flattens the property tree to dotted dimension paths:
  | mapping shape | result |
  | --- | --- |
  | scalar | one dimension at the field path |
  | `date`/`date_nanos` | `timestamp` |
  | object (`properties`) | dotted child dims; no container dim |
  | `nested` | dotted child dims, `nested: true` |
  | multi-field (`fields`) | main field **+** each sub-field (`title.keyword`), `multi_field: true` |

  Numeric ES types → `number`; `text`/`keyword`/`ip`/unsupported → `string`. System (dot-prefixed) indices skipped.

- **Thin client** — appended a localized `getMapping(index?)` to the client (interface + impl), mirroring `ping`'s timeout/abort/scrub. Deliberately minimal so the merge with #3262's concurrent `query()` is a trivial both-added resolution.

- **CLI** — ES profiler (`lib/profilers/elasticsearch.ts`), `detectDBType` + `testDatabaseConnection` ES cases, `init`/`diff` ES branches, and `esEntityToSnapshot` that reuses the existing pure `computeDiff`/`formatDiff`.

## Security

- API key read from **`ATLAS_ES_API_KEY`**, never the URL (the parser rejects credentials).
- Mapping-fetch failures are secret-scrubbed (`scrubElasticsearchError`); non-2xx responses report the status line only, never the body. The client drops the error `cause` chain (raw fetch error can echo the key); the CLI re-throws with `cause` only where the caught error is already scrubbed/credential-free.

## Tests

- `plugins/elasticsearch/__tests__/mapping.test.ts` — pure transform, table-driven (scalar/object/nested/multi-field/date) — TDD'd first.
- `getMapping` cases added to `elasticsearch.test.ts` (URL-encoding, scrubbing, status-only errors, close).
- `packages/cli/src/__tests__/elasticsearch-profiler.test.ts` — profiler, system-index filtering, `esEntityToSnapshot`, and an end-to-end **diff round-trip** (clean re-profile → no drift; mutated mapping → added/removed/changed).

## CI

Full `/ci` green locally: lint · type (tsgo) · **full `bun run test`** · syncpack · template-drift · railway-watch.

## Coordination

`#3262` (SQL surface) also extends `connection.ts` (adds `query()`). This PR's `getMapping()` add is appended to the same client object/interface — merge should be a trivial both-added methods resolution. Note for #3262: dotted/hyphenated index names (`logs-2024.01`) will need ES SQL `FROM` quoting; `table:` keeps the raw index name here.

Closes #3268

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783385522&installation_id=135337507&pr_number=3294&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3294&signature=1e59460006872f64c3fd4e826657b977792e822ca9112121cd3464693e82dcd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Elasticsearch/OpenSearch support across the CLI: profile index mappings into entity YAML, generate a catalog, and use in atlas init/diff; CLI can test ES connectivity (requires ATLAS_ES_API_KEY) and recognizes elasticsearch:// URLs.

* **Documentation**
  * Updated Elasticsearch plugin README with profiling behavior, mapping rules, security notes, and examples.

* **Tests**
  * Added tests covering mapping conversion, mapping retrieval, profiling, diff round-trips, and catalog generation.

* **Config**
  * .env.example includes commented Elasticsearch datasource and API key placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->