### PR TITLE
chore(ci): settings-registry reader-presence drift check (parity contract Rule 1)

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -14,6 +14,7 @@ bash scripts/check-schema-drift.sh   # Drizzle schema.ts ↔ migrations parity
 bash scripts/check-oauth-helper-drift.sh  # plugins/mcp/src/_oauth-helper ↔ packages/oauth-helper/src parity
 bash scripts/check-test-discipline.sh  # No new top-level env/chdir mutations in test files
 bash scripts/check-twenty-resolver-imports.sh  # Twenty operator resolver confined to ee/saas-crm (#2850)
+bash scripts/check-settings-readers.sh  # Every settings-registry key has a non-test runtime reader (#3382)
 bun run scripts/check-published-symbols.ts  # @useatlas/* imports in scaffold-bound source ↔ pinned-published exports parity
 ```
 
@@ -32,6 +33,7 @@ Use the full `bun run test` here — `/ci` is the pre-PR check, not an iteration
 | Schema drift | `Schema drift check passed` (every migration table is in `packages/api/src/lib/db/schema.ts`) |
 | OAuth helper drift | `vendored _oauth-helper matches canonical packages/oauth-helper/src` |
 | Test discipline | `Test discipline check passed — env: N allowlisted, chdir: N allowlisted.` New offenders fail; new allowlist entries need justifying comment (see #2796). `mock.module()` is NOT gated — slice 5a verdict (#2801) proved bun's `--isolate` resets module mocks between files |
+| Settings readers | `Settings reader check passed — …` Every key in `packages/api/src/lib/settings.ts` has a non-test runtime reader: a literal/const-indirected `getSetting`/`getSettingAuto`/`getSettingLive` call, or (platform-scoped keys only) a `process.env.<ENVVAR>` read. Fix by adding the reader, allowlisting with a justification comment in the script, or removing the setting (parity contract Rule 1, #3382) |
 | Published symbols | `Published symbol check passed.` Diffs braced **value** imports from `@useatlas/*` packages in scaffold-bound source (`packages/{api,cli,web,schemas}/src`, `ee/src`, `examples/nextjs-standalone/src`, `create-atlas/overrides`) against the symbols exported by the version `npm view` resolves for the range pinned in `create-atlas/templates/*/package.json`. Type-only imports are skipped (they erase; the scaffold's `next build` runs with `ignoreBuildErrors: true`). Fix per the version-bump-ordering rule: publish the plugin first, then bump the template ref in a follow-up PR |
 
 **If any gate fails:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Check test-file discipline (1.5.4 / #2796)
         run: bash scripts/check-test-discipline.sh
 
+      - name: Check settings-registry reader presence (#3382)
+        run: bash scripts/check-settings-readers.sh
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+# Verify that every key in the settings registry
+# (packages/api/src/lib/settings.ts) has at least one NON-TEST runtime
+# reader — catching drift class 1 from the #3374 deploy-mode parity audit:
+# a setting that is admin-visible (and writable) in the UI but consumed by
+# nothing at runtime. Parity contract Rule 1 (#3380): every admin-writable
+# value names its runtime reader.
+#
+# Matching rules (a key passes if ANY rule matches; all matching runs
+# against comment-stripped, non-test source — see SCOPE/EXCLUSIONS below):
+#
+#   R1 — direct literal read:
+#          getSetting("KEY") / getSettingAuto("KEY") / getSettingLive("KEY")
+#   R2 — const-indirected read: a const is bound to the key literal
+#          (`const FOO_SETTING = "KEY"`) and that const is passed to
+#          getSetting/getSettingAuto/getSettingLive. This is the
+#          house pattern for keys whose name is also surfaced in error
+#          copy (email-tool.ts, scim-provenance.ts, mcp prompts/gating.ts).
+#   R3 — env-mirror read, PLATFORM-SCOPED KEYS ONLY:
+#          `process.env.ENVVAR` / `process.env["ENVVAR"]` (reads only —
+#          assignments don't count). Platform-scoped keys are legitimately
+#          consumed at boot via env before/instead of the settings tier
+#          chain (ATLAS_DEPLOY_MODE in config.ts, ATLAS_LOG_LEVEL in
+#          logger.ts, DATABASE_URL in db/internal.ts, the provider API
+#          keys in providers.ts/cli init). For WORKSPACE-scoped keys an
+#          env-only reader is NOT accepted: getSetting's tier chain
+#          already falls through to env, so an env-only read means the
+#          per-workspace DB override the admin UI writes is runtime-inert
+#          — exactly the drift this script exists to catch. Workspace
+#          keys in that state go on the ALLOWLIST with a justification
+#          and a tracking note, never silently pass.
+#
+# SCOPE: packages/*/src, ee/src, plugins/*/src. apps/ (www, docs) and
+# examples/ are intentionally out of scope — a docs-site or example
+# mention is not a runtime reader.
+#
+# EXCLUSIONS:
+#   - test code: *.test.ts(x), __tests__/, __mocks__/, __test-utils__/,
+#     testing/, test-setup.ts
+#   - packages/api/src/lib/settings.ts itself (the registry + tier-chain
+#     implementation reads every key by definition)
+#   - packages/api/src/api/routes/admin.ts — the generic admin settings
+#     GET/PUT/DELETE routes live there. Today they pass keys as variables
+#     (getSettingDefinition(key), setSetting(key, …)) so the literal
+#     matcher can't count them anyway; the file-level exclusion makes the
+#     issue-#3382 rule structural: a hardcoded display-only echo added to
+#     the generic routes must never satisfy the reader requirement. If a
+#     REAL reader ever lands in admin.ts, this check fails noisily — move
+#     the read into lib/ (CLAUDE.md: lib/ must not import from api/routes/,
+#     and routes should delegate to lib helpers), don't widen this scope.
+#
+# Limits (conservative by design — failures are noisy, never silent):
+#   - line-based matching: a reader call split so the key literal is on a
+#     different line than `getSetting(` won't match. Prettier keeps them
+#     together in practice; if you hit this, keep the key on the call line.
+#   - R2 resolves const names textually across the whole evidence set, not
+#     via the module graph.
+
+set -euo pipefail
+
+SETTINGS_FILE="packages/api/src/lib/settings.ts"
+GENERIC_SETTINGS_ROUTES_FILE="packages/api/src/api/routes/admin.ts"
+
+# ---------------------------------------------------------------------------
+# Allowlist — keys intentionally exempt from the reader requirement.
+# EVERY entry needs a justification comment saying WHY (parity contract
+# Rule 1). Do not add a key here just to make CI green: name the reader
+# or remove the setting.
+# ---------------------------------------------------------------------------
+ALLOWLIST=(
+  # The four Semantic Expert keys are WORKSPACE-scoped in the registry but
+  # their only runtime readers are process.env reads, so the per-workspace
+  # DB override the admin settings page writes is runtime-inert above the
+  # env tier (adjacent finding from #3382 — predates this check; do not
+  # fix here). Remove each entry when its reader moves to getSetting(key,
+  # orgId).
+  #
+  # ATLAS_EXPERT_SCHEDULER_ENABLED — read via process.env in
+  #   lib/semantic/expert/scheduler.ts:isExpertSchedulerEnabled() (consumed
+  #   by the scheduler layer in lib/effect/layers.ts).
+  "ATLAS_EXPERT_SCHEDULER_ENABLED"
+  # ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS — read via process.env in
+  #   lib/semantic/expert/scheduler.ts:getExpertSchedulerIntervalMs().
+  "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS"
+  # ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD — read via process.env in
+  #   lib/db/internal.ts:getAutoApproveThreshold().
+  "ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD"
+  # ATLAS_EXPERT_AUTO_APPROVE_TYPES — read via process.env in
+  #   lib/db/internal.ts:getAutoApproveTypes().
+  "ATLAS_EXPERT_AUTO_APPROVE_TYPES"
+)
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+  echo "::error::settings registry not found at $SETTINGS_FILE" >&2
+  echo "::error::if the file moved, update SETTINGS_FILE in $(basename "$0")." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Parse the registry into KEY|ENVVAR|SCOPE triples.
+# `key` is always the first field of each entry, so it delimits records.
+# ---------------------------------------------------------------------------
+REGISTRY=$(awk '
+  /^const SETTINGS_REGISTRY/ { inreg = 1; next }
+  inreg && /^\];/            { inreg = 0 }
+  !inreg                     { next }
+  /^[[:space:]]*key: "/    { if (k != "") print k "|" e "|" s
+                             match($0, /"[^"]+"/); k = substr($0, RSTART+1, RLENGTH-2); e = ""; s = "" }
+  /^[[:space:]]*envVar: "/ { match($0, /"[^"]+"/); e = substr($0, RSTART+1, RLENGTH-2) }
+  /^[[:space:]]*scope: "/  { match($0, /"[^"]+"/); s = substr($0, RSTART+1, RLENGTH-2) }
+  END                      { if (k != "") print k "|" e "|" s }
+' "$SETTINGS_FILE")
+
+KEY_COUNT=$(echo "$REGISTRY" | grep -c . || true)
+if [ "$KEY_COUNT" -lt 10 ]; then
+  echo "::error::registry parse extracted only $KEY_COUNT key(s) from $SETTINGS_FILE — the SETTINGS_REGISTRY shape probably changed. Update the awk program in $(basename "$0")." >&2
+  exit 2
+fi
+while IFS='|' read -r key envvar scope; do
+  if [ -z "$envvar" ] || [ -z "$scope" ]; then
+    echo "::error::registry entry '$key' parsed without envVar/scope — the SETTINGS_REGISTRY shape probably changed. Update the awk program in $(basename "$0")." >&2
+    exit 2
+  fi
+done <<<"$REGISTRY"
+
+# ---------------------------------------------------------------------------
+# 2. Build the comment-stripped evidence set from non-test source.
+# Without stripping, a key whose only "reader" is a doc-comment reference
+# (several exist: layers.ts, env-profile.ts, dpa-guard.ts) would falsely
+# pass. Three substitutions, in order:
+#   1. strip same-line block comments (`/* x */`, `/** x */`)
+#   2. drop lines that are block-comment openers/continuations/closers
+#      (leading whitespace then `*` or `/*`) — the JSDoc shape every
+#      multi-line comment in this repo uses. NOTE: deliberately NOT the
+#      check-ee-imports.sh range delete (`/\/\*/,/\*\// d`): glob strings
+#      in template literals (e.g. "metrics/*.yml" in cli init.ts) contain
+#      `/*` and would open a range that deletes real code to EOF,
+#      producing false "no reader" failures.
+#   3. strip trailing `//` comments. Limit: a `//` inside a string
+#      literal (URLs) also truncates the line — harmless unless a reader
+#      call sits AFTER a URL on the same line, which would fail noisily,
+#      not silently pass.
+# ---------------------------------------------------------------------------
+STRIP_COMMENTS='sed -E "s#/\*([^*]|\*+[^*/])*\*+/##g; /^[[:space:]]*(\*|\/\*)/d; s#//.*\$##"'
+
+# Fast-path: only files that can possibly contain reader evidence
+# (a getSetting call, a process.env read, or an ALL-CAPS string literal
+# that could be a const-bound key).
+CANDIDATES=$(grep -rlE 'getSetting|process\.env|"[A-Z][A-Z0-9_]{2,}"' \
+  packages/*/src ee/src plugins/*/src \
+  --include='*.ts' --include='*.tsx' \
+  --exclude='*.test.ts' --exclude='*.test.tsx' \
+  --exclude='test-setup.ts' \
+  --exclude-dir=__tests__ --exclude-dir=__mocks__ --exclude-dir=__test-utils__ \
+  --exclude-dir=testing \
+  --exclude-dir=node_modules --exclude-dir=dist \
+  2>/dev/null \
+  | grep -vx "$SETTINGS_FILE" \
+  | grep -vx "$GENERIC_SETTINGS_ROUTES_FILE" \
+  || true)
+
+if [ -z "$CANDIDATES" ]; then
+  echo "::error::no candidate source files found under packages/*/src — scope globs in $(basename "$0") are probably stale." >&2
+  exit 2
+fi
+
+EVIDENCE=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  # tr -d '\0' + grep -a: one web page file contains a byte sequence grep
+  # detects as binary; without these the evidence pass degrades to
+  # "binary file matches" and drops the file's lines.
+  EVIDENCE+=$(eval "$STRIP_COMMENTS \"\$f\"" \
+    | tr -d '\0' \
+    | grep -aE 'getSetting|process\.env|"[A-Z][A-Z0-9_]{2,}"' \
+    | sed "s|^|$f: |" || true)
+  EVIDENCE+=$'\n'
+done <<<"$CANDIDATES"
+
+# ---------------------------------------------------------------------------
+# 3. Per-key reader check.
+# ---------------------------------------------------------------------------
+MISSING=0
+R1_COUNT=0
+R2_COUNT=0
+R3_COUNT=0
+ALLOWLISTED_COUNT=0
+
+is_allowlisted() {
+  local key="$1" entry
+  for entry in "${ALLOWLIST[@]}"; do
+    [ "$entry" = "$key" ] && return 0
+  done
+  return 1
+}
+
+while IFS='|' read -r key envvar scope; do
+  [ -z "$key" ] && continue
+
+  if is_allowlisted "$key"; then
+    ALLOWLISTED_COUNT=$((ALLOWLISTED_COUNT + 1))
+    continue
+  fi
+
+  # R1 — direct literal read.
+  if grep -qE "getSetting(Auto|Live)?\(\s*[\"']${key}[\"']" <<<"$EVIDENCE"; then
+    R1_COUNT=$((R1_COUNT + 1))
+    continue
+  fi
+
+  # R2 — const-indirected read.
+  CONST_NAMES=$(grep -oE "(const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*[\"']${key}[\"']" <<<"$EVIDENCE" \
+    | awk '{print $2}' | sort -u || true)
+  FOUND_VIA_CONST=0
+  for name in $CONST_NAMES; do
+    if grep -qE "getSetting(Auto|Live)?\(\s*${name}\b" <<<"$EVIDENCE"; then
+      FOUND_VIA_CONST=1
+      break
+    fi
+  done
+  if [ "$FOUND_VIA_CONST" -eq 1 ]; then
+    R2_COUNT=$((R2_COUNT + 1))
+    continue
+  fi
+
+  # R3 — env-mirror read, platform-scoped keys only (see header).
+  if [ "$scope" = "platform" ]; then
+    ENV_READS=$(grep -E "process\.env\.${envvar}\b|process\.env\[[\"']${envvar}[\"']\]" <<<"$EVIDENCE" \
+      | grep -vE "process\.env(\.${envvar}|\[[\"']${envvar}[\"']\])[[:space:]]*=([^=]|$)" || true)
+    if [ -n "$ENV_READS" ]; then
+      R3_COUNT=$((R3_COUNT + 1))
+      continue
+    fi
+  fi
+
+  echo "::error::setting '$key' has no runtime reader — name the reader or remove the setting (parity contract Rule 1)"
+  MISSING=$((MISSING + 1))
+done <<<"$REGISTRY"
+
+if [ "$MISSING" -gt 0 ]; then
+  echo ""
+  echo "Found $MISSING registry key(s) in $SETTINGS_FILE with no non-test runtime reader."
+  echo ""
+  echo "Every admin-writable setting must name its runtime reader (parity"
+  echo "contract Rule 1, #3380/#3382). Fix one of:"
+  echo "  1. Add the reader: call getSetting/getSettingAuto/getSettingLive"
+  echo "     with the key (workspace-scoped keys must pass orgId so the"
+  echo "     per-workspace override is honored)."
+  echo "  2. Platform-scoped boot keys read via env are accepted as-is"
+  echo "     (process.env.<ENVVAR> in non-test source)."
+  echo "  3. If the exemption is intentional, add the key to ALLOWLIST in"
+  echo "     scripts/$(basename "$0") WITH a justification comment naming"
+  echo "     why no getSetting reader exists."
+  echo "  4. Otherwise remove the setting from the registry — a key nothing"
+  echo "     reads is UI-visible but runtime-inert (drift class 1, #3374)."
+  exit 1
+fi
+
+echo "Settings reader check passed — $KEY_COUNT registry key(s): $R1_COUNT direct getSetting, $R2_COUNT const-indirected, $R3_COUNT env-mirror (platform-scoped), $ALLOWLISTED_COUNT allowlisted."


### PR DESCRIPTION
Closes #3382. Part of the #3374 deploy-mode drift audit (the recurring-prevention deliverable).

**What**
- New `scripts/check-settings-readers.sh` (house style of `check-schema-drift.sh` / `check-ee-imports.sh`: `::error::` annotations, exit 1 on drift, exit 2 on infrastructure breakage, success summary): every key in the settings registry must have at least one **non-test** runtime reader, or the build fails with *"name the reader or remove the setting (parity contract Rule 1)"* plus a 4-option fix block.
- **Matching rules** (documented in the script header): R1 direct `getSetting|getSettingAuto|getSettingLive("KEY")` (26 keys today); R2 const-indirection — the house pattern for keys whose name appears in error copy (3 keys); R3 `process.env.<ENVVAR>` reads for **platform-scoped keys only** (6 keys) — env-only reads are deliberately NOT accepted for workspace-scoped keys, because `getSetting`'s tier chain already falls through to env, so env-only means the per-workspace DB override is runtime-inert — the exact class-1 drift this check exists to catch.
- All matching runs against comment-stripped source in `packages/*/src`, `ee/src`, `plugins/*/src` (apps/examples excluded — docs mentions aren't readers). Structural exclusions: `settings.ts` itself, and `api/routes/admin.ts` (the generic settings routes) so a display-only echo can never satisfy the requirement.
- **Allowlist: 4 entries**, each with a justification comment — the `ATLAS_EXPERT_*` keys, which are workspace-scoped but env-only-read. That's a *real* class-1 instance the check caught on its first run, filed as **#3392** (the allowlist entries carry the tracking note and get deleted when it's fixed).
- **CI wiring** in both places: a `Check settings-registry reader presence` step in `.github/workflows/ci.yml` alongside the existing drift checks, and the `/ci` skill's parallel-gates block + pass-criteria table.

**Item 2 of the issue (saasVisible write-gate test): already satisfied, nothing added.** #3376/#3390 shipped both halves — route tests for the `saasWritable` gate (403 on inherit-hidden keys, split-axis sandbox key writable, platform-admin/self-hosted/null-config bypasses) and real-registry pins including a closed-set test that the only split-axis key is `ATLAS_SANDBOX_BACKEND`, which covers the "future hidden key without explicit saasWritable" case.

**Validation (re-run independently by the orchestrator, not just the implementer)**
- Current registry passes: `39 registry key(s): 26 direct getSetting, 3 const-indirected, 6 env-mirror (platform-scoped), 4 allowlisted` (~1.6s).
- Fake key with no reader → exit 1 with the actionable message; fake key with a malformed registry shape → exit 2 parser-sanity failure (fails noisy, never silently passes).
- Comment-stripping is load-bearing (several keys have doc-comment-only `getSetting("…")` mentions that must not count); the script uses a JSDoc-shape line filter rather than `check-ee-imports`' block-comment range delete, which glob strings like `metrics/*.yml` turn into phantom ranges.
- `bun run lint`, `bun run type`, `bash -n` clean; no tests import the changed files.

**What stays review discipline** (recorded in #3382): write→reader pairing for non-settings surfaces, value-vocabulary agreement, and web-hide↔API-reject pairing — per the audit's conclusion, those have no single registry to enumerate mechanically.

https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc

---
_Generated by [Claude Code](https://claude.ai/code/session_014yftfC3DqP8vWr9szPsfzc)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783760966&installation_id=135337507&pr_number=3393&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3393&signature=9c0feddfc8bd0b3266faefedaffe7913add881661993b430b20b690d78584e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated validation step to the CI pipeline to verify configuration settings integrity and proper system integration.
  * Updated CI documentation with the new validation gate, including acceptance criteria and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->