### PR TITLE
refactor(install): collapse the form-install persistence spine — and fix the three handlers it exposed as broken

### DIFF
--- a/.claude/research/architecture-review-2026-06-09.md
+++ b/.claude/research/architecture-review-2026-06-09.md
@@ -25,15 +25,7 @@ Vocabulary per the skill: module / interface / seam / deep / shallow / locality 
 
 ---
 
-## 2. Collapse the Form-install persistence spine — **Strong**
-
-**Files:** `packages/api/src/lib/integrations/install/{email,webhook,obsidian,linear-apikey,github-pat}-form-handler.ts`
-
-**Problem:** Every Form install handler repeats the same spine: Zod parse → SaaS keyset gate → `encryptSecretFields` → `workspace_plugins` upsert → returned-id invariant check (~80 lines × 5 ≈ 400 duplicated lines; email/webhook are 95% identical). The Workspace Install write path has five places to be wrong.
-
-**Solution:** One `persistFormInstall` module owns the spine (keyset gate, encrypt, upsert, id invariant, optional post-persist hook for Email's lazy-evict). Handlers shrink to parse-and-validate + one call.
-
-**Wins:** upsert invariant lives once; ~320 lines deleted; one spine test; a sixth Form install is parse + one call.
+## 2. Collapse the Form-install persistence spine — **Strong** ← *shipped; see architecture-wins.md #89*
 
 ---
 
@@ -99,7 +91,7 @@ Vocabulary per the skill: module / interface / seam / deep / shallow / locality 
 
 ## Top recommendation
 
-**Candidate 1** — it sits on the security spine (whitelist enforcement is a CLAUDE.md core rule), the duplication is days old so consolidation is cheapest now, and it completes the arc wins #87–#88 started: one resolver, one fail-closed signal, one membership semantic. Candidate 2 is the best second: equally mechanical, ~320 lines back immediately.
+**Candidate 1** — it sits on the security spine (whitelist enforcement is a CLAUDE.md core rule), the duplication is days old so consolidation is cheapest now, and it completes the arc wins #87–#88 started: one resolver, one fail-closed signal, one membership semantic. Candidate 2 (shipped — wins #89) was the best second: equally mechanical, ~320 lines back immediately.
 
 ## Explicitly not surfaced (explored, judged not worth a card)
 

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2527,3 +2527,26 @@ The admin form is a shared, type-aware `<ConfigSchemaFields>` renderer (extracte
 - **Builds on #3232's seam without churn.** Win #87 introduced `getEntityDirs` as the single layout-traversal point and filed this as the hardening follow-up; this slice turns its lossy `rootScanFailed` boolean into the typed `failedScans` the later group-namespace slices (#3240/#3245) can extend.
 
 **Category:** Security-boundary hardening / fail-closed — a discovery-layer failure that was silently swallowed and then *inverted the partition decision* (widening a connection onto the default group's whitelist) becomes a typed signal threaded into a single resolver that fails closed on it, with the swallowed-error path that picked the wrong boundary deleted, not merely logged.
+
+---
+
+## 89. One persistence spine behind six Form-install handlers — and the collapse surfaced that half of them were already broken
+
+**Date:** 2026-06-10
+**Issue:** — (architecture-review-2026-06-09, candidate 2)
+**PR:** #TBD
+
+**Problem:** Every single-instance Form install handler repeated the same spine after its per-Platform Zod parse: SaaS keyset gate → `encryptSecretFields` → `workspace_plugins` upsert → returned-id invariant check → (for Email/Linear/GitHub-PAT) lazy-loader evict — ~80 lines × 6 handlers (email/webhook are 95% identical). The Workspace Install write path had six places to be wrong. **And it was wrong, three times, in exactly the way the review predicted:** the Email / Webhook / Obsidian copies still carried the pre-0092 INSERT shape (no `install_id`/`pillar`, bare `ON CONFLICT (workspace_id, catalog_id)`), which depended on a BEFORE INSERT trigger and a non-partial unique index that migration 0096 dropped. Against the live schema, every Email / Webhook / Obsidian install attempt fails at plan time with 42P10 ("no unique or exclusion constraint matching the ON CONFLICT specification") — a hard 500 on a customer-facing install path. The per-handler tests mock `internalQuery`, so no test could see a plan-time SQL error; the copies that got pivoted in #2739 (Linear, GitHub PAT, Twenty) worked, the ones that didn't silently rotted.
+
+**Solution:** One `persistFormInstall` module (`integrations/install/persist-form-install.ts`) owns the spine: keyset gate (`assertSaasEncryptionKeyset`, also exported standalone so Twenty can gate its `twenty_integrations` credential write *before* any byte persists), optional `encryptSecretFields`, the canonical post-0092 upsert (explicit `install_id` + `pillar='action'`, partial-index conflict target — exported as `buildFormInstallUpsertSql` so tests execute the real string), the returned-id invariant, and the optional post-persist lazy-loader evict (warn-never-fail). Handlers shrink to parse-and-validate + one call + their per-Platform completion log. Two data-shaped knobs absorb the genuine variation: `updateConfigOnConflict: false` (Twenty's re-install must keep the existing row's config) and `persistFailureMessage` (Twenty's documents its partial-write recovery semantics).
+
+**Deliberately NOT on the spine** (the deletion-test boundary): `DatasourceFormInstallHandler` + its `ElasticsearchFormInstallHandler` subclass (pillar `datasource`, `status='draft'`, fixed per-workspace `install_id`, catalog-schema-driven mask/restore — the ADR-0013 `createFromConfig` bridge is already its own deep module), and `persistOpenApiDatasourceInstall` + `DataCandidateFormInstallHandler` (multi-instance fresh-`install_id`-per-submit, probe-on-install — already consolidated in #3028). Forcing either onto the chat/action singleton spine would have meant knobs for pillar, status, conflict target, and probe hooks — a shallow seam.
+
+**Impact:**
+- **Email / Webhook / Obsidian installs work again.** The consolidation *was* the bug fix: pivoting the three stale copies onto the one canonical upsert is what candidate 2's "five places to be wrong" warning was about. Wire formats and DB rows for the already-working handlers (Linear, GitHub PAT, Twenty) are unchanged.
+- **The SQL is now pinned against real Postgres.** `migrate-pg.test.ts` executes `buildFormInstallUpsertSql` verbatim against the fully-migrated schema (fresh insert, conflict-returns-existing-id, config-preserving variant) and pins the legacy shape's 42P10 rejection as regression documentation — the exact test class whose absence let three handlers rot invisibly behind mock pools.
+- **One spine test** (`persist-form-install.test.ts`, 16 cases) covers gate/encrypt/upsert/invariant/evict once; the six per-handler suites keep covering their parse/validate remainder and still pass through the spine unchanged (they mock the same `db/internal` seam).
+- ~300 lines of duplicated persistence deleted; a seventh single-instance Form install is parse + one call.
+- **Follow-up filed, not folded in:** the Salesforce and Jira OAuth handlers carry the same broken pre-0092 upsert shape — same fix, different handler family (OAuth, not Form), tracked separately.
+
+**Category:** Consolidation that doubled as an outage fix — six copies of a security-adjacent write path collapse behind one deep module, and the act of collapsing exposed that the three oldest copies had silently broken when the schema contract moved under them; the spine's SQL is now a single exported artifact executed verbatim against real Postgres.

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2533,8 +2533,8 @@ The admin form is a shared, type-aware `<ConfigSchemaFields>` renderer (extracte
 ## 89. One persistence spine behind six Form-install handlers — and the collapse surfaced that half of them were already broken
 
 **Date:** 2026-06-10
-**Issue:** — (architecture-review-2026-06-09, candidate 2)
-**PR:** #TBD
+**Issue:** — (architecture-review-2026-06-09, candidate 2); follow-up #3357 (Salesforce/Jira OAuth share the bug)
+**PR:** #3358
 
 **Problem:** Every single-instance Form install handler repeated the same spine after its per-Platform Zod parse: SaaS keyset gate → `encryptSecretFields` → `workspace_plugins` upsert → returned-id invariant check → (for Email/Linear/GitHub-PAT) lazy-loader evict — ~80 lines × 6 handlers (email/webhook are 95% identical). The Workspace Install write path had six places to be wrong. **And it was wrong, three times, in exactly the way the review predicted:** the Email / Webhook / Obsidian copies still carried the pre-0092 INSERT shape (no `install_id`/`pillar`, bare `ON CONFLICT (workspace_id, catalog_id)`), which depended on a BEFORE INSERT trigger and a non-partial unique index that migration 0096 dropped. Against the live schema, every Email / Webhook / Obsidian install attempt fails at plan time with 42P10 ("no unique or exclusion constraint matching the ON CONFLICT specification") — a hard 500 on a customer-facing install path. The per-handler tests mock `internalQuery`, so no test could see a plan-time SQL error; the copies that got pivoted in #2739 (Linear, GitHub PAT, Twenty) worked, the ones that didn't silently rotted.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual lever: lets an operator/agent re-create required check runs when
+  # GitHub drops pull_request event deliveries (observed 2026-06-10 on #3358).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual lever: lets an operator/agent re-create required check runs when
+  # GitHub drops pull_request event deliveries (observed 2026-06-10 on #3358).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1893,6 +1893,111 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       }
     }, PG_TEST_TIMEOUT_MS);
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Form-install persistence spine — the upsert SQL is valid against the
+  // live post-migration schema.
+  //
+  // The spine's SQL is imported and executed VERBATIM (the readFileSync
+  // pattern above, applied to code instead of a migration file): drift in
+  // `buildFormInstallUpsertSql` fails here, not a hand-rolled copy. This
+  // is exactly the class of regression the spine consolidation fixed —
+  // the pre-spine Email/Webhook/Obsidian handlers carried a pre-0092
+  // INSERT (no install_id/pillar, bare `ON CONFLICT (workspace_id,
+  // catalog_id)`) that relied on the 0092 BEFORE INSERT trigger and the
+  // global unique index, BOTH dropped by 0096 — every install attempt
+  // failed with 42P10 at plan time, invisible to the mock-pool handler
+  // tests.
+  // ─────────────────────────────────────────────────────────────────────
+  describe("form-install spine: workspace_plugins upsert against the live schema", () => {
+    beforeAll(async () => {
+      // Action catalog rows aren't seeded by migrations (catalog-seeder
+      // runs at boot) — seed one for the FK target.
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES ('catalog:spine-email', 'Email', 'spine-email', 'integration', 'action', 'form')
+         ON CONFLICT (id) DO NOTHING`,
+      );
+    });
+
+    it("both spine variants plan + execute, and the conflict path returns the existing row id", async () => {
+      const { buildFormInstallUpsertSql } = await import(
+        "@atlas/api/lib/integrations/install/persist-form-install"
+      );
+      const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+      const ws = `ws-spine-${stamp}`;
+
+      // Fresh INSERT (config-updating variant) — returns the candidate id.
+      const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+        `spine-a-${stamp}`,
+        ws,
+        "catalog:spine-email",
+        JSON.stringify({ host: "smtp.example.com" }),
+      ]);
+      expect(fresh.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+      // Re-install (conflict path) — config updates, id stays the
+      // existing row's (the returned-id invariant the handlers rely on).
+      const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+        `spine-b-${stamp}`,
+        ws,
+        "catalog:spine-email",
+        JSON.stringify({ host: "smtp2.example.com" }),
+      ]);
+      expect(conflict.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+      // Non-config-updating variant (Twenty) — keeps the stored config.
+      const stub = await pool.query<{ id: string }>(buildFormInstallUpsertSql(false), [
+        `spine-c-${stamp}`,
+        ws,
+        "catalog:spine-email",
+        JSON.stringify({}),
+      ]);
+      expect(stub.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+      const { rows } = await pool.query<{
+        install_id: string;
+        pillar: string;
+        config: { host?: string };
+        enabled: boolean;
+        status: string;
+      }>(
+        `SELECT install_id, pillar, config, enabled, status
+           FROM workspace_plugins WHERE workspace_id = $1`,
+        [ws],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.install_id).toBe(`spine-a-${stamp}`);
+      expect(rows[0]?.pillar).toBe("action");
+      // The stub variant did NOT clobber the config the second install wrote.
+      expect(rows[0]?.config.host).toBe("smtp2.example.com");
+      expect(rows[0]?.enabled).toBe(true);
+      expect(rows[0]?.status).toBe("published");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("the pre-spine legacy shape is rejected by the live schema (42P10 — regression documentation)", async () => {
+      // The exact SQL the Email/Webhook/Obsidian handlers carried before
+      // the spine. If this ever starts SUCCEEDING, a non-partial unique
+      // on (workspace_id, catalog_id) has been reintroduced — datasource
+      // multi-instance installs would break; investigate before relying
+      // on it.
+      let err: { code?: string } | null = null;
+      try {
+        await pool.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+           VALUES ($1, $2, $3, $4::jsonb, true, NOW())
+           ON CONFLICT (workspace_id, catalog_id) DO UPDATE
+             SET config = EXCLUDED.config,
+                 enabled = true
+           RETURNING id`,
+          [`spine-legacy-${Date.now()}`, `ws-spine-legacy`, "catalog:spine-email", "{}"],
+        );
+      } catch (e) {
+        err = e as { code?: string };
+      }
+      expect(err?.code).toBe("42P10");
+    }, PG_TEST_TIMEOUT_MS);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1895,21 +1895,16 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────
-  // Form-install persistence spine — the upsert SQL is valid against the
-  // live post-migration schema.
+  // Form-install singleton upsert — schema-side pin.
   //
-  // The spine's SQL is imported and executed VERBATIM (the readFileSync
-  // pattern above, applied to code instead of a migration file): drift in
-  // `buildFormInstallUpsertSql` fails here, not a hand-rolled copy. This
-  // is exactly the class of regression the spine consolidation fixed —
-  // the pre-spine Email/Webhook/Obsidian handlers carried a pre-0092
-  // INSERT (no install_id/pillar, bare `ON CONFLICT (workspace_id,
-  // catalog_id)`) that relied on the 0092 BEFORE INSERT trigger and the
-  // global unique index, BOTH dropped by 0096 — every install attempt
-  // failed with 42P10 at plan time, invisible to the mock-pool handler
-  // tests.
+  // The form-install spine's upsert is executed VERBATIM against the
+  // live schema in `integrations/install/__tests__/
+  // persist-form-install-pg.test.ts` (module-colocated per the
+  // chat-cap-pg precedent). What stays HERE is the pure schema
+  // property that consolidation was forced by: the pre-spine legacy
+  // INSERT shape must keep being rejected at plan time.
   // ─────────────────────────────────────────────────────────────────────
-  describe("form-install spine: workspace_plugins upsert against the live schema", () => {
+  describe("form-install singleton upsert: legacy-shape rejection (schema property)", () => {
     beforeAll(async () => {
       // Action catalog rows aren't seeded by migrations (catalog-seeder
       // runs at boot) — seed one for the FK target.
@@ -1919,61 +1914,6 @@ describeIfPg("migrate-pg (real Postgres)", () => {
          ON CONFLICT (id) DO NOTHING`,
       );
     });
-
-    it("both spine variants plan + execute, and the conflict path returns the existing row id", async () => {
-      const { buildFormInstallUpsertSql } = await import(
-        "@atlas/api/lib/integrations/install/persist-form-install"
-      );
-      const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
-      const ws = `ws-spine-${stamp}`;
-
-      // Fresh INSERT (config-updating variant) — returns the candidate id.
-      const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
-        `spine-a-${stamp}`,
-        ws,
-        "catalog:spine-email",
-        JSON.stringify({ host: "smtp.example.com" }),
-      ]);
-      expect(fresh.rows[0]?.id).toBe(`spine-a-${stamp}`);
-
-      // Re-install (conflict path) — config updates, id stays the
-      // existing row's (the returned-id invariant the handlers rely on).
-      const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
-        `spine-b-${stamp}`,
-        ws,
-        "catalog:spine-email",
-        JSON.stringify({ host: "smtp2.example.com" }),
-      ]);
-      expect(conflict.rows[0]?.id).toBe(`spine-a-${stamp}`);
-
-      // Non-config-updating variant (Twenty) — keeps the stored config.
-      const stub = await pool.query<{ id: string }>(buildFormInstallUpsertSql(false), [
-        `spine-c-${stamp}`,
-        ws,
-        "catalog:spine-email",
-        JSON.stringify({}),
-      ]);
-      expect(stub.rows[0]?.id).toBe(`spine-a-${stamp}`);
-
-      const { rows } = await pool.query<{
-        install_id: string;
-        pillar: string;
-        config: { host?: string };
-        enabled: boolean;
-        status: string;
-      }>(
-        `SELECT install_id, pillar, config, enabled, status
-           FROM workspace_plugins WHERE workspace_id = $1`,
-        [ws],
-      );
-      expect(rows).toHaveLength(1);
-      expect(rows[0]?.install_id).toBe(`spine-a-${stamp}`);
-      expect(rows[0]?.pillar).toBe("action");
-      // The stub variant did NOT clobber the config the second install wrote.
-      expect(rows[0]?.config.host).toBe("smtp2.example.com");
-      expect(rows[0]?.enabled).toBe(true);
-      expect(rows[0]?.status).toBe("published");
-    }, PG_TEST_TIMEOUT_MS);
 
     it("the pre-spine legacy shape is rejected by the live schema (42P10 — regression documentation)", async () => {
       // The exact SQL the Email/Webhook/Obsidian handlers carried before

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1508,8 +1508,13 @@ export const workspacePlugins = pgTable(
     workspaceId: text("workspace_id").notNull(),
     catalogId: text("catalog_id").notNull().references(() => pluginCatalog.id, { onDelete: "cascade" }),
     // 0092 / #2739 — per-instance install identifier.
-    //  - chat/action installs: catalog_id sentinel (singleton enforced
-    //    by `workspace_plugins_singleton` partial unique).
+    //  - chat/action installs: singleton enforced by the
+    //    `workspace_plugins_singleton` partial unique. Rows backfilled
+    //    by 0092 carry the catalog_id sentinel; every post-#2739
+    //    writer (Slack/Telegram/static-bots, the form-install spine in
+    //    integrations/install/persist-form-install.ts) writes the row
+    //    id — both conventions coexist, so never join/filter on
+    //    install_id for these pillars; key on (workspace_id, catalog_id).
     //  - datasource installs (#2743 / #2744): user-facing id like
     //    `prod-us`, multi-instance per (workspace, catalog).
     installId: text("install_id").notNull(),

--- a/packages/api/src/lib/integrations/install/__tests__/email-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/email-form-handler.test.ts
@@ -2,7 +2,7 @@
  * Tests for {@link EmailFormInstallHandler} — slice 7 of #2649 (issue #2660).
  *
  * Covers the contract documented on {@link FormBasedInstallHandler}:
- * validation rejection emits `EmailFormValidationError` with per-field
+ * validation rejection emits `FormInstallValidationError` with per-field
  * detail; happy path encrypts only the `password` field (secret-marked
  * in the inline schema) and round-trips back to the same plaintext;
  * `workspace_plugins` row is upserted under the canonical `catalog:email`
@@ -42,14 +42,14 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 const WSID = "ws-email-1" as WorkspaceId;
 
 type EmailFormInstallHandlerCtor = typeof import("../email-form-handler").EmailFormInstallHandler;
-type EmailFormValidationErrorCtor = typeof import("../email-form-handler").EmailFormValidationError;
+type FormInstallValidationErrorCtor = typeof import("../email-form-handler").FormInstallValidationError;
 let EmailFormInstallHandler!: EmailFormInstallHandlerCtor;
-let EmailFormValidationError!: EmailFormValidationErrorCtor;
+let FormInstallValidationError!: FormInstallValidationErrorCtor;
 
 beforeAll(async () => {
   const mod = await import("../email-form-handler");
   EmailFormInstallHandler = mod.EmailFormInstallHandler;
-  EmailFormValidationError = mod.EmailFormValidationError;
+  FormInstallValidationError = mod.FormInstallValidationError;
 });
 
 const ORIGINAL_ENV = { ...process.env };
@@ -102,7 +102,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("EmailFormInstallHandler.validateConfig — input validation", () => {
-  it("rejects entirely missing fields with EmailFormValidationError", async () => {
+  it("rejects entirely missing fields with FormInstallValidationError", async () => {
     const handler = new EmailFormInstallHandler();
     let caught: unknown;
     try {
@@ -110,8 +110,8 @@ describe("EmailFormInstallHandler.validateConfig — input validation", () => {
     } catch (err) {
       caught = err;
     }
-    expect(caught).toBeInstanceOf(EmailFormValidationError);
-    const errs = (caught as InstanceType<typeof EmailFormValidationError>).fieldErrors;
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const errs = (caught as InstanceType<typeof FormInstallValidationError>).fieldErrors;
     // Required field detection — at least the primary credentials must surface.
     expect(errs.host).toBeDefined();
     expect(errs.username).toBeDefined();
@@ -129,8 +129,8 @@ describe("EmailFormInstallHandler.validateConfig — input validation", () => {
     } catch (err) {
       caught = err;
     }
-    expect(caught).toBeInstanceOf(EmailFormValidationError);
-    const errs = (caught as InstanceType<typeof EmailFormValidationError>).fieldErrors;
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const errs = (caught as InstanceType<typeof FormInstallValidationError>).fieldErrors;
     expect(errs.fromAddress).toBeDefined();
   });
 
@@ -142,8 +142,8 @@ describe("EmailFormInstallHandler.validateConfig — input validation", () => {
     } catch (err) {
       caught = err;
     }
-    expect(caught).toBeInstanceOf(EmailFormValidationError);
-    const errs = (caught as InstanceType<typeof EmailFormValidationError>).fieldErrors;
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const errs = (caught as InstanceType<typeof FormInstallValidationError>).fieldErrors;
     expect(errs.port).toBeDefined();
   });
 

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Real-Postgres coverage for the form-install spine's upsert. Mirrors
+ * the `migrate-pg.test.ts` harness (per the `billing/__tests__/
+ * chat-cap-pg.test.ts` precedent for module-colocated real-PG contract
+ * tests): skips cleanly when `TEST_DATABASE_URL` is unset, runs every
+ * migration into a unique per-test schema, and executes
+ * {@link buildFormInstallUpsertSql} VERBATIM against the live schema.
+ *
+ * What this catches that the mock-pool spine/handler tests can't:
+ * plan-time SQL errors. The pre-spine Email/Webhook/Obsidian handlers
+ * carried a pre-0092 INSERT (no install_id/pillar, bare `ON CONFLICT
+ * (workspace_id, catalog_id)`) that relied on the 0092 BEFORE INSERT
+ * trigger and the global unique index, BOTH dropped by 0096 — every
+ * install attempt failed with 42P10 at plan time, invisible behind
+ * mocked `internalQuery`. (The schema-side 42P10 pin for the legacy
+ * shape lives in `db/__tests__/migrate-pg.test.ts`, where pure schema
+ * properties belong.)
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { buildFormInstallUpsertSql } from "../persist-form-install";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+// Full migration set + queries can take several seconds on shared CI
+// runners (matches migrate-pg.test.ts's budget).
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("form-install spine: workspace_plugins upsert against the live schema", () => {
+  let pool: Pool;
+  const schemaName = `spine_pg_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`spine-pg: SET search_path failed on new connection: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Catalog rows aren't seeded by migrations (catalog-seeder runs at
+    // boot) — seed FK targets for both pillars the builder emits.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES
+         ('catalog:spine-email', 'Email', 'spine-email', 'integration', 'action', 'form'),
+         ('catalog:spine-chat',  'Chat',  'spine-chat',  'chat',        'chat',   'static-bot')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`spine-pg: schema cleanup failed: ${message}`);
+    });
+    await pool.end();
+  });
+
+  it("action pillar: both variants plan + execute, and the conflict path returns the existing row id", async () => {
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-spine-${stamp}`;
+
+    // Fresh INSERT (config-updating variant) — returns the candidate id.
+    const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+      `spine-a-${stamp}`,
+      ws,
+      "catalog:spine-email",
+      JSON.stringify({ host: "smtp.example.com" }),
+    ]);
+    expect(fresh.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+    // Re-install (conflict path) — config updates, id stays the
+    // existing row's (the returned-id invariant the handlers rely on).
+    const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+      `spine-b-${stamp}`,
+      ws,
+      "catalog:spine-email",
+      JSON.stringify({ host: "smtp2.example.com" }),
+    ]);
+    expect(conflict.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+    // Non-config-updating variant (Twenty) — keeps the stored config.
+    const stub = await pool.query<{ id: string }>(buildFormInstallUpsertSql(false), [
+      `spine-c-${stamp}`,
+      ws,
+      "catalog:spine-email",
+      JSON.stringify({}),
+    ]);
+    expect(stub.rows[0]?.id).toBe(`spine-a-${stamp}`);
+
+    const { rows } = await pool.query<{
+      install_id: string;
+      pillar: string;
+      config: { host?: string };
+      enabled: boolean;
+      status: string;
+    }>(
+      `SELECT install_id, pillar, config, enabled, status
+         FROM workspace_plugins WHERE workspace_id = $1`,
+      [ws],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.install_id).toBe(`spine-a-${stamp}`);
+    expect(rows[0]?.pillar).toBe("action");
+    // The stub variant did NOT clobber the config the second install wrote.
+    expect(rows[0]?.config.host).toBe("smtp2.example.com");
+    expect(rows[0]?.enabled).toBe(true);
+    expect(rows[0]?.status).toBe("published");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("chat pillar variant plans + executes with the same singleton semantics", async () => {
+    // No form handler writes 'chat' yet — the parameter exists so the
+    // five static-bot handlers and the #3357 OAuth fix can converge on
+    // this tested artifact. Pin it against the live schema now so the
+    // first consumer inherits a known-good string.
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-spine-chat-${stamp}`;
+
+    const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true, "chat"), [
+      `chat-a-${stamp}`,
+      ws,
+      "catalog:spine-chat",
+      JSON.stringify({ chat_id: stamp }),
+    ]);
+    expect(fresh.rows[0]?.id).toBe(`chat-a-${stamp}`);
+
+    const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true, "chat"), [
+      `chat-b-${stamp}`,
+      ws,
+      "catalog:spine-chat",
+      JSON.stringify({ chat_id: `${stamp}-rotated` }),
+    ]);
+    expect(conflict.rows[0]?.id).toBe(`chat-a-${stamp}`);
+
+    const { rows } = await pool.query<{ pillar: string; config: { chat_id?: string } }>(
+      `SELECT pillar, config FROM workspace_plugins WHERE workspace_id = $1`,
+      [ws],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.pillar).toBe("chat");
+    expect(rows[0]?.config.chat_id).toBe(`${stamp}-rotated`);
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for the shared form-install persistence spine —
+ * {@link persistFormInstall} + {@link assertSaasEncryptionKeyset} +
+ * {@link buildFormInstallUpsertSql}.
+ *
+ * The spine owns the behavior the six single-instance form handlers
+ * (Email / Webhook / Obsidian / Linear API-key / GitHub PAT / Twenty)
+ * used to each carry a copy of: SaaS keyset gate, selective-field
+ * encryption, the post-0092 `workspace_plugins` upsert, the
+ * returned-id invariant, and the optional lazy-loader evict. Each
+ * behavior is pinned ONCE here; the per-handler tests keep covering
+ * their parse-and-validate remainder (and the full path through the
+ * spine, since they mock the same `db/internal` seam).
+ *
+ * SQL-shape note: the upsert must name `install_id` + `pillar` and
+ * spell the partial-index predicate on the conflict target — the
+ * pre-spine Email/Webhook/Obsidian copies used the pre-0092 shape and
+ * failed against the live schema with 42P10 (no arbiter index). The
+ * real-Postgres execution of {@link buildFormInstallUpsertSql} lives
+ * in `db/__tests__/migrate-pg.test.ts`; here we pin the string shape
+ * so a regression is visible without a live Postgres.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import type { WorkspaceId } from "@useatlas/types";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const evictMock: Mock<(workspaceId: string, catalogId: string) => Promise<boolean>> = mock(
+  async () => true,
+);
+// Mock all value exports (CLAUDE.md partial-mock rule) — classes ride
+// along so `instanceof` call sites elsewhere keep working.
+mock.module("@atlas/api/lib/plugins/lazy-loader", () => ({
+  lazyPluginLoader: { evict: evictMock },
+  LazyPluginLoader: class {},
+  LazyPluginBuilderMissingError: class extends Error {},
+  LazyPluginInstallNotFoundError: class extends Error {},
+}));
+
+const WSID = "ws-spine-1" as WorkspaceId;
+
+const SECRET_SCHEMA: ConfigSchema = {
+  state: "parsed",
+  fields: [
+    { key: "host", type: "string" },
+    { key: "token", type: "string", secret: true },
+  ],
+};
+
+type SpineModule = typeof import("../persist-form-install");
+let persistFormInstall!: SpineModule["persistFormInstall"];
+let assertSaasEncryptionKeyset!: SpineModule["assertSaasEncryptionKeyset"];
+let buildFormInstallUpsertSql!: SpineModule["buildFormInstallUpsertSql"];
+
+beforeAll(async () => {
+  const mod = await import("../persist-form-install");
+  persistFormInstall = mod.persistFormInstall;
+  assertSaasEncryptionKeyset = mod.assertSaasEncryptionKeyset;
+  buildFormInstallUpsertSql = mod.buildFormInstallUpsertSql;
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+// Logger stub — capture calls so log-or-rethrow behavior is assertable.
+function makeLog() {
+  const calls: Array<{ level: string; msg: string }> = [];
+  const log = {
+    error: (_obj: unknown, msg: string) => calls.push({ level: "error", msg }),
+    warn: (_obj: unknown, msg: string) => calls.push({ level: "warn", msg }),
+    info: (_obj: unknown, msg: string) => calls.push({ level: "info", msg }),
+    debug: () => {},
+  } as unknown as Parameters<typeof persistFormInstall>[0]["log"];
+  return { log, calls };
+}
+
+function baseParams(overrides: Partial<Parameters<typeof persistFormInstall>[0]> = {}) {
+  const { log } = makeLog();
+  return {
+    workspaceId: WSID,
+    catalogId: "catalog:spine-test",
+    catalogSlug: "spine-test",
+    displayName: "Spine Test",
+    log,
+    config: { host: "example.com", token: "plaintext-token-xyz" },
+    secretFieldsSchema: SECRET_SCHEMA,
+    plaintextSecretLabel: "token",
+    newId: () => "candidate-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-spine-unit-tests-must-be-long-enough";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.ATLAS_DEPLOY_MODE;
+  _resetEncryptionKeyCache();
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
+  evictMock.mockClear();
+  evictMock.mockImplementation(async () => true);
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ---------------------------------------------------------------------------
+// SaaS keyset gate
+// ---------------------------------------------------------------------------
+
+describe("assertSaasEncryptionKeyset / spine keyset gate", () => {
+  it("refuses to persist when SaaS deploy has no encryption keyset", async () => {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+
+    const { log, calls } = makeLog();
+    await expect(persistFormInstall(baseParams({ log }))).rejects.toThrow(
+      /Encryption keyset unavailable in SaaS mode/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // The refusal names the credential field (breadcrumb, never the value).
+    expect(calls.some((c) => c.level === "error" && c.msg.includes("plaintext token"))).toBe(true);
+  });
+
+  it("standalone gate throws under SaaS + keyless (Twenty gates its credential-table write)", () => {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+    const { log } = makeLog();
+    expect(() => assertSaasEncryptionKeyset(log, WSID, "api_key")).toThrow(
+      /Encryption keyset unavailable/,
+    );
+  });
+
+  it("self-hosted keyless deploys pass the gate (dev passthrough parity)", async () => {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    _resetEncryptionKeyCache();
+    const result = await persistFormInstall(baseParams());
+    expect(result.id).toBe("candidate-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Encryption
+// ---------------------------------------------------------------------------
+
+describe("persistFormInstall — selective-field encryption", () => {
+  it("encrypts only secret-marked fields; operational fields stay plaintext", async () => {
+    await persistFormInstall(baseParams());
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const stored = JSON.parse((params as unknown[])[3] as string) as Record<string, unknown>;
+    expect(stored.host).toBe("example.com");
+    expect(stored.token as string).toMatch(/^enc:v1:/);
+    expect(decryptSecret(stored.token as string)).toBe("plaintext-token-xyz");
+  });
+
+  it("persists config as-is when no secret schema is given (Twenty's {} stub)", async () => {
+    await persistFormInstall(
+      baseParams({ config: {}, secretFieldsSchema: undefined }),
+    );
+    const [, params] = mockInternalQuery.mock.calls[0];
+    expect(JSON.parse((params as unknown[])[3] as string)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upsert shape + returned-id invariant
+// ---------------------------------------------------------------------------
+
+describe("persistFormInstall — workspace_plugins upsert", () => {
+  it("uses the post-0092 shape: explicit install_id + pillar='action' + partial-index conflict target", async () => {
+    await persistFormInstall(baseParams());
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO workspace_plugins");
+    expect(sql).toMatch(/install_id/);
+    expect(sql).toMatch(/'action'/);
+    // The WHERE predicate is load-bearing: only the partial unique
+    // `workspace_plugins_singleton` remains post-0096, and Postgres
+    // won't infer a partial index as arbiter without it (42P10).
+    expect(sql).toMatch(/ON CONFLICT \(workspace_id, catalog_id\) WHERE pillar IN \('chat', 'action'\)/);
+    expect(sql).toMatch(/SET config = EXCLUDED\.config/);
+    const p = params as unknown[];
+    expect(p[0]).toBe("candidate-1");
+    expect(p[1]).toBe(WSID);
+    expect(p[2]).toBe("catalog:spine-test");
+  });
+
+  it("omits the config overwrite on conflict when updateConfigOnConflict is false", async () => {
+    await persistFormInstall(baseParams({ updateConfigOnConflict: false }));
+    const [sql] = mockInternalQuery.mock.calls[0];
+    expect(sql).not.toMatch(/SET config = EXCLUDED\.config/);
+    expect(sql).toMatch(/SET enabled = true/);
+  });
+
+  it("returns the persisted id on conflict (re-install keeps the original row id)", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("RETURNING id")) return [{ id: "preexisting-id" }];
+      return [];
+    });
+    const result = await persistFormInstall(baseParams({ newId: () => "fresh-id" }));
+    expect(result).toEqual({ id: "preexisting-id", workspaceId: WSID, catalogId: "spine-test" });
+  });
+
+  it("fails loud when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    const { log, calls } = makeLog();
+    await expect(persistFormInstall(baseParams({ log }))).rejects.toThrow(
+      /upsert returned no id/,
+    );
+    expect(calls.some((c) => c.level === "error")).toBe(true);
+  });
+
+  it("fails loud when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    await expect(persistFormInstall(baseParams())).rejects.toThrow(/upsert returned no id/);
+  });
+
+  it("logs the (overridable) failure message and rethrows when the upsert throws", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("pg pool exhausted")));
+    const { log, calls } = makeLog();
+    await expect(
+      persistFormInstall(baseParams({ log, persistFailureMessage: "custom failure breadcrumb" })),
+    ).rejects.toThrow("pg pool exhausted");
+    expect(calls.some((c) => c.level === "error" && c.msg === "custom failure breadcrumb")).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-persist evict hook
+// ---------------------------------------------------------------------------
+
+describe("persistFormInstall — lazy-loader evict", () => {
+  it("evicts the (workspace, catalog) plugin cache when evictAfterPersist is set", async () => {
+    await persistFormInstall(baseParams({ evictAfterPersist: true }));
+    expect(evictMock).toHaveBeenCalledWith(WSID, "catalog:spine-test");
+  });
+
+  it("does not evict by default", async () => {
+    await persistFormInstall(baseParams());
+    expect(evictMock).not.toHaveBeenCalled();
+  });
+
+  it("an evict failure warns but never fails the install (DB row already persisted)", async () => {
+    evictMock.mockImplementation(() => Promise.reject(new Error("teardown blew up")));
+    const { log, calls } = makeLog();
+    const result = await persistFormInstall(baseParams({ log, evictAfterPersist: true }));
+    expect(result.id).toBe("candidate-1");
+    expect(
+      calls.some((c) => c.level === "warn" && c.msg.includes("Spine Test install upsert")),
+    ).toBe(true);
+  });
+
+  it("evict runs after the upsert, never on the failure path", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("boom")));
+    await expect(persistFormInstall(baseParams({ evictAfterPersist: true }))).rejects.toThrow(
+      "boom",
+    );
+    expect(evictMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQL builder — both variants stay parseable-by-inspection here; the real-PG
+// execution lives in db/__tests__/migrate-pg.test.ts.
+// ---------------------------------------------------------------------------
+
+describe("buildFormInstallUpsertSql", () => {
+  it("both variants target the partial singleton index and RETURNING id", () => {
+    for (const updateConfig of [true, false]) {
+      const sql = buildFormInstallUpsertSql(updateConfig);
+      expect(sql).toContain("ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')");
+      expect(sql).toContain("RETURNING id");
+      expect(sql).toContain("'action'");
+    }
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -27,6 +27,7 @@ import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
 import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { WorkspaceId } from "@useatlas/types";
 import { z } from "zod";
+import * as actualDbInternal from "@atlas/api/lib/db/internal";
 
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
   async (sql: string, params?: unknown[]) => {
@@ -38,7 +39,11 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
   },
 );
 
+// Mock all exports (CLAUDE.md partial-mock rule): spread the real module
+// so every named export (MANAGED_AUTH_MIGRATIONS, _resetPool, …) stays
+// importable, overriding only the three seams the spine touches.
 mock.module("@atlas/api/lib/db/internal", () => ({
+  ...actualDbInternal,
   internalQuery: mockInternalQuery,
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -1,23 +1,23 @@
 /**
  * Tests for the shared form-install persistence spine —
  * {@link persistFormInstall} + {@link assertSaasEncryptionKeyset} +
- * {@link buildFormInstallUpsertSql}.
+ * {@link parseFormInstall} + {@link buildFormInstallUpsertSql}.
  *
  * The spine owns the behavior the six single-instance form handlers
  * (Email / Webhook / Obsidian / Linear API-key / GitHub PAT / Twenty)
  * used to each carry a copy of: SaaS keyset gate, selective-field
  * encryption, the post-0092 `workspace_plugins` upsert, the
- * returned-id invariant, and the optional lazy-loader evict. Each
- * behavior is pinned ONCE here; the per-handler tests keep covering
- * their parse-and-validate remainder (and the full path through the
- * spine, since they mock the same `db/internal` seam).
+ * returned-id invariant, and the lazy-loader evict. Each behavior is
+ * pinned ONCE here; the per-handler tests keep covering their
+ * parse-and-validate remainder (and the full path through the spine,
+ * since they mock the same `db/internal` seam).
  *
  * SQL-shape note: the upsert must name `install_id` + `pillar` and
  * spell the partial-index predicate on the conflict target — the
  * pre-spine Email/Webhook/Obsidian copies used the pre-0092 shape and
  * failed against the live schema with 42P10 (no arbiter index). The
  * real-Postgres execution of {@link buildFormInstallUpsertSql} lives
- * in `db/__tests__/migrate-pg.test.ts`; here we pin the string shape
+ * in `./persist-form-install-pg.test.ts`; here we pin the string shape
  * so a regression is visible without a live Postgres.
  */
 
@@ -26,6 +26,7 @@ import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
 import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
 import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { WorkspaceId } from "@useatlas/types";
+import { z } from "zod";
 
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
   async (sql: string, params?: unknown[]) => {
@@ -69,39 +70,48 @@ type SpineModule = typeof import("../persist-form-install");
 let persistFormInstall!: SpineModule["persistFormInstall"];
 let assertSaasEncryptionKeyset!: SpineModule["assertSaasEncryptionKeyset"];
 let buildFormInstallUpsertSql!: SpineModule["buildFormInstallUpsertSql"];
+let parseFormInstall!: SpineModule["parseFormInstall"];
+let FormInstallValidationError!: SpineModule["FormInstallValidationError"];
 
 beforeAll(async () => {
   const mod = await import("../persist-form-install");
   persistFormInstall = mod.persistFormInstall;
   assertSaasEncryptionKeyset = mod.assertSaasEncryptionKeyset;
   buildFormInstallUpsertSql = mod.buildFormInstallUpsertSql;
+  parseFormInstall = mod.parseFormInstall;
+  FormInstallValidationError = mod.FormInstallValidationError;
 });
 
 const ORIGINAL_ENV = { ...process.env };
 
-// Logger stub — capture calls so log-or-rethrow behavior is assertable.
+// Logger stub — satisfies the spine's narrowed InstallLogger (Pick of
+// error/warn) without casts, and captures calls so log-or-rethrow
+// behavior is assertable.
 function makeLog() {
-  const calls: Array<{ level: string; msg: string }> = [];
-  const log = {
-    error: (_obj: unknown, msg: string) => calls.push({ level: "error", msg }),
-    warn: (_obj: unknown, msg: string) => calls.push({ level: "warn", msg }),
-    info: (_obj: unknown, msg: string) => calls.push({ level: "info", msg }),
-    debug: () => {},
-  } as unknown as Parameters<typeof persistFormInstall>[0]["log"];
-  return { log, calls };
+  const calls: Array<{ level: string; msg: string; fields: Record<string, unknown> }> = [];
+  const record =
+    (level: string) =>
+    (objOrMsg: unknown, msg?: string): void => {
+      calls.push({
+        level,
+        msg: typeof objOrMsg === "string" ? objOrMsg : (msg ?? ""),
+        fields: typeof objOrMsg === "object" && objOrMsg !== null
+          ? (objOrMsg as Record<string, unknown>)
+          : {},
+      });
+    };
+  return { log: { error: record("error"), warn: record("warn") }, calls };
 }
 
 function baseParams(overrides: Partial<Parameters<typeof persistFormInstall>[0]> = {}) {
   const { log } = makeLog();
   return {
     workspaceId: WSID,
-    catalogId: "catalog:spine-test",
     catalogSlug: "spine-test",
     displayName: "Spine Test",
     log,
     config: { host: "example.com", token: "plaintext-token-xyz" },
     secretFieldsSchema: SECRET_SCHEMA,
-    plaintextSecretLabel: "token",
     newId: () => "candidate-1",
     ...overrides,
   };
@@ -131,6 +141,32 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// Parse step
+// ---------------------------------------------------------------------------
+
+describe("parseFormInstall", () => {
+  const Schema = z.object({ name: z.string().min(1, "name is required") }).strict();
+
+  it("returns the parsed data on success", () => {
+    expect(parseFormInstall(Schema, { name: "ok" })).toEqual({ name: "ok" });
+  });
+
+  it("throws FormInstallValidationError with field detail on failure", () => {
+    let caught: unknown;
+    try {
+      parseFormInstall(Schema, { name: "", extra: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const e = caught as InstanceType<typeof FormInstallValidationError>;
+    expect(e.fieldErrors.name).toBeDefined();
+    // .strict() unrecognized-key reports land in formErrors.
+    expect(e.formErrors.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // SaaS keyset gate
 // ---------------------------------------------------------------------------
 
@@ -145,18 +181,48 @@ describe("assertSaasEncryptionKeyset / spine keyset gate", () => {
       /Encryption keyset unavailable in SaaS mode/,
     );
     expect(mockInternalQuery).not.toHaveBeenCalled();
-    // The refusal names the credential field (breadcrumb, never the value).
+    // The refusal names the credential field, DERIVED from the schema's
+    // secret:true key (breadcrumb, never the value).
     expect(calls.some((c) => c.level === "error" && c.msg.includes("plaintext token"))).toBe(true);
   });
 
-  it("standalone gate throws under SaaS + keyless (Twenty gates its credential-table write)", () => {
+  it("an explicit plaintextSecretLabel overrides the derived one (Twenty's schema-less path)", async () => {
     delete process.env.ATLAS_ENCRYPTION_KEYS;
     process.env.ATLAS_DEPLOY_MODE = "saas";
     _resetEncryptionKeyCache();
-    const { log } = makeLog();
-    expect(() => assertSaasEncryptionKeyset(log, WSID, "api_key")).toThrow(
+
+    const { log, calls } = makeLog();
+    await expect(
+      persistFormInstall(
+        baseParams({ log, config: {}, secretFieldsSchema: undefined, plaintextSecretLabel: "api_key" }),
+      ),
+    ).rejects.toThrow(/Encryption keyset unavailable/);
+    expect(calls.some((c) => c.msg.includes("plaintext api_key"))).toBe(true);
+  });
+
+  it("standalone gate throws under SaaS + keyless, sanitizing the label out of the message", () => {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+    const { log, calls } = makeLog();
+    // The label lands in the log MESSAGE — a config-derived value must
+    // not be able to splice newlines/forged content into it.
+    expect(() => assertSaasEncryptionKeyset(log, WSID, "x) — ok\nforged=1")).toThrow(
       /Encryption keyset unavailable/,
     );
+    const refusal = calls.find((c) => c.level === "error");
+    expect(refusal?.msg).not.toContain("\n");
+    expect(refusal?.msg).not.toContain("forged=1");
+  });
+
+  it("extraLogFields ride along on the refusal log (OpenAPI per-candidate attribution)", () => {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+    const { log, calls } = makeLog();
+    expect(() => assertSaasEncryptionKeyset(log, WSID, "auth_value", { catalogSlug: "stripe-data" }))
+      .toThrow(/Encryption keyset unavailable/);
+    expect(calls[0]?.fields.catalogSlug).toBe("stripe-data");
   });
 
   it("self-hosted keyless deploys pass the gate (dev passthrough parity)", async () => {
@@ -183,7 +249,7 @@ describe("persistFormInstall — selective-field encryption", () => {
 
   it("persists config as-is when no secret schema is given (Twenty's {} stub)", async () => {
     await persistFormInstall(
-      baseParams({ config: {}, secretFieldsSchema: undefined }),
+      baseParams({ config: {}, secretFieldsSchema: undefined, plaintextSecretLabel: "api_key" }),
     );
     const [, params] = mockInternalQuery.mock.calls[0];
     expect(JSON.parse((params as unknown[])[3] as string)).toEqual({});
@@ -195,7 +261,7 @@ describe("persistFormInstall — selective-field encryption", () => {
 // ---------------------------------------------------------------------------
 
 describe("persistFormInstall — workspace_plugins upsert", () => {
-  it("uses the post-0092 shape: explicit install_id + pillar='action' + partial-index conflict target", async () => {
+  it("uses the post-0092 shape and derives the catalog:<slug> FK from the slug", async () => {
     await persistFormInstall(baseParams());
     const [sql, params] = mockInternalQuery.mock.calls[0];
     expect(sql).toContain("INSERT INTO workspace_plugins");
@@ -209,6 +275,8 @@ describe("persistFormInstall — workspace_plugins upsert", () => {
     const p = params as unknown[];
     expect(p[0]).toBe("candidate-1");
     expect(p[1]).toBe(WSID);
+    // One param at the seam — the FK is derived, so a mismatched
+    // catalogId/catalogSlug pair is unrepresentable.
     expect(p[2]).toBe("catalog:spine-test");
   });
 
@@ -255,24 +323,19 @@ describe("persistFormInstall — workspace_plugins upsert", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Post-persist evict hook
+// Post-persist evict
 // ---------------------------------------------------------------------------
 
 describe("persistFormInstall — lazy-loader evict", () => {
-  it("evicts the (workspace, catalog) plugin cache when evictAfterPersist is set", async () => {
-    await persistFormInstall(baseParams({ evictAfterPersist: true }));
-    expect(evictMock).toHaveBeenCalledWith(WSID, "catalog:spine-test");
-  });
-
-  it("does not evict by default", async () => {
+  it("always evicts the (workspace, catalog) plugin cache after a persist", async () => {
     await persistFormInstall(baseParams());
-    expect(evictMock).not.toHaveBeenCalled();
+    expect(evictMock).toHaveBeenCalledWith(WSID, "catalog:spine-test");
   });
 
   it("an evict failure warns but never fails the install (DB row already persisted)", async () => {
     evictMock.mockImplementation(() => Promise.reject(new Error("teardown blew up")));
     const { log, calls } = makeLog();
-    const result = await persistFormInstall(baseParams({ log, evictAfterPersist: true }));
+    const result = await persistFormInstall(baseParams({ log }));
     expect(result.id).toBe("candidate-1");
     expect(
       calls.some((c) => c.level === "warn" && c.msg.includes("Spine Test install upsert")),
@@ -281,25 +344,31 @@ describe("persistFormInstall — lazy-loader evict", () => {
 
   it("evict runs after the upsert, never on the failure path", async () => {
     mockInternalQuery.mockImplementation(() => Promise.reject(new Error("boom")));
-    await expect(persistFormInstall(baseParams({ evictAfterPersist: true }))).rejects.toThrow(
-      "boom",
-    );
+    await expect(persistFormInstall(baseParams())).rejects.toThrow("boom");
     expect(evictMock).not.toHaveBeenCalled();
   });
 });
 
 // ---------------------------------------------------------------------------
-// SQL builder — both variants stay parseable-by-inspection here; the real-PG
-// execution lives in db/__tests__/migrate-pg.test.ts.
+// SQL builder — both knob variants and both pillars stay inspectable here;
+// the real-PG execution lives in ./persist-form-install-pg.test.ts.
 // ---------------------------------------------------------------------------
 
 describe("buildFormInstallUpsertSql", () => {
-  it("both variants target the partial singleton index and RETURNING id", () => {
+  it("every variant targets the partial singleton index and RETURNING id", () => {
     for (const updateConfig of [true, false]) {
-      const sql = buildFormInstallUpsertSql(updateConfig);
-      expect(sql).toContain("ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')");
-      expect(sql).toContain("RETURNING id");
-      expect(sql).toContain("'action'");
+      for (const pillar of ["chat", "action"] as const) {
+        const sql = buildFormInstallUpsertSql(updateConfig, pillar);
+        expect(sql).toContain(
+          "ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')",
+        );
+        expect(sql).toContain("RETURNING id");
+        expect(sql).toContain(`'${pillar}'`);
+      }
     }
+  });
+
+  it("defaults to the action pillar (the form spine's only value today)", () => {
+    expect(buildFormInstallUpsertSql(true)).toContain("'action'");
   });
 });

--- a/packages/api/src/lib/integrations/install/datasource-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/datasource-form-handler.ts
@@ -53,7 +53,7 @@
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { assertSaasEncryptionKeyset } from "./persist-form-install";
 import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
 import {
   encryptSecretFields,
@@ -179,21 +179,10 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
     }
 
     // ── 4. SaaS keyset gate ─────────────────────────────────────────
-    // `encryptSecret` falls back to plaintext when no key is configured (dev
-    // convenience). In SaaS that would leak the credential — refuse the install
-    // so a misconfigured deploy fails closed at the credential boundary. Checked
+    // Shared fail-closed gate (see persist-form-install.ts). Checked
     // BEFORE the existing-row read so a re-save under misconfigured SaaS surfaces
     // this actionable message rather than an opaque decrypt failure.
-    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-      this.log.error(
-        { workspaceId },
-        "Refusing datasource install: SaaS mode + no encryption keyset (would persist a plaintext credential)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-          "Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
+    assertSaasEncryptionKeyset(this.log, workspaceId, "credential");
 
     // ── 5. Restore masked secrets against the existing install ──────
     // Read the current row (if any) so an unchanged masked secret round-trips

--- a/packages/api/src/lib/integrations/install/email-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/email-form-handler.ts
@@ -19,9 +19,9 @@
  *
  * Persistence (keyset gate → encrypt → upsert → id invariant → lazy-
  * loader evict) lives on the shared spine — see
- * {@link persistFormInstall}. The evict matters here: a re-install
- * that rotates SMTP credentials must not keep the stale in-memory
- * transport from before the upsert.
+ * {@link persistFormInstall}. The keyset gate is ALSO called explicitly
+ * before the TLS-disabled warn so a refused install never logs a
+ * phantom "admin opted out of secure SMTP" event.
  *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./persist-form-install.ts — {@link persistFormInstall}
@@ -31,11 +31,15 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { WorkspaceId } from "@useatlas/types";
 import {
-  EMAIL_CATALOG_ID,
   EMAIL_SECRET_FIELDS_SCHEMA,
   EmailFormDataSchema,
 } from "./email-secret-schema";
-import { persistFormInstall } from "./persist-form-install";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+  parseFormInstall,
+  persistFormInstall,
+} from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -43,11 +47,12 @@ import type {
 } from "./types";
 
 // Re-export so existing call sites that imported from this module
-// (admin route, tests, install/index.ts barrel) keep compiling. The
-// canonical home is `./email-secret-schema` — new code should import
-// from there.
+// (admin route, tests, install/index.ts barrel, every sibling handler)
+// keep compiling. The canonical homes are `./email-secret-schema` and
+// `./persist-form-install` — new code should import from there.
 export { EmailFormDataSchema };
 export type { EmailFormData } from "./email-secret-schema";
+export { FormInstallValidationError };
 
 const log = createLogger("integrations.install.email");
 
@@ -75,11 +80,12 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    const parsed = EmailFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const config = parsed.data;
+    const config = parseFormInstall(EmailFormDataSchema, formData);
+
+    // Gate BEFORE the TLS warn (the spine re-checks, harmlessly): a
+    // SaaS deploy with no keyset must refuse without logging a phantom
+    // TLS-opt-out event for an install that never happened.
+    assertSaasEncryptionKeyset(log, workspaceId, "password");
 
     if (config.secure === false) {
       log.warn(
@@ -90,15 +96,12 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
 
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: EMAIL_CATALOG_ID,
       catalogSlug: EMAIL_SLUG,
       displayName: "Email",
       log,
       config,
       secretFieldsSchema: EMAIL_SECRET_FIELDS_SCHEMA,
-      plaintextSecretLabel: "password",
-      newId: this.newId,
-      evictAfterPersist: true,
+      newId: () => this.newId(),
     });
 
     log.info(
@@ -108,68 +111,3 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
     return { installRecord, credentialWritten: true };
   }
 }
-
-/**
- * Validation failure surface for every form-based install handler.
- * `kind` is the catalog `install_model` value so future handlers
- * (Webhook / Obsidian per #2661) can throw the same class — the
- * route's catch is a single `instanceof FormInstallValidationError`
- * check rather than a growing list of per-Platform error types.
- *
- * `fieldErrors` is normalized at construction: only fields with
- * actual issues land in the map (Zod's `flatten().fieldErrors`
- * carries `string[] | undefined` values; we drop the undefineds so
- * the public contract is clean).
- *
- * `formErrors` carries top-level issues — `.strict()` "unrecognized
- * key" reports, schema-level `.refine` failures — that don't bind to
- * any single field. The route surfaces both so the admin UI can
- * render a generic banner alongside per-field messages.
- *
- * Tagged class rather than `Data.TaggedError` because this throws out
- * through the legacy Hono handler — `runHandler`'s typed-error mapper
- * doesn't currently know about install-handler-internal tagged
- * errors; the route catches via `instanceof` and emits the 400
- * directly. Promoting to a tagged Effect error is a follow-up once
- * the dispatch grows.
- */
-export class FormInstallValidationError extends Error {
-  readonly _tag = "FormInstallValidationError" as const;
-  readonly fieldErrors: Readonly<Record<string, readonly string[]>>;
-  readonly formErrors: readonly string[];
-
-  constructor(input: {
-    fieldErrors: Record<string, string[] | undefined>;
-    formErrors?: readonly string[];
-  }) {
-    super("Form install validation failed");
-    this.name = "FormInstallValidationError";
-    const cleaned: Record<string, readonly string[]> = {};
-    for (const [k, v] of Object.entries(input.fieldErrors)) {
-      if (v && v.length > 0) cleaned[k] = v;
-    }
-    this.fieldErrors = cleaned;
-    this.formErrors = input.formErrors ?? [];
-  }
-
-  /** Build from `parsed.error.flatten()` — the canonical Zod adapter. */
-  static fromZodFlatten(flat: {
-    fieldErrors: Record<string, string[] | undefined>;
-    formErrors: string[];
-  }): FormInstallValidationError {
-    return new FormInstallValidationError({
-      fieldErrors: flat.fieldErrors,
-      formErrors: flat.formErrors,
-    });
-  }
-}
-
-/**
- * @deprecated Use {@link FormInstallValidationError}. Kept as a
- * named alias so test callers that still spell out the Email-specific
- * symbol compile, and so a future Webhook / Obsidian handler doesn't
- * have to invent its own subclass. New code should import the shared
- * name directly.
- */
-export const EmailFormValidationError = FormInstallValidationError;
-export type EmailFormValidationError = FormInstallValidationError;

--- a/packages/api/src/lib/integrations/install/email-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/email-form-handler.ts
@@ -2,7 +2,7 @@
  * `EmailFormInstallHandler` — first {@link FormBasedInstallHandler}
  * implementation. SMTP credentials submitted by a workspace admin
  * persist into `workspace_plugins.config` with `password` encrypted
- * at rest via {@link encryptSecretFields}; operational fields
+ * at rest via `encryptSecretFields`; operational fields
  * (host / port / username / fromAddress / secure) stay plaintext so
  * admin-UI reads don't need a decrypt.
  *
@@ -17,22 +17,25 @@
  * failures at the worst moment. The first send-email tool call
  * surfaces real errors with the full path intact.
  *
+ * Persistence (keyset gate → encrypt → upsert → id invariant → lazy-
+ * loader evict) lives on the shared spine — see
+ * {@link persistFormInstall}. The evict matters here: a re-install
+ * that rotates SMTP credentials must not keep the stale in-memory
+ * transport from before the upsert.
+ *
  * @see ./types.ts — {@link FormBasedInstallHandler}
- * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  */
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
-import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   EMAIL_CATALOG_ID,
   EMAIL_SECRET_FIELDS_SCHEMA,
   EmailFormDataSchema,
 } from "./email-secret-schema";
+import { persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -72,31 +75,11 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    // ── 1. Validate the form against the SMTP schema ───────────────
     const parsed = EmailFormDataSchema.safeParse(formData);
     if (!parsed.success) {
       throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
     }
     const config = parsed.data;
-
-    // ── 2. SaaS keyset gate ─────────────────────────────────────────
-    // `encryptSecret` falls back to plaintext when no key is
-    // configured (dev convenience). Boot logs a one-shot warning,
-    // but a missed log in SaaS would leak the password plaintext.
-    // Refuse the install per-call so a misconfigured deploy fails
-    // closed at the credential boundary.
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      !getEncryptionKeyset()
-    ) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext password)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
 
     if (config.secure === false) {
       log.warn(
@@ -105,82 +88,24 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
       );
     }
 
-    // ── 3. Encrypt secret fields (password) at rest ─────────────────
-    const encryptedConfig = encryptSecretFields(config, EMAIL_SECRET_FIELDS_SCHEMA);
-
-    // ── 4. Upsert workspace_plugins ─────────────────────────────────
-    // ON CONFLICT updates config + flips enabled back to true so a
-    // re-install after disconnect lands cleanly. `installed_at` is
-    // NOT bumped on conflict (matches the Slack OAuth handler) — the
-    // column tracks the first install, not the most recent edit.
-    //
-    // `RETURNING id` returns the persisted id — on a fresh INSERT
-    // it's the one we generated, on a CONFLICT it's the row's
-    // existing id (NOT the freshly-generated one). Callers that
-    // treat `installId` as a stable identifier for the saved row
-    // would otherwise read a phantom id on re-installs.
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, EMAIL_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist Email install record — aborting install",
-      );
-      throw err;
-    }
-
-    // Evict any cached PluginLike for this (workspace, catalog) so the
-    // next tool dispatch rebuilds the transport against the freshly-
-    // persisted config. Without this, a re-install that rotates SMTP
-    // credentials (host / port / user / password / fromAddress) keeps
-    // the stale in-memory transport from before the upsert. Fire-and-
-    // forget — `evict` swallows teardown errors internally.
-    try {
-      await lazyPluginLoader.evict(workspaceId, EMAIL_CATALOG_ID);
-    } catch (err) {
-      log.warn(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "LazyPluginLoader.evict threw after Email install upsert — DB row is persisted anyway",
-      );
-    }
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: EMAIL_CATALOG_ID,
+      catalogSlug: EMAIL_SLUG,
+      displayName: "Email",
+      log,
+      config,
+      secretFieldsSchema: EMAIL_SECRET_FIELDS_SCHEMA,
+      plaintextSecretLabel: "password",
+      newId: this.newId,
+      evictAfterPersist: true,
+    });
 
     log.info(
-      { workspaceId, installId: persistedId, host: config.host, port: config.port },
+      { workspaceId, installId: installRecord.id, host: config.host, port: config.port },
       "Email install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: EMAIL_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }
 

--- a/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
@@ -4,14 +4,16 @@
  *
  * Form-based install mirroring {@link LinearApiKeyFormInstallHandler}.
  * The admin pastes a PAT from https://github.com/settings/tokens; the
- * token encrypts inline via {@link encryptSecretFields} into
+ * token encrypts inline via `encryptSecretFields` into
  * `workspace_plugins.config.pat`.
  *
  * Self-host only: the matching catalog row carries `saas_eligible:
  * false`. Failure mode is too sharp for SaaS — a PAT is tied to one
  * GitHub user and dies if that user leaves the org or rotates the
  * token. The integrations-catalog route filters this row out on SaaS
- * deploys.
+ * deploys. The spine's SaaS keyset gate stays as defense-in-depth: if
+ * a SaaS deploy somehow surfaces the install path, it refuses to
+ * persist plaintext.
  *
  * Connection liveness: NOT probed at install time. A failed GitHub API
  * round-trip at install would surface as a misleading "couldn't reach
@@ -19,18 +21,19 @@
  * agent-issued GitHub call surfaces real auth errors with the full
  * path intact (HTTP 401 vs API rate-limit vs network).
  *
+ * Persistence lives on the shared spine — see {@link persistFormInstall}.
+ * The evict rides along even though the GitHub action tool ships in a
+ * follow-up PR, so re-installs that rotate the PAT don't leave a stale
+ * in-memory instance behind once the tool lands.
+ *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./github-pat-secret-schema.ts — shared form + secret schema
  * @see ./linear-apikey-form-handler.ts — sibling form-handler reference
- * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  */
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
-import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   GITHUB_PAT_CATALOG_ID,
@@ -38,6 +41,7 @@ import {
   GitHubPatFormDataSchema,
 } from "./github-pat-secret-schema";
 import { FormInstallValidationError } from "./email-form-handler";
+import { persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -74,107 +78,33 @@ export class GitHubPatFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    // ── 1. Validate the form against the PAT schema ────────────────
     const parsed = GitHubPatFormDataSchema.safeParse(formData);
     if (!parsed.success) {
       throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
     }
     const config = parsed.data;
 
-    // ── 2. SaaS keyset gate ─────────────────────────────────────────
-    // The matching catalog row is `saas_eligible: false`, so the
-    // integrations-catalog route already hides this install path on
-    // SaaS — a caller would have to bypass that filter to reach here.
-    // The keyset gate stays as defense-in-depth: if a SaaS deploy
-    // somehow surfaces the install path, refuse to persist plaintext.
-    // Mirrors LinearApiKeyFormInstallHandler's posture.
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      !getEncryptionKeyset()
-    ) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext pat)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    // ── 3. Encrypt secret fields (pat) at rest ──────────────────────
-    const encryptedConfig = encryptSecretFields(config, GITHUB_PAT_SECRET_FIELDS_SCHEMA);
-
-    // ── 4. Upsert workspace_plugins ─────────────────────────────────
-    // Pillar='action' + install_id named explicitly per migration 0092
-    // (#2739). The partial unique index keys re-installs to the same
-    // row; `RETURNING id` lets us pick up the existing id rather than a
-    // phantom freshly-generated one on conflict.
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, GITHUB_PAT_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist GitHub PAT install record — aborting install",
-      );
-      throw err;
-    }
-
-    // Evict any cached PluginLike for this (workspace, catalog) so a
-    // future agent-tool dispatch rebuilds against the freshly-persisted
-    // config. The GitHub action tool ships in a follow-up PR; the evict
-    // call stays here so re-installs that rotate the PAT don't leave a
-    // stale in-memory instance behind once the tool lands.
-    try {
-      await lazyPluginLoader.evict(workspaceId, GITHUB_PAT_CATALOG_ID);
-    } catch (err) {
-      log.warn(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "LazyPluginLoader.evict threw after GitHub PAT install upsert — DB row is persisted anyway",
-      );
-    }
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: GITHUB_PAT_CATALOG_ID,
+      catalogSlug: GITHUB_PAT_SLUG,
+      displayName: "GitHub PAT",
+      log,
+      config,
+      secretFieldsSchema: GITHUB_PAT_SECRET_FIELDS_SCHEMA,
+      plaintextSecretLabel: "pat",
+      newId: this.newId,
+      evictAfterPersist: true,
+    });
 
     log.info(
       {
         workspaceId,
-        installId: persistedId,
+        installId: installRecord.id,
         defaultOwner: config.default_owner ?? null,
       },
       "GitHub PAT install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: GITHUB_PAT_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }

--- a/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
@@ -22,9 +22,9 @@
  * path intact (HTTP 401 vs API rate-limit vs network).
  *
  * Persistence lives on the shared spine — see {@link persistFormInstall}.
- * The evict rides along even though the GitHub action tool ships in a
- * follow-up PR, so re-installs that rotate the PAT don't leave a stale
- * in-memory instance behind once the tool lands.
+ * The spine's unconditional evict means re-installs that rotate the PAT
+ * never leave a stale in-memory instance behind once the GitHub action
+ * tool (follow-up PR) lands its lazy builder.
  *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./github-pat-secret-schema.ts — shared form + secret schema
@@ -36,12 +36,14 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { WorkspaceId } from "@useatlas/types";
 import {
-  GITHUB_PAT_CATALOG_ID,
   GITHUB_PAT_SECRET_FIELDS_SCHEMA,
   GitHubPatFormDataSchema,
 } from "./github-pat-secret-schema";
-import { FormInstallValidationError } from "./email-form-handler";
-import { persistFormInstall } from "./persist-form-install";
+import {
+  FormInstallValidationError,
+  parseFormInstall,
+  persistFormInstall,
+} from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -50,8 +52,7 @@ import type {
 
 // Re-export the validation error class for callers that catch with
 // `instanceof`. {@link FormInstallValidationError} is the canonical
-// throw type for every form-based install handler — declared in the
-// Email module first per #2697.
+// throw type for every form-based install handler.
 export { FormInstallValidationError };
 
 const log = createLogger("integrations.install.github-pat");
@@ -78,23 +79,16 @@ export class GitHubPatFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    const parsed = GitHubPatFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const config = parsed.data;
+    const config = parseFormInstall(GitHubPatFormDataSchema, formData);
 
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: GITHUB_PAT_CATALOG_ID,
       catalogSlug: GITHUB_PAT_SLUG,
       displayName: "GitHub PAT",
       log,
       config,
       secretFieldsSchema: GITHUB_PAT_SECRET_FIELDS_SCHEMA,
-      plaintextSecretLabel: "pat",
-      newId: this.newId,
-      evictAfterPersist: true,
+      newId: () => this.newId(),
     });
 
     log.info(

--- a/packages/api/src/lib/integrations/install/index.ts
+++ b/packages/api/src/lib/integrations/install/index.ts
@@ -89,11 +89,17 @@ export type {
 export {
   EmailFormInstallHandler,
   EmailFormDataSchema,
-  EmailFormValidationError,
   FormInstallValidationError,
   type EmailFormData,
   type EmailFormInstallHandlerOptions,
 } from "./email-form-handler";
+export {
+  persistFormInstall,
+  parseFormInstall,
+  assertSaasEncryptionKeyset,
+  buildFormInstallUpsertSql,
+  type PersistFormInstallParams,
+} from "./persist-form-install";
 export {
   registerBuiltinInstallHandlers,
   _resetRegistrationLatch,

--- a/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
@@ -4,7 +4,7 @@
  * Second {@link FormBasedInstallHandler} implementation after Email
  * (#2697). The admin pastes a Linear Personal API Key from their
  * Linear settings page; the key encrypts inline via
- * {@link encryptSecretFields} into `workspace_plugins.config.api_key`.
+ * `encryptSecretFields` into `workspace_plugins.config.api_key`.
  *
  * Trade-off vs the OAuth mode (`linear` slug — see
  * {@link LinearOAuthInstallHandler}):
@@ -31,18 +31,17 @@
  * agent-issued `createLinearIssue` call surfaces real auth errors with
  * the full path intact (HTTP 401 vs API rate-limit vs network).
  *
+ * Persistence (keyset gate → encrypt → upsert → id invariant → lazy-
+ * loader evict so a rotated key never serves a stale in-memory
+ * instance) lives on the shared spine — see {@link persistFormInstall}.
+ *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./linear-apikey-secret-schema.ts — shared form + secret schema
- * @see ./email-form-handler.ts — first form-based handler reference
- * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  */
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
-import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   LINEAR_APIKEY_CATALOG_ID,
@@ -50,6 +49,7 @@ import {
   LinearApiKeyFormDataSchema,
 } from "./linear-apikey-secret-schema";
 import { FormInstallValidationError } from "./email-form-handler";
+import { persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -88,107 +88,33 @@ export class LinearApiKeyFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    // ── 1. Validate the form against the API-key schema ─────────────
     const parsed = LinearApiKeyFormDataSchema.safeParse(formData);
     if (!parsed.success) {
       throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
     }
     const config = parsed.data;
 
-    // ── 2. SaaS keyset gate ─────────────────────────────────────────
-    // `encryptSecret` falls back to plaintext when no key is configured
-    // (dev convenience). Boot logs a one-shot warning, but a missed log
-    // in SaaS would leak the API key plaintext. Refuse the install per-
-    // call so a misconfigured deploy fails closed at the credential
-    // boundary. Mirrors EmailFormInstallHandler's posture.
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      !getEncryptionKeyset()
-    ) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext api_key)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    // ── 3. Encrypt secret fields (api_key) at rest ──────────────────
-    const encryptedConfig = encryptSecretFields(config, LINEAR_APIKEY_SECRET_FIELDS_SCHEMA);
-
-    // ── 4. Upsert workspace_plugins ─────────────────────────────────
-    // Pillar='action' + install_id named explicitly per migration 0092
-    // (#2739). The partial unique index keys re-installs to the same
-    // row; `RETURNING id` lets us pick up the existing id rather than a
-    // phantom freshly-generated one on conflict (per EmailFormInstallHandler
-    // commentary).
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, LINEAR_APIKEY_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist Linear API-key install record — aborting install",
-      );
-      throw err;
-    }
-
-    // Evict any cached PluginLike for this (workspace, catalog) so the
-    // next tool dispatch rebuilds against the freshly-persisted config.
-    // Without this, a re-install that rotates the API key keeps the
-    // stale in-memory instance from before the upsert. Fire-and-forget
-    // — `evict` swallows teardown errors internally.
-    try {
-      await lazyPluginLoader.evict(workspaceId, LINEAR_APIKEY_CATALOG_ID);
-    } catch (err) {
-      log.warn(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "LazyPluginLoader.evict threw after Linear API-key install upsert — DB row is persisted anyway",
-      );
-    }
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: LINEAR_APIKEY_CATALOG_ID,
+      catalogSlug: LINEAR_APIKEY_SLUG,
+      displayName: "Linear API-key",
+      log,
+      config,
+      secretFieldsSchema: LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
+      plaintextSecretLabel: "api_key",
+      newId: this.newId,
+      evictAfterPersist: true,
+    });
 
     log.info(
       {
         workspaceId,
-        installId: persistedId,
+        installId: installRecord.id,
         workspaceName: config.workspace_name ?? null,
       },
       "Linear API-key install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: LINEAR_APIKEY_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }

--- a/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
@@ -44,12 +44,14 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { WorkspaceId } from "@useatlas/types";
 import {
-  LINEAR_APIKEY_CATALOG_ID,
   LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
   LinearApiKeyFormDataSchema,
 } from "./linear-apikey-secret-schema";
-import { FormInstallValidationError } from "./email-form-handler";
-import { persistFormInstall } from "./persist-form-install";
+import {
+  FormInstallValidationError,
+  parseFormInstall,
+  persistFormInstall,
+} from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -58,8 +60,7 @@ import type {
 
 // Re-export the validation error class for callers that catch with
 // `instanceof`. {@link FormInstallValidationError} is the canonical
-// throw type for every form-based install handler — declared in the
-// Email module first per #2697.
+// throw type for every form-based install handler.
 export { FormInstallValidationError };
 
 const log = createLogger("integrations.install.linear-apikey");
@@ -88,23 +89,16 @@ export class LinearApiKeyFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    const parsed = LinearApiKeyFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const config = parsed.data;
+    const config = parseFormInstall(LinearApiKeyFormDataSchema, formData);
 
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: LINEAR_APIKEY_CATALOG_ID,
       catalogSlug: LINEAR_APIKEY_SLUG,
       displayName: "Linear API-key",
       log,
       config,
       secretFieldsSchema: LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
-      plaintextSecretLabel: "api_key",
-      newId: this.newId,
-      evictAfterPersist: true,
+      newId: () => this.newId(),
     });
 
     log.info(

--- a/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
@@ -52,6 +52,8 @@ const ApiUrlSchema = z
         new URL(raw);
         return true;
       } catch {
+        // intentionally ignored: URL constructor throw is the negative
+        // validation signal — the user sees the .refine message.
         return false;
       }
     },

--- a/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
@@ -26,8 +26,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { WorkspaceId } from "@useatlas/types";
-import { FormInstallValidationError } from "./email-form-handler";
-import { persistFormInstall } from "./persist-form-install";
+import { parseFormInstall, persistFormInstall } from "./persist-form-install";
+import { safeHost } from "./safe-host";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -36,7 +36,6 @@ import type {
 
 const log = createLogger("integrations.install.obsidian");
 
-const OBSIDIAN_CATALOG_ID = "catalog:obsidian";
 const OBSIDIAN_SLUG: CatalogId = "obsidian";
 
 /** Default Obsidian Local REST API endpoint (loopback, the plugin's stock binding). */
@@ -71,7 +70,12 @@ export const ObsidianFormDataSchema = z
 
 export type ObsidianFormData = z.infer<typeof ObsidianFormDataSchema>;
 
-const OBSIDIAN_SECRET_FIELDS_SCHEMA: ConfigSchema & {
+/**
+ * Exported (unlike the original module-local const) so decrypt-side
+ * consumers and cross-schema-agreement tests can pin the secret-field
+ * routing against {@link ObsidianFormDataSchema}.
+ */
+export const OBSIDIAN_SECRET_FIELDS_SCHEMA: ConfigSchema & {
   state: "parsed";
   fields: ReadonlyArray<ConfigSchemaField & { key: keyof ObsidianFormData }>;
 } = {
@@ -103,22 +107,16 @@ export class ObsidianFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    const parsed = ObsidianFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const config = parsed.data;
+    const config = parseFormInstall(ObsidianFormDataSchema, formData);
 
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: OBSIDIAN_CATALOG_ID,
       catalogSlug: OBSIDIAN_SLUG,
       displayName: "Obsidian",
       log,
       config,
       secretFieldsSchema: OBSIDIAN_SECRET_FIELDS_SCHEMA,
-      plaintextSecretLabel: "api_key",
-      newId: this.newId,
+      newId: () => this.newId(),
     });
 
     log.info(
@@ -126,13 +124,5 @@ export class ObsidianFormInstallHandler implements FormBasedInstallHandler {
       "Obsidian install completed",
     );
     return { installRecord, credentialWritten: true };
-  }
-}
-
-function safeHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return "<unparseable>";
   }
 }

--- a/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
@@ -13,20 +13,21 @@
  * field is parsed as a well-formed URL; tighter validation lives in
  * the docs.
  *
+ * Persistence lives on the shared spine — see {@link persistFormInstall}.
+ *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./email-form-handler.ts — first form handler, shape canon
- * @see ./webhook-form-handler.ts — sibling form handler
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  */
 
 import crypto from "crypto";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { encryptSecretFields, type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { WorkspaceId } from "@useatlas/types";
 import { FormInstallValidationError } from "./email-form-handler";
+import { persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -108,68 +109,23 @@ export class ObsidianFormInstallHandler implements FormBasedInstallHandler {
     }
     const config = parsed.data;
 
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      !getEncryptionKeyset()
-    ) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext api_key)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    const encryptedConfig = encryptSecretFields(config, OBSIDIAN_SECRET_FIELDS_SCHEMA);
-
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, OBSIDIAN_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist Obsidian install record — aborting install",
-      );
-      throw err;
-    }
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: OBSIDIAN_CATALOG_ID,
+      catalogSlug: OBSIDIAN_SLUG,
+      displayName: "Obsidian",
+      log,
+      config,
+      secretFieldsSchema: OBSIDIAN_SECRET_FIELDS_SCHEMA,
+      plaintextSecretLabel: "api_key",
+      newId: this.newId,
+    });
 
     log.info(
-      { workspaceId, installId: persistedId, host: safeHost(config.api_url) },
+      { workspaceId, installId: installRecord.id, host: safeHost(config.api_url) },
       "Obsidian install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: OBSIDIAN_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }
 

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -39,7 +39,8 @@ import crypto from "crypto";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { assertSaasEncryptionKeyset } from "./persist-form-install";
+import { safeHost } from "./safe-host";
 import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
 import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { assertBaseUrlAllowed, EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
@@ -328,16 +329,9 @@ export async function persistOpenApiDatasourceInstall(
   } = params;
 
   // ── SaaS keyset gate ──────────────────────────────────────────────
-  if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-    log.error(
-      { workspaceId, catalogSlug },
-      "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext auth_value)",
-    );
-    throw new Error(
-      "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-        "Set ATLAS_ENCRYPTION_KEYS and retry.",
-    );
-  }
+  // Shared fail-closed gate (see persist-form-install.ts); catalogSlug
+  // rides along so per-candidate installs stay attributable in the log.
+  assertSaasEncryptionKeyset(log, workspaceId, "auth_value", { catalogSlug });
 
   // ── Self-hosted plaintext-credential warning (non-fatal) ──────────
   // The SaaS gate above hard-fails. A self-hosted prod-like deploy with a
@@ -502,15 +496,4 @@ export async function persistOpenApiDatasourceInstall(
     installRecord: { id: persistedId, workspaceId, catalogId: catalogSlug },
     credentialWritten: authKind !== "none",
   };
-}
-
-/** Best-effort host extraction for log breadcrumbs — never throws, never leaks the path. */
-function safeHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    // intentionally ignored: log breadcrumb only — the URL was already
-    // validated by the zod refine above.
-    return "<unparseable>";
-  }
 }

--- a/packages/api/src/lib/integrations/install/persist-form-install.ts
+++ b/packages/api/src/lib/integrations/install/persist-form-install.ts
@@ -5,7 +5,7 @@
  * Email / Webhook / Obsidian / Linear API-key / GitHub PAT / Twenty all
  * repeated the same sequence after their per-Platform Zod parse: SaaS
  * keyset gate → `encryptSecretFields` → `workspace_plugins` upsert →
- * returned-id invariant check → optional lazy-loader evict. Five-plus
+ * returned-id invariant check → lazy-loader evict. Five-plus
  * copies of that spine meant five places for the Workspace Install
  * write path to be wrong — and three of them WERE wrong: the Email /
  * Webhook / Obsidian copies still carried the pre-0092 INSERT shape
@@ -15,8 +15,9 @@
  * specification") because 0096 dropped both the column-filling BEFORE
  * INSERT trigger and the non-partial unique index that shape relied
  * on. The spine writes the one canonical post-0092 shape (explicit
- * `install_id` + `pillar='action'`, partial-index conflict target),
- * pinned against real Postgres in `db/__tests__/migrate-pg.test.ts`.
+ * `install_id` + denormalized `pillar`, partial-index conflict
+ * target), pinned against real Postgres in
+ * `__tests__/persist-form-install-pg.test.ts`.
  *
  * Intentionally NOT on this spine (different persistence shapes):
  *   - `DatasourceFormInstallHandler` — `pillar='datasource'`,
@@ -38,17 +39,30 @@ import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { WorkspaceId } from "@useatlas/types";
 import type { CatalogId, InstallRecord } from "./types";
 
-type InstallLogger = ReturnType<typeof createLogger>;
+/**
+ * The spine only writes log lines — narrow to exactly the levels it
+ * uses so test loggers and lightweight scoped loggers satisfy the type
+ * without casting (precedent: `_shared/oauth-retry.ts`'s RetryLogger).
+ */
+type InstallLogger = Pick<ReturnType<typeof createLogger>, "error" | "warn">;
 
 /**
  * The canonical single-instance form-install upsert (post-0092 shape,
  * #2739). `install_id` is named explicitly (= the candidate row id,
- * matching the Linear / GitHub PAT / Twenty convention) and
- * `pillar='action'` is denormalized so the partial unique index
- * `workspace_plugins_singleton` — the only `(workspace_id, catalog_id)`
- * unique gate left after 0096 — can arbitrate the conflict. The WHERE
- * clause on the conflict target is load-bearing: Postgres only infers a
- * partial index as the arbiter when the predicate is spelled out.
+ * matching the convention of every working writer — Slack, Telegram,
+ * Linear, GitHub PAT, Twenty; pre-0096 rows backfilled by 0092 carry
+ * the older `install_id = catalog_id` sentinel and are healed to the
+ * existing row id never being touched on conflict) and `pillar` is
+ * denormalized so the partial unique index `workspace_plugins_singleton`
+ * — the only `(workspace_id, catalog_id)` unique gate left after 0096 —
+ * can arbitrate the conflict. The WHERE clause on the conflict target
+ * is load-bearing: Postgres only infers a partial index as the arbiter
+ * when the predicate is spelled out.
+ *
+ * `pillar` is a parameter (defaulting to `'action'`, the only value the
+ * form spine writes today) so the five static-bot chat handlers and the
+ * #3357 Salesforce/Jira fix can converge on this single tested artifact
+ * instead of hand-rolling an eleventh copy.
  *
  * `RETURNING id` returns the persisted id — on a fresh INSERT it's the
  * one we generated, on a CONFLICT it's the row's existing id (NOT the
@@ -60,12 +74,15 @@ type InstallLogger = ReturnType<typeof createLogger>;
  * handler) — the column tracks the first install, not the most recent
  * edit.
  *
- * Exported so the real-Postgres migration smoke executes this exact
- * string against the live schema — the drift class that broke the
- * pre-spine Email/Webhook/Obsidian copies (mock-based handler tests
- * can't see plan-time SQL errors).
+ * Exported so the real-Postgres smoke executes this exact string
+ * against the live schema — the drift class that broke the pre-spine
+ * Email/Webhook/Obsidian copies (mock-based handler tests can't see
+ * plan-time SQL errors).
  */
-export function buildFormInstallUpsertSql(updateConfigOnConflict: boolean): string {
+export function buildFormInstallUpsertSql(
+  updateConfigOnConflict: boolean,
+  pillar: "chat" | "action" = "action",
+): string {
   // Twenty keeps the existing row's config on re-install — its config
   // is a catalog-binding stub (credential lives in twenty_integrations).
   const conflictSet = updateConfigOnConflict
@@ -74,7 +91,7 @@ export function buildFormInstallUpsertSql(updateConfigOnConflict: boolean): stri
     : `SET enabled = true`;
   return `INSERT INTO workspace_plugins
            (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
+         VALUES ($1, $2, $3, $1, '${pillar}', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
          DO UPDATE
            ${conflictSet}
@@ -89,22 +106,30 @@ export function buildFormInstallUpsertSql(updateConfigOnConflict: boolean): stri
  * credential boundary.
  *
  * Runs inside {@link persistFormInstall}; exported for handlers that
- * write a credential store BEFORE the workspace_plugins upsert (Twenty's
- * `twenty_integrations` row) and must gate that earlier write too.
+ * must gate an EARLIER write — Twenty's `twenty_integrations` credential
+ * row lands before the catalog upsert, and Email's TLS-disabled warn
+ * must not fire for an install the gate refuses.
  *
  * @param plaintextSecretLabel - the credential field named in the
  *   refusal log line ("password", "api_key", "pat", …). Log breadcrumb
- *   only — never the secret value itself.
+ *   only — never the secret value itself. Sanitized to a word-ish token
+ *   because it lands in the log MESSAGE: this is an exported seam, and
+ *   a future caller passing a config-derived label must not be able to
+ *   splice newlines/control chars into the alertable refusal string.
+ * @param extraLogFields - additional structured fields for the refusal
+ *   log (the shared OpenAPI install core attributes per-candidate slugs).
  */
 export function assertSaasEncryptionKeyset(
   log: InstallLogger,
   workspaceId: WorkspaceId,
   plaintextSecretLabel: string,
+  extraLogFields: Record<string, unknown> = {},
 ): void {
   if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+    const label = plaintextSecretLabel.replace(/[^\w./-]/g, "_");
     log.error(
-      { workspaceId },
-      `Refusing form install: SaaS mode + no encryption keyset (would persist plaintext ${plaintextSecretLabel})`,
+      { workspaceId, ...extraLogFields },
+      `Refusing form install: SaaS mode + no encryption keyset (would persist plaintext ${label})`,
     );
     throw new Error(
       "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
@@ -112,11 +137,47 @@ export function assertSaasEncryptionKeyset(
   }
 }
 
+/**
+ * Structural subset of a Zod schema's `safeParse` — kept structural so
+ * the spine doesn't pin a zod version, and so `.strict()` / `.refine()`
+ * / `.transform()` wrappers all satisfy it.
+ */
+interface ParseableFormSchema<T> {
+  safeParse(data: unknown):
+    | { success: true; data: T }
+    | {
+        success: false;
+        error: {
+          flatten(): {
+            fieldErrors: Record<string, string[] | undefined>;
+            formErrors: string[];
+          };
+        };
+      };
+}
+
+/**
+ * The canonical parse-or-throw step every form handler starts with:
+ * validate `formData` against the handler's Zod schema and throw
+ * {@link FormInstallValidationError} (the single error type the route's
+ * `instanceof` catch maps to a field-level 400) on failure.
+ */
+export function parseFormInstall<T>(schema: ParseableFormSchema<T>, formData: unknown): T {
+  const parsed = schema.safeParse(formData);
+  if (!parsed.success) {
+    throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
+  }
+  return parsed.data;
+}
+
 export interface PersistFormInstallParams {
   readonly workspaceId: WorkspaceId;
-  /** `plugin_catalog.id` FK — `catalog:<slug>` per the seeder. */
-  readonly catalogId: string;
-  /** Bare catalog slug — becomes {@link InstallRecord.catalogId}. */
+  /**
+   * Bare catalog slug — the dispatch key and {@link InstallRecord.catalogId}.
+   * The `plugin_catalog.id` FK is derived as `catalog:<slug>` (the
+   * seeder's invariant, `catalog-seeder.ts::upsertEntry`) so a handler
+   * can never pass a mismatched id/slug pair.
+   */
   readonly catalogSlug: CatalogId;
   /** Human-readable Platform name composed into log lines ("Email", "GitHub PAT"). */
   readonly displayName: string;
@@ -131,8 +192,12 @@ export interface PersistFormInstallParams {
    * `twenty_integrations` table, the config here is a `{}` stub).
    */
   readonly secretFieldsSchema?: ConfigSchema;
-  /** Credential field named in the SaaS keyset-gate refusal log. */
-  readonly plaintextSecretLabel: string;
+  /**
+   * Credential field named in the SaaS keyset-gate refusal log. Derived
+   * from the schema's `secret: true` field keys when omitted; required
+   * in spirit for schema-less callers (falls back to "credential").
+   */
+  readonly plaintextSecretLabel?: string;
   /** Candidate row-id generator (handlers inject a fixed one in tests). */
   readonly newId: () => string;
   /**
@@ -140,15 +205,6 @@ export interface PersistFormInstallParams {
    * existing row's config rather than overwrite it with the stub.
    */
   readonly updateConfigOnConflict?: boolean;
-  /**
-   * Evict the cached PluginLike for this (workspace, catalog) after the
-   * upsert so the next tool dispatch rebuilds against the freshly-
-   * persisted config. Without this, a re-install that rotates
-   * credentials keeps the stale in-memory instance from before the
-   * upsert. Fire-and-forget — a failed evict warns but never fails the
-   * install (the DB row is already persisted).
-   */
-  readonly evictAfterPersist?: boolean;
   /**
    * Override for the persist-failure log line. Twenty uses it to
    * document partial-write recovery (its credential row lands first and
@@ -160,17 +216,25 @@ export interface PersistFormInstallParams {
 
 /**
  * The shared spine: SaaS keyset gate → encrypt secret fields →
- * `workspace_plugins` upsert → returned-id invariant → optional
- * lazy-loader evict. Handlers shrink to parse-and-validate + one call;
- * the per-Platform completion `log.info` (host/port/owner breadcrumbs)
+ * `workspace_plugins` upsert → returned-id invariant → lazy-loader
+ * evict. Handlers shrink to parse-and-validate + one call; the
+ * per-Platform completion `log.info` (host/port/owner breadcrumbs)
  * stays with the handler.
+ *
+ * The evict is unconditional: a re-install that rotates credentials
+ * must never keep serving a stale cached PluginLike built from the
+ * pre-upsert config, and `lazyPluginLoader.evict` is a free no-op when
+ * nothing is cached — so there is no consumer for which skipping it
+ * would be right (the pre-spine Webhook/Obsidian copies skipped it and
+ * carried exactly that stale-instance bug, latent until their lazy
+ * builders register). Fire-and-forget: a failed evict warns but never
+ * fails the install (the DB row is already persisted).
  */
 export async function persistFormInstall(
   params: PersistFormInstallParams,
 ): Promise<InstallRecord> {
   const {
     workspaceId,
-    catalogId,
     catalogSlug,
     displayName,
     log,
@@ -179,12 +243,19 @@ export async function persistFormInstall(
     plaintextSecretLabel,
     newId,
     updateConfigOnConflict = true,
-    evictAfterPersist = false,
     persistFailureMessage = `Failed to persist ${displayName} install record — aborting install`,
   } = params;
 
+  // The seeder derives every catalog row id as `catalog:${slug}` — one
+  // param, so a mismatched id/slug pair is unrepresentable at the seam.
+  const catalogId = `catalog:${catalogSlug}`;
+
   // ── 1. SaaS keyset gate ─────────────────────────────────────────────
-  assertSaasEncryptionKeyset(log, workspaceId, plaintextSecretLabel);
+  assertSaasEncryptionKeyset(
+    log,
+    workspaceId,
+    plaintextSecretLabel ?? deriveSecretLabel(secretFieldsSchema),
+  );
 
   // ── 2. Encrypt secret fields at rest ────────────────────────────────
   const persistedConfig = secretFieldsSchema
@@ -228,17 +299,82 @@ export async function persistFormInstall(
     throw err;
   }
 
-  // ── 4. Optional post-persist evict ──────────────────────────────────
-  if (evictAfterPersist) {
-    try {
-      await lazyPluginLoader.evict(workspaceId, catalogId);
-    } catch (err) {
-      log.warn(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        `LazyPluginLoader.evict threw after ${displayName} install upsert — DB row is persisted anyway`,
-      );
-    }
+  // ── 4. Evict any cached PluginLike for this (workspace, catalog) ────
+  try {
+    await lazyPluginLoader.evict(workspaceId, catalogId);
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      `LazyPluginLoader.evict threw after ${displayName} install upsert — DB row is persisted anyway`,
+    );
   }
 
   return { id: persistedId, workspaceId, catalogId: catalogSlug };
+}
+
+/** The `secret: true` field keys of a parsed schema — the gate-log breadcrumb. */
+function deriveSecretLabel(schema: ConfigSchema | undefined): string {
+  if (schema?.state === "parsed") {
+    const keys = schema.fields.filter((f) => f.secret === true).map((f) => f.key);
+    if (keys.length > 0) return keys.join("/");
+  }
+  return "credential";
+}
+
+/**
+ * Validation failure surface for every form-based install handler.
+ * `kind` is the catalog `install_model` value so every handler throws
+ * the same class — the route's catch is a single
+ * `instanceof FormInstallValidationError` check rather than a growing
+ * list of per-Platform error types. (Declared in the Email module first
+ * per #2697; moved here with the spine so {@link parseFormInstall} can
+ * throw it without an email-handler import cycle. `email-form-handler`
+ * re-exports it, so existing import sites keep compiling.)
+ *
+ * `fieldErrors` is normalized at construction: only fields with
+ * actual issues land in the map (Zod's `flatten().fieldErrors`
+ * carries `string[] | undefined` values; we drop the undefineds so
+ * the public contract is clean).
+ *
+ * `formErrors` carries top-level issues — `.strict()` "unrecognized
+ * key" reports, schema-level `.refine` failures — that don't bind to
+ * any single field. The route surfaces both so the admin UI can
+ * render a generic banner alongside per-field messages.
+ *
+ * Tagged class rather than `Data.TaggedError` because this throws out
+ * through the legacy Hono handler — `runHandler`'s typed-error mapper
+ * doesn't currently know about install-handler-internal tagged
+ * errors; the route catches via `instanceof` and emits the 400
+ * directly. Promoting to a tagged Effect error is a follow-up once
+ * the dispatch grows.
+ */
+export class FormInstallValidationError extends Error {
+  readonly _tag = "FormInstallValidationError" as const;
+  readonly fieldErrors: Readonly<Record<string, readonly string[]>>;
+  readonly formErrors: readonly string[];
+
+  constructor(input: {
+    fieldErrors: Record<string, string[] | undefined>;
+    formErrors?: readonly string[];
+  }) {
+    super("Form install validation failed");
+    this.name = "FormInstallValidationError";
+    const cleaned: Record<string, readonly string[]> = {};
+    for (const [k, v] of Object.entries(input.fieldErrors)) {
+      if (v && v.length > 0) cleaned[k] = v;
+    }
+    this.fieldErrors = cleaned;
+    this.formErrors = input.formErrors ?? [];
+  }
+
+  /** Build from `parsed.error.flatten()` — the canonical Zod adapter. */
+  static fromZodFlatten(flat: {
+    fieldErrors: Record<string, string[] | undefined>;
+    formErrors: string[];
+  }): FormInstallValidationError {
+    return new FormInstallValidationError({
+      fieldErrors: flat.fieldErrors,
+      formErrors: flat.formErrors,
+    });
+  }
 }

--- a/packages/api/src/lib/integrations/install/persist-form-install.ts
+++ b/packages/api/src/lib/integrations/install/persist-form-install.ts
@@ -1,0 +1,244 @@
+/**
+ * `persistFormInstall` — the shared persistence spine for every
+ * single-instance (chat/action-pillar) {@link FormBasedInstallHandler}.
+ *
+ * Email / Webhook / Obsidian / Linear API-key / GitHub PAT / Twenty all
+ * repeated the same sequence after their per-Platform Zod parse: SaaS
+ * keyset gate → `encryptSecretFields` → `workspace_plugins` upsert →
+ * returned-id invariant check → optional lazy-loader evict. Five-plus
+ * copies of that spine meant five places for the Workspace Install
+ * write path to be wrong — and three of them WERE wrong: the Email /
+ * Webhook / Obsidian copies still carried the pre-0092 INSERT shape
+ * (no `install_id` / `pillar`, bare `ON CONFLICT (workspace_id,
+ * catalog_id)`), which fails against the post-0096 schema with 42P10
+ * ("no unique or exclusion constraint matching the ON CONFLICT
+ * specification") because 0096 dropped both the column-filling BEFORE
+ * INSERT trigger and the non-partial unique index that shape relied
+ * on. The spine writes the one canonical post-0092 shape (explicit
+ * `install_id` + `pillar='action'`, partial-index conflict target),
+ * pinned against real Postgres in `db/__tests__/migrate-pg.test.ts`.
+ *
+ * Intentionally NOT on this spine (different persistence shapes):
+ *   - `DatasourceFormInstallHandler` — `pillar='datasource'`,
+ *     `status='draft'`, fixed per-workspace `install_id`, catalog-
+ *     schema-driven mask/restore. The ADR-0013 `createFromConfig`
+ *     bridge owns that flow.
+ *   - `persistOpenApiDatasourceInstall` — multi-instance (fresh
+ *     `install_id` per submit), probe-on-install, `status='draft'`.
+ *
+ * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ */
+
+import type { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { encryptSecretFields, type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import type { WorkspaceId } from "@useatlas/types";
+import type { CatalogId, InstallRecord } from "./types";
+
+type InstallLogger = ReturnType<typeof createLogger>;
+
+/**
+ * The canonical single-instance form-install upsert (post-0092 shape,
+ * #2739). `install_id` is named explicitly (= the candidate row id,
+ * matching the Linear / GitHub PAT / Twenty convention) and
+ * `pillar='action'` is denormalized so the partial unique index
+ * `workspace_plugins_singleton` — the only `(workspace_id, catalog_id)`
+ * unique gate left after 0096 — can arbitrate the conflict. The WHERE
+ * clause on the conflict target is load-bearing: Postgres only infers a
+ * partial index as the arbiter when the predicate is spelled out.
+ *
+ * `RETURNING id` returns the persisted id — on a fresh INSERT it's the
+ * one we generated, on a CONFLICT it's the row's existing id (NOT the
+ * freshly-generated one). Callers that treat `installId` as a stable
+ * identifier for the saved row would otherwise read a phantom id on
+ * re-installs.
+ *
+ * `installed_at` is NOT bumped on conflict (matches the Slack OAuth
+ * handler) — the column tracks the first install, not the most recent
+ * edit.
+ *
+ * Exported so the real-Postgres migration smoke executes this exact
+ * string against the live schema — the drift class that broke the
+ * pre-spine Email/Webhook/Obsidian copies (mock-based handler tests
+ * can't see plan-time SQL errors).
+ */
+export function buildFormInstallUpsertSql(updateConfigOnConflict: boolean): string {
+  // Twenty keeps the existing row's config on re-install — its config
+  // is a catalog-binding stub (credential lives in twenty_integrations).
+  const conflictSet = updateConfigOnConflict
+    ? `SET config = EXCLUDED.config,
+               enabled = true`
+    : `SET enabled = true`;
+  return `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           ${conflictSet}
+         RETURNING id`;
+}
+
+/**
+ * SaaS keyset gate. `encryptSecret` falls back to plaintext when no key
+ * is configured (dev convenience). Boot logs a one-shot warning, but a
+ * missed log in SaaS would leak the credential plaintext. Refuse the
+ * install per-call so a misconfigured deploy fails closed at the
+ * credential boundary.
+ *
+ * Runs inside {@link persistFormInstall}; exported for handlers that
+ * write a credential store BEFORE the workspace_plugins upsert (Twenty's
+ * `twenty_integrations` row) and must gate that earlier write too.
+ *
+ * @param plaintextSecretLabel - the credential field named in the
+ *   refusal log line ("password", "api_key", "pat", …). Log breadcrumb
+ *   only — never the secret value itself.
+ */
+export function assertSaasEncryptionKeyset(
+  log: InstallLogger,
+  workspaceId: WorkspaceId,
+  plaintextSecretLabel: string,
+): void {
+  if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+    log.error(
+      { workspaceId },
+      `Refusing form install: SaaS mode + no encryption keyset (would persist plaintext ${plaintextSecretLabel})`,
+    );
+    throw new Error(
+      "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
+    );
+  }
+}
+
+export interface PersistFormInstallParams {
+  readonly workspaceId: WorkspaceId;
+  /** `plugin_catalog.id` FK — `catalog:<slug>` per the seeder. */
+  readonly catalogId: string;
+  /** Bare catalog slug — becomes {@link InstallRecord.catalogId}. */
+  readonly catalogSlug: CatalogId;
+  /** Human-readable Platform name composed into log lines ("Email", "GitHub PAT"). */
+  readonly displayName: string;
+  /** The handler's own logger so install lines stay attributable per slug. */
+  readonly log: InstallLogger;
+  /** Validated plaintext config destined for `workspace_plugins.config`. */
+  readonly config: Record<string, unknown>;
+  /**
+   * When present, fields flagged `secret: true` encrypt at rest via
+   * {@link encryptSecretFields}. Omit only when the config carries no
+   * credential (Twenty: the apiKey lives in its dedicated
+   * `twenty_integrations` table, the config here is a `{}` stub).
+   */
+  readonly secretFieldsSchema?: ConfigSchema;
+  /** Credential field named in the SaaS keyset-gate refusal log. */
+  readonly plaintextSecretLabel: string;
+  /** Candidate row-id generator (handlers inject a fixed one in tests). */
+  readonly newId: () => string;
+  /**
+   * Default `true`. Twenty sets `false`: a re-install must keep the
+   * existing row's config rather than overwrite it with the stub.
+   */
+  readonly updateConfigOnConflict?: boolean;
+  /**
+   * Evict the cached PluginLike for this (workspace, catalog) after the
+   * upsert so the next tool dispatch rebuilds against the freshly-
+   * persisted config. Without this, a re-install that rotates
+   * credentials keeps the stale in-memory instance from before the
+   * upsert. Fire-and-forget — a failed evict warns but never fails the
+   * install (the DB row is already persisted).
+   */
+  readonly evictAfterPersist?: boolean;
+  /**
+   * Override for the persist-failure log line. Twenty uses it to
+   * document partial-write recovery (its credential row lands first and
+   * is intentionally not rolled back — re-running the install heals the
+   * catalog row).
+   */
+  readonly persistFailureMessage?: string;
+}
+
+/**
+ * The shared spine: SaaS keyset gate → encrypt secret fields →
+ * `workspace_plugins` upsert → returned-id invariant → optional
+ * lazy-loader evict. Handlers shrink to parse-and-validate + one call;
+ * the per-Platform completion `log.info` (host/port/owner breadcrumbs)
+ * stays with the handler.
+ */
+export async function persistFormInstall(
+  params: PersistFormInstallParams,
+): Promise<InstallRecord> {
+  const {
+    workspaceId,
+    catalogId,
+    catalogSlug,
+    displayName,
+    log,
+    config,
+    secretFieldsSchema,
+    plaintextSecretLabel,
+    newId,
+    updateConfigOnConflict = true,
+    evictAfterPersist = false,
+    persistFailureMessage = `Failed to persist ${displayName} install record — aborting install`,
+  } = params;
+
+  // ── 1. SaaS keyset gate ─────────────────────────────────────────────
+  assertSaasEncryptionKeyset(log, workspaceId, plaintextSecretLabel);
+
+  // ── 2. Encrypt secret fields at rest ────────────────────────────────
+  const persistedConfig = secretFieldsSchema
+    ? encryptSecretFields(config, secretFieldsSchema)
+    : config;
+
+  // ── 3. Upsert workspace_plugins ─────────────────────────────────────
+  // ON CONFLICT updates config (unless the handler opted out) + flips
+  // enabled back to true so a re-install after disconnect lands cleanly.
+  const candidateId = newId();
+  let persistedId: string;
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      buildFormInstallUpsertSql(updateConfigOnConflict),
+      [candidateId, workspaceId, catalogId, JSON.stringify(persistedConfig)],
+    );
+    const returned = rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+      // by Postgres to emit exactly one row on both paths. Reaching
+      // here means a structural anomaly (driver rewrite, RLS hiding
+      // the result, partial-index miss). Falling back to candidateId
+      // would silently return a WRONG id on the DO UPDATE path
+      // (persisted row keeps its existing id, not the candidate),
+      // and downstream lookups would create phantom updates. Fail
+      // loud so the operator sees the invariant break with a 500.
+      log.error(
+        { workspaceId, candidateId },
+        "workspace_plugins upsert returned no id — Postgres invariant violation",
+      );
+      throw new Error(
+        "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+      );
+    }
+    persistedId = returned;
+  } catch (err) {
+    log.error(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      persistFailureMessage,
+    );
+    throw err;
+  }
+
+  // ── 4. Optional post-persist evict ──────────────────────────────────
+  if (evictAfterPersist) {
+    try {
+      await lazyPluginLoader.evict(workspaceId, catalogId);
+    } catch (err) {
+      log.warn(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        `LazyPluginLoader.evict threw after ${displayName} install upsert — DB row is persisted anyway`,
+      );
+    }
+  }
+
+  return { id: persistedId, workspaceId, catalogId: catalogSlug };
+}

--- a/packages/api/src/lib/integrations/install/safe-host.ts
+++ b/packages/api/src/lib/integrations/install/safe-host.ts
@@ -1,0 +1,16 @@
+/**
+ * Best-effort host extraction for install-log breadcrumbs — never
+ * throws, never leaks the URL's path/query/userinfo into logs. One
+ * definition for every install handler (Webhook / Obsidian / Twenty /
+ * the OpenAPI core) so a change to the redaction policy lands once.
+ */
+export function safeHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    // intentionally ignored: log breadcrumb only — the URL was already
+    // validated by the caller's Zod refine, so reaching this branch
+    // implies a malformed log entry, not malformed user input.
+    return "<unparseable>";
+  }
+}

--- a/packages/api/src/lib/integrations/install/twenty-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/twenty-form-handler.ts
@@ -41,8 +41,12 @@ import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { WorkspaceId } from "@useatlas/types";
 import { saveTwentyIntegration } from "@atlas/api/lib/integrations/twenty/store";
-import { FormInstallValidationError } from "./email-form-handler";
-import { assertSaasEncryptionKeyset, persistFormInstall } from "./persist-form-install";
+import {
+  assertSaasEncryptionKeyset,
+  parseFormInstall,
+  persistFormInstall,
+} from "./persist-form-install";
+import { safeHost } from "./safe-host";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -58,6 +62,8 @@ export const TWENTY_SLUG: CatalogId = "twenty";
  * Stable `plugin_catalog.id` for Twenty. The seeder derives row ids
  * as `catalog:${slug}` (see `catalog-seeder.ts::upsertEntry`), so the
  * FK target in `workspace_plugins.catalog_id` is `catalog:twenty`.
+ * (The spine derives the same id from {@link TWENTY_SLUG}; this export
+ * remains for the dispatcher/store call sites that key on it.)
  */
 export const TWENTY_CATALOG_ID = "catalog:twenty";
 
@@ -129,11 +135,7 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
     readonly credentialWritten: boolean;
   }> {
     // ── 1. Validate the form against the Twenty schema ──────────────
-    const parsed = TwentyFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const { apiKey, baseUrl } = parsed.data;
+    const { apiKey, baseUrl } = parseFormInstall(TwentyFormDataSchema, formData);
 
     // ── 2. SaaS keyset gate — BEFORE the credential write ────────────
     assertSaasEncryptionKeyset(log, workspaceId, "api_key");
@@ -162,13 +164,12 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
     // (the failure log below says so).
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: TWENTY_CATALOG_ID,
       catalogSlug: TWENTY_SLUG,
       displayName: "Twenty",
       log,
       config: {},
       plaintextSecretLabel: "api_key",
-      newId: this.newId,
+      newId: () => this.newId(),
       updateConfigOnConflict: false,
       persistFailureMessage:
         "Failed to persist Twenty install record — twenty_integrations row is persisted (retrying the install is safe; the credential write is idempotent)",
@@ -183,17 +184,5 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
       "Twenty admin-UI install completed",
     );
     return { installRecord, credentialWritten: true };
-  }
-}
-
-/** Best-effort host extraction for log breadcrumbs — never throws. */
-function safeHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    // intentionally ignored: log breadcrumb only — URL was already
-    // validated by zod refine above, so reaching this branch implies
-    // a malformed log entry, not a malformed user input.
-    return "<unparseable>";
   }
 }

--- a/packages/api/src/lib/integrations/install/twenty-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/twenty-form-handler.ts
@@ -13,7 +13,10 @@
  *     is what the SaaS dispatcher consults at flush time.
  *   2. `workspace_plugins` — the catalog install record (ADR-0003 dual
  *     store). Enables the catalog UI's "Installed" state + the
- *     standard catalog DELETE teardown path.
+ *     standard catalog DELETE teardown path. Persisted via the shared
+ *     spine ({@link persistFormInstall}) with an empty config stub —
+ *     the credential is never duplicated into `config`, and a conflict
+ *     re-install keeps the existing row's config untouched.
  *
  * **No Atlas-SaaS leak in defaults.** The form requires `baseUrl` —
  * there is no default `https://crm.useatlas.dev`. That URL is Atlas's
@@ -22,25 +25,24 @@
  * deployment carries `crm.useatlas.dev` separately via
  * `ATLAS_TWENTY_BASE_URL` / `TWENTY_BASE_URL`.
  *
- * **SaaS-mode keyset gate.** When `ATLAS_DEPLOY_MODE=saas` and no
- * encryption keyset is configured, `encryptSecret` falls back to
- * plaintext (dev convenience). Boot logs a one-shot warning, but a
- * missed log in SaaS would leak the apiKey plaintext. Refuse the
- * install per-call so a misconfigured SaaS deploy fails closed at the
- * credential boundary. Mirrors the EmailFormInstallHandler posture.
+ * **SaaS-mode keyset gate.** Checked explicitly BEFORE the
+ * `twenty_integrations` write (the spine re-checks before the catalog
+ * upsert, but by then the credential row would already exist) — a
+ * misconfigured SaaS deploy must fail closed before any credential
+ * byte is persisted. See {@link assertSaasEncryptionKeyset}.
  *
  * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  * @see ../twenty/store.ts — `saveTwentyIntegration` (credential table)
  */
 
 import crypto from "crypto";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { WorkspaceId } from "@useatlas/types";
 import { saveTwentyIntegration } from "@atlas/api/lib/integrations/twenty/store";
 import { FormInstallValidationError } from "./email-form-handler";
+import { assertSaasEncryptionKeyset, persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -133,20 +135,8 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
     }
     const { apiKey, baseUrl } = parsed.data;
 
-    // ── 2. SaaS keyset gate ─────────────────────────────────────────
-    // Refuse the install when SaaS mode + no keyset — encryptSecret
-    // would otherwise silently persist plaintext. Mirrors the Email +
-    // Linear API-key handler posture.
-    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext api_key)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-          "Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
+    // ── 2. SaaS keyset gate — BEFORE the credential write ────────────
+    assertSaasEncryptionKeyset(log, workspaceId, "api_key");
 
     // ── 3. Write the credential row in twenty_integrations ──────────
     // Encryption happens inside the store; we never see ciphertext at
@@ -164,79 +154,35 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
     }
 
     // ── 4. Upsert workspace_plugins (catalog install record) ────────
-    // The credential is NOT duplicated here — it lives in the
-    // dedicated `twenty_integrations` table. The workspace_plugins
-    // row carries only catalog binding state so the admin UI's
-    // catalog card reflects "Installed" and the standard catalog
-    // DELETE path (which removes the workspace_plugins row) flows
-    // through.
-    //
-    // Pillar='action' + install_id named explicitly per the
-    // `workspace_plugins` partial unique index on
-    // `(workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')`.
-    // `RETURNING id` lets us pick up the existing id rather than a
-    // phantom freshly-generated one on conflict.
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET enabled = true
-         RETURNING id`,
-        [
-          candidateId,
-          workspaceId,
-          TWENTY_CATALOG_ID,
-          // Empty config — credentials live in twenty_integrations.
-          JSON.stringify({}),
-        ],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+    // Empty config — credentials live in twenty_integrations; the
+    // workspace_plugins row carries only catalog binding state. On
+    // the spine's failure path the twenty_integrations row is NOT
+    // rolled back — the credential is the load-bearing artefact; the
+    // catalog row is a UI mirror, and re-running the install heals it
+    // (the failure log below says so).
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: TWENTY_CATALOG_ID,
+      catalogSlug: TWENTY_SLUG,
+      displayName: "Twenty",
+      log,
+      config: {},
+      plaintextSecretLabel: "api_key",
+      newId: this.newId,
+      updateConfigOnConflict: false,
+      persistFailureMessage:
         "Failed to persist Twenty install record — twenty_integrations row is persisted (retrying the install is safe; the credential write is idempotent)",
-      );
-      // Don't roll back the twenty_integrations row — the credential
-      // is the load-bearing artefact; the catalog row is a UI mirror.
-      // Re-running the install heals the catalog row.
-      throw err;
-    }
+    });
 
     log.info(
       {
         workspaceId,
-        installId: persistedId,
+        installId: installRecord.id,
         baseUrlHost: safeHost(baseUrl),
       },
       "Twenty admin-UI install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: TWENTY_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }
 

--- a/packages/api/src/lib/integrations/install/webhook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/webhook-form-handler.ts
@@ -26,8 +26,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { WorkspaceId } from "@useatlas/types";
-import { FormInstallValidationError } from "./email-form-handler";
-import { persistFormInstall } from "./persist-form-install";
+import { parseFormInstall, persistFormInstall } from "./persist-form-install";
+import { safeHost } from "./safe-host";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -35,9 +35,6 @@ import type {
 } from "./types";
 
 const log = createLogger("integrations.install.webhook");
-
-/** Stable `plugin_catalog.id` for Webhook — `catalog:${slug}` per the seeder. */
-const WEBHOOK_CATALOG_ID = "catalog:webhook";
 
 /** Catalog slug — the dispatch key in {@link registerFormHandler}. */
 const WEBHOOK_SLUG: CatalogId = "webhook";
@@ -84,7 +81,13 @@ export const WebhookFormDataSchema = z
 
 export type WebhookFormData = z.infer<typeof WebhookFormDataSchema>;
 
-const WEBHOOK_SECRET_FIELDS_SCHEMA: ConfigSchema & {
+/**
+ * Exported (unlike the original module-local const) so decrypt-side
+ * consumers and cross-schema-agreement tests can pin the secret-field
+ * routing against {@link WebhookFormDataSchema} — the email family's
+ * Zod↔secret-schema drift test needs both halves importable.
+ */
+export const WEBHOOK_SECRET_FIELDS_SCHEMA: ConfigSchema & {
   state: "parsed";
   fields: ReadonlyArray<ConfigSchemaField & { key: keyof WebhookFormData }>;
 } = {
@@ -117,22 +120,16 @@ export class WebhookFormInstallHandler implements FormBasedInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialWritten: boolean;
   }> {
-    const parsed = WebhookFormDataSchema.safeParse(formData);
-    if (!parsed.success) {
-      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
-    }
-    const config = parsed.data;
+    const config = parseFormInstall(WebhookFormDataSchema, formData);
 
     const installRecord = await persistFormInstall({
       workspaceId,
-      catalogId: WEBHOOK_CATALOG_ID,
       catalogSlug: WEBHOOK_SLUG,
       displayName: "Webhook",
       log,
       config,
       secretFieldsSchema: WEBHOOK_SECRET_FIELDS_SCHEMA,
-      plaintextSecretLabel: "signing_secret",
-      newId: this.newId,
+      newId: () => this.newId(),
     });
 
     log.info(
@@ -140,14 +137,5 @@ export class WebhookFormInstallHandler implements FormBasedInstallHandler {
       "Webhook install completed",
     );
     return { installRecord, credentialWritten: true };
-  }
-}
-
-/** Best-effort host extraction for log breadcrumbs — never throws. */
-function safeHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return "<unparseable>";
   }
 }

--- a/packages/api/src/lib/integrations/install/webhook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/webhook-form-handler.ts
@@ -56,6 +56,8 @@ const HttpsUrlSchema = z
         const u = new URL(raw);
         return u.protocol === "https:";
       } catch {
+        // intentionally ignored: URL constructor throw is the negative
+        // validation signal — the user sees the .refine message.
         return false;
       }
     },

--- a/packages/api/src/lib/integrations/install/webhook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/webhook-form-handler.ts
@@ -3,10 +3,11 @@
  *
  * Mirrors the Email shape exactly: an admin submits a destination
  * URL + HMAC signing secret + retry policy, the handler validates,
- * encrypts the secret via {@link encryptSecretFields}, and upserts
+ * encrypts the secret via `encryptSecretFields`, and upserts
  * `workspace_plugins.config`. The plugin code (under
  * `plugins/webhook-action/`) reads the same JSONB at lazy-load time
- * and decrypts via `decryptSecretFields`.
+ * and decrypts via `decryptSecretFields`. Persistence lives on the
+ * shared spine — see {@link persistFormInstall}.
  *
  * URL validation pins https — webhooks routinely carry sensitive
  * analysis output, and http destinations would leak that traffic in
@@ -16,18 +17,17 @@
  *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./email-form-handler.ts — first form handler, shape canon
- * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ * @see ./persist-form-install.ts — {@link persistFormInstall}
  */
 
 import crypto from "crypto";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { encryptSecretFields, type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
-import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { type ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { WorkspaceId } from "@useatlas/types";
 import { FormInstallValidationError } from "./email-form-handler";
+import { persistFormInstall } from "./persist-form-install";
 import type {
   CatalogId,
   FormBasedInstallHandler,
@@ -123,68 +123,23 @@ export class WebhookFormInstallHandler implements FormBasedInstallHandler {
     }
     const config = parsed.data;
 
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      !getEncryptionKeyset()
-    ) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext signing_secret)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    const encryptedConfig = encryptSecretFields(config, WEBHOOK_SECRET_FIELDS_SCHEMA);
-
-    const candidateId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, WEBHOOK_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-        // by Postgres to emit exactly one row on both paths. Reaching
-        // here means a structural anomaly (driver rewrite, RLS hiding
-        // the result, partial-index miss). Falling back to candidateId
-        // would silently return a WRONG id on the DO UPDATE path
-        // (persisted row keeps its existing id, not the candidate),
-        // and downstream lookups would create phantom updates. Fail
-        // loud so the operator sees the invariant break with a 500.
-        log.error(
-          { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist Webhook install record — aborting install",
-      );
-      throw err;
-    }
+    const installRecord = await persistFormInstall({
+      workspaceId,
+      catalogId: WEBHOOK_CATALOG_ID,
+      catalogSlug: WEBHOOK_SLUG,
+      displayName: "Webhook",
+      log,
+      config,
+      secretFieldsSchema: WEBHOOK_SECRET_FIELDS_SCHEMA,
+      plaintextSecretLabel: "signing_secret",
+      newId: this.newId,
+    });
 
     log.info(
-      { workspaceId, installId: persistedId, host: safeHost(config.url) },
+      { workspaceId, installId: installRecord.id, host: safeHost(config.url) },
       "Webhook install completed",
     );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: WEBHOOK_SLUG },
-      credentialWritten: true,
-    };
+    return { installRecord, credentialWritten: true };
   }
 }
 


### PR DESCRIPTION
Implements **candidate 2** of `.claude/research/architecture-review-2026-06-09.md`: one `persistFormInstall` module owns the persistence spine every single-instance form handler repeated — SaaS keyset gate → `encryptSecretFields` → `workspace_plugins` upsert → returned-id invariant → lazy-loader evict. Handlers shrink to parse + one call + their per-Platform completion log.

## ⚠️ The consolidation surfaced a production bug — half the spine's copies were already broken

The review predicted "five places to be wrong"; three of them **were**. The Email / Webhook / Obsidian copies still carried the pre-0092 INSERT shape (no `install_id`/`pillar`, bare `ON CONFLICT (workspace_id, catalog_id)`), which depended on a BEFORE INSERT trigger and a non-partial unique index that **migration 0096 both dropped**. Verified against a fully-migrated real Postgres: the exact SQL those handlers ran fails at plan time with `42P10` — every Email / Webhook / Obsidian install attempt has been a hard 500 since 0096 shipped. The per-handler tests mock `internalQuery`, so plan-time SQL errors were invisible.

For the handlers that worked (Linear API-key, GitHub PAT, Twenty) the upsert SQL, params, and return shapes are unchanged. For Email / Webhook / Obsidian the pivot onto the canonical post-0092 shape **is** the fix.

**Same bug elsewhere:** the Salesforce + Jira **OAuth** handlers carry the identical stale copy — filed as #3357.

## Spine shape (after the second commit's review pass)

- `persistFormInstall({ workspaceId, catalogSlug, displayName, log, config, secretFieldsSchema?, plaintextSecretLabel?, newId, updateConfigOnConflict?, persistFailureMessage? })` → `InstallRecord`
  - The catalog FK is **derived** as `catalog:<slug>` (seeder invariant) — a mismatched id/slug pair is unrepresentable.
  - `plaintextSecretLabel` defaults to the schema's `secret: true` field keys; only schema-less Twenty passes it.
  - **Evict is unconditional** — `lazyPluginLoader.evict` is a free no-op when nothing is cached, and the old opt-in encoded which handlers historically had the copy-pasted block, not a domain rule (Webhook/Obsidian carried a latent stale-instance bug on credential rotation).
- `parseFormInstall(schema, formData)` — the one parse-or-throw step; `FormInstallValidationError` moved here with it (`email-form-handler` re-exports, zero import churn; the dead `EmailFormValidationError` alias is deleted).
- `assertSaasEncryptionKeyset(log, workspaceId, label, extraLogFields?)` — exported for pre-spine gating (Twenty before its `twenty_integrations` write; Email before its TLS-disabled warn, so a refused install can't log a phantom opt-out event). Label sanitized before message interpolation. The `datasource` and `openapi-generic` handlers' inlined gates fold into it.
- `buildFormInstallUpsertSql(updateConfigOnConflict, pillar = "action")` — the one canonical singleton upsert; the `pillar` param exists so the five static-bot chat handlers and the #3357 fix can converge on the single PG-pinned artifact.
- `safeHost` hoisted to one module (was 4 byte-identical copies).

## Per-handler scope decisions

| Handler | Decision |
|---|---|
| `email` | On the spine; explicit pre-gate so the TLS warn never fires for a refused install. |
| `webhook`, `obsidian` | On the spine; secret schemas now exported for cross-schema-agreement tests. |
| `linear-apikey`, `github-pat` | On the spine; SQL byte-identical to before. |
| `twenty` | On the spine with `updateConfigOnConflict: false` + `persistFailureMessage` (partial-write recovery semantics); credential-first gate ordering preserved via the exported gate. |
| `datasource` (+ `elasticsearch`) | **Off the spine** (ADR-0013 `createFromConfig` bridge: `pillar='datasource'`, draft status, mask/restore) — only its keyset gate folds into the shared helper. |
| `openapi-generic`, `data-candidate` | **Off the spine** (already consolidated behind `persistOpenApiDatasourceInstall`, #3028) — keyset gate + `safeHost` fold in. |

## Tests

- Spine unit suite (`persist-form-install.test.ts`, 20 cases): parse-or-throw, gate (refusal, derived/explicit label, sanitization, extra fields, keyless self-host passthrough), selective-field encryption, SQL shape both knobs × both pillars, conflict-returns-existing-id, invariant, failure log-and-rethrow, evict always/warn-on-throw/not-on-failure.
- **Real-Postgres contract suite** colocated with the module (`persist-form-install-pg.test.ts`, chat-cap-pg precedent): executes `buildFormInstallUpsertSql` verbatim against the fully-migrated schema for both pillars — exactly the test class whose absence let three handlers rot. The schema-property pin (legacy shape → `42P10`) stays in `migrate-pg.test.ts`.
- All per-handler suites pass unchanged through the spine.

## Review

A 7-angle code review (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude → verify) ran against the first commit; the second commit applies its findings. Both correctness tracers confirmed callers (`routes/integrations.ts`, `workspace-installer.ts`), readers (lazy-loader, pillar-catalog-query, uninstall-by-id), and the previously-working handlers byte-compatible. Deliberately not done: dropping the `persistFailureMessage` knob (Twenty would double-log) and OAuth-family gate consolidation (deferred to the #3357 neighborhood).

## Docs

Candidate-2 entry moved to `architecture-wins.md` as **win #90** (renumbered after merging main, whose #3360 landed win #89); `schema.ts`'s `install_id` comment updated to document the coexisting sentinel/row-id conventions (never key on `install_id` for chat/action pillars).

## Gates

`/ci` local: lint, type, full test suite, syncpack, template drift, security-headers, railway-watch, schema-drift, oauth-helper drift, test discipline, twenty-resolver imports, published symbols — all pass. Both real-PG suites additionally run against a local Postgres 16. `origin/main` (#3359, #3360) merged back in with the wins-doc conflict resolved; affected tests + type + lint re-run green on the merge.

https://claude.ai/code/session_01XWX7cWnCgQRubTcmBPokn4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared, single-instance persistence pipeline for form installs and a safe-host utility for install logs.

* **Bug Fixes**
  * Resolved migration-related install failures that caused hard 500s for several form-based integrations.

* **Refactor**
  * Consolidated per-handler persistence/encryption into the shared pipeline and simplified handler flows.

* **Tests**
  * Added real-DB and unit/regression suites covering upsert behavior, encryption gating, and eviction semantics.

* **Documentation**
  * Updated architecture notes and inline schema guidance to reflect the new persistence approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->