### PR TITLE
fix(api): scope SaaS requiresRestart suppression to hot-reloaded keys (#3399)

### DIFF
--- a/docs/development/enterprise-gating.md
+++ b/docs/development/enterprise-gating.md
@@ -66,6 +66,8 @@ Before shipping any admin mutation (settings PUT, connect/install endpoint, conf
 
 The same test applies in reverse when *removing* a reader: if runtime code stops consuming a stored value, the admin surface that writes it must go (or be re-scoped) in the same PR.
 
+The `requiresRestart` hint follows the same consumption-model discipline (#3399): on SaaS, `getSettingsForAdmin` suppresses the hint **only** for keys `applySettingSideEffect` actually hot-reloads (the `HOT_RELOADED_KEYS` set in `lib/settings.ts`, derived from the side-effect dispatch map — adding a handler updates both automatically). Boot-consumed restart-flagged keys (e.g. the expert scheduler pair, #3392) keep the hint in **both** modes, because no cache refresh can apply a value the process read once at startup — the old blanket SaaS suppression was the same silent-staleness class as a write with no reader. The web settings pages render the flag exactly as the API returns it, with no second client-side mode branch.
+
 ### Rule 2 — where deploy-mode branches may live
 
 Mode branch points are expensive (each one is half of a potential drift pair), so they're restricted to the blessed sources of truth and their direct consumers:

--- a/packages/api/src/lib/__tests__/settings-saas.test.ts
+++ b/packages/api/src/lib/__tests__/settings-saas.test.ts
@@ -2,7 +2,9 @@
  * Settings tests that require SaaS mode (mock.module for config).
  *
  * Covers:
- * - requiresRestart is suppressed in SaaS mode (#1089)
+ * - requiresRestart suppression in SaaS mode is scoped to keys
+ *   applySettingSideEffect hot-reloads; boot-consumed flagged keys keep
+ *   the hint (#1089, #3399)
  * - applySettingSideEffect calls setLogLevel in SaaS mode (#1089)
  */
 
@@ -119,22 +121,43 @@ describe("settings (SaaS mode)", () => {
   // -------------------------------------------------------------------------
 
   describe("requiresRestart in SaaS mode", () => {
-    it("restart-required settings have requiresRestart suppressed in SaaS mode", () => {
+    // #3399 — the suppression is scoped to keys applySettingSideEffect
+    // actually hot-reloads (today: ATLAS_LOG_LEVEL only). The old blanket
+    // `!inSaas` suppression hid the hint for boot-consumed keys too,
+    // leaving SaaS platform admins with silent staleness.
+    it("hot-reloaded keys have requiresRestart suppressed in SaaS mode", () => {
       const settings = getSettingsForAdmin(undefined, true);
-
-      // In SaaS mode, normally-restart-required settings are hot-reloadable
-      const provider = settings.find((s) => s.key === "ATLAS_PROVIDER");
-      expect(provider).toBeDefined();
-      // requiresRestart should be undefined (suppressed) in SaaS mode
-      expect(provider!.requiresRestart).toBeFalsy();
-
-      const model = settings.find((s) => s.key === "ATLAS_MODEL");
-      expect(model).toBeDefined();
-      expect(model!.requiresRestart).toBeFalsy();
 
       const logLevel = settings.find((s) => s.key === "ATLAS_LOG_LEVEL");
       expect(logLevel).toBeDefined();
-      expect(logLevel!.requiresRestart).toBeFalsy();
+      // ATLAS_LOG_LEVEL is hot-reloaded by applySettingSideEffect, so the
+      // hint stays suppressed (no false restart warning).
+      expect(logLevel!.requiresRestart).toBeUndefined();
+    });
+
+    it("boot-consumed restart-flagged non-immutable keys KEEP requiresRestart: true in SaaS mode (#3399)", () => {
+      const settings = getSettingsForAdmin(undefined, true);
+
+      // #3392 — the expert scheduler pair is consumed once at boot by the
+      // process-global scheduler fiber; no cache refresh can apply a
+      // change, so the SaaS platform admin must see the restart hint.
+      for (const key of [
+        "ATLAS_EXPERT_SCHEDULER_ENABLED",
+        "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
+      ]) {
+        const setting = settings.find((s) => s.key === key);
+        expect(setting).toBeDefined();
+        expect(setting!.requiresRestart).toBe(true);
+      }
+
+      // Other flagged keys without a side-effect handler keep the hint too.
+      const provider = settings.find((s) => s.key === "ATLAS_PROVIDER");
+      expect(provider).toBeDefined();
+      expect(provider!.requiresRestart).toBe(true);
+
+      const model = settings.find((s) => s.key === "ATLAS_MODEL");
+      expect(model).toBeDefined();
+      expect(model!.requiresRestart).toBe(true);
     });
 
     it("non-restart settings remain unchanged in SaaS mode", () => {

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -16,6 +16,8 @@ import {
   getSettingsForAdmin,
   getSettingsRegistry,
   getSettingDefinition,
+  HOT_RELOADED_KEYS,
+  isHotReloadedKey,
   _resetSettingsCache,
 } from "../settings";
 
@@ -679,6 +681,10 @@ describe("settings module", () => {
         // RateLimitGuardLive at boot. Hot-reloading would re-open
         // the DDoS hole until next restart.
         "ATLAS_RATE_LIMIT_RPM",
+        // #3392/#3399 — the expert scheduler is a single process-global
+        // fiber forked once at boot; both keys are consumed only there,
+        // so they need a restart in BOTH deploy modes.
+        "ATLAS_EXPERT_SCHEDULER_ENABLED", "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
       ];
       for (const key of restartRequired) {
         const def = registry.find((s) => s.key === key);
@@ -891,6 +897,55 @@ describe("settings module", () => {
       expect(provider).toBeDefined();
       // In self-hosted (default), requiresRestart should be true
       expect(provider!.requiresRestart).toBe(true);
+    });
+
+    // #3399 — self-hosted shows the hint for EVERY flagged key, including
+    // keys that would be hot-reloaded on SaaS (applySettingSideEffect is
+    // SaaS-gated, so ATLAS_LOG_LEVEL still needs a restart here) and the
+    // boot-consumed scheduler pair (#3392).
+    it("self-hosted keeps requiresRestart: true for hot-reloaded and boot-consumed flagged keys alike", () => {
+      const settings = getSettingsForAdmin(undefined, true);
+      for (const key of [
+        "ATLAS_LOG_LEVEL",
+        "ATLAS_EXPERT_SCHEDULER_ENABLED",
+        "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
+      ]) {
+        const setting = settings.find((s) => s.key === key);
+        expect(setting).toBeDefined();
+        expect(setting!.requiresRestart).toBe(true);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HOT_RELOADED_KEYS — single source of truth for the SaaS suppression (#3399)
+  // ---------------------------------------------------------------------------
+
+  describe("HOT_RELOADED_KEYS (#3399)", () => {
+    it("contains exactly the keys applySettingSideEffect dispatches on", () => {
+      // Pin the set's contents: it is derived from SETTING_SIDE_EFFECTS in
+      // settings.ts, so this only changes when a side-effect handler is
+      // added/removed — which is exactly when the SaaS requiresRestart
+      // suppression should widen/narrow with it.
+      expect([...HOT_RELOADED_KEYS].toSorted()).toEqual(["ATLAS_LOG_LEVEL"]);
+    });
+
+    it("isHotReloadedKey matches the set", () => {
+      expect(isHotReloadedKey("ATLAS_LOG_LEVEL")).toBe(true);
+      expect(isHotReloadedKey("ATLAS_EXPERT_SCHEDULER_ENABLED")).toBe(false);
+      expect(isHotReloadedKey("ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS")).toBe(false);
+      expect(isHotReloadedKey("NONEXISTENT_KEY")).toBe(false);
+    });
+
+    it("every hot-reloaded key is restart-flagged in the registry (suppression has a target)", () => {
+      // A side-effect handler on a non-flagged key would be dead suppression
+      // logic — the registry never sets the hint for it in the first place.
+      const registry = getSettingsRegistry();
+      for (const key of HOT_RELOADED_KEYS) {
+        const def = registry.find((s) => s.key === key);
+        expect(def).toBeDefined();
+        expect(def!.requiresRestart).toBe(true);
+      }
     });
   });
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -15,6 +15,10 @@
  * restart are hot-reloadable: a short-TTL live cache re-reads from the DB so
  * changes take effect within seconds without restarting the server.
  * Self-hosted mode preserves the original restart-required behavior.
+ * Boot-consumed keys are the exception (#3399): a value read once at process
+ * start (e.g. the expert scheduler pair) cannot be hot-reloaded by any cache,
+ * so its `requiresRestart` hint is kept in BOTH modes — only keys
+ * `applySettingSideEffect` actually hot-reloads suppress the hint on SaaS.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -501,9 +505,11 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     // a hot-reload of this key via setSetting would silently bypass the
     // guard. Self-hosted admins see the "restart required" banner;
     // SaaS writes are additionally blocked by `SAAS_IMMUTABLE_KEYS`
-    // below because the SaaS-mode requiresRestart suppression at the
-    // metadata layer would otherwise leave SaaS admins thinking the
-    // change took effect.
+    // below — a restart hint alone would still let a SaaS admin persist
+    // a value the boot-time contract guard never re-evaluates. (Since
+    // #3399 the SaaS metadata suppression no longer applies to
+    // boot-consumed keys like this one, but the write block remains the
+    // real guard.)
     requiresRestart: true,
     scope: "platform",
     saasVisible: false,
@@ -700,7 +706,7 @@ function resolveDeployModeSnapshot(): DeployModeSnapshot {
 /**
  * UX-oriented SaaS check — fail open (treat unloaded/errored as
  * non-SaaS) so the `requiresRestart` metadata suppression and
- * `SIDE_EFFECT_KEYS` gating don't render spurious banners during
+ * `SETTING_SIDE_EFFECTS` gating don't render spurious banners during
  * early module init. Used by `getSettingsForAdmin` and
  * `applySettingSideEffect`.
  */
@@ -1068,11 +1074,18 @@ export function getSettingsForAdmin(orgId?: string, isPlatformAdmin?: boolean): 
         }
       }
 
-      // In SaaS mode, hot-reloadable settings don't require restart
+      // #3399 — the SaaS suppression of the requiresRestart hint is
+      // scoped to the keys `applySettingSideEffect` actually hot-reloads
+      // (derived as HOT_RELOADED_KEYS below). Boot-consumed flagged keys
+      // (e.g. the expert scheduler pair, #3392) genuinely need a restart
+      // on SaaS too — the previous blanket `!inSaas` suppression left a
+      // SaaS platform admin editing them with no staleness hint.
+      // Self-hosted always shows the hint for flagged keys.
       const inSaas = isSaasMode();
-      const requiresRestart = (def.requiresRestart && !inSaas)
-        ? true
-        : undefined;
+      const requiresRestart =
+        def.requiresRestart && !(inSaas && isHotReloadedKey(def.key))
+          ? true
+          : undefined;
 
       // #1978 — surface SaaS immutability so the admin UI can disable
       // the input rather than letting the operator submit and get a 409.
@@ -1114,8 +1127,45 @@ export async function refreshSettingsTick(): Promise<void> {
 // Runtime side effects — applied when hot-reloadable settings change
 // ---------------------------------------------------------------------------
 
-/** Settings that produce immediate runtime side effects when changed. */
-const SIDE_EFFECT_KEYS = new Set(["ATLAS_LOG_LEVEL"]);
+/**
+ * Settings that produce immediate runtime side effects when changed —
+ * the single source of truth for "hot-reloaded in SaaS mode" (#3399).
+ *
+ * `applySettingSideEffect` dispatches on this map, and `HOT_RELOADED_KEYS`
+ * (which scopes the SaaS `requiresRestart` suppression in
+ * `getSettingsForAdmin`) is derived from the same map's keys. Adding a
+ * side-effect handler therefore automatically suppresses the restart hint
+ * for that key on SaaS — there is no second list to forget.
+ */
+const SETTING_SIDE_EFFECTS: Readonly<Record<string, (value: string) => void>> = {
+  ATLAS_LOG_LEVEL: (value) => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency
+      const { setLogLevel } = require("@atlas/api/lib/logger") as { setLogLevel: (level: string) => boolean };
+      if (setLogLevel(value)) {
+        log.info({ level: value }, "Log level updated via hot-reload");
+      } else {
+        log.warn({ level: value }, "Log level change rejected — invalid level");
+      }
+    } catch (err) {
+      log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to apply log level change");
+    }
+  },
+};
+
+/**
+ * Keys `applySettingSideEffect` hot-reloads at runtime in SaaS mode —
+ * derived from `SETTING_SIDE_EFFECTS`, never maintained by hand. These
+ * are the ONLY restart-flagged keys whose `requiresRestart` hint is
+ * suppressed on SaaS; every other flagged key keeps the hint in both
+ * deploy modes because its value is consumed at boot (#3399).
+ */
+export const HOT_RELOADED_KEYS: ReadonlySet<string> = new Set(Object.keys(SETTING_SIDE_EFFECTS));
+
+/** True when `applySettingSideEffect` hot-reloads `key` in SaaS mode. */
+export function isHotReloadedKey(key: string): boolean {
+  return HOT_RELOADED_KEYS.has(key);
+}
 
 /**
  * Settings that boot-time guards depend on (`DpaGuardLive`,
@@ -1152,19 +1202,6 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  * Only runs in SaaS mode for hot-reloadable settings.
  */
 function applySettingSideEffect(key: string, value: string): void {
-  if (!isSaasMode() || !SIDE_EFFECT_KEYS.has(key)) return;
-
-  if (key === "ATLAS_LOG_LEVEL") {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency
-      const { setLogLevel } = require("@atlas/api/lib/logger") as { setLogLevel: (level: string) => boolean };
-      if (setLogLevel(value)) {
-        log.info({ level: value }, "Log level updated via hot-reload");
-      } else {
-        log.warn({ level: value }, "Log level change rejected — invalid level");
-      }
-    } catch (err) {
-      log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to apply log level change");
-    }
-  }
+  if (!isSaasMode()) return;
+  SETTING_SIDE_EFFECTS[key]?.(value);
 }

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -294,7 +294,11 @@ function SettingRow({
   const Icon = sectionIcon(setting.section);
   const isOverride =
     setting.source === "override" || setting.source === "workspace-override";
-  const showRestart = !isSaas && setting.requiresRestart && isOverride;
+  // #3399 — render whatever the API returns: getSettingsForAdmin already
+  // suppresses requiresRestart on SaaS for hot-reloaded keys and keeps it
+  // for boot-consumed keys that genuinely need a restart in both modes.
+  // A second client-side mode branch here would re-hide the hint.
+  const showRestart = setting.requiresRestart && isOverride;
   // Render "not set" and "" distinctly so an admin clearing an override to the
   // empty string can tell it apart from "never configured."
   const valueDisplay =

--- a/packages/web/src/app/platform/settings/page.tsx
+++ b/packages/web/src/app/platform/settings/page.tsx
@@ -242,7 +242,12 @@ function SettingRow({
           <span className="text-sm font-medium">{setting.label}</span>
           <SourceBadge source={setting.source} />
           {setting.secret && <Lock className="size-3 text-muted-foreground" />}
-          {!isSaas && setting.requiresRestart ? (
+          {/* #3399 — render whatever the API returns: getSettingsForAdmin
+              already suppresses requiresRestart on SaaS for hot-reloaded
+              keys and keeps it for boot-consumed keys that genuinely need
+              a restart in both modes. A client-side !isSaas branch here
+              would re-hide the hint (and falsely mark those keys "Live"). */}
+          {setting.requiresRestart ? (
             <Badge variant="outline" className="gap-1 text-[10px] text-amber-600 border-amber-500/30 dark:text-amber-400">
               <RefreshCw className="size-2.5" />
               Requires restart


### PR DESCRIPTION
## What

`getSettingsForAdmin` blanket-suppressed the `requiresRestart` metadata on SaaS (`def.requiresRestart && !inSaas`). Correct for hot-reloadable keys, but boot-consumed restart-flagged non-immutable platform keys (e.g. `ATLAS_EXPERT_SCHEDULER_ENABLED` / `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS`, boot-consumed since #3392) genuinely need a restart on SaaS too — a SaaS platform admin editing them got no staleness hint.

Mechanism (per the issue's option B): the suppression is scoped to the keys `applySettingSideEffect` actually hot-reloads. The old `SIDE_EFFECT_KEYS` set + if-chain becomes a `SETTING_SIDE_EFFECTS` dispatch map — the single source of truth — and `HOT_RELOADED_KEYS` / `isHotReloadedKey()` are derived from its keys, so adding a side-effect handler automatically widens the suppression with no second list to forget. New expression: `def.requiresRestart && !(inSaas && isHotReloadedKey(def.key))`. The `applySettingSideEffect` refactor is behavior-identical (same SaaS gate, same handler body; keys are validated against `SETTINGS_MAP` before dispatch, so no unregistered key reaches the map).

Effect across all 13 restart-flagged registry keys on SaaS: 12 boot-consumed keys regain the hint (incl. the scheduler pair — the bug — and the three `SAAS_IMMUTABLE` keys, where the write block remains the real guard); `ATLAS_LOG_LEVEL` (the only side-effect key) keeps the suppression. Self-hosted output is unchanged for every key.

Also: the two web settings pages (`admin/settings`, `platform/settings`) each had their own client-side `!isSaas` badge gate that would have re-hidden the hint (and the platform page falsely labeled suppressed keys "Live") — removed so they render exactly what the API returns (fewer mode branch points, parity Rule 2). Semantics recorded under parity Rule 1 in `enterprise-gating.md`.

## Why

Issue #3399 (filed during #3392, part of the #3374 parity-audit follow-ups) — the UI hint must match the runtime consumption model; the #1978 silent-staleness class for ordinary boot keys.

## Deviations

- The web pages needed the gate removal (the brief expected render-as-returned to already hold) — without it the API fix was invisible, breaking the PR's own stated contract; the issue's Key files named these pages.
- SaaS-mode assertions live in `settings-saas.test.ts` (the established mock.module home — `settings.test.ts` deliberately avoids module mocks), self-hosted + addendum + set/predicate pins in `settings.test.ts`.
- Conservative over-warning accepted for keys read per-request via `getSettingAuto` (`ATLAS_PROVIDER`, `ATLAS_MODEL`, RLS trio, etc.): they keep the hint since they have no side-effect handler; noted as a possible follow-up if false warnings matter.

## Tests

- `settings.test.ts`: 66 pass / 0 fail (198 expects) — includes the **#3399 addendum** (scheduler pair pinned `requiresRestart: true` in the registry assertions), self-hosted parity, `HOT_RELOADED_KEYS` exact-contents pin (`["ATLAS_LOG_LEVEL"]`), predicate unit test, and an "every hot-reloaded key is restart-flagged" invariant against the real registry.
- `settings-saas.test.ts`: 16 pass / 0 fail — hot-reloaded key suppressed on SaaS; scheduler pair + `ATLAS_PROVIDER`/`ATLAS_MODEL` keep `requiresRestart: true` on SaaS (verified to fail on main's blanket suppression).
- `test-isolated.ts --affected`: 50/50 files pass (re-run post-rebase onto `5bc498d2`). Lint/type exit 0; `check-settings-readers.sh` pass (39 keys); OpenAPI artifacts: no drift.

## Review summary

Three parallel review angles, all clean: **semantics** (refactor behavior-identical via truth table; four-quadrant suppression expression verified; fail-open `isSaasMode()` for GET unchanged; no prototype-lookup path — keys validated before dispatch), **exports/tests** (no mock blast radius: zero of the 129 `createApiTestMocks` consumers import the new names; new assertions fail on main), **UI consumers** (only two render sites exist, both fixed; wire field already optional — no `@useatlas/types` change; self-hosted `ATLAS_LOG_LEVEL` correctly keeps the badge since side effects are SaaS-gated).

Closes #3399. Ref #3374 (parity-audit umbrella, Rule 1 adjacent).

https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783773117&installation_id=135337507&pr_number=3404&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3404&signature=623d2da175e21fea35d6c9a5899ce4759e51f4bc57752114ba2b58bbc3a22ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated enterprise settings documentation to clarify when restart-required hints are displayed for different setting types.

* **Bug Fixes**
  * Improved accuracy of "restart required" hints in SaaS mode; settings that truly require server restart now correctly display the hint, with hot-reloadable settings properly distinguished from boot-time-only settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->