### PR TITLE
fix(api): close settings write-path guard gaps — DELETE immutable bypass, fail-closed mode probe, no-org edge (#3389)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -64252,6 +64252,31 @@
               }
             }
           },
+          "409": {
+            "description": "Setting is SaaS-immutable — clearing the override is a write too (#3389); change via env var and restart (#1978)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit exceeded",
             "content": {

--- a/docs/development/enterprise-gating.md
+++ b/docs/development/enterprise-gating.md
@@ -89,6 +89,8 @@ If a setting is hidden from SaaS workspace admins on `GET /admin/settings`, the 
 
 A key managed by a dedicated admin page on SaaS (today: `ATLAS_SANDBOX_BACKEND` via `/admin/sandbox` — its sibling `ATLAS_SANDBOX_URL` is written only by the self-hosted view, so it inherits hidden ⇒ un-writable) uses the split — `saasVisible: false, saasWritable: true` — so it stays off the generic settings page but its own surface keeps saving through the same PUT route. Platform admins and self-hosted deployments are never restricted by either flag, and both flags are registry-internal (stripped from the GET response).
 
+Two probe decisions ride on this rule (#3389). Settings **write-path** mode probes fail closed: the PUT/DELETE gates share `isSaasModeForGuard()` from `lib/settings.ts`, so a config-resolution *failure* at request time is treated as SaaS (restrictive) — only a legitimately-unloaded config (`getConfig()` → `null`) counts as self-hosted, and the GET filter's probe stays display-only and permissive. And the write path classifies a "SaaS workspace admin" exactly as GET does — `!isPlatformAdmin`, with no `orgId` requirement — so a SaaS session with no active workspace gets workspace-admin restrictions on writes, not a platform-scope bypass; because clearing an override is a write, `deleteSetting` also enforces `SAAS_IMMUTABLE_KEYS` like `setSetting` (DELETE returns the same 409 envelope as PUT).
+
 ### Rule 5 — docs state mode scope explicitly
 
 A guide for a surface that behaves differently per mode says so per mode; "works on Atlas" claims that are true in only one mode are class-6 drift. When a parity bug is fixed or scoped (e.g. a feature declared SaaS-only), the docs change rides the same PR — same discipline as the chat-plugin contract table.

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -685,6 +685,10 @@ export function createApiTestMocks(
     loadSettings: mock(async () => 0),
     getAllSettingOverrides: mock(async () => []),
     _resetSettingsCache: mock(() => {}),
+    // #3389 — the settings route write gates probe deploy mode via this.
+    // Default false (non-SaaS/permissive) to match the `getConfig: () =>
+    // null` mock below ("unloaded" → self-hosted in the real probe).
+    isSaasModeForGuard: mock(() => false),
   }));
 
   // ── Config ────────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/admin-archive-restore.test.ts
+++ b/packages/api/src/api/__tests__/admin-archive-restore.test.ts
@@ -105,6 +105,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: async () => 0,
   getAllSettingOverrides: async () => [],
   _resetSettingsCache: () => {},
+  isSaasModeForGuard: () => false, // #3389 — admin settings write gates probe via this
 }));
 
 // Replace the default no-op semantic/entities mock with full-fidelity

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -253,6 +253,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingLive: mock(async () => undefined),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mock(() => false), // #3389 — admin settings write gates probe via this
 }));
 
 mock.module("@atlas/api/lib/plugins/registry", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -273,6 +273,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingLive: mock(async () => undefined),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mock(() => false), // #3389 — admin settings write gates probe via this
 }));
 
 mock.module("@atlas/api/lib/plugins/registry", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -229,6 +229,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingLive: mock(async () => undefined),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mock(() => false), // #3389 — admin settings write gates probe via this
 }));
 
 mock.module("@atlas/api/lib/plugins/registry", () => ({

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -98,6 +98,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: async () => 0,
   getAllSettingOverrides: async () => [],
   _resetSettingsCache: () => {},
+  isSaasModeForGuard: () => false, // #3389 — admin settings write gates probe via this
 }));
 
 // Override the semantic/entities mock with full-fidelity stubs matching

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -373,8 +373,12 @@ describe("admin settings routes", () => {
         body: JSON.stringify({ value: "500" }),
       });
       // Generic errors must NOT be silently mapped to 409 — verify the
-      // catch block's `throw err` re-raise path stays intact.
+      // catch block's `throw err` re-raise path stays intact, and that
+      // the 500 envelope carries a requestId for log correlation.
       expect(res.status).toBe(500);
+      const data = (await res.json()) as { requestId?: string };
+      expect(typeof data.requestId).toBe("string");
+      expect(data.requestId).not.toBe("");
     });
   });
 
@@ -445,8 +449,12 @@ describe("admin settings routes", () => {
         method: "DELETE",
       });
       // Generic errors must NOT be silently mapped to 409 — verify the
-      // catch block's `throw err` re-raise path stays intact.
+      // catch block's `throw err` re-raise path stays intact, and that
+      // the 500 envelope carries a requestId for log correlation.
       expect(res.status).toBe(500);
+      const data = (await res.json()) as { requestId?: string };
+      expect(typeof data.requestId).toBe("string");
+      expect(data.requestId).not.toBe("");
     });
   });
 

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -137,6 +137,16 @@ const mockGetSettingsRegistry = mock(() => settingsRegistryData);
 const settingsMap = new Map(settingsRegistryData.map((s) => [s.key, s]));
 const mockGetSettingDefinition = mock((key: string) => settingsMap.get(key));
 
+// #3389 — the route write gates consult the shared fail-closed probe from
+// lib/settings instead of reading getConfig() directly. The default mock
+// mirrors the resolved-config happy path (saas ⇒ true, anything else ⇒
+// false); fail-closed-on-config-resolution-failure semantics of the REAL
+// probe are covered in lib/__tests__/settings-saas.test.ts. Tests that
+// simulate a config-resolution failure override this to return true.
+const saasGuardDefaultImpl = () =>
+  (mockConfigOverride as { deployMode?: string } | null)?.deployMode === "saas";
+const mockIsSaasModeForGuard = mock(saasGuardDefaultImpl);
+
 mock.module("@atlas/api/lib/settings", () => ({
   getSettingsForAdmin: mockGetSettingsForAdmin,
   getSettingsRegistry: mockGetSettingsRegistry,
@@ -149,6 +159,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingLive: mock(async () => undefined),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mockIsSaasModeForGuard,
 }));
 
 // --- Import the app AFTER mocks ---
@@ -176,6 +187,8 @@ describe("admin settings routes", () => {
     mockConfigOverride = null;
     mockSetSetting.mockClear();
     mockDeleteSetting.mockClear();
+    mockIsSaasModeForGuard.mockClear();
+    mockIsSaasModeForGuard.mockImplementation(saasGuardDefaultImpl);
   });
 
   // ─── GET /settings ──────────────────────────────────────────────
@@ -399,6 +412,41 @@ describe("admin settings routes", () => {
         method: "DELETE",
       });
       expect(res.status).toBe(404);
+    });
+
+    // #3389 — deleteSetting now enforces SAAS_IMMUTABLE_KEYS like
+    // setSetting (clearing an override is a write). The route must map
+    // the error to the SAME 409 envelope the PUT handler produces, so
+    // the admin UI handles both verbs uniformly.
+    it("maps SaasImmutableSettingError to 409 with saas_immutable error code (#3389)", async () => {
+      const { SaasImmutableSettingError } = await import("@atlas/api/lib/settings-errors");
+      mockDeleteSetting.mockImplementationOnce(() => {
+        return Promise.reject(new SaasImmutableSettingError("ATLAS_EMAIL_PROVIDER"));
+      });
+
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(409);
+
+      const data = (await res.json()) as { error: string; message: string; requestId?: string };
+      expect(data.error).toBe("saas_immutable");
+      expect(data.message).toContain("cannot be changed at runtime");
+      // Same requestId contract as the PUT 409 path.
+      expect(typeof data.requestId === "string" || data.requestId === undefined).toBe(true);
+    });
+
+    it("propagates non-SaasImmutable deleteSetting errors as 500", async () => {
+      mockDeleteSetting.mockImplementationOnce(() => {
+        return Promise.reject(new Error("unrelated DB connection failure"));
+      });
+
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "DELETE",
+      });
+      // Generic errors must NOT be silently mapped to 409 — verify the
+      // catch block's `throw err` re-raise path stays intact.
+      expect(res.status).toBe(500);
     });
   });
 
@@ -676,7 +724,10 @@ describe("admin settings routes", () => {
       expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
     });
 
-    it("unresolved config (getConfig() → null) is treated as self-hosted — write allowed", async () => {
+    // #3389 — "unloaded" (getConfig() → null: config legitimately never
+    // loaded, the AGPL/dev case) stays permissive. Only config-resolution
+    // FAILURE fails closed — see the "fail-closed mode probe" block below.
+    it("unloaded config (getConfig() → null) is treated as self-hosted — write allowed", async () => {
       mockConfigOverride = null;
       asSaasWorkspaceAdmin();
       const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
@@ -720,6 +771,150 @@ describe("admin settings routes", () => {
       expect(res.status).toBe(403);
       const data = (await res.json()) as { message: string };
       expect(data.message).toContain("platform-level setting");
+    });
+  });
+
+  // ─── Fail-closed mode probe (#3389) ─────────────────────────────
+
+  describe("fail-closed mode probe on the write path (#3389)", () => {
+    // Simulate config resolution FAILING at request time: the real
+    // isSaasModeForGuard() returns true ("errored" → assume SaaS) — that
+    // behavior is pinned in lib/__tests__/settings-saas.test.ts. Here we
+    // verify the route gates consume the probe's fail-closed verdict
+    // (restrictive) instead of the old permissive getConfig() → null read.
+    function simulateConfigResolutionFailure() {
+      mockConfigOverride = null; // getConfig() would yield nothing useful
+      mockIsSaasModeForGuard.mockImplementation(() => true);
+    }
+
+    function asWorkspaceAdmin() {
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: { id: "ws-admin-1", mode: "better-auth", label: "WS Admin", role: "admin", activeOrganizationId: "org-1" },
+        }),
+      );
+    }
+
+    it("saasWritable gate is restrictive on PUT when the probe fails closed", async () => {
+      simulateConfigResolutionFailure();
+      asWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "healthcare" }),
+      });
+      expect(res.status).toBe(403);
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+
+    it("saasWritable gate is restrictive on DELETE when the probe fails closed", async () => {
+      simulateConfigResolutionFailure();
+      asWorkspaceAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+      expect(mockDeleteSetting).not.toHaveBeenCalled();
+    });
+
+    it("platform-scope gate (no-org session) is restrictive when the probe fails closed", async () => {
+      simulateConfigResolutionFailure();
+      // Default auth mock: role=admin, NO activeOrganizationId
+      const res = await request("/api/v1/admin/settings/ATLAS_PROVIDER", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "openai" }),
+      });
+      expect(res.status).toBe(403);
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+
+    it("platform admins are not affected by the fail-closed probe", async () => {
+      simulateConfigResolutionFailure();
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: { id: "platform-admin-1", mode: "better-auth", label: "Platform Admin", role: "platform_admin", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await request("/api/v1/admin/settings/ATLAS_PROVIDER", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "openai" }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ─── No-org SaaS session edge (#3389) ───────────────────────────
+
+  describe("no-org SaaS session is classified like GET (#3389)", () => {
+    // GET filters with `!isPlatformAdmin` only — a SaaS session with no
+    // activeOrganizationId is a workspace admin there. The write path
+    // must classify it the same way instead of letting `orgId &&
+    // !isPlatformAdmin` wave the session past the platform-scope gate.
+    function asSaasNoOrgAdmin() {
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: { id: "no-org-admin-1", mode: "better-auth", label: "No-Org Admin", role: "admin" },
+        }),
+      );
+    }
+
+    beforeEach(() => {
+      mockConfigOverride = { deployMode: "saas" };
+    });
+
+    it("no-org SaaS admin PUT on a platform-scoped key → 403", async () => {
+      asSaasNoOrgAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_PROVIDER", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "openai" }),
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { message: string };
+      expect(data.message).toContain("platform-level setting");
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+
+    it("no-org SaaS admin DELETE on a platform-scoped key → 403", async () => {
+      asSaasNoOrgAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_RLS_ENABLED", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+      const data = (await res.json()) as { message: string };
+      expect(data.message).toContain("platform-level setting");
+      expect(mockDeleteSetting).not.toHaveBeenCalled();
+    });
+
+    it("no-org SaaS admin PUT on a hidden workspace key → 403 (saasWritable gate already org-independent)", async () => {
+      asSaasNoOrgAdmin();
+      const res = await request("/api/v1/admin/settings/ATLAS_DEMO_INDUSTRY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "healthcare" }),
+      });
+      expect(res.status).toBe(403);
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+
+    it("self-hosted no-org admin keeps platform-scope write access", async () => {
+      mockConfigOverride = { deployMode: "self-hosted" };
+      // Default auth mock: role=admin, no activeOrganizationId
+      const res = await request("/api/v1/admin/settings/ATLAS_PROVIDER", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "openai" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -234,6 +234,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: mock(async () => 0),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mock(() => false), // #3389 — admin settings write gates probe via this
 }));
 
 mock.module("@atlas/api/lib/plugins/settings", () => ({

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -300,6 +300,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: mock(async () => 0),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: mock(() => {}),
+  isSaasModeForGuard: mock(() => false), // #3389 — admin settings write gates probe via this
 }));
 
 mock.module("@atlas/api/lib/plugins/settings", () => ({

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -45,6 +45,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: async () => 0,
   getAllSettingOverrides: async () => [],
   _resetSettingsCache: () => {},
+  isSaasModeForGuard: () => false, // #3389 — admin settings write gates probe via this
 }));
 
 // --- Import the app AFTER mocks ---

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -36,6 +36,7 @@ import {
   getSettingDefinition,
   setSetting,
   deleteSetting,
+  isSaasModeForGuard,
 } from "@atlas/api/lib/settings";
 import { SaasImmutableSettingError } from "@atlas/api/lib/settings-errors";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
@@ -1550,6 +1551,7 @@ const deleteSettingRoute = createRoute({
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Setting is SaaS-immutable — clearing the override is a write too (#3389); change via env var and restart (#1978)", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: AuthErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -3598,10 +3600,17 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
     return c.json({ error: "forbidden", message: "Secret settings cannot be modified from the UI." , requestId}, 403);
   }
 
-  // Platform-scoped settings require platform_admin (or no org context = self-hosted)
+  // Platform-scoped settings require platform_admin. An org context always
+  // marks a workspace admin; with NO org context, self-hosted admins keep
+  // full access but on SaaS a non-platform-admin session is still a
+  // workspace admin — #3389 aligned this with the GET filter's
+  // `!isPlatformAdmin` classification (a no-org SaaS session must not
+  // escalate to platform scope). Mode probe is isSaasModeForGuard()
+  // (fail-closed: config-resolution failure ⇒ SaaS ⇒ restrictive), the
+  // same probe the SAAS_IMMUTABLE guard in lib/settings.ts uses.
   const orgId = authResult.user?.activeOrganizationId;
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  if (def.scope === "platform" && orgId && !isPlatformAdmin) {
+  if (def.scope === "platform" && !isPlatformAdmin && (orgId || isSaasModeForGuard())) {
     return c.json({ error: "forbidden", message: `"${key}" is a platform-level setting and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
@@ -3610,10 +3619,12 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   // writable. Effective writability is `saasWritable`, defaulting to
   // `saasVisible` (itself defaulting to true). The sandbox keys split the
   // axes (`saasVisible: false, saasWritable: true`) because the dedicated
-  // /admin/sandbox page writes them through this route on SaaS. Mirrors
-  // the GET filter's mode probe (resolved config deployMode + role).
+  // /admin/sandbox page writes them through this route on SaaS. Matches
+  // the GET filter's role classification (`!isPlatformAdmin`); the mode
+  // probe is the shared fail-closed isSaasModeForGuard() (#3389) rather
+  // than GET's display-only `getConfig()?.deployMode` read.
   const saasWritable = def.saasWritable ?? def.saasVisible ?? true;
-  if (!saasWritable && !isPlatformAdmin && (getConfig()?.deployMode ?? "self-hosted") === "saas") {
+  if (!saasWritable && !isPlatformAdmin && isSaasModeForGuard()) {
     return c.json({ error: "forbidden", message: `"${key}" is managed by Atlas in SaaS mode and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
@@ -3706,23 +3717,41 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
     return c.json({ error: "forbidden", message: "Secret settings cannot be modified from the UI." , requestId}, 403);
   }
 
-  // Platform-scoped settings require platform_admin (or no org context = self-hosted)
+  // Platform-scoped settings require platform_admin — same classification
+  // as PUT (#3389): an org context always marks a workspace admin, and a
+  // no-org non-platform-admin on SaaS is a workspace admin too (matches
+  // GET's `!isPlatformAdmin`). Fail-closed mode probe, see PUT.
   const orgId = authResult.user?.activeOrganizationId;
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  if (def.scope === "platform" && orgId && !isPlatformAdmin) {
+  if (def.scope === "platform" && !isPlatformAdmin && (orgId || isSaasModeForGuard())) {
     return c.json({ error: "forbidden", message: `"${key}" is a platform-level setting and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
   // #3376 — same write gate as PUT: DELETE clears an override, which is a
   // write. A SaaS workspace admin must not be able to reset a key they
-  // cannot see or set. See the PUT handler for the axis semantics.
+  // cannot see or set. See the PUT handler for the axis semantics and
+  // the shared fail-closed mode probe (#3389).
   const saasWritable = def.saasWritable ?? def.saasVisible ?? true;
-  if (!saasWritable && !isPlatformAdmin && (getConfig()?.deployMode ?? "self-hosted") === "saas") {
+  if (!saasWritable && !isPlatformAdmin && isSaasModeForGuard()) {
     return c.json({ error: "forbidden", message: `"${key}" is managed by Atlas in SaaS mode and cannot be modified by workspace admins.`, requestId }, 403);
   }
 
   const effectiveOrgId = def.scope === "workspace" ? orgId : undefined;
-  await deleteSetting(key, authResult.user?.id, effectiveOrgId);
+  try {
+    await deleteSetting(key, authResult.user?.id, effectiveOrgId);
+  } catch (err) {
+    // #3389 — deleteSetting enforces SAAS_IMMUTABLE_KEYS like setSetting
+    // (clearing an override is a write). Map to the same 409 envelope the
+    // PUT handler produces so the admin UI handles both verbs uniformly.
+    if (err instanceof SaasImmutableSettingError) {
+      log.warn({ requestId, key, actorId: authResult.user?.id }, "Rejected SaaS-immutable setting delete");
+      return c.json(
+        { error: "saas_immutable", message: err.message, requestId },
+        409,
+      );
+    }
+    throw err;
+  }
   log.info({ requestId, key, orgId: effectiveOrgId, actorId: authResult.user?.id }, "Setting override removed via admin API");
 
   logAdminAction({

--- a/packages/api/src/lib/__tests__/settings-saas.test.ts
+++ b/packages/api/src/lib/__tests__/settings-saas.test.ts
@@ -45,8 +45,12 @@ function setResults(...results: Array<{ rows: Record<string, unknown>[] }>) {
 // Mock config module to return SaaS mode
 // ---------------------------------------------------------------------------
 
+// Controllable so the #3389 probe tests can simulate self-hosted, unloaded
+// (null) and errored (throwing) config resolution. Defaults to SaaS.
+let mockGetConfigImpl: () => { deployMode?: string } | null = () => ({ deployMode: "saas" });
+
 mock.module("@atlas/api/lib/config", () => ({
-  getConfig: () => ({ deployMode: "saas" }),
+  getConfig: () => mockGetConfigImpl(),
   defineConfig: (c: unknown) => c,
 }));
 
@@ -78,6 +82,8 @@ mock.module("@atlas/api/lib/logger", () => ({
 const {
   getSettingsForAdmin,
   setSetting,
+  deleteSetting,
+  isSaasModeForGuard,
   _resetSettingsCache,
 } = await import("../settings");
 const { SaasImmutableSettingError } = await import("../settings-errors");
@@ -95,6 +101,7 @@ describe("settings (SaaS mode)", () => {
     queryResults = [];
     queryResultIndex = 0;
     logLevelCalls = [];
+    mockGetConfigImpl = () => ({ deployMode: "saas" });
     _resetSettingsCache();
   });
 
@@ -225,6 +232,85 @@ describe("settings (SaaS mode)", () => {
       await expect(
         setSetting("ATLAS_ROW_LIMIT", "500", "admin-1"),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteSetting SAAS_IMMUTABLE_KEYS rejection (#3389)
+  // -------------------------------------------------------------------------
+
+  describe("deleteSetting SAAS_IMMUTABLE_KEYS rejection (#3389)", () => {
+    it("deleteSetting rejects ATLAS_EMAIL_PROVIDER in SaaS mode with SaasImmutableSettingError", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      let captured: unknown;
+      try {
+        await deleteSetting("ATLAS_EMAIL_PROVIDER", "admin-1");
+      } catch (err) {
+        captured = err;
+      }
+
+      // Same error type + shape as the setSetting guard — the route maps
+      // both to the same 409 envelope.
+      expect(captured).toBeInstanceOf(SaasImmutableSettingError);
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>).key).toBe("ATLAS_EMAIL_PROVIDER");
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>)._tag).toBe("SaasImmutableSettingError");
+      // No DB delete — clearing the override would silently reset the key
+      // to env/default behind the boot-time contract guard.
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it("deleteSetting rejects ATLAS_DEPLOY_MODE and ATLAS_RATE_LIMIT_RPM in SaaS mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      await expect(
+        deleteSetting("ATLAS_DEPLOY_MODE", "admin-1"),
+      ).rejects.toThrow(SaasImmutableSettingError);
+      await expect(
+        deleteSetting("ATLAS_RATE_LIMIT_RPM", "admin-1"),
+      ).rejects.toThrow(SaasImmutableSettingError);
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it("deleteSetting allows non-immutable keys in SaaS mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      await expect(
+        deleteSetting("ATLAS_ROW_LIMIT", "admin-1"),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isSaasModeForGuard probe discipline (#3389)
+  // -------------------------------------------------------------------------
+
+  describe("isSaasModeForGuard probe discipline (#3389)", () => {
+    // Exported in #3389 so the route-level write gates on PUT/DELETE
+    // /admin/settings/{key} share the lib guard's fail-closed discipline.
+
+    it("returns true when deployMode is saas", () => {
+      expect(isSaasModeForGuard()).toBe(true);
+    });
+
+    it("returns false when deployMode is self-hosted (resolved config stays permissive)", () => {
+      mockGetConfigImpl = () => ({ deployMode: "self-hosted" });
+      expect(isSaasModeForGuard()).toBe(false);
+    });
+
+    it("returns false when config is unloaded (getConfig() → null — legitimate AGPL/dev state)", () => {
+      mockGetConfigImpl = () => null;
+      expect(isSaasModeForGuard()).toBe(false);
+    });
+
+    it("fails CLOSED (true) when getConfig() throws — config-resolution failure is not self-hosted", () => {
+      mockGetConfigImpl = () => {
+        throw new Error("config resolution exploded");
+      };
+      expect(isSaasModeForGuard()).toBe(true);
     });
   });
 });

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -423,6 +423,19 @@ describe("settings module", () => {
       );
     });
 
+    // #3389 — mirror of the setSetting self-hosted test above: the delete
+    // guard must stay isSaasModeForGuard()-gated, so clearing an immutable
+    // key's override outside SaaS keeps working. SaaS rejection is covered
+    // in settings-saas.test.ts.
+    it("permits deletes of SAAS_IMMUTABLE_KEYS overrides in self-hosted mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      await expect(
+        deleteSetting("ATLAS_EMAIL_PROVIDER", "admin-1"),
+      ).resolves.toBeUndefined();
+    });
+
     it("removes platform override, reverts to env var", async () => {
       process.env.ATLAS_ROW_LIMIT = "500";
       enableInternalDB();

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -210,6 +210,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   loadSettings: mock(async () => 0),
   getAllSettingOverrides: mock(async () => []),
   _resetSettingsCache: () => {},
+  isSaasModeForGuard: () => false, // #3389 — admin settings write gates probe via this
   initializeSettings: mock(() => Promise.resolve()),
 }));
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -696,13 +696,16 @@ function isSaasMode(): boolean {
 }
 
 /**
- * Guard-oriented SaaS check — used by `setSetting` only.
+ * Guard-oriented SaaS check — used by `setSetting`/`deleteSetting` and,
+ * since #3389, by the route-level write gates on PUT/DELETE
+ * `/admin/settings/{key}` so the whole settings write path shares one
+ * probe discipline.
  *
  * Fails CLOSED on `"errored"` (require() or getConfig() threw, which
  * shouldn't happen at request-handling time and is the silent-bypass
  * vector #1978's silent-failure finding flagged). Treats `"unloaded"`
  * as non-SaaS, matching the legitimate AGPL/dev case where config
- * was never loaded.
+ * was never loaded — self-hosted normal operation stays permissive.
  *
  * Asymmetry rationale: the boot guards in `lib/effect/saas-guards.ts`
  * read `config.deployMode` via `yield* Config` (typed, no fallback);
@@ -713,7 +716,7 @@ function isSaasMode(): boolean {
  * "ok", walks away while the contract is silently broken on next
  * restart).
  */
-function isSaasModeForGuard(): boolean {
+export function isSaasModeForGuard(): boolean {
   const snapshot = resolveDeployModeSnapshot();
   if (snapshot === "saas") return true;
   if (snapshot === "errored") {
@@ -927,13 +930,24 @@ export async function setSetting(key: string, value: string, userId?: string, or
  * Throws if no internal DB is available.
  */
 export async function deleteSetting(key: string, userId?: string, orgId?: string): Promise<void> {
-  if (!hasInternalDB()) {
-    throw new Error("Internal database required to manage settings overrides");
-  }
-
   const def = SETTINGS_MAP.get(key);
   if (!def) {
     throw new Error(`Unknown setting key: "${key}"`);
+  }
+
+  // #3389 — clearing an override is a write: deleting a SAAS_IMMUTABLE
+  // key's override on SaaS would reset it to env/default behind the
+  // boot-time contract guards, the same silent-bypass class #1978 closed
+  // for setSetting. Same guard, same error, same ordering rationale:
+  // runs BEFORE the hasInternalDB() check so the more-specific contract
+  // error fires first, and uses isSaasModeForGuard() (fails closed) so a
+  // transient getConfig() failure cannot bypass.
+  if (isSaasImmutableKey(key) && isSaasModeForGuard()) {
+    throw new SaasImmutableSettingError(key);
+  }
+
+  if (!hasInternalDB()) {
+    throw new Error("Internal database required to manage settings overrides");
   }
   const effectiveOrgId = def.scope === "platform" ? undefined : orgId;
 


### PR DESCRIPTION
Closes #3389. Part of the #3374 deploy-mode parity umbrella (completes the write-gate symmetry #3376 / PR #3390 started).

## What

1. **DELETE immutable guard** — `deleteSetting` now enforces `SAAS_IMMUTABLE_KEYS` exactly like `setSetting` (clearing an override is a write): same `SaasImmutableSettingError`, same ordering (contract error before the internal-DB error), and the DELETE route maps it to the identical `{error: "saas_immutable", message, requestId}` 409 envelope PUT produces. The 409 is declared on the DELETE route's OpenAPI responses and `apps/docs/openapi.json` is regenerated.
2. **One probe discipline, fail-closed** — both verbs' route gates (platform-scope + `saasWritable`) now share the exported `isSaasModeForGuard()` instead of the permissive `getConfig()?.deployMode ?? "self-hosted"` read: a config-resolution *failure* at request time is treated as SaaS (restrictive), while a legitimately-unloaded config still counts as self-hosted — so dev/self-hosted operation is untouched (pinned by tests). Recorded in the parity contract under Rule 4.
3. **No-org edge** — platform-scope write gates changed from `orgId && !isPlatformAdmin` to `!isPlatformAdmin && (orgId || isSaasModeForGuard())`: a SaaS session with no `activeOrganizationId` now gets workspace-admin restrictions on writes, matching GET's `!isPlatformAdmin` classification, instead of a platform-scope bypass. Self-hosted no-org admins keep full access.

## Why

Same shape #3376 closed for `saasVisible`: guards enforced on one verb (or one layer) but not the other. The no-org case was a privilege-escalation edge — a SaaS non-platform-admin without an active workspace could write platform-scoped settings.

## Deviations from the issue sketch

- No shared-helper refactor was needed for the no-org fix: the permissive helper near `admin.ts:238` is `verifyOrgMembership` (user-mutation routes only); the settings scope checks are inline in the two handlers, so the change is naturally scoped.
- The DELETE route's OpenAPI definition gained a `409` entry (required by tsgo; it's the contract surface of fix 1).

## Tests

- `packages/api` isolated runner `--affected`: **150/150 files pass**. Targeted: `settings.test.ts` 62/0, `settings-saas.test.ts` 15/0 (incl. "fails CLOSED when getConfig() throws"), `admin-settings.test.ts` 57/0 (DELETE 409 + 500-passthrough, fail-closed probe describe, no-org SaaS describe with self-hosted mirror).
- `bun run lint`, `bun run type` exit 0; `bash scripts/check-settings-readers.sh` green (39 keys).
- 9 test files with partial `mock.module("@atlas/api/lib/settings")` mocks gained the new export (mock-all-exports rule); the shared `api-test-mocks.ts` default is `isSaasModeForGuard: () => false` (self-hosted), matching its `getConfig: () => null` default.

## Review summary

Three independent review passes (line-scan, gate-semantics/behavior-change, cross-file tracer):
- Truth-tabled the new gate across all role/org/mode combinations — matches intent in every cell; org-having workspace admins were already 403'd on platform keys in both modes (parity preserved).
- Every `deleteSetting` caller traced: the only non-test caller besides the settings route is the sandbox disconnect flow (`admin-sandbox.ts:403`), which deletes `ATLAS_SANDBOX_BACKEND` — not in `SAAS_IMMUTABLE_KEYS`, so SaaS sandbox flows are unaffected.
- Web DELETE error handling verified: `useAdminMutation` surfaces the 409's server message.
- One candidate (3 cors/security-header test files with partial settings mocks) was empirically REFUTED — all pass on this branch.

Adjacent finding filed as #3395 (no-org SaaS write to a workspace-scoped key lands on the global `org_id IS NULL` override — out of this PR's stated contract, which covers the platform-scope and immutable gates).

https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783765329&installation_id=135337507&pr_number=3396&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3396&signature=1d745603df46ed471c5cf40e0ea48922bf7f569baa1b662dd386142e5bcb1c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAPI docs with a detailed 409 error response schema for SaaS-immutable settings.
  * Expanded enterprise gating docs clarifying mode-probe behavior and write-path enforcement.

* **Bug Fixes**
  * Delete now enforces SaaS immutability like updates, returning the same 409 error envelope.
  * Admin settings routes tighten SaaS/workspace authorization for platform- vs workspace-scoped writes.

* **Tests**
  * Broader tests covering SaaS immutability, probe behaviors, and admin/settings workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->