### PR TITLE
fix(plugins): enforce per-index/object semantic whitelist in ES Query DSL & SOQL tools (#3307)

### DIFF
--- a/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
+++ b/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
@@ -151,12 +151,14 @@ and an optional Query DSL `body`.
 The surface is gated by a **default-deny** read-only validator: only read
 endpoints are allowed; mutating/administrative endpoints, smuggled bulk-write
 actions, mutating (`ctx`-referencing) scripts, and wildcard / `_all` /
-system-index targets are rejected. These structural rails are always enforced;
-per-index *membership* against the semantic-layer index list is **not** yet
-enforced from the DSL tool (the SQL surface enforces the real whitelist via the
-core pipeline) — tracked in [#3307](https://github.com/AtlasDevHQ/atlas/issues/3307).
-Every `_search` is resource-bounded — `size` clamped to `ATLAS_ROW_LIMIT`, a
-search `timeout`, and a non-aggregation `terminate_after`
+system-index targets are rejected. On top of those always-on structural rails,
+the tool enforces **per-index membership** against the semantic layer: the
+queried index must be a profiled entity (the same index/table whitelist
+`executeSQL` validates against), so the DSL surface honors the identical access
+boundary as the SQL surface ([#3307](https://github.com/AtlasDevHQ/atlas/issues/3307)).
+When a connection has no semantic layer the membership check is skipped and only
+the structural rails apply. Every `_search` is resource-bounded — `size` clamped
+to `ATLAS_ROW_LIMIT`, a search `timeout`, and a non-aggregation `terminate_after`
 (`ATLAS_ES_TERMINATE_AFTER`).
 
 The `queryElasticsearch` tool is registered **only** for a static,

--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -430,7 +430,7 @@ beforeAll(async () => {
 
   await plugin.initialize!({
     db: null,
-    connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+    connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
     tools: { register: () => {} },
     logger: {
       info: () => {},

--- a/packages/api/src/__tests__/plugin-mcp-tools.test.ts
+++ b/packages/api/src/__tests__/plugin-mcp-tools.test.ts
@@ -189,7 +189,7 @@ describe("wireMcpToolPlugins", () => {
     pluginRegistry.register(makePlugin("docs", [makeTool({ name: "list" })]));
     await pluginRegistry.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},
@@ -215,7 +215,7 @@ describe("wireMcpToolPlugins", () => {
     } as PluginLike);
     await pluginRegistry.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},
@@ -236,7 +236,7 @@ describe("wireMcpToolPlugins", () => {
     pluginRegistry.register(makePlugin("good", [makeTool({ name: "ok" })]));
     await pluginRegistry.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},
@@ -262,7 +262,7 @@ describe("wireMcpToolPlugins", () => {
     } as PluginLike);
     await pluginRegistry.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},
@@ -287,7 +287,7 @@ describe("wireMcpToolPlugins", () => {
     } as PluginLike);
     await pluginRegistry.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},

--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -21,6 +21,7 @@ import { app } from "./index";
 import { createLogger } from "@atlas/api/lib/logger";
 import { initializeConfig } from "@atlas/api/lib/config";
 import { connections } from "@atlas/api/lib/db/connection";
+import { getWhitelistedTables } from "@atlas/api/lib/semantic";
 import { closeInternalDB } from "@atlas/api/lib/db/internal";
 import {
   plugins,
@@ -124,6 +125,12 @@ if (config.plugins?.length) {
       // tools — #3109). Plugin-managed pools register on the bare map anyway.
       get: (id: string) => connections.get(id),
       list: () => connections.list(),
+      // Semantic-layer object names for a connection — the per-object
+      // membership whitelist for plugin query tools (SOQL / ES Query DSL).
+      // Self-host / static datasource mode: filesystem-backed, the same source
+      // `executeSQL` validates against (`getWhitelistedTables`), so a plugin's
+      // bespoke tool honors the identical boundary as the SQL path (#3307).
+      tables: (id: string) => Array.from(getWhitelistedTables(id)),
     },
     tools: {
       register: (tool) =>

--- a/packages/api/src/lib/__tests__/plugin-aware-validation.test.ts
+++ b/packages/api/src/lib/__tests__/plugin-aware-validation.test.ts
@@ -35,7 +35,7 @@ function mockConn(): DBConnection {
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
@@ -16,7 +16,7 @@ import type {
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/hooks-integration.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/hooks-integration.test.ts
@@ -99,7 +99,7 @@ const exec = (sql: string) =>
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/hooks.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/hooks.test.ts
@@ -5,7 +5,7 @@ import { dispatchHook, dispatchMutableHook } from "../hooks";
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/mcp-boot.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/mcp-boot.test.ts
@@ -142,7 +142,7 @@ describe("bootPluginsForMcp", () => {
     );
     await plugins.initializeAll({
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {},
       config: {},

--- a/packages/api/src/lib/plugins/__tests__/registry.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/registry.test.ts
@@ -23,7 +23,7 @@ import type { PluginLike, PluginContextLike } from "../registry";
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},
@@ -103,7 +103,7 @@ describe("PluginRegistry", () => {
 
       const fakeCtx: PluginContextLike = {
         db: null,
-        connections: { get: () => ({}), list: () => [] },
+        connections: { get: () => ({}), list: () => [], tables: () => [] },
         tools: { register: () => {} },
         logger: {},
         config: { test: true },

--- a/packages/api/src/lib/plugins/__tests__/tool-call-hooks-integration.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/tool-call-hooks-integration.test.ts
@@ -38,7 +38,7 @@ const { dispatchMutableHook } = await import("../hooks");
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/tool-call-hooks.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/tool-call-hooks.test.ts
@@ -13,7 +13,7 @@ import { dispatchHook, dispatchMutableHook } from "../hooks";
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/__tests__/wiring.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/wiring.test.ts
@@ -6,7 +6,7 @@ import type { SandboxExecBackend } from "../wiring";
 
 const minimalCtx: PluginContextLike = {
   db: null,
-  connections: { get: () => ({}), list: () => [] },
+  connections: { get: () => ({}), list: () => [], tables: () => [] },
   tools: { register: () => {} },
   logger: {},
   config: {},

--- a/packages/api/src/lib/plugins/mcp-boot.ts
+++ b/packages/api/src/lib/plugins/mcp-boot.ts
@@ -68,10 +68,14 @@ export async function bootPluginsForMcp(): Promise<{
       // analytics ConnectionRegistry — those are boot products of the
       // Hono server. Plugins designed to run in MCP context must
       // tolerate `db: null` and an empty connections list. `tables` is
-      // likewise empty (no semantic whitelist) — fine here because
-      // `tools.register` below is a no-op, so a plugin's bespoke query tool
-      // (which would consult `tables` for its whitelist) is never served from
-      // this path; the real, whitelist-backed context is the Hono boot's.
+      // likewise empty (no semantic whitelist) — fine here for two independent
+      // reasons: (1) `tools.register` below is a no-op, so the bespoke query
+      // tool a plugin builds in `initialize` (which consults `tables` for its
+      // whitelist) is built-and-discarded; and (2) MCP serves only the tools a
+      // plugin returns from `mcpTools()` (wired separately by
+      // `wireMcpToolPlugins`), never the agent tools passed to `tools.register`
+      // — and the ES/SF DSL tools register only via `tools.register`. The real,
+      // whitelist-backed context is the Hono boot's.
       db: null,
       connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },

--- a/packages/api/src/lib/plugins/mcp-boot.ts
+++ b/packages/api/src/lib/plugins/mcp-boot.ts
@@ -67,9 +67,13 @@ export async function bootPluginsForMcp(): Promise<{
       // The MCP boot path does NOT have an internal DB pool wired or
       // analytics ConnectionRegistry — those are boot products of the
       // Hono server. Plugins designed to run in MCP context must
-      // tolerate `db: null` and an empty connections list.
+      // tolerate `db: null` and an empty connections list. `tables` is
+      // likewise empty (no semantic whitelist) — fine here because
+      // `tools.register` below is a no-op, so a plugin's bespoke query tool
+      // (which would consult `tables` for its whitelist) is never served from
+      // this path; the real, whitelist-backed context is the Hono boot's.
       db: null,
-      connections: { get: () => ({}), list: () => [] },
+      connections: { get: () => ({}), list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: log as unknown as Record<string, unknown>,
       config: (config ?? {}) as unknown as Record<string, unknown>,

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -95,7 +95,7 @@ export interface ConfigSchemaField {
  */
 export interface PluginContextLike {
   db: { query(sql: string, params?: unknown[]): Promise<unknown>; execute(sql: string, params?: unknown[]): Promise<void> } | null;
-  connections: { get(id: string): unknown; list(): string[]; tables(id: string): string[] };
+  connections: { get(id: string): unknown; list(): string[]; tables(id: string): readonly string[] };
   tools: { register(tool: { name: string; description: string; tool: unknown }): void };
   logger: Record<string, unknown>;
   config: Record<string, unknown>;

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -95,7 +95,7 @@ export interface ConfigSchemaField {
  */
 export interface PluginContextLike {
   db: { query(sql: string, params?: unknown[]): Promise<unknown>; execute(sql: string, params?: unknown[]): Promise<void> } | null;
-  connections: { get(id: string): unknown; list(): string[] };
+  connections: { get(id: string): unknown; list(): string[]; tables(id: string): string[] };
   tools: { register(tool: { name: string; description: string; tool: unknown }): void };
   logger: Record<string, unknown>;
   config: Record<string, unknown>;

--- a/packages/plugin-sdk/src/testing.ts
+++ b/packages/plugin-sdk/src/testing.ts
@@ -272,6 +272,7 @@ export function createMockContext(
           );
         }),
       list: overrides.connections?.list ?? (() => []),
+      tables: overrides.connections?.tables ?? (() => []),
     },
     tools: {
       register:

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -124,7 +124,18 @@ export interface AtlasPluginContext {
   /** Connection registry for analytics datasources. */
   connections: {
     get(id: string): PluginDBConnection;
+    /** Registered connection IDs — NOT semantic-layer object names. */
     list(): string[];
+    /**
+     * Semantic-layer entity/table (for ES: index) names registered for a
+     * connection — the per-object membership whitelist a plugin query tool must
+     * enforce. Mirrors the source `executeSQL` validates against
+     * (`getWhitelistedTables(connectionId)`), so a plugin's bespoke query tool
+     * (SOQL / Query DSL) honors the same boundary as the SQL path. Returns `[]`
+     * when the connection has no semantic layer; a tool fed an empty set falls
+     * back to structural-only validation. See #3307.
+     */
+    tables(id: string): string[];
   };
   /** Tool registry — plugins can register additional tools. */
   tools: {

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -129,13 +129,19 @@ export interface AtlasPluginContext {
     /**
      * Semantic-layer entity/table (for ES: index) names registered for a
      * connection — the per-object membership whitelist a plugin query tool must
-     * enforce. Mirrors the source `executeSQL` validates against
+     * enforce. In self-host / static-datasource mode this mirrors the
+     * filesystem whitelist `executeSQL` validates against
      * (`getWhitelistedTables(connectionId)`), so a plugin's bespoke query tool
-     * (SOQL / Query DSL) honors the same boundary as the SQL path. Returns `[]`
-     * when the connection has no semantic layer; a tool fed an empty set falls
-     * back to structural-only validation. See #3307.
+     * (SOQL / Query DSL) honors the same boundary as the SQL path. (Org-scoped
+     * SaaS validates `executeSQL` against the DB-backed `getOrgWhitelistedTables`;
+     * the static-config tools this serves are a self-host surface.)
+     *
+     * `id` must be a registered connection id (typically the plugin's own `id`);
+     * an unrecognized id returns `[]`. Returns `[]` when the connection has no
+     * semantic layer — a tool fed an empty set falls back to structural-only
+     * validation, so a typo'd id silently downgrades enforcement. See #3307.
      */
-    tables(id: string): string[];
+    tables(id: string): readonly string[];
   };
   /** Tool registry — plugins can register additional tools. */
   tools: {

--- a/plugins/bigquery/__tests__/bigquery.test.ts
+++ b/plugins/bigquery/__tests__/bigquery.test.ts
@@ -331,7 +331,7 @@ describe("adapter-only mode", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -628,7 +628,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -653,7 +653,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -818,7 +818,7 @@ describe("chat plugin lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
@@ -839,7 +839,7 @@ describe("chat plugin lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -855,7 +855,7 @@ describe("chat plugin lifecycle", () => {
     const plugin = createTestPlugin();
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -1341,7 +1341,7 @@ describe("chat plugin streaming lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -1357,7 +1357,7 @@ describe("chat plugin streaming lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -1389,7 +1389,7 @@ describe("chat plugin streaming lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -1415,7 +1415,7 @@ describe("chat plugin streaming lifecycle", () => {
 
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -2207,7 +2207,7 @@ describe("chatPlugin webhook routes", () => {
     const { app, plugin } = await mountPlugin(TELEGRAM_CATALOG);
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
@@ -2261,7 +2261,7 @@ describe("chatPlugin webhook routes", () => {
     const { app, plugin } = await mountPlugin(GCHAT_CATALOG);
     await plugin.initialize!({
       db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},

--- a/plugins/clickhouse/__tests__/clickhouse.test.ts
+++ b/plugins/clickhouse/__tests__/clickhouse.test.ts
@@ -314,7 +314,7 @@ describe("adapter-only mode", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -650,7 +650,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },

--- a/plugins/daytona/__tests__/daytona-sandbox.test.ts
+++ b/plugins/daytona/__tests__/daytona-sandbox.test.ts
@@ -295,6 +295,7 @@ describe("initialize", () => {
           throw new Error("not implemented");
         },
         list: () => [],
+        tables: () => [],
       },
       tools: { register: () => {} },
       logger: {

--- a/plugins/duckdb/__tests__/duckdb.test.ts
+++ b/plugins/duckdb/__tests__/duckdb.test.ts
@@ -322,7 +322,7 @@ describe("adapter-only mode", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -632,7 +632,7 @@ describe("healthCheck", () => {
     const warnings: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: () => {},
@@ -662,7 +662,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -685,7 +685,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },

--- a/plugins/e2b/__tests__/e2b-sandbox.test.ts
+++ b/plugins/e2b/__tests__/e2b-sandbox.test.ts
@@ -281,6 +281,7 @@ describe("initialize", () => {
           throw new Error("not implemented");
         },
         list: () => [],
+        tables: () => [],
       },
       tools: { register: () => {} },
       logger: {

--- a/plugins/elasticsearch/__tests__/dsl-tool.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl-tool.test.ts
@@ -490,8 +490,10 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
   // deliberately disjoint here so a test can tell which one the tool consulted.
   function makeCapturingCtx(tables: string[]) {
     const registered: { name: string; description: string; tool: unknown }[] = [];
+    const tablesCalls: string[] = [];
     return {
       registered,
+      tablesCalls,
       ctx: {
         db: null,
         connections: {
@@ -499,7 +501,10 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
             throw new Error("not implemented");
           },
           list: () => ["elasticsearch-datasource"] as string[],
-          tables: () => tables,
+          tables: (id: string) => {
+            tablesCalls.push(id);
+            return tables;
+          },
         },
         tools: {
           register: (t: { name: string; description: string; tool: unknown }) => registered.push(t),
@@ -510,23 +515,28 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
     };
   }
 
-  async function registerEsTool(tables: string[]): Promise<ExecTool> {
+  async function registerEsTool(tables: string[]): Promise<{ esTool: ExecTool; tablesCalls: string[] }> {
     const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
-    const { ctx, registered } = makeCapturingCtx(tables);
+    const { ctx, registered, tablesCalls } = makeCapturingCtx(tables);
     await plugin.initialize!(ctx as unknown as Parameters<NonNullable<typeof plugin.initialize>>[0]);
     const entry = registered.find((t) => t.name === "queryElasticsearch");
     if (!entry) throw new Error("queryElasticsearch tool was not registered");
-    return entry.tool as ExecTool;
+    return { esTool: entry.tool as ExecTool, tablesCalls };
   }
 
-  test("rejects an index absent from the semantic layer (membership enforced from tables())", async () => {
-    const esTool = await registerEsTool(["flights"]);
+  test("rejects an index absent from the semantic layer, keyed on the plugin's connection id", async () => {
+    const { esTool, tablesCalls } = await registerEsTool(["flights"]);
     const result = await esTool.execute(
       { index: "secret_logs", endpoint: "_search", body: {}, explanation: "x" },
       EXEC_OPTS,
     );
     expect(result).toMatchObject({ success: false });
     expect((result as { error: string }).error).toMatch(/not in the semantic layer/);
+    // Pin the whitelist key: the tool must look up tables() under the same id
+    // the static connection registers in the ConnectionRegistry under
+    // (`registerDirect(plugin.id, …)`), else getWhitelistedTables silently
+    // returns [] and the tool drops to structural-only.
+    expect(tablesCalls).toContain("elasticsearch-datasource");
   });
 
   test("rejects the connection id itself — proves tables(), not list(), is the source", async () => {
@@ -534,7 +544,7 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
     // which would have made the connection id the ONLY 'allowed index'. The fix
     // sources index names from the semantic layer, so the connection id is now
     // (correctly) not a queryable index.
-    const esTool = await registerEsTool(["flights"]);
+    const { esTool } = await registerEsTool(["flights"]);
     const result = await esTool.execute(
       { index: "elasticsearch-datasource", endpoint: "_search", body: {}, explanation: "x" },
       EXEC_OPTS,
@@ -547,14 +557,14 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
     const realFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => fetchResponse(HITS_RESPONSE)) as unknown as typeof fetch;
     try {
-      const esTool = await registerEsTool(["flights"]);
+      const { esTool } = await registerEsTool(["flights"]);
       const result = await esTool.execute(
         { index: "flights", endpoint: "_search", body: {}, explanation: "x" },
         EXEC_OPTS,
       );
-      // The whitelist gate passed — not rejected for membership (it reached the
-      // mocked cluster and returned a normal result).
-      expect((result as { error?: string }).error ?? "").not.toMatch(/not in the semantic layer/);
+      // The whitelist gate passed — the query reached the mocked cluster and
+      // returned a normal, successful result.
+      expect(result).toMatchObject({ success: true });
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/plugins/elasticsearch/__tests__/dsl-tool.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl-tool.test.ts
@@ -412,6 +412,7 @@ function makeCtx() {
           throw new Error("not implemented");
         },
         list: () => ["products"] as string[],
+        tables: () => [],
       },
       tools: { register: (t: { name: string; description: string; tool: unknown }) => registered.push(t) },
       logger: {
@@ -473,5 +474,89 @@ describe("plugin wiring — queryElasticsearch registration", () => {
     expect(plugin.dialect).not.toMatch(/queryElasticsearch/);
     // SQL guidance still applies in per-workspace mode.
     expect(plugin.dialect).toMatch(/executeSQL/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Index whitelist is sourced from the semantic layer via ctx.connections.tables
+// — NOT ctx.connections.list() (connection IDs). Regression guard for #3307.
+// ---------------------------------------------------------------------------
+
+describe("plugin wiring — index whitelist comes from ctx.connections.tables (#3307)", () => {
+  type ExecTool = { execute: (args: unknown, opts: unknown) => Promise<unknown> };
+
+  // `list()` returns CONNECTION IDs (the pre-#3307 — wrong — whitelist source);
+  // `tables()` returns SEMANTIC-LAYER index names (the correct source). They are
+  // deliberately disjoint here so a test can tell which one the tool consulted.
+  function makeCapturingCtx(tables: string[]) {
+    const registered: { name: string; description: string; tool: unknown }[] = [];
+    return {
+      registered,
+      ctx: {
+        db: null,
+        connections: {
+          get: () => {
+            throw new Error("not implemented");
+          },
+          list: () => ["elasticsearch-datasource"] as string[],
+          tables: () => tables,
+        },
+        tools: {
+          register: (t: { name: string; description: string; tool: unknown }) => registered.push(t),
+        },
+        logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+        config: {},
+      },
+    };
+  }
+
+  async function registerEsTool(tables: string[]): Promise<ExecTool> {
+    const plugin = elasticsearchPlugin({ url: VALID_URL, apiKey: API_KEY });
+    const { ctx, registered } = makeCapturingCtx(tables);
+    await plugin.initialize!(ctx as unknown as Parameters<NonNullable<typeof plugin.initialize>>[0]);
+    const entry = registered.find((t) => t.name === "queryElasticsearch");
+    if (!entry) throw new Error("queryElasticsearch tool was not registered");
+    return entry.tool as ExecTool;
+  }
+
+  test("rejects an index absent from the semantic layer (membership enforced from tables())", async () => {
+    const esTool = await registerEsTool(["flights"]);
+    const result = await esTool.execute(
+      { index: "secret_logs", endpoint: "_search", body: {}, explanation: "x" },
+      EXEC_OPTS,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toMatch(/not in the semantic layer/);
+  });
+
+  test("rejects the connection id itself — proves tables(), not list(), is the source", async () => {
+    // Pre-#3307 the whitelist was `ctx.connections.list()` = ["elasticsearch-datasource"],
+    // which would have made the connection id the ONLY 'allowed index'. The fix
+    // sources index names from the semantic layer, so the connection id is now
+    // (correctly) not a queryable index.
+    const esTool = await registerEsTool(["flights"]);
+    const result = await esTool.execute(
+      { index: "elasticsearch-datasource", endpoint: "_search", body: {}, explanation: "x" },
+      EXEC_OPTS,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toMatch(/not in the semantic layer/);
+  });
+
+  test("a semantic-layer index passes the membership gate (reaches the cluster)", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => fetchResponse(HITS_RESPONSE)) as unknown as typeof fetch;
+    try {
+      const esTool = await registerEsTool(["flights"]);
+      const result = await esTool.execute(
+        { index: "flights", endpoint: "_search", body: {}, explanation: "x" },
+        EXEC_OPTS,
+      );
+      // The whitelist gate passed — not rejected for membership (it reached the
+      // mocked cluster and returned a normal result).
+      expect((result as { error?: string }).error ?? "").not.toMatch(/not in the semantic layer/);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -752,7 +752,7 @@ describe("adapter-only mode", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -865,6 +865,7 @@ function makeCtx() {
           throw new Error("not implemented");
         },
         list: () => [] as string[],
+        tables: () => [],
       },
       tools: { register: () => {} },
       logger: {

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -216,6 +216,13 @@ export function buildElasticsearchPlugin(
   let cachedConn: ElasticsearchConnection | undefined;
   let log: PluginLogger | undefined;
 
+  // This plugin's static connection registers in the ConnectionRegistry under
+  // its plugin id (wiring.ts `registerDirect(plugin.id, …)`), which is also the
+  // connectionId `getWhitelistedTables` / `executeSQL` key the index whitelist
+  // on. The DSL tool MUST use the same id so its membership whitelist agrees
+  // with the SQL path.
+  const DATASOURCE_ID = "elasticsearch-datasource";
+
   // A static config-defined ES datasource (self-host / operator-baked) needs an
   // endpoint source (`url`/`cloudId`) AND an auth signal (apiKey / username+
   // password / awsRegion). Without a complete config the plugin is registered
@@ -277,7 +284,7 @@ export function buildElasticsearchPlugin(
   }
 
   return {
-    id: "elasticsearch-datasource",
+    id: DATASOURCE_ID,
     types: ["datasource"] as const,
     version: "0.1.0",
     name: "Elasticsearch DataSource",
@@ -415,19 +422,16 @@ export function buildElasticsearchPlugin(
       if (staticConfig) {
         const esTool = createQueryElasticsearchTool({
           getConnection: () => getOrCreateConnection(),
-          // The index MEMBERSHIP whitelist should be the semantic layer's index
-          // names — but the plugin context exposes no accessor for them today:
-          // `ctx.connections.list()` returns registered CONNECTION IDs (e.g.
-          // "elasticsearch-datasource"), NOT index names. Feeding those in would
-          // make `validateIndexAccess` reject every legitimate query (an index
-          // like "flights" is never a connection id). So we pass an EMPTY set,
-          // which keeps validateIndexAccess in structural-only mode: the
-          // always-on rails (no wildcards / _all / system indices) still apply,
-          // and a named index is allowed. The SQL surface (`executeSQL`) still
-          // enforces the real table whitelist via the core pipeline. Per-index
-          // membership for the DSL tool lands when the context gains a
-          // semantic-table accessor — tracked in #3307.
-          getWhitelist: () => new Set<string>(),
+          // The index MEMBERSHIP whitelist is the semantic layer's index names
+          // for this connection — `ctx.connections.tables(id)`, the SAME source
+          // `executeSQL` validates against (`getWhitelistedTables`). So the DSL
+          // tool and the SQL surface enforce the identical per-index boundary
+          // (#3307). NOTE: `ctx.connections.list()` would be wrong here — it
+          // returns CONNECTION IDs, not index names, so it can never match a
+          // real index like "flights". When the semantic layer is empty the
+          // accessor returns `[]` and `validateIndexAccess` falls back to its
+          // always-on structural rails (no wildcards / _all / system indices).
+          getWhitelist: () => new Set(ctx.connections.tables(DATASOURCE_ID)),
           logger: ctx.logger,
         });
 

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -423,10 +423,12 @@ export function buildElasticsearchPlugin(
         const esTool = createQueryElasticsearchTool({
           getConnection: () => getOrCreateConnection(),
           // The index MEMBERSHIP whitelist is the semantic layer's index names
-          // for this connection — `ctx.connections.tables(id)`, the SAME source
-          // `executeSQL` validates against (`getWhitelistedTables`). So the DSL
-          // tool and the SQL surface enforce the identical per-index boundary
-          // (#3307). NOTE: `ctx.connections.list()` would be wrong here — it
+          // for this connection — `ctx.connections.tables(id)`, the same
+          // filesystem whitelist `executeSQL` validates against in self-host /
+          // static mode (`getWhitelistedTables`). So the DSL tool and the SQL
+          // surface enforce the identical per-index boundary (#3307). (This tool
+          // is static-only; SaaS per-workspace ES is queried over the SQL path.)
+          // NOTE: `ctx.connections.list()` would be wrong here — it
           // returns CONNECTION IDs, not index names, so it can never match a
           // real index like "flights". When the semantic layer is empty the
           // accessor returns `[]` and `validateIndexAccess` falls back to its

--- a/plugins/mysql/__tests__/mysql.test.ts
+++ b/plugins/mysql/__tests__/mysql.test.ts
@@ -436,7 +436,7 @@ describe("initialize", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },

--- a/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
+++ b/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
@@ -192,7 +192,7 @@ describe("initialize", () => {
     const logged: { level: string; msg: string }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push({ level: "info", msg: String(args[0]) }); },

--- a/plugins/salesforce/__tests__/salesforce.test.ts
+++ b/plugins/salesforce/__tests__/salesforce.test.ts
@@ -74,14 +74,16 @@ import { createSalesforceConnection } from "../src/connection";
 
 const VALID_URL = "salesforce://user:pass@login.salesforce.com?token=TOKEN";
 
-function makeCtx(overrides?: Partial<{ logged: string[]; warned: string[]; registered: { name: string }[] }>) {
+function makeCtx(overrides?: Partial<{ logged: string[]; warned: string[]; registered: { name: string }[]; tables: string[] }>) {
   const logged = overrides?.logged ?? [];
   const warned = overrides?.warned ?? [];
   const registered = overrides?.registered ?? [];
   return {
     ctx: {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] as string[] },
+      // `tables()` returns SEMANTIC-LAYER object names — the whitelist source
+      // the querySalesforce tool must consult (#3307), NOT `list()` (connection IDs).
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] as string[], tables: () => overrides?.tables ?? [] },
       tools: { register: (t: { name: string; description: string; tool: unknown }) => { registered.push(t); } },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -1026,13 +1028,34 @@ describe("initialize", () => {
     expect(registered[0].name).toBe("querySalesforce");
   });
 
+  test("object whitelist is sourced from ctx.connections.tables() — rejects non-members (#3307)", async () => {
+    // Wiring guard: the tool's SOQL object whitelist must come from the semantic
+    // layer (`tables()`), not `list()` (connection IDs). With `tables() = [Account]`
+    // and the default empty `list()`, a query against Contact must be REJECTED —
+    // if the tool still read the empty `list()` it would fall back to
+    // structural-only and (wrongly) allow Contact.
+    const plugin = salesforcePlugin({ url: VALID_URL });
+    const registered: { name: string; tool: unknown }[] = [];
+    const { ctx } = makeCtx({ tables: ["Account"], registered });
+    await plugin.initialize!(ctx);
+    const sfTool = registered[0].tool as {
+      execute: (args: unknown, opts: unknown) => Promise<unknown>;
+    };
+    const result = await sfTool.execute(
+      { soql: "SELECT Id FROM Contact", explanation: "x" },
+      { toolCallId: "test", messages: [], abortSignal: undefined as unknown as AbortSignal },
+    );
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("not in the allowed list");
+  });
+
   test("logs warning when whitelist loading fails", async () => {
     const plugin = salesforcePlugin({ url: VALID_URL });
     const warned: string[] = [];
     const registered: { name: string; tool: unknown }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => { throw new Error("registry not ready"); } },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => { throw new Error("semantic layer not ready"); } },
       tools: { register: (t: { name: string; description: string; tool: unknown }) => { registered.push(t); } },
       logger: {
         info: () => {},
@@ -1045,7 +1068,7 @@ describe("initialize", () => {
     await plugin.initialize!(ctx);
 
     // The warning happens lazily when getWhitelist is called, so trigger it
-    const sfTool = registered[0].tool as { execute?: Function };
+    const sfTool = registered[0].tool as { execute?: (args: unknown, opts: unknown) => Promise<unknown> };
     if (sfTool.execute) {
       await sfTool.execute(
         { soql: "SELECT Id FROM Account", explanation: "test" },

--- a/plugins/salesforce/__tests__/salesforce.test.ts
+++ b/plugins/salesforce/__tests__/salesforce.test.ts
@@ -1049,33 +1049,29 @@ describe("initialize", () => {
     expect((result as { error: string }).error).toContain("not in the allowed list");
   });
 
-  test("logs warning when whitelist loading fails", async () => {
+  test("fails CLOSED when the whitelist can't be loaded (does not silently allow)", async () => {
+    // If `tables()` throws (whitelist unloadable), the query must be REFUSED —
+    // not swallowed into an empty set, which validateSOQL treats as
+    // structural-only (a silent widening of access). #3307.
     const plugin = salesforcePlugin({ url: VALID_URL });
-    const warned: string[] = [];
     const registered: { name: string; tool: unknown }[] = [];
     const ctx = {
       db: null,
       connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => { throw new Error("semantic layer not ready"); } },
       tools: { register: (t: { name: string; description: string; tool: unknown }) => { registered.push(t); } },
-      logger: {
-        info: () => {},
-        warn: (...args: unknown[]) => { warned.push(JSON.stringify(args)); },
-        error: () => {},
-        debug: () => {},
-      },
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
       config: {},
     };
     await plugin.initialize!(ctx);
 
-    // The warning happens lazily when getWhitelist is called, so trigger it
-    const sfTool = registered[0].tool as { execute?: (args: unknown, opts: unknown) => Promise<unknown> };
-    if (sfTool.execute) {
-      await sfTool.execute(
+    const sfTool = registered[0].tool as { execute: (args: unknown, opts: unknown) => Promise<unknown> };
+    // getWhitelist throws → execute rejects → the SELECT never runs (fail-closed).
+    await expect(
+      sfTool.execute(
         { soql: "SELECT Id FROM Account", explanation: "test" },
-        { toolCallId: "test", messages: [], abortSignal: undefined },
-      );
-    }
-    expect(warned.some((w) => w.includes("whitelist"))).toBe(true);
+        { toolCallId: "test", messages: [], abortSignal: undefined as unknown as AbortSignal },
+      ),
+    ).rejects.toThrow(/semantic layer not ready/);
   });
 });
 

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -104,6 +104,12 @@ export function buildSalesforcePlugin(
   let cachedConn: SalesforceConnection | undefined;
   let log: PluginLogger | undefined;
 
+  // The static connection registers in the ConnectionRegistry under this plugin
+  // id (wiring.ts `registerDirect(plugin.id, …)`), which is also the
+  // connectionId the semantic-layer whitelist (`getWhitelistedTables`) keys on.
+  // The querySalesforce tool's object whitelist must use the same id.
+  const DATASOURCE_ID = "salesforce-datasource";
+
   // When a static url is configured the plugin wires a config-defined
   // connection at boot; without one it is registered adapter-only. The url is
   // only parsed where present — never on the adapter-only build path.
@@ -158,7 +164,7 @@ export function buildSalesforcePlugin(
   }
 
   return {
-    id: "salesforce-datasource",
+    id: DATASOURCE_ID,
     types: ["datasource"] as const,
     version: "0.1.0",
     name: "Salesforce DataSource",
@@ -211,10 +217,15 @@ export function buildSalesforcePlugin(
       if (staticUrl) {
         const sfTool = createQuerySalesforceTool({
           getConnection: () => getOrCreateConnection(),
+          // The object MEMBERSHIP whitelist is the semantic layer's object names
+          // for this connection — `ctx.connections.tables(id)`, the same source
+          // the SQL pipeline validates against (#3307). `ctx.connections.list()`
+          // would be wrong: it returns CONNECTION IDs, never object names like
+          // "Account", so validateSOQL would reject every legitimate query. An
+          // empty layer returns `[]` → validateSOQL falls back to structural-only.
           getWhitelist: () => {
             try {
-              const tables = ctx.connections.list();
-              return new Set(tables);
+              return new Set(ctx.connections.tables(DATASOURCE_ID));
             } catch (err) {
               ctx.logger.warn(
                 { err: err instanceof Error ? err.message : String(err) },

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -219,21 +219,18 @@ export function buildSalesforcePlugin(
           getConnection: () => getOrCreateConnection(),
           // The object MEMBERSHIP whitelist is the semantic layer's object names
           // for this connection — `ctx.connections.tables(id)`, the same source
-          // the SQL pipeline validates against (#3307). `ctx.connections.list()`
-          // would be wrong: it returns CONNECTION IDs, never object names like
-          // "Account", so validateSOQL would reject every legitimate query. An
-          // empty layer returns `[]` → validateSOQL falls back to structural-only.
-          getWhitelist: () => {
-            try {
-              return new Set(ctx.connections.tables(DATASOURCE_ID));
-            } catch (err) {
-              ctx.logger.warn(
-                { err: err instanceof Error ? err.message : String(err) },
-                "Failed to load Salesforce object whitelist — queries may be rejected",
-              );
-              return new Set<string>();
-            }
-          },
+          // the SQL pipeline validates against in self-host/static mode (#3307).
+          // `ctx.connections.list()` would be wrong: it returns CONNECTION IDs,
+          // never object names like "Account", so validateSOQL would reject
+          // every legitimate query. An empty layer returns `[]` → validateSOQL
+          // falls back to structural-only.
+          //
+          // Fail CLOSED: we deliberately do NOT catch here. If the whitelist
+          // can't be loaded the error propagates and the query is refused —
+          // swallowing it into an empty set would silently widen access to
+          // structural-only (the "false negative on a security check" anti-pattern).
+          // Symmetric with the ES DSL tool.
+          getWhitelist: () => new Set(ctx.connections.tables(DATASOURCE_ID)),
           connectionId: "salesforce",
           logger: ctx.logger,
         });

--- a/plugins/sidecar/__tests__/sidecar-sandbox.test.ts
+++ b/plugins/sidecar/__tests__/sidecar-sandbox.test.ts
@@ -308,7 +308,7 @@ describe("initialize", () => {
     const logged: { level: string; msg: string }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push({ level: "info", msg: String(args[0]) }); },

--- a/plugins/snowflake/__tests__/plugin.test.ts
+++ b/plugins/snowflake/__tests__/plugin.test.ts
@@ -391,7 +391,7 @@ describe("adapter-only mode", () => {
     const logged: string[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push(String(args[0])); },
@@ -791,7 +791,7 @@ describe("initialize", () => {
     const logged: { level: string; msg: string }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push({ level: "info", msg: String(args[0]) }); },

--- a/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
+++ b/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
@@ -316,7 +316,7 @@ describe("initialize", () => {
     const logged: { level: string; msg: string }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push({ level: "info", msg: String(args[0]) }); },
@@ -339,7 +339,7 @@ describe("initialize", () => {
     const logged: { level: string; msg: string }[] = [];
     const ctx = {
       db: null,
-      connections: { get: () => { throw new Error("not implemented"); }, list: () => [] },
+      connections: { get: () => { throw new Error("not implemented"); }, list: () => [], tables: () => [] },
       tools: { register: () => {} },
       logger: {
         info: (...args: unknown[]) => { logged.push({ level: "info", msg: String(args[0]) }); },


### PR DESCRIPTION
Closes #3307.

## Problem
The plugin-registered query tools enforced an *ineffective* object/index membership whitelist in **static-datasource (self-host) mode**:

- **`queryElasticsearch`** (ES Query DSL, #3267) passed an **empty set** → `validateIndexAccess` ran in structural-only mode, so **any explicitly-named, non-system index was queryable** — including indices with no entity YAML.
- **`querySalesforce`** (SOQL) passed **`ctx.connections.list()`** → registered **connection IDs** (e.g. `salesforce-datasource`), never object names like `Account`, so `validateSOQL` either over-rejected every real query or fell back to structural-only.

Net: the semantic layer is the access boundary the **SQL path (`executeSQL`) enforces**, but the bespoke DSL/SOQL surfaces onto the *same cluster* did **not** honor it. This is read-only and bounded (always-on structural rails block wildcards / `_all` / system indices; endpoints are default-deny read-only), so it's a **confidentiality / defense-in-depth gap**, not a write/escalation hole — but it contradicts the documented invariant that only `semantic/entities/*.yml` tables are queryable.

## Fix
Add a `connections.tables(id)` accessor to the plugin context returning the semantic-layer entity names for a connection — the **same source `executeSQL` validates against** (`getWhitelistedTables`). Both tools whitelist against it, so the DSL/SOQL surfaces enforce the **identical per-object boundary** as the SQL path.

| Layer | Change |
|---|---|
| `@useatlas/plugin-sdk` `AtlasPluginContext` + internal `PluginContextLike` | new **required** `connections.tables(id): string[]` |
| `api/server.ts` | wires `tables: (id) => Array.from(getWhitelistedTables(id))` |
| `plugins/elasticsearch`, `plugins/salesforce` | `getWhitelist` reads `ctx.connections.tables(<plugin id>)` — the id the static connection registers under (`registerDirect(plugin.id, …)`), matching the SQL whitelist key |
| `api/plugins/mcp-boot.ts` | stays empty — tool registration is a **no-op** on that standalone path, so the bespoke tools are never served there; the real whitelist-backed context is the Hono boot's (comment added) |

Empty semantic layer → `tables()` returns `[]` → validators fall back to their always-on structural rails (unchanged).

## Tests
- **ES** (`dsl-tool.test.ts`): proves `tables()` (not `list()`) drives the whitelist — a non-member index is rejected, the **connection id itself** (what `list()` returned pre-fix) is rejected, and a semantic-layer index passes the gate.
- **SF** (`salesforce.test.ts`): a non-member object (`Contact` when `tables()=[Account]`) is rejected via the plugin's `initialize` wiring; fixed the pre-existing "whitelist load fails" test to inject failure on `tables()` (was `list()`).
- Mechanical: `tables: () => []` added to plugin-context mocks across plugin/api tests for the new required field; `createMockContext` helper updated.

## Notes
- Broad test touch is from the new **required** context field (deliberate — the type now guarantees every context supplies a real whitelist source).
- The 16 pre-existing `@typescript-eslint/no-unsafe-function-type` lint findings in `plugins/snowflake/__tests__` are unrelated and predate this branch (CI lint scope is `packages/ ee/`; `plugins/` test files aren't gated). Not touched.
- ✅ `bun run type` clean · ✅ `packages/` lint clean · ✅ affected ES/SF/api plugin tests green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783440326&installation_id=135337507&pr_number=3312&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3312&signature=5cb64f33f3047f74f5bd7a23f79ed3a503bf3fdae4484b540ea37335d7f71aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query tools now enforce per-index/object membership against the semantic-layer whitelist; when no semantic layer exists the structural validation remains.
  * Whitelist lookups now fail closed (errors surface instead of falling back to an empty whitelist).

* **Documentation**
  * Updated Elasticsearch query docs to describe per-index membership enforcement and resource bounding behavior.

* **Tests**
  * Expanded tests and mocks to cover semantic-layer whitelist validation across multiple plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->