### PR TITLE
fix(web): blur-time clamp for numeric retention inputs (#3361)

### DIFF
--- a/packages/web/src/app/admin/audit/__tests__/numeric-clamp.test.ts
+++ b/packages/web/src/app/admin/audit/__tests__/numeric-clamp.test.ts
@@ -4,6 +4,7 @@ import {
   isIntInRange,
   RETENTION_CUSTOM_DAYS_MIN,
   RETENTION_HARD_DELETE_DELAY_MIN,
+  RETENTION_INPUT_MAX,
 } from "../numeric-clamp";
 
 describe("isIntInRange", () => {
@@ -32,6 +33,17 @@ describe("isIntInRange", () => {
     expect(isIntInRange("400", 1, 365)).toBe(false);
     expect(isIntInRange("365", 1, 365)).toBe(true);
   });
+
+  test("rejects pasted huge values above the integer cap", () => {
+    // Number("999…9" × 24) is 1e+24 — still an integer per Number.isInteger,
+    // so without the cap it sails through here and dies at the DB column.
+    expect(isIntInRange("999999999999999999999999", 7, RETENTION_INPUT_MAX)).toBe(
+      false,
+    );
+    expect(isIntInRange(String(RETENTION_INPUT_MAX), 7, RETENTION_INPUT_MAX)).toBe(
+      true,
+    );
+  });
 });
 
 describe("clampIntInput", () => {
@@ -58,6 +70,12 @@ describe("clampIntInput", () => {
 
   test("clamps above an optional maximum", () => {
     expect(clampIntInput("400", 1, 365)).toBe("365");
+  });
+
+  test("clamps pasted huge values to the integer cap, never scientific notation", () => {
+    expect(clampIntInput("999999999999999999999999", 7, RETENTION_INPUT_MAX)).toBe(
+      String(RETENTION_INPUT_MAX),
+    );
   });
 });
 

--- a/packages/web/src/app/admin/audit/__tests__/numeric-clamp.test.ts
+++ b/packages/web/src/app/admin/audit/__tests__/numeric-clamp.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clampIntInput,
+  isIntInRange,
+  RETENTION_CUSTOM_DAYS_MIN,
+  RETENTION_HARD_DELETE_DELAY_MIN,
+} from "../numeric-clamp";
+
+describe("isIntInRange", () => {
+  test("accepts integers at or above the minimum", () => {
+    expect(isIntInRange("7", 7)).toBe(true);
+    expect(isIntInRange("30", 7)).toBe(true);
+    expect(isIntInRange("0", 0)).toBe(true);
+  });
+
+  test("rejects integers below the minimum", () => {
+    expect(isIntInRange("3", 7)).toBe(false);
+    expect(isIntInRange("-5", 0)).toBe(false);
+  });
+
+  test("rejects empty / whitespace input — Number('') is 0, which must not pass", () => {
+    expect(isIntInRange("", 0)).toBe(false);
+    expect(isIntInRange("   ", 0)).toBe(false);
+  });
+
+  test("rejects non-numeric and non-integer input", () => {
+    expect(isIntInRange("abc", 0)).toBe(false);
+    expect(isIntInRange("7.5", 7)).toBe(false);
+  });
+
+  test("honors an optional maximum", () => {
+    expect(isIntInRange("400", 1, 365)).toBe(false);
+    expect(isIntInRange("365", 1, 365)).toBe(true);
+  });
+});
+
+describe("clampIntInput", () => {
+  test("clamps below-minimum values up to the minimum", () => {
+    expect(clampIntInput("3", 7)).toBe("7");
+    expect(clampIntInput("-5", 0)).toBe("0");
+  });
+
+  test("passes in-range values through, normalized", () => {
+    expect(clampIntInput("30", 7)).toBe("30");
+    expect(clampIntInput(" 30 ", 7)).toBe("30");
+  });
+
+  test("falls back to the minimum on empty or unparseable input", () => {
+    expect(clampIntInput("", 7)).toBe("7");
+    expect(clampIntInput("abc", 0)).toBe("0");
+  });
+
+  test("rounds fractional input to the nearest integer before clamping", () => {
+    expect(clampIntInput("7.4", 7)).toBe("7");
+    expect(clampIntInput("8.6", 7)).toBe("9");
+    expect(clampIntInput("6.9", 7)).toBe("7");
+  });
+
+  test("clamps above an optional maximum", () => {
+    expect(clampIntInput("400", 1, 365)).toBe("365");
+  });
+});
+
+describe("documented retention minimums", () => {
+  test("match the server contract (customDays ≥ 7, hardDeleteDelay ≥ 0)", () => {
+    expect(RETENTION_CUSTOM_DAYS_MIN).toBe(7);
+    expect(RETENTION_HARD_DELETE_DELAY_MIN).toBe(0);
+  });
+});

--- a/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
@@ -147,8 +147,29 @@ describe.each(panels)("$name numeric clamp", ({ Component, customDaysLabel, dela
 
     fireEvent.change(customDays, { target: { value: "3" } });
     expect(save.disabled).toBe(true);
+    // The "clearly errored" half of the contract: the field is marked
+    // invalid and the inline hint is visible, not just the Save gate.
+    expect(customDays.getAttribute("aria-invalid")).toBe("true");
+    expect(
+      screen.getByText("Enter a whole number of at least 7 days."),
+    ).toBeTruthy();
 
     fireEvent.change(customDays, { target: { value: "30" } });
+    expect(save.disabled).toBe(false);
+    expect(customDays.getAttribute("aria-invalid")).toBeNull();
+    expect(
+      screen.queryByText("Enter a whole number of at least 7 days."),
+    ).toBeNull();
+  });
+
+  test("a pasted huge value gates save, then blur clamps it to the integer cap", async () => {
+    const { customDays, save } = await renderPanel();
+
+    fireEvent.change(customDays, { target: { value: "999999999999999999999999" } });
+    expect(save.disabled).toBe(true);
+
+    fireEvent.blur(customDays);
+    expect(customDays.value).toBe("2147483647");
     expect(save.disabled).toBe(false);
   });
 

--- a/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
@@ -1,0 +1,200 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { createElement, type ComponentType, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+import { RetentionPanel } from "../retention-panel";
+import { AdminActionRetentionPanel } from "../admin-action-retention-panel";
+
+/* ------------------------------------------------------------------ */
+/*  Setup (mirrors use-config-form.test.ts)                             */
+/* ------------------------------------------------------------------ */
+
+const stubAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * GETs serve a policy whose retentionDays maps to the "custom" preset in
+ * BOTH panels (45 is not a preset in either), so the custom-days input
+ * renders. Writes are recorded and answered 200.
+ */
+let recordedWrites: { url: string; method: string; body: unknown }[];
+
+function installRouteMock() {
+  recordedWrites = [];
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (method === "GET") {
+      return new Response(
+        JSON.stringify({
+          policy: {
+            orgId: "org-1",
+            retentionDays: 45,
+            hardDeleteDelayDays: 30,
+            updatedAt: "2026-06-01T00:00:00Z",
+            updatedBy: null,
+            lastPurgeAt: null,
+            lastPurgeCount: null,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    recordedWrites.push({
+      url,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Both panels must behave identically (issue #3361 AC 4)              */
+/* ------------------------------------------------------------------ */
+
+interface PanelCase {
+  name: string;
+  Component: ComponentType;
+  customDaysLabel: string;
+  delayLabel: string;
+}
+
+const panels: PanelCase[] = [
+  {
+    name: "RetentionPanel",
+    Component: RetentionPanel,
+    customDaysLabel: "Custom days (min 7)",
+    delayLabel: "Hard delete delay (days)",
+  },
+  {
+    name: "AdminActionRetentionPanel",
+    Component: AdminActionRetentionPanel,
+    customDaysLabel: "Custom days (min 7)",
+    delayLabel: "Hard delete delay (days)",
+  },
+];
+
+describe.each(panels)("$name numeric clamp", ({ Component, customDaysLabel, delayLabel }) => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    installRouteMock();
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  async function renderPanel() {
+    render(createElement(Component), { wrapper });
+    const customDays = (await screen.findByLabelText(customDaysLabel)) as HTMLInputElement;
+    const delay = screen.getByLabelText(delayLabel) as HTMLInputElement;
+    const save = screen.getByRole("button", { name: "Save Policy" }) as HTMLButtonElement;
+    return { customDays, delay, save };
+  }
+
+  test("intermediate out-of-range typing is not blocked", async () => {
+    const { customDays } = await renderPanel();
+
+    // "3" en route to "30" — must land in the input, not be swallowed.
+    fireEvent.change(customDays, { target: { value: "3" } });
+    expect(customDays.value).toBe("3");
+
+    fireEvent.change(customDays, { target: { value: "30" } });
+    expect(customDays.value).toBe("30");
+  });
+
+  test("save is disabled while customDays is below the minimum, re-enabled when valid", async () => {
+    const { customDays, save } = await renderPanel();
+    expect(save.disabled).toBe(false);
+
+    fireEvent.change(customDays, { target: { value: "3" } });
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(customDays, { target: { value: "30" } });
+    expect(save.disabled).toBe(false);
+  });
+
+  test("blur clamps customDays up to the documented minimum of 7", async () => {
+    const { customDays, save } = await renderPanel();
+
+    fireEvent.change(customDays, { target: { value: "3" } });
+    fireEvent.blur(customDays);
+
+    expect(customDays.value).toBe("7");
+    expect(save.disabled).toBe(false);
+  });
+
+  test("blur clamps an emptied customDays field back to the minimum", async () => {
+    const { customDays } = await renderPanel();
+
+    fireEvent.change(customDays, { target: { value: "" } });
+    expect(customDays.value).toBe(""); // clearing is allowed while focused
+    fireEvent.blur(customDays);
+
+    expect(customDays.value).toBe("7");
+  });
+
+  test("blur clamps hardDeleteDelay up to its minimum of 0", async () => {
+    const { delay, save } = await renderPanel();
+
+    fireEvent.change(delay, { target: { value: "-5" } });
+    expect(save.disabled).toBe(true);
+    fireEvent.blur(delay);
+
+    expect(delay.value).toBe("0");
+    expect(save.disabled).toBe(false);
+  });
+
+  test("in-range values survive blur unchanged and save sends numbers", async () => {
+    const { customDays, save } = await renderPanel();
+
+    fireEvent.change(customDays, { target: { value: "60" } });
+    fireEvent.blur(customDays);
+    expect(customDays.value).toBe("60");
+
+    fireEvent.click(save);
+    await waitFor(() => expect(recordedWrites).toHaveLength(1));
+    expect(recordedWrites[0]!.body).toEqual({
+      retentionDays: 60,
+      hardDeleteDelayDays: 30,
+    });
+  });
+});

--- a/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
@@ -5,6 +5,12 @@ import type { AuditRetentionPolicy } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { useConfigForm } from "@/ui/hooks/use-config-form";
+import {
+  clampIntInput,
+  isIntInRange,
+  RETENTION_CUSTOM_DAYS_MIN,
+  RETENTION_HARD_DELETE_DELAY_MIN,
+} from "./numeric-clamp";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -102,10 +108,26 @@ interface PolicyResponse {
   policy: AuditRetentionPolicy | null;
 }
 
+// Numeric fields are strings so intermediate values ("3" en route to "30",
+// or an emptied field) can exist while focused; blur clamps them and Save
+// is gated on `isIntInRange` (#3361). Mirrors retention-panel.tsx exactly.
 interface AdminActionRetentionFormValues extends Record<string, unknown> {
   preset: RetentionPreset;
-  customDays: number;
-  hardDeleteDelay: number;
+  customDays: string;
+  hardDeleteDelay: string;
+}
+
+/** Per-field range checks — drive the Save gate and the inline hints. */
+function numericFieldErrors(v: AdminActionRetentionFormValues) {
+  return {
+    customDays:
+      v.preset === "custom" &&
+      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN),
+    hardDeleteDelay: !isIntInRange(
+      v.hardDeleteDelay,
+      RETENTION_HARD_DELETE_DELAY_MIN,
+    ),
+  };
 }
 
 // ── Component ─────────────────────────────────────────────────────
@@ -125,21 +147,21 @@ export function AdminActionRetentionPanel() {
     saveMethod: "PUT",
     toForm: (d) => {
       if (!d.policy) {
-        return { preset: "2555", customDays: 2555, hardDeleteDelay: 30 };
+        return { preset: "2555", customDays: "2555", hardDeleteDelay: "30" };
       }
       const pr = presetFromDays(d.policy.retentionDays);
       return {
         preset: pr,
         customDays:
           pr === "custom" && d.policy.retentionDays !== null
-            ? d.policy.retentionDays
-            : 2555,
-        hardDeleteDelay: d.policy.hardDeleteDelayDays,
+            ? String(d.policy.retentionDays)
+            : "2555",
+        hardDeleteDelay: String(d.policy.hardDeleteDelayDays),
       };
     },
     toPayload: (v) => ({
-      retentionDays: daysFromPreset(v.preset, v.customDays),
-      hardDeleteDelayDays: v.hardDeleteDelay,
+      retentionDays: daysFromPreset(v.preset, Number(v.customDays)),
+      hardDeleteDelayDays: Number(v.hardDeleteDelay),
     }),
   });
 
@@ -180,6 +202,13 @@ export function AdminActionRetentionPanel() {
 
   async function handleSave() {
     setSaveSuccess(false);
+    // Defense-in-depth: the Save button is disabled while a numeric field
+    // is out of range, but guard direct calls too so an out-of-range draft
+    // can never reach the server as a 400.
+    if (form.values) {
+      const errs = numericFieldErrors(form.values);
+      if (errs.customDays || errs.hardDeleteDelay) return;
+    }
     const result = await form.save();
     if (result.ok) {
       // Banner auto-clears via the unmount-safe effect above.
@@ -277,6 +306,14 @@ export function AdminActionRetentionPanel() {
   }
   const { fields } = form;
 
+  // Out-of-range numeric drafts gate Save; blur clamps them back in range.
+  const fieldErrors = numericFieldErrors({
+    preset: fields.preset.value,
+    customDays: fields.customDays.value,
+    hardDeleteDelay: fields.hardDeleteDelay.value,
+  });
+  const numericFieldsInvalid = fieldErrors.customDays || fieldErrors.hardDeleteDelay;
+
   return (
     <div className="space-y-6">
       {/* Status cards */}
@@ -358,19 +395,22 @@ export function AdminActionRetentionPanel() {
                 <Input
                   id="admin-action-custom-days"
                   type="number"
-                  min={7}
+                  min={RETENTION_CUSTOM_DAYS_MIN}
                   value={fields.customDays.value}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === "") return;
-                    const n = Number.parseInt(v, 10);
-                    if (Number.isFinite(n) && n >= 7) fields.customDays.set(n);
-                  }}
+                  onChange={(e) => fields.customDays.set(e.target.value)}
+                  onBlur={(e) =>
+                    fields.customDays.set(
+                      clampIntInput(e.target.value, RETENTION_CUSTOM_DAYS_MIN),
+                    )
+                  }
+                  aria-invalid={fieldErrors.customDays || undefined}
                   className="w-full"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Server rejects values below 7 days. Type a valid integer.
-                </p>
+                {fieldErrors.customDays && (
+                  <p className="text-xs text-destructive">
+                    Enter a whole number of at least 7 days.
+                  </p>
+                )}
               </div>
             )}
 
@@ -379,16 +419,22 @@ export function AdminActionRetentionPanel() {
               <Input
                 id="admin-action-hard-delete-delay"
                 type="number"
-                min={0}
+                min={RETENTION_HARD_DELETE_DELAY_MIN}
                 value={fields.hardDeleteDelay.value}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  if (v === "") return;
-                  const n = Number.parseInt(v, 10);
-                  if (Number.isFinite(n) && n >= 0) fields.hardDeleteDelay.set(n);
-                }}
+                onChange={(e) => fields.hardDeleteDelay.set(e.target.value)}
+                onBlur={(e) =>
+                  fields.hardDeleteDelay.set(
+                    clampIntInput(e.target.value, RETENTION_HARD_DELETE_DELAY_MIN),
+                  )
+                }
+                aria-invalid={fieldErrors.hardDeleteDelay || undefined}
                 className="w-full"
               />
+              {fieldErrors.hardDeleteDelay && (
+                <p className="text-xs text-destructive">
+                  Enter a whole number of days (0 or more).
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">
                 Reserved for future parity with audit-log retention. Default 30.
               </p>
@@ -405,7 +451,7 @@ export function AdminActionRetentionPanel() {
           )}
 
           <div className="flex items-center gap-3">
-            <Button onClick={handleSave} disabled={form.saving}>
+            <Button onClick={handleSave} disabled={form.saving || numericFieldsInvalid}>
               {form.saving ? "Saving..." : "Save Policy"}
             </Button>
             <AlertDialog>

--- a/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/admin-action-retention-panel.tsx
@@ -10,6 +10,7 @@ import {
   isIntInRange,
   RETENTION_CUSTOM_DAYS_MIN,
   RETENTION_HARD_DELETE_DELAY_MIN,
+  RETENTION_INPUT_MAX,
 } from "./numeric-clamp";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
@@ -122,10 +123,11 @@ function numericFieldErrors(v: AdminActionRetentionFormValues) {
   return {
     customDays:
       v.preset === "custom" &&
-      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN),
+      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN, RETENTION_INPUT_MAX),
     hardDeleteDelay: !isIntInRange(
       v.hardDeleteDelay,
       RETENTION_HARD_DELETE_DELAY_MIN,
+      RETENTION_INPUT_MAX,
     ),
   };
 }
@@ -301,17 +303,15 @@ export function AdminActionRetentionPanel() {
     );
   }
 
-  if (!form.fields) {
+  if (!form.fields || !form.values) {
     return <LoadingState message="Loading admin-action retention settings..." />;
   }
-  const { fields } = form;
+  const { fields, values } = form;
 
   // Out-of-range numeric drafts gate Save; blur clamps them back in range.
-  const fieldErrors = numericFieldErrors({
-    preset: fields.preset.value,
-    customDays: fields.customDays.value,
-    hardDeleteDelay: fields.hardDeleteDelay.value,
-  });
+  // `values` IS the field set — don't rebuild it from `fields`, or a field
+  // added to `numericFieldErrors` silently goes unchecked here.
+  const fieldErrors = numericFieldErrors(values);
   const numericFieldsInvalid = fieldErrors.customDays || fieldErrors.hardDeleteDelay;
 
   return (
@@ -400,7 +400,11 @@ export function AdminActionRetentionPanel() {
                   onChange={(e) => fields.customDays.set(e.target.value)}
                   onBlur={(e) =>
                     fields.customDays.set(
-                      clampIntInput(e.target.value, RETENTION_CUSTOM_DAYS_MIN),
+                      clampIntInput(
+                        e.target.value,
+                        RETENTION_CUSTOM_DAYS_MIN,
+                        RETENTION_INPUT_MAX,
+                      ),
                     )
                   }
                   aria-invalid={fieldErrors.customDays || undefined}
@@ -424,7 +428,11 @@ export function AdminActionRetentionPanel() {
                 onChange={(e) => fields.hardDeleteDelay.set(e.target.value)}
                 onBlur={(e) =>
                   fields.hardDeleteDelay.set(
-                    clampIntInput(e.target.value, RETENTION_HARD_DELETE_DELAY_MIN),
+                    clampIntInput(
+                      e.target.value,
+                      RETENTION_HARD_DELETE_DELAY_MIN,
+                      RETENTION_INPUT_MAX,
+                    ),
                   )
                 }
                 aria-invalid={fieldErrors.hardDeleteDelay || undefined}

--- a/packages/web/src/app/admin/audit/numeric-clamp.ts
+++ b/packages/web/src/app/admin/audit/numeric-clamp.ts
@@ -12,10 +12,25 @@
  * concern, not form-state bookkeeping.
  */
 
-/** Server contract: `retentionDays` must be an integer ≥ 7 when set. */
+/**
+ * Server contract: `retentionDays` must be an integer ≥ 7 when set.
+ * Mirrors `MIN_RETENTION_DAYS` in `ee/src/audit/retention.ts` — the
+ * frontend can't import `@atlas/ee`, so keep the two in sync by hand.
+ */
 export const RETENTION_CUSTOM_DAYS_MIN = 7;
-/** Server contract: `hardDeleteDelayDays` must be an integer ≥ 0. */
+/**
+ * Server contract: `hardDeleteDelayDays` must be an integer ≥ 0.
+ * Mirrors the `hardDeleteDelay < 0` check in `ee/src/audit/retention.ts`.
+ */
 export const RETENTION_HARD_DELETE_DELAY_MIN = 0;
+/**
+ * Upper bound for both fields: the Postgres `integer` column cap. Without
+ * it, a pasted huge value "clamps" to scientific notation (`1e+24`), passes
+ * the integer checks here *and* server-side, and dies at the DB as an
+ * opaque error. Server validation has no explicit max, so the column type
+ * is the real contract.
+ */
+export const RETENTION_INPUT_MAX = 2_147_483_647;
 
 /**
  * Parse a numeric-input string. Returns null for empty/whitespace or

--- a/packages/web/src/app/admin/audit/numeric-clamp.ts
+++ b/packages/web/src/app/admin/audit/numeric-clamp.ts
@@ -1,0 +1,54 @@
+/**
+ * Blur-time clamp helpers for the numeric retention inputs (#3361).
+ *
+ * The two retention panels keep their numeric fields as *strings* in form
+ * state so any intermediate value can exist while the field is focused
+ * (you can't type "30" if "3" is coerced away). On blur the value clamps
+ * to the documented range; while it's out of range, Save is disabled.
+ *
+ * Deliberately local to the audit panels rather than generalized into
+ * `useConfigForm`: the hook's contract excludes per-field validation
+ * ("pages derive those from values"), and min/max is an input-event
+ * concern, not form-state bookkeeping.
+ */
+
+/** Server contract: `retentionDays` must be an integer ≥ 7 when set. */
+export const RETENTION_CUSTOM_DAYS_MIN = 7;
+/** Server contract: `hardDeleteDelayDays` must be an integer ≥ 0. */
+export const RETENTION_HARD_DELETE_DELAY_MIN = 0;
+
+/**
+ * Parse a numeric-input string. Returns null for empty/whitespace or
+ * unparseable input — notably, `Number("")` is `0`, which must NOT count
+ * as a valid zero.
+ */
+function parseNumericInput(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * True when `raw` parses to an integer within `[min, max]`. Drives the
+ * Save gate: a focused field holding an intermediate out-of-range value
+ * disables Save until blur clamps it (or the user finishes typing).
+ */
+export function isIntInRange(raw: string, min: number, max?: number): boolean {
+  const n = parseNumericInput(raw);
+  return (
+    n !== null && Number.isInteger(n) && n >= min && (max === undefined || n <= max)
+  );
+}
+
+/**
+ * Blur handler: normalize `raw` to the nearest valid integer string in
+ * `[min, max]`. Empty or unparseable input falls back to `min`.
+ */
+export function clampIntInput(raw: string, min: number, max?: number): string {
+  const n = parseNumericInput(raw);
+  if (n === null) return String(min);
+  const rounded = Math.round(n);
+  const clamped = Math.min(max ?? Number.POSITIVE_INFINITY, Math.max(min, rounded));
+  return String(clamped);
+}

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -5,6 +5,12 @@ import type { AuditRetentionPolicy } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { useConfigForm } from "@/ui/hooks/use-config-form";
+import {
+  clampIntInput,
+  isIntInRange,
+  RETENTION_CUSTOM_DAYS_MIN,
+  RETENTION_HARD_DELETE_DELAY_MIN,
+} from "./numeric-clamp";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
 import { DatePicker } from "@/components/ui/date-picker";
@@ -74,10 +80,26 @@ interface PolicyResponse {
   policy: RetentionPolicy | null;
 }
 
+// Numeric fields are strings so intermediate values ("3" en route to "30",
+// or an emptied field) can exist while focused; blur clamps them and Save
+// is gated on `isIntInRange` (#3361).
 interface RetentionFormValues extends Record<string, unknown> {
   preset: RetentionPreset;
-  customDays: number;
-  hardDeleteDelay: number;
+  customDays: string;
+  hardDeleteDelay: string;
+}
+
+/** Per-field range checks — drive the Save gate and the inline hints. */
+function numericFieldErrors(v: RetentionFormValues) {
+  return {
+    customDays:
+      v.preset === "custom" &&
+      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN),
+    hardDeleteDelay: !isIntInRange(
+      v.hardDeleteDelay,
+      RETENTION_HARD_DELETE_DELAY_MIN,
+    ),
+  };
 }
 
 // ── Component ─────────────────────────────────────────────────────
@@ -97,21 +119,21 @@ export function RetentionPanel() {
     saveMethod: "PUT",
     toForm: (d) => {
       if (!d.policy) {
-        return { preset: "unlimited", customDays: 90, hardDeleteDelay: 30 };
+        return { preset: "unlimited", customDays: "90", hardDeleteDelay: "30" };
       }
       const pr = presetFromDays(d.policy.retentionDays);
       return {
         preset: pr,
         customDays:
           pr === "custom" && d.policy.retentionDays !== null
-            ? d.policy.retentionDays
-            : 90,
-        hardDeleteDelay: d.policy.hardDeleteDelayDays,
+            ? String(d.policy.retentionDays)
+            : "90",
+        hardDeleteDelay: String(d.policy.hardDeleteDelayDays),
       };
     },
     toPayload: (v) => ({
-      retentionDays: daysFromPreset(v.preset, v.customDays),
-      hardDeleteDelayDays: v.hardDeleteDelay,
+      retentionDays: daysFromPreset(v.preset, Number(v.customDays)),
+      hardDeleteDelayDays: Number(v.hardDeleteDelay),
     }),
   });
 
@@ -135,6 +157,13 @@ export function RetentionPanel() {
 
   async function handleSave() {
     setSaveSuccess(false);
+    // Defense-in-depth: the Save button is disabled while a numeric field
+    // is out of range, but guard direct calls too so an out-of-range draft
+    // can never reach the server as a 400.
+    if (form.values) {
+      const errs = numericFieldErrors(form.values);
+      if (errs.customDays || errs.hardDeleteDelay) return;
+    }
     const result = await form.save();
     if (result.ok) {
       setSaveSuccess(true);
@@ -210,6 +239,14 @@ export function RetentionPanel() {
   }
   const { fields } = form;
 
+  // Out-of-range numeric drafts gate Save; blur clamps them back in range.
+  const fieldErrors = numericFieldErrors({
+    preset: fields.preset.value,
+    customDays: fields.customDays.value,
+    hardDeleteDelay: fields.hardDeleteDelay.value,
+  });
+  const numericFieldsInvalid = fieldErrors.customDays || fieldErrors.hardDeleteDelay;
+
   return (
     <div className="space-y-6">
       {/* Status cards */}
@@ -275,11 +312,22 @@ export function RetentionPanel() {
                 <Input
                   id="custom-days"
                   type="number"
-                  min={7}
+                  min={RETENTION_CUSTOM_DAYS_MIN}
                   value={fields.customDays.value}
-                  onChange={(e) => fields.customDays.set(parseInt(e.target.value, 10) || 7)}
+                  onChange={(e) => fields.customDays.set(e.target.value)}
+                  onBlur={(e) =>
+                    fields.customDays.set(
+                      clampIntInput(e.target.value, RETENTION_CUSTOM_DAYS_MIN),
+                    )
+                  }
+                  aria-invalid={fieldErrors.customDays || undefined}
                   className="w-full"
                 />
+                {fieldErrors.customDays && (
+                  <p className="text-xs text-destructive">
+                    Enter a whole number of at least 7 days.
+                  </p>
+                )}
               </div>
             )}
 
@@ -288,11 +336,22 @@ export function RetentionPanel() {
               <Input
                 id="hard-delete-delay"
                 type="number"
-                min={0}
+                min={RETENTION_HARD_DELETE_DELAY_MIN}
                 value={fields.hardDeleteDelay.value}
-                onChange={(e) => fields.hardDeleteDelay.set(parseInt(e.target.value, 10) || 0)}
+                onChange={(e) => fields.hardDeleteDelay.set(e.target.value)}
+                onBlur={(e) =>
+                  fields.hardDeleteDelay.set(
+                    clampIntInput(e.target.value, RETENTION_HARD_DELETE_DELAY_MIN),
+                  )
+                }
+                aria-invalid={fieldErrors.hardDeleteDelay || undefined}
                 className="w-full"
               />
+              {fieldErrors.hardDeleteDelay && (
+                <p className="text-xs text-destructive">
+                  Enter a whole number of days (0 or more).
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">
                 Days after soft-delete before permanent removal. Default 30.
               </p>
@@ -309,7 +368,7 @@ export function RetentionPanel() {
           )}
 
           <div className="flex items-center gap-3">
-            <Button onClick={handleSave} disabled={form.saving}>
+            <Button onClick={handleSave} disabled={form.saving || numericFieldsInvalid}>
               {form.saving ? "Saving..." : "Save Policy"}
             </Button>
             <AlertDialog>

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { AuditRetentionPolicy } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -10,6 +10,7 @@ import {
   isIntInRange,
   RETENTION_CUSTOM_DAYS_MIN,
   RETENTION_HARD_DELETE_DELAY_MIN,
+  RETENTION_INPUT_MAX,
 } from "./numeric-clamp";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
@@ -94,10 +95,11 @@ function numericFieldErrors(v: RetentionFormValues) {
   return {
     customDays:
       v.preset === "custom" &&
-      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN),
+      !isIntInRange(v.customDays, RETENTION_CUSTOM_DAYS_MIN, RETENTION_INPUT_MAX),
     hardDeleteDelay: !isIntInRange(
       v.hardDeleteDelay,
       RETENTION_HARD_DELETE_DELAY_MIN,
+      RETENTION_INPUT_MAX,
     ),
   };
 }
@@ -155,6 +157,14 @@ export function RetentionPanel() {
       method: "POST",
     });
 
+  // Clear the transient save-success banner on unmount so a state update
+  // doesn't land on a disposed component if the user navigates away mid-flash.
+  useEffect(() => {
+    if (!saveSuccess) return;
+    const handle = setTimeout(() => setSaveSuccess(false), 3000);
+    return () => clearTimeout(handle);
+  }, [saveSuccess]);
+
   async function handleSave() {
     setSaveSuccess(false);
     // Defense-in-depth: the Save button is disabled while a numeric field
@@ -166,8 +176,8 @@ export function RetentionPanel() {
     }
     const result = await form.save();
     if (result.ok) {
+      // Banner auto-clears via the unmount-safe effect above.
       setSaveSuccess(true);
-      setTimeout(() => setSaveSuccess(false), 3000);
     }
   }
 
@@ -234,17 +244,15 @@ export function RetentionPanel() {
     );
   }
 
-  if (!form.fields) {
+  if (!form.fields || !form.values) {
     return <LoadingState message="Loading retention settings..." />;
   }
-  const { fields } = form;
+  const { fields, values } = form;
 
   // Out-of-range numeric drafts gate Save; blur clamps them back in range.
-  const fieldErrors = numericFieldErrors({
-    preset: fields.preset.value,
-    customDays: fields.customDays.value,
-    hardDeleteDelay: fields.hardDeleteDelay.value,
-  });
+  // `values` IS the field set — don't rebuild it from `fields`, or a field
+  // added to `numericFieldErrors` silently goes unchecked here.
+  const fieldErrors = numericFieldErrors(values);
   const numericFieldsInvalid = fieldErrors.customDays || fieldErrors.hardDeleteDelay;
 
   return (
@@ -317,7 +325,11 @@ export function RetentionPanel() {
                   onChange={(e) => fields.customDays.set(e.target.value)}
                   onBlur={(e) =>
                     fields.customDays.set(
-                      clampIntInput(e.target.value, RETENTION_CUSTOM_DAYS_MIN),
+                      clampIntInput(
+                        e.target.value,
+                        RETENTION_CUSTOM_DAYS_MIN,
+                        RETENTION_INPUT_MAX,
+                      ),
                     )
                   }
                   aria-invalid={fieldErrors.customDays || undefined}
@@ -341,7 +353,11 @@ export function RetentionPanel() {
                 onChange={(e) => fields.hardDeleteDelay.set(e.target.value)}
                 onBlur={(e) =>
                   fields.hardDeleteDelay.set(
-                    clampIntInput(e.target.value, RETENTION_HARD_DELETE_DELAY_MIN),
+                    clampIntInput(
+                      e.target.value,
+                      RETENTION_HARD_DELETE_DELAY_MIN,
+                      RETENTION_INPUT_MAX,
+                    ),
                   )
                 }
                 aria-invalid={fieldErrors.hardDeleteDelay || undefined}


### PR DESCRIPTION
Closes #3361

## What

The numeric retention inputs coerced values during `onChange` (`parseInt || fallback` in one panel, a `>= min` guard in the other), so either an out-of-range draft could be saved as a server-side 400, or digit-by-digit typing was blocked ("3" en route to "30" never landed).

Both panels' numeric fields now use string-typed form state:

- **`onChange` sets the raw string** — any intermediate value can exist while the field is focused, including an emptied field
- **`onBlur` clamps** to the documented range via a shared `clampIntInput` helper (`customDays ≥ 7`, `hardDeleteDelay ≥ 0`; empty/unparseable → min)
- **Save is disabled** (plus an inline destructive hint + `aria-invalid`) while a field is out of range, with a defense-in-depth guard in `handleSave` so a 400 draft can never reach the server

## Design decision: per-page, not `useConfigForm`

The clamp stays local to the two panels (shared `numeric-clamp.ts` next to them) rather than generalizing into `useConfigForm`: the hook's contract explicitly excludes per-field validation, and min/max clamping is an input-event concern, not form-state bookkeeping. Behavior is identical across both retention panels.

## Files

- `packages/web/src/app/admin/audit/numeric-clamp.ts` — shared clamp helper
- `packages/web/src/app/admin/audit/retention-panel.tsx` — `customDays` (min 7)
- `packages/web/src/app/admin/audit/admin-action-retention-panel.tsx` — `hardDeleteDelay` (min 0)
- `packages/web/src/app/admin/audit/__tests__/numeric-clamp.test.ts` + `__tests__/retention-clamp-behavior.test.tsx` — 23 tests: intermediate values allowed, blur clamps, save gated, both panels covered

## Gates

All six pass: lint ✓ · type ✓ · full `bun run test` ✓ · syncpack ✓ · template drift ✓ · railway-watch ✓

https://claude.ai/code/session_01RLnTtTSnKvTNVq2iqzw8Xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLnTtTSnKvTNVq2iqzw8Xr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783686975&installation_id=135337507&pr_number=3364&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3364&signature=92b15f619c246a3bf1c56529addeb3c4811539d2ada792b52892656b24cca431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced retention fields to keep raw typed input, validate integers per-field, show inline destructive errors, and clamp values back into allowed ranges on blur.
  * Save button now disables while numeric drafts are invalid; save blocked defensively.

* **Bug Fixes**
  * Prevented invalid numeric values from being submitted and ensured save-success state clears on unmount.

* **Tests**
  * Added end-to-end tests covering typing, pasting, clamping, validation UI, and save payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->