### PR TITLE
fix(sandbox): one backend-id vocabulary for ATLAS_SANDBOX_BACKEND end to end

### DIFF
--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -31,7 +31,7 @@ In SaaS mode the page is titled **Execution Environment** and presents a card gr
 
 ### Atlas Cloud Sandbox
 
-Managed container service with HTTP isolation. No credentials needed and no setup required. This is the default for all workspaces and is marked **(Recommended)**.
+Managed Firecracker microVM with network isolation (the `vercel-sandbox` backend, pinned by the SaaS platform). No credentials needed and no setup required. This is the default for all workspaces and is marked **(Recommended)**.
 
 - **Active state** — highlighted border with "Active" badge
 - **Inactive state** — click **Select** to make it active
@@ -92,7 +92,7 @@ sandboxes per environment (10 Trial/Free, 50 Hobby, 100 Pro/Enterprise).
 2. Enter credentials in the dialog
 3. Click **Validate & Connect** — credentials are verified against the provider API
 4. On success, the card shows as **Connected** with the account name and connection date
-5. Click **Select** to make a connected provider the active sandbox
+5. Click **Select** to make a connected provider the active sandbox — this stores the provider's backend ID (`vercel-sandbox`, `e2b-sandbox`, `daytona-sandbox`, `railway-sandbox`) in the `ATLAS_SANDBOX_BACKEND` workspace setting
 6. Click **Disconnect** to remove credentials (reverts to Atlas Cloud Sandbox, the platform default, if this was the active provider)
 
 <Callout type="info">
@@ -174,7 +174,7 @@ You can override this chain with the `ATLAS_SANDBOX_PRIORITY` environment variab
 | Providers | Not applicable | Atlas Cloud, Vercel, E2B, Daytona |
 | Credential storage | Not applicable | Per-workspace in `sandbox_credentials` table |
 | Active selection | Dropdown + Save in admin UI (sets `ATLAS_SANDBOX_BACKEND`) | Click **Select** on a connected provider |
-| Default fallback | Auto-detect priority chain | Atlas Cloud Sandbox (sidecar) |
+| Default fallback | Auto-detect priority chain | Atlas Cloud Sandbox (`vercel-sandbox`) |
 | Sidecar URL | Configurable via admin UI | Managed by platform |
 
 ---

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -476,7 +476,7 @@ Explore tool isolation backends (also used by `executePython` when nsjail is act
 | `ATLAS_NSJAIL_TIME_LIMIT` | explore: `10`, python: `30` | nsjail per-command time limit in seconds. **Defaults differ per backend**: the explore tool (semantic FS sandbox) uses 10s, the Python tool (`executePython`) uses 30s. Setting this env var overrides both backends with the same value |
 | `ATLAS_NSJAIL_MEMORY_LIMIT` | explore: `256`, python: `512` | nsjail per-command memory limit in MB. **Defaults differ per backend**: explore uses 256 MB, Python uses 512 MB (data-science workloads need more headroom). Setting this env var overrides both backends with the same value |
 | `ATLAS_SANDBOX_PRIORITY` | — | Comma-separated backend priority order (e.g. `sidecar,nsjail,just-bash`). Valid values: `vercel-sandbox`, `nsjail`, `sidecar`, `just-bash`. Plugin backends always take highest priority. See [Configuration](/reference/config#sandbox) |
-| `ATLAS_SANDBOX_BACKEND` | — | SaaS admin-facing selector for the workspace's sandbox backend: `vercel-sandbox`, `sidecar`, `e2b-sandbox`, `daytona-sandbox`, or a plugin ID. Set via the Settings UI in the hosted product; self-hosted operators typically use `ATLAS_SANDBOX_PRIORITY` instead |
+| `ATLAS_SANDBOX_BACKEND` | — | SaaS admin-facing selector for the workspace's sandbox backend: `vercel-sandbox`, `sidecar`, `e2b-sandbox`, `daytona-sandbox`, `railway-sandbox`, or a plugin ID (legacy bare provider keys like `e2b` are normalized to their backend IDs on read). Set via the Settings UI in the hosted product; self-hosted operators typically use `ATLAS_SANDBOX_PRIORITY` instead |
 
 <Tabs items={["Docker Compose (dev)", "Production sidecar", "nsjail (self-hosted)"]}>
 <Tab value="Docker Compose (dev)">

--- a/packages/api/src/api/__tests__/admin-sandbox.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for admin sandbox routes — backend-id vocabulary (#3375, #3371).
+ *
+ * GET /status must speak one vocabulary: `ATLAS_SANDBOX_BACKEND` stores
+ * backend ids ("e2b-sandbox"), but legacy workspaces may hold bare provider
+ * keys ("e2b") written before the fix. Both spellings must resolve
+ * identically, and `connectedProviders[].isActive` must never contradict
+ * `activeBackend`.
+ *
+ * Tests the adminSandbox sub-router directly (not through the parent admin
+ * router) to avoid mocking every sibling sub-router dependency.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock, type Mock } from "bun:test";
+import { SANDBOX_PROVIDER_KEYS } from "@useatlas/schemas";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+// --- Settings mock (overrides the factory's) ---
+
+const mockSettings = new Map<string, string>();
+const mockDeleteSetting: Mock<(key: string, userId?: string, orgId?: string) => Promise<void>> =
+  mock(async () => {});
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingAuto: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingLive: async (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingsForAdmin: mock(() => []),
+  getSettingsRegistry: mock(() => []),
+  getSettingDefinition: mock(() => undefined),
+  setSetting: mock(async () => {}),
+  deleteSetting: mockDeleteSetting,
+  loadSettings: mock(async () => 0),
+  getAllSettingOverrides: mock(async () => []),
+  _resetSettingsCache: mock(() => {}),
+}));
+
+// --- Explore mock — platform default is the SaaS pin ---
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  getExploreBackendType: () => "vercel-sandbox",
+  getActiveSandboxPluginId: () => null,
+  explore: { type: "function" },
+  invalidateExploreBackend: mock(() => {}),
+  markNsjailFailed: mock(() => {}),
+  markSidecarFailed: mock(() => {}),
+  _formatSandboxPriorityFailureForTest: mock(() => ""),
+}));
+
+// --- Built-in backend detection ---
+
+mock.module("@atlas/api/lib/tools/backends/detect", () => ({
+  vercelSandboxAccess: () => undefined,
+  useVercelSandbox: () => true,
+  useSidecar: () => false,
+  _resetVercelSandboxDetectForTest: () => {},
+  _partialCredsWarnedForTest: () => false,
+}));
+
+// --- Plugin registry — mutable sandbox plugin list ---
+
+let mockSandboxPlugins: Array<{ id: string; name?: string }> = [];
+
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    describe: () => [],
+    get: () => undefined,
+    getStatus: () => undefined,
+    enable: () => false,
+    disable: () => false,
+    isEnabled: () => false,
+    getAllHealthy: () => [],
+    getByType: (type: string) => (type === "sandbox" ? mockSandboxPlugins : []),
+    size: 0,
+  },
+  PluginRegistry: class {},
+}));
+
+// --- Sandbox credentials — mutable connected list ---
+
+interface MockCredential {
+  id: string;
+  orgId: string;
+  provider: (typeof SANDBOX_PROVIDER_KEYS)[number];
+  credentials: Record<string, unknown>;
+  displayName: string | null;
+  validatedAt: string | null;
+  connectedAt: string;
+}
+
+let mockCredentials: MockCredential[] = [];
+const mockDeleteCredential: Mock<(orgId: string, provider: string) => Promise<boolean>> =
+  mock(async () => true);
+
+mock.module("@atlas/api/lib/sandbox/credentials", () => ({
+  SANDBOX_PROVIDERS: SANDBOX_PROVIDER_KEYS,
+  getSandboxCredentials: mock(async () => mockCredentials),
+  getSandboxCredentialByProvider: mock(async () => null),
+  saveSandboxCredential: mock(async () => {}),
+  deleteSandboxCredential: mockDeleteCredential,
+}));
+
+mock.module("@atlas/api/lib/sandbox/validate", () => ({
+  isSafeExternalUrl: () => true,
+  validateVercelCredentials: mock(async () => ({ valid: true as const })),
+  validateE2BCredentials: mock(async () => ({ valid: true as const })),
+  validateDaytonaCredentials: mock(async () => ({ valid: true as const })),
+  validateRailwayCredentials: mock(async () => ({ valid: true as const })),
+  validateCredentials: mock(async () => ({ valid: true as const, displayName: "Acme" })),
+}));
+
+// --- Import sub-router AFTER mocks ---
+
+const { adminSandbox } = await import("../routes/admin-sandbox");
+
+// --- Helpers ---
+
+function makeCredential(provider: MockCredential["provider"]): MockCredential {
+  return {
+    id: `cred-${provider}`,
+    orgId: "org-1",
+    provider,
+    credentials: { apiKey: "test" },
+    displayName: `${provider}-account`,
+    validatedAt: "2026-06-01T00:00:00.000Z",
+    connectedAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+interface StatusResponse {
+  activeBackend: string;
+  platformDefault: string;
+  workspaceOverride: string | null;
+  connectedProviders: Array<{ provider: string; isActive: boolean }>;
+}
+
+async function getStatus(): Promise<StatusResponse> {
+  const res = await adminSandbox.request("http://localhost/status");
+  expect(res.status).toBe(200);
+  return (await res.json()) as StatusResponse;
+}
+
+const BACKEND_ID_BY_PROVIDER: Record<string, string> = {
+  vercel: "vercel-sandbox",
+  e2b: "e2b-sandbox",
+  daytona: "daytona-sandbox",
+  railway: "railway-sandbox",
+};
+
+/** The #3375 invariant: a "Live" provider row implies the runtime actually
+ *  resolves that provider's backend — the two fields can never contradict. */
+function expectNoContradiction(status: StatusResponse) {
+  for (const p of status.connectedProviders) {
+    if (p.isActive) {
+      expect(status.activeBackend).toBe(BACKEND_ID_BY_PROVIDER[p.provider]!);
+    }
+  }
+}
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+beforeEach(() => {
+  mockSettings.clear();
+  mockSandboxPlugins = [];
+  mockCredentials = [];
+  mockDeleteSetting.mockClear();
+  mockDeleteCredential.mockClear();
+});
+
+// --- Tests ---
+
+describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => {
+  it("legacy provider-key override 'e2b' resolves to the e2b-sandbox backend", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockSandboxPlugins = [{ id: "e2b-sandbox", name: "E2B" }];
+    mockCredentials = [makeCredential("e2b")];
+
+    const status = await getStatus();
+    expect(status.workspaceOverride).toBe("e2b-sandbox");
+    expect(status.activeBackend).toBe("e2b-sandbox");
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "e2b", isActive: true }),
+    ]);
+    expectNoContradiction(status);
+  });
+
+  it("canonical backend-id override 'e2b-sandbox' resolves identically", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockSandboxPlugins = [{ id: "e2b-sandbox", name: "E2B" }];
+    mockCredentials = [makeCredential("e2b")];
+
+    const status = await getStatus();
+    expect(status.workspaceOverride).toBe("e2b-sandbox");
+    expect(status.activeBackend).toBe("e2b-sandbox");
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "e2b", isActive: true }),
+    ]);
+    expectNoContradiction(status);
+  });
+
+  it("only the selected provider row is active when several are connected", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockSandboxPlugins = [
+      { id: "e2b-sandbox", name: "E2B" },
+      { id: "daytona-sandbox", name: "Daytona" },
+    ];
+    mockCredentials = [makeCredential("e2b"), makeCredential("daytona")];
+
+    const status = await getStatus();
+    const byProvider = Object.fromEntries(
+      status.connectedProviders.map((p) => [p.provider, p.isActive]),
+    );
+    expect(byProvider).toEqual({ e2b: true, daytona: false });
+    expectNoContradiction(status);
+  });
+
+  it("override for an unavailable backend falls back without marking the row active", async () => {
+    // e2b selected but the plugin isn't registered → runtime falls back to
+    // platform default. isActive must NOT claim the row is live (the old
+    // bug's mirror image: fields contradicting each other).
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockSandboxPlugins = [];
+    mockCredentials = [makeCredential("e2b")];
+
+    const status = await getStatus();
+    expect(status.activeBackend).toBe("vercel-sandbox"); // platform default
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "e2b", isActive: false }),
+    ]);
+    expectNoContradiction(status);
+  });
+
+  it("no override: platform default vercel-sandbox does not mark a connected vercel BYOC row active", async () => {
+    // The SaaS platform default IS vercel-sandbox; without an explicit
+    // workspace selection the BYOC vercel row must not read "Live".
+    mockCredentials = [makeCredential("vercel")];
+
+    const status = await getStatus();
+    expect(status.workspaceOverride).toBeNull();
+    expect(status.activeBackend).toBe("vercel-sandbox");
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "vercel", isActive: false }),
+    ]);
+  });
+});
+
+describe("DELETE /api/v1/admin/sandbox/disconnect/{provider} — override reset", () => {
+  it("resets a legacy provider-key override when its provider is disconnected", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+
+    const res = await adminSandbox.request("http://localhost/disconnect/e2b", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    expect(mockDeleteSetting).toHaveBeenCalledWith("ATLAS_SANDBOX_BACKEND", undefined, "org-1");
+  });
+
+  it("resets a backend-id override when its provider is disconnected", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+
+    const res = await adminSandbox.request("http://localhost/disconnect/e2b", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    expect(mockDeleteSetting).toHaveBeenCalledWith("ATLAS_SANDBOX_BACKEND", undefined, "org-1");
+  });
+
+  it("leaves the override alone when a different provider is disconnected", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+
+    const res = await adminSandbox.request("http://localhost/disconnect/daytona", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    expect(mockDeleteSetting).not.toHaveBeenCalled();
+  });
+
+  it("rejects backend ids as the provider URL segment", async () => {
+    const res = await adminSandbox.request("http://localhost/disconnect/e2b-sandbox", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api/src/api/__tests__/admin-sandbox.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll, mock, type Mock } from "bun:test";
-import { SANDBOX_PROVIDER_KEYS } from "@useatlas/schemas";
+import { SANDBOX_PROVIDER_KEYS, SANDBOX_PROVIDER_BACKEND_IDS } from "@useatlas/schemas";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
 const mocks = createApiTestMocks({
@@ -150,19 +150,15 @@ async function getStatus(): Promise<StatusResponse> {
   return (await res.json()) as StatusResponse;
 }
 
-const BACKEND_ID_BY_PROVIDER: Record<string, string> = {
-  vercel: "vercel-sandbox",
-  e2b: "e2b-sandbox",
-  daytona: "daytona-sandbox",
-  railway: "railway-sandbox",
-};
-
 /** The #3375 invariant: a "Live" provider row implies the runtime actually
  *  resolves that provider's backend — the two fields can never contradict. */
 function expectNoContradiction(status: StatusResponse) {
   for (const p of status.connectedProviders) {
     if (p.isActive) {
-      expect(status.activeBackend).toBe(BACKEND_ID_BY_PROVIDER[p.provider]!);
+      const backendId =
+        SANDBOX_PROVIDER_BACKEND_IDS[p.provider as keyof typeof SANDBOX_PROVIDER_BACKEND_IDS];
+      expect(backendId).toBeDefined();
+      expect(status.activeBackend).toBe(backendId);
     }
   }
 }

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -8,6 +8,11 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import {
+  SANDBOX_PROVIDER_BACKEND_IDS,
+  SandboxStatusSchema,
+  normalizeSandboxBackendValue,
+} from "@useatlas/schemas";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -33,36 +38,9 @@ const log = createLogger("admin-sandbox");
 // Schemas
 // ---------------------------------------------------------------------------
 
-const SandboxBackendSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.enum(["built-in", "plugin"]),
-  available: z.boolean(),
-  description: z.string().optional(),
-});
-
-const ConnectedProviderSchema = z.object({
-  provider: z.enum(SANDBOX_PROVIDERS),
-  displayName: z.string().nullable(),
-  connectedAt: z.string(),
-  validatedAt: z.string().nullable(),
-  isActive: z.boolean(),
-});
-
-const SandboxStatusSchema = z.object({
-  /** Currently active backend for this workspace (after override resolution) */
-  activeBackend: z.string(),
-  /** Platform default backend (no workspace override) */
-  platformDefault: z.string(),
-  /** Workspace override backend (if set) */
-  workspaceOverride: z.string().nullable(),
-  /** Custom sidecar URL (if set at workspace level) */
-  workspaceSidecarUrl: z.string().nullable(),
-  /** All available backends in this deployment */
-  availableBackends: z.array(SandboxBackendSchema),
-  /** Connected BYOC sandbox providers for this org */
-  connectedProviders: z.array(ConnectedProviderSchema),
-});
+// Status response wire shapes (SandboxStatusSchema and friends) live in
+// `@useatlas/schemas` — single source of truth shared with the web admin
+// page's `useAdminFetch` parse (#3371).
 
 const ConnectRequestSchema = z.object({
   credentials: z.record(z.string(), z.unknown()),
@@ -260,8 +238,13 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
         return c.json({ error: "Bad Request", message: "No active organization." }, 400);
       }
 
-      // Workspace override
-      const workspaceOverride = getSetting("ATLAS_SANDBOX_BACKEND", orgId) ?? null;
+      // Workspace override — normalized once to backend-id vocabulary so
+      // legacy stored provider keys ("e2b") resolve like backend ids
+      // ("e2b-sandbox"), matching the explore runtime (#3375).
+      const storedOverride = getSetting("ATLAS_SANDBOX_BACKEND", orgId) ?? null;
+      const workspaceOverride = storedOverride
+        ? normalizeSandboxBackendValue(storedOverride)
+        : null;
       const workspaceSidecarUrl = getSetting("ATLAS_SANDBOX_URL", orgId) ?? null;
 
       // Platform default (the backend that would be used without any workspace override)
@@ -281,14 +264,24 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
         activeBackend = activePluginId ?? platformDefault;
       }
 
-      // Build connected providers list
-      const connectedProviders = credentials.map((cred) => ({
-        provider: cred.provider,
-        displayName: cred.displayName,
-        connectedAt: cred.connectedAt,
-        validatedAt: cred.validatedAt,
-        isActive: workspaceOverride === cred.provider,
-      }));
+      // Build connected providers list. `isActive` requires BOTH the
+      // (normalized) workspace override selecting this provider's backend id
+      // AND the resolved `activeBackend` landing on it, so `isActive` can
+      // never contradict `activeBackend` — previously this compared the
+      // provider key against the stored override, which always mismatched
+      // backend-id values (#3375). The override condition keeps a connected
+      // vercel BYOC row from reading "Live" merely because the SaaS platform
+      // default is `vercel-sandbox`.
+      const connectedProviders = credentials.map((cred) => {
+        const backendId = SANDBOX_PROVIDER_BACKEND_IDS[cred.provider];
+        return {
+          provider: cred.provider,
+          displayName: cred.displayName,
+          connectedAt: cred.connectedAt,
+          validatedAt: cred.validatedAt,
+          isActive: workspaceOverride === backendId && activeBackend === backendId,
+        };
+      });
 
       return c.json(
         {
@@ -399,9 +392,14 @@ adminSandbox.openapi(disconnectRoute, async (c) => {
         deleteSandboxCredential(orgId, provider),
       );
 
-      // If this was the active sandbox, reset to platform default
+      // If this was the active sandbox, reset to platform default. The
+      // setting stores backend ids (legacy rows may hold provider keys),
+      // so normalize before comparing against this provider's backend id.
       const workspaceOverride = getSetting("ATLAS_SANDBOX_BACKEND", orgId);
-      if (workspaceOverride === provider) {
+      const normalizedOverride = workspaceOverride
+        ? normalizeSandboxBackendValue(workspaceOverride)
+        : null;
+      if (normalizedOverride === SANDBOX_PROVIDER_BACKEND_IDS[provider]) {
         yield* Effect.promise(() => deleteSetting("ATLAS_SANDBOX_BACKEND", undefined, orgId));
         log.info({ orgId, provider }, "Active sandbox provider disconnected — reset to platform default");
       }

--- a/packages/api/src/lib/sandbox/credentials.ts
+++ b/packages/api/src/lib/sandbox/credentials.ts
@@ -6,6 +6,7 @@
  * `packages/api/src/lib/github/store.ts`.
  */
 
+import { SANDBOX_PROVIDER_KEYS, type SandboxProviderKey } from "@useatlas/schemas";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { encryptSecret, decryptSecret, type OpaqueSecret } from "@atlas/api/lib/db/secret-encryption";
 import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
@@ -17,9 +18,11 @@ const log = createLogger("sandbox-credentials");
 // Types
 // ---------------------------------------------------------------------------
 
-export const SANDBOX_PROVIDERS = ["vercel", "e2b", "daytona", "railway"] as const;
+// Canonical vocabulary lives in `@useatlas/schemas` (#3371) — re-exported
+// under the historical names so existing call sites don't churn.
+export const SANDBOX_PROVIDERS = SANDBOX_PROVIDER_KEYS;
 
-export type SandboxProvider = (typeof SANDBOX_PROVIDERS)[number];
+export type SandboxProvider = SandboxProviderKey;
 
 export interface SandboxCredential {
   id: string;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -266,7 +266,10 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     label: "Sandbox Backend",
     description:
       "Sandbox backend for explore/Python tool isolation. " +
-      "Valid values: vercel-sandbox, sidecar, e2b-sandbox, daytona-sandbox, railway-sandbox, or a registered plugin ID.",
+      "Valid values are backend ids only: vercel-sandbox, sidecar, e2b-sandbox, " +
+      "daytona-sandbox, railway-sandbox, or a registered sandbox plugin ID. " +
+      "Legacy bare provider keys (vercel, e2b, daytona, railway) are normalized " +
+      "to their backend ids on read.",
     type: "string",
     envVar: "ATLAS_SANDBOX_BACKEND",
     scope: "workspace",

--- a/packages/api/src/lib/tools/__tests__/explore-workspace-override.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-workspace-override.test.ts
@@ -15,6 +15,13 @@ import type { ExploreBackend, ExecResult } from "../../tools/explore";
 // Mocks — must register before any import of explore.ts
 // ---------------------------------------------------------------------------
 
+// Mutable request context — tests that need the workspace-override branch
+// (it only runs when an orgId is present) set this; default undefined
+// preserves the original self-hosted behavior of the older tests.
+let mockRequestContext:
+  | { user?: { activeOrganizationId?: string }; atlasMode?: string }
+  | undefined;
+
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
@@ -41,8 +48,18 @@ mock.module("@atlas/api/lib/logger", () => ({
     }),
   }),
   withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
-  getRequestContext: () => undefined,
+  getRequestContext: () => mockRequestContext,
   redactPaths: [],
+}));
+
+// When an orgId is present, explore resolves an org-scoped semantic root via
+// `ensureOrgModeSemanticRoot` (filesystem dual-write machinery we don't want
+// in this test). Pass through to the base semantic root; all other exports
+// stay real.
+const realSemanticSync = await import("@atlas/api/lib/semantic/sync");
+mock.module("@atlas/api/lib/semantic/sync", () => ({
+  ...realSemanticSync,
+  ensureOrgModeSemanticRoot: async () => realSemanticSync.getSemanticRoot(),
 }));
 
 mock.module("@atlas/api/lib/tracing", () => ({
@@ -151,6 +168,7 @@ describe("workspace sandbox backend override", () => {
   beforeEach(() => {
     mockSettings.clear();
     mockSandboxPlugins = [];
+    mockRequestContext = undefined;
     // Disable all built-in detection
     delete process.env.ATLAS_RUNTIME;
     delete process.env.VERCEL;
@@ -335,5 +353,71 @@ describe("workspace sandbox backend override", () => {
     const mod = await freshExploreModule();
     // getExploreBackendType doesn't take orgId — reports default chain
     expect(mod.getExploreBackendType()).toBe("just-bash");
+  });
+
+  // ── Legacy provider-key normalization (#3375) ─────────────────────
+  //
+  // `ATLAS_SANDBOX_BACKEND` canonically stores backend ids ("e2b-sandbox"),
+  // but workspaces configured before #3375 may hold bare provider keys
+  // ("e2b") written by the SaaS admin page. Those must resolve identically.
+  //
+  // These tests set `ATLAS_SANDBOX=nsjail`, which skips the Priority-0
+  // plugin chain — so the ONLY way the mocked plugin backend can be
+  // selected is through the workspace-override branch. Without the
+  // normalization, "e2b" matches neither the built-in names nor the
+  // plugin id "e2b-sandbox" and the override silently falls through.
+
+  it("normalizes a legacy provider-key override ('e2b') to its plugin backend id", async () => {
+    const pluginBackend = makeMockBackend("e2b-sandbox");
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => pluginBackend, priority: 50 },
+      },
+    ];
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    process.env.ATLAS_SANDBOX = "nsjail"; // skip Priority-0 plugin chain
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute(
+      { command: "ls" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: new AbortController().signal,
+      },
+    );
+
+    expect(result).toContain("[e2b-sandbox]");
+  });
+
+  it("canonical backend-id override ('e2b-sandbox') resolves identically", async () => {
+    const pluginBackend = makeMockBackend("e2b-sandbox");
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => pluginBackend, priority: 50 },
+      },
+    ];
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    process.env.ATLAS_SANDBOX = "nsjail"; // skip Priority-0 plugin chain
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute(
+      { command: "ls" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: new AbortController().signal,
+      },
+    );
+
+    expect(result).toContain("[e2b-sandbox]");
   });
 });

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -22,6 +22,7 @@
 
 import { tool } from "ai";
 import { z } from "zod";
+import { normalizeSandboxBackendValue } from "@useatlas/schemas";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { withSpan } from "@atlas/api/lib/tracing";
@@ -335,8 +336,11 @@ export function markSidecarFailed(): void {
 }
 
 function getExploreBackend(semanticRoot: string, orgId?: string): Promise<ExploreBackend> {
-  // Workspace override changes the effective backend, so include it in the cache key
-  const wsOverride = orgId ? getSetting("ATLAS_SANDBOX_BACKEND", orgId) : undefined;
+  // Workspace override changes the effective backend, so include it in the cache key.
+  // Normalize legacy stored provider keys ("e2b") to backend ids ("e2b-sandbox")
+  // BEFORE building the cache key, so both spellings share one entry (#3375).
+  const rawOverride = orgId ? getSetting("ATLAS_SANDBOX_BACKEND", orgId) : undefined;
+  const wsOverride = rawOverride ? normalizeSandboxBackendValue(rawOverride) : undefined;
   const cacheKeyVal = wsOverride ? `${semanticRoot}\0${wsOverride}` : semanticRoot;
 
   let promise = backendCache.get(cacheKeyVal);

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -25,6 +25,7 @@
     "./mcp-usage": "./src/mcp-usage.ts",
     "./platform": "./src/platform.ts",
     "./residency": "./src/residency.ts",
+    "./sandbox": "./src/sandbox.ts",
     "./sla": "./src/sla.ts"
   },
   "main": "./src/index.ts",

--- a/packages/schemas/src/__tests__/sandbox.test.ts
+++ b/packages/schemas/src/__tests__/sandbox.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SANDBOX_PROVIDER_KEYS,
+  SANDBOX_PROVIDER_BACKEND_IDS,
+  SandboxProviderKeySchema,
+  SandboxConnectedProviderSchema,
+  SandboxStatusSchema,
+  normalizeSandboxBackendValue,
+} from "../sandbox";
+
+describe("SANDBOX_PROVIDER_BACKEND_IDS", () => {
+  test("every provider key maps to a backend id", () => {
+    for (const key of SANDBOX_PROVIDER_KEYS) {
+      const backendId = SANDBOX_PROVIDER_BACKEND_IDS[key];
+      expect(typeof backendId).toBe("string");
+      expect(backendId.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("maps to the registered plugin ids", () => {
+    expect(SANDBOX_PROVIDER_BACKEND_IDS).toEqual({
+      vercel: "vercel-sandbox",
+      e2b: "e2b-sandbox",
+      daytona: "daytona-sandbox",
+      railway: "railway-sandbox",
+    });
+  });
+
+  test("no two providers share a backend id", () => {
+    const ids = Object.values(SANDBOX_PROVIDER_BACKEND_IDS);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("normalizeSandboxBackendValue", () => {
+  test("maps legacy provider keys to backend ids", () => {
+    expect(normalizeSandboxBackendValue("vercel")).toBe("vercel-sandbox");
+    expect(normalizeSandboxBackendValue("e2b")).toBe("e2b-sandbox");
+    expect(normalizeSandboxBackendValue("daytona")).toBe("daytona-sandbox");
+    expect(normalizeSandboxBackendValue("railway")).toBe("railway-sandbox");
+  });
+
+  test("is identity for backend ids", () => {
+    for (const backendId of Object.values(SANDBOX_PROVIDER_BACKEND_IDS)) {
+      expect(normalizeSandboxBackendValue(backendId)).toBe(backendId);
+    }
+  });
+
+  test("is identity for built-in backend names", () => {
+    for (const builtIn of ["vercel-sandbox", "nsjail", "sidecar", "just-bash"]) {
+      expect(normalizeSandboxBackendValue(builtIn)).toBe(builtIn);
+    }
+  });
+
+  test("is identity for unknown plugin ids", () => {
+    expect(normalizeSandboxBackendValue("my-custom-sandbox")).toBe("my-custom-sandbox");
+  });
+
+  test("is idempotent", () => {
+    for (const key of SANDBOX_PROVIDER_KEYS) {
+      const once = normalizeSandboxBackendValue(key);
+      expect(normalizeSandboxBackendValue(once)).toBe(once);
+    }
+  });
+});
+
+describe("SandboxProviderKeySchema", () => {
+  test("accepts every provider key", () => {
+    for (const key of SANDBOX_PROVIDER_KEYS) {
+      expect(SandboxProviderKeySchema.safeParse(key).success).toBe(true);
+    }
+  });
+
+  test("rejects backend ids (vocabularies must not blur)", () => {
+    expect(SandboxProviderKeySchema.safeParse("e2b-sandbox").success).toBe(false);
+    expect(SandboxProviderKeySchema.safeParse("sidecar").success).toBe(false);
+  });
+});
+
+describe("SandboxStatusSchema", () => {
+  const validStatus = {
+    activeBackend: "e2b-sandbox",
+    platformDefault: "vercel-sandbox",
+    workspaceOverride: "e2b-sandbox",
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      {
+        id: "vercel-sandbox",
+        name: "Vercel Sandbox",
+        type: "built-in" as const,
+        available: true,
+        description: "Firecracker microVM",
+      },
+      { id: "e2b-sandbox", name: "E2B", type: "plugin" as const, available: true },
+    ],
+    connectedProviders: [
+      {
+        provider: "e2b" as const,
+        displayName: "Acme",
+        connectedAt: "2026-06-01T00:00:00.000Z",
+        validatedAt: null,
+        isActive: true,
+      },
+    ],
+  };
+
+  test("parses a full status payload", () => {
+    expect(SandboxStatusSchema.safeParse(validStatus).success).toBe(true);
+  });
+
+  test("rejects a connected provider with a backend-id provider value", () => {
+    const result = SandboxConnectedProviderSchema.safeParse({
+      ...validStatus.connectedProviders[0],
+      provider: "e2b-sandbox",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -14,5 +14,6 @@ export * from "./mcp-prompts";
 export * from "./mcp-usage";
 export * from "./platform";
 export * from "./residency";
+export * from "./sandbox";
 export * from "./security";
 export * from "./sla";

--- a/packages/schemas/src/sandbox.ts
+++ b/packages/schemas/src/sandbox.ts
@@ -1,0 +1,105 @@
+/**
+ * Sandbox wire-format schemas — BYOC provider keys + `/admin/sandbox/status`.
+ *
+ * Single source of truth for the BYOC sandbox provider vocabulary (#3371).
+ * Before this module, the provider enum was hand-mirrored between
+ * `packages/api/src/lib/sandbox/credentials.ts` and the web sandbox admin
+ * page, and the two halves of the system spoke different vocabularies:
+ * connect/disconnect routes use provider keys (`"e2b"`), while the
+ * `ATLAS_SANDBOX_BACKEND` workspace setting and the explore runtime use
+ * backend ids (`"e2b-sandbox"`). `SANDBOX_PROVIDER_BACKEND_IDS` is the one
+ * statement of that mapping; `normalizeSandboxBackendValue` is the
+ * compatibility shim for values stored before the vocabulary was unified.
+ */
+import { z } from "zod";
+
+/**
+ * BYOC sandbox provider keys. Used as the URL segment of
+ * `/api/v1/admin/sandbox/{connect,disconnect}/{provider}` and as the
+ * `provider` column of `sandbox_credentials`.
+ */
+export const SANDBOX_PROVIDER_KEYS = ["vercel", "e2b", "daytona", "railway"] as const;
+
+export const SandboxProviderKeySchema = z.enum(SANDBOX_PROVIDER_KEYS);
+
+export type SandboxProviderKey = z.infer<typeof SandboxProviderKeySchema>;
+
+/**
+ * Maps each BYOC provider key to the sandbox backend id the explore runtime
+ * resolves (`getExploreBackend`) and the `ATLAS_SANDBOX_BACKEND` workspace
+ * setting stores. Backend ids are the plugin ids registered by
+ * `plugins/{vercel-sandbox,e2b,daytona,railway-sandbox}` — `vercel-sandbox`
+ * doubles as a built-in backend name when the plugin isn't installed.
+ */
+export const SANDBOX_PROVIDER_BACKEND_IDS: Record<SandboxProviderKey, string> = {
+  vercel: "vercel-sandbox",
+  e2b: "e2b-sandbox",
+  daytona: "daytona-sandbox",
+  railway: "railway-sandbox",
+};
+
+/**
+ * Normalize an `ATLAS_SANDBOX_BACKEND` value to backend-id vocabulary.
+ *
+ * Legacy workspaces may have stored bare provider keys (`"e2b"`) before
+ * #3375 unified the setting on backend ids — the SaaS admin page wrote
+ * provider keys, which matched neither the built-in backend names nor any
+ * plugin id and silently fell through to the platform default. Readers of
+ * the setting normalize through this function so those stored values keep
+ * working; any non-provider-key value (backend ids, built-in names, custom
+ * plugin ids) passes through unchanged.
+ */
+export function normalizeSandboxBackendValue(value: string): string {
+  const parsed = SandboxProviderKeySchema.safeParse(value);
+  return parsed.success ? SANDBOX_PROVIDER_BACKEND_IDS[parsed.data] : value;
+}
+
+// ── /api/v1/admin/sandbox/status wire shapes ──────────────────────
+// Shared by the API route's OpenAPI contract and the web admin page's
+// `useAdminFetch` response parse, so the two can't drift (#3371).
+
+export const SandboxBackendSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["built-in", "plugin"]),
+  available: z.boolean(),
+  description: z.string().optional(),
+});
+
+export type SandboxBackend = z.infer<typeof SandboxBackendSchema>;
+
+export const SandboxConnectedProviderSchema = z.object({
+  provider: SandboxProviderKeySchema,
+  displayName: z.string().nullable(),
+  connectedAt: z.string(),
+  validatedAt: z.string().nullable(),
+  /**
+   * True when the workspace's resolved active backend is this provider's
+   * backend id (`SANDBOX_PROVIDER_BACKEND_IDS[provider]`). Derived from
+   * `activeBackend` so the two fields can never contradict (#3375).
+   */
+  isActive: z.boolean(),
+});
+
+export type SandboxConnectedProvider = z.infer<typeof SandboxConnectedProviderSchema>;
+
+export const SandboxStatusSchema = z.object({
+  /** Currently active backend id for this workspace (after override resolution) */
+  activeBackend: z.string(),
+  /** Platform default backend id (no workspace override) */
+  platformDefault: z.string(),
+  /**
+   * Workspace override backend id (if set). Normalized to backend-id
+   * vocabulary — legacy stored provider keys are reported as their
+   * backend ids.
+   */
+  workspaceOverride: z.string().nullable(),
+  /** Custom sidecar URL (if set at workspace level) */
+  workspaceSidecarUrl: z.string().nullable(),
+  /** All available backends in this deployment */
+  availableBackends: z.array(SandboxBackendSchema),
+  /** Connected BYOC sandbox providers for this org */
+  connectedProviders: z.array(SandboxConnectedProviderSchema),
+});
+
+export type SandboxStatus = z.infer<typeof SandboxStatusSchema>;

--- a/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Regression guard for the SaaS sandbox save-value mapping (#3375).
+ *
+ * `ATLAS_SANDBOX_BACKEND` stores backend ids. The SaaS view previously
+ * wrote bare provider keys ("e2b") for BYOC cards and "sidecar" for the
+ * managed card — neither matched anything the explore runtime resolves,
+ * so every selection silently fell through to the platform default.
+ * These tests pin the values each card actually saves.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import { SaasSandboxView } from "../page";
+import type { SandboxStatus } from "@/ui/lib/admin-schemas";
+
+// ProviderRow wires useAdminMutation, which reads the Atlas config context
+// and the react-query client — the mutations are never fired in these
+// tests, but the hooks must mount.
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+function makeStatus(overrides: Partial<SandboxStatus>): SandboxStatus {
+  return {
+    activeBackend: "vercel-sandbox",
+    platformDefault: "vercel-sandbox",
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
+      { id: "e2b-sandbox", name: "E2B", type: "plugin", available: true },
+    ],
+    connectedProviders: [],
+    ...overrides,
+  };
+}
+
+function renderView(status: SandboxStatus) {
+  const onSelectBackend = mock(async (_backendId: string) => undefined);
+  const utils = render(
+    createElement(SaasSandboxView, {
+      status,
+      onSelectBackend,
+      onRefetch: mock(() => {}),
+      saving: false,
+    }),
+    { wrapper },
+  );
+  return { ...utils, onSelectBackend };
+}
+
+describe("SaasSandboxView — backend-id save values", () => {
+  test("selecting a connected BYOC provider saves its backend id, not the provider key", () => {
+    const { getAllByText, onSelectBackend } = renderView(
+      makeStatus({
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: false,
+          },
+        ],
+      }),
+    );
+
+    // Managed is active (no provider row is live), so the only
+    // "Use this" button belongs to the connected e2b row.
+    const buttons = getAllByText("Use this");
+    expect(buttons.length).toBe(1);
+    fireEvent.click(buttons[0]!);
+
+    expect(onSelectBackend).toHaveBeenCalledTimes(1);
+    expect(onSelectBackend.mock.calls[0]?.[0]).toBe("e2b-sandbox");
+    cleanup();
+  });
+
+  test("selecting the managed card saves 'vercel-sandbox' (the SaaS pin), not 'sidecar'", () => {
+    const { getAllByText, onSelectBackend } = renderView(
+      makeStatus({
+        activeBackend: "e2b-sandbox",
+        workspaceOverride: "e2b-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+
+    // The e2b row is live, so the only "Use this" button is the managed card's.
+    const buttons = getAllByText("Use this");
+    expect(buttons.length).toBe(1);
+    fireEvent.click(buttons[0]!);
+
+    expect(onSelectBackend).toHaveBeenCalledTimes(1);
+    expect(onSelectBackend.mock.calls[0]?.[0]).toBe("vercel-sandbox");
+    cleanup();
+  });
+
+  test("managed card reads active from server-derived isActive, not the override string", () => {
+    // Legacy contradiction scenario: an override is set but no provider row
+    // is live (e.g. the selected backend was unavailable and the runtime
+    // fell back). Managed must present as the active card.
+    const { getByText, queryAllByText } = renderView(
+      makeStatus({
+        workspaceOverride: "e2b-sandbox",
+        activeBackend: "vercel-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: false,
+          },
+        ],
+      }),
+    );
+
+    expect(getByText("Atlas Cloud Sandbox")).toBeTruthy();
+    // Managed active → its "Use this" button is hidden; only e2b's remains.
+    expect(queryAllByText("Use this").length).toBe(1);
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
@@ -79,7 +79,7 @@ function renderView(status: SandboxStatus) {
 
 describe("SaasSandboxView — backend-id save values", () => {
   test("selecting a connected BYOC provider saves its backend id, not the provider key", () => {
-    const { getAllByText, onSelectBackend } = renderView(
+    const { getAllByText, onSelectBackend, onSelectManaged } = renderView(
       makeStatus({
         connectedProviders: [
           {
@@ -101,6 +101,7 @@ describe("SaasSandboxView — backend-id save values", () => {
 
     expect(onSelectBackend).toHaveBeenCalledTimes(1);
     expect(onSelectBackend.mock.calls[0]?.[0]).toBe("e2b-sandbox");
+    expect(onSelectManaged).not.toHaveBeenCalled();
     cleanup();
   });
 
@@ -151,7 +152,7 @@ describe("SaasSandboxView — backend-id save values", () => {
       }),
     );
 
-    expect(getByText("Atlas Cloud Sandbox")).toBeTruthy();
+    getByText("Atlas Cloud Sandbox");
     // Managed active → its "Use this" button is hidden; only e2b's remains.
     expect(queryAllByText("Use this").length).toBe(1);
     cleanup();

--- a/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
@@ -5,7 +5,9 @@
  * wrote bare provider keys ("e2b") for BYOC cards and "sidecar" for the
  * managed card — neither matched anything the explore runtime resolves,
  * so every selection silently fell through to the platform default.
- * These tests pin the values each card actually saves.
+ * These tests pin what each card does: BYOC cards save the provider's
+ * backend id; the Managed card clears the override (follow the platform
+ * default) instead of writing a value.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -61,16 +63,18 @@ function makeStatus(overrides: Partial<SandboxStatus>): SandboxStatus {
 
 function renderView(status: SandboxStatus) {
   const onSelectBackend = mock(async (_backendId: string) => undefined);
+  const onSelectManaged = mock(async () => undefined);
   const utils = render(
     createElement(SaasSandboxView, {
       status,
       onSelectBackend,
+      onSelectManaged,
       onRefetch: mock(() => {}),
       saving: false,
     }),
     { wrapper },
   );
-  return { ...utils, onSelectBackend };
+  return { ...utils, onSelectBackend, onSelectManaged };
 }
 
 describe("SaasSandboxView — backend-id save values", () => {
@@ -100,8 +104,8 @@ describe("SaasSandboxView — backend-id save values", () => {
     cleanup();
   });
 
-  test("selecting the managed card saves 'vercel-sandbox' (the SaaS pin), not 'sidecar'", () => {
-    const { getAllByText, onSelectBackend } = renderView(
+  test("selecting the managed card clears the override (follows the platform default), not a 'sidecar' write", () => {
+    const { getAllByText, onSelectBackend, onSelectManaged } = renderView(
       makeStatus({
         activeBackend: "e2b-sandbox",
         workspaceOverride: "e2b-sandbox",
@@ -122,8 +126,8 @@ describe("SaasSandboxView — backend-id save values", () => {
     expect(buttons.length).toBe(1);
     fireEvent.click(buttons[0]!);
 
-    expect(onSelectBackend).toHaveBeenCalledTimes(1);
-    expect(onSelectBackend.mock.calls[0]?.[0]).toBe("vercel-sandbox");
+    expect(onSelectManaged).toHaveBeenCalledTimes(1);
+    expect(onSelectBackend).not.toHaveBeenCalled();
     cleanup();
   });
 

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -221,8 +221,13 @@ export default function SandboxPage() {
                   onSelectBackend={(backendId) =>
                     saveMutation.mutate({ body: { value: backendId } })
                   }
+                  onSelectManaged={() =>
+                    resetMutation.mutate({
+                      path: "/api/v1/admin/settings/ATLAS_SANDBOX_BACKEND",
+                    })
+                  }
                   onRefetch={refetch}
-                  saving={saveMutation.saving}
+                  saving={saveMutation.saving || resetMutation.saving}
                 />
               ) : (
                 <SelfHostedSandboxView
@@ -265,11 +270,13 @@ export default function SandboxPage() {
 export function SaasSandboxView({
   status,
   onSelectBackend,
+  onSelectManaged,
   onRefetch,
   saving,
 }: {
   status: SandboxStatus;
   onSelectBackend: (backendId: string) => Promise<unknown>;
+  onSelectManaged: () => Promise<unknown>;
   onRefetch: () => void;
   saving: boolean;
 }) {
@@ -288,11 +295,13 @@ export function SaasSandboxView({
         />
         <ManagedSandboxShell
           isActive={isManagedActive}
-          // SaaS pins the managed backend to `vercel-sandbox`
-          // (deploy/api/atlas.config.ts `sandbox.priority`); there is no
-          // sidecar service on SaaS, so the previous "sidecar" value never
-          // matched a real backend.
-          onSelect={() => onSelectBackend("vercel-sandbox")}
+          // "Managed" means *follow the platform default* (the SaaS
+          // `vercel-sandbox` pin in deploy/api/atlas.config.ts), so it
+          // clears the workspace override rather than writing a value —
+          // the previous "sidecar" write never matched a real backend,
+          // and pinning the current default would go stale if the
+          // platform pin ever changes (#3375).
+          onSelect={() => onSelectManaged()}
           saving={saving}
         />
       </section>

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, type ComponentType } from "react";
-import { z } from "zod";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,6 +37,16 @@ import {
 } from "@/ui/components/admin/compact";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+// Provider-key vocabulary and status wire schemas are shared with the
+// API route layer via `@useatlas/schemas` (#3371).
+import {
+  SANDBOX_PROVIDER_KEYS,
+  SANDBOX_PROVIDER_BACKEND_IDS,
+  SandboxStatusSchema,
+  type SandboxConnectedProvider as ConnectedProvider,
+  type SandboxProviderKey,
+  type SandboxStatus,
+} from "@/ui/lib/admin-schemas";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
@@ -55,38 +64,6 @@ import {
   TrainFront,
   Trash2,
 } from "lucide-react";
-
-// ── Types ─────────────────────────────────────────────────────────
-
-const SandboxProviderKeySchema = z.enum(["vercel", "e2b", "daytona", "railway"]);
-type SandboxProviderKey = z.infer<typeof SandboxProviderKeySchema>;
-
-const SandboxBackendSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.enum(["built-in", "plugin"]),
-  available: z.boolean(),
-  description: z.string().optional(),
-});
-
-const ConnectedProviderSchema = z.object({
-  provider: SandboxProviderKeySchema,
-  displayName: z.string().nullable(),
-  connectedAt: z.string(),
-  validatedAt: z.string().nullable(),
-  isActive: z.boolean(),
-});
-type ConnectedProvider = z.infer<typeof ConnectedProviderSchema>;
-
-const SandboxStatusSchema = z.object({
-  activeBackend: z.string(),
-  platformDefault: z.string(),
-  workspaceOverride: z.string().nullable(),
-  workspaceSidecarUrl: z.string().nullable(),
-  availableBackends: z.array(SandboxBackendSchema),
-  connectedProviders: z.array(ConnectedProviderSchema),
-});
-type SandboxStatus = z.infer<typeof SandboxStatusSchema>;
 
 // ── Provider metadata ─────────────────────────────────────────────
 
@@ -142,7 +119,10 @@ const PROVIDERS: Record<SandboxProviderKey, ProviderInfo> = {
   },
 };
 
-const PROVIDER_KEYS = Object.keys(PROVIDERS) as SandboxProviderKey[];
+// Compile-time guard: a provider key added to `SANDBOX_PROVIDER_KEYS`
+// without a `PROVIDERS` entry fails the `Record<SandboxProviderKey, ...>`
+// annotation above; iteration order comes from the shared tuple.
+const PROVIDER_KEYS = SANDBOX_PROVIDER_KEYS;
 
 // ── StatusPill (page-specific labels) ─────────────────────────────
 // Kept inline because this page uses several custom labels ("Available",
@@ -278,8 +258,11 @@ export default function SandboxPage() {
 }
 
 // ── SaaS view ─────────────────────────────────────────────────────
+// Exported for the save-value-mapping regression test (#3375) — the
+// backend-id vocabulary written to ATLAS_SANDBOX_BACKEND is asserted in
+// `__tests__/saas-backend-selection.test.tsx`.
 
-function SaasSandboxView({
+export function SaasSandboxView({
   status,
   onSelectBackend,
   onRefetch,
@@ -291,20 +274,25 @@ function SaasSandboxView({
   saving: boolean;
 }) {
   const connected = status.connectedProviders;
-  const isManagedActive =
-    !status.workspaceOverride ||
-    !connected.some((p) => p.provider === status.workspaceOverride);
+  // Managed is the active card whenever no BYOC provider row is live —
+  // `isActive` is server-derived in backend-id vocabulary (#3375), so this
+  // can't disagree with the runtime resolution.
+  const isManagedActive = !connected.some((p) => p.isActive);
 
   return (
     <>
       <section>
         <SectionHeading
           title="Managed"
-          description="Atlas-hosted container service. No setup — always available."
+          description="Atlas-hosted sandbox. No setup — always available."
         />
         <ManagedSandboxShell
           isActive={isManagedActive}
-          onSelect={() => onSelectBackend("sidecar")}
+          // SaaS pins the managed backend to `vercel-sandbox`
+          // (deploy/api/atlas.config.ts `sandbox.priority`); there is no
+          // sidecar service on SaaS, so the previous "sidecar" value never
+          // matched a real backend.
+          onSelect={() => onSelectBackend("vercel-sandbox")}
           saving={saving}
         />
       </section>
@@ -323,7 +311,10 @@ function SaasSandboxView({
                 providerKey={key}
                 connection={provider ?? null}
                 isActive={provider?.isActive ?? false}
-                onSelect={() => onSelectBackend(key)}
+                // ATLAS_SANDBOX_BACKEND stores backend ids, not provider
+                // keys — saving the bare key used to fall through to the
+                // platform default silently (#3375).
+                onSelect={() => onSelectBackend(SANDBOX_PROVIDER_BACKEND_IDS[key])}
                 onRefetch={onRefetch}
                 saving={saving}
               />
@@ -351,7 +342,7 @@ function ManagedSandboxShell({
     <Shell
       icon={Cloud}
       title="Atlas Cloud Sandbox"
-      description="Managed container service with HTTP isolation. Recommended for most workspaces."
+      description="Managed Firecracker microVM with network isolation. Recommended for most workspaces."
       status={status}
       trailing={
         isActive ? (

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -442,6 +442,22 @@ export {
   PlatformSecurityMetricsSchema,
 } from "@useatlas/schemas";
 
+// ── Sandbox (/admin/sandbox) ──────────────────────────────────
+// Provider-key vocabulary + status wire schemas live in
+// `@useatlas/schemas` (single source of truth shared with the API route
+// layer, #3371). `SANDBOX_PROVIDER_BACKEND_IDS` maps provider keys to the
+// backend ids that `ATLAS_SANDBOX_BACKEND` stores (#3375).
+
+export {
+  SANDBOX_PROVIDER_KEYS,
+  SANDBOX_PROVIDER_BACKEND_IDS,
+  SandboxProviderKeySchema,
+  SandboxStatusSchema,
+  type SandboxProviderKey,
+  type SandboxConnectedProvider,
+  type SandboxStatus,
+} from "@useatlas/schemas";
+
 export type {
   SecurityBuckets,
   WorkspaceSecurityMetrics,


### PR DESCRIPTION
Closes #3375. Closes #3371. Part of the #3374 deploy-mode drift audit (taxonomy class 1 + class 4).

**What**
- `@useatlas/schemas` is now the SSOT for the sandbox provider vocabulary (new `packages/schemas/src/sandbox.ts`): `SANDBOX_PROVIDER_KEYS`, `SandboxProviderKeySchema`, the one statement of the provider-key → backend-id mapping (`SANDBOX_PROVIDER_BACKEND_IDS`), `normalizeSandboxBackendValue()` for legacy stored values, and the `/admin/sandbox/status` wire schemas. `@atlas/api` (`credentials.ts`, `admin-sandbox.ts`) and `@atlas/web` (via the `@/ui/lib/admin-schemas` re-export) both consume it — no `@atlas/web → @atlas/api` import, no hand-mirrored enums (#3371).
- The SaaS sandbox view now writes backend ids (`e2b-sandbox`, …) into `ATLAS_SANDBOX_BACKEND` instead of provider keys (`e2b`) that the explore runtime could never match — selection no longer silently falls through to the platform pin (#3375).
- The Managed card clears the override (DELETE, same revert-to-default path the self-hosted reset uses) instead of writing `"sidecar"` — a value with no backing service on SaaS. "Managed" now means *follow the platform default* (`vercel-sandbox` per the `deploy/api/atlas.config.ts` pin), and stays correct if the pin ever changes.
- `isActive` can no longer contradict `activeBackend`: the status route derives `isActive` as "(normalized) override selects this provider's backend id AND the resolved activeBackend landed on it". The web's `isManagedActive` derives from the server's `isActive`, not a string compare.
- Legacy stored values keep working: readers (`explore.ts` override resolution incl. the cache key, the status route, the disconnect-reset compare) normalize bare provider keys through `normalizeSandboxBackendValue`. The settings-registry description documents backend ids as the canonical value set (parity contract Rule 3).
- Docs ride-along (Rule 5): `guides/sandbox.mdx` + `reference/environment-variables.mdx` updated to the backend-id vocabulary and the real SaaS managed backend.

**Why**
Audit finding #3375: a SaaS workspace admin connecting E2B and clicking "Use this" saved `"e2b"`, the UI showed the row as **Live** (`isActive` compared provider keys), and every explore call silently ran on Vercel Sandbox instead. Three components held three different opinions of the same setting's vocabulary.

**Notes for review**
- Out of scope, unchanged: wiring stored BYOC credentials into backend construction is #3370 (sibling issue, own product decision). Until it lands, a BYOC selection resolves through the normal plugin chain.
- Write-path normalization (settings PUT) deliberately not added here — the generic settings write path is being touched by #3376's `saasWritable` work; read-time normalization + the registry description cover the legacy-value window.
- `platformDefault: activePluginId ?? platformDefault` in the status response is pre-existing and correct per the field's contract (reviewed, left alone).

**Tests**
- `packages/schemas` — mapping completeness + normalize identity/translation (12 tests)
- `packages/api` — status-route vocabulary agreement (legacy `"e2b"` and canonical `"e2b-sandbox"` both resolve; `isActive` ⇔ `activeBackend` coherence), explore override normalization incl. cache-key behavior (9 + 9 tests)
- `packages/web` — SaaS view save-value mapping: BYOC saves backend id; Managed clears the override (3 tests)
- Verified: 92/92 affected API test files, `bun run lint`, `bun run type`

https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc

---
_Generated by [Claude Code](https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753247&installation_id=135337507&pr_number=3383&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3383&signature=379a6b1fa313f66ed5e8274098edef68e055b0168fbc2ec000807d089d5c9c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Atlas Cloud Sandbox description (managed Firecracker microVM) and set it as the recommended/default fallback
  * Clarified sandbox environment variable docs and added supported backend IDs

* **New Features**
  * Introduced shared sandbox provider/backend schemas for consistent handling
  * Workspace override normalization now accepts legacy keys and maps them to backend IDs

* **Bug Fixes**
  * Resolved contradictory active-provider flags and improved managed vs BYOC selection logic

* **Tests**
  * Added comprehensive endpoint, schema, and UI regression tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->