### PR TITLE
fix(security): sidecar fail-closed auth, no default admin password in prod, auto-LIMIT comment bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -468,7 +468,7 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_SANDBOX=nsjail    # Process isolation for explore tool (auto-detected when nsjail is on PATH)
 # ATLAS_SANDBOX_PRIORITY=                        # Custom backend priority (comma-separated: vercel-sandbox,nsjail,sidecar,just-bash)
 # ATLAS_SANDBOX_BACKEND=                         # SaaS admin-facing selector: vercel-sandbox | sidecar | e2b-sandbox | daytona-sandbox | <plugin-id>. Self-hosted operators typically use ATLAS_SANDBOX_PRIORITY instead
-# SIDECAR_AUTH_TOKEN=                            # Optional shared secret for sidecar auth (set on both API and sidecar)
+# SIDECAR_AUTH_TOKEN=                            # Shared secret for sidecar auth (set on both API and sidecar). The sidecar refuses to boot without it unless SIDECAR_AUTH_DISABLE=1 (loopback dev only)
 # Vercel Sandbox access tokens — required when calling @vercel/sandbox from
 # off-Vercel hosts (Railway, Fly, external CI, etc.). On Vercel itself, OIDC
 # handles auth via VERCEL_OIDC_TOKEN and these three are unnecessary.

--- a/create-atlas/templates/docker/sidecar/server.ts
+++ b/create-atlas/templates/docker/sidecar/server.ts
@@ -11,7 +11,7 @@
  *   POST /exec   — { command, timeout? } → { stdout, stderr, exitCode }
  */
 
-import { randomUUID } from "crypto";
+import { createHash, randomUUID, timingSafeEqual } from "crypto";
 import { readdirSync } from "fs";
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
@@ -76,10 +76,12 @@ async function readLimited(stream: ReadableStream, max: number): Promise<string>
 
 async function handleExec(req: Request): Promise<Response> {
   // Auth check — AUTH_TOKEN is only unset when SIDECAR_AUTH_DISABLE=1 was
-  // explicitly given (the boot guard above exits otherwise).
+  // explicitly given (the boot guard above exits otherwise). Hash both sides
+  // to fixed-length digests so timingSafeEqual never leaks token length.
   if (AUTH_TOKEN) {
-    const authHeader = req.headers.get("Authorization");
-    if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
+    const got = createHash("sha256").update(req.headers.get("Authorization") ?? "").digest();
+    const want = createHash("sha256").update(`Bearer ${AUTH_TOKEN}`).digest();
+    if (!timingSafeEqual(got, want)) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
   }

--- a/create-atlas/templates/docker/sidecar/server.ts
+++ b/create-atlas/templates/docker/sidecar/server.ts
@@ -33,7 +33,21 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_TIMEOUT_MS = 60_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024; // 1 MB
 
+// Fail closed: the sidecar executes arbitrary commands, so it refuses to
+// boot without auth unless an operator explicitly opts out for loopback dev.
 const AUTH_TOKEN = process.env.SIDECAR_AUTH_TOKEN;
+if (!AUTH_TOKEN && process.env.SIDECAR_AUTH_DISABLE !== "1") {
+  console.error(
+    "[sandbox-sidecar] SIDECAR_AUTH_TOKEN is not set. Set it to a shared secret (matching the API service), " +
+      "or set SIDECAR_AUTH_DISABLE=1 to explicitly run without auth (local loopback dev only).",
+  );
+  process.exit(1);
+}
+if (!AUTH_TOKEN) {
+  console.warn(
+    "[sandbox-sidecar] auth explicitly disabled via SIDECAR_AUTH_DISABLE=1 — every /exec is unauthenticated. Bind to 127.0.0.1 only.",
+  );
+}
 
 let activeExecs = 0;
 const MAX_CONCURRENT = 10;
@@ -61,7 +75,8 @@ async function readLimited(stream: ReadableStream, max: number): Promise<string>
 }
 
 async function handleExec(req: Request): Promise<Response> {
-  // Optional auth check — if SIDECAR_AUTH_TOKEN is set, require it
+  // Auth check — AUTH_TOKEN is only unset when SIDECAR_AUTH_DISABLE=1 was
+  // explicitly given (the boot guard above exits otherwise).
   if (AUTH_TOKEN) {
     const authHeader = req.headers.get("Authorization");
     if (authHeader !== `Bearer ${AUTH_TOKEN}`) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,13 +32,17 @@ services:
       context: .
       dockerfile: packages/sandbox-sidecar/Dockerfile
     ports:
-      - "8080:8080"
+      # Loopback only — the sidecar runs with auth disabled in local dev and
+      # must never be reachable from other hosts on the network.
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./semantic:/semantic:ro
     environment:
       SEMANTIC_DIR: /semantic
-      # No SIDECAR_AUTH_TOKEN in local dev — the sandbox is only reachable on localhost.
-      # Production deploys should set SIDECAR_AUTH_TOKEN on both the API and sandbox services.
+      # Local dev runs without a token; the sidecar fails closed otherwise, so
+      # the no-auth mode requires this explicit opt-out. Production deploys must
+      # set SIDECAR_AUTH_TOKEN on both the API and sandbox services instead.
+      SIDECAR_AUTH_DISABLE: "1"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 10s

--- a/docs/design/sandbox-architecture.md
+++ b/docs/design/sandbox-architecture.md
@@ -346,7 +346,7 @@ The `executePython` tool has defense-in-depth across all sandbox backends:
 |----------|---------|-------------|
 | `ATLAS_SANDBOX` | auto-detect | Force sandbox backend: `nsjail` |
 | `ATLAS_SANDBOX_URL` | -- | Sidecar service URL (enables sidecar backend) |
-| `SIDECAR_AUTH_TOKEN` | -- | Shared secret for sidecar auth (set on both services) |
+| `SIDECAR_AUTH_TOKEN` | -- | Shared secret for sidecar auth (set on both services). The sidecar refuses to boot without it unless `SIDECAR_AUTH_DISABLE=1` is set (loopback local dev only) |
 | `ATLAS_NSJAIL_PATH` | -- | Explicit path to nsjail binary |
 | `ATLAS_NSJAIL_TIME_LIMIT` | `10` | nsjail per-command time limit in seconds |
 | `ATLAS_NSJAIL_MEMORY_LIMIT` | `256` | nsjail per-command memory limit in MB |

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -48,6 +48,9 @@ services:
   #   environment:
   #     PORT: "8080"
   #     SEMANTIC_DIR: /semantic
+  #     # Required — the sidecar refuses to boot without it. Set the same value
+  #     # on the app service (SIDECAR_AUTH_DISABLE=1 is the loopback-dev-only escape hatch).
+  #     SIDECAR_AUTH_TOKEN: ${SIDECAR_AUTH_TOKEN:?set a shared sidecar secret}
   #   expose:
   #     - "8080"
   #   volumes:

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -6,6 +6,7 @@ import {
   migrateAuthTables,
   resetMigrationState,
   getMigrationError,
+  resolveSeedAdminPassword,
 } from "@atlas/api/lib/auth/migrate";
 
 // ---------------------------------------------------------------------------
@@ -561,5 +562,56 @@ describe("migrateAuthTables", () => {
     expect(newlyRecorded).toContain("0027_organization_saas_columns.sql");
     // Already-applied files do not re-run.
     expect(newlyRecorded).not.toContain("0000_baseline.sql");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seed admin password resolution (#3334 — no default credential in production)
+// ---------------------------------------------------------------------------
+
+describe("resolveSeedAdminPassword", () => {
+  const SEED_ENV_VARS = ["NODE_ENV", "ATLAS_DEPLOY_MODE"] as const;
+  const seedSaved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of SEED_ENV_VARS) seedSaved[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of SEED_ENV_VARS) {
+      if (seedSaved[key] !== undefined) process.env[key] = seedSaved[key];
+      else delete process.env[key];
+    }
+  });
+
+  it("uses the documented dev password outside production", () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.ATLAS_DEPLOY_MODE;
+    expect(resolveSeedAdminPassword()).toEqual({ password: "atlas-dev", generated: false });
+  });
+
+  it("never seeds the published constant when NODE_ENV=production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ATLAS_DEPLOY_MODE;
+    const { password, generated } = resolveSeedAdminPassword();
+    expect(generated).toBe(true);
+    expect(password).not.toBe("atlas-dev");
+    // 24 random bytes base64url-encoded — 32 chars of entropy
+    expect(password.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("never seeds the published constant when ATLAS_DEPLOY_MODE=saas", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    const { password, generated } = resolveSeedAdminPassword();
+    expect(generated).toBe(true);
+    expect(password).not.toBe("atlas-dev");
+  });
+
+  it("generates a fresh password per call (no reusable constant)", () => {
+    process.env.NODE_ENV = "production";
+    const first = resolveSeedAdminPassword().password;
+    const second = resolveSeedAdminPassword().password;
+    expect(first).not.toBe(second);
   });
 });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
+import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
 import { _resetPool } from "@atlas/api/lib/db/internal";
 import { _setAuthInstance } from "@atlas/api/lib/auth/server";
 import {
@@ -613,5 +614,29 @@ describe("resolveSeedAdminPassword", () => {
     const first = resolveSeedAdminPassword().password;
     const second = resolveSeedAdminPassword().password;
     expect(first).not.toBe(second);
+  });
+
+  it("never seeds the published constant when the config file resolves deployMode saas", () => {
+    // The SaaS deploy sets deployMode in atlas.config.ts, not the env var —
+    // the resolver must honor the config-resolved mode too.
+    process.env.NODE_ENV = "development";
+    delete process.env.ATLAS_DEPLOY_MODE;
+    const saasConfig: ResolvedConfig = {
+      datasources: {},
+      tools: ["explore", "executeSQL"],
+      auth: "managed",
+      semanticLayer: "./semantic",
+      maxTotalConnections: 100,
+      source: "file",
+      deployMode: "saas",
+    };
+    _setConfigForTest(saasConfig);
+    try {
+      const { password, generated } = resolveSeedAdminPassword();
+      expect(generated).toBe(true);
+      expect(password).not.toBe("atlas-dev");
+    } finally {
+      _setConfigForTest(null);
+    }
   });
 });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -630,8 +630,8 @@ describe("resolveSeedAdminPassword", () => {
       source: "file",
       deployMode: "saas",
     };
-    _setConfigForTest(saasConfig);
     try {
+      _setConfigForTest(saasConfig);
       const { password, generated } = resolveSeedAdminPassword();
       expect(generated).toBe(true);
       expect(password).not.toBe("atlas-dev");

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -8,6 +8,7 @@
 
 import { randomBytes } from "crypto";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { getConfig } from "@atlas/api/lib/config";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { createPlatformAdminUser } from "@atlas/api/lib/auth/admin-user-ops";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -190,14 +191,21 @@ async function bootstrapAdminUser(): Promise<void> {
  * Resolve the password for the first-boot seeded admin account.
  *
  * The published constant `atlas-dev` is a dev-loop convenience only: in
- * anything production-shaped (`NODE_ENV=production` or `ATLAS_DEPLOY_MODE=saas`)
- * a fresh instance must never boot a platform admin with public credentials,
- * so a random one-time password is generated instead and logged once by the
- * caller. `password_change_required` is stamped in both cases.
+ * anything production-shaped (`NODE_ENV=production`, `ATLAS_DEPLOY_MODE=saas`,
+ * or a config-file `deployMode: "saas"`) a fresh instance must never boot a
+ * platform admin with public credentials, so a random one-time password is
+ * generated instead and logged once by the caller. `password_change_required`
+ * is stamped in both cases.
+ *
+ * The config check matters because the SaaS deploy sets `deployMode` in
+ * `deploy/api/atlas.config.ts` rather than the env var — env-only sniffing
+ * would miss it whenever NODE_ENV isn't also set.
  */
 export function resolveSeedAdminPassword(): { password: string; generated: boolean } {
   const isProductionLike =
-    process.env.NODE_ENV === "production" || process.env.ATLAS_DEPLOY_MODE === "saas";
+    process.env.NODE_ENV === "production" ||
+    process.env.ATLAS_DEPLOY_MODE === "saas" ||
+    getConfig()?.deployMode === "saas";
   if (isProductionLike) {
     return { password: randomBytes(24).toString("base64url"), generated: true };
   }
@@ -243,15 +251,11 @@ async function seedDevUser(auth: { api: Record<string, unknown> }): Promise<void
       return;
     }
 
-    // Mark as requiring password change AND verify the email so the seeded
-    // admin can sign in without a manual SQL update on a fresh DB. The dev
-    // seed only runs when no users exist (idempotency check above), so this
-    // never auto-verifies a real signup.
-    await internalQuery(
-      `UPDATE "user" SET password_change_required = true, "emailVerified" = true WHERE id = $1`,
-      [userId],
-    );
-
+    // Log the credential IMMEDIATELY after creation, before the flag UPDATE
+    // below: the user row already exists at this point, so if a later step
+    // throws, reseeding is skipped on the next boot (userCount > 0) and a
+    // not-yet-logged generated password would be lost — an admin account
+    // nobody can sign in to.
     if (generated) {
       // Deliberately logged in the message text (not a redactable field): this
       // is the operator's only chance to read the bootstrap credential, and a
@@ -263,6 +267,15 @@ async function seedDevUser(auth: { api: Record<string, unknown> }): Promise<void
     } else {
       log.info({ email: adminEmail }, "Dev admin account seeded (password: atlas-dev)");
     }
+
+    // Mark as requiring password change AND verify the email so the seeded
+    // admin can sign in without a manual SQL update on a fresh DB. The dev
+    // seed only runs when no users exist (idempotency check above), so this
+    // never auto-verifies a real signup.
+    await internalQuery(
+      `UPDATE "user" SET password_change_required = true, "emailVerified" = true WHERE id = $1`,
+      [userId],
+    );
 
     // ── 2. Create organization ──────────────────────────────────────
     const createOrg = auth.api.createOrganization as ((opts: {

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -6,6 +6,7 @@
  * entry point (server.ts) calls migrateAuthTables() once on startup.
  */
 
+import { randomBytes } from "crypto";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { createPlatformAdminUser } from "@atlas/api/lib/auth/admin-user-ops";
@@ -186,6 +187,24 @@ async function bootstrapAdminUser(): Promise<void> {
 }
 
 /**
+ * Resolve the password for the first-boot seeded admin account.
+ *
+ * The published constant `atlas-dev` is a dev-loop convenience only: in
+ * anything production-shaped (`NODE_ENV=production` or `ATLAS_DEPLOY_MODE=saas`)
+ * a fresh instance must never boot a platform admin with public credentials,
+ * so a random one-time password is generated instead and logged once by the
+ * caller. `password_change_required` is stamped in both cases.
+ */
+export function resolveSeedAdminPassword(): { password: string; generated: boolean } {
+  const isProductionLike =
+    process.env.NODE_ENV === "production" || process.env.ATLAS_DEPLOY_MODE === "saas";
+  if (isProductionLike) {
+    return { password: randomBytes(24).toString("base64url"), generated: true };
+  }
+  return { password: "atlas-dev", generated: false };
+}
+
+/**
  * Seed a complete dev environment when no users exist:
  *   1. Platform admin user (ATLAS_ADMIN_EMAIL / atlas-dev)
  *   2. "Atlas" organization with the admin as owner
@@ -211,11 +230,12 @@ async function seedDevUser(auth: { api: Record<string, unknown> }): Promise<void
     // removed; create via core signUpEmail + promote to platform_admin directly
     // (`role` is an input:false additionalField). The dev seed only runs when no
     // users exist (idempotency check above).
+    const { password, generated } = resolveSeedAdminPassword();
     let userId: string;
     try {
       userId = await createPlatformAdminUser(auth.api as Record<string, unknown>, {
         email: adminEmail,
-        password: "atlas-dev",
+        password,
         name: "Atlas Admin",
       });
     } catch (err) {
@@ -232,7 +252,17 @@ async function seedDevUser(auth: { api: Record<string, unknown> }): Promise<void
       [userId],
     );
 
-    log.info({ email: adminEmail }, "Dev admin account seeded (password: atlas-dev)");
+    if (generated) {
+      // Deliberately logged in the message text (not a redactable field): this
+      // is the operator's only chance to read the bootstrap credential, and a
+      // password change is forced at first login.
+      log.warn(
+        { email: adminEmail },
+        `Admin account seeded with a generated one-time password: ${password} — sign in and change it now (password change is required at first login)`,
+      );
+    } else {
+      log.info({ email: adminEmail }, "Dev admin account seeded (password: atlas-dev)");
+    }
 
     // ── 2. Create organization ──────────────────────────────────────
     const createOrg = auth.api.createOrganization as ((opts: {

--- a/packages/api/src/lib/db/__tests__/connection-runtime-guards.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection-runtime-guards.test.ts
@@ -104,9 +104,11 @@ describe("runtime guards — validator-layer auto-LIMIT", () => {
   it("appends LIMIT when not already present in the query", () => {
     // Anchored to the actual statement shape in sql.ts so a comment-out
     // cannot satisfy the pin. Detection delegates to hasLimitClause (auto-limit.ts,
-    // #3325) — which strips string literals before the LIMIT word test — but the
-    // append guard itself must stay wired at the call site.
-    expect(sqlSrc).toMatch(/if \(!customValidator && !hasLimitClause\(querySql, \{ backslashEscapes: dbType === "mysql" \}\)\) \{\s*querySql \+= ` LIMIT \$\{rowLimit\}`;\s*\}/);
+    // #3325) — which strips string literals before the LIMIT word test — and the
+    // append goes through appendRowLimit (#3335, newline append so a trailing
+    // line comment can't swallow the cap) — but the guard must stay wired at
+    // the call site.
+    expect(sqlSrc).toMatch(/if \(!customValidator && !hasLimitClause\(querySql, \{ backslashEscapes: dbType === "mysql" \}\)\) \{\s*querySql = appendRowLimit\(querySql, rowLimit\);\s*\}/);
   });
 
   it("reads row limit from settings cache (hot-reload path) with default 1000", () => {

--- a/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/auto-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { hasLimitClause, stripSqlNonClauseText } from "../auto-limit";
+import { appendRowLimit, hasLimitClause, stripSqlNonClauseText } from "../auto-limit";
 
 // Regression coverage for the auto-LIMIT bypass class (#3325): the presence
 // check must ignore the word LIMIT when it appears anywhere it isn't a real
@@ -256,5 +256,41 @@ describe("hasLimitClause", () => {
     expect(
       hasLimitClause("SELECT * FROM t WHERE note = $$oops LIMIT 5"),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendRowLimit (#3335 — trailing line comment must not swallow the cap)
+// ---------------------------------------------------------------------------
+
+describe("appendRowLimit", () => {
+  /** The cap is effective iff a bare LIMIT survives comment/literal blanking. */
+  function effectiveLimit(sql: string, opts?: { backslashEscapes?: boolean }): boolean {
+    return /\bLIMIT 1000\b/i.test(stripSqlNonClauseText(sql, opts));
+  }
+
+  it("appends the cap on its own line", () => {
+    expect(appendRowLimit("SELECT * FROM t", 1000)).toBe("SELECT * FROM t\nLIMIT 1000");
+  });
+
+  it("keeps the cap effective after a trailing -- line comment", () => {
+    const sql = "SELECT * FROM t --";
+    expect(hasLimitClause(sql)).toBe(false);
+    expect(effectiveLimit(appendRowLimit(sql, 1000))).toBe(true);
+  });
+
+  it("keeps the cap effective after a trailing -- comment with text", () => {
+    const sql = "SELECT * FROM t -- just exploring";
+    expect(effectiveLimit(appendRowLimit(sql, 1000))).toBe(true);
+  });
+
+  it("keeps the cap effective after a trailing MySQL # comment", () => {
+    const sql = "SELECT * FROM t #";
+    expect(effectiveLimit(appendRowLimit(sql, 1000), { backslashEscapes: true })).toBe(true);
+  });
+
+  it("keeps the cap effective after a terminated trailing block comment", () => {
+    const sql = "SELECT * FROM t /* note */";
+    expect(effectiveLimit(appendRowLimit(sql, 1000))).toBe(true);
   });
 });

--- a/packages/api/src/lib/tools/auto-limit.ts
+++ b/packages/api/src/lib/tools/auto-limit.ts
@@ -217,3 +217,16 @@ export function hasLimitClause(
   if (!/\bLIMIT\b/i.test(sql)) return false;
   return /\bLIMIT\b/i.test(stripSqlNonClauseText(sql, opts));
 }
+
+/**
+ * Append the auto-LIMIT row cap to a query. The clause goes on its OWN line:
+ * a same-line append after a trailing `--` (or `#`) line comment would be
+ * swallowed by the comment (`SELECT * FROM t -- LIMIT 1000`) and the query
+ * would run uncapped. A newline terminates any line comment, so the cap is
+ * always effective. Trailing block comments are no hazard either way — an
+ * unterminated slash-star never survives AST validation, and a terminated one
+ * doesn't extend past its close. See #3335.
+ */
+export function appendRowLimit(sql: string, rowLimit: number): string {
+  return `${sql}\nLIMIT ${rowLimit}`;
+}

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -42,7 +42,7 @@ import {
   RLSError, PluginRejectedError, EnterpriseUnavailableError,
 } from "@atlas/api/lib/effect/errors";
 import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
-import { hasLimitClause } from "./auto-limit";
+import { appendRowLimit, hasLimitClause } from "./auto-limit";
 import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
@@ -1475,7 +1475,7 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
         const queryTimeout = getQueryTimeout();
         let querySql = normalizedMutated;
         if (!customValidator && !hasLimitClause(querySql, { backslashEscapes: dbType === "mysql" })) {
-          querySql += ` LIMIT ${rowLimit}`;
+          querySql = appendRowLimit(querySql, rowLimit);
         }
 
         const result = yield* executeAndAuditEffect({
@@ -1884,7 +1884,7 @@ async function executeSqlForConnection({
           const queryTimeout = getQueryTimeout();
           let querySql = normalizedMutated;
           if (!customValidator && !hasLimitClause(querySql, { backslashEscapes: dbType === "mysql" })) {
-            querySql += ` LIMIT ${rowLimit}`;
+            querySql = appendRowLimit(querySql, rowLimit);
           }
 
           // Execute the query

--- a/packages/sandbox-sidecar/src/__tests__/auth.test.ts
+++ b/packages/sandbox-sidecar/src/__tests__/auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { resolveSidecarAuth } from "../auth";
+
+describe("resolveSidecarAuth", () => {
+  it("returns token mode when SIDECAR_AUTH_TOKEN is set", () => {
+    const config = resolveSidecarAuth({ SIDECAR_AUTH_TOKEN: "shared-secret" });
+    expect(config).toEqual({ mode: "token", token: "shared-secret" });
+  });
+
+  it("prefers the token when both token and disable flag are set", () => {
+    const config = resolveSidecarAuth({
+      SIDECAR_AUTH_TOKEN: "shared-secret",
+      SIDECAR_AUTH_DISABLE: "1",
+    });
+    expect(config).toEqual({ mode: "token", token: "shared-secret" });
+  });
+
+  it("returns disabled mode only with the explicit SIDECAR_AUTH_DISABLE=1 opt-out", () => {
+    const config = resolveSidecarAuth({ SIDECAR_AUTH_DISABLE: "1" });
+    expect(config).toEqual({ mode: "disabled" });
+  });
+
+  it("throws (fail closed) when the token is unset and auth was not explicitly disabled", () => {
+    expect(() => resolveSidecarAuth({})).toThrow(/SIDECAR_AUTH_TOKEN is not set/);
+  });
+
+  it("throws when the token is an empty string", () => {
+    expect(() => resolveSidecarAuth({ SIDECAR_AUTH_TOKEN: "" })).toThrow(
+      /SIDECAR_AUTH_TOKEN is not set/,
+    );
+  });
+
+  it("does not accept disable values other than exactly '1'", () => {
+    expect(() => resolveSidecarAuth({ SIDECAR_AUTH_DISABLE: "true" })).toThrow(
+      /SIDECAR_AUTH_TOKEN is not set/,
+    );
+    expect(() => resolveSidecarAuth({ SIDECAR_AUTH_DISABLE: "0" })).toThrow(
+      /SIDECAR_AUTH_TOKEN is not set/,
+    );
+  });
+});

--- a/packages/sandbox-sidecar/src/__tests__/server.test.ts
+++ b/packages/sandbox-sidecar/src/__tests__/server.test.ts
@@ -91,7 +91,7 @@ async function startServer(opts?: {
   const { readdirSync } = await import("fs");
   const { mkdir, rm } = await import("fs/promises");
   const { join: joinPath } = await import("path");
-  const { randomUUID } = await import("crypto");
+  const { createHash, randomUUID, timingSafeEqual } = await import("crypto");
 
   async function readLimited(stream: ReadableStream, max: number): Promise<string> {
     const reader = stream.getReader();
@@ -116,8 +116,9 @@ async function startServer(opts?: {
 
   async function handleExec(req: Request): Promise<Response> {
     if (AUTH_TOKEN) {
-      const authHeader = req.headers.get("Authorization");
-      if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
+      const got = createHash("sha256").update(req.headers.get("Authorization") ?? "").digest();
+      const want = createHash("sha256").update(`Bearer ${AUTH_TOKEN}`).digest();
+      if (!timingSafeEqual(got, want)) {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/packages/sandbox-sidecar/src/auth.ts
+++ b/packages/sandbox-sidecar/src/auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Sidecar auth configuration — resolved once at boot, fail-closed.
+ *
+ * The sidecar executes arbitrary bash and Python, so running it without auth
+ * is only acceptable when an operator has explicitly opted in for loopback
+ * local dev. A missing token is a misconfiguration, not a default: the server
+ * refuses to boot rather than silently accepting unauthenticated /exec.
+ *
+ * Kept in a standalone module (server.ts has top-level Bun.serve side effects)
+ * so the boot decision can be unit-tested directly.
+ */
+
+export type SidecarAuthConfig =
+  | { mode: "token"; token: string }
+  | { mode: "disabled" };
+
+/**
+ * Resolve the auth mode from the environment. Throws when no token is set and
+ * auth was not explicitly disabled — callers should treat that as a fatal
+ * boot error.
+ */
+export function resolveSidecarAuth(env: {
+  SIDECAR_AUTH_TOKEN?: string;
+  SIDECAR_AUTH_DISABLE?: string;
+}): SidecarAuthConfig {
+  if (env.SIDECAR_AUTH_TOKEN) {
+    return { mode: "token", token: env.SIDECAR_AUTH_TOKEN };
+  }
+  if (env.SIDECAR_AUTH_DISABLE === "1") {
+    return { mode: "disabled" };
+  }
+  throw new Error(
+    "SIDECAR_AUTH_TOKEN is not set. The sidecar executes arbitrary commands and refuses to start without auth. " +
+      "Set SIDECAR_AUTH_TOKEN to a shared secret (matching the API service), or set SIDECAR_AUTH_DISABLE=1 " +
+      "to explicitly run without auth (local loopback dev only — never expose the port).",
+  );
+}

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -23,6 +23,7 @@ import { randomUUID } from "crypto";
 import { readdirSync, writeFileSync } from "fs";
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
+import { resolveSidecarAuth, type SidecarAuthConfig } from "./auth";
 
 const PORT = parseInt(process.env.PORT ?? "8080", 10);
 const SEMANTIC_DIR = process.env.SEMANTIC_DIR ?? "/semantic";
@@ -30,7 +31,25 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_TIMEOUT_MS = 60_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024; // 1 MB
 
-const AUTH_TOKEN = process.env.SIDECAR_AUTH_TOKEN;
+// Fail closed: no token + no explicit opt-out = refuse to boot. The sidecar
+// is a raw arbitrary-code-execution surface; the command/AST guards live on
+// the API side, so an unauthenticated sidecar must never come up by accident.
+let authConfig: SidecarAuthConfig;
+try {
+  authConfig = resolveSidecarAuth({
+    SIDECAR_AUTH_TOKEN: process.env.SIDECAR_AUTH_TOKEN,
+    SIDECAR_AUTH_DISABLE: process.env.SIDECAR_AUTH_DISABLE,
+  });
+} catch (err) {
+  console.error(`[sandbox-sidecar] ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}
+if (authConfig.mode === "disabled") {
+  console.warn(
+    "[sandbox-sidecar] auth explicitly disabled via SIDECAR_AUTH_DISABLE=1 — every /exec is unauthenticated. Bind to 127.0.0.1 only.",
+  );
+}
+const AUTH_TOKEN = authConfig.mode === "token" ? authConfig.token : undefined;
 
 let activeExecs = 0;
 const MAX_CONCURRENT = 10;
@@ -94,7 +113,11 @@ async function readLimited(stream: ReadableStream, max: number): Promise<string>
   return new TextDecoder().decode(Buffer.concat(chunks));
 }
 
-/** Shared auth check. Returns a 401 Response if auth fails, null if OK. */
+/**
+ * Shared auth check. Returns a 401 Response if auth fails, null if OK.
+ * AUTH_TOKEN is only ever undefined when auth was explicitly disabled via
+ * SIDECAR_AUTH_DISABLE=1 — the boot guard above exits otherwise.
+ */
 function checkAuth(req: Request): Response | null {
   if (!AUTH_TOKEN) return null;
   const authHeader = req.headers.get("Authorization");

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -19,7 +19,7 @@ import type {
   SidecarPythonRequest,
   SidecarPythonResponse,
 } from "@atlas/api/lib/sidecar-types";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID, timingSafeEqual } from "crypto";
 import { readdirSync, writeFileSync } from "fs";
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
@@ -117,11 +117,15 @@ async function readLimited(stream: ReadableStream, max: number): Promise<string>
  * Shared auth check. Returns a 401 Response if auth fails, null if OK.
  * AUTH_TOKEN is only ever undefined when auth was explicitly disabled via
  * SIDECAR_AUTH_DISABLE=1 — the boot guard above exits otherwise.
+ *
+ * Hash both sides to fixed-length digests so timingSafeEqual never leaks
+ * token length — same convention as the API's simple-key auth.
  */
 function checkAuth(req: Request): Response | null {
   if (!AUTH_TOKEN) return null;
-  const authHeader = req.headers.get("Authorization");
-  if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
+  const got = createHash("sha256").update(req.headers.get("Authorization") ?? "").digest();
+  const want = createHash("sha256").update(`Bearer ${AUTH_TOKEN}`).digest();
+  if (!timingSafeEqual(got, want)) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
   return null;


### PR DESCRIPTION
Knocks out the top three findings from the June 2026 security review (#3332), in the report's recommended priority order.

Fixes #3333
Fixes #3334
Fixes #3335
Part of #3332

## H-1 — sidecar fails closed without `SIDECAR_AUTH_TOKEN` (#3333)

The sidecar executes arbitrary bash/Python and previously allowed **every** request when the token was unset. Now:

- New `resolveSidecarAuth()` (`packages/sandbox-sidecar/src/auth.ts`) resolves the auth mode at boot and the server **refuses to start** when the token is unset, unless `SIDECAR_AUTH_DISABLE=1` is set as an explicit loopback-dev-only opt-out (logged with a loud warning).
- Dev compose now binds `127.0.0.1:8080:8080` and sets the explicit opt-out.
- The `create-atlas` docker template sidecar gets the same boot guard; the `examples/docker` commented sidecar block now requires the token; `.env.example` + sandbox-architecture doc updated.
- Unit tests cover token / explicit-disable / fail-closed paths.

> ⚠️ **Deploy note:** any environment that boots the sidecar without `SIDECAR_AUTH_TOKEN` (and without the opt-out) will now fail its health check at startup instead of running open. Per `deploy/README.md` the Railway sidecar already sets the token; worth a quick confirm before merging.

## H-2 — no published default admin password in production (#3334)

`seedDevUser` seeded `admin@useatlas.dev` / `atlas-dev` in every environment. New `resolveSeedAdminPassword()`:

- `NODE_ENV=production` or `ATLAS_DEPLOY_MODE=saas` → cryptographically random one-time password (24 bytes, base64url), logged **once** at boot; `password_change_required` still stamped.
- Dev keeps the documented `atlas-dev` workflow (e2e/global-setup depend on it in dev only).

Note: the review's pass-2 comment found `password_change_required` is enforced client-side only — that's tracked separately as #3345 and not addressed here.

## M-1 — auto-LIMIT can't be swallowed by a trailing comment (#3335)

`SELECT * FROM t --` produced `SELECT * FROM t -- LIMIT 1000` (cap commented out, query uncapped). New `appendRowLimit()` in `auto-limit.ts` appends the cap on its **own line**; both execute sites in `sql.ts` use it. Regression tests cover `--`, `#`, and block-comment tails.

## Verification

- `packages/api` affected suite: 70/70 files pass
- `packages/sandbox-sidecar`: 57/57 pass
- `bun run type`, `bun run lint`, `bun run deps:lint`, template drift: clean

## Remaining from #3332 (follow-ups)

M-5/M-6 (SSRF routing through `guardedFetch`), M-2/M-3/M-4 (RLS hardening), M-7 (sendEmail allowlist), #3345 (server-side forced-password-change), and the low-severity backlog (#3342) are each scoped as separate sub-issues.

https://claude.ai/code/session_011c9JYixkStVFCfYi3YDYUW

---
_Generated by [Claude Code](https://claude.ai/code/session_011c9JYixkStVFCfYi3YDYUW)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783623557&installation_id=135337507&pr_number=3352&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3352&signature=f3df7fb7b0722a1e926b3b781a9e894068da8267d7a3354b6bccb4b3f295d42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidecar now enforces boot-time authentication by default; admin password is auto-generated in production-like deployments (defaults to `atlas-dev` for local dev).

* **Improvements**
  * SQL auto-LIMIT handling now reliably appends LIMIT even with trailing comments.
  * Token verification hardened to resist timing attacks.

* **Documentation**
  * Docs updated to reflect required sidecar auth and local-dev opt-out.

* **Chores**
  * Local dev opt-out via `SIDECAR_AUTH_DISABLE=1`; sandbox now bound to loopback; examples updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->