### PR TITLE
feat(api): wire DB-stored plugin datasources via createFromConfig seam (#3253)

### DIFF
--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -51,6 +51,7 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
+import { clickhousePlugin } from "./plugins/clickhouse/src/index";
 import { getProactiveAiRuntime } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
@@ -85,6 +86,26 @@ import { createChatPluginExecuteQuery } from "./packages/api/src/lib/chat-plugin
 // under packages/api/node_modules and isn't on the upward walk from
 // /app/atlas.config.ts). Process-lifetime cached on the helper side.
 const proactiveAiRuntime = getProactiveAiRuntime();
+
+/**
+ * Datasource ADAPTER plugins for the staging soak matrix (#3253). Each is
+ * registered only when its staging connection URL env var is set — an unset
+ * env never trips the plugin's required-url config schema at boot, and prod
+ * (which doesn't set these) is unaffected.
+ *
+ * Registering the plugin makes its `connection.createFromConfig` available to
+ * the datasource bridge, which is what lets DB-stored (admin-UI-registered)
+ * datasources of that `dbType` actually connect (ADR-0013). The config-time
+ * URL below also yields a working static config-defined datasource as a bonus.
+ */
+function stagingDatasourcePlugins(): unknown[] {
+  const list: unknown[] = [];
+  const clickhouseUrl = process.env.ATLAS_STAGING_CLICKHOUSE_URL;
+  if (clickhouseUrl) {
+    list.push(clickhousePlugin({ url: clickhouseUrl }));
+  }
+  return list;
+}
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────
@@ -778,6 +799,9 @@ export default defineConfig({
   // at rest via AES-256-GCM. OMIT `botToken` so the adapter operates
   // in multi-workspace mode.
   plugins: [
+    // Datasource adapter plugins (#3253) — registered before chat so their
+    // adapters are available when DB-stored datasources wire at boot.
+    ...stagingDatasourcePlugins(),
     chatPlugin({
       // Catalog-driven adapter activation (#2650 slice 2). The chat
       // plugin's `AdapterRegistry` reads the chat-type subset of the

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -799,8 +799,10 @@ export default defineConfig({
   // at rest via AES-256-GCM. OMIT `botToken` so the adapter operates
   // in multi-workspace mode.
   plugins: [
-    // Datasource adapter plugins (#3253) — registered before chat so their
-    // adapters are available when DB-stored datasources wire at boot.
+    // Datasource adapter plugins (#3253). Listed first for clarity — order
+    // within plugins[] doesn't affect boot wiring (the bridge resolves adapters
+    // via the registry's getAll(), order-independent); what matters is that the
+    // whole array registers before loadSavedConnections runs.
     ...stagingDatasourcePlugins(),
     chatPlugin({
       // Catalog-driven adapter activation (#2650 slice 2). The chat

--- a/docs/adr/0013-db-stored-plugin-datasource-connections.md
+++ b/docs/adr/0013-db-stored-plugin-datasource-connections.md
@@ -1,0 +1,55 @@
+# ADR-0013: DB-stored plugin datasource connections via `createFromConfig`
+
+**Status:** Accepted
+**Date:** 2026-06-06
+**Context milestone:** Staging Environment (#57) — staging datasource matrix (#3253)
+**Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md) (adapter extraction to plugins), [ADR-0007](./0007-unified-install-pipeline.md) (datasource pillar / `workspace_plugins`)
+
+## Context
+
+Datasource adapters beyond the two core engines (Postgres, MySQL) were extracted into plugins (`@useatlas/clickhouse`, `@useatlas/snowflake`, `@useatlas/bigquery`, `@useatlas/duckdb`, `@useatlas/salesforce`, `@useatlas/elasticsearch`) per ADR-0006. Core `@atlas/api` deliberately does **not** import those packages — `db/connection.ts`'s `detectDBType` / `createConnection` switch on postgres/mysql only and throw "this adapter is now a plugin" for anything else (`connection.test.ts:132` codifies that boundary).
+
+A plugin datasource could be wired two ways, but only one worked:
+
+1. **Static, config-defined** — `clickhousePlugin({ url })` in `atlas.config.ts` → boot-time `wireDatasourcePlugins()` calls the plugin's nullary `connection.create()` (closing over the config-time url) and registers one connection via `connections.registerDirect()`. **Worked.**
+2. **DB-stored, admin-UI-registered** — a `workspace_plugins` row (`pillar='datasource'`, `db_type='clickhouse'`, encrypted url). At boot `loadSavedConnections()` and at install time `WorkspaceInstaller.installDatasource()` both route through `datasource-registry-bridge.ts`, which resolved + validated the row and then **`return false`'d for any dbType that wasn't postgres/mysql** (`registerDatasourceInstall`). The row persisted but no connection was ever registered, so `executeSQL` fell through to the core `createConnection` switch and threw `Unsupported database URL scheme "clickhouse://"`. **Broken — silently.**
+
+So the admin UI offered ClickHouse/Snowflake/etc. as connectable datasource types (catalog rows seeded by migration 0093), customers could fill in the form and save, but every query failed. The runtime seam between a DB-stored plugin row and the plugin's connection factory was never built.
+
+The blocker surfaced while provisioning a multi-engine datasource matrix in staging (#3253): a ClickHouse instance was deployed and seeded, but connecting it through the admin UI failed with the scheme error.
+
+## Decision
+
+**Datasource plugins gain an optional `connection.createFromConfig(config)` factory; the bridge looks the plugin up in the registry by `dbType` and builds a per-(workspace, install_id) connection from the DB-stored config. Core stays decoupled from the plugin packages — the lookup goes through the `PluginRegistry`, not a core import.**
+
+Concretely:
+
+- **SDK (`@useatlas/plugin-sdk`)** — `AtlasDatasourcePlugin["connection"]` gains an optional
+  `createFromConfig(config: Readonly<Record<string, unknown>>): Promise<PluginDBConnection> | PluginDBConnection`.
+  Purely additive — `create()` (the static, config-time factory) is unchanged and still required, so existing plugins compile untouched. Unlike `create()` (nullary, closes over config-time config), `createFromConfig` accepts the decrypted per-install config and re-validates it with the plugin's own schema.
+- **Plugins** — each datasource plugin implements `createFromConfig` by re-parsing the runtime config through its existing `configSchema` and delegating to its existing connection factory (e.g. `createClickHouseConnection`). ClickHouse ships first (tracer); the other five follow.
+- **Core `ConnectionRegistry`** — a new `workspacePluginEntries` map holds a live connection per (workspace, install_id) for plugin dbTypes (they can't be cloned by the core `createConnection` switch the way native configs are). New methods `registerDirectForWorkspace` / `hasDirectForWorkspace` / `unregisterDirectForWorkspace`; `getForWorkspace` and the metadata getters (`getDBType` / `getTargetHost` / `getValidator` / `getParserDialect` / `getForbiddenPatterns`) consult plugin entries first. The plugin's validator / parser dialect / forbidden patterns ride on the entry so SQL validation stays correct per dialect.
+- **Bridge (`datasource-registry-bridge.ts`)** — for plugin dbTypes, `registerDatasourceInstall` (now async) lazy-imports the `PluginRegistry`, finds the registered datasource plugin whose `connection.dbType` matches, calls `createFromConfig(decryptedConfig)`, and registers the result via `registerDirectForWorkspace`. If no plugin is registered for the dbType (or it lacks `createFromConfig`) it throws a clear "add the plugin to atlas.config.ts" error — caught + logged per-row at boot, surfaced to the admin on the install path.
+- **Deploy config** — registering the plugin in `atlas.config.ts`'s `plugins` array is what makes its adapter available to the bridge. Staging registers `clickhousePlugin({ url })` conditionally on a staging env var (`ATLAS_STAGING_CLICKHOUSE_URL`); an unset env never trips the plugin's required-url schema, and prod is unaffected.
+
+## Alternatives considered
+
+### Core dbType→factory switch that `require()`s the plugin packages (rejected)
+
+A `plugin-connection-factory.ts` in core with a `switch (dbType)` that dynamically `require()`s `@useatlas/clickhouse/connection` etc. Smallest diff (no SDK change), and the packages are present in the deploy image. **Rejected:** it reintroduces a core→plugin dependency direction that ADR-0006 deliberately removed and that `connection.test.ts:132` codifies. The registry-based seam keeps `config.plugins` as the contract ("add it to the plugins array", which the error message already promised) and lets the operator gate which datasource types are enabled.
+
+### Make `connection.create()` accept a runtime config (rejected)
+
+Overload the existing nullary `create()` to optionally take a config. **Rejected:** muddies the two distinct call sites (static boot wiring vs. DB-driven per-install) and is a more disruptive change to the existing `create()` contract than adding a separate optional method.
+
+### url-optional `configSchema` so `clickhousePlugin()` registers adapter-only (deferred)
+
+The cleanest "every plugin in config, no static url" shape, but it requires changing every plugin's `configSchema` (url → optional) and teaching `wireDatasourcePlugins` to skip adapter-only instances. Deferred as a follow-up — staging has real connection URLs, so the conditional-static-url wiring above suffices for now. Generalizing to prod / no-static-instance hosts is tracked separately.
+
+## Consequences
+
+- DB-stored (admin-UI-registered) plugin datasources connect end-to-end once the plugin is in `config.plugins`. ClickHouse first; Snowflake / BigQuery / DuckDB / Salesforce / Elasticsearch are mechanical follow-up slices (each implements `createFromConfig` + gets wired into the deploy config).
+- `registerDatasourceInstall` is now async; both callers (`loadSavedConnections`, `WorkspaceInstaller`) await it (the Effect callers bridge via `Effect.tryPromise`).
+- Multi-tenant routing holds: two workspaces sharing an install_id get independent plugin connections keyed by (workspace, install_id).
+- A plugin row whose adapter isn't registered fails loud (clear error) instead of silently — boot logs per-row; the admin install path surfaces it.
+- The admin UI offering a datasource type whose plugin isn't deployed remains a separate UX gap (the type picker is catalog-driven, independent of `config.plugins`) — out of scope here, worth a follow-up.

--- a/docs/adr/0013-db-stored-plugin-datasource-connections.md
+++ b/docs/adr/0013-db-stored-plugin-datasource-connections.md
@@ -3,11 +3,11 @@
 **Status:** Accepted
 **Date:** 2026-06-06
 **Context milestone:** Staging Environment (#57) — staging datasource matrix (#3253)
-**Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md) (adapter extraction to plugins), [ADR-0007](./0007-unified-install-pipeline.md) (datasource pillar / `workspace_plugins`)
+**Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md) (three-pillar datasource taxonomy), [ADR-0007](./0007-unified-install-pipeline.md) (datasource pillar / `workspace_plugins`)
 
 ## Context
 
-Datasource adapters beyond the two core engines (Postgres, MySQL) were extracted into plugins (`@useatlas/clickhouse`, `@useatlas/snowflake`, `@useatlas/bigquery`, `@useatlas/duckdb`, `@useatlas/salesforce`, `@useatlas/elasticsearch`) per ADR-0006. Core `@atlas/api` deliberately does **not** import those packages — `db/connection.ts`'s `detectDBType` / `createConnection` switch on postgres/mysql only and throw "this adapter is now a plugin" for anything else (`connection.test.ts:132` codifies that boundary).
+Datasource adapters beyond the two core engines (Postgres, MySQL) were extracted into plugins (`@useatlas/clickhouse`, `@useatlas/snowflake`, `@useatlas/bigquery`, `@useatlas/duckdb`, `@useatlas/salesforce`, `@useatlas/elasticsearch`). That package extraction is its own refactor (not formally ADR'd); ADR-0006 established the datasource pillar those plugins live under. Core `@atlas/api` deliberately does **not** import those packages — `db/connection.ts`'s `detectDBType` / `createConnection` switch on postgres/mysql only and throw "this adapter is now a plugin" for anything else (`connection.test.ts:124` codifies that boundary).
 
 A plugin datasource could be wired two ways, but only one worked:
 
@@ -36,7 +36,7 @@ Concretely:
 
 ### Core dbType→factory switch that `require()`s the plugin packages (rejected)
 
-A `plugin-connection-factory.ts` in core with a `switch (dbType)` that dynamically `require()`s `@useatlas/clickhouse/connection` etc. Smallest diff (no SDK change), and the packages are present in the deploy image. **Rejected:** it reintroduces a core→plugin dependency direction that ADR-0006 deliberately removed and that `connection.test.ts:132` codifies. The registry-based seam keeps `config.plugins` as the contract ("add it to the plugins array", which the error message already promised) and lets the operator gate which datasource types are enabled.
+A `plugin-connection-factory.ts` in core with a `switch (dbType)` that dynamically `require()`s `@useatlas/clickhouse/connection` etc. Smallest diff (no SDK change), and the packages are present in the deploy image. **Rejected:** it reintroduces a core→plugin dependency direction that the adapter-to-plugin extraction deliberately removed and that `connection.test.ts:124` codifies. The registry-based seam keeps `config.plugins` as the contract ("add it to the plugins array", which the error message already promised) and lets the operator gate which datasource types are enabled.
 
 ### Make `connection.create()` accept a runtime config (rejected)
 

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -208,6 +208,20 @@ describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () 
     registry._reset();
   });
 
+  it("getForOrg returns the plugin connection (the org-pooling-ON / SaaS resolution path)", () => {
+    // Regression guard: with pool.perOrg.enabled (staging + prod), the SQL path
+    // resolves via getForOrg/getRegionAwareConnection, NOT getForWorkspace. A
+    // plugin install lives only in workspacePluginEntries, so getForOrg must
+    // short-circuit to it instead of throwing ConnectionNotRegisteredError.
+    const registry = new ConnectionRegistry();
+    const conn = fakeConn("ch");
+    registry.registerDirectForWorkspace("ws-1", "ch", conn, "clickhouse");
+    expect(registry.getForOrg("ws-1", "ch")).toBe(conn);
+    // getForWorkspace agrees regardless of pooling mode.
+    expect(registry.getForWorkspace("ws-1", "ch")).toBe(conn);
+    registry._reset();
+  });
+
   it("surfaces the plugin's validator / dialect / forbidden patterns (not native defaults)", () => {
     const registry = new ConnectionRegistry();
     const conn = fakeConn("ch");

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -182,3 +182,82 @@ describe("ConnectionRegistry.unregister()", () => {
     registry._reset();
   });
 });
+
+describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () => {
+  const fakeConn = (label: string) => {
+    let closed = false;
+    return {
+      query: async () => ({ columns: ["src"], rows: [{ src: label }] }),
+      close: async () => {
+        closed = true;
+      },
+      get closed() {
+        return closed;
+      },
+    };
+  };
+
+  it("registerDirectForWorkspace + getForWorkspace round-trips the live connection", () => {
+    const registry = new ConnectionRegistry();
+    const conn = fakeConn("ch");
+    registry.registerDirectForWorkspace("ws-1", "ch", conn, "clickhouse", "ClickHouse", undefined, undefined, "h.example");
+    expect(registry.hasDirectForWorkspace("ws-1", "ch")).toBe(true);
+    expect(registry.getForWorkspace("ws-1", "ch")).toBe(conn);
+    expect(registry.getDBType("ch", "ws-1")).toBe("clickhouse");
+    expect(registry.getTargetHost("ch", "ws-1")).toBe("h.example");
+    registry._reset();
+  });
+
+  it("surfaces the plugin's validator / dialect / forbidden patterns (not native defaults)", () => {
+    const registry = new ConnectionRegistry();
+    const conn = fakeConn("ch");
+    const validate = (q: string) => ({ valid: !/DROP/i.test(q) });
+    const forbidden = [/\bINSERT\b/i];
+    registry.registerDirectForWorkspace("ws-1", "ch", conn, "clickhouse", undefined, validate, {
+      parserDialect: "PostgresQL",
+      forbiddenPatterns: forbidden,
+    });
+    expect(registry.getValidator("ch", "ws-1")).toBe(validate);
+    expect(registry.getParserDialect("ch", "ws-1")).toBe("PostgresQL");
+    expect(registry.getForbiddenPatterns("ch", "ws-1")).toBe(forbidden);
+    registry._reset();
+  });
+
+  it("routes two workspaces sharing an install_id to their own plugin connections", () => {
+    const registry = new ConnectionRegistry();
+    const a = fakeConn("a");
+    const b = fakeConn("b");
+    registry.registerDirectForWorkspace("ws-a", "ch", a, "clickhouse", undefined, undefined, undefined, "a.host");
+    registry.registerDirectForWorkspace("ws-b", "ch", b, "clickhouse", undefined, undefined, undefined, "b.host");
+    expect(registry.getForWorkspace("ws-a", "ch")).toBe(a);
+    expect(registry.getForWorkspace("ws-b", "ch")).toBe(b);
+    expect(registry.getTargetHost("ch", "ws-a")).toBe("a.host");
+    expect(registry.getTargetHost("ch", "ws-b")).toBe("b.host");
+    registry._reset();
+  });
+
+  it("re-registration closes the previous connection", async () => {
+    const registry = new ConnectionRegistry();
+    const first = fakeConn("first");
+    const second = fakeConn("second");
+    registry.registerDirectForWorkspace("ws-1", "ch", first, "clickhouse");
+    registry.registerDirectForWorkspace("ws-1", "ch", second, "clickhouse");
+    await Promise.resolve();
+    expect(first.closed).toBe(true);
+    expect(registry.getForWorkspace("ws-1", "ch")).toBe(second);
+    registry._reset();
+  });
+
+  it("unregisterDirectForWorkspace closes + removes the connection", async () => {
+    const registry = new ConnectionRegistry();
+    const conn = fakeConn("ch");
+    registry.registerDirectForWorkspace("ws-1", "ch", conn, "clickhouse");
+    expect(registry.unregisterDirectForWorkspace("ws-1", "ch")).toBe(true);
+    await Promise.resolve();
+    expect(conn.closed).toBe(true);
+    expect(registry.hasDirectForWorkspace("ws-1", "ch")).toBe(false);
+    // Second call is a no-op.
+    expect(registry.unregisterDirectForWorkspace("ws-1", "ch")).toBe(false);
+    registry._reset();
+  });
+});

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -1,12 +1,14 @@
 /**
- * Tests for `datasource-registry-bridge` (#2744).
+ * Tests for `datasource-registry-bridge` (#2744, #3253).
  *
  * The bridge is the shared (workspace_plugins row → ConnectionRegistry)
  * glue used by both boot-time `loadSavedConnections` and runtime
- * `WorkspaceInstaller.installDatasource`. The behavioral contract that
- * matters here is the native-vs-plugin dbType filter and the
- * already-registered idempotency guard — the per-dbType translation is
- * delegated to `DatasourcePoolResolver` (covered by its own tests).
+ * `WorkspaceInstaller.installDatasource`. Two behavioral contracts matter:
+ *  - native postgres/mysql → cloneable config registration (#2744/#2783)
+ *  - plugin dbTypes (clickhouse / …) → a live per-(workspace, install_id)
+ *    connection built from the registered plugin's `createFromConfig` (#3253)
+ * The per-dbType translation is delegated to `DatasourcePoolResolver`
+ * (covered by its own tests).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -21,6 +23,10 @@ let registeredIds = new Set<string>();
 const wsRegisterCalls: Array<{ workspaceId: string; installId: string; url: string; schema?: string; description?: string }> = [];
 let wsRegisteredKeys = new Set<string>();
 const wsKey = (workspaceId: string, installId: string) => `${workspaceId}::${installId}`;
+
+// Per-(workspace, install_id) PLUGIN connections — the #3253 seam.
+const wsPluginRegisterCalls: Array<{ workspaceId: string; installId: string; dbType: string; description?: string; targetHost?: string }> = [];
+let wsPluginKeys = new Set<string>();
 
 const mockRegister: Mock<(id: string, cfg: { url: string; schema?: string; description?: string }) => void> = mock(
   (id: string, cfg: { url: string; schema?: string; description?: string }) => {
@@ -62,6 +68,28 @@ const mockDrainWorkspacePool: Mock<(workspaceId: string, installId: string) => n
     return 0;
   },
 );
+// Plugin connection registration seam (#3253).
+const mockRegisterDirectForWorkspace = mock(
+  (
+    workspaceId: string,
+    installId: string,
+    _conn: unknown,
+    dbType: string,
+    description?: string,
+    _validate?: unknown,
+    _meta?: unknown,
+    targetHost?: string,
+  ) => {
+    wsPluginRegisterCalls.push({ workspaceId, installId, dbType, description, targetHost });
+    wsPluginKeys.add(wsKey(workspaceId, installId));
+  },
+);
+const mockHasDirectForWorkspace = mock((workspaceId: string, installId: string) =>
+  wsPluginKeys.has(wsKey(workspaceId, installId)),
+);
+const mockUnregisterDirectForWorkspace = mock((workspaceId: string, installId: string) =>
+  wsPluginKeys.delete(wsKey(workspaceId, installId)),
+);
 
 mock.module("@atlas/api/lib/db/connection", () => ({
   connections: {
@@ -73,8 +101,36 @@ mock.module("@atlas/api/lib/db/connection", () => ({
     unregisterForWorkspace: mockUnregisterForWorkspace,
     hasWorkspacePoolsFor: mockHasWorkspacePoolsFor,
     drainWorkspacePool: mockDrainWorkspacePool,
+    registerDirectForWorkspace: mockRegisterDirectForWorkspace,
+    hasDirectForWorkspace: mockHasDirectForWorkspace,
+    unregisterDirectForWorkspace: mockUnregisterDirectForWorkspace,
   },
 }));
+
+// Plugin registry seam — the bridge lazy-imports this to find a datasource
+// plugin by dbType. `fakeDatasourcePlugins` is swapped per test.
+let fakeDatasourcePlugins: unknown[] = [];
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    getAll: () => fakeDatasourcePlugins,
+  },
+}));
+
+const fakeClickhouseConn = {
+  query: async () => ({ columns: [], rows: [] }),
+  close: async () => {},
+};
+const mockCreateFromConfig = mock((_cfg: Readonly<Record<string, unknown>>) => fakeClickhouseConn);
+const fakeClickhousePlugin = {
+  id: "clickhouse-datasource",
+  types: ["datasource"],
+  connection: {
+    dbType: "clickhouse",
+    parserDialect: "PostgresQL",
+    forbiddenPatterns: [/\bINSERT\b/i],
+    createFromConfig: mockCreateFromConfig,
+  },
+};
 
 type BridgeModule = typeof import("../datasource-registry-bridge");
 let bridge!: BridgeModule;
@@ -84,9 +140,12 @@ beforeEach(async () => {
   registerCalls.length = 0;
   unregisterCalls.length = 0;
   wsRegisterCalls.length = 0;
+  wsPluginRegisterCalls.length = 0;
   drainCalls.length = 0;
   registeredIds = new Set<string>();
   wsRegisteredKeys = new Set<string>();
+  wsPluginKeys = new Set<string>();
+  fakeDatasourcePlugins = [];
   mockRegister.mockClear();
   mockUnregister.mockClear();
   mockHas.mockClear();
@@ -95,15 +154,22 @@ beforeEach(async () => {
   mockUnregisterForWorkspace.mockClear();
   mockHasWorkspacePoolsFor.mockClear();
   mockDrainWorkspacePool.mockClear();
+  mockRegisterDirectForWorkspace.mockClear();
+  mockHasDirectForWorkspace.mockClear();
+  mockUnregisterDirectForWorkspace.mockClear();
+  mockCreateFromConfig.mockClear();
 });
 
 afterEach(() => {
   registerCalls.length = 0;
   unregisterCalls.length = 0;
   wsRegisterCalls.length = 0;
+  wsPluginRegisterCalls.length = 0;
   drainCalls.length = 0;
   registeredIds = new Set<string>();
   wsRegisteredKeys = new Set<string>();
+  wsPluginKeys = new Set<string>();
+  fakeDatasourcePlugins = [];
 });
 
 const ROW = (slug: string) =>
@@ -116,8 +182,8 @@ const ROW = (slug: string) =>
   });
 
 describe("registerDatasourceInstall", () => {
-  it("registers postgres installs", () => {
-    const ok = bridge.registerDatasourceInstall(ROW("postgres"), {
+  it("registers postgres installs", async () => {
+    const ok = await bridge.registerDatasourceInstall(ROW("postgres"), {
       url: "postgresql://u@h/d",
       schema: "analytics",
       description: "Prod",
@@ -132,8 +198,8 @@ describe("registerDatasourceInstall", () => {
     });
   });
 
-  it("registers mysql installs (no schema)", () => {
-    const ok = bridge.registerDatasourceInstall(ROW("mysql"), {
+  it("registers mysql installs (no schema)", async () => {
+    const ok = await bridge.registerDatasourceInstall(ROW("mysql"), {
       url: "mysql://u@h/d",
     });
     expect(ok).toBe(true);
@@ -141,24 +207,57 @@ describe("registerDatasourceInstall", () => {
     expect(registerCalls[0].schema).toBeUndefined();
   });
 
-  it("skips plugin-managed dbTypes (clickhouse/snowflake/bigquery/duckdb/salesforce)", () => {
-    const cases: Array<{ slug: string; cfg: Record<string, unknown> }> = [
-      { slug: "clickhouse", cfg: { url: "http://localhost:8123" } },
-      { slug: "snowflake", cfg: { url: "snowflake://x" } },
-      { slug: "bigquery", cfg: { service_account_json: "{}", project_id: "p" } },
-      { slug: "duckdb", cfg: { path: "/tmp/x.duckdb" } },
-      { slug: "salesforce", cfg: {} },
-    ];
-    for (const { slug, cfg } of cases) {
-      const ok = bridge.registerDatasourceInstall(ROW(slug), cfg);
-      expect(ok).toBe(false);
-    }
+  it("builds a plugin (clickhouse) connection via the registered plugin's createFromConfig (#3253)", async () => {
+    fakeDatasourcePlugins = [fakeClickhousePlugin];
+    const ok = await bridge.registerDatasourceInstall(ROW("clickhouse"), {
+      url: "clickhouse://u:p@h:8123/db",
+    });
+    expect(ok).toBe(true);
+    // The plugin's runtime factory is called with the decrypted config.
+    expect(mockCreateFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFromConfig.mock.calls[0][0]).toMatchObject({ url: "clickhouse://u:p@h:8123/db" });
+    // Registered as a per-(workspace, install_id) plugin connection, with the
+    // plugin's dbType + host parsed from the URL for audit.
+    expect(wsPluginRegisterCalls).toHaveLength(1);
+    expect(wsPluginRegisterCalls[0]).toMatchObject({
+      workspaceId: "ws-1",
+      installId: "prod",
+      dbType: "clickhouse",
+      targetHost: "h",
+    });
+    // No native registration for a plugin type.
     expect(registerCalls).toHaveLength(0);
+    expect(wsRegisterCalls).toHaveLength(0);
   });
 
-  it("is idempotent for the same (workspace, install_id) — returns false on re-register", () => {
-    bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
-    const second = bridge.registerDatasourceInstall(ROW("postgres"), {
+  it("is idempotent for a plugin install — returns false on re-register", async () => {
+    fakeDatasourcePlugins = [fakeClickhousePlugin];
+    const first = await bridge.registerDatasourceInstall(ROW("clickhouse"), { url: "clickhouse://h:8123/db" });
+    const second = await bridge.registerDatasourceInstall(ROW("clickhouse"), { url: "clickhouse://h:8123/db" });
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it("throws for a plugin dbType when no matching plugin is registered (#3253)", async () => {
+    fakeDatasourcePlugins = []; // clickhouse plugin absent from atlas.config.ts
+    await expect(
+      bridge.registerDatasourceInstall(ROW("clickhouse"), { url: "clickhouse://h:8123/db" }),
+    ).rejects.toThrow(/No datasource plugin registered for type "clickhouse"/);
+    expect(wsPluginRegisterCalls).toHaveLength(0);
+  });
+
+  it("throws for a plugin present but lacking createFromConfig", async () => {
+    fakeDatasourcePlugins = [
+      { id: "ch", types: ["datasource"], connection: { dbType: "clickhouse" } },
+    ];
+    await expect(
+      bridge.registerDatasourceInstall(ROW("clickhouse"), { url: "clickhouse://h:8123/db" }),
+    ).rejects.toThrow(/No datasource plugin registered for type "clickhouse"/);
+  });
+
+  it("is idempotent for the same (workspace, install_id) — returns false on re-register", async () => {
+    await bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
+    const second = await bridge.registerDatasourceInstall(ROW("postgres"), {
       url: "postgresql://u@different/d2",
     });
     expect(second).toBe(false);
@@ -166,115 +265,102 @@ describe("registerDatasourceInstall", () => {
     expect(registerCalls).toHaveLength(1);
   });
 
-  it("registers two workspaces sharing an install_id independently (#2783)", () => {
-    // Pre-#2783, the bridge keyed only on install_id, so the second workspace's
-    // install collapsed onto the first's bare row. Now each (workspace,
-    // install_id) gets its own routing config.
-    const alpha = bridge.registerDatasourceInstall(
+  it("registers two workspaces sharing an install_id independently (#2783)", async () => {
+    const alpha = await bridge.registerDatasourceInstall(
       { ...ROW("postgres"), workspaceId: "ws-alpha" },
       { url: "postgresql://alpha-host/wh" },
     );
-    const beta = bridge.registerDatasourceInstall(
+    const beta = await bridge.registerDatasourceInstall(
       { ...ROW("postgres"), workspaceId: "ws-beta" },
       { url: "postgresql://beta-host/wh" },
     );
 
-    // Both are fresh registrations — no collapse.
     expect(alpha).toBe(true);
     expect(beta).toBe(true);
 
-    // Two distinct per-(workspace, install_id) configs, each with its own URL.
     expect(wsRegisterCalls).toHaveLength(2);
     expect(wsRegisterCalls[0]).toMatchObject({ workspaceId: "ws-alpha", installId: "prod", url: "postgresql://alpha-host/wh" });
     expect(wsRegisterCalls[1]).toMatchObject({ workspaceId: "ws-beta", installId: "prod", url: "postgresql://beta-host/wh" });
 
-    // The bare install-id row is written once (first-write-wins) — it backs
-    // only install-id-keyed metadata, not routing.
     expect(registerCalls).toHaveLength(1);
     expect(registerCalls[0].url).toBe("postgresql://alpha-host/wh");
   });
 
-  it("throws when the resolver rejects (missing required field)", () => {
-    expect(() =>
+  it("throws when the resolver rejects (missing required field)", async () => {
+    await expect(
       bridge.registerDatasourceInstall(ROW("postgres"), { schema: "public" }),
-    ).toThrow(/missing required field `url`/);
+    ).rejects.toThrow(/missing required field `url`/);
     expect(registerCalls).toHaveLength(0);
   });
 
-  it("throws when pillar is not datasource", () => {
-    expect(() =>
+  it("throws when pillar is not datasource", async () => {
+    await expect(
       bridge.registerDatasourceInstall(
         { ...ROW("postgres"), pillar: "chat" as never },
         { url: "postgresql://u@h/d" },
       ),
-    ).toThrow(/pillar must be 'datasource'/);
+    ).rejects.toThrow(/pillar must be 'datasource'/);
   });
 
-  it("omits postgres schema when set to 'public' (it's the default)", () => {
-    // The resolver explicitly skips initSql for 'public', and the bridge
-    // mirrors the convention by not forwarding `schema` when it's
-    // 'public'. Verifies the bridge's spread guard.
-    const ok = bridge.registerDatasourceInstall(ROW("postgres"), {
+  it("forwards postgres schema 'public' (resolver contract — bridge does not filter)", async () => {
+    const ok = await bridge.registerDatasourceInstall(ROW("postgres"), {
       url: "postgresql://u@h/d",
       schema: "public",
     });
     expect(ok).toBe(true);
     expect(registerCalls[0].schema).toBe("public");
-    // The resolver returned schema='public' so the bridge forwards it;
-    // postgres pool driver no-ops on the SET. Documenting that the
-    // bridge does NOT filter — that's the resolver's contract.
   });
 });
 
 describe("unregisterDatasourceInstall", () => {
-  it("removes both the per-workspace config and the bare row when registered", () => {
-    bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
+  it("removes both the per-workspace config and the bare row when registered", async () => {
+    await bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
     const result = bridge.unregisterDatasourceInstall("ws-1", "prod");
     expect(result).toBe(true);
-    // Per-workspace routing config gone — no stale route survives.
     expect(wsRegisteredKeys.has(wsKey("ws-1", "prod"))).toBe(false);
-    // Bare row removed too (no sibling workspace owns the install_id).
     expect(unregisterCalls).toContain("prod");
   });
 
-  it("eagerly drains the live org-pool clone for the (workspace, install_id) (#3109)", () => {
-    // Both uninstall and updateDatasourceConfig route through this bridge fn, so
-    // a single drain hook here covers both — the cloned pool can't keep serving
-    // the prior config until LRU/restart.
-    bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
+  it("closes + removes a DB-stored plugin connection (#3253)", async () => {
+    fakeDatasourcePlugins = [fakeClickhousePlugin];
+    await bridge.registerDatasourceInstall(ROW("clickhouse"), { url: "clickhouse://h:8123/db" });
+    expect(wsPluginKeys.has(wsKey("ws-1", "prod"))).toBe(true);
+    const result = bridge.unregisterDatasourceInstall("ws-1", "prod");
+    expect(result).toBe(true);
+    expect(mockUnregisterDirectForWorkspace).toHaveBeenCalledWith("ws-1", "prod");
+    expect(wsPluginKeys.has(wsKey("ws-1", "prod"))).toBe(false);
+  });
+
+  it("eagerly drains the live org-pool clone for the (workspace, install_id) (#3109)", async () => {
+    await bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
     bridge.unregisterDatasourceInstall("ws-1", "prod");
     expect(drainCalls).toEqual([{ workspaceId: "ws-1", installId: "prod" }]);
   });
 
-  it("drains the targeted clone even when a sibling keeps the bare row", () => {
-    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-a" }, { url: "postgresql://a/d" });
-    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-b" }, { url: "postgresql://b/d" });
+  it("drains the targeted clone even when a sibling keeps the bare row", async () => {
+    await bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-a" }, { url: "postgresql://a/d" });
+    await bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-b" }, { url: "postgresql://b/d" });
 
     bridge.unregisterDatasourceInstall("ws-a", "prod");
-    // Only ws-a's clone is drained; ws-b's pool is left intact.
     expect(drainCalls).toEqual([{ workspaceId: "ws-a", installId: "prod" }]);
     expect(unregisterCalls).not.toContain("prod");
   });
 
-  it("keeps the shared bare row when a sibling workspace still owns the install_id", () => {
-    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-a" }, { url: "postgresql://a/d" });
-    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-b" }, { url: "postgresql://b/d" });
+  it("keeps the shared bare row when a sibling workspace still owns the install_id", async () => {
+    await bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-a" }, { url: "postgresql://a/d" });
+    await bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-b" }, { url: "postgresql://b/d" });
 
     const result = bridge.unregisterDatasourceInstall("ws-a", "prod");
     expect(result).toBe(true);
 
-    // ws-a's routing config is gone; ws-b's survives.
     expect(wsRegisteredKeys.has(wsKey("ws-a", "prod"))).toBe(false);
     expect(wsRegisteredKeys.has(wsKey("ws-b", "prod"))).toBe(true);
-    // Bare row is NOT torn down while ws-b still owns `prod` — sibling metadata
-    // (getDBType / getTargetHost) keeps resolving.
     expect(unregisterCalls).not.toContain("prod");
   });
 
-  it("returns false when install_id was never registered (plugin-managed pool)", () => {
+  it("returns false when install_id was never registered", async () => {
     const result = bridge.unregisterDatasourceInstall("ws-1", "never-registered");
     expect(result).toBe(false);
-    // Nothing to remove — neither the per-workspace config nor the bare row.
     expect(unregisterCalls).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -472,12 +472,14 @@ describe("internal DB module", () => {
       expect(connections.has("bad")).toBe(false);
     });
 
-    it("skips non-native datasource installs (plugin-managed)", async () => {
+    it("plugin-managed install whose plugin isn't registered throws → caught per-row, counted 0 (#3253)", async () => {
       process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
       const { pool } = createMockPool();
-      // Snowflake / ClickHouse / etc. are plugin-managed; their installs
-      // surface here but the registry's native-adapter path can't create
-      // them — the plugin's boot path calls `registerDirect` instead.
+      // Snowflake / ClickHouse / etc. are plugin-managed. Post-#3253 the bridge
+      // looks the plugin up by dbType; with no such plugin registered (the real
+      // global registry is empty in this test) registerDatasourceInstall throws
+      // "No datasource plugin registered…". The boot loop catches that per-row
+      // and continues, so the row contributes 0 and never lands in the registry.
       pool._setResult({
         rows: [
           {
@@ -494,6 +496,7 @@ describe("internal DB module", () => {
       const count = await loadSavedConnections();
       expect(count).toBe(0);
       expect(connections.has("warehouse")).toBe(false);
+      expect(connections.hasDirectForWorkspace("ws-1", "warehouse")).toBe(false);
     });
 
     it("returns 0 when query throws (workspace_plugins not exist)", async () => {

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -439,6 +439,25 @@ interface WorkspaceBaseEntry {
   targetHost: string;
 }
 
+/**
+ * A live, pre-built connection for a DB-stored PLUGIN datasource, keyed by
+ * (workspace, install_id). Unlike {@link WorkspaceBaseEntry} (native
+ * postgres/mysql configs that are cloned lazily per-org via `createConnection`),
+ * plugin-managed dbTypes can't be cloned by the core `createConnection` switch,
+ * so the connection is built once (by the plugin's `connection.createFromConfig`)
+ * and held here directly. The plugin's own validator / parser dialect /
+ * forbidden patterns ride along on the entry (they do NOT default off the way
+ * native per-workspace configs do).
+ */
+interface WorkspacePluginEntry {
+  conn: DBConnection;
+  dbType: DBType;
+  description?: string;
+  targetHost: string;
+  validate?: (query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>;
+  pluginMeta?: ConnectionPluginMeta;
+}
+
 /** Configuration for per-org pool isolation. */
 export interface OrgPoolSettings {
   /** Whether org-scoped pooling is active. Only true when pool.perOrg is explicitly configured. */
@@ -487,6 +506,15 @@ export class ConnectionRegistry {
    * no live connections are held here. See {@link WorkspaceBaseEntry} and #2783.
    */
   private workspaceEntries = new Map<string, WorkspaceBaseEntry>();
+
+  /**
+   * Per-(workspace, install_id) live connections for DB-stored plugin
+   * datasources (clickhouse / snowflake / bigquery / duckdb / salesforce /
+   * elasticsearch), keyed by {@link _workspaceKey}. Built by the datasource
+   * bridge via {@link registerDirectForWorkspace} from the plugin's
+   * `connection.createFromConfig`. See {@link WorkspacePluginEntry}.
+   */
+  private workspacePluginEntries = new Map<string, WorkspacePluginEntry>();
 
   // --- Org-scoped pool isolation ---
   /** Org pool entries keyed by "orgId:connectionId". */
@@ -747,6 +775,11 @@ export class ConnectionRegistry {
    * `get(installId)` path (org pooling off) would otherwise collide.
    */
   getForWorkspace(workspaceId: string, installId: string, region?: string): DBConnection {
+    // DB-stored plugin datasources hold a pre-built live connection per
+    // (workspace, install_id) — return it directly (no org-clone path, since
+    // the core `createConnection` switch can't build plugin dbTypes).
+    const pluginEntry = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, installId));
+    if (pluginEntry) return pluginEntry.conn;
     if (this.workspaceEntries.has(this._workspaceKey(workspaceId, installId))) {
       return this.getForOrg(workspaceId, installId, region);
     }
@@ -973,6 +1006,67 @@ export class ConnectionRegistry {
     return this.workspaceEntries.delete(this._workspaceKey(workspaceId, installId));
   }
 
+  /**
+   * Register a pre-built live connection for a DB-stored PLUGIN datasource,
+   * scoped to (workspace, install_id). The datasource bridge builds `conn`
+   * from the plugin's `connection.createFromConfig(decryptedConfig)` and passes
+   * the plugin's validator / parser dialect / forbidden patterns so SQL
+   * validation stays correct for the dialect. Re-registration closes the prior
+   * connection. See {@link WorkspacePluginEntry} and {@link getForWorkspace}.
+   */
+  registerDirectForWorkspace(
+    workspaceId: string,
+    installId: string,
+    conn: DBConnection,
+    dbType: DBType,
+    description?: string,
+    validate?: (query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>,
+    meta?: ConnectionPluginMeta,
+    targetHost = "(direct)",
+  ): void {
+    const key = this._workspaceKey(workspaceId, installId);
+    const existing = this.workspacePluginEntries.get(key);
+    this.workspacePluginEntries.set(key, {
+      conn,
+      dbType,
+      description,
+      targetHost,
+      validate,
+      pluginMeta: meta,
+    });
+    if (existing) {
+      existing.conn.close().catch((err) => {
+        log.warn(
+          { err: errorMessage(err), workspaceId, installId },
+          "Failed to close previous plugin connection during re-registration",
+        );
+      });
+    }
+  }
+
+  /** True if a DB-stored plugin connection is registered for (workspace, install_id). */
+  hasDirectForWorkspace(workspaceId: string, installId: string): boolean {
+    return this.workspacePluginEntries.has(this._workspaceKey(workspaceId, installId));
+  }
+
+  /**
+   * Close + remove a DB-stored plugin connection for (workspace, install_id).
+   * Returns true if one was present. Called by the bridge on uninstall /
+   * config-update so a stale plugin connection doesn't outlive its install.
+   */
+  unregisterDirectForWorkspace(workspaceId: string, installId: string): boolean {
+    const key = this._workspaceKey(workspaceId, installId);
+    const entry = this.workspacePluginEntries.get(key);
+    if (!entry) return false;
+    entry.conn.close().catch((err) => {
+      log.warn(
+        { err: errorMessage(err), workspaceId, installId },
+        "Failed to close plugin connection during unregister",
+      );
+    });
+    return this.workspacePluginEntries.delete(key);
+  }
+
   /** Register a pre-built connection (e.g. for benchmark harness or datasource plugin). */
   registerDirect(
     id: string,
@@ -1132,6 +1226,8 @@ export class ConnectionRegistry {
    */
   getDBType(id: string, workspaceId?: string): DBType {
     if (workspaceId) {
+      const pe = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, id));
+      if (pe) return pe.dbType;
       const ws = this.workspaceEntries.get(this._workspaceKey(workspaceId, id));
       if (ws) return ws.dbType;
     }
@@ -1151,6 +1247,8 @@ export class ConnectionRegistry {
    */
   getTargetHost(id: string, workspaceId?: string): string {
     if (workspaceId) {
+      const pe = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, id));
+      if (pe) return pe.targetHost;
       const ws = this.workspaceEntries.get(this._workspaceKey(workspaceId, id));
       if (ws) return ws.targetHost;
     }
@@ -1171,8 +1269,12 @@ export class ConnectionRegistry {
    * bare validator (#3109).
    */
   getValidator(id: string, workspaceId?: string): ((query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>) | undefined {
-    if (workspaceId && this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
-      return undefined;
+    if (workspaceId) {
+      const pe = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, id));
+      if (pe) return pe.validate;
+      if (this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
+        return undefined;
+      }
     }
     return this.entries.get(id)?.validate;
   }
@@ -1184,8 +1286,12 @@ export class ConnectionRegistry {
    * fall through to the dbType-based default (#3109).
    */
   getParserDialect(id: string, workspaceId?: string): string | undefined {
-    if (workspaceId && this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
-      return undefined;
+    if (workspaceId) {
+      const pe = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, id));
+      if (pe) return pe.pluginMeta?.parserDialect;
+      if (this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
+        return undefined;
+      }
     }
     return this.entries.get(id)?.pluginMeta?.parserDialect;
   }
@@ -1196,8 +1302,12 @@ export class ConnectionRegistry {
    * base + dbType-specific patterns apply — return [] for them (#3109).
    */
   getForbiddenPatterns(id: string, workspaceId?: string): RegExp[] {
-    if (workspaceId && this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
-      return [];
+    if (workspaceId) {
+      const pe = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, id));
+      if (pe) return pe.pluginMeta?.forbiddenPatterns ?? [];
+      if (this.workspaceEntries.has(this._workspaceKey(workspaceId, id))) {
+        return [];
+      }
     }
     return this.entries.get(id)?.pluginMeta?.forbiddenPatterns ?? [];
   }
@@ -1597,9 +1707,17 @@ export class ConnectionRegistry {
         }),
       );
     }
+    for (const [key, entry] of this.workspacePluginEntries.entries()) {
+      closing.push(
+        entry.conn.close().catch((err) => {
+          log.warn({ err: errorMessage(err), workspacePluginKey: key }, "Failed to close plugin connection during shutdown");
+        }),
+      );
+    }
     await Promise.all(closing);
     this.entries.clear();
     this.workspaceEntries.clear();
+    this.workspacePluginEntries.clear();
     this.orgEntries.clear();
     this.orgAccessSeq.clear();
     _resetWhitelists();
@@ -1620,8 +1738,14 @@ export class ConnectionRegistry {
         log.warn({ err: errorMessage(err), orgPoolKey: key }, "Failed to close org pool during registry reset");
       });
     }
+    for (const [key, entry] of this.workspacePluginEntries.entries()) {
+      entry.conn.close().catch((err) => {
+        log.warn({ err: errorMessage(err), workspacePluginKey: key }, "Failed to close plugin connection during registry reset");
+      });
+    }
     this.entries.clear();
     this.workspaceEntries.clear();
+    this.workspacePluginEntries.clear();
     this.orgEntries.clear();
     this.orgAccessSeq.clear();
     _resetWhitelists();

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -652,6 +652,15 @@ export class ConnectionRegistry {
       return existing.conn;
     }
 
+    // DB-stored plugin datasources hold a pre-built live connection per
+    // (workspace, install_id) and are never cloned into orgEntries (the core
+    // createConnection switch can't build plugin dbTypes). Return it directly —
+    // mirrors getForWorkspace, and is required because the SaaS/org-pooling
+    // query path resolves through getForOrg, not getForWorkspace (#3253).
+    // `orgId` IS the workspace id in Atlas.
+    const pluginEntry = this.workspacePluginEntries.get(this._workspaceKey(orgId, connectionId));
+    if (pluginEntry) return pluginEntry.conn;
+
     // Ensure the base connection exists (trigger lazy init for "default")
     if (connectionId === "default" && !this.entries.has("default")) {
       this.getDefault();
@@ -1261,12 +1270,13 @@ export class ConnectionRegistry {
    * Custom query validator for a connection, if one was registered. Callers must
    * verify connection existence first.
    *
-   * A per-(workspace, install_id) routing config is always a NATIVE
-   * postgres/mysql datasource — custom validators (and all plugin metadata) live
-   * only on the bare entry, registered via `registerDirect`. So when a
-   * per-workspace config exists for `(workspaceId, id)`, there is no custom
-   * validator for that workspace: return undefined rather than leak a sibling's
-   * bare validator (#3109).
+   * A DB-stored plugin entry (`workspacePluginEntries`) carries its OWN validator
+   * and is checked first — returned directly (#3253). Otherwise: a per-(workspace,
+   * install_id) NATIVE config is always postgres/mysql, where custom validators
+   * (and all plugin metadata) live only on the bare entry registered via
+   * `registerDirect`. So when only a native per-workspace config exists for
+   * `(workspaceId, id)`, return undefined rather than leak a sibling's bare
+   * validator (#3109).
    */
   getValidator(id: string, workspaceId?: string): ((query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>) | undefined {
     if (workspaceId) {
@@ -1280,10 +1290,11 @@ export class ConnectionRegistry {
   }
 
   /**
-   * Plugin-provided parser dialect for a connection, if any. Like
-   * {@link getValidator}, a per-(workspace, install_id) config is native, so its
-   * dialect derives from `getDBType` (not plugin metadata) — return undefined to
-   * fall through to the dbType-based default (#3109).
+   * Plugin-provided parser dialect for a connection, if any. A DB-stored plugin
+   * entry returns its own dialect first (#3253). Otherwise, like
+   * {@link getValidator}, a native per-(workspace, install_id) config derives its
+   * dialect from `getDBType` (not plugin metadata) — return undefined to fall
+   * through to the dbType-based default (#3109).
    */
   getParserDialect(id: string, workspaceId?: string): string | undefined {
     if (workspaceId) {
@@ -1298,7 +1309,8 @@ export class ConnectionRegistry {
 
   /**
    * Plugin-provided forbidden patterns for a connection. Empty array if none.
-   * Per-(workspace, install_id) configs are native (no plugin patterns), so the
+   * A DB-stored plugin entry returns its own patterns first (#3253). Otherwise
+   * native per-(workspace, install_id) configs carry no plugin patterns, so the
    * base + dbType-specific patterns apply — return [] for them (#3109).
    */
   getForbiddenPatterns(id: string, workspaceId?: string): RegExp[] {

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -39,8 +39,8 @@ import {
  * Structural shape of a datasource plugin's `connection` object, matched
  * against `PluginRegistry` entries by `dbType`. Declared locally (not imported
  * from `@useatlas/plugin-sdk`) so core `@atlas/api` stays decoupled from the
- * plugin packages — the same convention `lib/plugins/wiring.ts` uses, and what
- * ADR-0006's adapter extraction requires.
+ * plugin packages — the same convention `lib/plugins/wiring.ts` uses, preserving
+ * the core→plugin decoupling the adapter-to-plugin extraction established.
  */
 interface DatasourceConnectionShape {
   dbType: string;
@@ -54,6 +54,7 @@ interface DatasourceConnectionShape {
   forbiddenPatterns?: RegExp[];
 }
 
+/** Narrow a registry plugin to its datasource `connection` shape, or undefined if it isn't one. */
 function getDatasourceConnection(plugin: unknown): DatasourceConnectionShape | undefined {
   const c = (plugin as { connection?: unknown } | null)?.connection;
   if (c && typeof c === "object" && typeof (c as { dbType?: unknown }).dbType === "string") {
@@ -69,6 +70,8 @@ function pluginTargetHost(poolConfig: DatasourcePoolConfig): string {
     try {
       return new URL(url).hostname || "(plugin)";
     } catch {
+      // intentionally ignored: targetHost is a best-effort audit label, not a
+      // routing/security value — a malformed URL falls back to "(plugin)".
       return "(plugin)";
     }
   }
@@ -120,7 +123,9 @@ async function registerPluginDatasourceInstall(
   connections.registerDirectForWorkspace(
     row.workspaceId,
     row.installId,
-    built as unknown as DBConnection,
+    // Single structural assertion (DBConnection is a superset of the plugin's
+    // {query,close} shape) — mirrors lib/plugins/wiring.ts; no `unknown` launder.
+    built as DBConnection,
     poolConfig.dbType,
     (poolConfig as { description?: string }).description,
     conn.validate,
@@ -217,14 +222,18 @@ export async function registerDatasourceInstall(
  *     config update / uninstall propagates immediately instead of serving the
  *     OLD config until LRU eviction / restart (#3109). Step 1 drops the routing
  *     config; this drops the live pool, keeping them symmetric.
- *  3. Removes the shared bare `entries` row ONLY when no OTHER workspace still
+ *  3. Closes + drops a DB-stored plugin connection (clickhouse / snowflake / …)
+ *     held in `workspacePluginEntries` for this (workspace, install_id) — the
+ *     plugin counterpart to step 1+2's native teardown (#3253).
+ *  4. Removes the shared bare `entries` row ONLY when no OTHER workspace still
  *     owns the install_id (`hasWorkspacePoolsFor`). A sibling sharing the
  *     install_id keeps the bare row so its install-id-keyed metadata
  *     (getDBType / getTargetHost / validators) keeps resolving.
  *
  * The registry's own `unregister` throws if the id isn't present; we guard
- * with `has()` so the soft-archive path (status → archived) is a no-op when
- * the row was never pooled (e.g. clickhouse).
+ * with `has()` so the soft-archive path (status → archived) is a no-op for the
+ * BARE row when the install never populated it (plugin datasources never do —
+ * their teardown is step 3's `unregisterDirectForWorkspace`).
  */
 export function unregisterDatasourceInstall(workspaceId: string, installId: string): boolean {
   const removedWorkspace = connections.unregisterForWorkspace(workspaceId, installId);

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -28,11 +28,107 @@
  */
 
 import { connections } from "@atlas/api/lib/db/connection";
+import type { ConnectionPluginMeta, DBConnection } from "@atlas/api/lib/db/connection";
 import {
   type DatasourcePoolConfig,
   type DatasourceWorkspacePluginRow,
   resolveDatasourcePoolConfig,
 } from "@atlas/api/lib/db/datasource-pool-resolver";
+
+/**
+ * Structural shape of a datasource plugin's `connection` object, matched
+ * against `PluginRegistry` entries by `dbType`. Declared locally (not imported
+ * from `@useatlas/plugin-sdk`) so core `@atlas/api` stays decoupled from the
+ * plugin packages — the same convention `lib/plugins/wiring.ts` uses, and what
+ * ADR-0006's adapter extraction requires.
+ */
+interface DatasourceConnectionShape {
+  dbType: string;
+  /** Build a connection from a runtime (DB-stored) config — see SDK `AtlasDatasourcePlugin`. */
+  createFromConfig?(
+    config: Readonly<Record<string, unknown>>,
+  ): Promise<{ query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> }>
+    | { query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> };
+  validate?: (query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>;
+  parserDialect?: string;
+  forbiddenPatterns?: RegExp[];
+}
+
+function getDatasourceConnection(plugin: unknown): DatasourceConnectionShape | undefined {
+  const c = (plugin as { connection?: unknown } | null)?.connection;
+  if (c && typeof c === "object" && typeof (c as { dbType?: unknown }).dbType === "string") {
+    return c as DatasourceConnectionShape;
+  }
+  return undefined;
+}
+
+/** Best-effort host for audit logging from a plugin pool config's URL (no credentials). */
+function pluginTargetHost(poolConfig: DatasourcePoolConfig): string {
+  const url = (poolConfig as { url?: unknown }).url;
+  if (typeof url === "string") {
+    try {
+      return new URL(url).hostname || "(plugin)";
+    } catch {
+      return "(plugin)";
+    }
+  }
+  return "(plugin)";
+}
+
+/**
+ * Register a DB-stored datasource of a PLUGIN type (clickhouse / snowflake /
+ * bigquery / duckdb / salesforce / elasticsearch). Looks up the plugin in the
+ * registry by `dbType`, builds a per-(workspace, install_id) connection via the
+ * plugin's `connection.createFromConfig(decryptedConfig)`, and registers it
+ * with the plugin's validator / dialect / forbidden patterns so SQL validation
+ * stays correct.
+ *
+ * Throws (caught + logged per-row by `loadSavedConnections` at boot; surfaced
+ * to the admin on the install path) when no plugin is registered for the
+ * dbType, or the plugin doesn't implement `createFromConfig`.
+ */
+async function registerPluginDatasourceInstall(
+  row: DatasourceWorkspacePluginRow,
+  poolConfig: DatasourcePoolConfig,
+  decryptedConfig: Readonly<Record<string, unknown>>,
+): Promise<boolean> {
+  // Lazy import keeps the plugin registry out of this module's static import
+  // graph — several tests partial-mock this bridge's imports.
+  const { plugins } = await import("@atlas/api/lib/plugins/registry");
+  // Use getAll() (not getByType, which filters to status==="healthy"): the
+  // plugin is consulted purely as an ADAPTER via createFromConfig, independent
+  // of whether a static config-defined connection of its dbType is healthy.
+  const conn = plugins
+    .getAll()
+    .map(getDatasourceConnection)
+    .find((c): c is DatasourceConnectionShape => c != null && c.dbType === poolConfig.dbType);
+
+  if (!conn || typeof conn.createFromConfig !== "function") {
+    throw new Error(
+      `No datasource plugin registered for type "${poolConfig.dbType}". Add the ` +
+        `corresponding plugin (e.g. clickhousePlugin()) to the plugins array in ` +
+        `atlas.config.ts, listed before any datasources that use it.`,
+    );
+  }
+
+  const already = connections.hasDirectForWorkspace(row.workspaceId, row.installId);
+  const built = await conn.createFromConfig(decryptedConfig);
+  const meta: ConnectionPluginMeta = {
+    ...(conn.parserDialect ? { parserDialect: conn.parserDialect } : {}),
+    ...(conn.forbiddenPatterns ? { forbiddenPatterns: conn.forbiddenPatterns } : {}),
+  };
+  connections.registerDirectForWorkspace(
+    row.workspaceId,
+    row.installId,
+    built as unknown as DBConnection,
+    poolConfig.dbType,
+    (poolConfig as { description?: string }).description,
+    conn.validate,
+    meta,
+    pluginTargetHost(poolConfig),
+  );
+  return !already;
+}
 
 /**
  * Resolve `(row, decryptedConfig)` and register the resulting native pool
@@ -55,14 +151,17 @@ import {
  * reject every plugin-managed dbType at the URL-scheme check and the
  * boot loop would log a noisy warning per row.
  */
-export function registerDatasourceInstall(
+export async function registerDatasourceInstall(
   row: DatasourceWorkspacePluginRow,
   decryptedConfig: Readonly<Record<string, unknown>>,
-): boolean {
+): Promise<boolean> {
   const poolConfig: DatasourcePoolConfig = resolveDatasourcePoolConfig(row, decryptedConfig);
 
+  // Plugin-managed dbTypes can't be cloned by the core `createConnection`
+  // switch — build a live per-(workspace, install_id) connection from the
+  // registered plugin's `createFromConfig` instead (#3253 seam).
   if (poolConfig.dbType !== "postgres" && poolConfig.dbType !== "mysql") {
-    return false;
+    return registerPluginDatasourceInstall(row, poolConfig, decryptedConfig);
   }
 
   const config = {
@@ -133,11 +232,15 @@ export function unregisterDatasourceInstall(workspaceId: string, installId: stri
   // so a config update / uninstall takes effect on the next query — without
   // this the cloned pool keeps the prior config until LRU/restart (#3109).
   connections.drainWorkspacePool(workspaceId, installId);
+  // Close + drop a DB-stored plugin connection (clickhouse / snowflake / …) for
+  // this (workspace, install_id) — the plugin counterpart to the native
+  // unregisterForWorkspace + drain above (#3253 seam).
+  const removedPlugin = connections.unregisterDirectForWorkspace(workspaceId, installId);
   // Drop the shared bare row only once the last workspace owning this
   // install_id is gone — siblings keep their install-id-keyed metadata.
   const removedBare =
     !connections.hasWorkspacePoolsFor(installId) &&
     connections.has(installId) &&
     connections.unregister(installId);
-  return removedWorkspace || removedBare;
+  return removedWorkspace || removedPlugin || removedBare;
 }

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1030,7 +1030,7 @@ export async function loadSavedConnections(): Promise<number> {
         stage = "decrypt";
         const decryptedConfig = decryptSecretFields(row.config ?? {}, schema);
         stage = "bridge";
-        const didRegister = registerDatasourceInstall(
+        const didRegister = await registerDatasourceInstall(
           {
             workspaceId: row.workspace_id,
             catalogId: "",

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -1399,7 +1399,10 @@ describe("WorkspaceInstaller.installDatasource", () => {
         !sql.includes("INSERT"),
       rows: [],
     });
-    mockBridgeRegister.mockImplementation(() => {
+    // registerDatasourceInstall is async — exercise the realistic rejected-promise
+    // path (the plugin branch builds a connection), not just a sync throw. Both
+    // flow through Effect.tryPromise's catch → catchAll(log.warn), non-fatal.
+    mockBridgeRegister.mockImplementation(async () => {
       throw new Error("simulated registry rejection");
     });
     const installer = await getLiveService();

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -190,8 +190,11 @@ mock.module("@atlas/api/lib/integrations/install/dispatch", () => ({
 // register / unregister calls without spinning up real pg pools.
 const bridgeRegisterCalls: Array<{ workspaceId: string; installId: string; catalogSlug: string }> = [];
 const bridgeUnregisterCalls: string[] = [];
+// Async to match the real `registerDatasourceInstall` (now Promise<boolean>) —
+// keeps the mock's type signature accurate so `.mockImplementation(async …)`
+// overrides type-check.
 const mockBridgeRegister = mock(
-  (row: { workspaceId: string; installId: string; catalogSlug: string }, _cfg: unknown) => {
+  async (row: { workspaceId: string; installId: string; catalogSlug: string }, _cfg: unknown) => {
     bridgeRegisterCalls.push({
       workspaceId: row.workspaceId,
       installId: row.installId,
@@ -246,7 +249,7 @@ function resetState() {
   // override them get the happy path. Individual tests can swap via
   // mockImplementation(() => { throw new Error(...) }).
   mockBridgeRegister.mockImplementation(
-    (row: { workspaceId: string; installId: string; catalogSlug: string }, _cfg: unknown) => {
+    async (row: { workspaceId: string; installId: string; catalogSlug: string }, _cfg: unknown) => {
       bridgeRegisterCalls.push({
         workspaceId: row.workspaceId,
         installId: row.installId,

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -678,7 +678,8 @@ export interface WorkspaceInstallerShape {
    * per-`db_type` accuracy, writes the `workspace_plugins` row with
    * `status` derived from `input.atlasMode`, and registers the resulting
    * native pool with the `ConnectionRegistry` via
-   * `registerDatasourceInstall` (no-op for plugin-managed dbTypes).
+   * `registerDatasourceInstall` (for plugin-managed dbTypes this builds the
+   * connection from the registered plugin's `createFromConfig` — #3253 seam).
    *
    * Route ownership of `connection.healthCheck()` is preserved: the
    * route does its pre-flight test against a freshly-registered pool,
@@ -1480,35 +1481,43 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(Effect.catchAll((err) => Effect.die(err)));
 
-      // Register the native pool (idempotent for plugin dbTypes and for
-      // route-pre-registered pools).
-      try {
-        lazyDatasourceBridge().registerDatasourceInstall(
-          {
-            workspaceId,
-            catalogId: catalog.id,
-            installId: input.installId,
-            pillar: "datasource",
-            catalogSlug,
-          },
-          input.formData,
-        );
-      } catch (err) {
-        // Registry rejection is best-effort post-write: the DB row
-        // landed, so subsequent boots' `loadSavedConnections` will pick
-        // it up. Surface the warning rather than rolling back the
-        // install — the route's pre-flight test-connect would have
-        // caught a real connectivity issue.
-        log.warn(
-          {
-            workspaceId,
-            installId: input.installId,
-            catalogSlug,
-            err: err instanceof Error ? err.message : String(err),
-          },
-          "registerDatasourceInstall threw post-install — row persisted; next boot will reload",
-        );
-      }
+      // Register the native pool, or (for plugin dbTypes) build the live
+      // per-(workspace, install_id) plugin connection via the registered
+      // plugin's createFromConfig. Idempotent for route-pre-registered pools.
+      // `registerDatasourceInstall` is async (the plugin path builds a
+      // connection), so it's bridged into the Effect generator here.
+      yield* Effect.tryPromise({
+        try: () =>
+          lazyDatasourceBridge().registerDatasourceInstall(
+            {
+              workspaceId,
+              catalogId: catalog.id,
+              installId: input.installId,
+              pillar: "datasource",
+              catalogSlug,
+            },
+            input.formData,
+          ),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          // Registry rejection is best-effort post-write: the DB row landed, so
+          // subsequent boots' `loadSavedConnections` will pick it up. Surface
+          // the warning rather than rolling back the install — the route's
+          // pre-flight test-connect would have caught a real connectivity issue.
+          Effect.sync(() => {
+            log.warn(
+              {
+                workspaceId,
+                installId: input.installId,
+                catalogSlug,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "registerDatasourceInstall threw post-install — row persisted; next boot will reload",
+            );
+          }),
+        ),
+      );
 
       log.info(
         { workspaceId, catalogSlug, installId: input.installId, dbType: dryRun.dbType, status },
@@ -1776,28 +1785,34 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
         );
       }
       if (nextStatus !== "archived") {
-        try {
-          lazyDatasourceBridge().registerDatasourceInstall(
-            {
-              workspaceId,
-              catalogId: catalog.id,
-              installId,
-              pillar: "datasource",
-              catalogSlug,
-            },
-            merged,
-          );
-        } catch (err) {
-          log.warn(
-            {
-              workspaceId,
-              installId,
-              catalogSlug,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "registerDatasourceInstall threw during updateDatasourceConfig — DB row updated; next query may surface ConnectionNotRegisteredError until restart",
-          );
-        }
+        yield* Effect.tryPromise({
+          try: () =>
+            lazyDatasourceBridge().registerDatasourceInstall(
+              {
+                workspaceId,
+                catalogId: catalog.id,
+                installId,
+                pillar: "datasource",
+                catalogSlug,
+              },
+              merged,
+            ),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn(
+                {
+                  workspaceId,
+                  installId,
+                  catalogSlug,
+                  err: err instanceof Error ? err.message : String(err),
+                },
+                "registerDatasourceInstall threw during updateDatasourceConfig — DB row updated; next query may surface ConnectionNotRegisteredError until restart",
+              );
+            }),
+          ),
+        );
       }
 
       log.info(

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -578,8 +578,33 @@ export type EntityProvider =
 
 export interface AtlasDatasourcePlugin<TConfig = undefined> extends AtlasPluginBase<TConfig> {
   readonly connection: {
-    /** Factory: create a DBConnection for the registry. */
+    /**
+     * Factory: create a DBConnection for the registry from the plugin's
+     * config-time config (the object passed to the plugin factory in
+     * `atlas.config.ts`). Used by the boot-time static wiring path
+     * (`wireDatasourcePlugins`) to register a single config-defined
+     * connection.
+     */
     create(): Promise<PluginDBConnection> | PluginDBConnection;
+    /**
+     * Factory: create a DBConnection from a runtime config resolved from a
+     * DB-stored datasource install (admin-UI-registered, persisted in
+     * `workspace_plugins`). Unlike {@link create}, which closes over the
+     * config-time config, this accepts the per-(workspace, install) config
+     * decrypted from the database — enabling multi-tenant, DB-driven
+     * datasources of this plugin's `dbType` rather than a single static
+     * connection.
+     *
+     * The `config` is the raw decrypted config record; the plugin validates
+     * it with its own schema (typically the same `configSchema`) and builds
+     * the connection. Throw a clear error when required fields are missing.
+     *
+     * Plugins that only support static config-defined connections may omit
+     * this; DB-stored installs of their `dbType` then remain unsupported.
+     */
+    createFromConfig?(
+      config: Readonly<Record<string, unknown>>,
+    ): Promise<PluginDBConnection> | PluginDBConnection;
     /** Database type identifier (used for SQL dialect selection). */
     dbType: PluginDBType;
     /**

--- a/plugins/clickhouse/__tests__/clickhouse.test.ts
+++ b/plugins/clickhouse/__tests__/clickhouse.test.ts
@@ -183,6 +183,31 @@ describe("plugin shape", () => {
     expect(plugin.connection.dbType).toBe("clickhouse");
   });
 
+  test("connection.createFromConfig builds a connection from a runtime (DB-stored) config (#3253)", () => {
+    const plugin = clickhousePlugin(validConfig);
+    // The config-time url is ignored on this path — pass a DIFFERENT runtime url.
+    const conn = plugin.connection.createFromConfig!({
+      url: "clickhouse://runtime-user:pw@runtime-host:8123/runtime_db",
+      // Extra keys from the decrypted workspace_plugins.config record are tolerated.
+      db_type: "clickhouse",
+      group_id: "g_default",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("connection.createFromConfig validates the runtime config (rejects non-clickhouse url)", () => {
+    const plugin = clickhousePlugin(validConfig);
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow();
+  });
+
+  test("connection.createFromConfig rejects a missing url", () => {
+    const plugin = clickhousePlugin(validConfig);
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+  });
+
   test("connection.parserDialect is 'PostgresQL'", () => {
     const plugin = clickhousePlugin(validConfig);
     const conn = plugin.connection as Record<string, unknown>;

--- a/plugins/clickhouse/src/index.ts
+++ b/plugins/clickhouse/src/index.ts
@@ -64,6 +64,18 @@ export function buildClickHousePlugin(
         // ClickHouse HTTP transport is stateless — safe to create per call.
         // Pool-based databases (Postgres, MySQL) should cache the connection.
         createClickHouseConnection({ url: config.url, database: config.database, logger: log }),
+      // DB-driven (admin-UI-registered) datasources: build a connection from
+      // the per-(workspace, install) config decrypted from `workspace_plugins`,
+      // re-validated through the same schema. The config-time `config.url`
+      // above is ignored on this path.
+      createFromConfig: (runtimeConfig) => {
+        const parsed = ClickHouseConfigSchema.parse(runtimeConfig);
+        return createClickHouseConnection({
+          url: parsed.url,
+          database: parsed.database,
+          logger: log,
+        });
+      },
       dbType: "clickhouse",
       parserDialect: "PostgresQL", // closest match in node-sql-parser
       forbiddenPatterns: CLICKHOUSE_FORBIDDEN_PATTERNS,


### PR DESCRIPTION
## Why

Admin-UI-registered datasources of **plugin types** (clickhouse / snowflake / bigquery / duckdb / salesforce / elasticsearch) were persisted to `workspace_plugins` but **never became live connections**. `datasource-registry-bridge.ts` short-circuited (`return false`) for any `dbType` that wasn't postgres/mysql, so at query time `executeSQL` fell through to the core `createConnection` switch and threw `Unsupported database URL scheme "clickhouse://"`. Only **static config-defined** datasources (`clickhousePlugin({url})` in `atlas.config.ts`) worked — the DB-driven path was a known-but-unwired gap from ADR-0007.

Surfaced while standing up the staging datasource matrix (#3253): a ClickHouse instance was deployed + seeded, but connecting it through the admin UI failed.

## What

Builds the missing runtime seam — **registry-based**, so core `@atlas/api` stays decoupled from the plugin packages (respects ADR-0006's adapter extraction). Full rationale + alternatives in **[ADR-0013](docs/adr/0013-db-stored-plugin-datasource-connections.md)**.

- **SDK (`@useatlas/plugin-sdk`)** — add optional `connection.createFromConfig(config)` to `AtlasDatasourcePlugin`. Purely additive; `create()` (static factory) unchanged, so existing plugins compile untouched.
- **ClickHouse plugin** — implement `createFromConfig` (re-validates the runtime config through `ClickHouseConfigSchema`, delegates to `createClickHouseConnection`). **Tracer slice** — the other 5 datasource plugins are mechanical follow-ups.
- **`ConnectionRegistry`** — new `workspacePluginEntries` map holds a live connection per `(workspace, install_id)` for plugin dbTypes (they can't be cloned by the core `createConnection` switch). New `registerDirectForWorkspace` / `hasDirectForWorkspace` / `unregisterDirectForWorkspace`; `getForWorkspace` + metadata getters consult plugin entries first (and surface the plugin's validator / dialect / forbidden patterns). Multi-tenant routing preserved.
- **Bridge** — for plugin dbTypes, `registerDatasourceInstall` (now async) looks the plugin up by `dbType` in the registry and builds the connection from the DB-stored config; throws a clear "add the plugin to `atlas.config.ts`" error otherwise (caught + logged per-row at boot; surfaced to the admin on install). Callers `await` (Effect callers via `Effect.tryPromise`).
- **Staging config** — register `clickhousePlugin` conditionally on `ATLAS_STAGING_CLICKHOUSE_URL` (unset env never trips the required-url schema; **prod config untouched**).

## Test plan

- `bun run type` ✅ · `eslint` (changed files) ✅
- **301 affected API test files** ✅ (`test-isolated.ts --affected`)
- New/updated unit tests ✅:
  - bridge — plugin branch builds via `createFromConfig`, idempotency, throws when plugin absent / lacks `createFromConfig`, native path unregressed
  - `ConnectionRegistry` — round-trip, metadata getters return plugin meta, two-workspace isolation, re-register/unregister lifecycle close
  - ClickHouse `createFromConfig` — builds from runtime config, validates url

## Scope / follow-ups

- **Tracer = ClickHouse only.** Snowflake / BigQuery / DuckDB / Salesforce / Elasticsearch each need `createFromConfig` + deploy wiring — follow-up slices (the Elasticsearch one coordinates with the active ES milestone work).
- **url-optional adapter registration** (so `clickhousePlugin()` registers adapter-only with no static URL, for prod / no-static hosts) is deferred — see ADR-0013 Alternatives.
- No schema/migration changes. No `@useatlas/*` published-version bumps (monorepo-internal, additive SDK change; deploy imports plugin source).
- After merge + staging deploy, set `ATLAS_STAGING_CLICKHOUSE_URL` on `api-staging` to the internal ClickHouse URL so the adapter activates.

Part of #3253.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783387359&installation_id=135337507&pr_number=3297&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3297&signature=c24d7c2ac5d693922d74c55dc871e7b4b1ac8ad65601c7c644c8ee2c7429cb9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-workspace DB-stored plugin datasource connections, enabling plugins to build runtime connections from stored configs.
  * ClickHouse plugin now supports runtime-configured connections.

* **Documentation**
  * Added ADR describing plugin datasource connection design and runtime behavior.

* **Tests**
  * Expanded coverage for plugin-managed datasource registration, lifecycle, loading, and ClickHouse runtime connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->