### PR TITLE
feat(cli): ES profiler supports all plugin auth modes + OpenSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,15 @@ DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
 # When atlas.config.ts defines datasources, this env var is not needed.
 ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 # ATLAS_DATASOURCE_URL=mysql://user:pass@localhost:3306/mydb
-# ATLAS_DATASOURCE_URL=elasticsearch://my-cluster.es.io:9243   # Elasticsearch (HTTPS; append ?ssl=false for a local cluster)
-# ATLAS_ES_API_KEY=                            # Base64 API key for the Elasticsearch datasource above. Required by `atlas init`/`diff` — the key is NOT carried in the elasticsearch:// URL
+# ATLAS_DATASOURCE_URL=elasticsearch://my-cluster.es.io:9243   # Elasticsearch (HTTPS; append ?ssl=false for a local cluster). opensearch://host:9200 selects the OpenSearch engine
+# ATLAS_ES_CLOUD_ID=                           # Elastic Cloud ID (<name>:<base64>) — endpoint alternative to the elasticsearch:// URL above
+# Elasticsearch auth for `atlas init`/`diff` — pick ONE mode; credentials are NOT carried in the URL (precedence: SigV4 → Basic → API key):
+# ATLAS_ES_API_KEY=                            # Base64 API key
+# ATLAS_ES_USERNAME=                           # HTTP Basic username (requires ATLAS_ES_PASSWORD)
+# ATLAS_ES_PASSWORD=                           # HTTP Basic password (requires ATLAS_ES_USERNAME)
+# ATLAS_ES_AWS_REGION=                         # Selects AWS SigV4 (Amazon OpenSearch Service); keys from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN)
+# ATLAS_ES_AWS_SERVICE=                        # SigV4 service code (default "es"; "aoss" for OpenSearch Serverless)
+# ATLAS_ES_ENGINE=                             # Optional engine override: elasticsearch | opensearch (wins over the URL scheme)
 
 # === LLM Provider (pick one) ===
 # ATLAS_PROVIDER=anthropic

--- a/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
+++ b/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
@@ -115,6 +115,44 @@ ambient AWS environment chain (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
 `AWS_SESSION_TOKEN`). Every request is signed fresh (Signature Version 4) with
 the configured region and service.
 
+### Profiling with `atlas init` / `atlas diff`
+
+The CLI semantic-layer profiler supports the same auth modes and engines as the
+plugin, configured through `ATLAS_ES_*` environment variables — credentials are
+**never** carried in the URL
+([#3309](https://github.com/AtlasDevHQ/atlas/issues/3309)):
+
+| Variable | Maps to | Description |
+| -------- | ------- | ----------- |
+| `ATLAS_DATASOURCE_URL` | `url` | `elasticsearch://host[:port]` or `opensearch://host[:port]` |
+| `ATLAS_ES_CLOUD_ID` | `cloudId` | Elastic Cloud ID — the endpoint when no URL is set |
+| `ATLAS_ES_API_KEY` | `apiKey` | Base64 API key |
+| `ATLAS_ES_USERNAME` / `ATLAS_ES_PASSWORD` | `username` / `password` | HTTP Basic (both required) |
+| `ATLAS_ES_AWS_REGION` | `awsRegion` | Selects AWS SigV4; keys come from the ambient `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ `AWS_SESSION_TOKEN`) chain |
+| `ATLAS_ES_AWS_SERVICE` | `awsService` | SigV4 service code (default `es`) |
+| `ATLAS_ES_ENGINE` | `engine` | Explicit engine override |
+
+The auth-mode precedence (SigV4 → Basic → API key) is the plugin's — the CLI
+builds the same config shape and hands it to the same resolver.
+
+```bash
+# Basic-secured self-hosted cluster
+export ATLAS_DATASOURCE_URL="elasticsearch://logs.internal:9200?ssl=false"
+export ATLAS_ES_USERNAME="atlas_reader"
+export ATLAS_ES_PASSWORD="…"
+bun run atlas -- init
+
+# Amazon OpenSearch Service via SigV4
+export ATLAS_DATASOURCE_URL="opensearch://search-mydomain.us-east-1.es.amazonaws.com"
+export ATLAS_ES_AWS_REGION="us-east-1"   # keys from the AWS env chain
+bun run atlas -- init
+
+# Elastic Cloud — no URL needed, the Cloud ID names the endpoint
+export ATLAS_ES_CLOUD_ID="my-deployment:…"
+export ATLAS_ES_API_KEY="…"
+bun run atlas -- init
+```
+
 ## SQL query surface
 
 Ask a tabular or aggregate question over a single index in chat and the agent

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -132,6 +132,13 @@ describe("detectDBType", () => {
     expect(() => detectDBType("clickhouses://localhost:8443/default")).toThrow("@useatlas/clickhouse");
   });
 
+  it("suggests @useatlas/elasticsearch for opensearch:// (no @useatlas/opensearch exists)", () => {
+    expect(() => detectDBType("opensearch://search-domain.us-east-1.es.amazonaws.com")).toThrow(
+      "@useatlas/elasticsearch"
+    );
+    expect(() => detectDBType("elasticsearch://host:9200")).toThrow("@useatlas/elasticsearch");
+  });
+
   it("includes the detected scheme in the error message", () => {
     expect(() => detectDBType("duckdb://:memory:")).toThrow("duckdb://");
     expect(() => detectDBType("clickhouse://localhost")).toThrow("clickhouse://");

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -178,10 +178,13 @@ export function detectDBType(url?: string): DBType {
   const rawScheme = connStr.split("://")[0] || "(empty)";
   // Normalize TLS variants (e.g. clickhouses → clickhouse) for the plugin hint
   const baseScheme = rawScheme.replace(/s$/, "");
+  // Both engines are served by the one @useatlas/elasticsearch plugin — there
+  // is no @useatlas/opensearch package, so the hint must not derive it (#3309).
+  const pluginName = baseScheme === "opensearch" ? "elasticsearch" : baseScheme;
   throw new Error(
     `Unsupported database URL scheme "${rawScheme}://". ` +
     `This adapter is now a plugin. Install the appropriate datasource plugin ` +
-    `(e.g. @useatlas/${baseScheme}) and add it to the plugins array in atlas.config.ts. ` +
+    `(e.g. @useatlas/${pluginName}) and add it to the plugins array in atlas.config.ts. ` +
     `Ensure the plugin is listed before any datasources that use it. ` +
     `Core adapters support postgresql:// and mysql:// only.`
   );

--- a/packages/cli/lib/cli-utils.ts
+++ b/packages/cli/lib/cli-utils.ts
@@ -106,7 +106,7 @@ export function detectDBType(url: string): DBType {
   const scheme = url.split("://")[0] || "(empty)";
   throw new Error(
     `Unsupported database URL scheme "${scheme}://". ` +
-      "Supported: postgresql://, mysql://, clickhouse://, snowflake://, duckdb://, salesforce://, elasticsearch://, opensearch://.",
+      "Supported: postgresql:// (or postgres://), mysql:// (or mysql2://), clickhouse:// (or clickhouses://), snowflake://, duckdb://, salesforce://, elasticsearch://, opensearch://.",
   );
 }
 

--- a/packages/cli/lib/cli-utils.ts
+++ b/packages/cli/lib/cli-utils.ts
@@ -99,11 +99,14 @@ export function detectDBType(url: string): DBType {
   if (url.startsWith("snowflake://")) return "snowflake";
   if (url.startsWith("duckdb://")) return "duckdb";
   if (url.startsWith("salesforce://")) return "salesforce";
-  if (url.startsWith("elasticsearch://")) return "elasticsearch";
+  // Both engines route through the Elasticsearch profiler — the plugin's
+  // resolver picks the engine (SQL endpoint) from the scheme (#3266/#3309).
+  if (url.startsWith("elasticsearch://") || url.startsWith("opensearch://"))
+    return "elasticsearch";
   const scheme = url.split("://")[0] || "(empty)";
   throw new Error(
     `Unsupported database URL scheme "${scheme}://". ` +
-      "Supported: postgresql://, mysql://, clickhouse://, snowflake://, duckdb://, salesforce://, elasticsearch://.",
+      "Supported: postgresql://, mysql://, clickhouse://, snowflake://, duckdb://, salesforce://, elasticsearch://, opensearch://.",
   );
 }
 

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -14,6 +14,8 @@ export interface SubcommandHelp {
   flags?: Array<{ flag: string; description: string }>;
   subcommands?: Array<{ name: string; description: string }>;
   examples?: string[];
+  /** Free-form lines printed after the examples (env-var contracts, caveats). */
+  notes?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +53,12 @@ export function printSubcommandHelp(help: SubcommandHelp): void {
     console.log("Examples:");
     for (const ex of help.examples) {
       console.log(`  ${ex}`);
+    }
+    console.log();
+  }
+  if (help.notes?.length) {
+    for (const note of help.notes) {
+      console.log(note);
     }
     console.log();
   }
@@ -133,6 +141,20 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas init --csv sales.csv,products.csv",
       "atlas init --org org-123",
     ],
+    notes: [
+      "Elasticsearch / OpenSearch datasources authenticate via environment",
+      "variables — credentials are never carried in the URL:",
+      "  ATLAS_DATASOURCE_URL    elasticsearch://host:9200 or opensearch://host:9200",
+      "  ATLAS_ES_CLOUD_ID       Elastic Cloud ID (endpoint alternative to the URL)",
+      "  ATLAS_ES_API_KEY        Base64 API key",
+      "  ATLAS_ES_USERNAME       HTTP Basic username (with ATLAS_ES_PASSWORD)",
+      "  ATLAS_ES_PASSWORD       HTTP Basic password (with ATLAS_ES_USERNAME)",
+      "  ATLAS_ES_AWS_REGION     Selects AWS SigV4 (Amazon OpenSearch Service);",
+      "                          keys from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY",
+      "                          (+ AWS_SESSION_TOKEN)",
+      "  ATLAS_ES_AWS_SERVICE    SigV4 service code (default: es)",
+      "  ATLAS_ES_ENGINE         Engine override: elasticsearch | opensearch",
+    ],
   },
   diff: {
     description:
@@ -157,6 +179,10 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas diff",
       "atlas diff --tables users,orders",
       'atlas diff || echo "Schema drift detected!"',
+    ],
+    notes: [
+      "Elasticsearch / OpenSearch datasources use the same ATLAS_ES_* environment",
+      "contract as `atlas init` — see `atlas init --help`.",
     ],
   },
   query: {

--- a/packages/cli/lib/profilers/elasticsearch.ts
+++ b/packages/cli/lib/profilers/elasticsearch.ts
@@ -80,10 +80,13 @@ export function elasticsearchConfigFromEnv(
     const trimmed = typeof value === "string" ? value.trim() : "";
     return trimmed.length > 0 ? trimmed : undefined;
   };
-  // The password is deliberately NOT trimmed — it is an opaque secret and the
-  // plugin's resolveAuth treats it verbatim.
+  // The password VALUE is deliberately not trimmed — it is an opaque secret
+  // the plugin's resolveAuth treats verbatim (leading/trailing spaces may be
+  // real). But a whitespace-ONLY value is misconfiguration, not a secret, so
+  // the set/unset check trims like every other env var — otherwise it would
+  // count as an auth signal and skip the actionable no-auth error below.
   const password =
-    typeof env.ATLAS_ES_PASSWORD === "string" && env.ATLAS_ES_PASSWORD.length > 0
+    typeof env.ATLAS_ES_PASSWORD === "string" && env.ATLAS_ES_PASSWORD.trim().length > 0
       ? env.ATLAS_ES_PASSWORD
       : undefined;
 

--- a/packages/cli/lib/profilers/elasticsearch.ts
+++ b/packages/cli/lib/profilers/elasticsearch.ts
@@ -10,12 +10,17 @@
  * standalone index entity. `atlas init` serializes the docs to
  * `semantic/entities/*.yml`; `atlas diff` compares them against the on-disk layer.
  *
- * The API key is NOT carried in the `elasticsearch://` URL (the URL parser
- * rejects credentials); the caller passes it separately (resolved from
- * `ATLAS_ES_API_KEY`).
+ * Credentials are NOT carried in the `elasticsearch://` URL (the URL parser
+ * rejects credentials); the caller passes a full plugin-shaped config — auth
+ * mode and engine are resolved by the plugin's `resolveElasticsearchConfig`
+ * (#3309), typically built from the `ATLAS_ES_*` environment contract via
+ * {@link elasticsearchConfigFromEnv}.
  */
 
 import type { ProfileError } from "@atlas/api/lib/profiler";
+// Type-only — erased at compile time, so this does NOT pull the plugin's
+// connection runtime (sigv4 signer, dsl safeguards) into module load.
+import type { ElasticsearchPluginConfig } from "../../../../plugins/elasticsearch/src/connection";
 import type {
   EsEntityDoc,
   EsMappingResponse,
@@ -29,6 +34,94 @@ import {
 
 // Re-exported so callers (e.g. `atlas init`) slug entity filenames identically.
 export { entityFileSlug, buildUniqueFileSlugs };
+
+/**
+ * One-line summary of the `ATLAS_ES_*` environment contract, appended to the
+ * actionable errors {@link elasticsearchConfigFromEnv} throws and reused by the
+ * init/diff missing-URL hints so the contract is documented in one place.
+ */
+export const ELASTICSEARCH_ENV_VARS_HINT =
+  "Auth (one mode): ATLAS_ES_API_KEY (Base64 API key), " +
+  "ATLAS_ES_USERNAME + ATLAS_ES_PASSWORD (HTTP Basic), or " +
+  "ATLAS_ES_AWS_REGION (AWS SigV4 — credentials from AWS_ACCESS_KEY_ID / " +
+  "AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN; optional ATLAS_ES_AWS_SERVICE, default \"es\"). " +
+  "Endpoint: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (or opensearch://), " +
+  "or ATLAS_ES_CLOUD_ID=<name>:<base64>. Optional ATLAS_ES_ENGINE overrides the engine.";
+
+/**
+ * Build the plugin-shaped {@link ElasticsearchPluginConfig} for `atlas init` /
+ * `atlas diff` from the `ATLAS_ES_*` environment contract (#3309). The CLI
+ * mirrors every auth mode + engine the plugin supports — the actual precedence
+ * (SigV4 → Basic → API key) and validation live in the plugin's
+ * `resolveElasticsearchConfig`, never duplicated here.
+ *
+ *   - `ATLAS_ES_API_KEY` — Base64 API key
+ *   - `ATLAS_ES_USERNAME` / `ATLAS_ES_PASSWORD` — HTTP Basic
+ *   - `ATLAS_ES_AWS_REGION` — selects AWS SigV4; access keys come from the
+ *     ambient AWS env chain (the CLI runs in the operator's shell, so
+ *     `allowAmbientAwsCreds` is set at resolve time — the multi-tenant
+ *     "per-tenant creds never read operator env" rule guards DB-stored
+ *     configs, not an operator-invoked CLI)
+ *   - `ATLAS_ES_AWS_SERVICE` — SigV4 service code (default `es`)
+ *   - `ATLAS_ES_CLOUD_ID` — Elastic Cloud ID, the endpoint when there is no URL
+ *   - `ATLAS_ES_ENGINE` — explicit engine override (`elasticsearch`|`opensearch`)
+ *
+ * Throws an actionable, secret-free error when no auth mode (or no endpoint) is
+ * configured, so `atlas init` fails with the env contract instead of a generic
+ * resolver message. A *partial* signal (lone username, url+cloudId both set) is
+ * passed through so the plugin resolver rejects it with its specific message.
+ */
+export function elasticsearchConfigFromEnv(
+  url?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ElasticsearchPluginConfig {
+  const read = (name: string): string | undefined => {
+    const value = env[name];
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    return trimmed.length > 0 ? trimmed : undefined;
+  };
+  // The password is deliberately NOT trimmed — it is an opaque secret and the
+  // plugin's resolveAuth treats it verbatim.
+  const password =
+    typeof env.ATLAS_ES_PASSWORD === "string" && env.ATLAS_ES_PASSWORD.length > 0
+      ? env.ATLAS_ES_PASSWORD
+      : undefined;
+
+  const cloudId = read("ATLAS_ES_CLOUD_ID");
+  const apiKey = read("ATLAS_ES_API_KEY");
+  const username = read("ATLAS_ES_USERNAME");
+  const awsRegion = read("ATLAS_ES_AWS_REGION");
+  const awsService = read("ATLAS_ES_AWS_SERVICE");
+  // Validated downstream by resolveElasticsearchConfig (runtime union check).
+  const engine = read("ATLAS_ES_ENGINE") as ElasticsearchPluginConfig["engine"];
+  const trimmedUrl = typeof url === "string" && url.trim().length > 0 ? url.trim() : undefined;
+
+  if (!trimmedUrl && !cloudId) {
+    throw new Error(
+      "No Elasticsearch endpoint configured. Set ATLAS_DATASOURCE_URL to an " +
+        "elasticsearch:// or opensearch:// URL, or ATLAS_ES_CLOUD_ID to an Elastic Cloud ID. " +
+        ELASTICSEARCH_ENV_VARS_HINT,
+    );
+  }
+  // No auth *signal* at all — a partial pair (lone username/password) falls
+  // through so the resolver rejects it with its specific "both required" error.
+  if (!apiKey && !username && !password && !awsRegion) {
+    throw new Error(
+      "No Elasticsearch authentication configured. " + ELASTICSEARCH_ENV_VARS_HINT,
+    );
+  }
+
+  return {
+    ...(trimmedUrl ? { url: trimmedUrl } : {}),
+    ...(cloudId ? { cloudId } : {}),
+    ...(apiKey ? { apiKey } : {}),
+    ...(username ? { username } : {}),
+    ...(password ? { password } : {}),
+    ...(awsRegion ? { awsRegion } : {}),
+    ...(awsService ? { awsService } : {}),
+    ...(engine ? { engine } : {}),
+  };
+}
 
 export interface ElasticsearchProfilingResult {
   entities: EsEntityDoc[];
@@ -54,14 +147,15 @@ export interface ProfileElasticsearchOptions {
  * continues with the entities it can build. Connection / mapping-fetch failures
  * surface as a secret-scrubbed error.
  *
- * @param connectionString `elasticsearch://host[:port][/prefix]` (no credentials).
- * @param apiKey Base64 API key (from `ATLAS_ES_API_KEY`).
+ * @param config Plugin-shaped connection config — endpoint (`url` or `cloudId`),
+ *   auth mode (API key / Basic / SigV4), and engine, resolved by the plugin's
+ *   `resolveElasticsearchConfig` (#3309). Usually built by
+ *   {@link elasticsearchConfigFromEnv}.
  * @param filterIndices When set, only these entities (by logical name) are
  *   profiled; any requested name absent from the result is reported in `errors`.
  */
 export async function profileElasticsearch(
-  connectionString: string,
-  apiKey: string,
+  config: ElasticsearchPluginConfig,
   filterIndices?: string[],
   options?: ProfileElasticsearchOptions,
 ): Promise<ElasticsearchProfilingResult> {
@@ -70,11 +164,21 @@ export async function profileElasticsearch(
     import("../../../../plugins/elasticsearch/src/connection"),
     import("../../../../plugins/elasticsearch/src/mapping"),
   ]);
-  const { resolveElasticsearchConfig, createElasticsearchClient, scrubElasticsearchError } =
-    connectionModule;
+  const {
+    resolveElasticsearchConfig,
+    createElasticsearchClient,
+    scrubElasticsearchError,
+    collectConfigSecrets,
+  } = connectionModule;
   const { collapseMappings, parseDataStreams } = mappingModule;
 
-  const resolved = resolveElasticsearchConfig({ url: connectionString, apiKey });
+  // Every secret in the raw config (API key, password, AWS secret/session) —
+  // the scrub list for any error this function surfaces.
+  const secrets = collectConfigSecrets(config);
+  // Ambient AWS creds are allowed: the CLI runs in the operator's own shell
+  // (same trust model as the static atlas.config.ts path) — see
+  // elasticsearchConfigFromEnv.
+  const resolved = resolveElasticsearchConfig(config, { allowAmbientAwsCreds: true });
   const client = createElasticsearchClient(
     resolved,
     options?.fetchImpl ? { fetchImpl: options.fetchImpl } : undefined,
@@ -171,7 +275,7 @@ export async function profileElasticsearch(
     // errors carry no credential — so the caught error is credential-free and
     // its cause chain is safe to preserve (unlike inside the client, which must
     // drop the cause because the raw fetch error can echo the API key).
-    throw new Error(scrubElasticsearchError(err, apiKey), { cause: err });
+    throw new Error(scrubElasticsearchError(err, secrets), { cause: err });
   } finally {
     client.close();
   }

--- a/packages/cli/lib/profilers/index.ts
+++ b/packages/cli/lib/profilers/index.ts
@@ -26,4 +26,6 @@ export {
   type ElasticsearchProfilingResult,
   type ProfileElasticsearchOptions,
   profileElasticsearch,
+  elasticsearchConfigFromEnv,
+  ELASTICSEARCH_ENV_VARS_HINT,
 } from "./elasticsearch";

--- a/packages/cli/lib/test-connection.ts
+++ b/packages/cli/lib/test-connection.ts
@@ -261,22 +261,24 @@ export async function testDatabaseConnection(
     }
 
     case "elasticsearch": {
-      // The API key is NOT in the elasticsearch:// URL (the parser rejects
-      // credentials) — it is a separate secret, read from ATLAS_ES_API_KEY.
-      const apiKey = process.env.ATLAS_ES_API_KEY;
-      if (!apiKey) {
-        throw new Error(
-          "ATLAS_ES_API_KEY is required for an Elasticsearch datasource. " +
-            "Set it to the base64 API key for the cluster.",
-        );
-      }
+      // Credentials are NOT in the elasticsearch:// / opensearch:// URL (the
+      // parser rejects them) — the auth mode (API key / Basic / SigV4) and an
+      // optional Elastic Cloud ID come from the ATLAS_ES_* env contract,
+      // mirroring the plugin config (#3309). An empty connStr means the
+      // endpoint is ATLAS_ES_CLOUD_ID.
+      const { elasticsearchConfigFromEnv } = await import("./profilers/elasticsearch");
+      const config = elasticsearchConfigFromEnv(connStr || undefined);
       const {
         resolveElasticsearchConfig,
         createElasticsearchClient,
         scrubElasticsearchError,
+        collectConfigSecrets,
       } = await import("../../../plugins/elasticsearch/src/connection");
+      const secrets = collectConfigSecrets(config);
+      // Ambient AWS creds allowed — the CLI runs in the operator's own shell
+      // (same trust model as the static atlas.config.ts path).
       const client = createElasticsearchClient(
-        resolveElasticsearchConfig({ url: connStr, apiKey }),
+        resolveElasticsearchConfig(config, { allowAmbientAwsCreds: true }),
       );
       try {
         const info = await client.ping(5000);
@@ -289,7 +291,7 @@ export async function testDatabaseConnection(
         // credential, so the caught error is credential-free — preserving the
         // cause chain is safe here.
         throw new Error(
-          `Cannot connect to Elasticsearch: ${scrubElasticsearchError(err, apiKey)}`,
+          `Cannot connect to Elasticsearch: ${scrubElasticsearchError(err, secrets)}`,
           { cause: err },
         );
       } finally {

--- a/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
+++ b/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
@@ -507,8 +507,19 @@ describe("elasticsearchConfigFromEnv", () => {
       elasticsearchConfigFromEnv(URL, {
         ATLAS_ES_API_KEY: "  ",
         ATLAS_ES_USERNAME: "",
+        ATLAS_ES_PASSWORD: "   ",
       }),
     ).toThrow(/No Elasticsearch authentication configured/);
+  });
+
+  test("a password with interior content keeps its leading/trailing whitespace", () => {
+    // Whitespace-ONLY is unset (above), but real surrounding whitespace in an
+    // opaque secret must survive verbatim.
+    const config = elasticsearchConfigFromEnv(URL, {
+      ATLAS_ES_USERNAME: "user",
+      ATLAS_ES_PASSWORD: " pw ",
+    });
+    expect(config.password).toBe(" pw ");
   });
 
   test("a lone username passes through so the plugin resolver rejects the pair", () => {

--- a/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
+++ b/packages/cli/src/__tests__/elasticsearch-profiler.test.ts
@@ -4,7 +4,9 @@ import * as yaml from "js-yaml";
 import {
   profileElasticsearch,
   elasticsearchCatalog,
+  elasticsearchConfigFromEnv,
 } from "../../lib/profilers/elasticsearch";
+import { detectDBType } from "../../lib/cli-utils";
 import {
   esEntityToSnapshot,
   parseEntityYAML,
@@ -14,6 +16,8 @@ import {
 
 const URL = "elasticsearch://localhost:9200?ssl=false";
 const API_KEY = "dGVzdC1lcy1rZXk=";
+/** The plugin-shaped config most tests profile with (API-key auth). */
+const CONFIG = { url: URL, apiKey: API_KEY };
 
 /** Minimal Response-like object for the mocked fetch (client reads ok/status/json). */
 function fetchResponse(
@@ -61,7 +65,7 @@ const MAPPING = {
 
 describe("profileElasticsearch", () => {
   test("profiles every non-system index into an entity doc", async () => {
-    const { entities, errors } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities, errors } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch(MAPPING),
     });
     expect(errors).toEqual([]);
@@ -76,8 +80,7 @@ describe("profileElasticsearch", () => {
 
   test("filters to requested indices and reports missing ones", async () => {
     const { entities, errors } = await profileElasticsearch(
-      URL,
-      API_KEY,
+      CONFIG,
       ["products", "does_not_exist"],
       { fetchImpl: mappingFetch(MAPPING) },
     );
@@ -87,7 +90,7 @@ describe("profileElasticsearch", () => {
   });
 
   test("threads the connection-group scope onto each entity", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       group: "warehouse",
       fetchImpl: mappingFetch(MAPPING),
     });
@@ -95,7 +98,7 @@ describe("profileElasticsearch", () => {
   });
 
   test("includes system indices only when asked", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       includeSystem: true,
       fetchImpl: mappingFetch(MAPPING),
     });
@@ -105,7 +108,7 @@ describe("profileElasticsearch", () => {
   test("returns empty (no entities, no errors) for a cluster with no user indices", async () => {
     // A fresh cluster (or one exposing only system/empty indices) — the empty
     // result is the contract the init/diff callers turn into a clear error.
-    const onlySystem = await profileElasticsearch(URL, API_KEY, undefined, {
+    const onlySystem = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch({
         ".kibana": { mappings: { properties: { config: { type: "keyword" } } } },
         empty_index: { mappings: { properties: {} } },
@@ -114,7 +117,7 @@ describe("profileElasticsearch", () => {
     expect(onlySystem.entities).toEqual([]);
     expect(onlySystem.errors).toEqual([]);
 
-    const emptyMapping = await profileElasticsearch(URL, API_KEY, undefined, {
+    const emptyMapping = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch({}),
     });
     expect(emptyMapping.entities).toEqual([]);
@@ -130,7 +133,7 @@ describe("profileElasticsearch", () => {
     ) as unknown as typeof fetch;
     let message = "";
     try {
-      await profileElasticsearch(URL, API_KEY, undefined, { fetchImpl: failing });
+      await profileElasticsearch(CONFIG, undefined, { fetchImpl: failing });
     } catch (err) {
       message = err instanceof Error ? err.message : String(err);
     }
@@ -174,7 +177,7 @@ function routingFetch(bodies: {
 
 describe("profileElasticsearch — logical sources", () => {
   test("collapses a time-partitioned index family into one pattern entity", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: routingFetch({
         mapping: {
           "logs-2024.01.01": { mappings: { properties: { ts: { type: "date" } } } },
@@ -191,7 +194,7 @@ describe("profileElasticsearch — logical sources", () => {
   });
 
   test("emits an alias entity and does not also emit its backing index", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: routingFetch({
         mapping: { orders_v3: { mappings: { properties: { id: { type: "keyword" } } } } },
         aliases: { orders_v3: { aliases: { orders: {} } } },
@@ -210,26 +213,26 @@ describe("profileElasticsearch — logical sources", () => {
     });
     // A concrete index that collapsed into `logs-*` is still addressable by name:
     // it resolves to the pattern entity instead of a spurious "not found".
-    const byMember = await profileElasticsearch(URL, API_KEY, ["logs-2024.01.01"], {
+    const byMember = await profileElasticsearch(CONFIG, ["logs-2024.01.01"], {
       fetchImpl,
     });
     expect(byMember.entities.map((e) => e.table)).toEqual(["logs-*"]);
     expect(byMember.errors).toEqual([]);
 
     // The logical name itself still works too.
-    const byName = await profileElasticsearch(URL, API_KEY, ["logs-*"], { fetchImpl });
+    const byName = await profileElasticsearch(CONFIG, ["logs-*"], { fetchImpl });
     expect(byName.entities.map((e) => e.table)).toEqual(["logs-*"]);
     expect(byName.errors).toEqual([]);
 
     // A genuinely-absent index still reports not-found.
-    const missing = await profileElasticsearch(URL, API_KEY, ["nope"], { fetchImpl });
+    const missing = await profileElasticsearch(CONFIG, ["nope"], { fetchImpl });
     expect(missing.entities).toEqual([]);
     expect(missing.errors).toHaveLength(1);
     expect(missing.errors[0].table).toBe("nope");
   });
 
   test("emits a data-stream entity from its backing-index mapping", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: routingFetch({
         mapping: {},
         dataStreams: {
@@ -255,7 +258,7 @@ describe("profileElasticsearch — logical sources", () => {
 
 describe("esEntityToSnapshot", () => {
   test("maps each dimension to a column (name → type), no FKs", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, ["products"], {
+    const { entities } = await profileElasticsearch(CONFIG, ["products"], {
       fetchImpl: mappingFetch(MAPPING),
     });
     const snap = esEntityToSnapshot(entities[0]);
@@ -271,7 +274,7 @@ describe("Elasticsearch diff round-trip", () => {
   /** Profile a mapping, serialize each entity to YAML, parse it back — the
    *  on-disk semantic-layer side of `atlas diff`. */
   async function yamlSnapshotsFor(body: unknown): Promise<Map<string, EntitySnapshot>> {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch(body),
     });
     const snapshots = new Map<string, EntitySnapshot>();
@@ -284,7 +287,7 @@ describe("Elasticsearch diff round-trip", () => {
 
   test("a freshly-profiled index diffs clean against its own YAML", async () => {
     const yamlSnaps = await yamlSnapshotsFor(MAPPING);
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch(MAPPING),
     });
     const dbSnaps = new Map<string, EntitySnapshot>(
@@ -316,7 +319,7 @@ describe("Elasticsearch diff round-trip", () => {
       customers: MAPPING.customers,
     };
 
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch(MUTATED),
     });
     const dbSnaps = new Map<string, EntitySnapshot>(
@@ -333,12 +336,208 @@ describe("Elasticsearch diff round-trip", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Auth modes + engines (#3309) — the profiler accepts the same config the
+// plugin does: Basic, SigV4, Cloud ID, and opensearch://, via the shared
+// resolveElasticsearchConfig (no duplicated precedence).
+// ---------------------------------------------------------------------------
+
+/** A mapping fetch that also records each request's URL + headers. */
+function capturingFetch(body: unknown): {
+  fetchImpl: typeof fetch;
+  calls: { url: string; headers: Record<string, string> }[];
+} {
+  const calls: { url: string; headers: Record<string, string> }[] = [];
+  const fetchImpl = mock(async (input: string | URL, init?: RequestInit) => {
+    calls.push({
+      url: typeof input === "string" ? input : input.toString(),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+    });
+    return fetchResponse(body);
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("profileElasticsearch — auth modes + engines (#3309)", () => {
+  test("HTTP Basic: profiles and sends a Basic Authorization header", async () => {
+    const { fetchImpl, calls } = capturingFetch(MAPPING);
+    const { entities } = await profileElasticsearch(
+      { url: URL, username: "atlas_reader", password: "s3cret-pw" },
+      undefined,
+      { fetchImpl },
+    );
+    expect(entities.map((e) => e.table).sort()).toEqual(["customers", "products"]);
+    const auth = calls[0].headers.Authorization;
+    expect(auth).toStartWith("Basic ");
+    expect(Buffer.from(auth.slice("Basic ".length), "base64").toString("utf8")).toBe(
+      "atlas_reader:s3cret-pw",
+    );
+  });
+
+  test("AWS SigV4: profiles an Amazon OpenSearch domain with signed requests", async () => {
+    const { fetchImpl, calls } = capturingFetch(MAPPING);
+    const { entities } = await profileElasticsearch(
+      {
+        url: "opensearch://search-mydomain.us-east-1.es.amazonaws.com",
+        awsRegion: "us-east-1",
+        awsAccessKeyId: "AKIAEXAMPLE",
+        awsSecretAccessKey: "aws-secret-example",
+      },
+      undefined,
+      { fetchImpl },
+    );
+    expect(entities.length).toBeGreaterThan(0);
+    const headers = calls[0].headers;
+    expect(headers.Authorization).toStartWith("AWS4-HMAC-SHA256 ");
+    expect(headers.Authorization).toContain("us-east-1/es/aws4_request");
+    expect(headers["X-Amz-Date"]).toMatch(/^\d{8}T\d{6}Z$/);
+    expect(headers["X-Amz-Content-Sha256"]).toBeTruthy();
+  });
+
+  test("Elastic Cloud ID: decodes the endpoint and profiles over HTTPS", async () => {
+    // domain$es-uuid$kibana-uuid → https://<es-uuid>.<domain>
+    const cloudId = `my-deployment:${Buffer.from(
+      "es.example.com$abc123$kibana456",
+      "utf8",
+    ).toString("base64")}`;
+    const { fetchImpl, calls } = capturingFetch(MAPPING);
+    const { entities } = await profileElasticsearch(
+      { cloudId, apiKey: API_KEY },
+      undefined,
+      { fetchImpl },
+    );
+    expect(entities.length).toBeGreaterThan(0);
+    const target = new globalThis.URL(calls[0].url);
+    expect(target.protocol).toBe("https:");
+    expect(target.hostname).toBe("abc123.es.example.com");
+  });
+
+  test("opensearch:// scheme: profiles an OpenSearch cluster", async () => {
+    const { entities } = await profileElasticsearch(
+      { url: "opensearch://localhost:9200?ssl=false", apiKey: API_KEY },
+      undefined,
+      { fetchImpl: mappingFetch(MAPPING) },
+    );
+    expect(entities.map((e) => e.table).sort()).toEqual(["customers", "products"]);
+  });
+
+  test("scrubs every config secret from a failing profile (Basic password)", async () => {
+    const password = "super-secret-pw";
+    const failing = mock(async () =>
+      fetchResponse(
+        { error: `auth failed for password ${password}` },
+        { ok: false, status: 401, statusText: "Unauthorized" },
+      ),
+    ) as unknown as typeof fetch;
+    let message = "";
+    try {
+      await profileElasticsearch(
+        { url: URL, username: "reader", password },
+        undefined,
+        { fetchImpl: failing },
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).not.toContain(password);
+  });
+});
+
+describe("detectDBType — opensearch:// routes to the Elasticsearch profiler", () => {
+  test("both engine schemes resolve to the elasticsearch DB type", () => {
+    expect(detectDBType("elasticsearch://host:9200")).toBe("elasticsearch");
+    expect(detectDBType("opensearch://host:9200")).toBe("elasticsearch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elasticsearchConfigFromEnv — the ATLAS_ES_* env contract (#3309)
+// ---------------------------------------------------------------------------
+
+describe("elasticsearchConfigFromEnv", () => {
+  test("maps the full ATLAS_ES_* contract onto the plugin config shape", () => {
+    const config = elasticsearchConfigFromEnv("opensearch://host:9200", {
+      ATLAS_ES_API_KEY: " key ",
+      ATLAS_ES_USERNAME: "user",
+      ATLAS_ES_PASSWORD: "pass with spaces ",
+      ATLAS_ES_AWS_REGION: "us-east-1",
+      ATLAS_ES_AWS_SERVICE: "aoss",
+      ATLAS_ES_ENGINE: "opensearch",
+    });
+    expect(config).toEqual({
+      url: "opensearch://host:9200",
+      apiKey: "key",
+      username: "user",
+      // The password is an opaque secret — never trimmed.
+      password: "pass with spaces ",
+      awsRegion: "us-east-1",
+      awsService: "aoss",
+      engine: "opensearch",
+    });
+  });
+
+  test("uses ATLAS_ES_CLOUD_ID as the endpoint when there is no URL", () => {
+    const config = elasticsearchConfigFromEnv(undefined, {
+      ATLAS_ES_CLOUD_ID: "deploy:abc",
+      ATLAS_ES_API_KEY: "key",
+    });
+    expect(config).toEqual({ cloudId: "deploy:abc", apiKey: "key" });
+  });
+
+  test("a SigV4 region alone is a valid auth signal (keys come from the AWS chain)", () => {
+    const config = elasticsearchConfigFromEnv("elasticsearch://host:9200", {
+      ATLAS_ES_AWS_REGION: "eu-west-1",
+    });
+    expect(config).toEqual({ url: "elasticsearch://host:9200", awsRegion: "eu-west-1" });
+  });
+
+  test("throws an actionable, secret-free error when no auth mode is configured", () => {
+    expect(() => elasticsearchConfigFromEnv(URL, {})).toThrow(
+      /No Elasticsearch authentication configured.*ATLAS_ES_API_KEY.*ATLAS_ES_USERNAME.*ATLAS_ES_AWS_REGION/s,
+    );
+  });
+
+  test("throws when neither a URL nor a Cloud ID names the endpoint", () => {
+    expect(() =>
+      elasticsearchConfigFromEnv(undefined, { ATLAS_ES_API_KEY: "key" }),
+    ).toThrow(/No Elasticsearch endpoint configured.*ATLAS_ES_CLOUD_ID/s);
+  });
+
+  test("empty / whitespace-only env values are treated as unset", () => {
+    expect(() =>
+      elasticsearchConfigFromEnv(URL, {
+        ATLAS_ES_API_KEY: "  ",
+        ATLAS_ES_USERNAME: "",
+      }),
+    ).toThrow(/No Elasticsearch authentication configured/);
+  });
+
+  test("a lone username passes through so the plugin resolver rejects the pair", () => {
+    // Not the env layer's call — resolveAuth owns "Basic needs both" with its
+    // specific message; the env layer only catches the no-signal-at-all case.
+    const config = elasticsearchConfigFromEnv(URL, { ATLAS_ES_USERNAME: "user" });
+    expect(config).toEqual({ url: URL, username: "user" });
+  });
+
+  test("passes url AND cloudId through so the resolver rejects the ambiguity loudly", async () => {
+    const config = elasticsearchConfigFromEnv(URL, {
+      ATLAS_ES_CLOUD_ID: "deploy:abc",
+      ATLAS_ES_API_KEY: "key",
+    });
+    expect(config.url).toBe(URL);
+    expect(config.cloudId).toBe("deploy:abc");
+    await expect(
+      profileElasticsearch(config, undefined, { fetchImpl: mappingFetch(MAPPING) }),
+    ).rejects.toThrow(/either a url or a cloudId, not both/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // elasticsearchCatalog
 // ---------------------------------------------------------------------------
 
 describe("elasticsearchCatalog", () => {
   test("lists one catalog entry per entity", async () => {
-    const { entities } = await profileElasticsearch(URL, API_KEY, undefined, {
+    const { entities } = await profileElasticsearch(CONFIG, undefined, {
       fetchImpl: mappingFetch(MAPPING),
     });
     const catalog = elasticsearchCatalog(entities) as {

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -33,11 +33,15 @@ import {
   formatDiff,
   type EntitySnapshot,
 } from "../../lib/diff";
-import { profileElasticsearch } from "../../lib/profilers/elasticsearch";
+import {
+  profileElasticsearch,
+  elasticsearchConfigFromEnv,
+} from "../../lib/profilers/elasticsearch";
 
 export async function handleDiff(args: string[]): Promise<void> {
-  const connStr = process.env.ATLAS_DATASOURCE_URL;
-  if (!connStr) {
+  // An Elastic Cloud ID names the endpoint without a URL (#3309).
+  const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+  if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) {
     console.error("Error: ATLAS_DATASOURCE_URL is required for atlas diff.");
     console.error(
       "  PostgreSQL:  ATLAS_DATASOURCE_URL=postgresql://user:pass@host:5432/dbname",
@@ -52,7 +56,13 @@ export async function handleDiff(args: string[]): Promise<void> {
       "  Salesforce:  ATLAS_DATASOURCE_URL=salesforce://user:pass@login.salesforce.com?token=TOKEN",
     );
     console.error(
-      "  Elasticsearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (+ ATLAS_ES_API_KEY)",
+      "  Elasticsearch / OpenSearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (or opensearch://host:9200),",
+    );
+    console.error(
+      "                 or ATLAS_ES_CLOUD_ID=<cloud-id> for an Elastic Cloud deployment (no URL needed).",
+    );
+    console.error(
+      "                 Auth via ATLAS_ES_API_KEY, ATLAS_ES_USERNAME/ATLAS_ES_PASSWORD, or ATLAS_ES_AWS_REGION (AWS SigV4).",
     );
     process.exit(1);
   }
@@ -82,7 +92,9 @@ export async function handleDiff(args: string[]): Promise<void> {
 
   let dbType: DBType;
   try {
-    dbType = detectDBType(connStr);
+    // An empty connStr is only reachable on the Elastic Cloud ID path —
+    // ATLAS_ES_CLOUD_ID names the endpoint, so there is no scheme to sniff.
+    dbType = connStr ? detectDBType(connStr) : "elasticsearch";
   } catch (err) {
     console.error(
       `\nError: ${err instanceof Error ? err.message : String(err)}`,
@@ -113,21 +125,14 @@ export async function handleDiff(args: string[]): Promise<void> {
 
   if (dbType === "elasticsearch") {
     // Elasticsearch profiles index mappings into entity docs — no SQL
-    // TableProfile pipeline, no --schema (Postgres-only). The API key is read
-    // from ATLAS_ES_API_KEY, never the URL.
-    const apiKey = process.env.ATLAS_ES_API_KEY;
-    if (!apiKey) {
-      console.error(
-        "Error: ATLAS_ES_API_KEY is required to diff an Elasticsearch datasource.",
-      );
-      process.exit(1);
-    }
-
+    // TableProfile pipeline, no --schema (Postgres-only). Credentials are read
+    // from the ATLAS_ES_* env contract (API key / Basic / SigV4, optional
+    // Cloud ID + engine override), never the URL (#3309).
     console.log(`\nProfiling Elasticsearch mappings...\n`);
     try {
+      const esConfig = elasticsearchConfigFromEnv(connStr || undefined);
       const { entities, errors } = await profileElasticsearch(
-        connStr,
-        apiKey,
+        esConfig,
         filterTables,
       );
       for (const e of errors) {

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -39,8 +39,10 @@ import {
 } from "../../lib/profilers/elasticsearch";
 
 export async function handleDiff(args: string[]): Promise<void> {
-  // An Elastic Cloud ID names the endpoint without a URL (#3309).
-  const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+  // An Elastic Cloud ID names the endpoint without a URL (#3309). Trimmed so
+  // a whitespace-only value behaves like unset (and reaches the Cloud-ID
+  // branch instead of failing scheme detection).
+  const connStr = (process.env.ATLAS_DATASOURCE_URL ?? "").trim();
   if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) {
     console.error("Error: ATLAS_DATASOURCE_URL is required for atlas diff.");
     console.error(
@@ -111,9 +113,18 @@ export async function handleDiff(args: string[]): Promise<void> {
     console.error(
       `\nError: ${err instanceof Error ? err.message : String(err)}`,
     );
-    console.error(
-      `\nCheck that ATLAS_DATASOURCE_URL is correct and the server is running.`,
-    );
+    if (dbType === "elasticsearch") {
+      // The endpoint may be a Cloud ID with no URL at all — point at the full
+      // ATLAS_ES_* contract instead of the (possibly absent) URL.
+      console.error(
+        `\nCheck the endpoint (elasticsearch:// / opensearch:// URL or ` +
+          `ATLAS_ES_CLOUD_ID) and the ATLAS_ES_* credentials.`,
+      );
+    } else {
+      console.error(
+        `\nCheck that ATLAS_DATASOURCE_URL is correct and the server is running.`,
+      );
+    }
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1232,8 +1232,9 @@ Next steps:
     ];
   } else if (sourceArg) {
     // Legacy --source flag: single datasource from env var, output to semantic/{source}/
-    // An Elastic Cloud ID names the endpoint without a URL (#3309).
-    const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+    // An Elastic Cloud ID names the endpoint without a URL (#3309); trimmed so
+    // a whitespace-only value behaves like unset.
+    const connStr = (process.env.ATLAS_DATASOURCE_URL ?? "").trim();
     if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) exitMissingDatasourceUrl();
     // Warn if --source and --demo are used together
     if (demoDataset) {
@@ -1315,8 +1316,9 @@ Next steps:
     }
   } else {
     // No config -- fall back to ATLAS_DATASOURCE_URL (backward-compatible single-source behavior).
-    // An Elastic Cloud ID names the endpoint without a URL (#3309).
-    const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+    // An Elastic Cloud ID names the endpoint without a URL (#3309); trimmed so
+    // a whitespace-only value behaves like unset.
+    const connStr = (process.env.ATLAS_DATASOURCE_URL ?? "").trim();
     if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) exitMissingDatasourceUrl();
     datasources = [
       {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -65,6 +65,7 @@ import { profileMySQL, profilePostgres } from "@atlas/api/lib/profiler";
 import {
   profileElasticsearch,
   elasticsearchCatalog,
+  elasticsearchConfigFromEnv,
   buildUniqueFileSlugs,
 } from "../../lib/profilers/elasticsearch";
 
@@ -233,10 +234,12 @@ interface DatasourceEntry {
 }
 
 /**
- * Profile an Elasticsearch datasource: fetch every index `_mapping`, transform
- * to entity docs, and write `entities/*.yml` + `catalog.yml`. The API key is
- * read from `ATLAS_ES_API_KEY` (never the URL). No SQL TableProfile pipeline,
- * no LLM enrichment in this slice.
+ * Profile an Elasticsearch / OpenSearch datasource: fetch every index
+ * `_mapping`, transform to entity docs, and write `entities/*.yml` +
+ * `catalog.yml`. Credentials are never read from the URL — the auth mode
+ * (API key / HTTP Basic / AWS SigV4), an optional Elastic Cloud ID, and an
+ * optional engine override come from the `ATLAS_ES_*` env contract (#3309).
+ * No SQL TableProfile pipeline, no LLM enrichment in this slice.
  */
 async function profileElasticsearchDatasource(
   opts: ProfileDatasourceOpts,
@@ -249,13 +252,9 @@ async function profileElasticsearchDatasource(
     );
   }
 
-  const apiKey = process.env.ATLAS_ES_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      "ATLAS_ES_API_KEY is required to profile an Elasticsearch datasource. " +
-        "Set it to the base64 API key for the cluster.",
-    );
-  }
+  // Throws an actionable, secret-free error when no auth mode (or endpoint)
+  // is configured. An empty url means the endpoint is ATLAS_ES_CLOUD_ID.
+  const esConfig = elasticsearchConfigFromEnv(url || undefined);
 
   const sourceId = id === "default" ? undefined : id;
 
@@ -269,7 +268,8 @@ async function profileElasticsearchDatasource(
       `\nError: ${err instanceof Error ? err.message : String(err)}`,
     );
     console.error(
-      `\nCheck that the elasticsearch:// URL and ATLAS_ES_API_KEY are correct.`,
+      `\nCheck that the endpoint (elasticsearch:// / opensearch:// URL or ` +
+        `ATLAS_ES_CLOUD_ID) and the ATLAS_ES_* credentials are correct.`,
     );
     throw err;
   }
@@ -278,8 +278,7 @@ async function profileElasticsearchDatasource(
   const start = Date.now();
 
   const { entities, errors } = await profileElasticsearch(
-    url,
-    apiKey,
+    esConfig,
     filterTables,
     sourceId ? { group: sourceId } : undefined,
   );
@@ -894,7 +893,13 @@ export function exitMissingDatasourceUrl(): never {
     "  DuckDB:      ATLAS_DATASOURCE_URL=duckdb://path/to/file.duckdb",
   );
   console.error(
-    "  Elasticsearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (+ ATLAS_ES_API_KEY)",
+    "  Elasticsearch / OpenSearch: ATLAS_DATASOURCE_URL=elasticsearch://host:9200 (or opensearch://host:9200),",
+  );
+  console.error(
+    "                 or ATLAS_ES_CLOUD_ID=<cloud-id> for an Elastic Cloud deployment (no URL needed).",
+  );
+  console.error(
+    "                 Auth via ATLAS_ES_API_KEY, ATLAS_ES_USERNAME/ATLAS_ES_PASSWORD, or ATLAS_ES_AWS_REGION (AWS SigV4).",
   );
   console.error(
     "  CSV/Parquet: Use --csv or --parquet flags (no database required)",
@@ -1227,8 +1232,9 @@ Next steps:
     ];
   } else if (sourceArg) {
     // Legacy --source flag: single datasource from env var, output to semantic/{source}/
-    const connStr = process.env.ATLAS_DATASOURCE_URL;
-    if (!connStr) exitMissingDatasourceUrl();
+    // An Elastic Cloud ID names the endpoint without a URL (#3309).
+    const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+    if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) exitMissingDatasourceUrl();
     // Warn if --source and --demo are used together
     if (demoDataset) {
       console.warn(
@@ -1308,9 +1314,10 @@ Next steps:
       process.exit(1);
     }
   } else {
-    // No config -- fall back to ATLAS_DATASOURCE_URL (backward-compatible single-source behavior)
-    const connStr = process.env.ATLAS_DATASOURCE_URL;
-    if (!connStr) exitMissingDatasourceUrl();
+    // No config -- fall back to ATLAS_DATASOURCE_URL (backward-compatible single-source behavior).
+    // An Elastic Cloud ID names the endpoint without a URL (#3309).
+    const connStr = process.env.ATLAS_DATASOURCE_URL ?? "";
+    if (!connStr && !process.env.ATLAS_ES_CLOUD_ID) exitMissingDatasourceUrl();
     datasources = [
       {
         id: "default",
@@ -1333,7 +1340,9 @@ Next steps:
   for (const ds of datasources) {
     let dbType: DBType;
     try {
-      dbType = detectDBType(ds.url);
+      // An empty URL is only produced by the Elastic Cloud ID path —
+      // ATLAS_ES_CLOUD_ID names the endpoint, so there is no scheme to sniff.
+      dbType = ds.url ? detectDBType(ds.url) : "elasticsearch";
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (isMultiSource) {

--- a/plugins/elasticsearch/README.md
+++ b/plugins/elasticsearch/README.md
@@ -128,8 +128,15 @@ Atlas profiles an Elasticsearch cluster into the semantic layer straight from
 index `_mapping`s — there is no SQL schema to introspect, so each index becomes
 an entity and each mapped field becomes a dimension.
 
-Because the API key is **not** carried in the `elasticsearch://` URL (the URL
-parser rejects credentials), the CLI reads it from `ATLAS_ES_API_KEY`:
+Because credentials are **not** carried in the `elasticsearch://` /
+`opensearch://` URL (the URL parser rejects them), the CLI reads the same
+auth-mode + engine config the plugin supports from `ATLAS_ES_*` environment
+variables (#3309): `ATLAS_ES_API_KEY` (Base64 API key), `ATLAS_ES_USERNAME` +
+`ATLAS_ES_PASSWORD` (HTTP Basic), or `ATLAS_ES_AWS_REGION` (AWS SigV4 — keys
+from the ambient `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` chain, optional
+`ATLAS_ES_AWS_SERVICE`). `ATLAS_ES_CLOUD_ID` names an Elastic Cloud endpoint
+when there is no URL, and `ATLAS_ES_ENGINE` overrides the engine. Precedence
+(SigV4 → Basic → API key) is the plugin resolver's — never duplicated in the CLI.
 
 ```bash
 export ATLAS_DATASOURCE_URL="elasticsearch://my-cluster.es.io:9243"


### PR DESCRIPTION
Closes #3309

## Problem

`atlas init` / `atlas diff` built an **API-key-only** Elasticsearch connection from `ATLAS_ES_API_KEY` + an `elasticsearch://` URL, while the `@useatlas/elasticsearch` plugin (since #3263/#3264/#3265/#3266) supports four auth modes (API key / HTTP Basic / Elastic Cloud ID / AWS SigV4) and both engines. A cluster reachable for *querying* — Basic-secured self-host, Amazon OpenSearch Service via SigV4, an Elastic Cloud deployment, or an `opensearch://` cluster — could not be profiled.

## Changes

- **`profileElasticsearch` takes the plugin's `ElasticsearchPluginConfig`** and resolves it via the plugin's `resolveElasticsearchConfig` — the auth precedence (SigV4 → Basic → API key) and engine selection are never duplicated in the CLI. Error scrubbing now uses `collectConfigSecrets` (passwords + AWS secrets, not just the API key).
- **New `elasticsearchConfigFromEnv`** maps the `ATLAS_ES_*` env contract onto the plugin config shape:
  - `ATLAS_ES_API_KEY` — Base64 API key
  - `ATLAS_ES_USERNAME` / `ATLAS_ES_PASSWORD` — HTTP Basic
  - `ATLAS_ES_AWS_REGION` — selects AWS SigV4; keys from the ambient `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ `AWS_SESSION_TOKEN`) chain; optional `ATLAS_ES_AWS_SERVICE` (default `es`)
  - `ATLAS_ES_CLOUD_ID` — Elastic Cloud ID; works with **no URL at all** in both `init` and `diff`
  - `ATLAS_ES_ENGINE` — explicit engine override

  Throws actionable, secret-free errors when no auth mode or endpoint is configured; partial signals (lone username, url+cloudId both set) pass through so the plugin resolver rejects them with its specific message.
- **`detectDBType` recognizes `opensearch://`** (routes to the same profiler; the plugin picks the SQL engine from the scheme).
- **Ambient AWS creds are allowed** for the CLI with an explicit rationale: it runs in the operator's own shell — the same trust model as the static `atlas.config.ts` path. The #2850 "per-tenant creds never read operator env" rule guards DB-stored configs, which this is not.
- **Docs**: env contract documented in `atlas init --help` / `atlas diff --help` (new `notes` field in the help renderer), `.env.example`, the ES datasource docs page (with Basic / SigV4 / Cloud ID examples), and the plugin README.

## Acceptance criteria (from #3309)

- [x] The ES profiler accepts the same auth-mode + engine config the plugin does (Basic via username/password env, SigV4 via `awsRegion` + AWS env chain, Cloud ID, `opensearch://`)
- [x] `atlas init` and `atlas diff` profile a Basic-secured, SigV4, Cloud ID, and OpenSearch cluster (mocked unit tests)
- [x] Env-var contract documented in `init.ts` help + the ES datasource doc page
- [x] No secret leaked in profiler errors (reuses `scrubElasticsearchError` / `collectConfigSecrets`)

## Testing

- Mocked unit tests: Basic (asserts the `Authorization: Basic` header), SigV4 (asserts `AWS4-HMAC-SHA256` signature + `X-Amz-Date` + credential scope), Cloud ID (asserts the decoded HTTPS endpoint), `opensearch://` profiling, Basic-password scrubbing, and the env resolver's mappings + error cases
- Full CLI suite green (30/30 files), elasticsearch plugin suite green, `bun run type` + `bun run lint` clean
- Smoke-tested `atlas init --help` and the no-auth error path end-to-end

https://claude.ai/code/session_01AdceNXrYZtxQ4Q4cfLi8wA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdceNXrYZtxQ4Q4cfLi8wA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783620343&installation_id=135337507&pr_number=3331&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3331&signature=d75d0bc4e000713998c3e29e18cc2beab714001f47853ce2aaf4903fc5fd6ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now supports HTTP Basic, AWS SigV4, API key auth, Elastic Cloud ID, and an explicit engine override for Elasticsearch vs OpenSearch.
  * CLI help/notes surface the shared env-var auth contract for init/diff.

* **Documentation**
  * Expanded env-var docs, examples, and README/CLI guidance for all auth modes and cloud-id usage.

* **Bug Fixes**
  * Treats opensearch:// as Elasticsearch-type and improves related error/help messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->