### PR TITLE
feat(datasource): url-optional adapter-only plugin registration for SaaS per-workspace connections

### DIFF
--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -51,7 +51,18 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
+// Datasource ADAPTER plugins (#3253 / ADR-0013) — mirrors deploy/api/atlas.config.ts.
+// Registered with empty config so each is available purely as an adapter:
+// customers add their own connection per workspace via Admin → Connections
+// (DB-stored, encrypted), resolved through the datasource bridge's
+// `createFromConfig`. No operator env var, no static datasource. DuckDB is
+// intentionally excluded (file-path based, not a safe multi-tenant datasource);
+// Postgres + MySQL need no plugin (the bridge registers those natively).
 import { clickhousePlugin } from "./plugins/clickhouse/src/index";
+import { salesforcePlugin } from "./plugins/salesforce/src/index";
+import { snowflakePlugin } from "./plugins/snowflake/src/index";
+import { bigqueryPlugin } from "./plugins/bigquery/src/index";
+import { elasticsearchPlugin } from "./plugins/elasticsearch/src/index";
 import { getProactiveAiRuntime } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
@@ -86,26 +97,6 @@ import { createChatPluginExecuteQuery } from "./packages/api/src/lib/chat-plugin
 // under packages/api/node_modules and isn't on the upward walk from
 // /app/atlas.config.ts). Process-lifetime cached on the helper side.
 const proactiveAiRuntime = getProactiveAiRuntime();
-
-/**
- * Datasource ADAPTER plugins for the staging soak matrix (#3253). Each is
- * registered only when its staging connection URL env var is set — an unset
- * env never trips the plugin's required-url config schema at boot, and prod
- * (which doesn't set these) is unaffected.
- *
- * Registering the plugin makes its `connection.createFromConfig` available to
- * the datasource bridge, which is what lets DB-stored (admin-UI-registered)
- * datasources of that `dbType` actually connect (ADR-0013). The config-time
- * URL below also yields a working static config-defined datasource as a bonus.
- */
-function stagingDatasourcePlugins(): unknown[] {
-  const list: unknown[] = [];
-  const clickhouseUrl = process.env.ATLAS_STAGING_CLICKHOUSE_URL;
-  if (clickhouseUrl) {
-    list.push(clickhousePlugin({ url: clickhouseUrl }));
-  }
-  return list;
-}
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────
@@ -799,11 +790,16 @@ export default defineConfig({
   // at rest via AES-256-GCM. OMIT `botToken` so the adapter operates
   // in multi-workspace mode.
   plugins: [
-    // Datasource adapter plugins (#3253). Listed first for clarity — order
-    // within plugins[] doesn't affect boot wiring (the bridge resolves adapters
-    // via the registry's getAll(), order-independent); what matters is that the
-    // whole array registers before loadSavedConnections runs.
-    ...stagingDatasourcePlugins(),
+    // ── Datasource adapters (adapter-only / SaaS per-workspace) ──────
+    // Mirrors deploy/api/atlas.config.ts. Order within plugins[] doesn't affect
+    // boot wiring — the bridge resolves adapters via the registry's getAll()
+    // (order-independent). Each registers as an adapter only (no static
+    // connection); customers bring their own datasource per workspace.
+    clickhousePlugin({}),
+    salesforcePlugin({}),
+    snowflakePlugin({}),
+    bigqueryPlugin({}),
+    elasticsearchPlugin({}),
     chatPlugin({
       // Catalog-driven adapter activation (#2650 slice 2). The chat
       // plugin's `AdapterRegistry` reads the chat-type subset of the

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -149,17 +149,24 @@ COPY --from=builder --chown=atlas:atlas /app/ee ./ee
 # Plugins (loaded at runtime by the plugin system)
 COPY --from=builder --chown=atlas:atlas /app/plugins ./plugins
 # Defensive symlink rebuild: bun ci in the deps stage creates
-# `plugins/chat/node_modules/@useatlas/{plugin-sdk,types}` as relative
+# `plugins/<p>/node_modules/@useatlas/{plugin-sdk,types}` as relative
 # workspace symlinks, but the multi-stage COPY chain isn't reliably
 # preserving them for every Docker driver. Recreate explicitly so
-# atlas.config.ts's transitive load of `./plugins/chat/src/index`
-# (added in #2608 / slice 1 of #2607) can resolve the chat plugin's
-# `@useatlas/plugin-sdk` peerDep at boot regardless of upstream
-# COPY-symlink behavior. The `-f` flag overwrites any pre-existing
-# (possibly dangling) symlink that survived the COPY.
-RUN mkdir -p /app/plugins/chat/node_modules/@useatlas && \
-    ln -sfn /app/packages/plugin-sdk /app/plugins/chat/node_modules/@useatlas/plugin-sdk && \
-    ln -sfn /app/packages/types /app/plugins/chat/node_modules/@useatlas/types
+# atlas.config.ts's transitive loads of `./plugins/<p>/src/index` can
+# resolve each plugin's `@useatlas/plugin-sdk` peerDep at boot regardless
+# of upstream COPY-symlink behavior. The `-f` flag overwrites any
+# pre-existing (possibly dangling) symlink that survived the COPY.
+#
+# `chat` is the interaction plugin (#2608); the rest are the datasource
+# ADAPTER plugins atlas.config.ts now loads at boot (#3253 / ADR-0013).
+# Keep this list in lockstep with the plugins[] array in atlas.config.ts —
+# a boot-loaded plugin missing here ENOENTs its plugin-sdk import and
+# hard-fails the API boot.
+RUN for p in chat clickhouse salesforce snowflake bigquery elasticsearch; do \
+      mkdir -p /app/plugins/$p/node_modules/@useatlas && \
+      ln -sfn /app/packages/plugin-sdk /app/plugins/$p/node_modules/@useatlas/plugin-sdk && \
+      ln -sfn /app/packages/types /app/plugins/$p/node_modules/@useatlas/types; \
+    done
 # Demo seeding (ATLAS_SEED_DEMO=true) — single canonical seed since 1.4.0 (#2021)
 COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/demo.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -33,6 +33,19 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
+// Datasource ADAPTER plugins (#3253 / ADR-0013). Registered with empty config
+// so each is available purely as an adapter: customers add their own connection
+// per workspace via Admin → Connections (DB-stored, encrypted), resolved through
+// the datasource bridge's `createFromConfig`. No operator env var, no static
+// datasource. DuckDB is intentionally NOT registered here — it is file-path
+// based and not a safe multi-tenant SaaS datasource (its plugin still supports
+// adapter-only mode for self-host). Postgres + MySQL need no plugin — the bridge
+// registers those DB-stored installs natively.
+import { clickhousePlugin } from "./plugins/clickhouse/src/index";
+import { salesforcePlugin } from "./plugins/salesforce/src/index";
+import { snowflakePlugin } from "./plugins/snowflake/src/index";
+import { bigqueryPlugin } from "./plugins/bigquery/src/index";
+import { elasticsearchPlugin } from "./plugins/elasticsearch/src/index";
 import { getProactiveAiRuntime } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
@@ -760,6 +773,18 @@ export default defineConfig({
   // at rest via AES-256-GCM. OMIT `botToken` so the adapter operates
   // in multi-workspace mode.
   plugins: [
+    // ── Datasource adapters (adapter-only / SaaS per-workspace) ──────
+    // Order within plugins[] doesn't affect boot wiring — the datasource bridge
+    // resolves adapters via the registry's getAll() (order-independent). Each
+    // registers as an adapter only (no static connection); customers bring their
+    // own ClickHouse / Salesforce / Snowflake / BigQuery / Elasticsearch per
+    // workspace. See the import block above for why DuckDB is excluded and why
+    // Postgres + MySQL need no entry.
+    clickhousePlugin({}),
+    salesforcePlugin({}),
+    snowflakePlugin({}),
+    bigqueryPlugin({}),
+    elasticsearchPlugin({}),
     chatPlugin({
       // Catalog-driven adapter activation (#2650 slice 2). The chat
       // plugin's `AdapterRegistry` reads the chat-type subset of the

--- a/packages/api/src/lib/plugins/__tests__/wiring.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/wiring.test.ts
@@ -124,6 +124,38 @@ describe("wireDatasourcePlugins", () => {
     expect(connRegistry.registered[0].dbType).toBe("postgres");
   });
 
+  test("skips adapter-only plugins (no connection.create) but keeps them registered", async () => {
+    // Adapter-only plugin (SaaS per-workspace model): exposes createFromConfig
+    // for the datasource bridge but NO static create(). Static boot wiring must
+    // skip it without erroring, and it must stay in the registry so the bridge's
+    // getAll() can resolve it for DB-stored installs.
+    const adapterOnly: PluginLike = {
+      id: "adapter-only-ds",
+      types: ["datasource"],
+      version: "1.0.0",
+      connection: {
+        createFromConfig: () => ({
+          query: async () => ({ columns: [], rows: [] }),
+          close: async () => {},
+        }),
+        dbType: "clickhouse",
+      },
+    };
+    registry.register(adapterOnly);
+    await registry.initializeAll(minimalCtx);
+
+    const result = await wireDatasourcePlugins(
+      registry,
+      connRegistry as unknown as import("@atlas/api/lib/db/connection").ConnectionRegistry,
+    );
+
+    expect(result.wired).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(connRegistry.registered).toHaveLength(0);
+    // Still registered — reachable by the datasource bridge's getAll() lookup.
+    expect(registry.getAll().some((p) => p.id === "adapter-only-ds")).toBe(true);
+  });
+
   test("passes connection.validate through to registerDirect", async () => {
     const validator = (q: string) => ({ valid: /^SELECT/i.test(q) });
     const plugin: PluginLike = {

--- a/packages/api/src/lib/plugins/wiring.ts
+++ b/packages/api/src/lib/plugins/wiring.ts
@@ -25,7 +25,10 @@ interface ContextShape {
 
 interface DatasourceShape {
   connection: {
-    create(): Promise<{ query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> }> | { query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> };
+    // Optional: adapter-only plugins (SaaS per-workspace model) omit `create`
+    // and expose only `createFromConfig`, consulted by the datasource bridge
+    // for DB-stored installs. They are skipped for static boot-time wiring.
+    create?(): Promise<{ query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> }> | { query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> };
     dbType: string;
     validate?(query: string): { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>;
     parserDialect?: string;
@@ -106,8 +109,23 @@ export async function wireDatasourcePlugins(
       log.warn({ pluginId: plugin.id }, "Datasource plugin missing connection property — skipped");
       continue;
     }
+    // Adapter-only plugins (SaaS per-workspace model) have no static
+    // config-defined connection — they implement only `createFromConfig` and
+    // are consulted by the datasource bridge via the registry's `getAll()` for
+    // DB-stored installs. They stay registered; there's just nothing to wire
+    // statically. (Entities/dialect hints attach to a static connection, so
+    // they're skipped here too — DB-stored connections carry their own
+    // validation dialect via ConnectionPluginMeta at register time.)
+    const createConn = plugin.connection.create;
+    if (typeof createConn !== "function") {
+      log.debug(
+        { pluginId: plugin.id, dbType: plugin.connection.dbType },
+        "Adapter-only datasource plugin — no static connection to wire",
+      );
+      continue;
+    }
     try {
-      const conn = await plugin.connection.create();
+      const conn = await createConn();
       const meta = (plugin.connection.parserDialect || plugin.connection.forbiddenPatterns)
         ? { parserDialect: plugin.connection.parserDialect, forbiddenPatterns: plugin.connection.forbiddenPatterns }
         : undefined;

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -42,9 +42,12 @@ Atlas has five plugin types. Each extends `AtlasPluginBase` with variant-specifi
 
 Connect to a database. Provides a connection factory, SQL dialect hints, and optional entity definitions.
 
+A datasource plugin must provide **at least one** connection factory: `create()` for a static config-defined connection, `createFromConfig()` for a DB-stored (admin-registered) per-workspace connection, or both. A plugin with only `createFromConfig()` is an **adapter-only** plugin — registered for use but with no static datasource (the multi-tenant SaaS model, where every connection is added per workspace).
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `connection.create()` | `() => PluginDBConnection` | Yes | Factory that returns a connection with `query()` and `close()` |
+| `connection.create()` | `() => PluginDBConnection \| Promise<PluginDBConnection>` | One of create/createFromConfig | Factory that returns a connection with `query()` and `close()` from the plugin's config-time config (static / self-host) |
+| `connection.createFromConfig()` | `(config) => PluginDBConnection \| Promise<PluginDBConnection>` | One of create/createFromConfig | Factory that builds a connection from a DB-stored per-(workspace, install) config (adapter-only / SaaS) |
 | `connection.dbType` | `PluginDBType` | Yes | Database type identifier (`postgres`, `mysql`, `clickhouse`, `snowflake`, `duckdb`, or custom) |
 | `entities` | `EntityProvider` | No | Semantic layer fragments merged into the table whitelist at boot |
 | `dialect` | `string` | No | SQL dialect guidance injected into the agent system prompt |

--- a/packages/plugin-sdk/src/__tests__/types.test.ts
+++ b/packages/plugin-sdk/src/__tests__/types.test.ts
@@ -363,6 +363,48 @@ describe("definePlugin validation", () => {
     } as any)).toThrow('must have a "connection"');
   });
 
+  test("accepts adapter-only datasource (createFromConfig, no create)", () => {
+    const plugin = definePlugin({
+      id: "adapter-only-ds",
+      types: ["datasource"],
+      version: "1.0.0",
+      connection: {
+        createFromConfig: () => ({ query: async () => ({ columns: [], rows: [] }), close: async () => {} }),
+        dbType: "clickhouse",
+      },
+    } as AtlasDatasourcePlugin);
+    expect(plugin.id).toBe("adapter-only-ds");
+    expect(plugin.connection.create).toBeUndefined();
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("throws when datasource connection has neither create nor createFromConfig", () => {
+    expect(() => definePlugin({
+      id: "test",
+      types: ["datasource"],
+      version: "1.0.0",
+      connection: { dbType: "postgres" },
+    } as any)).toThrow('must have a "create()" or "createFromConfig()" factory function');
+  });
+
+  test("throws when datasource connection.create is not a function", () => {
+    expect(() => definePlugin({
+      id: "test",
+      types: ["datasource"],
+      version: "1.0.0",
+      connection: { create: "nope", dbType: "postgres" },
+    } as any)).toThrow('"create" must be a function when provided');
+  });
+
+  test("throws when datasource connection.createFromConfig is not a function", () => {
+    expect(() => definePlugin({
+      id: "test",
+      types: ["datasource"],
+      version: "1.0.0",
+      connection: { createFromConfig: "nope", dbType: "postgres" },
+    } as any)).toThrow('"createFromConfig" must be a function when provided');
+  });
+
   test("throws when action plugin missing actions array", () => {
     expect(() => definePlugin({
       id: "test",

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -42,8 +42,26 @@ function validatePluginShape(plugin: AtlasPlugin): void {
     if (!ds.connection || typeof ds.connection !== "object") {
       throw new Error('Datasource plugin must have a "connection" property');
     }
-    if (typeof ds.connection.create !== "function") {
-      throw new Error('Datasource plugin connection must have a "create()" factory function');
+    // A datasource plugin must expose at least one connection factory:
+    //   - `create()`           — a static config-defined connection (self-host /
+    //                            operator-baked datasource), wired at boot.
+    //   - `createFromConfig()` — an ADAPTER-ONLY connection built per-(workspace,
+    //                            install) from a DB-stored config (the SaaS
+    //                            per-workspace model). Plugins registered purely
+    //                            as adapters omit `create`.
+    // Each, when present, must be a function.
+    const hasCreate = ds.connection.create !== undefined;
+    const hasCreateFromConfig = ds.connection.createFromConfig !== undefined;
+    if (!hasCreate && !hasCreateFromConfig) {
+      throw new Error(
+        'Datasource plugin connection must have a "create()" or "createFromConfig()" factory function',
+      );
+    }
+    if (hasCreate && typeof ds.connection.create !== "function") {
+      throw new Error('Datasource plugin connection "create" must be a function when provided');
+    }
+    if (hasCreateFromConfig && typeof ds.connection.createFromConfig !== "function") {
+      throw new Error('Datasource plugin connection "createFromConfig" must be a function when provided');
     }
     if (ds.entities !== undefined && !Array.isArray(ds.entities) && typeof ds.entities !== "function") {
       throw new Error('Datasource plugin "entities" must be an array or a function');

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -584,8 +584,18 @@ export interface AtlasDatasourcePlugin<TConfig = undefined> extends AtlasPluginB
      * `atlas.config.ts`). Used by the boot-time static wiring path
      * (`wireDatasourcePlugins`) to register a single config-defined
      * connection.
+     *
+     * Optional: a plugin registered as an ADAPTER ONLY — the SaaS
+     * per-workspace model where every datasource is DB-stored
+     * (admin-UI-registered, encrypted), not baked into operator config —
+     * omits `create` and implements only {@link createFromConfig}.
+     * `wireDatasourcePlugins` skips adapter-only plugins for static wiring;
+     * the datasource bridge still finds them via the registry's `getAll()`
+     * to build per-(workspace, install) connections on demand. At least one
+     * of `create` / `createFromConfig` must be present — enforced by
+     * `validatePluginShape`.
      */
-    create(): Promise<PluginDBConnection> | PluginDBConnection;
+    create?(): Promise<PluginDBConnection> | PluginDBConnection;
     /**
      * Factory: create a DBConnection from a runtime config resolved from a
      * DB-stored datasource install (admin-UI-registered, persisted in
@@ -841,7 +851,7 @@ type _InferFrom<P, C> = {
  * import type { clickhousePlugin } from "@useatlas/clickhouse";
  *
  * type CH = $InferServerPlugin<typeof clickhousePlugin>;
- * // CH["Config"] → { url: string; database?: string }
+ * // CH["Config"] → { url?: string; database?: string }
  * // CH["Types"]  → readonly ["datasource"]
  * // CH["Id"]     → string
  * ```

--- a/plugins/bigquery/__tests__/bigquery.test.ts
+++ b/plugins/bigquery/__tests__/bigquery.test.ts
@@ -194,6 +194,160 @@ describe("plugin shape", () => {
 });
 
 // ---------------------------------------------------------------------------
+// createFromConfig (DB-stored per-workspace datasources, #3253)
+// ---------------------------------------------------------------------------
+
+describe("connection.createFromConfig", () => {
+  const validConfig = { projectId: "my-project" };
+
+  test("builds a connection from a runtime (DB-stored) config", () => {
+    const plugin = bigqueryPlugin(validConfig);
+    // The config-time projectId is ignored on this path — pass a DIFFERENT
+    // runtime project, plus extra keys the decrypted record may carry.
+    const conn = plugin.connection.createFromConfig!({
+      projectId: "runtime-project",
+      dataset: "runtime_dataset",
+      location: "EU",
+      db_type: "bigquery",
+      group_id: "g_default",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+    expect(mockBigQuery).toHaveBeenCalledWith({ projectId: "runtime-project" });
+  });
+
+  test("rejects a runtime config missing projectId", () => {
+    const plugin = bigqueryPlugin(validConfig);
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+  });
+
+  test("rejects a runtime config with an empty projectId", () => {
+    const plugin = bigqueryPlugin(validConfig);
+    expect(() => plugin.connection.createFromConfig!({ projectId: "" })).toThrow();
+  });
+
+  test("accepts the Admin → Connections catalog form shape (service_account_json + project_id)", () => {
+    // The catalog form persists snake_case `project_id` + a `service_account_json`
+    // JSON string; createFromConfig must normalize these to projectId/credentials
+    // or every admin-installed BigQuery datasource would be rejected at boot.
+    const plugin = bigqueryPlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      project_id: "form-project",
+      service_account_json: JSON.stringify({
+        client_email: "svc@form-project.iam.gserviceaccount.com",
+        private_key: "k",
+      }),
+      description: "prod warehouse",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    // projectId came from project_id; credentials parsed from service_account_json.
+    expect(mockBigQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "form-project",
+        credentials: expect.objectContaining({
+          client_email: "svc@form-project.iam.gserviceaccount.com",
+        }),
+      }),
+    );
+  });
+
+  test("rejects an invalid service_account_json string", () => {
+    const plugin = bigqueryPlugin({});
+    expect(() =>
+      plugin.connection.createFromConfig!({
+        project_id: "p",
+        service_account_json: "{not valid json",
+      }),
+    ).toThrow(/not valid JSON/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no projectId is configured", () => {
+    const plugin = bigqueryPlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = bigqueryPlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = bigqueryPlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("bigquery");
+  });
+
+  test("createFromConfig builds a connection from a runtime config even with no static projectId", () => {
+    const plugin = bigqueryPlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      projectId: "runtime-project",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig still rejects a runtime config missing projectId", () => {
+    const plugin = bigqueryPlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+  });
+
+  test("static-config mode still wires connection.create when a projectId is given", () => {
+    const plugin = bigqueryPlugin({ projectId: "my-project" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("static-config mode wires connection.create from keyFilename alone (projectId inferred from key/ADC)", () => {
+    // BigQuery can run static with NO projectId — the project is inferred from
+    // the service-account key. Gating adapter-only on projectId alone would have
+    // silently demoted this to adapter-only and dropped the operator's datasource.
+    const plugin = bigqueryPlugin({ keyFilename: "/path/to/key.json" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("static-config mode wires connection.create from inline credentials alone", () => {
+    const plugin = bigqueryPlugin({
+      credentials: { client_email: "svc@proj.iam.gserviceaccount.com", private_key: "k" },
+    });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = bigqueryPlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+    // No client is constructed when there is no static datasource.
+    expect(mockBigQuery).not.toHaveBeenCalled();
+  });
+
+  test("initialize logs adapter-only (no projectId, no credentials, no crash)", async () => {
+    const plugin = bigqueryPlugin({});
+    const logged: string[] = [];
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) => { logged.push(String(args[0])); },
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    };
+    await plugin.initialize!(ctx);
+    const msg = logged.find((m) => m.includes("adapter-only"));
+    expect(msg).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Forbidden patterns
 // ---------------------------------------------------------------------------
 
@@ -257,7 +411,7 @@ describe("BIGQUERY_FORBIDDEN_PATTERNS", () => {
 describe("connection factory", () => {
   test("connection.create() returns a PluginDBConnection", async () => {
     const plugin = bigqueryPlugin({ projectId: "my-project" });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });
@@ -492,7 +646,9 @@ describe("initialize", () => {
     expect(msg).not.toContain("/path/to");
   });
 
-  test("logs (default-project) when projectId is omitted", async () => {
+  test("logs adapter-only when projectId is omitted", async () => {
+    // Without a projectId there is no static datasource — the plugin registers
+    // adapter-only and initialize logs that, not a project-specific message.
     const plugin = bigqueryPlugin({});
     const logged: string[] = [];
     const ctx = {
@@ -508,8 +664,7 @@ describe("initialize", () => {
       config: {},
     };
     await plugin.initialize!(ctx);
-    const msg = logged.find((m) => m.includes("BigQuery datasource plugin initialized"));
+    const msg = logged.find((m) => m.includes("adapter-only"));
     expect(msg).toBeDefined();
-    expect(msg).toContain("(default-project)");
   });
 });

--- a/plugins/bigquery/src/index.ts
+++ b/plugins/bigquery/src/index.ts
@@ -5,7 +5,10 @@
  * Supports service account JSON key files, inline credentials objects, and
  * Application Default Credentials (ADC) for GCP-native environments.
  *
- * Usage in atlas.config.ts:
+ * Two registration modes:
+ *
+ * 1. Static config-defined datasource (self-host / operator-baked) — pass a
+ *    `projectId` and the plugin wires a single connection at boot:
  * ```typescript
  * import { defineConfig } from "@atlas/api/lib/config";
  * import { bigqueryPlugin } from "@useatlas/bigquery";
@@ -18,6 +21,16 @@
  *       dataset: "analytics",
  *     }),
  *   ],
+ * });
+ * ```
+ *
+ * 2. Adapter-only (SaaS per-workspace) — pass no `projectId` and the plugin
+ *    registers purely as an adapter, so customers add their own BigQuery
+ *    project per workspace via Admin → Connections (DB-stored, encrypted). No
+ *    operator config, no static datasource:
+ * ```typescript
+ * export default defineConfig({
+ *   plugins: [bigqueryPlugin({})],
  * });
  * ```
  */
@@ -57,6 +70,57 @@ const BigQueryConfigSchema = z.object({
 });
 
 /**
+ * Strict runtime schema for a DB-stored (admin-UI-registered) BigQuery
+ * datasource install. The config-time {@link BigQueryConfigSchema} leaves
+ * `projectId` optional so the plugin can register as an ADAPTER ONLY
+ * (`bigqueryPlugin({})` parses), but a per-(workspace, install) datasource
+ * must identify a concrete project — credentials may still come from a
+ * keyFilename, inline credentials, or ADC, but the project is mandatory.
+ * Used by `connection.createFromConfig` so a runtime config missing
+ * `projectId` is REJECTED.
+ */
+const BigQueryRuntimeConfigSchema = BigQueryConfigSchema.extend({
+  projectId: z.string().min(1, "BigQuery projectId must not be empty"),
+});
+
+/**
+ * Normalize a DB-stored BigQuery datasource config into the connection factory's
+ * field shape. The Admin → Connections catalog form
+ * (`seed-builtin-datasource-catalog.ts`) collects `service_account_json` (the raw
+ * key JSON, as a string) + `project_id` (snake_case); the connection factory and
+ * {@link BigQueryRuntimeConfigSchema} use `credentials` (object) + `projectId`
+ * (camelCase). Map the form shape onto the factory shape WITHOUT clobbering
+ * explicit camelCase values (so a programmatic `createFromConfig` caller passing
+ * `projectId`/`credentials` directly still works). Without this, every
+ * admin-installed BigQuery datasource would be rejected by the runtime schema
+ * (missing `projectId`) and never register as a live connection.
+ */
+function normalizeBigQueryRuntimeConfig(
+  raw: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw };
+  if (out.projectId === undefined && typeof out.project_id === "string") {
+    out.projectId = out.project_id;
+  }
+  if (
+    out.credentials === undefined &&
+    out.keyFilename === undefined &&
+    typeof out.service_account_json === "string" &&
+    out.service_account_json.trim().length > 0
+  ) {
+    try {
+      out.credentials = JSON.parse(out.service_account_json);
+    } catch (err) {
+      throw new Error(
+        `BigQuery service_account_json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+  return out;
+}
+
+/**
  * BigQuery config type. Uses `z.input` so both the `bigqueryPlugin()` factory
  * (which applies Zod defaults) and direct `buildBigQueryPlugin()` callers work
  * without requiring cost fields to be explicitly passed.
@@ -75,6 +139,15 @@ export function buildBigQueryPlugin(
 
   const costApproval = config.costApproval ?? "threshold";
   const costThreshold = config.costThreshold ?? 1.0;
+
+  // A static config-defined BigQuery datasource is identified by ANY connection
+  // field: an explicit projectId, a keyFilename, or inline credentials. Unlike
+  // the url-based datasources, BigQuery can run static with NO projectId — the
+  // project is inferred from the key/credentials or Application Default
+  // Credentials (createBigQueryConnection omits projectId in that case). Only
+  // when none of these is present does the plugin register adapter-only (SaaS
+  // per-workspace — datasources are DB-stored, added via Admin → Connections).
+  const hasStaticConfig = !!(config.projectId || config.keyFilename || config.credentials);
 
   const hooks: PluginHooks = {
     beforeQuery: [
@@ -115,6 +188,48 @@ export function buildBigQueryPlugin(
     ],
   };
 
+  const connection: AtlasDatasourcePlugin<BigQueryConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from the
+    // per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict runtime schema (projectId required).
+    // Always available — this is the SaaS per-workspace path and the only path
+    // in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      // Normalize the catalog form's snake_case / service_account_json shape onto
+      // the factory's camelCase / credentials shape before validating.
+      const parsed = BigQueryRuntimeConfigSchema.parse(
+        normalizeBigQueryRuntimeConfig(runtimeConfig),
+      );
+      return createBigQueryConnection({
+        projectId: parsed.projectId,
+        dataset: parsed.dataset,
+        location: parsed.location,
+        keyFilename: parsed.keyFilename,
+        credentials: parsed.credentials,
+        logger: log,
+      });
+    },
+    dbType: "bigquery",
+    parserDialect: "BigQuery",
+    forbiddenPatterns: BIGQUERY_FORBIDDEN_PATTERNS,
+  };
+
+  // When any static connection field is configured the plugin wires a
+  // config-defined connection at boot; without one it is registered adapter-only.
+  // `config.projectId` may be undefined here (key/credentials/ADC supply it) —
+  // createBigQueryConnection handles an absent projectId.
+  if (hasStaticConfig) {
+    connection.create = () =>
+      createBigQueryConnection({
+        projectId: config.projectId,
+        dataset: config.dataset,
+        location: config.location,
+        keyFilename: config.keyFilename,
+        credentials: config.credentials,
+        logger: log,
+      });
+  }
+
   return {
     id: "bigquery-datasource",
     types: ["datasource"] as const,
@@ -122,20 +237,7 @@ export function buildBigQueryPlugin(
     name: "BigQuery DataSource",
     config,
 
-    connection: {
-      create: () =>
-        createBigQueryConnection({
-          projectId: config.projectId,
-          dataset: config.dataset,
-          location: config.location,
-          keyFilename: config.keyFilename,
-          credentials: config.credentials,
-          logger: log,
-        }),
-      dbType: "bigquery",
-      parserDialect: "BigQuery",
-      forbiddenPatterns: BIGQUERY_FORBIDDEN_PATTERNS,
-    },
+    connection,
 
     entities: [],
 
@@ -158,10 +260,22 @@ export function buildBigQueryPlugin(
 
     async initialize(ctx) {
       log = ctx.logger;
-      ctx.logger.info(`BigQuery datasource plugin initialized (project: ${extractProjectId(config)})`);
+      if (hasStaticConfig) {
+        ctx.logger.info(`BigQuery datasource plugin initialized (project: ${extractProjectId(config)})`);
+      } else {
+        ctx.logger.info(
+          "BigQuery datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!hasStaticConfig) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
       const start = performance.now();
       let conn: PluginDBConnection | undefined;
       try {
@@ -200,7 +314,10 @@ export function buildBigQueryPlugin(
  *
  * @example
  * ```typescript
+ * // Static datasource (self-host):
  * plugins: [bigqueryPlugin({ projectId: "my-project", dataset: "analytics" })]
+ * // Adapter-only (SaaS — customers bring their own per workspace):
+ * plugins: [bigqueryPlugin({})]
  * ```
  */
 export const bigqueryPlugin = createPlugin({

--- a/plugins/clickhouse/__tests__/clickhouse.test.ts
+++ b/plugins/clickhouse/__tests__/clickhouse.test.ts
@@ -146,9 +146,10 @@ describe("config validation", () => {
     ).toThrow(/URL must start with clickhouse:\/\/ or clickhouses:\/\//);
   });
 
-  test("rejects missing URL", () => {
-    // @ts-expect-error — intentionally passing invalid config
-    expect(() => clickhousePlugin({})).toThrow();
+  test("accepts empty config — adapter-only registration (SaaS per-workspace)", () => {
+    const plugin = clickhousePlugin({});
+    expect(plugin.id).toBe("clickhouse-datasource");
+    expect(plugin.config).toEqual({});
   });
 });
 
@@ -257,6 +258,79 @@ describe("plugin shape", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no url is configured", () => {
+    const plugin = clickhousePlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = clickhousePlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = clickhousePlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("clickhouse");
+  });
+
+  test("createFromConfig builds a connection from a runtime config even with no static url", () => {
+    const plugin = clickhousePlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      url: "clickhouse://runtime-host:8123/runtime_db",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig still rejects a missing/invalid runtime url", () => {
+    const plugin = clickhousePlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow();
+  });
+
+  test("static-config mode still wires connection.create when a url is given", () => {
+    const plugin = clickhousePlugin({ url: "clickhouse://localhost:8123/default" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = clickhousePlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+    // No connection is constructed when there is no static datasource.
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  test("initialize logs adapter-only (no url, no credentials, no crash)", async () => {
+    const plugin = clickhousePlugin({});
+    const logged: string[] = [];
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) => { logged.push(String(args[0])); },
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    };
+    await plugin.initialize!(ctx);
+    const msg = logged.find((m) => m.includes("adapter-only"));
+    expect(msg).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Forbidden patterns
 // ---------------------------------------------------------------------------
 
@@ -340,7 +414,7 @@ describe("connection factory", () => {
     const plugin = clickhousePlugin({
       url: "clickhouse://localhost:8123/default",
     });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });

--- a/plugins/clickhouse/src/index.ts
+++ b/plugins/clickhouse/src/index.ts
@@ -4,16 +4,26 @@
  * Demonstrates how the AtlasDatasourcePlugin interface can wrap real adapter
  * code extracted from the core ClickHouse adapter in packages/api/src/lib/db/connection.ts.
  *
- * Usage in atlas.config.ts (monorepo workspace — for external projects,
- * copy this plugin into your project or adjust the import path):
+ * Two registration modes:
+ *
+ * 1. Static config-defined datasource (self-host / operator-baked) — pass a
+ *    `url` and the plugin wires a single connection at boot:
  * ```typescript
  * import { defineConfig } from "@atlas/api/lib/config";
  * import { clickhousePlugin } from "@useatlas/clickhouse";
  *
  * export default defineConfig({
- *   plugins: [
- *     clickhousePlugin({ url: "clickhouse://localhost:8123/default" }),
- *   ],
+ *   plugins: [clickhousePlugin({ url: "clickhouse://localhost:8123/default" })],
+ * });
+ * ```
+ *
+ * 2. Adapter-only (SaaS per-workspace) — pass no `url` and the plugin registers
+ *    purely as an adapter, so customers add their own ClickHouse per workspace
+ *    via Admin → Connections (DB-stored, encrypted). No operator env var, no
+ *    static datasource:
+ * ```typescript
+ * export default defineConfig({
+ *   plugins: [clickhousePlugin({})],
  * });
  * ```
  */
@@ -27,7 +37,13 @@ import {
 } from "./connection";
 import { CLICKHOUSE_FORBIDDEN_PATTERNS } from "./validation";
 
-const ClickHouseConfigSchema = z.object({
+/**
+ * Strict schema for a fully-specified ClickHouse connection. A `url` is
+ * required. Used by `connection.createFromConfig` to validate the decrypted
+ * per-(workspace, install) config of a DB-stored datasource (which always
+ * carries a url) before building the connection.
+ */
+const ClickHouseConnectionConfigSchema = z.object({
   /** ClickHouse connection URL (clickhouse:// or clickhouses://). */
   url: z
     .string()
@@ -39,6 +55,15 @@ const ClickHouseConfigSchema = z.object({
   /** ClickHouse database name override. When omitted, uses the database from the URL path. */
   database: z.string().optional(),
 });
+
+/**
+ * Lenient config-time schema — every field optional so the plugin can be
+ * registered as an ADAPTER ONLY: `clickhousePlugin({})` parses, registering the
+ * plugin so its `createFromConfig` is available to the datasource bridge for
+ * DB-stored per-workspace installs (the SaaS model), with no static datasource.
+ * A `url`, when supplied, is still validated for scheme.
+ */
+const ClickHouseConfigSchema = ClickHouseConnectionConfigSchema.partial();
 
 export type ClickHouseConfig = z.infer<typeof ClickHouseConfigSchema>;
 
@@ -52,6 +77,35 @@ export function buildClickHousePlugin(
 ): AtlasDatasourcePlugin<ClickHouseConfig> {
   let log: PluginLogger | undefined;
 
+  // When a static url is configured the plugin wires a config-defined
+  // connection at boot; without one it is registered adapter-only.
+  const staticUrl = config.url;
+
+  const connection: AtlasDatasourcePlugin<ClickHouseConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from
+    // the per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict schema. Always available — this is the
+    // SaaS per-workspace path and the only path in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      const parsed = ClickHouseConnectionConfigSchema.parse(runtimeConfig);
+      return createClickHouseConnection({
+        url: parsed.url,
+        database: parsed.database,
+        logger: log,
+      });
+    },
+    dbType: "clickhouse",
+    parserDialect: "PostgresQL", // closest match in node-sql-parser
+    forbiddenPatterns: CLICKHOUSE_FORBIDDEN_PATTERNS,
+  };
+
+  if (staticUrl) {
+    connection.create = () =>
+      // ClickHouse HTTP transport is stateless — safe to create per call.
+      // Pool-based databases (Postgres, MySQL) should cache the connection.
+      createClickHouseConnection({ url: staticUrl, database: config.database, logger: log });
+  }
+
   return {
     id: "clickhouse-datasource",
     types: ["datasource"] as const,
@@ -59,27 +113,7 @@ export function buildClickHousePlugin(
     name: "ClickHouse DataSource",
     config,
 
-    connection: {
-      create: () =>
-        // ClickHouse HTTP transport is stateless — safe to create per call.
-        // Pool-based databases (Postgres, MySQL) should cache the connection.
-        createClickHouseConnection({ url: config.url, database: config.database, logger: log }),
-      // DB-driven (admin-UI-registered) datasources: build a connection from
-      // the per-(workspace, install) config decrypted from `workspace_plugins`,
-      // re-validated through the same schema. The config-time `config.url`
-      // above is ignored on this path.
-      createFromConfig: (runtimeConfig) => {
-        const parsed = ClickHouseConfigSchema.parse(runtimeConfig);
-        return createClickHouseConnection({
-          url: parsed.url,
-          database: parsed.database,
-          logger: log,
-        });
-      },
-      dbType: "clickhouse",
-      parserDialect: "PostgresQL", // closest match in node-sql-parser
-      forbiddenPatterns: CLICKHOUSE_FORBIDDEN_PATTERNS,
-    },
+    connection,
 
     entities: [],
 
@@ -96,14 +130,26 @@ export function buildClickHousePlugin(
 
     async initialize(ctx) {
       log = ctx.logger;
-      ctx.logger.info(`ClickHouse datasource plugin initialized (${extractHost(config.url)})`);
+      if (staticUrl) {
+        ctx.logger.info(`ClickHouse datasource plugin initialized (${extractHost(staticUrl)})`);
+      } else {
+        ctx.logger.info(
+          "ClickHouse datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!staticUrl) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
       const start = performance.now();
       let conn: PluginDBConnection | undefined;
       try {
-        conn = createClickHouseConnection({ url: config.url, database: config.database });
+        conn = createClickHouseConnection({ url: staticUrl, database: config.database });
         await conn.query("SELECT 1", 5000);
         return {
           healthy: true,
@@ -131,7 +177,10 @@ export function buildClickHousePlugin(
  *
  * @example
  * ```typescript
+ * // Static datasource (self-host):
  * plugins: [clickhousePlugin({ url: "clickhouse://localhost:8123/default" })]
+ * // Adapter-only (SaaS — customers bring their own per workspace):
+ * plugins: [clickhousePlugin({})]
  * ```
  */
 export const clickhousePlugin = createPlugin({

--- a/plugins/duckdb/__tests__/duckdb.test.ts
+++ b/plugins/duckdb/__tests__/duckdb.test.ts
@@ -148,8 +148,10 @@ describe("config validation", () => {
     ).toThrow(/URL must start with duckdb:\/\//);
   });
 
-  test("rejects config with neither url nor path", () => {
-    expect(() => duckdbPlugin({})).toThrow(/Either url or path is required/);
+  test("accepts empty config — adapter-only registration (SaaS per-workspace)", () => {
+    const plugin = duckdbPlugin({});
+    expect(plugin.id).toBe("duckdb-datasource");
+    expect(plugin.config).toEqual({});
   });
 
   test("accepts path-based config", () => {
@@ -241,6 +243,102 @@ describe("plugin shape", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no url/path is configured", () => {
+    const plugin = duckdbPlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = duckdbPlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = duckdbPlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("duckdb");
+  });
+
+  test("createFromConfig builds a connection from a runtime url even with no static config", () => {
+    const plugin = duckdbPlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      url: "duckdb://runtime/analytics.duckdb",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig builds a connection from a runtime path even with no static config", () => {
+    const plugin = duckdbPlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      path: "/runtime/analytics.duckdb",
+      // Extra keys from the decrypted workspace_plugins.config record are tolerated.
+      db_type: "duckdb",
+      group_id: "g_default",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig rejects a runtime config with neither url nor path", () => {
+    const plugin = duckdbPlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow(
+      /Either url or path is required/,
+    );
+  });
+
+  test("createFromConfig rejects an invalid runtime url scheme", () => {
+    const plugin = duckdbPlugin({});
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow(/URL must start with duckdb:\/\//);
+  });
+
+  test("static-config mode still wires connection.create when a url is given", () => {
+    const plugin = duckdbPlugin({ url: "duckdb://analytics.duckdb" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("static-config mode still wires connection.create when a path is given", () => {
+    const plugin = duckdbPlugin({ path: "/data/analytics.duckdb" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = duckdbPlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+    // No connection is constructed when there is no static datasource.
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test("initialize logs adapter-only (no url/path, no crash)", async () => {
+    const plugin = duckdbPlugin({});
+    const logged: string[] = [];
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) => { logged.push(String(args[0])); },
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    };
+    await plugin.initialize!(ctx);
+    const msg = logged.find((m) => m.includes("adapter-only"));
+    expect(msg).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Forbidden patterns behavioral tests
 // ---------------------------------------------------------------------------
 
@@ -304,7 +402,7 @@ describe("connection factory", () => {
     const plugin = duckdbPlugin({
       url: "duckdb://analytics.duckdb",
     });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });
@@ -420,7 +518,7 @@ describe("connection factory", () => {
 
   test("url-based config without readOnly defaults to READ_ONLY for files", async () => {
     const plugin = duckdbPlugin({ url: "duckdb://analytics.duckdb" });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     await conn.query("SELECT 1");
     expect(mockCreate).toHaveBeenCalledWith("analytics.duckdb", {
       access_mode: "READ_ONLY",
@@ -429,21 +527,21 @@ describe("connection factory", () => {
 
   test("url-based in-memory config without readOnly skips READ_ONLY", async () => {
     const plugin = duckdbPlugin({ url: "duckdb://" });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     await conn.query("SELECT 1");
     expect(mockCreate).toHaveBeenCalledWith(":memory:", {});
   });
 
   test("path-based in-memory config without readOnly skips READ_ONLY", async () => {
     const plugin = duckdbPlugin({ path: ":memory:" });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     await conn.query("SELECT 1");
     expect(mockCreate).toHaveBeenCalledWith(":memory:", {});
   });
 
   test("path-based config creates connection with correct path", async () => {
     const plugin = duckdbPlugin({ path: "/data/analytics.duckdb" });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     await conn.query("SELECT 1");
     expect(mockCreate).toHaveBeenCalledWith("/data/analytics.duckdb", {
       access_mode: "READ_ONLY",
@@ -452,7 +550,7 @@ describe("connection factory", () => {
 
   test("path-based config with readOnly false skips READ_ONLY", async () => {
     const plugin = duckdbPlugin({ path: "/data/analytics.duckdb", readOnly: false });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     await conn.query("SELECT 1");
     expect(mockCreate).toHaveBeenCalledWith("/data/analytics.duckdb", {});
   });

--- a/plugins/duckdb/src/index.ts
+++ b/plugins/duckdb/src/index.ts
@@ -4,15 +4,28 @@
  * Wraps the in-process DuckDB adapter extracted from
  * packages/api/src/lib/db/duckdb.ts.
  *
- * Usage in atlas.config.ts:
+ * Two registration modes:
+ *
+ * 1. Static config-defined datasource (self-host / operator-baked) — pass a
+ *    `url` or `path` and the plugin wires a single connection at boot:
  * ```typescript
  * import { defineConfig } from "@atlas/api/lib/config";
  * import { duckdbPlugin } from "@useatlas/duckdb";
  *
  * export default defineConfig({
- *   plugins: [
- *     duckdbPlugin({ url: "duckdb://path/to/analytics.duckdb" }),
- *   ],
+ *   plugins: [duckdbPlugin({ url: "duckdb://path/to/analytics.duckdb" })],
+ * });
+ * ```
+ *
+ * 2. Adapter-only — pass no `url`/`path` and the plugin registers purely as an
+ *    adapter (DB-stored per-workspace connections via `createFromConfig`). This
+ *    mode exists for self-host parity with the other datasource plugins; DuckDB
+ *    is deliberately NOT registered in the hosted SaaS deploy configs
+ *    (deploy/api and deploy/api-staging) because it is file-path based and a
+ *    local filesystem path is not a safe multi-tenant datasource. On self-host:
+ * ```typescript
+ * export default defineConfig({
+ *   plugins: [duckdbPlugin({})],
  * });
  * ```
  */
@@ -24,7 +37,12 @@ import { createDuckDBConnection, parseDuckDBUrl } from "./connection";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import { DUCKDB_FORBIDDEN_PATTERNS } from "./validation";
 
-const DuckDBConfigSchema = z.object({
+/**
+ * Base object schema for a DuckDB connection. `url` and `path` are both
+ * optional here; the requirement that at least one be present is layered on by
+ * the strict schema below.
+ */
+const DuckDBConfigBaseSchema = z.object({
   /** DuckDB connection URL (duckdb://). */
   url: z
     .string()
@@ -39,10 +57,28 @@ const DuckDBConfigSchema = z.object({
   path: z.string().trim().min(1, "Path must not be empty").optional(),
   /** Open in read-only mode. Defaults to true for file databases. */
   readOnly: z.boolean().optional(),
-}).refine(
+});
+
+/**
+ * Strict schema for a fully-specified DuckDB connection. Either a `url` or a
+ * `path` is required. Used by `connection.createFromConfig` to validate the
+ * decrypted per-(workspace, install) config of a DB-stored datasource (which
+ * always carries a url or path) before building the connection.
+ */
+const DuckDBConnectionConfigSchema = DuckDBConfigBaseSchema.refine(
   (cfg) => cfg.url || cfg.path,
   "Either url or path is required",
 );
+
+/**
+ * Lenient config-time schema — neither url nor path required so the plugin can
+ * be registered as an ADAPTER ONLY: `duckdbPlugin({})` parses, registering the
+ * plugin so its `createFromConfig` is available to the datasource bridge for
+ * DB-stored per-workspace installs, with no static datasource. This is for
+ * self-host parity — DuckDB is not registered in the hosted SaaS configs (see
+ * the file header). A `url`/`path`, when supplied, is still validated.
+ */
+const DuckDBConfigSchema = DuckDBConfigBaseSchema;
 
 export type DuckDBPluginConfig = z.infer<typeof DuckDBConfigSchema>;
 
@@ -54,11 +90,52 @@ export type DuckDBPluginConfig = z.infer<typeof DuckDBConfigSchema>;
 export function buildDuckDBPlugin(
   config: DuckDBPluginConfig,
 ): AtlasDatasourcePlugin<DuckDBPluginConfig> {
-  const parsed = config.url
-    ? parseDuckDBUrl(config.url)
-    : { path: config.path!, readOnly: config.path !== ":memory:" };
-  const dbConfig = { ...parsed, readOnly: config.readOnly ?? parsed.readOnly };
   let log: PluginLogger | undefined;
+
+  // When a static url/path is configured the plugin wires a config-defined
+  // connection at boot; without one it is registered adapter-only.
+  const hasStaticConfig = !!(config.url || config.path);
+  const staticUrl = config.url;
+  const staticPath = config.path;
+  const staticReadOnly = config.readOnly;
+
+  /** Resolve a DuckDBConnectionConfig from a url/path/readOnly triple, matching the build-time logic. */
+  const resolveDbConfig = (input: {
+    url?: string;
+    path?: string;
+    readOnly?: boolean;
+  }) => {
+    const parsed = input.url
+      ? parseDuckDBUrl(input.url)
+      : { path: input.path as string, readOnly: input.path !== ":memory:" };
+    return { ...parsed, readOnly: input.readOnly ?? parsed.readOnly };
+  };
+
+  const connection: AtlasDatasourcePlugin<DuckDBPluginConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from
+    // the per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict schema. Always available — this is the
+    // SaaS per-workspace path and the only path in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      const parsed = DuckDBConnectionConfigSchema.parse(runtimeConfig);
+      const dbConfig = resolveDbConfig(parsed);
+      return createDuckDBConnection({ ...dbConfig, logger: log });
+    },
+    dbType: "duckdb",
+    parserDialect: "PostgresQL",
+    forbiddenPatterns: DUCKDB_FORBIDDEN_PATTERNS,
+  };
+
+  if (hasStaticConfig) {
+    // Parse the static config once, inside the create closure so adapter-only
+    // mode never calls parseDuckDBUrl on an undefined url/path.
+    const dbConfig = resolveDbConfig({
+      url: staticUrl,
+      path: staticPath,
+      readOnly: staticReadOnly,
+    });
+    connection.create = () => createDuckDBConnection({ ...dbConfig, logger: log });
+  }
 
   return {
     id: "duckdb-datasource",
@@ -67,12 +144,7 @@ export function buildDuckDBPlugin(
     name: "DuckDB DataSource",
     config,
 
-    connection: {
-      create: () => createDuckDBConnection({ ...dbConfig, logger: log }),
-      dbType: "duckdb",
-      parserDialect: "PostgresQL",
-      forbiddenPatterns: DUCKDB_FORBIDDEN_PATTERNS,
-    },
+    connection,
 
     entities: [],
 
@@ -90,11 +162,33 @@ export function buildDuckDBPlugin(
 
     async initialize(ctx) {
       log = ctx.logger;
-      const label = dbConfig.path === ":memory:" ? "in-memory" : dbConfig.path;
-      ctx.logger.info(`DuckDB datasource plugin initialized (${label})`);
+      if (hasStaticConfig) {
+        const dbConfig = resolveDbConfig({
+          url: staticUrl,
+          path: staticPath,
+          readOnly: staticReadOnly,
+        });
+        const label = dbConfig.path === ":memory:" ? "in-memory" : dbConfig.path;
+        ctx.logger.info(`DuckDB datasource plugin initialized (${label})`);
+      } else {
+        ctx.logger.info(
+          "DuckDB datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!hasStaticConfig) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
+      const dbConfig = resolveDbConfig({
+        url: staticUrl,
+        path: staticPath,
+        readOnly: staticReadOnly,
+      });
       const start = performance.now();
       let conn: PluginDBConnection | undefined;
       try {
@@ -126,7 +220,10 @@ export function buildDuckDBPlugin(
  *
  * @example
  * ```typescript
+ * // Static datasource (self-host):
  * plugins: [duckdbPlugin({ url: "duckdb://analytics.duckdb" })]
+ * // Adapter-only (SaaS — customers bring their own per workspace):
+ * plugins: [duckdbPlugin({})]
  * ```
  */
 export const duckdbPlugin = createPlugin({

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -605,9 +605,17 @@ describe("config validation", () => {
     ).toThrow(/elasticsearch:\/\//);
   });
 
-  test("rejects a missing API key", () => {
-    // @ts-expect-error — intentionally omitting apiKey
-    expect(() => elasticsearchPlugin({ url: VALID_URL })).toThrow();
+  test("accepts a url with no apiKey — adapter-only registration (SaaS per-workspace)", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL });
+    expect(plugin.id).toBe("elasticsearch-datasource");
+    // Incomplete static config (url but no apiKey) → no static connection wired.
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("accepts a fully empty config — adapter-only registration", () => {
+    const plugin = elasticsearchPlugin({});
+    expect(plugin.id).toBe("elasticsearch-datasource");
+    expect(plugin.config).toEqual({});
   });
 
   test("rejects an empty API key", () => {
@@ -648,7 +656,7 @@ describe("plugin shape", () => {
 
   test("connection.create() returns a PluginDBConnection", async () => {
     const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });
@@ -656,6 +664,74 @@ describe("plugin shape", () => {
   test("has teardown method", () => {
     const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
     expect(typeof plugin.teardown).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no url/apiKey is configured", () => {
+    const plugin = elasticsearchPlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = elasticsearchPlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = elasticsearchPlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("elasticsearch");
+  });
+
+  test("createFromConfig builds a connection from a runtime config even with no static config", () => {
+    const plugin = elasticsearchPlugin({});
+    const conn = plugin.connection.createFromConfig!({ url: VALID_URL, apiKey: API_KEY });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig still rejects a missing/invalid runtime config", () => {
+    const plugin = elasticsearchPlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db", apiKey: API_KEY }),
+    ).toThrow();
+  });
+
+  test("static-config mode still wires connection.create when url + apiKey are given", () => {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = elasticsearchPlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+  });
+
+  test("initialize logs adapter-only (no url, no crash)", async () => {
+    const plugin = elasticsearchPlugin({});
+    const logged: string[] = [];
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) => { logged.push(String(args[0])); },
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    };
+    await plugin.initialize!(ctx);
+    expect(logged.some((m) => m.includes("adapter-only"))).toBe(true);
   });
 });
 

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -61,7 +61,13 @@ const ELASTICSEARCH_DIALECT_GUIDE = [
   "- Read-only: only SELECT is allowed. SHOW/DESCRIBE and any DML/DDL are rejected.",
 ].join("\n");
 
-const ElasticsearchConfigSchema = z.object({
+/**
+ * Strict schema for a fully-specified Elasticsearch connection — both `url` and
+ * `apiKey` are required. Used by `connection.createFromConfig` to validate the
+ * decrypted per-(workspace, install) config of a DB-stored datasource (which
+ * always carries both) before building the connection.
+ */
+const ElasticsearchConnectionConfigSchema = z.object({
   /** Elasticsearch connection URL (elasticsearch://host:9200). */
   url: z
     .string()
@@ -86,13 +92,23 @@ const ElasticsearchConfigSchema = z.object({
   description: z.string().optional(),
 });
 
+/**
+ * Lenient config-time schema — every field optional so the plugin can be
+ * registered as an ADAPTER ONLY: `elasticsearchPlugin({})` parses, registering
+ * the plugin so its `createFromConfig` is available to the datasource bridge for
+ * DB-stored per-workspace installs (the SaaS model), with no static datasource.
+ * A `url` / `apiKey`, when supplied, is still validated.
+ */
+const ElasticsearchConfigSchema = ElasticsearchConnectionConfigSchema.partial();
+
 export type ElasticsearchConfig = z.infer<typeof ElasticsearchConfigSchema>;
 
-// Compile-time guard: the Zod-inferred config and the connection module's raw
-// config shape must stay structurally identical, so adding a field to one
-// without the other fails the build instead of drifting silently.
-type _ConfigsAligned = [ElasticsearchConfig] extends [ElasticsearchPluginConfig]
-  ? [ElasticsearchPluginConfig] extends [ElasticsearchConfig]
+// Compile-time guard: the STRICT schema's inferred config and the connection
+// module's raw config shape must stay structurally identical, so adding a field
+// to one without the other fails the build instead of drifting silently.
+type StrictElasticsearchConfig = z.infer<typeof ElasticsearchConnectionConfigSchema>;
+type _ConfigsAligned = [StrictElasticsearchConfig] extends [ElasticsearchPluginConfig]
+  ? [ElasticsearchPluginConfig] extends [StrictElasticsearchConfig]
     ? true
     : never
   : never;
@@ -110,12 +126,54 @@ export function buildElasticsearchPlugin(
   let cachedConn: ElasticsearchConnection | undefined;
   let log: PluginLogger | undefined;
 
-  /** Cached singleton so health checks and teardown share one client. */
+  // A static config-defined ES datasource (self-host / operator-baked) needs
+  // both a url and an apiKey. Without them the plugin is registered ADAPTER ONLY
+  // (the SaaS per-workspace model): no static connection, customers add their
+  // own per workspace via Admin → Connections, and the datasource bridge builds
+  // each connection via `createFromConfig`.
+  const staticConfig: ElasticsearchPluginConfig | undefined =
+    config.url && config.apiKey
+      ? {
+          url: config.url,
+          apiKey: config.apiKey,
+          ...(config.description ? { description: config.description } : {}),
+        }
+      : undefined;
+
+  /** Cached singleton so health checks and teardown share one client (static mode). */
   function getOrCreateConnection(): ElasticsearchConnection {
+    if (!staticConfig) {
+      throw new Error(
+        "Elasticsearch plugin is adapter-only — no static datasource configured",
+      );
+    }
     if (!cachedConn) {
-      cachedConn = createElasticsearchConnection(config, { logger: log });
+      cachedConn = createElasticsearchConnection(staticConfig, { logger: log });
     }
     return cachedConn;
+  }
+
+  const connection: AtlasDatasourcePlugin<ElasticsearchConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from the
+    // per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict schema. Always available — this is the
+    // SaaS per-workspace path and the only path in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      const parsed = ElasticsearchConnectionConfigSchema.parse(runtimeConfig);
+      return createElasticsearchConnection(parsed, { logger: log });
+    },
+    dbType: "elasticsearch",
+    // ES SQL is real SQL, so there is intentionally NO custom `validate`: the
+    // host's standard 4-layer pipeline (regex guard → AST parse → index/table
+    // whitelist → auto-LIMIT + timeout) applies unchanged. We only tell it
+    // which grammar to parse with and add ES-specific guards on top of the
+    // base DML/DDL regex.
+    parserDialect: ELASTICSEARCH_PARSER_DIALECT,
+    forbiddenPatterns: ELASTICSEARCH_FORBIDDEN_PATTERNS,
+  };
+
+  if (staticConfig) {
+    connection.create = () => getOrCreateConnection();
   }
 
   return {
@@ -125,17 +183,7 @@ export function buildElasticsearchPlugin(
     name: "Elasticsearch DataSource",
     config,
 
-    connection: {
-      create: () => getOrCreateConnection(),
-      dbType: "elasticsearch",
-      // ES SQL is real SQL, so there is intentionally NO custom `validate`: the
-      // host's standard 4-layer pipeline (regex guard → AST parse → index/table
-      // whitelist → auto-LIMIT + timeout) applies unchanged. We only tell it
-      // which grammar to parse with and add ES-specific guards on top of the
-      // base DML/DDL regex.
-      parserDialect: ELASTICSEARCH_PARSER_DIALECT,
-      forbiddenPatterns: ELASTICSEARCH_FORBIDDEN_PATTERNS,
-    },
+    connection,
 
     entities: [],
 
@@ -177,12 +225,24 @@ export function buildElasticsearchPlugin(
 
     async initialize(ctx) {
       log = ctx.logger;
-      ctx.logger.info(
-        `Elasticsearch datasource plugin initialized (${extractHost(config.url)})`,
-      );
+      if (staticConfig) {
+        ctx.logger.info(
+          `Elasticsearch datasource plugin initialized (${extractHost(staticConfig.url)})`,
+        );
+      } else {
+        ctx.logger.info(
+          "Elasticsearch datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!staticConfig) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
       const start = performance.now();
       try {
         // The client owns the timeout/abort (it rejects with a clear "timed out"
@@ -191,7 +251,7 @@ export function buildElasticsearchPlugin(
         await getOrCreateConnection().ping(5000);
         return { healthy: true, latencyMs: Math.round(performance.now() - start) };
       } catch (err) {
-        const message = scrubElasticsearchError(err, config.apiKey);
+        const message = scrubElasticsearchError(err, staticConfig.apiKey);
         log?.warn(`Elasticsearch health check failed: ${message}`);
         return {
           healthy: false,

--- a/plugins/mysql/__tests__/mysql.test.ts
+++ b/plugins/mysql/__tests__/mysql.test.ts
@@ -187,7 +187,7 @@ describe("connection factory", () => {
     const plugin = mysqlPlugin({
       url: "mysql://localhost:3306/mydb",
     });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });
@@ -196,8 +196,8 @@ describe("connection factory", () => {
     const plugin = mysqlPlugin({
       url: "mysql://localhost:3306/mydb",
     });
-    const conn1 = plugin.connection.create();
-    const conn2 = plugin.connection.create();
+    const conn1 = plugin.connection.create!();
+    const conn2 = plugin.connection.create!();
     expect(conn1).toBe(conn2);
     expect(mockCreatePool).toHaveBeenCalledTimes(1);
   });

--- a/plugins/salesforce/__tests__/salesforce.test.ts
+++ b/plugins/salesforce/__tests__/salesforce.test.ts
@@ -236,9 +236,10 @@ describe("config validation", () => {
     ).toThrow(/URL must start with salesforce:\/\//);
   });
 
-  test("rejects missing URL", () => {
-    // @ts-expect-error — intentionally passing invalid config
-    expect(() => salesforcePlugin({})).toThrow();
+  test("accepts empty config — adapter-only registration (SaaS per-workspace)", () => {
+    const plugin = salesforcePlugin({});
+    expect(plugin.id).toBe("salesforce-datasource");
+    expect(plugin.config).toEqual({});
   });
 
   test("rejects URL with missing credentials", () => {
@@ -317,6 +318,97 @@ describe("plugin shape", () => {
   test("has teardown method", () => {
     const plugin = salesforcePlugin({ url: VALID_URL });
     expect(typeof plugin.teardown).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no url is configured", () => {
+    const plugin = salesforcePlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = salesforcePlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = salesforcePlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("salesforce");
+  });
+
+  test("SOQL validate is still present and working in adapter-only mode", async () => {
+    const plugin = salesforcePlugin({});
+    expect(typeof plugin.connection.validate).toBe("function");
+    const ok = await plugin.connection.validate!("SELECT Id FROM Account");
+    expect(ok.valid).toBe(true);
+    const bad = await plugin.connection.validate!("DELETE FROM Account");
+    expect(bad.valid).toBe(false);
+    expect(bad.reason).toContain("Forbidden");
+  });
+
+  test("createFromConfig builds a connection from a runtime config even with no static url", async () => {
+    const plugin = salesforcePlugin({});
+    const conn = await plugin.connection.createFromConfig!({
+      url: "salesforce://runtime-user:runtime-pass@runtime.salesforce.com?token=RTOKEN",
+      // Extra keys from the decrypted workspace_plugins.config record are tolerated.
+      db_type: "salesforce",
+      group_id: "g_default",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig still rejects a missing/invalid runtime url", () => {
+    const plugin = salesforcePlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow();
+  });
+
+  test("static-config mode still wires connection.create when a url is given", () => {
+    const plugin = salesforcePlugin({ url: VALID_URL });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = salesforcePlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+    // No connection is constructed when there is no static datasource.
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  test("initialize logs adapter-only (no url, no credentials, no crash)", async () => {
+    const plugin = salesforcePlugin({});
+    const { ctx, logged } = makeCtx();
+    await plugin.initialize!(ctx);
+    const msg = logged.find((m) => m.includes("adapter-only"));
+    expect(msg).toBeDefined();
+  });
+
+  test("does NOT register the static querySalesforce tool in adapter-only mode", async () => {
+    const plugin = salesforcePlugin({});
+    const { ctx, registered } = makeCtx();
+    await plugin.initialize!(ctx);
+    // The querySalesforce tool is hardwired to the static connection; on SaaS
+    // per-workspace Salesforce is queried via executeSQL through the bridge.
+    expect(registered.some((t) => t.name === "querySalesforce")).toBe(false);
+  });
+
+  test("dialect recommends executeSQL (not querySalesforce) in adapter-only mode", () => {
+    // The dialect must stay consistent with tool registration: adapter-only mode
+    // skips querySalesforce, so the guidance must not point the agent at it.
+    const plugin = salesforcePlugin({});
+    expect(plugin.dialect).toContain("executeSQL");
+    expect(plugin.dialect).not.toContain("querySalesforce");
   });
 });
 
@@ -706,7 +798,9 @@ describe("SENSITIVE_PATTERNS", () => {
 describe("connection factory", () => {
   test("connection.create() returns a PluginDBConnection", async () => {
     const plugin = salesforcePlugin({ url: VALID_URL });
-    const conn = await plugin.connection.create();
+    // `create` is optional on the type now (omitted in adapter-only mode), but
+    // static config wires it — non-null assert in this static-mode test.
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -5,7 +5,10 @@
  * uses SOQL and has a custom validation pipeline (validateSOQL) instead of
  * the standard node-sql-parser-based SQL validation.
  *
- * Usage in atlas.config.ts:
+ * Two registration modes:
+ *
+ * 1. Static config-defined datasource (self-host / operator-baked) — pass a
+ *    `url` and the plugin wires a single connection at boot:
  * ```typescript
  * import { defineConfig } from "@atlas/api/lib/config";
  * import { salesforcePlugin } from "@useatlas/salesforce";
@@ -14,6 +17,16 @@
  *   plugins: [
  *     salesforcePlugin({ url: "salesforce://user:pass@login.salesforce.com?token=TOKEN" }),
  *   ],
+ * });
+ * ```
+ *
+ * 2. Adapter-only (SaaS per-workspace) — pass no `url` and the plugin registers
+ *    purely as an adapter, so customers add their own Salesforce per workspace
+ *    via Admin → Connections (DB-stored, encrypted). No operator env var, no
+ *    static datasource:
+ * ```typescript
+ * export default defineConfig({
+ *   plugins: [salesforcePlugin({})],
  * });
  * ```
  */
@@ -30,7 +43,13 @@ import type { SalesforceConnection } from "./connection";
 import { validateSOQLStructure } from "./validation";
 import { createQuerySalesforceTool } from "./tool";
 
-const SalesforceConfigSchema = z.object({
+/**
+ * Strict schema for a fully-specified Salesforce connection. A `url` is
+ * required. Used by `connection.createFromConfig` to validate the decrypted
+ * per-(workspace, install) config of a DB-stored datasource (which always
+ * carries a url) before building the connection.
+ */
+const SalesforceConnectionConfigSchema = z.object({
   /** Salesforce connection URL (salesforce://user:pass@login.salesforce.com?token=TOKEN). */
   url: z
     .string()
@@ -51,6 +70,15 @@ const SalesforceConfigSchema = z.object({
     }),
 });
 
+/**
+ * Lenient config-time schema — every field optional so the plugin can be
+ * registered as an ADAPTER ONLY: `salesforcePlugin({})` parses, registering the
+ * plugin so its `createFromConfig` is available to the datasource bridge for
+ * DB-stored per-workspace installs (the SaaS model), with no static datasource.
+ * A `url`, when supplied, is still validated for scheme + credentials.
+ */
+const SalesforceConfigSchema = SalesforceConnectionConfigSchema.partial();
+
 export type SalesforcePluginConfig = z.infer<typeof SalesforceConfigSchema>;
 
 /**
@@ -61,16 +89,58 @@ export type SalesforcePluginConfig = z.infer<typeof SalesforceConfigSchema>;
 export function buildSalesforcePlugin(
   config: SalesforcePluginConfig,
 ): AtlasDatasourcePlugin<SalesforcePluginConfig> {
-  const sfConfig = parseSalesforceURL(config.url);
   let cachedConn: SalesforceConnection | undefined;
   let log: PluginLogger | undefined;
 
-  /** Cached singleton — jsforce session is stateful, so we reuse the connection. */
+  // When a static url is configured the plugin wires a config-defined
+  // connection at boot; without one it is registered adapter-only. The url is
+  // only parsed where present — never on the adapter-only build path.
+  const staticUrl = config.url;
+  const hasStaticConfig = !!staticUrl;
+
+  /**
+   * Cached singleton for the STATIC datasource — jsforce session is stateful,
+   * so we reuse the connection. Only reachable when a static url is configured.
+   */
   function getOrCreateConnection(): SalesforceConnection {
+    if (!staticUrl) {
+      throw new Error(
+        "Salesforce datasource is adapter-only — no static connection. Use createFromConfig for per-workspace datasources.",
+      );
+    }
     if (!cachedConn) {
-      cachedConn = createSalesforceConnection(sfConfig, log);
+      cachedConn = createSalesforceConnection(parseSalesforceURL(staticUrl), log);
     }
     return cachedConn;
+  }
+
+  const connection: AtlasDatasourcePlugin<SalesforcePluginConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from
+    // the per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict schema. Always available — this is the
+    // SaaS per-workspace path and the only path in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      const parsed = SalesforceConnectionConfigSchema.parse(runtimeConfig);
+      // Parse the runtime url here (never at build time) — surfaces parser
+      // errors as a thrown error for the datasource bridge to handle.
+      return createSalesforceConnection(parseSalesforceURL(parsed.url), log);
+    },
+    dbType: "salesforce",
+    validate(query: string): QueryValidationResult {
+      // Structural checks only (SELECT-only, no DML, no semicolons).
+      // Object whitelist is applied in the querySalesforce tool which
+      // has access to the semantic layer. Url-independent — present in both
+      // static and adapter-only modes.
+      const result = validateSOQLStructure(query);
+      return {
+        valid: result.valid,
+        reason: result.error,
+      };
+    },
+  };
+
+  if (hasStaticConfig) {
+    connection.create = () => getOrCreateConnection();
   }
 
   return {
@@ -80,20 +150,7 @@ export function buildSalesforcePlugin(
     name: "Salesforce DataSource",
     config,
 
-    connection: {
-      create: () => getOrCreateConnection(),
-      dbType: "salesforce",
-      validate(query: string): QueryValidationResult {
-        // Structural checks only (SELECT-only, no DML, no semicolons).
-        // Object whitelist is applied in the querySalesforce tool which
-        // has access to the semantic layer.
-        const result = validateSOQLStructure(query);
-        return {
-          valid: result.valid,
-          reason: result.error,
-        };
-      },
-    },
+    connection,
 
     entities: [],
 
@@ -108,40 +165,65 @@ export function buildSalesforcePlugin(
       "- Use LIMIT to restrict result sets.",
       "- Date literals: YESTERDAY, TODAY, LAST_WEEK, THIS_MONTH, LAST_N_DAYS:n, etc.",
       "- No wildcards in field lists — always list specific fields (no `SELECT *`).",
-      "- Use `querySalesforce` tool (not `executeSQL`) for Salesforce queries.",
+      // Mode-aware: the dedicated `querySalesforce` tool is only registered in
+      // static mode (see initialize). In adapter-only / SaaS per-workspace mode
+      // the per-workspace connection is queried via `executeSQL`, routed through
+      // the bridge-built connection that carries this plugin's SOQL `validate`.
+      staticUrl
+        ? "- Use `querySalesforce` tool (not `executeSQL`) for Salesforce queries."
+        : "- Use `executeSQL` for Salesforce queries (per-workspace mode — the connection enforces SOQL validation).",
     ].join("\n"),
 
     async initialize(ctx) {
       log = ctx.logger;
-      ctx.logger.info(`Salesforce datasource plugin initialized (${extractHost(config.url)})`);
+      if (staticUrl) {
+        ctx.logger.info(`Salesforce datasource plugin initialized (${extractHost(staticUrl)})`);
+      } else {
+        ctx.logger.info(
+          "Salesforce datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
 
-      // Register the querySalesforce tool
-      const sfTool = createQuerySalesforceTool({
-        getConnection: () => getOrCreateConnection(),
-        getWhitelist: () => {
-          try {
-            const tables = ctx.connections.list();
-            return new Set(tables);
-          } catch (err) {
-            ctx.logger.warn(
-              { err: err instanceof Error ? err.message : String(err) },
-              "Failed to load Salesforce object whitelist — queries may be rejected",
-            );
-            return new Set<string>();
-          }
-        },
-        connectionId: "salesforce",
-        logger: ctx.logger,
-      });
+      // Register the querySalesforce tool ONLY in static-datasource mode. The
+      // tool is hardwired to the static connection (`getOrCreateConnection()` /
+      // `connectionId: "salesforce"`), so in adapter-only mode it would throw on
+      // every call. SaaS per-workspace Salesforce datasources are queried via
+      // the standard `executeSQL` path, routed through the bridge-built
+      // connection (which carries this plugin's SOQL `validate`).
+      if (staticUrl) {
+        const sfTool = createQuerySalesforceTool({
+          getConnection: () => getOrCreateConnection(),
+          getWhitelist: () => {
+            try {
+              const tables = ctx.connections.list();
+              return new Set(tables);
+            } catch (err) {
+              ctx.logger.warn(
+                { err: err instanceof Error ? err.message : String(err) },
+                "Failed to load Salesforce object whitelist — queries may be rejected",
+              );
+              return new Set<string>();
+            }
+          },
+          connectionId: "salesforce",
+          logger: ctx.logger,
+        });
 
-      ctx.tools.register({
-        name: "querySalesforce",
-        description: "Execute a read-only SOQL query against Salesforce",
-        tool: sfTool,
-      });
+        ctx.tools.register({
+          name: "querySalesforce",
+          description: "Execute a read-only SOQL query against Salesforce",
+          tool: sfTool,
+        });
+      }
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!staticUrl) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
       const start = performance.now();
       try {
         const conn = getOrCreateConnection();
@@ -191,7 +273,10 @@ export function buildSalesforcePlugin(
  *
  * @example
  * ```typescript
+ * // Static datasource (self-host):
  * plugins: [salesforcePlugin({ url: "salesforce://user:pass@login.salesforce.com?token=TOKEN" })]
+ * // Adapter-only (SaaS — customers bring their own per workspace):
+ * plugins: [salesforcePlugin({})]
  * ```
  */
 export const salesforcePlugin = createPlugin({

--- a/plugins/snowflake/__tests__/plugin.test.ts
+++ b/plugins/snowflake/__tests__/plugin.test.ts
@@ -198,9 +198,10 @@ describe("config validation", () => {
     ).toThrow(/URL must start with snowflake:\/\//);
   });
 
-  test("rejects missing URL", () => {
-    // @ts-expect-error — intentionally passing invalid config
-    expect(() => snowflakePlugin({})).toThrow();
+  test("accepts empty config — adapter-only registration (SaaS per-workspace)", () => {
+    const plugin = snowflakePlugin({});
+    expect(plugin.id).toBe("snowflake-datasource");
+    expect(plugin.config).toEqual({});
   });
 
   test("rejects URL with missing username with specific error", () => {
@@ -306,6 +307,104 @@ describe("plugin shape", () => {
     expect(plugin.connection.forbiddenPatterns).toBe(SNOWFLAKE_FORBIDDEN_PATTERNS);
     expect(plugin.connection.forbiddenPatterns!.length).toBeGreaterThan(0);
   });
+
+  test("connection.createFromConfig builds a connection from a runtime (DB-stored) config (#3253)", () => {
+    const plugin = snowflakePlugin(validConfig);
+    // The config-time url is ignored on this path — pass a DIFFERENT runtime url.
+    const conn = plugin.connection.createFromConfig!({
+      url: "snowflake://runtime-user:pw@runtime-acct/runtime_db/public?warehouse=RT_WH",
+      // Extra keys from the decrypted workspace_plugins.config record are tolerated.
+      db_type: "snowflake",
+      group_id: "g_default",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("connection.createFromConfig validates the runtime config (rejects non-snowflake url)", () => {
+    const plugin = snowflakePlugin(validConfig);
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow();
+  });
+
+  test("connection.createFromConfig rejects a missing url", () => {
+    const plugin = snowflakePlugin(validConfig);
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter-only mode (SaaS per-workspace — no static datasource)
+// ---------------------------------------------------------------------------
+
+describe("adapter-only mode", () => {
+  test("omits connection.create when no url is configured", () => {
+    const plugin = snowflakePlugin({});
+    expect(plugin.connection.create).toBeUndefined();
+  });
+
+  test("still exposes connection.createFromConfig (the per-workspace adapter)", () => {
+    const plugin = snowflakePlugin({});
+    expect(typeof plugin.connection.createFromConfig).toBe("function");
+  });
+
+  test("still validates as a datasource plugin", () => {
+    const plugin = snowflakePlugin({});
+    expect(isDatasourcePlugin(plugin)).toBe(true);
+    expect(plugin.connection.dbType).toBe("snowflake");
+  });
+
+  test("createFromConfig builds a connection from a runtime config even with no static url", () => {
+    const plugin = snowflakePlugin({});
+    const conn = plugin.connection.createFromConfig!({
+      url: "snowflake://runtime-user:pw@runtime-acct/runtime_db",
+    });
+    expect(typeof (conn as { query?: unknown }).query).toBe("function");
+    expect(typeof (conn as { close?: unknown }).close).toBe("function");
+  });
+
+  test("createFromConfig still rejects a missing/invalid runtime url", () => {
+    const plugin = snowflakePlugin({});
+    expect(() => plugin.connection.createFromConfig!({})).toThrow();
+    expect(() =>
+      plugin.connection.createFromConfig!({ url: "postgresql://localhost:5432/db" }),
+    ).toThrow();
+  });
+
+  test("static-config mode still wires connection.create when a url is given", () => {
+    const plugin = snowflakePlugin({ url: "snowflake://user:pass@xy12345/db" });
+    expect(typeof plugin.connection.create).toBe("function");
+  });
+
+  test("healthCheck reports healthy without probing when adapter-only", async () => {
+    const plugin = snowflakePlugin({});
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("adapter-only");
+    // No connection is constructed when there is no static datasource.
+    expect(mockCreatePool).not.toHaveBeenCalled();
+  });
+
+  test("initialize logs adapter-only (no url, no credentials, no crash)", async () => {
+    const plugin = snowflakePlugin({});
+    const logged: string[] = [];
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) => { logged.push(String(args[0])); },
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    };
+    await plugin.initialize!(ctx);
+    const msg = logged.find((m) => m.includes("adapter-only"));
+    expect(msg).toBeDefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -388,7 +487,7 @@ describe("connection factory", () => {
 
   test("connection.create() returns a PluginDBConnection", async () => {
     const plugin = snowflakePlugin({ url: testUrl });
-    const conn = await plugin.connection.create();
+    const conn = await plugin.connection.create!();
     expect(typeof conn.query).toBe("function");
     expect(typeof conn.close).toBe("function");
   });

--- a/plugins/snowflake/src/index.ts
+++ b/plugins/snowflake/src/index.ts
@@ -4,7 +4,10 @@
  * Demonstrates how the AtlasDatasourcePlugin interface can wrap the callback-based
  * snowflake-sdk adapter extracted from packages/api/src/lib/db/connection.ts.
  *
- * Usage in atlas.config.ts:
+ * Two registration modes:
+ *
+ * 1. Static config-defined datasource (self-host / operator-baked) — pass a
+ *    `url` and the plugin wires a single connection at boot:
  * ```typescript
  * import { defineConfig } from "@atlas/api/lib/config";
  * import { snowflakePlugin } from "@useatlas/snowflake";
@@ -13,6 +16,16 @@
  *   plugins: [
  *     snowflakePlugin({ url: "snowflake://user:pass@account/db/schema?warehouse=WH&role=ROLE" }),
  *   ],
+ * });
+ * ```
+ *
+ * 2. Adapter-only (SaaS per-workspace) — pass no `url` and the plugin registers
+ *    purely as an adapter, so customers add their own Snowflake per workspace
+ *    via Admin → Connections (DB-stored, encrypted). No operator env var, no
+ *    static datasource:
+ * ```typescript
+ * export default defineConfig({
+ *   plugins: [snowflakePlugin({})],
  * });
  * ```
  */
@@ -27,7 +40,13 @@ import {
 } from "./connection";
 import { SNOWFLAKE_FORBIDDEN_PATTERNS } from "./validation";
 
-const SnowflakeConfigSchema = z.object({
+/**
+ * Strict schema for a fully-specified Snowflake connection. A `url` is
+ * required. Used by `connection.createFromConfig` to validate the decrypted
+ * per-(workspace, install) config of a DB-stored datasource (which always
+ * carries a url) before building the connection.
+ */
+const SnowflakeConnectionConfigSchema = z.object({
   /** Snowflake connection URL (snowflake://user:pass@account/db/schema?warehouse=WH&role=ROLE). */
   url: z
     .string()
@@ -50,6 +69,15 @@ const SnowflakeConfigSchema = z.object({
   maxConnections: z.number().int().positive().max(100).optional(),
 });
 
+/**
+ * Lenient config-time schema — every field optional so the plugin can be
+ * registered as an ADAPTER ONLY: `snowflakePlugin({})` parses, registering the
+ * plugin so its `createFromConfig` is available to the datasource bridge for
+ * DB-stored per-workspace installs (the SaaS model), with no static datasource.
+ * A `url`, when supplied, is still validated for scheme + parseability.
+ */
+const SnowflakeConfigSchema = SnowflakeConnectionConfigSchema.partial();
+
 export type SnowflakeConfig = z.infer<typeof SnowflakeConfigSchema>;
 
 /**
@@ -62,6 +90,33 @@ export function buildSnowflakePlugin(
 ): AtlasDatasourcePlugin<SnowflakeConfig> {
   let log: PluginLogger | undefined;
 
+  // When a static url is configured the plugin wires a config-defined
+  // connection at boot; without one it is registered adapter-only.
+  const staticUrl = config.url;
+
+  const connection: AtlasDatasourcePlugin<SnowflakeConfig>["connection"] = {
+    // DB-driven (admin-UI-registered) datasources: build a connection from
+    // the per-(workspace, install) config decrypted from `workspace_plugins`,
+    // re-validated through the strict schema. Always available — this is the
+    // SaaS per-workspace path and the only path in adapter-only mode.
+    createFromConfig: (runtimeConfig) => {
+      const parsed = SnowflakeConnectionConfigSchema.parse(runtimeConfig);
+      return createSnowflakeConnection({
+        url: parsed.url,
+        maxConnections: parsed.maxConnections,
+        logger: log,
+      });
+    },
+    dbType: "snowflake",
+    parserDialect: "Snowflake",
+    forbiddenPatterns: SNOWFLAKE_FORBIDDEN_PATTERNS,
+  };
+
+  if (staticUrl) {
+    connection.create = () =>
+      createSnowflakeConnection({ url: staticUrl, maxConnections: config.maxConnections, logger: log });
+  }
+
   return {
     id: "snowflake-datasource",
     types: ["datasource"] as const,
@@ -69,13 +124,7 @@ export function buildSnowflakePlugin(
     name: "Snowflake DataSource",
     config,
 
-    connection: {
-      create: () =>
-        createSnowflakeConnection({ url: config.url, maxConnections: config.maxConnections, logger: log }),
-      dbType: "snowflake",
-      parserDialect: "Snowflake",
-      forbiddenPatterns: SNOWFLAKE_FORBIDDEN_PATTERNS,
-    },
+    connection,
 
     entities: [],
 
@@ -93,7 +142,13 @@ export function buildSnowflakePlugin(
 
     async initialize(ctx) {
       log = ctx.logger;
-      ctx.logger.info(`Snowflake datasource plugin initialized (${extractAccount(config.url)})`);
+      if (staticUrl) {
+        ctx.logger.info(`Snowflake datasource plugin initialized (${extractAccount(staticUrl)})`);
+      } else {
+        ctx.logger.info(
+          "Snowflake datasource plugin registered as adapter-only — per-workspace datasources via Admin → Connections",
+        );
+      }
       ctx.logger.warn(
         "Snowflake has no session-level read-only mode — Atlas enforces SELECT-only " +
         "via SQL validation (regex + AST). For defense-in-depth, configure the " +
@@ -103,10 +158,16 @@ export function buildSnowflakePlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
+      // Adapter-only: no static datasource to probe. The plugin itself is a
+      // healthy adapter; per-workspace connections are health-checked by the
+      // ConnectionRegistry once installed.
+      if (!staticUrl) {
+        return { healthy: true, message: "adapter-only: no static datasource configured" };
+      }
       const start = performance.now();
       let conn: PluginDBConnection | undefined;
       try {
-        conn = createSnowflakeConnection({ url: config.url, maxConnections: config.maxConnections });
+        conn = createSnowflakeConnection({ url: staticUrl, maxConnections: config.maxConnections });
         await conn.query("SELECT 1", 5000);
         return {
           healthy: true,
@@ -138,7 +199,10 @@ export function buildSnowflakePlugin(
  *
  * @example
  * ```typescript
+ * // Static datasource (self-host):
  * plugins: [snowflakePlugin({ url: "snowflake://user:pass@xy12345/mydb/public?warehouse=COMPUTE_WH" })]
+ * // Adapter-only (SaaS — customers bring their own per workspace):
+ * plugins: [snowflakePlugin({})]
  * ```
  */
 export const snowflakePlugin = createPlugin({


### PR DESCRIPTION
## What

Makes **every datasource plugin registerable as an adapter only** — no static operator URL/env var — so multi-tenant SaaS customers add their own connection **per workspace** (DB-stored, encrypted) via Admin → Connections, resolved through the datasource bridge's `createFromConfig` (#3253 / ADR-0013).

Builds directly on PR #3297 (the `createFromConfig` registry seam) and extends it from ClickHouse to all datasource plugins.

## Why

On SaaS the datasource URL belongs to the **customer, per workspace** — not the operator. The previous model required a static config URL (or the `ATLAS_STAGING_CLICKHOUSE_URL` env var) at boot, which is the wrong abstraction for multi-tenant. Every datasource should onboard the same way; we'd only wired ClickHouse.

## How

**SDK (`@useatlas/plugin-sdk`)**
- `AtlasDatasourcePlugin.connection.create` is now **optional**; `validatePluginShape` requires **either** `create()` (static / self-host) **or** `createFromConfig()` (adapter-only / SaaS).
- `wireDatasourcePlugins` skips adapter-only plugins for static boot wiring; they stay in the registry so the bridge's `getAll()` finds them for DB-stored installs.

**Plugins** — each gets the same shape: a lenient config-time schema (so `plugin({})` registers adapter-only) + a retained **strict** schema used by `createFromConfig` (DB-stored runtime config still rejects missing/invalid fields); `initialize`/`healthCheck` short-circuit when there's no static config.
- clickhouse, salesforce, snowflake, bigquery, duckdb, elasticsearch.
- **BigQuery**: `createFromConfig` normalizes the Admin form's `service_account_json`/`project_id` (snake) onto the factory's `credentials`/`projectId` (camel) — without it every admin-installed BigQuery datasource would be rejected at boot. `hasStaticConfig` gates on `projectId || keyFilename || credentials` (BigQuery can run static with no explicit project via key/ADC).
- **Salesforce**: the static `querySalesforce` tool registers only in static mode (per-workspace Salesforce is queried via the OAuth/lazy path — see Follow-ups).

**Deploy (SaaS)** — `deploy/api/atlas.config.ts` + `deploy/api-staging/atlas.config.ts` register the 5 network adapters (clickhouse/salesforce/snowflake/bigquery/elasticsearch) with empty config.
- **DuckDB excluded** from the hosted configs — file-path based, not a safe multi-tenant datasource (its plugin still supports adapter-only for self-host parity).
- **Postgres/MySQL** need no plugin — the bridge registers those DB-stored installs natively.
- Removes the `ATLAS_STAGING_CLICKHOUSE_URL` env-var approach.
- Dockerfile: extends the `@useatlas/plugin-sdk` nested-symlink workaround to the boot-loaded datasource plugins so their imports resolve at boot.

## Review

Ran the full PR-review toolkit (code / tests / silent-failure / type-design / comments). Findings addressed inline:
- **BigQuery field-mapping** regression fixed (the `service_account_json`/`project_id` normalization above) + regression tests.
- Symmetric SDK `createFromConfig`-non-function validation test; stale `plugin-sdk/README.md` updated; DuckDB comments clarified (self-host parity, not hosted SaaS).

Deferred by design (recorded, not fixed here): the type-level "at least one factory" encoding stays **runtime-enforced** (well-tested; a `RequireAtLeastOne` conditional type would hurt plugin-author error messages); `_ConfigsAligned` drift guard remains ES-only (pre-existing).

## Gaps found by an end-to-end SaaS audit → tracked as follow-ups

This PR is the **foundation** (the uniform adapter + connect path). To make ClickHouse/Snowflake/BigQuery fully *addable* on SaaS, three repeatable-onboarding pieces remain and are filed as issues:
1. **Generalize the Elasticsearch form-install handler** into one reusable `DatasourceFormInstallHandler` (keyed by catalog slug) covering ClickHouse/Snowflake/BigQuery — so adding a datasource is catalog-row + one registration line, no bespoke code. (#3295 territory.)
2. **Marketplace `saas_eligible` gating** + mark `duckdb` `saas_eligible=false`, so non-eligible datasources don't surface in the SaaS picker (today duckdb's card shows but install fails safe).
3. **Reconcile Salesforce-datasource onto the bridge** (`createFromConfig`) or document OAuth as the deliberate exception — its adapter-only registration is currently inert.

## Verification

- `bun run type` clean (incl. `deploy/*/atlas.config.ts`).
- All 6 plugin suites + SDK + wiring + bridge + 99 affected `@atlas/api` files pass.
- CI-only drift gates pass: check-published-symbols, check-template-drift, check-schema-drift.
- Staging soak after merge: `main` auto-deploys to `api-staging`; confirm the datasource plugins appear in `All plugins initialized` and a per-workspace ClickHouse install connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783394299&installation_id=135337507&pr_number=3299&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3299&signature=eb138e6c185e0fb768263d51d9c93a1ebbf4279247d1491d3c725b7ec7ad665d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-workspace datasource adapters: ClickHouse, Salesforce, Snowflake, BigQuery, Elasticsearch, DuckDB now support adapter-only registration so connections can be managed via Admin → Connections without deployment changes.
  * Plugins report healthy in adapter-only mode and support runtime (DB-stored) connection creation.

* **Chores**
  * Deployment and plugin runtime wiring updated to ensure adapter plugins are discoverable and symlinked for runtime-loaded plugins.

* **Tests**
  * Added coverage verifying adapter-only wiring and runtime connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->