### PR TITLE
fix(web): useDeployMode consumers stop committing to a guessed mode (parity Rule 2 tiers)

### DIFF
--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -123,7 +123,7 @@ export default function BillingPage() {
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/billing", {
     schema: BillingStatusSchema,
   });
-  const { deployMode, resolved: modeResolved } = useDeployMode();
+  const { deployMode, error: modeError, resolved: modeResolved } = useDeployMode();
 
   // Framework-level 404 (billing routes not mounted) means self-hosted / no Stripe.
   // API-level 404s ("Workspace not found", "no internal database") have descriptive
@@ -139,13 +139,18 @@ export default function BillingPage() {
   // mode (deploy-mode parity contract Rule 2, #3378): while the mode is
   // still a hostname guess (loading / settings-fetch error), fall through to
   // the generic loading/error path instead of the self-hosted empty state.
-  const isSelfHosted =
-    modeResolved &&
-    deployMode === "self-hosted" &&
+  const isFramework404 =
     !loading &&
     !data &&
     error?.status === 404 &&
     (error.message === "Not Found" || error.message === "HTTP 404");
+  const isSelfHosted = modeResolved && deployMode === "self-hosted" && isFramework404;
+  // While the mode is still resolving, a framework 404 is ambiguous — the
+  // self-hosted empty state on a healthy deploy, or a SaaS misconfiguration.
+  // Hold the neutral loading state instead of flashing the 404 error and
+  // then swapping to the card (#3391 review). A settings-fetch error ends
+  // the hold: the ambiguity is then surfaced as the real error below.
+  const holdForMode = isFramework404 && !modeResolved && !modeError;
 
   if (isSelfHosted) {
     return (
@@ -166,8 +171,8 @@ export default function BillingPage() {
         <Hero stat={stat} />
 
         <AdminContentWrapper
-          loading={loading}
-          error={error}
+          loading={loading || holdForMode}
+          error={holdForMode ? null : error}
           feature="Billing"
           onRetry={refetch}
           loadingMessage="Loading billing details..."

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -123,7 +123,7 @@ export default function BillingPage() {
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/billing", {
     schema: BillingStatusSchema,
   });
-  const { deployMode } = useDeployMode();
+  const { deployMode, resolved: modeResolved } = useDeployMode();
 
   // Framework-level 404 (billing routes not mounted) means self-hosted / no Stripe.
   // API-level 404s ("Workspace not found", "no internal database") have descriptive
@@ -134,7 +134,13 @@ export default function BillingPage() {
   // unavailable), NOT that the deployment is self-hosted. Showing the
   // "Self-hosted · no billing" card in that case lies to the user — let the
   // generic error path surface the failure so it's visible to operators.
+  //
+  // `modeResolved` makes this view swap commit only to the server-confirmed
+  // mode (deploy-mode parity contract Rule 2, #3378): while the mode is
+  // still a hostname guess (loading / settings-fetch error), fall through to
+  // the generic loading/error path instead of the self-hosted empty state.
   const isSelfHosted =
+    modeResolved &&
     deployMode === "self-hosted" &&
     !loading &&
     !data &&

--- a/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
@@ -124,6 +124,21 @@ describe("SandboxPage deploy-mode gating (#3378)", () => {
     cleanup();
   });
 
+  test("version-skew guess (loading:false, error:null, resolved:false) holds the neutral state", () => {
+    // A settings response missing `deployMode` (frontend/API version skew)
+    // is the third guess path: no loading, no error, but not resolved. The
+    // page must hold the neutral loading state — rendering either view here
+    // would expose a guessed mode's ATLAS_SANDBOX_BACKEND save path (#3391
+    // review).
+    modeReturn = { deployMode: "saas", loading: false, error: null, resolved: false };
+    const { queryByText, getByText } = render(createElement(SandboxPage));
+
+    expect(queryByText(SAAS_MARKER)).toBeNull();
+    expect(queryByText(SELF_HOSTED_MARKER)).toBeNull();
+    getByText("Loading...");
+    cleanup();
+  });
+
   test("resolved saas renders the SaaS view", () => {
     modeReturn = { deployMode: "saas", loading: false, error: null, resolved: true };
     const { getByText, queryByText } = render(createElement(SandboxPage));

--- a/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Deploy-mode gating for the sandbox page (#3378).
+ *
+ * `/admin/sandbox` swaps whole mode-specific views on `useDeployMode()` and
+ * each view writes a different `ATLAS_SANDBOX_BACKEND` vocabulary, so it sits
+ * in the strictest tier of the deploy-mode parity contract (Rule 2 in
+ * docs/development/enterprise-gating.md): it must never commit to a guessed
+ * mode. These tests pin the three gate states:
+ *
+ *  - settings-fetch failure (the guess says "saas" on a custom-domain
+ *    self-host) → error surface, NOT the SaaS view;
+ *  - mode still loading → neutral loading state, no view (and therefore no
+ *    reachable save path), while the cosmetic heading may render the guess;
+ *  - mode resolved → the matching view renders.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { buildFetchError, type FetchError } from "@/ui/lib/fetch-error";
+import type { SandboxStatus } from "@/ui/lib/admin-schemas";
+import type { DeployMode } from "@/ui/lib/types";
+
+// ── Module mocks ──────────────────────────────────────────────────
+
+// Staged return for the page's `useDeployMode()` call. Mutated per test.
+let modeReturn: {
+  deployMode: DeployMode;
+  loading: boolean;
+  error: FetchError | null;
+  resolved: boolean;
+} = { deployMode: "saas", loading: false, error: null, resolved: true };
+
+mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => modeReturn,
+}));
+
+function makeStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
+  return {
+    activeBackend: "vercel-sandbox",
+    platformDefault: "vercel-sandbox",
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
+    ],
+    connectedProviders: [],
+    ...overrides,
+  };
+}
+
+// The sandbox-status fetch always succeeds in these tests — the point is
+// that a healthy status payload alone must NOT be enough to render a view
+// while the deploy mode is still a guess.
+mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => ({
+    data: makeStatus(),
+    loading: false,
+    error: null,
+    setError: () => {},
+    refetch: () => {},
+  }),
+  useInProgressSet: () => ({
+    has: () => false,
+    start: () => {},
+    stop: () => {},
+  }),
+  friendlyError: (e: FetchError) => e.message,
+}));
+
+mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: async () => ({ ok: true as const, data: undefined }),
+    saving: false,
+    error: null,
+    clearError: () => {},
+    errorsByItemId: {},
+    isMutating: () => false,
+    reset: () => {},
+  }),
+}));
+
+const { default: SandboxPage } = await import("../page");
+
+// ── Markers ───────────────────────────────────────────────────────
+// "Bring your own cloud" only exists in SaasSandboxView; "Sandbox backend"
+// only in SelfHostedSandboxView.
+
+const SAAS_MARKER = "Bring your own cloud";
+const SELF_HOSTED_MARKER = "Sandbox backend";
+
+describe("SandboxPage deploy-mode gating (#3378)", () => {
+  test("settings fetch failure does not render the SaaS view from the hostname guess", () => {
+    // Custom-domain self-host scenario: /api/v1/admin/settings 403s, so the
+    // hook falls back to the public-hostname guess ("saas") with
+    // resolved: false. The page must surface the failure, not the guessed
+    // SaaS view whose saves write SaaS-vocabulary values.
+    modeReturn = {
+      deployMode: "saas",
+      loading: false,
+      error: buildFetchError({ message: "HTTP 403", status: 403 }),
+      resolved: false,
+    };
+    const { queryByText, getByRole } = render(createElement(SandboxPage));
+
+    expect(queryByText(SAAS_MARKER)).toBeNull();
+    expect(queryByText(SELF_HOSTED_MARKER)).toBeNull();
+    // The mode error surfaces through the page's error path.
+    expect(getByRole("alert").textContent).toContain("HTTP 403");
+    cleanup();
+  });
+
+  test("renders a neutral loading state (no view, no save path) until loading === false", () => {
+    modeReturn = { deployMode: "saas", loading: true, error: null, resolved: false };
+    const { queryByText, getByText } = render(createElement(SandboxPage));
+
+    expect(queryByText(SAAS_MARKER)).toBeNull();
+    expect(queryByText(SELF_HOSTED_MARKER)).toBeNull();
+    // Neutral loading presentation from AdminContentWrapper.
+    getByText("Loading...");
+    // Cosmetic tier is allowed to render from the guess: the heading copy
+    // may show the guessed mode's title while the view stays neutral.
+    getByText("Execution Environment");
+    cleanup();
+  });
+
+  test("resolved saas renders the SaaS view", () => {
+    modeReturn = { deployMode: "saas", loading: false, error: null, resolved: true };
+    const { getByText, queryByText } = render(createElement(SandboxPage));
+
+    getByText(SAAS_MARKER);
+    expect(queryByText(SELF_HOSTED_MARKER)).toBeNull();
+    cleanup();
+  });
+
+  test("resolved self-hosted renders the self-hosted view", () => {
+    modeReturn = { deployMode: "self-hosted", loading: false, error: null, resolved: true };
+    const { getByText, queryByText } = render(createElement(SandboxPage));
+
+    getByText(SELF_HOSTED_MARKER);
+    expect(queryByText(SAAS_MARKER)).toBeNull();
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -153,8 +153,17 @@ export default function SandboxPage() {
   // (ATLAS_SANDBOX_BACKEND vocabulary differs per view), so it must never
   // commit to a guessed mode. Mode loading/error are folded into the
   // AdminContentWrapper below — neither view (and neither view's save path)
-  // renders until the mode is authoritative.
-  const { deployMode, loading: modeLoading, error: modeError } = useDeployMode();
+  // renders until the mode is authoritative. `resolved` (not just
+  // loading/error) is the authoritative signal: a settings response missing
+  // `deployMode` (frontend/API version skew) reports loading:false,
+  // error:null, resolved:false, and must hold the neutral state rather than
+  // render a guessed view's save path (#3391 review).
+  const {
+    deployMode,
+    loading: modeLoading,
+    error: modeError,
+    resolved: modeResolved,
+  } = useDeployMode();
   const isSaas = deployMode === "saas";
 
   const { data, loading, error, refetch } = useAdminFetch(
@@ -208,7 +217,7 @@ export default function SandboxPage() {
         </div>
 
         <AdminContentWrapper
-          loading={loading || modeLoading}
+          loading={loading || modeLoading || (!modeResolved && !modeError)}
           error={error ?? modeError}
           isEmpty={!data}
           emptyIcon={Box}

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -148,7 +148,13 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
 // ── Page ──────────────────────────────────────────────────────────
 
 export default function SandboxPage() {
-  const { deployMode } = useDeployMode();
+  // View-swapping consumer (deploy-mode parity contract Rule 2, #3378): this
+  // page swaps whole mode-specific views AND writes mode-specific values
+  // (ATLAS_SANDBOX_BACKEND vocabulary differs per view), so it must never
+  // commit to a guessed mode. Mode loading/error are folded into the
+  // AdminContentWrapper below — neither view (and neither view's save path)
+  // renders until the mode is authoritative.
+  const { deployMode, loading: modeLoading, error: modeError } = useDeployMode();
   const isSaas = deployMode === "saas";
 
   const { data, loading, error, refetch } = useAdminFetch(
@@ -188,6 +194,8 @@ export default function SandboxPage() {
   return (
     <div className="p-6">
       <ErrorBoundary>
+        {/* Heading copy is cosmetic-tier (Rule 2) — it may render from the
+            hostname guess while the mode resolves. */}
         <div className="mx-auto mb-8 max-w-3xl">
           <h1 className="text-2xl font-semibold tracking-tight">
             {isSaas ? "Execution Environment" : "Sandbox"}
@@ -200,8 +208,8 @@ export default function SandboxPage() {
         </div>
 
         <AdminContentWrapper
-          loading={loading}
-          error={error}
+          loading={loading || modeLoading}
+          error={error ?? modeError}
           isEmpty={!data}
           emptyIcon={Box}
           emptyTitle="Sandbox unavailable"

--- a/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
+++ b/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
@@ -32,7 +32,7 @@ mock.module("@/ui/context", () => ({
 }));
 
 mock.module("@/ui/hooks/use-deploy-mode", () => ({
-  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null }),
+  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null, resolved: true }),
 }));
 
 mock.module("@/ui/hooks/use-demo-readonly", () => ({

--- a/packages/web/src/app/admin/semantic/__tests__/import-empty-state.test.tsx
+++ b/packages/web/src/app/admin/semantic/__tests__/import-empty-state.test.tsx
@@ -46,7 +46,7 @@ mock.module("@/ui/context", () => ({
 }));
 
 mock.module("@/ui/hooks/use-deploy-mode", () => ({
-  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null }),
+  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null, resolved: true }),
 }));
 
 mock.module("@/ui/hooks/use-demo-readonly", () => ({

--- a/packages/web/src/app/platform/plugin-registry/page.tsx
+++ b/packages/web/src/app/platform/plugin-registry/page.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/ui/lib/admin-schemas";
 import { extractFetchError, friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
+import { LoadingState } from "@/ui/components/admin/loading-state";
 import type { DeployMode } from "@/ui/lib/types";
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -615,9 +616,14 @@ function SelfHostedPlugins() {
 // ── Main Page ─────────────────────────────────────────────────────
 
 export default function PluginsPage() {
-  const { deployMode } = useDeployMode();
+  const { deployMode, loading: modeLoading, resolved: modeResolved } = useDeployMode();
   const router = useRouter();
-  const isSaas = deployMode === "saas";
+  // View-swapping consumer (deploy-mode parity contract Rule 2, #3378):
+  // redirecting away IS the SaaS view here, so it must only fire on the
+  // server-confirmed mode — a hostname guess on a custom-domain self-host
+  // (loading window or settings-fetch failure) must not bounce a platform
+  // admin off this page.
+  const isSaas = modeResolved && deployMode === "saas";
 
   // SaaS mode: plugins are managed via dedicated admin pages (Connections,
   // Integrations, Sandbox, etc.) — redirect to admin overview. Must live in
@@ -627,6 +633,19 @@ export default function PluginsPage() {
   }, [isSaas, router]);
 
   if (isSaas) return null;
+
+  // Neutral state until the mode resolves. On a settings-fetch error
+  // (`!modeLoading && !modeResolved`) we fall through to the self-hosted
+  // view: this page is read-gated to platform admins, its mutations are
+  // API-gated, and the self-hosted view is the safe default for the only
+  // deploys where a platform admin realistically lands here.
+  if (modeLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <LoadingState />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">

--- a/packages/web/src/app/platform/plugin-registry/page.tsx
+++ b/packages/web/src/app/platform/plugin-registry/page.tsx
@@ -616,7 +616,12 @@ function SelfHostedPlugins() {
 // ── Main Page ─────────────────────────────────────────────────────
 
 export default function PluginsPage() {
-  const { deployMode, loading: modeLoading, resolved: modeResolved } = useDeployMode();
+  const {
+    deployMode,
+    loading: modeLoading,
+    error: modeError,
+    resolved: modeResolved,
+  } = useDeployMode();
   const router = useRouter();
   // View-swapping consumer (deploy-mode parity contract Rule 2, #3378):
   // redirecting away IS the SaaS view here, so it must only fire on the
@@ -634,15 +639,29 @@ export default function PluginsPage() {
 
   if (isSaas) return null;
 
-  // Neutral state until the mode resolves. On a settings-fetch error
-  // (`!modeLoading && !modeResolved`) we fall through to the self-hosted
-  // view: this page is read-gated to platform admins, its mutations are
-  // API-gated, and the self-hosted view is the safe default for the only
-  // deploys where a platform admin realistically lands here.
-  if (modeLoading) {
+  // Neutral state until the mode resolves — including the version-skew case
+  // where the settings response lacks deployMode (loading:false, error:null,
+  // resolved:false). This page may NOT fall through to a guessed view: the
+  // self-hosted plugin surface carries enable/disable/config mutations whose
+  // backing routes are platform-gated but not deploy-mode-gated, so
+  // committing on an unresolved mode would expose a self-hosted-only write
+  // surface on SaaS (#3391 review; parity contract Rule 2).
+  if (modeLoading || (!modeResolved && !modeError)) {
     return (
       <div className="mx-auto max-w-3xl px-6 py-10">
         <LoadingState />
+      </div>
+    );
+  }
+
+  // Settings-fetch error: surface it rather than committing to either mode's
+  // view. The wrapper's error surface includes the standard retry affordance.
+  if (!modeResolved && modeError) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <AdminContentWrapper loading={false} error={modeError}>
+          {null}
+        </AdminContentWrapper>
       </div>
     );
   }

--- a/packages/web/src/ui/__tests__/admin-sidebar-saas.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar-saas.test.tsx
@@ -26,7 +26,7 @@ mock.module("@/ui/hooks/use-branding", () => ({
 
 // Mock useDeployMode — SaaS mode for this test file
 mock.module("@/ui/hooks/use-deploy-mode", () => ({
-  useDeployMode: () => ({ deployMode: "saas", loading: false }),
+  useDeployMode: () => ({ deployMode: "saas", loading: false, error: null, resolved: true }),
 }));
 
 // Mock shadcn sidebar

--- a/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
@@ -26,7 +26,7 @@ mock.module("@/ui/hooks/use-branding", () => ({
 
 // Mock useDeployMode — default to self-hosted
 mock.module("@/ui/hooks/use-deploy-mode", () => ({
-  useDeployMode: () => ({ deployMode: "self-hosted", loading: false }),
+  useDeployMode: () => ({ deployMode: "self-hosted", loading: false, error: null, resolved: true }),
 }));
 
 // Mock shadcn sidebar — complex component with deep dependency chain (radix-ui, hooks, etc.)

--- a/packages/web/src/ui/__tests__/command-palette.test.tsx
+++ b/packages/web/src/ui/__tests__/command-palette.test.tsx
@@ -20,7 +20,7 @@ mock.module("@/ui/hooks/use-platform-admin-guard", () => ({
 }));
 
 mock.module("@/ui/hooks/use-deploy-mode", () => ({
-  useDeployMode: () => ({ deployMode: "self-hosted", loading: false }),
+  useDeployMode: () => ({ deployMode: "self-hosted", loading: false, error: null, resolved: true }),
 }));
 
 mock.module("@/ui/hooks/use-admin-fetch", () => ({

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -81,7 +81,7 @@ export function AdminSidebar() {
   const pathname = usePathname();
   const userRole = useUserRole();
   const { branding } = useBranding();
-  const { deployMode } = useDeployMode();
+  const { deployMode, resolved: modeResolved } = useDeployMode();
   const { mode, setMode, isAdmin } = useMode();
   const pendingCount = usePendingAmendmentCount();
   const isSaas = deployMode === "saas";
@@ -114,8 +114,13 @@ export function AdminSidebar() {
       ...group,
       items: group.items
         .filter((item) => !item.requiredRole || item.requiredRole === userRole)
-        .filter((item) => !item.selfHostedOnly || !isSaas)
-        .filter((item) => !item.saasOnly || isSaas)
+        // Mode-specific nav items gate navigation to whole mode-specific
+        // views, so they only appear once the deploy mode is server-confirmed
+        // (deploy-mode parity contract Rule 2, #3378). Until then the neutral
+        // state is "mode-agnostic items only" — a hostname guess must not
+        // surface (or hide) the wrong mode's pages.
+        .filter((item) => !item.selfHostedOnly || (modeResolved && !isSaas))
+        .filter((item) => !item.saasOnly || (modeResolved && isSaas))
         .map((item) =>
           item.href === "/admin/semantic/improve" && pendingCount > 0
             ? { ...item, badge: pendingCount }

--- a/packages/web/src/ui/components/palette/__tests__/palette-items.test.ts
+++ b/packages/web/src/ui/components/palette/__tests__/palette-items.test.ts
@@ -53,6 +53,28 @@ describe("buildAdminPaletteGroups", () => {
     expect(selfHasRegistry).toBe(true);
   });
 
+  test("unresolved mode (isSaas: null) hides mode-specific items in both directions", () => {
+    // Deploy-mode parity contract Rule 2 (#3378): while `useDeployMode` is
+    // still on the hostname guess (loading / settings-fetch error / fetch
+    // disabled) the palette must not commit to either mode — neither
+    // self-hosted-only nor SaaS-only items may appear.
+    const groups = buildAdminPaletteGroups({
+      userRole: "platform_admin",
+      isSaas: null,
+    });
+    const hrefs = groups
+      .flatMap((g) => g.items.map((i) => i.action))
+      .filter((a) => a.kind === "navigate")
+      .map((a) => a.href);
+
+    // selfHostedOnly item hidden…
+    expect(hrefs).not.toContain("/platform/plugin-registry");
+    // …and saasOnly item hidden too.
+    expect(hrefs).not.toContain("/platform/crm-outbox");
+    // Mode-agnostic items still present — null is neutral, not empty.
+    expect(hrefs.length).toBeGreaterThan(0);
+  });
+
   test("badges from the caller decorate the matching nav item", () => {
     const groups = buildAdminPaletteGroups({
       userRole: "admin",

--- a/packages/web/src/ui/components/palette/global-command-palette.tsx
+++ b/packages/web/src/ui/components/palette/global-command-palette.tsx
@@ -49,8 +49,13 @@ export function GlobalCommandPalette({
   // `/platform/plugin-registry`). Without this guard the palette mounted
   // on the chat shell would fire `/api/v1/admin/settings` for every signed-
   // in member/viewer and 403 on each chat load.
-  const { deployMode } = useDeployMode({ enabled: isPlatformAdmin });
-  const isSaas = deployMode === "saas";
+  const { deployMode, resolved: modeResolved } = useDeployMode({ enabled: isPlatformAdmin });
+  // `null` while the mode is still a hostname guess (loading / fetch error /
+  // fetch disabled) — `buildAdminPaletteGroups` then hides mode-specific
+  // items in both directions instead of committing to the guess (deploy-mode
+  // parity contract Rule 2, #3378). For non-platform-admins (`enabled:
+  // false`) the mode never resolves, but their admin groups are `[]` anyway.
+  const isSaas = modeResolved ? deployMode === "saas" : null;
 
   // Cmd/Ctrl-K (and `?` outside an input) toggle the palette. Also listen
   // for the existing PALETTE_EVENT so the chat help menu's "Open command

--- a/packages/web/src/ui/components/palette/palette-items.ts
+++ b/packages/web/src/ui/components/palette/palette-items.ts
@@ -12,7 +12,13 @@ import type { PaletteGroup, PaletteItem } from "./palette-types";
  */
 export function buildAdminPaletteGroups(opts: {
   userRole: "admin" | "member" | "platform_admin" | "viewer" | null;
-  isSaas: boolean;
+  /**
+   * `null` means the deploy mode is unresolved — still a hostname guess
+   * (loading, settings-fetch error, or fetch disabled). Mode-specific items
+   * are then hidden in both directions until the mode is server-confirmed
+   * (deploy-mode parity contract Rule 2, #3378).
+   */
+  isSaas: boolean | null;
   badges?: Record<string, number>;
 }): PaletteGroup[] {
   const { userRole, isSaas, badges = {} } = opts;
@@ -25,8 +31,8 @@ export function buildAdminPaletteGroups(opts: {
     .map((group): PaletteGroup => {
       const items = group.items
         .filter((item) => !item.requiredRole || item.requiredRole === userRole)
-        .filter((item) => !item.selfHostedOnly || !isSaas)
-        .filter((item) => !item.saasOnly || isSaas)
+        .filter((item) => !item.selfHostedOnly || isSaas === false)
+        .filter((item) => !item.saasOnly || isSaas === true)
         .map((item): PaletteItem => navItemToPaletteItem(item, group.title, badges));
       return { heading: group.title, items };
     })

--- a/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
@@ -1,15 +1,30 @@
 import { describe, expect, test, mock } from "bun:test";
 import { renderHook } from "@testing-library/react";
+import { buildFetchError } from "@/ui/lib/fetch-error";
 
 // Capture the opts `useAdminFetch` was called with so we can assert
 // `enabled` is forwarded — that's the contract the chat-surface palette
 // relies on to skip the admin-only fetch for member/viewer sessions.
+// `fetchReturn` is mutable so each test can stage loading / error / data
+// states without re-mocking the module.
 let lastOpts: { enabled?: boolean } | undefined;
+let fetchReturn: {
+  data: unknown;
+  loading: boolean;
+  error: unknown;
+  refetch: () => void;
+} = { data: null, loading: false, error: null, refetch: () => {} };
+
 mock.module("@/ui/hooks/use-admin-fetch", () => ({
   useAdminFetch: (_path: string, opts?: { enabled?: boolean }) => {
     lastOpts = opts;
-    return { data: null, loading: false, error: null, refetch: () => {} };
+    return fetchReturn;
   },
+  useInProgressSet: () => ({
+    has: () => false,
+    start: () => {},
+    stop: () => {},
+  }),
   friendlyError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
 }));
 
@@ -20,8 +35,19 @@ mock.module("@/lib/api-url", () => ({
 
 const { useDeployMode } = await import("../use-deploy-mode");
 
+function staged(overrides: Partial<typeof fetchReturn>) {
+  fetchReturn = {
+    data: null,
+    loading: false,
+    error: null,
+    refetch: () => {},
+    ...overrides,
+  };
+}
+
 describe("useDeployMode { enabled } forwarding", () => {
   test("default (no opts) leaves enabled undefined — useAdminFetch fetches by default", () => {
+    staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode());
     expect(lastOpts).toEqual({ enabled: undefined });
@@ -30,12 +56,14 @@ describe("useDeployMode { enabled } forwarding", () => {
   test("explicit enabled: false threads through to skip the fetch", () => {
     // This is the security/perf contract for the chat-surface palette:
     // members and viewers must NOT fire `/api/v1/admin/settings`.
+    staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode({ enabled: false }));
     expect(lastOpts).toEqual({ enabled: false });
   });
 
   test("explicit enabled: true also threads through", () => {
+    staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode({ enabled: true }));
     expect(lastOpts).toEqual({ enabled: true });
@@ -44,7 +72,50 @@ describe("useDeployMode { enabled } forwarding", () => {
   test("falls back to the hostname guess when the fetch is disabled", () => {
     // On the test runner the URL is localhost (set in test-setup.ts);
     // localhost always resolves to self-hosted.
+    staged({});
     const { result } = renderHook(() => useDeployMode({ enabled: false }));
     expect(result.current.deployMode).toBe("self-hosted");
+  });
+});
+
+describe("useDeployMode resolved (guess vs authoritative, #3378)", () => {
+  // `resolved` is the consumer contract for the deploy-mode parity rules
+  // (Rule 2 in docs/development/enterprise-gating.md): view-swapping and
+  // value-writing consumers must not commit to the mode unless it came
+  // from the server. It must be false on ALL three guess paths — loading,
+  // fetch error, and `enabled: false` — the last of which `loading`/`error`
+  // alone cannot distinguish from a successful resolve.
+
+  test("resolved is true when the server answered, and the server value wins over the guess", () => {
+    // Test runner host is localhost → guess would say "self-hosted"; the
+    // server says "saas". The authoritative answer must win.
+    staged({ data: { settings: [], manageable: true, deployMode: "saas" } });
+    const { result } = renderHook(() => useDeployMode());
+    expect(result.current.resolved).toBe(true);
+    expect(result.current.deployMode).toBe("saas");
+  });
+
+  test("resolved is false while loading", () => {
+    staged({ loading: true });
+    const { result } = renderHook(() => useDeployMode());
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.loading).toBe(true);
+  });
+
+  test("resolved is false on fetch error — the returned mode is only a guess", () => {
+    staged({ error: buildFetchError({ message: "HTTP 403", status: 403 }) });
+    const { result } = renderHook(() => useDeployMode());
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    // The guess is still returned for cosmetic-tier consumers.
+    expect(result.current.deployMode).toBe("self-hosted");
+  });
+
+  test("resolved is false when the fetch is disabled (enabled: false reports loading: false, error: null)", () => {
+    staged({});
+    const { result } = renderHook(() => useDeployMode({ enabled: false }));
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/web/src/ui/hooks/use-deploy-mode.ts
+++ b/packages/web/src/ui/hooks/use-deploy-mode.ts
@@ -16,11 +16,24 @@ interface SettingsResponse {
  * Returns the resolved deploy mode from the admin settings API.
  *
  * Fetches from `/api/v1/admin/settings` and extracts the `deployMode` field.
- * Falls back to a hostname-based guess while loading or on error (localhost
- * and private-network hosts → "self-hosted"; public-internet hosts → "saas")
- * so a slow fetch on `app.useatlas.dev` doesn't briefly lie to the user that
- * they're on a self-hosted deploy. Exposes the error so consumers can still
- * detect when the resolution is a guess rather than an authoritative answer.
+ * Falls back to a hostname-based guess while loading, on error, and when the
+ * fetch is disabled (localhost and private-network hosts → "self-hosted";
+ * public-internet hosts → "saas") so a slow fetch on `app.useatlas.dev`
+ * doesn't briefly lie to the user that they're on a self-hosted deploy. The
+ * guess is wrong for every custom-domain self-host (`atlas.company.com`),
+ * so it is deliberately **not** a failure-path answer — `resolved` is `false`
+ * on every guess path, and consumers commit to the mode by risk tier
+ * (deploy-mode parity contract, Rule 2 in
+ * docs/development/enterprise-gating.md, #3378):
+ *
+ * - **Cosmetic-only** branches (copy, icons) may render from the guess.
+ * - **View-swapping** components (whole mode-specific views, redirects,
+ *   mode-only nav items) render a neutral/loading state until
+ *   `loading === false`, and must not commit to a guessed mode on `error`
+ *   (use `resolved`, or surface the error).
+ * - **Flows that write mode-specific values** must not save while `loading`
+ *   is `true` or `error` is non-null — a guessed mode never decides what
+ *   gets persisted.
  *
  * Also applies the regional API URL override when the settings response
  * includes a `regionApiUrl` (tier-2 data residency).
@@ -39,6 +52,13 @@ export function useDeployMode(opts?: { enabled?: boolean }): {
   deployMode: DeployMode;
   loading: boolean;
   error: FetchError | null;
+  /**
+   * `true` only when `deployMode` came from the server. `false` on every
+   * guess path — while loading, after a fetch error, and when the fetch is
+   * disabled (`enabled: false`) — which `loading`/`error` alone can't
+   * distinguish (a disabled fetch reports `loading: false, error: null`).
+   */
+  resolved: boolean;
 } {
   // `enabled: false` skips the network call so non-admins don't 403 on
   // `/api/v1/admin/settings`. The returned `deployMode` then comes from
@@ -71,5 +91,6 @@ export function useDeployMode(opts?: { enabled?: boolean }): {
     deployMode: data?.deployMode ?? guessDeployModeFromHost(),
     loading,
     error,
+    resolved: data?.deployMode !== undefined,
   };
 }


### PR DESCRIPTION
Closes #3378. Part of the #3374 deploy-mode drift audit (taxonomy class 4).

**What**
- `useDeployMode` gains `resolved: boolean` — `true` only when `deployMode` came from the server. It is genuinely non-derivable from `loading`/`error`: both the `enabled: false` path and the version-skew path (a settings response missing `deployMode`) report `loading: false, error: null`. The hostname guess stays as the **cosmetic-tier fallback only**; the hook's docstring encodes the Rule 2 tiers.
- **Failure-path default**: no `"unknown"` member added to `DeployMode` (would force a third wire value on every consumer) and the public-host guess stays `"saas"` (flipping it would reintroduce the `app.useatlas.dev` flash the guess exists to prevent). Instead, every guess path is marked `resolved: false` and consumers render neutral per tier.
- **Consumers fixed (view-swap/nav/write tiers):**
  - `/admin/sandbox` — mode loading/error **and the unresolved-skew tuple** fold into the page's `AdminContentWrapper`, so neither view (nor its `ATLAS_SANDBOX_BACKEND` save path) renders until the mode is authoritative; heading copy stays cosmetic-tier.
  - `/platform/plugin-registry` — the SaaS redirect fires only on `resolved && saas`; the page never commits to `SelfHostedPlugins` on an unresolved mode (skew → neutral loading, settings-fetch error → standard error surface) because the backing plugins router is platform-gated but not deploy-mode-gated.
  - `/admin/billing` — the self-hosted empty-state swap requires `resolved`, and a mode-ambiguous framework 404 holds the neutral loading state instead of flashing the error before the card.
  - Admin sidebar — `saasOnly`/`selfHostedOnly` nav items hidden in both directions until `resolved`.
  - Command palette — `buildAdminPaletteGroups` takes `isSaas: boolean | null`; `null` (unresolved, incl. the non-admin `enabled: false` path) hides mode-specific items both ways.
- **Consumers verified cosmetic-tier and left alone** (copy/icons/read-only stats): admin overview, admin settings, platform settings, semantic page + entity-editor, residency page; `ai-agents` settings reads mode from its own authoritative response. The audit's "2 dead imports" no longer exist on main (cleaned up by the #3375 merge).

**Why**
Audit finding #3378: the hook's hostname fallback guesses "saas" for every public host — wrong for every custom-domain self-host — and no mode-branching consumer read `loading`/`error`, so view-swapping surfaces (notably the sandbox page, which writes a per-mode settings vocabulary) committed to a guess. The parity contract's Rule 2 already prescribed the tiers; this makes the code conform.

**Tests**
- `admin/sandbox/__tests__/mode-gating.test.tsx` (5) — settings-fetch failure on a custom domain renders the error surface, neither mode view; neutral until `loading === false`; the version-skew tuple (`loading:false, error:null, resolved:false`) holds neutral; cosmetic heading renders from the guess; both resolved views
- `use-deploy-mode.test.tsx` — `resolved` semantics on all three guess paths + server-wins-over-guess
- `palette-items.test.ts` — `isSaas: null` hides mode-specific items both ways
- 5 existing test files: mock updates only
- Verified: 203/203 web test files, `bun run lint`, `bun run type` (no API files touched)

A 3-angle code review surfaced no surviving findings pre-PR; the three Codex review findings (billing 404 flash, plugin-registry unresolved fall-through, sandbox skew gating) were all valid against the hook's own contract and are fixed in `a1a9bb21`.

**Adjacent findings** (pre-existing, not folded in): plugin-registry carries dead `deployMode === "saas"` branches in `PluginRow` (only caller hardcodes self-hosted); admin overview hand-rolls fetch instead of `useAdminFetch`; `AdminContentWrapper` renders `error` before `loading`; the sandbox page passes no `feature`/`onRetry` to its wrapper.

https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc