### PR TITLE
feat(plugin-sdk): semantic-whitelist load policy module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -310,7 +310,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@useatlas/plugin-sdk",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "devDependencies": {
         "ai": "^6.0.193",
         "hono": "^4.12.23",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@useatlas/plugin-sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Type definitions and helpers for authoring Atlas plugins",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepare": "bun run build",
-    "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts"
+    "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts && bun test src/__tests__/semantic-whitelist.test.ts"
   },
   "exports": {
     ".": {

--- a/packages/plugin-sdk/src/__tests__/semantic-whitelist.test.ts
+++ b/packages/plugin-sdk/src/__tests__/semantic-whitelist.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Canonical test set for the semantic-whitelist load policy (#3243 / #3313).
+ *
+ * Every dialect tool that gates on `gateOnSemanticWhitelist` /
+ * `warnIfStructuralOnly` inherits exactly these semantics — plugins assert
+ * their wiring, not the policy.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  gateOnSemanticWhitelist,
+  warnIfStructuralOnly,
+  type SemanticWhitelistSubject,
+} from "../semantic-whitelist";
+import type { PluginLogger } from "../types";
+
+const SUBJECT: SemanticWhitelistSubject = {
+  toolName: "queryExample",
+  member: "index",
+  structuralExposure: "any explicitly-named, non-system index",
+  queryKind: "DSL queries",
+  logLabel: "Example DSL",
+};
+
+function makeLogger() {
+  const calls: { level: string; args: unknown[] }[] = [];
+  const record = (level: string) =>
+    mock((...args: unknown[]) => {
+      calls.push({ level, args });
+    });
+  const logger = {
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    debug: record("debug"),
+  } as unknown as PluginLogger;
+  return { logger, calls };
+}
+
+describe("gateOnSemanticWhitelist", () => {
+  test("non-empty whitelist → ok gate with the member set", () => {
+    const gate = gateOnSemanticWhitelist(SUBJECT, () => ["Orders", "Flights"]);
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.allowed).toEqual(new Set(["Orders", "Flights"]));
+      expect(gate.structuralOnly).toBe(false);
+    }
+  });
+
+  test("legitimately-empty whitelist → ok gate flagged structural-only", () => {
+    const gate = gateOnSemanticWhitelist(SUBJECT, () => []);
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.allowed.size).toBe(0);
+      expect(gate.structuralOnly).toBe(true);
+    }
+  });
+
+  test("read() throws → fails CLOSED with the canonical refusal, never structural-only", () => {
+    const { logger, calls } = makeLogger();
+    const gate = gateOnSemanticWhitelist(
+      SUBJECT,
+      () => {
+        throw new Error("scan failed — whitelist load incomplete");
+      },
+      logger,
+      { index: "products" },
+    );
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) {
+      // The shape downstream tool tests assert against (/unavailable|refus/i).
+      expect(gate.error).toMatch(/unavailable|refus/i);
+      // The dialect noun lands in the agent-facing copy.
+      expect(gate.error).toContain("index access cannot be verified");
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe("error");
+    expect(calls[0].args[0]).toMatchObject({
+      index: "products",
+      error: "scan failed — whitelist load incomplete",
+    });
+    expect(calls[0].args[1]).toBe("Example DSL refused — semantic layer unavailable (scan failed)");
+  });
+
+  test("works without a logger (refusal still returned)", () => {
+    const gate = gateOnSemanticWhitelist(SUBJECT, () => {
+      throw new Error("nope");
+    });
+    expect(gate.ok).toBe(false);
+  });
+
+  test("non-Error throw is stringified into the log payload", () => {
+    const { logger, calls } = makeLogger();
+    const gate = gateOnSemanticWhitelist(SUBJECT, () => {
+      throw "raw failure"; // exercising the non-Error throw path
+    }, logger);
+    expect(gate.ok).toBe(false);
+    expect(calls[0].args[0]).toMatchObject({ error: "raw failure" });
+  });
+});
+
+describe("warnIfStructuralOnly", () => {
+  test("empty whitelist → one STRUCTURAL-ONLY operator warning with the consequence", () => {
+    const { logger, calls } = makeLogger();
+    warnIfStructuralOnly(SUBJECT, () => [], logger);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe("warn");
+    const msg = calls[0].args[0] as string;
+    expect(msg).toContain("queryExample registered with an empty semantic-layer whitelist");
+    expect(msg).toContain("STRUCTURAL-ONLY");
+    expect(msg).toContain("any explicitly-named, non-system index the credential can read is queryable");
+    expect(msg).toContain("per-index allow-list");
+  });
+
+  test("structuralExposure defaults from the member noun", () => {
+    const { logger, calls } = makeLogger();
+    warnIfStructuralOnly(
+      { toolName: "querySObjects", member: "object", queryKind: "SOQL queries", logLabel: "SOQL" },
+      () => [],
+      logger,
+    );
+    const msg = calls[0].args[0] as string;
+    expect(msg).toContain("any explicitly-named object the credential can read is queryable");
+    expect(msg).toContain("per-object allow-list");
+  });
+
+  test("non-empty whitelist → silent", () => {
+    const { logger, calls } = makeLogger();
+    warnIfStructuralOnly(SUBJECT, () => ["orders"], logger);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("read() throws → scan-failure warning naming the fail-closed consequence", () => {
+    const { logger, calls } = makeLogger();
+    warnIfStructuralOnly(
+      SUBJECT,
+      () => {
+        throw new Error("semantic layer not ready");
+      },
+      logger,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe("warn");
+    const msg = calls[0].args[0] as string;
+    expect(msg).toContain("queryExample: semantic-layer scan failed at registration");
+    expect(msg).toContain("DSL queries will fail closed");
+    expect(msg).toContain("semantic layer not ready");
+  });
+});

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -69,6 +69,9 @@ export {
 
 export type { CreatePluginOptions } from "./helpers";
 
+export { gateOnSemanticWhitelist, warnIfStructuralOnly } from "./semantic-whitelist";
+export type { SemanticWhitelistSubject, SemanticWhitelistGate } from "./semantic-whitelist";
+
 // ---------------------------------------------------------------------------
 // Peer dependency type re-exports (type-only — erased at runtime, safe even
 // when the optional peer deps are not installed)

--- a/packages/plugin-sdk/src/semantic-whitelist.ts
+++ b/packages/plugin-sdk/src/semantic-whitelist.ts
@@ -1,0 +1,118 @@
+/**
+ * Semantic-layer whitelist load policy for datasource query tools.
+ *
+ * Every dialect query tool (ES Query DSL, SOQL, future datasource plugins)
+ * gates member access on the semantic layer via `ctx.connections.tables(id)`.
+ * That accessor has three outcomes, and the policy for each is a SECURITY
+ * contract (#3243 / #3313) — stated here once instead of re-implemented (and
+ * re-explained in comments) by every plugin:
+ *
+ * - **throws** — the semantic-layer scan FAILED: the whitelist load is
+ *   incomplete. The query must be REFUSED (fail closed) rather than the error
+ *   swallowed into an empty set, which would silently widen access to
+ *   structural-only — the "false negative on a security check" anti-pattern.
+ *   {@link gateOnSemanticWhitelist} returns the canonical refusal.
+ * - **empty** — a legitimately-empty layer: STRUCTURAL-ONLY mode. The dialect
+ *   validator's always-on rails still apply, but any explicitly named member
+ *   the credential can read is queryable. Surfaced to the operator once at
+ *   registration via {@link warnIfStructuralOnly}.
+ * - **non-empty** — the membership whitelist the dialect validator checks
+ *   names against.
+ */
+
+import type { PluginLogger } from "./types";
+
+/**
+ * The dialect's vocabulary for whitelist policy copy. Declared once per
+ * plugin and shared by the query-time gate and the registration-time warning
+ * so the two surfaces can't drift.
+ */
+export interface SemanticWhitelistSubject {
+  /** Registered tool name, e.g. `"queryElasticsearch"`. */
+  readonly toolName: string;
+  /** Singular noun for one queryable member: `"index"`, `"object"`, `"table"`. */
+  readonly member: string;
+  /**
+   * What structural-only mode exposes, e.g. `"any explicitly-named,
+   * non-system index"`. Defaults to `any explicitly-named ${member}`.
+   */
+  readonly structuralExposure?: string;
+  /** Plural query kind for log copy, e.g. `"DSL queries"`, `"SOQL queries"`. */
+  readonly queryKind: string;
+  /** Short label for query-time refusal logs, e.g. `"ES DSL"`, `"SOQL"`. */
+  readonly logLabel: string;
+}
+
+/** Result of the query-time whitelist load. */
+export type SemanticWhitelistGate =
+  | {
+      readonly ok: true;
+      /** Member names to validate against. Empty = structural-only mode. */
+      readonly allowed: Set<string>;
+      /** True when the layer is legitimately empty (structural-only mode). */
+      readonly structuralOnly: boolean;
+    }
+  | {
+      readonly ok: false;
+      /** Canonical agent-facing refusal — return it as the tool error. */
+      readonly error: string;
+    };
+
+/**
+ * Load the semantic whitelist at query time, owning the fail-closed policy.
+ *
+ * Call this at the top of a dialect tool's `execute`; on `ok: false` return
+ * `{ success: false, error: gate.error }` without issuing any request. The
+ * scan-failure path is logged here (`logger.error`) so callers don't repeat
+ * the policy.
+ */
+export function gateOnSemanticWhitelist(
+  subject: SemanticWhitelistSubject,
+  read: () => Iterable<string>,
+  logger?: PluginLogger,
+  logContext?: Record<string, unknown>,
+): SemanticWhitelistGate {
+  let allowed: Set<string>;
+  try {
+    allowed = new Set(read());
+  } catch (err) {
+    logger?.error(
+      { ...logContext, error: err instanceof Error ? err.message : String(err) },
+      `${subject.logLabel} refused — semantic layer unavailable (scan failed)`,
+    );
+    return {
+      ok: false,
+      error: `The semantic layer is temporarily unavailable (its scan failed), so ${subject.member} access cannot be verified. Refusing the query to avoid unsafe access — retry once it recovers.`,
+    };
+  }
+  return { ok: true, allowed, structuralOnly: allowed.size === 0 };
+}
+
+/**
+ * One-time operator signal at tool registration (#3313).
+ *
+ * - Empty whitelist → warn that the tool runs in STRUCTURAL-ONLY mode, naming
+ *   the consequence so operators know to add entity YAMLs.
+ * - Whitelist read throws → warn that the scan failed and queries will fail
+ *   closed (the query-time gate logs each refusal; this only flags the state
+ *   at registration).
+ * - Non-empty → silent.
+ */
+export function warnIfStructuralOnly(
+  subject: SemanticWhitelistSubject,
+  read: () => Iterable<string>,
+  logger: PluginLogger,
+): void {
+  try {
+    if (new Set(read()).size === 0) {
+      const exposure = subject.structuralExposure ?? `any explicitly-named ${subject.member}`;
+      logger.warn(
+        `${subject.toolName} registered with an empty semantic-layer whitelist — running in STRUCTURAL-ONLY mode: ${exposure} the credential can read is queryable. Add entity YAMLs to enforce a per-${subject.member} allow-list.`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `${subject.toolName}: semantic-layer scan failed at registration — ${subject.queryKind} will fail closed until it recovers (${err instanceof Error ? err.message : String(err)}).`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

SDK-only half of the architecture-review candidate "one semantic-whitelist load policy" (review doc lands with the consumer PR). One module now owns the #3243/#3313 load policy that the ES Query DSL and SOQL dialect tools currently re-implement inline:

- **`gateOnSemanticWhitelist`** — query-time load; a throwing whitelist read (scan failed) fails **closed** with the canonical refusal; an empty layer passes through as structural-only
- **`warnIfStructuralOnly`** — registration-time operator signal for the empty-layer and scan-failed states
- **`SemanticWhitelistSubject`** — per-dialect vocabulary declared once, shared by both surfaces so policy copy can't drift
- Canonical test set covering all three accessor outcomes (available / empty / throwing)

plugin-sdk `0.0.7 → 0.0.8`. No consumers wired here — the elasticsearch/salesforce rewiring follows in a separate PR.

## Merge sequence (publish-then-bump)

1. Merge **this PR**
2. Tag `plugin-sdk-v0.0.8` → publish workflow ships 0.0.8 to npm
3. Merge the consumer PR (rewires both plugins, bumps their peer ranges to `>=0.0.8`, adds a publish ordering guard)

## Verification

- `bun run test` (plugin-sdk incl. 9 new policy tests), `bun run build` (dist emits `semantic-whitelist.d.ts`), repo-wide `bun run type`, lint, `check-published-symbols` all green

https://claude.ai/code/session_01ExNTL9MdLzhYWtc69qoXPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExNTL9MdLzhYWtc69qoXPm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783622358&installation_id=135337507&pr_number=3343&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3343&signature=adb7d097dd6137ebca8b78b25d33ac4c7ead024d5826a7c10d13258cc274f0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Semantic whitelist functionality now available in the public API, enabling query-time gating and registration-time warnings for controlled access to semantic layer members.

* **Tests**
  * Added comprehensive test suite for semantic whitelist behavior, including fail-closed error handling and warning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->