### PR TITLE
fix(integrations): resolve ATLAS_QUERY_TIMEOUT lazily per call in salesforce-tool (#3402)

### DIFF
--- a/packages/api/src/lib/integrations/__tests__/salesforce-tool.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/salesforce-tool.test.ts
@@ -470,6 +470,106 @@ describe("querySalesforce — ATLAS_ROW_LIMIT lazy resolution (#3400)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ATLAS_QUERY_TIMEOUT lazy resolution (#3402)
+//
+// The SOQL query timeout must resolve ATLAS_QUERY_TIMEOUT per call via
+// getSetting (DB override > env var > default 30000) — matching
+// getQueryTimeout() in tools/sql.ts — not freeze it from env at module
+// import. Same injection pattern as the #3400 block above; asserts the
+// timeout argument passed to the plugin instance's query().
+// ---------------------------------------------------------------------------
+
+describe("querySalesforce — ATLAS_QUERY_TIMEOUT lazy resolution (#3402)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  const origQueryTimeout = process.env.ATLAS_QUERY_TIMEOUT;
+
+  const mockPool: InternalPool = {
+    query: async () => ({ rows: [] }),
+    async connect() {
+      return { query: async () => ({ rows: [] }), release() {} };
+    },
+    end: async () => {},
+    on: () => {},
+  };
+
+  beforeEach(() => {
+    delete process.env.ATLAS_QUERY_TIMEOUT;
+    _resetSettingsCache();
+  });
+
+  afterEach(() => {
+    if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    if (origQueryTimeout !== undefined) process.env.ATLAS_QUERY_TIMEOUT = origQueryTimeout;
+    else delete process.env.ATLAS_QUERY_TIMEOUT;
+    _resetPool(null);
+    _resetSettingsCache();
+  });
+
+  function enableInternalDB() {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+  }
+
+  it("honors a platform DB override written AFTER module import", async () => {
+    enableInternalDB();
+    // The tool module was imported long before this write — a frozen
+    // module-level const would still pass the env/default timeout.
+    await setSetting("ATLAS_QUERY_TIMEOUT", "5000", "admin-test");
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "db override honored",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(instance.query.mock.calls[0]?.[1]).toBe(5000);
+  });
+
+  it("falls back to the env var when no DB override exists", async () => {
+    process.env.ATLAS_QUERY_TIMEOUT = "7000";
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "env fallback",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(instance.query.mock.calls[0]?.[1]).toBe(7000);
+  });
+
+  it("defaults to 30000 when neither DB override nor env var is set", async () => {
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "registry default",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(instance.query.mock.calls[0]?.[1]).toBe(30000);
+  });
+
+  it("uses the 30000 default for an invalid (non-numeric) value", async () => {
+    process.env.ATLAS_QUERY_TIMEOUT = "not-a-number";
+
+    const instance = makeFakeInstance();
+    const tool = createQuerySalesforceTool(makeDeps(instance));
+    const result = await runTool<{ status: string }>(tool, {
+      soql: "SELECT Id FROM Account",
+      explanation: "invalid value falls back",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(instance.query.mock.calls[0]?.[1]).toBe(30000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Input validation
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/integrations/salesforce-tool.ts
+++ b/packages/api/src/lib/integrations/salesforce-tool.ts
@@ -66,14 +66,6 @@ import { validateSOQL, appendSOQLLimit, SENSITIVE_PATTERNS } from "./salesforce/
 
 const log = createLogger("integrations.salesforce.tool");
 
-/** Parse a positive-integer env var, falling back when missing/non-numeric/≤0. */
-function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
-  const parsed = Number.parseInt(raw ?? "", 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-const QUERY_TIMEOUT = parsePositiveIntEnv(process.env.ATLAS_QUERY_TIMEOUT, 30000);
-
 let lastWarnedRowLimit: string | undefined;
 
 /**
@@ -93,6 +85,30 @@ function getRowLimit(): number {
       lastWarnedRowLimit = raw;
     }
     return 1000;
+  }
+  return n;
+}
+
+let lastWarnedQueryTimeout: string | undefined;
+
+/**
+ * Read query timeout from settings cache (DB override > env var > default).
+ * Resolved per call — not frozen at module import — so platform DB overrides
+ * of `ATLAS_QUERY_TIMEOUT` written via the admin UI take effect without a
+ * restart. Copies `getQueryTimeout()` in `tools/sql.ts` exactly (including
+ * the no-orgId `getSetting` resolution and warn-once invalid-value handling)
+ * so SQL and SOQL query timeouts share one vocabulary of truth (parity
+ * Rule 3, #3402 — the `ATLAS_QUERY_TIMEOUT` sibling of #3400).
+ */
+function getQueryTimeout(): number {
+  const raw = getSetting("ATLAS_QUERY_TIMEOUT") ?? "30000";
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    if (raw !== lastWarnedQueryTimeout) {
+      log.warn({ value: raw }, "Invalid ATLAS_QUERY_TIMEOUT value; using default 30000ms");
+      lastWarnedQueryTimeout = raw;
+    }
+    return 30000;
   }
   return n;
 }
@@ -323,7 +339,8 @@ export function createQuerySalesforceTool(deps: QuerySalesforceToolDeps = {}) {
       // ── 5. Execute the query ──
       const start = performance.now();
       try {
-        const result = await instance.query(querySoql, QUERY_TIMEOUT);
+        // Query timeout resolved lazily per call (#3402), like the row limit.
+        const result = await instance.query(querySoql, getQueryTimeout());
         const durationMs = Math.round(performance.now() - start);
         const truncated = result.rows.length >= rowLimit;
         log.debug(


### PR DESCRIPTION
## What

`salesforce-tool.ts` read `ATLAS_QUERY_TIMEOUT` from env once at module import (`const QUERY_TIMEOUT = parsePositiveIntEnv(...)`) — the exact sibling of #3400, one line down. A platform DB override of `ATLAS_QUERY_TIMEOUT` applied to SQL statement timeouts (via `getQueryTimeout()` in `tools/sql.ts`) but silently not to the Salesforce SOQL query timeout (parity contract Rule 3). This PR resolves it lazily per call via `getSetting("ATLAS_QUERY_TIMEOUT")`, copying `getQueryTimeout()` from `tools/sql.ts` exactly (same no-orgId resolution, warn-once invalid-value handling, 30000 default — registry default verified as `"30000"`), sitting next to the `getRowLimit()` that #3400 (`fa2c6fe8`) established in this file. The now-unused `parsePositiveIntEnv` helper is deleted.

## Why

Issue #3402, filed during the #3400 implementation (deliberately not folded into that PR — its stated contract was `ATLAS_ROW_LIMIT` only). Same invisibility to `check-settings-readers.sh` (the key has another compliant reader; the script header documents this limitation since #3401).

## Tests

- 4 new tests extending the #3400 block pattern in `salesforce-tool.test.ts`, asserting the timeout argument passed to the plugin instance's `query()`: DB override written **after** module import honored (5000); env fallback (7000); default 30000; invalid value → warn + 30000. File total: 25 pass / 0 fail (77 expects).
- `test-isolated.ts --affected`: 1/1 files pass. `bun run lint` + `bun run type`: exit 0. `check-settings-readers.sh`: pass (39 keys). OpenAPI artifacts: no drift.

Closes #3402. Ref #3374 (parity-audit umbrella) and #3400 (PR #3401, the pattern this copies).

https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZCcMMEqs3D3L3odA6uZCK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774377&installation_id=135337507&pr_number=3405&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3405&signature=5562110decdf23913e7f0e2aab24c9512280d38a7eb6df956661fd24e7558f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Salesforce query timeout configuration now supports dynamic, per-call settings resolution. Database admins can override timeouts without restarting the application.

* **Tests**
  * Added test coverage for query timeout lazy resolution pattern, verifying environment variables, database overrides, and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->