### PR TITLE
feat(web): deepen admin config pages behind a useConfigForm hook

### DIFF
--- a/.claude/research/architecture-review-2026-06-09.md
+++ b/.claude/research/architecture-review-2026-06-09.md
@@ -49,15 +49,14 @@ Vocabulary per the skill: module / interface / seam / deep / shallow / locality 
 
 ---
 
-## 4. Deepen admin config pages behind `useConfigForm` — **Strong**
+## 4. Deepen admin config pages behind `useConfigForm` — **Shipped** → wins #89
 
-**Files:** `packages/web/src/app/admin/{proactive-chat,connections,approval,compliance,semantic,…}/page.tsx` — 16 pages
+Shipped as `packages/web/src/ui/hooks/use-config-form.ts` + migrations of proactive-chat and both audit retention panels. Implementation survey narrowed the candidate sharply: the original "16 pages" count conflated the hand-wired config-form loop with CRUD-of-many dialogs, action pages, and react-hook-form surfaces. Remainder notes for future passes:
 
-**Problem:** Sixteen admin pages hand-wire the same load → per-field `useState` → hand-rolled dirty compare → manual reset-on-refetch → save loop on top of `useAdminFetch`/`useAdminMutation` (~150–250 lines per page; e.g. proactive-chat is ~40% state bookkeeping). The dirty/reset logic is a module with no interface; forgetting a field in a dirty compare is a silent bug.
-
-**Solution:** A `useConfigForm<T>` hook absorbs the loop — returns `{ fields, dirty, reset, save, saving, error }`. Natural successor to win #1 (`useAdminMutation`) and wins #29–31 (structured-error passthrough).
-
-**Wins:** dirty/reset semantics in one hook; one interface, 16 pages; ~1,500 lines of bookkeeping deleted; hook testable without rendering pages.
+- **email-provider** (`admin/email-provider/page.tsx`) — has the loop, but its reset key is deliberately *narrower* than data identity (`provider|fromAddress|installedAt` — secrets are never echoed back, so values intentionally don't mirror server state), and the reset also clears page-level test/error state. Fitting it would need a `resetKey` override + post-reset callback on the hook — add those options only when a second consumer wants them.
+- **branding** (`admin/branding/page.tsx`), **model-config** (`ui/components/admin/model-provider-section.tsx`) — already delegate dirty/reset to react-hook-form (zod per-field validation, `FormField` context). Converting RHF → `useConfigForm` is a rewrite, not a deepening; revisit only if RHF gets retired.
+- **sandbox** (`admin/sandbox/page.tsx`, self-hosted view) — dirty flag exists but the save conditionally fans out to *two* settings endpoints (`ATLAS_SANDBOX_BACKEND`, `ATLAS_SANDBOX_URL`) or a reset call; multi-endpoint saves are out of the hook's scope by design.
+- **sso enforcement, residency, custom-domain, cache, scheduler** — action/confirm flows without a form-state copy; **approval, compliance, connections, semantic, settings, scim, ip-allowlist, oauth-clients, roles, prompts** — CRUD-of-many via dialogs (dialog reset-on-open is a different loop). Candidate 5 (`usePaginatedTable`) covers the list halves of these.
 
 ---
 

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -702,7 +702,7 @@ The hook's own `error: string | null` state is explicitly unchanged — out of s
 
 **Date:** 2026-04-19
 **Issue:** #1615 (primary), #1617, #1616
-**PR:** TBD
+**PR:** #3356
 
 **Problem:** #1614 (win #29) widened `MutateResult.error` from `string` to `FetchError` so mutation *callbacks* could branch on `code === "enterprise_required"` and feed structured errors into `AdminContentWrapper`. The hook-level `error: string | null` state was explicitly out-of-scope and stayed flat. ~40 admin pages (api-keys, scheduled-tasks, ip-allowlist, connections, platform/plugins, sandbox, approval, plugins, branding, roles, settings, residency, users, prompts, scim, sso, sessions, billing, compliance, cache, email-provider, integrations, model-config, semantic editor, custom-domain, audit retention, platform/*, dashboards, starter-prompts, scheduled-task dialog, version history, SSO dialogs, etc.) read `mutation.error` directly — for those pages, EE-gated endpoints 403ing with `enterprise_required` rendered a generic banner instead of `EnterpriseUpsell`, and `requestId` was dropped from banner copy. Same #1595 class, different surface.
 
@@ -766,7 +766,7 @@ Phase 1 migration (this PR) covers 5 highest-value pages — the ones called out
 
 **Date:** 2026-04-19
 **Issue:** #1642
-**PR:** TBD
+**PR:** #3356
 
 **Problem:** Type-design-analyzer review of PR #1641 surfaced parallel Zod schemas describing the same wire shapes — one inside the API route (for `@hono/zod-openapi` response validation) and one inside the web admin client (for `useAdminFetch` runtime parsing). A field rename on either side type-checked cleanly while the other kept the old key, so drift went undetected until a runtime response arrived shaped differently than the parser expected. The abuse surface alone had six duplicated schemas (`AbuseEvent`, `AbuseStatus`, `AbuseThresholdConfig`, `AbuseCounters`, `AbuseInstance`, `AbuseDetail`); the issue mapped 15+ comparable pairs across the admin surface (approval, custom-domain, integrations, billing, SLA, backups, regions, audit analytics).
 

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2534,7 +2534,7 @@ The admin form is a shared, type-aware `<ConfigSchemaFields>` renderer (extracte
 
 **Date:** 2026-06-10
 **Issue:** none (architecture-review-2026-06-09.md candidate 4)
-**PR:** TBD
+**PR:** #3356
 
 **Problem:** Admin config pages hand-wired the same load → per-field `useState` → hand-rolled dirty compare → manual reset-on-refetch → save loop on top of `useAdminFetch`/`useAdminMutation`. Proactive-chat (the worst offender, ~40% state bookkeeping) listed every field four times — useState, reset effect, dirty compare, save payload — so adding a field to the form but forgetting it in the dirty compare was a silent bug (Save stays disabled, or stays enabled forever). The two audit retention panels additionally hand-rolled the entire fetch lifecycle (cancelled flag, loading/error state, manual JSON cast) that `useAdminFetch` already owns.
 

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -702,7 +702,7 @@ The hook's own `error: string | null` state is explicitly unchanged — out of s
 
 **Date:** 2026-04-19
 **Issue:** #1615 (primary), #1617, #1616
-**PR:** #3356
+**PR:** TBD
 
 **Problem:** #1614 (win #29) widened `MutateResult.error` from `string` to `FetchError` so mutation *callbacks* could branch on `code === "enterprise_required"` and feed structured errors into `AdminContentWrapper`. The hook-level `error: string | null` state was explicitly out-of-scope and stayed flat. ~40 admin pages (api-keys, scheduled-tasks, ip-allowlist, connections, platform/plugins, sandbox, approval, plugins, branding, roles, settings, residency, users, prompts, scim, sso, sessions, billing, compliance, cache, email-provider, integrations, model-config, semantic editor, custom-domain, audit retention, platform/*, dashboards, starter-prompts, scheduled-task dialog, version history, SSO dialogs, etc.) read `mutation.error` directly — for those pages, EE-gated endpoints 403ing with `enterprise_required` rendered a generic banner instead of `EnterpriseUpsell`, and `requestId` was dropped from banner copy. Same #1595 class, different surface.
 
@@ -766,7 +766,7 @@ Phase 1 migration (this PR) covers 5 highest-value pages — the ones called out
 
 **Date:** 2026-04-19
 **Issue:** #1642
-**PR:** #3356
+**PR:** TBD
 
 **Problem:** Type-design-analyzer review of PR #1641 surfaced parallel Zod schemas describing the same wire shapes — one inside the API route (for `@hono/zod-openapi` response validation) and one inside the web admin client (for `useAdminFetch` runtime parsing). A field rename on either side type-checked cleanly while the other kept the old key, so drift went undetected until a runtime response arrived shaped differently than the parser expected. The abuse surface alone had six duplicated schemas (`AbuseEvent`, `AbuseStatus`, `AbuseThresholdConfig`, `AbuseCounters`, `AbuseInstance`, `AbuseDetail`); the issue mapped 15+ comparable pairs across the admin surface (approval, custom-domain, integrations, billing, SLA, backups, regions, audit analytics).
 

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2527,3 +2527,26 @@ The admin form is a shared, type-aware `<ConfigSchemaFields>` renderer (extracte
 - **Builds on #3232's seam without churn.** Win #87 introduced `getEntityDirs` as the single layout-traversal point and filed this as the hardening follow-up; this slice turns its lossy `rootScanFailed` boolean into the typed `failedScans` the later group-namespace slices (#3240/#3245) can extend.
 
 **Category:** Security-boundary hardening / fail-closed — a discovery-layer failure that was silently swallowed and then *inverted the partition decision* (widening a connection onto the default group's whitelist) becomes a typed signal threaded into a single resolver that fails closed on it, with the swallowed-error path that picked the wrong boundary deleted, not merely logged.
+
+---
+
+## 89. Admin config-form loop behind `useConfigForm` — dirty/reset semantics stated once
+
+**Date:** 2026-06-10
+**Issue:** none (architecture-review-2026-06-09.md candidate 4)
+**PR:** TBD
+
+**Problem:** Admin config pages hand-wired the same load → per-field `useState` → hand-rolled dirty compare → manual reset-on-refetch → save loop on top of `useAdminFetch`/`useAdminMutation`. Proactive-chat (the worst offender, ~40% state bookkeeping) listed every field four times — useState, reset effect, dirty compare, save payload — so adding a field to the form but forgetting it in the dirty compare was a silent bug (Save stays disabled, or stays enabled forever). The two audit retention panels additionally hand-rolled the entire fetch lifecycle (cancelled flag, loading/error state, manual JSON cast) that `useAdminFetch` already owns.
+
+**Solution:** `packages/web/src/ui/hooks/use-config-form.ts` — `useConfigForm<TData, TValues>` composes `useAdminFetch` + `useAdminMutation` and returns `{ fields, values, dirty, reset, save, saving, error }` plus the load side (`data, loading, loadError, refetch`). One declaration (`toForm`) is the canonical statement of what the form edits: its keys drive both the per-field accessors **and** the deep-equality dirty compare, so a field cannot be editable yet missing from the compare. `toPayload` owns the save-time transformations (trim, `"" → null`, string → number). Re-baseline rides TanStack Query's structural sharing — the form resets exactly when fetched content actually changes (post-save invalidation refetch) and never clobbers in-flight edits on a no-change background refetch.
+
+The implementation survey narrowed the candidate's "16 pages" to the surfaces that genuinely contain this loop — migrated: **proactive-chat**, **audit/retention-panel**, **audit/admin-action-retention-panel**. The remainder are CRUD-of-many dialogs, action/confirm flows, react-hook-form surfaces, or multi-endpoint saves — documented per-page in the review doc entry rather than forced through the seam.
+
+**Impact:**
+- Dirty/reset semantics live in one hook with 10 direct tests (no page rendering): canonical compare, deep array participation, save → invalidate → re-baseline, edit preservation across no-change refetches, save-failure state retention.
+- Both retention panels dropped their hand-rolled fetch lifecycle (~45 lines each) and gained the platform behaviors they were missing: TanStack caching/dedup, window-focus revalidation, MFA-gate routing — while keeping their bespoke 403 banner copy via an explicit `loadError.status` map.
+- Proactive-chat's field list went from four statements per field to two (`toForm`/`toPayload`); the dirty compare can no longer drift from the field set.
+- Bonus hardening: `useAdminFetch` now normalizes 2xx-non-JSON bodies (misconfigured proxy) into actionable copy for **all** consumers, generalizing the panel-local #1511 fix instead of losing it in migration.
+- A future config page is `useConfigForm` + JSX — no bookkeeping to hand-wire or forget.
+
+**Category:** Tightly-coupled page-level state machines consolidated into a deep hook with a small interface — the natural successor to win #1 (`useAdminMutation`), with honest scope: the seam absorbed the pages that have the loop and documented the ones that don't.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ export default defineConfig({
 ```
 
 ### Admin Page Hooks
-Admin pages use two shared hooks — never hand-roll fetch/mutation logic:
+Admin pages use shared hooks — never hand-roll fetch/mutation logic:
 ```typescript
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -298,6 +298,17 @@ const { data, loading, error, refetch } = useAdminFetch<T>("/api/v1/admin/...");
 const { mutate, saving, error } = useAdminMutation<T>({
   path: "/api/v1/admin/...", method: "POST", invalidates: refetch,
 });
+```
+Config-form pages (load one settings object → edit fields → dirty-gated save → reset on refetch) use `useConfigForm` instead of wiring those two by hand — `toForm` is the single statement of the field set, and the dirty compare derives from it so a new field can't be forgotten:
+```typescript
+import { useConfigForm } from "@/ui/hooks/use-config-form";
+
+const form = useConfigForm<WireConfig, FormValues>({
+  path: "/api/v1/admin/...", schema: WireConfigSchema,
+  toForm: (d) => ({ enabled: d.enabled, cap: d.cap === null ? "" : String(d.cap) }),
+  toPayload: (v) => ({ enabled: v.enabled, cap: v.cap === "" ? null : Number(v.cap) }),
+});
+// form.fields.enabled.{value,set} · form.{dirty,reset,save,saving,error,loadError}
 ```
 
 ## Template Sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ const form = useConfigForm<WireConfig, FormValues>({
   toForm: (d) => ({ enabled: d.enabled, cap: d.cap === null ? "" : String(d.cap) }),
   toPayload: (v) => ({ enabled: v.enabled, cap: v.cap === "" ? null : Number(v.cap) }),
 });
-// form.fields.enabled.{value,set} · form.{dirty,reset,save,saving,error,loadError}
+// form.fields.enabled.{value,set} · form.{data,loading,loadError,refetch,values,dirty,reset,save,saving,error}
 ```
 
 ## Template Sync

--- a/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
@@ -264,7 +264,7 @@ export function AdminActionRetentionPanel() {
     return (
       <ErrorBanner
         message={
-          form.loadError.status === 403
+          form.loadError.code === "enterprise_required"
             ? "Enterprise license required for admin-action retention settings."
             : form.loadError.message
         }

--- a/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import type { AuditRetentionPolicy } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { useConfigForm } from "@/ui/hooks/use-config-form";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -94,21 +95,55 @@ async function safeJson<T>(res: Response): Promise<T | undefined> {
   }
 }
 
+// Wire + form shapes for the policy config-form loop. The GET response is
+// typed (not Zod-validated) to match the previous behavior of casting the
+// parsed JSON — the canonical shape lives in `@useatlas/types`.
+interface PolicyResponse {
+  policy: AuditRetentionPolicy | null;
+}
+
+interface AdminActionRetentionFormValues extends Record<string, unknown> {
+  preset: RetentionPreset;
+  customDays: number;
+  hardDeleteDelay: number;
+}
+
 // ── Component ─────────────────────────────────────────────────────
 
 export function AdminActionRetentionPanel() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
-  const [policy, setPolicy] = useState<AuditRetentionPolicy | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
-  // Policy form state
-  const [preset, setPreset] = useState<RetentionPreset>("2555");
-  const [customDays, setCustomDays] = useState(2555);
-  const [hardDeleteDelay, setHardDeleteDelay] = useState(30);
+  const form = useConfigForm<
+    PolicyResponse,
+    AdminActionRetentionFormValues,
+    { policy: AuditRetentionPolicy }
+  >({
+    path: "/api/v1/admin/audit/admin-action-retention",
+    saveMethod: "PUT",
+    toForm: (d) => {
+      if (!d.policy) {
+        return { preset: "2555", customDays: 2555, hardDeleteDelay: 30 };
+      }
+      const pr = presetFromDays(d.policy.retentionDays);
+      return {
+        preset: pr,
+        customDays:
+          pr === "custom" && d.policy.retentionDays !== null
+            ? d.policy.retentionDays
+            : 2555,
+        hardDeleteDelay: d.policy.hardDeleteDelayDays,
+      };
+    },
+    toPayload: (v) => ({
+      retentionDays: daysFromPreset(v.preset, v.customDays),
+      hardDeleteDelayDays: v.hardDeleteDelay,
+    }),
+  });
+
+  const policy = form.data?.policy ?? null;
 
   // Purge state
   const [purgeResult, setPurgeResult] = useState<string | null>(null);
@@ -123,12 +158,6 @@ export function AdminActionRetentionPanel() {
   const [eraseDialogOpen, setEraseDialogOpen] = useState(false);
 
   // Mutation hooks
-  const { mutate: saveMutate, saving, error: saveError, clearError: clearSaveError } =
-    useAdminMutation<{ policy: AuditRetentionPolicy }>({
-      path: "/api/v1/admin/audit/admin-action-retention",
-      method: "PUT",
-    });
-
   const { mutate: purgeMutate, saving: purging, error: purgeError, clearError: clearPurgeError } =
     useAdminMutation<{ results: Array<{ orgId: string; deletedCount: number }> }>({
       path: "/api/v1/admin/audit/admin-action-retention/purge",
@@ -141,52 +170,6 @@ export function AdminActionRetentionPanel() {
       method: "POST",
     });
 
-  // Fetch current policy
-  useEffect(() => {
-    let cancelled = false;
-    async function fetchPolicy() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`${apiUrl}/api/v1/admin/audit/admin-action-retention`, { credentials });
-        if (!res.ok) {
-          if (res.status === 403) {
-            if (!cancelled) setError("Enterprise license required for admin-action retention settings.");
-            return;
-          }
-          const e = await extractFetchError(res);
-          if (!cancelled) setError(e.message);
-          return;
-        }
-        const data = await safeJson<{ policy: AuditRetentionPolicy | null }>(res);
-        if (!data) {
-          if (!cancelled) setError("Server returned a non-JSON response. Check your proxy / deploy configuration.");
-          return;
-        }
-        if (!cancelled) {
-          const p = data.policy;
-          setPolicy(p);
-          if (p) {
-            const pr = presetFromDays(p.retentionDays);
-            setPreset(pr);
-            if (pr === "custom" && p.retentionDays !== null) {
-              setCustomDays(p.retentionDays);
-            }
-            setHardDeleteDelay(p.hardDeleteDelayDays);
-          }
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Failed to load admin-action retention policy");
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    fetchPolicy();
-    return () => { cancelled = true; };
-  }, [apiUrl, credentials]);
-
   // Clear the transient save-success banner on unmount so a state update
   // doesn't land on a disposed component if the user navigates away mid-flash.
   useEffect(() => {
@@ -197,13 +180,8 @@ export function AdminActionRetentionPanel() {
 
   async function handleSave() {
     setSaveSuccess(false);
-    clearSaveError();
-    const retentionDays = daysFromPreset(preset, customDays);
-    const result = await saveMutate({
-      body: { retentionDays, hardDeleteDelayDays: hardDeleteDelay },
-    });
-    if (result.ok && result.data) {
-      setPolicy(result.data.policy);
+    const result = await form.save();
+    if (result.ok) {
       // Banner auto-clears via the unmount-safe effect above.
       setSaveSuccess(true);
     }
@@ -278,13 +256,26 @@ export function AdminActionRetentionPanel() {
     }
   }
 
-  if (loading) {
+  if (form.loading) {
     return <LoadingState message="Loading admin-action retention settings..." />;
   }
 
-  if (error) {
-    return <ErrorBanner message={error} />;
+  if (form.loadError) {
+    return (
+      <ErrorBanner
+        message={
+          form.loadError.status === 403
+            ? "Enterprise license required for admin-action retention settings."
+            : form.loadError.message
+        }
+      />
+    );
   }
+
+  if (!form.fields) {
+    return <LoadingState message="Loading admin-action retention settings..." />;
+  }
+  const { fields } = form;
 
   return (
     <div className="space-y-6">
@@ -339,13 +330,13 @@ export function AdminActionRetentionPanel() {
             <div className="space-y-2">
               <Label htmlFor="admin-action-retention-preset">Retention period</Label>
               <Select
-                value={preset}
+                value={fields.preset.value}
                 onValueChange={(v) => {
                   // Runtime guard — SelectItem `value` strings and the
                   // `RETENTION_PRESETS` tuple are two sources of truth;
                   // an invalid value can only mean a future SelectItem
                   // typo, which we swallow rather than cast-and-pray.
-                  if (isRetentionPreset(v)) setPreset(v);
+                  if (isRetentionPreset(v)) fields.preset.set(v);
                 }}
               >
                 <SelectTrigger id="admin-action-retention-preset" className="w-full">
@@ -361,19 +352,19 @@ export function AdminActionRetentionPanel() {
               </Select>
             </div>
 
-            {preset === "custom" && (
+            {fields.preset.value === "custom" && (
               <div className="space-y-2">
                 <Label htmlFor="admin-action-custom-days">Custom days (min 7)</Label>
                 <Input
                   id="admin-action-custom-days"
                   type="number"
                   min={7}
-                  value={customDays}
+                  value={fields.customDays.value}
                   onChange={(e) => {
                     const v = e.target.value;
                     if (v === "") return;
                     const n = Number.parseInt(v, 10);
-                    if (Number.isFinite(n) && n >= 7) setCustomDays(n);
+                    if (Number.isFinite(n) && n >= 7) fields.customDays.set(n);
                   }}
                   className="w-full"
                 />
@@ -389,12 +380,12 @@ export function AdminActionRetentionPanel() {
                 id="admin-action-hard-delete-delay"
                 type="number"
                 min={0}
-                value={hardDeleteDelay}
+                value={fields.hardDeleteDelay.value}
                 onChange={(e) => {
                   const v = e.target.value;
                   if (v === "") return;
                   const n = Number.parseInt(v, 10);
-                  if (Number.isFinite(n) && n >= 0) setHardDeleteDelay(n);
+                  if (Number.isFinite(n) && n >= 0) fields.hardDeleteDelay.set(n);
                 }}
                 className="w-full"
               />
@@ -405,17 +396,17 @@ export function AdminActionRetentionPanel() {
           </div>
 
           <MutationErrorSurface
-            error={saveError}
+            error={form.error}
             feature="Admin Action Retention"
-            onRetry={clearSaveError}
+            onRetry={form.clearError}
           />
           {saveSuccess && (
             <p className="text-sm text-green-600">Admin-action retention policy saved successfully.</p>
           )}
 
           <div className="flex items-center gap-3">
-            <Button onClick={handleSave} disabled={saving}>
-              {saving ? "Saving..." : "Save Policy"}
+            <Button onClick={handleSave} disabled={form.saving}>
+              {form.saving ? "Saving..." : "Save Policy"}
             </Button>
             <AlertDialog>
               <AlertDialogTrigger asChild>

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { AuditRetentionPolicy } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { useConfigForm } from "@/ui/hooks/use-config-form";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
 import { DatePicker } from "@/components/ui/date-picker";
@@ -66,21 +67,55 @@ function daysFromPreset(preset: RetentionPreset, customDays: number): number | n
   return customDays;
 }
 
+// Wire + form shapes for the policy config-form loop. The GET response is
+// typed (not Zod-validated) to match the previous behavior of casting the
+// parsed JSON — the canonical shape lives in `@useatlas/types`.
+interface PolicyResponse {
+  policy: RetentionPolicy | null;
+}
+
+interface RetentionFormValues extends Record<string, unknown> {
+  preset: RetentionPreset;
+  customDays: number;
+  hardDeleteDelay: number;
+}
+
 // ── Component ─────────────────────────────────────────────────────
 
 export function RetentionPanel() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
-  const [policy, setPolicy] = useState<RetentionPolicy | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
-  // Form state
-  const [preset, setPreset] = useState<RetentionPreset>("unlimited");
-  const [customDays, setCustomDays] = useState(90);
-  const [hardDeleteDelay, setHardDeleteDelay] = useState(30);
+  const form = useConfigForm<
+    PolicyResponse,
+    RetentionFormValues,
+    { policy: RetentionPolicy }
+  >({
+    path: "/api/v1/admin/audit/retention",
+    saveMethod: "PUT",
+    toForm: (d) => {
+      if (!d.policy) {
+        return { preset: "unlimited", customDays: 90, hardDeleteDelay: 30 };
+      }
+      const pr = presetFromDays(d.policy.retentionDays);
+      return {
+        preset: pr,
+        customDays:
+          pr === "custom" && d.policy.retentionDays !== null
+            ? d.policy.retentionDays
+            : 90,
+        hardDeleteDelay: d.policy.hardDeleteDelayDays,
+      };
+    },
+    toPayload: (v) => ({
+      retentionDays: daysFromPreset(v.preset, v.customDays),
+      hardDeleteDelayDays: v.hardDeleteDelay,
+    }),
+  });
+
+  const policy = form.data?.policy ?? null;
 
   // Export state
   const [exporting, setExporting] = useState(false);
@@ -92,70 +127,16 @@ export function RetentionPanel() {
   // Purge state
   const [purgeResult, setPurgeResult] = useState<string | null>(null);
 
-  // Mutation hooks
-  const { mutate: saveMutate, saving, error: saveError, clearError: clearSaveError } =
-    useAdminMutation<{ policy: RetentionPolicy }>({
-      path: "/api/v1/admin/audit/retention",
-      method: "PUT",
-    });
-
   const { mutate: purgeMutate, saving: purging, error: purgeError, clearError: clearPurgeError } =
     useAdminMutation<{ results: Array<{ orgId: string; softDeletedCount: number }> }>({
       path: "/api/v1/admin/audit/retention/purge",
       method: "POST",
     });
 
-  // Fetch current policy
-  useEffect(() => {
-    let cancelled = false;
-    async function fetchPolicy() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`${apiUrl}/api/v1/admin/audit/retention`, { credentials });
-        if (!res.ok) {
-          if (res.status === 403) {
-            if (!cancelled) setError("Enterprise license required for audit retention settings.");
-            return;
-          }
-          const e = await extractFetchError(res);
-          if (!cancelled) setError(e.message);
-          return;
-        }
-        const data = await res.json();
-        if (!cancelled) {
-          const p = data.policy as RetentionPolicy | null;
-          setPolicy(p);
-          if (p) {
-            const pr = presetFromDays(p.retentionDays);
-            setPreset(pr);
-            if (pr === "custom" && p.retentionDays !== null) {
-              setCustomDays(p.retentionDays);
-            }
-            setHardDeleteDelay(p.hardDeleteDelayDays);
-          }
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Failed to load retention policy");
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    fetchPolicy();
-    return () => { cancelled = true; };
-  }, [apiUrl, credentials]);
-
   async function handleSave() {
     setSaveSuccess(false);
-    clearSaveError();
-    const retentionDays = daysFromPreset(preset, customDays);
-    const result = await saveMutate({
-      body: { retentionDays, hardDeleteDelayDays: hardDeleteDelay },
-    });
-    if (result.ok && result.data) {
-      setPolicy(result.data.policy);
+    const result = await form.save();
+    if (result.ok) {
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 3000);
     }
@@ -208,13 +189,26 @@ export function RetentionPanel() {
     }
   }
 
-  if (loading) {
+  if (form.loading) {
     return <LoadingState message="Loading retention settings..." />;
   }
 
-  if (error) {
-    return <ErrorBanner message={error} />;
+  if (form.loadError) {
+    return (
+      <ErrorBanner
+        message={
+          form.loadError.status === 403
+            ? "Enterprise license required for audit retention settings."
+            : form.loadError.message
+        }
+      />
+    );
   }
+
+  if (!form.fields) {
+    return <LoadingState message="Loading retention settings..." />;
+  }
+  const { fields } = form;
 
   return (
     <div className="space-y-6">
@@ -259,8 +253,8 @@ export function RetentionPanel() {
             <div className="space-y-2">
               <Label htmlFor="retention-preset">Retention period</Label>
               <Select
-                value={preset}
-                onValueChange={(v) => setPreset(v as RetentionPreset)}
+                value={fields.preset.value}
+                onValueChange={(v) => fields.preset.set(v as RetentionPreset)}
               >
                 <SelectTrigger id="retention-preset" className="w-full">
                   <SelectValue />
@@ -275,15 +269,15 @@ export function RetentionPanel() {
               </Select>
             </div>
 
-            {preset === "custom" && (
+            {fields.preset.value === "custom" && (
               <div className="space-y-2">
                 <Label htmlFor="custom-days">Custom days (min 7)</Label>
                 <Input
                   id="custom-days"
                   type="number"
                   min={7}
-                  value={customDays}
-                  onChange={(e) => setCustomDays(parseInt(e.target.value, 10) || 7)}
+                  value={fields.customDays.value}
+                  onChange={(e) => fields.customDays.set(parseInt(e.target.value, 10) || 7)}
                   className="w-full"
                 />
               </div>
@@ -295,8 +289,8 @@ export function RetentionPanel() {
                 id="hard-delete-delay"
                 type="number"
                 min={0}
-                value={hardDeleteDelay}
-                onChange={(e) => setHardDeleteDelay(parseInt(e.target.value, 10) || 0)}
+                value={fields.hardDeleteDelay.value}
+                onChange={(e) => fields.hardDeleteDelay.set(parseInt(e.target.value, 10) || 0)}
                 className="w-full"
               />
               <p className="text-xs text-muted-foreground">
@@ -306,17 +300,17 @@ export function RetentionPanel() {
           </div>
 
           <MutationErrorSurface
-            error={saveError}
+            error={form.error}
             feature="Audit Retention"
-            onRetry={clearSaveError}
+            onRetry={form.clearError}
           />
           {saveSuccess && (
             <p className="text-sm text-green-600">Retention policy saved successfully.</p>
           )}
 
           <div className="flex items-center gap-3">
-            <Button onClick={handleSave} disabled={saving}>
-              {saving ? "Saving..." : "Save Policy"}
+            <Button onClick={handleSave} disabled={form.saving}>
+              {form.saving ? "Saving..." : "Save Policy"}
             </Button>
             <AlertDialog>
               <AlertDialogTrigger asChild>

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -197,7 +197,7 @@ export function RetentionPanel() {
     return (
       <ErrorBanner
         message={
-          form.loadError.status === 403
+          form.loadError.code === "enterprise_required"
             ? "Enterprise license required for audit retention settings."
             : form.loadError.message
         }

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -27,7 +27,7 @@
  * routed by `<AdminContentWrapper feature="Proactive Chat">`.
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Bot,
   Hash,
@@ -39,6 +39,10 @@ import {
 import { z } from "zod";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import {
+  useConfigForm,
+  type UseConfigFormReturn,
+} from "@/ui/hooks/use-config-form";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
@@ -132,21 +136,58 @@ function Hero() {
   );
 }
 
+// Form-value shape: numeric cap is held as the raw input string so typing
+// stays free-form; `toPayload` parses it at save time.
+interface WorkspaceFormValues extends Record<string, unknown> {
+  enabled: boolean;
+  sensitivity: Sensitivity;
+  classifierMode: ClassifierMode;
+  announcementChannelId: string;
+  monthlyCap: string;
+}
+
+type WorkspaceConfigForm = UseConfigFormReturn<
+  WorkspaceConfig,
+  WorkspaceFormValues
+>;
+
 function PageBody() {
-  const { data, loading, error, refetch } = useAdminFetch<WorkspaceConfig>(
-    "/api/v1/admin/proactive/workspace",
-    { schema: WorkspaceConfigSchema },
-  );
+  const form = useConfigForm<WorkspaceConfig, WorkspaceFormValues>({
+    path: "/api/v1/admin/proactive/workspace",
+    schema: WorkspaceConfigSchema,
+    saveMethod: "PUT",
+    toForm: (data) => ({
+      enabled: data.enabled,
+      sensitivity: data.sensitivity,
+      classifierMode: data.classifierMode,
+      announcementChannelId: data.announcementChannelId ?? "",
+      monthlyCap:
+        data.monthlyClassifierCap === null
+          ? ""
+          : String(data.monthlyClassifierCap),
+    }),
+    toPayload: (v) => ({
+      enabled: v.enabled,
+      sensitivity: v.sensitivity,
+      classifierMode: v.classifierMode,
+      announcementChannelId:
+        v.announcementChannelId.trim() === ""
+          ? null
+          : v.announcementChannelId.trim(),
+      monthlyClassifierCap:
+        v.monthlyCap.trim() === "" ? null : Number(v.monthlyCap),
+    }),
+  });
 
   return (
     <AdminContentWrapper
-      loading={loading}
-      error={error}
+      loading={form.loading}
+      error={form.loadError}
       feature="Proactive Chat"
-      onRetry={refetch}
+      onRetry={form.refetch}
       loadingMessage="Loading proactive-chat settings..."
     >
-      {data ? <ConfigForm initial={data} refetchWorkspace={refetch} /> : null}
+      {form.fields ? <ConfigForm form={form} /> : null}
     </AdminContentWrapper>
   );
 }
@@ -155,69 +196,19 @@ function PageBody() {
 // Workspace config form
 // ---------------------------------------------------------------------------
 
-interface ConfigFormProps {
-  initial: WorkspaceConfig;
-  refetchWorkspace: () => void;
-}
-
-function ConfigForm({ initial, refetchWorkspace }: ConfigFormProps) {
-  const [enabled, setEnabled] = useState(initial.enabled);
-  const [sensitivity, setSensitivity] = useState<Sensitivity>(initial.sensitivity);
-  const [classifierMode, setClassifierMode] = useState<ClassifierMode>(
-    initial.classifierMode,
-  );
-  const [announcementChannelId, setAnnouncementChannelId] = useState(
-    initial.announcementChannelId ?? "",
-  );
-  const [monthlyCap, setMonthlyCap] = useState<string>(
-    initial.monthlyClassifierCap === null ? "" : String(initial.monthlyClassifierCap),
-  );
-
-  // Reset form state when the fetched row changes — happens after a refetch
-  // following save or after the master toggle drops into a different shape.
-  useEffect(() => {
-    setEnabled(initial.enabled);
-    setSensitivity(initial.sensitivity);
-    setClassifierMode(initial.classifierMode);
-    setAnnouncementChannelId(initial.announcementChannelId ?? "");
-    setMonthlyCap(
-      initial.monthlyClassifierCap === null
-        ? ""
-        : String(initial.monthlyClassifierCap),
-    );
-  }, [initial]);
-
-  const save = useAdminMutation({
-    path: "/api/v1/admin/proactive/workspace",
-    method: "PUT",
-    invalidates: refetchWorkspace,
-  });
+function ConfigForm({ form }: { form: WorkspaceConfigForm }) {
+  const { fields, values } = form;
+  if (!fields || !values) return null;
 
   const monthlyCapNumeric =
-    monthlyCap.trim() === "" ? null : Number(monthlyCap);
+    values.monthlyCap.trim() === "" ? null : Number(values.monthlyCap);
   const monthlyCapInvalid =
     monthlyCapNumeric !== null &&
     (!Number.isInteger(monthlyCapNumeric) || monthlyCapNumeric < 0);
 
-  const dirty =
-    enabled !== initial.enabled ||
-    sensitivity !== initial.sensitivity ||
-    classifierMode !== initial.classifierMode ||
-    announcementChannelId !== (initial.announcementChannelId ?? "") ||
-    monthlyCapNumeric !== initial.monthlyClassifierCap;
-
   async function handleSave() {
     if (monthlyCapInvalid) return;
-    await save.mutate({
-      body: {
-        enabled,
-        sensitivity,
-        classifierMode,
-        announcementChannelId:
-          announcementChannelId.trim() === "" ? null : announcementChannelId.trim(),
-        monthlyClassifierCap: monthlyCapNumeric,
-      },
-    });
+    await form.save();
   }
 
   return (
@@ -227,7 +218,10 @@ function ConfigForm({ initial, refetchWorkspace }: ConfigFormProps) {
           title="Activation"
           description="Master switch — controls whether Atlas ever speaks up on its own."
         />
-        <MasterToggleRow enabled={enabled} onToggle={setEnabled} />
+        <MasterToggleRow
+          enabled={fields.enabled.value}
+          onToggle={fields.enabled.set}
+        />
       </section>
 
       <section>
@@ -236,25 +230,28 @@ function ConfigForm({ initial, refetchWorkspace }: ConfigFormProps) {
           description="Workspace defaults applied unless a channel override says otherwise."
         />
         <div className="space-y-6">
-          <SensitivityRadio value={sensitivity} onChange={setSensitivity} />
+          <SensitivityRadio
+            value={fields.sensitivity.value}
+            onChange={fields.sensitivity.set}
+          />
           <ClassifierModeRadio
-            value={classifierMode}
-            onChange={setClassifierMode}
+            value={fields.classifierMode.value}
+            onChange={fields.classifierMode.set}
           />
           <AnnouncementChannelField
-            value={announcementChannelId}
-            onChange={setAnnouncementChannelId}
+            value={fields.announcementChannelId.value}
+            onChange={fields.announcementChannelId.set}
           />
           <MonthlyCapField
-            value={monthlyCap}
-            onChange={setMonthlyCap}
+            value={fields.monthlyCap.value}
+            onChange={fields.monthlyCap.set}
             invalid={monthlyCapInvalid}
           />
         </div>
       </section>
 
       <MutationErrorSurface
-        error={save.error}
+        error={form.error}
         feature="Proactive Chat"
         variant="inline"
         inlinePrefix="Save failed."
@@ -269,11 +266,11 @@ function ConfigForm({ initial, refetchWorkspace }: ConfigFormProps) {
         <Button
           type="button"
           onClick={handleSave}
-          disabled={save.saving || monthlyCapInvalid || !dirty}
+          disabled={form.saving || monthlyCapInvalid || !form.dirty}
           size="sm"
         >
-          {save.saving && <Loader2 className="mr-1.5 size-3 animate-spin" />}
-          {dirty ? "Save changes" : "Saved"}
+          {form.saving && <Loader2 className="mr-1.5 size-3 animate-spin" />}
+          {form.dirty ? "Save changes" : "Saved"}
         </Button>
       </footer>
 

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -362,6 +362,29 @@ describe("useAdminMutation", () => {
     }
   });
 
+  test("2xx claiming JSON with a non-JSON body surfaces actionable proxy copy, not a SyntaxError", async () => {
+    mockFetch(new Response("<html>gateway</html>", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/test" }),
+      { wrapper },
+    );
+
+    let mutateResult: MutateResult<unknown>;
+    await act(async () => {
+      mutateResult = await result.current.mutate();
+    });
+
+    expect(mutateResult!.ok).toBe(false);
+    if (!mutateResult!.ok) {
+      expect(mutateResult!.error.message).toContain("non-JSON response");
+      expect(mutateResult!.error.message).toContain("/api/v1/admin/test");
+    }
+  });
+
   /* ---------------------------------------------------------------- */
   /*  Per-item mutation tracking (itemId / isMutating)                  */
   /* ---------------------------------------------------------------- */

--- a/packages/web/src/ui/__tests__/use-config-form.test.ts
+++ b/packages/web/src/ui/__tests__/use-config-form.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { renderHook, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { z } from "zod";
+import { useConfigForm } from "../hooks/use-config-form";
+import { AtlasProvider } from "../context";
+
+/* ------------------------------------------------------------------ */
+/*  Setup (mirrors use-admin-mutation.test.ts)                         */
+/* ------------------------------------------------------------------ */
+
+const stubAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Route-aware fetch mock: GETs serve from a mutable `serverConfig`,
+ * writes are recorded and answered with 200. Lets tests drive the full
+ * load → edit → save → invalidate → refetch → re-baseline loop.
+ */
+let serverConfig: Record<string, unknown>;
+let recordedWrites: { url: string; method: string; body: unknown }[];
+
+function installRouteMock(opts?: { getStatus?: number; saveStatus?: number; saveBody?: unknown }) {
+  recordedWrites = [];
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (method === "GET") {
+      if (opts?.getStatus && opts.getStatus >= 400) {
+        return jsonResponse({ error: "load failed" }, opts.getStatus);
+      }
+      return jsonResponse(serverConfig);
+    }
+    recordedWrites.push({
+      url,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    if (opts?.saveStatus && opts.saveStatus >= 400) {
+      return jsonResponse({ error: "save failed" }, opts.saveStatus);
+    }
+    return jsonResponse(opts?.saveBody ?? { ok: true });
+  }) as unknown as typeof fetch;
+}
+
+const ConfigSchema = z.object({
+  enabled: z.boolean(),
+  name: z.string(),
+  cap: z.number().int().nullable(),
+  tags: z.array(z.string()),
+  updatedAt: z.string(),
+});
+type Config = z.infer<typeof ConfigSchema>;
+
+interface FormValues extends Record<string, unknown> {
+  enabled: boolean;
+  name: string;
+  cap: string;
+  tags: string[];
+}
+
+function renderConfigForm() {
+  return renderHook(
+    () =>
+      useConfigForm<Config, FormValues>({
+        path: "/api/v1/admin/test-config",
+        schema: ConfigSchema,
+        toForm: (d) => ({
+          enabled: d.enabled,
+          name: d.name,
+          cap: d.cap === null ? "" : String(d.cap),
+          tags: d.tags,
+        }),
+        toPayload: (v) => ({
+          enabled: v.enabled,
+          name: v.name.trim(),
+          cap: v.cap.trim() === "" ? null : Number(v.cap),
+          tags: v.tags,
+        }),
+      }),
+    { wrapper },
+  );
+}
+
+describe("useConfigForm", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    serverConfig = {
+      enabled: false,
+      name: "alpha",
+      cap: null,
+      tags: ["a"],
+      updatedAt: "2026-06-01T00:00:00Z",
+    };
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Load → fields                                                    */
+  /* ---------------------------------------------------------------- */
+
+  test("derives fields from toForm(data) after load", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+
+    expect(result.current.fields).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.fields!.enabled.value).toBe(false);
+    expect(result.current.fields!.name.value).toBe("alpha");
+    expect(result.current.fields!.cap.value).toBe("");
+    expect(result.current.fields!.tags.value).toEqual(["a"]);
+    expect(result.current.dirty).toBe(false);
+  });
+
+  test("surfaces load failures via loadError, fields stay null", async () => {
+    installRouteMock({ getStatus: 500 });
+    const { result } = renderConfigForm();
+
+    await waitFor(() => expect(result.current.loadError).not.toBeNull());
+    expect(result.current.fields).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Dirty compare                                                    */
+  /* ---------------------------------------------------------------- */
+
+  test("dirty flips on edit and back on revert — single canonical compare", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    act(() => result.current.fields!.name.set("beta"));
+    expect(result.current.dirty).toBe(true);
+
+    act(() => result.current.fields!.name.set("alpha"));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  test("dirty compare is deep — array fields participate without page wiring", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    // New array with equal contents — NOT dirty (deep compare, not identity).
+    act(() => result.current.fields!.tags.set(["a"]));
+    expect(result.current.dirty).toBe(false);
+
+    act(() => result.current.fields!.tags.set(["a", "b"]));
+    expect(result.current.dirty).toBe(true);
+  });
+
+  test("reset restores the server-derived baseline", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    act(() => {
+      result.current.fields!.enabled.set(true);
+      result.current.fields!.cap.set("42");
+    });
+    expect(result.current.dirty).toBe(true);
+
+    act(() => result.current.reset());
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.fields!.enabled.value).toBe(false);
+    expect(result.current.fields!.cap.value).toBe("");
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Save                                                             */
+  /* ---------------------------------------------------------------- */
+
+  test("save posts toPayload(values) to the path with the configured method", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    act(() => {
+      result.current.fields!.enabled.set(true);
+      result.current.fields!.cap.set(" 10 ");
+    });
+
+    // Refetch after save returns the new server truth.
+    serverConfig = { ...serverConfig, enabled: true, cap: 10, updatedAt: "2026-06-02T00:00:00Z" };
+
+    await act(async () => {
+      const res = await result.current.save();
+      expect(res.ok).toBe(true);
+    });
+
+    expect(recordedWrites).toHaveLength(1);
+    expect(recordedWrites[0]!.method).toBe("PUT");
+    expect(recordedWrites[0]!.url).toBe("http://localhost:3001/api/v1/admin/test-config");
+    expect(recordedWrites[0]!.body).toEqual({
+      enabled: true,
+      name: "alpha",
+      cap: 10,
+      tags: ["a"],
+    });
+
+    // Post-save invalidation refetches and re-baselines: dirty returns false.
+    await waitFor(() => expect(result.current.dirty).toBe(false));
+    expect(result.current.fields!.cap.value).toBe("10");
+  });
+
+  test("save failure populates error and keeps edits + dirty", async () => {
+    installRouteMock({ saveStatus: 500 });
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    act(() => result.current.fields!.name.set("gamma"));
+
+    await act(async () => {
+      const res = await result.current.save();
+      expect(res.ok).toBe(false);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.fields!.name.value).toBe("gamma");
+    expect(result.current.dirty).toBe(true);
+
+    act(() => result.current.clearError());
+    expect(result.current.error).toBeNull();
+  });
+
+  test("save before load resolves { ok: false } without a request", async () => {
+    installRouteMock({ getStatus: 500 });
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.loadError).not.toBeNull());
+
+    await act(async () => {
+      const res = await result.current.save();
+      expect(res.ok).toBe(false);
+    });
+    expect(recordedWrites).toHaveLength(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Re-baseline semantics                                            */
+  /* ---------------------------------------------------------------- */
+
+  test("refetch with changed server data re-baselines the form", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    serverConfig = { ...serverConfig, name: "renamed", updatedAt: "2026-06-03T00:00:00Z" };
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => expect(result.current.fields!.name.value).toBe("renamed"));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  test("refetch with identical server data does not clobber in-flight edits", async () => {
+    installRouteMock();
+    const { result } = renderConfigForm();
+    await waitFor(() => expect(result.current.fields).not.toBeNull());
+
+    act(() => result.current.fields!.name.set("editing..."));
+
+    // Same JSON content — TanStack structural sharing keeps the same data
+    // reference, so the hook must not re-baseline.
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.fields!.name.value).toBe("editing...");
+    expect(result.current.dirty).toBe(true);
+  });
+});

--- a/packages/web/src/ui/hooks/use-admin-fetch.ts
+++ b/packages/web/src/ui/hooks/use-admin-fetch.ts
@@ -104,7 +104,18 @@ export function useAdminFetch<T>(
         }
         throw fetchError;
       }
-      const json: unknown = await res.json();
+      let json: unknown;
+      try {
+        json = await res.json();
+      } catch {
+        // A misconfigured proxy can return a 2xx with a non-JSON body —
+        // `res.json()` throws an unhelpful "Unexpected token" SyntaxError.
+        // Normalize to actionable copy (mirrors the starter-prompts fix,
+        // PR #1511).
+        throw buildFetchError({
+          message: `Server returned a non-JSON response from ${path}. Check your proxy / deploy configuration.`,
+        });
+      }
 
       if (opts?.schema) {
         const parsed = opts.schema.safeParse(json);

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -293,7 +293,17 @@ export function useAdminMutation<TResponse = unknown>(
       if (res.status === 204 || !contentType?.includes("application/json")) {
         return undefined;
       }
-      return (await res.json()) as TResponse;
+      try {
+        return (await res.json()) as TResponse;
+      } catch {
+        // Mirror the read-path guard in use-admin-fetch: a misconfigured
+        // proxy can return a 2xx claiming JSON with a non-JSON body, and the
+        // raw SyntaxError would surface as a generic "Request failed".
+        const fetchError = buildFetchError({
+          message: `Server returned a non-JSON response from ${path}. Check your proxy / deploy configuration.`,
+        });
+        throw Object.assign(new Error(fetchError.message), { fetchError });
+      }
     },
     onSuccess: () => {
       // Invalidate all admin-fetch queries so useAdminFetch consumers get fresh data.

--- a/packages/web/src/ui/hooks/use-config-form.ts
+++ b/packages/web/src/ui/hooks/use-config-form.ts
@@ -87,10 +87,10 @@ export interface UseConfigFormReturn<
   /** Discard edits — restore values to the server-derived baseline. */
   reset: () => void;
   /**
-   * Save the current values: `toPayload(values, data)` → mutation →
-   * refetch on success (which re-baselines the form, flipping `dirty`
-   * back to false). Resolves with the same discriminated result as
-   * `useAdminMutation.mutate()`.
+   * Save the current values: `toPayload(values, data)` → mutation → the
+   * mutation's success invalidation refetches the GET, which re-baselines
+   * the form, flipping `dirty` back to false. Resolves with the same
+   * discriminated result as `useAdminMutation.mutate()`.
    */
   save: () => Promise<MutateResult<TResponse>>;
   /** True while a save is in flight. */
@@ -141,10 +141,15 @@ export function useConfigForm<
     options.schema ? { schema: options.schema } : undefined,
   );
 
+  // No explicit `invalidates: refetch` — useAdminMutation's onSuccess already
+  // invalidates every admin-fetch query, which refetches this one and drives
+  // the re-baseline. Passing refetch as well just cancels that in-flight GET
+  // and dispatches a second one. The save test below ("re-baselines after a
+  // successful save") guards this coupling if the broad invalidation is ever
+  // narrowed.
   const mutation = useAdminMutation<TResponse>({
     path: options.savePath ?? options.path,
     method: options.saveMethod ?? "PUT",
-    invalidates: refetch,
   });
 
   // Re-baseline when the fetched data changes — the React-sanctioned

--- a/packages/web/src/ui/hooks/use-config-form.ts
+++ b/packages/web/src/ui/hooks/use-config-form.ts
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+import type { z } from "zod";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import {
+  useAdminMutation,
+  type MutateResult,
+} from "@/ui/hooks/use-admin-mutation";
+import { buildFetchError, type FetchError } from "@/ui/lib/fetch-error";
+
+/** HTTP methods that make sense for a whole-config save. */
+type SaveMethod = "POST" | "PUT" | "PATCH";
+
+/**
+ * Per-field accessor pair. `value` renders into the input; `set` replaces
+ * that field. The key set is exactly `Object.keys(toForm(data))`, so adding
+ * a field to `toForm` automatically gives it an accessor — and enrolls it
+ * in the dirty compare (see {@link UseConfigFormReturn.dirty}).
+ */
+export type ConfigFormFields<TValues> = {
+  [K in keyof TValues]: {
+    value: TValues[K];
+    set: (next: TValues[K]) => void;
+  };
+};
+
+export interface UseConfigFormOptions<
+  TData,
+  TValues extends Record<string, unknown>,
+> {
+  /** GET path for the config object (e.g. "/api/v1/admin/proactive/workspace"). */
+  path: string;
+  /** Zod schema for the GET response — passed through to `useAdminFetch`. */
+  schema?: z.ZodType<TData>;
+  /**
+   * Derive form values from fetched data. Must be pure — it runs during
+   * render whenever the fetched data changes. The returned object is the
+   * single canonical statement of what this form edits: its keys drive the
+   * `fields` accessors AND the dirty compare, so a field can't be editable
+   * yet missing from the compare.
+   */
+  toForm: (data: TData) => TValues;
+  /**
+   * Build the save request body from form values. Defaults to sending the
+   * values object as-is. This is where pages trim strings, map "" → null,
+   * and parse numeric inputs.
+   */
+  toPayload?: (values: TValues, data: TData) => Record<string, unknown>;
+  /** Save endpoint. Defaults to `path`. */
+  savePath?: string;
+  /** Save HTTP method. Defaults to "PUT". */
+  saveMethod?: SaveMethod;
+}
+
+export interface UseConfigFormReturn<
+  TData,
+  TValues extends Record<string, unknown>,
+  TResponse = unknown,
+> {
+  /** Latest fetched config, or null while loading / on load error. */
+  data: TData | null;
+  /** True while the initial GET is in flight. */
+  loading: boolean;
+  /**
+   * Load-side error — feed into `AdminContentWrapper`'s `error` prop.
+   * Distinct from `error` (the save-side slot) because the two render into
+   * different surfaces on every admin page.
+   */
+  loadError: FetchError | null;
+  /** Re-run the GET. */
+  refetch: () => void;
+  /**
+   * Per-field accessors, or null until the first successful load. Pages
+   * gate the form section on this (`form.fields ? <Form/> : null`) the same
+   * way they previously gated on `data`.
+   */
+  fields: ConfigFormFields<TValues> | null;
+  /** Current form values as one object — for derived validation/preview. */
+  values: TValues | null;
+  /**
+   * True when any field differs from the server-derived baseline. One deep
+   * compare of `values` vs `toForm(data)` — there is no per-field compare
+   * for a new field to be forgotten from.
+   */
+  dirty: boolean;
+  /** Discard edits — restore values to the server-derived baseline. */
+  reset: () => void;
+  /**
+   * Save the current values: `toPayload(values, data)` → mutation →
+   * refetch on success (which re-baselines the form, flipping `dirty`
+   * back to false). Resolves with the same discriminated result as
+   * `useAdminMutation.mutate()`.
+   */
+  save: () => Promise<MutateResult<TResponse>>;
+  /** True while a save is in flight. */
+  saving: boolean;
+  /** Save-side error — feed into `<MutationErrorSurface>`. */
+  error: FetchError | null;
+  /** Clear the save-side error manually. */
+  clearError: () => void;
+}
+
+/**
+ * Shared load → edit → dirty → save → re-baseline loop for admin config
+ * pages. Composes `useAdminFetch` (read) + `useAdminMutation` (write) and
+ * absorbs the state bookkeeping every config page used to hand-wire:
+ * per-field useState, the dirty compare, and the reset-on-refetch effect.
+ *
+ * ```tsx
+ * const form = useConfigForm<WireConfig, FormValues>({
+ *   path: "/api/v1/admin/thing",
+ *   schema: WireConfigSchema,
+ *   toForm: (d) => ({ enabled: d.enabled, cap: d.cap === null ? "" : String(d.cap) }),
+ *   toPayload: (v) => ({ enabled: v.enabled, cap: v.cap === "" ? null : Number(v.cap) }),
+ * });
+ * // <Switch checked={form.fields.enabled.value} onCheckedChange={form.fields.enabled.set} />
+ * // <Button onClick={form.save} disabled={form.saving || !form.dirty} />
+ * ```
+ *
+ * Re-baseline semantics: the form resets to `toForm(data)` whenever the
+ * fetched `data` reference changes. TanStack Query's structural sharing
+ * makes reference change ≈ content change, so a background refetch that
+ * returns identical data does NOT clobber in-flight edits, while the
+ * post-save invalidation refetch resets the form to server truth — the
+ * same behavior the hand-wired `useEffect([data])` resets had.
+ *
+ * Out of scope by design: per-field validation messages (pages derive
+ * those from `values`), transient UI state (stays `useState` in the page),
+ * URL state (nuqs), and multi-endpoint saves.
+ */
+export function useConfigForm<
+  TData,
+  TValues extends Record<string, unknown>,
+  TResponse = unknown,
+>(
+  options: UseConfigFormOptions<TData, TValues>,
+): UseConfigFormReturn<TData, TValues, TResponse> {
+  const { data, loading, error: loadError, refetch } = useAdminFetch<TData>(
+    options.path,
+    options.schema ? { schema: options.schema } : undefined,
+  );
+
+  const mutation = useAdminMutation<TResponse>({
+    path: options.savePath ?? options.path,
+    method: options.saveMethod ?? "PUT",
+    invalidates: refetch,
+  });
+
+  // Re-baseline when the fetched data changes — the React-sanctioned
+  // "adjust state during render" pattern (state-stored previous value, not
+  // a ref, so it stays render-pure). `data` flips to null on load error;
+  // values are kept so an error during a background refetch doesn't eat
+  // the user's edits.
+  const [prevData, setPrevData] = useState<TData | null | undefined>(undefined);
+  const [baseline, setBaseline] = useState<TValues | null>(null);
+  const [values, setValues] = useState<TValues | null>(null);
+  if (data !== prevData) {
+    setPrevData(data);
+    if (data !== null) {
+      const next = options.toForm(data);
+      setBaseline(next);
+      setValues(next);
+    }
+  }
+
+  function setField<K extends keyof TValues>(key: K, next: TValues[K]) {
+    setValues((prev) => (prev === null ? prev : { ...prev, [key]: next }));
+  }
+
+  let fields: ConfigFormFields<TValues> | null = null;
+  if (values !== null) {
+    const accessors = {} as ConfigFormFields<TValues>;
+    for (const key of Object.keys(values) as (keyof TValues)[]) {
+      accessors[key] = {
+        value: values[key],
+        set: (next) => setField(key, next),
+      };
+    }
+    fields = accessors;
+  }
+
+  const dirty =
+    values !== null && baseline !== null && !deepEqual(values, baseline);
+
+  function reset() {
+    setValues(baseline);
+  }
+
+  async function save(): Promise<MutateResult<TResponse>> {
+    // Guard rather than throw: pages call save from event handlers where a
+    // thrown error would escape to the console instead of the error surface.
+    if (values === null || data === null) {
+      return {
+        ok: false,
+        error: buildFetchError({
+          message: "Settings haven't finished loading — try again in a moment.",
+        }),
+      };
+    }
+    const body = options.toPayload
+      ? options.toPayload(values, data)
+      : (values as Record<string, unknown>);
+    return mutation.mutate({ body });
+  }
+
+  return {
+    data,
+    loading,
+    loadError,
+    refetch,
+    fields,
+    values,
+    dirty,
+    reset,
+    save,
+    saving: mutation.saving,
+    error: mutation.error,
+    clearError: mutation.clearError,
+  };
+}
+
+/**
+ * Structural equality over JSON-shaped form values (primitives, arrays,
+ * plain objects). Local on purpose: the dirty compare is the hook's core
+ * invariant and shouldn't drift with a general-purpose util's semantics.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  const aIsArray = Array.isArray(a);
+  if (aIsArray !== Array.isArray(b)) return false;
+  if (aIsArray) {
+    const bArr = b as unknown[];
+    return a.length === bArr.length && a.every((v, i) => deepEqual(v, bArr[i]));
+  }
+  const aRec = a as Record<string, unknown>;
+  const bRec = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRec);
+  if (aKeys.length !== Object.keys(bRec).length) return false;
+  return aKeys.every(
+    (k) => Object.hasOwn(bRec, k) && deepEqual(aRec[k], bRec[k]),
+  );
+}

--- a/packages/web/src/ui/hooks/use-config-form.ts
+++ b/packages/web/src/ui/hooks/use-config-form.ts
@@ -160,13 +160,11 @@ export function useConfigForm<
   const [prevData, setPrevData] = useState<TData | null | undefined>(undefined);
   const [baseline, setBaseline] = useState<TValues | null>(null);
   const [values, setValues] = useState<TValues | null>(null);
-  if (data !== prevData) {
+  if (data !== null && data !== prevData) {
     setPrevData(data);
-    if (data !== null) {
-      const next = options.toForm(data);
-      setBaseline(next);
-      setValues(next);
-    }
+    const next = options.toForm(data);
+    setBaseline(next);
+    setValues(next);
   }
 
   function setField<K extends keyof TValues>(key: K, next: TValues[K]) {


### PR DESCRIPTION
Implements **candidate 4** from `.claude/research/architecture-review-2026-06-09.md`: admin config pages hand-wired the same load → per-field `useState` → hand-rolled dirty compare → manual reset-on-refetch → save loop on top of `useAdminFetch`/`useAdminMutation`. A field missing from a dirty compare is a silent bug.

## The hook

`packages/web/src/ui/hooks/use-config-form.ts` — `useConfigForm<TData, TValues>` composes `useAdminFetch` + `useAdminMutation` and returns `{ fields, values, dirty, reset, save, saving, error }` plus the load side (`data, loading, loadError, refetch`).

- **One canonical compare:** `toForm(data)` is the single statement of what the form edits. Its keys drive both the per-field accessors (`fields.x.value` / `fields.x.set`) and the deep-equality dirty compare — a new field cannot be editable yet missing from the compare.
- **`toPayload`** owns save-time transformations (trim, `"" → null`, string → number), keeping wire payloads byte-identical to the hand-wired versions.
- **Re-baseline rides TanStack structural sharing:** the form resets exactly when fetched content changes (post-save invalidation refetch), and never clobbers in-flight edits on a no-change background refetch — the same semantics the hand-wired `useEffect([data])` resets had.
- Out of scope by design: per-field validation messages (pages derive from `values`), transient UI state (`useState`), URL state (nuqs), multi-endpoint saves.
- 10 direct hook tests (`src/ui/__tests__/use-config-form.test.ts`) — no page rendering required.

## Survey & classification

The review's "16 pages" conflated several patterns. Full sweep of `packages/web/src/app/admin/`:

**Config-form loop — migrated in this PR**
| Surface | Notes |
|---|---|
| `proactive-chat/page.tsx` | The review's worst offender (~40% bookkeeping). Every field was stated 4× (useState, reset effect, dirty compare, payload); now 2× (`toForm`/`toPayload`). |
| `audit/retention-panel.tsx` | Also dropped a hand-rolled fetch lifecycle (cancelled flag, manual loading/error state). Bespoke 403 banner copy preserved via an explicit `loadError.status` map. |
| `audit/admin-action-retention-panel.tsx` | Twin of the above. Its #1511 non-JSON-response guard is preserved by generalizing it into `useAdminFetch` (see below). |

**Has the loop, deliberately not forced (noted in the review doc entry)**
- `email-provider` — reset key is intentionally *narrower* than data identity (`provider|fromAddress|installedAt`; secrets are never echoed back, so form values don't mirror server state), and reset also clears page-level test/error state. Fitting it needs a `resetKey` override + post-reset callback — add those options only when a second consumer wants them.
- `sandbox` (self-hosted view) — dirty flag exists, but save conditionally fans out to two settings endpoints; multi-endpoint saves are out of the hook's scope.

**Already behind a form library (react-hook-form: zod per-field validation, `FormField` context)**
- `branding`, `model-config` (`model-provider-section.tsx`) — RHF already owns dirty/reset; converting is a rewrite, not a deepening.

**Action/confirm flows, no form-state copy** — `sso` (enforcement), `residency`, `custom-domain`, `cache`, `scheduler/tasks`, `integrations`.

**CRUD-of-many / list-table (candidate 5 territory, out of scope)** — `approval`, `compliance`, `connections`, `semantic`, `settings`, `scim`, `ip-allowlist`, `oauth-clients`, `roles`, `prompts`, `api-keys`, `audit` (log), `usage`, `sessions`, `learned-patterns`, `scheduled-tasks`, `starter-prompts`, `users`, `actions`, `billing`, `account-security`, plus redirects (`action-log`, `token-usage`, `settings/mcp`).

## Behavioral notes (deltas reviewed deliberately)

- **Same requests, same payloads, same error surfaces** on all three migrated pages; `MutationErrorSurface`/`FeatureName` usage unchanged.
- Retention panels' GET moves from raw `fetch` to `useAdminFetch`: same request, plus the platform behaviors every other admin page already has (TanStack caching/dedup, window-focus revalidation, MFA-gate routing) and one extra GET after save (invalidation refetch — previously the panel patched state from the PUT response; the visible end state is identical).
- `useAdminFetch` hardening: a 2xx non-JSON body (misconfigured proxy) now surfaces actionable copy instead of a raw `SyntaxError` — generalizes the admin-action panel's #1511 fix to all consumers instead of losing it in migration.
- Proactive-chat dirty edge: comparisons now happen on raw input strings vs server-derived strings (e.g. typing `007` when the cap is `7` enables Save where the old numeric compare didn't — the resulting payload is identical). The new compare is never *less* sensitive than the old one, so no real change can be hidden.

## Docs

- Candidate-4 entry moved to `.claude/research/architecture-wins.md` (#89); the review doc keeps per-page remainder notes for future passes.
- `CLAUDE.md` Admin Page Hooks section documents the hook.

## Verification

- `/ci`: lint, type, full `bun run test` (api + others, isolated runner), syncpack, template drift, security-headers drift, railway-watch, schema drift, oauth-helper drift, test discipline, twenty-resolver imports, published symbols — **all pass**.
- Web suite: 199/199 files pass, including the 10 new hook tests and the existing proactive-chat page tests.

https://claude.ai/code/session_01Swdg35irgUBSyJ4ey6wFMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Swdg35irgUBSyJ4ey6wFMR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650064&installation_id=135337507&pr_number=3356&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3356&signature=419567568d9412e3e6056de0d48a01fa69a398a6822c0f14310fb7afdb75e170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared config-form hook for admin pages; adopted by proactive-chat and audit retention settings.

* **Bug Fixes**
  * Normalized error handling for successful API responses with non-JSON bodies (clear, actionable errors) for both fetches and mutations.

* **Documentation**
  * Updated architecture guidance and admin-page docs with examples for the shared config-form pattern.

* **Tests**
  * Added comprehensive hook tests covering load/save/reset/dirty, deep-equality, re-baseline/refetch, pre-load-save guards, save failures, and non-JSON responses.

* **Refactor**
  * Migrated multiple admin config pages to the shared form workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->