### PR TITLE
fix(plugins): v0.0.13 pre-closeout review hardening for ES/OpenSearch datasource

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -73483,10 +73483,10 @@
         ],
         "responses": {
           "302": {
-            "description": "Redirect to Platform OAuth authorization page on success, or to `/admin/integrations?error=<platform>&reason=<code>` when the install is refused before the redirect (browser callers): `plan_upgrade_required` when the workspace's plan tier does not admit the install, or `plan_limit_reached` (#2998) when a chat integration would exceed the plan's chat-integration cap."
+            "description": "Redirect to Platform OAuth authorization page on success, or to `/admin/integrations?error=<platform>&reason=<code>` when the install is refused before the redirect (browser callers): `plan_upgrade_required` when the workspace's plan tier does not admit the install, `saas_ineligible` when the platform is not available on SaaS (#3301), or `plan_limit_reached` (#2998) when a chat integration would exceed the plan's chat-integration cap."
           },
           "400": {
-            "description": "Platform is not OAuth-installable, or unknown",
+            "description": "Platform is not OAuth-installable, unknown, or not available on SaaS (`saas_ineligible`, #3301; JSON callers)",
             "content": {
               "application/json": {
                 "schema": {
@@ -74086,7 +74086,7 @@
             "description": "Install complete or failed in a recoverable way — redirected to /admin/integrations. Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. Hard failure (browser caller): `?error=<platform>&reason=<code>` (chat-integration cap reached → `reason=plan_limit_reached`). JSON callers receive 400/429/502/503 instead."
           },
           "400": {
-            "description": "Invalid or expired state, or unknown platform (JSON-Accept caller)",
+            "description": "Invalid or expired state, unknown platform, or platform not available on SaaS (`saas_ineligible`, #3301) (JSON-Accept caller)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -591,20 +591,26 @@ describe("OAuth routes — saas_eligible gate (#3301)", () => {
     expect(body.error).toBe("saas_ineligible");
   });
 
-  it("/install does NOT block the same row on a self-hosted deploy", async () => {
+  it("/install admits a saas_eligible=false row on a self-hosted deploy", async () => {
+    // Use `slack` (which has a registered OAuth handler stub) so the control
+    // proves real admission — the request reaches the handler and redirects to
+    // the authorize URL — rather than merely avoiding `saas_ineligible` while
+    // tripping a 501 handler_unavailable, which a slug with no handler would.
     deployModeImpl = () => undefined;
-    const res = await request("/api/v1/integrations/github-single-tenant/install", {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization")) {
+        return [{ plan_tier: "business", is_operator_workspace: false }];
+      }
+      return [
+        { slug: "slack", install_model: "oauth", enabled: true, min_plan: "free", saas_eligible: false },
+      ];
+    });
+    const res = await request("/api/v1/integrations/slack/install", {
       headers: { Accept: "text/html" },
       redirect: "manual",
     });
-    // Gate skipped → proceeds into handler dispatch (302 redirect or a
-    // handler-level outcome), never the saas_ineligible refusal.
-    if (res.status === 400) {
-      const body = (await res.json()) as { error?: string };
-      expect(body.error).not.toBe("saas_ineligible");
-    } else {
-      expect(res.status).not.toBe(400);
-    }
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location") ?? "").toContain("slack.com/oauth/v2/authorize");
   });
 });
 

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -1130,6 +1130,61 @@ describe("POST /api/v1/integrations/:platform/install-form — wrong install_mod
   });
 });
 
+// ---------------------------------------------------------------------------
+// SaaS-eligibility gate (#3301) — a `saas_eligible = false` row must be refused
+// on the /install-form route under SaaS, mirroring the /install gate, so a known
+// slug can't bypass the hidden marketplace card by POSTing directly.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/integrations/:platform/install-form — saas_eligible gate", () => {
+  beforeEach(() => {
+    // A form-install row marked saas_eligible=false (e.g. a non-multi-tenant-safe
+    // datasource). Slug "email" reuses the registered fake form handler so the
+    // self-hosted path can reach handler dispatch; the gate itself is slug-agnostic.
+    mockInternalQuery.mockImplementation(async () => [
+      { slug: "email", install_model: "form", enabled: true, min_plan: "free", saas_eligible: false },
+    ]);
+    validateImpl = async () => ({
+      installRecord: { id: "install-email-ineligible", workspaceId: "ws-1" as never, catalogId: "email" },
+      credentialWritten: true,
+    });
+  });
+
+  it("refuses with 400 saas_ineligible under SaaS deploy", async () => {
+    deployModeImpl = () => "saas";
+    const res = await request("/api/v1/integrations/email/install-form", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        host: "smtp.example.com",
+        port: 587,
+        username: "u",
+        password: "p",
+        fromAddress: "atlas@example.com",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("saas_ineligible");
+  });
+
+  it("still allows the same row on a self-hosted deploy (gate not triggered)", async () => {
+    deployModeImpl = () => undefined;
+    const res = await request("/api/v1/integrations/email/install-form", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        host: "smtp.example.com",
+        port: 587,
+        username: "u",
+        password: "p",
+        fromAddress: "atlas@example.com",
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("POST /api/v1/integrations/:platform/install-form — unknown platform", () => {
   beforeEach(() => {
     mockInternalQuery.mockImplementation(async () => []);

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -545,6 +545,69 @@ describe("GET /api/v1/integrations/slack/install — startInstall error passthro
   });
 });
 
+describe("OAuth routes — saas_eligible gate (#3301)", () => {
+  beforeEach(() => {
+    // A saas_eligible=false OAuth row (e.g. github-single-tenant). Mock both the
+    // catalog lookup and the organization plan read so the gate (which precedes
+    // the plan gate) is exercised in isolation.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization")) {
+        return [{ plan_tier: "business", is_operator_workspace: false }];
+      }
+      return [
+        { slug: "github-single-tenant", install_model: "oauth", enabled: true, min_plan: "free", saas_eligible: false },
+      ];
+    });
+    deployModeImpl = () => "saas";
+  });
+
+  it("/install refuses with 400 saas_ineligible (JSON caller) under SaaS", async () => {
+    const res = await request("/api/v1/integrations/github-single-tenant/install", {
+      redirect: "manual",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("saas_ineligible");
+  });
+
+  it("/install redirects a browser to the admin error page under SaaS", async () => {
+    const res = await request("/api/v1/integrations/github-single-tenant/install", {
+      headers: { Accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location") ?? "").toContain("saas_ineligible");
+  });
+
+  it("/callback refuses with 400 saas_ineligible (JSON caller) before persisting, under SaaS", async () => {
+    const res = await request(
+      // installation_id is required by the github-single-tenant identifier check
+      // that precedes the catalog lookup; supply it so the request reaches the gate.
+      "/api/v1/integrations/github-single-tenant/callback?code=auth-abc&state=stub&installation_id=42",
+      { redirect: "manual" },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("saas_ineligible");
+  });
+
+  it("/install does NOT block the same row on a self-hosted deploy", async () => {
+    deployModeImpl = () => undefined;
+    const res = await request("/api/v1/integrations/github-single-tenant/install", {
+      headers: { Accept: "text/html" },
+      redirect: "manual",
+    });
+    // Gate skipped → proceeds into handler dispatch (302 redirect or a
+    // handler-level outcome), never the saas_ineligible refusal.
+    if (res.status === 400) {
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).not.toBe("saas_ineligible");
+    } else {
+      expect(res.status).not.toBe(400);
+    }
+  });
+});
+
 describe("GET /api/v1/integrations/slack/callback — happy path", () => {
   it("redirects to /admin/integrations?installed=slack on success", async () => {
     callbackImpl = async () => happyResult();

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -816,6 +816,34 @@ integrations.openapi(installRoute, async (c) =>
       );
     }
 
+    // ── SaaS-eligibility gate (#3301, defense-in-depth) ───────────
+    // Mirror the /install-form + marketplace gates on this OAuth entrypoint: the
+    // catalog listing hides `saas_eligible = false` rows on SaaS, but a workspace
+    // admin who knows the slug could POST here directly (e.g. github-single-tenant,
+    // an `oauth` row that is `saas_eligible: false`). Refuse before minting any
+    // authorize URL. Browser callers get the same redirect UX as the plan gate;
+    // JSON callers get the structured 400. `=== false` (stale/NULL stays
+    // installable) matches admin-marketplace.ts.
+    if (deployMode === "saas" && row.saas_eligible === false) {
+      log.warn(
+        { platform, deployMode },
+        "Refused OAuth install: platform is not saas_eligible (#3301)",
+      );
+      if (prefersHtml(c.req.raw)) {
+        return c.redirect(
+          buildPlatformAdminUrl("error", platform, { reason: "saas_ineligible" }),
+        );
+      }
+      return c.json(
+        {
+          error: "saas_ineligible",
+          message: `"${platform}" is not available on Atlas Cloud — it can only be configured on a self-hosted deploy.`,
+          requestId,
+        },
+        400,
+      );
+    }
+
     // ── Plan-tier gate (#2701) ────────────────────────────────────
     // Browser callers expect a redirect-driven UX (clicking Connect on a
     // locked card already routes through the UI, but a direct deep-link
@@ -1336,6 +1364,32 @@ integrations.openapi(callbackRoute, async (c) =>
     if (row.install_model !== "oauth" && row.install_model !== "oauth-datasource") {
       return c.json(
         { error: "wrong_install_model", message: `Platform "${platform}" uses install_model "${row.install_model}" — not OAuth-installable via this route.`, requestId },
+        400,
+      );
+    }
+
+    // ── SaaS-eligibility gate (#3301, defense-in-depth) ───────────
+    // The callback is the PERSISTENCE point: a self-redirecting handler can reach
+    // it without re-passing /install, so the saas_eligible refusal must also live
+    // here, before any install record is written, not only at /install. Same gate
+    // as /install (browser redirect / JSON 400); `=== false` keeps stale/NULL rows
+    // installable.
+    if (getConfig()?.deployMode === "saas" && row.saas_eligible === false) {
+      log.warn(
+        { platform },
+        "Refused OAuth callback: platform is not saas_eligible (#3301)",
+      );
+      if (prefersHtml(c.req.raw)) {
+        return c.redirect(
+          buildPlatformAdminUrl("error", platform, { reason: "saas_ineligible" }),
+        );
+      }
+      return c.json(
+        {
+          error: "saas_ineligible",
+          message: `"${platform}" is not available on Atlas Cloud — it can only be configured on a self-hosted deploy.`,
+          requestId,
+        },
         400,
       );
     }

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -493,6 +493,13 @@ interface CatalogRowFromDb extends Record<string, unknown> {
    * from ever reaching a not-yet-cap-gated handler.
    */
   readonly implementation_status?: string;
+  /**
+   * `saas_eligible` (#3301) — `false` marks a row that must never install on a
+   * SaaS deploy (e.g. DuckDB, file-path based and not multi-tenant safe). The
+   * marketplace `/install` route refuses these server-side; the `/install-form`
+   * route mirrors that gate so a known slug can't bypass it directly.
+   */
+  readonly saas_eligible?: boolean | null;
 }
 
 /**
@@ -564,9 +571,10 @@ async function getInstallableCatalogRowBySlug(slug: string): Promise<{
   min_plan: string;
   config_schema: unknown;
   implementation_status: string | null;
+  saas_eligible: boolean | null;
 } | null> {
   const rows = await internalQuery<CatalogRowFromDb>(
-    `SELECT slug, install_model, enabled, min_plan, config_schema, implementation_status
+    `SELECT slug, install_model, enabled, min_plan, config_schema, implementation_status, saas_eligible
        FROM plugin_catalog
       WHERE slug = $1 AND enabled = true
       LIMIT 1`,
@@ -589,6 +597,7 @@ async function getInstallableCatalogRowBySlug(slug: string): Promise<{
     min_plan: row.min_plan,
     config_schema: row.config_schema ?? null,
     implementation_status: row.implementation_status ?? null,
+    saas_eligible: row.saas_eligible ?? null,
   };
 }
 
@@ -972,6 +981,28 @@ integrations.openapi(installFormRoute, async (c) =>
       );
       return c.json(
         { error: "wrong_install_model", message: `Platform "${platform}" uses install_model "${row.install_model}" — not installable via this route (OAuth platforms use /install).`, requestId },
+        400,
+      );
+    }
+
+    // ── SaaS-eligibility gate (#3301, defense-in-depth) ───────────
+    // The marketplace `/available` listing hides `saas_eligible = false` rows on
+    // SaaS, and the `/install` route refuses them server-side. This parallel
+    // form-install route must mirror that gate — otherwise a workspace admin who
+    // knows the slug could POST it here directly and bypass the hidden card. Use
+    // `=== false` (not `!== true`) so a stale/NULL row stays installable, exactly
+    // like the `/install` gate in admin-marketplace.ts. Resolved deploy mode.
+    if (deployMode === "saas" && row.saas_eligible === false) {
+      log.warn(
+        { platform, deployMode },
+        "Refused install-form: platform is not saas_eligible (#3301)",
+      );
+      return c.json(
+        {
+          error: "saas_ineligible",
+          message: `"${platform}" is not available on Atlas Cloud — it can only be configured on a self-hosted deploy.`,
+          requestId,
+        },
         400,
       );
     }

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -205,11 +205,12 @@ const installRoute = createRoute({
         "Redirect to Platform OAuth authorization page on success, or to " +
         "`/admin/integrations?error=<platform>&reason=<code>` when the install is " +
         "refused before the redirect (browser callers): `plan_upgrade_required` " +
-        "when the workspace's plan tier does not admit the install, or " +
+        "when the workspace's plan tier does not admit the install, " +
+        "`saas_ineligible` when the platform is not available on SaaS (#3301), or " +
         "`plan_limit_reached` (#2998) when a chat integration would exceed the " +
         "plan's chat-integration cap.",
     },
-    400: { description: "Platform is not OAuth-installable, or unknown", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Platform is not OAuth-installable, unknown, or not available on SaaS (`saas_ineligible`, #3301; JSON callers)", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Not authenticated", content: { "application/json": { schema: AuthErrorSchema } } },
     403: {
       description:
@@ -400,7 +401,7 @@ const callbackRoute = createRoute({
         "Hard failure (browser caller): `?error=<platform>&reason=<code>` (chat-integration cap reached → " +
         "`reason=plan_limit_reached`). JSON callers receive 400/429/502/503 instead.",
     },
-    400: { description: "Invalid or expired state, or unknown platform (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Invalid or expired state, unknown platform, or platform not available on SaaS (`saas_ineligible`, #3301) (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
     403: {
       description:
         "Workspace plan changed mid-OAuth and no longer admits this " +

--- a/plugins/elasticsearch/__tests__/dsl.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl.test.ts
@@ -251,6 +251,21 @@ describe("validateEsDslRequest — adversarial: stored-script references", () =>
     });
     expect(result.valid).toBe(true);
   });
+
+  test("does NOT false-positive on a terms LOOKUP against a field named like a script", () => {
+    // `{ terms: { <field>: { index, id, path } } }` carries a string `id`, and the
+    // looked-up field may legitimately be named `*_script`. The index/path markers
+    // distinguish it from a real stored-script reference.
+    const result = validateEsDslRequest({
+      endpoint: "_search",
+      body: {
+        query: {
+          terms: { deploy_script: { index: "deployments", id: "rel-42", path: "scripts" } },
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
 });
 
 describe("isReadEndpoint", () => {
@@ -341,6 +356,13 @@ describe("validateIndexAccess", () => {
 
   test("allows ordinary date-suffixed concrete index names (dots and hyphens)", () => {
     expect(validateIndexAccess("logs-2024.01.01", new Set()).valid).toBe(true);
+  });
+
+  test("allows a whitelisted Unicode (non-ASCII) index name (deny-list, not ASCII allow-list)", () => {
+    // Elasticsearch permits Unicode index names; the path-injection guard is a
+    // deny-list of dangerous chars, so a CJK-named whitelisted index still passes.
+    expect(validateIndexAccess("ログ", new Set(["ログ"])).valid).toBe(true);
+    expect(validateIndexAccess("café-logs", new Set()).valid).toBe(true);
   });
 
   test("allows a wildcard index-pattern entity that is an explicit whitelist member (#3269)", () => {

--- a/plugins/elasticsearch/__tests__/dsl.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl.test.ts
@@ -266,6 +266,21 @@ describe("validateEsDslRequest — adversarial: stored-script references", () =>
     });
     expect(result.valid).toBe(true);
   });
+
+  test("still denies a stored-script id cloaked behind only ONE terms-lookup marker", () => {
+    // A real terms lookup carries BOTH `index` and `path`. A single bogus marker
+    // (here `index` without `path`) must not exempt a `*_script` value that
+    // otherwise looks like a stored-script reference — otherwise it's a bypass.
+    const result = validateEsDslRequest({
+      endpoint: "_search",
+      body: {
+        query: {
+          script_fields: { x: { script: { id: "evil_stored_script", index: "x" } } },
+        },
+      },
+    });
+    expect(result.valid === false && result.reason).toMatch(/stored-script reference/i);
+  });
 });
 
 describe("isReadEndpoint", () => {

--- a/plugins/elasticsearch/__tests__/dsl.test.ts
+++ b/plugins/elasticsearch/__tests__/dsl.test.ts
@@ -223,6 +223,36 @@ describe("validateEsDslRequest — adversarial: mutating scripts", () => {
   });
 });
 
+describe("validateEsDslRequest — adversarial: stored-script references", () => {
+  test("denies a stored-script reference (script.id) — body is server-side, unverifiable", () => {
+    const result = validateEsDslRequest({
+      endpoint: "_search",
+      body: { script_fields: { x: { script: { id: "my_stored_script" } } } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.reason).toMatch(/stored-script reference/i);
+  });
+
+  test("denies a stored-script reference nested under script_score", () => {
+    const result = validateEsDslRequest({
+      endpoint: "_search",
+      body: { query: { function_score: { script_score: { script: { id: "x" } } } } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.reason).toMatch(/stored-script reference/i);
+  });
+
+  test("still allows an inline read-only script (script.source)", () => {
+    const result = validateEsDslRequest({
+      endpoint: "_search",
+      body: {
+        query: { function_score: { script_score: { script: { source: "doc['likes'].value" } } } },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
 describe("isReadEndpoint", () => {
   test("strips surrounding slashes before matching", () => {
     expect(isReadEndpoint("/_search/")).toBe(true);
@@ -290,6 +320,27 @@ describe("validateIndexAccess", () => {
     expect(validateIndexAccess("flights", new Set()).valid).toBe(true);
     expect(validateIndexAccess("anything-not-in-layer", new Set()).valid).toBe(true);
     expect(validateIndexAccess("*", new Set()).valid).toBe(false);
+  });
+
+  test.each([
+    "products/_doc/1/_update",
+    "products/_doc/1",
+    "orders%0a",
+    "orders flights",
+    'a"b',
+    "a<b",
+    "a|b",
+  ])("rejects an out-of-charset index segment %p (path-injection guard)", (idx) => {
+    // Self-contained safety: the validator must reject illegal index-name chars
+    // (slashes, whitespace, control, quotes) on its own — not rely on a downstream
+    // caller URL-encoding the segment. Checked even in structural-only mode.
+    const result = validateIndexAccess(idx, new Set());
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/not allowed in an index name/);
+  });
+
+  test("allows ordinary date-suffixed concrete index names (dots and hyphens)", () => {
+    expect(validateIndexAccess("logs-2024.01.01", new Set()).valid).toBe(true);
   });
 
   test("allows a wildcard index-pattern entity that is an explicit whitelist member (#3269)", () => {

--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -200,6 +200,49 @@ describe("resolveElasticsearchConfig", () => {
       /no authentication configured/,
     );
   });
+
+  test("rejects an explicit engine outside the union", () => {
+    expect(() =>
+      resolveElasticsearchConfig({
+        url: VALID_URL,
+        apiKey: API_KEY,
+        engine: "solr" as unknown as "elasticsearch",
+      }),
+    ).toThrow(/engine must be "elasticsearch" or "opensearch"/);
+  });
+
+  test("rejects SigV4 auth over plaintext HTTP to a remote host", () => {
+    expect(() =>
+      resolveElasticsearchConfig({
+        url: "elasticsearch://search.example.com:9200?ssl=false",
+        awsRegion: "us-east-1",
+        awsAccessKeyId: "AKIDEXAMPLE",
+        awsSecretAccessKey: "secret",
+      }),
+    ).toThrow(/SigV4 \(AWS\) auth requires HTTPS for a remote host/);
+  });
+
+  test("allows SigV4 over plaintext HTTP to a loopback host (local mock)", () => {
+    // VALID_URL is http://localhost — a LocalStack-style local AWS mock is valid.
+    const resolved = resolveElasticsearchConfig({
+      url: VALID_URL,
+      awsRegion: "us-east-1",
+      awsAccessKeyId: "AKIDEXAMPLE",
+      awsSecretAccessKey: "secret",
+    });
+    expect(resolved.auth.mode).toBe("sigv4");
+  });
+
+  test("allows SigV4 over HTTPS (the managed-AWS path)", () => {
+    const resolved = resolveElasticsearchConfig({
+      url: "elasticsearch://search.example.com:9200",
+      awsRegion: "us-east-1",
+      awsAccessKeyId: "AKIDEXAMPLE",
+      awsSecretAccessKey: "secret",
+    });
+    expect(resolved.auth.mode).toBe("sigv4");
+    expect(resolved.endpoint).toBe("https://search.example.com:9200");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -277,6 +320,45 @@ describe("SENSITIVE_PATTERNS", () => {
 // ---------------------------------------------------------------------------
 
 describe("createElasticsearchClient", () => {
+  test("warns when Basic credentials would go over plaintext HTTP to a remote host", () => {
+    const warn = mock(() => {});
+    createElasticsearchClient(
+      resolveElasticsearchConfig({
+        url: "elasticsearch://search.example.com:9200?ssl=false",
+        username: "u",
+        password: "s3cr3t-pw-xyz",
+      }),
+      { logger: { info: () => {}, warn, debug: () => {}, error: () => {} } },
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [, message] = warn.mock.calls[0] as unknown as [unknown, string];
+    expect(message).toMatch(/plaintext HTTP/);
+    // The warning must not echo the credential.
+    expect(message).not.toContain("s3cr3t-pw-xyz");
+  });
+
+  test("does NOT warn for plaintext HTTP to a loopback host", () => {
+    const warn = mock(() => {});
+    createElasticsearchClient(
+      // VALID_URL is http://localhost — local dev plaintext is fine.
+      resolveElasticsearchConfig({ url: VALID_URL, username: "u", password: "p" }),
+      { logger: { info: () => {}, warn, debug: () => {}, error: () => {} } },
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("does NOT warn when transport is HTTPS", () => {
+    const warn = mock(() => {});
+    createElasticsearchClient(
+      resolveElasticsearchConfig({
+        url: "elasticsearch://search.example.com:9200",
+        apiKey: API_KEY,
+      }),
+      { logger: { info: () => {}, warn, debug: () => {}, error: () => {} } },
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   test("ping returns a normalized cluster-info result", async () => {
     const fetchImpl = mock(async () => fetchResponse(CLUSTER_INFO_BODY));
     const client = createElasticsearchClient(
@@ -1617,6 +1699,11 @@ describe("Elastic Cloud ID (#3264)", () => {
     // "hello" base64-decodes fine but has no `$` separator.
     const cloudId = cloudIdOf("hello");
     expect(() => decodeCloudId(cloudId)).toThrow(/malformed/);
+  });
+
+  test("rejects a decoded domain carrying a non-numeric port", () => {
+    const cloudId = cloudIdOf("cloud.example.com:notaport$esid$kbnid");
+    expect(() => decodeCloudId(cloudId)).toThrow(/non-numeric port/);
   });
 
   test("resolveElasticsearchConfig combines a Cloud ID with API-key creds", () => {

--- a/plugins/elasticsearch/__tests__/mapping.test.ts
+++ b/plugins/elasticsearch/__tests__/mapping.test.ts
@@ -553,4 +553,31 @@ describe("collapseMappings — coverage map", () => {
     // A standalone index maps to itself.
     expect(coverage.get("products")).toBe("products");
   });
+
+  test("a data-stream backing index also targeted by an alias resolves to the STREAM, not the alias", () => {
+    // With includeSystem, parseAliases retains the `.ds-…` backing index, so the
+    // alias and the data stream both reference it. Step 1 (data streams) claims it
+    // for the stream; step 2 must NOT re-emit it under the alias or it would
+    // overwrite the coverage entry (last-write-wins) and mis-resolve the index.
+    const { coverage } = collapseMappings(
+      {
+        mapping: { web: { mappings: { properties: { url: { type: "keyword" } } } } },
+        dataStreamMapping: {
+          ".ds-events-000001": { mappings: { properties: { ts: { type: "date" } } } },
+        },
+        dataStreams: {
+          data_streams: [{ name: "events", indices: [{ index_name: ".ds-events-000001" }] }],
+        },
+        aliases: {
+          ".ds-events-000001": { aliases: { mixed: {} } },
+          web: { aliases: { mixed: {} } },
+        },
+      },
+      { includeSystem: true },
+    );
+    // The shared backing index stays owned by its data stream.
+    expect(coverage.get(".ds-events-000001")).toBe("events");
+    // The alias still covers its own, non-claimed member.
+    expect(coverage.get("web")).toBe("mixed");
+  });
 });

--- a/plugins/elasticsearch/src/connection.ts
+++ b/plugins/elasticsearch/src/connection.ts
@@ -504,12 +504,10 @@ export function decodeCloudId(cloudId: string): string {
   }
 
   const encoded = trimmed.slice(sep + 1);
-  let decoded: string;
-  try {
-    decoded = Buffer.from(encoded, "base64").toString("utf8");
-  } catch {
-    throw new Error("Invalid Elastic Cloud ID: the base64 segment could not be decoded.");
-  }
+  // `Buffer.from(x, "base64")` never throws — it decodes what it can and drops
+  // invalid characters — so a malformed segment is caught by the `parts.length`
+  // check below rather than by a (dead) try/catch around the decode.
+  const decoded = Buffer.from(encoded, "base64").toString("utf8");
   // A valid Cloud ID decodes to the full `domain[:port]$es-uuid$kibana-uuid`
   // triple (kibana-uuid, and occasionally es-uuid, may be empty — but the `$`
   // separators are always present). Require all three parts so a truncated or
@@ -528,6 +526,11 @@ export function decodeCloudId(cloudId: string): string {
   const colonIdx = domainPart.indexOf(":");
   const domain = colonIdx === -1 ? domainPart : domainPart.slice(0, colonIdx);
   const port = colonIdx === -1 ? "" : domainPart.slice(colonIdx + 1);
+  if (port && !/^\d+$/.test(port)) {
+    throw new Error(
+      "Invalid Elastic Cloud ID: the decoded domain carries a non-numeric port.",
+    );
+  }
 
   const host = esUuid && esUuid.length > 0 ? `${esUuid}.${domain}` : domain;
   return `https://${host}${port ? `:${port}` : ""}`;
@@ -645,6 +648,73 @@ export function resolveAuth(
  *
  * Error messages never echo a secret.
  */
+/**
+ * Loopback hosts where plaintext (`?ssl=false`) transport is acceptable — a
+ * local dev cluster never leaves the machine. Everything else is "remote" for
+ * the purposes of the plaintext-credential checks below.
+ */
+function isLoopbackHost(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, "");
+  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h.endsWith(".localhost");
+}
+
+/**
+ * SigV4 (Amazon OpenSearch Service / IAM-protected domains) is only ever reached
+ * over HTTPS — managed AWS endpoints don't serve plaintext. A SigV4 descriptor
+ * paired with a remote `http://` endpoint (via `?ssl=false`) can only be a
+ * misconfiguration that would put the signed request and `X-Amz-Security-Token`
+ * on the wire in cleartext, so reject it at resolve time rather than sign over
+ * plaintext. Loopback is exempt (a local AWS-compatible mock such as LocalStack
+ * is a valid test target). Basic/API-key over remote plaintext is warned, not
+ * rejected — see {@link warnIfPlaintextCredentials} — because a self-hosted
+ * cluster reachable only over an internal network is a legitimate, if
+ * discouraged, setup.
+ */
+function assertSecureTransportForSigV4(
+  endpoint: string,
+  auth: ElasticsearchAuthDescriptor,
+): void {
+  if (auth.mode !== "sigv4" || !endpoint.startsWith("http://")) return;
+  let host = "";
+  try {
+    host = new URL(endpoint).hostname;
+  } catch {
+    // Unparseable endpoint — the request will fail loudly later; nothing to assert here.
+    return;
+  }
+  if (isLoopbackHost(host)) return;
+  throw new Error(
+    "Invalid Elasticsearch config: SigV4 (AWS) auth requires HTTPS for a remote host; refusing to sign a request over plaintext HTTP (drop `?ssl=false`).",
+  );
+}
+
+/**
+ * Warn — once, at client construction — when Basic or API-key credentials would
+ * be sent over plaintext HTTP to a non-loopback host. Not a hard error: an
+ * internal-network self-hosted cluster is a valid (if discouraged) deployment.
+ * SigV4 is rejected outright upstream in {@link assertSecureTransportForSigV4}.
+ */
+function warnIfPlaintextCredentials(
+  endpoint: string,
+  auth: ElasticsearchAuthDescriptor,
+  logger?: PluginLogger,
+): void {
+  if (!endpoint.startsWith("http://")) return;
+  if (auth.mode !== "basic" && auth.mode !== "apiKey") return;
+  let host = "";
+  try {
+    host = new URL(endpoint).hostname;
+  } catch {
+    // Unparseable endpoint — the fetch will fail loudly later; nothing to warn on here.
+    return;
+  }
+  if (isLoopbackHost(host)) return;
+  logger?.warn(
+    { host, authMode: auth.mode },
+    `Elasticsearch ${auth.mode} credentials will be sent over plaintext HTTP to a non-local host (${host}); use HTTPS (remove \`?ssl=false\`) so they aren't exposed on the wire.`,
+  );
+}
+
 export function resolveElasticsearchConfig(
   config: ElasticsearchPluginConfig,
   options?: ResolveAuthOptions,
@@ -672,8 +742,21 @@ export function resolveElasticsearchConfig(
     );
   }
 
+  // Validate an explicit `engine` against the union at runtime — the admin form
+  // constrains it via a Zod `select`, but a raw static-config caller is otherwise
+  // untyped and a bad value would silently route SQL to the wrong endpoint.
+  if (
+    config.engine !== undefined &&
+    config.engine !== "elasticsearch" &&
+    config.engine !== "opensearch"
+  ) {
+    throw new Error(
+      `Invalid Elasticsearch config: engine must be "elasticsearch" or "opensearch" (got "${String(config.engine)}").`,
+    );
+  }
   const engine: ElasticsearchEngine = config.engine ?? schemeEngine ?? "elasticsearch";
   const auth = resolveAuth(config, options);
+  assertSecureTransportForSigV4(endpoint, auth);
 
   return {
     engine,
@@ -837,6 +920,7 @@ export function createElasticsearchClient(
   options?: ElasticsearchClientOptions,
 ): ElasticsearchClient {
   const { endpoint, auth, engine } = resolved;
+  warnIfPlaintextCredentials(endpoint, auth, options?.logger);
   const secrets = collectAuthSecrets(auth);
   const sqlProfile = engineSqlProfile(engine);
   let closed = false;

--- a/plugins/elasticsearch/src/connection.ts
+++ b/plugins/elasticsearch/src/connection.ts
@@ -655,7 +655,10 @@ export function resolveAuth(
  */
 function isLoopbackHost(host: string): boolean {
   const h = host.toLowerCase().replace(/^\[|\]$/g, "");
-  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h.endsWith(".localhost");
+  if (h === "localhost" || h.endsWith(".localhost") || h === "::1") return true;
+  // The whole 127.0.0.0/8 block is loopback (127.0.0.1 is just the common case),
+  // including the IPv4-mapped-IPv6 form of a v4 loopback address.
+  return /^(?:::ffff:)?127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
 }
 
 /**

--- a/plugins/elasticsearch/src/dsl.ts
+++ b/plugins/elasticsearch/src/dsl.ts
@@ -187,13 +187,26 @@ function bodyHasMutatingScript(node: unknown): boolean {
  * a `_search` / `_count` context a script can't actually mutate documents, so
  * this is belt-and-suspenders: refuse the opaque reference rather than execute a
  * body we can't inspect. Inline read-only scripts (`script.source`) are unaffected.
+ *
+ * A terms LOOKUP (`{ "terms": { "<field>": { "index", "id", "path" } } }`) also
+ * carries a string `id`, and its `<field>` may legitimately be named `*_script`,
+ * so it would otherwise false-positive here — exclude any value that carries the
+ * `index`/`path` terms-lookup markers (a real stored-script ref never has them).
  */
 function bodyReferencesStoredScript(node: unknown): boolean {
   if (Array.isArray(node)) return node.some(bodyReferencesStoredScript);
   if (!isPlainObject(node)) return false;
   for (const [key, value] of Object.entries(node)) {
     const isScriptKey = key === "script" || /_script$/.test(key);
-    if (isScriptKey && isPlainObject(value) && typeof value.id === "string") return true;
+    if (
+      isScriptKey &&
+      isPlainObject(value) &&
+      typeof value.id === "string" &&
+      !("index" in value) &&
+      !("path" in value)
+    ) {
+      return true;
+    }
     if (bodyReferencesStoredScript(value)) return true;
   }
   return false;
@@ -291,15 +304,17 @@ export function validateIndexAccess(
   const allowedLower = new Set(Array.from(allowed, (s) => s.toLowerCase()));
 
   for (const seg of segments) {
-    // Reject anything outside the legal index-name charset BEFORE the
+    // Reject path-injection / illegal characters BEFORE the
     // membership/pattern/system checks, so this validator is self-contained: its
-    // safety must not depend on a downstream caller URL-encoding the segment. ES
-    // index names are lowercase alnum plus `. _ - +`; the wildcard chars `* ?`
-    // are permitted here but gated by the pattern-membership rule below. A `/`,
-    // whitespace, control char, or quote slipping through (e.g. in structural-only
-    // mode, where membership isn't enforced) would otherwise enable path injection
-    // if interpolated into a request path unescaped.
-    if (!/^[A-Za-z0-9._+*?-]+$/.test(seg)) {
+    // safety must not depend on a downstream caller URL-encoding the segment. A
+    // `/`, backslash, whitespace, control char, quote, or `< > | %` slipping
+    // through (e.g. in structural-only mode, where membership isn't enforced)
+    // would otherwise enable path injection if interpolated into a request path
+    // unescaped. This is a DENY-list, not an ASCII allow-list: Elasticsearch
+    // permits Unicode index names (e.g. CJK), so a legitimately whitelisted
+    // non-ASCII index must still pass. The wildcard chars `* ?` are deliberately
+    // NOT denied — they're gated by the pattern-membership rule below.
+    if (/[\x00-\x1f/\\\s"'`<>|%]/.test(seg)) {
       return {
         valid: false,
         reason: `Index "${seg}" contains characters that are not allowed in an index name.`,

--- a/plugins/elasticsearch/src/dsl.ts
+++ b/plugins/elasticsearch/src/dsl.ts
@@ -181,6 +181,25 @@ function bodyHasMutatingScript(node: unknown): boolean {
 }
 
 /**
+ * Detect a stored-script reference (`{ "script": { "id": "…" } }`) under any
+ * script-bearing key. A stored script's body lives server-side, so it is
+ * INVISIBLE to {@link bodyHasMutatingScript} — we cannot prove it read-only. From
+ * a `_search` / `_count` context a script can't actually mutate documents, so
+ * this is belt-and-suspenders: refuse the opaque reference rather than execute a
+ * body we can't inspect. Inline read-only scripts (`script.source`) are unaffected.
+ */
+function bodyReferencesStoredScript(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(bodyReferencesStoredScript);
+  if (!isPlainObject(node)) return false;
+  for (const [key, value] of Object.entries(node)) {
+    const isScriptKey = key === "script" || /_script$/.test(key);
+    if (isScriptKey && isPlainObject(value) && typeof value.id === "string") return true;
+    if (bodyReferencesStoredScript(value)) return true;
+  }
+  return false;
+}
+
+/**
  * Validate a Query DSL request against the read-only boundary. **Default-deny**:
  *
  *  1. Endpoint must be a known read shape ({@link isReadEndpoint}) — every
@@ -209,6 +228,12 @@ export function validateEsDslRequest(request: EsDslRequest): EsDslValidationResu
       return {
         valid: false,
         reason: "Mutating script detected in the request body — scripts that reference `ctx` are write-context and are not allowed.",
+      };
+    }
+    if (bodyReferencesStoredScript(body)) {
+      return {
+        valid: false,
+        reason: "Stored-script reference (`script.id`) is not allowed — its body lives server-side and can't be verified read-only. Use an inline read-only script (`script.source`) instead.",
       };
     }
     if (isPlainObject(body)) {
@@ -266,6 +291,21 @@ export function validateIndexAccess(
   const allowedLower = new Set(Array.from(allowed, (s) => s.toLowerCase()));
 
   for (const seg of segments) {
+    // Reject anything outside the legal index-name charset BEFORE the
+    // membership/pattern/system checks, so this validator is self-contained: its
+    // safety must not depend on a downstream caller URL-encoding the segment. ES
+    // index names are lowercase alnum plus `. _ - +`; the wildcard chars `* ?`
+    // are permitted here but gated by the pattern-membership rule below. A `/`,
+    // whitespace, control char, or quote slipping through (e.g. in structural-only
+    // mode, where membership isn't enforced) would otherwise enable path injection
+    // if interpolated into a request path unescaped.
+    if (!/^[A-Za-z0-9._+*?-]+$/.test(seg)) {
+      return {
+        valid: false,
+        reason: `Index "${seg}" contains characters that are not allowed in an index name.`,
+      };
+    }
+
     const isMember = allowedLower.has(seg.toLowerCase());
 
     // `_all` / wildcards fan out beyond the named index — allowed ONLY when the

--- a/plugins/elasticsearch/src/dsl.ts
+++ b/plugins/elasticsearch/src/dsl.ts
@@ -190,8 +190,11 @@ function bodyHasMutatingScript(node: unknown): boolean {
  *
  * A terms LOOKUP (`{ "terms": { "<field>": { "index", "id", "path" } } }`) also
  * carries a string `id`, and its `<field>` may legitimately be named `*_script`,
- * so it would otherwise false-positive here — exclude any value that carries the
- * `index`/`path` terms-lookup markers (a real stored-script ref never has them).
+ * so it would otherwise false-positive here. A real terms lookup always carries
+ * BOTH `index` and `path`; a stored-script ref never does. So we treat the value
+ * as a stored-script reference unless it has both lookup markers — requiring both
+ * (not either) keeps an attacker from cloaking a stored-script id behind a single
+ * bogus `index`/`path` key.
  */
 function bodyReferencesStoredScript(node: unknown): boolean {
   if (Array.isArray(node)) return node.some(bodyReferencesStoredScript);
@@ -202,8 +205,7 @@ function bodyReferencesStoredScript(node: unknown): boolean {
       isScriptKey &&
       isPlainObject(value) &&
       typeof value.id === "string" &&
-      !("index" in value) &&
-      !("path" in value)
+      !("index" in value && "path" in value)
     ) {
       return true;
     }
@@ -313,8 +315,11 @@ export function validateIndexAccess(
     // unescaped. This is a DENY-list, not an ASCII allow-list: Elasticsearch
     // permits Unicode index names (e.g. CJK), so a legitimately whitelisted
     // non-ASCII index must still pass. The wildcard chars `* ?` are deliberately
-    // NOT denied — they're gated by the pattern-membership rule below.
-    if (/[\x00-\x1f/\\\s"'`<>|%]/.test(seg)) {
+    // NOT denied — they're gated by the pattern-membership rule below. Control
+    // chars are matched via the Unicode `\p{Cc}` class (C0+C1+DEL) under the `u`
+    // flag rather than an `\x00-\x1f` literal range, which both widens coverage
+    // and avoids ESLint `no-control-regex` on a literal control escape.
+    if (/[\p{Cc}/\\\s"'`<>|%]/u.test(seg)) {
       return {
         valid: false,
         reason: `Index "${seg}" contains characters that are not allowed in an index name.`,

--- a/plugins/elasticsearch/src/mapping.ts
+++ b/plugins/elasticsearch/src/mapping.ts
@@ -616,7 +616,12 @@ export function collapseMappings(
   const aliases = parseAliases(input.aliases, { includeSystem });
   for (const [name, indices] of aliases) {
     if (dataStreams.has(name)) continue;
-    const members = [...indices];
+    // Drop backing indices already claimed by a data stream (step 1): re-emitting
+    // one under the alias would double-count it in `coverage` (last-write-wins)
+    // and mis-resolve it away from its owning stream. If every member is already
+    // claimed, the alias is fully subsumed — skip it. Mirrors step 4's re-check.
+    const members = [...indices].filter((m) => !claimed.has(m));
+    if (members.length === 0) continue;
     for (const m of members) claimed.add(m);
     emit(
       buildLogicalEntity({


### PR DESCRIPTION
## What

Addresses the findings from a pre-closeout code review of the v0.0.13 Elasticsearch/OpenSearch datasource work (the plugin internals + its install/query seams). All findings were **defense-in-depth / correctness hardening — no Critical, no happy-path behavior change**. Bundled into one PR per request.

## Security

- **TLS / credential transport guard** (`connection.ts`) — *High*. `?ssl=false` previously let Basic/SigV4 credentials traverse plaintext HTTP with no guard. Now: **reject SigV4-over-HTTP to a remote host** (managed AWS is HTTPS-only; loopback exempt for LocalStack-style local mocks), and **warn once at client construction** when Basic/API-key creds would go over plaintext HTTP to a non-loopback host. Self-hosted internal-network plaintext stays allowed (warned, not blocked) so Docker-network deploys aren't broken.
- **`validateIndexAccess` charset guard** (`dsl.ts`) — *Medium*. Reject out-of-charset index segments (slashes, whitespace, control chars, quotes) **before** membership checks, so the exported validator is self-contained and no longer depends on the connection layer's `encodeURIComponent` for path-injection safety (matters in structural-only mode).
- **Stored-script reference deny** (`dsl.ts`) — *Low*. Deny `{"script":{"id":…}}` in a read body — a server-side stored script is opaque to the read-only validator. Inline `script.source` is unaffected.
- **`saas_eligible` gate on `/install-form`** (`integrations.ts`) — *Medium, #3301*. The marketplace `/install` route enforces `saas_eligible` server-side but the parallel `/install-form` route didn't — a known slug could bypass the hidden card by POSTing directly under SaaS. Mirrors the `/install` gate (`=== false`, resolved deploy mode).

## Correctness

- **`collapseMappings` alias/data-stream collision** (`mapping.ts`) — drop alias backing indices already claimed by a data stream, so a shared backing index resolves to its owning stream instead of being double-counted in the coverage map.
- **`decodeCloudId`** (`connection.ts`) — remove a dead `try/catch` around a never-throwing base64 decode; validate the decoded port is numeric.
- **`resolveElasticsearchConfig`** (`connection.ts`) — validate an explicit `engine` against the union at runtime (the raw static-config path was previously untyped).

## Deliberately not changed
- SigV4 minimal-header signing, the by-design wildcard time-of-query expansion, the row-cap "materialized vs fetched" comment, and the `coming_soon` form-branch parity nit (pre-existing, all datasource rows seed `available`) — each flagged by the review as no-action / by-design.

## Tests
Added coverage for **every** fix: TLS guard (SigV4 remote-reject / loopback-allow / HTTPS-allow, Basic plaintext warn + non-leak), Cloud ID port, engine-union, DSL charset path-injection (parametrized), stored-script refs, the mapping collision coverage assertion, and the `/install-form` `saas_eligible` gate (SaaS-refuse + self-hosted-allow).

- Plugin suites: `elasticsearch` 165, `dsl` 116, `mapping` 68, `dsl-tool` 28 — all pass.
- `integrations.test.ts`: 82 pass.
- `bun run lint` clean · `bun run type` clean · 83 affected API test files pass.

https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr

---
_Generated by [Claude Code](https://claude.ai/code/session_011wKbAvWsW5bjZvuryMtjsr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783467485&installation_id=135337507&pr_number=3322&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3322&signature=a05cd866831a6080240000dc4044d0cc5d3ab84c97cf9d3e97fcead9a2daa98b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced SaaS eligibility gate on integration install flows (OAuth, form, callback) to block ineligible installs in SaaS mode; self-hosted installs remain allowed.
  * Hardened Elasticsearch safety: reject stored-script references in DSL, stricter index-name segment validation, safer Cloud ID handling, require SigV4 over HTTPS for remote hosts, warn on plaintext credential usage, and resolve data-stream vs alias ownership collisions.

* **Tests**
  * Added extensive tests covering eligibility gates, DSL/index validation, connection/auth rules, and mapping conflict scenarios.

* **Documentation**
  * OpenAPI docs updated to document the new saas_ineligible responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->