### PR TITLE
fix(semantic): read ATLAS_EXPERT_* keys through getSetting so admin overrides apply (#3392)

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -341,8 +341,6 @@ Per-workspace configuration — query limits, agent behavior, sandbox backend, a
 | Sandbox | `ATLAS_SANDBOX_BACKEND` | Sandbox backend for explore/Python tool isolation |
 | Sandbox | `ATLAS_SANDBOX_URL` | Custom sidecar service URL (sidecar backend only) |
 | Agent | `ATLAS_AGENT_MAX_STEPS` | Maximum tool-call steps per agent run (1–100, default: 25) |
-| Intelligence | `ATLAS_EXPERT_SCHEDULER_ENABLED` | Enable periodic semantic layer analysis (default: false) |
-| Intelligence | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | Hours between scheduled expert analysis runs (default: 24) |
 | Intelligence | `ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD` | Auto-approve proposals above this confidence (empty = disabled) |
 | Intelligence | `ATLAS_EXPERT_AUTO_APPROVE_TYPES` | Comma-separated amendment types eligible for auto-approval |
 
@@ -358,7 +356,7 @@ Requires the `platform_admin` role. In self-hosted deployments, the first user t
 
 Global settings that affect all workspaces — security policies, LLM provider, deploy mode, branding, and secrets. Only platform admins can access this page. Changes here apply across every workspace.
 
-- **Sections** — Security, Platform, Agent, Email, Appearance, Secrets
+- **Sections** — Security, Platform, Agent, Intelligence, Email, Appearance, Secrets
 - **Brand color** — A dedicated card lets you preview and set the primary brand color in oklch format, with a live color swatch. Changes apply immediately
 - **Live vs Restart** — Settings marked **Live** take effect immediately. Settings marked **Requires restart** need a server restart (self-hosted only — on **app.useatlas.dev**, most settings are hot-reloadable)
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
@@ -374,6 +372,8 @@ Global settings that affect all workspaces — security policies, LLM provider, 
 | Agent | `ATLAS_PROVIDER` | LLM provider selection |
 | Agent | `ATLAS_MODEL` | Model ID override |
 | Agent | `ATLAS_LOG_LEVEL` | Application log level |
+| Intelligence | `ATLAS_EXPERT_SCHEDULER_ENABLED` | Enable periodic semantic layer analysis (default: false; restart required) |
+| Intelligence | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | Hours between scheduled expert analysis runs (default: 24; restart required) |
 | Email | `ATLAS_EMAIL_PROVIDER` | Platform default email provider |
 | Email | `RESEND_API_KEY` | Resend API key (masked, read-only) |
 | Email | `SENDGRID_API_KEY` | SendGrid API key (masked, read-only) |

--- a/apps/docs/content/docs/guides/semantic-expert.mdx
+++ b/apps/docs/content/docs/guides/semantic-expert.mdx
@@ -273,14 +273,14 @@ The expert agent can run on a schedule, automatically analyzing your semantic la
 
 ### Enabling the Scheduler
 
-Set these environment variables or configure through the admin Settings page under **Intelligence**:
+Set these environment variables or configure through the admin Settings pages under **Intelligence**. The two scheduler settings are platform-wide — the scheduler is one process-global background job, so they live on **Platform Settings** and changes require a restart. The two auto-approve settings are workspace-scoped — they live on **Workspace Settings**, are read per proposal, and a per-workspace override takes effect without a restart.
 
-| Setting | Env var | Default | Description |
-|---------|---------|---------|-------------|
-| Expert Scheduler | `ATLAS_EXPERT_SCHEDULER_ENABLED` | `false` | Enable periodic analysis |
-| Schedule Interval | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | `24` | Hours between runs |
-| Auto-Approve Threshold | `ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD` | (disabled) | Proposals with confidence ≥ this value and an eligible type are auto-applied |
-| Auto-Approve Types | `ATLAS_EXPERT_AUTO_APPROVE_TYPES` | `update_description,add_dimension` | Comma-separated amendment types eligible for auto-approval. Types not in this list always queue for review |
+| Setting | Env var | Scope | Default | Description |
+|---------|---------|-------|---------|-------------|
+| Expert Scheduler | `ATLAS_EXPERT_SCHEDULER_ENABLED` | Platform (restart) | `false` | Enable periodic analysis |
+| Schedule Interval | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | Platform (restart) | `24` | Hours between runs |
+| Auto-Approve Threshold | `ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD` | Workspace | (disabled) | Proposals with confidence ≥ this value and an eligible type are auto-applied |
+| Auto-Approve Types | `ATLAS_EXPERT_AUTO_APPROVE_TYPES` | Workspace | `update_description,add_dimension` | Comma-separated amendment types eligible for auto-approval. Types not in this list always queue for review |
 
 ### Cached Profiles
 

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -625,6 +625,9 @@ describe("settings module", () => {
       const workspaceKeys = [
         "ATLAS_ROW_LIMIT", "ATLAS_QUERY_TIMEOUT", "ATLAS_RATE_LIMIT_RPM",
         "ATLAS_SESSION_IDLE_TIMEOUT", "ATLAS_SESSION_ABSOLUTE_TIMEOUT", "ATLAS_AGENT_MAX_STEPS",
+        // #3392 — read per proposal via getSetting(key, orgId) in
+        // lib/db/internal.ts, so the workspace override is honored.
+        "ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD", "ATLAS_EXPERT_AUTO_APPROVE_TYPES",
       ];
       for (const key of workspaceKeys) {
         const def = getSettingDefinition(key);
@@ -639,6 +642,9 @@ describe("settings module", () => {
         "ATLAS_RLS_ENABLED", "ATLAS_RLS_COLUMN", "ATLAS_RLS_CLAIM",
         "ATLAS_TABLE_WHITELIST", "ATLAS_CORS_ORIGIN", "ATLAS_BRAND_COLOR",
         "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DATABASE_URL", "ATLAS_DATASOURCE_URL",
+        // #3392 — the expert scheduler is one process-global boot-time
+        // fiber; no per-workspace tick exists, so these are platform-scoped.
+        "ATLAS_EXPERT_SCHEDULER_ENABLED", "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
       ];
       for (const key of platformKeys) {
         const def = getSettingDefinition(key);

--- a/packages/api/src/lib/db/__tests__/auto-approve-workspace-override.test.ts
+++ b/packages/api/src/lib/db/__tests__/auto-approve-workspace-override.test.ts
@@ -1,0 +1,128 @@
+/**
+ * #3392 — getAutoApproveThreshold / getAutoApproveTypes are workspace-scoped
+ * settings and must resolve through getSetting(key, orgId) so per-workspace
+ * DB overrides written from the admin settings page are honored.
+ *
+ * The settings module is mocked here (all value exports — mock-all-exports
+ * rule) so we can observe exactly which (key, orgId) pair each helper asks
+ * for and simulate a workspace override without a DB. Env-fallback behavior
+ * with the REAL settings module is covered by auto-approve-types.test.ts.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () => undefined,
+}));
+
+// Stub out heavy deps that internal.ts imports at module level
+mock.module("@effect/sql", () => ({ SqlClient: { Tag: () => ({}) } }));
+mock.module("@effect/sql-pg", () => ({ PgClient: { layerFromPool: () => ({}) } }));
+
+// Per-(key, orgId) value map the mock getSetting resolves from. Keyed
+// "KEY" for platform-tier and "KEY\0orgId" for workspace-tier — mirrors
+// the real cache-key shape in settings.ts.
+let settingValues = new Map<string, string>();
+
+function mockResolve(key: string, orgId?: string): string | undefined {
+  if (orgId) {
+    const ws = settingValues.get(`${key}\0${orgId}`);
+    if (ws !== undefined) return ws;
+  }
+  return settingValues.get(key);
+}
+
+const getSettingMock = mock(mockResolve);
+
+// Mock ALL value exports of the settings module (mock-all-exports rule).
+mock.module("@atlas/api/lib/settings", () => ({
+  _resetSettingsCache: () => {},
+  getSetting: getSettingMock,
+  getSettingAuto: getSettingMock,
+  getSettingLive: async (key: string, orgId?: string) => mockResolve(key, orgId),
+  loadSettings: async () => 0,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getAllSettingOverrides: async () => [],
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  refreshSettingsTick: async () => {},
+  isSaasModeForGuard: () => false,
+}));
+
+const { getAutoApproveThreshold, getAutoApproveTypes } = await import("../internal");
+
+describe("getAutoApproveThreshold — workspace override (#3392)", () => {
+  beforeEach(() => {
+    settingValues = new Map();
+    getSettingMock.mockClear();
+  });
+
+  it("asks getSetting for the key with the orgId", () => {
+    getAutoApproveThreshold("org-1");
+    expect(getSettingMock).toHaveBeenCalledWith("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD", "org-1");
+  });
+
+  it("honors a workspace override over the platform value", () => {
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD", "0.9");
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD\0org-1", "0.5");
+    expect(getAutoApproveThreshold("org-1")).toBe(0.5);
+  });
+
+  it("falls back to the platform value when the workspace has no override", () => {
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD", "0.9");
+    expect(getAutoApproveThreshold("org-2")).toBe(0.9);
+  });
+
+  it("is disabled (returns > 1) when nothing is configured", () => {
+    expect(getAutoApproveThreshold()).toBe(2);
+    expect(getAutoApproveThreshold("org-1")).toBe(2);
+  });
+
+  it("rejects an invalid workspace override and stays disabled", () => {
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD\0org-1", "5");
+    expect(getAutoApproveThreshold("org-1")).toBe(2);
+  });
+});
+
+describe("getAutoApproveTypes — workspace override (#3392)", () => {
+  beforeEach(() => {
+    settingValues = new Map();
+    getSettingMock.mockClear();
+  });
+
+  it("asks getSetting for the key with the orgId", () => {
+    getAutoApproveTypes("org-1");
+    expect(getSettingMock).toHaveBeenCalledWith("ATLAS_EXPERT_AUTO_APPROVE_TYPES", "org-1");
+  });
+
+  it("honors a workspace override over the platform value", () => {
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_TYPES", "update_description");
+    settingValues.set("ATLAS_EXPERT_AUTO_APPROVE_TYPES\0org-1", "add_join,add_measure");
+    expect(getAutoApproveTypes("org-1")).toEqual(new Set(["add_join", "add_measure"]));
+  });
+
+  it("falls back to the built-in default when nothing is configured", () => {
+    expect(getAutoApproveTypes("org-1")).toEqual(
+      new Set(["update_description", "add_dimension"]),
+    );
+  });
+});
+
+describe("insertSemanticAmendment threads its orgId into the helpers (#3392)", () => {
+  // insertSemanticAmendment can't run without a DB, so pin the threading
+  // structurally — same source-shape pattern as
+  // connection-runtime-guards.test.ts for ATLAS_ROW_LIMIT.
+  it("passes the amendment orgId to both auto-approve readers", async () => {
+    const src = await Bun.file(new URL("../internal.ts", import.meta.url)).text();
+    expect(src).toContain("const settingsOrgId = amendment.orgId ?? undefined;");
+    expect(src).toContain("getAutoApproveThreshold(settingsOrgId)");
+    expect(src).toContain("getAutoApproveTypes(settingsOrgId)");
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1151,11 +1151,31 @@ export function insertLearnedPattern(pattern: {
 }
 
 /**
- * Parse the auto-approve threshold from env. Returns a value > 1 (disabled) if
- * not set or invalid. Single source of truth for the threshold logic.
+ * Lazily resolve `getSetting` from the settings module.
+ *
+ * settings.ts statically imports db/internal.ts (hasInternalDB /
+ * internalQuery), so a static import here would create a module cycle —
+ * same lazy-require pattern settings.ts itself uses for config/logger.
  */
-export function getAutoApproveThreshold(): number {
-  const raw = process.env.ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD;
+function requireGetSetting(): (key: string, orgId?: string) => string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency (settings.ts imports db/internal.ts)
+  const { getSetting } = require("@atlas/api/lib/settings") as {
+    getSetting: (key: string, orgId?: string) => string | undefined;
+  };
+  return getSetting;
+}
+
+/**
+ * Parse the auto-approve threshold. Returns a value > 1 (disabled) if not
+ * set or invalid. Single source of truth for the threshold logic.
+ *
+ * Workspace-scoped (#3392): resolved via getSetting(key, orgId) so a
+ * per-workspace DB override written from the admin settings page wins
+ * over the platform override / env var / default.
+ */
+export function getAutoApproveThreshold(orgId?: string): number {
+  const getSetting = requireGetSetting();
+  const raw = getSetting("ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD", orgId);
   if (!raw) return 2; // Disabled by default
   const parsed = parseFloat(raw);
   if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
@@ -1177,9 +1197,13 @@ const VALID_AMENDMENT_TYPES: ReadonlySet<string> = new Set([
  * Parse the comma-separated list of amendment types eligible for auto-approval.
  * Defaults to `update_description,add_dimension` when `ATLAS_EXPERT_AUTO_APPROVE_TYPES` is not set.
  * Unrecognized type names are logged and ignored.
+ *
+ * Workspace-scoped (#3392): resolved via getSetting(key, orgId) — see
+ * getAutoApproveThreshold.
  */
-export function getAutoApproveTypes(): Set<string> {
-  const raw = process.env.ATLAS_EXPERT_AUTO_APPROVE_TYPES ?? DEFAULT_AUTO_APPROVE_TYPES;
+export function getAutoApproveTypes(orgId?: string): Set<string> {
+  const getSetting = requireGetSetting();
+  const raw = getSetting("ATLAS_EXPERT_AUTO_APPROVE_TYPES", orgId) ?? DEFAULT_AUTO_APPROVE_TYPES;
   const tokens = raw.split(",").map((t) => t.trim()).filter(Boolean);
   const result = new Set<string>();
   for (const t of tokens) {
@@ -1213,8 +1237,12 @@ export async function insertSemanticAmendment(amendment: {
    */
   connectionGroupId?: string | null;
 }): Promise<{ id: string; status: "approved" | "pending" }> {
-  const threshold = getAutoApproveThreshold();
-  const allowedTypes = getAutoApproveTypes();
+  // #3392 — thread the amendment's org through so a per-workspace
+  // auto-approve override (admin settings page) governs its own proposals.
+  // null orgId (self-hosted / global scope) resolves at the platform tier.
+  const settingsOrgId = amendment.orgId ?? undefined;
+  const threshold = getAutoApproveThreshold(settingsOrgId);
+  const allowedTypes = getAutoApproveTypes(settingsOrgId);
   const rawType = amendment.amendmentPayload.amendmentType;
   const amendmentType = typeof rawType === "string" ? rawType : undefined;
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2806,8 +2806,15 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // `AuditRetention` in #2569) so it can start the EE audit purge worker
   // via the Tag — `EnterpriseLayer` provides both the no-op default and
   // the real EE implementation.
+  //
+  // `settingsLayer` is provided as an ordering barrier (#3392): the expert
+  // scheduler reads ATLAS_EXPERT_SCHEDULER_ENABLED / _INTERVAL_HOURS via
+  // getSetting() at layer-construction time, so `loadSettings()` must warm
+  // the cache first or a platform DB override would race boot — same
+  // Settings-edge rationale as ProactiveProviderKeyGuardLive below. Layer
+  // memoization keeps the shared `settingsLayer` reference built once.
   const schedulerLayer = makeSchedulerLive(config).pipe(
-    Layer.provide(EnterpriseLayer),
+    Layer.provide(Layer.merge(EnterpriseLayer, settingsLayer)),
   );
 
   // DpaGuardLive depends on Config + Settings — provide them so the boot

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -1,15 +1,27 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   isExpertSchedulerEnabled,
   getExpertSchedulerIntervalMs,
   DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS,
 } from "../scheduler";
+import { loadSettings, _resetSettingsCache } from "@atlas/api/lib/settings";
 
-// Mock internal DB
+// Mock internal DB. `dbAvailable` / `settingsRows` are mutable so the
+// #3392 tests below can seed the settings cache via loadSettings() (the
+// readers now resolve through getSetting's tier chain, not raw env).
+let dbAvailable = false;
+let settingsRows: Array<{
+  key: string;
+  value: string;
+  updated_at: string;
+  updated_by: string | null;
+  org_id: string | null;
+}> = [];
+
 mock.module("@atlas/api/lib/db/internal", () => ({
-  hasInternalDB: () => false,
+  hasInternalDB: () => dbAvailable,
   getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: async () => [],
+  internalQuery: async () => settingsRows,
   internalExecute: () => {},
   getAutoApproveThreshold: () => 2, // disabled
   getAutoApproveTypes: () => new Set(["update_description", "add_dimension"]),
@@ -84,5 +96,65 @@ describe("getExpertSchedulerIntervalMs", () => {
   it("returns default for negative", () => {
     process.env.ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS = "-5";
     expect(getExpertSchedulerIntervalMs()).toBe(DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS);
+  });
+});
+
+// #3392 — the readers resolve through getSetting's tier chain, so a
+// platform-level DB override (admin settings page) must beat the env var.
+describe("platform DB override via getSetting (#3392)", () => {
+  beforeEach(() => {
+    delete process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
+    delete process.env.ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS;
+    _resetSettingsCache();
+    dbAvailable = false;
+    settingsRows = [];
+  });
+
+  afterEach(() => {
+    delete process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
+    delete process.env.ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS;
+    _resetSettingsCache();
+    dbAvailable = false;
+    settingsRows = [];
+  });
+
+  it("platform DB override for ATLAS_EXPERT_SCHEDULER_ENABLED beats the env var", async () => {
+    process.env.ATLAS_EXPERT_SCHEDULER_ENABLED = "false";
+    dbAvailable = true;
+    settingsRows = [
+      {
+        key: "ATLAS_EXPERT_SCHEDULER_ENABLED",
+        value: "true",
+        updated_at: "2026-01-01",
+        updated_by: null,
+        org_id: null,
+      },
+    ];
+    await loadSettings();
+    expect(isExpertSchedulerEnabled()).toBe(true);
+  });
+
+  it("platform DB override for ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS beats the env var", async () => {
+    process.env.ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS = "24";
+    dbAvailable = true;
+    settingsRows = [
+      {
+        key: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
+        value: "6",
+        updated_at: "2026-01-01",
+        updated_by: null,
+        org_id: null,
+      },
+    ];
+    await loadSettings();
+    expect(getExpertSchedulerIntervalMs()).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it("falls back to env when no DB override exists", async () => {
+    process.env.ATLAS_EXPERT_SCHEDULER_ENABLED = "true";
+    dbAvailable = true;
+    settingsRows = [];
+    await loadSettings();
+    expect(isExpertSchedulerEnabled()).toBe(true);
   });
 });

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSetting } from "@atlas/api/lib/settings";
 
 const log = createLogger("semantic-expert-scheduler");
 
@@ -23,20 +24,29 @@ export interface ExpertTickResult {
 /**
  * Check whether the expert scheduler is enabled.
  *
- * Reads from the env var — the settings system wraps this with
- * per-workspace overrides at the layer level.
+ * Platform-scoped (#3392): the scheduler is a single process-global fiber
+ * forked once at boot by `makeSchedulerLive` (lib/effect/layers.ts) — there
+ * is no per-workspace tick, so this key takes no workspace override.
+ * Resolved via getSetting() so a platform-level DB override (admin
+ * settings page) wins over the env var (platform DB override > env >
+ * default). Consumed once at boot — changes require a restart
+ * (`requiresRestart` in the registry); the scheduler layer sequences
+ * after `loadSettings()` so the DB override is visible here.
  */
 export function isExpertSchedulerEnabled(): boolean {
-  const v = process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
+  const v = getSetting("ATLAS_EXPERT_SCHEDULER_ENABLED");
   return v === "true" || v === "1";
 }
 
 /**
  * Get the scheduler interval in milliseconds.
- * Reads ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS, defaults to 24.
+ *
+ * Resolves ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS through getSetting()
+ * (platform DB override > env > registry default of 24). Platform-scoped
+ * and boot-consumed — see isExpertSchedulerEnabled.
  */
 export function getExpertSchedulerIntervalMs(): number {
-  const raw = process.env.ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS;
+  const raw = getSetting("ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS");
   if (!raw) return DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS;
   const hours = parseFloat(raw);
   if (!Number.isFinite(hours) || hours <= 0) return DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -385,6 +385,15 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   },
 
   // Semantic Expert
+  //
+  // Scope split (#3392): the scheduler pair is PLATFORM-scoped — the expert
+  // scheduler is a single process-global fiber forked once at boot
+  // (`makeSchedulerLive` in lib/effect/layers.ts); there is no per-workspace
+  // tick, so a workspace override would have nothing to apply to. Both are
+  // consumed once at boot, hence `requiresRestart`. The auto-approve pair
+  // below stays WORKSPACE-scoped: it is read per proposal in
+  // `insertSemanticAmendment` (lib/db/internal.ts), which has the
+  // amendment's orgId in scope.
   {
     key: "ATLAS_EXPERT_SCHEDULER_ENABLED",
     section: "Intelligence",
@@ -393,7 +402,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "boolean",
     default: "false",
     envVar: "ATLAS_EXPERT_SCHEDULER_ENABLED",
-    scope: "workspace",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
@@ -403,7 +414,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "number",
     default: "24",
     envVar: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
-    scope: "workspace",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD",

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -68,26 +68,8 @@ GENERIC_SETTINGS_ROUTES_FILE="packages/api/src/api/routes/admin.ts"
 # or remove the setting.
 # ---------------------------------------------------------------------------
 ALLOWLIST=(
-  # The four Semantic Expert keys are WORKSPACE-scoped in the registry but
-  # their only runtime readers are process.env reads, so the per-workspace
-  # DB override the admin settings page writes is runtime-inert above the
-  # env tier (adjacent finding from #3382 — predates this check; do not
-  # fix here). Remove each entry when its reader moves to getSetting(key,
-  # orgId).
-  #
-  # ATLAS_EXPERT_SCHEDULER_ENABLED — read via process.env in
-  #   lib/semantic/expert/scheduler.ts:isExpertSchedulerEnabled() (consumed
-  #   by the scheduler layer in lib/effect/layers.ts).
-  "ATLAS_EXPERT_SCHEDULER_ENABLED"
-  # ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS — read via process.env in
-  #   lib/semantic/expert/scheduler.ts:getExpertSchedulerIntervalMs().
-  "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS"
-  # ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD — read via process.env in
-  #   lib/db/internal.ts:getAutoApproveThreshold().
-  "ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD"
-  # ATLAS_EXPERT_AUTO_APPROVE_TYPES — read via process.env in
-  #   lib/db/internal.ts:getAutoApproveTypes().
-  "ATLAS_EXPERT_AUTO_APPROVE_TYPES"
+  # (empty — the four Semantic Expert keys were removed by #3392 when their
+  # readers moved to getSetting; new entries need a justification comment.)
 )
 
 if [ ! -f "$SETTINGS_FILE" ]; then
@@ -188,6 +170,8 @@ ALLOWLISTED_COUNT=0
 
 is_allowlisted() {
   local key="$1" entry
+  # Empty-array guard: bash < 4.4 errors on "${ALLOWLIST[@]}" under set -u.
+  [ "${#ALLOWLIST[@]}" -eq 0 ] && return 1
   for entry in "${ALLOWLIST[@]}"; do
     [ "$entry" = "$key" ] && return 0
   done


### PR DESCRIPTION
Closes #3392. Part of the #3374 deploy-mode parity umbrella — the live class-1 instance (UI-visible but runtime-inert) caught by `check-settings-readers.sh` (#3382) on its first run.

## What

Per-key decision (parity Rule 1, decided from the actual read sites):

| Key | Decision | Why |
|---|---|---|
| `ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD` | stays **workspace**; read `getSetting(key, orgId)` | Read per proposal in `insertSemanticAmendment`, which has the amendment's org — `orgId` now threaded so a workspace's auto-approve override governs its own proposals |
| `ATLAS_EXPERT_AUTO_APPROVE_TYPES` | stays **workspace**; read `getSetting(key, orgId)` | Same read site, same threading |
| `ATLAS_EXPERT_SCHEDULER_ENABLED` | **re-scoped to platform** (`requiresRestart`, `saasVisible: false`); read `getSetting(key)` | Sole consumer is one process-global fiber forked once at boot (`makeSchedulerLive`); no per-workspace tick exists, so a workspace override never had anything to apply to |
| `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | **re-scoped to platform**, same flags | `Schedule.spaced(...)` fixed at fiber fork — boot-consumed, global |

Plus: the stale "settings system wraps this with per-workspace overrides at the layer level" comment in `scheduler.ts` replaced with the real contract; `schedulerLayer` gains a `settingsLayer` ordering barrier so `loadSettings()` warms the cache before the boot-time reads (env fallback works regardless — the barrier is for DB overrides); the four `ALLOWLIST` entries deleted from `scripts/check-settings-readers.sh` (now **0 allowlisted** — the check enforces this forever); docs tables updated to the new scope split (Rule 5).

Rule 4 note: the two platform keys set `saasVisible: false` explicitly with `saasWritable` omitted, inheriting hidden ⇒ un-writable for SaaS workspace admins; the admin UI moves them to the platform settings page automatically (pages render from registry scope — no web change needed). Parsing semantics are byte-identical to the old env reads; env-var fallback is fully preserved for self-hosted deployments without an internal DB (`getSetting` tier 3).

## Tests

- `packages/api` isolated runner `--affected`: **251/251 files pass**. `bun run lint` / `bun run type` exit 0. `bash scripts/check-settings-readers.sh`: 39 keys, 30 direct getSetting, 0 allowlisted. OpenAPI extract: zero drift.
- New coverage: scheduler tests exercise the REAL resolution chain (DB override beats env, env fallback intact via `loadSettings()` + real cache); new `auto-approve-workspace-override.test.ts` pins `(key, orgId)` threading, workspace-beats-platform, defaults, and invalid-override rejection; `settings.test.ts` pins the four keys' scopes.

## Review summary

Three independent passes:
- **Line-scan**: clean — `getSetting` contract verified (sync, 4-tier resolution, never loses the env value), parsing identical to old env reads, `Layer.provide` ordering semantics confirmed, no import cycle (settings.ts never reaches scheduler.ts; the `db/internal.ts` lazy require mirrors settings.ts's own config/logger pattern).
- **Behavior-change**: clean — all callers traced (only `insertSemanticAmendment`, orgId threaded); stale pre-#3392 org rows for the re-scoped keys were already runtime-inert and stay inert/unsurfaced; post-#3396 route gates give the correct visibility/writability matrix in both modes.
- **Cross-file tracer**: one candidate REFUTED — claimed cross-file mock pollution between the two new/extended test files, which only manifests when multiple files share a bun process; the repo's per-file isolated runner (the documented, CI-enforced contract) precludes that, and both files pass in isolation (9/0, 12/0).

Adjacent findings deliberately not fixed here (will file): SaaS restart-hint suppression for boot-consumed platform keys; `salesforce-tool.ts:73` freezes `ATLAS_ROW_LIMIT` from env at import time, bypassing workspace overrides.

https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TehKJyEW9dcmCnjwtXHjY3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783768052&installation_id=135337507&pr_number=3398&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3398&signature=237e36b195ce8cd24683958b68304df063a70a1e7cd236a6bc9d6c5d4047278b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Admin Console and Expert configuration guides to clarify settings organization and scope (workspace vs. platform level).

* **Settings & Configuration**
  * Expert auto-approval settings are now workspace-scoped, enabling per-workspace customization without requiring restart.
  * Expert scheduler settings are now platform-scoped and require restart when modified.
  * Reorganized Platform Settings to display Intelligence configuration in a dedicated section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->