### PR TITLE
refactor(catalog): expose formInstallable on the pillar listing — picker derives tiles from the handler registry (#3387)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -64421,6 +64421,9 @@
                               "null"
                             ],
                             "additionalProperties": {}
+                          },
+                          "formInstallable": {
+                            "type": "boolean"
                           }
                         },
                         "required": [

--- a/packages/api/src/api/__tests__/integrations-catalog.test.ts
+++ b/packages/api/src/api/__tests__/integrations-catalog.test.ts
@@ -17,7 +17,7 @@
  * circuit, and the wire-shape projection (including the two new fields).
  */
 
-import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { describe, it, expect, afterEach, beforeEach, mock, type Mock } from "bun:test";
 import { Effect } from "effect";
 import type { CatalogEntryWithState } from "@atlas/api/lib/effect/pillar-catalog-query";
 
@@ -124,6 +124,12 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
 
 const { integrationsCatalog } = await import("../routes/integrations-catalog");
 const { OpenAPIHono } = await import("@hono/zod-openapi");
+// Real (unmocked) form-handler registry — the route derives
+// `formInstallable` from it (#3387), so the tests below register/clear
+// handlers per-test (never at module top-level).
+const { registerFormHandler, _resetInstallHandlerRegistries } = await import(
+  "@atlas/api/lib/integrations/install/dispatch"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -303,6 +309,107 @@ describe("GET /api/v1/integrations/catalog", () => {
         { key: "description", type: "string" },
       ]);
       expect(entry.installed).toBe(false);
+    });
+  });
+
+  describe("formInstallable derivation (#3387)", () => {
+    // Minimal registry entry — the flag derivation only consults
+    // registration, never invokes the handler.
+    const fakeFormHandler = {
+      kind: "form" as const,
+      validateConfig: () =>
+        Promise.reject(new Error("test handler: validateConfig must not be called")),
+    };
+
+    afterEach(() => {
+      _resetInstallHandlerRegistries();
+    });
+
+    it("derives formInstallable from the live form-handler registry on the pillar listing", async () => {
+      registerFormHandler("clickhouse", fakeFormHandler);
+      const rows = [
+        // form model + registered handler → installable
+        makeRichRow({
+          id: "catalog:clickhouse",
+          slug: "clickhouse",
+          name: "ClickHouse",
+          type: "datasource",
+          installModel: "form",
+          pillar: "datasource",
+        }),
+        // form model, NO registered handler (duckdb is deliberately
+        // handler-less — atlas.config.ts-only) → not installable. This is
+        // the drift scenario #3387 closes: the row must self-report false
+        // so the picker can never render a submittable tile that would
+        // 500 with "No form-based install handler registered".
+        makeRichRow({
+          id: "catalog:duckdb",
+          slug: "duckdb",
+          name: "DuckDB",
+          type: "datasource",
+          installModel: "form",
+          pillar: "datasource",
+        }),
+        // non-form model → false regardless of registry state
+        makeRichRow({
+          id: "catalog:salesforce",
+          slug: "salesforce",
+          name: "Salesforce",
+          type: "datasource",
+          installModel: "oauth",
+          pillar: "datasource",
+        }),
+      ];
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed(rows));
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog?pillar=datasource");
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      const bySlug: Record<string, { formInstallable?: boolean }> = {};
+      for (const e of body.catalog) bySlug[e.slug] = e;
+      expect(bySlug["clickhouse"]?.formInstallable).toBe(true);
+      expect(bySlug["duckdb"]?.formInstallable).toBe(false);
+      expect(bySlug["salesforce"]?.formInstallable).toBe(false);
+    });
+
+    it("gates on installModel: a non-form row stays false even when a form handler shares its slug", async () => {
+      // Defensive: the oauth/form registries are namespaced separately
+      // (dispatch.ts) — a same-slug form handler must not flip an
+      // oauth-datasource row to form-installable.
+      registerFormHandler("github-data", fakeFormHandler);
+      mockWithInstallStatusFor.mockReturnValueOnce(
+        Effect.succeed([
+          makeRichRow({
+            id: "catalog:github-data",
+            slug: "github-data",
+            name: "GitHub Data",
+            type: "datasource",
+            installModel: "oauth-datasource",
+            pillar: "datasource",
+          }),
+        ]),
+      );
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog?pillar=datasource");
+      const body = await json(res);
+      expect(body.catalog[0].formInstallable).toBe(false);
+    });
+
+    it("never emits the key on the default listing, even with handlers registered (byte-stability)", async () => {
+      // The default (no-pillar) branch must omit the key entirely — the
+      // exact-body pin above covers the serialized form; this pins the
+      // key-absence semantics directly even when the registry would say
+      // true.
+      registerFormHandler("slack", fakeFormHandler);
+      const row = makeRichRow({ installModel: "form" });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog");
+      const body = await json(res);
+      expect("formInstallable" in body.catalog[0]).toBe(false);
     });
   });
 

--- a/packages/api/src/api/__tests__/teams.test.ts
+++ b/packages/api/src/api/__tests__/teams.test.ts
@@ -34,6 +34,7 @@ const mockConfirmInstall: Mock<
 
 mock.module("@atlas/api/lib/integrations/install/dispatch", () => ({
   getInstallHandler: mock(() => ({ kind: "static-bot" as const, oauthShaped: true as const, confirmInstall: mockConfirmInstall })),
+  hasFormInstallHandler: mock(() => false),
   registerOAuthHandler: mock(() => {}),
   registerFormHandler: mock(() => {}),
   registerStaticBotHandler: mock(() => {}),

--- a/packages/api/src/api/routes/integrations-catalog.ts
+++ b/packages/api/src/api/routes/integrations-catalog.ts
@@ -34,6 +34,7 @@ import {
   maskSecretFields,
   parseConfigSchema,
 } from "@atlas/api/lib/plugins/secrets";
+import { hasFormInstallHandler } from "@atlas/api/lib/integrations/install";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -124,6 +125,23 @@ const CatalogEntryResponseSchema = z.object({
    * org" + "instance URL" detail rows without a second round-trip.
    */
   installConfig: z.record(z.string(), z.unknown()).nullable(),
+  /**
+   * Whether this row can be installed through the schema-driven
+   * form-install (`POST /:platform/install-form`) — i.e. its
+   * `installModel` is `form` AND a form-install handler is actually
+   * registered for the slug ({@link hasFormInstallHandler}, the same
+   * registry the install route's dispatch consults). Emitted ONLY on
+   * the `?pillar=datasource` listing (#3387); the default (no-pillar)
+   * response stays byte-identical and omits the key entirely.
+   *
+   * The Add-datasource picker derives its form-install tiles from this
+   * flag instead of a hardcoded slug list, so a catalog row without a
+   * registered handler (postgres/mysql — native URL-form path;
+   * demo-postgres — auto-installed; duckdb — deliberately handler-less,
+   * `atlas.config.ts`-only) can never render a submittable tile.
+   * Derivation is deploy-mode agnostic — no `deployMode` branch.
+   */
+  formInstallable: z.boolean().optional(),
 });
 
 const CatalogResponseSchema = z.object({
@@ -254,6 +272,18 @@ integrationsCatalog.openapi(listCatalogRoute, async (c) => {
         pillar: row.pillar,
         implementationStatus: row.implementationStatus,
         installConfig,
+        // `formInstallable` (#3387): pillar listing only — the default
+        // branch must stay byte-identical (pinned by the exact-body test),
+        // so the key is omitted entirely there, not set to false. Derived
+        // from the live form-handler registry (the same source the
+        // /install-form dispatch consults), never from a parallel slug
+        // list, and never from deploy mode.
+        ...(pillar === undefined
+          ? {}
+          : {
+              formInstallable:
+                row.installModel === "form" && hasFormInstallHandler(row.slug),
+            }),
       };
     });
 

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -205,9 +205,11 @@ const mockGetInstallHandler = mock((catalogRow: { slug: string; install_model: s
 // "mock all exports" rule.
 mock.module("@atlas/api/lib/integrations/install/dispatch", () => ({
   getInstallHandler: mockGetInstallHandler,
+  hasFormInstallHandler: mock(() => false),
   registerOAuthHandler: mock(() => {}),
   registerFormHandler: mock(() => {}),
   registerStaticBotHandler: mock(() => {}),
+  registerOAuthDatasourceHandler: mock(() => {}),
   _resetInstallHandlerRegistries: mock(() => {}),
 }));
 

--- a/packages/api/src/lib/integrations/install/dispatch.ts
+++ b/packages/api/src/lib/integrations/install/dispatch.ts
@@ -105,6 +105,23 @@ export function registerOAuthDatasourceHandler(
   oauthDatasourceHandlers.set(slug, handler);
 }
 
+/**
+ * Whether a form-based install handler is registered for the given catalog
+ * slug (#3387). This is the SAME registry `getInstallHandler` consults for
+ * `install_model: "form"` rows on the `/install-form` route — so a catalog
+ * listing that derives "form-installable" from this predicate can never
+ * drift from what the install route will actually accept. The
+ * `?pillar=datasource` catalog listing uses it to emit a per-row
+ * `formInstallable` flag, replacing the web picker's hardcoded slug lists.
+ *
+ * Deploy-mode agnostic by construction: form handlers register without
+ * env gates (customer-supplied credentials), and this reads only the
+ * in-process registry — no `deployMode` branch.
+ */
+export function hasFormInstallHandler(slug: string): boolean {
+  return formHandlers.has(slug);
+}
+
 /** @internal Test-only — clears all four registries between tests. */
 export function _resetInstallHandlerRegistries(): void {
   oauthHandlers.clear();

--- a/packages/api/src/lib/integrations/install/index.ts
+++ b/packages/api/src/lib/integrations/install/index.ts
@@ -28,6 +28,7 @@ export type {
 
 export {
   getInstallHandler,
+  hasFormInstallHandler,
   registerFormHandler,
   registerOAuthDatasourceHandler,
   registerOAuthHandler,

--- a/packages/web/src/app/admin/connections/__tests__/add-connection-picker.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/add-connection-picker.test.tsx
@@ -12,9 +12,14 @@
  *   2. Plugin datasources render as catalog-driven form-install tiles fed by
  *      `GET /api/v1/integrations/catalog?pillar=datasource`, and picking one
  *      routes to the marketplace form-install (`onPickDatasourceForm`).
- *   3. Native / duplicated catalog slugs (postgres, mysql, demo-postgres,
- *      salesforce, openapi-generic, curated REST candidates) never render as
- *      form-install tiles.
+ *   3. Tiles render only for rows the server flags `formInstallable` (#3387 —
+ *      derived from the actual form-handler registry, replacing the deleted
+ *      FORM_TILE_EXCLUDED slug list). Rows without a registered handler
+ *      (postgres, mysql, demo-postgres, duckdb — `formInstallable: false`),
+ *      OAuth rows (salesforce, github-data), and rows grouped elsewhere in
+ *      the picker (openapi-generic → Custom, curated REST candidates →
+ *      Popular APIs) never render as form-install tiles. An absent flag
+ *      (older API) fails closed.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -86,27 +91,51 @@ function makeEntry(overrides: Record<string, unknown> = {}) {
     pillar: "datasource",
     implementationStatus: "available",
     installConfig: null,
+    // Server-derived (#3387): true only for `form` rows whose slug has a
+    // registered form-install handler. Defaults true here; fixtures for
+    // handler-less / OAuth rows override to false, mirroring the API.
+    formInstallable: true,
     access: { kind: "accessible" },
     ...overrides,
   };
 }
 
-/** The full datasource-pillar listing a self-hosted deploy would return. */
+/** The full datasource-pillar listing a self-hosted deploy would return,
+ *  with `formInstallable` exactly as the server derives it from the
+ *  handler registry (register.ts): clickhouse/snowflake/bigquery/
+ *  elasticsearch/openapi-generic/stripe-data have form handlers; postgres/
+ *  mysql/demo-postgres/duckdb don't; salesforce is OAuth. */
 function selfHostedCatalog() {
   return [
-    makeEntry({ id: "catalog:postgres", slug: "postgres", name: "PostgreSQL" }),
-    makeEntry({ id: "catalog:mysql", slug: "mysql", name: "MySQL" }),
+    makeEntry({
+      id: "catalog:postgres",
+      slug: "postgres",
+      name: "PostgreSQL",
+      formInstallable: false,
+    }),
+    makeEntry({ id: "catalog:mysql", slug: "mysql", name: "MySQL", formInstallable: false }),
     makeEntry(),
     makeEntry({ id: "catalog:snowflake", slug: "snowflake", name: "Snowflake" }),
     makeEntry({ id: "catalog:bigquery", slug: "bigquery", name: "BigQuery" }),
-    makeEntry({ id: "catalog:duckdb", slug: "duckdb", name: "DuckDB" }),
+    makeEntry({
+      id: "catalog:duckdb",
+      slug: "duckdb",
+      name: "DuckDB",
+      formInstallable: false,
+    }),
     makeEntry({ id: "catalog:elasticsearch", slug: "elasticsearch", name: "Elasticsearch" }),
-    makeEntry({ id: "catalog:demo-postgres", slug: "demo-postgres", name: "Demo Dataset" }),
+    makeEntry({
+      id: "catalog:demo-postgres",
+      slug: "demo-postgres",
+      name: "Demo Dataset",
+      formInstallable: false,
+    }),
     makeEntry({
       id: "catalog:salesforce",
       slug: "salesforce",
       name: "Salesforce",
       installModel: "oauth",
+      formInstallable: false,
     }),
     makeEntry({ id: "catalog:openapi-generic", slug: "openapi-generic", name: "OpenAPI REST" }),
     makeEntry({ id: "catalog:stripe-data", slug: "stripe-data", name: "Stripe" }),
@@ -164,6 +193,9 @@ describe("AddConnectionPicker — datasource tile routing (#3377)", () => {
   });
 
   test("native / duplicated catalog slugs never render as form-install tiles", () => {
+    // postgres/mysql/demo-postgres report `formInstallable: false` (no
+    // registered handler); salesforce is OAuth; openapi-generic and
+    // stripe-data are form-installable but grouped elsewhere in the picker.
     renderPicker();
     for (const slug of [
       "postgres",
@@ -179,10 +211,53 @@ describe("AddConnectionPicker — datasource tile routing (#3377)", () => {
     expect(screen.getByTestId("add-curated-stripe-data")).toBeTruthy();
   });
 
+  test("a row without a registered handler (formInstallable=false) never renders a submittable tile (#3387)", () => {
+    // The drift scenario #3387 closes: a brand-new catalog row lands with
+    // NO registered form-install handler. Pre-#3387 the hardcoded
+    // FORM_TILE_EXCLUDED list wouldn't know the slug, the tile would
+    // render, and submit would 500 with "No form-based install handler
+    // registered". Now the server-derived flag keeps it out with zero web
+    // changes.
+    fetchState = {
+      data: {
+        catalog: [
+          makeEntry({
+            id: "catalog:newwarehouse",
+            slug: "newwarehouse",
+            name: "New Warehouse",
+            formInstallable: false,
+          }),
+        ],
+      },
+      loading: false,
+    };
+    renderPicker();
+    expect(screen.queryByTestId("add-ds-newwarehouse")).toBeNull();
+  });
+
+  test("an absent formInstallable flag fails closed (older API during deploy overlap)", () => {
+    fetchState = {
+      data: {
+        catalog: [
+          makeEntry({
+            id: "catalog:newwarehouse",
+            slug: "newwarehouse",
+            name: "New Warehouse",
+            formInstallable: undefined,
+          }),
+        ],
+      },
+      loading: false,
+    };
+    renderPicker();
+    expect(screen.queryByTestId("add-ds-newwarehouse")).toBeNull();
+  });
+
   test("DuckDB never renders a tile (no form handler; SaaS additionally server-filters it)", () => {
-    // Self-hosted: the catalog row exists, but there is no registered
-    // form-install handler for duckdb — a tile would dead-end in a 500
-    // (the class-2 path #3377 removes). Neither group offers it.
+    // Self-hosted: the catalog row exists but reports `formInstallable:
+    // false` — register.ts deliberately has no duckdb handler, so a tile
+    // would dead-end in a 500 (the class-2 path #3377 removes). Neither
+    // group offers it.
     renderPicker();
     expect(screen.queryByTestId("add-ds-duckdb")).toBeNull();
     expect(screen.queryByTestId("add-db-duckdb")).toBeNull();
@@ -259,6 +334,7 @@ describe("AddConnectionPicker — datasource tile routing (#3377)", () => {
             slug: "github-data",
             name: "GitHub Data",
             installModel: "oauth-datasource",
+            formInstallable: false,
           }),
         ],
       },

--- a/packages/web/src/app/admin/connections/add-connection-picker.tsx
+++ b/packages/web/src/app/admin/connections/add-connection-picker.tsx
@@ -52,28 +52,23 @@ const CURATED: ReadonlyArray<{ slug: string; icon: LucideIcon }> = [
 ];
 const CURATED_SLUGS = new Set(CURATED.map((c) => c.slug));
 
-/** Datasource-pillar catalog rows that must NOT render as form-install tiles
- *  in the Databases group:
- *  - `postgres` / `mysql` connect through the native URL-form dialog
- *    (`DATABASE_PROVIDERS` tiles) — their catalog rows back `atlas.config.ts`
- *    installs, not this picker.
- *  - `demo-postgres` is the auto-installed Atlas-managed demo dataset.
- *  - `salesforce` installs via OAuth from its own block on the page.
- *  - `openapi-generic` is the "Custom REST API" tile below.
+/** Form-installable rows that render in a DIFFERENT group of this picker, so
+ *  they must not double-render as Databases tiles. Pure presentation grouping
+ *  (allowed to stay client-side per #3387):
+ *  - `openapi-generic` is the static "Custom REST API" tile below.
  *  - Curated REST candidates (Stripe/Notion/GitHub) render in "Popular APIs".
- *  - `duckdb` has NO registered form-install handler (it's a local file —
- *    `atlas.config.ts`-only on self-hosted; on SaaS the server already hides
- *    the row via `saas_eligible = false`, #3301). Rendering its tile would
- *    recreate the exact class-2 dead end #3377 removes: the submit would
- *    throw "No form-based install handler registered" server-side. Drop the
- *    exclusion if/when `register.ts` gains a duckdb DatasourceFormInstallHandler. */
-const FORM_TILE_EXCLUDED: ReadonlySet<string> = new Set([
-  "postgres",
-  "mysql",
-  "demo-postgres",
-  "salesforce",
+ *
+ *  Installability itself is no longer a client-side slug list: the server
+ *  derives `formInstallable` per row from its actual form-install handler
+ *  registry (#3387) — the same registry `POST /:platform/install-form`
+ *  dispatches against. That flag is what keeps native URL-form slugs
+ *  (postgres/mysql), the auto-installed `demo-postgres`, OAuth rows
+ *  (salesforce, github-data), and deliberately handler-less rows (duckdb,
+ *  `atlas.config.ts`-only) out of the tile set — if `register.ts` ever gains
+ *  a handler for one of them, the tile appears with zero web changes, and a
+ *  catalog row without a handler can never render a submittable tile. */
+const RENDERED_IN_OTHER_GROUPS: ReadonlySet<string> = new Set([
   "openapi-generic",
-  "duckdb",
   ...CURATED_SLUGS,
 ]);
 
@@ -192,11 +187,19 @@ export function AddConnectionPicker({
   }).filter((c): c is { entry: IntegrationsCatalogEntry; icon: LucideIcon } => c !== null);
 
   // Plugin datasources installable through the schema-driven form-install
-  // (the path #3300 shipped). `installModel === "form"` only — OAuth
-  // datasources (github-data) ride the curated branch; the slug denylist
-  // keeps native/duplicated surfaces out (see FORM_TILE_EXCLUDED).
+  // (the path #3300 shipped). Tiles render only for rows the server flags
+  // `formInstallable` — derived from the actual handler registry (#3387) —
+  // so a handler-less row can never produce a submittable tile. The strict
+  // `=== true` fails closed when the flag is absent (an older API during a
+  // deploy-overlap window: tiles briefly missing beats a tile that 500s).
+  // `installModel === "form"` is implied by the flag but kept as
+  // defense-in-depth; RENDERED_IN_OTHER_GROUPS is presentation grouping
+  // only (those rows render in Custom / Popular APIs).
   const formDatasources = datasourceEntries.filter(
-    (e) => e.installModel === "form" && !FORM_TILE_EXCLUDED.has(e.slug),
+    (e) =>
+      e.installModel === "form" &&
+      e.formInstallable === true &&
+      !RENDERED_IN_OTHER_GROUPS.has(e.slug),
   );
 
   function pickDatabase(dbType: DBType) {

--- a/packages/web/src/ui/lib/__tests__/integrations-catalog-schema.test.ts
+++ b/packages/web/src/ui/lib/__tests__/integrations-catalog-schema.test.ts
@@ -54,4 +54,43 @@ describe("IntegrationsCatalogResponseSchema — install models (#3377/#3384)", (
       expect(parsed.data.catalog.length).toBe(2);
     }
   });
+
+  // ── formInstallable (#3387) ────────────────────────────────────────────
+  // The `?pillar=datasource` listing carries a server-derived per-row
+  // `formInstallable`; the default listing omits it. Both shapes must
+  // parse, and the flag must survive the access-union transform so the
+  // Add picker can read it.
+  it("passes formInstallable through the transform when present", () => {
+    const parsed = IntegrationsCatalogResponseSchema.safeParse({
+      catalog: [
+        entry({
+          id: "catalog:clickhouse",
+          slug: "clickhouse",
+          installModel: "form",
+          formInstallable: true,
+        }),
+        entry({
+          id: "catalog:duckdb",
+          slug: "duckdb",
+          installModel: "form",
+          formInstallable: false,
+        }),
+      ],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.catalog[0]?.formInstallable).toBe(true);
+      expect(parsed.data.catalog[1]?.formInstallable).toBe(false);
+    }
+  });
+
+  it("parses rows without formInstallable (default listing / older API)", () => {
+    const parsed = IntegrationsCatalogResponseSchema.safeParse({
+      catalog: [entry({ installModel: "oauth" })],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.catalog[0]?.formInstallable).toBeUndefined();
+    }
+  });
 });

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -370,6 +370,17 @@ const RawCatalogEntrySchema = z.object({
   // the field is absent. `null` is the explicit "row not installed"
   // signal; treat it the same as absent at the render layer.
   installConfig: z.record(z.string(), z.unknown()).nullable().optional(),
+  // ── New in #3387 ─────────────────────────────────────────────────
+  // Server-derived "this row can be installed via the schema-driven
+  // form-install": `installModel === "form"` AND a form-install handler
+  // is actually registered for the slug (the same registry the
+  // /install-form dispatch consults). Emitted ONLY on the
+  // `?pillar=datasource` listing; the default listing omits it (its
+  // wire shape is pinned byte-identical), hence `.optional()`.
+  // Consumers must fail closed: absent ⇒ not form-installable —
+  // rendering a submittable tile for a handler-less row would 500 at
+  // submit.
+  formInstallable: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
Closes #3387. Part of the #3374 deploy-mode parity umbrella (follow-up to #3377 / PR #3384).

## What

- The `?pillar=datasource` catalog listing now emits a per-row `formInstallable: boolean`, derived from the **live form-install handler registry** (`hasFormInstallHandler` in `lib/integrations/install/dispatch.ts` — the same `formHandlers` map `POST /:platform/install-form` dispatches against). No parallel slug list.
- The Add-datasource picker renders form tiles from that flag; the hardcoded `FORM_TILE_EXCLUDED` set is **deleted**. What remains client-side (`RENDERED_IN_OTHER_GROUPS`: `openapi-generic` + curated REST slugs) is pure presentation grouping — those rows are form-installable but render in the Custom / Popular APIs groups of the same picker, as the issue's AC permits.
- The default (no-pillar) catalog response stays **byte-identical**: the key is omitted entirely (not `false`) when no pillar is requested; the #3384 exact-body pin test passes unmodified, plus a new explicit omission test.
- Strict `formInstallable === true` in the picker fails closed when the flag is absent (older API during a deploy-overlap window) — a briefly missing tile beats a tile that 500s on submit.

## Why

Form-installability was decided by web slug lists that mirrored a server-side fact (handler registration in `register.ts`) with nothing keeping them in sync — the exact class-2 drift shape #3377 fixed, ready to recur on the next catalog row. Now a row without a handler can never render a submittable tile, and a new handler shows its tile with zero web changes.

## Deviations from the issue sketch

- Derivation lives in the route projection (`integrations-catalog.ts`), not inside `pillar-catalog-query.ts`: the facade stays the DB-read layer, the route stays the wire projector, and the byte-identical guarantee stays in one file.
- `URL_FORM_EXCLUDED` in `provider-meta.ts` is untouched (explicitly allowed by the AC — URL-form grouping may stay client-side).

## Tests

- API (`packages/api`, isolated runner `--affected`): **7/7 files pass** — includes new derivation tests (registered handler ⇒ true; handler-less duckdb ⇒ false; non-form model ⇒ false even with a same-slug handler; default listing never carries the key).
- Web (per-file): `add-connection-picker.test.tsx` 11/0 (incl. handler-less-row-never-renders and absent-flag-fails-closed), `integrations-catalog-schema.test.ts` 4/0, `catalog-section.test.tsx` 22/0.
- `bun run lint` and `bun run type` exit 0 (type independently re-verified). `check-published-symbols` passes — no `@useatlas/types`/`@useatlas/schemas` changes, no publish-pin exposure.
- OpenAPI artifacts regenerated and committed (`apps/docs/openapi.json` +3); re-running the extract on the final tree produces zero drift.

## Review summary

Three independent review passes (line-scan, removed-behavior, cross-file tracer) — all clean:
- Every slug from the deleted `FORM_TILE_EXCLUDED` verified against the catalog seed + `register.ts`: postgres/mysql/demo-postgres/duckdb have no form handler (flag false), salesforce is `oauth` model, openapi-generic/curated rows stay grouped elsewhere client-side. Handler registration is synchronous at boot before the server listens, so the flag can't race registration.
- The web schema transform preserves the flag end to end; all three catalog consumers parse with `.optional()` (no strict-schema break).
- Both test files that `mock.module` the dispatch module carry the new export (mock-all-exports rule); no other dispatch mocks exist.

https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783764881&installation_id=135337507&pr_number=3394&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3394&signature=2fffce72bc6889dd98c482ca29fcd446ab9664d96a571e94cd614c9d77f3cf47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `formInstallable` flag to datasource catalog listings indicating form-handler availability
  * Form-install tiles now only render for integrations marked as form-installable

* **Improvements**
  * Enhanced filtering logic to respect server-provided form-installability indicators
  * System safely defaults to hiding form tiles when the flag is absent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->