### PR TITLE
refactor(integrations): shared lazy-plugin tool scaffolding + boot-time tool-shadow warning (#3326)

### DIFF
--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -97,7 +97,13 @@ if (config.plugins?.length) {
 
   // Build plugin context — gives plugins typed access to Atlas internals
   const { connections } = await import("@atlas/api/lib/db/connection");
-  const { ToolRegistry, defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+  const {
+    ToolRegistry,
+    defaultRegistry,
+    buildRegistry,
+    INTENTIONAL_TOOL_SHADOWS,
+    TOOL_SHADOW_REMEDIATIONS,
+  } = await import("@atlas/api/lib/tools/registry");
   const { hasInternalDB, internalQuery, getInternalDB } = await import(
     "@atlas/api/lib/db/internal"
   );
@@ -220,21 +226,40 @@ if (config.plugins?.length) {
   if (pluginToolRegistry.size > 0) {
     // #3326 — a plugin tool that reuses a core tool's name is silently
     // shadowed: the chat route merges with `ToolRegistry.merge(base, plugin)`
-    // and the base (core) entry wins, so the plugin tool never executes.
-    // Known instance: static-url `querySalesforce` (plugin) vs the OAuth
-    // `querySalesforce` (core, gated on SALESFORCE_CLIENT_ID/SECRET) — in
-    // single-tenant self-host the OAuth tool returns `no_workspace` on every
-    // call, making static Salesforce unqueryable. The configurations are meant
-    // to be mutually exclusive, so surface the conflict loudly at boot instead
-    // of resolving it.
-    for (const name of ToolRegistry.shadowedNames(defaultRegistry, pluginToolRegistry)) {
-      const remediation =
-        name === "querySalesforce"
-          ? " Unset SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET to use the static-url Salesforce tool, or remove the static salesforce:// datasource to use the OAuth per-workspace tool."
-          : "";
+    // and the base (core/action) entry wins, so the plugin tool never
+    // executes. Known instance: static-url `querySalesforce` (plugin) vs the
+    // OAuth `querySalesforce` (core, gated on SALESFORCE_CLIENT_ID/SECRET) —
+    // in single-tenant self-host the OAuth tool returns `no_workspace` on
+    // every call, making static Salesforce unqueryable. The configurations
+    // are meant to be mutually exclusive, so surface the conflict loudly at
+    // boot instead of resolving it. Per-name remediation copy and the
+    // intentional-overlap allowlist live next to the registration sites in
+    // tools/registry.ts.
+    //
+    // The base mirrors what chat.ts actually merges against: the action-
+    // augmented registry when ATLAS_ACTIONS_ENABLED, else defaultRegistry —
+    // so action-tool collisions (e.g. a plugin reusing an action name) are
+    // covered too.
+    let shadowBase = defaultRegistry;
+    if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
+      try {
+        const { registry } = await buildRegistry({ includeActions: true });
+        shadowBase = registry;
+      } catch (err) {
+        // Non-fatal here — chat.ts handles (and reports) the same failure per
+        // request; the shadow check just degrades to the core-tool base.
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Tool-shadow check: buildRegistry failed — checking against core tools only",
+        );
+      }
+    }
+    for (const name of ToolRegistry.shadowedNames(shadowBase, pluginToolRegistry)) {
+      if (INTENTIONAL_TOOL_SHADOWS.has(name)) continue;
+      const remediation = TOOL_SHADOW_REMEDIATIONS[name];
       log.error(
         { tool: name },
-        `Plugin tool "${name}" is shadowed by a core tool with the same name — the core tool takes precedence and the plugin tool will never run.${remediation}`,
+        `Plugin tool "${name}" is shadowed by a core tool with the same name — the core tool takes precedence and the plugin tool will never run.${remediation ? ` ${remediation}` : ""}`,
       );
     }
     pluginToolRegistry.freeze();

--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -97,7 +97,7 @@ if (config.plugins?.length) {
 
   // Build plugin context — gives plugins typed access to Atlas internals
   const { connections } = await import("@atlas/api/lib/db/connection");
-  const { ToolRegistry } = await import("@atlas/api/lib/tools/registry");
+  const { ToolRegistry, defaultRegistry } = await import("@atlas/api/lib/tools/registry");
   const { hasInternalDB, internalQuery, getInternalDB } = await import(
     "@atlas/api/lib/db/internal"
   );
@@ -218,6 +218,25 @@ if (config.plugins?.length) {
   }
 
   if (pluginToolRegistry.size > 0) {
+    // #3326 — a plugin tool that reuses a core tool's name is silently
+    // shadowed: the chat route merges with `ToolRegistry.merge(base, plugin)`
+    // and the base (core) entry wins, so the plugin tool never executes.
+    // Known instance: static-url `querySalesforce` (plugin) vs the OAuth
+    // `querySalesforce` (core, gated on SALESFORCE_CLIENT_ID/SECRET) — in
+    // single-tenant self-host the OAuth tool returns `no_workspace` on every
+    // call, making static Salesforce unqueryable. The configurations are meant
+    // to be mutually exclusive, so surface the conflict loudly at boot instead
+    // of resolving it.
+    for (const name of ToolRegistry.shadowedNames(defaultRegistry, pluginToolRegistry)) {
+      const remediation =
+        name === "querySalesforce"
+          ? " Unset SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET to use the static-url Salesforce tool, or remove the static salesforce:// datasource to use the OAuth per-workspace tool."
+          : "";
+      log.error(
+        { tool: name },
+        `Plugin tool "${name}" is shadowed by a core tool with the same name — the core tool takes precedence and the plugin tool will never run.${remediation}`,
+      );
+    }
     pluginToolRegistry.freeze();
     setPluginTools(pluginToolRegistry);
   }

--- a/packages/api/src/lib/integrations/_shared/__tests__/lazy-plugin-tool.test.ts
+++ b/packages/api/src/lib/integrations/_shared/__tests__/lazy-plugin-tool.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the shared lazy-plugin-tool scaffolding (#3326).
+ *
+ * The per-tool ladders (status discriminants, remediation copy) are covered
+ * end-to-end by `email-tool.test.ts` / `linear-tool.test.ts` /
+ * `salesforce-tool.test.ts`; these tests pin the shared pieces those tools
+ * compose: the instantiate helper's `null`-vs-rethrow contract, the error
+ * classifier's mapping, and the deps-defaulting seam.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import {
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+  type LazyPluginLoader,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import type { PluginLike } from "@atlas/api/lib/plugins/registry";
+import {
+  classifyLazyInstantiateError,
+  defaultResolveRequestId,
+  defaultResolveWorkspaceId,
+  resolveLazyPluginToolDeps,
+  tryInstantiate,
+} from "../lazy-plugin-tool";
+
+const WSID = "ws-lazy-plugin-tool-test";
+const CATALOG = "catalog:test";
+
+function makeLoader(
+  outcome: PluginLike | Error,
+): Pick<LazyPluginLoader, "getOrInstantiate"> {
+  return {
+    getOrInstantiate: (async () => {
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
+    }) as LazyPluginLoader["getOrInstantiate"],
+  };
+}
+
+const fakeInstance = { id: "test:instance", types: ["action"], version: "0.0.0", name: "Test" } as unknown as PluginLike;
+
+describe("tryInstantiate", () => {
+  it("returns the instance on success", async () => {
+    const result = await tryInstantiate<PluginLike>(makeLoader(fakeInstance), WSID, CATALOG);
+    expect(result).toBe(fakeInstance);
+  });
+
+  it("returns null on LazyPluginInstallNotFoundError", async () => {
+    const loader = makeLoader(new LazyPluginInstallNotFoundError(WSID, CATALOG));
+    const result = await tryInstantiate<PluginLike>(loader, WSID, CATALOG);
+    expect(result).toBeNull();
+  });
+
+  it("rethrows every other error class for the caller's status ladder", async () => {
+    const builderMissing = new LazyPluginBuilderMissingError(CATALOG);
+    await expect(
+      tryInstantiate<PluginLike>(makeLoader(builderMissing), WSID, CATALOG),
+    ).rejects.toBe(builderMissing);
+
+    const plain = new Error("decrypt blew up");
+    await expect(
+      tryInstantiate<PluginLike>(makeLoader(plain), WSID, CATALOG),
+    ).rejects.toBe(plain);
+  });
+});
+
+describe("classifyLazyInstantiateError", () => {
+  it("maps LazyPluginInstallNotFoundError to install_not_found", () => {
+    expect(
+      classifyLazyInstantiateError(new LazyPluginInstallNotFoundError(WSID, CATALOG)),
+    ).toBe("install_not_found");
+  });
+
+  it("maps IntegrationReconnectRequiredError to reconnect_required", () => {
+    const err = new IntegrationReconnectRequiredError({
+      message: "refresh failed permanently",
+      workspaceId: WSID,
+      platform: "salesforce",
+      upstreamError: "invalid_grant",
+    });
+    expect(classifyLazyInstantiateError(err)).toBe("reconnect_required");
+  });
+
+  it("maps LazyPluginBuilderMissingError to builder_missing", () => {
+    expect(classifyLazyInstantiateError(new LazyPluginBuilderMissingError(CATALOG))).toBe(
+      "builder_missing",
+    );
+  });
+
+  it("maps everything else (tool-specific classes, plain errors, non-Errors) to unknown", () => {
+    class ToolSpecificError extends Error {}
+    expect(classifyLazyInstantiateError(new ToolSpecificError("x"))).toBe("unknown");
+    expect(classifyLazyInstantiateError(new Error("plain"))).toBe("unknown");
+    expect(classifyLazyInstantiateError("a string")).toBe("unknown");
+    expect(classifyLazyInstantiateError(undefined)).toBe("unknown");
+  });
+});
+
+describe("resolveLazyPluginToolDeps", () => {
+  it("keeps injected deps", () => {
+    const loader = makeLoader(fakeInstance);
+    const resolveWorkspaceId = () => WSID;
+    const resolveRequestId = () => "req-1";
+    const resolved = resolveLazyPluginToolDeps({ loader, resolveWorkspaceId, resolveRequestId });
+    expect(resolved.loader).toBe(loader);
+    expect(resolved.resolveWorkspaceId).toBe(resolveWorkspaceId);
+    expect(resolved.resolveRequestId).toBe(resolveRequestId);
+  });
+
+  it("falls back to the production defaults for omitted deps", () => {
+    const resolved = resolveLazyPluginToolDeps({});
+    expect(resolved.resolveWorkspaceId).toBe(defaultResolveWorkspaceId);
+    expect(resolved.resolveRequestId).toBe(defaultResolveRequestId);
+    expect(typeof resolved.loader.getOrInstantiate).toBe("function");
+  });
+
+  it("default resolvers return undefined outside a request context", () => {
+    expect(defaultResolveWorkspaceId()).toBeUndefined();
+    expect(defaultResolveRequestId()).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/integrations/_shared/lazy-plugin-tool.ts
+++ b/packages/api/src/lib/integrations/_shared/lazy-plugin-tool.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared scaffolding for per-Workspace lazy-plugin agent tools (#3326).
+ *
+ * `sendEmail` (#2698), `createLinearIssue` (#2750), and `querySalesforce`
+ * (#3311) all follow the same shape: registered globally at boot, with the
+ * workspace + install gate running at execute time through
+ * `lazyPluginLoader.getOrInstantiate(workspaceId, catalogId)`. Before this
+ * module each carried a verbatim copy of the request-context resolvers, a
+ * near-identical `*ToolDeps` test seam, and a structurally-similar
+ * error→status ladder. The next lazy-plugin tool (Jira) extends this module
+ * instead of adding a fourth copy.
+ *
+ * What stays in each tool: the agent-facing status discriminants and their
+ * remediation copy, tool-specific error classes (decrypt failures, API-key
+ * rejections), and any message scrubbing (e.g. the SOQL `SENSITIVE_PATTERNS`
+ * gate) — those are the tool's contract with the agent, not scaffolding.
+ *
+ * @see ../email-tool.ts / ../linear-tool.ts / ../salesforce-tool.ts — consumers
+ * @see ../../plugins/lazy-loader.ts — the per-Workspace caching seam
+ */
+
+import { getRequestContext } from "@atlas/api/lib/logger";
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import {
+  lazyPluginLoader,
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+  type LazyPluginLoader,
+} from "@atlas/api/lib/plugins/lazy-loader";
+
+/**
+ * Base test seam shared by every per-Workspace lazy-plugin tool. Production
+ * calls go through the singleton `lazyPluginLoader` and the request-context
+ * resolvers; tests inject fakes so the execute path runs without booting the
+ * loader. Tools with extra seams (whitelist resolution, member-email lookup)
+ * extend this interface.
+ */
+export interface LazyPluginToolDeps {
+  readonly loader?: Pick<LazyPluginLoader, "getOrInstantiate">;
+  readonly resolveWorkspaceId?: () => string | undefined;
+  readonly resolveRequestId?: () => string | undefined;
+}
+
+/** {@link LazyPluginToolDeps} with the production defaults applied. */
+export interface ResolvedLazyPluginToolDeps {
+  readonly loader: Pick<LazyPluginLoader, "getOrInstantiate">;
+  readonly resolveWorkspaceId: () => string | undefined;
+  readonly resolveRequestId: () => string | undefined;
+}
+
+/** Active workspace for the current request — the per-Workspace dispatch key. */
+export function defaultResolveWorkspaceId(): string | undefined {
+  return getRequestContext()?.user?.activeOrganizationId;
+}
+
+/** Request id for ops correlation in agent-visible error payloads. */
+export function defaultResolveRequestId(): string | undefined {
+  return getRequestContext()?.requestId;
+}
+
+/** Apply the production defaults to an injected (possibly partial) deps object. */
+export function resolveLazyPluginToolDeps(
+  deps: LazyPluginToolDeps,
+): ResolvedLazyPluginToolDeps {
+  return {
+    loader: deps.loader ?? lazyPluginLoader,
+    resolveWorkspaceId: deps.resolveWorkspaceId ?? defaultResolveWorkspaceId,
+    resolveRequestId: deps.resolveRequestId ?? defaultResolveRequestId,
+  };
+}
+
+/**
+ * Try to instantiate a lazy plugin for `(workspaceId, catalogId)`.
+ *
+ * Returns the instance on success, `null` on
+ * {@link LazyPluginInstallNotFoundError} (no enabled install row — the one
+ * "not an error" outcome, used by multi-catalog dispatch like Linear's
+ * OAuth→API-key fallback), and rethrows everything else for the caller's
+ * status ladder (see {@link classifyLazyInstantiateError}).
+ *
+ * The cast to `T` is unchecked — same contract as the loader itself, whose
+ * builders are registered per catalog id by the boot DAG.
+ */
+export async function tryInstantiate<T>(
+  loader: Pick<LazyPluginLoader, "getOrInstantiate">,
+  workspaceId: string,
+  catalogId: string,
+): Promise<T | null> {
+  try {
+    return (await loader.getOrInstantiate(workspaceId, catalogId)) as T;
+  } catch (err) {
+    if (err instanceof LazyPluginInstallNotFoundError) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * The loader-level failure classes every lazy-plugin tool maps to a status:
+ *
+ * - `install_not_found` — no enabled `workspace_plugins` row → `no_install`.
+ * - `reconnect_required` — OAuth refresh failed permanently / install marked
+ *   `reconnect_needed` → `reconnect_required`.
+ * - `builder_missing` — install row present but the boot DAG registered no
+ *   builder for the catalog id (operator-side bug) → `misconfigured`.
+ * - `unknown` — anything else (decrypt failures, malformed config, builder
+ *   construction errors); the tool maps it to its terminal `*_failure`
+ *   status after checking its own tool-specific error classes.
+ */
+export type LazyInstantiateErrorKind =
+  | "install_not_found"
+  | "reconnect_required"
+  | "builder_missing"
+  | "unknown";
+
+/**
+ * Classify a `getOrInstantiate` throw into the shared rungs of the
+ * error→status ladder. Tool-specific classes (e.g. decrypt failures) must be
+ * checked by the tool BEFORE calling this — they all classify as `unknown`.
+ */
+export function classifyLazyInstantiateError(err: unknown): LazyInstantiateErrorKind {
+  if (err instanceof LazyPluginInstallNotFoundError) return "install_not_found";
+  if (err instanceof IntegrationReconnectRequiredError) return "reconnect_required";
+  if (err instanceof LazyPluginBuilderMissingError) return "builder_missing";
+  return "unknown";
+}

--- a/packages/api/src/lib/integrations/email-tool.ts
+++ b/packages/api/src/lib/integrations/email-tool.ts
@@ -77,7 +77,7 @@ import nodemailer, {
 import { tool } from "ai";
 import { z } from "zod";
 
-import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { decryptSecretFields } from "@atlas/api/lib/plugins/secrets";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -85,13 +85,14 @@ import { getSettingAuto } from "@atlas/api/lib/settings";
 import { resolveOutboundClampRegion } from "@atlas/api/lib/email/delivery";
 import { clampOutbound } from "@atlas/api/lib/staging/clamp";
 import {
-  lazyPluginLoader,
-  LazyPluginBuilderMissingError,
-  LazyPluginInstallNotFoundError,
   type LazyPluginBuilder,
   type LazyPluginBuilderArgs,
-  type LazyPluginLoader,
 } from "@atlas/api/lib/plugins/lazy-loader";
+import {
+  classifyLazyInstantiateError,
+  resolveLazyPluginToolDeps,
+  type LazyPluginToolDeps,
+} from "./_shared/lazy-plugin-tool";
 import type { PluginLike } from "@atlas/api/lib/plugins/registry";
 import {
   EMAIL_CATALOG_ID,
@@ -431,12 +432,10 @@ export async function checkRecipientsAllowed(
  * Test seam — production calls go through the singleton
  * `lazyPluginLoader`. Tests inject a fake loader (and a fake context
  * source) so the tool's execute path can be exercised without booting
- * the loader.
+ * the loader. Base loader/context seams come from the shared
+ * lazy-plugin-tool scaffolding (#3326).
  */
-export interface SendEmailToolDeps {
-  readonly loader?: Pick<LazyPluginLoader, "getOrInstantiate">;
-  readonly resolveWorkspaceId?: () => string | undefined;
-  readonly resolveRequestId?: () => string | undefined;
+export interface SendEmailToolDeps extends LazyPluginToolDeps {
   /** Test seam for the recipient gate's member-email lookup (#3341). */
   readonly resolveMemberEmails?: (workspaceId: string) => Promise<string[]>;
 }
@@ -496,18 +495,8 @@ type SendEmailExecuteResult =
       requestId: string | undefined;
     };
 
-function defaultResolveWorkspaceId(): string | undefined {
-  return getRequestContext()?.user?.activeOrganizationId;
-}
-
-function defaultResolveRequestId(): string | undefined {
-  return getRequestContext()?.requestId;
-}
-
 export function createSendEmailTool(deps: SendEmailToolDeps = {}) {
-  const loader = deps.loader ?? lazyPluginLoader;
-  const resolveWorkspaceId = deps.resolveWorkspaceId ?? defaultResolveWorkspaceId;
-  const resolveRequestId = deps.resolveRequestId ?? defaultResolveRequestId;
+  const { loader, resolveWorkspaceId, resolveRequestId } = resolveLazyPluginToolDeps(deps);
 
   return tool({
     description:
@@ -561,17 +550,8 @@ export function createSendEmailTool(deps: SendEmailToolDeps = {}) {
         const raw = await loader.getOrInstantiate(workspaceId, EMAIL_CATALOG_ID);
         instance = raw as EmailPluginInstance;
       } catch (err) {
-        if (err instanceof LazyPluginInstallNotFoundError) {
-          log.info(
-            { workspaceId },
-            "sendEmail rejected — workspace has no Email install",
-          );
-          return {
-            status: "no_install",
-            message:
-              "Install the Email integration at /admin/integrations before sending. No workspace_plugins row is enabled for catalog:email.",
-          };
-        }
+        // Tool-specific class first — the shared classifier files it under
+        // `unknown`, which would lose the dedicated decrypt_failure status.
         if (err instanceof EmailDecryptFailureError) {
           const requestId = resolveRequestId();
           log.error(
@@ -584,39 +564,58 @@ export function createSendEmailTool(deps: SendEmailToolDeps = {}) {
             requestId,
           };
         }
-        if (err instanceof LazyPluginBuilderMissingError) {
-          // Catalog + workspace install present, but no builder. This
-          // is the boot-DAG-misconfigured failure mode — `register.ts`
-          // pairs the form handler with the builder, so the only way
-          // this fires is if `registerBuiltinInstallHandlers` itself
-          // didn't run. Distinct status so the agent stops looping and
-          // surfaces an operator-actionable error.
-          const requestId = resolveRequestId();
-          log.error(
-            { workspaceId, requestId, err: err.message },
-            "sendEmail aborted — Email lazy builder not registered (boot DAG issue)",
-          );
-          return {
-            status: "misconfigured",
-            message: `Email integration is installed but no builder is registered for catalog:email. This is a deploy-side configuration issue; contact your operator. Request id ${requestId ?? "<unset>"}.`,
-            requestId,
-          };
+        switch (classifyLazyInstantiateError(err)) {
+          case "install_not_found": {
+            log.info(
+              { workspaceId },
+              "sendEmail rejected — workspace has no Email install",
+            );
+            return {
+              status: "no_install",
+              message:
+                "Install the Email integration at /admin/integrations before sending. No workspace_plugins row is enabled for catalog:email.",
+            };
+          }
+          case "builder_missing": {
+            // Catalog + workspace install present, but no builder. This
+            // is the boot-DAG-misconfigured failure mode — `register.ts`
+            // pairs the form handler with the builder, so the only way
+            // this fires is if `registerBuiltinInstallHandlers` itself
+            // didn't run. Distinct status so the agent stops looping and
+            // surfaces an operator-actionable error.
+            const requestId = resolveRequestId();
+            log.error(
+              { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+              "sendEmail aborted — Email lazy builder not registered (boot DAG issue)",
+            );
+            return {
+              status: "misconfigured",
+              message: `Email integration is installed but no builder is registered for catalog:email. This is a deploy-side configuration issue; contact your operator. Request id ${requestId ?? "<unset>"}.`,
+              requestId,
+            };
+          }
+          // `reconnect_required` is unreachable for catalog:email (form-installed
+          // SMTP, no OAuth tokens to refresh) — folded into the generic terminal
+          // status rather than given a status the agent copy doesn't support.
+          case "reconnect_required":
+          case "unknown": {
+            // Anything else — config missing fields, builder throwing on
+            // construction. Surfaces as send_failure so the agent has
+            // something actionable. Messages are scrubbed via
+            // `errorMessage()` so a connection string embedded in an
+            // upstream error doesn't leak to the agent's tool-output.
+            const requestId = resolveRequestId();
+            log.error(
+              { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+              "sendEmail aborted — failed to instantiate Email plugin",
+            );
+            return {
+              status: "send_failure",
+              message: `Could not initialise the Email integration: ${errorMessage(err)}`,
+              requestId,
+            };
+          }
         }
-        // Anything else — config missing fields, builder throwing on
-        // construction. Surfaces as send_failure so the agent has
-        // something actionable. Messages are scrubbed via
-        // `errorMessage()` so a connection string embedded in an
-        // upstream error doesn't leak to the agent's tool-output.
-        const requestId = resolveRequestId();
-        log.error(
-          { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
-          "sendEmail aborted — failed to instantiate Email plugin",
-        );
-        return {
-          status: "send_failure",
-          message: `Could not initialise the Email integration: ${errorMessage(err)}`,
-          requestId,
-        };
       }
 
       try {

--- a/packages/api/src/lib/integrations/linear-tool.ts
+++ b/packages/api/src/lib/integrations/linear-tool.ts
@@ -56,14 +56,14 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
-  lazyPluginLoader,
-  LazyPluginBuilderMissingError,
-  LazyPluginInstallNotFoundError,
-  type LazyPluginLoader,
-} from "@atlas/api/lib/plugins/lazy-loader";
+  classifyLazyInstantiateError,
+  resolveLazyPluginToolDeps,
+  tryInstantiate,
+  type LazyPluginToolDeps,
+} from "./_shared/lazy-plugin-tool";
 import {
   LINEAR_CATALOG_ID,
   LINEAR_APIKEY_CATALOG_ID,
@@ -91,13 +91,9 @@ Use createLinearIssue to create a new Linear issue based on the agent's findings
  * Test seam — production calls go through the singleton
  * `lazyPluginLoader`. Tests inject a fake loader (and a fake context
  * source) so the tool's execute path can be exercised without booting
- * the loader.
+ * the loader. The shape is exactly the shared lazy-plugin-tool seam (#3326).
  */
-export interface CreateLinearIssueToolDeps {
-  readonly loader?: Pick<LazyPluginLoader, "getOrInstantiate">;
-  readonly resolveWorkspaceId?: () => string | undefined;
-  readonly resolveRequestId?: () => string | undefined;
-}
+export type CreateLinearIssueToolDeps = LazyPluginToolDeps;
 
 const CreateLinearIssueInput = z.object({
   title: z
@@ -160,42 +156,8 @@ type CreateLinearIssueExecuteResult =
       requestId: string | undefined;
     };
 
-function defaultResolveWorkspaceId(): string | undefined {
-  return getRequestContext()?.user?.activeOrganizationId;
-}
-
-function defaultResolveRequestId(): string | undefined {
-  return getRequestContext()?.requestId;
-}
-
-/**
- * Try to instantiate a Linear plugin for `(workspaceId, catalogId)`.
- * Returns:
- *   - `instance` on success
- *   - `null` on `LazyPluginInstallNotFoundError` (no enabled install row)
- *   - throws on every other class so the caller can branch into
- *     decrypt_failure / misconfigured / reconnect_required / create_failure
- */
-async function tryInstantiate(
-  loader: Pick<LazyPluginLoader, "getOrInstantiate">,
-  workspaceId: string,
-  catalogId: string,
-): Promise<LinearPluginInstance | null> {
-  try {
-    const raw = await loader.getOrInstantiate(workspaceId, catalogId);
-    return raw as LinearPluginInstance;
-  } catch (err) {
-    if (err instanceof LazyPluginInstallNotFoundError) {
-      return null;
-    }
-    throw err;
-  }
-}
-
 export function createCreateLinearIssueTool(deps: CreateLinearIssueToolDeps = {}) {
-  const loader = deps.loader ?? lazyPluginLoader;
-  const resolveWorkspaceId = deps.resolveWorkspaceId ?? defaultResolveWorkspaceId;
-  const resolveRequestId = deps.resolveRequestId ?? defaultResolveRequestId;
+  const { loader, resolveWorkspaceId, resolveRequestId } = resolveLazyPluginToolDeps(deps);
 
   return tool({
     description:
@@ -231,24 +193,18 @@ export function createCreateLinearIssueTool(deps: CreateLinearIssueToolDeps = {}
       let instance: LinearPluginInstance | null;
 
       try {
-        instance = await tryInstantiate(loader, workspaceId, LINEAR_CATALOG_ID);
+        instance = await tryInstantiate<LinearPluginInstance>(loader, workspaceId, LINEAR_CATALOG_ID);
         if (!instance) {
-          instance = await tryInstantiate(loader, workspaceId, LINEAR_APIKEY_CATALOG_ID);
+          instance = await tryInstantiate<LinearPluginInstance>(
+            loader,
+            workspaceId,
+            LINEAR_APIKEY_CATALOG_ID,
+          );
           if (instance) mode = "apikey";
         }
       } catch (err) {
-        if (err instanceof IntegrationReconnectRequiredError) {
-          log.warn(
-            { workspaceId, err: err.message },
-            "createLinearIssue aborted — Linear OAuth install needs Reconnect",
-          );
-          return {
-            status: "reconnect_required",
-            mode: "oauth",
-            message:
-              "Linear install needs to be reconnected. Open /admin/integrations and click Reconnect on the Linear (OAuth) card.",
-          };
-        }
+        // Tool-specific classes first — the shared classifier files them under
+        // `unknown`, which would lose their dedicated statuses.
         if (err instanceof LinearApiKeyDecryptFailureError) {
           const requestId = resolveRequestId();
           log.error(
@@ -273,28 +229,48 @@ export function createCreateLinearIssueTool(deps: CreateLinearIssueToolDeps = {}
             requestId,
           };
         }
-        if (err instanceof LazyPluginBuilderMissingError) {
-          const requestId = resolveRequestId();
-          log.error(
-            { workspaceId, requestId, err: err.message },
-            "createLinearIssue aborted — Linear lazy builder not registered (boot DAG issue)",
-          );
-          return {
-            status: "misconfigured",
-            message: `Linear integration is installed but no builder is registered. This is a deploy-side configuration issue; contact your operator. Request id ${requestId ?? "<unset>"}.`,
-            requestId,
-          };
+        switch (classifyLazyInstantiateError(err)) {
+          case "reconnect_required": {
+            log.warn(
+              { workspaceId, err: err instanceof Error ? err.message : String(err) },
+              "createLinearIssue aborted — Linear OAuth install needs Reconnect",
+            );
+            return {
+              status: "reconnect_required",
+              mode: "oauth",
+              message:
+                "Linear install needs to be reconnected. Open /admin/integrations and click Reconnect on the Linear (OAuth) card.",
+            };
+          }
+          case "builder_missing": {
+            const requestId = resolveRequestId();
+            log.error(
+              { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+              "createLinearIssue aborted — Linear lazy builder not registered (boot DAG issue)",
+            );
+            return {
+              status: "misconfigured",
+              message: `Linear integration is installed but no builder is registered. This is a deploy-side configuration issue; contact your operator. Request id ${requestId ?? "<unset>"}.`,
+              requestId,
+            };
+          }
+          // `install_not_found` is unreachable here — `tryInstantiate` maps it
+          // to `null` (the dual-catalog fallback) — so it shares the terminal
+          // branch rather than inventing a second no_install path.
+          case "install_not_found":
+          case "unknown": {
+            const requestId = resolveRequestId();
+            log.error(
+              { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+              "createLinearIssue aborted — failed to instantiate Linear plugin",
+            );
+            return {
+              status: "create_failure",
+              message: `Could not initialise the Linear integration: ${errorMessage(err)}`,
+              requestId,
+            };
+          }
         }
-        const requestId = resolveRequestId();
-        log.error(
-          { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
-          "createLinearIssue aborted — failed to instantiate Linear plugin",
-        );
-        return {
-          status: "create_failure",
-          message: `Could not initialise the Linear integration: ${errorMessage(err)}`,
-          requestId,
-        };
       }
 
       if (!instance) {

--- a/packages/api/src/lib/integrations/salesforce-tool.ts
+++ b/packages/api/src/lib/integrations/salesforce-tool.ts
@@ -53,14 +53,13 @@ import { z } from "zod";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
-  lazyPluginLoader,
-  LazyPluginBuilderMissingError,
-  LazyPluginInstallNotFoundError,
-  type LazyPluginLoader,
-} from "@atlas/api/lib/plugins/lazy-loader";
+  classifyLazyInstantiateError,
+  resolveLazyPluginToolDeps,
+  type LazyPluginToolDeps,
+} from "./_shared/lazy-plugin-tool";
+import type { SalesforcePluginInstance } from "./salesforce/lazy-builder";
 import { SALESFORCE_CATALOG_ID } from "./install/salesforce-oauth-handler";
 import { IntegrationReconnectRequiredError } from "./install/salesforce-token-refresh";
-import type { SalesforcePluginInstance } from "./salesforce/lazy-builder";
 import { validateSOQL, appendSOQLLimit, SENSITIVE_PATTERNS } from "./salesforce/soql-validation";
 
 const log = createLogger("integrations.salesforce.tool");
@@ -79,12 +78,13 @@ const QUERY_TIMEOUT = parsePositiveIntEnv(process.env.ATLAS_QUERY_TIMEOUT, 30000
  * the static plugin's `DATASOURCE_ID` so the self-host filesystem path reads the
  * same entity YAMLs.
  *
- * CAVEAT (tracked separately): the OAuth/SaaS path has no entity profiling wired
- * yet, so the org whitelist under this key is always empty → structural-only
- * (fail-OPEN to SELECT-only/no-DML, never fail-closed). When SaaS Salesforce
- * object profiling lands, the org entities will likely be keyed by the per-
- * install connection id, not this static-mode constant — so this binding must be
- * revisited then for per-object enforcement to actually apply.
+ * CAVEAT (deferred to the profiler-seam work, PRD #3303 / #3326 item 2): the
+ * OAuth/SaaS path has no entity profiling wired yet, so the org whitelist under
+ * this key is always empty → structural-only (fail-OPEN to SELECT-only/no-DML,
+ * never fail-closed). SaaS Salesforce object profiling lands with the datasource
+ * profiler seam (provisionally v0.0.14), which decides how org entities are
+ * keyed (likely the per-install connection id, not this static-mode constant) —
+ * revisit this binding there for per-object enforcement to actually apply.
  */
 const SALESFORCE_CONNECTION_ID = "salesforce-datasource";
 
@@ -99,12 +99,10 @@ Use querySalesforce to run a read-only SOQL query against the workspace's connec
 /**
  * Test seam — production calls go through the singleton `lazyPluginLoader` and
  * the request-context-derived whitelist. Tests inject fakes so the execute path
- * runs without booting the loader or the semantic layer.
+ * runs without booting the loader or the semantic layer. Base loader/context
+ * seams come from the shared lazy-plugin-tool scaffolding (#3326).
  */
-export interface QuerySalesforceToolDeps {
-  readonly loader?: Pick<LazyPluginLoader, "getOrInstantiate">;
-  readonly resolveWorkspaceId?: () => string | undefined;
-  readonly resolveRequestId?: () => string | undefined;
+export interface QuerySalesforceToolDeps extends LazyPluginToolDeps {
   /**
    * Resolve the Salesforce object whitelist. MUST throw when a semantic-layer
    * directory scan failed so the tool can fail closed (`scan_unavailable`); a
@@ -138,14 +136,6 @@ type QuerySalesforceExecuteResult =
   | { status: "misconfigured"; message: string; requestId: string | undefined }
   | { status: "query_failure"; message: string; requestId: string | undefined };
 
-function defaultResolveWorkspaceId(): string | undefined {
-  return getRequestContext()?.user?.activeOrganizationId;
-}
-
-function defaultResolveRequestId(): string | undefined {
-  return getRequestContext()?.requestId;
-}
-
 /**
  * Default whitelist resolution, mirroring `executeSQL` (tools/sql.ts): org-scoped
  * (DB-backed) when an org context exists, else filesystem-backed STRICT (throws
@@ -172,9 +162,7 @@ async function defaultResolveWhitelist(): Promise<Set<string>> {
 }
 
 export function createQuerySalesforceTool(deps: QuerySalesforceToolDeps = {}) {
-  const loader = deps.loader ?? lazyPluginLoader;
-  const resolveWorkspaceId = deps.resolveWorkspaceId ?? defaultResolveWorkspaceId;
-  const resolveRequestId = deps.resolveRequestId ?? defaultResolveRequestId;
+  const { loader, resolveWorkspaceId, resolveRequestId } = resolveLazyPluginToolDeps(deps);
   const resolveWhitelist = deps.resolveWhitelist ?? defaultResolveWhitelist;
 
   return tool({
@@ -243,64 +231,68 @@ export function createQuerySalesforceTool(deps: QuerySalesforceToolDeps = {}) {
         const raw = await loader.getOrInstantiate(workspaceId, SALESFORCE_CATALOG_ID);
         instance = raw as SalesforcePluginInstance;
       } catch (err) {
-        if (err instanceof LazyPluginInstallNotFoundError) {
-          log.info(
-            { workspaceId },
-            "querySalesforce rejected — workspace has no Salesforce OAuth install",
-          );
-          return {
-            status: "no_install",
-            message:
-              "Install the Salesforce integration at /admin/integrations before querying. No workspace_plugins row is enabled for catalog:salesforce.",
-          };
+        switch (classifyLazyInstantiateError(err)) {
+          case "install_not_found": {
+            log.info(
+              { workspaceId },
+              "querySalesforce rejected — workspace has no Salesforce OAuth install",
+            );
+            return {
+              status: "no_install",
+              message:
+                "Install the Salesforce integration at /admin/integrations before querying. No workspace_plugins row is enabled for catalog:salesforce.",
+            };
+          }
+          case "reconnect_required": {
+            log.warn(
+              { workspaceId, err: err instanceof Error ? err.message : String(err) },
+              "querySalesforce aborted — Salesforce OAuth install needs Reconnect",
+            );
+            return {
+              status: "reconnect_required",
+              message:
+                "Salesforce install needs to be reconnected. Open /admin/integrations and click Reconnect on the Salesforce card.",
+            };
+          }
+          case "builder_missing": {
+            const requestId = resolveRequestId();
+            log.error(
+              { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+              "querySalesforce aborted — Salesforce lazy builder not registered (boot DAG issue)",
+            );
+            return {
+              status: "misconfigured",
+              message: `Salesforce integration is installed but no builder is registered for catalog:salesforce. This is a deploy-side configuration issue (SALESFORCE_CLIENT_ID/SECRET likely unset); contact your operator. Request id ${requestId ?? "<unset>"}.`,
+              requestId,
+            };
+          }
+          case "unknown": {
+            // Credential decrypt failure, missing bundle / instance_url, or
+            // construction error — surfaced as query_failure so the agent stops
+            // looping. These can carry auth/credential substrings (decrypt errors,
+            // INVALID_CLIENT_ID, …), so gate on SENSITIVE_PATTERNS exactly like the
+            // query-execution branch below — `errorMessage()` only strips
+            // connection-string userinfo, not those tokens.
+            const requestId = resolveRequestId();
+            const instErr = err instanceof Error ? err.message : String(err);
+            log.error(
+              { workspaceId, requestId, err: instErr },
+              "querySalesforce aborted — failed to instantiate Salesforce plugin",
+            );
+            if (SENSITIVE_PATTERNS.test(instErr)) {
+              return {
+                status: "query_failure",
+                message: `Could not initialise the Salesforce integration — check server logs for details. Request id ${requestId ?? "<unset>"}.`,
+                requestId,
+              };
+            }
+            return {
+              status: "query_failure",
+              message: `Could not initialise the Salesforce integration: ${errorMessage(err)}`,
+              requestId,
+            };
+          }
         }
-        if (err instanceof IntegrationReconnectRequiredError) {
-          log.warn(
-            { workspaceId, err: err.message },
-            "querySalesforce aborted — Salesforce OAuth install needs Reconnect",
-          );
-          return {
-            status: "reconnect_required",
-            message:
-              "Salesforce install needs to be reconnected. Open /admin/integrations and click Reconnect on the Salesforce card.",
-          };
-        }
-        if (err instanceof LazyPluginBuilderMissingError) {
-          const requestId = resolveRequestId();
-          log.error(
-            { workspaceId, requestId, err: err.message },
-            "querySalesforce aborted — Salesforce lazy builder not registered (boot DAG issue)",
-          );
-          return {
-            status: "misconfigured",
-            message: `Salesforce integration is installed but no builder is registered for catalog:salesforce. This is a deploy-side configuration issue (SALESFORCE_CLIENT_ID/SECRET likely unset); contact your operator. Request id ${requestId ?? "<unset>"}.`,
-            requestId,
-          };
-        }
-        // Credential decrypt failure, missing bundle / instance_url, or
-        // construction error — surfaced as query_failure so the agent stops
-        // looping. These can carry auth/credential substrings (decrypt errors,
-        // INVALID_CLIENT_ID, …), so gate on SENSITIVE_PATTERNS exactly like the
-        // query-execution branch below — `errorMessage()` only strips
-        // connection-string userinfo, not those tokens.
-        const requestId = resolveRequestId();
-        const instErr = err instanceof Error ? err.message : String(err);
-        log.error(
-          { workspaceId, requestId, err: instErr },
-          "querySalesforce aborted — failed to instantiate Salesforce plugin",
-        );
-        if (SENSITIVE_PATTERNS.test(instErr)) {
-          return {
-            status: "query_failure",
-            message: `Could not initialise the Salesforce integration — check server logs for details. Request id ${requestId ?? "<unset>"}.`,
-            requestId,
-          };
-        }
-        return {
-          status: "query_failure",
-          message: `Could not initialise the Salesforce integration: ${errorMessage(err)}`,
-          requestId,
-        };
       }
 
       // ── 5. Execute the query ──

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -36,9 +36,13 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
   },
 }));
 
-const { ToolRegistry, defaultRegistry, buildRegistry } = await import(
-  "@atlas/api/lib/tools/registry"
-);
+const {
+  ToolRegistry,
+  defaultRegistry,
+  buildRegistry,
+  INTENTIONAL_TOOL_SHADOWS,
+  TOOL_SHADOW_REMEDIATIONS,
+} = await import("@atlas/api/lib/tools/registry");
 
 function makeTool(name: string) {
   return tool({
@@ -293,5 +297,27 @@ describe("buildRegistry", () => {
   it("returns empty warnings when all tools load successfully", async () => {
     const { warnings } = await buildRegistry({ includeActions: true });
     expect(warnings).toEqual([]);
+  });
+});
+
+describe("tool-shadow policy (#3326)", () => {
+  it("action-augmented base catches a plugin tool shadowed by an action tool", async () => {
+    const { registry } = await buildRegistry({ includeActions: true });
+    const plugin = new ToolRegistry();
+    plugin.register({ name: "sendEmailReport", description: "Plugin Resend action", tool: makeTool("p") });
+    plugin.register({ name: "queryWidgets", description: "No collision", tool: makeTool("q") });
+
+    // defaultRegistry alone would miss this collision — the action base sees it.
+    expect(ToolRegistry.shadowedNames(defaultRegistry, plugin)).toEqual([]);
+    expect(ToolRegistry.shadowedNames(registry, plugin)).toEqual(["sendEmailReport"]);
+  });
+
+  it("the sendEmailReport overlap is allowlisted as intentional", () => {
+    expect(INTENTIONAL_TOOL_SHADOWS.has("sendEmailReport")).toBe(true);
+  });
+
+  it("remediation copy exists for the known querySalesforce collision", () => {
+    expect(TOOL_SHADOW_REMEDIATIONS.querySalesforce).toContain("SALESFORCE_CLIENT_ID");
+    expect(TOOL_SHADOW_REMEDIATIONS.querySalesforce).toContain("salesforce://");
   });
 });

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -140,6 +140,32 @@ describe("ToolRegistry", () => {
       registry.register({ name: "b", description: "B", tool: makeTool("b") })
     ).toThrow();
   });
+
+  describe("shadowedNames", () => {
+    it("returns overlay names that collide with base (the entries merge() would shadow)", () => {
+      const base = new ToolRegistry();
+      base.register({ name: "querySalesforce", description: "OAuth", tool: makeTool("a") });
+      base.register({ name: "executeSQL", description: "SQL", tool: makeTool("b") });
+      const overlay = new ToolRegistry();
+      overlay.register({ name: "querySalesforce", description: "Static", tool: makeTool("c") });
+      overlay.register({ name: "queryElasticsearch", description: "ES", tool: makeTool("d") });
+
+      expect(ToolRegistry.shadowedNames(base, overlay)).toEqual(["querySalesforce"]);
+      // merge() must agree: the base entry wins for the shadowed name.
+      const merged = ToolRegistry.merge(base, overlay);
+      expect(merged.get("querySalesforce")!.description).toBe("OAuth");
+      expect(merged.get("queryElasticsearch")!.description).toBe("ES");
+    });
+
+    it("returns empty when there is no collision", () => {
+      const base = new ToolRegistry();
+      base.register({ name: "executeSQL", description: "SQL", tool: makeTool("a") });
+      const overlay = new ToolRegistry();
+      overlay.register({ name: "querySalesforce", description: "Static", tool: makeTool("b") });
+      expect(ToolRegistry.shadowedNames(base, overlay)).toEqual([]);
+      expect(ToolRegistry.shadowedNames(base, new ToolRegistry())).toEqual([]);
+    });
+  });
 });
 
 describe("defaultRegistry", () => {

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -76,6 +76,20 @@ export class ToolRegistry {
   }
 
   /**
+   * Names registered in BOTH `base` and `overlay`. Under {@link merge} the
+   * base entry wins, so each of these overlay entries is shadowed — it will
+   * never be invoked. Pure helper; the caller surfaces the conflict (boot-time
+   * operator warning in `api/server.ts`, #3326).
+   */
+  static shadowedNames(base: ToolRegistry, overlay: ToolRegistry): string[] {
+    const shadowed: string[] = [];
+    for (const [name] of overlay.entries()) {
+      if (base.get(name)) shadowed.push(name);
+    }
+    return shadowed;
+  }
+
+  /**
    * Create a new registry by merging one or more registries on top of a base.
    * Entries in later registries take precedence. The returned registry is
    * **unfrozen** — the caller should freeze it when ready.
@@ -211,12 +225,14 @@ defaultRegistry.register({
 // tool (`@useatlas/salesforce`, registered via the plugin context in self-host
 // static-url mode) needs a `salesforce://` url but NOT the OAuth env, so the two
 // modes don't normally coexist and this env gate keeps them apart.
-// KNOWN EDGE: if an operator sets BOTH a static url AND the OAuth env, both
-// register name `querySalesforce`; `ToolRegistry.merge(base, plugin)` gives this
-// base entry precedence, so the OAuth tool shadows the static one (and in
-// single-tenant self-host returns `no_workspace`). Tracked as a follow-up; the
-// expected deployments are mutually exclusive. Like sendEmail / createLinearIssue,
-// the workspace + install gate runs at execute time.
+// KNOWN EDGE (#3326): if an operator sets BOTH a static url AND the OAuth env,
+// both register name `querySalesforce`; `ToolRegistry.merge(base, plugin)` gives
+// this base entry precedence, so the OAuth tool shadows the static one (and in
+// single-tenant self-host returns `no_workspace` on every call). The expected
+// deployments are mutually exclusive, so the conflict is surfaced — not
+// resolved: `api/server.ts` detects it at boot via `ToolRegistry.shadowedNames`
+// and logs an operator-facing error naming the remediation. Like sendEmail /
+// createLinearIssue, the workspace + install gate runs at execute time.
 if (isSalesforceOAuthConfigured()) {
   defaultRegistry.register({
     name: "querySalesforce",

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -243,6 +243,39 @@ if (isSalesforceOAuthConfigured()) {
 
 defaultRegistry.freeze();
 
+// ---------------------------------------------------------------------------
+// Tool-name shadow policy (#3326)
+//
+// `api/server.ts` warns at boot when a plugin tool is shadowed by a core/action
+// tool of the same name (`ToolRegistry.shadowedNames`). The per-name knowledge
+// lives here, next to the registration sites, so the generic boot loop stays
+// tool-agnostic.
+// ---------------------------------------------------------------------------
+
+/**
+ * Known-INTENTIONAL overlaps — the same capability registered by two wiring
+ * paths, where the core/action entry winning the merge is by design. The boot
+ * warning skips these.
+ *
+ * - `sendEmailReport`: the operator-env action (`tools/actions/email.ts`) and
+ *   the `plugins/email` Resend plugin both register this name with
+ *   `actionType: "email:send"` — same Resend-backed report sender (see the
+ *   coexistence note in `integrations/email-tool.ts`).
+ */
+export const INTENTIONAL_TOOL_SHADOWS: ReadonlySet<string> = new Set(["sendEmailReport"]);
+
+/**
+ * Operator remediation copy for known tool-name collisions, keyed by tool
+ * name. Appended to the generic boot warning when the shadowed name matches.
+ *
+ * - `querySalesforce`: the static-url plugin tool vs the OAuth per-workspace
+ *   tool (the KNOWN EDGE above) — the deployments are mutually exclusive.
+ */
+export const TOOL_SHADOW_REMEDIATIONS: Readonly<Record<string, string>> = {
+  querySalesforce:
+    "Unset SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET to use the static-url Salesforce tool, or remove the static salesforce:// datasource to use the OAuth per-workspace tool.",
+};
+
 interface BuildRegistryResult {
   registry: ToolRegistry;
   warnings: string[];


### PR DESCRIPTION
Works #3326 (follow-ups from the OAuth Salesforce query-tool review, #3311/#3324/#3327). Items 1 and 3 are done here; item 2 is deferred — see below.

## 1. Tool-name shadow (static-url vs OAuth `querySalesforce`) — surfaced at boot

The conflict stays mutually exclusive by design, so it is **surfaced, not resolved**: renaming the shipped OAuth tool would churn a model-facing name for a configuration that shouldn't exist.

- `ToolRegistry.shadowedNames(base, overlay)` — pure helper returning overlay entries that `merge()` would shadow (`packages/api/src/lib/tools/registry.ts`).
- `api/server.ts` calls it at the plugin-tool freeze site and logs an operator-facing **error** for each shadowed plugin tool. The base mirrors what chat.ts actually merges against — the action-augmented `buildRegistry` base when `ATLAS_ACTIONS_ENABLED`, else `defaultRegistry` — so action-tool collisions are covered too (second commit, from the code-review pass).
- Per-name policy lives next to the registration sites in `tools/registry.ts`: `TOOL_SHADOW_REMEDIATIONS` (the `querySalesforce` remediation copy) and `INTENTIONAL_TOOL_SHADOWS` (`sendEmailReport` — the `tools/actions` and `plugins/email` entries are the same Resend-backed `email:send` capability, so that overlap is by design and not warned).
- The `KNOWN EDGE` comment in `registry.ts` now points at the boot-time warning instead of calling the footgun silent.

## 3. Dedupe per-Workspace lazy-plugin tool scaffolding

New `packages/api/src/lib/integrations/_shared/lazy-plugin-tool.ts` (sibling to `_shared/oauth-retry.ts`):

- `defaultResolveWorkspaceId` / `defaultResolveRequestId` + `resolveLazyPluginToolDeps` — the request-context resolvers and deps-defaulting previously copied verbatim into all three tools.
- Base `LazyPluginToolDeps` test seam — `SendEmailToolDeps` / `QuerySalesforceToolDeps` extend it with their extra seams; `CreateLinearIssueToolDeps` is a type alias.
- Generic `tryInstantiate<T>` — lifted from `linear-tool.ts` (`null` on `LazyPluginInstallNotFoundError`, rethrow otherwise), used for Linear's dual-catalog dispatch.
- `classifyLazyInstantiateError` — the shared rungs of the `getOrInstantiate` error→status ladder (`install_not_found` / `reconnect_required` / `builder_missing` / `unknown`); each tool keeps its own statuses, remediation copy, tool-specific error classes (decrypt failures, API-key rejections), and the SOQL `SENSITIVE_PATTERNS` scrub. **No agent-visible behavior changes** — the existing per-tool tests pin every ladder branch and pass unchanged.

The next lazy-plugin tool (Jira) extends this module instead of adding a fourth copy. No new plugin-sdk exports were needed, so no publish sequencing applies.

## 2. SaaS whitelist connectionId binding — deferred (intentionally)

Deferred to the datasource profiler-seam work (PRD #3303, provisionally v0.0.14): the binding can only be fixed when SaaS Salesforce object profiling exists and decides how org entities are keyed (likely the per-install connection id, not the static `salesforce-datasource` constant). Fixing the keying now would be guessing at a contract that PRD explicitly owns. The `CAVEAT` comment on `SALESFORCE_CONNECTION_ID` now points at #3303/#3326-item-2 so the seam work picks it up. Today's behavior is unchanged and safe-by-construction for the documented posture: empty whitelist → structural-only (SELECT-only/no-DML still enforced), scan failure → fail-closed.

Suggest closing #3326 with item 2 folded into the #3303 epic at kickoff, rather than auto-closing here.

## Security posture (unchanged, verified)

Fail-closed `scan_unavailable` on whitelist-resolve throw, SELECT-only structural validation, per-object membership when the whitelist is populated, auto-LIMIT, and the sensitive-substring scrub are all pinned by the existing `salesforce-tool.test.ts` cases, which pass unchanged.

## Code review

A 7-angle review (line-by-line, removed-behavior audit, cross-file trace, reuse, simplification, efficiency, altitude) was run on the first commit. The correctness angles independently verified the refactor as behavior-preserving (identical statuses/messages/log levels; the catch-ladder reorder is safe because the error-class hierarchies are disjoint). Two confirmed cleanup findings — the shadow check missing action-tool collisions, and the hardcoded `querySalesforce` remediation at the generic site — are fixed in the second commit. One PLAUSIBLE finding (a shared status-result builder on top of the classifier) was deliberately not taken: per-tool variation (different terminal statuses, Linear's `mode` field, Salesforce's `SENSITIVE_PATTERNS` gate, differing log levels) would make the abstraction as complex as the duplication it removes.

## Testing

- New: `_shared/__tests__/lazy-plugin-tool.test.ts` (classifier mapping, `tryInstantiate` contract, deps defaulting) and `shadowedNames` + tool-shadow policy cases in `registry.test.ts` (including merge-agreement and the action-base collision).
- `bun run scripts/test-isolated.ts --affected` — 64/64 files pass on both commits.
- `/ci` — lint, type, full test suite (api 570, web 198, cli 30, mcp 18, ee 27 + plugin packages), syncpack, template/security-headers/railway-watch/schema/oauth-helper/test-discipline/twenty-resolver drift checks, published symbols: all pass. Remote CI on `main` green (Railway commit statuses not reachable from this environment's tooling).

https://claude.ai/code/session_0126tme1ny5En2Fs3KTqyR2D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup validation now detects plugin tools that are shadowed by core/action tools and logs operator-facing errors with remediation guidance; added intentional-shadow allowlist and remediation text.

* **Bug Fixes**
  * Unified error classification for lazy plugin instantiation across email, Linear, and Salesforce integrations to produce consistent agent-visible statuses and messages.

* **Tests**
  * Added test coverage for lazy plugin instantiation behavior, error classification, and tool-registry shadowing detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->