### PR TITLE
feat(plugins): generic DatasourceFormInstallHandler — ClickHouse/Snowflake/BigQuery form-installable on SaaS (#3300)

### DIFF
--- a/apps/docs/content/docs/integrations/admin-console.mdx
+++ b/apps/docs/content/docs/integrations/admin-console.mdx
@@ -41,8 +41,11 @@ Cards are grouped by `type`:
 - **Integrations** — Salesforce, Jira, GitHub, Linear, Email, Webhook,
   Obsidian, and others. These extend Atlas's data surface or delivery channels.
 - **Datasources** — read-only query targets. PostgreSQL and MySQL are native;
-  Elasticsearch / OpenSearch and others install here from the console (a
-  config-schema-driven form) instead of editing `atlas.config.ts`.
+  Elasticsearch / OpenSearch, ClickHouse, Snowflake, and BigQuery install here
+  from the console (a config-schema-driven form) instead of editing
+  `atlas.config.ts`. These plugin datasources are form-installable on SaaS too —
+  the credentials you enter are encrypted at rest and the connection becomes
+  queryable once the deployment reloads.
 
 ## Install state
 
@@ -80,11 +83,14 @@ Clicking **Connect** runs the install flow for the card's `installModel`:
   authorization tab against the Platform. After you approve, Atlas writes
   a `workspace_plugins` row and the card flips to **Installed**.
 - **Form** (Email, Webhook, Obsidian, Linear via API key, Elasticsearch /
-  OpenSearch) — opens a modal that collects the credentials inline and writes
-  the `workspace_plugins` row on submit. The form fields are rendered from the
-  catalog entry's `config_schema`, and any field marked `secret: true` (e.g.
-  the Elasticsearch API key) is encrypted at rest, masked on read, and
-  preserved on save when left unchanged.
+  OpenSearch, ClickHouse, Snowflake, BigQuery) — opens a modal that collects
+  the credentials inline and writes the `workspace_plugins` row on submit. The
+  form fields are rendered from the catalog entry's `config_schema`, and any
+  field marked `secret: true` (e.g. the Elasticsearch API key, the ClickHouse /
+  Snowflake connection URL, or the BigQuery service-account JSON) is encrypted
+  at rest, masked on read, and preserved on save when left unchanged. After
+  install, the connection is registered on the next deployment reload and the
+  agent can query it via `executeSQL`.
 - **Static-bot** (Discord, Telegram, WhatsApp, Google Chat, Teams) —
   installed from their per-platform admin blocks further down the page
   rather than via the catalog card's Connect button (which is inert for

--- a/apps/docs/content/docs/integrations/admin-console.mdx
+++ b/apps/docs/content/docs/integrations/admin-console.mdx
@@ -41,11 +41,14 @@ Cards are grouped by `type`:
 - **Integrations** — Salesforce, Jira, GitHub, Linear, Email, Webhook,
   Obsidian, and others. These extend Atlas's data surface or delivery channels.
 - **Datasources** — read-only query targets. PostgreSQL and MySQL are native;
-  Elasticsearch / OpenSearch, ClickHouse, Snowflake, and BigQuery install here
-  from the console (a config-schema-driven form) instead of editing
-  `atlas.config.ts`. These plugin datasources are form-installable on SaaS too —
-  the credentials you enter are encrypted at rest and the connection becomes
-  queryable once the deployment reloads.
+  Elasticsearch / OpenSearch, ClickHouse, Snowflake, and BigQuery install from
+  the [Connections](/guides/admin-console#connections) page (a
+  config-schema-driven form) instead of editing `atlas.config.ts`. Datasource
+  cards are surfaced under **Admin → Connections**, not in this Integrations
+  marketplace, but use the same form-install model described below. These plugin
+  datasources are form-installable on SaaS too — the credentials you enter are
+  encrypted at rest and the connection becomes queryable once the deployment
+  reloads.
 
 ## Install state
 
@@ -82,14 +85,15 @@ Clicking **Connect** runs the install flow for the card's `installModel`:
 - **OAuth** (Slack, Salesforce, Jira, Linear, GitHub) — opens an
   authorization tab against the Platform. After you approve, Atlas writes
   a `workspace_plugins` row and the card flips to **Installed**.
-- **Form** (Email, Webhook, Obsidian, Linear via API key, Elasticsearch /
-  OpenSearch, ClickHouse, Snowflake, BigQuery) — opens a modal that collects
-  the credentials inline and writes the `workspace_plugins` row on submit. The
-  form fields are rendered from the catalog entry's `config_schema`, and any
-  field marked `secret: true` (e.g. the Elasticsearch API key, the ClickHouse /
-  Snowflake connection URL, or the BigQuery service-account JSON) is encrypted
-  at rest, masked on read, and preserved on save when left unchanged. After
-  install, the connection is registered on the next deployment reload and the
+- **Form** (Email, Webhook, Obsidian, Linear via API key — plus the datasource
+  forms surfaced under [Connections](/guides/admin-console#connections):
+  Elasticsearch / OpenSearch, ClickHouse, Snowflake, BigQuery) — opens a modal
+  that collects the credentials inline and writes the `workspace_plugins` row on
+  submit. The form fields are rendered from the catalog entry's `config_schema`,
+  and any field marked `secret: true` (e.g. the Elasticsearch API key, the
+  ClickHouse / Snowflake connection URL, or the BigQuery service-account JSON) is
+  encrypted at rest, masked on read, and preserved on save when left unchanged.
+  After install, the connection is registered on the next deployment reload and the
   agent can query it via `executeSQL`.
 - **Static-bot** (Discord, Telegram, WhatsApp, Google Chat, Teams) —
   installed from their per-platform admin blocks further down the page

--- a/apps/docs/content/docs/plugins/datasources/bigquery.mdx
+++ b/apps/docs/content/docs/plugins/datasources/bigquery.mdx
@@ -54,7 +54,7 @@ When running locally, either set `GOOGLE_APPLICATION_CREDENTIALS` to a service a
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a BigQuery connection. With the catalog row enabled, a workspace admin can install BigQuery from **Admin → Connections**: pick the BigQuery card, paste the full service-account key JSON and your GCP project ID into the form, and submit. The service-account JSON is encrypted at rest (it's a `secret: true` field) while the project ID stays in plaintext, and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+You don't have to edit `atlas.config.ts` to add a BigQuery connection. With the catalog row enabled, a workspace admin can install BigQuery from **Admin → Connections**: pick the BigQuery card, paste the full service-account key JSON and your GCP project ID into the form, and submit. The service-account JSON is encrypted at rest (it's a `secret: true` field) while the project ID stays in plaintext, and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
 
 ## SQL Dialect
 

--- a/apps/docs/content/docs/plugins/datasources/bigquery.mdx
+++ b/apps/docs/content/docs/plugins/datasources/bigquery.mdx
@@ -52,6 +52,10 @@ The plugin supports three authentication methods, tried in priority order:
 
 When running locally, either set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file path or use `gcloud auth application-default login`.
 
+### Install from the admin console
+
+You don't have to edit `atlas.config.ts` to add a BigQuery connection. With the catalog row enabled, a workspace admin can install BigQuery from **Admin → Connections**: pick the BigQuery card, paste the full service-account key JSON and your GCP project ID into the form, and submit. The service-account JSON is encrypted at rest (it's a `secret: true` field) while the project ID stays in plaintext, and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+
 ## SQL Dialect
 
 The following hints are injected into the agent's system prompt so it writes valid BigQuery Standard SQL:

--- a/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
+++ b/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
@@ -37,6 +37,10 @@ export default defineConfig({
 
 The plugin rewrites `clickhouse://` to `http://` and `clickhouses://` to `https://` for the HTTP transport internally.
 
+### Install from the admin console
+
+You don't have to edit `atlas.config.ts` to add a ClickHouse connection. With the catalog row enabled, a workspace admin can install ClickHouse from **Admin → Connections**: pick the ClickHouse card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+
 ### Connection string format
 
 ```

--- a/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
+++ b/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
@@ -39,7 +39,7 @@ The plugin rewrites `clickhouse://` to `http://` and `clickhouses://` to `https:
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a ClickHouse connection. With the catalog row enabled, a workspace admin can install ClickHouse from **Admin → Connections**: pick the ClickHouse card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+You don't have to edit `atlas.config.ts` to add a ClickHouse connection. With the catalog row enabled, a workspace admin can install ClickHouse from **Admin → Connections**: pick the ClickHouse card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
 
 ### Connection string format
 

--- a/apps/docs/content/docs/plugins/datasources/snowflake.mdx
+++ b/apps/docs/content/docs/plugins/datasources/snowflake.mdx
@@ -37,6 +37,10 @@ export default defineConfig({
 | `url` | `string` | Yes | -- | Connection URL in the format `snowflake://user:pass@account/database/schema?warehouse=WH&role=ROLE` |
 | `maxConnections` | `number` | No | `10` | Maximum pool connections (1--100) |
 
+### Install from the admin console
+
+You don't have to edit `atlas.config.ts` to add a Snowflake connection. With the catalog row enabled, a workspace admin can install Snowflake from **Admin → Connections**: pick the Snowflake card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+
 ### Connection string format
 
 ```

--- a/apps/docs/content/docs/plugins/datasources/snowflake.mdx
+++ b/apps/docs/content/docs/plugins/datasources/snowflake.mdx
@@ -39,7 +39,7 @@ export default defineConfig({
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a Snowflake connection. With the catalog row enabled, a workspace admin can install Snowflake from **Admin → Connections**: pick the Snowflake card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console](/integrations/admin-console).
+You don't have to edit `atlas.config.ts` to add a Snowflake connection. With the catalog row enabled, a workspace admin can install Snowflake from **Admin → Connections**: pick the Snowflake card, paste the connection URL into the form, and submit. The URL is encrypted at rest (it's a `secret: true` field), and the connection becomes queryable via `executeSQL` once the deployment reloads. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
 
 ### Connection string format
 

--- a/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
@@ -341,6 +341,22 @@ describe("DatasourceFormInstallHandler — corrupt catalog schema", () => {
   });
 });
 
+// ── Absent-schema guard (fail closed — #3300 review) ─────────────────────────
+
+describe("DatasourceFormInstallHandler — absent catalog schema (NULL config_schema)", () => {
+  it("refuses the install (no INSERT) when config_schema is NULL — never persists a plaintext credential", async () => {
+    // A NULL config_schema parses to `absent`, which makes the secret walkers
+    // no-op: without this guard the `url` credential would persist in plaintext
+    // and the required check would be skipped. Must fail closed like `corrupt`.
+    catalogSchemaOverride = { value: null };
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, { url: "clickhouse://h:8443/db" }),
+    ).rejects.toThrow(/missing/i);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
 // ── Catalog row missing / disabled ────────────────────────────────────────────
 
 describe("DatasourceFormInstallHandler — catalog row missing", () => {

--- a/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for {@link DatasourceFormInstallHandler} (#3300) — the reusable
+ * datasource form-install handler extracted from the ES handler (#3270) and
+ * registered for ClickHouse / Snowflake / BigQuery.
+ *
+ * The ES specialization keeps its own characterization suite
+ * (`elasticsearch-form-handler.test.ts`); this file pins the generic across the
+ * SQL datasources whose `config_schema` has a different secret-field shape:
+ *
+ *   - ClickHouse — single `secret: true` field is the connection `url` itself
+ *     (the whole URL carries the credential, unlike ES where only `apiKey` is
+ *     secret and the `url` is plaintext).
+ *   - BigQuery — `service_account_json` is secret, `project_id` is a required
+ *     non-secret field that must survive plaintext.
+ *
+ * The catalog `config_schema` is read live from `plugin_catalog`, so the handler
+ * encrypts whatever the schema marks `secret: true` with no per-type branch —
+ * these tests assert that schema-driven behavior holds for both shapes.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret, encryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import { MASKED_PLACEHOLDER } from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+
+/** ClickHouse catalog schema — the `url` is the `secret: true` field. */
+const CLICKHOUSE_CONFIG_SCHEMA = [
+  { key: "url", type: "string", label: "Connection URL", required: true, secret: true },
+  { key: "description", type: "string", label: "Description" },
+];
+
+/** BigQuery catalog schema — `service_account_json` is secret, `project_id` is not. */
+const BIGQUERY_CONFIG_SCHEMA = [
+  {
+    key: "service_account_json",
+    type: "string",
+    label: "Service Account JSON",
+    required: true,
+    secret: true,
+  },
+  { key: "project_id", type: "string", label: "GCP Project ID", required: true },
+  { key: "description", type: "string", label: "Description" },
+];
+
+/** Resolve the schema the mock returns, keyed off the slug ($1 of the catalog query). */
+const SCHEMA_BY_SLUG: Record<string, unknown> = {
+  clickhouse: CLICKHOUSE_CONFIG_SCHEMA,
+  bigquery: BIGQUERY_CONFIG_SCHEMA,
+};
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+let captured: CapturedQuery[] = [];
+/** Per-test override for the existing-install lookup (restore-on-save path). */
+let existingInstallRows: unknown[] = [];
+/** Per-test override for the catalog row's config_schema (corrupt-schema path). */
+let catalogSchemaOverride: { value: unknown } | null = null;
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    captured.push({ sql, params: params ?? [] });
+    if (sql.includes("FROM plugin_catalog")) {
+      const slug = (params?.[0] as string | undefined) ?? "clickhouse";
+      const config_schema = catalogSchemaOverride
+        ? catalogSchemaOverride.value
+        : SCHEMA_BY_SLUG[slug] ?? CLICKHOUSE_CONFIG_SCHEMA;
+      return [{ id: `catalog:${slug}`, config_schema }];
+    }
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    // Existing-install lookup (FROM workspace_plugins ... config).
+    return existingInstallRows;
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// Mock EVERY value export of the logger module — a partial mock.module() trips
+// "Export not found" on a transitive import (CLAUDE.md).
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogger = {
+  warn: mockLogWarn,
+  info: mockLogInfo,
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  silent: () => {},
+  child: () => mockLogger,
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => mockLogger,
+  getLogger: () => mockLogger,
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  setLogLevel: () => true,
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (obj: Record<string, unknown>) => obj,
+  hashShareToken: (token: string) => token.slice(0, 16),
+  redactPaths: [] as string[],
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
+}));
+
+const WSID = "ws-ds-1" as WorkspaceId;
+
+type HandlerCtor = typeof import("../datasource-form-handler").DatasourceFormInstallHandler;
+type FormErrCtor = typeof import("../email-form-handler").FormInstallValidationError;
+let DatasourceFormInstallHandler!: HandlerCtor;
+let FormInstallValidationError!: FormErrCtor;
+
+beforeAll(async () => {
+  DatasourceFormInstallHandler = (await import("../datasource-form-handler"))
+    .DatasourceFormInstallHandler;
+  FormInstallValidationError = (await import("../email-form-handler")).FormInstallValidationError;
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-ds-handler-unit-tests-long-enough-32bytes";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.ATLAS_DEPLOY_MODE;
+  _resetEncryptionKeyCache();
+}
+
+function newHandler(
+  slug: string,
+  installId: string = slug,
+  idGenerator: () => string = () => `${slug}-install-1`,
+) {
+  return new DatasourceFormInstallHandler({ slug, installId, idGenerator });
+}
+
+/** The config blob written by the (single) upsert INSERT, parsed from JSON. */
+function upsertedConfig(): Record<string, unknown> {
+  const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+  if (!insert) throw new Error("no INSERT captured");
+  const json = insert.params[4] as string;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  setKeys();
+  captured = [];
+  existingInstallRows = [];
+  catalogSchemaOverride = null;
+  mockLogWarn.mockClear();
+  mockLogInfo.mockClear();
+  mockInternalQuery.mockClear();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+describe("DatasourceFormInstallHandler — validation", () => {
+  it("rejects a missing required url (ClickHouse) with per-field detail", async () => {
+    const handler = newHandler("clickhouse");
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, { description: "no url" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<FormErrCtor>).fieldErrors.url).toBeDefined();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+
+  it("rejects a non-object body", async () => {
+    const handler = newHandler("clickhouse");
+    await expect(handler.validateConfig(WSID, "not-an-object")).rejects.toBeInstanceOf(
+      FormInstallValidationError,
+    );
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
+// ── Persistence + encryption (ClickHouse — the url IS the secret) ─────────────
+
+describe("DatasourceFormInstallHandler — ClickHouse persistence + encryption", () => {
+  it("inserts a datasource-pillar row keyed on the slug install id and encrypts the url", async () => {
+    const handler = newHandler("clickhouse", "clickhouse", () => "ch-uuid-1");
+    const result = await handler.validateConfig(WSID, {
+      url: "clickhouse://user:pass@host:8443/analytics",
+      description: "Prod ClickHouse",
+    });
+
+    expect(result.installRecord).toEqual({
+      id: "ch-uuid-1",
+      workspaceId: WSID,
+      catalogId: "clickhouse",
+    });
+    expect(result.credentialWritten).toBe(true);
+
+    const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain("'datasource'");
+    expect(insert!.sql).toContain("ON CONFLICT (workspace_id, catalog_id, install_id)");
+    // install_id ($4) is the slug for these single-instance datasources.
+    expect(insert!.params[3]).toBe("clickhouse");
+    // catalog_id ($3) is read live from the catalog row.
+    expect(insert!.params[2]).toBe("catalog:clickhouse");
+
+    const cfg = upsertedConfig();
+    // The url is `secret: true` here — it must be encrypted at rest (it carries
+    // the credential), unlike ES where the url is plaintext.
+    expect(typeof cfg.url).toBe("string");
+    expect((cfg.url as string).startsWith("enc:v1:")).toBe(true);
+    expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:pass@host:8443/analytics");
+    // Non-secret description stays plaintext.
+    expect(cfg.description).toBe("Prod ClickHouse");
+  });
+});
+
+// ── Persistence + encryption (BigQuery — JSON secret + plaintext project_id) ──
+
+describe("DatasourceFormInstallHandler — BigQuery persistence + encryption", () => {
+  it("encrypts service_account_json and persists project_id in plaintext", async () => {
+    const handler = newHandler("bigquery", "bigquery", () => "bq-uuid-1");
+    const serviceAccount = JSON.stringify({ type: "service_account", project_id: "atlas-bq" });
+    const result = await handler.validateConfig(WSID, {
+      service_account_json: serviceAccount,
+      project_id: "atlas-bq",
+    });
+
+    expect(result.installRecord.catalogId).toBe("bigquery");
+    expect(result.credentialWritten).toBe(true);
+
+    const cfg = upsertedConfig();
+    // The secret service account JSON encrypts and round-trips.
+    expect(typeof cfg.service_account_json).toBe("string");
+    expect((cfg.service_account_json as string).startsWith("enc:v1:")).toBe(true);
+    expect(decryptSecret(cfg.service_account_json as string)).toBe(serviceAccount);
+    // project_id is required-but-not-secret → persisted plaintext so the
+    // resolver / createFromConfig (#3299) can read it directly.
+    expect(cfg.project_id).toBe("atlas-bq");
+  });
+
+  it("rejects a missing required project_id", async () => {
+    const handler = newHandler("bigquery");
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, {
+        service_account_json: JSON.stringify({ type: "service_account" }),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<FormErrCtor>).fieldErrors.project_id).toBeDefined();
+  });
+});
+
+// ── Restore-on-save (the highest-risk piece, inherited from #3270) ────────────
+
+describe("DatasourceFormInstallHandler — restore-on-save", () => {
+  it("preserves the stored ClickHouse url when the masked sentinel is re-submitted", async () => {
+    const storedCipher = encryptSecret("clickhouse://user:secret@old-host:8443/db");
+    existingInstallRows = [{ config: { url: storedCipher, description: "old" } }];
+
+    const handler = newHandler("clickhouse");
+    // Admin edits the description but leaves the (masked) url untouched.
+    await handler.validateConfig(WSID, {
+      url: MASKED_PLACEHOLDER,
+      description: "renamed",
+    });
+
+    const cfg = upsertedConfig();
+    expect(cfg.description).toBe("renamed");
+    expect(cfg.url).not.toBe(MASKED_PLACEHOLDER);
+    expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:secret@old-host:8443/db");
+  });
+
+  it("replaces the stored secret when an explicit new value is submitted", async () => {
+    const storedCipher = encryptSecret("clickhouse://user:secret@old-host:8443/db");
+    existingInstallRows = [{ config: { url: storedCipher } }];
+
+    const handler = newHandler("clickhouse");
+    await handler.validateConfig(WSID, {
+      url: "clickhouse://user:rotated@new-host:8443/db",
+    });
+
+    const cfg = upsertedConfig();
+    expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:rotated@new-host:8443/db");
+  });
+
+  it("preserves the stored secret when the field is omitted from the form (dirty-fields save)", async () => {
+    const storedCipher = encryptSecret("clickhouse://user:secret@old-host:8443/db");
+    existingInstallRows = [{ config: { url: storedCipher, description: "old" } }];
+
+    const handler = newHandler("clickhouse");
+    const result = await handler.validateConfig(WSID, { description: "only-desc-changed" });
+
+    const cfg = upsertedConfig();
+    expect(cfg.description).toBe("only-desc-changed");
+    // url was absent yet required — restored, so validation passes and it persists.
+    expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:secret@old-host:8443/db");
+    expect(result.credentialWritten).toBe(true);
+  });
+
+  it("fails closed (no INSERT) when the existing row's secret cannot be decrypted", async () => {
+    const storedCipher = encryptSecret("clickhouse://user:secret@old-host:8443/db");
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:a-completely-different-key-than-the-encrypt-one-32b";
+    _resetEncryptionKeyCache();
+    existingInstallRows = [{ config: { url: storedCipher } }];
+
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, { url: MASKED_PLACEHOLDER }),
+    ).rejects.toThrow();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
+// ── Corrupt-schema guard (fail closed) ────────────────────────────────────────
+
+describe("DatasourceFormInstallHandler — corrupt catalog schema", () => {
+  it("refuses the install (no INSERT) when the catalog config_schema is corrupt", async () => {
+    catalogSchemaOverride = { value: "not-an-array" };
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, { url: "clickhouse://h:8443/db" }),
+    ).rejects.toThrow(/corrupt/i);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});
+
+// ── Catalog row missing / disabled ────────────────────────────────────────────
+
+describe("DatasourceFormInstallHandler — catalog row missing", () => {
+  it("throws (not a validation error) when no enabled catalog row exists", async () => {
+    catalogSchemaOverride = null;
+    // Force the catalog lookup to return no rows by using an unknown slug whose
+    // mock returns []. We special-case via an empty existingInstallRows path: the
+    // mock returns the catalog row for any slug, so instead drive the missing-row
+    // branch by overriding the mock for this test.
+    mockInternalQuery.mockImplementationOnce(async (sql: string, params?: unknown[]) => {
+      captured.push({ sql, params: params ?? [] });
+      return []; // catalog lookup → no row
+    });
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, { url: "clickhouse://h:8443/db" }),
+    ).rejects.toThrow(/not found or disabled/i);
+  });
+});
+
+// ── SaaS keyset gate ──────────────────────────────────────────────────────────
+
+describe("DatasourceFormInstallHandler — SaaS keyset gate", () => {
+  it("refuses the install in SaaS mode with no encryption keyset (no plaintext persist)", async () => {
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, { url: "clickhouse://h:8443/db" }),
+    ).rejects.toThrow(/keyset/i);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/datasource-form-install-roundtrip.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/datasource-form-install-roundtrip.test.ts
@@ -1,0 +1,234 @@
+/**
+ * End-to-end roundtrip for a form-installed SQL plugin datasource (#3300):
+ *
+ *   install (DatasourceFormInstallHandler.validateConfig)
+ *     → persist (encrypted config captured from the workspace_plugins upsert)
+ *       → boot-register (decrypt + registerDatasourceInstall via the bridge)
+ *         → query (the plugin connection the bridge built is queryable)
+ *
+ * This proves the slice's whole point: a workspace admin installs ClickHouse
+ * from Admin → Connections, the credential lands encrypted, and after a reload
+ * `loadSavedConnections` rebuilds a live, queryable connection from that row via
+ * the plugin's `createFromConfig` (#3253/#3297). The handler and bridge are
+ * exercised against the SAME encrypted blob, so a regression in either half
+ * (handler persists the wrong shape, or the bridge can't rebuild it) fails here.
+ *
+ * The catalog `config_schema` is read live; we mock `internalQuery` to return
+ * the ClickHouse schema (`url` is the `secret: true` field) and capture the
+ * upserted config, then decrypt it exactly as `loadSavedConnections` does
+ * before handing it to the bridge.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+
+const CLICKHOUSE_CONFIG_SCHEMA = [
+  { key: "url", type: "string", label: "Connection URL", required: true, secret: true },
+  { key: "description", type: "string", label: "Description" },
+];
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+let captured: CapturedQuery[] = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    captured.push({ sql, params: params ?? [] });
+    if (sql.includes("FROM plugin_catalog")) {
+      return [{ id: "catalog:clickhouse", config_schema: CLICKHOUSE_CONFIG_SCHEMA }];
+    }
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      return [{ id: (params?.[0] as string | undefined) ?? "unknown" }];
+    }
+    return []; // no existing install (fresh)
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// Logger — mock every value export (CLAUDE.md partial-mock rule).
+const mockLogger = {
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  silent: () => {},
+  child: () => mockLogger,
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => mockLogger,
+  getLogger: () => mockLogger,
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  setLogLevel: () => true,
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (obj: Record<string, unknown>) => obj,
+  hashShareToken: (token: string) => token.slice(0, 16),
+  redactPaths: [] as string[],
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
+}));
+
+// ── ConnectionRegistry seam — capture the built plugin connection ─────────────
+interface BuiltConn {
+  query(sql: string, timeoutMs?: number): Promise<unknown>;
+  close(): Promise<void>;
+}
+let registeredPlugin: {
+  workspaceId: string;
+  installId: string;
+  conn: BuiltConn;
+  dbType: string;
+  validate?: unknown;
+} | null = null;
+
+mock.module("@atlas/api/lib/db/connection", () => ({
+  connections: {
+    hasDirectForWorkspace: mock(() => false),
+    registerDirectForWorkspace: mock(
+      (
+        workspaceId: string,
+        installId: string,
+        conn: BuiltConn,
+        dbType: string,
+        _description?: string,
+        validate?: unknown,
+      ) => {
+        registeredPlugin = { workspaceId, installId, conn, dbType, validate };
+      },
+    ),
+    // Native-path seam (unused for clickhouse but referenced structurally).
+    register: mock(() => {}),
+    has: mock(() => false),
+    registerForWorkspace: mock(() => {}),
+    hasForWorkspace: mock(() => false),
+  },
+}));
+
+// Plugin registry seam — a fake ClickHouse datasource plugin whose
+// createFromConfig builds a queryable connection from the decrypted config.
+let lastCreateFromConfigArg: Readonly<Record<string, unknown>> | null = null;
+const fakeClickhousePlugin = {
+  id: "clickhouse-datasource",
+  types: ["datasource"],
+  connection: {
+    dbType: "clickhouse",
+    parserDialect: "PostgresQL",
+    forbiddenPatterns: [/\bINSERT\b/i],
+    createFromConfig: (cfg: Readonly<Record<string, unknown>>): BuiltConn => {
+      lastCreateFromConfigArg = cfg;
+      return {
+        query: async (_sql: string) => ({
+          columns: ["count"],
+          rows: [{ count: 42 }],
+          // Echo the URL the plugin connected with so the test can assert the
+          // decrypted credential reached the live connection.
+          connectedUrl: cfg.url,
+        }),
+        close: async () => {},
+      };
+    },
+  },
+};
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: { getAll: () => [fakeClickhousePlugin] },
+}));
+
+const WSID = "ws-roundtrip-1" as WorkspaceId;
+
+type HandlerCtor = typeof import("../datasource-form-handler").DatasourceFormInstallHandler;
+type BridgeModule = typeof import("@atlas/api/lib/db/datasource-registry-bridge");
+let DatasourceFormInstallHandler!: HandlerCtor;
+let bridge!: BridgeModule;
+
+beforeAll(async () => {
+  DatasourceFormInstallHandler = (await import("../datasource-form-handler"))
+    .DatasourceFormInstallHandler;
+  bridge = await import("@atlas/api/lib/db/datasource-registry-bridge");
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:roundtrip-test-key-long-enough-to-be-32-bytes!!";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.ATLAS_DEPLOY_MODE;
+  _resetEncryptionKeyCache();
+  captured = [];
+  registeredPlugin = null;
+  lastCreateFromConfigArg = null;
+  mockInternalQuery.mockClear();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+describe("ClickHouse form-install roundtrip — install → persist → boot-register → query", () => {
+  it("rebuilds a queryable connection from the persisted, encrypted install row", async () => {
+    const url = "clickhouse://reader:s3cret@ch.example.com:8443/analytics";
+
+    // 1. INSTALL — admin submits the form.
+    const handler = new DatasourceFormInstallHandler({
+      slug: "clickhouse",
+      installId: "clickhouse",
+      idGenerator: () => "ch-install-roundtrip",
+    });
+    const result = await handler.validateConfig(WSID, { url, description: "Prod CH" });
+    expect(result.credentialWritten).toBe(true);
+
+    // 2. PERSIST — read back the encrypted config blob from the captured upsert.
+    const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert).toBeDefined();
+    const persistedConfig = JSON.parse(insert!.params[4] as string) as Record<string, unknown>;
+    expect((persistedConfig.url as string).startsWith("enc:v1:")).toBe(true);
+
+    // 3. BOOT-REGISTER — exactly what `loadSavedConnections` does: decrypt the
+    // schema-marked secrets, then hand (row, decryptedConfig) to the bridge.
+    const schema = parseConfigSchema(CLICKHOUSE_CONFIG_SCHEMA);
+    const decrypted = decryptSecretFields(persistedConfig, schema);
+    expect(decrypted.url).toBe(url); // decrypts back to the submitted credential
+
+    const fresh = await bridge.registerDatasourceInstall(
+      {
+        workspaceId: WSID,
+        catalogId: "catalog:clickhouse",
+        installId: "clickhouse",
+        pillar: "datasource",
+        catalogSlug: "clickhouse",
+      },
+      decrypted,
+    );
+    expect(fresh).toBe(true);
+
+    // The plugin's runtime factory received the DECRYPTED config (not ciphertext).
+    expect(lastCreateFromConfigArg).toMatchObject({ url });
+    expect(registeredPlugin).not.toBeNull();
+    expect(registeredPlugin!.dbType).toBe("clickhouse");
+    expect(registeredPlugin!.workspaceId).toBe(WSID);
+    expect(registeredPlugin!.installId).toBe("clickhouse");
+
+    // 4. QUERY — the registered connection is live and returns rows.
+    const queryResult = (await registeredPlugin!.conn.query("SELECT count() FROM events")) as {
+      columns: string[];
+      rows: Array<Record<string, unknown>>;
+      connectedUrl: string;
+    };
+    expect(queryResult.columns).toEqual(["count"]);
+    expect(queryResult.rows).toEqual([{ count: 42 }]);
+    // The credential that round-tripped install → persist(encrypted) → decrypt →
+    // createFromConfig is the one the live connection actually uses.
+    expect(queryResult.connectedUrl).toBe(url);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -108,6 +108,29 @@ afterEach(() => {
   _resetInstallHandlerRegistries();
 });
 
+describe("registerBuiltinInstallHandlers — SQL plugin datasources (#3300)", () => {
+  // ClickHouse / Snowflake / BigQuery register the generic
+  // DatasourceFormInstallHandler with no env gate — the customer admin supplies
+  // credentials at install, same as every other form handler. So they're
+  // resolvable as a `form` handler immediately after registration.
+  for (const slug of ["clickhouse", "snowflake", "bigquery"] as const) {
+    it(`registers a form handler for ${slug} with no env gate`, () => {
+      registerBuiltinInstallHandlers();
+      const handler = getInstallHandler({ slug, install_model: "form" });
+      expect(handler.kind).toBe("form");
+    });
+  }
+
+  it("registers all three independently of any chat-platform env wiring", () => {
+    // No DATASOURCE-specific env vars exist; registration must not depend on the
+    // chat-platform gates (which are all cleared in beforeEach).
+    registerBuiltinInstallHandlers();
+    expect(getInstallHandler({ slug: "clickhouse", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "snowflake", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "bigquery", install_model: "form" }).kind).toBe("form");
+  });
+});
+
 describe("registerBuiltinInstallHandlers — Telegram env gate", () => {
   it("does not register the Telegram handler when TELEGRAM_BOT_TOKEN is unset", () => {
     registerBuiltinInstallHandlers();

--- a/packages/api/src/lib/integrations/install/datasource-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/datasource-form-handler.ts
@@ -1,0 +1,338 @@
+/**
+ * `DatasourceFormInstallHandler` — the reusable {@link FormBasedInstallHandler}
+ * for plugin-backed analytics datasources installed from Admin → Connections.
+ * Lets a workspace admin connect a datasource (Elasticsearch / OpenSearch,
+ * ClickHouse, Snowflake, BigQuery, …) from the UI instead of editing
+ * `atlas.config.ts`: validate → encrypt schema-marked secrets → upsert a
+ * `pillar='datasource'` `workspace_plugins` row.
+ *
+ * Extracted from `ElasticsearchFormInstallHandler` (#3270) and generalized for
+ * #3300 so ClickHouse / Snowflake / BigQuery become form-installable on SaaS
+ * now that the runtime connect path is uniform across plugin datasources
+ * (#3297/#3299 adapter registration + `createFromConfig` bridge, #3295 query
+ * wiring). The handler is parameterized by `slug` (the catalog dispatch key)
+ * and `installId` (the stable per-workspace install id) — every other behavior
+ * is identical across datasources because it is driven by the catalog schema,
+ * not per-datasource field knowledge.
+ *
+ * **Schema-driven, not field-hardcoded.** The catalog row's `config_schema` is
+ * read live from `plugin_catalog` (it mirrors the plugin's `getConfigSchema()` /
+ * the built-in datasource catalog seed), so the encryption walker, the
+ * masked-secret restore, and the required-field check all key off the catalog
+ * schema. The only field names this handler knows are the ones the schema
+ * declares as `secret: true` — so ES's `apiKey`, ClickHouse/Snowflake's `url`,
+ * and BigQuery's `service_account_json` all encrypt at rest with NO per-type
+ * branch here. Future auth fields propagate automatically when the catalog row
+ * (and the plugin's `getConfigSchema()`) gains them.
+ *
+ * **Mask-on-read / restore-on-save (the #3270 invariant).** Admin reads mask
+ * `secret: true` fields to the masked sentinel (`••••••••`) (see
+ * `integrations-catalog` / marketplace `/available`). On save, a field still
+ * carrying it — or omitted entirely — MUST NOT clear the stored credential:
+ * {@link restoreMaskedSecrets} swaps the bullets back to the persisted value
+ * before re-encryption. An explicit new value is trusted and replaces it.
+ * Decryption of the existing row surfaces as an error (never a silent plaintext
+ * fallback).
+ *
+ * **SaaS keyset gate.** Mirrors the Email / OpenAPI posture: refuse the install
+ * when `ATLAS_DEPLOY_MODE=saas` and no encryption keyset is configured, so a
+ * misconfigured SaaS deploy fails closed at the credential boundary rather than
+ * persisting a credential in plaintext.
+ *
+ * **Single-instance per workspace.** One install per (workspace, datasource) — a
+ * fixed `installId`; re-submitting the form edits the same row. Query wiring for
+ * admin-installed plugin datasources lives in the bridge boot path
+ * (`loadSavedConnections` → `registerDatasourceInstall`, #3295) — this handler
+ * owns install/edit/persist only.
+ *
+ * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ./elasticsearch-form-handler.ts — the #3270 ES specialization
+ * @see ../../plugins/secrets.ts — encrypt / mask / restore walkers
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
+import {
+  encryptSecretFields,
+  decryptSecretFields,
+  restoreMaskedSecrets,
+  parseConfigSchema,
+  type ConfigSchema,
+} from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+import { FormInstallValidationError } from "./email-form-handler";
+import type { CatalogId, FormBasedInstallHandler, InstallRecord } from "./types";
+
+/** Construction parameters — the only per-datasource knobs. */
+export interface DatasourceFormInstallHandlerOptions {
+  /** Catalog slug — the dispatch key in `registerFormHandler` + the `plugin_catalog` lookup. */
+  readonly slug: CatalogId;
+  /**
+   * Stable per-workspace install id. Datasource installs are single-instance for
+   * this slice, so a fixed id makes re-submits edit-in-place (and the
+   * restore-on-save lookup unambiguous). Conventionally the slug itself.
+   */
+  readonly installId: string;
+  /** Test-only injection of the install-row id generator. */
+  readonly idGenerator?: () => string;
+}
+
+interface CatalogSchemaRow extends Record<string, unknown> {
+  readonly id: string;
+  readonly config_schema: unknown;
+}
+
+interface ExistingInstallRow extends Record<string, unknown> {
+  readonly config: Record<string, unknown> | null;
+}
+
+export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  protected readonly slug: CatalogId;
+  protected readonly installId: string;
+  private readonly newId: () => string;
+  private readonly log: ReturnType<typeof createLogger>;
+
+  constructor(options: DatasourceFormInstallHandlerOptions) {
+    this.slug = options.slug;
+    this.installId = options.installId;
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    // Per-slug logger so install lines stay attributable per datasource type.
+    this.log = createLogger(`integrations.install.${options.slug}`);
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+    readonly credentialWritten: boolean;
+  }> {
+    // ── 1. Shape guard ──────────────────────────────────────────────
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const incoming = formData as Record<string, unknown>;
+
+    // ── 2. Load the catalog row (id + live config_schema) ───────────
+    // The schema is the source of truth for which fields are secret / required
+    // — read it from the catalog so future auth fields propagate automatically.
+    const catalogRows = await internalQuery<CatalogSchemaRow>(
+      `SELECT id, config_schema
+         FROM plugin_catalog
+        WHERE slug = $1 AND enabled = true
+        LIMIT 1`,
+      [this.slug],
+    );
+    if (catalogRows.length === 0) {
+      // The route pre-checks the catalog row, so reaching here is a seed/boot
+      // misconfig (row missing or disabled) — surface as a 500, not a 400.
+      this.log.error({ workspaceId }, "Datasource catalog row missing or disabled — cannot install");
+      throw new Error(
+        `Catalog row "${this.slug}" not found or disabled — the built-in datasource catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+    const schema = parseConfigSchema(catalogRows[0].config_schema);
+
+    // ── 3. Corrupt-schema guard (fail closed) ───────────────────────
+    // The catalog `config_schema` is operator-controlled, not user input, and
+    // the built-in datasource row is seeded ON CONFLICT DO NOTHING (no
+    // self-heal of a drifted schema). A corrupt schema makes
+    // `restoreMaskedSecrets` / `encryptSecretFields` fall back to "act on every
+    // string" — which on a fresh install would encrypt-and-persist the masked
+    // sentinel itself as the credential while `validateAgainstSchema` skips the
+    // required check. Refuse loudly (operator must fix the row) instead of
+    // silently storing junk.
+    if (schema.state === "corrupt") {
+      this.log.error(
+        { workspaceId, reason: schema.reason },
+        "Datasource catalog config_schema is corrupt — refusing install rather than persisting the mask sentinel as a credential",
+      );
+      throw new Error(
+        `Catalog "${this.slug}" config_schema is corrupt (${schema.reason}) — fix the catalog row before installing.`,
+      );
+    }
+
+    // ── 4. SaaS keyset gate ─────────────────────────────────────────
+    // `encryptSecret` falls back to plaintext when no key is configured (dev
+    // convenience). In SaaS that would leak the credential — refuse the install
+    // so a misconfigured deploy fails closed at the credential boundary. Checked
+    // BEFORE the existing-row read so a re-save under misconfigured SaaS surfaces
+    // this actionable message rather than an opaque decrypt failure.
+    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+      this.log.error(
+        { workspaceId },
+        "Refusing datasource install: SaaS mode + no encryption keyset (would persist a plaintext credential)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
+          "Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 5. Restore masked secrets against the existing install ──────
+    // Read the current row (if any) so an unchanged masked secret round-trips
+    // back to its stored value instead of persisting the bullet sentinel.
+    const existingDecrypted = await this.loadExistingDecryptedConfig(
+      workspaceId,
+      catalogId,
+      schema,
+    );
+    const restored = restoreMaskedSecrets(incoming, existingDecrypted, schema);
+
+    // ── 6. Catalog-schema required + type validation ────────────────
+    // Runs on the RESTORED config so a masked-but-preserved secret satisfies
+    // its `required` rule. The schema is guaranteed `absent` or `parsed` here
+    // (corrupt was rejected in step 3).
+    const fieldErrors = validateAgainstSchema(restored, schema);
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new FormInstallValidationError({ fieldErrors, formErrors: [] });
+    }
+
+    // ── 7. Self-hosted plaintext-credential warning (non-fatal) ─────
+    const secretKeys = schema.state === "parsed" ? secretFieldKeys(schema) : [];
+    const credentialWritten = secretKeys.some(
+      (k) => typeof restored[k] === "string" && (restored[k] as string).length > 0,
+    );
+    if (credentialWritten && isPlaintextCredentialRisk()) {
+      this.log.warn(
+        { workspaceId },
+        "Persisting a datasource credential with no encryption keyset configured in a " +
+          "prod-like environment — the credential will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
+          "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
+      );
+    }
+
+    // ── 8. Encrypt secret fields + upsert the datasource install ────
+    // `encryptSecretFields` is idempotent against already-`enc:v1:` ciphertext.
+    const encryptedConfig = encryptSecretFields(restored, schema);
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, 'draft', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               updated_at = NOW()
+         RETURNING id`,
+        [candidateId, workspaceId, catalogId, this.installId, JSON.stringify(encryptedConfig)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING emits exactly one row
+        // on both paths; an empty result is a driver/RLS/query-rewrite anomaly.
+        // Falling back to candidateId would return a WRONG id on the conflict
+        // path (the row keeps its existing id). Fail loud with a 500.
+        this.log.error(
+          { workspaceId, candidateId },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      this.log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist datasource install record — aborting install",
+      );
+      throw err;
+    }
+
+    this.log.info(
+      { workspaceId, installId: persistedId, credentialWritten },
+      "Datasource install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: this.slug },
+      credentialWritten,
+    };
+  }
+
+  /**
+   * Read + decrypt the existing install's config so masked secrets can be
+   * restored. Returns `{}` when no row exists (fresh install). A decryption
+   * failure throws — a silently-empty config would let a re-save clear a live
+   * credential, turning a key-rotation glitch into a failed-open install.
+   */
+  private async loadExistingDecryptedConfig(
+    workspaceId: WorkspaceId,
+    catalogId: string,
+    schema: ConfigSchema,
+  ): Promise<Record<string, unknown>> {
+    const rows = await internalQuery<ExistingInstallRow>(
+      `SELECT config
+         FROM workspace_plugins
+        WHERE workspace_id = $1 AND catalog_id = $2 AND install_id = $3
+        LIMIT 1`,
+      [workspaceId, catalogId, this.installId],
+    );
+    if (rows.length === 0) return {};
+    return decryptSecretFields(rows[0].config ?? {}, schema);
+  }
+}
+
+/** Keys of every `secret: true` field in a parsed schema. */
+function secretFieldKeys(schema: Extract<ConfigSchema, { state: "parsed" }>): string[] {
+  return schema.fields.filter((f) => f.secret === true).map((f) => f.key);
+}
+
+/**
+ * Validate a (restored) config against the catalog `config_schema`: required
+ * fields must be present + non-empty, and declared types must match. Returns a
+ * field→messages map (empty = valid). Mirrors the installer's
+ * `validateAgainstConfigSchema` shape so the admin UI gets a consistent
+ * `fieldErrors` envelope. A corrupt / absent schema yields no errors — the
+ * encrypt walker still fail-closes on a corrupt schema.
+ */
+function validateAgainstSchema(
+  config: Record<string, unknown>,
+  schema: ConfigSchema,
+): Record<string, string[]> {
+  if (schema.state !== "parsed" || schema.fields.length === 0) return {};
+  const fieldErrors: Record<string, string[]> = {};
+  for (const field of schema.fields) {
+    const value = config[field.key];
+    const present = value !== undefined && value !== null && value !== "";
+    if (field.required === true && !present) {
+      (fieldErrors[field.key] ??= []).push(`${field.label ?? field.key} is required`);
+      continue;
+    }
+    if (!present) continue;
+    switch (field.type) {
+      case "string":
+      case "select":
+        if (typeof value !== "string") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a string`);
+        }
+        break;
+      case "number":
+        if (typeof value !== "number" || Number.isNaN(value)) {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a number`);
+        }
+        break;
+      case "boolean":
+        if (typeof value !== "boolean") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a boolean`);
+        }
+        break;
+      default:
+        // Unknown catalog type — skip (treat as pass), matching the installer.
+        break;
+    }
+  }
+  return fieldErrors;
+}

--- a/packages/api/src/lib/integrations/install/datasource-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/datasource-form-handler.ts
@@ -160,6 +160,23 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
         `Catalog "${this.slug}" config_schema is corrupt (${schema.reason}) — fix the catalog row before installing.`,
       );
     }
+    // An absent (NULL `config_schema` column) schema is just as unsafe as a
+    // corrupt one and must ALSO fail closed: `restoreMaskedSecrets`,
+    // `encryptSecretFields`, and `validateAgainstSchema` all no-op on `absent`,
+    // so a credential field would persist in PLAINTEXT and required fields go
+    // unchecked. Every built-in datasource row ships a non-empty `config_schema`
+    // (an empty array still parses to `parsed`), so `absent` means the row
+    // drifted to NULL — refuse rather than fail open at the credential boundary.
+    // (#3300 review — keeps datasource credential handling strictly schema-driven.)
+    if (schema.state === "absent") {
+      this.log.error(
+        { workspaceId },
+        "Datasource catalog config_schema is missing (NULL) — refusing install rather than persisting a credential in plaintext",
+      );
+      throw new Error(
+        `Catalog "${this.slug}" config_schema is missing — fix the catalog row before installing.`,
+      );
+    }
 
     // ── 4. SaaS keyset gate ─────────────────────────────────────────
     // `encryptSecret` falls back to plaintext when no key is configured (dev

--- a/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
@@ -2,59 +2,24 @@
  * `ElasticsearchFormInstallHandler` — Admin → Integrations install/edit for the
  * `@useatlas/elasticsearch` datasource (#3270). Lets a workspace admin connect an
  * Elasticsearch / OpenSearch cluster from the UI instead of editing
- * `atlas.config.ts`. Modeled on the openapi-generic datasource form handler
- * precedent: validate → encrypt schema-marked secrets → upsert a
- * `pillar='datasource'` `workspace_plugins` row.
+ * `atlas.config.ts`.
  *
- * **Schema-driven, not field-hardcoded.** The catalog row's `config_schema` is
- * read live from `plugin_catalog` (it mirrors the plugin's `getConfigSchema()`),
- * so the encryption walker, the masked-secret restore, and the required-field
- * check all key off the catalog schema. When the Basic / CloudID / SigV4 auth
- * slices (#3263–#3265) extend `getConfigSchema()` (+ the catalog row), this
- * handler picks the new fields up with NO code change here — the only field
- * names it knows are the ones the schema declares as `secret: true`.
+ * As of #3300 this is a thin specialization of the reusable
+ * {@link DatasourceFormInstallHandler}: the generic handler carries the entire
+ * behavior (config_schema-driven encryption, mask-on-read / restore-on-save,
+ * SaaS keyset gate, corrupt-schema fail-close, single-instance upsert) and ES
+ * supplies only its slug + install id. ClickHouse / Snowflake / BigQuery
+ * register the same generic handler with their own slug — so a change to the
+ * install behavior lands in one place, and ES's path stays identical (pinned by
+ * `__tests__/elasticsearch-form-handler.test.ts`).
  *
- * **Mask-on-read / restore-on-save (the #3270 invariant).** Admin reads mask
- * `secret: true` fields to the masked sentinel (`••••••••`) (see
- * `integrations-catalog` / marketplace `/available`). On save, a field still carrying it — or
- * omitted entirely — MUST NOT clear the stored credential: {@link
- * restoreMaskedSecrets} swaps the bullets back to the persisted value before
- * re-encryption. An explicit new value is trusted and replaces it. Decryption of
- * the existing row surfaces as an error (never a silent plaintext fallback).
- *
- * **SaaS keyset gate.** Mirrors the Email / OpenAPI posture: refuse the install
- * when `ATLAS_DEPLOY_MODE=saas` and no encryption keyset is configured, so a
- * misconfigured SaaS deploy fails closed at the credential boundary rather than
- * persisting `apiKey` in plaintext.
- *
- * **Single-instance per workspace.** One ES install per workspace (a fixed
- * `install_id`); re-submitting the form edits the same row. Connection
- * queryability for admin-installed plugin datasources is tracked separately
- * (#3295) — this slice owns install/edit/persist only, matching how every other
- * plugin-backed datasource admin-install behaves today.
- *
+ * @see ./datasource-form-handler.ts — {@link DatasourceFormInstallHandler}
  * @see ./types.ts — {@link FormBasedInstallHandler}
- * @see ./openapi-generic-form-handler.ts — datasource form-handler precedent
  * @see ../../plugins/secrets.ts — encrypt / mask / restore walkers
  */
 
-import crypto from "crypto";
-import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
-import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
-import {
-  encryptSecretFields,
-  decryptSecretFields,
-  restoreMaskedSecrets,
-  parseConfigSchema,
-  type ConfigSchema,
-} from "@atlas/api/lib/plugins/secrets";
-import type { WorkspaceId } from "@useatlas/types";
-import { FormInstallValidationError } from "./email-form-handler";
-import type { CatalogId, FormBasedInstallHandler, InstallRecord } from "./types";
-
-const log = createLogger("integrations.install.elasticsearch");
+import { DatasourceFormInstallHandler } from "./datasource-form-handler";
+import type { CatalogId } from "./types";
 
 /** Catalog slug — the dispatch key in `registerFormHandler`. */
 export const ELASTICSEARCH_SLUG: CatalogId = "elasticsearch";
@@ -73,252 +38,18 @@ export interface ElasticsearchFormInstallHandlerOptions {
   readonly idGenerator?: () => string;
 }
 
-interface CatalogSchemaRow extends Record<string, unknown> {
-  readonly id: string;
-  readonly config_schema: unknown;
-}
-
-interface ExistingInstallRow extends Record<string, unknown> {
-  readonly config: Record<string, unknown> | null;
-}
-
-export class ElasticsearchFormInstallHandler implements FormBasedInstallHandler {
-  readonly kind = "form" as const;
-
-  private readonly newId: () => string;
-
-  constructor(options: ElasticsearchFormInstallHandlerOptions = {}) {
-    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
-  }
-
-  async validateConfig(
-    workspaceId: WorkspaceId,
-    formData: unknown,
-  ): Promise<{
-    readonly installRecord: InstallRecord;
-    readonly credentialWritten: boolean;
-  }> {
-    // ── 1. Shape guard ──────────────────────────────────────────────
-    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
-      throw new FormInstallValidationError({
-        fieldErrors: {},
-        formErrors: ["Request body must be a JSON object of config fields."],
-      });
-    }
-    const incoming = formData as Record<string, unknown>;
-
-    // ── 2. Load the catalog row (id + live config_schema) ───────────
-    // The schema is the source of truth for which fields are secret / required
-    // — read it from the catalog so future auth fields propagate automatically.
-    const catalogRows = await internalQuery<CatalogSchemaRow>(
-      `SELECT id, config_schema
-         FROM plugin_catalog
-        WHERE slug = $1 AND enabled = true
-        LIMIT 1`,
-      [ELASTICSEARCH_SLUG],
-    );
-    if (catalogRows.length === 0) {
-      // The route pre-checks the catalog row, so reaching here is a seed/boot
-      // misconfig (row missing or disabled) — surface as a 500, not a 400.
-      log.error({ workspaceId }, "Elasticsearch catalog row missing or disabled — cannot install");
-      throw new Error(
-        `Catalog row "${ELASTICSEARCH_SLUG}" not found or disabled — the built-in datasource catalog seed has not run.`,
-      );
-    }
-    const catalogId = catalogRows[0].id;
-    const schema = parseConfigSchema(catalogRows[0].config_schema);
-
-    // ── 3. Corrupt-schema guard (fail closed) ───────────────────────
-    // The catalog `config_schema` is operator-controlled, not user input, and
-    // the built-in datasource row is seeded ON CONFLICT DO NOTHING (no
-    // self-heal of a drifted schema). A corrupt schema makes
-    // `restoreMaskedSecrets` / `encryptSecretFields` fall back to "act on every
-    // string" — which on a fresh install would encrypt-and-persist the masked
-    // sentinel itself as the credential while `validateAgainstSchema` skips the
-    // required check. Refuse loudly (operator must fix the row) instead of
-    // silently storing junk.
-    if (schema.state === "corrupt") {
-      log.error(
-        { workspaceId, reason: schema.reason },
-        "Elasticsearch catalog config_schema is corrupt — refusing install rather than persisting the mask sentinel as a credential",
-      );
-      throw new Error(
-        `Catalog "${ELASTICSEARCH_SLUG}" config_schema is corrupt (${schema.reason}) — fix the catalog row before installing.`,
-      );
-    }
-
-    // ── 4. SaaS keyset gate ─────────────────────────────────────────
-    // `encryptSecret` falls back to plaintext when no key is configured (dev
-    // convenience). In SaaS that would leak the credential — refuse the install
-    // so a misconfigured deploy fails closed at the credential boundary. Checked
-    // BEFORE the existing-row read so a re-save under misconfigured SaaS surfaces
-    // this actionable message rather than an opaque decrypt failure.
-    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-      log.error(
-        { workspaceId },
-        "Refusing Elasticsearch install: SaaS mode + no encryption keyset (would persist a plaintext credential)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-          "Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    // ── 5. Restore masked secrets against the existing install ──────
-    // Read the current row (if any) so an unchanged masked secret round-trips
-    // back to its stored value instead of persisting the bullet sentinel.
-    const existingDecrypted = await this.loadExistingDecryptedConfig(
-      workspaceId,
-      catalogId,
-      schema,
-    );
-    const restored = restoreMaskedSecrets(incoming, existingDecrypted, schema);
-
-    // ── 6. Catalog-schema required + type validation ────────────────
-    // Runs on the RESTORED config so a masked-but-preserved secret satisfies
-    // its `required` rule. The schema is guaranteed `absent` or `parsed` here
-    // (corrupt was rejected in step 3).
-    const fieldErrors = validateAgainstSchema(restored, schema);
-    if (Object.keys(fieldErrors).length > 0) {
-      throw new FormInstallValidationError({ fieldErrors, formErrors: [] });
-    }
-
-    // ── 7. Self-hosted plaintext-credential warning (non-fatal) ─────
-    const secretKeys = schema.state === "parsed" ? secretFieldKeys(schema) : [];
-    const credentialWritten = secretKeys.some(
-      (k) => typeof restored[k] === "string" && (restored[k] as string).length > 0,
-    );
-    if (credentialWritten && isPlaintextCredentialRisk()) {
-      log.warn(
-        { workspaceId },
-        "Persisting an Elasticsearch credential with no encryption keyset configured in a " +
-          "prod-like environment — the credential will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
-          "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
-      );
-    }
-
-    // ── 8. Encrypt secret fields + upsert the datasource install ────
-    // `encryptSecretFields` is idempotent against already-`enc:v1:` ciphertext.
-    const encryptedConfig = encryptSecretFields(restored, schema);
-
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
-         VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, 'draft', NOW(), NOW())
-         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true,
-               updated_at = NOW()
-         RETURNING id`,
-        [candidateId, workspaceId, catalogId, ELASTICSEARCH_INSTALL_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING emits exactly one row
-        // on both paths; an empty result is a driver/RLS/query-rewrite anomaly.
-        // Falling back to candidateId would return a WRONG id on the conflict
-        // path (the row keeps its existing id). Fail loud with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist Elasticsearch install record — aborting install",
-      );
-      throw err;
-    }
-
-    log.info(
-      { workspaceId, installId: persistedId, credentialWritten },
-      "Elasticsearch datasource install completed",
-    );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: ELASTICSEARCH_SLUG },
-      credentialWritten,
-    };
-  }
-
-  /**
-   * Read + decrypt the existing install's config so masked secrets can be
-   * restored. Returns `{}` when no row exists (fresh install). A decryption
-   * failure throws — a silently-empty config would let a re-save clear a live
-   * credential, turning a key-rotation glitch into a failed-open install.
-   */
-  private async loadExistingDecryptedConfig(
-    workspaceId: WorkspaceId,
-    catalogId: string,
-    schema: ConfigSchema,
-  ): Promise<Record<string, unknown>> {
-    const rows = await internalQuery<ExistingInstallRow>(
-      `SELECT config
-         FROM workspace_plugins
-        WHERE workspace_id = $1 AND catalog_id = $2 AND install_id = $3
-        LIMIT 1`,
-      [workspaceId, catalogId, ELASTICSEARCH_INSTALL_ID],
-    );
-    if (rows.length === 0) return {};
-    return decryptSecretFields(rows[0].config ?? {}, schema);
-  }
-}
-
-/** Keys of every `secret: true` field in a parsed schema. */
-function secretFieldKeys(schema: Extract<ConfigSchema, { state: "parsed" }>): string[] {
-  return schema.fields.filter((f) => f.secret === true).map((f) => f.key);
-}
-
 /**
- * Validate a (restored) config against the catalog `config_schema`: required
- * fields must be present + non-empty, and declared types must match. Returns a
- * field→messages map (empty = valid). Mirrors the installer's
- * `validateAgainstConfigSchema` shape so the admin UI gets a consistent
- * `fieldErrors` envelope. A corrupt / absent schema yields no errors — the
- * encrypt walker still fail-closes on a corrupt schema.
+ * Elasticsearch / OpenSearch datasource form-install handler. A
+ * {@link DatasourceFormInstallHandler} pinned to the `elasticsearch` slug — kept
+ * as a named subclass so the register + test call sites that spell out the
+ * ES-specific symbol keep compiling and the catalog wiring reads clearly.
  */
-function validateAgainstSchema(
-  config: Record<string, unknown>,
-  schema: ConfigSchema,
-): Record<string, string[]> {
-  if (schema.state !== "parsed" || schema.fields.length === 0) return {};
-  const fieldErrors: Record<string, string[]> = {};
-  for (const field of schema.fields) {
-    const value = config[field.key];
-    const present = value !== undefined && value !== null && value !== "";
-    if (field.required === true && !present) {
-      (fieldErrors[field.key] ??= []).push(`${field.label ?? field.key} is required`);
-      continue;
-    }
-    if (!present) continue;
-    switch (field.type) {
-      case "string":
-      case "select":
-        if (typeof value !== "string") {
-          (fieldErrors[field.key] ??= []).push(`${field.key} must be a string`);
-        }
-        break;
-      case "number":
-        if (typeof value !== "number" || Number.isNaN(value)) {
-          (fieldErrors[field.key] ??= []).push(`${field.key} must be a number`);
-        }
-        break;
-      case "boolean":
-        if (typeof value !== "boolean") {
-          (fieldErrors[field.key] ??= []).push(`${field.key} must be a boolean`);
-        }
-        break;
-      default:
-        // Unknown catalog type — skip (treat as pass), matching the installer.
-        break;
-    }
+export class ElasticsearchFormInstallHandler extends DatasourceFormInstallHandler {
+  constructor(options: ElasticsearchFormInstallHandlerOptions = {}) {
+    super({
+      slug: ELASTICSEARCH_SLUG,
+      installId: ELASTICSEARCH_INSTALL_ID,
+      ...(options.idGenerator ? { idGenerator: options.idGenerator } : {}),
+    });
   }
-  return fieldErrors;
 }

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -29,6 +29,7 @@ import {
   ElasticsearchFormInstallHandler,
   ELASTICSEARCH_SLUG,
 } from "./elasticsearch-form-handler";
+import { DatasourceFormInstallHandler } from "./datasource-form-handler";
 import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
@@ -165,6 +166,31 @@ export function registerBuiltinInstallHandlers(): void {
   // the install/edit path.
   registerFormHandler(ELASTICSEARCH_SLUG, new ElasticsearchFormInstallHandler());
   log.info("Registered ElasticsearchFormInstallHandler");
+  // SQL plugin datasources (#3300) — ClickHouse / Snowflake / BigQuery become
+  // form-installable on SaaS now that the runtime connect path is uniform across
+  // plugin datasources (#3297/#3299 adapter registration + the `createFromConfig`
+  // bridge; #3295 query-path wiring). Each registers the generic
+  // `DatasourceFormInstallHandler` pinned to its slug — single-instance per
+  // workspace (install_id = slug), config_schema-driven (reads the catalog row
+  // live so the `secret: true` field(s) — ClickHouse/Snowflake `url`, BigQuery
+  // `service_account_json` — encrypt at rest with no per-type branch). No env
+  // gate: the customer admin supplies credentials at install, same as every other
+  // form handler. `loadSavedConnections` boot-registers the persisted
+  // `pillar='datasource'` row via the bridge so the install becomes queryable
+  // after a reload. The catalog rows already exist (seed-builtin-datasource-
+  // catalog.ts) — this only wires the install handler. (Postgres / MySQL stay on
+  // the native config-managed path; DuckDB is a local file, not SaaS-installable;
+  // Salesforce uses the OAuth datasource handler.)
+  for (const datasourceSlug of ["clickhouse", "snowflake", "bigquery"] as const) {
+    registerFormHandler(
+      datasourceSlug,
+      new DatasourceFormInstallHandler({ slug: datasourceSlug, installId: datasourceSlug }),
+    );
+  }
+  log.info(
+    { slugs: ["clickhouse", "snowflake", "bigquery"] },
+    "Registered DatasourceFormInstallHandler(s) for SQL plugin datasources",
+  );
   registerFormHandler("obsidian", new ObsidianFormInstallHandler());
   log.info("Registered ObsidianFormInstallHandler");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance


### PR DESCRIPTION
## What

Closes #3300. Makes **ClickHouse, Snowflake, and BigQuery** form-installable from **Admin → Connections** (including on SaaS) by extracting a reusable `DatasourceFormInstallHandler` from the #3270 Elasticsearch handler and registering it for the three SQL datasources.

The runtime connect path was already uniform across plugin datasources (#3297/#3299 `createFromConfig` bridge + #3295 query wiring) and the catalog rows already exist (`seed-builtin-datasource-catalog.ts`). The remaining gap to make these *addable* was the admin install handler that creates the `workspace_plugins` row — that's this slice.

## How

- **`datasource-form-handler.ts` (new)** — `DatasourceFormInstallHandler`, parameterized by `slug` + `installId`. Carries the ES handler's behavior verbatim:
  - reads the catalog `config_schema` **live** from `plugin_catalog` (no hardcoded per-datasource shapes),
  - `encryptSecretFields` keyed on the schema `secret: true` flag,
  - mask-on-read / restore-on-save (masked sentinel or omitted field never clears a stored credential; decrypt failure fails closed — no plaintext fallback),
  - SaaS keyset gate (refuses install when `ATLAS_DEPLOY_MODE=saas` and no keyset),
  - corrupt-schema fail-close,
  - single-instance upsert of a `pillar='datasource'` row keyed on `(workspace_id, catalog_id, install_id)`.
  - Per-slug logger so install lines stay attributable.
- **`elasticsearch-form-handler.ts`** — now a thin subclass pinned to the `elasticsearch` slug. ES behavior is **identical**; its existing characterization suite stays green.
- **`register.ts`** — registers the generic handler for `clickhouse` / `snowflake` / `bigquery` (no env gate; `install_id = slug`).
- **Schema-driven, no per-type branch** — the differing secret shapes just work: ClickHouse/Snowflake `url`, BigQuery `service_account_json` encrypt at rest while BigQuery `project_id` stays plaintext for the resolver / `createFromConfig` (#3299).

## Tests

- `datasource-form-handler.test.ts` — the generic across both secret shapes: ClickHouse (`url` is the secret) and BigQuery (`service_account_json` secret + `project_id` plaintext); validation, restore-on-save (masked / explicit / omitted / undecryptable), corrupt-schema, missing-catalog-row, SaaS gate.
- `datasource-form-install-roundtrip.test.ts` — **install → persist → boot-register → query** for ClickHouse: installs via the handler, decrypts the captured encrypted row exactly as `loadSavedConnections` does, registers via the bridge, and asserts the rebuilt plugin connection is queryable with the round-tripped credential.
- `register.test.ts` — all three slugs resolve as `form` handlers with no env gate.
- ES regression suite unchanged and green.

## Docs

- `integrations/admin-console.mdx` — datasources + Form connect-flow now list ClickHouse/Snowflake/BigQuery and note they're form-installable on SaaS.
- `plugins/datasources/{clickhouse,snowflake,bigquery}.mdx` — each gains an "Install from the admin console" note.

## CI

All six `/ci` gates green locally: lint, type, full `bun run test:api` (563 files pass), `syncpack lint`, template-drift, railway-watch.

## Security

Per-tenant creds are DB-only (no operator env-var reads in the install path); secret fields encrypt at rest via the `secret: true` selective-field flow, mask on read, and are never logged or returned decrypted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783432983&installation_id=135337507&pr_number=3304&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3304&signature=214be7e59c7475095db7ec9e42b6e080b96538e3d91e7d1864b1f391ddf1faaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install BigQuery, ClickHouse, and Snowflake datasources directly from Admin → Connections; connections become queryable after deployment reload.
  * Entered credentials are encrypted at rest and supported on SaaS.

* **Documentation**
  * Added admin-console install instructions for BigQuery, ClickHouse, Snowflake, and updated datasource grouping/flow docs.

* **Refactor**
  * Simplified the Elasticsearch admin-console install path.

* **Tests**
  * Added comprehensive tests covering form-based installs, secret handling, and roundtrip registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->