### PR TITLE
fix(api): warn at scheduled-task create/update when the delivery channel has no sender; surface permanent failures distinctly

### DIFF
--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -83,6 +83,16 @@ mock.module("@atlas/api/lib/scheduled-tasks", () => ({
   validateCronExpression: mockValidateCronExpression,
 }));
 
+// #3379 — sender preflight (warn-don't-block). Mocked so route tests don't
+// walk the real email/Slack resolution chains; the chain itself is covered
+// in lib/scheduler/__tests__/sender-preflight.test.ts.
+const mockCheckDeliverySenders = mock((): Promise<string[]> => Promise.resolve([]));
+mock.module("@atlas/api/lib/scheduler/sender-preflight", () => ({
+  checkDeliverySenders: mockCheckDeliverySenders,
+  EMAIL_NO_SENDER_WARNING: "email-warning-stub",
+  SLACK_NO_SENDER_WARNING: "slack-warning-stub",
+}));
+
 // --- Other mocks (required by Hono app index.ts) ---
 
 mock.module("@atlas/api/lib/agent", () => ({
@@ -218,6 +228,8 @@ describe("scheduled-tasks routes", () => {
     mockListAllRuns.mockResolvedValue({ runs: [], total: 0 });
     mockValidateCronExpression.mockReset();
     mockValidateCronExpression.mockReturnValue({ valid: true });
+    mockCheckDeliverySenders.mockReset();
+    mockCheckDeliverySenders.mockResolvedValue([]);
     mockRunTick.mockReset();
     mockRunTick.mockResolvedValue({ tasksFound: 0, tasksDispatched: 0, tasksCompleted: 0, tasksFailed: 0 });
     mockGetConfig.mockReset();
@@ -348,6 +360,82 @@ describe("scheduled-tasks routes", () => {
       const opts = mockCreateScheduledTask.mock.calls[0][0] as { connectionGroupId?: string | null; connectionId?: string | null };
       expect("connectionId" in opts).toBe(false);
       expect(opts.connectionGroupId).toBe("g_prod");
+    });
+
+    // #3379 — sender preflight: warn, never block.
+
+    it("includes warnings: [] on create when senders are configured", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What was yesterday's revenue?",
+            cronExpression: "0 9 * * 1",
+            deliveryChannel: "email",
+            recipients: [{ type: "email", address: "test@test.com" }],
+            connectionGroupId: "g_prod",
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.warnings).toEqual([]);
+    });
+
+    it("returns 201 WITH warnings when the deployment has no sender (warn, never block) (#3379)", async () => {
+      mockCheckDeliverySenders.mockResolvedValueOnce(["email-warning-stub"]);
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What was yesterday's revenue?",
+            cronExpression: "0 9 * * 1",
+            deliveryChannel: "email",
+            recipients: [{ type: "email", address: "test@test.com" }],
+            connectionGroupId: "g_prod",
+          }),
+        }),
+      );
+      // Creation still succeeds — the warning rides on the response.
+      expect(response.status).toBe(201);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.warnings).toEqual(["email-warning-stub"]);
+      expect(mockCreateScheduledTask).toHaveBeenCalledTimes(1);
+      // The preflight sees only channel-matching recipients + the caller's org.
+      expect(mockCheckDeliverySenders).toHaveBeenCalledWith(
+        [{ type: "email", address: "test@test.com" }],
+        "org-1",
+      );
+    });
+
+    it("preflights only recipients matching the delivery channel (#3379)", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What was yesterday's revenue?",
+            cronExpression: "0 9 * * 1",
+            deliveryChannel: "webhook",
+            recipients: [
+              { type: "webhook", url: "https://hook.example.com" },
+              // Stale recipient of another channel — must not trigger a warning.
+              { type: "email", address: "stale@test.com" },
+            ],
+            connectionGroupId: "g_prod",
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      expect(mockCheckDeliverySenders).toHaveBeenCalledWith(
+        [{ type: "webhook", url: "https://hook.example.com" }],
+        "org-1",
+      );
     });
 
     it("returns 422 for missing name", async () => {
@@ -573,6 +661,43 @@ describe("scheduled-tasks routes", () => {
         }),
       );
       expect(response.status).toBe(400);
+    });
+
+    // #3379 — sender preflight on update: warn, never block.
+
+    it("returns 200 WITH warnings when updated recipients have no sender (#3379)", async () => {
+      mockCheckDeliverySenders.mockResolvedValueOnce(["slack-warning-stub"]);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/scheduled-tasks/${VALID_ID}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            deliveryChannel: "slack",
+            recipients: [{ type: "slack", channel: "#reports" }],
+          }),
+        }),
+      );
+      // Update still succeeds — the warning rides on the response.
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.warnings).toEqual(["slack-warning-stub"]);
+      expect(mockCheckDeliverySenders).toHaveBeenCalledWith(
+        [{ type: "slack", channel: "#reports" }],
+        "org-1",
+      );
+    });
+
+    it("includes warnings: [] on update when senders are configured (#3379)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/scheduled-tasks/${VALID_ID}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Updated Name" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.warnings).toEqual([]);
     });
 
     it("returns 400 for invalid JSON", async () => {

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -31,7 +31,14 @@ import {
 } from "@atlas/api/lib/scheduled-tasks";
 import type { TickResult } from "@atlas/api/lib/scheduler/engine";
 import { isBlockedUrl } from "@atlas/api/lib/scheduler/delivery";
-import { DELIVERY_CHANNELS, RUN_STATUSES, type RunStatus } from "@atlas/api/lib/scheduled-task-types";
+import { checkDeliverySenders } from "@atlas/api/lib/scheduler/sender-preflight";
+import {
+  DELIVERY_CHANNELS,
+  RUN_STATUSES,
+  type DeliveryChannel,
+  type Recipient,
+  type RunStatus,
+} from "@atlas/api/lib/scheduled-task-types";
 import { ACTION_APPROVAL_MODES } from "@atlas/api/lib/action-types";
 import { type AuthEnv } from "./middleware";
 import { ErrorSchema, parsePagination } from "./shared-schemas";
@@ -96,6 +103,22 @@ const UpdateScheduledTaskSchema = z.object({
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+
+/**
+ * Recipients the sender preflight should inspect — only those matching the
+ * task's delivery channel, mirroring the filter `deliverResult` applies at
+ * delivery time so a stale recipient of another channel can't produce a
+ * spurious warning (#3379). Tolerates `undefined` inputs defensively: the
+ * preflight is best-effort and must never turn a successful create/update
+ * into a 500.
+ */
+function recipientsForChannel(
+  recipients: Recipient[] | undefined,
+  channel: DeliveryChannel | undefined,
+): Recipient[] {
+  if (!recipients || !channel) return [];
+  return recipients.filter((r) => r.type === channel);
+}
 
 function crudFailResponse(reason: CrudFailReason, requestId?: string) {
   switch (reason) {
@@ -366,7 +389,17 @@ authed.openapi(
         metadata: { name: parsed.name },
       });
 
-      return c.json(createResult.data, 201);
+      // #3379 — sender preflight: warn (never block) when this deployment has
+      // no working sender for the chosen channel. The task is created either
+      // way; the admin can configure the sender afterwards.
+      const warnings = yield* Effect.promise(() =>
+        checkDeliverySenders(
+          recipientsForChannel(parsed.recipients, parsed.deliveryChannel),
+          orgId,
+        ),
+      );
+
+      return c.json({ ...createResult.data, warnings }, 201);
     }), { label: "create scheduled task" });
   },
   (result, c) => {
@@ -619,9 +652,25 @@ authed.openapi(
       }
 
       if (!updated.ok) {
-        return c.json({ ok: true }, 200);
+        // Update succeeded but the re-fetch failed — keep the legacy shape,
+        // with an empty warnings array for response-shape consistency.
+        return c.json({ ok: true, warnings: [] }, 200);
       }
-      return c.json(updated.data, 200);
+
+      // #3379 — sender preflight on the task's EFFECTIVE post-update state.
+      // The request body may omit recipients/deliveryChannel (partial PUT),
+      // so prefer the parsed values when present and fall back to the stored
+      // task. Warn, never block.
+      const warnings = yield* Effect.promise(() =>
+        checkDeliverySenders(
+          recipientsForChannel(
+            parsed.recipients ?? updated.data.recipients,
+            parsed.deliveryChannel ?? updated.data.deliveryChannel,
+          ),
+          orgId,
+        ),
+      );
+      return c.json({ ...updated.data, warnings }, 200);
     }), { label: "update scheduled task" });
   },
   (result, c) => {

--- a/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect } from "bun:test";
 import {
   DELIVERY_CHANNELS,
   RUN_STATUSES,
+  DELIVERY_STATUSES,
+  KNOWN_DELIVERY_STATUSES,
   type EmailRecipient,
   type SlackRecipient,
   type WebhookRecipient,
@@ -33,6 +35,19 @@ describe("scheduled-task-types", () => {
 
     it("is a readonly tuple (as const)", () => {
       expect(RUN_STATUSES.length).toBe(4);
+    });
+  });
+
+  describe("KNOWN_DELIVERY_STATUSES (#3379)", () => {
+    it("is the published DELIVERY_STATUSES plus failed_permanent", () => {
+      // The runtime accept-list must be a strict superset of the published
+      // value export — dropping a published status would null out existing
+      // rows at the rowToScheduledTaskRun boundary.
+      for (const status of DELIVERY_STATUSES) {
+        expect(KNOWN_DELIVERY_STATUSES).toContain(status);
+      }
+      expect(KNOWN_DELIVERY_STATUSES).toContain("failed_permanent");
+      expect(KNOWN_DELIVERY_STATUSES.length).toBe(DELIVERY_STATUSES.length + 1);
     });
   });
 

--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -25,6 +25,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 const {
   sendEmail,
+  resolveEmailSender,
   isAuthEmailDeliveryConfigured,
   sendTransactionalEmail,
   shouldEnqueueFailedSend,
@@ -99,6 +100,65 @@ describe("sendEmail — fallback chain", () => {
     expect(result.success).toBe(false);
     expect(result.provider).toBe("resend");
     expect(result.error).toContain("401");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEmailSender — resolution-only view of the chain (#3379)
+// ---------------------------------------------------------------------------
+
+describe("resolveEmailSender (#3379)", () => {
+  it("resolves to log when nothing is configured", async () => {
+    const resolved = await resolveEmailSender();
+    expect(resolved).toEqual({ kind: "log" });
+  });
+
+  it("resolves to resend-env when RESEND_API_KEY is set", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    const resolved = await resolveEmailSender();
+    expect(resolved.kind).toBe("resend-env");
+  });
+
+  it("resolves to smtp-webhook when ATLAS_SMTP_URL is set (priority over Resend env)", async () => {
+    process.env.ATLAS_SMTP_URL = "http://localhost:2525";
+    process.env.RESEND_API_KEY = "re_test_key";
+    const resolved = await resolveEmailSender();
+    expect(resolved.kind).toBe("smtp-webhook");
+  });
+
+  it("resolves to platform-transport when platform settings configure a provider", async () => {
+    settingsStore["ATLAS_EMAIL_PROVIDER"] = "sendgrid";
+    settingsStore["SENDGRID_API_KEY"] = "SG.platform_key";
+    const resolved = await resolveEmailSender();
+    expect(resolved.kind).toBe("platform-transport");
+    if (resolved.kind === "platform-transport") {
+      expect(resolved.transport.provider).toBe("sendgrid");
+    }
+  });
+
+  it("resolves to log when the platform provider is set but its key is missing", async () => {
+    settingsStore["ATLAS_EMAIL_PROVIDER"] = "resend";
+    const resolved = await resolveEmailSender();
+    expect(resolved.kind).toBe("log");
+  });
+
+  it("falls through an orgId with no DB-stored transport to the env chain", async () => {
+    // No internal DB in the unit-test env — getEmailTransport returns null
+    // (errors are caught + logged) and the chain continues to the env vars.
+    process.env.RESEND_API_KEY = "re_test_key";
+    const resolved = await resolveEmailSender("org-1");
+    expect(resolved.kind).toBe("resend-env");
+  });
+
+  it("agrees with sendEmail about the log fallback — the chain is shared, not duplicated", async () => {
+    // The scheduler sender preflight warns iff resolveEmailSender lands on
+    // "log"; sendEmail must report the same provider for the same env so the
+    // two can never disagree (#3379).
+    const resolved = await resolveEmailSender();
+    const sent = await sendEmail({ to: "t@example.com", subject: "S", html: "<p>x</p>" });
+    expect(resolved.kind).toBe("log");
+    expect(sent.provider).toBe("log");
+    expect(sent.success).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -14,6 +14,24 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSetting: (key: string) => settingsStore[key],
 }));
 
+// Controllable per-org email install (default: none). Mirrors the store's
+// read shape; `provider` is injected from the sibling column at read time in
+// the real store, so the mock includes it directly.
+let mockOrgInstall: {
+  provider: string;
+  sender_address: string;
+  config: Record<string, unknown>;
+} | null = null;
+
+mock.module("@atlas/api/lib/email/store", () => ({
+  EMAIL_PROVIDERS: ["resend", "sendgrid", "postmark", "smtp", "ses"],
+  getEmailInstallationByOrg: async () => mockOrgInstall,
+  saveEmailInstallation: async () => {
+    throw new Error("saveEmailInstallation not used in these tests");
+  },
+  deleteEmailInstallationByOrg: async () => false,
+}));
+
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
@@ -57,6 +75,7 @@ beforeEach(() => {
   delete process.env.RESEND_API_KEY;
   delete process.env.ATLAS_EMAIL_FROM;
   settingsStore = {};
+  mockOrgInstall = null;
 });
 
 afterEach(() => {
@@ -148,6 +167,53 @@ describe("resolveEmailSender (#3379)", () => {
     process.env.RESEND_API_KEY = "re_test_key";
     const resolved = await resolveEmailSender("org-1");
     expect(resolved.kind).toBe("resend-env");
+  });
+
+  it("resolves to org-transport with bridgeMissing when the org install is smtp/ses and ATLAS_SMTP_URL is unset (#3385 review)", async () => {
+    mockOrgInstall = {
+      provider: "smtp",
+      sender_address: "reports@acme.test",
+      config: { provider: "smtp", host: "mail.acme.test", port: 587 },
+    };
+    const resolved = await resolveEmailSender("org-1");
+    expect(resolved.kind).toBe("org-transport");
+    if (resolved.kind === "org-transport") {
+      expect(resolved.bridgeMissing).toBe(true);
+    }
+    // Chain agreement: the send for the same env refuses with the
+    // log-provider bridge failure the preflight is warning about.
+    const sent = await sendEmail({ to: "t@example.com", subject: "S", html: "<p>x</p>" }, "org-1");
+    expect(sent.success).toBe(false);
+    expect(sent.provider).toBe("log");
+    expect(sent.error).toContain("ATLAS_SMTP_URL");
+  });
+
+  it("resolves to org-transport WITHOUT bridgeMissing when the bridge is set", async () => {
+    process.env.ATLAS_SMTP_URL = "http://localhost:2525";
+    mockOrgInstall = {
+      provider: "ses",
+      sender_address: "reports@acme.test",
+      config: { provider: "ses", region: "us-east-1" },
+    };
+    const resolved = await resolveEmailSender("org-1");
+    expect(resolved.kind).toBe("org-transport");
+    if (resolved.kind === "org-transport") {
+      expect(resolved.bridgeMissing).toBeUndefined();
+    }
+  });
+
+  it("resolves to org-transport for API-based org providers regardless of the bridge", async () => {
+    mockOrgInstall = {
+      provider: "resend",
+      sender_address: "reports@acme.test",
+      config: { provider: "resend", apiKey: "re_org_key" },
+    };
+    const resolved = await resolveEmailSender("org-1");
+    expect(resolved.kind).toBe("org-transport");
+    if (resolved.kind === "org-transport") {
+      expect(resolved.bridgeMissing).toBeUndefined();
+      expect(resolved.transport.provider).toBe("resend");
+    }
   });
 
   it("agrees with sendEmail about the log fallback — the chain is shared, not duplicated", async () => {

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -219,7 +219,7 @@ export interface DeliveryResult {
   error?: string;
 }
 
-interface EmailTransport {
+export interface EmailTransport {
   provider: EmailProvider;
   senderAddress: string;
   /**
@@ -347,9 +347,65 @@ function getPlatformEmailConfig(): EmailTransport | null {
 }
 
 /**
+ * Resolution-only view of the provider chain: which backend WOULD
+ * {@link sendEmail} use right now? `"log"` means nothing is configured —
+ * the dev fallback that only writes the message to the server log.
+ */
+export type ResolvedEmailSender =
+  | { kind: "org-transport"; transport: EmailTransport }
+  | { kind: "platform-transport"; transport: EmailTransport }
+  | { kind: "smtp-webhook" }
+  | { kind: "resend-env" }
+  | { kind: "log" };
+
+/**
+ * Walk the provider chain WITHOUT sending anything and report where it lands.
+ *
+ * This is the single statement of the chain — {@link sendEmail} dispatches on
+ * its result, and the scheduler's sender preflight
+ * (`lib/scheduler/sender-preflight.ts`, #3379) calls it to warn at task
+ * create/update time when the chain would land on the `log` fallback. Because
+ * both consume the SAME resolution, the preflight and the actual send can
+ * never disagree about whether a sender exists.
+ *
+ * Priority: DB config (per-org) → platform email settings → ATLAS_SMTP_URL
+ * (webhook) → RESEND_API_KEY → `log` (nothing configured).
+ */
+export async function resolveEmailSender(orgId?: string): Promise<ResolvedEmailSender> {
+  // 1. DB-stored config for the org
+  if (orgId) {
+    const transport = await getEmailTransport(orgId);
+    if (transport) {
+      return { kind: "org-transport", transport };
+    }
+  }
+
+  // 2. Platform email provider (settings registry)
+  const platformConfig = getPlatformEmailConfig();
+  if (platformConfig) {
+    return { kind: "platform-transport", transport: platformConfig };
+  }
+
+  // 3. Webhook delivery (generic email API)
+  if (process.env.ATLAS_SMTP_URL) {
+    return { kind: "smtp-webhook" };
+  }
+
+  // 4. Resend API delivery (env-var fallback for backward compat)
+  if (process.env.RESEND_API_KEY) {
+    return { kind: "resend-env" };
+  }
+
+  // 5. Nothing configured — sendEmail's dev fallback logs instead of sending.
+  return { kind: "log" };
+}
+
+/**
  * Send an email using the configured delivery backend.
  *
  * Priority: DB config (per-org) → platform email settings → ATLAS_SMTP_URL (webhook) → RESEND_API_KEY → console log (dev fallback).
+ * The chain itself lives in {@link resolveEmailSender}; this function only
+ * dispatches on its result so the scheduler preflight reuses the exact logic.
  *
  * Pass `orgId` to enable DB-backed email config lookup. When omitted, falls back to platform/env settings.
  */
@@ -361,39 +417,34 @@ export async function sendEmail(message: EmailMessage, orgId?: string): Promise<
   // a path that kept using the raw `message` would leak.
   const outbound = clampForOutbound(message);
 
-  // 1. Try DB-stored config for the org
-  if (orgId) {
-    const transport = await getEmailTransport(orgId);
-    if (transport) {
-      return deliverViaTransport(outbound, transport);
-    }
-  }
-
-  // 2. Platform email provider (settings registry)
-  const platformConfig = getPlatformEmailConfig();
-  if (platformConfig) {
-    return deliverViaTransport(outbound, platformConfig);
-  }
-
+  const resolved = await resolveEmailSender(orgId);
   const fromAddress = process.env.ATLAS_EMAIL_FROM ?? "Atlas <noreply@ship.useatlas.dev>";
 
-  // 3. Webhook delivery (generic email API)
-  if (process.env.ATLAS_SMTP_URL) {
-    return deliverWebhook(outbound, fromAddress);
-  }
+  switch (resolved.kind) {
+    case "org-transport":
+    case "platform-transport":
+      return deliverViaTransport(outbound, resolved.transport);
 
-  // 4. Resend API delivery (env-var fallback for backward compat)
-  if (process.env.RESEND_API_KEY) {
-    return deliverResend(outbound, fromAddress);
-  }
+    case "smtp-webhook":
+      return deliverWebhook(outbound, fromAddress);
 
-  // 5. Dev fallback — log instead of sending. Returns success: false so the email
-  // is not recorded as sent, allowing retry when a provider is configured.
-  log.warn(
-    { to: outbound.to, subject: outbound.subject },
-    "Email delivery skipped — no email provider configured",
-  );
-  return { success: false, provider: "log", error: "No email delivery backend configured (configure a platform email provider or set RESEND_API_KEY)" };
+    case "resend-env":
+      return deliverResend(outbound, fromAddress);
+
+    case "log":
+      // Dev fallback — log instead of sending. Returns success: false so the email
+      // is not recorded as sent, allowing retry when a provider is configured.
+      log.warn(
+        { to: outbound.to, subject: outbound.subject },
+        "Email delivery skipped — no email provider configured",
+      );
+      return { success: false, provider: "log", error: "No email delivery backend configured (configure a platform email provider or set RESEND_API_KEY)" };
+
+    default: {
+      const _exhaustive: never = resolved;
+      return { success: false, provider: "log", error: `Unknown email sender resolution: ${JSON.stringify(_exhaustive)}` };
+    }
+  }
 }
 
 /**

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -352,7 +352,20 @@ function getPlatformEmailConfig(): EmailTransport | null {
  * the dev fallback that only writes the message to the server log.
  */
 export type ResolvedEmailSender =
-  | { kind: "org-transport"; transport: EmailTransport }
+  | {
+      kind: "org-transport";
+      transport: EmailTransport;
+      /**
+       * True when the org transport is `smtp`/`ses` but the
+       * `ATLAS_SMTP_URL` HTTP bridge those providers require is unset —
+       * `deliverViaTransport` will refuse the send with a log-provider
+       * failure. The send-path dispatch is unchanged (the failure still
+       * surfaces at delivery, matching pre-#3379 behavior); the sender
+       * preflight reads this to warn at create/update time instead of
+       * reporting the org transport as configured (#3385 review).
+       */
+      bridgeMissing?: boolean;
+    }
   | { kind: "platform-transport"; transport: EmailTransport }
   | { kind: "smtp-webhook" }
   | { kind: "resend-env" }
@@ -376,7 +389,12 @@ export async function resolveEmailSender(orgId?: string): Promise<ResolvedEmailS
   if (orgId) {
     const transport = await getEmailTransport(orgId);
     if (transport) {
-      return { kind: "org-transport", transport };
+      const bridgeMissing =
+        (transport.config.provider === "smtp" || transport.config.provider === "ses") &&
+        !process.env.ATLAS_SMTP_URL;
+      return bridgeMissing
+        ? { kind: "org-transport", transport, bridgeMissing }
+        : { kind: "org-transport", transport };
     }
   }
 

--- a/packages/api/src/lib/scheduled-task-types.ts
+++ b/packages/api/src/lib/scheduled-task-types.ts
@@ -13,6 +13,31 @@ export {
   DELIVERY_STATUSES,
   isRecipient,
 } from "@useatlas/types/scheduled-task";
+
+import { DELIVERY_STATUSES } from "@useatlas/types/scheduled-task";
+
+/**
+ * Runtime accept-list for `scheduled_task_runs.delivery_status` (#3379).
+ *
+ * Extends the published `DELIVERY_STATUSES` with `"failed_permanent"` —
+ * written by the executor when ALL delivery failures in a run were permanent
+ * (misconfiguration: no email sender, no Slack token, blocked webhook URL),
+ * so the run history can distinguish "fix your config" from "retry later".
+ *
+ * The new value lives HERE (scaffold-bound source) rather than in the
+ * `DELIVERY_STATUSES` value export of `@useatlas/types`, because that package
+ * is consumed from the npm registry by scaffold builds and a value change
+ * would drift until the next publish + ref bump. The union type in
+ * `@useatlas/types` carries `"failed_permanent"` type-only for the same
+ * reason. Annotated `readonly string[]` (not `satisfies readonly
+ * DeliveryStatus[]`) deliberately: scaffold builds type-check this file
+ * against the *published* `.d.ts`, whose union may not yet include the new
+ * member.
+ */
+export const KNOWN_DELIVERY_STATUSES: readonly string[] = [
+  ...DELIVERY_STATUSES,
+  "failed_permanent",
+];
 export type {
   DeliveryChannel,
   RunStatus,

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -28,7 +28,7 @@ import type {
   Recipient,
   RunStatus,
 } from "@atlas/api/lib/scheduled-task-types";
-import { DELIVERY_STATUSES } from "@atlas/api/lib/scheduled-task-types";
+import { KNOWN_DELIVERY_STATUSES } from "@atlas/api/lib/scheduled-task-types";
 import { isRecipient } from "@atlas/api/lib/scheduled-task-types";
 import type { ActionApprovalMode } from "@atlas/api/lib/action-types";
 
@@ -88,8 +88,11 @@ function rowToScheduledTask(r: Record<string, unknown>): ScheduledTask {
 
 function rowToScheduledTaskRun(r: Record<string, unknown>): ScheduledTaskRun {
   const rawDeliveryStatus = r.delivery_status as string | null | undefined;
+  // KNOWN_DELIVERY_STATUSES (not the published DELIVERY_STATUSES) so
+  // "failed_permanent" rows survive the boundary instead of mapping to null
+  // and hiding the misconfiguration signal from the run-history UI (#3379).
   const deliveryStatus: DeliveryStatus | null =
-    rawDeliveryStatus && (DELIVERY_STATUSES as readonly string[]).includes(rawDeliveryStatus)
+    rawDeliveryStatus && KNOWN_DELIVERY_STATUSES.includes(rawDeliveryStatus)
       ? (rawDeliveryStatus as DeliveryStatus)
       : null;
 
@@ -432,10 +435,17 @@ export async function createTaskRun(taskId: string): Promise<string | null> {
   }
 }
 
-/** Update delivery status on a run record. Fire-and-forget. */
+/**
+ * Update delivery status on a run record. Fire-and-forget.
+ *
+ * The `| "failed_permanent"` widening is redundant against the workspace
+ * `DeliveryStatus` union but load-bearing against the *published* `.d.ts`
+ * that scaffold builds compile this file with (see
+ * {@link KNOWN_DELIVERY_STATUSES}).
+ */
 export function updateRunDeliveryStatus(
   runId: string,
-  status: DeliveryStatus,
+  status: DeliveryStatus | "failed_permanent",
   error?: string,
 ): void {
   if (!hasInternalDB()) return;

--- a/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
@@ -72,7 +72,7 @@ describe("delivery dispatcher", () => {
   it("returns zero summary when no recipients", async () => {
     const task = makeTask({ recipients: [] });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 0, succeeded: 0, failed: 0 });
+    expect(summary).toEqual({ attempted: 0, succeeded: 0, failed: 0, permanentFailures: 0, firstPermanentError: null });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -82,7 +82,7 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "webhook", url: "https://hook.example.com" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 1, failed: 0 });
+    expect(summary).toEqual({ attempted: 1, succeeded: 1, failed: 0, permanentFailures: 0, firstPermanentError: null });
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const callArgs = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
     expect(callArgs[0]).toBe("https://hook.example.com");
@@ -115,7 +115,15 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "email", address: "test@example.com" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1 });
+    // #3379 — the log-provider fallback is a PERMANENT failure (no sender
+    // configured); the summary must say so and carry the actionable message.
+    expect(summary).toEqual({
+      attempted: 1,
+      succeeded: 0,
+      failed: 1,
+      permanentFailures: 1,
+      firstPermanentError: expect.stringContaining("No email delivery backend configured") as unknown as string,
+    });
     expect(mockFetch).not.toHaveBeenCalled();
 
     if (origKey) process.env.RESEND_API_KEY = origKey;
@@ -131,7 +139,8 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "webhook", url: "https://hook.example.com" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1 });
+    // Transient (5xx) — failed, but NOT permanent (#3379).
+    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1, permanentFailures: 0, firstPermanentError: null });
     // Should have retried (original + up to 3 retries)
     expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
   }, 30_000);
@@ -146,7 +155,7 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "webhook", url: "https://hook.example.com" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1 });
+    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1, permanentFailures: 0, firstPermanentError: null });
     expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
   }, 30_000);
 
@@ -179,7 +188,8 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "webhook", url: "http://169.254.169.254/latest/meta-data/" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1 });
+    // Blocked URL — permanent failure, surfaced as such (#3379).
+    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1, permanentFailures: 1, firstPermanentError: "Blocked URL" });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -229,7 +239,9 @@ describe("delivery dispatcher", () => {
       recipients: [{ type: "webhook", url: "https://hook.example.com" }],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 1, succeeded: 0, failed: 1 });
+    expect(summary.failed).toBe(1);
+    expect(summary.permanentFailures).toBe(1);
+    expect(summary.firstPermanentError).toContain("Blocked URL (egress guard)");
     // The first request goes out; the redirect target must never be fetched.
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const calledUrls = mockFetch.mock.calls.map((c) => (c as unknown as [string])[0]);
@@ -246,7 +258,7 @@ describe("delivery dispatcher", () => {
       ],
     });
     const summary = await deliverResult(task, makeResult());
-    expect(summary).toEqual({ attempted: 3, succeeded: 3, failed: 0 });
+    expect(summary).toEqual({ attempted: 3, succeeded: 3, failed: 0, permanentFailures: 0, firstPermanentError: null });
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
@@ -264,7 +276,32 @@ describe("delivery dispatcher", () => {
     expect(summary.attempted).toBe(3);
     expect(summary.succeeded).toBe(2);
     expect(summary.failed).toBe(1);
+    // The single failure is the blocked URL — a permanent one (#3379).
+    expect(summary.permanentFailures).toBe(1);
+    expect(summary.firstPermanentError).toBe("Blocked URL");
   });
+
+  it("counts only the permanent failures when failures are mixed (#3379)", async () => {
+    // One blocked URL (permanent, no retry) + one persistent 500 (transient,
+    // retries exhausted). permanentFailures must count ONLY the former, and
+    // firstPermanentError must carry its message — the executor uses
+    // permanentFailures === failed to decide "failed_permanent", so a mixed
+    // run stays plain "failed".
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(new Response("err", { status: 500 }));
+
+    const task = makeTask({
+      deliveryChannel: "webhook",
+      recipients: [
+        { type: "webhook", url: "http://localhost:3001/internal" },
+        { type: "webhook", url: "https://hook.example.com" },
+      ],
+    });
+    const summary = await deliverResult(task, makeResult());
+    expect(summary.failed).toBe(2);
+    expect(summary.permanentFailures).toBe(1);
+    expect(summary.firstPermanentError).toBe("Blocked URL");
+  }, 30_000);
 
   describe("OTel span coverage (#1979)", () => {
     it("emits atlas.scheduler.delivery once per recipient on the success path", async () => {

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -96,7 +96,7 @@ mock.module("@atlas/api/lib/agent-query", () => ({
 }));
 
 const mockDeliverResult = mock(() =>
-  Promise.resolve({ attempted: 1, succeeded: 1, failed: 0 }),
+  Promise.resolve({ attempted: 1, succeeded: 1, failed: 0, permanentFailures: 0, firstPermanentError: null as string | null }),
 );
 
 mock.module("../delivery", () => ({
@@ -163,7 +163,7 @@ describe("executor", () => {
       return Promise.resolve(result);
     });
     mockDeliverResult.mockReset();
-    mockDeliverResult.mockResolvedValue({ attempted: 1, succeeded: 1, failed: 0 });
+    mockDeliverResult.mockResolvedValue({ attempted: 1, succeeded: 1, failed: 0, permanentFailures: 0, firstPermanentError: null });
     mockUpdateRunDeliveryStatus.mockReset();
     mockResolveScheduledTaskConnection.mockReset();
     mockResolveScheduledTaskConnection.mockResolvedValue("resolved-connection");
@@ -189,20 +189,72 @@ describe("executor", () => {
     expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith("run-1", "sent");
   });
 
-  it("marks delivery as failed on full failure", async () => {
-    mockDeliverResult.mockResolvedValueOnce({ attempted: 2, succeeded: 0, failed: 2 });
+  it("marks delivery as failed on full transient failure", async () => {
+    mockDeliverResult.mockResolvedValueOnce({ attempted: 2, succeeded: 0, failed: 2, permanentFailures: 0, firstPermanentError: null });
     await executeScheduledTask("task-1", "run-1", 30_000);
     expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith("run-1", "failed", "All 2 deliveries failed");
   });
 
   it("marks delivery as failed on partial failure", async () => {
-    mockDeliverResult.mockResolvedValueOnce({ attempted: 3, succeeded: 1, failed: 2 });
+    mockDeliverResult.mockResolvedValueOnce({ attempted: 3, succeeded: 1, failed: 2, permanentFailures: 0, firstPermanentError: null });
     await executeScheduledTask("task-1", "run-1", 30_000);
     expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith("run-1", "failed", "Partial failure: 2/3 deliveries failed");
   });
 
+  // ── #3379: permanent-failure surfacing ─────────────────────────────
+
+  it("marks delivery as failed_permanent when ALL failures are permanent (#3379)", async () => {
+    mockDeliverResult.mockResolvedValueOnce({
+      attempted: 2,
+      succeeded: 0,
+      failed: 2,
+      permanentFailures: 2,
+      firstPermanentError: "No email delivery backend configured (configure a platform email provider or set RESEND_API_KEY)",
+    });
+    await executeScheduledTask("task-1", "run-1", 30_000);
+    expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith(
+      "run-1",
+      "failed_permanent",
+      "All 2 deliveries failed — No email delivery backend configured (configure a platform email provider or set RESEND_API_KEY)",
+    );
+  });
+
+  it("keeps plain failed when failures are mixed permanent + transient (#3379)", async () => {
+    mockDeliverResult.mockResolvedValueOnce({
+      attempted: 3,
+      succeeded: 0,
+      failed: 3,
+      permanentFailures: 1,
+      firstPermanentError: "Blocked URL",
+    });
+    await executeScheduledTask("task-1", "run-1", 30_000);
+    // Mixed → a retry may still help, so NOT failed_permanent; the first
+    // permanent error is still appended for context.
+    expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith(
+      "run-1",
+      "failed",
+      "All 3 deliveries failed — Blocked URL",
+    );
+  });
+
+  it("marks failed_permanent on partial success when every failure is permanent (#3379)", async () => {
+    mockDeliverResult.mockResolvedValueOnce({
+      attempted: 3,
+      succeeded: 1,
+      failed: 2,
+      permanentFailures: 2,
+      firstPermanentError: "No Slack bot token",
+    });
+    await executeScheduledTask("task-1", "run-1", 30_000);
+    expect(mockUpdateRunDeliveryStatus).toHaveBeenCalledWith(
+      "run-1",
+      "failed_permanent",
+      "Partial failure: 2/3 deliveries failed — No Slack bot token",
+    );
+  });
+
   it("skips delivery status when no recipients attempted", async () => {
-    mockDeliverResult.mockResolvedValueOnce({ attempted: 0, succeeded: 0, failed: 0 });
+    mockDeliverResult.mockResolvedValueOnce({ attempted: 0, succeeded: 0, failed: 0, permanentFailures: 0, firstPermanentError: null });
     await executeScheduledTask("task-1", "run-1", 30_000);
     expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
   });

--- a/packages/api/src/lib/scheduler/__tests__/sender-preflight.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/sender-preflight.test.ts
@@ -20,6 +20,7 @@ import type { ResolvedEmailSender } from "@atlas/api/lib/email/delivery";
 import {
   checkDeliverySenders,
   EMAIL_NO_SENDER_WARNING,
+  EMAIL_BRIDGE_WARNING,
   SLACK_NO_SENDER_WARNING,
 } from "../sender-preflight";
 
@@ -70,6 +71,36 @@ describe("checkDeliverySenders — email", () => {
       },
     });
     expect(seen).toEqual(["org-42"]);
+  });
+
+  it("warns when the org transport needs the ATLAS_SMTP_URL bridge and it is unset (#3385 review)", async () => {
+    const warnings = await checkDeliverySenders([EMAIL], "org-1", {
+      resolveEmailSender: async () => ({
+        kind: "org-transport",
+        transport: {
+          provider: "smtp",
+          senderAddress: "reports@acme.test",
+          config: { provider: "smtp", host: "mail.acme.test", port: 587, username: "u", password: "p", tls: true },
+        },
+        bridgeMissing: true,
+      }),
+    });
+    expect(warnings).toEqual([EMAIL_BRIDGE_WARNING]);
+    expect(warnings[0]).toContain("ATLAS_SMTP_URL");
+  });
+
+  it("does NOT warn for an org transport with no bridge problem", async () => {
+    const warnings = await checkDeliverySenders([EMAIL], "org-1", {
+      resolveEmailSender: async () => ({
+        kind: "org-transport",
+        transport: {
+          provider: "resend",
+          senderAddress: "reports@acme.test",
+          config: { provider: "resend", apiKey: "re_org_key" },
+        },
+      }),
+    });
+    expect(warnings).toEqual([]);
   });
 
   it("degrades to no warning (not a throw) when resolution itself fails", async () => {

--- a/packages/api/src/lib/scheduler/__tests__/sender-preflight.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/sender-preflight.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the scheduled-task sender preflight (#3379).
+ *
+ * Warn-don't-block: the preflight only produces warning strings — it never
+ * throws and never gates creation. These tests pin:
+ *  - email warns iff the provider chain resolves to the `log` fallback;
+ *  - slack warns iff BOTH the per-team token AND SLACK_BOT_TOKEN are absent;
+ *  - webhook recipients never warn;
+ *  - configured deployments (SaaS, self-hosted with a provider) get NO
+ *    warnings — the acceptance criterion that behavior there is unchanged;
+ *  - a failing lookup degrades to "no warning", not a throw.
+ *
+ * Dependencies are injected via the `SenderPreflightDeps` seam (mirrors
+ * `TransactionalEmailDeps` in lib/email/delivery.ts) — no module mocks, no
+ * top-level env mutation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { Recipient } from "@atlas/api/lib/scheduled-task-types";
+import type { ResolvedEmailSender } from "@atlas/api/lib/email/delivery";
+import {
+  checkDeliverySenders,
+  EMAIL_NO_SENDER_WARNING,
+  SLACK_NO_SENDER_WARNING,
+} from "../sender-preflight";
+
+const EMAIL: Recipient = { type: "email", address: "report@example.com" };
+const SLACK_NO_TEAM: Recipient = { type: "slack", channel: "#reports" };
+const SLACK_TEAM: Recipient = { type: "slack", channel: "#reports", teamId: "T123" };
+const WEBHOOK: Recipient = { type: "webhook", url: "https://hook.example.com" };
+
+const resolveLog = async (): Promise<ResolvedEmailSender> => ({ kind: "log" });
+const resolveResendEnv = async (): Promise<ResolvedEmailSender> => ({ kind: "resend-env" });
+
+let savedSlackToken: string | undefined;
+
+beforeEach(() => {
+  savedSlackToken = process.env.SLACK_BOT_TOKEN;
+  delete process.env.SLACK_BOT_TOKEN;
+});
+
+afterEach(() => {
+  if (savedSlackToken !== undefined) process.env.SLACK_BOT_TOKEN = savedSlackToken;
+  else delete process.env.SLACK_BOT_TOKEN;
+});
+
+describe("checkDeliverySenders — email", () => {
+  it("warns when the provider chain resolves to the log fallback", async () => {
+    const warnings = await checkDeliverySenders([EMAIL], "org-1", {
+      resolveEmailSender: resolveLog,
+    });
+    expect(warnings).toEqual([EMAIL_NO_SENDER_WARNING]);
+    expect(warnings[0]).toContain("server log");
+  });
+
+  it("does NOT warn when a real sender resolves (configured deployment unchanged)", async () => {
+    for (const kind of ["resend-env", "smtp-webhook"] as const) {
+      const warnings = await checkDeliverySenders([EMAIL], "org-1", {
+        resolveEmailSender: async () => ({ kind }),
+      });
+      expect(warnings).toEqual([]);
+    }
+  });
+
+  it("threads the orgId so per-org transports are honored", async () => {
+    const seen: Array<string | undefined> = [];
+    await checkDeliverySenders([EMAIL], "org-42", {
+      resolveEmailSender: async (orgId) => {
+        seen.push(orgId);
+        return { kind: "resend-env" };
+      },
+    });
+    expect(seen).toEqual(["org-42"]);
+  });
+
+  it("degrades to no warning (not a throw) when resolution itself fails", async () => {
+    const warnings = await checkDeliverySenders([EMAIL], "org-1", {
+      resolveEmailSender: async () => {
+        throw new Error("settings store unavailable");
+      },
+    });
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("checkDeliverySenders — slack", () => {
+  it("warns when there is no teamId and no SLACK_BOT_TOKEN", async () => {
+    const warnings = await checkDeliverySenders([SLACK_NO_TEAM], undefined, {
+      getBotToken: async () => null,
+    });
+    expect(warnings).toEqual([SLACK_NO_SENDER_WARNING]);
+  });
+
+  it("warns when the per-team token is absent AND SLACK_BOT_TOKEN is unset", async () => {
+    const warnings = await checkDeliverySenders([SLACK_TEAM], undefined, {
+      getBotToken: async () => null,
+    });
+    expect(warnings).toEqual([SLACK_NO_SENDER_WARNING]);
+  });
+
+  it("does NOT warn when the per-team token exists (installed workspace)", async () => {
+    const warnings = await checkDeliverySenders([SLACK_TEAM], undefined, {
+      getBotToken: async (teamId) => (teamId === "T123" ? "xoxb-token" : null),
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("does NOT warn when SLACK_BOT_TOKEN is set, even without a per-team token", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-env-token";
+    const warnings = await checkDeliverySenders([SLACK_NO_TEAM, SLACK_TEAM], undefined, {
+      getBotToken: async () => null,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("degrades to no warning (not a throw) when the token lookup fails", async () => {
+    const warnings = await checkDeliverySenders([SLACK_TEAM], undefined, {
+      getBotToken: async () => {
+        throw new Error("internal DB unavailable");
+      },
+    });
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("checkDeliverySenders — webhook + shape", () => {
+  it("never warns for webhook recipients", async () => {
+    const warnings = await checkDeliverySenders([WEBHOOK], "org-1", {
+      resolveEmailSender: resolveLog,
+      getBotToken: async () => null,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns an empty array for an empty recipient list", async () => {
+    const warnings = await checkDeliverySenders([], "org-1", {
+      resolveEmailSender: resolveLog,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("emits one warning per misconfigured channel (email + slack together)", async () => {
+    const warnings = await checkDeliverySenders([EMAIL, SLACK_TEAM], "org-1", {
+      resolveEmailSender: resolveLog,
+      getBotToken: async () => null,
+    });
+    expect(warnings).toEqual([EMAIL_NO_SENDER_WARNING, SLACK_NO_SENDER_WARNING]);
+  });
+
+  it("emits NO warnings on a fully configured deployment (SaaS parity)", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-env-token";
+    const warnings = await checkDeliverySenders([EMAIL, SLACK_TEAM, WEBHOOK], "org-1", {
+      resolveEmailSender: resolveResendEnv,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/shape-result.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/shape-result.test.ts
@@ -14,6 +14,11 @@ describe("shapeResult", () => {
   it("carries task and result metadata", () => {
     const shaped = shapeResult(makeTask(), makeResult());
     expect(shaped.taskId).toBe("task-123");
+    // orgId rides FormattedResult so deliverToEmail resolves the SAME
+    // provider-chain link (per-org transport) the sender preflight checked
+    // at create/update time (#3386).
+    expect(shaped.orgId).toBeNull();
+    expect(shapeResult(makeTask({ orgId: "org-7" }), makeResult()).orgId).toBe("org-7");
     expect(shaped.taskName).toBe("Daily Revenue");
     expect(shaped.question).toBe("What was yesterday's revenue?");
     expect(shaped.answer).toBe("Revenue was $1M");

--- a/packages/api/src/lib/scheduler/delivery.ts
+++ b/packages/api/src/lib/scheduler/delivery.ts
@@ -20,6 +20,7 @@ import {
 import type { ScheduledTask } from "@atlas/api/lib/scheduled-tasks";
 import type { AgentQueryResult } from "@atlas/api/lib/agent-query";
 import type { EmailRecipient, SlackRecipient, WebhookRecipient, Recipient } from "@atlas/api/lib/scheduled-task-types";
+import { resolveSlackBotToken } from "./slack-token";
 import { shapeResult, type FormattedResult } from "./shape-result";
 import { formatEmailReport } from "./format-email";
 import { formatSlackReport } from "./format-slack";
@@ -171,32 +172,18 @@ function deliverToSlack(
   return Effect.gen(function* () {
     const { text, blocks } = formatSlackReport(shaped);
 
-    let token: string | null = null;
-    if (recipient.teamId) {
-      const { getBotToken } = yield* Effect.tryPromise({
-        try: () => import("@atlas/api/lib/slack/store"),
-        catch: (err) =>
-          new DeliveryError({
-            message: `Failed to load Slack store: ${err instanceof Error ? err.message : String(err)}`,
-            channel: "slack",
-            recipient: recipient.channel,
-            permanent: false,
-          }),
-      });
-      token = yield* Effect.tryPromise({
-        try: () => getBotToken(recipient.teamId!),
-        catch: (err) =>
-          new DeliveryError({
-            message: `Failed to get bot token: ${err instanceof Error ? err.message : String(err)}`,
-            channel: "slack",
-            recipient: recipient.channel,
-            permanent: false,
-          }),
-      });
-    }
-    if (!token) {
-      token = process.env.SLACK_BOT_TOKEN ?? null;
-    }
+    // Per-team token, then SLACK_BOT_TOKEN env — via the shared resolver the
+    // sender preflight also uses (#3379), so the two can never disagree.
+    const token = yield* Effect.tryPromise({
+      try: () => resolveSlackBotToken(recipient.teamId),
+      catch: (err) =>
+        new DeliveryError({
+          message: `Failed to resolve Slack bot token: ${err instanceof Error ? err.message : String(err)}`,
+          channel: "slack",
+          recipient: recipient.channel,
+          permanent: false,
+        }),
+    });
     if (!token) {
       log.warn({ taskId: shaped.taskId, channel: recipient.channel }, "No Slack bot token available — delivery skipped");
       return yield* Effect.fail(

--- a/packages/api/src/lib/scheduler/delivery.ts
+++ b/packages/api/src/lib/scheduler/delivery.ts
@@ -136,7 +136,11 @@ function deliverToEmail(
     });
 
     const deliveryResult = yield* Effect.tryPromise({
-      try: () => sendEmail({ to: recipient.address, subject, html: body }),
+      // Threading shaped.orgId keeps the send on the SAME chain link the
+      // #3379 preflight resolved (per-org transport first) — without it,
+      // an org-transport-only deployment preflights clean and then falls
+      // through to platform/env/log at delivery time (#3386).
+      try: () => sendEmail({ to: recipient.address, subject, html: body }, shaped.orgId ?? undefined),
       catch: (err) =>
         new DeliveryError({
           message: err instanceof Error ? err.message : String(err),

--- a/packages/api/src/lib/scheduler/delivery.ts
+++ b/packages/api/src/lib/scheduler/delivery.ts
@@ -31,9 +31,29 @@ export interface DeliverySummary {
   attempted: number;
   succeeded: number;
   failed: number;
+  /**
+   * How many of `failed` were permanent (`DeliveryError.permanent` — missing
+   * credentials, blocked URL, HTTP 4xx) rather than transient. When ALL
+   * failures are permanent the executor records the run's delivery status as
+   * `"failed_permanent"` so misconfiguration is distinguishable from a
+   * transient outage in the run history (#3379).
+   */
+  permanentFailures: number;
+  /**
+   * The first permanent failure's message (e.g. "No email delivery backend
+   * configured…"), surfaced on the run row so the admin sees WHAT to fix —
+   * not just that delivery failed. Null when no permanent failures occurred.
+   */
+  firstPermanentError: string | null;
 }
 
-const EMPTY_SUMMARY: DeliverySummary = { attempted: 0, succeeded: 0, failed: 0 };
+const EMPTY_SUMMARY: DeliverySummary = {
+  attempted: 0,
+  succeeded: 0,
+  failed: 0,
+  permanentFailures: 0,
+  firstPermanentError: null,
+};
 
 const BLOCKED_HEADER_NAMES = new Set([
   "authorization",
@@ -340,6 +360,9 @@ export async function deliverResult(
   // Deliver to all recipients concurrently, with per-recipient retry.
   // Permanent errors (blocked URL, missing credentials, HTTP 4xx) fail immediately.
   // Transient errors (network, HTTP 5xx) get exponential backoff retry.
+  type Outcome =
+    | { kind: "succeeded" }
+    | { kind: "failed"; permanent: boolean; message: string };
   const outcomes = await Effect.runPromise(
     Effect.forEach(
       channelRecipients,
@@ -349,10 +372,10 @@ export async function deliverResult(
             schedule: retryPolicy,
             while: (err) => !err.permanent,
           }),
-          Effect.map(() => "succeeded" as const),
+          Effect.map((): Outcome => ({ kind: "succeeded" })),
           Effect.catchTag("DeliveryError", (err) => {
-            log.warn({ taskId: task.id, channel: err.channel, recipient: err.recipient, message: err.message }, "Delivery failed after retries exhausted");
-            return Effect.succeed("failed" as const);
+            log.warn({ taskId: task.id, channel: err.channel, recipient: err.recipient, message: err.message, permanent: err.permanent }, "Delivery failed after retries exhausted");
+            return Effect.succeed<Outcome>({ kind: "failed", permanent: err.permanent, message: err.message });
           }),
         ),
       { concurrency: 5 },
@@ -361,10 +384,19 @@ export async function deliverResult(
 
   let succeeded = 0;
   let failed = 0;
+  let permanentFailures = 0;
+  let firstPermanentError: string | null = null;
   for (const outcome of outcomes) {
-    if (outcome === "succeeded") succeeded++;
-    else failed++;
+    if (outcome.kind === "succeeded") {
+      succeeded++;
+    } else {
+      failed++;
+      if (outcome.permanent) {
+        permanentFailures++;
+        firstPermanentError ??= outcome.message;
+      }
+    }
   }
 
-  return { attempted: channelRecipients.length, succeeded, failed };
+  return { attempted: channelRecipients.length, succeeded, failed, permanentFailures, firstPermanentError };
 }

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -232,10 +232,23 @@ export async function executeScheduledTask(
     if (delivery.failed === 0) {
       updateRunDeliveryStatus(runId, "sent");
     } else {
-      const errorMsg = delivery.succeeded > 0
+      const baseMsg = delivery.succeeded > 0
         ? `Partial failure: ${delivery.failed}/${delivery.attempted} deliveries failed`
         : `All ${delivery.failed} deliveries failed`;
-      updateRunDeliveryStatus(runId, "failed", errorMsg);
+      // Surface the first permanent error so the admin sees WHAT to fix
+      // (e.g. "No email delivery backend configured"), not just a count.
+      const errorMsg = delivery.firstPermanentError
+        ? `${baseMsg} — ${delivery.firstPermanentError}`
+        : baseMsg;
+      // #3379 — when every failure is permanent (misconfiguration: no email
+      // sender, no Slack token, blocked webhook URL), record
+      // "failed_permanent" so the run history distinguishes "fix your
+      // config" from a transient outage. The task is deliberately NOT
+      // auto-paused: the admin may configure the sender at any moment and
+      // the next run should then deliver without further intervention.
+      const allPermanent =
+        delivery.permanentFailures === delivery.failed && delivery.permanentFailures > 0;
+      updateRunDeliveryStatus(runId, allPermanent ? "failed_permanent" : "failed", errorMsg);
     }
   }
 

--- a/packages/api/src/lib/scheduler/sender-preflight.ts
+++ b/packages/api/src/lib/scheduler/sender-preflight.ts
@@ -41,6 +41,10 @@ export const EMAIL_NO_SENDER_WARNING =
   "This deployment has no email sender configured — email reports will only be written to the server log and every delivery will fail. " +
   "Configure a platform email provider (Admin → Integrations → Email), or set ATLAS_SMTP_URL or RESEND_API_KEY.";
 
+export const EMAIL_BRIDGE_WARNING =
+  "This workspace's email integration (SMTP/SES) requires the ATLAS_SMTP_URL bridge, which is not set — email deliveries will fail. " +
+  "Set ATLAS_SMTP_URL, or switch the email integration to an API-based provider (Resend, SendGrid, Postmark).";
+
 export const SLACK_NO_SENDER_WARNING =
   "This deployment has no Slack bot token for the configured recipient — Slack deliveries will fail. " +
   "Install the Atlas Slack app for the workspace (so a per-team token exists), or set SLACK_BOT_TOKEN.";
@@ -94,7 +98,12 @@ async function checkEmailSender(
       deps.resolveEmailSender ??
       (await import("@atlas/api/lib/email/delivery")).resolveEmailSender;
     const resolved = await resolveEmailSender(orgId);
-    return resolved.kind === "log" ? EMAIL_NO_SENDER_WARNING : null;
+    if (resolved.kind === "log") return EMAIL_NO_SENDER_WARNING;
+    // An org smtp/ses transport without the ATLAS_SMTP_URL bridge resolves
+    // as org-transport but deliverViaTransport refuses the send (#3385
+    // review) — configured-in-name-only, so it warns too.
+    if (resolved.kind === "org-transport" && resolved.bridgeMissing) return EMAIL_BRIDGE_WARNING;
+    return null;
   } catch (err) {
     log.warn(
       { orgId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/scheduler/sender-preflight.ts
+++ b/packages/api/src/lib/scheduler/sender-preflight.ts
@@ -1,0 +1,129 @@
+/**
+ * Sender preflight for scheduled-task delivery channels (#3379).
+ *
+ * On default self-hosted installs, scheduled-task creation accepts `email`
+ * and `slack` recipients on a pure schema basis while the runtime sender is
+ * unconfigured — every run then fails `permanent: true` at delivery time and
+ * the admin only sees generic failed runs. This module checks, at task
+ * create/update time, whether the deployment actually has a working sender
+ * for the chosen channels and returns human-readable warnings when it does
+ * not.
+ *
+ * WARN, DON'T BLOCK (deliberate): creation/update still succeeds — an admin
+ * may configure the sender right after creating the task, and SaaS / properly
+ * configured self-hosted deployments must be unaffected. The warnings ride on
+ * the create/update responses as `warnings: string[]` (empty when no issues).
+ *
+ * - Email: reuses {@link resolveEmailSender} — the SAME provider-chain walk
+ *   `sendEmail` dispatches on — so the preflight and the actual send can
+ *   never disagree. A `log` resolution (nothing configured) warns.
+ * - Slack: warns only when BOTH the per-team token (`chat_cache` via
+ *   `getBotToken` for the recipient's teamId) AND `SLACK_BOT_TOKEN` are
+ *   absent — mirroring `deliverToSlack`'s token resolution in `delivery.ts`.
+ * - Webhook: no preflight (the URL is already SSRF-validated by the route
+ *   schema; reachability is only knowable at delivery time).
+ *
+ * A preflight that cannot determine the answer (e.g. the Slack token lookup
+ * throws because the internal DB is unavailable) logs and emits NO warning —
+ * a false "not configured" claim on a working deployment would be worse than
+ * staying quiet, and the delivery path itself still surfaces real failures.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { Recipient, SlackRecipient } from "@atlas/api/lib/scheduled-task-types";
+import type { ResolvedEmailSender } from "@atlas/api/lib/email/delivery";
+
+const log = createLogger("scheduler-sender-preflight");
+
+export const EMAIL_NO_SENDER_WARNING =
+  "This deployment has no email sender configured — email reports will only be written to the server log and every delivery will fail. " +
+  "Configure a platform email provider (Admin → Integrations → Email), or set ATLAS_SMTP_URL or RESEND_API_KEY.";
+
+export const SLACK_NO_SENDER_WARNING =
+  "This deployment has no Slack bot token for the configured recipient — Slack deliveries will fail. " +
+  "Install the Atlas Slack app for the workspace (so a per-team token exists), or set SLACK_BOT_TOKEN.";
+
+/**
+ * Injection seam for tests — mirrors the `TransactionalEmailDeps` pattern in
+ * `lib/email/delivery.ts`. Production callers omit it; the defaults
+ * dynamic-import the real modules so this file adds nothing heavy to the
+ * route module graph.
+ */
+export interface SenderPreflightDeps {
+  resolveEmailSender?: (orgId?: string) => Promise<ResolvedEmailSender>;
+  getBotToken?: (teamId: string) => Promise<string | null>;
+}
+
+/**
+ * Check whether the deployment has a working sender for each delivery
+ * channel present in `recipients`. Returns warnings (possibly empty) —
+ * NEVER throws and NEVER blocks; callers attach the result to the
+ * create/update response.
+ *
+ * Callers should pass only the recipients that match the task's
+ * `deliveryChannel` (the same filter `deliverResult` applies), so a stale
+ * recipient of a different channel can't produce a spurious warning.
+ */
+export async function checkDeliverySenders(
+  recipients: Recipient[],
+  orgId?: string,
+  deps: SenderPreflightDeps = {},
+): Promise<string[]> {
+  const hasEmail = recipients.some((r) => r.type === "email");
+  const slackRecipients = recipients.filter((r): r is SlackRecipient => r.type === "slack");
+
+  const [emailWarning, slackWarning] = await Promise.all([
+    hasEmail ? checkEmailSender(orgId, deps) : Promise.resolve(null),
+    slackRecipients.length > 0 ? checkSlackSender(slackRecipients, deps) : Promise.resolve(null),
+  ]);
+
+  const warnings: string[] = [];
+  if (emailWarning) warnings.push(emailWarning);
+  if (slackWarning) warnings.push(slackWarning);
+  return warnings;
+}
+
+async function checkEmailSender(
+  orgId: string | undefined,
+  deps: SenderPreflightDeps,
+): Promise<string | null> {
+  try {
+    const resolveEmailSender =
+      deps.resolveEmailSender ??
+      (await import("@atlas/api/lib/email/delivery")).resolveEmailSender;
+    const resolved = await resolveEmailSender(orgId);
+    return resolved.kind === "log" ? EMAIL_NO_SENDER_WARNING : null;
+  } catch (err) {
+    log.warn(
+      { orgId, err: err instanceof Error ? err.message : String(err) },
+      "Email sender preflight failed — skipping warning (delivery-time errors still surface on the run)",
+    );
+    return null;
+  }
+}
+
+async function checkSlackSender(
+  recipients: SlackRecipient[],
+  deps: SenderPreflightDeps,
+): Promise<string | null> {
+  // Env fallback present → every recipient has a sender, regardless of teamId.
+  const envToken = process.env.SLACK_BOT_TOKEN;
+  if (typeof envToken === "string" && envToken.length > 0) return null;
+
+  // Recipients without a teamId can ONLY use the env fallback — absent, warn.
+  if (recipients.some((r) => !r.teamId)) return SLACK_NO_SENDER_WARNING;
+
+  try {
+    const getBotToken =
+      deps.getBotToken ?? (await import("@atlas/api/lib/slack/store")).getBotToken;
+    const teamIds = [...new Set(recipients.map((r) => r.teamId).filter((t): t is string => !!t))];
+    const tokens = await Promise.all(teamIds.map((teamId) => getBotToken(teamId)));
+    return tokens.some((token) => !token) ? SLACK_NO_SENDER_WARNING : null;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Slack sender preflight failed — skipping warning (delivery-time errors still surface on the run)",
+    );
+    return null;
+  }
+}

--- a/packages/api/src/lib/scheduler/sender-preflight.ts
+++ b/packages/api/src/lib/scheduler/sender-preflight.ts
@@ -19,7 +19,8 @@
  *   never disagree. A `log` resolution (nothing configured) warns.
  * - Slack: warns only when BOTH the per-team token (`chat_cache` via
  *   `getBotToken` for the recipient's teamId) AND `SLACK_BOT_TOKEN` are
- *   absent — mirroring `deliverToSlack`'s token resolution in `delivery.ts`.
+ *   absent — resolved through the SAME `resolveSlackBotToken` helper
+ *   `deliverToSlack` dispatches on (`slack-token.ts`).
  * - Webhook: no preflight (the URL is already SSRF-validated by the route
  *   schema; reachability is only knowable at delivery time).
  *
@@ -32,6 +33,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import type { Recipient, SlackRecipient } from "@atlas/api/lib/scheduled-task-types";
 import type { ResolvedEmailSender } from "@atlas/api/lib/email/delivery";
+import { resolveSlackBotToken } from "@atlas/api/lib/scheduler/slack-token";
 
 const log = createLogger("scheduler-sender-preflight");
 
@@ -106,18 +108,15 @@ async function checkSlackSender(
   recipients: SlackRecipient[],
   deps: SenderPreflightDeps,
 ): Promise<string | null> {
-  // Env fallback present → every recipient has a sender, regardless of teamId.
-  const envToken = process.env.SLACK_BOT_TOKEN;
-  if (typeof envToken === "string" && envToken.length > 0) return null;
-
-  // Recipients without a teamId can ONLY use the env fallback — absent, warn.
-  if (recipients.some((r) => !r.teamId)) return SLACK_NO_SENDER_WARNING;
-
   try {
-    const getBotToken =
-      deps.getBotToken ?? (await import("@atlas/api/lib/slack/store")).getBotToken;
-    const teamIds = [...new Set(recipients.map((r) => r.teamId).filter((t): t is string => !!t))];
-    const tokens = await Promise.all(teamIds.map((teamId) => getBotToken(teamId)));
+    // One resolution per distinct teamId through the SAME resolver
+    // `deliverToSlack` uses (a teamId-less recipient collapses to one
+    // `undefined` probe of the env fallback), so the preflight and the
+    // delivery path can never disagree on the rule.
+    const teamIds = [...new Set(recipients.map((r) => (r.teamId ? r.teamId : undefined)))];
+    const tokens = await Promise.all(
+      teamIds.map((teamId) => resolveSlackBotToken(teamId, deps.getBotToken)),
+    );
     return tokens.some((token) => !token) ? SLACK_NO_SENDER_WARNING : null;
   } catch (err) {
     log.warn(

--- a/packages/api/src/lib/scheduler/shape-result.ts
+++ b/packages/api/src/lib/scheduler/shape-result.ts
@@ -65,6 +65,12 @@ export interface FormattedResult {
   totalTokens: number;
   /** ISO timestamp decided once so all channels report the same instant. */
   generatedAt: string;
+  /**
+   * The task's org — threaded so email delivery resolves the SAME
+   * provider-chain link (per-org transport first) the sender preflight
+   * checks at create/update time (#3379/#3386). `null` for org-less tasks.
+   */
+  orgId: string | null;
 }
 
 export function shapeResult(
@@ -75,6 +81,7 @@ export function shapeResult(
   return {
     taskId: task.id,
     taskName: task.name,
+    orgId: task.orgId,
     question: task.question,
     answer: result.answer,
     sql: result.sql,

--- a/packages/api/src/lib/scheduler/slack-token.ts
+++ b/packages/api/src/lib/scheduler/slack-token.ts
@@ -1,0 +1,25 @@
+/**
+ * Single statement of the scheduled-delivery Slack sender-resolution rule
+ * (#3379): per-team bot token from `chat_cache` (`getBotToken`) first, then
+ * the `SLACK_BOT_TOKEN` env fallback. Shared by the delivery path
+ * (`deliverToSlack`) and the create/update-time sender preflight so the two
+ * can never disagree about whether a recipient has a sender — the same
+ * one-chain discipline `resolveEmailSender` provides for the email channel.
+ *
+ * The Slack store stays dynamically imported here so neither consumer pulls
+ * it into its module graph at load time.
+ */
+export async function resolveSlackBotToken(
+  teamId: string | undefined,
+  getBotTokenImpl?: (teamId: string) => Promise<string | null>,
+): Promise<string | null> {
+  let token: string | null = null;
+  if (teamId) {
+    const getBotToken =
+      getBotTokenImpl ?? (await import("@atlas/api/lib/slack/store")).getBotToken;
+    token = await getBotToken(teamId);
+  }
+  if (token) return token;
+  const envToken = process.env.SLACK_BOT_TOKEN;
+  return typeof envToken === "string" && envToken.length > 0 ? envToken : null;
+}

--- a/packages/types/src/scheduled-task.ts
+++ b/packages/types/src/scheduled-task.ts
@@ -11,7 +11,21 @@ export const RUN_STATUSES = ["running", "success", "failed", "skipped"] as const
 export type RunStatus = (typeof RUN_STATUSES)[number];
 
 export const DELIVERY_STATUSES = ["pending", "sent", "failed"] as const;
-export type DeliveryStatus = (typeof DELIVERY_STATUSES)[number];
+/**
+ * `"failed_permanent"` (#3379) marks a run whose delivery failures were ALL
+ * permanent (misconfiguration — no email sender, no Slack token, blocked
+ * webhook URL) as opposed to transient (network, 5xx). It is appended to the
+ * union TYPE-ONLY rather than to the `DELIVERY_STATUSES` value above: this
+ * package is consumed from the npm registry by scaffold builds, and a value
+ * change would drift between the workspace and the pinned published version
+ * (publish-before-ref-bump rule — see CLAUDE.md "Publishing @useatlas/*").
+ * The runtime accept-list that includes it lives in
+ * `@atlas/api/lib/scheduled-task-types` (`KNOWN_DELIVERY_STATUSES`), which is
+ * scaffold-bound *source* and therefore always in sync. When this package is
+ * next published and refs bumped, fold `"failed_permanent"` into
+ * `DELIVERY_STATUSES` and collapse this union back to the derived form.
+ */
+export type DeliveryStatus = (typeof DELIVERY_STATUSES)[number] | "failed_permanent";
 
 // ---------------------------------------------------------------------------
 // Recipient discriminated union

--- a/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
@@ -436,8 +436,8 @@ describe("TaskFormDialog — sender preflight warnings (#3379)", () => {
     const close = Array.from(container.querySelectorAll("button")).find(
       (b) => b.textContent?.trim() === "Close",
     );
-    expect(close).not.toBeUndefined();
-    fireEvent.click(close!);
+    if (!close) throw new Error("Close button not found");
+    fireEvent.click(close);
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 

--- a/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
@@ -72,7 +72,13 @@ mock.module("@/ui/context", () => ({
   }),
 }));
 
-const mutateMock = mock(async () => undefined);
+// Default resolves like a successful mutation with no preflight warnings —
+// individual tests override via mockResolvedValueOnce.
+type MutateResultLike =
+  | { ok: true; data: unknown }
+  | { ok: false; error: { message: string } }
+  | undefined;
+const mutateMock = mock(async (): Promise<MutateResultLike> => ({ ok: true, data: {} }));
 mock.module("@/ui/hooks/use-admin-mutation", () => ({
   useAdminMutation: () => ({
     mutate: mutateMock,
@@ -87,7 +93,7 @@ mock.module("@/ui/components/admin/mutation-error-surface", () => ({
   MutationErrorSurface: () => null,
 }));
 
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, cleanup, waitFor, fireEvent } from "@testing-library/react";
 
 // Imported after mocks register.
 const { TaskFormDialog } = await import("../task-form-dialog");
@@ -365,5 +371,137 @@ describe("TaskFormDialog — zero-environment guard (#2418)", () => {
     );
     expect(retry).not.toBeUndefined();
     expect(getSaveButton(container).disabled).toBe(true);
+  });
+});
+
+// ── #3379: sender preflight warnings ──────────────────────────────────
+
+const ONE_GROUP = [
+  { id: "g_prod", name: "Production", memberCount: 1, resolvedConnectionId: "c1" },
+];
+
+/** Fill the minimum valid create form (email channel) and click Create. */
+async function fillAndSubmit(container: HTMLElement) {
+  await waitFor(() => {
+    expect(getSaveButton(container).disabled).toBe(false);
+  });
+
+  const name = container.querySelector<HTMLInputElement>("#task-name");
+  const question = container.querySelector<HTMLTextAreaElement>("#task-question");
+  const emailInput = Array.from(container.querySelectorAll("input")).find(
+    (i) => i.placeholder === "user@example.com",
+  );
+  if (!name || !question || !emailInput) {
+    throw new Error("form fields not found in rendered tree");
+  }
+  fireEvent.change(name, { target: { value: "Weekly digest" } });
+  fireEvent.change(question, { target: { value: "What changed this week?" } });
+  fireEvent.change(emailInput, { target: { value: "report@example.com" } });
+  fireEvent.keyDown(emailInput, { key: "Enter" });
+  fireEvent.click(getSaveButton(container));
+}
+
+describe("TaskFormDialog — sender preflight warnings (#3379)", () => {
+  test("a successful save WITH warnings keeps the dialog open and shows them", async () => {
+    installFetchMock(ONE_GROUP);
+    mutateMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: "task-1",
+        warnings: [
+          "This deployment has no email sender configured — email reports will only be written to the server log and every delivery will fail.",
+        ],
+      },
+    });
+    const onOpenChange = mock((_open: boolean) => {});
+
+    const { container } = render(
+      <TaskFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        task={null}
+        onSuccess={() => {}}
+      />,
+    );
+    await fillAndSubmit(container);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Task saved — delivery needs attention");
+      expect(container.textContent).toContain("no email sender configured");
+    });
+    // The save succeeded but the dialog must NOT auto-close — the warning is
+    // the whole point of surfacing this at save time.
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // Footer collapses to a single acknowledge button.
+    const close = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Close",
+    );
+    expect(close).not.toBeUndefined();
+    fireEvent.click(close!);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test("a successful save with warnings: [] closes the dialog as before", async () => {
+    installFetchMock(ONE_GROUP);
+    mutateMock.mockResolvedValueOnce({ ok: true, data: { id: "task-1", warnings: [] } });
+    const onOpenChange = mock((_open: boolean) => {});
+
+    const { container } = render(
+      <TaskFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        task={null}
+        onSuccess={() => {}}
+      />,
+    );
+    await fillAndSubmit(container);
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+    expect(container.textContent).not.toContain("delivery needs attention");
+  });
+
+  test("a response without a warnings field (older API) closes the dialog", async () => {
+    // extractWarnings tolerates any shape — warnings are best-effort UX.
+    installFetchMock(ONE_GROUP);
+    mutateMock.mockResolvedValueOnce({ ok: true, data: { id: "task-1" } });
+    const onOpenChange = mock((_open: boolean) => {});
+
+    const { container } = render(
+      <TaskFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        task={null}
+        onSuccess={() => {}}
+      />,
+    );
+    await fillAndSubmit(container);
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  test("a failed save shows no warning banner and keeps the dialog open", async () => {
+    installFetchMock(ONE_GROUP);
+    mutateMock.mockResolvedValueOnce({ ok: false, error: { message: "boom" } });
+    const onOpenChange = mock((_open: boolean) => {});
+
+    const { container } = render(
+      <TaskFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        task={null}
+        onSuccess={() => {}}
+      />,
+    );
+    await fillAndSubmit(container);
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain("delivery needs attention");
   });
 });

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -131,6 +131,18 @@ function parseRecipients(task: ScheduledTask) {
   return { emailAddresses, slackChannel, slackTeamId, webhookUrl, webhookHeaders };
 }
 
+/**
+ * Narrow the create/update response's `warnings` field (#3379 sender
+ * preflight). The API returns `warnings: string[]` (empty when no issues);
+ * tolerate any other shape — warnings are best-effort UX, never blocking.
+ */
+function extractWarnings(data: unknown): string[] {
+  if (typeof data !== "object" || data === null) return [];
+  const warnings = (data as { warnings?: unknown }).warnings;
+  if (!Array.isArray(warnings)) return [];
+  return warnings.filter((w): w is string => typeof w === "string");
+}
+
 function formStateFromTask(task: ScheduledTask): FormState {
   const recipients = parseRecipients(task);
   return {
@@ -168,6 +180,10 @@ export function TaskFormDialog({
   const isEdit = task !== null;
   const [form, setForm] = useState<FormState>(defaultFormState);
   const [validationError, setValidationError] = useState<string | null>(null);
+  // #3379 — non-empty after a SUCCESSFUL save whose response carried sender
+  // preflight warnings (e.g. no email provider configured). The save went
+  // through; the dialog stays open to show them instead of auto-closing.
+  const [senderWarnings, setSenderWarnings] = useState<string[]>([]);
   const [groups, setGroups] = useState<ConnectionGroupInfo[]>([]);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [fetchAttempt, setFetchAttempt] = useState(0);
@@ -181,6 +197,7 @@ export function TaskFormDialog({
     if (open) {
       setForm(task ? formStateFromTask(task) : defaultFormState());
       setValidationError(null);
+      setSenderWarnings([]);
       submitMutation.reset();
     }
   }, [open, task]);
@@ -312,6 +329,7 @@ export function TaskFormDialog({
 
   async function handleSubmit() {
     setValidationError(null);
+    setSenderWarnings([]);
     submitMutation.clearError();
 
     // Validate
@@ -345,12 +363,23 @@ export function TaskFormDialog({
       ? `/api/v1/scheduled-tasks/${encodeURIComponent(task.id)}`
       : `/api/v1/scheduled-tasks`;
 
-    await submitMutation.mutate({
+    const result = await submitMutation.mutate({
       path,
       method: task ? "PUT" : "POST",
       body: body as Record<string, unknown>,
-      onSuccess: () => onOpenChange(false),
     });
+    if (!result || !result.ok) return; // mutation error surfaces via submitMutation.error
+
+    // #3379 — the save SUCCEEDED; if the API's sender preflight returned
+    // warnings (e.g. no email provider configured on this deployment), keep
+    // the dialog open and show them so the admin learns at save time — not
+    // from a string of failed runs. No warnings → close as before.
+    const warnings = extractWarnings(result.data);
+    if (warnings.length > 0) {
+      setSenderWarnings(warnings);
+    } else {
+      onOpenChange(false);
+    }
   }
 
   // ── Cron preview ────────────────────────────────────────────────────
@@ -648,6 +677,23 @@ export function TaskFormDialog({
           )}
         </div>
 
+        {/* #3379 — sender preflight warnings from a SUCCESSFUL save. The
+            task exists/was updated; this is "it saved, but deliveries will
+            fail until you configure a sender" — hence not destructive. */}
+        {senderWarnings.length > 0 && (
+          <Alert>
+            <AlertTriangle />
+            <AlertTitle>Task saved — delivery needs attention</AlertTitle>
+            <AlertDescription>
+              <ul className="list-disc space-y-1 pl-4">
+                {senderWarnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+
         {/* Hide the server mutation error while a client-side validation
             error is showing — stacking two destructive banners doubles
             the noise for no new signal. handleSubmit clears both slots
@@ -666,16 +712,24 @@ export function TaskFormDialog({
         )}
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitMutation.saving}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={submitMutation.saving || groups.length === 0}
-          >
-            {submitMutation.saving && <Loader2 className="mr-2 size-4 animate-spin" />}
-            {isEdit ? "Save" : "Create"}
-          </Button>
+          {senderWarnings.length > 0 ? (
+            // The save already succeeded — the only remaining action is to
+            // acknowledge the warnings and close.
+            <Button onClick={() => onOpenChange(false)}>Close</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitMutation.saving}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={submitMutation.saving || groups.length === 0}
+              >
+                {submitMutation.saving && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isEdit ? "Save" : "Create"}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/web/src/ui/components/admin/__tests__/delivery-status-badge.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/delivery-status-badge.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Component tests for DeliveryStatusBadge (#3379).
+ *
+ * Pins the distinct `failed_permanent` rendering — a permanent
+ * (misconfiguration) delivery failure must be visually distinguishable from
+ * a transient `failed` so admins know retrying won't help.
+ */
+
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import React, { type ReactNode } from "react";
+
+// Tooltip primitives portal their content; stub them to passthrough divs so
+// the error text is assertable in the rendered tree. CLAUDE.md "Mock all
+// exports" — the module exports exactly these four.
+mock.module("@/components/ui/tooltip", () => {
+  const passthrough =
+    (tag: string) =>
+    ({ children, asChild: _asChild, ...rest }: { children?: ReactNode; asChild?: boolean } & Record<string, unknown>) =>
+      React.createElement(tag, rest, children as React.ReactNode);
+  const div = passthrough("div");
+  return {
+    Tooltip: div,
+    TooltipTrigger: div,
+    TooltipContent: div,
+    TooltipProvider: div,
+  };
+});
+
+import { render, cleanup } from "@testing-library/react";
+
+const { DeliveryStatusBadge } = await import("../delivery-status-badge");
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DeliveryStatusBadge", () => {
+  test("renders an em dash for null status", () => {
+    const { container } = render(<DeliveryStatusBadge status={null} error={null} />);
+    expect(container.textContent).toBe("—");
+  });
+
+  test("renders sent and failed with their canonical labels", () => {
+    const sent = render(<DeliveryStatusBadge status="sent" error={null} />);
+    expect(sent.container.textContent).toBe("sent");
+    cleanup();
+    const failed = render(<DeliveryStatusBadge status="failed" error={null} />);
+    expect(failed.container.textContent).toBe("failed");
+  });
+
+  test("renders failed_permanent with a distinct config label (#3379)", () => {
+    const { container } = render(
+      <DeliveryStatusBadge status="failed_permanent" error={null} />,
+    );
+    // Distinct from plain "failed" — signals misconfiguration, not a
+    // transient outage.
+    expect(container.textContent).toContain("failed — config");
+    expect(container.textContent).not.toBe("failed");
+  });
+
+  test("surfaces the misconfiguration error in the tooltip for failed_permanent (#3379)", () => {
+    const { container } = render(
+      <DeliveryStatusBadge
+        status="failed_permanent"
+        error="All 1 deliveries failed — No email delivery backend configured"
+      />,
+    );
+    expect(container.textContent).toContain("failed — config");
+    expect(container.textContent).toContain("No email delivery backend configured");
+  });
+
+  test("unknown statuses still fall back to the outline badge", () => {
+    const { container } = render(
+      <DeliveryStatusBadge status="pending" error={null} />,
+    );
+    expect(container.textContent).toBe("pending");
+  });
+});

--- a/packages/web/src/ui/components/admin/delivery-status-badge.tsx
+++ b/packages/web/src/ui/components/admin/delivery-status-badge.tsx
@@ -5,7 +5,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { CheckCircle2, XCircle, Clock } from "lucide-react";
+import { CheckCircle2, XCircle, Clock, TriangleAlert } from "lucide-react";
 
 export function DeliveryStatusBadge({ status, error }: { status: string | null; error: string | null }) {
   if (!status) return <span className="text-xs text-muted-foreground">—</span>;
@@ -26,6 +26,20 @@ export function DeliveryStatusBadge({ status, error }: { status: string | null; 
             failed
           </Badge>
         );
+      case "failed_permanent":
+        // #3379 — every failure in the run was permanent (misconfiguration:
+        // no email sender / no Slack token / blocked webhook URL), not a
+        // transient outage. Distinct amber styling so admins know retrying
+        // won't help — the deployment's sender config needs fixing.
+        return (
+          <Badge
+            variant="secondary"
+            className="gap-1 bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-400"
+          >
+            <TriangleAlert className="size-3" />
+            failed — config
+          </Badge>
+        );
       default:
         return (
           <Badge variant="outline" className="gap-1">
@@ -36,7 +50,7 @@ export function DeliveryStatusBadge({ status, error }: { status: string | null; 
     }
   })();
 
-  if (status === "failed" && error) {
+  if ((status === "failed" || status === "failed_permanent") && error) {
     return (
       <TooltipProvider>
         <Tooltip>


### PR DESCRIPTION
Closes #3379. Closes #3386. Part of the #3374 deploy-mode drift audit (taxonomy class 1).

**What**

*Sender preflight — warn, don't block (deliberate design)*
- New `lib/scheduler/sender-preflight.ts`: `checkDeliverySenders(recipients, orgId)` returns warning strings; never throws, never blocks creation. An admin may configure a sender right after creating the task, so creation always succeeds — and an undeterminable lookup (e.g. DB down) logs and emits **no** warning rather than a false positive.
- **Email**: `resolveEmailSender()` is extracted from `lib/email/delivery.ts`'s provider chain (per-org transport → platform settings → `ATLAS_SMTP_URL` → `RESEND_API_KEY` → `log`); `sendEmail` now dispatches on it, so the preflight and the actual send share one chain and cannot disagree. A `log` resolution (the out-of-the-box self-hosted state) warns. An org `smtp`/`ses` transport whose required `ATLAS_SMTP_URL` bridge is unset is marked `bridgeMissing` and warns too (it's configured-in-name-only — `deliverViaTransport` refuses those sends); send-path dispatch unchanged.
- **Slack**: warns only when both the per-team token and `SLACK_BOT_TOKEN` are absent — resolved through a new shared `resolveSlackBotToken()` (`lib/scheduler/slack-token.ts`) that `deliverToSlack` also dispatches on, mirroring the email one-chain discipline.
- **Webhook**: no preflight (URL already SSRF-validated; reachability only knowable at delivery time).
- `POST /api/v1/scheduled-tasks` and `PUT /:id` responses gain `warnings: string[]` (empty when configured); the PUT preflight runs on the effective post-update state.

*Preflight ⇔ delivery agreement (#3386)*
- `FormattedResult` carries the task's `orgId` and `deliverToEmail` threads it into `sendEmail`, so scheduled deliveries resolve the **same** chain link (per-org transport first) the preflight checks. Previously per-org email transports were silently unused by scheduled deliveries — an org-transport-only deployment preflighted clean and then fell through to platform/env/log at delivery time.

*Permanent-failure surfacing*
- `DeliverySummary` gains `permanentFailures` + `firstPermanentError` (previously `permanent: true` only fed the retry predicate). When ALL failures in a run are permanent, the executor writes `deliveryStatus: "failed_permanent"` (free-text column — no migration) and appends the first permanent error to `delivery_error` so admins see *what* to fix; mixed permanent+transient stays plain `"failed"`. Webhook participates naturally (blocked-URL/egress/4xx are permanent).
- **No auto-pause** (deliberate): once a sender is configured the next run delivers with zero intervention; pausing would add a recovery step.

*Wire types — publish-pin hazard handled*
- `"failed_permanent"` joins the `DeliveryStatus` union in `@useatlas/types` **type-only** (no version bump, no value-export change — the package is template-pinned; the inline comment documents the fold-in path at next publish). The runtime accept-list `KNOWN_DELIVERY_STATUSES` lives in scaffold-bound `@atlas/api/lib/scheduled-task-types`. `scripts/check-published-symbols.ts` passes.

*Web*
- Run history shows a distinct amber "failed — config" badge for `failed_permanent` (vs destructive "failed" for transient), with the error in the tooltip.
- The task form dialog surfaces save-response warnings ("Task saved — delivery needs attention") and stays open so the admin actually sees them; no warnings → closes as before. Warnings state resets on open/reopen/task-switch/resubmit.

**Why**
Audit finding #3379: on default self-hosted installs, scheduled-task creation accepts email/Slack recipients with no configured sender; every run then "delivers" email reports to the server console, fails `permanent: true`, and the admin sees only generic failed runs — the misconfiguration signal existed in the code and surfaced nowhere. SaaS and configured self-hosted deployments are unaffected (test-pinned: no warnings when a real sender resolves; success-path delivery summaries unchanged apart from additive zero-valued fields).

**Tests**
- `sender-preflight.test.ts` (15) — warning cases (log fallback, bridge-less org smtp/ses, tokenless Slack), no-warning cases for every configured-sender shape, orgId threading, degrade-to-no-warning on lookup failure; via the `SenderPreflightDeps` seam (no module mocks, no top-level env mutation)
- `email/delivery.test.ts` (39) — `resolveEmailSender` chain order, org-transport `bridgeMissing` semantics + send-path agreement, preflight/send log-fallback agreement
- scheduler `delivery.test.ts` / `executor.test.ts` / `shape-result.test.ts` — permanent counts on all summaries, mixed-failure stays `"failed"`, all-permanent writes `"failed_permanent"`, `orgId` rides `FormattedResult`
- route `scheduled-tasks.test.ts` (+5) — `warnings` shape on POST/PUT
- web `delivery-status-badge.test.tsx` (5) + `task-form-dialog.test.tsx` (11) — badge variants, warnings UX
- Verified: 22/22 affected API files, 202/202 web files, `bun run lint`, `bun run type`, `check-published-symbols`

A 7-angle code review of this diff produced one surviving finding — the Slack token-resolution rule stated twice (preflight + delivery) — fixed via the shared `resolveSlackBotToken`. The two Codex review findings (org-scope mismatch between preflight and delivery; bridge-less org transports resolving as configured) are fixed in `35410694`.

https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled task create/update now returns sender-configuration warnings (email/Slack) surfaced in the UI.
  * Deliveries distinguish permanent (configuration) vs transient failures; runs can be marked "failed_permanent".
  * Task dialog shows sender warnings and stays open until acknowledged; footer shows a Close action.
  * Delivery status badge and tooltips now show a distinct "failed — config" state with error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->