### PR TITLE
fix(plugins): exclude system backing indices in parseAliases when includeSystem is false

### DIFF
--- a/plugins/elasticsearch/__tests__/mapping.test.ts
+++ b/plugins/elasticsearch/__tests__/mapping.test.ts
@@ -323,6 +323,21 @@ describe("parseAliases", () => {
     expect(parseAliases({ products: { mappings: {} } } as unknown as EsAliasResponse).size).toBe(0);
     expect(parseAliases(undefined).size).toBe(0);
   });
+
+  test("excludes system backing indices for non-system aliases unless asked (#3319)", () => {
+    const resp: EsAliasResponse = {
+      ".kibana": { aliases: { "my-alias": {} } },
+      products: { aliases: { "my-alias": {} } },
+    };
+    // includeSystem: false — the non-system alias keeps only its non-system backing.
+    const filtered = parseAliases(resp);
+    expect([...filtered.get("my-alias")!]).toEqual(["products"]);
+    // includeSystem: true — the system backing index is retained.
+    expect([...parseAliases(resp, { includeSystem: true }).get("my-alias")!].sort()).toEqual([
+      ".kibana",
+      "products",
+    ]);
+  });
 });
 
 describe("parseDataStreams", () => {

--- a/plugins/elasticsearch/src/mapping.ts
+++ b/plugins/elasticsearch/src/mapping.ts
@@ -362,6 +362,9 @@ export function parseAliases(
   if (!response || typeof response !== "object") return out;
 
   for (const index of Object.keys(response)) {
+    // Skip system backing indices (e.g. `.kibana`) so a non-system alias
+    // pointing at one doesn't pull it into the alias's backing set (#3319).
+    if (!includeSystem && isSystemIndex(index)) continue;
     const aliases = response[index]?.aliases;
     if (!aliases || typeof aliases !== "object") continue;
     for (const alias of Object.keys(aliases)) {


### PR DESCRIPTION
## What

`parseAliases` in `plugins/elasticsearch/src/mapping.ts` filtered **alias names** against `isSystemIndex` when `includeSystem` is false, but never filtered the **backing concrete index**. So a non-system alias pointing at a system index (e.g. `my-alias → .kibana`) still pulled the system index into the alias's backing set. `collapseMappings` then profiled the alias entity from `.kibana`'s mapping and recorded `coverage.set(".kibana", "my-alias")` — leaking the system index even with `includeSystem: false`.

## Fix

Skip system backing indices in the outer loop when `includeSystem` is false:

```ts
for (const index of Object.keys(response)) {
  if (!includeSystem && isSystemIndex(index)) continue;  // added
  ...
```

`parseDataStreams` is unaffected — `.ds-…` backing indices are intentional and must be kept.

## Acceptance criteria

- [x] `includeSystem: false` → non-system alias → system backing index excluded from backing set & coverage
- [x] `includeSystem: true` still includes them
- [x] `parseDataStreams` behavior unchanged
- [x] Unit test in `plugins/elasticsearch/__tests__/mapping.test.ts` covering the alias→system-index case

## Verification

- All 4 elasticsearch plugin test suites pass (0 failures); new test in `mapping.test.ts` covers both `includeSystem` paths
- `bun run lint` clean

Closes #3319

https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr

---
_Generated by [Claude Code](https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783464848&installation_id=135337507&pr_number=3321&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3321&signature=049a79eb85b62acd0413486b30d2406bf2482f30c35bc105d21f55c07b797d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alias mapping to exclude system-backed indices by default. System indices are now only included in alias mappings when explicitly requested via the `includeSystem` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->