### PR TITLE
fix(plugins): fail closed on semantic-layer scan failure for plugin query tools (#3313)

### DIFF
--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -21,7 +21,7 @@ import { app } from "./index";
 import { createLogger } from "@atlas/api/lib/logger";
 import { initializeConfig } from "@atlas/api/lib/config";
 import { connections } from "@atlas/api/lib/db/connection";
-import { getWhitelistedTables } from "@atlas/api/lib/semantic";
+import { getWhitelistedTablesStrict } from "@atlas/api/lib/semantic";
 import { closeInternalDB } from "@atlas/api/lib/db/internal";
 import {
   plugins,
@@ -128,9 +128,16 @@ if (config.plugins?.length) {
       // Semantic-layer object names for a connection — the per-object
       // membership whitelist for plugin query tools (SOQL / ES Query DSL).
       // Self-host / static datasource mode: filesystem-backed, the same source
-      // `executeSQL` validates against (`getWhitelistedTables`), so a plugin's
-      // bespoke tool honors the identical boundary as the SQL path (#3307).
-      tables: (id: string) => Array.from(getWhitelistedTables(id)),
+      // `executeSQL` validates against, so a plugin's bespoke tool honors the
+      // identical boundary as the SQL path (#3307).
+      //
+      // Uses the STRICT accessor: it THROWS `SemanticLayerScanError` when the
+      // whitelist is empty because a semantic-layer directory scan FAILED
+      // (#3243), so a plugin tool fails CLOSED instead of dropping to
+      // structural-only (which would silently widen access on a scan failure).
+      // A legitimately-unconfigured layer still returns `[]` → structural-only
+      // (#3313). The bespoke tools catch the throw and return a clean refusal.
+      tables: (id: string) => Array.from(getWhitelistedTablesStrict(id)),
     },
     tools: {
       register: (tool) =>

--- a/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/group-scoped-loader.test.ts
@@ -40,7 +40,7 @@ mock.module("@atlas/api/lib/logger", () => ({
   ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
 }));
 
-const { getWhitelistedTables, getCrossSourceJoins, _resetWhitelists } = await import("../whitelist");
+const { getWhitelistedTables, getWhitelistedTablesStrict, SemanticLayerScanError, getCrossSourceJoins, _resetWhitelists } = await import("../whitelist");
 const { getEntityDirs, getGroupDirs, resolveEntityGroup } = await import("../scanner");
 
 const tmpBase = resolve(__dirname, ".tmp-group-scoped-loader-test");
@@ -494,6 +494,63 @@ describe("fail-closed on directory scan failure (#3243)", () => {
     expect(noEntitiesMsg).toBe(true);
     const scanFailedErr = logCalls.some((c) => c.level === "error" && /scan failed/i.test(c.message));
     expect(scanFailedErr).toBe(false);
+  });
+
+  // The bespoke plugin query tools (ES Query DSL / SOQL) treat an EMPTY set as
+  // structural-only, so they must distinguish "empty because scan failed" (fail
+  // closed) from "empty because no layer" (structural-only). `getWhitelistedTablesStrict`
+  // is that signal: it throws on the former and returns `[]` on the latter (#3313).
+  describe("getWhitelistedTablesStrict — fail closed on scan failure (#3313)", () => {
+    it("THROWS SemanticLayerScanError when an empty whitelist is caused by a failed scan", () => {
+      const root = ensureDir(`strict-scanfail-${testCounter}`);
+      const entities = ensureDir(`strict-scanfail-${testCounter}/entities`);
+      ensureDir(`strict-scanfail-${testCounter}/groups`);
+      writeEntity(entities, "orders.yml", entity("orders"));
+      const spy = throwReaddirOn(join(root, "groups"));
+      try {
+        // The group whose scan failed resolves to an empty set — strict refuses.
+        expect(() => getWhitelistedTablesStrict("warehouse", undefined, root)).toThrow(
+          SemanticLayerScanError,
+        );
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("returns [] (does NOT throw) for a legitimately unconfigured layer — structural-only preserved", () => {
+      const root = ensureDir(`strict-nolayer-${testCounter}`);
+      const entities = ensureDir(`strict-nolayer-${testCounter}/entities`);
+      ensureDir(`strict-nolayer-${testCounter}/groups/warehouse/entities`); // empty, real dir
+      writeEntity(entities, "orders.yml", entity("orders"));
+      // `crm` has no directory → empty set, but NO scan failed → must not throw.
+      const crm = getWhitelistedTablesStrict("crm", undefined, root);
+      expect(crm.size).toBe(0);
+    });
+
+    it("returns the resolved tables (does NOT throw) when the connection has a whitelist", () => {
+      const root = ensureDir(`strict-haslayer-${testCounter}`);
+      const entities = ensureDir(`strict-haslayer-${testCounter}/entities`);
+      writeEntity(entities, "orders.yml", entity("orders"));
+      const tables = getWhitelistedTablesStrict("default", undefined, root);
+      expect(tables.has("orders")).toBe(true);
+    });
+
+    it("does NOT throw when a scan failed but the connection still resolves a non-empty whitelist", () => {
+      // A non-empty set still enforces membership (unlisted names rejected), so an
+      // incomplete scan can only over-restrict it — never widen — and need not refuse.
+      const root = ensureDir(`strict-scanfail-nonempty-${testCounter}`);
+      const entities = ensureDir(`strict-scanfail-nonempty-${testCounter}/entities`);
+      ensureDir(`strict-scanfail-nonempty-${testCounter}/groups`);
+      writeEntity(entities, "orders.yml", entity("orders"));
+      const spy = throwReaddirOn(join(root, "groups"));
+      try {
+        // `default` is unaffected by the groups/ scan failure → non-empty → no throw.
+        const def = getWhitelistedTablesStrict("default", undefined, root);
+        expect(def.has("orders")).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 });
 

--- a/packages/api/src/lib/semantic/index.ts
+++ b/packages/api/src/lib/semantic/index.ts
@@ -15,6 +15,8 @@
 
 export {
   getWhitelistedTables,
+  getWhitelistedTablesStrict,
+  SemanticLayerScanError,
   getCrossSourceJoins,
   registerPluginEntities,
   _resetWhitelists,

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -338,6 +338,66 @@ function resolveGroupTables(
 }
 
 /**
+ * Thrown by {@link getWhitelistedTablesStrict} when a connection's whitelist is
+ * empty because a semantic-layer directory scan FAILED (#3243) — as opposed to a
+ * legitimately unconfigured semantic layer. Lets the bespoke plugin query tools
+ * (ES Query DSL / SOQL) distinguish the two and FAIL CLOSED on a scan failure
+ * rather than dropping to their structural-only fallback (#3313).
+ */
+export class SemanticLayerScanError extends Error {
+  readonly connectionId: string;
+  constructor(connectionId: string) {
+    super(
+      `Semantic-layer scan failed for connection "${connectionId}" — whitelist load incomplete; refusing query (fail-closed).`,
+    );
+    this.name = "SemanticLayerScanError";
+    this.connectionId = connectionId;
+  }
+}
+
+/**
+ * Resolve a connection's whitelist together with the **degraded** signal that
+ * distinguishes the two empty-set situations the bespoke plugin query tools
+ * must treat differently (#3313):
+ *
+ *  - `degraded: true`  — the resolved set is empty *because* a semantic-layer
+ *    directory scan FAILED (#3243). The load is incomplete, so a plugin query
+ *    tool must FAIL CLOSED (refuse) rather than drop to structural-only, which
+ *    would silently widen access to any explicitly-named index/object.
+ *  - `degraded: false` — either the connection has tables, or it is
+ *    legitimately empty (no scan failure → no semantic layer configured). The
+ *    empty case is the intended structural-only fallback.
+ *
+ * The flag mirrors the SQL path exactly: a scan failure only flips it when the
+ * connection's own set is empty. A non-empty set still enforces membership (any
+ * unlisted name is rejected), so an incomplete scan can only over-restrict such
+ * a connection — never widen it — and so need not refuse.
+ */
+function computeWhitelist(
+  connectionId: string,
+  entitiesDir?: string,
+  semanticRoot?: string,
+): { tables: Set<string>; degraded: boolean } {
+  // Custom paths (tests) load fresh; otherwise resolve from the cached load.
+  // Failing closed on a scan failure is enforced inside `resolveGroupTables`:
+  // a swallowed FS error must never drop the partition decision to shared-default
+  // mode (back-compat single-DB sharing applies only when every scan succeeded).
+  const { byConnection, failedScans } =
+    entitiesDir || semanticRoot
+      ? loadTablesByConnection(semanticRoot, entitiesDir)
+      : getTablesByConnection();
+  const tables = resolveGroupTables(byConnection, connectionId, failedScans);
+
+  // Merge plugin-provided entities for this connection.
+  const pluginTables = _pluginEntities.get(connectionId);
+  if (pluginTables && pluginTables.size > 0) {
+    for (const t of pluginTables) tables.add(t);
+  }
+
+  return { tables, degraded: failedScans.length > 0 && tables.size === 0 };
+}
+
+/**
  * Get the set of whitelisted table names for a given Connection group.
  *
  * The system switches to partitioned mode (each group only sees its own
@@ -348,6 +408,12 @@ function resolveGroupTables(
  *
  * When neither trigger is present, all connections share the same table
  * set (identical to pre-v0.7 single-DB behavior).
+ *
+ * Returns an empty set both when the layer is unconfigured AND when a directory
+ * scan failed (#3243): the SQL `executeSQL` path treats an empty set as
+ * deny-all, so either way it fails closed. Bespoke plugin query tools, which
+ * treat an empty set as structural-only, must instead read through
+ * {@link getWhitelistedTablesStrict} to tell the two apart (#3313).
  *
  * @param connectionId - Group to get tables for. Defaults to "default".
  * @param entitiesDir - Override for a single flat entities directory (DI for tests).
@@ -362,32 +428,45 @@ export function getWhitelistedTables(
 ): Set<string> {
   // When using custom paths (tests), bypass the global cache
   if (entitiesDir || semanticRoot) {
-    const { byConnection, failedScans } = loadTablesByConnection(semanticRoot, entitiesDir);
-    const tables = resolveGroupTables(byConnection, connectionId, failedScans);
-    // Merge plugin-provided entities even in custom-path mode
-    const pluginTables = _pluginEntities.get(connectionId);
-    if (pluginTables && pluginTables.size > 0) {
-      for (const t of pluginTables) tables.add(t);
-    }
-    return tables;
+    return computeWhitelist(connectionId, entitiesDir, semanticRoot).tables;
   }
 
   const cached = _whitelists.get(connectionId);
   if (cached) return cached;
 
-  // Resolve from the cached load, failing closed when a directory scan failed:
-  // a swallowed FS error must never drop the partition decision to shared-default
-  // mode (back-compat single-DB sharing applies only when every scan succeeded).
-  const { byConnection, failedScans } = getTablesByConnection();
-  const tables = resolveGroupTables(byConnection, connectionId, failedScans);
-
-  // Merge plugin-provided entities for this connection
-  const pluginTables = _pluginEntities.get(connectionId);
-  if (pluginTables && pluginTables.size > 0) {
-    for (const t of pluginTables) tables.add(t);
-  }
-
+  const { tables } = computeWhitelist(connectionId);
   _whitelists.set(connectionId, tables);
+  return tables;
+}
+
+/**
+ * Like {@link getWhitelistedTables}, but THROWS {@link SemanticLayerScanError}
+ * when the whitelist is empty because a semantic-layer directory scan FAILED
+ * (#3243), instead of returning the empty set.
+ *
+ * This is the accessor the bespoke plugin query tools (ES Query DSL / SOQL) read
+ * through (`AtlasPluginContext.connections.tables`). For the SQL `executeSQL`
+ * path an empty set already means deny-all, so a scan failure is fail-closed
+ * there. But those plugin tools treat an empty set as *structural-only* (allow
+ * any explicitly-named, non-system index/object) — so without this signal a
+ * scan failure would silently WIDEN their access. Throwing lets a tool refuse
+ * (fail-closed) on a scan failure while still receiving an empty set — and so
+ * structural-only — for a legitimately unconfigured layer. Mirrors the
+ * fail-closed intent of #3243 onto the plugin-tool surface (#3313).
+ *
+ * Unlike {@link getWhitelistedTables} it does not consult the `_whitelists`
+ * cache (it needs the live scan-failure signal), but it reuses the cached
+ * directory load via `getTablesByConnection`, so it triggers no disk re-scan.
+ */
+export function getWhitelistedTablesStrict(
+  connectionId: string = "default",
+  entitiesDir?: string,
+  semanticRoot?: string,
+): Set<string> {
+  const { tables, degraded } = computeWhitelist(connectionId, entitiesDir, semanticRoot);
+  if (degraded) {
+    throw new SemanticLayerScanError(connectionId);
+  }
   return tables;
 }
 

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -130,16 +130,23 @@ export interface AtlasPluginContext {
      * Semantic-layer entity/table (for ES: index) names registered for a
      * connection — the per-object membership whitelist a plugin query tool must
      * enforce. In self-host / static-datasource mode this mirrors the
-     * filesystem whitelist `executeSQL` validates against
-     * (`getWhitelistedTables(connectionId)`), so a plugin's bespoke query tool
-     * (SOQL / Query DSL) honors the same boundary as the SQL path. (Org-scoped
-     * SaaS validates `executeSQL` against the DB-backed `getOrgWhitelistedTables`;
+     * filesystem whitelist `executeSQL` validates against, so a plugin's bespoke
+     * query tool (SOQL / Query DSL) honors the same boundary as the SQL path.
+     * (Org-scoped SaaS validates `executeSQL` against the DB-backed whitelist;
      * the static-config tools this serves are a self-host surface.)
      *
      * `id` must be a registered connection id (typically the plugin's own `id`);
      * an unrecognized id returns `[]`. Returns `[]` when the connection has no
-     * semantic layer — a tool fed an empty set falls back to structural-only
-     * validation, so a typo'd id silently downgrades enforcement. See #3307.
+     * semantic layer configured — a tool fed an empty set falls back to
+     * structural-only validation (the intended behavior for an unconfigured
+     * layer). See #3307.
+     *
+     * THROWS when the whitelist is empty because a semantic-layer directory scan
+     * FAILED (#3243), rather than returning `[]`. This lets a bespoke query tool
+     * FAIL CLOSED (refuse the query) on a scan failure instead of silently
+     * dropping to structural-only — which would widen access to any
+     * explicitly-named, non-system object the credential can read. A tool should
+     * call this inside a try/catch and surface a clean refusal on throw (#3313).
      */
     tables(id: string): readonly string[];
   };

--- a/plugins/elasticsearch/__tests__/dsl-tool.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl-tool.test.ts
@@ -570,3 +570,50 @@ describe("plugin wiring — index whitelist comes from ctx.connections.tables (#
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// #3313 — fail CLOSED when the whitelist accessor throws (semantic-layer scan
+// failure), but keep structural-only for a legitimately-empty layer.
+// ---------------------------------------------------------------------------
+
+describe("queryElasticsearch — fail closed on semantic-layer scan failure (#3313)", () => {
+  function makeTool(opts: { getWhitelist: () => Set<string>; fetchImpl?: unknown }) {
+    const conn = createElasticsearchConnection(
+      { url: VALID_URL, apiKey: API_KEY },
+      { fetchImpl: (opts.fetchImpl ?? mock(async () => fetchResponse(HITS_RESPONSE))) as unknown as typeof fetch },
+    );
+    return createQueryElasticsearchTool({ getConnection: () => conn, getWhitelist: opts.getWhitelist });
+  }
+
+  test("refuses the query when getWhitelist throws — does NOT drop to structural-only, no request issued", async () => {
+    const fetchImpl = mock(async () => fetchResponse(HITS_RESPONSE));
+    const esTool = makeTool({
+      fetchImpl,
+      // Mirrors `new Set(ctx.connections.tables(id))` throwing because the
+      // strict accessor saw a scan failure.
+      getWhitelist: () => {
+        throw new Error("Semantic-layer scan failed — whitelist load incomplete");
+      },
+    });
+    const result = await esTool.execute!(
+      // `products` would PASS structural-only (named, non-system) — proving the
+      // refusal is the scan-failure fail-closed, not an ordinary membership reject.
+      { index: "products", endpoint: "_search", body: {}, explanation: "x" },
+      EXEC_OPTS,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toMatch(/unavailable|refus/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("structural-only still applies for a legitimately-empty whitelist (named index reaches the cluster)", async () => {
+    const fetchImpl = mock(async () => fetchResponse(HITS_RESPONSE));
+    const esTool = makeTool({ fetchImpl, getWhitelist: () => new Set() });
+    const result = await esTool.execute!(
+      { index: "products", endpoint: "_search", body: {}, explanation: "x" },
+      EXEC_OPTS,
+    );
+    expect(result).toMatchObject({ success: true });
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+});

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -425,14 +425,17 @@ export function buildElasticsearchPlugin(
           // The index MEMBERSHIP whitelist is the semantic layer's index names
           // for this connection — `ctx.connections.tables(id)`, the same
           // filesystem whitelist `executeSQL` validates against in self-host /
-          // static mode (`getWhitelistedTables`). So the DSL tool and the SQL
-          // surface enforce the identical per-index boundary (#3307). (This tool
-          // is static-only; SaaS per-workspace ES is queried over the SQL path.)
-          // NOTE: `ctx.connections.list()` would be wrong here — it
-          // returns CONNECTION IDs, not index names, so it can never match a
-          // real index like "flights". When the semantic layer is empty the
-          // accessor returns `[]` and `validateIndexAccess` falls back to its
-          // always-on structural rails (no wildcards / _all / system indices).
+          // static mode. So the DSL tool and the SQL surface enforce the
+          // identical per-index boundary (#3307). (This tool is static-only;
+          // SaaS per-workspace ES is queried over the SQL path.)
+          //
+          // `ctx.connections.list()` would be wrong here — it returns CONNECTION
+          // IDs, not index names, so it can never match a real index like
+          // "flights". A legitimately-empty semantic layer returns `[]` and
+          // `validateIndexAccess` falls back to its always-on structural rails
+          // (no wildcards / _all / system indices). A semantic-layer scan
+          // FAILURE instead THROWS (#3243) — the tool catches it and fails
+          // CLOSED rather than widening to structural-only (#3313).
           getWhitelist: () => new Set(ctx.connections.tables(DATASOURCE_ID)),
           logger: ctx.logger,
         });
@@ -442,6 +445,24 @@ export function buildElasticsearchPlugin(
           description: "Execute a read-only Elasticsearch Query DSL request (full-text / aggregations)",
           tool: esTool,
         });
+
+        // One-time operator warning (#3313): a query tool registered against an
+        // empty whitelist runs in STRUCTURAL-ONLY mode — any explicitly-named,
+        // non-system index the credential can read is queryable. Name the
+        // consequence so operators know to add entity YAMLs. A scan FAILURE is a
+        // different situation: `tables()` throws, and the tool fails closed at
+        // query time (logged there), so the catch below only flags that case.
+        try {
+          if (ctx.connections.tables(DATASOURCE_ID).length === 0) {
+            ctx.logger.warn(
+              "queryElasticsearch registered with an empty semantic-layer whitelist — running in STRUCTURAL-ONLY mode: any explicitly-named, non-system index the credential can read is queryable. Add entity YAMLs to enforce a per-index allow-list.",
+            );
+          }
+        } catch (err) {
+          ctx.logger.warn(
+            `queryElasticsearch: semantic-layer scan failed at registration — DSL queries will fail closed until it recovers (${err instanceof Error ? err.message : String(err)}).`,
+          );
+        }
       }
     },
 

--- a/plugins/elasticsearch/src/tool.ts
+++ b/plugins/elasticsearch/src/tool.ts
@@ -119,7 +119,26 @@ Rules:
       const op: ElasticsearchDslEndpoint = endpoint ?? "_search";
 
       // 1. Index whitelist (semantic layer) + always-on structural rails.
-      const indexCheck = validateIndexAccess(index, opts.getWhitelist());
+      // `getWhitelist` THROWS when the semantic-layer scan FAILED (#3243): the
+      // whitelist load is incomplete, so we FAIL CLOSED (refuse) rather than
+      // fall through to validateIndexAccess's structural-only mode, which would
+      // widen access to any explicitly-named index. A legitimately-empty layer
+      // does NOT throw — it returns `[]` and structural-only still applies (#3313).
+      let allowed: Set<string>;
+      try {
+        allowed = opts.getWhitelist();
+      } catch (err) {
+        opts.logger?.error(
+          { index, error: err instanceof Error ? err.message : String(err) },
+          "ES DSL refused — semantic layer unavailable (scan failed)",
+        );
+        return {
+          success: false,
+          error:
+            "The semantic layer is temporarily unavailable (its scan failed), so index access cannot be verified. Refusing the query to avoid unsafe access — retry once it recovers.",
+        };
+      }
+      const indexCheck = validateIndexAccess(index, allowed);
       if (!indexCheck.valid) {
         opts.logger?.debug({ index, error: indexCheck.reason }, "ES DSL index access rejected");
         return { success: false, error: indexCheck.reason };

--- a/plugins/salesforce/__tests__/salesforce.test.ts
+++ b/plugins/salesforce/__tests__/salesforce.test.ts
@@ -1050,9 +1050,10 @@ describe("initialize", () => {
   });
 
   test("fails CLOSED when the whitelist can't be loaded (does not silently allow)", async () => {
-    // If `tables()` throws (whitelist unloadable), the query must be REFUSED —
-    // not swallowed into an empty set, which validateSOQL treats as
-    // structural-only (a silent widening of access). #3307.
+    // If `tables()` throws (semantic-layer scan failed, #3243), the query must be
+    // REFUSED — not swallowed into an empty set, which validateSOQL treats as
+    // structural-only (a silent widening of access). The tool catches the throw
+    // and returns a clean refusal rather than letting it propagate (#3307/#3313).
     const plugin = salesforcePlugin({ url: VALID_URL });
     const registered: { name: string; tool: unknown }[] = [];
     const ctx = {
@@ -1065,13 +1066,15 @@ describe("initialize", () => {
     await plugin.initialize!(ctx);
 
     const sfTool = registered[0].tool as { execute: (args: unknown, opts: unknown) => Promise<unknown> };
-    // getWhitelist throws → execute rejects → the SELECT never runs (fail-closed).
-    await expect(
-      sfTool.execute(
-        { soql: "SELECT Id FROM Account", explanation: "test" },
-        { toolCallId: "test", messages: [], abortSignal: undefined as unknown as AbortSignal },
-      ),
-    ).rejects.toThrow(/semantic layer not ready/);
+    // getWhitelist throws → the tool refuses (success:false) and the SELECT never
+    // runs — `Account` would PASS structural-only, so a `success:true` here would
+    // be the fail-open bug this guards against.
+    const result = await sfTool.execute(
+      { soql: "SELECT Id FROM Account", explanation: "test" },
+      { toolCallId: "test", messages: [], abortSignal: undefined as unknown as AbortSignal },
+    );
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toMatch(/unavailable|refus/i);
   });
 });
 

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -222,14 +222,14 @@ export function buildSalesforcePlugin(
           // the SQL pipeline validates against in self-host/static mode (#3307).
           // `ctx.connections.list()` would be wrong: it returns CONNECTION IDs,
           // never object names like "Account", so validateSOQL would reject
-          // every legitimate query. An empty layer returns `[]` → validateSOQL
-          // falls back to structural-only.
+          // every legitimate query. A legitimately-empty layer returns `[]` →
+          // validateSOQL falls back to structural-only.
           //
-          // Fail CLOSED: we deliberately do NOT catch here. If the whitelist
-          // can't be loaded the error propagates and the query is refused —
-          // swallowing it into an empty set would silently widen access to
-          // structural-only (the "false negative on a security check" anti-pattern).
-          // Symmetric with the ES DSL tool.
+          // Fail CLOSED on a scan FAILURE: `tables()` THROWS (#3243) when the
+          // whitelist load is incomplete; the tool catches that and refuses the
+          // query rather than swallowing it into an empty set, which would
+          // silently widen access to structural-only (the "false negative on a
+          // security check" anti-pattern). Symmetric with the ES DSL tool (#3313).
           getWhitelist: () => new Set(ctx.connections.tables(DATASOURCE_ID)),
           connectionId: "salesforce",
           logger: ctx.logger,
@@ -240,6 +240,24 @@ export function buildSalesforcePlugin(
           description: "Execute a read-only SOQL query against Salesforce",
           tool: sfTool,
         });
+
+        // One-time operator warning (#3313): a query tool registered against an
+        // empty whitelist runs in STRUCTURAL-ONLY mode — any explicitly-named
+        // object the credential can read is queryable. Name the consequence so
+        // operators know to add entity YAMLs. A scan FAILURE is a different
+        // situation: `tables()` throws and the tool fails closed at query time
+        // (logged there), so the catch below only flags that case.
+        try {
+          if (ctx.connections.tables(DATASOURCE_ID).length === 0) {
+            ctx.logger.warn(
+              "querySalesforce registered with an empty semantic-layer whitelist — running in STRUCTURAL-ONLY mode: any explicitly-named object the credential can read is queryable. Add entity YAMLs to enforce a per-object allow-list.",
+            );
+          }
+        } catch (err) {
+          ctx.logger.warn(
+            `querySalesforce: semantic-layer scan failed at registration — SOQL queries will fail closed until it recovers (${err instanceof Error ? err.message : String(err)}).`,
+          );
+        }
       }
     },
 

--- a/plugins/salesforce/src/tool.ts
+++ b/plugins/salesforce/src/tool.ts
@@ -48,7 +48,26 @@ Rules:
 
     execute: async ({ soql, explanation }) => {
       const conn = opts.getConnection();
-      const allowed = opts.getWhitelist();
+
+      // `getWhitelist` THROWS when the semantic-layer scan FAILED (#3243): the
+      // object whitelist load is incomplete, so we FAIL CLOSED (refuse) rather
+      // than fall through to validateSOQL's structural-only mode, which would
+      // widen access to any explicitly-named object. A legitimately-empty layer
+      // does NOT throw — it returns `[]` and structural-only still applies (#3313).
+      let allowed: Set<string>;
+      try {
+        allowed = opts.getWhitelist();
+      } catch (err) {
+        opts.logger?.error(
+          { error: err instanceof Error ? err.message : String(err) },
+          "SOQL refused — semantic layer unavailable (scan failed)",
+        );
+        return {
+          success: false,
+          error:
+            "The semantic layer is temporarily unavailable (its scan failed), so object access cannot be verified. Refusing the query to avoid unsafe access — retry once it recovers.",
+        };
+      }
 
       // Validate SOQL
       const validation = validateSOQL(soql, allowed);


### PR DESCRIPTION
Closes #3313.

## Problem
A semantic-layer directory-scan failure (#3243) resolves a connection's whitelist to an **empty set**. The SQL `executeSQL` path treats empty as deny-all, so it already fails closed. But the bespoke plugin query tools — `queryElasticsearch` → `validateIndexAccess` and `querySalesforce` → `validateSOQL` — treat an empty set as *structural-only* (allow any explicitly-named, non-system index/object). So the **same empty-set signal was deny-all for SQL but allow-any-named for the plugin tools**: a scan failure silently *widened* access on the DSL/SOQL surface instead of locking it down.

## Fix
Distinguish the two empties by surfacing the scan-failure signal, mirroring #3243's fail-closed intent onto the plugin-tool surface.

- **`packages/api/src/lib/semantic/whitelist.ts`** — add `getWhitelistedTablesStrict` + `SemanticLayerScanError`. It throws when the whitelist is empty *because* a scan failed, and returns `[]` for a legitimately-unconfigured layer (structural-only preserved). The `degraded` flag mirrors the SQL path exactly — it only flips when the connection's own set is empty (a non-empty set still enforces membership, so an incomplete scan can only over-restrict, never widen).
- **`packages/api/src/api/server.ts`** — the plugin context's `connections.tables(id)` now reads through the strict accessor, so it throws on scan failure (no disk re-scan; reuses the cached load).
- **`packages/plugin-sdk/src/types.ts`** — document the throw-on-scan-failure contract on `tables()`.
- **ES + Salesforce tools** — catch the throw and return a clean fail-closed refusal instead of dropping to structural-only.
- **One-time operator warning** when a query tool registers against an empty whitelist, naming the structural-only consequence (optional AC).

## Acceptance criteria
- [x] A scan failure causes the plugin query tools to **refuse** (fail-closed), not drop to structural-only
- [x] A connection with legitimately no semantic layer still falls back to structural-only — the two empties are distinguished
- [x] One-time operator warn when a plugin query tool registers with an empty whitelist
- [x] Tests: scan-failure → refused; no-layer → structural-only allowed; scan-failure with a non-empty set → not refused

## Testing
- Lint OK · `tsgo` type-check clean · `check-ee-imports.sh` passes
- **135** affected `@atlas/api` test files pass
- ES plugin suite (28) + Salesforce suite (127) pass, including the new #3313 tests
- Updated one existing #3307 Salesforce test whose old expectation (uncaught throw) is now a clean refusal — a deliberate improvement

https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr

---
_Generated by [Claude Code](https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783451908&installation_id=135337507&pr_number=3314&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3314&signature=4b297058cc8d5e285c68512cb8bc2729c1bd77822628577913def62e9f143f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced semantic layer whitelist validation enforcement with stricter failure handling
  * Elasticsearch and Salesforce query tools now properly refuse requests when semantic layer is unavailable, preventing degradation to unvalidated access
  * Improved error messaging for semantic layer scan failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->