### PR TITLE
fix(api): don't split dotted ES index-pattern names into bogus whitelist keys (#3317)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic.test.ts
+++ b/packages/api/src/lib/__tests__/semantic.test.ts
@@ -226,6 +226,22 @@ describe("per-connection whitelists", () => {
     expect(tables.has("access-default")).toBe(false);
     expect(tables.size).toBe(1);
   });
+
+  // #3317: an `identifier_style: opaque` marker (which ES entities always carry)
+  // closes the name-undecidable residual — a pure word-dotted ES name that the
+  // name heuristic alone would split is registered as the full name only.
+  it("identifier_style: opaque suppresses the dot-split end-to-end (disk path)", () => {
+    const dir = ensureEntitiesDir(`es-opaque-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "stream.yml"),
+      `table: logs.app\nidentifier_style: opaque\ncolumns:\n  message:\n    type: text\n`,
+    );
+
+    const tables = getWhitelistedTables("default", dir);
+    expect(tables.has("logs.app")).toBe(true);
+    expect(tables.has("app")).toBe(false);
+    expect(tables.size).toBe(1);
+  });
 });
 
 describe("tableWhitelistKeys", () => {
@@ -276,11 +292,22 @@ describe("tableWhitelistKeys", () => {
     expect(tableWhitelistKeys("metrics.2024.01")).toEqual(["metrics.2024.01"]);
   });
 
-  // Documented residual: a pure word-dotted name (every segment a valid SQL
-  // identifier) is indistinguishable from `schema.table` by name alone, so it
-  // still contributes the unqualified key. Captures current behavior.
-  it("pure word-dotted name → still splits (name-undecidable residual)", () => {
+  // Heuristic fallback (no marker): a pure word-dotted name is name-undecidable
+  // — indistinguishable from `schema.table` — so it still splits. The opaque
+  // marker (below) is what closes this for ES entities.
+  it("pure word-dotted name without marker → still splits (heuristic fallback)", () => {
     expect(tableWhitelistKeys("logs.app").sort()).toEqual(["app", "logs.app"]);
+  });
+
+  // #3317: the `identifier_style: opaque` marker is authoritative — it forces
+  // full-name-only even for a name the heuristic would treat as SQL, closing
+  // the pure word-dotted residual.
+  it("opaque marker → full name only, even for a word-dotted name", () => {
+    expect(tableWhitelistKeys("logs.app", { opaque: true })).toEqual(["logs.app"]);
+  });
+
+  it("opaque marker → suppresses the unqualified key for a SQL-looking name", () => {
+    expect(tableWhitelistKeys("public.orders", { opaque: true })).toEqual(["public.orders"]);
   });
 });
 

--- a/packages/api/src/lib/__tests__/semantic.test.ts
+++ b/packages/api/src/lib/__tests__/semantic.test.ts
@@ -253,6 +253,12 @@ describe("tableWhitelistKeys", () => {
     expect(tableWhitelistKeys("orders")).toEqual(["orders"]);
   });
 
+  // #3317 review: a malformed empty `table:` must register no whitelist key.
+  it("empty table name → no keys (no bogus empty-string entry)", () => {
+    expect(tableWhitelistKeys("")).toEqual([]);
+    expect(tableWhitelistKeys("", { opaque: true })).toEqual([]);
+  });
+
   it("strips identifier quotes and lowercases", () => {
     expect(tableWhitelistKeys(`"User"`)).toEqual(["user"]);
     expect(tableWhitelistKeys('analytics."Events"').sort()).toEqual(["analytics.events", "events"]);

--- a/packages/api/src/lib/__tests__/semantic.test.ts
+++ b/packages/api/src/lib/__tests__/semantic.test.ts
@@ -211,6 +211,21 @@ describe("per-connection whitelists", () => {
     expect(tables.has("0-*")).toBe(false);
     expect(tables.size).toBe(1);
   });
+
+  // #3317: the same over-grant for a non-wildcard dotted ES name (data stream /
+  // dotted dataset) — `logs-nginx.access-default` must not inject `access-default`.
+  it("dotted ES data-stream name → only the full-name key, no bogus fragment", () => {
+    const dir = ensureEntitiesDir(`es-stream-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "stream.yml"),
+      `table: logs-nginx.access-default\ncolumns:\n  message:\n    type: text\n`,
+    );
+
+    const tables = getWhitelistedTables("default", dir);
+    expect(tables.has("logs-nginx.access-default")).toBe(true);
+    expect(tables.has("access-default")).toBe(false);
+    expect(tables.size).toBe(1);
+  });
 });
 
 describe("tableWhitelistKeys", () => {
@@ -227,14 +242,45 @@ describe("tableWhitelistKeys", () => {
     expect(tableWhitelistKeys('analytics."Events"').sort()).toEqual(["analytics.events", "events"]);
   });
 
-  // #3317: wildcard chars are never valid in an unquoted SQL identifier, so a
-  // name carrying `*`/`?` is an ES index pattern — skip the schema-split heuristic.
-  it("dotted ES pattern with `*` → only the full name (no bogus fragment)", () => {
+  it("3-part SQL identifier (db.schema.table) → full + unqualified", () => {
+    expect(tableWhitelistKeys("warehouse.public.orders").sort()).toEqual([
+      "orders",
+      "warehouse.public.orders",
+    ]);
+  });
+
+  // #3317: a `-`/`*`/`?` or digit-leading segment can't appear in a bare SQL
+  // identifier, so a dotted ES name carrying one is NOT schema-qualified — skip
+  // the last-segment split that would inject a bogus fragment.
+  it("dotted ES wildcard pattern → only the full name (no `0-*` fragment)", () => {
     expect(tableWhitelistKeys("filebeat-7.10.0-*")).toEqual(["filebeat-7.10.0-*"]);
   });
 
   it("ES pattern with `?` wildcard → only the full name", () => {
     expect(tableWhitelistKeys("logs-2024.01.0?")).toEqual(["logs-2024.01.0?"]);
+  });
+
+  it("dotted concrete date-suffixed index → only the full name (no `01` fragment)", () => {
+    expect(tableWhitelistKeys("metrics-2024.01.01")).toEqual(["metrics-2024.01.01"]);
+  });
+
+  it("dotted data-stream / alias name with a dash → only the full name", () => {
+    expect(tableWhitelistKeys("logs-nginx.access-default")).toEqual([
+      "logs-nginx.access-default",
+    ]);
+  });
+
+  it("dotted name with a digit-leading segment → only the full name", () => {
+    // `metrics.2024.01` has no dash/wildcard, but `2024`/`01` are digit-leading
+    // so it is not a SQL schema.table — still no bogus `01` fragment.
+    expect(tableWhitelistKeys("metrics.2024.01")).toEqual(["metrics.2024.01"]);
+  });
+
+  // Documented residual: a pure word-dotted name (every segment a valid SQL
+  // identifier) is indistinguishable from `schema.table` by name alone, so it
+  // still contributes the unqualified key. Captures current behavior.
+  it("pure word-dotted name → still splits (name-undecidable residual)", () => {
+    expect(tableWhitelistKeys("logs.app").sort()).toEqual(["app", "logs.app"]);
   });
 });
 

--- a/packages/api/src/lib/__tests__/semantic.test.ts
+++ b/packages/api/src/lib/__tests__/semantic.test.ts
@@ -16,6 +16,7 @@ const getWhitelistedTables = semMod.getWhitelistedTables as typeof import("../se
 const _resetWhitelists = semMod._resetWhitelists as typeof import("../semantic/whitelist")._resetWhitelists;
 const registerPluginEntities = semMod.registerPluginEntities as typeof import("../semantic/whitelist").registerPluginEntities;
 const _resetPluginEntities = semMod._resetPluginEntities as typeof import("../semantic/whitelist")._resetPluginEntities;
+const tableWhitelistKeys = semMod.tableWhitelistKeys as typeof import("../semantic/whitelist").tableWhitelistKeys;
 
 const tmpBase = resolve(__dirname, ".tmp-semantic-test");
 let testCounter = 0;
@@ -190,6 +191,51 @@ describe("per-connection whitelists", () => {
     expect(tables.has("good_table")).toBe(true);
     expect(tables.size).toBe(1); // Only the good table
   });
+
+  // #3317: an ES/OpenSearch index-pattern entity can have a dotted base
+  // (e.g. `filebeat-7.10.0-2024.01.01` collapses to `filebeat-7.10.0-*`). The
+  // SQL `schema.table` last-segment split must NOT fire on it — that injected a
+  // bogus `0-*` whitelist key and widened the allow-list.
+  it("dotted ES index pattern → only the full-name key, no bogus fragment", () => {
+    const dir = ensureEntitiesDir(`es-pattern-${testCounter}`);
+    writeFileSync(
+      resolve(dir, "filebeat.yml"),
+      `table: filebeat-7.10.0-*\ncolumns:\n  message:\n    type: text\n`,
+    );
+
+    const tables = getWhitelistedTables("default", dir);
+    // Full pattern name validates (SQL `FROM "filebeat-7.10.0-*"` and the DSL
+    // `index: "filebeat-7.10.0-*"` both look it up lowercased).
+    expect(tables.has("filebeat-7.10.0-*")).toBe(true);
+    // The dotted-split fragment must be absent.
+    expect(tables.has("0-*")).toBe(false);
+    expect(tables.size).toBe(1);
+  });
+});
+
+describe("tableWhitelistKeys", () => {
+  it("SQL schema.table → full + unqualified last-segment keys", () => {
+    expect(tableWhitelistKeys("public.orders").sort()).toEqual(["orders", "public.orders"]);
+  });
+
+  it("bare table name → single key", () => {
+    expect(tableWhitelistKeys("orders")).toEqual(["orders"]);
+  });
+
+  it("strips identifier quotes and lowercases", () => {
+    expect(tableWhitelistKeys(`"User"`)).toEqual(["user"]);
+    expect(tableWhitelistKeys('analytics."Events"').sort()).toEqual(["analytics.events", "events"]);
+  });
+
+  // #3317: wildcard chars are never valid in an unquoted SQL identifier, so a
+  // name carrying `*`/`?` is an ES index pattern — skip the schema-split heuristic.
+  it("dotted ES pattern with `*` → only the full name (no bogus fragment)", () => {
+    expect(tableWhitelistKeys("filebeat-7.10.0-*")).toEqual(["filebeat-7.10.0-*"]);
+  });
+
+  it("ES pattern with `?` wildcard → only the full name", () => {
+    expect(tableWhitelistKeys("logs-2024.01.0?")).toEqual(["logs-2024.01.0?"]);
+  });
 });
 
 describe("registerPluginEntities", () => {
@@ -227,6 +273,20 @@ describe("registerPluginEntities", () => {
     const tables = getWhitelistedTables("bq-plugin", dir);
     expect(tables.has("analytics.events")).toBe(true);
     expect(tables.has("events")).toBe(true);
+  });
+
+  // #3317: plugin-registered ES index-pattern entities must not get the bogus
+  // dotted-split key either (registerPluginEntities is one of the three paths).
+  it("dotted ES index pattern → only the full-name key (plugin path)", () => {
+    registerPluginEntities("es-plugin", [
+      { name: "filebeat", yaml: "table: filebeat-7.10.0-*\ndimensions:\n  message:\n    type: text\n" },
+    ]);
+
+    const dir = ensureEntitiesDir(`plugin-es-pattern-${testCounter}`);
+    const tables = getWhitelistedTables("es-plugin", dir);
+    expect(tables.has("filebeat-7.10.0-*")).toBe(true);
+    expect(tables.has("0-*")).toBe(false);
+    expect(tables.size).toBe(1);
   });
 
   it("merges with disk-based entities", () => {

--- a/packages/api/src/lib/semantic/shapes.ts
+++ b/packages/api/src/lib/semantic/shapes.ts
@@ -20,6 +20,16 @@ export const EntityShape = z
     table: z.string(),
     group: z.string().optional(),
     connection: z.string().optional(),
+    /**
+     * How `table` is interpreted when deriving whitelist keys (#3317).
+     * - `"sql"` (default when omitted) — a dot-qualified SQL identifier
+     *   (`schema.table`); the loader also registers the unqualified last
+     *   segment so `FROM orders` matches `public.orders`.
+     * - `"opaque"` — a literal datasource identifier (e.g. an Elasticsearch
+     *   index / alias / data-stream name) where `.` is an ordinary character;
+     *   the loader registers the full name only and never dot-splits it.
+     */
+    identifier_style: z.enum(["sql", "opaque"]).optional(),
   })
   .passthrough();
 

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -102,30 +102,45 @@ export function normalizeTableIdentifier(raw: string): string {
 }
 
 /**
+ * A bare (unquoted) SQL identifier segment: a letter or underscore followed by
+ * letters, digits, underscores, or `$` (Postgres/MySQL allow `$`). A dotted SQL
+ * table reference is `schema.table` (or `db.schema.table`) where EVERY segment
+ * matches this. Elasticsearch/OpenSearch index, alias, and data-stream names do
+ * not: they use `-`, `*`, `?`, `+`, `:` and digit-leading date fragments, with
+ * `.` as an ordinary character.
+ */
+const SQL_IDENTIFIER_SEGMENT = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+/**
  * Derive the whitelist key(s) a `table:` value contributes.
  *
- * Returns the lowercased normalized full name, plus — for SQL `schema.table`
- * identifiers — the unqualified last segment, so a `FROM orders` matches an
+ * Returns the lowercased normalized full name, plus — for a SQL `schema.table`
+ * identifier — the unqualified last segment, so a `FROM orders` matches an
  * entity declared as `public.orders`.
  *
- * The last-segment split is **skipped** for Elasticsearch/OpenSearch index
- * patterns (and data-stream/alias names) that carry a `*`/`?` wildcard. A
- * pattern base can legitimately contain `.` as an ordinary character — version
- * strings, date fragments — e.g. `filebeat-7.10.0-*`. Splitting that on `.`
- * yields a meaningless fragment (`0-*`) that widens the allow-list with a bogus
- * key (#3317). Wildcard chars never appear in an unquoted SQL identifier, so
- * their presence is a safe discriminator: when the normalized name contains one,
- * only the full name is registered.
+ * The unqualified last-segment key is derived **only** when the name is a
+ * genuine dotted SQL identifier: at least two segments, each a bare SQL
+ * identifier ({@link SQL_IDENTIFIER_SEGMENT}). Elasticsearch/OpenSearch index
+ * patterns, aliases, and data-stream names carry `.` as an ordinary character
+ * (version strings, date fragments, dotted datasets) — e.g. `filebeat-7.10.0-*`,
+ * `metrics-2024.01.01`, `logs-nginx.access-default`. Splitting those on `.`
+ * injects a meaningless fragment (`0-*`, `01`, `access-default`) that widens the
+ * allow-list with a bogus key (#3317). Because a `-`/`*`/`?` or a digit-leading
+ * segment can never appear in a bare SQL identifier, the segment shape is a safe
+ * discriminator: when any segment fails it, only the full name is registered.
+ *
+ * (A pure word-dotted name whose every segment is a valid SQL identifier — e.g.
+ * an alias literally named `logs.app` — is indistinguishable from `schema.table`
+ * by name alone and still contributes the unqualified key; closing that requires
+ * an engine signal the loader does not carry.)
  */
 export function tableWhitelistKeys(rawTable: string): string[] {
   const normalized = normalizeTableIdentifier(rawTable);
   const full = normalized.toLowerCase();
-  // ES/OpenSearch index pattern: `.` is an ordinary char, not a schema
-  // separator — don't derive a bogus unqualified key from the last segment.
-  if (normalized.includes("*") || normalized.includes("?")) {
+  const parts = normalized.split(".");
+  if (parts.length < 2 || !parts.every((seg) => SQL_IDENTIFIER_SEGMENT.test(seg))) {
     return [full];
   }
-  const parts = normalized.split(".");
   const last = parts[parts.length - 1].toLowerCase();
   return last === full ? [full] : [last, full];
 }

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -118,31 +118,43 @@ const SQL_IDENTIFIER_SEGMENT = /^[A-Za-z_][A-Za-z0-9_$]*$/;
  * identifier — the unqualified last segment, so a `FROM orders` matches an
  * entity declared as `public.orders`.
  *
- * The unqualified last-segment key is derived **only** when the name is a
- * genuine dotted SQL identifier: at least two segments, each a bare SQL
- * identifier ({@link SQL_IDENTIFIER_SEGMENT}). Elasticsearch/OpenSearch index
- * patterns, aliases, and data-stream names carry `.` as an ordinary character
- * (version strings, date fragments, dotted datasets) — e.g. `filebeat-7.10.0-*`,
- * `metrics-2024.01.01`, `logs-nginx.access-default`. Splitting those on `.`
- * injects a meaningless fragment (`0-*`, `01`, `access-default`) that widens the
- * allow-list with a bogus key (#3317). Because a `-`/`*`/`?` or a digit-leading
- * segment can never appear in a bare SQL identifier, the segment shape is a safe
- * discriminator: when any segment fails it, only the full name is registered.
+ * Whether the name is a SQL identifier (and so gets the unqualified key) is
+ * decided in two tiers (#3317):
  *
- * (A pure word-dotted name whose every segment is a valid SQL identifier — e.g.
- * an alias literally named `logs.app` — is indistinguishable from `schema.table`
- * by name alone and still contributes the unqualified key; closing that requires
- * an engine signal the loader does not carry.)
+ *  1. **Authoritative marker.** When the entity declares `identifier_style:
+ *     opaque` (`opts.opaque`), `table` is a literal datasource identifier
+ *     (e.g. an Elasticsearch index / alias / data-stream name) where `.` is an
+ *     ordinary character — only the full name is registered, never dot-split.
+ *     Elasticsearch entities always carry this marker.
+ *  2. **Name heuristic (fallback)** for entities without the marker: derive the
+ *     unqualified key only when the name is a genuine dotted SQL identifier — at
+ *     least two segments, each a bare SQL identifier
+ *     ({@link SQL_IDENTIFIER_SEGMENT}). A `-`/`*`/`?` or a digit-leading segment
+ *     can never appear in a bare SQL identifier, so a dotted ES name like
+ *     `filebeat-7.10.0-*`, `metrics-2024.01.01`, or `logs-nginx.access-default`
+ *     is recognized as opaque and not split (which would otherwise inject a
+ *     bogus `0-*` / `01` / `access-default` fragment that widens the allow-list).
+ *
+ * The marker (tier 1) is what closes the residual the heuristic cannot: a pure
+ * word-dotted opaque name whose every segment is a valid SQL identifier (e.g. an
+ * alias literally named `logs.app`) is indistinguishable from `schema.table` by
+ * name alone, so only the declared `identifier_style` can tell them apart.
  */
-export function tableWhitelistKeys(rawTable: string): string[] {
+export function tableWhitelistKeys(rawTable: string, opts?: { opaque?: boolean }): string[] {
   const normalized = normalizeTableIdentifier(rawTable);
   const full = normalized.toLowerCase();
+  if (opts?.opaque) return [full];
   const parts = normalized.split(".");
   if (parts.length < 2 || !parts.every((seg) => SQL_IDENTIFIER_SEGMENT.test(seg))) {
     return [full];
   }
   const last = parts[parts.length - 1].toLowerCase();
   return last === full ? [full] : [last, full];
+}
+
+/** True when an entity declares its `table` is an opaque (non-SQL) identifier. */
+function isOpaqueIdentifier(entity: { identifier_style?: "sql" | "opaque" }): boolean {
+  return entity.identifier_style === "opaque";
 }
 
 /** Plugin-provided entity tables, keyed by connection ID. */
@@ -219,8 +231,10 @@ function loadEntitiesFromDir(
       // `tableWhitelistKeys` normalizes identifier quotes so `"user"` /
       // `` `user` `` in the YAML matches the unquoted name `node-sql-parser`
       // returns from `FROM "user"`, registers the full + unqualified SQL keys,
-      // and skips the bogus last-segment split for ES wildcard patterns (#3317).
-      for (const key of tableWhitelistKeys(entity.table)) tables.add(key);
+      // and registers only the full name for opaque (ES) identifiers (#3317).
+      for (const key of tableWhitelistKeys(entity.table, { opaque: isOpaqueIdentifier(entity) })) {
+        tables.add(key);
+      }
 
       // Validate and collect cross-source joins separately from core entity parsing.
       // Invalid join entries are skipped individually without dropping the entity.
@@ -571,7 +585,9 @@ export function registerPluginEntities(
         skippedCount++;
         continue;
       }
-      for (const key of tableWhitelistKeys(parsed.data.table)) tables.add(key);
+      for (const key of tableWhitelistKeys(parsed.data.table, { opaque: isOpaqueIdentifier(parsed.data) })) {
+        tables.add(key);
+      }
     } catch (err) {
       log.warn(
         { connectionId, entity: entity.name, err: err instanceof Error ? err.message : String(err) },
@@ -746,7 +762,7 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
         log.warn({ orgId, entity: row.name, err: parsed.error.message }, "Skipping org entity — failed to validate");
         continue;
       }
-      const tableList = tableWhitelistKeys(parsed.data.table);
+      const tableList = tableWhitelistKeys(parsed.data.table, { opaque: isOpaqueIdentifier(parsed.data) });
       recordTables(row, readGroupField(parsed.data), tableList);
     } catch (err) {
       parseFailures++;

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -143,6 +143,10 @@ const SQL_IDENTIFIER_SEGMENT = /^[A-Za-z_][A-Za-z0-9_$]*$/;
 export function tableWhitelistKeys(rawTable: string, opts?: { opaque?: boolean }): string[] {
   const normalized = normalizeTableIdentifier(rawTable);
   const full = normalized.toLowerCase();
+  // A malformed entity with an empty `table:` (z.string() permits "") must
+  // contribute NO whitelist key — never register a meaningless "" that would
+  // sit in the allow-list (#3317 review).
+  if (!full) return [];
   if (opts?.opaque) return [full];
   const parts = normalized.split(".");
   if (parts.length < 2 || !parts.every((seg) => SQL_IDENTIFIER_SEGMENT.test(seg))) {

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -101,6 +101,35 @@ export function normalizeTableIdentifier(raw: string): string {
     .join(".");
 }
 
+/**
+ * Derive the whitelist key(s) a `table:` value contributes.
+ *
+ * Returns the lowercased normalized full name, plus — for SQL `schema.table`
+ * identifiers — the unqualified last segment, so a `FROM orders` matches an
+ * entity declared as `public.orders`.
+ *
+ * The last-segment split is **skipped** for Elasticsearch/OpenSearch index
+ * patterns (and data-stream/alias names) that carry a `*`/`?` wildcard. A
+ * pattern base can legitimately contain `.` as an ordinary character — version
+ * strings, date fragments — e.g. `filebeat-7.10.0-*`. Splitting that on `.`
+ * yields a meaningless fragment (`0-*`) that widens the allow-list with a bogus
+ * key (#3317). Wildcard chars never appear in an unquoted SQL identifier, so
+ * their presence is a safe discriminator: when the normalized name contains one,
+ * only the full name is registered.
+ */
+export function tableWhitelistKeys(rawTable: string): string[] {
+  const normalized = normalizeTableIdentifier(rawTable);
+  const full = normalized.toLowerCase();
+  // ES/OpenSearch index pattern: `.` is an ordinary char, not a schema
+  // separator — don't derive a bogus unqualified key from the last segment.
+  if (normalized.includes("*") || normalized.includes("?")) {
+    return [full];
+  }
+  const parts = normalized.split(".");
+  const last = parts[parts.length - 1].toLowerCase();
+  return last === full ? [full] : [last, full];
+}
+
 /** Plugin-provided entity tables, keyed by connection ID. */
 const _pluginEntities = new Map<string, Set<string>>();
 
@@ -172,13 +201,11 @@ function loadEntitiesFromDir(
       const tables = byConnection.get(connId)!;
 
       // Extract table name (may include schema prefix like "public.users").
-      // Normalize identifier quotes so `"user"` / `` `user` `` in the YAML
-      // matches the unquoted name `node-sql-parser` returns from `FROM "user"`.
-      const normalized = normalizeTableIdentifier(entity.table);
-      const parts = normalized.split(".");
-      tables.add(parts[parts.length - 1].toLowerCase());
-      // Also add the full qualified name
-      tables.add(normalized.toLowerCase());
+      // `tableWhitelistKeys` normalizes identifier quotes so `"user"` /
+      // `` `user` `` in the YAML matches the unquoted name `node-sql-parser`
+      // returns from `FROM "user"`, registers the full + unqualified SQL keys,
+      // and skips the bogus last-segment split for ES wildcard patterns (#3317).
+      for (const key of tableWhitelistKeys(entity.table)) tables.add(key);
 
       // Validate and collect cross-source joins separately from core entity parsing.
       // Invalid join entries are skipped individually without dropping the entity.
@@ -529,10 +556,7 @@ export function registerPluginEntities(
         skippedCount++;
         continue;
       }
-      const tableName = normalizeTableIdentifier(parsed.data.table);
-      const parts = tableName.split(".");
-      tables.add(parts[parts.length - 1].toLowerCase());
-      tables.add(tableName.toLowerCase());
+      for (const key of tableWhitelistKeys(parsed.data.table)) tables.add(key);
     } catch (err) {
       log.warn(
         { connectionId, entity: entity.name, err: err instanceof Error ? err.message : String(err) },
@@ -707,9 +731,7 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
         log.warn({ orgId, entity: row.name, err: parsed.error.message }, "Skipping org entity — failed to validate");
         continue;
       }
-      const normalized = normalizeTableIdentifier(parsed.data.table);
-      const parts = normalized.split(".");
-      const tableList = [parts[parts.length - 1].toLowerCase(), normalized.toLowerCase()];
+      const tableList = tableWhitelistKeys(parsed.data.table);
       recordTables(row, readGroupField(parsed.data), tableList);
     } catch (err) {
       parseFailures++;

--- a/plugins/elasticsearch/__tests__/mapping.test.ts
+++ b/plugins/elasticsearch/__tests__/mapping.test.ts
@@ -223,6 +223,8 @@ describe("mappingToEntity", () => {
     expect(entity!.type).toBe("fact_table");
     // table: must be the raw index name so the SQL whitelist + FROM resolve.
     expect(entity!.table).toBe("products");
+    // #3317: ES names are opaque identifiers — the whitelist must not dot-split them.
+    expect(entity!.identifier_style).toBe("opaque");
     expect(entity!.grain).toContain("products");
     expect(entity!.description).toContain("products");
   });
@@ -424,6 +426,8 @@ describe("buildLogicalEntity", () => {
       response: mapping,
     })!;
     expect(entity.table).toBe("logs-*");
+    // #3317: logical (pattern/alias/data-stream) names are opaque identifiers too.
+    expect(entity.identifier_style).toBe("opaque");
     expect(entity.dimensions.map((d) => d.name).sort()).toEqual(["level", "msg", "ts"]);
     expect(entity.description).toContain("index pattern");
     expect(entity.description).toContain("2 backing indices");
@@ -467,6 +471,8 @@ describe("mappingsToLogicalEntities", () => {
     const tables = entities.map((e) => e.table).sort();
     // pattern (logs-*) + alias (orders) + data stream (events) + standalone (products)
     expect(tables).toEqual(["events", "logs-*", "orders", "products"]);
+    // #3317: every emitted ES entity (logical and standalone) is opaque-marked.
+    expect(entities.every((e) => e.identifier_style === "opaque")).toBe(true);
     // The aliased index isn't ALSO emitted standalone, nor are the pattern members.
     expect(tables).not.toContain("orders_v3");
     expect(tables).not.toContain("logs-2024.01.01");

--- a/plugins/elasticsearch/src/mapping.ts
+++ b/plugins/elasticsearch/src/mapping.ts
@@ -120,6 +120,14 @@ export interface EsEntityDoc {
   type: "fact_table";
   /** Index name — the SQL whitelist + `FROM` qualifier. */
   table: string;
+  /**
+   * Marks `table` as an OPAQUE datasource identifier — an ES index / alias /
+   * data-stream name where `.` is an ordinary character (version strings, date
+   * fragments, dotted datasets), NOT a SQL `schema.table`. The Atlas whitelist
+   * loader reads this to register the full name only and never dot-split it into
+   * a bogus unqualified key (#3317). Always `"opaque"` for ES entities.
+   */
+  identifier_style: "opaque";
   /** Connection-group scope (ADR-0012). Omitted for the default group. */
   group?: string;
   grain: string;
@@ -301,6 +309,7 @@ export function mappingToEntity(
     name: indexToEntityName(index),
     type: "fact_table",
     table: index,
+    identifier_style: "opaque",
     ...(opts?.group ? { group: opts.group } : {}),
     grain: `one row per document in the ${index} index`,
     description: `Elasticsearch index "${index}" profiled from its mapping. Contains ${fields.length} field${fields.length === 1 ? "" : "s"}.`,
@@ -510,6 +519,7 @@ export function buildLogicalEntity(opts: {
     name: indexToEntityName(opts.name),
     type: "fact_table",
     table: opts.name,
+    identifier_style: "opaque",
     ...(opts.group ? { group: opts.group } : {}),
     grain,
     description,


### PR DESCRIPTION
Fixes #3317.

## Problem

The semantic whitelist loader treated every entity `table:` value as a SQL `schema.table` identifier and split it on `.` to derive an unqualified last-segment key. For a dotted Elasticsearch/OpenSearch name, that injects a meaningless fragment alongside the real full name — e.g. `filebeat-7.10.0-*` → bogus `0-*`, the concrete date index `metrics-2024.01.01` → `01`, the data stream `logs-nginx.access-default` → `access-default`.

Low severity (the full-name key is also added, so the real query path validates fine), but the bogus key is a latent over-grant: it's a member of the DSL whitelist, so `validateIndexAccess`'s wildcard-membership check would pass it. It widened the allow-list with noise.

## Fix

Two complementary tiers, so the over-grant is closed for **every** ES name — not just wildcard patterns.

**1. Engine-aware marker (authoritative).** Add an optional `identifier_style: "sql" | "opaque"` to the shared `EntityShape`. `"opaque"` means `table` is a literal datasource identifier where `.` is an ordinary character; the loader registers the full name only and never dot-splits it. ES entities **always** carry `identifier_style: "opaque"`, stamped in both `mapping.ts` builders (`mappingToEntity` + `buildLogicalEntity`), so it serializes to disk via the CLI profiler's `yaml.dump` and flows uniformly through all three load paths (disk, plugin-registration, org-DB) — each parses the YAML with `EntityShape` before deriving keys. `EntityShape` is `.passthrough()` and the CLI entity reader is tolerant, so no validator rejects the field.

**2. Name heuristic (fallback)** for any entity without the marker: extract the key derivation into a single `tableWhitelistKeys()` helper (also de-duplicates previously copy-pasted logic across `loadEntitiesFromDir`, `registerPluginEntities`, `loadOrgWhitelist`) and derive the unqualified key only when the name is a genuine dotted SQL identifier — ≥2 segments, each a bare SQL identifier (`[A-Za-z_][A-Za-z0-9_$]*`). A `-`/`*`/`?` or a digit-leading segment can never appear in a bare SQL identifier, so the segment shape safely discriminates ES names from SQL `schema.table` for every dialect's real table refs (BigQuery `dataset.table` with the project as connection config; Snowflake/ClickHouse/Postgres/MySQL unquoted).

The full (normalized, lowercased) name is always registered, so SQL `FROM "filebeat-7.10.0-*"` and DSL `index: "filebeat-7.10.0-*"` still validate.

Together: the marker closes 100% for profiled ES entities (**including** pure word-dotted names like an alias literally `logs.app`, which the heuristic alone can't distinguish from `schema.table`); the heuristic remains a safety net for any unmarked opaque name.

### Evolution of this PR

1. Initial commit: wildcard-only (`*`/`?`) guard for the exact `filebeat-7.10.0-*` case.
2. Review pass: found non-wildcard dotted ES names (date indices, data streams) with the same defect → generalized to the SQL-identifier-segment heuristic.
3. Final: added the engine-aware `identifier_style` marker to close the name-undecidable residual for good.

## Tests

- `tableWhitelistKeys` unit tests — SQL `schema.table` and `db.schema.table`; bare names; quoted-identifier stripping; wildcard patterns; dotted date indices; dotted data-stream/alias names; digit-leading segments; the heuristic-fallback residual; and the `opaque` marker overriding both a word-dotted and a SQL-looking name.
- Disk- and plugin-path regression tests for wildcard and non-wildcard dotted ES names, plus an end-to-end disk-path test that `identifier_style: opaque` suppresses the dot-split for a pure word-dotted name.
- `mapping.test.ts`: every emitted ES entity (standalone + logical) carries `identifier_style: "opaque"`.

## Acceptance criteria

- [x] A `filebeat-7.10.0-*` entity registers only the full-name whitelist key (no bogus `0-*`), on all three load paths
- [x] The full-name key still validates `FROM "filebeat-7.10.0-*"` and the DSL `index: "filebeat-7.10.0-*"`
- [x] Regression test covering a dotted-base ES pattern entity's whitelist keys
- [x] Extended beyond the issue to cover non-wildcard dotted ES names (data streams, date indices) and pure word-dotted names — the whole over-grant class is closed

## Verification

- `semantic.test.ts` → 35 pass; ES plugin suite → 356 pass; API affected isolated runner → 88 files pass
- Dependent suites green: `sql.test.ts` (103), `sql-connection-whitelist`, `sql-org-whitelist`, `semantic-org`, `semantic-multisource`, `group-scoped-loader`, `cli/elasticsearch-profiler`
- `bun run lint` clean; `bun run type` clean

Follow-up from #3316 / #3269.

https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect dot-splitting of dotted Elasticsearch index/data-stream/alias names so full identifiers are recognized correctly; ES-derived entities are now marked to avoid SQL-style splitting.
* **Tests**
  * Added regression and unit tests covering dotted patterns, wildcard/dashed/digit segments, quote-stripping/lowercasing, and opaque identifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->