### PR TITLE
fix(sandbox): consume BYOC provider credentials at runtime in the explore tool (#3370)

### DIFF
--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -43,8 +43,16 @@ Firecracker microVM with network isolation. Bring your own Vercel account.
 **Credentials:**
 - **Access Token** — Vercel API access token
 - **Team ID** — Vercel team identifier (e.g. `team_...`)
+- **Project ID** — Vercel project to bill sandbox usage against (e.g. `prj_...`)
 
-Credentials are validated against the Vercel API before saving. The team name is displayed after connection.
+Credentials are validated against the Vercel API before saving (team and
+project access). The team name is displayed after connection.
+
+<Callout type="info">
+Connections made before Project ID was collected show **Reconnect required**
+— the Vercel sandbox SDK needs the full token/team/project triple, so the
+provider can't run until you disconnect and reconnect with all three fields.
+</Callout>
 
 ### E2B
 
@@ -97,6 +105,40 @@ sandboxes per environment (10 Trial/Free, 50 Hobby, 100 Pro/Enterprise).
 
 <Callout type="info">
 Credentials are stored per-workspace in the `sandbox_credentials` table. Each workspace can connect different providers independently.
+</Callout>
+
+### How BYOC Runs at Runtime
+
+A connected provider executes **explore** commands on your own account when
+all of the following hold:
+
+1. The provider is **selected** (its backend ID is the workspace's
+   `ATLAS_SANDBOX_BACKEND` override) — connecting alone does not switch
+   execution.
+2. The stored credentials carry every field the runtime needs (otherwise the
+   card shows **Reconnect required**).
+3. The deployment can run the provider — the provider's plugin package and
+   SDK are installed on the API server (otherwise the card shows
+   **Unavailable**). The managed Vercel runtime is always available; on the
+   Atlas-hosted SaaS, E2B, Daytona, and Railway runtimes are not yet shipped.
+
+When engaged, the sandbox is created with your stored credentials on your
+provider account — never the platform operator's. If your sandbox fails to
+start (revoked token, quota), the explore tool **fails with an error** rather
+than silently falling back to the platform sandbox: you selected isolation on
+your own infrastructure, so Atlas won't quietly run elsewhere. Switch back to
+Atlas Cloud Sandbox or fix the credentials to recover.
+
+When *not* engaged (no selection, incomplete credentials, or missing
+runtime), execution falls back to the platform default and the card reflects
+that instead of showing the provider as live.
+
+Editing or disconnecting credentials tears down any cached sandbox for the
+workspace immediately; the next explore call rebuilds against the new state.
+
+<Callout type="warn">
+The **Python tool** currently always runs on the platform sandbox — BYOC
+selection applies to the explore tool only.
 </Callout>
 
 ---
@@ -171,7 +213,7 @@ You can override this chain with the `ATLAS_SANDBOX_PRIORITY` environment variab
 |----------|-------------|------|
 | Page title | Sandbox | Execution Environment |
 | UI | Backend dropdown + sidecar URL | Provider card grid with connect/disconnect |
-| Providers | Not applicable | Atlas Cloud, Vercel, E2B, Daytona |
+| Providers | Not applicable | Atlas Cloud, Vercel, E2B, Daytona, Railway |
 | Credential storage | Not applicable | Per-workspace in `sandbox_credentials` table |
 | Active selection | Dropdown + Save in admin UI (sets `ATLAS_SANDBOX_BACKEND`) | Click **Select** on a connected provider |
 | Default fallback | Auto-detect priority chain | Atlas Cloud Sandbox (`vercel-sandbox`) |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -46623,6 +46623,9 @@
                           },
                           "isActive": {
                             "type": "boolean"
+                          },
+                          "needsReconnect": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -46632,6 +46635,12 @@
                           "validatedAt",
                           "isActive"
                         ]
+                      }
+                    },
+                    "providerRuntimeAvailability": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "boolean"
                       }
                     }
                   },

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -1002,6 +1002,17 @@ export default defineConfig({
   // Railway api service. No fallback: a Vercel outage will hard-fail the
   // explore tool with a clear error rather than degrading to a less-isolated
   // backend that can't enforce multi-tenant boundaries.
+  //
+  // BYOC (#3370) deliberately supersedes this pin: when a workspace admin has
+  // connected provider credentials on /admin/sandbox AND selected that
+  // backend, explore runs on a sandbox built from the org's own stored
+  // credentials, on the org's own account. That doesn't weaken the pin's
+  // rationale — the pin exists because *shared* backends can't enforce
+  // multi-tenant boundaries, while a BYOC backend executes only that org's
+  // workload in that org's account, and fails closed (no silent fallback to
+  // the operator account) if it can't start. Only the vercel BYOC runtime is
+  // installed in this image today; E2B/Daytona/Railway cards report
+  // "Unavailable" until their plugin packages + SDKs ship here.
   sandbox: {
     priority: ["vercel-sandbox"],
   },

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -1012,7 +1012,10 @@ export default defineConfig({
   // workload in that org's account, and fails closed (no silent fallback to
   // the operator account) if it can't start. Only the vercel BYOC runtime is
   // installed in this image today; E2B/Daytona/Railway cards report
-  // "Unavailable" until their plugin packages + SDKs ship here.
+  // "Unavailable" until their SDKs are installed here (the plugin workspace
+  // packages already ship in the image; their optional-peer SDKs — e2b,
+  // @daytonaio/sdk, railway — don't). `/api/v1/admin/sandbox/status`'s
+  // providerRuntimeAvailability is the live source of truth.
   sandbox: {
     priority: ["vercel-sandbox"],
   },

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -563,6 +563,7 @@ export function createApiTestMocks(
     getActiveSandboxPluginId: () => null,
     explore: { type: "function" },
     invalidateExploreBackend: mock(() => {}),
+    invalidateOrgExploreBackends: mock(() => {}),
     markNsjailFailed: mock(() => {}),
     markSidecarFailed: mock(() => {}),
   }));

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -287,6 +287,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -307,6 +307,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -263,6 +263,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -182,6 +182,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin-sandbox.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox.test.ts
@@ -47,14 +47,39 @@ mock.module("@atlas/api/lib/settings", () => ({
 
 // --- Explore mock — platform default is the SaaS pin ---
 
+const mockInvalidateOrgExploreBackends: Mock<(orgId: string) => void> = mock(() => {});
+
 mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "vercel-sandbox",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
   invalidateExploreBackend: mock(() => {}),
+  invalidateOrgExploreBackends: mockInvalidateOrgExploreBackends,
   markNsjailFailed: mock(() => {}),
   markSidecarFailed: mock(() => {}),
   _formatSandboxPriorityFailureForTest: mock(() => ""),
+}));
+
+// --- BYOC runtime — real pure helpers, deterministic availability ---
+// `missingCredentialFields` / `sandboxProviderForBackendId` are pure and used
+// as-is; runtime availability is environment-dependent (module resolution),
+// so tests pin it. Defaults mirror the SaaS image: only vercel installed.
+
+const realSandboxRuntime = await import("@atlas/api/lib/sandbox/runtime");
+
+let mockRuntimeAvailability: Record<string, boolean> = {
+  vercel: true,
+  e2b: false,
+  daytona: false,
+  railway: false,
+};
+
+mock.module("@atlas/api/lib/sandbox/runtime", () => ({
+  ...realSandboxRuntime,
+  isProviderRuntimeAvailable: async (provider: string) =>
+    mockRuntimeAvailability[provider] ?? false,
+  getProviderRuntimeAvailability: async () => ({ ...mockRuntimeAvailability }),
+  tryCreateByocBackend: mock(async () => null),
 }));
 
 // --- Built-in backend detection ---
@@ -141,7 +166,12 @@ interface StatusResponse {
   activeBackend: string;
   platformDefault: string;
   workspaceOverride: string | null;
-  connectedProviders: Array<{ provider: string; isActive: boolean }>;
+  connectedProviders: Array<{
+    provider: string;
+    isActive: boolean;
+    needsReconnect: boolean;
+  }>;
+  providerRuntimeAvailability: Record<string, boolean>;
 }
 
 async function getStatus(): Promise<StatusResponse> {
@@ -171,8 +201,10 @@ beforeEach(() => {
   mockSettings.clear();
   mockSandboxPlugins = [];
   mockCredentials = [];
+  mockRuntimeAvailability = { vercel: true, e2b: false, daytona: false, railway: false };
   mockDeleteSetting.mockClear();
   mockDeleteCredential.mockClear();
+  mockInvalidateOrgExploreBackends.mockClear();
 });
 
 // --- Tests ---
@@ -249,6 +281,92 @@ describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => 
     expect(status.connectedProviders).toEqual([
       expect.objectContaining({ provider: "vercel", isActive: false }),
     ]);
+  });
+});
+
+describe("GET /api/v1/admin/sandbox/status — BYOC runtime resolution (#3370)", () => {
+  it("a usable BYOC selection resolves active even without a registered plugin", async () => {
+    // Complete creds + runtime installed, but the operator never registered
+    // an e2b plugin — BYOC backends are built on demand from stored
+    // credentials, so the selection must still resolve.
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRuntimeAvailability.e2b = true;
+    mockCredentials = [makeCredential("e2b")];
+
+    const status = await getStatus();
+    expect(status.activeBackend).toBe("e2b-sandbox");
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "e2b", isActive: true, needsReconnect: false }),
+    ]);
+    expectNoContradiction(status);
+  });
+
+  it("a BYOC selection whose runtime is not installed falls back to the platform default", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRuntimeAvailability.e2b = false;
+    mockCredentials = [makeCredential("e2b")];
+
+    const status = await getStatus();
+    expect(status.activeBackend).toBe("vercel-sandbox");
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "e2b", isActive: false }),
+    ]);
+  });
+
+  it("flags a legacy vercel row without projectId as needsReconnect and not active", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    const legacy = makeCredential("vercel");
+    legacy.credentials = { accessToken: "tok", teamId: "team_1" }; // pre-projectId row
+    mockCredentials = [legacy];
+    // vercel-sandbox is also a built-in here (useVercelSandbox → true), so
+    // activeBackend stays vercel-sandbox via the operator path — but the
+    // row itself must say the stored credentials can't run.
+    const status = await getStatus();
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "vercel", needsReconnect: true }),
+    ]);
+  });
+
+  it("a complete vercel triple reports needsReconnect false", async () => {
+    const cred = makeCredential("vercel");
+    cred.credentials = { accessToken: "tok", teamId: "team_1", projectId: "prj_1" };
+    mockCredentials = [cred];
+
+    const status = await getStatus();
+    expect(status.connectedProviders).toEqual([
+      expect.objectContaining({ provider: "vercel", needsReconnect: false }),
+    ]);
+  });
+
+  it("reports per-provider runtime availability", async () => {
+    mockRuntimeAvailability = { vercel: true, e2b: true, daytona: false, railway: false };
+    const status = await getStatus();
+    expect(status.providerRuntimeAvailability).toEqual({
+      vercel: true,
+      e2b: true,
+      daytona: false,
+      railway: false,
+    });
+  });
+});
+
+describe("BYOC credential edits invalidate the org's cached backends (#3370)", () => {
+  it("connect tears down cached backends for the org", async () => {
+    const res = await adminSandbox.request("http://localhost/connect/e2b", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ credentials: { apiKey: "e2b_key" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockInvalidateOrgExploreBackends).toHaveBeenCalledWith("org-1");
+  });
+
+  it("disconnect tears down cached backends for the org", async () => {
+    const res = await adminSandbox.request("http://localhost/disconnect/e2b", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    expect(mockInvalidateOrgExploreBackends).toHaveBeenCalledWith("org-1");
   });
 });
 

--- a/packages/api/src/api/__tests__/admin-sandbox.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox.test.ts
@@ -212,6 +212,7 @@ beforeEach(() => {
 describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => {
   it("legacy provider-key override 'e2b' resolves to the e2b-sandbox backend", async () => {
     mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockRuntimeAvailability.e2b = true;
     mockSandboxPlugins = [{ id: "e2b-sandbox", name: "E2B" }];
     mockCredentials = [makeCredential("e2b")];
 
@@ -226,6 +227,7 @@ describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => 
 
   it("canonical backend-id override 'e2b-sandbox' resolves identically", async () => {
     mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRuntimeAvailability.e2b = true;
     mockSandboxPlugins = [{ id: "e2b-sandbox", name: "E2B" }];
     mockCredentials = [makeCredential("e2b")];
 
@@ -240,6 +242,8 @@ describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => 
 
   it("only the selected provider row is active when several are connected", async () => {
     mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b");
+    mockRuntimeAvailability.e2b = true;
+    mockRuntimeAvailability.daytona = true;
     mockSandboxPlugins = [
       { id: "e2b-sandbox", name: "E2B" },
       { id: "daytona-sandbox", name: "Daytona" },
@@ -319,12 +323,21 @@ describe("GET /api/v1/admin/sandbox/status — BYOC runtime resolution (#3370)",
     legacy.credentials = { accessToken: "tok", teamId: "team_1" }; // pre-projectId row
     mockCredentials = [legacy];
     // vercel-sandbox is also a built-in here (useVercelSandbox → true), so
-    // activeBackend stays vercel-sandbox via the operator path — but the
-    // row itself must say the stored credentials can't run.
+    // activeBackend resolves to vercel-sandbox via the OPERATOR path. The
+    // row must not read "Live" off that coincidence — the org's stored
+    // credentials aren't what's running. Vercel is the one provider whose
+    // BYOC backend id collides with a built-in name, so manual testing on
+    // the other providers won't catch this.
     const status = await getStatus();
+    expect(status.activeBackend).toBe("vercel-sandbox");
     expect(status.connectedProviders).toEqual([
-      expect.objectContaining({ provider: "vercel", needsReconnect: true }),
+      expect.objectContaining({
+        provider: "vercel",
+        needsReconnect: true,
+        isActive: false,
+      }),
     ]);
+    expectNoContradiction(status);
   });
 
   it("a complete vercel triple reports needsReconnect false", async () => {

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -209,6 +209,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -275,6 +275,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -491,6 +491,8 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
 }));
 
 mock.module("@atlas/api/lib/agent", () => ({

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -265,8 +265,9 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
 
       // A connected BYOC provider is *usable* when its stored credentials
       // carry every runtime-required field AND this deployment can construct
-      // its backend. Mirrors the explore runtime's engagement rule (#3370)
-      // so `activeBackend`/`isActive` report what actually runs.
+      // its backend. Manual mirror of the explore runtime's engagement gates
+      // in `tryCreateByocBackend` (#3370) so `activeBackend`/`isActive`
+      // report what actually runs — a gate added there must be added here.
       const usableByocBackendIds = new Set(
         credentials
           .filter(
@@ -306,7 +307,16 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           displayName: cred.displayName,
           connectedAt: cred.connectedAt,
           validatedAt: cred.validatedAt,
-          isActive: workspaceOverride === backendId && activeBackend === backendId,
+          // Requires the usable-BYOC gate on top of the override/activeBackend
+          // match: for vercel, `activeBackend` can resolve to "vercel-sandbox"
+          // via the *operator's* built-in backend even when this row's stored
+          // credentials can't run (needsReconnect) — without the gate the row
+          // would read "Live" while explore actually executes on the
+          // operator's account (#3370 review).
+          isActive:
+            workspaceOverride === backendId &&
+            activeBackend === backendId &&
+            usableByocBackendIds.has(backendId),
           needsReconnect:
             missingCredentialFields(cred.provider, cred.credentials).length > 0,
         };

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -20,6 +20,7 @@ import { getSetting, deleteSetting } from "@atlas/api/lib/settings";
 import {
   getExploreBackendType,
   getActiveSandboxPluginId,
+  invalidateOrgExploreBackends,
 } from "@atlas/api/lib/tools/explore";
 import { useVercelSandbox, useSidecar } from "@atlas/api/lib/tools/backends/detect";
 import {
@@ -29,6 +30,10 @@ import {
   SANDBOX_PROVIDERS,
 } from "@atlas/api/lib/sandbox/credentials";
 import { validateCredentials } from "@atlas/api/lib/sandbox/validate";
+import {
+  getProviderRuntimeAvailability,
+  missingCredentialFields,
+} from "@atlas/api/lib/sandbox/runtime";
 import { ErrorSchema, AuthErrorSchema, createParamSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
@@ -250,16 +255,38 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
       // Platform default (the backend that would be used without any workspace override)
       const platformDefault = getExploreBackendType();
       const activePluginId = getActiveSandboxPluginId();
-      const [allBackends, credentials] = yield* Effect.promise(() =>
-        Promise.all([getAvailableBackends(), getSandboxCredentials(orgId)]),
+      const [allBackends, credentials, runtimeAvailability] = yield* Effect.promise(() =>
+        Promise.all([
+          getAvailableBackends(),
+          getSandboxCredentials(orgId),
+          getProviderRuntimeAvailability(),
+        ]),
+      );
+
+      // A connected BYOC provider is *usable* when its stored credentials
+      // carry every runtime-required field AND this deployment can construct
+      // its backend. Mirrors the explore runtime's engagement rule (#3370)
+      // so `activeBackend`/`isActive` report what actually runs.
+      const usableByocBackendIds = new Set(
+        credentials
+          .filter(
+            (cred) =>
+              missingCredentialFields(cred.provider, cred.credentials).length === 0 &&
+              runtimeAvailability[cred.provider],
+          )
+          .map((cred) => SANDBOX_PROVIDER_BACKEND_IDS[cred.provider]),
       );
 
       // Resolve the effective active backend
       let activeBackend: string;
       if (workspaceOverride) {
-        // Verify the override backend is actually available
+        // The override resolves when it's an available registered backend OR
+        // a usable BYOC provider (BYOC backends are built on demand from
+        // stored credentials and never appear in availableBackends).
         const found = allBackends.find((b) => b.id === workspaceOverride && b.available);
-        activeBackend = found ? workspaceOverride : platformDefault;
+        activeBackend = found || usableByocBackendIds.has(workspaceOverride)
+          ? workspaceOverride
+          : platformDefault;
       } else {
         activeBackend = activePluginId ?? platformDefault;
       }
@@ -280,6 +307,8 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           connectedAt: cred.connectedAt,
           validatedAt: cred.validatedAt,
           isActive: workspaceOverride === backendId && activeBackend === backendId,
+          needsReconnect:
+            missingCredentialFields(cred.provider, cred.credentials).length > 0,
         };
       });
 
@@ -291,6 +320,7 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           workspaceSidecarUrl,
           availableBackends: allBackends,
           connectedProviders,
+          providerRuntimeAvailability: runtimeAvailability,
         },
         200,
       );
@@ -355,6 +385,11 @@ adminSandbox.openapi(connectRoute, async (c) => {
         saveSandboxCredential(orgId, provider, credentials, result.displayName),
       );
 
+      // Tear down this org's cached explore backends so the next explore
+      // call rebuilds with the new credentials (#3370) — mirrors the
+      // ConnectionRegistry's workspace pool drain on credential edits.
+      invalidateOrgExploreBackends(orgId);
+
       log.info({ orgId, provider }, "Sandbox provider connected");
 
       return c.json(
@@ -391,6 +426,10 @@ adminSandbox.openapi(disconnectRoute, async (c) => {
       const deleted = yield* Effect.promise(() =>
         deleteSandboxCredential(orgId, provider),
       );
+
+      // Drop cached backends built from the deleted credentials so explore
+      // can't keep running on them after disconnect (#3370).
+      invalidateOrgExploreBackends(orgId);
 
       // If this was the active sandbox, reset to platform default. The
       // setting stores backend ids (legacy rows may hold provider keys),

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the BYOC sandbox runtime (#3370).
+ *
+ * Everything is exercised through the module's DI seams (`ByocDeps` /
+ * injectable ModuleLoader) — no mock.module, no DB, no network.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import type { SandboxCredential } from "../credentials";
+import {
+  sandboxProviderForBackendId,
+  missingCredentialFields,
+  isProviderRuntimeAvailable,
+  getProviderRuntimeAvailability,
+  tryCreateByocBackend,
+  _resetRuntimeAvailabilityCacheForTest,
+  type ModuleLoader,
+} from "../runtime";
+
+function makeCredential(
+  provider: SandboxCredential["provider"],
+  credentials: Record<string, unknown>,
+): SandboxCredential {
+  return {
+    id: `cred-${provider}`,
+    orgId: "org-1",
+    provider,
+    credentials,
+    displayName: null,
+    validatedAt: null,
+    connectedAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+const SEMANTIC_ROOT = "/tmp/semantic-test";
+
+/** Loader that resolves every module to the given map; rejects others. */
+function fakeLoader(modules: Record<string, unknown>): ModuleLoader {
+  return async (specifier) => {
+    if (specifier in modules) return modules[specifier];
+    throw Object.assign(new Error(`Cannot find module '${specifier}'`), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+  };
+}
+
+/** A plugin module whose factory records the config it was called with. */
+function fakePluginModule(factoryExport: string, execTag: string) {
+  const calls: Record<string, unknown>[] = [];
+  const mod = {
+    [factoryExport]: (config: Record<string, unknown>) => {
+      calls.push(config);
+      return {
+        sandbox: {
+          create: async (_root: string) => ({
+            exec: async () => ({ stdout: execTag, stderr: "", exitCode: 0 }),
+          }),
+        },
+      };
+    },
+  };
+  return { mod, calls };
+}
+
+beforeEach(() => {
+  _resetRuntimeAvailabilityCacheForTest();
+});
+
+describe("sandboxProviderForBackendId", () => {
+  it("inverts the provider → backend-id map", () => {
+    expect(sandboxProviderForBackendId("vercel-sandbox")).toBe("vercel");
+    expect(sandboxProviderForBackendId("e2b-sandbox")).toBe("e2b");
+    expect(sandboxProviderForBackendId("daytona-sandbox")).toBe("daytona");
+    expect(sandboxProviderForBackendId("railway-sandbox")).toBe("railway");
+  });
+
+  it("returns null for built-ins and unknown ids", () => {
+    expect(sandboxProviderForBackendId("sidecar")).toBeNull();
+    expect(sandboxProviderForBackendId("just-bash")).toBeNull();
+    expect(sandboxProviderForBackendId("nsjail")).toBeNull();
+    expect(sandboxProviderForBackendId("custom-plugin")).toBeNull();
+  });
+});
+
+describe("missingCredentialFields", () => {
+  it("vercel requires the full accessToken/teamId/projectId triple", () => {
+    expect(
+      missingCredentialFields("vercel", {
+        accessToken: "tok",
+        teamId: "team_1",
+        projectId: "prj_1",
+      }),
+    ).toEqual([]);
+    // Rows stored before the connect flow collected projectId
+    expect(
+      missingCredentialFields("vercel", { accessToken: "tok", teamId: "team_1" }),
+    ).toEqual(["projectId"]);
+  });
+
+  it("railway requires environmentId (no operator env-var fallback)", () => {
+    expect(
+      missingCredentialFields("railway", { token: "t", environmentId: "env-1" }),
+    ).toEqual([]);
+    expect(missingCredentialFields("railway", { token: "t" })).toEqual([
+      "environmentId",
+    ]);
+  });
+
+  it("rejects empty strings, not just absent fields", () => {
+    expect(missingCredentialFields("e2b", { apiKey: "" })).toEqual(["apiKey"]);
+    expect(missingCredentialFields("e2b", { apiKey: "k" })).toEqual([]);
+  });
+});
+
+describe("isProviderRuntimeAvailable", () => {
+  it("vercel is always available (in-tree backend)", async () => {
+    expect(await isProviderRuntimeAvailable("vercel", fakeLoader({}))).toBe(true);
+  });
+
+  it("e2b requires both the plugin package and the SDK", async () => {
+    expect(await isProviderRuntimeAvailable("e2b", fakeLoader({}))).toBe(false);
+    _resetRuntimeAvailabilityCacheForTest();
+    expect(
+      await isProviderRuntimeAvailable("e2b", fakeLoader({ "@useatlas/e2b": {} })),
+    ).toBe(false);
+    _resetRuntimeAvailabilityCacheForTest();
+    expect(
+      await isProviderRuntimeAvailable(
+        "e2b",
+        fakeLoader({ "@useatlas/e2b": {}, e2b: {} }),
+      ),
+    ).toBe(true);
+  });
+
+  it("getProviderRuntimeAvailability reports every provider", async () => {
+    const availability = await getProviderRuntimeAvailability(fakeLoader({}));
+    expect(availability).toEqual({
+      vercel: true,
+      e2b: false,
+      daytona: false,
+      railway: false,
+    });
+  });
+});
+
+describe("tryCreateByocBackend — not engaged (falls through to operator chain)", () => {
+  it("returns null for non-BYOC backend ids without touching credentials", async () => {
+    let credentialReads = 0;
+    const backend = await tryCreateByocBackend("org-1", "sidecar", SEMANTIC_ROOT, {
+      getCredential: async () => {
+        credentialReads++;
+        return null;
+      },
+      load: fakeLoader({}),
+    });
+    expect(backend).toBeNull();
+    expect(credentialReads).toBe(0);
+  });
+
+  it("returns null when the org has no stored credentials", async () => {
+    const backend = await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () => null,
+      load: fakeLoader({ "@useatlas/e2b": {}, e2b: {} }),
+    });
+    expect(backend).toBeNull();
+  });
+
+  it("returns null when stored credentials miss runtime-required fields", async () => {
+    // Legacy vercel row without projectId
+    const backend = await tryCreateByocBackend("org-1", "vercel-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () =>
+        makeCredential("vercel", { accessToken: "tok", teamId: "team_1" }),
+      load: fakeLoader({}),
+    });
+    expect(backend).toBeNull();
+  });
+
+  it("returns null when the provider runtime is not installed", async () => {
+    const backend = await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () => makeCredential("e2b", { apiKey: "e2b_key" }),
+      load: fakeLoader({}), // neither plugin nor SDK resolvable
+    });
+    expect(backend).toBeNull();
+  });
+});
+
+describe("tryCreateByocBackend — engaged", () => {
+  it("builds the e2b backend from the stored API key", async () => {
+    const { mod, calls } = fakePluginModule("e2bSandboxPlugin", "e2b-byoc");
+    const backend = await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () => makeCredential("e2b", { apiKey: "e2b_org_key" }),
+      load: fakeLoader({ "@useatlas/e2b": mod, e2b: {} }),
+    });
+    expect(backend).not.toBeNull();
+    expect(calls).toEqual([{ apiKey: "e2b_org_key" }]);
+    const result = await backend!.exec("ls");
+    expect(result.stdout).toBe("e2b-byoc");
+  });
+
+  it("builds the daytona backend with optional apiUrl when stored", async () => {
+    const { mod, calls } = fakePluginModule("daytonaSandboxPlugin", "daytona-byoc");
+    const loader = fakeLoader({ "@useatlas/daytona": mod, "@daytonaio/sdk": {} });
+
+    await tryCreateByocBackend("org-1", "daytona-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () =>
+        makeCredential("daytona", { apiKey: "d_key", apiUrl: "https://eu.daytona.io" }),
+      load: loader,
+    });
+    expect(calls).toEqual([{ apiKey: "d_key", apiUrl: "https://eu.daytona.io" }]);
+
+    _resetRuntimeAvailabilityCacheForTest();
+    calls.length = 0;
+    await tryCreateByocBackend("org-1", "daytona-sandbox", SEMANTIC_ROOT, {
+      getCredential: async () => makeCredential("daytona", { apiKey: "d_key" }),
+      load: loader,
+    });
+    expect(calls).toEqual([{ apiKey: "d_key" }]);
+  });
+
+  it("builds the railway backend passing token AND environmentId explicitly", async () => {
+    const { mod, calls } = fakePluginModule("railwaySandboxPlugin", "railway-byoc");
+    const backend = await tryCreateByocBackend(
+      "org-1",
+      "railway-sandbox",
+      SEMANTIC_ROOT,
+      {
+        getCredential: async () =>
+          makeCredential("railway", { token: "rw_tok", environmentId: "env-42" }),
+        load: fakeLoader({ "@useatlas/railway-sandbox": mod, railway: {} }),
+      },
+    );
+    expect(backend).not.toBeNull();
+    // Both fields explicit so the plugin's RAILWAY_* env fallback can never
+    // mix operator config into an org-credential path (#2850).
+    expect(calls).toEqual([{ token: "rw_tok", environmentId: "env-42" }]);
+  });
+
+  it("builds the vercel backend via the in-tree explore-sandbox with the stored triple", async () => {
+    const createCalls: Array<{ root: string; access: unknown }> = [];
+    const backend = await tryCreateByocBackend(
+      "org-1",
+      "vercel-sandbox",
+      SEMANTIC_ROOT,
+      {
+        getCredential: async () =>
+          makeCredential("vercel", {
+            accessToken: "vc_tok",
+            teamId: "team_1",
+            projectId: "prj_1",
+          }),
+        load: fakeLoader({
+          "@atlas/api/lib/tools/explore-sandbox": {
+            createSandboxBackend: async (root: string, access: unknown) => {
+              createCalls.push({ root, access });
+              return {
+                exec: async () => ({ stdout: "vercel-byoc", stderr: "", exitCode: 0 }),
+              };
+            },
+          },
+        }),
+      },
+    );
+    expect(backend).not.toBeNull();
+    expect(createCalls).toEqual([
+      {
+        root: SEMANTIC_ROOT,
+        access: { teamId: "team_1", projectId: "prj_1", token: "vc_tok" },
+      },
+    ]);
+  });
+
+  it("throws (fail-closed) without echoing the provider error into the message", async () => {
+    const mod = {
+      e2bSandboxPlugin: () => ({
+        sandbox: {
+          create: async () => {
+            // Provider SDK errors can echo the rejected key — the thrown
+            // message becomes agent tool output, so it must stay generic.
+            throw new Error("Unauthorized: API key 'e2b_sk_secret' is invalid");
+          },
+        },
+      }),
+    };
+    let thrown: unknown;
+    try {
+      await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+        getCredential: async () => makeCredential("e2b", { apiKey: "e2b_sk_secret" }),
+        load: fakeLoader({ "@useatlas/e2b": mod, e2b: {} }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("connected e2b sandbox failed to start");
+    expect(message).not.toContain("e2b_sk_secret");
+    // The detail stays on `cause` for operator-side diagnosis
+    expect(((thrown as Error).cause as Error).message).toContain("Unauthorized");
+  });
+
+  it("throws when an installed plugin lacks the expected factory export", async () => {
+    let thrown: unknown;
+    try {
+      await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+        getCredential: async () => makeCredential("e2b", { apiKey: "k" }),
+        load: fakeLoader({ "@useatlas/e2b": { somethingElse: 1 }, e2b: {} }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    // Generic message to the agent; the incompatibility detail rides on cause
+    expect((thrown as Error).message).toContain("connected e2b sandbox failed to start");
+    expect(((thrown as Error).cause as Error).message).toMatch(
+      /does not export e2bSandboxPlugin/,
+    );
+  });
+});

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -113,8 +113,27 @@ describe("missingCredentialFields", () => {
 });
 
 describe("isProviderRuntimeAvailable", () => {
-  it("vercel is always available (in-tree backend)", async () => {
-    expect(await isProviderRuntimeAvailable("vercel", fakeLoader({}))).toBe(true);
+  it("vercel requires @vercel/sandbox (an optionalDependency) to be resolvable", async () => {
+    expect(
+      await isProviderRuntimeAvailable("vercel", fakeLoader({ "@vercel/sandbox": {} })),
+    ).toBe(true);
+    _resetRuntimeAvailabilityCacheForTest();
+    // A deployment where the optional install failed must report Unavailable
+    // instead of failing at the first explore call.
+    expect(await isProviderRuntimeAvailable("vercel", fakeLoader({}))).toBe(false);
+  });
+
+  it("does not cache a transient (non-not-found) load failure", async () => {
+    let calls = 0;
+    const flakyLoader: ModuleLoader = async (specifier) => {
+      if (specifier !== "@vercel/sandbox") throw new Error("unexpected module");
+      calls++;
+      if (calls === 1) throw new Error("init failed under resource pressure");
+      return {};
+    };
+    expect(await isProviderRuntimeAvailable("vercel", flakyLoader)).toBe(false);
+    // Not-found is cached; transient failure is not — next probe retries.
+    expect(await isProviderRuntimeAvailable("vercel", flakyLoader)).toBe(true);
   });
 
   it("e2b requires both the plugin package and the SDK", async () => {
@@ -133,7 +152,9 @@ describe("isProviderRuntimeAvailable", () => {
   });
 
   it("getProviderRuntimeAvailability reports every provider", async () => {
-    const availability = await getProviderRuntimeAvailability(fakeLoader({}));
+    const availability = await getProviderRuntimeAvailability(
+      fakeLoader({ "@vercel/sandbox": {} }),
+    );
     expect(availability).toEqual({
       vercel: true,
       e2b: false,
@@ -236,7 +257,10 @@ describe("tryCreateByocBackend — engaged", () => {
   });
 
   it("builds the vercel backend via the in-tree explore-sandbox with the stored triple", async () => {
-    const createCalls: Array<{ root: string; access: unknown }> = [];
+    const createCalls: Array<{
+      root: string;
+      access: { teamId: string; projectId: string; token: { reveal(): string; toJSON(): string } };
+    }> = [];
     const backend = await tryCreateByocBackend(
       "org-1",
       "vercel-sandbox",
@@ -249,8 +273,9 @@ describe("tryCreateByocBackend — engaged", () => {
             projectId: "prj_1",
           }),
         load: fakeLoader({
+          "@vercel/sandbox": {},
           "@atlas/api/lib/tools/explore-sandbox": {
-            createSandboxBackend: async (root: string, access: unknown) => {
+            createSandboxBackend: async (root: string, access: (typeof createCalls)[number]["access"]) => {
               createCalls.push({ root, access });
               return {
                 exec: async () => ({ stdout: "vercel-byoc", stderr: "", exitCode: 0 }),
@@ -261,12 +286,35 @@ describe("tryCreateByocBackend — engaged", () => {
       },
     );
     expect(backend).not.toBeNull();
-    expect(createCalls).toEqual([
-      {
-        root: SEMANTIC_ROOT,
-        access: { teamId: "team_1", projectId: "prj_1", token: "vc_tok" },
-      },
-    ]);
+    expect(createCalls.length).toBe(1);
+    expect(createCalls[0].root).toBe(SEMANTIC_ROOT);
+    expect(createCalls[0].access.teamId).toBe("team_1");
+    expect(createCalls[0].access.projectId).toBe("prj_1");
+    // The token is RedactedSecret-branded: revealable at the create site,
+    // but serializing it (e.g. an accidental structured log) leaks nothing.
+    expect(createCalls[0].access.token.reveal()).toBe("vc_tok");
+    expect(JSON.stringify(createCalls[0].access)).not.toContain("vc_tok");
+  });
+
+  it("throws an incompatible-version error when the factory returns a shapeless plugin", async () => {
+    let thrown: unknown;
+    try {
+      await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+        getCredential: async () => makeCredential("e2b", { apiKey: "k" }),
+        load: fakeLoader({
+          "@useatlas/e2b": { e2bSandboxPlugin: () => ({ notASandbox: true }) },
+          e2b: {},
+        }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    // Misreporting this as a credentials problem would send the admin to the
+    // wrong fix — the cause names the real (deployment) issue.
+    expect(((thrown as Error).cause as Error).message).toMatch(
+      /without sandbox\.create\(\).*incompatible plugin version/,
+    );
   });
 
   it("throws (fail-closed) without echoing the provider error into the message", async () => {

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -203,6 +203,46 @@ describe("tryCreateByocBackend — not engaged (falls through to operator chain)
     });
     expect(backend).toBeNull();
   });
+
+  it("fails closed (throws) when the runtime is installed but fails to load", async () => {
+    // Installed-but-broken is a deployment defect, not the stable
+    // "not installed" state — the org's selection must not silently route
+    // to the operator chain.
+    const brokenLoader: ModuleLoader = async () => {
+      throw new Error("incompatible plugin init crashed"); // no not-found code
+    };
+    let thrown: unknown;
+    try {
+      await tryCreateByocBackend("org-1", "e2b-sandbox", SEMANTIC_ROOT, {
+        getCredential: async () => makeCredential("e2b", { apiKey: "e2b_key" }),
+        load: brokenLoader,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("runtime failed to load");
+    expect(((thrown as Error).cause as Error).message).toContain("init crashed");
+  });
+});
+
+describe("scrubCredentialValues", () => {
+  it("redacts stored credential values echoed by provider error text", async () => {
+    const { _scrubCredentialValuesForTest } = await import("../runtime");
+    const scrubbed = _scrubCredentialValuesForTest(
+      "Unauthorized: API key 'e2b_sk_secret123' is invalid (key e2b_sk_secret123 revoked)",
+      { apiKey: "e2b_sk_secret123" },
+    );
+    expect(scrubbed).not.toContain("e2b_sk_secret123");
+    expect(scrubbed).toContain("[REDACTED]");
+  });
+
+  it("skips short values that would shred ordinary words", async () => {
+    const { _scrubCredentialValuesForTest } = await import("../runtime");
+    expect(
+      _scrubCredentialValuesForTest("a team error", { teamId: "team" }),
+    ).toBe("a team error");
+  });
 });
 
 describe("tryCreateByocBackend — engaged", () => {

--- a/packages/api/src/lib/sandbox/__tests__/validate-railway.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/validate-railway.test.ts
@@ -64,11 +64,29 @@ describe("validateCredentials — railway dispatch", () => {
     expect(body.variables?.id).toBe("env-1");
   });
 
-  it("falls back to the me query without environmentId", async () => {
+  it("rejects a missing environmentId without any network call (#3370)", async () => {
+    // The BYOC runtime never falls back to the operator's
+    // RAILWAY_ENVIRONMENT_ID env var, so a connect without environmentId
+    // would store credentials that can never run.
+    let called = false;
+    globalThis.fetch = mock(async (): Promise<Response> => {
+      called = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as FetchFn;
+
+    const result = await validateCredentials("railway", { token: "rw_tok" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain("Environment ID is required");
+    expect(called).toBe(false);
+  });
+
+  it("validateRailwayCredentials still supports the me-query fallback directly", async () => {
+    // The function-level optional param remains for callers outside the
+    // connect dispatch (the dispatch itself requires environmentId).
     const fetchMock = mockFetchJson({ data: { me: { name: "Ada" } } });
     globalThis.fetch = fetchMock;
 
-    const result = await validateCredentials("railway", { token: "rw_tok" });
+    const result = await validateRailwayCredentials("rw_tok");
     expect(result.valid).toBe(true);
     if (result.valid) expect(result.displayName).toBe("Railway (Ada)");
 

--- a/packages/api/src/lib/sandbox/__tests__/validate-vercel.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/validate-vercel.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Vercel credential validation tests (#3370). The vercel branch of
+ * `validateCredentials` makes two sequential calls — team lookup, then a
+ * project-access check (the sandbox runtime needs the full
+ * token/teamId/projectId triple, so project access must fail at connect
+ * time, not at the org's first explore call). These tests mock
+ * `globalThis.fetch` with a per-call response queue and assert the dispatch
+ * contract: required fields, both probe outcomes, and status mapping.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { validateCredentials } from "../validate";
+
+type FetchFn = typeof globalThis.fetch;
+const realFetch: FetchFn = globalThis.fetch;
+
+interface QueuedResponse {
+  body: unknown;
+  status?: number;
+}
+
+/** Fetch mock that pops responses in call order and records request URLs. */
+function mockFetchQueue(responses: QueuedResponse[]): { fetch: FetchFn; urls: string[] } {
+  const urls: string[] = [];
+  const queue = [...responses];
+  const fetchMock = mock(async (input: string | URL | Request): Promise<Response> => {
+    urls.push(String(input));
+    const next = queue.shift();
+    if (!next) throw new Error("fetch called more times than queued responses");
+    return new Response(JSON.stringify(next.body), {
+      status: next.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as FetchFn;
+  return { fetch: fetchMock, urls };
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const FULL_CREDS = { accessToken: "vc_tok", teamId: "team_1", projectId: "prj_1" };
+
+describe("validateCredentials — vercel dispatch", () => {
+  it("rejects a missing projectId without any network call (#3370)", async () => {
+    let called = false;
+    globalThis.fetch = mock(async (): Promise<Response> => {
+      called = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as FetchFn;
+
+    const result = await validateCredentials("vercel", {
+      accessToken: "vc_tok",
+      teamId: "team_1",
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain("Project ID is required");
+    expect(called).toBe(false);
+  });
+
+  it("validates team then project and returns the team name", async () => {
+    const { fetch: fetchMock, urls } = mockFetchQueue([
+      { body: { name: "Acme Team" } }, // team lookup
+      { body: { id: "prj_1" } }, // project check
+    ]);
+    globalThis.fetch = fetchMock;
+
+    const result = await validateCredentials("vercel", FULL_CREDS);
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.displayName).toBe("Acme Team");
+
+    expect(urls.length).toBe(2);
+    expect(urls[0]).toBe("https://api.vercel.com/v2/teams/team_1");
+    expect(urls[1]).toBe("https://api.vercel.com/v9/projects/prj_1?teamId=team_1");
+  });
+
+  it("maps a project 404 to 'Project not found' even when the team check passes", async () => {
+    const { fetch: fetchMock } = mockFetchQueue([
+      { body: { name: "Acme Team" } },
+      { body: {}, status: 404 },
+    ]);
+    globalThis.fetch = fetchMock;
+
+    const result = await validateCredentials("vercel", FULL_CREDS);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain("Project not found");
+  });
+
+  it("maps a project 403 to a token-scope error", async () => {
+    const { fetch: fetchMock } = mockFetchQueue([
+      { body: { name: "Acme Team" } },
+      { body: {}, status: 403 },
+    ]);
+    globalThis.fetch = fetchMock;
+
+    const result = await validateCredentials("vercel", FULL_CREDS);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain("cannot access this project");
+  });
+
+  it("still fails fast on a bad token at the team check (no project call)", async () => {
+    const { fetch: fetchMock, urls } = mockFetchQueue([{ body: {}, status: 401 }]);
+    globalThis.fetch = fetchMock;
+
+    const result = await validateCredentials("vercel", FULL_CREDS);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain("Invalid access token");
+    expect(urls.length).toBe(1);
+  });
+});

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -6,12 +6,14 @@
  * this module is the runtime consumer. `tryCreateByocBackend` is called from
  * the explore tool's workspace-override branch and returns:
  *
- *   • `null`   — BYOC is *not engaged* for this (org, backend): no stored
- *                credentials, credentials missing runtime-required fields,
- *                or the provider runtime isn't installed in this deployment.
- *                The caller falls through to the operator-configured chain
- *                (the operator *instance* — never operator credentials
- *                injected into an org-credential path, per the #2850 seam).
+ *   • `null`   — BYOC is *not engaged* for this (org, backend): the backend
+ *                id isn't a BYOC provider's id (the common case — built-ins
+ *                and custom plugin ids), no stored credentials, credentials
+ *                missing runtime-required fields, or the provider runtime
+ *                isn't installed in this deployment. The caller falls
+ *                through to the operator-configured chain (the operator
+ *                *instance* — never operator credentials injected into an
+ *                org-credential path, per the #2850 seam).
  *   • backend  — BYOC engaged: backend built from the org's decrypted
  *                credentials, on the org's own provider account.
  *   • throws   — BYOC engaged but construction failed. Callers must fail
@@ -19,9 +21,12 @@
  *                the operator's account: the admin selected this provider
  *                expecting isolation on their own infrastructure.
  *
- * Credentials are decrypted by `credentials.ts` (db/secret-encryption.ts);
- * this module never logs credential values — only provider names and the
- * *names* of missing fields.
+ * Credentials are decrypted by `credentials.ts` (db/secret-encryption.ts).
+ * This module never logs *stored* credential values — only provider names
+ * and the *names* of missing fields. Provider SDK error text (which may
+ * echo a rejected key) is confined to operator-level logs and the thrown
+ * error's `cause`; the thrown *message* — which becomes agent tool output —
+ * stays generic.
  */
 
 import {
@@ -29,6 +34,7 @@ import {
   type SandboxProviderKey,
 } from "@useatlas/schemas";
 import type { ExploreBackend } from "@atlas/api/lib/tools/backends/types";
+import { redactedSecret, type RedactedSecret } from "@atlas/api/lib/tools/backends/detect";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   getSandboxCredentialByProvider,
@@ -146,31 +152,43 @@ function pluginRuntime(
         );
       }
       const plugin = factory(mapConfig(credentials)) as SandboxPluginLike;
+      // Same guard one level deeper: a factory from an incompatible plugin
+      // version could return a differently-shaped object, and without this
+      // check the resulting TypeError would be misreported to the admin as
+      // a credentials problem.
+      if (typeof plugin?.sandbox?.create !== "function") {
+        throw new Error(
+          `${packageName}'s ${factoryExport}() returned a plugin without sandbox.create() — incompatible plugin version installed`,
+        );
+      }
       return await plugin.sandbox.create(semanticRoot);
     },
   };
 }
 
 const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
-  // Vercel uses the in-tree backend (@vercel/sandbox is a regular dependency
-  // of @atlas/api, so this provider is runtime-available in every deployment).
-  // The published @useatlas/vercel-sandbox plugin's access-token mode passes
-  // an `accessToken` field @vercel/sandbox v2 ignores — the SDK requires the
-  // full { token, teamId, projectId } triple, which the in-tree backend
-  // forwards correctly.
+  // Vercel uses the in-tree backend. @vercel/sandbox is an
+  // *optionalDependency* of @atlas/api — installed in every supported
+  // deployment, but probed here so a deployment where the optional install
+  // failed reports the card as Unavailable instead of failing at the first
+  // explore call. The published @useatlas/vercel-sandbox plugin's
+  // access-token mode (as of 0.0.5) passes an `accessToken` field
+  // @vercel/sandbox v2 ignores — the SDK requires the full
+  // { token, teamId, projectId } triple, which the in-tree backend forwards
+  // correctly.
   vercel: {
-    requiredModules: [],
+    requiredModules: ["@vercel/sandbox"],
     async create(semanticRoot, credentials, load) {
       const mod = (await load("@atlas/api/lib/tools/explore-sandbox")) as {
         createSandboxBackend(
           semanticRoot: string,
-          access?: { teamId: string; projectId: string; token: string },
+          access?: { teamId: string; projectId: string; token: RedactedSecret },
         ): Promise<ExploreBackend>;
       };
       return await mod.createSandboxBackend(semanticRoot, {
         teamId: credentials.teamId as string,
         projectId: credentials.projectId as string,
-        token: credentials.accessToken as string,
+        token: redactedSecret(credentials.accessToken as string),
       });
     },
   },
@@ -205,33 +223,55 @@ const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
 /** Per-process probe cache — module installation can't change at runtime. */
 const runtimeAvailabilityCache = new Map<SandboxProviderKey, Promise<boolean>>();
 
+function isModuleNotFound(err: unknown): boolean {
+  const code =
+    err != null && typeof err === "object" && "code" in err
+      ? (err as NodeJS.ErrnoException).code
+      : undefined;
+  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+}
+
 /**
  * Whether this deployment can construct BYOC backends for a provider
- * (plugin package + provider SDK resolvable). Vercel is always available.
+ * (plugin package + provider SDK resolvable).
+ *
+ * Only not-found results are cached: module installation can't change at
+ * runtime, but an installed module whose import failed transiently (init
+ * throw, resource pressure) must not be pinned "unavailable" for the
+ * process lifetime — that would flip both the engagement rule and the
+ * admin status to a silent operator-chain fallback with no recovery short
+ * of a restart.
  */
 export function isProviderRuntimeAvailable(
   provider: SandboxProviderKey,
   load: ModuleLoader = dynamicImport,
 ): Promise<boolean> {
-  let cached = runtimeAvailabilityCache.get(provider);
-  if (!cached) {
-    cached = (async () => {
-      for (const specifier of PROVIDER_RUNTIMES[provider].requiredModules) {
-        try {
-          await load(specifier);
-        } catch (err) {
+  const cached = runtimeAvailabilityCache.get(provider);
+  if (cached) return cached;
+  const probe = (async () => {
+    for (const specifier of PROVIDER_RUNTIMES[provider].requiredModules) {
+      try {
+        await load(specifier);
+      } catch (err) {
+        if (isModuleNotFound(err)) {
           log.debug(
-            { provider, module: specifier, err: err instanceof Error ? err.message : String(err) },
-            "BYOC provider runtime module not resolvable",
+            { provider, module: specifier },
+            "BYOC provider runtime module not installed",
           );
           return false;
         }
+        runtimeAvailabilityCache.delete(provider); // retry on next probe
+        log.warn(
+          { provider, module: specifier, err: err instanceof Error ? err.message : String(err) },
+          "BYOC provider runtime module is installed but failed to load — treating as unavailable for this request",
+        );
+        return false;
       }
-      return true;
-    })();
-    runtimeAvailabilityCache.set(provider, cached);
-  }
-  return cached;
+    }
+    return true;
+  })();
+  runtimeAvailabilityCache.set(provider, probe);
+  return probe;
 }
 
 /** All providers' runtime availability, keyed by provider (status endpoint). */

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -16,9 +16,11 @@
  *                org-credential path, per the #2850 seam).
  *   • backend  — BYOC engaged: backend built from the org's decrypted
  *                credentials, on the org's own provider account.
- *   • throws   — BYOC engaged but construction failed. Callers must fail
- *                closed (surface the error) rather than silently degrade to
- *                the operator's account: the admin selected this provider
+ *   • throws   — BYOC engaged but construction failed, or the runtime is
+ *                installed yet failed to load (a deployment defect, not the
+ *                stable "not installed" state). Callers must fail closed
+ *                (surface the error) rather than silently degrade to the
+ *                operator's account: the admin selected this provider
  *                expecting isolation on their own infrastructure.
  *
  * Credentials are decrypted by `credentials.ts` (db/secret-encryption.ts).
@@ -221,7 +223,10 @@ const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
 };
 
 /** Per-process probe cache — module installation can't change at runtime. */
-const runtimeAvailabilityCache = new Map<SandboxProviderKey, Promise<boolean>>();
+const runtimeAvailabilityCache = new Map<
+  SandboxProviderKey,
+  Promise<RuntimeProbeResult>
+>();
 
 function isModuleNotFound(err: unknown): boolean {
   const code =
@@ -231,24 +236,29 @@ function isModuleNotFound(err: unknown): boolean {
   return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
 }
 
+type RuntimeProbeResult =
+  | { available: true }
+  | { available: false; reason: "not-installed" }
+  | { available: false; reason: "load-failed"; module: string; error: unknown };
+
 /**
- * Whether this deployment can construct BYOC backends for a provider
- * (plugin package + provider SDK resolvable).
+ * Probe a provider's required modules. Two distinct negative outcomes:
  *
- * Only not-found results are cached: module installation can't change at
- * runtime, but an installed module whose import failed transiently (init
- * throw, resource pressure) must not be pinned "unavailable" for the
- * process lifetime — that would flip both the engagement rule and the
- * admin status to a silent operator-chain fallback with no recovery short
- * of a restart.
+ *   • `not-installed` — module resolution failed. Stable per process and
+ *     cached; this is the state the admin UI surfaces as "Unavailable".
+ *   • `load-failed`   — the module resolved but its import threw (broken
+ *     install, incompatible version, transient init failure). NOT cached,
+ *     so the next probe retries; engaged BYOC callers treat it as a
+ *     deployment defect and fail closed rather than silently running the
+ *     org's workload on the operator chain.
  */
-export function isProviderRuntimeAvailable(
+function probeProviderRuntime(
   provider: SandboxProviderKey,
-  load: ModuleLoader = dynamicImport,
-): Promise<boolean> {
+  load: ModuleLoader,
+): Promise<RuntimeProbeResult> {
   const cached = runtimeAvailabilityCache.get(provider);
   if (cached) return cached;
-  const probe = (async () => {
+  const probe = (async (): Promise<RuntimeProbeResult> => {
     for (const specifier of PROVIDER_RUNTIMES[provider].requiredModules) {
       try {
         await load(specifier);
@@ -258,20 +268,34 @@ export function isProviderRuntimeAvailable(
             { provider, module: specifier },
             "BYOC provider runtime module not installed",
           );
-          return false;
+          return { available: false, reason: "not-installed" };
         }
         runtimeAvailabilityCache.delete(provider); // retry on next probe
         log.warn(
           { provider, module: specifier, err: err instanceof Error ? err.message : String(err) },
-          "BYOC provider runtime module is installed but failed to load — treating as unavailable for this request",
+          "BYOC provider runtime module is installed but failed to load",
         );
-        return false;
+        return { available: false, reason: "load-failed", module: specifier, error: err };
       }
     }
-    return true;
+    return { available: true };
   })();
   runtimeAvailabilityCache.set(provider, probe);
   return probe;
+}
+
+/**
+ * Whether this deployment can construct BYOC backends for a provider
+ * (plugin package + provider SDK resolvable). Boolean view of the probe
+ * for the status endpoint — a load-failed runtime reports unavailable
+ * here, while the engagement path in `tryCreateByocBackend` fails closed
+ * on it instead of falling through.
+ */
+export async function isProviderRuntimeAvailable(
+  provider: SandboxProviderKey,
+  load: ModuleLoader = dynamicImport,
+): Promise<boolean> {
+  return (await probeProviderRuntime(provider, load)).available;
 }
 
 /** All providers' runtime availability, keyed by provider (status endpoint). */
@@ -290,6 +314,28 @@ export async function getProviderRuntimeAvailability(
 export function _resetRuntimeAvailabilityCacheForTest(): void {
   runtimeAvailabilityCache.clear();
 }
+
+/**
+ * Replace every stored credential value appearing in `text` with a redaction
+ * marker. Exact-match against the org's own decrypted values — no pattern
+ * guessing — so a provider SDK error that echoes the rejected key can be
+ * logged without retaining the secret. Short values (< 6 chars) are skipped:
+ * they can't meaningfully be secrets and would shred ordinary words.
+ */
+function scrubCredentialValues(
+  text: string,
+  credentials: Record<string, unknown>,
+): string {
+  let scrubbed = text;
+  for (const value of Object.values(credentials)) {
+    if (typeof value === "string" && value.length >= 6) {
+      scrubbed = scrubbed.split(value).join("[REDACTED]");
+    }
+  }
+  return scrubbed;
+}
+
+export const _scrubCredentialValuesForTest = scrubCredentialValues;
 
 // ---------------------------------------------------------------------------
 // Backend construction
@@ -335,7 +381,24 @@ export async function tryCreateByocBackend(
     return null;
   }
 
-  if (!(await isProviderRuntimeAvailable(provider, load))) {
+  const probe = await probeProviderRuntime(provider, load);
+  if (!probe.available) {
+    if (probe.reason === "load-failed") {
+      // The org did everything right (connected + selected + complete creds)
+      // and the runtime IS installed — it just failed to load. That's a
+      // deployment defect; fail closed instead of silently running the
+      // org's workload on the operator chain.
+      log.error(
+        { orgId, provider, module: probe.module },
+        "BYOC provider runtime is installed but failed to load — failing closed",
+      );
+      throw new Error(
+        `Your connected ${provider} sandbox runtime failed to load on this server. ` +
+          "This is a deployment problem, not a credentials problem — contact your operator, " +
+          "or switch back to the platform default.",
+        { cause: probe.error },
+      );
+    }
     log.warn(
       { orgId, provider },
       "BYOC provider runtime is not installed in this deployment — using operator chain",
@@ -354,12 +417,18 @@ export async function tryCreateByocBackend(
     log.info({ orgId, provider, backendId }, "BYOC sandbox backend created from org credentials");
     return backend;
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    // Provider SDK errors can echo the rejected credential. The stored
+    // values are in scope, so scrub them by exact match before the detail
+    // reaches the operator log — keeps the log diagnosable without
+    // retaining a decrypted org secret.
+    const detail = scrubCredentialValues(
+      err instanceof Error ? err.message : String(err),
+      credential.credentials,
+    );
     log.error({ orgId, provider, err: detail }, "BYOC sandbox backend creation failed");
-    // The thrown message is surfaced as agent tool output. Provider SDK
-    // errors can echo the rejected API key, and the error-scrub layer only
-    // handles URL-embedded credentials — so keep the detail in the operator
-    // log (above) and on `cause`, never in the message itself.
+    // The thrown message is surfaced as agent tool output, and the
+    // error-scrub layer only handles URL-embedded credentials — so the
+    // message stays generic; the raw error rides on `cause` only.
     throw new Error(
       `Your connected ${provider} sandbox failed to start. ` +
         "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -1,0 +1,329 @@
+/**
+ * BYOC sandbox runtime — builds per-org explore backends from stored
+ * `sandbox_credentials` rows (#3370).
+ *
+ * The /admin/sandbox connect flow validates and stores provider credentials;
+ * this module is the runtime consumer. `tryCreateByocBackend` is called from
+ * the explore tool's workspace-override branch and returns:
+ *
+ *   • `null`   — BYOC is *not engaged* for this (org, backend): no stored
+ *                credentials, credentials missing runtime-required fields,
+ *                or the provider runtime isn't installed in this deployment.
+ *                The caller falls through to the operator-configured chain
+ *                (the operator *instance* — never operator credentials
+ *                injected into an org-credential path, per the #2850 seam).
+ *   • backend  — BYOC engaged: backend built from the org's decrypted
+ *                credentials, on the org's own provider account.
+ *   • throws   — BYOC engaged but construction failed. Callers must fail
+ *                closed (surface the error) rather than silently degrade to
+ *                the operator's account: the admin selected this provider
+ *                expecting isolation on their own infrastructure.
+ *
+ * Credentials are decrypted by `credentials.ts` (db/secret-encryption.ts);
+ * this module never logs credential values — only provider names and the
+ * *names* of missing fields.
+ */
+
+import {
+  SANDBOX_PROVIDER_BACKEND_IDS,
+  type SandboxProviderKey,
+} from "@useatlas/schemas";
+import type { ExploreBackend } from "@atlas/api/lib/tools/backends/types";
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  getSandboxCredentialByProvider,
+  SANDBOX_PROVIDERS,
+  type SandboxCredential,
+} from "./credentials";
+
+const log = createLogger("sandbox-byoc");
+
+// ---------------------------------------------------------------------------
+// Backend-id ↔ provider mapping
+// ---------------------------------------------------------------------------
+
+const BACKEND_ID_PROVIDERS: ReadonlyMap<string, SandboxProviderKey> = new Map(
+  (Object.entries(SANDBOX_PROVIDER_BACKEND_IDS) as [SandboxProviderKey, string][]).map(
+    ([provider, backendId]) => [backendId, provider],
+  ),
+);
+
+/** Inverse of SANDBOX_PROVIDER_BACKEND_IDS: backend id → BYOC provider key. */
+export function sandboxProviderForBackendId(
+  backendId: string,
+): SandboxProviderKey | null {
+  return BACKEND_ID_PROVIDERS.get(backendId) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Credential completeness
+// ---------------------------------------------------------------------------
+
+/**
+ * Fields a stored credential row must carry for the runtime to construct a
+ * backend. Stricter than the historical connect-time validation in two ways:
+ *
+ *   • vercel: `projectId` — @vercel/sandbox v2 requires the full
+ *     token/teamId/projectId triple for explicit (off-OIDC) auth; rows
+ *     stored before the connect flow collected projectId can't create a
+ *     sandbox and must be reconnected.
+ *   • railway: `environmentId` — the railway plugin falls back to the
+ *     operator's RAILWAY_ENVIRONMENT_ID env var when omitted, which would
+ *     mix org and operator config. BYOC requires it stored explicitly.
+ */
+const REQUIRED_CREDENTIAL_FIELDS: Record<SandboxProviderKey, readonly string[]> = {
+  vercel: ["accessToken", "teamId", "projectId"],
+  e2b: ["apiKey"],
+  daytona: ["apiKey"],
+  railway: ["token", "environmentId"],
+};
+
+/**
+ * Names of runtime-required fields absent from a stored credentials blob.
+ * Empty array = usable. Also consumed by the admin status route to surface
+ * `needsReconnect` on rows stored before a field became required.
+ */
+export function missingCredentialFields(
+  provider: SandboxProviderKey,
+  credentials: Record<string, unknown>,
+): string[] {
+  return REQUIRED_CREDENTIAL_FIELDS[provider].filter((field) => {
+    const value = credentials[field];
+    return typeof value !== "string" || value.length === 0;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Provider runtimes
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads a module by specifier. Injectable for tests. The default uses a
+ * computed-specifier dynamic import so bundlers (the create-atlas Next.js
+ * template) can't statically resolve the optional plugin packages.
+ */
+export type ModuleLoader = (specifier: string) => Promise<unknown>;
+
+const dynamicImport: ModuleLoader = (specifier) => import(specifier);
+
+interface SandboxPluginLike {
+  sandbox: {
+    create(semanticRoot: string): Promise<ExploreBackend> | ExploreBackend;
+  };
+}
+
+interface ProviderRuntime {
+  /**
+   * Modules that must be resolvable for this provider to run. The plugin
+   * package wraps the provider SDK, but loads it lazily — probing both is
+   * what lets the status endpoint report "unavailable on this deployment"
+   * instead of failing at first explore call.
+   */
+  readonly requiredModules: readonly string[];
+  /** Build a backend from a stored, completeness-checked credentials blob. */
+  create(
+    semanticRoot: string,
+    credentials: Record<string, unknown>,
+    load: ModuleLoader,
+  ): Promise<ExploreBackend>;
+}
+
+/** Build via a published `@useatlas/*` sandbox plugin factory. */
+function pluginRuntime(
+  packageName: string,
+  sdkModule: string,
+  factoryExport: string,
+  mapConfig: (creds: Record<string, unknown>) => Record<string, unknown>,
+): ProviderRuntime {
+  return {
+    requiredModules: [packageName, sdkModule],
+    async create(semanticRoot, credentials, load) {
+      const mod = (await load(packageName)) as Record<string, unknown>;
+      const factory = mod[factoryExport];
+      if (typeof factory !== "function") {
+        throw new Error(
+          `${packageName} does not export ${factoryExport}() — incompatible plugin version installed`,
+        );
+      }
+      const plugin = factory(mapConfig(credentials)) as SandboxPluginLike;
+      return await plugin.sandbox.create(semanticRoot);
+    },
+  };
+}
+
+const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
+  // Vercel uses the in-tree backend (@vercel/sandbox is a regular dependency
+  // of @atlas/api, so this provider is runtime-available in every deployment).
+  // The published @useatlas/vercel-sandbox plugin's access-token mode passes
+  // an `accessToken` field @vercel/sandbox v2 ignores — the SDK requires the
+  // full { token, teamId, projectId } triple, which the in-tree backend
+  // forwards correctly.
+  vercel: {
+    requiredModules: [],
+    async create(semanticRoot, credentials, load) {
+      const mod = (await load("@atlas/api/lib/tools/explore-sandbox")) as {
+        createSandboxBackend(
+          semanticRoot: string,
+          access?: { teamId: string; projectId: string; token: string },
+        ): Promise<ExploreBackend>;
+      };
+      return await mod.createSandboxBackend(semanticRoot, {
+        teamId: credentials.teamId as string,
+        projectId: credentials.projectId as string,
+        token: credentials.accessToken as string,
+      });
+    },
+  },
+  e2b: pluginRuntime("@useatlas/e2b", "e2b", "e2bSandboxPlugin", (creds) => ({
+    apiKey: creds.apiKey,
+  })),
+  daytona: pluginRuntime(
+    "@useatlas/daytona",
+    "@daytonaio/sdk",
+    "daytonaSandboxPlugin",
+    (creds) => ({
+      apiKey: creds.apiKey,
+      ...(typeof creds.apiUrl === "string" && creds.apiUrl
+        ? { apiUrl: creds.apiUrl }
+        : {}),
+    }),
+  ),
+  // Both fields passed explicitly — the plugin's env-var fallback
+  // (RAILWAY_API_TOKEN / RAILWAY_ENVIRONMENT_ID) must never fill in for an
+  // org-credential path (#2850).
+  railway: pluginRuntime(
+    "@useatlas/railway-sandbox",
+    "railway",
+    "railwaySandboxPlugin",
+    (creds) => ({
+      token: creds.token,
+      environmentId: creds.environmentId,
+    }),
+  ),
+};
+
+/** Per-process probe cache — module installation can't change at runtime. */
+const runtimeAvailabilityCache = new Map<SandboxProviderKey, Promise<boolean>>();
+
+/**
+ * Whether this deployment can construct BYOC backends for a provider
+ * (plugin package + provider SDK resolvable). Vercel is always available.
+ */
+export function isProviderRuntimeAvailable(
+  provider: SandboxProviderKey,
+  load: ModuleLoader = dynamicImport,
+): Promise<boolean> {
+  let cached = runtimeAvailabilityCache.get(provider);
+  if (!cached) {
+    cached = (async () => {
+      for (const specifier of PROVIDER_RUNTIMES[provider].requiredModules) {
+        try {
+          await load(specifier);
+        } catch (err) {
+          log.debug(
+            { provider, module: specifier, err: err instanceof Error ? err.message : String(err) },
+            "BYOC provider runtime module not resolvable",
+          );
+          return false;
+        }
+      }
+      return true;
+    })();
+    runtimeAvailabilityCache.set(provider, cached);
+  }
+  return cached;
+}
+
+/** All providers' runtime availability, keyed by provider (status endpoint). */
+export async function getProviderRuntimeAvailability(
+  load: ModuleLoader = dynamicImport,
+): Promise<Record<SandboxProviderKey, boolean>> {
+  const entries = await Promise.all(
+    SANDBOX_PROVIDERS.map(async (provider) => [
+      provider,
+      await isProviderRuntimeAvailable(provider, load),
+    ] as const),
+  );
+  return Object.fromEntries(entries) as Record<SandboxProviderKey, boolean>;
+}
+
+export function _resetRuntimeAvailabilityCacheForTest(): void {
+  runtimeAvailabilityCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Backend construction
+// ---------------------------------------------------------------------------
+
+export interface ByocDeps {
+  getCredential?: (
+    orgId: string,
+    provider: SandboxProviderKey,
+  ) => Promise<SandboxCredential | null>;
+  load?: ModuleLoader;
+}
+
+/**
+ * Build a BYOC explore backend for `(orgId, backendId)` from stored
+ * credentials. Returns `null` when BYOC is not engaged (see module docs);
+ * throws when engaged but construction fails — callers fail closed.
+ */
+export async function tryCreateByocBackend(
+  orgId: string,
+  backendId: string,
+  semanticRoot: string,
+  deps: ByocDeps = {},
+): Promise<ExploreBackend | null> {
+  const provider = sandboxProviderForBackendId(backendId);
+  if (!provider) return null;
+
+  const getCredential = deps.getCredential ?? getSandboxCredentialByProvider;
+  const load = deps.load ?? dynamicImport;
+
+  const credential = await getCredential(orgId, provider);
+  if (!credential) {
+    log.debug({ orgId, provider }, "No stored BYOC credentials — using operator chain");
+    return null;
+  }
+
+  const missing = missingCredentialFields(provider, credential.credentials);
+  if (missing.length > 0) {
+    log.warn(
+      { orgId, provider, missingFields: missing },
+      "Stored BYOC credentials are missing runtime-required fields — reconnect the provider on /admin/sandbox; using operator chain",
+    );
+    return null;
+  }
+
+  if (!(await isProviderRuntimeAvailable(provider, load))) {
+    log.warn(
+      { orgId, provider },
+      "BYOC provider runtime is not installed in this deployment — using operator chain",
+    );
+    return null;
+  }
+
+  // Engaged: from here on, errors propagate (fail closed — never silently
+  // run the org's workload on the operator's provider account).
+  try {
+    const backend = await PROVIDER_RUNTIMES[provider].create(
+      semanticRoot,
+      credential.credentials,
+      load,
+    );
+    log.info({ orgId, provider, backendId }, "BYOC sandbox backend created from org credentials");
+    return backend;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.error({ orgId, provider, err: detail }, "BYOC sandbox backend creation failed");
+    // The thrown message is surfaced as agent tool output. Provider SDK
+    // errors can echo the rejected API key, and the error-scrub layer only
+    // handles URL-embedded credentials — so keep the detail in the operator
+    // log (above) and on `cause`, never in the message itself.
+    throw new Error(
+      `Your connected ${provider} sandbox failed to start. ` +
+        "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",
+      { cause: err },
+    );
+  }
+}

--- a/packages/api/src/lib/sandbox/validate.ts
+++ b/packages/api/src/lib/sandbox/validate.ts
@@ -385,8 +385,7 @@ export async function validateCredentials(
       if (typeof teamId !== "string" || !teamId) {
         return { valid: false, error: "Team ID is required" };
       }
-      // Required for runtime use — @vercel/sandbox needs the full
-      // token/teamId/projectId triple (#3370).
+      // Runtime-required — see REQUIRED_CREDENTIAL_FIELDS in sandbox/runtime.ts (#3370).
       if (typeof projectId !== "string" || !projectId) {
         return { valid: false, error: "Project ID is required" };
       }
@@ -412,8 +411,8 @@ export async function validateCredentials(
       if (typeof token !== "string" || !token) {
         return { valid: false, error: "API token is required" };
       }
-      // Required for runtime use — the BYOC path never falls back to the
-      // operator's RAILWAY_ENVIRONMENT_ID env var (#2850 seam, #3370).
+      // Runtime-required — the BYOC path never env-falls-back (#2850 seam);
+      // see REQUIRED_CREDENTIAL_FIELDS in sandbox/runtime.ts (#3370).
       const environmentId = credentials.environmentId;
       if (typeof environmentId !== "string" || !environmentId) {
         return { valid: false, error: "Environment ID is required" };

--- a/packages/api/src/lib/sandbox/validate.ts
+++ b/packages/api/src/lib/sandbox/validate.ts
@@ -156,6 +156,7 @@ export function isSafeExternalUrl(url: string): boolean {
 export async function validateVercelCredentials(
   accessToken: string,
   teamId: string,
+  projectId: string,
 ): Promise<ValidationResult> {
   try {
     const res = await fetch(`https://api.vercel.com/v2/teams/${encodeURIComponent(teamId)}`, {
@@ -173,6 +174,29 @@ export async function validateVercelCredentials(
       return { valid: false, error: `Vercel API returned ${status}` };
     }
     const data = (await res.json().catch(() => ({}))) as { name?: string };
+
+    // The sandbox runtime needs a project to bill against — @vercel/sandbox
+    // requires the full token/teamId/projectId triple for explicit auth.
+    // Verify the token can see the project so the failure surfaces here, not
+    // on the first explore call.
+    const projectRes = await fetch(
+      `https://api.vercel.com/v9/projects/${encodeURIComponent(projectId)}?teamId=${encodeURIComponent(teamId)}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+      },
+    );
+    if (!projectRes.ok) {
+      const status = projectRes.status;
+      if (status === 404) {
+        return { valid: false, error: "Project not found — verify your Project ID" };
+      }
+      if (status === 401 || status === 403) {
+        return { valid: false, error: "Access token cannot access this project — check its scope" };
+      }
+      return { valid: false, error: `Vercel API returned ${status} for the project check` };
+    }
+
     return { valid: true, displayName: data.name ?? teamId };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -354,13 +378,19 @@ export async function validateCredentials(
     case "vercel": {
       const accessToken = credentials.accessToken;
       const teamId = credentials.teamId;
+      const projectId = credentials.projectId;
       if (typeof accessToken !== "string" || !accessToken) {
         return { valid: false, error: "Access token is required" };
       }
       if (typeof teamId !== "string" || !teamId) {
         return { valid: false, error: "Team ID is required" };
       }
-      return validateVercelCredentials(accessToken, teamId);
+      // Required for runtime use — @vercel/sandbox needs the full
+      // token/teamId/projectId triple (#3370).
+      if (typeof projectId !== "string" || !projectId) {
+        return { valid: false, error: "Project ID is required" };
+      }
+      return validateVercelCredentials(accessToken, teamId, projectId);
     }
     case "e2b": {
       const apiKey = credentials.apiKey;
@@ -382,10 +412,12 @@ export async function validateCredentials(
       if (typeof token !== "string" || !token) {
         return { valid: false, error: "API token is required" };
       }
-      const environmentId =
-        typeof credentials.environmentId === "string" && credentials.environmentId
-          ? credentials.environmentId
-          : undefined;
+      // Required for runtime use — the BYOC path never falls back to the
+      // operator's RAILWAY_ENVIRONMENT_ID env var (#2850 seam, #3370).
+      const environmentId = credentials.environmentId;
+      if (typeof environmentId !== "string" || !environmentId) {
+        return { valid: false, error: "Environment ID is required" };
+      }
       return validateRailwayCredentials(token, environmentId);
     }
     default:

--- a/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
@@ -131,6 +131,7 @@ let byocCalls: Array<{ orgId: string; backendId: string }> = [];
 mock.module("@atlas/api/lib/sandbox/runtime", () => ({
   sandboxProviderForBackendId: () => null,
   missingCredentialFields: () => [],
+  _scrubCredentialValuesForTest: (text: string) => text,
   isProviderRuntimeAvailable: async () => false,
   getProviderRuntimeAvailability: async () => ({
     vercel: true,

--- a/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
@@ -49,7 +49,12 @@ mock.module("@atlas/api/lib/logger", () => ({
 const realSemanticSync = await import("@atlas/api/lib/semantic/sync");
 mock.module("@atlas/api/lib/semantic/sync", () => ({
   ...realSemanticSync,
-  ensureOrgModeSemanticRoot: async () => realSemanticSync.getSemanticRoot(),
+  // Mode-dependent like the real implementation (`.orgs/{org}/modes/{mode}`)
+  // so an org accumulates one cache key per atlasMode — the invalidation
+  // tests below depend on that multiplicity. Org-context tests only use
+  // mocked backends, so the path never touches the filesystem.
+  ensureOrgModeSemanticRoot: async (orgId: string, mode: string) =>
+    `${realSemanticSync.getSemanticRoot()}/.orgs/${orgId}/modes/${mode}`,
 }));
 
 mock.module("@atlas/api/lib/tracing", () => ({
@@ -263,6 +268,13 @@ describe("explore BYOC backend selection", () => {
     expect(result).toContain("Explore tool is unavailable");
     expect(result).toContain("e2b sandbox failed to start");
     expect(result).not.toContain("[operator-e2b]");
+
+    // The rejected promise must be evicted, not cached: after the admin
+    // fixes the credentials, the next explore call re-attempts instead of
+    // replaying the failure until process restart.
+    mockByocResult = { kind: "backend", create: () => makeMockBackend("byoc-recovered") };
+    const retried = await mod.explore.execute({ command: "ls" }, toolOpts);
+    expect(retried).toContain("[byoc-recovered]");
   });
 
   it("does not consult BYOC without an org context", async () => {
@@ -315,6 +327,43 @@ describe("explore BYOC backend selection", () => {
     // close() is fire-and-forget — give the microtask queue a tick
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(closed).toBe(1);
+  });
+
+  it("invalidation covers every mode's cached backend for the org", async () => {
+    // Each atlasMode gets its own semantic root, hence its own cache key.
+    // A regression that tracks only the most recent key would leave the
+    // other mode's backend running on deleted/revoked credentials.
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+
+    let created = 0;
+    let closed = 0;
+    mockByocResult = {
+      kind: "backend",
+      create: () => {
+        created++;
+        return makeMockBackend(`byoc-${created}`, () => {
+          closed++;
+        });
+      },
+    };
+
+    const mod = await freshExploreModule();
+
+    mockRequestContext = { user: { activeOrganizationId: "org-1" }, atlasMode: "published" };
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-1]");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" }, atlasMode: "developer" };
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-2]");
+    expect(created).toBe(2);
+
+    mod.invalidateOrgExploreBackends("org-1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(closed).toBe(2);
+
+    // Both modes rebuild fresh
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-3]");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" }, atlasMode: "published" };
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-4]");
+    expect(created).toBe(4);
   });
 
   it("invalidating a different org leaves the cached backend in place", async () => {

--- a/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-byoc.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for BYOC backend selection in the explore tool (#3370).
+ *
+ * When a request carries an org whose workspace override selects a BYOC
+ * provider's backend id, the explore tool must consult the BYOC runtime
+ * BEFORE the operator-configured chain:
+ *
+ *   • engaged   → the org-credential backend runs the command
+ *   • null      → the override falls through to the operator chain
+ *   • throws    → explore fails closed (no silent operator fallback)
+ *
+ * Credential edits invalidate the org's cached backends via
+ * `invalidateOrgExploreBackends` (and close the evicted backend).
+ *
+ * Follows the mock.module idiom of explore-workspace-override.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { ExploreBackend, ExecResult } from "../../tools/explore";
+
+// ---------------------------------------------------------------------------
+// Mocks — must register before any import of explore.ts
+// ---------------------------------------------------------------------------
+
+let mockRequestContext:
+  | { user?: { activeOrganizationId?: string }; atlasMode?: string }
+  | undefined;
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  }),
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  }),
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => mockRequestContext,
+  redactPaths: [],
+}));
+
+const realSemanticSync = await import("@atlas/api/lib/semantic/sync");
+mock.module("@atlas/api/lib/semantic/sync", () => ({
+  ...realSemanticSync,
+  ensureOrgModeSemanticRoot: async () => realSemanticSync.getSemanticRoot(),
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async <T,>(_name: string, _attrs: unknown, fn: () => Promise<T>) => fn(),
+  withEffectSpan: <T,>(_n: string, _a: unknown, e: T) => e,
+}));
+
+mock.module("@atlas/api/lib/plugins/hooks", () => ({
+  dispatchHook: async () => {},
+  dispatchMutableHook: async <
+    T extends Record<string, unknown>,
+    K extends string & keyof T,
+  >(
+    _hookName: string,
+    context: T,
+    mutateKey: K,
+  ) => context[mutateKey],
+}));
+
+const mockSettings = new Map<string, string>();
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingAuto: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingLive: async (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
+
+let mockSandboxPlugins: Array<{
+  id: string;
+  types: string[];
+  version: string;
+  sandbox: {
+    create(root: string): Promise<ExploreBackend> | ExploreBackend;
+    priority?: number;
+  };
+  [k: string]: unknown;
+}> = [];
+
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    getByType: (type: string) => (type === "sandbox" ? mockSandboxPlugins : []),
+    getAllHealthy: () => [],
+    get: () => undefined,
+    getStatus: () => undefined,
+    describe: () => [],
+    size: 0,
+    register: () => {},
+    initializeAll: async () => ({ succeeded: [], failed: [] }),
+    healthCheckAll: async () => new Map(),
+    teardownAll: async () => {},
+    _reset: () => {},
+  },
+  PluginRegistry: class {},
+}));
+
+// --- BYOC runtime mock — per-test behavior, all exports mocked ---
+
+type ByocResult =
+  | { kind: "backend"; create: () => ExploreBackend }
+  | { kind: "null" }
+  | { kind: "throw"; message: string };
+
+let mockByocResult: ByocResult = { kind: "null" };
+let byocCalls: Array<{ orgId: string; backendId: string }> = [];
+
+mock.module("@atlas/api/lib/sandbox/runtime", () => ({
+  sandboxProviderForBackendId: () => null,
+  missingCredentialFields: () => [],
+  isProviderRuntimeAvailable: async () => false,
+  getProviderRuntimeAvailability: async () => ({
+    vercel: true,
+    e2b: false,
+    daytona: false,
+    railway: false,
+  }),
+  _resetRuntimeAvailabilityCacheForTest: () => {},
+  tryCreateByocBackend: async (orgId: string, backendId: string) => {
+    byocCalls.push({ orgId, backendId });
+    switch (mockByocResult.kind) {
+      case "backend":
+        return mockByocResult.create();
+      case "null":
+        return null;
+      case "throw":
+        throw new Error(mockByocResult.message);
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let importCounter = 0;
+
+async function freshExploreModule() {
+  importCounter++;
+  return await import(`@atlas/api/lib/tools/explore?byoc_test=${importCounter}`);
+}
+
+function makeMockBackend(tag: string, onClose?: () => void): ExploreBackend {
+  return {
+    exec: async (command: string): Promise<ExecResult> => ({
+      stdout: `[${tag}] ${command}`,
+      stderr: "",
+      exitCode: 0,
+    }),
+    close: async () => {
+      onClose?.();
+    },
+  };
+}
+
+const toolOpts = {
+  toolCallId: "test",
+  messages: [],
+  abortSignal: new AbortController().signal,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("explore BYOC backend selection", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockSettings.clear();
+    mockSandboxPlugins = [];
+    mockRequestContext = undefined;
+    mockByocResult = { kind: "null" };
+    byocCalls = [];
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.ATLAS_SANDBOX;
+    delete process.env.ATLAS_SANDBOX_URL;
+    delete process.env.ATLAS_NSJAIL_PATH;
+    process.env.PATH = "/usr/bin:/bin";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses the BYOC backend when the org's stored credentials engage", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "backend", create: () => makeMockBackend("byoc-e2b") };
+    // A registered operator plugin with the same id must NOT win over BYOC
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => makeMockBackend("operator-e2b"), priority: 50 },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute({ command: "ls" }, toolOpts);
+
+    expect(result).toContain("[byoc-e2b]");
+    expect(byocCalls).toEqual([{ orgId: "org-1", backendId: "e2b-sandbox" }]);
+  });
+
+  it("falls through to the operator chain when BYOC is not engaged", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "null" }; // no stored creds / runtime unavailable
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => makeMockBackend("operator-e2b"), priority: 50 },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute({ command: "ls" }, toolOpts);
+
+    expect(result).toContain("[operator-e2b]");
+    expect(byocCalls.length).toBe(1);
+  });
+
+  it("fails closed when the engaged BYOC backend cannot be built", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "throw", message: "your e2b sandbox failed to start" };
+    // Operator plugin available — it must NOT be used as a silent fallback
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => makeMockBackend("operator-e2b"), priority: 50 },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute({ command: "ls" }, toolOpts);
+
+    expect(result).toContain("Explore tool is unavailable");
+    expect(result).toContain("e2b sandbox failed to start");
+    expect(result).not.toContain("[operator-e2b]");
+  });
+
+  it("does not consult BYOC without an org context", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = undefined; // self-hosted, no org
+    mockSandboxPlugins = [
+      {
+        id: "e2b-sandbox",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: { create: async () => makeMockBackend("operator-e2b"), priority: 50 },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute({ command: "ls" }, toolOpts);
+
+    expect(result).toContain("[operator-e2b]");
+    expect(byocCalls).toEqual([]);
+  });
+
+  it("invalidateOrgExploreBackends drops the cached backend and closes it", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+
+    let closed = 0;
+    let created = 0;
+    mockByocResult = {
+      kind: "backend",
+      create: () => {
+        created++;
+        return makeMockBackend(`byoc-${created}`, () => {
+          closed++;
+        });
+      },
+    };
+
+    const mod = await freshExploreModule();
+
+    // First call creates and caches
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-1]");
+    // Second call hits the cache — no new backend
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-1]");
+    expect(created).toBe(1);
+
+    // Credential edit: invalidate this org → old backend closed, next call rebuilds
+    mod.invalidateOrgExploreBackends("org-1");
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-2]");
+    expect(created).toBe(2);
+    // close() is fire-and-forget — give the microtask queue a tick
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(closed).toBe(1);
+  });
+
+  it("invalidating a different org leaves the cached backend in place", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+
+    let created = 0;
+    mockByocResult = {
+      kind: "backend",
+      create: () => {
+        created++;
+        return makeMockBackend(`byoc-${created}`);
+      },
+    };
+
+    const mod = await freshExploreModule();
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-1]");
+
+    mod.invalidateOrgExploreBackends("org-other");
+    expect(await mod.explore.execute({ command: "ls" }, toolOpts)).toContain("[byoc-1]");
+    expect(created).toBe(1);
+  });
+});

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -18,7 +18,7 @@ export interface RedactedSecret {
   toString(): string;
 }
 
-function redactedSecret(value: string): RedactedSecret {
+export function redactedSecret(value: string): RedactedSecret {
   return Object.freeze({
     __brand: "RedactedSecret" as const,
     reveal: () => value,

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -11,7 +11,7 @@
 
 import type { ExploreBackend, ExecResult } from "./backends/types";
 import { sandboxErrorDetail, safeError } from "./backends/shared";
-import { vercelSandboxAccess } from "./backends/detect";
+import { vercelSandboxAccess, type RedactedSecret } from "./backends/detect";
 import * as path from "path";
 import * as fs from "fs";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -85,12 +85,14 @@ const SANDBOX_SEMANTIC_CWD = "/vercel/sandbox/semantic";
 /**
  * Explicit Vercel API credentials for sandbox creation. When provided
  * (the BYOC per-org path, #3370), they replace the operator-level env-var
- * detection entirely — values must never be logged.
+ * detection entirely. The token carries the same RedactedSecret brand as
+ * the operator path's VercelSandboxAccess, so an accidental structured log
+ * of this object can't leak it — it's revealed only at Sandbox.create.
  */
 export interface VercelSandboxAccessOverride {
   teamId: string;
   projectId: string;
-  token: string;
+  token: RedactedSecret;
 }
 
 export async function createSandboxBackend(
@@ -116,16 +118,14 @@ export async function createSandboxBackend(
   // VERCEL_TEAM_ID/VERCEL_PROJECT_ID/VERCEL_TOKEN are set we're running
   // off-Vercel (e.g. Railway) and pass explicit operator credentials; on
   // Vercel itself, OIDC handles auth automatically and these are undefined.
-  const access = accessOverride ? undefined : vercelSandboxAccess();
-  const explicitAccess = accessOverride
-    ? { ...accessOverride }
-    : access
-      ? {
-          teamId: access.teamId,
-          projectId: access.projectId,
-          token: access.token.reveal(),
-        }
-      : undefined;
+  const access = accessOverride ?? vercelSandboxAccess();
+  const explicitAccess = access
+    ? {
+        teamId: access.teamId,
+        projectId: access.projectId,
+        token: access.token.reveal(),
+      }
+    : undefined;
   let sandbox: InstanceType<typeof Sandbox>;
   try {
     sandbox = await Sandbox.create({

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -82,8 +82,20 @@ const SANDBOX_SEMANTIC_REL = "semantic";
 // Must match the absolute resolution of SANDBOX_SEMANTIC_REL (used as runCommand cwd).
 const SANDBOX_SEMANTIC_CWD = "/vercel/sandbox/semantic";
 
+/**
+ * Explicit Vercel API credentials for sandbox creation. When provided
+ * (the BYOC per-org path, #3370), they replace the operator-level env-var
+ * detection entirely — values must never be logged.
+ */
+export interface VercelSandboxAccessOverride {
+  teamId: string;
+  projectId: string;
+  token: string;
+}
+
 export async function createSandboxBackend(
-  semanticRoot: string
+  semanticRoot: string,
+  accessOverride?: VercelSandboxAccessOverride
 ): Promise<ExploreBackend> {
   // 1. Import the optional dependency
   let Sandbox: (typeof import("@vercel/sandbox"))["Sandbox"];
@@ -99,18 +111,21 @@ export async function createSandboxBackend(
     );
   }
 
-  // 2. Create the sandbox. When VERCEL_TEAM_ID/VERCEL_PROJECT_ID/VERCEL_TOKEN
-  // are set we're running off-Vercel (e.g. Railway) and need to pass explicit
-  // credentials; on Vercel itself, OIDC handles auth automatically and these
-  // are undefined.
-  const access = vercelSandboxAccess();
-  const explicitAccess = access
-    ? {
-        teamId: access.teamId,
-        projectId: access.projectId,
-        token: access.token.reveal(),
-      }
-    : undefined;
+  // 2. Create the sandbox. An accessOverride (per-org BYOC credentials)
+  // takes precedence and is used verbatim. Otherwise, when
+  // VERCEL_TEAM_ID/VERCEL_PROJECT_ID/VERCEL_TOKEN are set we're running
+  // off-Vercel (e.g. Railway) and pass explicit operator credentials; on
+  // Vercel itself, OIDC handles auth automatically and these are undefined.
+  const access = accessOverride ? undefined : vercelSandboxAccess();
+  const explicitAccess = accessOverride
+    ? { ...accessOverride }
+    : access
+      ? {
+          teamId: access.teamId,
+          projectId: access.projectId,
+          token: access.token.reveal(),
+        }
+      : undefined;
   let sandbox: InstanceType<typeof Sandbox>;
   try {
     sandbox = await Sandbox.create({

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -316,17 +316,65 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
  */
 const backendCache = new Map<string, Promise<ExploreBackend>>();
 
+/**
+ * Cache keys created under an org, for targeted invalidation when that org's
+ * BYOC sandbox credentials change (#3370). Mirrors how the ConnectionRegistry
+ * drains a workspace's pools on datasource credential edits (#3114).
+ */
+const orgBackendKeys = new Map<string, Set<string>>();
+
+/** Best-effort close of a cached backend's resources (logs, never throws). */
+function closeCachedBackend(promise: Promise<ExploreBackend>): void {
+  promise
+    .then((backend) => backend.close?.())
+    .catch((err) => {
+      log.debug(
+        { err: errorMessage(err) },
+        "Failed to close invalidated explore backend",
+      );
+    });
+}
+
 /** Clear cached backends so the next call recreates them. */
 export function invalidateExploreBackend(): void {
+  // Close before clearing — BYOC backends (#3370) hold live remote sandboxes
+  // (E2B/Daytona/Railway containers, Vercel sessions) that would otherwise
+  // bill until the provider's idle timeout reaps them.
+  for (const cached of backendCache.values()) {
+    closeCachedBackend(cached);
+  }
   backendCache.clear();
+  orgBackendKeys.clear();
   _activeSandboxPluginId = null;
+}
+
+/**
+ * Drop (and close) every cached backend created for an org. Called when the
+ * org's BYOC sandbox credentials are saved or deleted so the next explore
+ * call rebuilds against the new credential state.
+ */
+export function invalidateOrgExploreBackends(orgId: string): void {
+  const keys = orgBackendKeys.get(orgId);
+  if (!keys) return;
+  orgBackendKeys.delete(orgId);
+  for (const key of keys) {
+    const cached = backendCache.get(key);
+    if (cached) {
+      backendCache.delete(key);
+      closeCachedBackend(cached);
+    }
+  }
 }
 
 /** Permanently mark nsjail as failed and clear the backend cache.
  *  Called from explore-nsjail.ts on exit code 109 (sandbox setup failure). */
 export function markNsjailFailed(): void {
   _nsjailFailed = true;
+  for (const cached of backendCache.values()) {
+    closeCachedBackend(cached);
+  }
   backendCache.clear();
+  orgBackendKeys.clear();
 }
 
 /** Permanently mark the sidecar as failed so health reports "just-bash".
@@ -353,6 +401,25 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
           "Workspace sandbox override: %s",
           wsOverride,
         );
+        // Priority -1a: BYOC — the org connected its own provider credentials
+        // and selected that provider's backend (#3370). Built from the stored
+        // credentials on the org's own account. Returns null when not engaged
+        // (no/incomplete credentials, runtime not installed) and the override
+        // resolves through the operator chain below; throws when engaged but
+        // construction fails, which propagates so explore fails closed
+        // instead of silently running on the operator's account.
+        if (orgId) {
+          const { tryCreateByocBackend } = await import("@atlas/api/lib/sandbox/runtime");
+          const byocBackend = await tryCreateByocBackend(orgId, wsOverride, semanticRoot);
+          if (byocBackend) {
+            log.info(
+              { backend: wsOverride, orgId, source: "byoc" },
+              "Explore backend selected: %s (org BYOC credentials)",
+              wsOverride,
+            );
+            return byocBackend;
+          }
+        }
         // Check if override is a built-in backend name
         const builtInNames: readonly string[] = ["vercel-sandbox", "nsjail", "sidecar", "just-bash"];
         if (builtInNames.includes(wsOverride)) {
@@ -562,6 +629,14 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
       throw err;
     });
     backendCache.set(cacheKeyVal, promise);
+    if (orgId) {
+      let keys = orgBackendKeys.get(orgId);
+      if (!keys) {
+        keys = new Set();
+        orgBackendKeys.set(orgId, keys);
+      }
+      keys.add(cacheKeyVal);
+    }
   }
   return promise;
 }

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -319,17 +319,20 @@ const backendCache = new Map<string, Promise<ExploreBackend>>();
 /**
  * Cache keys created under an org, for targeted invalidation when that org's
  * BYOC sandbox credentials change (#3370). Mirrors how the ConnectionRegistry
- * drains a workspace's pools on datasource credential edits (#3114).
+ * drains a workspace's pools on datasource credential edits
+ * (drainWorkspacePool, #3109).
  */
 const orgBackendKeys = new Map<string, Set<string>>();
 
 /** Best-effort close of a cached backend's resources (logs, never throws). */
-function closeCachedBackend(promise: Promise<ExploreBackend>): void {
+function closeCachedBackend(promise: Promise<ExploreBackend>, cacheKey: string): void {
   promise
     .then((backend) => backend.close?.())
     .catch((err) => {
-      log.debug(
-        { err: errorMessage(err) },
+      // warn, not debug: for BYOC backends a failed teardown leaves a remote
+      // sandbox billing the org's provider account until its idle timeout.
+      log.warn(
+        { err: errorMessage(err), cacheKey },
         "Failed to close invalidated explore backend",
       );
     });
@@ -340,8 +343,8 @@ export function invalidateExploreBackend(): void {
   // Close before clearing — BYOC backends (#3370) hold live remote sandboxes
   // (E2B/Daytona/Railway containers, Vercel sessions) that would otherwise
   // bill until the provider's idle timeout reaps them.
-  for (const cached of backendCache.values()) {
-    closeCachedBackend(cached);
+  for (const [key, cached] of backendCache) {
+    closeCachedBackend(cached, key);
   }
   backendCache.clear();
   orgBackendKeys.clear();
@@ -352,6 +355,10 @@ export function invalidateExploreBackend(): void {
  * Drop (and close) every cached backend created for an org. Called when the
  * org's BYOC sandbox credentials are saved or deleted so the next explore
  * call rebuilds against the new credential state.
+ *
+ * Per-process only: in a multi-replica deployment, other replicas keep
+ * their cached backend until restart or their own invalidation — same
+ * limitation as the ConnectionRegistry workspace-pool drain it mirrors.
  */
 export function invalidateOrgExploreBackends(orgId: string): void {
   const keys = orgBackendKeys.get(orgId);
@@ -361,7 +368,7 @@ export function invalidateOrgExploreBackends(orgId: string): void {
     const cached = backendCache.get(key);
     if (cached) {
       backendCache.delete(key);
-      closeCachedBackend(cached);
+      closeCachedBackend(cached, key);
     }
   }
 }
@@ -370,8 +377,8 @@ export function invalidateOrgExploreBackends(orgId: string): void {
  *  Called from explore-nsjail.ts on exit code 109 (sandbox setup failure). */
 export function markNsjailFailed(): void {
   _nsjailFailed = true;
-  for (const cached of backendCache.values()) {
-    closeCachedBackend(cached);
+  for (const [key, cached] of backendCache) {
+    closeCachedBackend(cached, key);
   }
   backendCache.clear();
   orgBackendKeys.clear();
@@ -625,7 +632,12 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
       }
       return createBashBackend(semanticRoot);
     })().catch((err) => {
-      backendCache.delete(cacheKeyVal); // allow retry on next call
+      // Identity-guarded: if invalidation already evicted this promise and a
+      // newer backend was cached under the same key, deleting blindly would
+      // orphan that live backend (it would never be close()d).
+      if (backendCache.get(cacheKeyVal) === promise) {
+        backendCache.delete(cacheKeyVal); // allow retry on next call
+      }
       throw err;
     });
     backendCache.set(cacheKeyVal, promise);

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/schemas",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Shared Zod schemas for Atlas wire format — single source of truth for API route validation and web response parsing",
   "type": "module",
   "private": true,

--- a/packages/schemas/src/sandbox.ts
+++ b/packages/schemas/src/sandbox.ts
@@ -109,9 +109,15 @@ export const SandboxStatusSchema = z.object({
   connectedProviders: z.array(SandboxConnectedProviderSchema),
   /**
    * Whether this deployment can run each BYOC provider at runtime (provider
-   * plugin + SDK installed; `vercel` is always available). Providers absent
-   * or false cannot execute even with valid stored credentials (#3370).
-   * Optional: absent on responses from API versions predating the field.
+   * plugin + SDK resolvable). `false` means the provider cannot execute even
+   * with valid stored credentials (#3370). Consumers treat an absent key —
+   * and the absent field on API versions predating it — as *unknown* and
+   * assume usable: the optimistic default keeps older-API admin pages
+   * functional, and the connect/explore paths enforce the real check
+   * server-side. Keys are deliberately `z.string()` rather than
+   * `SandboxProviderKeySchema`: an enum-keyed record would make a newer API
+   * (with a fifth provider) fail this whole parse on an older web bundle
+   * during the deploy-overlap window.
    */
   providerRuntimeAvailability: z.record(z.string(), z.boolean()).optional(),
 });

--- a/packages/schemas/src/sandbox.ts
+++ b/packages/schemas/src/sandbox.ts
@@ -79,6 +79,13 @@ export const SandboxConnectedProviderSchema = z.object({
    * `activeBackend` so the two fields can never contradict (#3375).
    */
   isActive: z.boolean(),
+  /**
+   * True when the stored credentials are missing fields the runtime now
+   * requires (e.g. a Vercel row stored before `projectId` was collected).
+   * The provider must be reconnected before it can run (#3370). Optional:
+   * absent on responses from API versions predating the field.
+   */
+  needsReconnect: z.boolean().optional(),
 });
 
 export type SandboxConnectedProvider = z.infer<typeof SandboxConnectedProviderSchema>;
@@ -100,6 +107,13 @@ export const SandboxStatusSchema = z.object({
   availableBackends: z.array(SandboxBackendSchema),
   /** Connected BYOC sandbox providers for this org */
   connectedProviders: z.array(SandboxConnectedProviderSchema),
+  /**
+   * Whether this deployment can run each BYOC provider at runtime (provider
+   * plugin + SDK installed; `vercel` is always available). Providers absent
+   * or false cannot execute even with valid stored credentials (#3370).
+   * Optional: absent on responses from API versions predating the field.
+   */
+  providerRuntimeAvailability: z.record(z.string(), z.boolean()).optional(),
 });
 
 export type SandboxStatus = z.infer<typeof SandboxStatusSchema>;

--- a/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
@@ -132,6 +132,44 @@ describe("SaasSandboxView — backend-id save values", () => {
     cleanup();
   });
 
+  test("a connected row needing reconnect offers no 'Use this' and says why (#3370)", () => {
+    const { getByText, queryAllByText } = renderView(
+      makeStatus({
+        connectedProviders: [
+          {
+            provider: "vercel",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: false,
+            needsReconnect: true, // pre-projectId row
+          },
+        ],
+        providerRuntimeAvailability: { vercel: true, e2b: true, daytona: true, railway: true },
+      }),
+    );
+
+    getByText("Reconnect required");
+    // Selecting it would silently fall back to the platform default, so the
+    // action must not be offered. Managed is the active card here (no row is
+    // live) and hides its own button too — so no "Use this" anywhere.
+    expect(queryAllByText("Use this").length).toBe(0);
+    cleanup();
+  });
+
+  test("a provider without a runtime on this deployment shows Unavailable instead of Connect (#3370)", () => {
+    const { getAllByText, queryAllByText } = renderView(
+      makeStatus({
+        providerRuntimeAvailability: { vercel: true, e2b: false, daytona: true, railway: true },
+      }),
+    );
+
+    // The e2b card offers no connect flow; the other three still do.
+    expect(getAllByText("Unavailable").length).toBe(1);
+    expect(queryAllByText("Connect").length).toBe(3);
+    cleanup();
+  });
+
   test("managed card reads active from server-derived isActive, not the override string", () => {
     // Legacy contradiction scenario: an override is set but no provider row
     // is live (e.g. the selected backend was unavailable and the runtime

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -88,6 +88,9 @@ const PROVIDERS: Record<SandboxProviderKey, ProviderInfo> = {
     fields: [
       { key: "accessToken", label: "Access Token", type: "password", placeholder: "vercel_...", required: true },
       { key: "teamId", label: "Team ID", type: "text", placeholder: "team_...", required: true },
+      // Required at runtime — @vercel/sandbox needs the full
+      // token/teamId/projectId triple to create sandboxes (#3370).
+      { key: "projectId", label: "Project ID", type: "text", placeholder: "prj_...", required: true },
     ],
   },
   e2b: {
@@ -337,6 +340,11 @@ export function SaasSandboxView({
                 providerKey={key}
                 connection={provider ?? null}
                 isActive={provider?.isActive ?? false}
+                // Absent field (older API) defaults to available so the page
+                // degrades to its pre-#3370 behavior rather than locking
+                // every card.
+                runtimeAvailable={status.providerRuntimeAvailability?.[key] ?? true}
+                needsReconnect={provider?.needsReconnect ?? false}
                 // ATLAS_SANDBOX_BACKEND stores backend ids, not provider
                 // keys — saving the bare key used to fall through to the
                 // platform default silently (#3375).
@@ -401,6 +409,8 @@ function ProviderRow({
   providerKey,
   connection,
   isActive,
+  runtimeAvailable,
+  needsReconnect,
   onSelect,
   onRefetch,
   saving,
@@ -408,13 +418,27 @@ function ProviderRow({
   providerKey: SandboxProviderKey;
   connection: ConnectedProvider | null;
   isActive: boolean;
+  runtimeAvailable: boolean;
+  needsReconnect: boolean;
   onSelect: () => Promise<unknown>;
   onRefetch: () => void;
   saving: boolean;
 }) {
   const info = PROVIDERS[providerKey];
   const isConnected = !!connection;
-  const status: StatusKind = isActive ? "connected" : isConnected ? "ready" : "disconnected";
+  // A provider only runs when this deployment has its runtime AND the stored
+  // credentials are complete — otherwise selecting it silently falls back to
+  // the platform default, so the card must not offer "Use this" (#3370).
+  const isUsable = runtimeAvailable && !needsReconnect;
+  const status: StatusKind = isActive
+    ? "connected"
+    : isConnected
+      ? isUsable
+        ? "ready"
+        : "unavailable"
+      : runtimeAvailable
+        ? "disconnected"
+        : "unavailable";
 
   const disconnectMutation = useAdminMutation({
     path: `/api/v1/admin/sandbox/disconnect/${providerKey}`,
@@ -459,6 +483,21 @@ function ProviderRow({
   }, [isConnected, clearConnectError]);
 
   const showFull = isConnected || expanded;
+
+  // No runtime for this provider in this deployment: connecting credentials
+  // would store secrets that can never run. Say so instead of offering a
+  // connect flow that implies isolation that won't happen (#3370).
+  if (!runtimeAvailable && !isConnected) {
+    return (
+      <CompactRow
+        icon={info.icon}
+        title={info.label}
+        description={`${info.description} Not available on this deployment.`}
+        status={status}
+        action={<StatusPill kind="unavailable" label="Unavailable" />}
+      />
+    );
+  }
 
   if (!showFull) {
     return (
@@ -511,14 +550,20 @@ function ProviderRow({
         isActive ? (
           <StatusPill kind="connected" label="Live" />
         ) : isConnected ? (
-          <StatusPill kind="ready" label="Connected" />
+          needsReconnect ? (
+            <StatusPill kind="unavailable" label="Reconnect required" />
+          ) : runtimeAvailable ? (
+            <StatusPill kind="ready" label="Connected" />
+          ) : (
+            <StatusPill kind="unavailable" label="Unavailable" />
+          )
         ) : undefined
       }
       onCollapse={!isConnected ? collapse : undefined}
       actions={
         isConnected ? (
           <>
-            {!isActive && (
+            {!isActive && isUsable && (
               <Button size="sm" onClick={onSelect} disabled={saving}>
                 {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
                 Use this
@@ -574,15 +619,30 @@ function ProviderRow({
       }
     >
       {isConnected ? (
-        <DetailList>
-          {connection.displayName && (
-            <DetailRow label="Account" value={connection.displayName} />
+        <>
+          <DetailList>
+            {connection.displayName && (
+              <DetailRow label="Account" value={connection.displayName} />
+            )}
+            <DetailRow label="Connected" value={formatDateTime(connection.connectedAt)} />
+            {connection.validatedAt && (
+              <DetailRow label="Validated" value={formatDateTime(connection.validatedAt)} />
+            )}
+          </DetailList>
+          {needsReconnect && (
+            <p className="text-xs text-muted-foreground">
+              These credentials are missing fields now required to run sandboxes
+              (for Vercel, a Project ID). Disconnect and reconnect with the full
+              set to use this provider.
+            </p>
           )}
-          <DetailRow label="Connected" value={formatDateTime(connection.connectedAt)} />
-          {connection.validatedAt && (
-            <DetailRow label="Validated" value={formatDateTime(connection.validatedAt)} />
+          {!runtimeAvailable && (
+            <p className="text-xs text-muted-foreground">
+              This provider isn&apos;t available on this deployment, so the stored
+              credentials can&apos;t be used to run sandboxes yet.
+            </p>
           )}
-        </DetailList>
+        </>
       ) : (
         <div className="space-y-3">
           {info.fields.map((field) => (


### PR DESCRIPTION
Closes #3370. Surfaced by the #3369 review pass: the `/admin/sandbox` BYOC flow stored validated provider credentials encrypted in `sandbox_credentials`, but nothing ever read them — the explore tool always ran on operator-configured backends while the UI implied per-org isolation.

## Design decision: per-org instantiation semantics

**BYOC engages for a request iff all four hold:**

1. the request has org context, and
2. the normalized `ATLAS_SANDBOX_BACKEND` workspace override selects that provider's backend id (connecting alone never switches execution — mirrors the status route's `isActive` rule from #3375), and
3. the stored credential row carries every runtime-required field, and
4. the provider runtime is installed in the deployment (plugin package + SDK resolvable; vercel is in-tree and always available).

When engaged, the backend is built per `(org, provider)` from the org's decrypted credentials (via `db/secret-encryption.ts`, never logged) on the org's own account, and failures are **fail-closed**: explore errors rather than silently running the org's workload on the operator's account. When *not* engaged, the override falls through to today's operator chain — the operator *instance*, never operator creds injected into an org path (#2850 seam) — and the status endpoint/UI say why (`needsReconnect`, `providerRuntimeAvailability`).

**Caching/invalidation:** backends cache under the existing `semanticRoot + override` key (semantic roots are org-scoped); org-owned keys are tracked and `invalidateOrgExploreBackends(orgId)` closes + drops them on credential connect/disconnect, mirroring the ConnectionRegistry workspace-pool drain (#3114). The global invalidators now close evicted backends too (BYOC backends hold live remote sandboxes).

**SaaS pin interplay:** `sandbox.priority: ["vercel-sandbox"]` continues to govern the platform-default path. BYOC supersedes it only via the explicit two-step admin opt-in, and runs in the org's own account — the pin's rationale (shared backends can't hold multi-tenant boundaries) doesn't apply to a backend that executes exactly one org's workload in that org's account. Documented in `deploy/api/atlas.config.ts` and `docs/guides/sandbox.mdx`.

## Per-provider changes

| Provider | Change |
|----------|--------|
| **Vercel** | Works end-to-end, including on SaaS. Found while wiring: `@vercel/sandbox` v2 only accepts the full `{token, teamId, projectId}` triple — the stored `{accessToken, teamId}` shape could **never** create a sandbox (the published `@useatlas/vercel-sandbox` plugin's access-token mode has the same latent bug). The connect flow now collects + validates **Project ID**; runtime uses the in-tree backend (deny-all preserved) with the org triple. Legacy rows show **Reconnect required**. |
| **E2B / Daytona** | Built via the published plugin factories (`e2bSandboxPlugin` / `daytonaSandboxPlugin`) through computed-specifier dynamic import — works wherever the plugin + SDK are installed; reports **Unavailable** otherwise (incl. SaaS today). |
| **Railway** | Same mechanism; additionally `environmentId` is now **required** at connect and passed explicitly, so the plugin's `RAILWAY_API_TOKEN`/`RAILWAY_ENVIRONMENT_ID` env fallback can never mix operator config into an org path. |

No new dependency edges: `@useatlas/railway-sandbox` isn't published yet and the SDKs are optional peers, so plugin packages resolve at runtime only where installed (`isProviderRuntimeAvailable` probes and the UI reflects it).

## UI honesty

- Cards whose runtime isn't installed show **Unavailable** (no connect flow that stores secrets which can never run).
- Connected rows missing runtime-required fields show **Reconnect required** and hide **Use this**.
- `activeBackend`/`isActive` resolution now counts a *usable* BYOC selection, so the status page agrees with what actually executes.
- New wire fields are optional; older clients/scaffolds degrade to pre-#3370 behavior. `@useatlas/schemas` bumped 0.0.2 → 0.0.3 (refs stay pinned per the publish-sequencing rule).

## Split out

- #3409 — ship E2B/Daytona/Railway BYOC runtimes in the SaaS image (deploy decision: which providers, dependency edges, staging soak)
- #3410 — python tool ignores BYOC selection (explore-only parity gap; docs callout added meanwhile)

## Testing

- `lib/sandbox/__tests__/runtime.test.ts` — pure-DI: per-provider credential mapping (asserts the instantiated plugin received the stored creds), engagement gates, fail-closed without echoing provider error text (SDK errors can contain the rejected key; detail stays on `cause` + operator log).
- `lib/tools/__tests__/explore-byoc.test.ts` — BYOC wins over a same-id operator plugin; null falls through; throw fails closed (no silent operator fallback); per-org invalidation closes + rebuilds; no org → BYOC never consulted.
- `admin-sandbox.test.ts` — connect/disconnect drain the org cache; `needsReconnect` for legacy vercel rows; BYOC-selected resolution with/without runtime.
- Web: reconnect-required and unavailable card states; existing #3375 save-value tests still pass.

`/ci`: lint, type, syncpack, template/security-header/railway-watch/schema/oauth-helper/test-discipline/twenty-resolver/settings-readers/published-symbols all pass. Full suite: all failures across two runs were the documented load-flake set (#2776/#2710 family — different files each run, all pass via the isolated runner).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783797468&installation_id=135337507&pr_number=3411&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3411&signature=e0930a38a2eef817dfbd52376bd7b2632700359ce30b3bc3364d834dd5841777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Railway added to SaaS BYOC providers
  * Per-deployment runtime availability shown for BYOC providers
  * UI shows “Unavailable” for providers whose runtime isn’t present and a compact card instead of connect flow
  * Credentials edits now trigger backend refresh so changes take effect immediately

* **Bug Fixes**
  * Vercel now requires Project ID during validation
  * Prevents silent fallback to platform defaults when BYOC credentials are incomplete

* **Documentation**
  * Sandbox admin guide updated with BYOC credential and runtime behavior guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->