### PR TITLE
fix(api): saasWritable axis — settings PUT/DELETE enforce the saasVisible boundary for SaaS workspace admins

### DIFF
--- a/docs/development/enterprise-gating.md
+++ b/docs/development/enterprise-gating.md
@@ -82,7 +82,12 @@ A stored value must mean the same thing to every reader and every writer, in bot
 
 ### Rule 4 — `saasVisible` is a read+write contract, not a display hint
 
-If a setting is hidden from SaaS workspace admins on `GET /admin/settings`, the PUT/DELETE path must enforce the same boundary — an invisible-but-writable setting is undebuggable (written once, no UI to see or clear it). A dedicated admin page that needs to write a flagged key on SaaS (today: the sandbox page's `ATLAS_SANDBOX_BACKEND`) means the flag value is wrong or the flag semantics need a second axis — decide explicitly, don't rely on the gate's absence (#3376 tracks the decision).
+If a setting is hidden from SaaS workspace admins on `GET /admin/settings`, the PUT/DELETE path must enforce the same boundary — an invisible-but-writable setting is undebuggable (written once, no UI to see or clear it). The decided semantics (#3376) are two axes on `SettingDefinition`:
+
+- **`saasVisible`** is the read/display axis: it controls whether the key appears on the generic `GET /admin/settings` listing for SaaS workspace admins. Defaults to `true`.
+- **`saasWritable`** is the write axis: PUT and DELETE on `/admin/settings/{key}` reject (403) for SaaS workspace admins when the *effective* value is `false`. When unset it **defaults to the `saasVisible` value**, so for most keys visibility and writability remain a single decision and hidden ⇒ un-writable holds automatically.
+
+A key managed by a dedicated admin page on SaaS (today: `ATLAS_SANDBOX_BACKEND` and `ATLAS_SANDBOX_URL` via `/admin/sandbox`) uses the split — `saasVisible: false, saasWritable: true` — so it stays off the generic settings page but its own surface keeps saving through the same PUT route. Platform admins and self-hosted deployments are never restricted by either flag, and both flags are registry-internal (stripped from the GET response).
 
 ### Rule 5 — docs state mode scope explicitly
 
@@ -95,5 +100,5 @@ For any PR touching an admin surface, a settings key, an install path, or a `use
 1. Name the runtime reader of every new write, per mode (Rule 1).
 2. If the UI hides/shows something by mode, point to the API gate that matches it (Rule 2).
 3. If a setting's value set changed, confirm every reader and writer share the vocabulary (Rule 3).
-4. If a setting is `saasVisible: false`, confirm the write path enforces it (Rule 4).
+4. If a setting is `saasVisible: false`, decide its effective `saasWritable` explicitly — omit it to inherit hidden ⇒ un-writable, or set `saasWritable: true` only when a dedicated page is the writer (Rule 4).
 5. If mode behavior changed, the docs say which mode (Rule 5).

--- a/docs/development/enterprise-gating.md
+++ b/docs/development/enterprise-gating.md
@@ -87,7 +87,7 @@ If a setting is hidden from SaaS workspace admins on `GET /admin/settings`, the 
 - **`saasVisible`** is the read/display axis: it controls whether the key appears on the generic `GET /admin/settings` listing for SaaS workspace admins. Defaults to `true`.
 - **`saasWritable`** is the write axis: PUT and DELETE on `/admin/settings/{key}` reject (403) for SaaS workspace admins when the *effective* value is `false`. When unset it **defaults to the `saasVisible` value**, so for most keys visibility and writability remain a single decision and hidden ⇒ un-writable holds automatically.
 
-A key managed by a dedicated admin page on SaaS (today: `ATLAS_SANDBOX_BACKEND` and `ATLAS_SANDBOX_URL` via `/admin/sandbox`) uses the split — `saasVisible: false, saasWritable: true` — so it stays off the generic settings page but its own surface keeps saving through the same PUT route. Platform admins and self-hosted deployments are never restricted by either flag, and both flags are registry-internal (stripped from the GET response).
+A key managed by a dedicated admin page on SaaS (today: `ATLAS_SANDBOX_BACKEND` via `/admin/sandbox` — its sibling `ATLAS_SANDBOX_URL` is written only by the self-hosted view, so it inherits hidden ⇒ un-writable) uses the split — `saasVisible: false, saasWritable: true` — so it stays off the generic settings page but its own surface keeps saving through the same PUT route. Platform admins and self-hosted deployments are never restricted by either flag, and both flags are registry-internal (stripped from the GET response).
 
 ### Rule 5 — docs state mode scope explicitly
 

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -82,6 +82,33 @@ const settingsRegistryData = [
     envVar: "ANTHROPIC_API_KEY",
     scope: "platform",
   },
+  // #3376 — split-axis key: hidden from the generic settings page but
+  // writable on SaaS because the dedicated /admin/sandbox page saves it
+  // through PUT /admin/settings/{key}. Mirrors the real registry entry.
+  {
+    key: "ATLAS_SANDBOX_BACKEND",
+    section: "Sandbox",
+    label: "Sandbox Backend",
+    description: "Sandbox backend",
+    type: "string",
+    envVar: "ATLAS_SANDBOX_BACKEND",
+    scope: "workspace",
+    saasVisible: false,
+    saasWritable: true,
+  },
+  // #3376 — hidden key with no explicit saasWritable: effective
+  // writability inherits saasVisible=false, so SaaS workspace admins
+  // can neither see nor write it.
+  {
+    key: "ATLAS_DEMO_INDUSTRY",
+    section: "Demo",
+    label: "Demo Industry",
+    description: "Demo industry",
+    type: "string",
+    envVar: "ATLAS_DEMO_INDUSTRY",
+    scope: "workspace",
+    saasVisible: false,
+  },
 ];
 
 const mockGetSettingsForAdmin = mock(() => [
@@ -532,6 +559,167 @@ describe("admin settings routes", () => {
       expect(mockSetSetting).toHaveBeenCalledTimes(1);
       // Self-hosted: no orgId
       expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_PROVIDER", "openai", "admin-1", undefined);
+    });
+  });
+
+  // ─── SaaS write gate (#3376) ────────────────────────────────────
+
+  describe("saasWritable enforcement (#3376)", () => {
+    // Mock a SaaS workspace admin (org-scoped, role=admin, not platform_admin)
+    function asSaasWorkspaceAdmin() {
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: { id: "ws-admin-1", mode: "better-auth", label: "WS Admin", role: "admin", activeOrganizationId: "org-1" },
+        }),
+      );
+    }
+
+    function asSaasPlatformAdmin() {
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: { id: "platform-admin-1", mode: "better-auth", label: "Platform Admin", role: "platform_admin", activeOrganizationId: "org-1" },
+        }),
+      );
+    }
+
+    beforeEach(() => {
+      // Runs after the outer beforeEach (which resets to null), so every
+      // test in this block starts in SaaS mode unless it overrides.
+      mockConfigOverride = { deployMode: "saas" };
+    });
+
+    it("SaaS workspace admin PUT on a hidden key (saasWritable inherits saasVisible=false) → 403", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "healthcare" }),
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { error: string; message: string };
+      expect(data.error).toBe("forbidden");
+      expect(data.message).toContain("managed by Atlas in SaaS mode");
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+
+    it("SaaS workspace admin DELETE on a hidden key → 403", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toBe("forbidden");
+      expect(mockDeleteSetting).not.toHaveBeenCalled();
+    });
+
+    // Pins the /admin/sandbox save path: the sandbox page writes
+    // ATLAS_SANDBOX_BACKEND through this route on SaaS (#3375/#3376).
+    // If the split flag regresses to plain saasVisible enforcement,
+    // this test fails before the sandbox page breaks in prod.
+    it("SaaS workspace admin PUT on ATLAS_SANDBOX_BACKEND (saasVisible:false, saasWritable:true) succeeds", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_SANDBOX_BACKEND", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "vercel-sandbox" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
+      expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_SANDBOX_BACKEND", "vercel-sandbox", "ws-admin-1", "org-1");
+    });
+
+    it("SaaS workspace admin DELETE on ATLAS_SANDBOX_BACKEND succeeds", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_SANDBOX_BACKEND", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
+      expect(mockDeleteSetting).toHaveBeenCalledWith("ATLAS_SANDBOX_BACKEND", "ws-admin-1", "org-1");
+    });
+
+    it("SaaS platform admin PUT on a hidden key succeeds (flag never restricts platform admins)", async () => {
+      asSaasPlatformAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "ecommerce" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("self-hosted workspace admin PUT on a hidden key is unaffected", async () => {
+      mockConfigOverride = { deployMode: "self-hosted" };
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "cybersecurity" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("self-hosted workspace admin DELETE on a hidden key is unaffected", async () => {
+      mockConfigOverride = { deployMode: "self-hosted" };
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("unresolved config (getConfig() → null) is treated as self-hosted — write allowed", async () => {
+      mockConfigOverride = null;
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "saas" }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("SaaS workspace admin PUT on a visible workspace key still succeeds", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("secret check still fires under SaaS (unchanged by the write gate)", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ANTHROPIC_API_KEY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "sk-new" }),
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { message: string };
+      expect(data.message).toContain("Secret settings");
+    });
+
+    it("platform-scope check still fires under SaaS (unchanged by the write gate)", async () => {
+      asSaasWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_PROVIDER", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "openai" }),
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { message: string };
+      expect(data.message).toContain("platform-level setting");
     });
   });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3551,8 +3551,8 @@ admin.openapi(getSettingsRoute, async (c) => runHandler(c, "list settings", asyn
     ? allSettings.filter((s) => s.saasVisible !== false)
     : allSettings;
 
-  // Strip internal-only saasVisible field from response
-  const settings = filtered.map(({ saasVisible: _, ...rest }) => rest);
+  // Strip internal-only saasVisible/saasWritable fields from response
+  const settings = filtered.map(({ saasVisible: _v, saasWritable: _w, ...rest }) => rest);
 
   // Resolve regional API URL for the workspace (if residency is configured).
   // Wrapped in try-catch so a transient DB error doesn't break the entire settings response.
@@ -3603,6 +3603,18 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
   if (def.scope === "platform" && orgId && !isPlatformAdmin) {
     return c.json({ error: "forbidden", message: `"${key}" is a platform-level setting and cannot be modified by workspace admins.`, requestId }, 403);
+  }
+
+  // #3376 — `saasVisible` is a read+write contract (parity Rule 4): a key
+  // hidden from SaaS workspace admins on GET must not stay silently
+  // writable. Effective writability is `saasWritable`, defaulting to
+  // `saasVisible` (itself defaulting to true). The sandbox keys split the
+  // axes (`saasVisible: false, saasWritable: true`) because the dedicated
+  // /admin/sandbox page writes them through this route on SaaS. Mirrors
+  // the GET filter's mode probe (resolved config deployMode + role).
+  const saasWritable = def.saasWritable ?? def.saasVisible ?? true;
+  if (!saasWritable && !isPlatformAdmin && (getConfig()?.deployMode ?? "self-hosted") === "saas") {
+    return c.json({ error: "forbidden", message: `"${key}" is managed by Atlas in SaaS mode and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
   let body: { value?: unknown };
@@ -3699,6 +3711,14 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
   if (def.scope === "platform" && orgId && !isPlatformAdmin) {
     return c.json({ error: "forbidden", message: `"${key}" is a platform-level setting and cannot be modified by workspace admins.`, requestId }, 403);
+  }
+
+  // #3376 — same write gate as PUT: DELETE clears an override, which is a
+  // write. A SaaS workspace admin must not be able to reset a key they
+  // cannot see or set. See the PUT handler for the axis semantics.
+  const saasWritable = def.saasWritable ?? def.saasVisible ?? true;
+  if (!saasWritable && !isPlatformAdmin && (getConfig()?.deployMode ?? "self-hosted") === "saas") {
+    return c.json({ error: "forbidden", message: `"${key}" is managed by Atlas in SaaS mode and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
   const effectiveOrgId = def.scope === "workspace" ? orgId : undefined;

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -731,6 +731,46 @@ describe("settings module", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // saasVisible / saasWritable metadata (#3376)
+  // ---------------------------------------------------------------------------
+
+  describe("saasVisible / saasWritable metadata (#3376)", () => {
+    // Pins the split-axis flags on the real registry: the SaaS
+    // /admin/sandbox page saves these keys through the generic
+    // PUT /admin/settings/{key} route, which rejects writes when the
+    // effective saasWritable (saasWritable ?? saasVisible ?? true) is
+    // false. If either flag drifts, the sandbox page's save path on
+    // SaaS breaks (#3375 regression vector).
+    it("sandbox keys are hidden from the generic page but writable on SaaS", () => {
+      for (const key of ["ATLAS_SANDBOX_BACKEND", "ATLAS_SANDBOX_URL"]) {
+        const def = getSettingDefinition(key);
+        expect(def).toBeDefined();
+        expect(def!.saasVisible).toBe(false);
+        expect(def!.saasWritable).toBe(true);
+      }
+    });
+
+    it("ATLAS_DEMO_INDUSTRY inherits un-writability from saasVisible: false", () => {
+      const def = getSettingDefinition("ATLAS_DEMO_INDUSTRY");
+      expect(def).toBeDefined();
+      expect(def!.saasVisible).toBe(false);
+      // No explicit saasWritable — effective writability inherits the
+      // hidden flag, so SaaS workspace admins cannot write it.
+      expect(def!.saasWritable).toBeUndefined();
+    });
+
+    it("only dedicated-page keys split the axes (saasVisible: false + saasWritable: true)", () => {
+      const splitKeys = getSettingsRegistry()
+        .filter((s) => s.saasVisible === false && s.saasWritable === true)
+        .map((s) => s.key)
+        .toSorted();
+      // Append here ONLY when a dedicated SaaS admin page is the writer
+      // for the key (parity contract Rule 4, enterprise-gating.md).
+      expect(splitKeys).toEqual(["ATLAS_SANDBOX_BACKEND", "ATLAS_SANDBOX_URL"]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // getSettingDefinition
   // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -741,13 +741,18 @@ describe("settings module", () => {
     // effective saasWritable (saasWritable ?? saasVisible ?? true) is
     // false. If either flag drifts, the sandbox page's save path on
     // SaaS breaks (#3375 regression vector).
-    it("sandbox keys are hidden from the generic page but writable on SaaS", () => {
-      for (const key of ["ATLAS_SANDBOX_BACKEND", "ATLAS_SANDBOX_URL"]) {
-        const def = getSettingDefinition(key);
-        expect(def).toBeDefined();
-        expect(def!.saasVisible).toBe(false);
-        expect(def!.saasWritable).toBe(true);
-      }
+    it("ATLAS_SANDBOX_BACKEND is hidden from the generic page but writable on SaaS", () => {
+      const def = getSettingDefinition("ATLAS_SANDBOX_BACKEND");
+      expect(def).toBeDefined();
+      expect(def!.saasVisible).toBe(false);
+      expect(def!.saasWritable).toBe(true);
+    });
+
+    it("ATLAS_SANDBOX_URL inherits un-writability — only the self-hosted view writes it (#3390 review)", () => {
+      const def = getSettingDefinition("ATLAS_SANDBOX_URL");
+      expect(def).toBeDefined();
+      expect(def!.saasVisible).toBe(false);
+      expect(def!.saasWritable).toBeUndefined();
     });
 
     it("ATLAS_DEMO_INDUSTRY inherits un-writability from saasVisible: false", () => {
@@ -766,7 +771,7 @@ describe("settings module", () => {
         .toSorted();
       // Append here ONLY when a dedicated SaaS admin page is the writer
       // for the key (parity contract Rule 4, enterprise-gating.md).
-      expect(splitKeys).toEqual(["ATLAS_SANDBOX_BACKEND", "ATLAS_SANDBOX_URL"]);
+      expect(splitKeys).toEqual(["ATLAS_SANDBOX_BACKEND"]);
     });
   });
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -272,10 +272,12 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   },
 
   // Sandbox — managed via dedicated /admin/sandbox page in SaaS mode.
-  // `saasVisible: false, saasWritable: true` (#3376): hidden from the
+  // ATLAS_SANDBOX_BACKEND splits the axes (#3376): hidden from the
   // generic settings page (the sandbox page is the canonical surface),
-  // but the sandbox page saves through PUT /admin/settings/{key}, so
-  // SaaS workspace admins must keep write access.
+  // but the SaaS sandbox view saves it through PUT /admin/settings/{key},
+  // so SaaS workspace admins keep write access to it. ATLAS_SANDBOX_URL
+  // is written ONLY by the self-hosted view, so it inherits hidden ⇒
+  // un-writable on SaaS (no surface needs the exception — #3390 review).
   {
     key: "ATLAS_SANDBOX_BACKEND",
     section: "Sandbox",
@@ -302,7 +304,6 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_SANDBOX_URL",
     scope: "workspace",
     saasVisible: false,
-    saasWritable: true,
   },
 
   // Platform

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -46,6 +46,18 @@ export interface SettingDefinition {
   scope: SettingScope;
   /** Whether this setting is visible to workspace admins in SaaS mode. Defaults to true. Platform admins always see all settings. */
   saasVisible?: boolean;
+  /**
+   * #3376 — whether SaaS workspace admins may write (PUT/DELETE) this
+   * setting. When unset, the effective value defaults to `saasVisible`
+   * (itself defaulting to true), so visibility and writability stay one
+   * axis unless a key explicitly splits them. Keys managed by a dedicated
+   * admin page on SaaS (e.g. the sandbox keys via /admin/sandbox) set
+   * `saasVisible: false, saasWritable: true`: hidden from the generic
+   * settings page, but still writable through their own surface.
+   * Platform admins and self-hosted deployments are never restricted
+   * by this flag.
+   */
+  saasWritable?: boolean;
 }
 
 export interface SettingWithValue extends SettingDefinition {
@@ -259,7 +271,11 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "workspace",
   },
 
-  // Sandbox — managed via dedicated /admin/sandbox page in SaaS mode
+  // Sandbox — managed via dedicated /admin/sandbox page in SaaS mode.
+  // `saasVisible: false, saasWritable: true` (#3376): hidden from the
+  // generic settings page (the sandbox page is the canonical surface),
+  // but the sandbox page saves through PUT /admin/settings/{key}, so
+  // SaaS workspace admins must keep write access.
   {
     key: "ATLAS_SANDBOX_BACKEND",
     section: "Sandbox",
@@ -274,6 +290,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_SANDBOX_BACKEND",
     scope: "workspace",
     saasVisible: false,
+    saasWritable: true,
   },
   {
     key: "ATLAS_SANDBOX_URL",
@@ -285,6 +302,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_SANDBOX_URL",
     scope: "workspace",
     saasVisible: false,
+    saasWritable: true,
   },
 
   // Platform


### PR DESCRIPTION
Closes #3376. Part of the #3374 deploy-mode drift audit (taxonomy class 4).

**What**
- `SettingDefinition` gains a `saasWritable?: boolean` axis. Effective writability = `saasWritable ?? saasVisible ?? true`, so for most keys visibility and writability remain one decision and hidden ⇒ un-writable holds automatically. Both flags are registry-internal (stripped from the GET response).
- **PUT and DELETE `/admin/settings/{key}`** reject (403, with `requestId`, matching the neighboring scope/secret guards) for SaaS workspace admins when effective writability is false. DELETE is gated identically because clearing an override is a write. The mode probe mirrors the GET filter exactly (resolved config `deployMode` + `platform_admin` role — no new probe invented). Guard ordering preserved: secret → platform-scope → new gate → body/type validation → `SAAS_IMMUTABLE` (409 path unweakened — its workspace-visible keys never hit the new gate, and platform-scoped ones already 403'd on scope).
- **One key splits the axes**: `ATLAS_SANDBOX_BACKEND` is `saasVisible: false, saasWritable: true` — hidden from the generic settings page, still writable through its dedicated `/admin/sandbox` page (which saves via this same PUT route on SaaS; pinned by a route test so the just-merged #3375 flow can't regress). Its sibling `ATLAS_SANDBOX_URL` is written **only by the self-hosted view**, so it inherits hidden ⇒ un-writable — the initially-planned exception for it was dropped after review verified no SaaS surface writes it (Codex catch, fixed in fa4b3def).
- **Behavior change**: `ATLAS_DEMO_INDUSTRY` (the issue's failure scenario) and `ATLAS_SANDBOX_URL` are now truly un-writable by SaaS workspace admins. Every other `saasVisible: false` key was already blocked by the platform-scope or secret guards. GET filtering is untouched.
- **Parity contract Rule 4** (`docs/development/enterprise-gating.md`) rewritten to record the decided semantics (the "#3376 tracks the decision" placeholder is gone), and checklist item 4 updated to "decide effective `saasWritable` explicitly".

**Why**
Audit finding #3376: GET `/admin/settings` filtered `saasVisible` but PUT/DELETE never did — an invisible-but-writable setting is undebuggable (written once, no UI to see or clear it), and the SaaS sandbox page silently depended on the hole. The decision (made via review): split the flag rather than blanket-block, because dedicated admin pages are legitimate SaaS writers of hidden keys.

**Notes for review**
- The effective-writability expression is computed inline at the routes rather than exported from `settings.ts`: 32 test files `mock.module` the settings module with all-export mocks, and a new export would break every one of them for a 1-line derivation. The real registry's split-axis keys are drift-pinned by a `settings.test.ts` assertion (only `ATLAS_SANDBOX_BACKEND` may split).
- The mode probe deliberately treats unresolved config as self-hosted, matching the GET filter and the platform-scope gate (fail-open at the route layer). The pre-existing fail-open/fail-closed asymmetry against `setSetting`'s lib-level guard — plus the `SAAS_IMMUTABLE` DELETE bypass found during this work — is filed as #3389, not folded in.
- Server-side writers like the onboarding demo flow (`setSetting` direct calls) are intentionally outside this gate — it binds the generic admin settings surface, not internal product flows.

**Tests**
- 11 new route tests (`admin-settings.test.ts`): SaaS workspace admin PUT/DELETE on a hidden key → 403 with `setSetting`/`deleteSetting` never called; `ATLAS_SANDBOX_BACKEND` PUT/DELETE on SaaS → 200 with correct org passthrough; platform admin and self-hosted unaffected; unresolved config treated as self-hosted; secret + platform-scope 403s unchanged under SaaS
- 4 registry tests (`settings.test.ts`): real-registry flags for both sandbox keys (split vs inherited) + exhaustive split-axis drift check
- Verified: 135/135 affected API test files, `bun run lint`, `bun run type`, OpenAPI drift check clean

A 3-angle code review of this diff (line-scan, cross-file trace incl. all `setSetting`/`deleteSetting` call sites and `SAAS_IMMUTABLE` interplay, cleanup/altitude) surfaced no surviving findings; the one Codex review finding (the URL-key exception) is fixed in fa4b3def.

https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc