### PR TITLE
fix(integrations): resolve ATLAS_ROW_LIMIT lazily per call in salesforce-tool (#3400)

### DIFF
--- a/packages/api/src/lib/integrations/__tests__/salesforce-tool.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/salesforce-tool.test.ts
@@ -12,12 +12,14 @@
  * throwing resolver → fail-closed (`scan_unavailable`).
  */
 
-import { describe, expect, it, mock, type Mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
 
 import {
   createQuerySalesforceTool,
   type QuerySalesforceToolDeps,
 } from "../salesforce-tool";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
 import {
   LazyPluginBuilderMissingError,
   LazyPluginInstallNotFoundError,
@@ -345,6 +347,125 @@ describe("querySalesforce — failure surfaces", () => {
     expect(result.message).toMatch(/check server logs/i);
     expect(result.message).not.toMatch(/INVALID_CLIENT_ID/);
     expect(result.message).not.toMatch(/credential/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATLAS_ROW_LIMIT lazy resolution (#3400)
+//
+// The SOQL auto-LIMIT must resolve ATLAS_ROW_LIMIT per call via getSetting
+// (DB override > env var > default 1000) — matching getRowLimit() in
+// tools/sql.ts — not freeze it from env at module import. Uses the
+// _resetPool(mockPool) injection pattern from settings.test.ts so setSetting
+// writes a real platform DB override into the settings cache.
+// ---------------------------------------------------------------------------
+
+describe("querySalesforce — ATLAS_ROW_LIMIT lazy resolution (#3400)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  const origRowLimit = process.env.ATLAS_ROW_LIMIT;
+
+  const mockPool: InternalPool = {
+    query: async () => ({ rows: [] }),
+    async connect() {
+      return { query: async () => ({ rows: [] }), release() {} };
+    },
+    end: async () => {},
+    on: () => {},
+  };
+
+  beforeEach(() => {
+    delete process.env.ATLAS_ROW_LIMIT;
+    _resetSettingsCache();
+  });
+
+  afterEach(() => {
+    if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    if (origRowLimit !== undefined) process.env.ATLAS_ROW_LIMIT = origRowLimit;
+    else delete process.env.ATLAS_ROW_LIMIT;
+    _resetPool(null);
+    _resetSettingsCache();
+  });
+
+  function enableInternalDB() {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+  }
+
+  it("honors a platform DB override written AFTER module import", async () => {
+    enableInternalDB();
+    // The tool module was imported long before this write — a frozen
+    // module-level const would still append the env/default limit.
+    await setSetting("ATLAS_ROW_LIMIT", "5", "admin-test");
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "db override honored",
+    });
+
+    expect(result.status).toBe("ok");
+    const calledSoql = instance.query.mock.calls[0]?.[0] as string;
+    expect(calledSoql).toMatch(/LIMIT 5$/);
+  });
+
+  it("computes `truncated` against the DB override, not an import-time value", async () => {
+    enableInternalDB();
+    await setSetting("ATLAS_ROW_LIMIT", "1", "admin-test");
+
+    const instance = makeFakeInstance(); // default fake returns exactly 1 row
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string; truncated: boolean }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "truncated vs override",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.truncated).toBe(true); // 1 row >= overridden limit 1
+  });
+
+  it("falls back to the env var when no DB override exists", async () => {
+    process.env.ATLAS_ROW_LIMIT = "7";
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "env fallback",
+    });
+
+    expect(result.status).toBe("ok");
+    const calledSoql = instance.query.mock.calls[0]?.[0] as string;
+    expect(calledSoql).toMatch(/LIMIT 7$/);
+  });
+
+  it("defaults to 1000 when neither DB override nor env var is set", async () => {
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "registry default",
+    });
+
+    expect(result.status).toBe("ok");
+    const calledSoql = instance.query.mock.calls[0]?.[0] as string;
+    expect(calledSoql).toMatch(/LIMIT 1000$/);
+  });
+
+  it("uses the 1000 default for an invalid (non-numeric) value", async () => {
+    process.env.ATLAS_ROW_LIMIT = "not-a-number";
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "invalid value falls back",
+    });
+
+    expect(result.status).toBe("ok");
+    const calledSoql = instance.query.mock.calls[0]?.[0] as string;
+    expect(calledSoql).toMatch(/LIMIT 1000$/);
   });
 });
 

--- a/packages/api/src/lib/integrations/salesforce-tool.ts
+++ b/packages/api/src/lib/integrations/salesforce-tool.ts
@@ -26,7 +26,8 @@
  *      validator (./salesforce/soql-validation.ts) — core can't import the
  *      `@useatlas/salesforce` plugin package (the create-atlas scaffold excludes
  *      workspace plugins), so the identical semantics are duplicated, not shared.
- *   3. **Auto LIMIT** — `appendSOQLLimit` (`ATLAS_ROW_LIMIT`, default 1000).
+ *   3. **Auto LIMIT** — `appendSOQLLimit` (`ATLAS_ROW_LIMIT` resolved lazily per
+ *      call via `getSetting`, matching the SQL tool; default 1000, #3400).
  *
  * Status discriminants surfaced to the agent (so it can self-correct or stop):
  *   - **`ok`** — happy path; carries columns + rows.
@@ -51,6 +52,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { getSetting } from "@atlas/api/lib/settings";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   classifyLazyInstantiateError,
@@ -70,8 +72,30 @@ function parsePositiveIntEnv(raw: string | undefined, fallback: number): number 
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-const ROW_LIMIT = parsePositiveIntEnv(process.env.ATLAS_ROW_LIMIT, 1000);
 const QUERY_TIMEOUT = parsePositiveIntEnv(process.env.ATLAS_QUERY_TIMEOUT, 30000);
+
+let lastWarnedRowLimit: string | undefined;
+
+/**
+ * Read row limit from settings cache (DB override > env var > default).
+ * Resolved per call — not frozen at module import — so platform DB overrides
+ * of `ATLAS_ROW_LIMIT` written via the admin UI take effect without a restart.
+ * Copies `getRowLimit()` in `tools/sql.ts` exactly (including the no-orgId
+ * `getSetting` resolution and warn-once invalid-value handling) so SQL and
+ * SOQL auto-LIMIT share one vocabulary of truth (parity Rule 3, #3400).
+ */
+function getRowLimit(): number {
+  const raw = getSetting("ATLAS_ROW_LIMIT") ?? "1000";
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    if (raw !== lastWarnedRowLimit) {
+      log.warn({ value: raw }, "Invalid ATLAS_ROW_LIMIT value; using default 1000");
+      lastWarnedRowLimit = raw;
+    }
+    return 1000;
+  }
+  return n;
+}
 
 /**
  * Semantic-layer connection id the Salesforce object whitelist keys on. Matches
@@ -222,8 +246,9 @@ export function createQuerySalesforceTool(deps: QuerySalesforceToolDeps = {}) {
         };
       }
 
-      // ── 3. Auto-append LIMIT ──
-      const querySoql = appendSOQLLimit(soql.trim(), ROW_LIMIT);
+      // ── 3. Auto-append LIMIT (row limit resolved lazily per call, #3400) ──
+      const rowLimit = getRowLimit();
+      const querySoql = appendSOQLLimit(soql.trim(), rowLimit);
 
       // ── 4. Instantiate the per-Workspace OAuth Salesforce instance ──
       let instance: SalesforcePluginInstance;
@@ -300,7 +325,7 @@ export function createQuerySalesforceTool(deps: QuerySalesforceToolDeps = {}) {
       try {
         const result = await instance.query(querySoql, QUERY_TIMEOUT);
         const durationMs = Math.round(performance.now() - start);
-        const truncated = result.rows.length >= ROW_LIMIT;
+        const truncated = result.rows.length >= rowLimit;
         log.debug(
           { workspaceId, durationMs, rowCount: result.rows.length },
           "querySalesforce executed",

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -55,6 +55,10 @@
 #     together in practice; if you hit this, keep the key on the call line.
 #   - R2 resolves const names textually across the whole evidence set, not
 #     via the module graph.
+#   - per-key reader PRESENCE only: one compliant reader satisfies a key, so
+#     a second non-compliant reader of an already-compliant key (e.g. an
+#     env-frozen module-level read alongside a getSetting reader, #3400) is
+#     invisible to this check.
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

`salesforce-tool.ts` read `ATLAS_ROW_LIMIT` from env once at module import (`const ROW_LIMIT = parsePositiveIntEnv(...)`), so workspace/platform DB overrides written via the admin UI applied to SQL auto-LIMIT but silently **not** to the Salesforce SOQL auto-LIMIT — two readers, two vocabularies of truth for one setting (parity contract Rule 3). This PR resolves the limit lazily per call via `getSetting("ATLAS_ROW_LIMIT")`, copying `getRowLimit()` from `tools/sql.ts` exactly (same no-orgId resolution, same warn-once invalid-value handling, same 1000 default). The `truncated` flag now compares against the per-call limit.

Also adds the per-key-presence limitation note to `scripts/check-settings-readers.sh`'s header (per #3400 / #3382): one compliant reader satisfies a key, so a second non-compliant reader of an already-compliant key is invisible to the check — which is exactly how this bug escaped it.

## Why

Issue #3400 (filed during the #3392 review, part of the #3374 parity-audit follow-ups). A platform admin raising/lowering `ATLAS_ROW_LIMIT` via Admin → Settings saw the change take effect for SQL queries but not SOQL — same drift class #3392 fixed (registry key with a raw env reader), invisible to CI because the key has another compliant reader.

## Deviations

None. `QUERY_TIMEOUT` on the adjacent line has the same frozen-at-import shape and is deliberately **not** fixed here (scope discipline) — `ATLAS_QUERY_TIMEOUT` is a registry key with the same two-reader split; follow-up issue being filed.

## Tests

- New describe block in `salesforce-tool.test.ts` (5 tests): DB override written **after** module import honored (`LIMIT 5`); `truncated` computed against the override; env fallback (`LIMIT 7`); default 1000; invalid value → warn + 1000. Uses the `_resetPool`/`_resetSettingsCache` injection pattern from `settings.test.ts`.
- `bun test salesforce-tool.test.ts`: 21 pass / 0 fail. `test-isolated.ts --affected`: 1/1 files pass. `bun run lint` + `bun run type`: exit 0. `check-settings-readers.sh`: pass (39 keys). OpenAPI artifacts: no diff.

## Review summary

Three parallel review angles (resolution semantics, call-site/blast-radius coverage, test validity) — **zero findings**: registry default `"1000"` confirmed; resolution matches `sql.ts` (platform override > env > default, no orgId threading — same as the SQL tool); no import cycle (`settings.ts` has no reverse dep on integrations); no other frozen `ATLAS_ROW_LIMIT` reader in the tree; tests verified to fail on the old frozen-const code.

Closes #3400. Ref #3374 (parity-audit umbrella, drift classes 1/3).

https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783771240&installation_id=135337507&pr_number=3401&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3401&signature=734e80f938ce8f343ddb9f5c79d429fc8c408dff9979961f3f83acc9c1844594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Salesforce queries now support dynamic row-limit configuration via settings, allowing per-call override instead of module-level fixed values. Fallback precedence includes environment variables and default limits.

* **Tests**
  * Added comprehensive test coverage for lazy resolution of row limits per query call and override behaviors.

* **Documentation**
  * Updated script documentation for clarity on settings reader compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->