### PR TITLE
chore(security): low-severity hardening backlog + chat-adapter verification audit follow-ups

### DIFF
--- a/.github/workflows/load-test-mcp.yml
+++ b/.github/workflows/load-test-mcp.yml
@@ -126,17 +126,23 @@ jobs:
       - name: Install k6 + jq
         # k6 from the upstream stable apt repo; jq is preinstalled on
         # ubuntu-latest but pinning the install line keeps the workflow
-        # resilient to runner image changes. The keyserver + fingerprint
-        # match the manual install path documented in
+        # resilient to runner image changes. The key is fetched over HTTPS
+        # from dl.k6.io (#3342 L-11 — no plaintext keyserver hop) and the
+        # imported fingerprint is asserted before the repo is trusted. The
+        # URL + fingerprint match the manual install path documented in
         # `eval/load-tests/mcp/README.md` so a CI run reproduces what an
         # operator runs locally.
         run: |
           set -euo pipefail
-          sudo gpg -k
+          curl -fsSL https://dl.k6.io/key.gpg -o /tmp/k6-key.gpg
           sudo gpg --no-default-keyring \
             --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
-            --keyserver hkp://keyserver.ubuntu.com:80 \
-            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+            --import /tmp/k6-key.gpg
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --with-colons --fingerprint \
+            | grep -q "C5AD17C747E3415A3642D57D77C6C491D6AC1D69" \
+            || { echo "k6 signing key fingerprint mismatch" >&2; exit 1; }
           echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
             | sudo tee /etc/apt/sources.list.d/k6.list
           sudo apt-get update -qq

--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -21,9 +21,20 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install mcp-publisher
+        # Pinned version + SHA256 verification (#3342 L-10): this job holds
+        # OIDC publish rights, so a mutable `latest` download with no checksum
+        # was a supply-chain foothold. Bumping the tool = update MCP_PUBLISHER_VERSION
+        # and MCP_PUBLISHER_SHA256 together (sha256sum of the release tarball).
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
-            | tar xz mcp-publisher
+          set -euo pipefail
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check --strict
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Wait for npm to surface the new version

--- a/apps/docs/content/docs/guides/embedding-widget.mdx
+++ b/apps/docs/content/docs/guides/embedding-widget.mdx
@@ -617,10 +617,8 @@ window.addEventListener("message", (event) => {
 
   if (event.data?.type === "atlas:error") {
     // Error codes: "UNCAUGHT", "UNHANDLED_REJECTION", "RENDER_FAILED", "LOAD_FAILED"
-    console.error(
-      `Atlas error [${event.data.code}]:`,
-      event.data.message,
-    );
+    // (code only — full error text stays in the iframe's own console)
+    console.error(`Atlas error [${event.data.code}]`);
   }
 });
 ```
@@ -677,11 +675,11 @@ interface AtlasReadyMessage {
   type: "atlas:ready";
 }
 
-/** Widget error — includes error code and human-readable message */
+/** Widget error — opaque code only (the widget cannot know its host
+ *  origin, so the payload never carries error text) */
 interface AtlasErrorMessage {
   type: "atlas:error";
   code: "UNCAUGHT" | "UNHANDLED_REJECTION" | "RENDER_FAILED" | "LOAD_FAILED";
-  message: string;
 }
 
 type WidgetToHostMessage = AtlasReadyMessage | AtlasErrorMessage;
@@ -1066,7 +1064,7 @@ Atlas.on("error", (detail) => {
 
 #### iframe postMessage
 
-The widget emits `atlas:error` messages to the parent window for every error. The payload includes the error code, title, detail, and retryability:
+The widget emits `atlas:error` messages to the parent window for every error. The payload is restricted to an opaque error code and retryability — no message/detail strings, since the widget cannot know its host page's origin and must not broadcast server-derived error text:
 
 ```javascript
 window.addEventListener("message", (event) => {
@@ -1074,15 +1072,13 @@ window.addEventListener("message", (event) => {
   if (event.origin !== "https://your-atlas-api.example.com") return;
 
   if (event.data?.type === "atlas:error") {
-    const { code, message, detail, retryable } = event.data.error;
+    const { code, retryable } = event.data.error;
     // code: ClientErrorCode or ChatErrorCode (e.g. "api_unreachable", "auth_error")
-    // message: user-facing title (e.g. "Unable to connect to Atlas.")
-    // detail: optional secondary context
     // retryable: true for transient errors, false for permanent ones
 
     if (!retryable) {
       // Permanent error — show your own fallback UI or redirect to login
-      showFallbackUI(message);
+      showFallbackUI(code);
     }
   }
 });

--- a/create-atlas/templates/docker/docker-compose.yml
+++ b/create-atlas/templates/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./data/demo.sql:/docker-entrypoint-initdb.d/demo.sql

--- a/docker-compose.multi-env.yml
+++ b/docker-compose.multi-env.yml
@@ -22,7 +22,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - ./scripts/multi-env-seeds/dev.sql:/docker-entrypoint-initdb.d/00-seed.sql:ro
     healthcheck:
@@ -39,7 +39,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"
     volumes:
       - ./scripts/multi-env-seeds/staging.sql:/docker-entrypoint-initdb.d/00-seed.sql:ro
     healthcheck:
@@ -56,7 +56,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5435:5432"
+      - "127.0.0.1:5435:5432"
     volumes:
       - ./scripts/multi-env-seeds/prod.sql:/docker-entrypoint-initdb.d/00-seed.sql:ro
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql

--- a/docs/architecture/chat-plugin-atlas-contract.md
+++ b/docs/architecture/chat-plugin-atlas-contract.md
@@ -114,6 +114,31 @@ B and C are not implemented today. Reasons:
 
 Post-#2677 the resolver distinguishes them: case (2) emits a `warn` with `teamId` so the audit catches a write-path that bypassed both `saveInstallation` AND the pg-adapter merge. The warn is rate-limited via a module-scoped `Map<teamId, lastWarnAt>` with a 5-minute dedup window — a stuck-orgId tenant emits one warn per 5 minutes, not one per Slack event. Operator-actionable on first occurrence; bounded log volume thereafter.
 
+## Inbound webhook signature verification posture (#3350 audit, June 2026)
+
+All signature verification is delegated to the out-of-repo `@chat-adapter/*`
+packages (v4.23.0 at audit time). A read of the installed dist code confirmed
+the following per-platform posture. "Fail-closed init" means the adapter
+constructor throws when its secret is missing, so the AdapterRegistry never
+wires it and the in-repo route 404s.
+
+| Platform | Algorithm | Timing-safe compare | Fail-closed on missing secret | Replay protection |
+|----------|-----------|--------------------|-------------------------------|-------------------|
+| Slack | HMAC-SHA256 (`v0:ts:body`) | ✓ `timingSafeEqual` | ✓ throws at init | ✓ 300 s window |
+| Discord | Ed25519 (`discord-interactions`) | ✓ | ✓ throws at init | platform-level |
+| Teams | Bot Framework JWT (MS libs) | ✓ | ✓ throws at init | ✓ JWT claims |
+| WhatsApp | HMAC-SHA256 (`X-Hub-Signature-256`) | ✓ | ✓ throws at init | — |
+| GitHub | HMAC-SHA256 | ✓ | ✓ throws at init | delivery ids |
+| Linear | HMAC-SHA256 | ✓ | ✓ throws at init | ✓ 5 min window |
+| Telegram | secret-token header compare | ✓ | ⚠ adapter treats it as optional — **Atlas's `TELEGRAM_BUILDER` makes `TELEGRAM_WEBHOOK_SECRET` mandatory** (#3154 GAP 3), so the fail-open path is unreachable from this repo's wiring | — |
+| Google Chat | Google OAuth2 JWT | ✓ | ⚠ adapter treats `googleChatProjectNumber` / `pubsubAudience` as optional and processes UNVERIFIED HTTP webhooks when both are absent — **the in-repo `/webhooks/gchat` route fails closed with 403 when neither `GCHAT_PROJECT_NUMBER` nor `GCHAT_PUBSUB_AUDIENCE` is set** (#3350) | ✓ JWT claims (when configured) |
+
+Verification always runs against the raw request body before any payload
+processing; no debug bypass flags were found. Upstream follow-up worth filing
+against the chat-adapter packages: make the Telegram and Google Chat
+constructors throw on missing verification config, matching the other six.
+Re-audit this table whenever the pinned `@chat-adapter/*` version changes.
+
 ## How to update this doc
 
 Any PR that touches the chat-plugin × Atlas boundary updates the table above. The CLAUDE.md checklist enforces this. Concretely:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - e2e_pgdata:/var/lib/postgresql/data
       - ./seeds/pg-seed.sql:/docker-entrypoint-initdb.d/01-seed.sql

--- a/eval/load-tests/mcp/README.md
+++ b/eval/load-tests/mcp/README.md
@@ -22,10 +22,12 @@ WASM/CommonJS shim.
 # macOS
 brew install k6
 
-# Linux (Debian/Ubuntu)
-sudo gpg -k && \
+# Linux (Debian/Ubuntu) — key fetched over HTTPS; fingerprint asserted before trusting the repo
+curl -fsSL https://dl.k6.io/key.gpg -o /tmp/k6-key.gpg && \
   sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
-    --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69 && \
+    --import /tmp/k6-key.gpg && \
+  sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+    --with-colons --fingerprint | grep -q "C5AD17C747E3415A3642D57D77C6C491D6AC1D69" && \
   echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | \
     sudo tee /etc/apt/sources.list.d/k6.list && \
   sudo apt-get update && sudo apt-get install k6

--- a/examples/docker/docker-compose.ollama.yml
+++ b/examples/docker/docker-compose.ollama.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql

--- a/examples/docker/docker-compose.vllm.yml
+++ b/examples/docker/docker-compose.vllm.yml
@@ -19,7 +19,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_USER: atlas
       POSTGRES_PASSWORD: atlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -293,6 +293,14 @@ export const adminAuth = createMiddleware<AuthEnv>(async (c, next) => {
   }
   const { authResult } = auth;
 
+  // Defense-in-depth (#3342 L-1): `mode: "none"` is the no-auth local-dev
+  // carve-out and must never reach an admin gate in SaaS. Mirrors the
+  // platformAdminAuth guard below — the weaker tier was the unguarded one.
+  if (authResult.mode === "none" && isSaasDeployMode()) {
+    log.error({ requestId }, "mode:\"none\" reached adminAuth under SaaS deploy — rejecting");
+    return c.json({ error: "auth_misconfigured", message: "Admin auth is not configured.", requestId }, 500);
+  }
+
   // Enforce admin role — auth mode "none" (local dev) is an implicit admin
   if (
     authResult.mode !== "none" &&

--- a/packages/api/src/api/routes/widget.ts
+++ b/packages/api/src/api/routes/widget.ts
@@ -37,7 +37,9 @@
  *
  * Widget → parent messages:
  *   { type: "atlas:ready" }                                — widget loaded successfully
- *   { type: "atlas:error", code: string, message: string } — load/render/runtime error
+ *   { type: "atlas:error", code: string }                  — load/render/runtime error
+ *     (#3342 L-8 — code only: the widget cannot know its host origin, so the
+ *      "*"-targeted payload must not carry error text)
  *
  * Messages with unknown types or invalid shapes are silently ignored.
  *
@@ -253,8 +255,8 @@ body{background:#fff;color:#09090b}
 .atlas-custom-logo{height:1.75rem;width:1.75rem;object-fit:contain;flex-shrink:0}${accentCSS}
 </style>
 <script>
-window.onerror=function(m){console.error("[Atlas Widget]",m);try{window.parent.postMessage({type:"atlas:error",code:"UNCAUGHT",message:String(m)},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}};
-window.addEventListener("unhandledrejection",function(e){console.error("[Atlas Widget]",e.reason);try{window.parent.postMessage({type:"atlas:error",code:"UNHANDLED_REJECTION",message:String(e.reason)},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}});
+window.onerror=function(m){console.error("[Atlas Widget]",m);try{window.parent.postMessage({type:"atlas:error",code:"UNCAUGHT"},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}};
+window.addEventListener("unhandledrejection",function(e){console.error("[Atlas Widget]",e.reason);try{window.parent.postMessage({type:"atlas:error",code:"UNHANDLED_REJECTION"},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}});
 </script>
 <script>try{var t=localStorage.getItem("atlas-theme");var d=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){console.warn("[Atlas Widget] Could not read theme:",e.message)}</script>
 </head>
@@ -283,7 +285,7 @@ class EB extends Component{
   static getDerivedStateFromError(e){return{error:e}}
   componentDidCatch(e){
     console.error("[Atlas Widget] Render error:",e);
-    try{window.parent.postMessage({type:"atlas:error",code:"RENDER_FAILED",message:e.message},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}
+    try{window.parent.postMessage({type:"atlas:error",code:"RENDER_FAILED"},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}
   }
   render(){
     if(this.state.error)return createElement("div",{style:{padding:"2rem",textAlign:"center",color:"#888",fontFamily:"system-ui"}},
@@ -424,7 +426,7 @@ window.parent.postMessage({type:"atlas:ready"},"*");
 console.error("[Atlas Widget] Failed to load:",err);
 const el=document.getElementById("atlas-widget");
 if(el)el.innerHTML='<div style="padding:2rem;text-align:center;color:#888;font-family:system-ui"><p>Unable to load Atlas Chat.</p><p style="font-size:0.875rem;margin-top:0.5rem">Check your network connection or try refreshing.</p></div>';
-try{window.parent.postMessage({type:"atlas:error",code:"LOAD_FAILED",message:String(err.message||err)},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}
+try{window.parent.postMessage({type:"atlas:error",code:"LOAD_FAILED"},"*")}catch(x){console.warn("[Atlas Widget] Could not notify parent:",x)}
 }
 </script>
 </body>

--- a/packages/api/src/lib/__tests__/sql-validator-fuzz.test.ts
+++ b/packages/api/src/lib/__tests__/sql-validator-fuzz.test.ts
@@ -425,14 +425,13 @@ describe("fuzz: schema-qualified + quoted identifier whitelist", () => {
     expectValid('SELECT * FROM "companies"');
   });
 
-  it("accepts uppercase quoted identifier that normalizes to whitelist", async () => {
-    // See F-20 (case-fold collision) in the phase-3 audit. Current validator
-    // treats `"COMPANIES"` and `companies` as equivalent, which is the
-    // expected current behavior for self-hosted deployments that use
-    // case-insensitive identifiers. Databases with case-sensitive quoted
-    // tables need a dedicated fix; F-20 stays in the audit doc as a P3 tail
-    // item rather than getting its own issue.
-    expectValid('SELECT * FROM "COMPANIES"');
+  it("rejects uppercase QUOTED identifier that case-folds into a whitelist entry (#3342 L-4)", async () => {
+    // F-20 (case-fold collision) closed: a quoted mixed-case identifier is a
+    // DIFFERENT relation than the case-folded whitelist entry on PG, so it
+    // must not ride the lowercase match. Unquoted mixed-case stays accepted
+    // (the database itself case-folds it).
+    expectInvalid('SELECT * FROM "COMPANIES"');
+    expectValid("SELECT * FROM COMPANIES");
   });
 
   it("rejects quoted identifier that is not in the whitelist", async () => {
@@ -607,17 +606,17 @@ describe("fuzz: PostgreSQL dialect escape hatches", () => {
     expectValid("SELECT $tag$ hi $tag$ AS x FROM companies");
   });
 
-  it("does not block pg_read_file (known limitation — DB perms mitigate)", async () => {
-    // See F-21. Relies on the DB user lacking superuser privileges.
-    expectValid("SELECT pg_read_file('/etc/passwd')");
+  it("blocks pg_read_file (#3342 L-3 function denylist)", async () => {
+    // F-21 closed — the AST function-name walk rejects file-access functions.
+    expectInvalid("SELECT pg_read_file('/etc/passwd')");
   });
 
-  it("does not block pg_sleep (mitigated by statement_timeout)", async () => {
-    expectValid("SELECT pg_sleep(29)");
+  it("blocks pg_sleep (#3342 L-3 function denylist)", async () => {
+    expectInvalid("SELECT pg_sleep(29)");
   });
 
-  it("does not block pg_terminate_backend (known limitation)", async () => {
-    expectValid("SELECT pg_terminate_backend(12345)");
+  it("blocks pg_terminate_backend (#3342 L-3 function denylist)", async () => {
+    expectInvalid("SELECT pg_terminate_backend(12345)");
   });
 
   it("does not block generate_series set-returning function", async () => {
@@ -711,22 +710,20 @@ describe("fuzz: MySQL dialect escape hatches", () => {
     );
   });
 
-  it("does not block BENCHMARK (DoS, mitigated by statement_timeout)", async () => {
-    expectValid("SELECT BENCHMARK(1000000, MD5('a'))");
+  it("blocks BENCHMARK (#3342 L-3 function denylist)", async () => {
+    expectInvalid("SELECT BENCHMARK(1000000, MD5('a'))");
   });
 
-  it("does not block SLEEP (mitigated by statement_timeout)", async () => {
-    expectValid("SELECT SLEEP(29)");
+  it("blocks SLEEP (#3342 L-3 function denylist)", async () => {
+    expectInvalid("SELECT SLEEP(29)");
   });
 
   it("does not block GET_LOCK (known limitation — mitigated by connection lifecycle)", async () => {
     expectValid("SELECT GET_LOCK('x', 30)");
   });
 
-  it("does not block LOAD_FILE (known limitation — FILE privilege required)", async () => {
-    // Blocked at the DB permission layer; file reads need FILE priv which
-    // should not be granted to the Atlas user.
-    expectValid("SELECT LOAD_FILE('/etc/passwd')");
+  it("blocks LOAD_FILE (#3342 L-3 function denylist)", async () => {
+    expectInvalid("SELECT LOAD_FILE('/etc/passwd')");
   });
 
   it("accepts SELECT INTO @user_variable (session-local, no persistence)", async () => {

--- a/packages/api/src/lib/auth/__tests__/auth-secret.test.ts
+++ b/packages/api/src/lib/auth/__tests__/auth-secret.test.ts
@@ -1,0 +1,59 @@
+/**
+ * parseAuthSecret — length floor + published-placeholder denylist
+ * (#3342 L-6). The `.env.example` value passes the ≥32-char check and
+ * doubles as the at-rest encryption-key fallback, so a production deploy
+ * that shipped it would have a publicly-known signing AND encryption key.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { parseAuthSecret } from "../server";
+
+const PLACEHOLDER = "atlas-dev-secret-do-not-use-in-production!!";
+
+describe("parseAuthSecret", () => {
+  const origNodeEnv = process.env.NODE_ENV;
+  const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
+
+  beforeEach(() => {
+    delete process.env.ATLAS_DEPLOY_MODE;
+  });
+
+  afterEach(() => {
+    if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    else delete process.env.NODE_ENV;
+    if (origDeployMode !== undefined) process.env.ATLAS_DEPLOY_MODE = origDeployMode;
+    else delete process.env.ATLAS_DEPLOY_MODE;
+  });
+
+  it("throws on missing secret", () => {
+    expect(() => parseAuthSecret(undefined)).toThrow(/not set/);
+  });
+
+  it("throws on short secret", () => {
+    expect(() => parseAuthSecret("too-short")).toThrow(/at least 32/);
+  });
+
+  it("accepts a ≥32-char random secret", () => {
+    expect(parseAuthSecret("0123456789abcdef0123456789abcdef")).toBe(
+      "0123456789abcdef0123456789abcdef" as ReturnType<typeof parseAuthSecret>,
+    );
+  });
+
+  it("refuses the published .env.example placeholder in production (#3342 L-6)", () => {
+    process.env.NODE_ENV = "production";
+    expect(() => parseAuthSecret(PLACEHOLDER)).toThrow(/placeholder/);
+  });
+
+  it("refuses the published placeholder under SaaS deploy mode", () => {
+    process.env.NODE_ENV = "test";
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    expect(() => parseAuthSecret(PLACEHOLDER)).toThrow(/placeholder/);
+  });
+
+  it("allows (with a warning) the placeholder in local dev", () => {
+    process.env.NODE_ENV = "test";
+    expect(parseAuthSecret(PLACEHOLDER)).toBe(
+      PLACEHOLDER as ReturnType<typeof parseAuthSecret>,
+    );
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/byot-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/byot-integration.test.ts
@@ -192,7 +192,10 @@ describe("BYOT integration (real JWKS server)", () => {
     }
   });
 
-  it("empty ATLAS_AUTH_AUDIENCE skips audience check (accepts any audience)", async () => {
+  it("empty ATLAS_AUTH_AUDIENCE is a hard config error (#3342 L-2)", async () => {
+    // Pre-L-2 behavior silently skipped audience validation for an
+    // explicitly-set-but-empty value. Now it throws (middleware maps it to
+    // a 500); UNSET remains the documented no-audience-check mode.
     process.env.ATLAS_AUTH_AUDIENCE = "";
     resetJWKSCache();
 
@@ -200,10 +203,16 @@ describe("BYOT integration (real JWKS server)", () => {
       { sub: "user_integ_1" },
       { audience: "any-audience-should-work" },
     );
+    await expect(
+      validateBYOT(makeRequest({ Authorization: `Bearer ${token}` })),
+    ).rejects.toThrow(/ATLAS_AUTH_AUDIENCE/);
+
+    // Unset → audience check skipped, token accepted.
+    delete process.env.ATLAS_AUTH_AUDIENCE;
+    resetJWKSCache();
     const result = await validateBYOT(
       makeRequest({ Authorization: `Bearer ${token}` }),
     );
-
     expect(result.authenticated).toBe(true);
   });
 

--- a/packages/api/src/lib/auth/__tests__/byot.test.ts
+++ b/packages/api/src/lib/auth/__tests__/byot.test.ts
@@ -273,6 +273,22 @@ describe("validateBYOT()", () => {
     });
   });
 
+  describe("empty ATLAS_AUTH_AUDIENCE is a hard config error (#3342 L-2)", () => {
+    it("throws instead of silently skipping audience validation", async () => {
+      process.env.ATLAS_AUTH_AUDIENCE = "";
+      const token = await signJWT(
+        { sub: "user_123" },
+        { audience: "some-random-audience" },
+      );
+      // The throw is caught by lib/auth/middleware's dispatcher and surfaces
+      // as a 500 "Authentication service error" — fail-closed, never a
+      // token accepted with the audience check disabled.
+      await expect(
+        validateBYOT(makeRequest({ Authorization: `Bearer ${token}` })),
+      ).rejects.toThrow(/ATLAS_AUTH_AUDIENCE/);
+    });
+  });
+
   describe("role extraction from JWT claims", () => {
     it("JWT with role: 'admin' claim propagates to user object", async () => {
       const token = await signJWT({ sub: "user_123", role: "admin" });

--- a/packages/api/src/lib/auth/byot.ts
+++ b/packages/api/src/lib/auth/byot.ts
@@ -90,9 +90,16 @@ export async function validateBYOT(req: Request): Promise<AuthResult> {
   if (!issuer)
     throw new Error("ATLAS_AUTH_ISSUER is required for BYOT mode");
 
+  // #3342 L-2 — an explicitly-set-but-empty audience is a config error, not
+  // a request to skip audience validation. Silently disabling the check made
+  // any token from the issuer valid regardless of its intended audience.
+  // Unset (undefined) remains the documented "no audience check" mode.
   const rawAudience = process.env.ATLAS_AUTH_AUDIENCE;
   if (rawAudience === "") {
-    log.warn("ATLAS_AUTH_AUDIENCE is set to empty string — audience check will be skipped");
+    throw new Error(
+      "ATLAS_AUTH_AUDIENCE is set to an empty string. Set it to the expected JWT audience, " +
+        "or unset it entirely to skip audience validation.",
+    );
   }
   const audience = rawAudience || undefined;
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -842,6 +842,16 @@ export type AuthSecret = string & { readonly __brand: "AuthSecret" };
  * or short input — neither is recoverable at runtime, so failing early
  * beats a cryptographic weakness masquerading as a config quirk.
  */
+/**
+ * Published placeholder secrets that must never reach a production deploy
+ * (#3342 L-6). The `.env.example` value passes the ≥32-char floor, and it
+ * doubles as the at-rest encryption-key fallback — a deploy that shipped it
+ * would have a publicly-known session-signing AND data-encryption key.
+ */
+const KNOWN_DEFAULT_AUTH_SECRETS: ReadonlySet<string> = new Set([
+  "atlas-dev-secret-do-not-use-in-production!!",
+]);
+
 export function parseAuthSecret(raw: string | undefined): AuthSecret {
   if (!raw) {
     throw new Error(
@@ -851,6 +861,20 @@ export function parseAuthSecret(raw: string | undefined): AuthSecret {
   if (raw.length < 32) {
     throw new Error(
       `BETTER_AUTH_SECRET must be at least 32 characters (got ${raw.length}). Use a cryptographically random string.`,
+    );
+  }
+  if (KNOWN_DEFAULT_AUTH_SECRETS.has(raw)) {
+    if (
+      process.env.NODE_ENV === "production" ||
+      process.env.ATLAS_DEPLOY_MODE === "saas"
+    ) {
+      throw new Error(
+        "BETTER_AUTH_SECRET is set to the published .env.example placeholder — refusing to start in production. " +
+          "Generate a dedicated secret (e.g. `openssl rand -base64 33`).",
+      );
+    }
+    log.warn(
+      "BETTER_AUTH_SECRET is the published .env.example placeholder — fine for local dev, refused in production",
     );
   }
   return raw as AuthSecret;

--- a/packages/api/src/lib/tools/__tests__/sql.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql.test.ts
@@ -384,6 +384,87 @@ describe("validateSQL", () => {
     });
   });
 
+  // ----- Forbidden functions (#3342 L-3) --------------------------------------
+
+  describe("side-effecting / file / network function denylist (#3342 L-3)", () => {
+    it("rejects pg_read_file in a table-less SELECT", async () => {
+      await expectInvalid("SELECT pg_read_file('/etc/passwd')", "not allowed");
+    });
+
+    it("rejects pg_read_file behind obfuscated arguments", async () => {
+      await expectInvalid(
+        "SELECT pg_read_file(chr(47)||chr(101)||chr(116)||chr(99))",
+        "not allowed",
+      );
+    });
+
+    it("rejects schema-qualified pg_catalog.pg_read_file", async () => {
+      await expectInvalid(
+        "SELECT pg_catalog.pg_read_file('/etc/passwd')",
+        "not allowed",
+      );
+    });
+
+    it("rejects lo_import / lo_export", async () => {
+      await expectInvalid("SELECT lo_import('/etc/passwd')", "not allowed");
+      await expectInvalid("SELECT lo_export(123, '/tmp/x')", "not allowed");
+    });
+
+    it("rejects pg_sleep (timing/DoS)", async () => {
+      await expectInvalid("SELECT pg_sleep(60)", "not allowed");
+    });
+
+    it("rejects forbidden functions nested in WHERE clauses", async () => {
+      await expectInvalid(
+        "SELECT id FROM companies WHERE name = pg_read_file('/etc/passwd')",
+        "not allowed",
+      );
+    });
+
+    it("rejects BENCHMARK on MySQL", async () => {
+      process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
+      await expectInvalid("SELECT BENCHMARK(100000000, MD5('x'))", "not allowed");
+    });
+
+    it("rejects LOAD_FILE on MySQL", async () => {
+      process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
+      await expectInvalid("SELECT LOAD_FILE('/etc/passwd')", "not allowed");
+    });
+
+    it("does not false-positive on a string literal containing a forbidden name", async () => {
+      await expectValid(
+        "SELECT id FROM companies WHERE name = 'pg_read_file'",
+      );
+    });
+
+    it("does not block ordinary functions", async () => {
+      await expectValid("SELECT count(*), upper(name) FROM companies");
+    });
+  });
+
+  // ----- Quoted mixed-case identifiers (#3342 L-4) -----------------------------
+
+  describe("quoted mixed-case table identifiers (#3342 L-4)", () => {
+    it("rejects a double-quoted mixed-case table that case-folds into a whitelist entry", async () => {
+      // `"Companies"` is a DIFFERENT relation than `companies` on PG.
+      await expectInvalid('SELECT * FROM "Companies"', "case-sensitive");
+    });
+
+    it("rejects a backtick-quoted mixed-case table on MySQL", async () => {
+      process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
+      await expectInvalid("SELECT * FROM `Companies`", "case-sensitive");
+    });
+
+    it("still accepts unquoted mixed-case names (DB case-folds them)", async () => {
+      await expectValid("SELECT * FROM Companies");
+      await expectValid("SELECT * FROM PUBLIC.Companies");
+    });
+
+    it("still accepts quoted all-lowercase names", async () => {
+      await expectValid('SELECT * FROM "companies"');
+    });
+  });
+
   // ----- PG ONLY keyword (#3346) ---------------------------------------------
 
   describe("PG ONLY table modifier (#3346)", () => {
@@ -543,15 +624,13 @@ describe("validateSQL", () => {
 
   // ----- Known limitations ---------------------------------------------------
 
-  describe("known limitations", () => {
-    it("does not block dangerous PostgreSQL functions (mitigated by statement_timeout and DB permissions)", async () => {
-      // Functions like pg_sleep, pg_read_file, pg_terminate_backend pass
-      // validation because there is no function blocklist. Mitigation:
-      // - pg_sleep: bounded by statement_timeout (default 30s)
-      // - pg_read_file/pg_ls_dir: require superuser or explicit GRANT
-      // - pg_terminate_backend: requires pg_signal_backend role
-      // The DB user should have minimal permissions in production.
-      await expectValid("SELECT pg_sleep(1) FROM companies");
+  describe("formerly known limitations", () => {
+    it("blocks dangerous PostgreSQL functions (#3342 L-3 closed the gap)", async () => {
+      // Previously documented as a known limitation mitigated only by
+      // statement_timeout + DB permissions; the function denylist now
+      // rejects these at validation.
+      await expectInvalid("SELECT pg_sleep(1) FROM companies", "not allowed");
+      await expectInvalid("SELECT pg_terminate_backend(123)", "not allowed");
     });
   });
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -277,6 +277,92 @@ const FORBIDDEN_PATTERNS = [
   /\bINTO\s+(?:OUTFILE|DUMPFILE)\b/i,
 ];
 
+// #3342 L-3 — side-effecting / file / network / DoS functions that pass the
+// statement-shape layers (a table-less `SELECT pg_read_file(...)` is a valid
+// single SELECT against no whitelisted table). Checked via an AST walk over
+// function-call nodes, NOT regex, so a string literal containing one of these
+// names cannot false-positive. Defense-in-depth: the read-only role + the
+// statement timeout already bound most of these; `dblink` writes over a
+// separate connection, so only role privileges stop it without this list.
+const FORBIDDEN_FUNCTIONS = new Set([
+  // PostgreSQL — filesystem / large-object access
+  "pg_read_file",
+  "pg_read_binary_file",
+  "pg_ls_dir",
+  "pg_stat_file",
+  "pg_logdir_ls",
+  "lo_import",
+  "lo_export",
+  // PostgreSQL — server administration
+  "pg_terminate_backend",
+  "pg_cancel_backend",
+  "pg_reload_conf",
+  "pg_rotate_logfile",
+  "pg_create_restore_point",
+  "pg_switch_wal",
+  "pg_promote",
+  // dblink — side-channel connections (writes bypass the read-only session)
+  "dblink",
+  "dblink_exec",
+  "dblink_connect",
+  "dblink_connect_u",
+  "dblink_open",
+  "dblink_send_query",
+  // DoS / timing
+  "pg_sleep",
+  "pg_sleep_for",
+  "pg_sleep_until",
+  "sleep",
+  "benchmark",
+  // MySQL — filesystem / UDF escapes
+  "load_file",
+  "sys_eval",
+  "sys_exec",
+]);
+
+/**
+ * Extract the call name from a `function` / `aggr_func` AST node.
+ * node-sql-parser 5.x shapes: `aggr_func.name` is a string;
+ * `function.name` is `{ name: [{ value: "pg_read_file" }, ...] }` where a
+ * schema-qualified call (`pg_catalog.pg_read_file`) yields multiple parts —
+ * the last part is the function proper.
+ */
+function functionCallName(node: { name?: unknown }): string | undefined {
+  const name = node.name;
+  if (typeof name === "string") return name.toLowerCase();
+  if (name && typeof name === "object") {
+    const parts = (name as { name?: unknown }).name;
+    if (Array.isArray(parts) && parts.length > 0) {
+      const last = parts[parts.length - 1] as { value?: unknown };
+      if (typeof last?.value === "string") return last.value.toLowerCase();
+    }
+  }
+  return undefined;
+}
+
+/** Walk a statement AST and return the first forbidden function name, if any. */
+function findForbiddenFunction(node: unknown): string | undefined {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findForbiddenFunction(child);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!node || typeof node !== "object") return undefined;
+
+  const typed = node as { type?: unknown; name?: unknown };
+  if (typed.type === "function" || typed.type === "aggr_func") {
+    const callName = functionCallName(typed);
+    if (callName && FORBIDDEN_FUNCTIONS.has(callName)) return callName;
+  }
+  for (const value of Object.values(node)) {
+    const found = findForbiddenFunction(value);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 // MySQL-specific patterns — only applied when dbType === "mysql"
 // Note: LOAD DATA/XML is already caught by the base LOAD pattern above
 const MYSQL_FORBIDDEN_PATTERNS = [
@@ -476,6 +562,15 @@ export async function validateSQL(sql: string, connectionId?: string, workspaceI
           if (typeof name === "string") cteNames.add(name.toLowerCase());
         }
       }
+
+      // #3342 L-3 — block side-effecting / file / network / DoS functions.
+      const forbiddenFn = findForbiddenFunction(stmt);
+      if (forbiddenFn) {
+        return {
+          valid: false,
+          error: `Function "${forbiddenFn}" is not allowed — file, network, administrative, and timing functions are blocked.`,
+        };
+      }
     }
 
     // F-20 (#3346): reject PG-family queries whose extracted table set
@@ -553,11 +648,31 @@ export async function validateSQL(sql: string, connectionId?: string, workspaceI
       for (const ref of tables) {
         // tableList returns "select::schema::table" format
         const parts = ref.split("::");
-        const tableName = parts.pop()?.toLowerCase();
+        const rawTableName = parts.pop();
+        const tableName = rawTableName?.toLowerCase();
         // node-sql-parser returns "null" (the string) for unqualified tables — filter it out
         const rawSchema = parts.length > 1 ? parts[parts.length - 1]?.toLowerCase() : undefined;
         const schemaName = rawSchema && rawSchema !== "null" ? rawSchema : undefined;
         if (!tableName || cteNames.has(tableName)) continue;
+
+        // #3342 L-4 — quoted mixed-case identifiers resolve to a DIFFERENT
+        // relation than the case-folded whitelist entry (`FROM "Orders"` is
+        // not table `orders` on PG, and table names are case-sensitive on
+        // Linux MySQL). The parser drops quoting info, so detect the quoted
+        // form in the raw SQL: an unquoted mixed-case name (which the DB
+        // case-folds to the whitelist entry on PG) stays accepted.
+        if (
+          rawTableName &&
+          rawTableName !== tableName &&
+          (trimmed.includes(`"${rawTableName}"`) || trimmed.includes(`\`${rawTableName}\``))
+        ) {
+          return {
+            valid: false,
+            error:
+              `Quoted mixed-case table "${rawTableName}" does not match the semantic-layer table ` +
+              `"${tableName}" — quoted identifiers are case-sensitive. Use the unquoted lowercase name.`,
+          };
+        }
 
         const qualifiedName = schemaName ? `${schemaName}.${tableName}` : undefined;
         if (schemaName) {

--- a/packages/react/src/components/chat/error-banner.tsx
+++ b/packages/react/src/components/chat/error-banner.tsx
@@ -72,7 +72,13 @@ export function ErrorBanner({
     };
   }, [info.clientCode, onRetry]);
 
-  // Emit postMessage error event for widget host pages
+  // Emit postMessage error event for widget host pages.
+  //
+  // #3342 L-8 — the widget is embeddable on arbitrary pages, so the host
+  // origin is unknown and `targetOrigin: "*"` is unavoidable. The payload is
+  // therefore restricted to opaque, enumerable codes: no `message`/`detail`
+  // strings, which can carry server-derived error text (host names, request
+  // ids) to whatever frame embeds the widget.
   useEffect(() => {
     try {
       if (typeof window !== "undefined" && window.parent !== window) {
@@ -81,8 +87,6 @@ export function ErrorBanner({
             type: "atlas:error",
             error: {
               code: info.clientCode ?? info.code ?? "unknown",
-              message: info.title,
-              detail: info.detail,
               retryable: info.retryable,
             },
           },
@@ -92,7 +96,7 @@ export function ErrorBanner({
     } catch {
       // Silently ignore postMessage errors (cross-origin restrictions)
     }
-  }, [info.clientCode, info.code, info.title, info.detail, info.retryable]);
+  }, [info.clientCode, info.code, info.retryable]);
 
   // If we were offline but came back online, hide the banner
   if (info.clientCode === "offline" && restoredOnline) {

--- a/packages/web/src/app/report/[token]/report-view.tsx
+++ b/packages/web/src/app/report/[token]/report-view.tsx
@@ -114,7 +114,8 @@ function TextCell({ cell }: { cell: TextReportCell }) {
   return (
     <div className="report-cell">
       <div className="prose prose-zinc max-w-none text-sm prose-headings:tracking-tight prose-h2:mt-0 prose-h2:text-lg prose-h3:text-base dark:prose-invert">
-        <Markdown content={cell.content} />
+        {/* disallowImages (#3342 L-7): unauthenticated public surface. */}
+        <Markdown content={cell.content} disallowImages />
       </div>
     </div>
   );
@@ -146,7 +147,7 @@ function QueryCell({ cell }: { cell: QueryReportCell }) {
             if (part.type === "text") {
               const displayText = parseSuggestions(part.text).text;
               if (!displayText.trim()) return null;
-              return <Markdown key={i} content={displayText} />;
+              return <Markdown key={i} content={displayText} disallowImages />;
             }
             if (isToolUIPart(part)) {
               return <ToolPart key={i} part={part} />;

--- a/packages/web/src/app/shared/[token]/embed/view.tsx
+++ b/packages/web/src/app/shared/[token]/embed/view.tsx
@@ -74,7 +74,9 @@ export function EmbedView({ data, theme }: EmbedViewProps) {
                   </p>
                 ) : (
                   <div className="text-sm text-zinc-900 dark:text-zinc-100">
-                    <Markdown content={text} />
+                    {/* disallowImages (#3342 L-7): unauthenticated public surface — block
+                        LLM-markdown tracking pixels / viewer-IP leaks. */}
+                    <Markdown content={text} disallowImages />
                   </div>
                 )}
               </article>

--- a/packages/web/src/app/shared/[token]/page.tsx
+++ b/packages/web/src/app/shared/[token]/page.tsx
@@ -195,7 +195,9 @@ export default async function SharedConversationPage({
                     </p>
                   ) : (
                     <div className="text-zinc-900 dark:text-zinc-100">
-                      <Markdown content={text} />
+                      {/* disallowImages (#3342 L-7): unauthenticated public surface — block
+                          LLM-markdown tracking pixels / viewer-IP leaks. */}
+                      <Markdown content={text} disallowImages />
                     </div>
                   )}
                 </article>

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -2256,6 +2256,51 @@ describe("chatPlugin webhook routes", () => {
     expect(body.error).toContain("not yet initialized");
   });
 
+  it("returns 403 when the gchat adapter is wired but JWT verification is unconfigured (#3350)", async () => {
+    // Adapter env present (handler wires) but NEITHER GCHAT_PROJECT_NUMBER
+    // nor GCHAT_PUBSUB_AUDIENCE set — the upstream adapter would process
+    // UNVERIFIED HTTP webhooks after a single warn, so the route must
+    // fail closed instead of dispatching.
+    const snapshot = {
+      sa: process.env.GCHAT_SERVICE_ACCOUNT_JSON,
+      topic: process.env.GCHAT_PUBSUB_TOPIC,
+      project: process.env.GCHAT_PROJECT_NUMBER,
+      audience: process.env.GCHAT_PUBSUB_AUDIENCE,
+    };
+    process.env.GCHAT_SERVICE_ACCOUNT_JSON = JSON.stringify({
+      client_email: "fake@test-project.iam.gserviceaccount.com",
+      private_key: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+      project_id: "test-project",
+    });
+    process.env.GCHAT_PUBSUB_TOPIC = "projects/test-project/topics/fake-topic";
+    delete process.env.GCHAT_PROJECT_NUMBER;
+    delete process.env.GCHAT_PUBSUB_AUDIENCE;
+
+    const { app, plugin } = await mountPlugin(GCHAT_CATALOG);
+    await plugin.initialize!({
+      db: null,
+      connections: { get: () => { throw new Error("unused"); }, list: () => [], tables: () => [] },
+      tools: { register: () => {} },
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      config: {},
+    });
+    try {
+      const resp = await app.request("/webhooks/gchat", { method: "POST", body: "{}" });
+      expect(resp.status).toBe(403);
+      const body = (await resp.json()) as { error: string; requestId?: string };
+      expect(body.error).toContain("verification is not configured");
+      expect(typeof body.requestId).toBe("string");
+    } finally {
+      await plugin.teardown!();
+      if (snapshot.sa === undefined) delete process.env.GCHAT_SERVICE_ACCOUNT_JSON;
+      else process.env.GCHAT_SERVICE_ACCOUNT_JSON = snapshot.sa;
+      if (snapshot.topic === undefined) delete process.env.GCHAT_PUBSUB_TOPIC;
+      else process.env.GCHAT_PUBSUB_TOPIC = snapshot.topic;
+      if (snapshot.project !== undefined) process.env.GCHAT_PROJECT_NUMBER = snapshot.project;
+      if (snapshot.audience !== undefined) process.env.GCHAT_PUBSUB_AUDIENCE = snapshot.audience;
+    }
+  });
+
   it("returns 404 with a requestId when the bridge is initialized but the gchat adapter wasn't wired", async () => {
     // No GCHAT_SERVICE_ACCOUNT_JSON / GCHAT_PUBSUB_TOPIC in the env, so
     // AdapterRegistry returns null for the gchat slot. The runtime 404

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -523,6 +523,23 @@ function buildChatPlugin(
             );
             return c.json({ error: "Google Chat adapter not configured", requestId }, 404);
           }
+          // Fail closed when JWT verification is unconfigured (#3350). The
+          // upstream adapter treats GCHAT_PROJECT_NUMBER / GCHAT_PUBSUB_AUDIENCE
+          // as optional and, when both are absent, logs one warning and then
+          // processes UNVERIFIED HTTP webhooks — anyone who can reach this
+          // public route could forge Google Chat events. The Pub/Sub pull
+          // path the adapter binds at boot authenticates with the service
+          // account and is unaffected by this gate.
+          if (!process.env.GCHAT_PROJECT_NUMBER && !process.env.GCHAT_PUBSUB_AUDIENCE) {
+            (log ?? console).error(
+              { requestId, adapter: "gchat" },
+              "Google Chat HTTP webhook rejected — JWT verification is not configured. Set GCHAT_PROJECT_NUMBER (direct webhooks) and/or GCHAT_PUBSUB_AUDIENCE (Pub/Sub push) to enable verified inbound HTTP traffic",
+            );
+            return c.json(
+              { error: "Google Chat webhook verification is not configured", requestId },
+              403,
+            );
+          }
           try {
             const response = await handler(c.req.raw, {
               waitUntil: (task: Promise<unknown>) => {

--- a/plugins/duckdb/src/validation.ts
+++ b/plugins/duckdb/src/validation.ts
@@ -14,7 +14,9 @@ export const DUCKDB_FORBIDDEN_PATTERNS: RegExp[] = [
   /^\s*(CHECKPOINT)\b/i,
   /\b(DESCRIBE|EXPLAIN|SHOW)\b/i,
   // Block file-reading table functions that can access the host filesystem
+  // (#3342 L-5 — read_blob / read_ndjson* / glob round out the family)
   /\b(read_csv_auto|read_csv|read_parquet|read_json|read_json_auto|read_text)\b/i,
+  /\b(read_blob|read_ndjson|read_ndjson_auto|read_ndjson_objects|glob)\b/i,
   /\b(parquet_scan|csv_scan|json_scan)\b/i,
   // Block SET for configuration variables (DuckDB has no session-level read-only guard for :memory:).
   // Anchored to start-of-string (^\s*) to avoid false positives on column names


### PR DESCRIPTION
Fixes #3342
Fixes #3350

Follow-up to #3353. Triages all 14 Low findings from the June 2026 security review (11 fixed, 1 already fixed, 2 explicitly deferred) and lands the in-repo remediation + posture doc from the out-of-repo chat-adapter signature audit.

## Low-severity backlog (#3342)

**Fixed:**
- **L-1** — `adminAuth` gets the same SaaS `mode:"none"` fail-closed guard `platformAdminAuth` already had (500 `auth_misconfigured` instead of implicit admin).
- **L-2** — explicitly-set-but-empty `ATLAS_AUTH_AUDIENCE` is now a hard config error (500) instead of silently disabling audience validation; unset remains the documented no-check mode.
- **L-3** — AST-walk function denylist: `pg_read_file`/`pg_ls_dir`/`lo_import`/`lo_export`, `dblink*`, `pg_terminate_backend` and friends, `pg_sleep`/`SLEEP`/`BENCHMARK`, `LOAD_FILE`, `sys_eval`/`sys_exec`. Function nodes are matched in the AST (incl. schema-qualified `pg_catalog.…`), so string literals containing those names can't false-positive. The two "known limitation" tests documenting this gap are flipped to assert the block.
- **L-4** — quoted mixed-case table identifiers (`FROM "Orders"`) that case-fold into a whitelist entry are rejected (quoted identifiers are a *different* relation on PG / case-sensitive MySQL). Unquoted mixed-case stays accepted — the database itself case-folds it, so `FROM PUBLIC.Companies` keeps working.
- **L-5** — DuckDB denylist gains `read_blob`, `read_ndjson*`, `glob`.
- **L-6** — the published `.env.example` `BETTER_AUTH_SECRET` placeholder (which passes the ≥32-char floor and doubles as the at-rest encryption-key fallback) is refused at boot in production/SaaS; warns in dev.
- **L-7** — `disallowImages` on the unauthenticated shared/embed/report markdown surfaces (LLM-markdown tracking-pixel / viewer-IP leak).
- **L-8** — widget `atlas:error` postMessage payloads (ErrorBanner + the widget bootstrap script) scoped to opaque codes — no error text broadcast to `targetOrigin: "*"`. Docs updated.
- **L-10** — `mcp-publisher` download pinned to v1.7.9 with SHA256 verification (the job holds OIDC publish rights).
- **L-11** — k6 apt key fetched over HTTPS from dl.k6.io with a fingerprint assertion (workflow + README manual path).
- **L-14** — dev/e2e/example/template compose files bind Postgres host ports to `127.0.0.1`.

**Already fixed:** L-13 (dev sidecar bind + auth opt-out) shipped with the H-1 remediation in #3352.

**Deferred with rationale:**
- **L-9** (CSP `unsafe-inline`/`unsafe-eval`) — documented Next.js-hydration/Recharts tradeoff; removing it is a frontend-architecture change, not a hardening tweak.
- **L-12** (`--network=host` in deploy-validation) — ephemeral CI runner, hygiene only; changing the network mode risks breaking a required check for no attack-surface reduction.

## Chat-adapter audit follow-ups (#3350)

Per-platform signature-verification audit of the installed `@chat-adapter/*` v4.23.0 dist (full report on the issue; posture table added to `docs/architecture/chat-plugin-atlas-contract.md`). Six of eight platforms verify timing-safely and fail closed at init. The two fail-open adapters:

- **Telegram** — already unreachable from Atlas's wiring (#3154 made `TELEGRAM_WEBHOOK_SECRET` mandatory in the adapter registry).
- **Google Chat** — the `/webhooks/gchat` route now returns **403** when neither `GCHAT_PROJECT_NUMBER` nor `GCHAT_PUBSUB_AUDIENCE` is set, instead of letting the upstream adapter process forgeable unverified HTTP events. The service-account-authenticated Pub/Sub pull path is unaffected. Regression test added.

## Testing

`bun run lint`, `bun run type`, full `--affected` API sweep (278 files), chat-plugin suite, react suite, template-drift check — green. New regression tests per item (forbidden functions incl. obfuscated/nested/schema-qualified, quoted mixed-case rejection + unquoted acceptance, empty-audience hard error, placeholder-secret refusal matrix, gchat 403 gate).

https://claude.ai/code/session_01GaXcUQXXkMHCtwxdtPcUYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaXcUQXXkMHCtwxdtPcUYE)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783630358&installation_id=135337507&pr_number=3355&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3355&signature=869c7e353c6e6f26fa55ce24908056a575df30f0b7e77df395cd22aaec166dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Docker database ports restricted to localhost across all environments
  * Authentication system rejects unsafe default secrets in production/SaaS deployments
  * Enhanced SQL validation: new denylist blocks dangerous functions in PostgreSQL and MySQL
  * Widget error messages restricted to opaque codes; human-readable text removed to prevent leakage
  * Google Chat webhook verification configuration now enforced
  * Image rendering disabled in public and unauthenticated views

* **Documentation**
  * Added comprehensive webhook signature verification audit documentation

* **Chores**
  * k6 and mcp-publisher versions pinned with SHA256 checksum verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->