### PR TITLE
fix(api): handle Postgres dollar-quoted literals in auto-LIMIT sanitizer + scope plugin install hints

### DIFF
--- a/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
@@ -90,6 +90,15 @@ describe("stripSqlNonClauseText", () => {
       ).toBe("SELECT * FROM t WHERE note = $msg$$msg$");
     });
 
+    // Postgres dollar-quote tags follow unquoted-identifier rules, which allow
+    // diacritic/non-Latin letters — so a Unicode tag must be recognized and
+    // blanked, else a LIMIT inside it leaks past the cap.
+    it("blanks a Unicode-tagged $café$...$café$ literal", () => {
+      expect(
+        stripSqlNonClauseText("SELECT * FROM t WHERE note = $café$no LIMIT here$café$"),
+      ).toBe("SELECT * FROM t WHERE note = $café$$café$");
+    });
+
     it("blanks a multi-line dollar-quoted literal", () => {
       expect(
         stripSqlNonClauseText("SELECT $$first line\nLIMIT 5\nlast line$$ FROM t"),
@@ -199,6 +208,14 @@ describe("hasLimitClause", () => {
   it("does NOT treat LIMIT inside a $tag$...$tag$ dollar-quoted literal as a clause", () => {
     expect(
       hasLimitClause("SELECT * FROM t WHERE note = $msg$no LIMIT here$msg$"),
+    ).toBe(false);
+  });
+
+  // Regression: an ASCII-only tag matcher would miss a Unicode-tagged literal,
+  // letting the inner LIMIT spoof "already limited" and suppress the row cap.
+  it("does NOT treat LIMIT inside a Unicode-tagged $café$...$café$ literal as a clause", () => {
+    expect(
+      hasLimitClause("SELECT * FROM big WHERE note = $café$LIMIT$café$"),
     ).toBe(false);
   });
 

--- a/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
@@ -78,16 +78,19 @@ describe("stripSqlNonClauseText", () => {
   // LIMIT inside one is a string value, never a clause, so the whole region is
   // blanked to a boundary-preserving placeholder.
   describe("Postgres dollar-quoted literals", () => {
+    // The placeholder is a fixed empty anonymous dollar-quote (`$$`), not the
+    // echoed delimiter — echoing the tag would leak its text (see the
+    // tag-named-`limit` case below).
     it("blanks an anonymous $$...$$ literal", () => {
       expect(
         stripSqlNonClauseText("SELECT * FROM t WHERE note = $$no LIMIT here$$"),
-      ).toBe("SELECT * FROM t WHERE note = $$$$");
+      ).toBe("SELECT * FROM t WHERE note = $$");
     });
 
     it("blanks a tagged $tag$...$tag$ literal", () => {
       expect(
         stripSqlNonClauseText("SELECT * FROM t WHERE note = $msg$no LIMIT here$msg$"),
-      ).toBe("SELECT * FROM t WHERE note = $msg$$msg$");
+      ).toBe("SELECT * FROM t WHERE note = $$");
     });
 
     // Postgres dollar-quote tags follow unquoted-identifier rules, which allow
@@ -96,13 +99,21 @@ describe("stripSqlNonClauseText", () => {
     it("blanks a Unicode-tagged $café$...$café$ literal", () => {
       expect(
         stripSqlNonClauseText("SELECT * FROM t WHERE note = $café$no LIMIT here$café$"),
-      ).toBe("SELECT * FROM t WHERE note = $café$$café$");
+      ).toBe("SELECT * FROM t WHERE note = $$");
+    });
+
+    // The tag itself is word-bearing: echoing the delimiter would put "limit"
+    // back into the sanitized output and re-spoof detection. (CodeRabbit #3329.)
+    it("does not leak a word-bearing tag name into the placeholder", () => {
+      expect(
+        stripSqlNonClauseText("SELECT * FROM t WHERE note = $limit$no LIMIT here$limit$"),
+      ).toBe("SELECT * FROM t WHERE note = $$");
     });
 
     it("blanks a multi-line dollar-quoted literal", () => {
       expect(
         stripSqlNonClauseText("SELECT $$first line\nLIMIT 5\nlast line$$ FROM t"),
-      ).toBe("SELECT $$$$ FROM t");
+      ).toBe("SELECT $$ FROM t");
     });
 
     it("does not treat a positional parameter ($1) as a delimiter", () => {
@@ -118,7 +129,7 @@ describe("stripSqlNonClauseText", () => {
     it("does not confuse a different tag for the closing delimiter", () => {
       expect(
         stripSqlNonClauseText("SELECT $a$inner $b$ still LIMIT inside$a$ FROM t"),
-      ).toBe("SELECT $a$$a$ FROM t");
+      ).toBe("SELECT $$ FROM t");
     });
   });
 });
@@ -216,6 +227,14 @@ describe("hasLimitClause", () => {
   it("does NOT treat LIMIT inside a Unicode-tagged $café$...$café$ literal as a clause", () => {
     expect(
       hasLimitClause("SELECT * FROM big WHERE note = $café$LIMIT$café$"),
+    ).toBe(false);
+  });
+
+  // Regression (CodeRabbit #3329): a tag literally named `limit` must not leak
+  // its own text into the sanitized output and spoof detection.
+  it("does NOT let a word-bearing tag name ($limit$) spoof a clause", () => {
+    expect(
+      hasLimitClause("SELECT * FROM t WHERE note = $limit$no LIMIT here$limit$"),
     ).toBe(false);
   });
 

--- a/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
@@ -73,6 +73,45 @@ describe("stripSqlNonClauseText", () => {
       "WHERE x = '' AND y = 2",
     );
   });
+
+  // Postgres dollar-quoting: $$...$$ and $tag$...$tag$ (#3325 follow-up). A
+  // LIMIT inside one is a string value, never a clause, so the whole region is
+  // blanked to a boundary-preserving placeholder.
+  describe("Postgres dollar-quoted literals", () => {
+    it("blanks an anonymous $$...$$ literal", () => {
+      expect(
+        stripSqlNonClauseText("SELECT * FROM t WHERE note = $$no LIMIT here$$"),
+      ).toBe("SELECT * FROM t WHERE note = $$$$");
+    });
+
+    it("blanks a tagged $tag$...$tag$ literal", () => {
+      expect(
+        stripSqlNonClauseText("SELECT * FROM t WHERE note = $msg$no LIMIT here$msg$"),
+      ).toBe("SELECT * FROM t WHERE note = $msg$$msg$");
+    });
+
+    it("blanks a multi-line dollar-quoted literal", () => {
+      expect(
+        stripSqlNonClauseText("SELECT $$first line\nLIMIT 5\nlast line$$ FROM t"),
+      ).toBe("SELECT $$$$ FROM t");
+    });
+
+    it("does not treat a positional parameter ($1) as a delimiter", () => {
+      const q = "SELECT * FROM t WHERE id = $1 AND x = $2";
+      expect(stripSqlNonClauseText(q)).toBe(q);
+    });
+
+    it("leaves an unterminated $$ intact so a real clause stays visible", () => {
+      const input = "SELECT * FROM t WHERE note = $$oops LIMIT 5";
+      expect(stripSqlNonClauseText(input)).toBe(input);
+    });
+
+    it("does not confuse a different tag for the closing delimiter", () => {
+      expect(
+        stripSqlNonClauseText("SELECT $a$inner $b$ still LIMIT inside$a$ FROM t"),
+      ).toBe("SELECT $a$$a$ FROM t");
+    });
+  });
 });
 
 describe("hasLimitClause", () => {
@@ -146,5 +185,40 @@ describe("hasLimitClause", () => {
         backslashEscapes: true,
       }),
     ).toBe(false);
+  });
+
+  // Postgres dollar-quoting bypass (#3325 follow-up): a LIMIT inside $$...$$ or
+  // $tag$...$tag$ is a string value, so it must NOT count as an existing clause
+  // (else the row cap is silently suppressed).
+  it("does NOT treat LIMIT inside a $$...$$ dollar-quoted literal as a clause", () => {
+    expect(
+      hasLimitClause("SELECT * FROM t WHERE note = $$no LIMIT here$$"),
+    ).toBe(false);
+  });
+
+  it("does NOT treat LIMIT inside a $tag$...$tag$ dollar-quoted literal as a clause", () => {
+    expect(
+      hasLimitClause("SELECT * FROM t WHERE note = $msg$no LIMIT here$msg$"),
+    ).toBe(false);
+  });
+
+  it("still detects a real LIMIT alongside a dollar-quoted block containing the word", () => {
+    expect(
+      hasLimitClause("SELECT * FROM t WHERE note = $$no LIMIT here$$ LIMIT 100"),
+    ).toBe(true);
+  });
+
+  it("detects a real LIMIT even when a positional parameter precedes it", () => {
+    // `$1` must not be parsed as a dollar-quote opener that swallows the clause.
+    expect(hasLimitClause("SELECT * FROM t WHERE id = $1 LIMIT 5")).toBe(true);
+  });
+
+  it("does not emit a double LIMIT when a $$ block is unterminated", () => {
+    // Unterminated dollar-quote: remainder left intact, so the literal LIMIT
+    // text inside is still visible and (conservatively) counts as present —
+    // matching the existing unterminated-literal behavior, never uncapping.
+    expect(
+      hasLimitClause("SELECT * FROM t WHERE note = $$oops LIMIT 5"),
+    ).toBe(true);
   });
 });

--- a/packages/api/src/lib/tools/auto-limit.ts
+++ b/packages/api/src/lib/tools/auto-limit.ts
@@ -130,7 +130,11 @@ export function stripSqlNonClauseText(
           out += sql.slice(i);
           break;
         }
-        out += delim + delim; // blanked, boundary-preserving ($$$$ or $tag$$tag$)
+        // Blank to a fixed empty anonymous dollar-quote: boundary-preserving and
+        // word-char-free. Echoing the real delimiter (`delim + delim`) would leak
+        // the TAG text — a tag literally named `$limit$` would put "limit" back in
+        // the output and re-spoof detection. (CodeRabbit #3329.)
+        out += "$$";
         i = close + delim.length;
         continue;
       }

--- a/packages/api/src/lib/tools/auto-limit.ts
+++ b/packages/api/src/lib/tools/auto-limit.ts
@@ -37,6 +37,33 @@ function consumeQuoted(
   return -1;
 }
 
+const isTagStart = (ch: string | undefined): boolean =>
+  ch !== undefined &&
+  ((ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") || ch === "_");
+const isTagCont = (ch: string | undefined): boolean =>
+  isTagStart(ch) || (ch !== undefined && ch >= "0" && ch <= "9");
+
+/**
+ * Match a PostgreSQL dollar-quote OPENING delimiter at index `i` (where
+ * `sql[i] === "$"`). Returns the full delimiter (`$$` or `$tag$`, tag =
+ * `[A-Za-z_][A-Za-z0-9_]*`) or null if the `$` doesn't open a dollar-quote.
+ *
+ * Positional parameters (`$1`, `$2`, …) never match: the tag must start with
+ * `[A-Za-z_]`, so `$` + digit (or `$` + anything-but-`$`) returns null.
+ *
+ * Linear, no regex, no slicing of the body.
+ */
+function matchDollarTag(sql: string, i: number): string | null {
+  const n = sql.length;
+  let j = i + 1; // char after the opening `$`
+  if (isTagStart(sql[j])) {
+    j++;
+    while (j < n && isTagCont(sql[j])) j++;
+  }
+  if (j < n && sql[j] === "$") return sql.slice(i, j + 1);
+  return null;
+}
+
 /**
  * Blank every region of a SQL string that could contain the word `LIMIT`
  * without it being a real LIMIT clause: string literals, quoted identifiers,
@@ -60,6 +87,11 @@ function consumeQuoted(
  *   - `--` / `#` line comments and slash-star block comments. `--` and block
  *     comments are universal (Postgres + MySQL); `#` is MySQL-only, gated on
  *     `backslashEscapes` so a Postgres `#` operator isn't mistaken for a comment.
+ *   - `$$...$$` / `$tag$...$tag$` Postgres dollar-quoted string literals — handled
+ *     unconditionally (Postgres-only and unambiguous; the syntax doesn't exist in
+ *     MySQL, so there's nothing to mis-strip there). Positional parameters
+ *     (`$1`, `$2`) are not delimiters — the tag must start with `[A-Za-z_]`, so
+ *     `$` + digit never opens a dollar-quote.
  *
  * Unterminated regions leave the remainder intact (the query is malformed and
  * cannot reach here post-AST-validation; this only guards against mis-stripping
@@ -70,13 +102,29 @@ export function stripSqlNonClauseText(
   opts?: { backslashEscapes?: boolean },
 ): string {
   // Fast path: nothing that can hold a spurious keyword.
-  if (!/['"`#]|--|\/\*/.test(sql)) return sql;
+  if (!/['"`#$]|--|\/\*/.test(sql)) return sql;
   const backslashEscapes = opts?.backslashEscapes ?? false;
   let out = "";
   let i = 0;
   const n = sql.length;
   while (i < n) {
     const c = sql[i];
+    // PostgreSQL dollar-quoted literal: $$...$$ or $tag$...$tag$. Checked first
+    // so the inner text (which may contain quotes/comments/LIMIT) is blanked
+    // wholesale. Positional params ($1, $2) fall through (matchDollarTag → null).
+    if (c === "$") {
+      const delim = matchDollarTag(sql, i);
+      if (delim) {
+        const close = sql.indexOf(delim, i + delim.length);
+        if (close === -1) {
+          out += sql.slice(i);
+          break;
+        }
+        out += delim + delim; // blanked, boundary-preserving ($$$$ or $tag$$tag$)
+        i = close + delim.length;
+        continue;
+      }
+    }
     // String literal (') or double-quoted identifier (").
     if (c === "'" || c === '"') {
       const end = consumeQuoted(sql, i, c, backslashEscapes);

--- a/packages/api/src/lib/tools/auto-limit.ts
+++ b/packages/api/src/lib/tools/auto-limit.ts
@@ -37,21 +37,31 @@ function consumeQuoted(
   return -1;
 }
 
+// A dollar-quote tag follows PostgreSQL unquoted-identifier rules: it starts
+// with a letter or underscore and continues with letters, digits, or
+// underscores. "Letter" includes diacritic and non-Latin letters (`\p{L}`), so a
+// Unicode tag like `$café$` is recognized — an ASCII-only test would miss it and
+// let a `LIMIT` inside the literal leak past the cap. Digits are excluded from
+// the START position, so positional parameters (`$1`, `$2`) are never tags.
+// (Each test is a single-char, anchored match — O(1), no ReDoS surface.)
+const TAG_START_RE = /[\p{L}_]/u;
+const TAG_CONT_RE = /[\p{L}0-9_]/u;
 const isTagStart = (ch: string | undefined): boolean =>
-  ch !== undefined &&
-  ((ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") || ch === "_");
+  ch !== undefined && TAG_START_RE.test(ch);
 const isTagCont = (ch: string | undefined): boolean =>
-  isTagStart(ch) || (ch !== undefined && ch >= "0" && ch <= "9");
+  ch !== undefined && TAG_CONT_RE.test(ch);
 
 /**
  * Match a PostgreSQL dollar-quote OPENING delimiter at index `i` (where
- * `sql[i] === "$"`). Returns the full delimiter (`$$` or `$tag$`, tag =
- * `[A-Za-z_][A-Za-z0-9_]*`) or null if the `$` doesn't open a dollar-quote.
+ * `sql[i] === "$"`). Returns the full delimiter (`$$` or `$tag$`, where the tag
+ * follows Postgres identifier rules — see {@link isTagStart}/{@link isTagCont})
+ * or null if the `$` doesn't open a dollar-quote.
  *
- * Positional parameters (`$1`, `$2`, …) never match: the tag must start with
- * `[A-Za-z_]`, so `$` + digit (or `$` + anything-but-`$`) returns null.
+ * Positional parameters (`$1`, `$2`, …) never match: a tag can't start with a
+ * digit, so `$` + digit (or `$` + anything-but-`$`) returns null.
  *
- * Linear, no regex, no slicing of the body.
+ * Linear: the tag scan walks single chars via O(1) anchored char tests, and the
+ * only slice is of the short matched delimiter, never the body.
  */
 function matchDollarTag(sql: string, i: number): string | null {
   const n = sql.length;

--- a/plugins/bigquery/src/connection.ts
+++ b/plugins/bigquery/src/connection.ts
@@ -51,7 +51,16 @@ export function createBigQueryConnection(
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'@google-cloud/bigquery'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "BigQuery support requires the @google-cloud/bigquery package. Install it with: bun add @google-cloud/bigquery",
         { cause: err },

--- a/plugins/clickhouse/src/connection.ts
+++ b/plugins/clickhouse/src/connection.ts
@@ -61,7 +61,16 @@ export function createClickHouseConnection(
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'@clickhouse/client'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "ClickHouse support requires the @clickhouse/client package. Install it with: bun add @clickhouse/client",
         { cause: err },

--- a/plugins/daytona/src/index.ts
+++ b/plugins/daytona/src/index.ts
@@ -67,7 +67,16 @@ function loadDaytonaSdk(): any {
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'@daytonaio/sdk'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "Daytona support requires the @daytonaio/sdk package. Install it with: bun add @daytonaio/sdk",
         { cause: err },

--- a/plugins/duckdb/src/connection.ts
+++ b/plugins/duckdb/src/connection.ts
@@ -67,7 +67,17 @@ export function createDuckDBConnection(
             typeof err === "object" &&
             "code" in err &&
             (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-          if (isNotFound) {
+          // Only surface the install hint when the missing module is THIS
+          // package, not a transitive dep that failed to load (same
+          // MODULE_NOT_FOUND code, different named module). Node and bun both
+          // name the missing request quoted, so a transitive failure won't
+          // match our own specifier.
+          const ownPackageMissing =
+            isNotFound &&
+            (err instanceof Error ? err.message : String(err)).includes(
+              "'@duckdb/node-api'",
+            );
+          if (ownPackageMissing) {
             throw new Error(
               "DuckDB support requires the @duckdb/node-api package. Install it with: bun add @duckdb/node-api",
               { cause: err },

--- a/plugins/e2b/src/index.ts
+++ b/plugins/e2b/src/index.ts
@@ -65,7 +65,14 @@ function loadE2BSDK(): { Sandbox: any } {
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes("'e2b'");
+    if (ownPackageMissing) {
       throw new Error(
         "E2B support requires the e2b package. Install it with: bun add e2b",
         { cause: err },

--- a/plugins/mysql/src/connection.ts
+++ b/plugins/mysql/src/connection.ts
@@ -48,7 +48,16 @@ export function createMySQLConnection(
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'mysql2/promise'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "MySQL support requires the mysql2 package. Install it with: bun add mysql2",
         { cause: err },

--- a/plugins/snowflake/src/connection.ts
+++ b/plugins/snowflake/src/connection.ts
@@ -98,7 +98,16 @@ export function createSnowflakeConnection(
       typeof err === "object" &&
       "code" in err &&
       (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same MODULE_NOT_FOUND code, different
+    // named module). Node and bun both name the missing request quoted in the
+    // message, so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'snowflake-sdk'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "Snowflake support requires the snowflake-sdk package. Install it with: bun add snowflake-sdk",
         { cause: err },

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -178,7 +178,18 @@ async function loadSandboxModule(): Promise<{ Sandbox: SandboxConstructor }> {
         ? (err as NodeJS.ErrnoException).code
         : undefined;
     // `require()` threw MODULE_NOT_FOUND; dynamic import() throws ERR_MODULE_NOT_FOUND.
-    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
+    const isNotFound =
+      code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+    // Only surface the install hint when the missing module is THIS package, not
+    // a transitive dep that failed to load (same not-found code, different named
+    // module). Node and bun both name the missing request quoted in the message,
+    // so a transitive failure won't match our own specifier.
+    const ownPackageMissing =
+      isNotFound &&
+      (err instanceof Error ? err.message : String(err)).includes(
+        "'@vercel/sandbox'",
+      );
+    if (ownPackageMissing) {
       throw new Error(
         "Vercel Sandbox requires the @vercel/sandbox package. " +
           "Install it with: bun add @vercel/sandbox",


### PR DESCRIPTION
Two follow-ups from the #3328 review (both #3325-adjacent). They're independent — the second is a CodeRabbit-flagged pre-existing nit bundled in at the author's request.

---

## 1. Auto-LIMIT: Postgres dollar-quoted literals (the security fix)

Follow-up to #3325.

### Problem
`stripSqlNonClauseText` in `auto-limit.ts` blanks string literals, quoted
identifiers, and comments before the `\bLIMIT\b` presence test, but did **not**
handle PostgreSQL dollar-quoted string literals. So:

```sql
SELECT * FROM t WHERE note = $$no LIMIT here$$
SELECT * FROM t WHERE note = $msg$no LIMIT here$msg$
```

were treated as "already limited" → the auto-LIMIT row cap was silently
suppressed → uncapped query.

### Fix
The single-pass scanner now detects a dollar-quote **opening** delimiter
(`$$` or `$tag$`, tag = `[A-Za-z_][A-Za-z0-9_]*`) ahead of the existing
quote/comment handling, finds the matching closing delimiter, and blanks the
whole region with a boundary-preserving placeholder (`$$$$` / `$tag$$tag$`).
`$` is added to the fast-path regex so dollar-bearing queries don't early-return.

- **Postgres-only & unconditional** — dollar-quoting doesn't exist in MySQL and
  is unambiguous, so no dialect flag is needed. Blanking is monotonically safe:
  a real `LIMIT` clause is never inside a `$$...$$` block, so it can never be hidden.
- **Positional params excluded** — `$1`, `$2` never match (the tag must start
  with `[A-Za-z_]`), so a real `... WHERE id = $1 LIMIT 5` still detects the clause.
- **Unterminated delimiter** leaves the remainder intact (conservative: counts
  the inner LIMIT as present rather than appending a second one).
- Regex-free / provably-linear body (`matchDollarTag` slices only the short
  matched delimiter, never the scanned body). The `hasLimitClause` call-site
  signature is unchanged, so the `connection-runtime-guards` source pin holds.

### Tests (`auto-limit.test.ts`)
`stripSqlNonClauseText` blanks `$$...$$` / `$tag$...$tag$` (incl. multi-line),
ignores positional params, leaves unterminated `$$` intact, doesn't mistake a
different inner tag for the close. `hasLimitClause` → false for LIMIT inside a
dollar-quote, true alongside a real LIMIT, true for `$1 LIMIT 5`, true (no
double-LIMIT) on an unterminated `$$`.

---

## 2. Plugin install hints: scope MODULE_NOT_FOUND to the plugin's own package

Pre-existing nit from the #3328 review.

### Problem
The lazy SDK loaders in the datasource/sandbox plugins showed an
"install `<plugin package>`" hint on **any** `MODULE_NOT_FOUND`, so a missing
*transitive* dependency got mislabeled as the plugin's own package being absent.

### Fix
Gate the hint on the named missing module actually being the plugin's own
require specifier. Node and bun both name the missing request **quoted** in the
error message — verified across bare (`'snowflake-sdk'`), scoped
(`'@clickhouse/client'`), and subpath (`'mysql2/promise'`) forms, and both the
`MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` variants. A transitive failure names
a *different* module, so it no longer matches and falls through to the generic
`Failed to load <pkg>: <cause>` path, which surfaces the real underlying error.

Applied consistently to **clickhouse, bigquery, mysql, snowflake, daytona, e2b,
vercel-sandbox** — plus **duckdb**, which had the identical pattern/bug but
wasn't in the original list. (These blocks have no existing tests and `require()`
a string literal, so the failure path isn't cleanly injectable without
heavyweight module mocking; behavior is verified by runtime probes. No new tests
added, matching the existing untested style.)

---

## Validation
- `bun test src/lib/tools/__tests__/auto-limit.test.ts` → 32 pass
- `connection-runtime-guards.test.ts` → 12 pass (source pin intact)
- All 8 affected plugin suites green (snowflake 79, bigquery 98, mysql 39,
  clickhouse 69, daytona 24, e2b 25, duckdb 78, vercel-sandbox 27)
- `bun run type` (root tsgo) → clean
- `eslint` on all 10 changed files → clean

https://claude.ai/code/session_01R11LW6GLhK8xeRdQhtEkw5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL parsing to correctly handle PostgreSQL dollar-quoted string literals.
  * Enhanced error reporting for missing optional dependencies across database and plugin connectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->