### PR TITLE
feat(sandbox): BYOC selection covers the Python tool for Vercel

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -668,7 +668,7 @@ See [Integrations Hub](/guides/integrations) for the full guide.
 
 **Route:** `/admin/sandbox`
 
-In **self-hosted** mode, configure which sandbox backend the explore and Python tools use via a dropdown selector. In **SaaS** mode, the page shows an integration card grid where workspace admins connect their own cloud sandbox providers (Vercel, E2B, Daytona) alongside the managed Atlas Cloud Sandbox.
+In **self-hosted** mode, configure which sandbox backend the explore tool uses via a dropdown selector (the Python tool follows the platform-level sandbox configuration). In **SaaS** mode, the page shows an integration card grid where workspace admins connect their own cloud sandbox providers (Vercel, E2B, Daytona, Railway) alongside the managed Atlas Cloud Sandbox; a connected Vercel provider covers both explore and Python.
 
 See [Sandbox Configuration](/guides/sandbox) for the full guide.
 

--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -109,8 +109,9 @@ Credentials are stored per-workspace in the `sandbox_credentials` table. Each wo
 
 ### How BYOC Runs at Runtime
 
-A connected provider executes **explore** commands on your own account when
-all of the following hold:
+A connected provider executes **explore** commands — and, for providers with
+Python support (see the matrix below), **Python** executions — on your own
+account when all of the following hold:
 
 1. The provider is **selected** (its backend ID is the workspace's
    `ATLAS_SANDBOX_BACKEND` override) — connecting alone does not switch
@@ -135,10 +136,33 @@ that instead of showing the provider as live.
 
 Editing or disconnecting credentials tears down any cached sandbox for the
 workspace immediately; the next explore call rebuilds against the new state.
+(Python sandboxes are created per-request and re-read credentials on every
+call, so they pick up changes without a teardown step.)
 
-<Callout type="warn">
-The **Python tool** currently always runs on the platform sandbox — BYOC
-selection applies to the explore tool only.
+### Python Tool Coverage
+
+BYOC coverage for the **Python tool** is per-provider — Python needs more
+than the explore-shaped command surface (file upload, a Python interpreter,
+and the per-request REST egress allowlist):
+
+| Provider | Explore | Python |
+|----------|---------|--------|
+| Vercel Sandbox | Your account | Your account |
+| E2B | Your account | Platform sandbox |
+| Daytona | Your account | Platform sandbox |
+| Railway | Your account | Platform sandbox |
+
+With a connected **Vercel** provider selected, Python runs on your Vercel
+account with the same engagement and fail-closed rules as explore: if your
+sandbox can't start, the Python tool errors rather than silently falling back
+to the platform sandbox, and the egress allowlist for REST datasources is
+applied to your sandbox exactly as it would be to the managed one.
+
+<Callout type="info">
+E2B, Daytona, and Railway sandboxes are explore-only today — their plugin
+interface has no Python execution surface yet. With one of these selected,
+explore runs on your account while Python falls back to the platform
+sandbox.
 </Callout>
 
 ---
@@ -158,6 +182,12 @@ In self-hosted mode, the page shows the original dropdown UI:
 3. Click **Save**
 
 To return to the platform default, select **Use platform default** from the dropdown, or click **Reset to default**.
+
+<Callout type="info">
+The workspace backend override applies to the **explore** tool. The **Python**
+tool follows the platform-level sandbox configuration (the environment-driven
+priority chain below) — it is not affected by this dropdown.
+</Callout>
 
 ### Sidecar Configuration
 

--- a/bun.lock
+++ b/bun.lock
@@ -390,7 +390,7 @@
     },
     "packages/schemas": {
       "name": "@useatlas/schemas",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@useatlas/types": "workspace:*",
         "zod": "^4.4.3",

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -398,6 +398,9 @@ adminSandbox.openapi(connectRoute, async (c) => {
       // Tear down this org's cached explore backends so the next explore
       // call rebuilds with the new credentials (#3370) — mirrors the
       // ConnectionRegistry's workspace pool drain on credential edits.
+      // The Python tool needs no counterpart: its backends are per-request
+      // (python.ts builds a fresh one each call, re-reading stored
+      // credentials), so there is nothing cached to drain (#3410).
       invalidateOrgExploreBackends(orgId);
 
       log.info({ orgId, provider }, "Sandbox provider connected");

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -7,12 +7,15 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import type { SandboxCredential } from "../credentials";
+import type { PythonSandboxOptions } from "@atlas/api/lib/tools/python-sandbox";
 import {
   sandboxProviderForBackendId,
   missingCredentialFields,
   isProviderRuntimeAvailable,
   getProviderRuntimeAvailability,
+  providerSupportsPython,
   tryCreateByocBackend,
+  tryCreateByocPythonBackend,
   _resetRuntimeAvailabilityCacheForTest,
   type ModuleLoader,
 } from "../runtime";
@@ -402,5 +405,204 @@ describe("tryCreateByocBackend — engaged", () => {
     expect(((thrown as Error).cause as Error).message).toMatch(
       /does not export e2bSandboxPlugin/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Python (#3410)
+// ---------------------------------------------------------------------------
+
+describe("providerSupportsPython", () => {
+  it("vercel is the only python-capable provider (plugin SDK has no python surface)", () => {
+    expect(providerSupportsPython("vercel")).toBe(true);
+    expect(providerSupportsPython("e2b")).toBe(false);
+    expect(providerSupportsPython("daytona")).toBe(false);
+    expect(providerSupportsPython("railway")).toBe(false);
+  });
+});
+
+/** Fake in-tree python-sandbox module whose factory records its options. */
+function fakePythonSandboxModule(
+  execResult: { success: boolean; error?: string } = { success: true },
+) {
+  const factoryCalls: PythonSandboxOptions[] = [];
+  const mod = {
+    createPythonSandboxBackend: (options: PythonSandboxOptions = {}) => {
+      factoryCalls.push(options);
+      return {
+        exec: async () => execResult,
+      };
+    },
+  };
+  return { mod, factoryCalls };
+}
+
+const VERCEL_TRIPLE = {
+  accessToken: "vc_org_token",
+  teamId: "team_1",
+  projectId: "prj_1",
+};
+
+describe("tryCreateByocPythonBackend — not engaged (falls through to operator chain)", () => {
+  it("returns null for non-BYOC backend ids without touching credentials", async () => {
+    let credentialReads = 0;
+    const backend = await tryCreateByocPythonBackend("org-1", "sidecar", {}, {
+      getCredential: async () => {
+        credentialReads++;
+        return null;
+      },
+      load: fakeLoader({}),
+    });
+    expect(backend).toBeNull();
+    expect(credentialReads).toBe(0);
+  });
+
+  it("returns null for python-incapable providers without touching credentials", async () => {
+    // The org's e2b selection covers explore only — python falls through to
+    // the operator chain, and the capability gate short-circuits before any
+    // credential read.
+    let credentialReads = 0;
+    const backend = await tryCreateByocPythonBackend("org-1", "e2b-sandbox", {}, {
+      getCredential: async () => {
+        credentialReads++;
+        return makeCredential("e2b", { apiKey: "e2b_key" });
+      },
+      load: fakeLoader({ "@useatlas/e2b": {}, e2b: {} }),
+    });
+    expect(backend).toBeNull();
+    expect(credentialReads).toBe(0);
+  });
+
+  it("returns null when the org has no stored vercel credentials", async () => {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      getCredential: async () => null,
+      load: fakeLoader({ "@vercel/sandbox": {} }),
+    });
+    expect(backend).toBeNull();
+  });
+
+  it("returns null when stored credentials miss runtime-required fields", async () => {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      getCredential: async () =>
+        makeCredential("vercel", { accessToken: "tok", teamId: "team_1" }),
+      load: fakeLoader({ "@vercel/sandbox": {} }),
+    });
+    expect(backend).toBeNull();
+  });
+
+  it("returns null when @vercel/sandbox is not installed", async () => {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+      load: fakeLoader({}),
+    });
+    expect(backend).toBeNull();
+  });
+
+  it("fails closed (throws) when the runtime is installed but fails to load", async () => {
+    const brokenLoader: ModuleLoader = async () => {
+      throw new Error("init failed under resource pressure"); // no not-found code
+    };
+    let thrown: unknown;
+    try {
+      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+        getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+        load: brokenLoader,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("runtime failed to load");
+  });
+});
+
+describe("tryCreateByocPythonBackend — engaged", () => {
+  it("constructs the python sandbox with the stored triple as an access override", async () => {
+    const { mod, factoryCalls } = fakePythonSandboxModule();
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+      load: fakeLoader({
+        "@vercel/sandbox": {},
+        "@atlas/api/lib/tools/python-sandbox": mod,
+      }),
+    });
+    expect(backend).not.toBeNull();
+    expect(factoryCalls.length).toBe(1);
+    const access = factoryCalls[0].access!;
+    expect(access.teamId).toBe("team_1");
+    expect(access.projectId).toBe("prj_1");
+    // RedactedSecret-branded: revealable at the create site, but an
+    // accidental structured log of the options leaks nothing.
+    expect(access.token.reveal()).toBe("vc_org_token");
+    expect(JSON.stringify(factoryCalls[0])).not.toContain("vc_org_token");
+    const result = await backend!.exec("print(1)");
+    expect(result.success).toBe(true);
+  });
+
+  it("threads the caller's per-request network policy through to the sandbox options", async () => {
+    const { mod, factoryCalls } = fakePythonSandboxModule();
+    const networkPolicy = { allow: { "api.example.com": {} } } as never;
+    await tryCreateByocPythonBackend(
+      "org-1",
+      "vercel-sandbox",
+      { networkPolicy },
+      {
+        getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+        load: fakeLoader({
+          "@vercel/sandbox": {},
+          "@atlas/api/lib/tools/python-sandbox": mod,
+        }),
+      },
+    );
+    expect(factoryCalls[0].networkPolicy).toBe(networkPolicy);
+  });
+
+  it("scrubs stored credential values from failed exec results", async () => {
+    // The lazy backend maps provider failures to result objects (not throws),
+    // so the error text the agent sees must be scrubbed against the org's
+    // stored values — a Sandbox.create failure can echo the rejected token.
+    const { mod } = fakePythonSandboxModule({
+      success: false,
+      error: "Failed to create Python Vercel Sandbox: token vc_org_token rejected.",
+    });
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+      load: fakeLoader({
+        "@vercel/sandbox": {},
+        "@atlas/api/lib/tools/python-sandbox": mod,
+      }),
+    });
+    const result = await backend!.exec("print(1)");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toContain("vc_org_token");
+      expect(result.error).toContain("[REDACTED]");
+    }
+  });
+
+  it("throws a generic credential-scrubbed error when construction itself fails", async () => {
+    const brokenModule = {
+      createPythonSandboxBackend: () => {
+        throw new Error("factory exploded with token vc_org_token");
+      },
+    };
+    let thrown: unknown;
+    try {
+      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+        getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+        load: fakeLoader({
+          "@vercel/sandbox": {},
+          "@atlas/api/lib/tools/python-sandbox": brokenModule,
+        }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("connected vercel sandbox failed to start");
+    expect(message).not.toContain("vc_org_token");
+    // The detail stays on `cause` for operator-side diagnosis
+    expect(((thrown as Error).cause as Error).message).toContain("factory exploded");
   });
 });

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -337,6 +337,12 @@ describe("tryCreateByocBackend — engaged", () => {
     // but serializing it (e.g. an accidental structured log) leaks nothing.
     expect(createCalls[0].access.token.reveal()).toBe("vc_tok");
     expect(JSON.stringify(createCalls[0].access)).not.toContain("vc_tok");
+    // The backend logs Sandbox.create failures itself — the threaded
+    // scrubErrorDetail must redact stored values at the source (#3413 P1).
+    const scrub = (createCalls[0].access as { scrubErrorDetail?: (d: string) => string })
+      .scrubErrorDetail;
+    expect(scrub).toBeDefined();
+    expect(scrub!("401: token vc_tok rejected")).not.toContain("vc_tok");
   });
 
   it("throws an incompatible-version error when the factory returns a shapeless plugin", async () => {
@@ -571,6 +577,13 @@ describe("tryCreateByocPythonBackend — engaged", () => {
     // accidental structured log of the options leaks nothing.
     expect(access.token.reveal()).toBe("vc_org_token");
     expect(JSON.stringify(factoryCalls[0])).not.toContain("vc_org_token");
+    // The backend logs provider errors before the wrapper's result scrub —
+    // the threaded scrubErrorDetail must redact stored values at the source
+    // (#3413 P1).
+    expect(factoryCalls[0].scrubErrorDetail).toBeDefined();
+    expect(
+      factoryCalls[0].scrubErrorDetail!("401: token vc_org_token rejected"),
+    ).not.toContain("vc_org_token");
     const result = await backend!.exec("print(1)");
     expect(result.success).toBe(true);
   });

--- a/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/runtime.test.ts
@@ -443,10 +443,13 @@ const VERCEL_TRIPLE = {
   projectId: "prj_1",
 };
 
+/** Default options thunk for calls that don't exercise the egress policy. */
+const NO_OPTIONS = async () => ({});
+
 describe("tryCreateByocPythonBackend — not engaged (falls through to operator chain)", () => {
   it("returns null for non-BYOC backend ids without touching credentials", async () => {
     let credentialReads = 0;
-    const backend = await tryCreateByocPythonBackend("org-1", "sidecar", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "sidecar", NO_OPTIONS, {
       getCredential: async () => {
         credentialReads++;
         return null;
@@ -462,7 +465,7 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
     // the operator chain, and the capability gate short-circuits before any
     // credential read.
     let credentialReads = 0;
-    const backend = await tryCreateByocPythonBackend("org-1", "e2b-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "e2b-sandbox", NO_OPTIONS, {
       getCredential: async () => {
         credentialReads++;
         return makeCredential("e2b", { apiKey: "e2b_key" });
@@ -474,7 +477,7 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
   });
 
   it("returns null when the org has no stored vercel credentials", async () => {
-    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
       getCredential: async () => null,
       load: fakeLoader({ "@vercel/sandbox": {} }),
     });
@@ -482,7 +485,7 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
   });
 
   it("returns null when stored credentials miss runtime-required fields", async () => {
-    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
       getCredential: async () =>
         makeCredential("vercel", { accessToken: "tok", teamId: "team_1" }),
       load: fakeLoader({ "@vercel/sandbox": {} }),
@@ -491,7 +494,7 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
   });
 
   it("returns null when @vercel/sandbox is not installed", async () => {
-    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
       getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
       load: fakeLoader({}),
     });
@@ -504,7 +507,7 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
     };
     let thrown: unknown;
     try {
-      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
         getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
         load: brokenLoader,
       });
@@ -514,12 +517,45 @@ describe("tryCreateByocPythonBackend — not engaged (falls through to operator 
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toContain("runtime failed to load");
   });
+
+  it("does not invoke the options thunk unless engaged", async () => {
+    // The thunk fronts a per-request datasource resolve (#2927) — a
+    // selected-but-unusable override must not pay that I/O.
+    let optionReads = 0;
+    const countingOptions = async () => {
+      optionReads++;
+      return {};
+    };
+    // Not engaged: incomplete credentials
+    await tryCreateByocPythonBackend("org-1", "vercel-sandbox", countingOptions, {
+      getCredential: async () =>
+        makeCredential("vercel", { accessToken: "tok", teamId: "team_1" }),
+      load: fakeLoader({ "@vercel/sandbox": {} }),
+    });
+    // Not engaged: python-incapable provider
+    await tryCreateByocPythonBackend("org-1", "e2b-sandbox", countingOptions, {
+      getCredential: async () => makeCredential("e2b", { apiKey: "k" }),
+      load: fakeLoader({ "@useatlas/e2b": {}, e2b: {} }),
+    });
+    expect(optionReads).toBe(0);
+
+    // Engaged: thunk runs exactly once
+    const { mod } = fakePythonSandboxModule();
+    await tryCreateByocPythonBackend("org-1", "vercel-sandbox", countingOptions, {
+      getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
+      load: fakeLoader({
+        "@vercel/sandbox": {},
+        "@atlas/api/lib/tools/python-sandbox": mod,
+      }),
+    });
+    expect(optionReads).toBe(1);
+  });
 });
 
 describe("tryCreateByocPythonBackend — engaged", () => {
   it("constructs the python sandbox with the stored triple as an access override", async () => {
     const { mod, factoryCalls } = fakePythonSandboxModule();
-    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
       getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
       load: fakeLoader({
         "@vercel/sandbox": {},
@@ -545,7 +581,7 @@ describe("tryCreateByocPythonBackend — engaged", () => {
     await tryCreateByocPythonBackend(
       "org-1",
       "vercel-sandbox",
-      { networkPolicy },
+      async () => ({ networkPolicy }),
       {
         getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
         load: fakeLoader({
@@ -565,7 +601,7 @@ describe("tryCreateByocPythonBackend — engaged", () => {
       success: false,
       error: "Failed to create Python Vercel Sandbox: token vc_org_token rejected.",
     });
-    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+    const backend = await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
       getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
       load: fakeLoader({
         "@vercel/sandbox": {},
@@ -588,7 +624,7 @@ describe("tryCreateByocPythonBackend — engaged", () => {
     };
     let thrown: unknown;
     try {
-      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", {}, {
+      await tryCreateByocPythonBackend("org-1", "vercel-sandbox", NO_OPTIONS, {
         getCredential: async () => makeCredential("vercel", VERCEL_TRIPLE),
         load: fakeLoader({
           "@vercel/sandbox": {},

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -45,10 +45,11 @@ import {
   type SandboxProviderKey,
 } from "@useatlas/schemas";
 import type { ExploreBackend } from "@atlas/api/lib/tools/backends/types";
-import type { PythonBackend } from "@atlas/api/lib/tools/python";
+import type { PythonBackend, PythonResult } from "@atlas/api/lib/tools/python";
 import type { PythonSandboxOptions } from "@atlas/api/lib/tools/python-sandbox";
+import type { VercelSandboxAccessOverride } from "@atlas/api/lib/tools/explore-sandbox";
 import type { SandboxNetworkPolicy } from "@atlas/api/lib/tools/backends/network-allowlist";
-import { redactedSecret, type RedactedSecret } from "@atlas/api/lib/tools/backends/detect";
+import { redactedSecret } from "@atlas/api/lib/tools/backends/detect";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   getSandboxCredentialByProvider,
@@ -132,6 +133,11 @@ interface SandboxPluginLike {
   };
 }
 
+/** Options for BYOC *Python* backend construction (#3410). */
+export interface ByocPythonOptions {
+  readonly networkPolicy?: SandboxNetworkPolicy;
+}
+
 interface ProviderRuntime {
   /**
    * Modules that must be resolvable for this provider to run. The plugin
@@ -146,6 +152,39 @@ interface ProviderRuntime {
     credentials: Record<string, unknown>,
     load: ModuleLoader,
   ): Promise<ExploreBackend>;
+  /**
+   * Build a *Python* backend from the same stored credentials (#3410).
+   * Optional — the presence of this method IS the provider's Python
+   * capability (`providerSupportsPython` derives from it), so adding Python
+   * support for a provider is a single edit to its entry here and capability
+   * can never drift from implementation. Python needs more than the
+   * explore-shaped plugin exec surface (file upload, an interpreter, package
+   * install, the per-request egress allowlist #2927), which is why
+   * e2b/daytona/railway — whose backends come from sandbox plugins with an
+   * explore-only contract — don't carry it yet (plugin-SDK capability work
+   * split out of #3410).
+   */
+  createPython?(
+    options: ByocPythonOptions,
+    credentials: Record<string, unknown>,
+    load: ModuleLoader,
+  ): Promise<PythonBackend>;
+}
+
+/**
+ * The @vercel/sandbox explicit-auth triple from a stored vercel credentials
+ * blob. One construction site shared by the explore and Python runtimes so a
+ * shape change (e.g. a new required field) can't update one and miss the
+ * other. Completeness is guaranteed upstream by `missingCredentialFields`.
+ */
+function vercelAccessOverride(
+  credentials: Record<string, unknown>,
+): VercelSandboxAccessOverride {
+  return {
+    teamId: credentials.teamId as string,
+    projectId: credentials.projectId as string,
+    token: redactedSecret(credentials.accessToken as string),
+  };
 }
 
 /** Build via a published `@useatlas/*` sandbox plugin factory. */
@@ -196,13 +235,20 @@ const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
       const mod = (await load("@atlas/api/lib/tools/explore-sandbox")) as {
         createSandboxBackend(
           semanticRoot: string,
-          access?: { teamId: string; projectId: string; token: RedactedSecret },
+          access?: VercelSandboxAccessOverride,
         ): Promise<ExploreBackend>;
       };
-      return await mod.createSandboxBackend(semanticRoot, {
-        teamId: credentials.teamId as string,
-        projectId: credentials.projectId as string,
-        token: redactedSecret(credentials.accessToken as string),
+      return await mod.createSandboxBackend(semanticRoot, vercelAccessOverride(credentials));
+    },
+    // Python runs on the same in-tree @vercel/sandbox path as explore — see
+    // the interface doc for why only vercel carries this method today.
+    async createPython(options, credentials, load) {
+      const mod = (await load("@atlas/api/lib/tools/python-sandbox")) as {
+        createPythonSandboxBackend(options?: PythonSandboxOptions): PythonBackend;
+      };
+      return mod.createPythonSandboxBackend({
+        ...(options.networkPolicy ? { networkPolicy: options.networkPolicy } : {}),
+        access: vercelAccessOverride(credentials),
       });
     },
   },
@@ -421,6 +467,35 @@ async function resolveEngagedCredential(
 }
 
 /**
+ * Scrub, log, and wrap a construction failure on an *engaged* BYOC path
+ * (fail closed). Provider SDK errors can echo the rejected credential, so
+ * the operator-log detail is exact-match scrubbed against the org's own
+ * decrypted values — keeps the log diagnosable without retaining a secret.
+ * The returned error's *message* — which becomes agent tool output (the
+ * error-scrub layer only handles URL-embedded credentials) — stays generic;
+ * the raw error rides on `cause` only. One construction site for both the
+ * explore and Python paths so the admin guidance can't diverge.
+ */
+function engagedConstructionFailure(
+  orgId: string,
+  provider: SandboxProviderKey,
+  credentials: Record<string, unknown>,
+  err: unknown,
+  label: string,
+): Error {
+  const detail = scrubCredentialValues(
+    err instanceof Error ? err.message : String(err),
+    credentials,
+  );
+  log.error({ orgId, provider, err: detail }, `${label} creation failed`);
+  return new Error(
+    `Your connected ${provider} sandbox failed to start. ` +
+      "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",
+    { cause: err },
+  );
+}
+
+/**
  * Build a BYOC explore backend for `(orgId, backendId)` from stored
  * credentials. Returns `null` when BYOC is not engaged (see module docs);
  * throws when engaged but construction fails — callers fail closed.
@@ -449,22 +524,12 @@ export async function tryCreateByocBackend(
     log.info({ orgId, provider, backendId }, "BYOC sandbox backend created from org credentials");
     return backend;
   } catch (err) {
-    // Provider SDK errors can echo the rejected credential. The stored
-    // values are in scope, so scrub them by exact match before the detail
-    // reaches the operator log — keeps the log diagnosable without
-    // retaining a decrypted org secret.
-    const detail = scrubCredentialValues(
-      err instanceof Error ? err.message : String(err),
+    throw engagedConstructionFailure(
+      orgId,
+      provider,
       credential.credentials,
-    );
-    log.error({ orgId, provider, err: detail }, "BYOC sandbox backend creation failed");
-    // The thrown message is surfaced as agent tool output, and the
-    // error-scrub layer only handles URL-embedded credentials — so the
-    // message stays generic; the raw error rides on `cause` only.
-    throw new Error(
-      `Your connected ${provider} sandbox failed to start. ` +
-        "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",
-      { cause: err },
+      err,
+      "BYOC sandbox backend",
     );
   }
 }
@@ -474,30 +539,18 @@ export async function tryCreateByocBackend(
 // ---------------------------------------------------------------------------
 
 /**
- * Providers whose BYOC credentials can run the *Python* tool. Python needs
- * more than the explore-shaped exec surface the plugin SDK exposes — file
- * upload, a Python interpreter, package install, and the per-request egress
- * allowlist (#2927) — so support is per-provider:
- *
- *   • vercel — supported: the in-tree python-sandbox backend creates the
- *     sandbox directly via @vercel/sandbox (runtime "python3.13"), the same
- *     in-tree path explore's vercel runtime uses.
- *   • e2b / daytona / railway — not yet: their backends come from sandbox
- *     plugins whose contract is explore-only (`sandbox.create()` →
- *     `exec(command)`); a Python surface is a plugin-SDK capability
- *     follow-up split out of #3410.
- *
- * An unsupported provider is *not engaged* for Python — the tool falls
- * through to the operator chain (and the docs say so) rather than failing
- * closed: the org's explore isolation still applies, and hard-erroring
- * Python for every e2b/daytona/railway org would break the tool with no
- * recovery path the org controls.
+ * Whether a BYOC provider's selection covers the Python tool (#3410).
+ * Derived from the runtime table — a provider supports Python exactly when
+ * its `ProviderRuntime` declares `createPython`, so capability can never
+ * drift from implementation (see the interface doc for why only vercel
+ * carries it today). An unsupported provider is *not engaged* for Python:
+ * the tool falls through to the operator chain (and the docs say so) rather
+ * than failing closed — the org's explore isolation still applies, and
+ * hard-erroring Python for every e2b/daytona/railway org would break the
+ * tool with no recovery path the org controls.
  */
-const PYTHON_CAPABLE_PROVIDERS: ReadonlySet<SandboxProviderKey> = new Set(["vercel"]);
-
-/** Whether a BYOC provider's selection covers the Python tool (#3410). */
 export function providerSupportsPython(provider: SandboxProviderKey): boolean {
-  return PYTHON_CAPABLE_PROVIDERS.has(provider);
+  return PROVIDER_RUNTIMES[provider].createPython !== undefined;
 }
 
 /**
@@ -507,9 +560,11 @@ export function providerSupportsPython(provider: SandboxProviderKey): boolean {
  * no/incomplete credentials, runtime not installed); throws when engaged
  * but unusable — callers fail closed, never the operator chain.
  *
- * `networkPolicy` is the per-request REST egress allowlist computed by the
- * caller from the request's resolved datasource (#2927 layer 0) — the org's
- * own sandbox gets the same egress bound as the platform one.
+ * `getOptions` supplies the per-request REST egress allowlist (#2927
+ * layer 0) — the org's own sandbox gets the same egress bound as the
+ * platform one. It is invoked only once BYOC is engaged, so callers can
+ * defer the datasource resolve behind it until it's known to be needed
+ * (a selected-but-unusable override costs no extra I/O).
  *
  * Construction is lazy (the sandbox is created on first `exec`), so provider
  * failures surface as `{ success: false }` results rather than throws; the
@@ -519,13 +574,14 @@ export function providerSupportsPython(provider: SandboxProviderKey): boolean {
 export async function tryCreateByocPythonBackend(
   orgId: string,
   backendId: string,
-  options: { readonly networkPolicy?: SandboxNetworkPolicy } = {},
+  getOptions: () => Promise<ByocPythonOptions> = async () => ({}),
   deps: ByocDeps = {},
 ): Promise<PythonBackend | null> {
   const provider = sandboxProviderForBackendId(backendId);
   if (!provider) return null;
 
-  if (!providerSupportsPython(provider)) {
+  const createPython = PROVIDER_RUNTIMES[provider].createPython;
+  if (!createPython) {
     log.debug(
       { orgId, provider, backendId },
       "BYOC provider has no Python runtime support — Python uses the operator chain (explore still runs on org credentials)",
@@ -537,53 +593,43 @@ export async function tryCreateByocPythonBackend(
   const credential = await resolveEngagedCredential(orgId, provider, deps);
   if (!credential) return null;
 
-  // Engaged: errors from here propagate (fail closed). Only vercel is
-  // python-capable today, so construction goes straight to the in-tree
-  // python-sandbox backend with the stored triple as an access override —
-  // the analogue of the vercel ProviderRuntime above.
+  // Engaged: errors from here propagate (fail closed).
   let inner: PythonBackend;
   try {
-    const mod = (await load("@atlas/api/lib/tools/python-sandbox")) as {
-      createPythonSandboxBackend(options?: PythonSandboxOptions): PythonBackend;
-    };
-    inner = mod.createPythonSandboxBackend({
-      ...(options.networkPolicy ? { networkPolicy: options.networkPolicy } : {}),
-      access: {
-        teamId: credential.credentials.teamId as string,
-        projectId: credential.credentials.projectId as string,
-        token: redactedSecret(credential.credentials.accessToken as string),
-      },
-    });
+    inner = await createPython(await getOptions(), credential.credentials, load);
   } catch (err) {
-    const detail = scrubCredentialValues(
-      err instanceof Error ? err.message : String(err),
+    throw engagedConstructionFailure(
+      orgId,
+      provider,
       credential.credentials,
-    );
-    log.error({ orgId, provider, err: detail }, "BYOC Python backend creation failed");
-    throw new Error(
-      `Your connected ${provider} sandbox failed to start. ` +
-        "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",
-      { cause: err },
+      err,
+      "BYOC Python backend",
     );
   }
 
   log.info({ orgId, provider, backendId }, "BYOC Python backend created from org credentials");
 
+  // Provider error text can echo the rejected credential (the lazy backend
+  // maps infra failures to result objects, so the throw-site scrub above
+  // never sees them). Exact-match scrub against the org's own stored values
+  // before the message becomes agent tool output.
+  const scrub = (result: PythonResult): PythonResult =>
+    result.success
+      ? result
+      : { ...result, error: scrubCredentialValues(result.error, credential.credentials) };
+
   return {
-    exec: async (code, data) => {
-      const result = await inner.exec(code, data);
-      if (!result.success) {
-        // Provider error text can echo the rejected credential (the lazy
-        // backend maps infra failures to result objects, so the explore
-        // path's throw-site scrub never sees them). Exact-match scrub
-        // against the org's own stored values before the message becomes
-        // agent tool output.
-        return {
-          ...result,
-          error: scrubCredentialValues(result.error, credential.credentials),
-        };
-      }
-      return result;
-    },
+    exec: async (code, data) => scrub(await inner.exec(code, data)),
+    // Mirror an inner execStream so a future streaming python backend
+    // neither silently loses the capability here nor bypasses the scrub.
+    ...(inner.execStream
+      ? {
+          execStream: async (
+            code: string,
+            data: { columns: string[]; rows: unknown[][] } | undefined,
+            onProgress: Parameters<NonNullable<PythonBackend["execStream"]>>[2],
+          ) => scrub(await inner.execStream!(code, data, onProgress)),
+        }
+      : {}),
   };
 }

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -238,7 +238,13 @@ const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
           access?: VercelSandboxAccessOverride,
         ): Promise<ExploreBackend>;
       };
-      return await mod.createSandboxBackend(semanticRoot, vercelAccessOverride(credentials));
+      // scrubErrorDetail: the backend logs provider errors itself, before
+      // this module's catch-site scrub can intervene — a 401 echoing the
+      // rejected token must be redacted at the source (#3413).
+      return await mod.createSandboxBackend(semanticRoot, {
+        ...vercelAccessOverride(credentials),
+        scrubErrorDetail: (detail) => scrubCredentialValues(detail, credentials),
+      });
     },
     // Python runs on the same in-tree @vercel/sandbox path as explore — see
     // the interface doc for why only vercel carries this method today.
@@ -249,6 +255,7 @@ const PROVIDER_RUNTIMES: Record<SandboxProviderKey, ProviderRuntime> = {
       return mod.createPythonSandboxBackend({
         ...(options.networkPolicy ? { networkPolicy: options.networkPolicy } : {}),
         access: vercelAccessOverride(credentials),
+        scrubErrorDetail: (detail) => scrubCredentialValues(detail, credentials),
       });
     },
   },

--- a/packages/api/src/lib/sandbox/runtime.ts
+++ b/packages/api/src/lib/sandbox/runtime.ts
@@ -1,6 +1,6 @@
 /**
- * BYOC sandbox runtime — builds per-org explore backends from stored
- * `sandbox_credentials` rows (#3370).
+ * BYOC sandbox runtime — builds per-org explore and Python backends from
+ * stored `sandbox_credentials` rows (#3370, #3410).
  *
  * The /admin/sandbox connect flow validates and stores provider credentials;
  * this module is the runtime consumer. `tryCreateByocBackend` is called from
@@ -23,6 +23,15 @@
  *                operator's account: the admin selected this provider
  *                expecting isolation on their own infrastructure.
  *
+ * `tryCreateByocPythonBackend` (#3410) is the Python-tool counterpart with the
+ * same tri-state contract, plus a capability gate: only providers in
+ * `PYTHON_CAPABLE_PROVIDERS` can run Python (see that constant for why), and
+ * an incapable provider is *not engaged* for Python — the tool falls through
+ * to the operator chain while explore stays on the org's account. Python
+ * backends are per-request (python.ts builds a fresh one each call and
+ * re-reads credentials), so unlike explore there is no cached backend to
+ * drain on credential edits.
+ *
  * Credentials are decrypted by `credentials.ts` (db/secret-encryption.ts).
  * This module never logs *stored* credential values — only provider names
  * and the *names* of missing fields. Provider SDK error text (which may
@@ -36,6 +45,9 @@ import {
   type SandboxProviderKey,
 } from "@useatlas/schemas";
 import type { ExploreBackend } from "@atlas/api/lib/tools/backends/types";
+import type { PythonBackend } from "@atlas/api/lib/tools/python";
+import type { PythonSandboxOptions } from "@atlas/api/lib/tools/python-sandbox";
+import type { SandboxNetworkPolicy } from "@atlas/api/lib/tools/backends/network-allowlist";
 import { redactedSecret, type RedactedSecret } from "@atlas/api/lib/tools/backends/detect";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
@@ -350,19 +362,18 @@ export interface ByocDeps {
 }
 
 /**
- * Build a BYOC explore backend for `(orgId, backendId)` from stored
- * credentials. Returns `null` when BYOC is not engaged (see module docs);
- * throws when engaged but construction fails — callers fail closed.
+ * Shared engagement gate for explore and Python BYOC paths. Returns the
+ * stored credential when BYOC is engaged for `(orgId, provider)` — stored
+ * credentials present, runtime-required fields complete, provider runtime
+ * loadable. Returns `null` when not engaged (caller falls through to the
+ * operator chain); throws (fail closed) when the runtime is installed but
+ * failed to load — a deployment defect, not the stable "not installed" state.
  */
-export async function tryCreateByocBackend(
+async function resolveEngagedCredential(
   orgId: string,
-  backendId: string,
-  semanticRoot: string,
-  deps: ByocDeps = {},
-): Promise<ExploreBackend | null> {
-  const provider = sandboxProviderForBackendId(backendId);
-  if (!provider) return null;
-
+  provider: SandboxProviderKey,
+  deps: ByocDeps,
+): Promise<SandboxCredential | null> {
   const getCredential = deps.getCredential ?? getSandboxCredentialByProvider;
   const load = deps.load ?? dynamicImport;
 
@@ -406,6 +417,27 @@ export async function tryCreateByocBackend(
     return null;
   }
 
+  return credential;
+}
+
+/**
+ * Build a BYOC explore backend for `(orgId, backendId)` from stored
+ * credentials. Returns `null` when BYOC is not engaged (see module docs);
+ * throws when engaged but construction fails — callers fail closed.
+ */
+export async function tryCreateByocBackend(
+  orgId: string,
+  backendId: string,
+  semanticRoot: string,
+  deps: ByocDeps = {},
+): Promise<ExploreBackend | null> {
+  const provider = sandboxProviderForBackendId(backendId);
+  if (!provider) return null;
+
+  const load = deps.load ?? dynamicImport;
+  const credential = await resolveEngagedCredential(orgId, provider, deps);
+  if (!credential) return null;
+
   // Engaged: from here on, errors propagate (fail closed — never silently
   // run the org's workload on the operator's provider account).
   try {
@@ -435,4 +467,123 @@ export async function tryCreateByocBackend(
       { cause: err },
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Python backend construction (#3410)
+// ---------------------------------------------------------------------------
+
+/**
+ * Providers whose BYOC credentials can run the *Python* tool. Python needs
+ * more than the explore-shaped exec surface the plugin SDK exposes — file
+ * upload, a Python interpreter, package install, and the per-request egress
+ * allowlist (#2927) — so support is per-provider:
+ *
+ *   • vercel — supported: the in-tree python-sandbox backend creates the
+ *     sandbox directly via @vercel/sandbox (runtime "python3.13"), the same
+ *     in-tree path explore's vercel runtime uses.
+ *   • e2b / daytona / railway — not yet: their backends come from sandbox
+ *     plugins whose contract is explore-only (`sandbox.create()` →
+ *     `exec(command)`); a Python surface is a plugin-SDK capability
+ *     follow-up split out of #3410.
+ *
+ * An unsupported provider is *not engaged* for Python — the tool falls
+ * through to the operator chain (and the docs say so) rather than failing
+ * closed: the org's explore isolation still applies, and hard-erroring
+ * Python for every e2b/daytona/railway org would break the tool with no
+ * recovery path the org controls.
+ */
+const PYTHON_CAPABLE_PROVIDERS: ReadonlySet<SandboxProviderKey> = new Set(["vercel"]);
+
+/** Whether a BYOC provider's selection covers the Python tool (#3410). */
+export function providerSupportsPython(provider: SandboxProviderKey): boolean {
+  return PYTHON_CAPABLE_PROVIDERS.has(provider);
+}
+
+/**
+ * Build a BYOC Python backend for `(orgId, backendId)` from stored
+ * credentials. Same tri-state contract as {@link tryCreateByocBackend}:
+ * `null` when not engaged (non-BYOC id, provider without Python support,
+ * no/incomplete credentials, runtime not installed); throws when engaged
+ * but unusable — callers fail closed, never the operator chain.
+ *
+ * `networkPolicy` is the per-request REST egress allowlist computed by the
+ * caller from the request's resolved datasource (#2927 layer 0) — the org's
+ * own sandbox gets the same egress bound as the platform one.
+ *
+ * Construction is lazy (the sandbox is created on first `exec`), so provider
+ * failures surface as `{ success: false }` results rather than throws; the
+ * wrapper below scrubs stored credential values from those error messages
+ * before they reach agent tool output.
+ */
+export async function tryCreateByocPythonBackend(
+  orgId: string,
+  backendId: string,
+  options: { readonly networkPolicy?: SandboxNetworkPolicy } = {},
+  deps: ByocDeps = {},
+): Promise<PythonBackend | null> {
+  const provider = sandboxProviderForBackendId(backendId);
+  if (!provider) return null;
+
+  if (!providerSupportsPython(provider)) {
+    log.debug(
+      { orgId, provider, backendId },
+      "BYOC provider has no Python runtime support — Python uses the operator chain (explore still runs on org credentials)",
+    );
+    return null;
+  }
+
+  const load = deps.load ?? dynamicImport;
+  const credential = await resolveEngagedCredential(orgId, provider, deps);
+  if (!credential) return null;
+
+  // Engaged: errors from here propagate (fail closed). Only vercel is
+  // python-capable today, so construction goes straight to the in-tree
+  // python-sandbox backend with the stored triple as an access override —
+  // the analogue of the vercel ProviderRuntime above.
+  let inner: PythonBackend;
+  try {
+    const mod = (await load("@atlas/api/lib/tools/python-sandbox")) as {
+      createPythonSandboxBackend(options?: PythonSandboxOptions): PythonBackend;
+    };
+    inner = mod.createPythonSandboxBackend({
+      ...(options.networkPolicy ? { networkPolicy: options.networkPolicy } : {}),
+      access: {
+        teamId: credential.credentials.teamId as string,
+        projectId: credential.credentials.projectId as string,
+        token: redactedSecret(credential.credentials.accessToken as string),
+      },
+    });
+  } catch (err) {
+    const detail = scrubCredentialValues(
+      err instanceof Error ? err.message : String(err),
+      credential.credentials,
+    );
+    log.error({ orgId, provider, err: detail }, "BYOC Python backend creation failed");
+    throw new Error(
+      `Your connected ${provider} sandbox failed to start. ` +
+        "Check the provider credentials on the Sandbox admin page, or switch back to the platform default.",
+      { cause: err },
+    );
+  }
+
+  log.info({ orgId, provider, backendId }, "BYOC Python backend created from org credentials");
+
+  return {
+    exec: async (code, data) => {
+      const result = await inner.exec(code, data);
+      if (!result.success) {
+        // Provider error text can echo the rejected credential (the lazy
+        // backend maps infra failures to result objects, so the explore
+        // path's throw-site scrub never sees them). Exact-match scrub
+        // against the org's own stored values before the message becomes
+        // agent tool output.
+        return {
+          ...result,
+          error: scrubCredentialValues(result.error, credential.credentials),
+        };
+      }
+      return result;
+    },
+  };
 }

--- a/packages/api/src/lib/sandbox/workspace-override.ts
+++ b/packages/api/src/lib/sandbox/workspace-override.ts
@@ -1,0 +1,28 @@
+/**
+ * Workspace sandbox-backend override resolution.
+ *
+ * One statement of the `ATLAS_SANDBOX_BACKEND` read + #3375 normalization,
+ * shared by the explore and Python tools: the two tools resolving the
+ * override independently is how they would drift into reporting different
+ * backends for the same stored setting (e.g. a future legacy-key alias
+ * landing in one read path but not the other).
+ *
+ * Kept separate from `runtime.ts` so tests that mock the BYOC runtime
+ * module wholesale don't have to stub settings plumbing too.
+ */
+
+import { normalizeSandboxBackendValue } from "@useatlas/schemas";
+import { getSetting } from "@atlas/api/lib/settings";
+
+/**
+ * The workspace's `ATLAS_SANDBOX_BACKEND` override, normalized to backend-id
+ * vocabulary (legacy stored provider keys like `"e2b"` resolve to
+ * `"e2b-sandbox"`, #3375). `undefined` when there is no org or no override.
+ */
+export function getWorkspaceSandboxOverride(
+  orgId: string | undefined,
+): string | undefined {
+  if (!orgId) return undefined;
+  const raw = getSetting("ATLAS_SANDBOX_BACKEND", orgId);
+  return raw ? normalizeSandboxBackendValue(raw) : undefined;
+}

--- a/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
@@ -132,11 +132,16 @@ mock.module("@atlas/api/lib/sandbox/runtime", () => ({
         return mockByocResult.create();
       }
       case "null":
+        // Not engaged — the real contract never invokes the thunk here.
         byocCalls.push({ orgId, backendId, options: {} });
         return null;
-      case "throw":
-        byocCalls.push({ orgId, backendId, options: {} });
+      case "throw": {
+        // Engaged-but-failed — the real contract invokes the thunk before
+        // construction throws, so the mock mirrors that ordering.
+        const options = await getOptions();
+        byocCalls.push({ orgId, backendId, options });
         throw new Error(mockByocResult.message);
+      }
     }
   },
 }));

--- a/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
@@ -122,15 +122,20 @@ mock.module("@atlas/api/lib/sandbox/runtime", () => ({
   tryCreateByocPythonBackend: async (
     orgId: string,
     backendId: string,
-    options: { networkPolicy?: unknown } = {},
+    getOptions: () => Promise<{ networkPolicy?: unknown }> = async () => ({}),
   ) => {
-    byocCalls.push({ orgId, backendId, options });
     switch (mockByocResult.kind) {
-      case "backend":
+      case "backend": {
+        // Mirror the real contract: the options thunk runs only once engaged.
+        const options = await getOptions();
+        byocCalls.push({ orgId, backendId, options });
         return mockByocResult.create();
+      }
       case "null":
+        byocCalls.push({ orgId, backendId, options: {} });
         return null;
       case "throw":
+        byocCalls.push({ orgId, backendId, options: {} });
         throw new Error(mockByocResult.message);
     }
   },
@@ -306,6 +311,24 @@ describe("executePython BYOC backend selection (#3410)", () => {
     // Resolve failure narrows egress (deny-all), never breaks the call
     expect(result.output).toBe("[byoc-vercel]");
     expect(byocCalls[0].options.networkPolicy).toBeUndefined();
+  });
+
+  it("does not resolve the REST datasource when BYOC is not engaged and the operator chain is not Vercel", async () => {
+    // The egress derivation rides behind the options thunk, which the BYOC
+    // runtime only invokes once engaged — a selected-but-unusable override
+    // must not pay the datasource resolve when the sidecar serves the call.
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "null" };
+    let resolves = 0;
+
+    const result = await runPython(async () => {
+      resolves++;
+      return null;
+    });
+
+    expect(result.output).toBe("[sidecar]");
+    expect(resolves).toBe(0);
   });
 
   it("re-consults the BYOC runtime on every call — credential edits need no drain", async () => {

--- a/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-byoc.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for BYOC backend selection in the Python tool (#3410).
+ *
+ * When a request carries an org whose workspace override selects a BYOC
+ * provider's backend id AND that provider can run Python, the tool must
+ * consult the BYOC runtime BEFORE the operator-configured chain:
+ *
+ *   • engaged   → the org-credential backend runs the code (even when a
+ *                 sidecar is configured — the override outranks it, matching
+ *                 explore's priority -1)
+ *   • null      → the override falls through to the operator chain
+ *   • throws    → the tool fails closed (no silent operator fallback)
+ *
+ * Unlike explore, Python backends are per-request: every call re-consults
+ * the BYOC runtime (and therefore re-reads stored credentials), so
+ * credential edits take effect on the next call with no drain step.
+ *
+ * Follows the mock.module idiom of explore-byoc.test.ts; the BYOC runtime
+ * itself is unit-tested in lib/sandbox/__tests__/runtime.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { PythonBackend } from "../python";
+import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
+import type { OperationGraph } from "@atlas/api/lib/openapi/types";
+
+// ---------------------------------------------------------------------------
+// Mocks — must register before any import of python.ts
+// ---------------------------------------------------------------------------
+
+let mockRequestContext:
+  | { user?: { activeOrganizationId?: string } }
+  | undefined;
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  }),
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  }),
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => mockRequestContext,
+  redactPaths: [],
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async <T,>(_name: string, _attrs: unknown, fn: () => Promise<T>) => fn(),
+  withEffectSpan: <T,>(_n: string, _a: unknown, e: T) => e,
+}));
+
+const mockSettings = new Map<string, string>();
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingAuto: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingLive: async (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
+
+// --- sidecar backend mock: the operator chain proxy (ATLAS_SANDBOX_URL) ---
+
+let mockSidecarExecCalls = 0;
+mock.module("@atlas/api/lib/tools/python-sidecar", () => ({
+  executePythonViaSidecar: async () => {
+    mockSidecarExecCalls += 1;
+    return { success: true, output: "[sidecar]" };
+  },
+  executePythonViaSidecarStream: async () => {
+    mockSidecarExecCalls += 1;
+    return { success: true, output: "[sidecar]" };
+  },
+}));
+
+// --- BYOC runtime mock — per-test behavior, all exports mocked ---
+
+type ByocPythonResult =
+  | { kind: "backend"; create: () => PythonBackend }
+  | { kind: "null" }
+  | { kind: "throw"; message: string };
+
+let mockByocResult: ByocPythonResult = { kind: "null" };
+let byocCalls: Array<{ orgId: string; backendId: string; options: { networkPolicy?: unknown } }> = [];
+
+const PROVIDER_FOR_BACKEND: Record<string, string> = {
+  "vercel-sandbox": "vercel",
+  "e2b-sandbox": "e2b",
+  "daytona-sandbox": "daytona",
+  "railway-sandbox": "railway",
+};
+
+mock.module("@atlas/api/lib/sandbox/runtime", () => ({
+  sandboxProviderForBackendId: (backendId: string) =>
+    PROVIDER_FOR_BACKEND[backendId] ?? null,
+  providerSupportsPython: (provider: string) => provider === "vercel",
+  missingCredentialFields: () => [],
+  _scrubCredentialValuesForTest: (text: string) => text,
+  isProviderRuntimeAvailable: async () => false,
+  getProviderRuntimeAvailability: async () => ({
+    vercel: true,
+    e2b: false,
+    daytona: false,
+    railway: false,
+  }),
+  _resetRuntimeAvailabilityCacheForTest: () => {},
+  tryCreateByocBackend: async () => null,
+  tryCreateByocPythonBackend: async (
+    orgId: string,
+    backendId: string,
+    options: { networkPolicy?: unknown } = {},
+  ) => {
+    byocCalls.push({ orgId, backendId, options });
+    switch (mockByocResult.kind) {
+      case "backend":
+        return mockByocResult.create();
+      case "null":
+        return null;
+      case "throw":
+        throw new Error(mockByocResult.message);
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeByocBackend(tag: string): PythonBackend {
+  return {
+    exec: async () => ({ success: true as const, output: `[${tag}]` }),
+  };
+}
+
+function makeDatasource(id: string, baseUrl: string): RestDatasource {
+  const graph: OperationGraph = {
+    operations: new Map(),
+    schemas: new Map(),
+    security: new Map(),
+    servers: [],
+    info: { title: id, version: "1", openapiVersion: "3.1.0" },
+  };
+  return {
+    id,
+    displayName: id,
+    graph,
+    baseUrl,
+    auth: { kind: "bearer", token: "tok" },
+    representationMode: "operation-graph",
+    writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
+  };
+}
+
+async function runPython(
+  resolveRestDatasource?: () => Promise<RestDatasource | null>,
+): Promise<{ success: boolean; output?: string; error?: string }> {
+  const { createExecutePythonTool } = await import("@atlas/api/lib/tools/python");
+  const tool = createExecutePythonTool(
+    resolveRestDatasource ? { resolveRestDatasource } : {},
+  );
+  const result = await tool.execute!(
+    { code: "print(1)", explanation: "test", data: undefined },
+    { toolCallId: "t", messages: [] } as never,
+  );
+  return result as { success: boolean; output?: string; error?: string };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executePython BYOC backend selection (#3410)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockSettings.clear();
+    mockRequestContext = undefined;
+    mockByocResult = { kind: "null" };
+    byocCalls = [];
+    mockSidecarExecCalls = 0;
+    // Operator chain = sidecar (so a BYOC win is unambiguous: the sidecar
+    // would otherwise be priority 1 in getPythonBackend).
+    process.env.ATLAS_SANDBOX_URL = "http://sidecar.test";
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.ATLAS_SANDBOX;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses the BYOC backend when the org's stored credentials engage — even over a configured sidecar", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "backend", create: () => makeByocBackend("byoc-vercel") };
+
+    const result = await runPython();
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("[byoc-vercel]");
+    expect(mockSidecarExecCalls).toBe(0);
+    expect(byocCalls.length).toBe(1);
+    expect(byocCalls[0].orgId).toBe("org-1");
+    expect(byocCalls[0].backendId).toBe("vercel-sandbox");
+  });
+
+  it("falls through to the operator chain when BYOC is not engaged", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "null" }; // no stored creds / runtime unavailable
+
+    const result = await runPython();
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("[sidecar]");
+    expect(byocCalls.length).toBe(1);
+  });
+
+  it("fails closed when the engaged BYOC backend cannot be built", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "throw", message: "your vercel sandbox failed to start" };
+
+    const result = await runPython();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("vercel sandbox failed to start");
+    // Never silently run the org's Python on the operator chain
+    expect(mockSidecarExecCalls).toBe(0);
+  });
+
+  it("does not consult BYOC without an org context", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = undefined; // self-hosted, no org
+
+    const result = await runPython();
+
+    expect(result.output).toBe("[sidecar]");
+    expect(byocCalls).toEqual([]);
+  });
+
+  it("skips BYOC for python-incapable providers (selection covers explore only)", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "e2b-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    // Would engage if consulted — but the capability gate must short-circuit
+    mockByocResult = { kind: "backend", create: () => makeByocBackend("byoc-e2b") };
+
+    const result = await runPython();
+
+    expect(result.output).toBe("[sidecar]");
+    expect(byocCalls).toEqual([]);
+  });
+
+  it("normalizes legacy provider-key overrides before the BYOC lookup (#3375)", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel"); // legacy stored value
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "backend", create: () => makeByocBackend("byoc-vercel") };
+
+    const result = await runPython();
+
+    expect(result.output).toBe("[byoc-vercel]");
+    expect(byocCalls[0].backendId).toBe("vercel-sandbox");
+  });
+
+  it("threads the per-request REST egress allowlist into the BYOC backend (#2927)", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "backend", create: () => makeByocBackend("byoc-vercel") };
+
+    await runPython(async () => makeDatasource("crm", "https://api.example.com"));
+
+    expect(byocCalls.length).toBe(1);
+    const policy = byocCalls[0].options.networkPolicy;
+    expect(policy).toBeDefined();
+    expect(JSON.stringify(policy)).toContain("api.example.com");
+  });
+
+  it("leaves the BYOC sandbox at deny-all when the datasource resolve fails (fail-soft)", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    mockByocResult = { kind: "backend", create: () => makeByocBackend("byoc-vercel") };
+
+    const result = await runPython(async () => {
+      throw new Error("resolver down");
+    });
+
+    // Resolve failure narrows egress (deny-all), never breaks the call
+    expect(result.output).toBe("[byoc-vercel]");
+    expect(byocCalls[0].options.networkPolicy).toBeUndefined();
+  });
+
+  it("re-consults the BYOC runtime on every call — credential edits need no drain", async () => {
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockRequestContext = { user: { activeOrganizationId: "org-1" } };
+    let creations = 0;
+    mockByocResult = {
+      kind: "backend",
+      create: () => {
+        creations++;
+        return makeByocBackend(`byoc-${creations}`);
+      },
+    };
+
+    expect((await runPython()).output).toBe("[byoc-1]");
+    expect((await runPython()).output).toBe("[byoc-2]");
+    expect(creations).toBe(2);
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
@@ -260,6 +260,31 @@ describe("createPythonSandboxBackend", () => {
     expect(createOpts.token).toBe("org-token");
   });
 
+  it("scrubErrorDetail redacts provider error text in creation-failure results (#3413)", async () => {
+    // A Sandbox.create failure can echo the submitted credential; this module
+    // logs and embeds the detail before the BYOC wrapper sees the result, so
+    // the scrub must apply at the source.
+    setupSandboxMock({ createError: "401 Unauthorized: token org-secret-token rejected" });
+    const mod = await import("@atlas/api/lib/tools/python-sandbox");
+    const { redactedSecret } = await import("@atlas/api/lib/tools/backends/detect");
+    const backend = mod.createPythonSandboxBackend({
+      access: {
+        teamId: "org_team",
+        projectId: "org_prj",
+        token: redactedSecret("org-secret-token"),
+      },
+      scrubErrorDetail: (detail) => detail.split("org-secret-token").join("[REDACTED]"),
+    });
+
+    const result = await backend.exec("print(1)");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toContain("org-secret-token");
+      expect(result.error).toContain("[REDACTED]");
+    }
+  });
+
   it("writes wrapper, user code, and data files to sandbox", async () => {
     setupSandboxMock();
     const backend = await freshBackend();

--- a/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
@@ -231,6 +231,35 @@ describe("createPythonSandboxBackend", () => {
     expect(createOpts.token).toBe("vercel-token");
   });
 
+  it("a BYOC access override replaces operator env credentials entirely (#3410)", async () => {
+    // Operator env creds set — the override must win, never merge (#2850 seam).
+    process.env.VERCEL_TEAM_ID = "operator_team";
+    process.env.VERCEL_PROJECT_ID = "operator_prj";
+    process.env.VERCEL_TOKEN = "operator-token";
+
+    setupSandboxMock();
+    const mod = await import("@atlas/api/lib/tools/python-sandbox");
+    const { redactedSecret } = await import("@atlas/api/lib/tools/backends/detect");
+    const backend = mod.createPythonSandboxBackend({
+      access: {
+        teamId: "org_team",
+        projectId: "org_prj",
+        token: redactedSecret("org-token"),
+      },
+    });
+    await backend.exec("print(1)");
+
+    expect(mockCreateCalls.length).toBe(1);
+    const createOpts = mockCreateCalls[0] as {
+      teamId?: string;
+      projectId?: string;
+      token?: string;
+    };
+    expect(createOpts.teamId).toBe("org_team");
+    expect(createOpts.projectId).toBe("org_prj");
+    expect(createOpts.token).toBe("org-token");
+  });
+
   it("writes wrapper, user code, and data files to sandbox", async () => {
     setupSandboxMock();
     const backend = await freshBackend();

--- a/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
@@ -4,13 +4,25 @@ import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
 // Mocks
 // ---------------------------------------------------------------------------
 
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
 mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-  }),
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
+  createLogger: () => silentLogger,
+  getLogger: () => silentLogger,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (value: unknown) => value,
+  hashShareToken: (token: string) => token,
+  setLogLevel: () => true,
 }));
 
 mock.module("@atlas/api/lib/tracing", () => ({
@@ -20,6 +32,7 @@ mock.module("@atlas/api/lib/tracing", () => ({
 
 mock.module("@atlas/api/lib/security", () => ({
   SENSITIVE_PATTERNS: /postgresql:\/\/|mysql:\/\/|sk-ant-/,
+  maskConnectionUrl: (url: string) => url,
 }));
 
 // --- @vercel/sandbox mock infrastructure ---

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -93,12 +93,25 @@ export interface VercelSandboxAccessOverride {
   teamId: string;
   projectId: string;
   token: RedactedSecret;
+  /**
+   * Applied to provider error text before it is logged or embedded in error
+   * messages. The BYOC path supplies an exact-match scrub of the org's
+   * stored credential values: a provider error that echoes the rejected key
+   * (e.g. a 401 on `Sandbox.create`) must not land in operator logs — this
+   * module logs before the BYOC runtime's catch-site scrub ever sees the
+   * error (#3413). Defaults to identity (the operator path logs its own
+   * provider's errors).
+   */
+  scrubErrorDetail?: (detail: string) => string;
 }
 
 export async function createSandboxBackend(
   semanticRoot: string,
   accessOverride?: VercelSandboxAccessOverride
 ): Promise<ExploreBackend> {
+  // Provider error text passes through this before any log or message —
+  // see VercelSandboxAccessOverride.scrubErrorDetail (#3413).
+  const scrubDetail = accessOverride?.scrubErrorDetail ?? ((detail: string) => detail);
   // 1. Import the optional dependency
   let Sandbox: (typeof import("@vercel/sandbox"))["Sandbox"];
   try {
@@ -137,7 +150,7 @@ export async function createSandboxBackend(
       ...(explicitAccess ?? {}),
     });
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = scrubDetail(err instanceof Error ? err.message : String(err));
     log.error({ err: detail }, "Sandbox.create() failed");
     throw new Error(
       `Failed to create Vercel Sandbox: ${detail}. ` +
@@ -156,7 +169,7 @@ export async function createSandboxBackend(
       await s.stop();
     } catch (stopErr) {
       log.warn(
-        { err: stopErr instanceof Error ? stopErr.message : String(stopErr) },
+        { err: scrubDetail(stopErr instanceof Error ? stopErr.message : String(stopErr)) },
         "Failed to stop sandbox during error cleanup",
       );
     }
@@ -205,7 +218,7 @@ export async function createSandboxBackend(
     try {
       await sandbox.mkDir(dir);
     } catch (err) {
-      const detail = sandboxErrorDetail(err);
+      const detail = scrubDetail(sandboxErrorDetail(err));
       log.error({ err: detail, dir }, "Failed to create directory in sandbox");
       throw new Error(
         `Failed to create directory "${dir}" in sandbox: ${safeError(detail)}.`,
@@ -217,7 +230,7 @@ export async function createSandboxBackend(
   try {
     await sandbox.writeFiles(files);
   } catch (err) {
-    const detail = sandboxErrorDetail(err);
+    const detail = scrubDetail(sandboxErrorDetail(err));
     log.error({ err: detail, fileCount: files.length }, "Failed to write files into sandbox");
     throw new Error(
       `Failed to upload ${files.length} semantic files to sandbox: ${safeError(detail)}.`,
@@ -243,14 +256,14 @@ export async function createSandboxBackend(
           exitCode: result.exitCode,
         };
       } catch (err) {
-        const detail = sandboxErrorDetail(err);
+        const detail = scrubDetail(sandboxErrorDetail(err));
         log.error({ err: detail }, "Sandbox command failed");
         // Stop the broken sandbox before invalidating the cache
         try {
           await sandbox.stop();
         } catch (stopErr) {
           log.warn(
-            { err: stopErr instanceof Error ? stopErr.message : String(stopErr) },
+            { err: scrubDetail(stopErr instanceof Error ? stopErr.message : String(stopErr)) },
             "Failed to stop sandbox during error cleanup",
           );
         }
@@ -268,7 +281,7 @@ export async function createSandboxBackend(
         await sandbox.stop();
       } catch (err) {
         log.warn(
-          { err: err instanceof Error ? err.message : String(err) },
+          { err: scrubDetail(err instanceof Error ? err.message : String(err)) },
           "Failed to stop sandbox during close",
         );
       }

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -22,13 +22,13 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { normalizeSandboxBackendValue } from "@useatlas/schemas";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig, type SandboxBackendName } from "@atlas/api/lib/config";
 import { getSemanticRoot, ensureOrgModeSemanticRoot } from "@atlas/api/lib/semantic/sync";
 import { getSetting } from "@atlas/api/lib/settings";
+import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
 import { EXPLORE_TOOL_DESCRIPTION } from "./descriptions";
 
@@ -392,10 +392,10 @@ export function markSidecarFailed(): void {
 
 function getExploreBackend(semanticRoot: string, orgId?: string): Promise<ExploreBackend> {
   // Workspace override changes the effective backend, so include it in the cache key.
-  // Normalize legacy stored provider keys ("e2b") to backend ids ("e2b-sandbox")
-  // BEFORE building the cache key, so both spellings share one entry (#3375).
-  const rawOverride = orgId ? getSetting("ATLAS_SANDBOX_BACKEND", orgId) : undefined;
-  const wsOverride = rawOverride ? normalizeSandboxBackendValue(rawOverride) : undefined;
+  // Normalized to backend-id vocabulary BEFORE building the cache key, so legacy
+  // provider-key spellings share one entry (#3375); the read+normalize pair is
+  // shared with the Python tool via getWorkspaceSandboxOverride.
+  const wsOverride = getWorkspaceSandboxOverride(orgId);
   const cacheKeyVal = wsOverride ? `${semanticRoot}\0${wsOverride}` : semanticRoot;
 
   let promise = backendCache.get(cacheKeyVal);

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -59,6 +59,15 @@ export interface PythonSandboxOptions {
    * branded: revealed only at `Sandbox.create`, serializes to "[REDACTED]".
    */
   readonly access?: VercelSandboxAccessOverride;
+  /**
+   * Applied to provider error text before it is logged or embedded in error
+   * messages. The BYOC path supplies an exact-match scrub of the org's
+   * stored credential values: a provider error that echoes the rejected key
+   * (e.g. a 401 on `Sandbox.create`) must not land in operator logs — this
+   * module logs before the BYOC result wrapper ever sees the error (#3413).
+   * Defaults to identity (the operator path logs its own provider's errors).
+   */
+  readonly scrubErrorDetail?: (detail: string) => string;
 }
 
 /** Default Python execution timeout in ms. */
@@ -210,6 +219,10 @@ export function createPythonSandboxBackend(
   // account whose credentials it was constructed with.
   const accessOverride = options.access;
 
+  // Provider error text passes through this before any log or message —
+  // see PythonSandboxOptions.scrubErrorDetail (#3413).
+  const scrubDetail = options.scrubErrorDetail ?? ((detail: string) => detail);
+
   interface SandboxInstance {
     sandbox: InstanceType<(typeof import("@vercel/sandbox"))["Sandbox"]>;
     packagesInstalled: boolean;
@@ -255,7 +268,7 @@ export function createPythonSandboxBackend(
             ...(explicitAccess ?? {}),
           }),
         catch: (err) => {
-          const detail = sandboxErrorDetail(err);
+          const detail = scrubDetail(sandboxErrorDetail(err));
           log.warn({ err: detail }, "Python Sandbox.create() attempt failed");
           return new SandboxInfraError({
             message: `Failed to create Python Vercel Sandbox: ${safeError(detail)}.`,
@@ -291,7 +304,7 @@ export function createPythonSandboxBackend(
           }
         },
         catch: (err) => {
-          const detail = sandboxErrorDetail(err);
+          const detail = scrubDetail(sandboxErrorDetail(err));
           log.warn({ err: detail }, "pip install failed — continuing without data science packages");
           return err instanceof Error ? err : new Error(String(err));
         },
@@ -309,7 +322,7 @@ export function createPythonSandboxBackend(
       yield* Effect.tryPromise({
         try: () => sandbox.updateNetworkPolicy(lockdownPolicy),
         catch: (err) => {
-          const detail = sandboxErrorDetail(err);
+          const detail = scrubDetail(sandboxErrorDetail(err));
           log.error({ err: detail }, "Failed to set sandbox network policy");
           return new SandboxInfraError({
             message: `Failed to lock down sandbox network: ${safeError(detail)}.`,
@@ -421,7 +434,7 @@ export function createPythonSandboxBackend(
             await sandbox.mkDir(chartDir);
           },
           catch: (err) => {
-            const detail = sandboxErrorDetail(err);
+            const detail = scrubDetail(sandboxErrorDetail(err));
             log.error({ err: detail, execId }, "Failed to create exec dirs in sandbox");
             return new SandboxInfraError({
               message: `Sandbox infrastructure error: ${safeError(detail)}`,
@@ -441,7 +454,7 @@ export function createPythonSandboxBackend(
         yield* Effect.tryPromise({
           try: () => sandbox.writeFiles(files),
           catch: (err) => {
-            const detail = sandboxErrorDetail(err);
+            const detail = scrubDetail(sandboxErrorDetail(err));
             log.error({ err: detail, execId }, "Failed to write Python files to sandbox");
             return new SandboxInfraError({
               message: `Sandbox infrastructure error: ${safeError(detail)}`,
@@ -473,7 +486,7 @@ export function createPythonSandboxBackend(
               },
             }),
           catch: (err) => {
-            const detail = sandboxErrorDetail(err);
+            const detail = scrubDetail(sandboxErrorDetail(err));
             log.error({ err: detail, execId }, "Sandbox runCommand failed for Python");
             return new SandboxInfraError({
               message: `Sandbox infrastructure error: ${safeError(detail)}. Will retry with a fresh sandbox.`,
@@ -497,7 +510,7 @@ export function createPythonSandboxBackend(
         const stderr = yield* Effect.tryPromise({
           try: () => cmdResult.stderr(),
           catch: (err) => {
-            const detail = sandboxErrorDetail(err);
+            const detail = scrubDetail(sandboxErrorDetail(err));
             log.error({ err: detail, execId }, "Failed to read stderr from sandbox");
             return new SandboxInfraError({
               message: `Failed to read execution output: ${safeError(detail)}`,
@@ -510,7 +523,7 @@ export function createPythonSandboxBackend(
         const resultBuffer = yield* Effect.tryPromise({
           try: () => sandbox.readFileToBuffer({ path: resultPathAbs }),
           catch: (err) => {
-            const detail = sandboxErrorDetail(err);
+            const detail = scrubDetail(sandboxErrorDetail(err));
             log.error({ err: detail, execId }, "Failed to read result file from sandbox");
             return new SandboxInfraError({
               message: `Failed to read execution output: ${safeError(detail)}`,
@@ -557,7 +570,7 @@ export function createPythonSandboxBackend(
               return bufs.filter((buf): buf is Buffer => buf !== null);
             },
             catch: (err) => {
-              const detail = sandboxErrorDetail(err);
+              const detail = scrubDetail(sandboxErrorDetail(err));
               log.error({ err: detail, execId }, "Failed to read chart artifacts from sandbox");
               return new SandboxInfraError({
                 message: `Failed to read chart artifacts: ${safeError(detail)}`,
@@ -635,7 +648,7 @@ export function createPythonSandboxBackend(
           ),
           // Unexpected defects: invalidate and return sanitized error
           Effect.catchAllDefect((defect) => {
-            const detail = defect instanceof Error ? defect.message : String(defect);
+            const detail = scrubDetail(defect instanceof Error ? defect.message : String(defect));
             log.error({ err: detail, execId }, "Unexpected error in Python sandbox execution");
             invalidate();
             return Effect.succeed({

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -26,6 +26,7 @@
 import { Effect, Data, Duration, Schedule } from "effect";
 import type { PythonBackend, PythonResult } from "./python";
 import type { SandboxNetworkPolicy } from "./backends/network-allowlist";
+import type { VercelSandboxAccessOverride } from "./explore-sandbox";
 import { PYTHON_SECURITY_AND_SETUP } from "./python-wrapper";
 import { sandboxErrorDetail, safeError, MAX_OUTPUT } from "./backends/shared";
 import { vercelSandboxAccess } from "./backends/detect";
@@ -50,6 +51,14 @@ export interface PythonSandboxOptions {
    * authenticated read path stays the host-side `executeRestOperation` tool).
    */
   readonly networkPolicy?: SandboxNetworkPolicy;
+  /**
+   * Explicit Vercel API credentials for sandbox creation — the BYOC per-org
+   * path (#3410). When provided they replace the operator-level env-var
+   * detection entirely (never merged with it, per the #2850 seam), mirroring
+   * explore-sandbox.ts's `accessOverride`. The token is RedactedSecret-
+   * branded: revealed only at `Sandbox.create`, serializes to "[REDACTED]".
+   */
+  readonly access?: VercelSandboxAccessOverride;
 }
 
 /** Default Python execution timeout in ms. */
@@ -196,6 +205,11 @@ export function createPythonSandboxBackend(
   // never carry tenant B's host (#2927, layer 0).
   const lockdownPolicy: SandboxNetworkPolicy = options.networkPolicy ?? "deny-all";
 
+  // Per-org BYOC access override (#3410), captured for the same per-request
+  // scoping reason: this backend can only ever create sandboxes on the
+  // account whose credentials it was constructed with.
+  const accessOverride = options.access;
+
   interface SandboxInstance {
     sandbox: InstanceType<(typeof import("@vercel/sandbox"))["Sandbox"]>;
     packagesInstalled: boolean;
@@ -216,11 +230,12 @@ export function createPythonSandboxBackend(
         },
       });
 
-      // 2. Create sandbox with retry for transient failures. Off-Vercel
-      // (e.g. Railway) requires explicit VERCEL_TEAM_ID/VERCEL_PROJECT_ID/
-      // VERCEL_TOKEN; on Vercel proper, OIDC handles auth and `access` is
-      // undefined.
-      const access = vercelSandboxAccess();
+      // 2. Create sandbox with retry for transient failures. A BYOC access
+      // override (per-org credentials, #3410) takes precedence and is used
+      // verbatim. Otherwise: off-Vercel (e.g. Railway) requires explicit
+      // VERCEL_TEAM_ID/VERCEL_PROJECT_ID/VERCEL_TOKEN; on Vercel proper,
+      // OIDC handles auth and `access` is undefined.
+      const access = accessOverride ?? vercelSandboxAccess();
       const explicitAccess = access
         ? {
             teamId: access.teamId,

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -14,11 +14,10 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { normalizeSandboxBackendValue } from "@useatlas/schemas";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig } from "@atlas/api/lib/config";
-import { getSetting } from "@atlas/api/lib/settings";
+import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
 import { getStreamWriter } from "./python-stream";
 import type { PythonSandboxOptions } from "./python-sandbox";
@@ -566,22 +565,22 @@ Blocked: subprocess, os, socket, shutil, sys, ctypes, importlib, exec(), eval(),
       };
 
       const orgId = getRequestContext()?.user?.activeOrganizationId;
-      const rawOverride = orgId ? getSetting("ATLAS_SANDBOX_BACKEND", orgId) : undefined;
-      const wsOverride = rawOverride ? normalizeSandboxBackendValue(rawOverride) : undefined;
+      const wsOverride = getWorkspaceSandboxOverride(orgId);
       if (orgId && wsOverride) {
         const { sandboxProviderForBackendId, providerSupportsPython, tryCreateByocPythonBackend } =
           await import("@atlas/api/lib/sandbox/runtime");
         const provider = sandboxProviderForBackendId(wsOverride);
         if (provider && providerSupportsPython(provider)) {
-          // The org's sandbox gets the same per-request egress bound as the
-          // platform one (#2927 layer 0) — resolve before construction.
-          await resolveRestDatasourceFailSoft();
           try {
-            resolvedBackend = await tryCreateByocPythonBackend(
-              orgId,
-              wsOverride,
-              await vercelSandboxOptionsFor(restDatasource),
-            );
+            // The options thunk runs only once BYOC is engaged, so a
+            // selected-but-unusable override (e.g. incomplete credentials)
+            // costs no datasource resolve. When it runs, the org's sandbox
+            // gets the same per-request egress bound as the platform one
+            // (#2927 layer 0).
+            resolvedBackend = await tryCreateByocPythonBackend(orgId, wsOverride, async () => {
+              await resolveRestDatasourceFailSoft();
+              return vercelSandboxOptionsFor(restDatasource);
+            });
           } catch (err) {
             // Engaged but unusable (runtime load failure / construction
             // error): fail closed — surface the error, never run the org's

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -14,11 +14,14 @@
 
 import { tool } from "ai";
 import { z } from "zod";
+import { normalizeSandboxBackendValue } from "@useatlas/schemas";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig } from "@atlas/api/lib/config";
+import { getSetting } from "@atlas/api/lib/settings";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
 import { getStreamWriter } from "./python-stream";
+import type { PythonSandboxOptions } from "./python-sandbox";
 import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
 
 const log = createLogger("python");
@@ -286,6 +289,47 @@ export interface PythonBackend {
 // --- Backend selection ---
 
 /**
+ * Derive the Vercel Python sandbox options for a resolved REST datasource:
+ * the per-tenant egress allowlist (#2927 layer 0), or `{}` (deny-all) when no
+ * datasource is active. Computed server-side from the resolved datasource's
+ * base URL — never from the agent's `code`. Shared by the operator Vercel
+ * branch in {@link getPythonBackend} and the BYOC Vercel path (#3410) so the
+ * org's own sandbox gets the same egress bound as the platform one.
+ */
+async function vercelSandboxOptionsFor(
+  restDatasource: RestDatasource | null,
+): Promise<PythonSandboxOptions> {
+  if (!restDatasource) return {};
+  const { computeNetworkAllowlist, networkPolicyFromAllowlist } = await import(
+    "./backends/network-allowlist"
+  );
+  const allowlist = computeNetworkAllowlist([restDatasource.baseUrl]);
+  if (allowlist.length === 0) {
+    // Honor network-allowlist.ts's "caller logs the drop" contract: a
+    // configured datasource whose base URL doesn't parse to a host
+    // collapses to deny-all (fail-closed) — surface why so the operator
+    // isn't left guessing. Log the datasource id, not the URL (a base URL
+    // could carry a token in a query param).
+    log.warn(
+      { datasource: restDatasource.id },
+      "REST datasource base URL did not yield a reachable host — Python sandbox egress stays deny-all",
+    );
+  } else if (restDatasource.baseUrl.toLowerCase().startsWith("http://")) {
+    // Vercel's sandbox domain allowlist matches hosts by SNI (TLS), so a
+    // plain-http:// datasource host may not be reachable from the sandbox
+    // even though it is listed. The policy is still applied (the boundary is
+    // fail-closed either way — an unmatched host stays denied, not opened);
+    // we warn so an operator on a non-TLS datasource isn't left wondering why
+    // egress is blocked. Prefer https:// for REST datasources on SaaS. (#2975)
+    log.warn(
+      { datasource: restDatasource.id },
+      "REST datasource base URL is plain http:// — the Vercel sandbox domain allowlist matches HTTPS hosts (by SNI), so sandbox egress to this host may stay blocked even though it is listed; prefer https://",
+    );
+  }
+  return { networkPolicy: networkPolicyFromAllowlist(allowlist) };
+}
+
+/**
  * Resolve the Python execution backend.
  *
  * Priority:
@@ -328,41 +372,9 @@ async function getPythonBackend(
       log.error({ err: detail }, "Vercel Python sandbox module not available");
       return { error: `Vercel Python sandbox unavailable: ${detail}` };
     }
-    // Bound egress to the datasource host, computed server-side from the
-    // resolved datasource's base URL — never from the agent's `code`. Absent
+    // Bound egress to the datasource host (#2927 layer 0). Absent
     // datasource → default options (deny-all network).
-    if (restDatasource) {
-      const { computeNetworkAllowlist, networkPolicyFromAllowlist } = await import(
-        "./backends/network-allowlist"
-      );
-      const allowlist = computeNetworkAllowlist([restDatasource.baseUrl]);
-      if (allowlist.length === 0) {
-        // Honor network-allowlist.ts's "caller logs the drop" contract: a
-        // configured datasource whose base URL doesn't parse to a host
-        // collapses to deny-all (fail-closed) — surface why so the operator
-        // isn't left guessing. Log the datasource id, not the URL (a base URL
-        // could carry a token in a query param).
-        log.warn(
-          { datasource: restDatasource.id },
-          "REST datasource base URL did not yield a reachable host — Python sandbox egress stays deny-all",
-        );
-      } else if (restDatasource.baseUrl.toLowerCase().startsWith("http://")) {
-        // Vercel's sandbox domain allowlist matches hosts by SNI (TLS), so a
-        // plain-http:// datasource host may not be reachable from the sandbox
-        // even though it is listed. The policy is still applied (the boundary is
-        // fail-closed either way — an unmatched host stays denied, not opened);
-        // we warn so an operator on a non-TLS datasource isn't left wondering why
-        // egress is blocked. Prefer https:// for REST datasources on SaaS. (#2975)
-        log.warn(
-          { datasource: restDatasource.id },
-          "REST datasource base URL is plain http:// — the Vercel sandbox domain allowlist matches HTTPS hosts (by SNI), so sandbox egress to this host may stay blocked even though it is listed; prefer https://",
-        );
-      }
-      return createPythonSandboxBackend({
-        networkPolicy: networkPolicyFromAllowlist(allowlist),
-      });
-    }
-    return createPythonSandboxBackend();
+    return createPythonSandboxBackend(await vercelSandboxOptionsFor(restDatasource ?? null));
   }
 
   // 3. nsjail explicit (ATLAS_SANDBOX=nsjail) — hard-fail
@@ -525,15 +537,23 @@ Blocked: subprocess, os, socket, shutil, sys, ctypes, importlib, exec(), eval(),
     }),
 
     execute: async ({ code, explanation, data }, options) => {
-      // 0a. Resolve the active REST datasource (server-side) so the Vercel
-      // sandbox's egress can be bounded to its host (#2927 layer 0). Only when
-      // the Vercel backend will actually be selected — the sidecar / nsjail
-      // backends have no network policy to narrow (see getPythonBackend).
-      // Fail-soft: a resolve error leaves the sandbox at deny-all, never breaks
-      // the tool call. NB: the allowlist derives from this resolved datasource,
-      // NOT from `code` — the agent cannot widen it.
+      // 0a. BYOC workspace override (#3410): when the request's org selected
+      // a BYOC provider that can run Python (currently vercel only — see
+      // PYTHON_CAPABLE_PROVIDERS in sandbox/runtime.ts), build the backend
+      // from the org's stored credentials, with the same engagement and
+      // fail-closed semantics as the explore tool (#3370). Not engaged
+      // (no/incomplete credentials, runtime not installed, provider without
+      // Python support) falls through to the operator chain in 0b; engaged
+      // failures surface as tool errors and never silently run the org's
+      // workload on the operator's account.
+      let resolvedBackend: PythonBackend | { error: string } | null = null;
       let restDatasource: RestDatasource | null = null;
-      if (useVercelSandbox() && !useSidecar()) {
+      let restDatasourceResolved = false;
+
+      const resolveRestDatasourceFailSoft = async () => {
+        // Fail-soft: a resolve error leaves the sandbox at deny-all, never
+        // breaks the tool call. NB: the allowlist derives from this resolved
+        // datasource, NOT from `code` — the agent cannot widen it.
         try {
           restDatasource = await resolveRestDatasource();
         } catch (err) {
@@ -542,14 +562,57 @@ Blocked: subprocess, os, socket, shutil, sys, ctypes, importlib, exec(), eval(),
             "REST datasource resolve failed for Python sandbox — egress stays deny-all this turn",
           );
         }
+        restDatasourceResolved = true;
+      };
+
+      const orgId = getRequestContext()?.user?.activeOrganizationId;
+      const rawOverride = orgId ? getSetting("ATLAS_SANDBOX_BACKEND", orgId) : undefined;
+      const wsOverride = rawOverride ? normalizeSandboxBackendValue(rawOverride) : undefined;
+      if (orgId && wsOverride) {
+        const { sandboxProviderForBackendId, providerSupportsPython, tryCreateByocPythonBackend } =
+          await import("@atlas/api/lib/sandbox/runtime");
+        const provider = sandboxProviderForBackendId(wsOverride);
+        if (provider && providerSupportsPython(provider)) {
+          // The org's sandbox gets the same per-request egress bound as the
+          // platform one (#2927 layer 0) — resolve before construction.
+          await resolveRestDatasourceFailSoft();
+          try {
+            resolvedBackend = await tryCreateByocPythonBackend(
+              orgId,
+              wsOverride,
+              await vercelSandboxOptionsFor(restDatasource),
+            );
+          } catch (err) {
+            // Engaged but unusable (runtime load failure / construction
+            // error): fail closed — surface the error, never run the org's
+            // Python on the operator chain. The message from the BYOC
+            // runtime is already credential-scrubbed and generic.
+            const detail = err instanceof Error ? err.message : String(err);
+            log.error(
+              { err: detail, orgId, backend: wsOverride },
+              "BYOC Python backend failed — failing closed",
+            );
+            return { success: false, error: detail };
+          }
+        }
       }
 
-      // 0b. Resolve backend
-      const backend = await getPythonBackend(restDatasource);
-      if ("error" in backend) {
-        log.error(backend.error);
-        return { success: false, error: backend.error };
+      // 0b. Operator chain (BYOC not engaged). Resolve the REST datasource
+      // only when the Vercel backend will actually be selected — the
+      // sidecar / nsjail backends have no network policy to narrow (see
+      // getPythonBackend).
+      if (!resolvedBackend) {
+        const operatorVercel = useVercelSandbox() && !useSidecar();
+        if (operatorVercel && !restDatasourceResolved) {
+          await resolveRestDatasourceFailSoft();
+        }
+        resolvedBackend = await getPythonBackend(operatorVercel ? restDatasource : null);
       }
+      if ("error" in resolvedBackend) {
+        log.error(resolvedBackend.error);
+        return { success: false, error: resolvedBackend.error };
+      }
+      const backend: PythonBackend = resolvedBackend;
 
       // 1. Validate imports (defense-in-depth — sandbox is the real boundary)
       const validation = await validatePythonCode(code);

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -215,7 +215,7 @@ export default function SandboxPage() {
           <p className="mt-1 text-sm text-muted-foreground">
             {isSaas
               ? "Atlas runs code in isolated sandboxes. Use the managed one, or connect your own cloud."
-              : "Choose how the explore and Python tools execute commands for this workspace."}
+              : "Choose how the explore tool executes commands for this workspace. The Python tool follows the platform-level sandbox configuration."}
           </p>
         </div>
 
@@ -724,7 +724,7 @@ function SelfHostedSandboxView({
     <section>
       <SectionHeading
         title="Backend"
-        description="Select which backend executes explore and Python tool calls."
+        description="Select which backend executes explore tool calls. The Python tool follows the platform-level sandbox configuration."
       />
       <Shell
         icon={Server}

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -105,7 +105,7 @@ const SECTION_DESCRIPTIONS: Record<KnownSection, string> = {
   "Query Limits": "Row caps and execution timeouts for user queries",
   "Rate Limiting": "Request throttles per user and per workspace",
   Sessions: "Auth session lifetimes and refresh behavior",
-  Sandbox: "Where explore and Python tools run",
+  Sandbox: "Where the explore tool runs (Python follows only for a connected Vercel sandbox)",
   Agent: "LLM behavior, model selection, and step caps",
   Intelligence: "Learning and memory features",
   MCP: "What MCP-connected agents can see and do",

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -105,7 +105,7 @@ const SECTION_DESCRIPTIONS: Record<KnownSection, string> = {
   "Query Limits": "Row caps and execution timeouts for user queries",
   "Rate Limiting": "Request throttles per user and per workspace",
   Sessions: "Auth session lifetimes and refresh behavior",
-  Sandbox: "Where the explore tool runs (Python follows only for a connected Vercel sandbox)",
+  Sandbox: "Where the explore tool runs; Python follows the platform sandbox unless a BYOC provider that supports Python is selected",
   Agent: "LLM behavior, model selection, and step caps",
   Intelligence: "Learning and memory features",
   MCP: "What MCP-connected agents can see and do",


### PR DESCRIPTION
Fixes #3410.

The Python tool always ran on the operator's sandbox — BYOC selection (#3370) applied to explore only (`python-sandbox.ts` built its Vercel sandbox from operator env creds and never consulted `sandbox_credentials` or `ATLAS_SANDBOX_BACKEND`). Now, when an org's workspace override selects a BYOC provider that can run Python, the Python sandbox is built from the org's stored credentials with the same engagement + fail-closed semantics as explore.

## Support matrix

Python needs more than the explore-shaped plugin exec surface (`sandbox.create()` → `exec(command)`): file upload, a Python interpreter, package install, and the per-request REST egress allowlist (#2927). Support is therefore per-provider:

| Provider | Explore | Python |
|----------|---------|--------|
| Vercel | org account | **org account (this PR)** |
| E2B | org account | platform chain — documented |
| Daytona | org account | platform chain — documented |
| Railway | org account | platform chain — documented |

E2B/Daytona/Railway Python coverage needs a Python execution surface in the plugin SDK sandbox contract — split out of #3410 as follow-up capability work rather than gold-plated here. The docs matrix and admin copy now say so instead of implying coverage.

## What changed

- **`sandbox/runtime.ts`** — the engagement gate (credential fetch → completeness → runtime probe → fail-closed on load failure) is extracted into `resolveEngagedCredential`, shared by `tryCreateByocBackend` (explore, unchanged behavior) and the new `tryCreateByocPythonBackend`. A `providerSupportsPython` capability gate short-circuits before any credential read. Failed exec results are scrubbed against the org's stored credential values before reaching agent tool output (the lazy backend maps infra failures to result objects, so the explore path's throw-site scrub never sees them).
- **`python-sandbox.ts`** — `PythonSandboxOptions.access`: a BYOC access override replaces operator env-var detection entirely, never merged (#2850 seam). Token is `RedactedSecret`-branded, revealed only at `Sandbox.create`.
- **`python.ts`** — BYOC branch runs ahead of the operator chain (matching explore's priority −1, so an engaged org backend outranks a configured sidecar). The #2927 egress-allowlist derivation is extracted to `vercelSandboxOptionsFor` and applied identically to the org's sandbox; resolve failures stay fail-soft to deny-all. Engaged failures return errors — never operator fallback.
- **Cache/teardown** — no drain was needed: Python backends are per-request (`getPythonBackend` runs inside `execute` each call) and re-read credentials every call, unlike explore's cached backends. Documented at the `invalidateOrgExploreBackends` call site in `admin-sandbox.ts` and in the docs.
- **Honesty pass** — `sandbox.mdx`: Python coverage matrix replaces the blanket "Python always runs on the platform sandbox" callout; self-hosted section now states the workspace dropdown is explore-only (it always was — Python's chain is env-driven). Web admin copy fixed at three sites (`admin/sandbox` ×2, `admin/settings` section description), plus `admin-console.mdx`.

## Tests

- `runtime.test.ts` — `tryCreateByocPythonBackend` unit suite mirroring the explore one: capability gate before credential reads, not-engaged tri-state, fail-closed on load-failed probe, stored triple → access override (RedactedSecret round-trip, JSON-redacted), networkPolicy threading, credential scrubbing on failed exec results and construction throws.
- `python-byoc.test.ts` (new) — tool-level wiring mirroring `explore-byoc.test.ts`: engaged-over-sidecar, not-engaged falls through unchanged, fail-closed with zero operator calls, no-org skips BYOC, python-incapable provider skips BYOC, legacy provider-key normalization (#3375), egress allowlist threading + fail-soft resolve, per-call credential re-read (the no-drain property).
- `python-sandbox.test.ts` — access override reaches `Sandbox.create` and wins over operator env creds.

Orgs without stored credentials see zero behavior change (`python-rest-egress*.test.ts` unchanged and green).

`/ci`: lint, type, full test suite, syncpack, template/security-header/railway/schema/oauth-helper/test-discipline/twenty-resolver/settings-readers/published-symbols — all pass.

https://claude.ai/code/session_01GDi92GpP4atCZPLEaFPBqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDi92GpP4atCZPLEaFPBqR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783801532&installation_id=135337507&pr_number=3413&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3413&signature=7895489f7d67b4d407b5d4ff66f7649ac17d01a2b9ba6cf317a492df08f44faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python tool gains BYOC (Bring Your Own Compute) execution with per-request credential overrides and provider support detection
  * Railway added to SaaS workspace-level sandbox provider list

* **Bug Fixes**
  * Fail-closed behavior when BYOC runtimes or credentials fail to load
  * Provider error texts are scrubbed to redact stored credentials

* **Documentation**
  * Clarified explore vs Python sandbox behavior and per-provider Python coverage/credential semantics

* **Tests**
  * Added and expanded test coverage for Python BYOC and sandbox credential handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->