### PR TITLE
feat(datasource): @useatlas/elasticsearch Admin → Integrations install + credential mask/restore (#3270)

### DIFF
--- a/apps/docs/content/docs/integrations/admin-console.mdx
+++ b/apps/docs/content/docs/integrations/admin-console.mdx
@@ -40,6 +40,9 @@ Cards are grouped by `type`:
   These are message-driven adapters that send and receive in chat threads.
 - **Integrations** — Salesforce, Jira, GitHub, Linear, Email, Webhook,
   Obsidian, and others. These extend Atlas's data surface or delivery channels.
+- **Datasources** — read-only query targets. PostgreSQL and MySQL are native;
+  Elasticsearch / OpenSearch and others install here from the console (a
+  config-schema-driven form) instead of editing `atlas.config.ts`.
 
 ## Install state
 
@@ -76,9 +79,12 @@ Clicking **Connect** runs the install flow for the card's `installModel`:
 - **OAuth** (Slack, Salesforce, Jira, Linear, GitHub) — opens an
   authorization tab against the Platform. After you approve, Atlas writes
   a `workspace_plugins` row and the card flips to **Installed**.
-- **Form** (Email, Webhook, Obsidian, Linear via API key) — opens a modal
-  that collects the credentials inline and writes the `workspace_plugins`
-  row on submit.
+- **Form** (Email, Webhook, Obsidian, Linear via API key, Elasticsearch /
+  OpenSearch) — opens a modal that collects the credentials inline and writes
+  the `workspace_plugins` row on submit. The form fields are rendered from the
+  catalog entry's `config_schema`, and any field marked `secret: true` (e.g.
+  the Elasticsearch API key) is encrypted at rest, masked on read, and
+  preserved on save when left unchanged.
 - **Static-bot** (Discord, Telegram, WhatsApp, Google Chat, Teams) —
   installed from their per-platform admin blocks further down the page
   rather than via the catalog card's Connect button (which is inert for

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -368,6 +368,7 @@ describe("migrateAuthTables", () => {
             { name: "0120_static_bot_routing_id_unique.sql" },
             { name: "0121_dashboard_card_annotations.sql" },
             { name: "0122_learned_patterns_connection_group.sql" },
+            { name: "0123_elasticsearch_datasource_catalog.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/datasource-pool-resolver.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-pool-resolver.test.ts
@@ -68,6 +68,7 @@ describe("resolveDatasourcePoolConfig", () => {
         { slug: "bigquery", dbType: "bigquery" as const },
         { slug: "duckdb", dbType: "duckdb" as const },
         { slug: "salesforce", dbType: "salesforce" as const },
+        { slug: "elasticsearch", dbType: "elasticsearch" as const },
       ];
       for (const { slug, dbType } of cases) {
         expect(catalogSlugToDbType(slug)).toBe(dbType);
@@ -81,7 +82,7 @@ describe("resolveDatasourcePoolConfig", () => {
     });
 
     it("covers every BUILTIN_DATASOURCE_CATALOG_SLUGS entry", () => {
-      expect(BUILTIN_DATASOURCE_CATALOG_SLUGS).toHaveLength(8);
+      expect(BUILTIN_DATASOURCE_CATALOG_SLUGS).toHaveLength(9);
       for (const slug of BUILTIN_DATASOURCE_CATALOG_SLUGS) {
         catalogSlugToDbType(slug);
       }
@@ -266,6 +267,39 @@ describe("resolveDatasourcePoolConfig", () => {
     });
   });
 
+  describe("elasticsearch", () => {
+    it("emits an ElasticsearchPoolConfig with url + apiKey + description", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("elasticsearch"), {
+        url: "elasticsearch://es.example.com:9243",
+        apiKey: "base64-encoded-api-key",
+        description: "Prod cluster",
+      });
+      expect(config.dbType).toBe("elasticsearch");
+      if (config.dbType !== "elasticsearch") throw new Error("type narrowing");
+      expect(config.url).toBe("elasticsearch://es.example.com:9243");
+      expect(config.apiKey).toBe("base64-encoded-api-key");
+      expect(config.description).toBe("Prod cluster");
+    });
+
+    it("requires `url` (the one universal field across auth modes)", () => {
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("elasticsearch"), {
+          apiKey: "k",
+        }),
+      ).toThrow(/missing.+url/i);
+    });
+
+    it("does not hardcode `apiKey` as required (future Basic/CloudID/SigV4 auth)", () => {
+      // The catalog config_schema enforces per-auth-mode credential requirements;
+      // the resolver only pins `url`. A url-only config must resolve cleanly.
+      const config = resolveDatasourcePoolConfig(baseRow("elasticsearch"), {
+        url: "elasticsearch://es.example.com:9243",
+      });
+      if (config.dbType !== "elasticsearch") throw new Error("type narrowing");
+      expect(config.apiKey).toBeUndefined();
+    });
+  });
+
   describe("optional pool tuning fields", () => {
     it.each(["postgres", "mysql"] as const)(
       "passes maxConnections + idleTimeoutMs through for %s",
@@ -298,6 +332,7 @@ describe("resolveDatasourcePoolConfig", () => {
         duckdb: { path: "/tmp/x.db" },
         salesforce: {},
         "demo-postgres": { url: "postgresql://demo:demo@h/demo" },
+        elasticsearch: { url: "elasticsearch://h:9243", apiKey: "k" },
       };
       const seen = new Set<DatasourcePoolConfig["dbType"]>();
       for (const slug of BUILTIN_DATASOURCE_CATALOG_SLUGS) {
@@ -307,8 +342,9 @@ describe("resolveDatasourcePoolConfig", () => {
         );
         seen.add(config.dbType);
       }
-      // Every built-in db_type produced at least one PoolConfig.
-      expect(seen.size).toBe(7);
+      // Every built-in db_type produced at least one PoolConfig (8 distinct:
+      // postgres+demo-postgres collapse to `postgres`).
+      expect(seen.size).toBe(8);
     });
   });
 });

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -141,13 +141,14 @@ describe("registerDatasourceInstall", () => {
     expect(registerCalls[0].schema).toBeUndefined();
   });
 
-  it("skips plugin-managed dbTypes (clickhouse/snowflake/bigquery/duckdb/salesforce)", () => {
+  it("skips plugin-managed dbTypes (clickhouse/snowflake/bigquery/duckdb/salesforce/elasticsearch)", () => {
     const cases: Array<{ slug: string; cfg: Record<string, unknown> }> = [
       { slug: "clickhouse", cfg: { url: "http://localhost:8123" } },
       { slug: "snowflake", cfg: { url: "snowflake://x" } },
       { slug: "bigquery", cfg: { service_account_json: "{}", project_id: "p" } },
       { slug: "duckdb", cfg: { path: "/tmp/x.duckdb" } },
       { slug: "salesforce", cfg: {} },
+      { slug: "elasticsearch", cfg: { url: "elasticsearch://h:9243", apiKey: "k" } },
     ];
     for (const { slug, cfg } of cases) {
       const ok = bridge.registerDatasourceInstall(ROW(slug), cfg);

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -142,7 +142,8 @@ describe("runMigrations", () => {
     //   Plus 0121 (dashboard_cards.annotations for event annotations, #3209) = 122.
     //   Plus 0122 (learned_patterns.connection_group_id for group-aware expert
     //   apply, #3284) = 123.
-    expect(count).toBe(123);
+    //   Plus 0123 (elasticsearch built-in datasource catalog row, #3270) = 124.
+    expect(count).toBe(124);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -294,6 +295,7 @@ describe("runMigrations", () => {
         "0120_static_bot_routing_id_unique.sql",
         "0121_dashboard_card_annotations.sql",
         "0122_learned_patterns_connection_group.sql",
+        "0123_elasticsearch_datasource_catalog.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -54,8 +54,8 @@ const captureDb = (
 };
 
 describe("BUILTIN_DATASOURCE_CATALOG_ROWS", () => {
-  it("contains exactly the eight built-in slugs", () => {
-    expect(BUILTIN_DATASOURCE_CATALOG_ROWS).toHaveLength(8);
+  it("contains exactly the nine built-in slugs", () => {
+    expect(BUILTIN_DATASOURCE_CATALOG_ROWS).toHaveLength(9);
     const slugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
     expect(new Set(slugs)).toEqual(new Set(BUILTIN_DATASOURCE_CATALOG_SLUGS));
   });
@@ -83,6 +83,8 @@ describe("BUILTIN_DATASOURCE_CATALOG_ROWS", () => {
       duckdb: [],
       salesforce: [],
       "demo-postgres": [],
+      // ES `url` carries no credential (apiKey is separate) — only apiKey is secret.
+      elasticsearch: ["apiKey"],
     };
     for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
       const expectedSecrets = secretFieldsBySlug[row.slug] ?? [];
@@ -103,6 +105,7 @@ describe("BUILTIN_DATASOURCE_CATALOG_ROWS", () => {
       duckdb: "path",
       salesforce: null, // handler-managed, empty schema
       "demo-postgres": null, // operator-managed, empty schema
+      elasticsearch: "url", // connection URL is the primary required field
     };
     for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
       const key = primary[row.slug];
@@ -144,8 +147,8 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
   it("emits 7 params per row (id, name, slug, description, install_model, auto_install, config_schema)", async () => {
     const { db, captured } = captureDb();
     await seedBuiltinDatasourceCatalog(db);
-    // 8 rows × 7 params per row = 56 bound params total.
-    expect(captured[0]!.params).toHaveLength(8 * 7);
+    // 9 rows × 7 params per row = 63 bound params total.
+    expect(captured[0]!.params).toHaveLength(9 * 7);
   });
 
   it("reports every slug as inserted on a fresh catalog (no conflicts)", async () => {
@@ -162,7 +165,7 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
     const result = await seedBuiltinDatasourceCatalog(db);
     const preserved: string[] = [...result.preservedSlugs];
     expect(preserved.sort()).toEqual(["demo-postgres", "postgres"]);
-    expect(result.insertedSlugs).toHaveLength(6);
+    expect(result.insertedSlugs).toHaveLength(7);
     expect(result.insertedSlugs).not.toContain("postgres");
   });
 
@@ -200,15 +203,24 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
 });
 
 describe("migration 0093 and seed module stay aligned", () => {
-  // The migration file's VALUES block and the seed module's
-  // BUILTIN_DATASOURCE_CATALOG_ROWS need to express the same eight rows.
+  // The migration files' VALUES blocks and the seed module's
+  // BUILTIN_DATASOURCE_CATALOG_ROWS need to express the same nine rows.
   // A migration-only edit (or a seed-only edit) would let live DBs and
   // fresh DBs disagree until the next boot. These tests catch the drift.
-
-  const migrationSql = readFileSync(
-    join(import.meta.dir, "..", "migrations", "0093_builtin_datasource_catalog.sql"),
-    "utf8",
-  );
+  //
+  // The original eight rows ship in 0093; `elasticsearch` (#3270) ships in
+  // 0123 (0093 is immutable). Concatenate both so every seed slug is covered
+  // by some migration's VALUES block.
+  const migrationSql =
+    readFileSync(
+      join(import.meta.dir, "..", "migrations", "0093_builtin_datasource_catalog.sql"),
+      "utf8",
+    ) +
+    "\n" +
+    readFileSync(
+      join(import.meta.dir, "..", "migrations", "0123_elasticsearch_datasource_catalog.sql"),
+      "utf8",
+    );
 
   it("references every seed slug in the migration SQL", () => {
     for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
@@ -317,7 +329,7 @@ describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
     const result = await runBuiltinDatasourceCatalogSeedBoot();
     expect(result.kind).toBe("seeded");
     if (result.kind === "seeded") {
-      expect(result.insertedSlugs).toHaveLength(8);
+      expect(result.insertedSlugs).toHaveLength(9);
       expect(result.preservedSlugs).toHaveLength(0);
     }
   });

--- a/packages/api/src/lib/db/datasource-pool-resolver.ts
+++ b/packages/api/src/lib/db/datasource-pool-resolver.ts
@@ -193,6 +193,12 @@ export interface ElasticsearchPoolConfig {
    * authenticate without an `apiKey` — the catalog `config_schema` enforces
    * which auth fields are required per mode. Decrypted upstream by the caller
    * (`decryptSecretFields`) before the resolver sees it.
+   *
+   * TRANSITIONAL: with only API-key auth shipping today this optional under-
+   * constrains the type (a valid install always has `apiKey`). When a second
+   * auth mode lands, promote this to a tagged per-auth-mode sub-union
+   * (`{ authMode: "apiKey"; apiKey: string } | { authMode: "basic"; ... }`)
+   * so each mode's credential is non-optional and exhaustive-switchable.
    */
   readonly apiKey?: string;
   readonly description?: string;

--- a/packages/api/src/lib/db/datasource-pool-resolver.ts
+++ b/packages/api/src/lib/db/datasource-pool-resolver.ts
@@ -22,10 +22,10 @@
  */
 
 /**
- * Catalog slugs for the eight built-in datasource catalog rows seeded by
- * migration 0093 + the boot-time `seed-builtin-datasource-catalog` pass.
- * Two slugs map to the same `db_type` (`postgres` and `demo-postgres`); see
- * {@link catalogSlugToDbType}.
+ * Catalog slugs for the built-in datasource catalog rows seeded by migration
+ * 0093 (the original eight) + migration 0123 (`elasticsearch`, #3270) + the
+ * boot-time `seed-builtin-datasource-catalog` pass. Two slugs map to the same
+ * `db_type` (`postgres` and `demo-postgres`); see {@link catalogSlugToDbType}.
  */
 export const BUILTIN_DATASOURCE_CATALOG_SLUGS = [
   "postgres",
@@ -36,6 +36,7 @@ export const BUILTIN_DATASOURCE_CATALOG_SLUGS = [
   "duckdb",
   "salesforce",
   "demo-postgres",
+  "elasticsearch",
 ] as const;
 export type BuiltinDatasourceCatalogSlug =
   (typeof BUILTIN_DATASOURCE_CATALOG_SLUGS)[number];
@@ -52,7 +53,8 @@ export type BuiltinDatasourceDbType =
   | "clickhouse"
   | "bigquery"
   | "duckdb"
-  | "salesforce";
+  | "salesforce"
+  | "elasticsearch";
 
 /**
  * Map a built-in datasource catalog slug to its `db_type`. The mapping is
@@ -79,6 +81,8 @@ export function catalogSlugToDbType(
       return "duckdb";
     case "salesforce":
       return "salesforce";
+    case "elasticsearch":
+      return "elasticsearch";
     default:
       throw new Error(
         `Unknown built-in datasource catalog slug "${slug}". ` +
@@ -179,6 +183,21 @@ export interface SalesforcePoolConfig {
   readonly description?: string;
 }
 
+export interface ElasticsearchPoolConfig {
+  readonly dbType: "elasticsearch";
+  /** `elasticsearch://host:9243` — carries no credential (the API key is separate). */
+  readonly url: string;
+  /**
+   * Base64-encoded API key. Optional in the shape so the resolver stays
+   * future-proof for the Basic / CloudID / SigV4 auth modes (#3263–#3265) that
+   * authenticate without an `apiKey` — the catalog `config_schema` enforces
+   * which auth fields are required per mode. Decrypted upstream by the caller
+   * (`decryptSecretFields`) before the resolver sees it.
+   */
+  readonly apiKey?: string;
+  readonly description?: string;
+}
+
 export type DatasourcePoolConfig =
   | PostgresPoolConfig
   | MySQLPoolConfig
@@ -186,7 +205,8 @@ export type DatasourcePoolConfig =
   | ClickHousePoolConfig
   | BigQueryPoolConfig
   | DuckDBPoolConfig
-  | SalesforcePoolConfig;
+  | SalesforcePoolConfig
+  | ElasticsearchPoolConfig;
 
 // ---------------------------------------------------------------------------
 // Resolver
@@ -238,6 +258,8 @@ export function resolveDatasourcePoolConfig(
       return resolveDuckDB(decryptedConfig);
     case "salesforce":
       return resolveSalesforce(decryptedConfig);
+    case "elasticsearch":
+      return resolveElasticsearch(decryptedConfig);
   }
 }
 
@@ -382,6 +404,28 @@ function resolveDuckDB(c: Readonly<Record<string, unknown>>): DuckDBPoolConfig {
 function resolveSalesforce(c: Readonly<Record<string, unknown>>): SalesforcePoolConfig {
   return {
     dbType: "salesforce",
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+  };
+}
+
+function resolveElasticsearch(
+  c: Readonly<Record<string, unknown>>,
+): ElasticsearchPoolConfig {
+  // `url` is the one universal field across every ES auth mode; per-auth-mode
+  // credential requirements (API key today; Basic / CloudID / SigV4 later) are
+  // enforced by the catalog `config_schema`, not hardcoded here.
+  const url = asString(c.url);
+  if (!url) {
+    throw new Error(
+      "DatasourcePoolResolver(elasticsearch): missing required field `url`",
+    );
+  }
+  return {
+    dbType: "elasticsearch",
+    url,
+    ...(asString(c.apiKey) !== undefined ? { apiKey: asString(c.apiKey)! } : {}),
     ...(asString(c.description) !== undefined
       ? { description: asString(c.description)! }
       : {}),

--- a/packages/api/src/lib/db/migrations/0123_elasticsearch_datasource_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0123_elasticsearch_datasource_catalog.sql
@@ -1,0 +1,57 @@
+-- 0123_elasticsearch_datasource_catalog.sql
+--
+-- v0.0.13 (#3270 / milestone #63) — seed the built-in Elasticsearch /
+-- OpenSearch Datasource catalog row so a workspace admin can install it from
+-- Admin → Integrations instead of editing `atlas.config.ts`.
+--
+-- This is the ninth built-in datasource catalog row. The original eight ship in
+-- 0093; this row lands separately because 0093 already ran on every existing
+-- deploy (migrations are immutable). The companion boot-time seed pass
+-- (`packages/api/src/lib/db/seed-builtin-datasource-catalog.ts`) re-asserts ALL
+-- nine rows on every boot, so a self-host operator who deleted this row gets it
+-- back without a redeploy. Keeping this VALUES block structurally identical to
+-- `BUILTIN_DATASOURCE_CATALOG_ROWS`'s `elasticsearch` entry is enforced by the
+-- `migration-and-seed-stay-aligned` test in
+-- `__tests__/seed-builtin-datasource-catalog.test.ts`.
+--
+-- `pillar = 'datasource'`, `install_model = 'form'` (config_schema-driven admin
+-- install, NOT OAuth), `auto_install = false`. `config_schema` mirrors the
+-- plugin's `getConfigSchema()` (plugins/elasticsearch/src/index.ts): `apiKey` is
+-- the only `secret: true` field — the `url` carries no credential. The
+-- `secret: true` flag drives `plugins/secrets.ts::encryptSecretFields` so the
+-- API key lands encrypted in `workspace_plugins.config` JSONB, and the admin
+-- mask-on-read / restore-on-save flow (ElasticsearchFormInstallHandler) keys off
+-- it. Future auth modes (Basic / CloudID / SigV4, #3263–#3265) extend this list
+-- + getConfigSchema in lockstep.
+--
+-- Idempotent via unqualified ON CONFLICT DO NOTHING — re-runs and re-deploys are
+-- no-ops at the DB layer. The unqualified form covers both the slug unique index
+-- AND the id primary key (matches 0093).
+
+INSERT INTO plugin_catalog
+  (id, name, slug, description, type, install_model, pillar,
+   implementation_status, auto_install, min_plan, enabled, saas_eligible,
+   config_schema, created_at, updated_at)
+VALUES
+  (
+    'catalog:elasticsearch',
+    'Elasticsearch',
+    'elasticsearch',
+    'Connect an Elasticsearch or OpenSearch cluster as a read-only analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "url", "type": "string", "label": "Connection URL", "required": true, "description": "elasticsearch://host:9200 — HTTPS by default; append ?ssl=false for a plaintext local cluster."},
+      {"key": "apiKey", "type": "string", "label": "API Key", "required": true, "secret": true, "description": "Base64-encoded Elasticsearch API key, sent as `Authorization: ApiKey`. Encrypted at rest."},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  )
+ON CONFLICT DO NOTHING;

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -13,21 +13,23 @@
  *   > in `atlas.config.ts` — they ship with Atlas.
  *
  * Idempotency:
- *   - Uses `ON CONFLICT (slug) DO NOTHING` so re-running on a populated
+ *   - Uses unqualified `ON CONFLICT DO NOTHING` (covers both the `slug`
+ *     unique index AND the `id` primary key) so re-running on a populated
  *     catalog is a no-op. The atlas.config.ts catalog seeder
  *     (`integrations/catalog-seeder.ts`) updates mutable fields on
  *     existing rows; this seed deliberately leaves them alone — once
  *     a built-in row exists, an operator who edited its `name` or
  *     `description` via SQL keeps that edit.
- *   - Slice 5 ships the resolver inert (no ConnectionRegistry consumer);
- *     a seed-time failure logs at error and the API keeps booting —
+ *   - A seed-time failure logs at error and the API keeps booting —
  *     pre-existing rows answer admin-UI reads.
  *
- * Inert until slice 6 (#2744): no production caller reads from these
- * rows. The seeded rows do, however, surface as catalog entries in
- * admin-UI listings — they appear in the integrations marketplace as
- * `pillar = 'datasource'` cards (slice 8 / #2746 pivots the UI to
- * surface them on `/admin/connections`).
+ * These rows are live: they surface as catalog entries in admin-UI listings
+ * (integrations marketplace `pillar = 'datasource'` cards), and form-install
+ * handlers read them at install time to drive config_schema-based encryption
+ * (e.g. `ElasticsearchFormInstallHandler`, #3270, reads the `elasticsearch`
+ * row's `config_schema`). The `DatasourcePoolResolver` registry path remains
+ * native-only (postgres/mysql) — query wiring for admin-installed plugin
+ * datasources is tracked in #3295.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -1,8 +1,8 @@
 /**
- * Boot-time idempotent seed pass for the eight built-in Datasource
- * catalog rows. Re-asserts the same rows migration 0093 inserts on
- * fresh DBs — keeps the catalog consistent if an operator deleted a
- * row out-of-band.
+ * Boot-time idempotent seed pass for the nine built-in Datasource
+ * catalog rows. Re-asserts the same rows migrations 0093 (the original
+ * eight) + 0123 (`elasticsearch`, #3270) insert on fresh DBs — keeps the
+ * catalog consistent if an operator deleted a row out-of-band.
  *
  * Per ADR-0007 §"Catalog seeding for Datasources":
  *
@@ -63,11 +63,11 @@ export interface BuiltinDatasourceCatalogRow {
 }
 
 /**
- * The eight built-in Datasource catalog rows seeded by this module +
- * migration 0093. The single source of truth for `name` / `description`
- * / `config_schema` across both surfaces — keeping the SQL migration
- * structurally identical to this table is enforced by the
- * `migration-and-seed-stay-aligned` test in
+ * The nine built-in Datasource catalog rows seeded by this module +
+ * migrations 0093 (original eight) and 0123 (`elasticsearch`, #3270).
+ * The single source of truth for `name` / `description` / `config_schema`
+ * across both surfaces — keeping the SQL migrations structurally identical
+ * to this table is enforced by the `migration-and-seed-stay-aligned` test in
  * `__tests__/seed-builtin-datasource-catalog.test.ts`.
  *
  * `config_schema` `secret: true` fields drive
@@ -253,6 +253,46 @@ export const BUILTIN_DATASOURCE_CATALOG_ROWS: ReadonlyArray<BuiltinDatasourceCat
     autoInstall: true,
     configSchema: [],
   },
+  {
+    // #3270 — added after the original eight (migration 0123, not 0093). The
+    // boot seed re-asserts all nine; only this row also ships in 0123 for
+    // existing DBs that already ran 0093. `config_schema` mirrors the plugin's
+    // `getConfigSchema()` (plugins/elasticsearch/src/index.ts): `apiKey` is the
+    // only `secret: true` field — the `url` carries no credential. Future auth
+    // modes (#3263–#3265) extend this list + getConfigSchema in lockstep.
+    id: "catalog:elasticsearch",
+    slug: "elasticsearch",
+    name: "Elasticsearch",
+    description:
+      "Connect an Elasticsearch or OpenSearch cluster as a read-only analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "url",
+        type: "string",
+        label: "Connection URL",
+        required: true,
+        description:
+          "elasticsearch://host:9200 — HTTPS by default; append ?ssl=false for a plaintext local cluster.",
+      },
+      {
+        key: "apiKey",
+        type: "string",
+        label: "API Key",
+        required: true,
+        secret: true,
+        description:
+          "Base64-encoded Elasticsearch API key, sent as `Authorization: ApiKey`. Encrypted at rest.",
+      },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
 ];
 
 /**
@@ -272,9 +312,9 @@ export interface BuiltinDatasourceCatalogSeedResult {
 }
 
 /**
- * Idempotently seed the eight built-in Datasource catalog rows.
+ * Idempotently seed the nine built-in Datasource catalog rows.
  *
- * Bulk INSERT keeps the seed cheap (single statement vs eight) and lets
+ * Bulk INSERT keeps the seed cheap (single statement vs nine) and lets
  * the result set (`RETURNING slug`) report which rows actually inserted
  * vs which were preserved. Unqualified `ON CONFLICT DO NOTHING` covers
  * both the `slug` unique index AND the `id` primary key — so a stray

--- a/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
@@ -38,12 +38,15 @@ interface CapturedQuery {
 let captured: CapturedQuery[] = [];
 /** Per-test override for the existing-install lookup (restore-on-save path). */
 let existingInstallRows: unknown[] = [];
+/** Per-test override for the catalog row's config_schema (corrupt-schema path). */
+let catalogSchemaOverride: { value: unknown } | null = null;
 
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
   async (sql: string, params?: unknown[]) => {
     captured.push({ sql, params: params ?? [] });
     if (sql.includes("FROM plugin_catalog")) {
-      return [{ id: "catalog:elasticsearch", config_schema: ES_CONFIG_SCHEMA }];
+      const config_schema = catalogSchemaOverride ? catalogSchemaOverride.value : ES_CONFIG_SCHEMA;
+      return [{ id: "catalog:elasticsearch", config_schema }];
     }
     if (sql.includes("INSERT INTO workspace_plugins")) {
       const id = (params?.[0] as string | undefined) ?? "unknown";
@@ -134,6 +137,7 @@ beforeEach(() => {
   setKeys();
   captured = [];
   existingInstallRows = [];
+  catalogSchemaOverride = null;
   mockLogWarn.mockClear();
   mockLogInfo.mockClear();
   mockInternalQuery.mockClear();
@@ -235,6 +239,54 @@ describe("ElasticsearchFormInstallHandler — restore-on-save", () => {
 
     const cfg = upsertedConfig();
     expect(decryptSecret(cfg.apiKey as string)).toBe("a-freshly-rotated-key");
+  });
+
+  it("preserves the stored secret when apiKey is omitted from the form (dirty-fields save)", async () => {
+    // A UI that PATCHes only changed fields omits the untouched apiKey entirely.
+    // restoreMaskedSecrets' absent-key branch must preserve it — never clear it.
+    const storedCipher = encryptSecret("the-original-api-key");
+    existingInstallRows = [{ config: { url: "elasticsearch://old:9243", apiKey: storedCipher } }];
+
+    const handler = newHandler();
+    const result = await handler.validateConfig(WSID, { url: "elasticsearch://new:9243" });
+
+    const cfg = upsertedConfig();
+    expect(cfg.url).toBe("elasticsearch://new:9243");
+    // apiKey was absent from the form yet must still decrypt to the original —
+    // required validation runs on the restored config so it isn't rejected.
+    expect(decryptSecret(cfg.apiKey as string)).toBe("the-original-api-key");
+    // credentialWritten reflects the restored (preserved) credential.
+    expect(result.credentialWritten).toBe(true);
+  });
+
+  it("fails closed (no INSERT) when the existing row's secret cannot be decrypted", async () => {
+    // Encrypt under the test key, then rotate the v1 key out from under it so
+    // decryptSecretFields throws on read. A silently-empty config here would let
+    // this re-save wipe the live credential — the handler must surface the error.
+    const storedCipher = encryptSecret("the-original-api-key");
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:a-completely-different-key-than-the-encrypt-one-32b";
+    _resetEncryptionKeyCache();
+    existingInstallRows = [{ config: { url: "elasticsearch://old:9243", apiKey: storedCipher } }];
+
+    const handler = newHandler();
+    await expect(
+      handler.validateConfig(WSID, validForm({ apiKey: MASKED_PLACEHOLDER })),
+    ).rejects.toThrow();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
+// ── Corrupt-schema guard (fail closed) ────────────────────────────────────────
+
+describe("ElasticsearchFormInstallHandler — corrupt catalog schema", () => {
+  it("refuses the install (no INSERT) when the catalog config_schema is corrupt", async () => {
+    // A non-array config_schema (ops edit / migration typo) would make the
+    // walkers act on every string and persist the mask sentinel as the
+    // credential — the handler must reject instead.
+    catalogSchemaOverride = { value: "not-an-array" };
+    const handler = newHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(/corrupt/i);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for {@link ElasticsearchFormInstallHandler} (#3270).
+ *
+ * Mirrors `openapi-generic-form-handler.test.ts`: validation rejection emits
+ * {@link FormInstallValidationError} with per-field detail; the happy path
+ * encrypts the `secret: true` field (`apiKey`), and upserts a
+ * `datasource`-pillar `workspace_plugins` row.
+ *
+ * The highest-risk piece (#3270) is the mask-on-read / restore-on-save flow:
+ * a re-save that carries the masked sentinel for `apiKey` MUST preserve the
+ * stored credential (decrypts to the original), while an explicit new value
+ * replaces it. Those are the load-bearing assertions below.
+ *
+ * The catalog `config_schema` is read live from `plugin_catalog`, so the
+ * handler picks up future auth fields (Basic / CloudID / SigV4 — #3263–#3265)
+ * the moment they land in the catalog row, with no handler change. The mock
+ * returns the API-key-only schema the foundation (#3261) ships today.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret, encryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import { MASKED_PLACEHOLDER } from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+
+/** The API-key-only config schema the ES foundation (#3261) ships today. */
+const ES_CONFIG_SCHEMA = [
+  { key: "url", type: "string", label: "Connection URL", required: true },
+  { key: "apiKey", type: "string", label: "API Key", required: true, secret: true },
+  { key: "description", type: "string", label: "Description" },
+];
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+let captured: CapturedQuery[] = [];
+/** Per-test override for the existing-install lookup (restore-on-save path). */
+let existingInstallRows: unknown[] = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    captured.push({ sql, params: params ?? [] });
+    if (sql.includes("FROM plugin_catalog")) {
+      return [{ id: "catalog:elasticsearch", config_schema: ES_CONFIG_SCHEMA }];
+    }
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    // Existing-install lookup (FROM workspace_plugins ... config).
+    return existingInstallRows;
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// Mock EVERY value export of the logger module — a partial mock.module() trips
+// "Export not found" on a transitive import (CLAUDE.md).
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogger = {
+  warn: mockLogWarn,
+  info: mockLogInfo,
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  silent: () => {},
+  child: () => mockLogger,
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => mockLogger,
+  getLogger: () => mockLogger,
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  setLogLevel: () => true,
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (obj: Record<string, unknown>) => obj,
+  hashShareToken: (token: string) => token.slice(0, 16),
+  redactPaths: [] as string[],
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
+}));
+
+const WSID = "ws-es-1" as WorkspaceId;
+
+type HandlerCtor = typeof import("../elasticsearch-form-handler").ElasticsearchFormInstallHandler;
+type FormErrCtor = typeof import("../email-form-handler").FormInstallValidationError;
+let ElasticsearchFormInstallHandler!: HandlerCtor;
+let FormInstallValidationError!: FormErrCtor;
+
+beforeAll(async () => {
+  ElasticsearchFormInstallHandler = (await import("../elasticsearch-form-handler"))
+    .ElasticsearchFormInstallHandler;
+  FormInstallValidationError = (await import("../email-form-handler")).FormInstallValidationError;
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-es-handler-unit-tests-long-enough-32bytes";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.ATLAS_DEPLOY_MODE;
+  _resetEncryptionKeyCache();
+}
+
+function validForm(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    url: "elasticsearch://es.example.com:9243",
+    apiKey: "base64-encoded-api-key",
+    ...overrides,
+  };
+}
+
+function newHandler(idGenerator: () => string = () => "es-install-1") {
+  return new ElasticsearchFormInstallHandler({ idGenerator });
+}
+
+/** The config blob written by the (single) upsert INSERT, parsed from JSON. */
+function upsertedConfig(): Record<string, unknown> {
+  const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+  if (!insert) throw new Error("no INSERT captured");
+  const json = insert.params[4] as string;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  setKeys();
+  captured = [];
+  existingInstallRows = [];
+  mockLogWarn.mockClear();
+  mockLogInfo.mockClear();
+  mockInternalQuery.mockClear();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+describe("ElasticsearchFormInstallHandler — validation", () => {
+  it("rejects a missing required url", async () => {
+    const handler = newHandler();
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, { apiKey: "k" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<FormErrCtor>).fieldErrors.url).toBeDefined();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+
+  it("rejects a missing required apiKey on a fresh install", async () => {
+    const handler = newHandler();
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, { url: "elasticsearch://es.example.com:9243" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<FormErrCtor>).fieldErrors.apiKey).toBeDefined();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
+// ── Persistence + encryption ──────────────────────────────────────────────────
+
+describe("ElasticsearchFormInstallHandler — persistence + encryption", () => {
+  it("inserts a datasource-pillar row and encrypts apiKey at rest", async () => {
+    const handler = newHandler(() => "es-uuid-1");
+    const result = await handler.validateConfig(WSID, validForm());
+
+    expect(result.installRecord).toEqual({
+      id: "es-uuid-1",
+      workspaceId: WSID,
+      catalogId: "elasticsearch",
+    });
+    expect(result.credentialWritten).toBe(true);
+
+    const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain("'datasource'");
+    expect(insert!.sql).toContain("ON CONFLICT (workspace_id, catalog_id, install_id)");
+
+    const cfg = upsertedConfig();
+    // Non-secret url stays plaintext (DB ops grep-able).
+    expect(cfg.url).toBe("elasticsearch://es.example.com:9243");
+    // apiKey is encrypted at rest and decrypts to the submitted value.
+    expect(typeof cfg.apiKey).toBe("string");
+    expect((cfg.apiKey as string).startsWith("enc:v1:")).toBe(true);
+    expect(decryptSecret(cfg.apiKey as string)).toBe("base64-encoded-api-key");
+  });
+});
+
+// ── Restore-on-save (the highest-risk piece, #3270) ───────────────────────────
+
+describe("ElasticsearchFormInstallHandler — restore-on-save", () => {
+  it("preserves the stored secret when the masked sentinel is re-submitted", async () => {
+    // Existing install: apiKey already encrypted at rest.
+    const storedCipher = encryptSecret("the-original-api-key");
+    existingInstallRows = [{ config: { url: "elasticsearch://old:9243", apiKey: storedCipher } }];
+
+    const handler = newHandler();
+    // Admin edits the URL but leaves the (masked) apiKey untouched.
+    await handler.validateConfig(
+      WSID,
+      validForm({ url: "elasticsearch://new:9243", apiKey: MASKED_PLACEHOLDER }),
+    );
+
+    const cfg = upsertedConfig();
+    expect(cfg.url).toBe("elasticsearch://new:9243");
+    // The masked sentinel must NOT clear or persist the bullets — the original
+    // credential is preserved (round-trips to the same plaintext).
+    expect(cfg.apiKey).not.toBe(MASKED_PLACEHOLDER);
+    expect(decryptSecret(cfg.apiKey as string)).toBe("the-original-api-key");
+  });
+
+  it("replaces the stored secret when an explicit new value is submitted", async () => {
+    const storedCipher = encryptSecret("the-original-api-key");
+    existingInstallRows = [{ config: { url: "elasticsearch://old:9243", apiKey: storedCipher } }];
+
+    const handler = newHandler();
+    await handler.validateConfig(WSID, validForm({ apiKey: "a-freshly-rotated-key" }));
+
+    const cfg = upsertedConfig();
+    expect(decryptSecret(cfg.apiKey as string)).toBe("a-freshly-rotated-key");
+  });
+});
+
+// ── SaaS keyset gate ──────────────────────────────────────────────────────────
+
+describe("ElasticsearchFormInstallHandler — SaaS keyset gate", () => {
+  it("refuses the install in SaaS mode with no encryption keyset (no plaintext persist)", async () => {
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+
+    const handler = newHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(/keyset/i);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
@@ -1,0 +1,304 @@
+/**
+ * `ElasticsearchFormInstallHandler` — Admin → Integrations install/edit for the
+ * `@useatlas/elasticsearch` datasource (#3270). Lets a workspace admin connect an
+ * Elasticsearch / OpenSearch cluster from the UI instead of editing
+ * `atlas.config.ts`. Modeled on the openapi-generic datasource form handler
+ * precedent: validate → encrypt schema-marked secrets → upsert a
+ * `pillar='datasource'` `workspace_plugins` row.
+ *
+ * **Schema-driven, not field-hardcoded.** The catalog row's `config_schema` is
+ * read live from `plugin_catalog` (it mirrors the plugin's `getConfigSchema()`),
+ * so the encryption walker, the masked-secret restore, and the required-field
+ * check all key off the catalog schema. When the Basic / CloudID / SigV4 auth
+ * slices (#3263–#3265) extend `getConfigSchema()` (+ the catalog row), this
+ * handler picks the new fields up with NO code change here — the only field
+ * names it knows are the ones the schema declares as `secret: true`.
+ *
+ * **Mask-on-read / restore-on-save (the #3270 invariant).** Admin reads mask
+ * `secret: true` fields to {@link MASKED_PLACEHOLDER} (see `integrations-catalog`
+ * / marketplace `/available`). On save, a field still carrying the sentinel — or
+ * omitted entirely — MUST NOT clear the stored credential: {@link
+ * restoreMaskedSecrets} swaps the bullets back to the persisted value before
+ * re-encryption. An explicit new value is trusted and replaces it. Decryption of
+ * the existing row surfaces as an error (never a silent plaintext fallback).
+ *
+ * **SaaS keyset gate.** Mirrors the Email / OpenAPI posture: refuse the install
+ * when `ATLAS_DEPLOY_MODE=saas` and no encryption keyset is configured, so a
+ * misconfigured SaaS deploy fails closed at the credential boundary rather than
+ * persisting `apiKey` in plaintext.
+ *
+ * **Single-instance per workspace.** One ES install per workspace (a fixed
+ * `install_id`); re-submitting the form edits the same row. Connection
+ * queryability for admin-installed plugin datasources is tracked separately
+ * (#3295) — this slice owns install/edit/persist only, matching how every other
+ * plugin-backed datasource admin-install behaves today.
+ *
+ * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ./openapi-generic-form-handler.ts — datasource form-handler precedent
+ * @see ../../plugins/secrets.ts — encrypt / mask / restore walkers
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
+import {
+  encryptSecretFields,
+  decryptSecretFields,
+  restoreMaskedSecrets,
+  parseConfigSchema,
+  type ConfigSchema,
+} from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+import { FormInstallValidationError } from "./email-form-handler";
+import type { CatalogId, FormBasedInstallHandler, InstallRecord } from "./types";
+
+const log = createLogger("integrations.install.elasticsearch");
+
+/** Catalog slug — the dispatch key in `registerFormHandler`. */
+export const ELASTICSEARCH_SLUG: CatalogId = "elasticsearch";
+/** Catalog FK — the canonical `catalog:<slug>` id seeded in `plugin_catalog`. */
+export const ELASTICSEARCH_CATALOG_ID = "catalog:elasticsearch";
+/**
+ * Stable per-workspace install id — ES is single-instance for this slice, so a
+ * fixed id makes re-submits edit-in-place (and the restore-on-save lookup
+ * unambiguous). Multi-instance support rides along with the query-wiring slice
+ * (#3295).
+ */
+export const ELASTICSEARCH_INSTALL_ID = "elasticsearch";
+
+/** Test-only injection of the install id generator. */
+export interface ElasticsearchFormInstallHandlerOptions {
+  readonly idGenerator?: () => string;
+}
+
+interface CatalogSchemaRow extends Record<string, unknown> {
+  readonly id: string;
+  readonly config_schema: unknown;
+}
+
+interface ExistingInstallRow extends Record<string, unknown> {
+  readonly config: Record<string, unknown> | null;
+}
+
+export class ElasticsearchFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+
+  constructor(options: ElasticsearchFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+    readonly credentialWritten: boolean;
+  }> {
+    // ── 1. Shape guard ──────────────────────────────────────────────
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const incoming = formData as Record<string, unknown>;
+
+    // ── 2. Load the catalog row (id + live config_schema) ───────────
+    // The schema is the source of truth for which fields are secret / required
+    // — read it from the catalog so future auth fields propagate automatically.
+    const catalogRows = await internalQuery<CatalogSchemaRow>(
+      `SELECT id, config_schema
+         FROM plugin_catalog
+        WHERE slug = $1 AND enabled = true
+        LIMIT 1`,
+      [ELASTICSEARCH_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      // The route pre-checks the catalog row, so reaching here is a seed/boot
+      // misconfig (row missing or disabled) — surface as a 500, not a 400.
+      log.error({ workspaceId }, "Elasticsearch catalog row missing or disabled — cannot install");
+      throw new Error(
+        `Catalog row "${ELASTICSEARCH_SLUG}" not found or disabled — the built-in datasource catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+    const schema = parseConfigSchema(catalogRows[0].config_schema);
+
+    // ── 3. Restore masked secrets against the existing install ──────
+    // Read the current row (if any) so an unchanged masked secret round-trips
+    // back to its stored value instead of persisting the bullet sentinel.
+    const existingDecrypted = await this.loadExistingDecryptedConfig(
+      workspaceId,
+      catalogId,
+      schema,
+    );
+    const restored = restoreMaskedSecrets(incoming, existingDecrypted, schema);
+
+    // ── 4. Catalog-schema required + type validation ────────────────
+    // Runs on the RESTORED config so a masked-but-preserved secret satisfies
+    // its `required` rule. Skipped on a corrupt schema (the encrypt walker
+    // fail-closes by encrypting every string anyway — matching the installer's
+    // posture).
+    const fieldErrors = validateAgainstSchema(restored, schema);
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new FormInstallValidationError({ fieldErrors, formErrors: [] });
+    }
+
+    // ── 5. SaaS keyset gate ─────────────────────────────────────────
+    // `encryptSecret` falls back to plaintext when no key is configured (dev
+    // convenience). In SaaS that would leak `apiKey` plaintext — refuse the
+    // install so a misconfigured deploy fails closed at the credential boundary.
+    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+      log.error(
+        { workspaceId },
+        "Refusing Elasticsearch install: SaaS mode + no encryption keyset (would persist plaintext apiKey)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
+          "Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 6. Self-hosted plaintext-credential warning (non-fatal) ─────
+    const secretKeys = schema.state === "parsed" ? secretFieldKeys(schema) : [];
+    const credentialWritten = secretKeys.some(
+      (k) => typeof restored[k] === "string" && (restored[k] as string).length > 0,
+    );
+    if (credentialWritten && isPlaintextCredentialRisk()) {
+      log.warn(
+        { workspaceId },
+        "Persisting an Elasticsearch credential with no encryption keyset configured in a " +
+          "prod-like environment — apiKey will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
+          "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
+      );
+    }
+
+    // ── 7. Encrypt secret fields + upsert the datasource install ────
+    // `encryptSecretFields` is idempotent against already-`enc:v1:` ciphertext.
+    const encryptedConfig = encryptSecretFields(restored, schema);
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, 'draft', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               updated_at = NOW()
+         RETURNING id`,
+        [candidateId, workspaceId, catalogId, ELASTICSEARCH_INSTALL_ID, JSON.stringify(encryptedConfig)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING emits exactly one row
+        // on both paths; an empty result is a driver/RLS/query-rewrite anomaly.
+        // Falling back to candidateId would return a WRONG id on the conflict
+        // path (the row keeps its existing id). Fail loud with a 500.
+        log.error(
+          { workspaceId, candidateId },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist Elasticsearch install record — aborting install",
+      );
+      throw err;
+    }
+
+    log.info(
+      { workspaceId, installId: persistedId, credentialWritten },
+      "Elasticsearch datasource install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: ELASTICSEARCH_SLUG },
+      credentialWritten,
+    };
+  }
+
+  /**
+   * Read + decrypt the existing install's config so masked secrets can be
+   * restored. Returns `{}` when no row exists (fresh install). A decryption
+   * failure throws — a silently-empty config would let a re-save clear a live
+   * credential, turning a key-rotation glitch into a failed-open install.
+   */
+  private async loadExistingDecryptedConfig(
+    workspaceId: WorkspaceId,
+    catalogId: string,
+    schema: ConfigSchema,
+  ): Promise<Record<string, unknown>> {
+    const rows = await internalQuery<ExistingInstallRow>(
+      `SELECT config
+         FROM workspace_plugins
+        WHERE workspace_id = $1 AND catalog_id = $2 AND install_id = $3
+        LIMIT 1`,
+      [workspaceId, catalogId, ELASTICSEARCH_INSTALL_ID],
+    );
+    if (rows.length === 0) return {};
+    return decryptSecretFields(rows[0].config ?? {}, schema);
+  }
+}
+
+/** Keys of every `secret: true` field in a parsed schema. */
+function secretFieldKeys(schema: Extract<ConfigSchema, { state: "parsed" }>): string[] {
+  return schema.fields.filter((f) => f.secret === true).map((f) => f.key);
+}
+
+/**
+ * Validate a (restored) config against the catalog `config_schema`: required
+ * fields must be present + non-empty, and declared types must match. Returns a
+ * field→messages map (empty = valid). Mirrors the installer's
+ * `validateAgainstConfigSchema` shape so the admin UI gets a consistent
+ * `fieldErrors` envelope. A corrupt / absent schema yields no errors — the
+ * encrypt walker still fail-closes on a corrupt schema.
+ */
+function validateAgainstSchema(
+  config: Record<string, unknown>,
+  schema: ConfigSchema,
+): Record<string, string[]> {
+  if (schema.state !== "parsed" || schema.fields.length === 0) return {};
+  const fieldErrors: Record<string, string[]> = {};
+  for (const field of schema.fields) {
+    const value = config[field.key];
+    const present = value !== undefined && value !== null && value !== "";
+    if (field.required === true && !present) {
+      (fieldErrors[field.key] ??= []).push(`${field.label ?? field.key} is required`);
+      continue;
+    }
+    if (!present) continue;
+    switch (field.type) {
+      case "string":
+      case "select":
+        if (typeof value !== "string") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a string`);
+        }
+        break;
+      case "number":
+        if (typeof value !== "number" || Number.isNaN(value)) {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a number`);
+        }
+        break;
+      case "boolean":
+        if (typeof value !== "boolean") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a boolean`);
+        }
+        break;
+      default:
+        // Unknown catalog type — skip (treat as pass), matching the installer.
+        break;
+    }
+  }
+  return fieldErrors;
+}

--- a/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
@@ -15,8 +15,8 @@
  * names it knows are the ones the schema declares as `secret: true`.
  *
  * **Mask-on-read / restore-on-save (the #3270 invariant).** Admin reads mask
- * `secret: true` fields to {@link MASKED_PLACEHOLDER} (see `integrations-catalog`
- * / marketplace `/available`). On save, a field still carrying the sentinel — or
+ * `secret: true` fields to the masked sentinel (`••••••••`) (see
+ * `integrations-catalog` / marketplace `/available`). On save, a field still carrying it — or
  * omitted entirely — MUST NOT clear the stored credential: {@link
  * restoreMaskedSecrets} swaps the bullets back to the persisted value before
  * re-encryption. An explicit new value is trusted and replaces it. Decryption of
@@ -128,7 +128,43 @@ export class ElasticsearchFormInstallHandler implements FormBasedInstallHandler 
     const catalogId = catalogRows[0].id;
     const schema = parseConfigSchema(catalogRows[0].config_schema);
 
-    // ── 3. Restore masked secrets against the existing install ──────
+    // ── 3. Corrupt-schema guard (fail closed) ───────────────────────
+    // The catalog `config_schema` is operator-controlled, not user input, and
+    // the built-in datasource row is seeded ON CONFLICT DO NOTHING (no
+    // self-heal of a drifted schema). A corrupt schema makes
+    // `restoreMaskedSecrets` / `encryptSecretFields` fall back to "act on every
+    // string" — which on a fresh install would encrypt-and-persist the masked
+    // sentinel itself as the credential while `validateAgainstSchema` skips the
+    // required check. Refuse loudly (operator must fix the row) instead of
+    // silently storing junk.
+    if (schema.state === "corrupt") {
+      log.error(
+        { workspaceId, reason: schema.reason },
+        "Elasticsearch catalog config_schema is corrupt — refusing install rather than persisting the mask sentinel as a credential",
+      );
+      throw new Error(
+        `Catalog "${ELASTICSEARCH_SLUG}" config_schema is corrupt (${schema.reason}) — fix the catalog row before installing.`,
+      );
+    }
+
+    // ── 4. SaaS keyset gate ─────────────────────────────────────────
+    // `encryptSecret` falls back to plaintext when no key is configured (dev
+    // convenience). In SaaS that would leak the credential — refuse the install
+    // so a misconfigured deploy fails closed at the credential boundary. Checked
+    // BEFORE the existing-row read so a re-save under misconfigured SaaS surfaces
+    // this actionable message rather than an opaque decrypt failure.
+    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+      log.error(
+        { workspaceId },
+        "Refusing Elasticsearch install: SaaS mode + no encryption keyset (would persist a plaintext credential)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
+          "Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 5. Restore masked secrets against the existing install ──────
     // Read the current row (if any) so an unchanged masked secret round-trips
     // back to its stored value instead of persisting the bullet sentinel.
     const existingDecrypted = await this.loadExistingDecryptedConfig(
@@ -138,32 +174,16 @@ export class ElasticsearchFormInstallHandler implements FormBasedInstallHandler 
     );
     const restored = restoreMaskedSecrets(incoming, existingDecrypted, schema);
 
-    // ── 4. Catalog-schema required + type validation ────────────────
+    // ── 6. Catalog-schema required + type validation ────────────────
     // Runs on the RESTORED config so a masked-but-preserved secret satisfies
-    // its `required` rule. Skipped on a corrupt schema (the encrypt walker
-    // fail-closes by encrypting every string anyway — matching the installer's
-    // posture).
+    // its `required` rule. The schema is guaranteed `absent` or `parsed` here
+    // (corrupt was rejected in step 3).
     const fieldErrors = validateAgainstSchema(restored, schema);
     if (Object.keys(fieldErrors).length > 0) {
       throw new FormInstallValidationError({ fieldErrors, formErrors: [] });
     }
 
-    // ── 5. SaaS keyset gate ─────────────────────────────────────────
-    // `encryptSecret` falls back to plaintext when no key is configured (dev
-    // convenience). In SaaS that would leak `apiKey` plaintext — refuse the
-    // install so a misconfigured deploy fails closed at the credential boundary.
-    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-      log.error(
-        { workspaceId },
-        "Refusing Elasticsearch install: SaaS mode + no encryption keyset (would persist plaintext apiKey)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-          "Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    // ── 6. Self-hosted plaintext-credential warning (non-fatal) ─────
+    // ── 7. Self-hosted plaintext-credential warning (non-fatal) ─────
     const secretKeys = schema.state === "parsed" ? secretFieldKeys(schema) : [];
     const credentialWritten = secretKeys.some(
       (k) => typeof restored[k] === "string" && (restored[k] as string).length > 0,
@@ -172,12 +192,12 @@ export class ElasticsearchFormInstallHandler implements FormBasedInstallHandler 
       log.warn(
         { workspaceId },
         "Persisting an Elasticsearch credential with no encryption keyset configured in a " +
-          "prod-like environment — apiKey will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
+          "prod-like environment — the credential will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
           "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
       );
     }
 
-    // ── 7. Encrypt secret fields + upsert the datasource install ────
+    // ── 8. Encrypt secret fields + upsert the datasource install ────
     // `encryptSecretFields` is idempotent against already-`enc:v1:` ciphertext.
     const encryptedConfig = encryptSecretFields(restored, schema);
 

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -25,6 +25,10 @@ import {
 } from "./dispatch";
 import { SlackOAuthInstallHandler } from "./slack-oauth-handler";
 import { EmailFormInstallHandler } from "./email-form-handler";
+import {
+  ElasticsearchFormInstallHandler,
+  ELASTICSEARCH_SLUG,
+} from "./elasticsearch-form-handler";
 import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
@@ -153,6 +157,14 @@ export function registerBuiltinInstallHandlers(): void {
     lazyPluginLoader.registerBuilder(EMAIL_CATALOG_ID, createEmailLazyBuilder());
   }
   log.info("Registered EmailFormInstallHandler + LazyPluginLoader builder");
+  // Elasticsearch / OpenSearch datasource form-install (#3270). Datasource-
+  // pillar, config_schema-driven (encrypts `apiKey`, masks on read, restores on
+  // save). No env gate — the customer admin supplies the cluster URL + API key
+  // at install time, same as every other form handler. Queryability for admin-
+  // installed plugin datasources is tracked separately (#3295); this slice owns
+  // the install/edit path.
+  registerFormHandler(ELASTICSEARCH_SLUG, new ElasticsearchFormInstallHandler());
+  log.info("Registered ElasticsearchFormInstallHandler");
   registerFormHandler("obsidian", new ObsidianFormInstallHandler());
   log.info("Registered ObsidianFormInstallHandler");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance


### PR DESCRIPTION
## What & why
Implements #3270 (milestone v0.0.13). Adds the **Admin → Integrations** install/edit path for the `@useatlas/elasticsearch` datasource so a workspace admin can connect an Elasticsearch / OpenSearch cluster from the UI instead of editing `atlas.config.ts`. Builds on the connection foundation #3261.

Follows the existing **openapi-generic datasource form-handler** precedent: a config-schema-driven `form` install that encrypts secret fields at rest, masks them on read, and restores them on save.

## Acceptance criteria
- [x] Catalog entry with `config_schema` covering URL + the configured auth field(s)
- [x] Install/edit from Admin → Integrations persists an encrypted config blob
- [x] Secret fields masked on read; unchanged masked values restored on save (no accidental clearing); explicit edits trusted
- [~] Installed datasource queryable end-to-end — **deferred to #3295** (shared plugin-datasource query-wiring gap); see **Scope note** below. ES is queryable via `atlas.config.ts` today.

## What's included
- **`ElasticsearchFormInstallHandler`** (`FormBasedInstallHandler`, registered for slug `elasticsearch`) reached via `POST /api/v1/integrations/elasticsearch/install-form`. It reads the **live catalog `config_schema`** (mirrors the plugin's `getConfigSchema()`), so when the Basic / CloudID / SigV4 auth slices (#3263–#3265) extend `getConfigSchema()` + the catalog row, this handler picks the new fields up with **no code change** — only `apiKey` is hardcoded as `secret` via the schema flag, never the auth fields themselves.
  - **Restore-on-save** (the highest-risk piece): a re-save carrying the masked sentinel (`••••••••`), or omitting the field, preserves the stored credential; an explicit new value replaces it. Decryption failures surface as errors — never a silent plaintext fallback.
  - **SaaS keyset gate**: refuses the install under `ATLAS_DEPLOY_MODE=saas` with no encryption keyset (fail-closed at the credential boundary), with a self-hosted plaintext-risk warning.
- **Built-in catalog row** (`slug 'elasticsearch'`, `install_model 'form'`, `pillar 'datasource'`) in the boot seed + **migration 0123**. `datasource-pool-resolver` gains the `elasticsearch` slug / dbType / `ElasticsearchPoolConfig` + `resolveElasticsearch` (requires `url`; `apiKey` optional so the resolver stays auth-mode-agnostic).
- **Web**: no changes needed — the Admin → Integrations `FormInstallModal` renders fields generically from `config_schema`, and `provider-meta` already has the Elasticsearch icon/label.
- **Docs**: `admin-console.mdx` documents datasource installs (incl. Elasticsearch) via the config-schema form with mask/restore/encrypt.

## Scope note — queryability
The `config_schema` / install / mask-restore-encrypt flow is fully delivered. End-to-end **query** wiring for admin-installed *plugin-backed* datasources is a shared gap (clickhouse/snowflake/salesforce/ES all return `false` from the registry bridge today; the API doesn't bundle plugin packages). That's tracked separately in **#3295**. ES remains queryable via `atlas.config.ts` per #3261. Confirmed as the intended slice boundary.

## Tests
- New `elasticsearch-form-handler.test.ts`: validation, fresh-install encryption, **restore-on-save** (masked→preserve, explicit→replace), SaaS keyset gate.
- Updated resolver / seed-catalog / registry-bridge / migrate-count tests for the 9th datasource + migration 0123.

## CI
`bun run type`, `bun run lint`, `bun x syncpack lint`, schema-drift, template-drift, railway-watch — all green. Affected + install/db + marketplace/catalog route suites pass (isolated per-file).

Closes #3270. Refs #3261, #3295.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783386658&installation_id=135337507&pr_number=3296&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3296&signature=d176b0e8ef3a724567127e21ad1727b09280f4f0c4b833d8014a22f39ea3bad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Elasticsearch/OpenSearch as a built-in datasource with form-based install. Credentials are encrypted at rest, masked on display, and preserved on save when unchanged; form install validates required fields and supports restore-on-save behavior.

* **Documentation**
  * Updated Integrations admin console docs: new Datasources card, expanded Form install flow (credential collection via modal), and Elasticsearch/OpenSearch examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->