### PR TITLE
feat(billing): self-serve checkout and plan picker — close the trial→paid dead end (#3418)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -73018,6 +73018,60 @@
                         "plan",
                         "status"
                       ]
+                    },
+                    "availablePlans": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "tier": {
+                            "type": "string",
+                            "enum": [
+                              "free",
+                              "trial",
+                              "starter",
+                              "pro",
+                              "business"
+                            ]
+                          },
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "pricePerSeat": {
+                            "type": "number"
+                          },
+                          "tokenBudgetPerSeat": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "maxSeats": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "maxConnections": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "configured": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "tier",
+                          "displayName",
+                          "pricePerSeat",
+                          "tokenBudgetPerSeat",
+                          "maxSeats",
+                          "maxConnections",
+                          "configured"
+                        ]
+                      }
                     }
                   },
                   "required": [

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -229,6 +229,27 @@ describe("billing routes", () => {
       expect(body.overagePerMillionTokens).toBe(1.0);
       // Total token budget = tokenBudgetPerSeat * seatCount = 2M * 3 = 6M
       expect(body.limits.totalTokenBudget).toBe(6_000_000);
+      // #3418 — the plan picker's source of truth. All three paid tiers are
+      // always listed; `configured` reflects whether the deployment has the
+      // tier's Stripe Price ID env var (none set in this test env).
+      expect(body.availablePlans.map((p: { tier: string }) => p.tier)).toEqual([
+        "starter",
+        "pro",
+        "business",
+      ]);
+      expect(body.availablePlans[0]).toMatchObject({
+        tier: "starter",
+        displayName: "Starter",
+        pricePerSeat: 29,
+        tokenBudgetPerSeat: 2_000_000,
+        maxSeats: 10,
+        maxConnections: 1,
+      });
+      expect(body.availablePlans[2]).toMatchObject({
+        tier: "business",
+        maxSeats: null,
+        maxConnections: null,
+      });
     });
 
     it("defaults seat count to 1 when member query fails", async () => {

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -31,7 +31,7 @@ import {
   internalQuery,
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
-import { getPlanDefinition, getPlanLimits, computeTokenBudget, isUnlimited } from "@atlas/api/lib/billing/plans";
+import { getPlanDefinition, getPlanLimits, getStripePlans, computeTokenBudget, isUnlimited, type PaidPlanTier } from "@atlas/api/lib/billing/plans";
 import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
 import { getSettingLive } from "@atlas/api/lib/settings";
 import { resolveModelId } from "@atlas/api/lib/providers";
@@ -152,6 +152,40 @@ const toggleByotRoute = createRoute({
     },
   },
 });
+
+// ---------------------------------------------------------------------------
+// Available plans (#3418)
+// ---------------------------------------------------------------------------
+
+/**
+ * Paid tiers the plan picker can move a workspace to. `configured` is
+ * derived from {@link getStripePlans} — a tier without its Stripe Price ID
+ * env var renders as a disabled card rather than disappearing, so a
+ * misconfigured deployment is visible instead of silently smaller.
+ */
+function buildAvailablePlans(): Array<{
+  tier: PaidPlanTier;
+  displayName: string;
+  pricePerSeat: number;
+  tokenBudgetPerSeat: number | null;
+  maxSeats: number | null;
+  maxConnections: number | null;
+  configured: boolean;
+}> {
+  const configured = new Set(getStripePlans().map((p) => p.name));
+  return (["starter", "pro", "business"] as const).map((tier) => {
+    const def = getPlanDefinition(tier);
+    return {
+      tier,
+      displayName: def.displayName,
+      pricePerSeat: def.pricePerSeat,
+      tokenBudgetPerSeat: isUnlimited(def.limits.tokenBudgetPerSeat) ? null : def.limits.tokenBudgetPerSeat,
+      maxSeats: isUnlimited(def.limits.maxSeats) ? null : def.limits.maxSeats,
+      maxConnections: isUnlimited(def.limits.maxConnections) ? null : def.limits.maxConnections,
+      configured: configured.has(tier),
+    };
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Router
@@ -322,6 +356,7 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         plan: subscription.plan,
         status: subscription.status,
       } : null,
+      availablePlans: buildAvailablePlans(),
     }, 200);
   }), { label: "fetch billing status" });
 });

--- a/packages/api/src/lib/auth/__tests__/stripe-checkout.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-checkout.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Self-serve checkout E2E (#3418): drives the Better Auth Stripe plugin's
+ * `/api/auth/subscription/upgrade` with a REAL session against the
+ * production plugin options ({@link buildStripePluginOptions}) and a
+ * mocked Stripe client.
+ *
+ * Pins the money-critical contract of a first org subscription:
+ *   - seat-only checkout: ONE line item priced per seat with
+ *     quantity = member count (seatPriceId === priceId in plans.ts)
+ *   - double-trial suppression: an org that consumed the Atlas
+ *     pre-checkout trial gets `trial_period_days: undefined` overriding
+ *     the plugin's freeTrial spread (#3426 one-trial decision)
+ *   - lazy org customer creation: the plugin creates the Stripe customer
+ *     with `metadata.organizationId` and persists
+ *     organization."stripeCustomerId" (#3417 contract)
+ *   - org scoping: client passes customerType "organization" +
+ *     referenceId; non-admin members are rejected by authorizeReference
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock, type Mock } from "bun:test";
+// NOT createApiTestMocks: the factory mocks @atlas/api/lib/auth/server,
+// which provides the unit under test (buildStripePluginOptions).
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+// ── Mocks (must precede the server import) ──────────────────────────
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
+  mock(() => Promise.resolve([]));
+const mockGetWorkspaceDetails: Mock<(orgId: string) => Promise<unknown>> =
+  mock(() => Promise.resolve(null));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({ internalQuery: mockInternalQuery }),
+  getWorkspaceDetails: mockGetWorkspaceDetails,
+}));
+
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: async () => undefined,
+  getEnterpriseRuntime: () => ({ runPromise: async () => undefined }),
+  EnterpriseLayer: {},
+}));
+
+const { buildStripePluginOptions } = await import("../server");
+const { betterAuth } = await import("better-auth");
+const { memoryAdapter } = await import("better-auth/adapters/memory");
+const { organization } = await import("better-auth/plugins");
+const { stripe: stripePlugin } = await import("@better-auth/stripe");
+
+const STARTER_PRICE = "price_starter_test";
+const CHECKOUT_URL = "https://checkout.stripe.com/c/cs_test_123";
+
+const checkoutSessionsCreate: Mock<(params: Record<string, unknown>) => Promise<unknown>> =
+  mock((params) => Promise.resolve({ id: "cs_test_123", url: CHECKOUT_URL, ...params }));
+const customersCreate: Mock<(params: Record<string, unknown>) => Promise<unknown>> =
+  mock(() => Promise.resolve({ id: "cus_org_new" }));
+
+function makeStripeClient() {
+  return {
+    webhooks: {
+      constructEventAsync: async (payload: string) => JSON.parse(payload),
+    },
+    checkout: {
+      sessions: { create: checkoutSessionsCreate },
+    },
+    customers: {
+      // No pre-existing org customer → forces the lazy-creation path.
+      search: mock(() => Promise.resolve({ data: [] })),
+      create: customersCreate,
+      retrieve: mock(() => Promise.resolve({ id: "cus_org_new", email: "owner@example.com" })),
+      update: mock(() => Promise.resolve({ id: "cus_org_new" })),
+    },
+    prices: {
+      retrieve: mock(() =>
+        Promise.resolve({ id: STARTER_PRICE, recurring: { usage_type: "licensed" } }),
+      ),
+      list: mock(() => Promise.resolve({ data: [] })),
+    },
+    subscriptions: {
+      list: mock(() => Promise.resolve({ data: [] })),
+      retrieve: mock(() => Promise.resolve({})),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe double
+  } as any;
+}
+
+type MemoryDB = Record<string, Record<string, unknown>[]>;
+
+function emptyDB(): MemoryDB {
+  return {
+    user: [],
+    session: [],
+    account: [],
+    verification: [],
+    organization: [],
+    member: [],
+    subscription: [],
+  };
+}
+
+function makeAuth(db: MemoryDB) {
+  return betterAuth({
+    baseURL: "http://localhost:3000",
+    secret: "test-secret-test-secret-test-secret",
+    database: memoryAdapter(db),
+    emailAndPassword: { enabled: true },
+    plugins: [
+      organization(),
+      stripePlugin(
+        buildStripePluginOptions({
+          stripeClient: makeStripeClient(),
+          webhookSecret: "whsec_test",
+        }),
+      ),
+    ],
+  });
+}
+
+async function signUp(auth: ReturnType<typeof makeAuth>): Promise<string> {
+  const res = await auth.handler(
+    new Request("http://localhost:3000/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "owner@example.com",
+        password: "password-123",
+        name: "Owner",
+      }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  // createCustomerOnSignUp fires a USER customers.create during sign-up;
+  // clear it so assertions below isolate the ORG customer-creation path.
+  customersCreate.mockClear();
+  return res.headers.get("set-cookie")!.split(";")[0];
+}
+
+async function postUpgrade(
+  auth: ReturnType<typeof makeAuth>,
+  cookie: string,
+  body: Record<string, unknown>,
+) {
+  return auth.handler(
+    new Request("http://localhost:3000/api/auth/subscription/upgrade", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+/** Seed an org with N members (ids don't need user rows for adapter.count). */
+function seedOrg(db: MemoryDB, memberCount: number) {
+  db.organization.push({ id: "org-1", name: "Acme", slug: "acme", createdAt: new Date() });
+  for (let i = 0; i < memberCount; i++) {
+    db.member.push({
+      id: `member-${i}`,
+      organizationId: "org-1",
+      userId: `user-${i}`,
+      role: i === 0 ? "owner" : "member",
+      createdAt: new Date(),
+    });
+  }
+}
+
+const ENV_KEYS = ["STRIPE_STARTER_PRICE_ID", "STRIPE_PRO_PRICE_ID"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+  process.env.STRIPE_STARTER_PRICE_ID = STARTER_PRICE;
+  delete process.env.STRIPE_PRO_PRICE_ID;
+});
+
+afterAll(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+beforeEach(() => {
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mockGetWorkspaceDetails.mockReset();
+  // Default: org consumed the Atlas pre-checkout trial.
+  mockGetWorkspaceDetails.mockImplementation(() =>
+    Promise.resolve({ id: "org-1", trial_ends_at: "2026-06-01T00:00:00.000Z" }),
+  );
+  checkoutSessionsCreate.mockClear();
+  customersCreate.mockClear();
+});
+
+describe("POST /api/auth/subscription/upgrade (org-scoped first subscription)", () => {
+  const upgradeBody = {
+    plan: "starter",
+    customerType: "organization",
+    referenceId: "org-1",
+    successUrl: "http://localhost:3000/admin/billing?checkout=success",
+    cancelUrl: "http://localhost:3000/admin/billing?checkout=cancelled",
+    disableRedirect: true,
+  };
+
+  it("creates a seat-only Checkout session with quantity = member count and a suppressed trial", async () => {
+    const db = emptyDB();
+    seedOrg(db, 3);
+    const auth = makeAuth(db);
+    const cookie = await signUp(auth);
+    // authorizeReference member lookup (internal DB) — caller is an owner.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([{ role: "owner" }]));
+
+    const res = await postUpgrade(auth, cookie, upgradeBody);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url?: string };
+    expect(body.url).toBe(CHECKOUT_URL);
+
+    expect(checkoutSessionsCreate).toHaveBeenCalledTimes(1);
+    const [params] = checkoutSessionsCreate.mock.calls[0] as [Record<string, unknown>];
+
+    // Seat-only plan: ONE line item, per-seat price, quantity = members.
+    expect(params.line_items).toEqual([{ price: STARTER_PRICE, quantity: 3 }]);
+
+    // referenceId travels as client_reference_id for the webhook.
+    expect(params.client_reference_id).toBe("org-1");
+
+    // Double-trial suppression: the plugin's freeTrial spread is overridden
+    // with undefined (the Stripe SDK drops undefined keys on the wire).
+    const subData = params.subscription_data as Record<string, unknown>;
+    expect("trial_period_days" in subData).toBe(true);
+    expect(subData.trial_period_days).toBeUndefined();
+
+    // Lazy org customer creation (#3417): created with org metadata and
+    // persisted on the plugin-owned organization."stripeCustomerId".
+    expect(customersCreate).toHaveBeenCalledTimes(1);
+    const [custParams] = customersCreate.mock.calls[0] as [Record<string, unknown>];
+    expect((custParams.metadata as Record<string, unknown>).organizationId).toBe("org-1");
+    expect(db.organization[0].stripeCustomerId).toBe("cus_org_new");
+    expect(params.customer).toBe("cus_org_new");
+  });
+
+  it("keeps the plugin trial for an org that never consumed the Atlas trial", async () => {
+    mockGetWorkspaceDetails.mockImplementation(() =>
+      Promise.resolve({ id: "org-1", trial_ends_at: null }),
+    );
+    const db = emptyDB();
+    seedOrg(db, 1);
+    const auth = makeAuth(db);
+    const cookie = await signUp(auth);
+    mockInternalQuery.mockImplementation(() => Promise.resolve([{ role: "owner" }]));
+
+    const res = await postUpgrade(auth, cookie, upgradeBody);
+
+    expect(res.status).toBe(200);
+    const [params] = checkoutSessionsCreate.mock.calls[0] as [Record<string, unknown>];
+    const subData = params.subscription_data as Record<string, unknown>;
+    expect(subData.trial_period_days).toBe(14);
+  });
+
+  it("rejects a plain member with 401 before any Stripe call", async () => {
+    const db = emptyDB();
+    seedOrg(db, 2);
+    const auth = makeAuth(db);
+    const cookie = await signUp(auth);
+    mockInternalQuery.mockImplementation(() => Promise.resolve([{ role: "member" }]));
+
+    const res = await postUpgrade(auth, cookie, upgradeBody);
+
+    expect(res.status).toBe(401);
+    expect(checkoutSessionsCreate).not.toHaveBeenCalled();
+    expect(customersCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bare user-mode upgrade (no customerType/referenceId) at the checkout gate", async () => {
+    const db = emptyDB();
+    seedOrg(db, 1);
+    const auth = makeAuth(db);
+    const cookie = await signUp(auth);
+
+    const res = await postUpgrade(auth, cookie, {
+      plan: "starter",
+      successUrl: "http://localhost:3000/admin/billing?checkout=success",
+      cancelUrl: "http://localhost:3000/admin/billing?checkout=cancelled",
+      disableRedirect: true,
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message ?? "").toContain("organization-scoped");
+    expect(checkoutSessionsCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -34,10 +34,14 @@ const mockUpdateWorkspaceStatus: Mock<(orgId: string, status: string) => Promise
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
   mock(() => Promise.resolve([]));
 
+const mockGetWorkspaceDetails: Mock<(orgId: string) => Promise<unknown>> =
+  mock(() => Promise.resolve(null));
+
 mock.module("@atlas/api/lib/db/internal", () => ({
   ...buildInternalDbMockDefaults({ internalQuery: mockInternalQuery }),
   updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
   updateWorkspaceStatus: mockUpdateWorkspaceStatus,
+  getWorkspaceDetails: mockGetWorkspaceDetails,
 }));
 
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
@@ -173,6 +177,8 @@ afterAll(() => {
 beforeEach(() => {
   mockUpdateWorkspacePlanTier.mockClear();
   mockUpdateWorkspaceStatus.mockClear();
+  mockGetWorkspaceDetails.mockReset();
+  mockGetWorkspaceDetails.mockImplementation(() => Promise.resolve(null));
   mockInternalQuery.mockReset();
   mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   subscriptionsRetrieve.mockClear();
@@ -209,27 +215,56 @@ describe("getCheckoutSessionParams — org-scope guard", () => {
     return options.subscription.getCheckoutSessionParams;
   }
 
-  it("throws for a subscription whose referenceId is the calling user (user-scoped checkout)", () => {
+  it("rejects a subscription whose referenceId is the calling user (user-scoped checkout)", async () => {
     const cb = getCallback();
-    expect(() =>
-      cb(
-        {
-          user: { id: "user-1" },
-          session: {},
-          plan: { name: "starter" },
-          subscription: { id: "subrow_1", referenceId: "user-1" },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural fixtures for the plugin callback
-        } as any,
-        undefined,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ctx unused by the guard
-        {} as any,
+    await expect(
+      Promise.resolve(
+        cb(
+          {
+            user: { id: "user-1" },
+            session: {},
+            plan: { name: "starter" },
+            subscription: { id: "subrow_1", referenceId: "user-1" },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural fixtures for the plugin callback
+          } as any,
+          undefined,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ctx unused by the guard
+          {} as any,
+        ),
       ),
-    ).toThrow(/organization-scoped/);
+    ).rejects.toThrow(/organization-scoped/);
   });
 
-  it("passes org-scoped subscriptions through", () => {
+  it("suppresses the Stripe trial for an org that consumed the Atlas pre-checkout trial (#3418)", async () => {
+    mockGetWorkspaceDetails.mockImplementation(() =>
+      Promise.resolve({ id: "org-1", trial_ends_at: "2026-06-01T00:00:00.000Z" }),
+    );
     const cb = getCallback();
-    const result = cb(
+    const result = await cb(
+      {
+        user: { id: "user-1" },
+        session: {},
+        plan: { name: "starter" },
+        subscription: { id: "subrow_1", referenceId: "org-1" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural fixtures for the plugin callback
+      } as any,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ctx unused by the guard
+      {} as any,
+    );
+    // trial_period_days: undefined overrides the plugin's freeTrial spread;
+    // the Stripe SDK drops undefined keys from the request.
+    expect(result).toEqual({
+      params: { subscription_data: { trial_period_days: undefined } },
+    });
+  });
+
+  it("leaves the plugin trial in place for an org that never consumed the Atlas trial", async () => {
+    mockGetWorkspaceDetails.mockImplementation(() =>
+      Promise.resolve({ id: "org-1", trial_ends_at: null }),
+    );
+    const cb = getCallback();
+    const result = await cb(
       {
         user: { id: "user-1" },
         session: {},
@@ -242,6 +277,26 @@ describe("getCheckoutSessionParams — org-scope guard", () => {
       {} as any,
     );
     expect(result).toEqual({});
+  });
+
+  it("suppresses the trial when the workspace lookup fails (fail toward no double trial)", async () => {
+    mockGetWorkspaceDetails.mockImplementation(() => Promise.reject(new Error("pg blip")));
+    const cb = getCallback();
+    const result = await cb(
+      {
+        user: { id: "user-1" },
+        session: {},
+        plan: { name: "starter" },
+        subscription: { id: "subrow_1", referenceId: "org-1" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural fixtures for the plugin callback
+      } as any,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ctx unused by the guard
+      {} as any,
+    );
+    expect(result).toEqual({
+      params: { subscription_data: { trial_period_days: undefined } },
+    });
   });
 });
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -33,7 +33,7 @@ import {
 import { listUserWorkspaceIds } from "@atlas/api/lib/auth/oauth-workspace-grants";
 import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit";
 import Stripe from "stripe";
-import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
+import { getInternalDB, getWorkspaceDetails, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   resolveRequireEmailVerification as envProfileResolveRequireEmailVerification,
@@ -1400,14 +1400,30 @@ export function buildStripePluginOptions(deps: {
           customerType: body?.customerType ?? query?.customerType,
         });
       },
-      // Last-gate guard for the one path authorizeReference cannot see: a
-      // user-mode upgrade with NO explicit referenceId skips the reference
-      // middleware entirely (referenceId defaults to user.id) and would
-      // create a Checkout session whose webhook referenceId never matches
-      // an organization — the customer pays, the workspace gets nothing.
-      // #3418 extends this callback with trial suppression.
-      getCheckoutSessionParams({ user, subscription }) {
-        if (subscription.referenceId === user.id) {
+      // Two jobs at the last gate before Stripe Checkout (#3418):
+      //
+      // 1. Org-scope guard — the one path authorizeReference cannot see: a
+      //    user-mode upgrade with NO explicit referenceId skips the
+      //    reference middleware entirely (referenceId defaults to user.id)
+      //    and would create a Checkout session whose webhook referenceId
+      //    never matches an organization — the customer pays, the
+      //    workspace gets nothing.
+      //
+      // 2. Double-trial suppression (#3426 one-trial decision) — every
+      //    paid plan carries `freeTrial`, and the plugin's own one-trial
+      //    guard only consults its own subscription table. An org that
+      //    consumed Atlas's PRE-checkout trial (assignSaasTrial stamps
+      //    `trial_ends_at` at workspace creation) has no subscription row,
+      //    so the plugin would grant a SECOND 14-day Stripe trial at first
+      //    checkout. The plugin spreads our `subscription_data` AFTER its
+      //    `freeTrial` computation, so `trial_period_days: undefined`
+      //    overrides it and the Stripe SDK drops the undefined key.
+      //    Fails toward suppression: if the workspace lookup errors, the
+      //    customer starts billing immediately rather than risking a
+      //    double trial grant.
+      async getCheckoutSessionParams({ user, subscription }) {
+        const orgId = subscription.referenceId;
+        if (orgId === user.id) {
           billingLog.error(
             { userId: user.id, subscriptionId: subscription.id },
             "Blocked user-scoped checkout — Atlas subscriptions must be org-scoped (customerType \"organization\")",
@@ -1416,6 +1432,27 @@ export function buildStripePluginOptions(deps: {
             message:
               "Atlas subscriptions are organization-scoped. Retry with customerType \"organization\".",
           });
+        }
+
+        let trialConsumed = true;
+        try {
+          const workspace = await getWorkspaceDetails(orgId);
+          trialConsumed = workspace?.trial_ends_at != null;
+        } catch (err) {
+          billingLog.error(
+            { err: errorMessage(err), orgId },
+            "Workspace lookup failed during checkout trial check — suppressing Stripe trial (fail toward no double trial)",
+          );
+        }
+
+        if (trialConsumed) {
+          billingLog.info(
+            { orgId, subscriptionId: subscription.id },
+            "Suppressing Stripe checkout trial — org already consumed the Atlas pre-checkout trial",
+          );
+          return {
+            params: { subscription_data: { trial_period_days: undefined } },
+          };
         }
         return {};
       },

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1436,6 +1436,10 @@ export function buildStripePluginOptions(deps: {
 
         let trialConsumed = true;
         try {
+          // null workspace (no organization row) → the org never received
+          // an Atlas trial → let the plugin's Stripe trial stand. Distinct
+          // from the catch below: a lookup ERROR is unknown state and
+          // fails toward suppression.
           const workspace = await getWorkspaceDetails(orgId);
           trialConsumed = workspace?.trial_ends_at != null;
         } catch (err) {

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -205,6 +205,20 @@ describe("billing/plans", () => {
       expect(plans.length).toBe(3);
       expect(plans.map((p) => p.name)).toEqual(["starter", "pro", "business"]);
     });
+
+    it("sets seatPriceId === priceId on every plan (seat-only auto-managed seats, #3418)", () => {
+      // seatPriceId === priceId is the plugin's "seat-only plan" shape:
+      // checkout emits a single per-seat line item with quantity = member
+      // count, and the plugin's member add/remove hooks keep the Stripe
+      // quantity synced. A drift between the two would silently re-add a
+      // base line item on top of the seat item — double billing.
+      process.env.STRIPE_STARTER_PRICE_ID = "price_starter_123";
+      process.env.STRIPE_PRO_PRICE_ID = "price_pro_456";
+      process.env.STRIPE_BUSINESS_PRICE_ID = "price_biz_789";
+      for (const plan of getStripePlans()) {
+        expect(plan.seatPriceId).toBe(plan.priceId);
+      }
+    });
   });
 
   describe("resolvePlanTierFromPriceId", () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -198,6 +198,15 @@ export function computeTokenBudget(tier: PlanTier, seatCount: number): number {
 /**
  * Returns plan configs in the format expected by @better-auth/stripe's
  * `subscription.plans` option. Only called when STRIPE_SECRET_KEY is set.
+ *
+ * Every plan sets `seatPriceId === priceId` — the plugin's "seat-only
+ * plan" shape (#3418): checkout emits a single line item priced per seat
+ * with quantity = member count, and the plugin's member
+ * add/remove/invite-accept hooks keep the Stripe quantity synced to
+ * membership automatically. This matches Atlas's $/seat pricing and the
+ * member-count basis enforcement uses for token budgets. The pairing is
+ * pinned by plans.test.ts — a drift would re-add a base line item on top
+ * of the seat item (double billing).
  */
 export function getStripePlans(): Array<{
   name: string;
@@ -221,12 +230,6 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "starter",
       priceId: starterPriceId,
-      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
-      // single checkout line item priced per seat with quantity = member
-      // count, and its member add/remove/invite-accept hooks keep the
-      // Stripe quantity synced to membership automatically (#3418). This
-      // matches Atlas's $/seat pricing and the member-count basis
-      // enforcement uses for token budgets.
       seatPriceId: starterPriceId,
       annualDiscountPriceId: process.env.STRIPE_STARTER_ANNUAL_PRICE_ID,
       limits: {
@@ -244,12 +247,6 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "pro",
       priceId: proPriceId,
-      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
-      // single checkout line item priced per seat with quantity = member
-      // count, and its member add/remove/invite-accept hooks keep the
-      // Stripe quantity synced to membership automatically (#3418). This
-      // matches Atlas's $/seat pricing and the member-count basis
-      // enforcement uses for token budgets.
       seatPriceId: proPriceId,
       annualDiscountPriceId: process.env.STRIPE_PRO_ANNUAL_PRICE_ID,
       limits: {
@@ -267,12 +264,6 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "business",
       priceId: businessPriceId,
-      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
-      // single checkout line item priced per seat with quantity = member
-      // count, and its member add/remove/invite-accept hooks keep the
-      // Stripe quantity synced to membership automatically (#3418). This
-      // matches Atlas's $/seat pricing and the member-count basis
-      // enforcement uses for token budgets.
       seatPriceId: businessPriceId,
       annualDiscountPriceId: process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID,
       limits: {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -71,6 +71,9 @@ const UNLIMITED = -1;
 /** Trial duration in days. Single source of truth — used in plan definitions, Stripe config, and enforcement. */
 export const TRIAL_DAYS = 14;
 
+/** The tiers self-serve checkout can move a workspace to (#3418). */
+export type PaidPlanTier = "starter" | "pro" | "business";
+
 const NO_FEATURES: PlanFeatures = {
   customDomain: false,
   sso: false,
@@ -200,6 +203,7 @@ export function getStripePlans(): Array<{
   name: string;
   priceId: string;
   annualDiscountPriceId?: string;
+  seatPriceId?: string;
   limits: Record<string, number>;
   freeTrial?: { days: number };
 }> {
@@ -207,6 +211,7 @@ export function getStripePlans(): Array<{
     name: string;
     priceId: string;
     annualDiscountPriceId?: string;
+    seatPriceId?: string;
     limits: Record<string, number>;
     freeTrial?: { days: number };
   }> = [];
@@ -216,6 +221,13 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "starter",
       priceId: starterPriceId,
+      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
+      // single checkout line item priced per seat with quantity = member
+      // count, and its member add/remove/invite-accept hooks keep the
+      // Stripe quantity synced to membership automatically (#3418). This
+      // matches Atlas's $/seat pricing and the member-count basis
+      // enforcement uses for token budgets.
+      seatPriceId: starterPriceId,
       annualDiscountPriceId: process.env.STRIPE_STARTER_ANNUAL_PRICE_ID,
       limits: {
         tokenBudgetPerSeat: PLANS.starter.limits.tokenBudgetPerSeat,
@@ -232,6 +244,13 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "pro",
       priceId: proPriceId,
+      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
+      // single checkout line item priced per seat with quantity = member
+      // count, and its member add/remove/invite-accept hooks keep the
+      // Stripe quantity synced to membership automatically (#3418). This
+      // matches Atlas's $/seat pricing and the member-count basis
+      // enforcement uses for token budgets.
+      seatPriceId: proPriceId,
       annualDiscountPriceId: process.env.STRIPE_PRO_ANNUAL_PRICE_ID,
       limits: {
         tokenBudgetPerSeat: PLANS.pro.limits.tokenBudgetPerSeat,
@@ -248,6 +267,13 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "business",
       priceId: businessPriceId,
+      // Seat-only plan: seatPriceId === priceId makes the plugin emit a
+      // single checkout line item priced per seat with quantity = member
+      // count, and its member add/remove/invite-accept hooks keep the
+      // Stripe quantity synced to membership automatically (#3418). This
+      // matches Atlas's $/seat pricing and the member-count basis
+      // enforcement uses for token budgets.
+      seatPriceId: businessPriceId,
       annualDiscountPriceId: process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID,
       limits: {
         tokenBudgetPerSeat: PLANS.business.limits.tokenBudgetPerSeat,

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/schemas",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Shared Zod schemas for Atlas wire format — single source of truth for API route validation and web response parsing",
   "type": "module",
   "private": true,

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -103,6 +103,22 @@ export interface BillingSubscription {
   status: string;
 }
 
+/**
+ * A plan tier the workspace can move to via self-serve checkout (#3418).
+ * `configured` is false when the deployment has no Stripe Price ID for the
+ * tier — the picker renders the card but disables its CTA. Limits are
+ * nullable with null = unlimited, mirroring {@link BillingLimits}.
+ */
+export interface BillingAvailablePlan {
+  tier: PlanTier;
+  displayName: string;
+  pricePerSeat: number;
+  tokenBudgetPerSeat: number | null;
+  maxSeats: number | null;
+  maxConnections: number | null;
+  configured: boolean;
+}
+
 export interface BillingStatus {
   workspaceId: string;
   plan: BillingPlan;
@@ -113,6 +129,12 @@ export interface BillingStatus {
   currentModel: string;
   overagePerMillionTokens: number;
   subscription: BillingSubscription | null;
+  /**
+   * Optional so a web bundle pinned to an older published schema keeps
+   * parsing (z.object strips unknown keys; the picker hides itself when
+   * the field is absent). The API always sends it.
+   */
+  availablePlans?: BillingAvailablePlan[];
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +183,16 @@ export const BillingSubscriptionSchema = z.object({
   status: z.string(),
 }) satisfies z.ZodType<BillingSubscription>;
 
+export const BillingAvailablePlanSchema = z.object({
+  tier: PlanTierEnum,
+  displayName: z.string(),
+  pricePerSeat: z.number(),
+  tokenBudgetPerSeat: z.number().nullable(),
+  maxSeats: z.number().nullable(),
+  maxConnections: z.number().nullable(),
+  configured: z.boolean(),
+}) satisfies z.ZodType<BillingAvailablePlan>;
+
 export const BillingStatusSchema = z.object({
   workspaceId: z.string(),
   plan: BillingPlanSchema,
@@ -171,4 +203,5 @@ export const BillingStatusSchema = z.object({
   currentModel: z.string(),
   overagePerMillionTokens: z.number(),
   subscription: BillingSubscriptionSchema.nullable(),
+  availablePlans: z.array(BillingAvailablePlanSchema).optional(),
 }) satisfies z.ZodType<BillingStatus>;

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -201,6 +201,7 @@ export default function BillingPage() {
               {checkout && (
                 <CheckoutReturnBanner
                   state={checkout}
+                  targetPlan={planParam}
                   data={data}
                   refetch={refetch}
                   onDone={() => void setParams({ checkout: null })}
@@ -415,29 +416,45 @@ function PlanShell({ data }: { data: BillingStatus }) {
 
 // ── Checkout return banner (#3418) ────────────────────────────────
 
+// The plan tier is written by Stripe webhooks, which race the redirect.
+// The server caches plan reads for 60s, so the poll must outlive that
+// TTL or a webhook landing at t=45s against a warm cache strands the
+// user on "refresh in a minute" (#3418 triage: "a refetch poll past the
+// 60s plan-cache TTL"). 25 × 3s = 75s.
+const POLL_INTERVAL_MS = 3000;
+const POLL_MAX_ATTEMPTS = 25;
+
 /**
- * Shown after the user returns from Stripe Checkout. The plan tier is
- * written by the checkout.session.completed webhook, which races the
- * redirect — so on `success` this polls the billing endpoint until the
- * paid tier (or an active/trialing subscription) appears, then clears
- * the URL param. If the webhook is slow (~30s of polling), the copy
- * degrades to "refresh in a minute" instead of spinning forever.
+ * Shown after the user returns from Stripe — covering all three
+ * journeys:
+ *   - `success` — first-subscription Checkout; polls until a paid tier
+ *     (or active/trialing subscription) appears.
+ *   - `changed` — immediate plan change on an existing subscription;
+ *     polls until the target tier (from `?plan=`) appears.
+ *   - `scheduled` — period-end downgrade; static notice, nothing to poll.
+ *   - `cancelled` — dismissable no-charge notice.
+ * If the webhook outlives the poll window, the copy degrades to
+ * "refresh in a minute" instead of spinning forever.
  */
 function CheckoutReturnBanner({
   state,
+  targetPlan,
   data,
   refetch,
   onDone,
 }: {
-  state: "success" | "cancelled";
+  state: "success" | "cancelled" | "changed" | "scheduled";
+  targetPlan: string | null;
   data: BillingStatus;
   refetch: () => void;
   onDone: () => void;
 }) {
   const landed =
-    (PAID_TIERS as readonly string[]).includes(data.plan.tier) ||
-    data.subscription?.status === "active" ||
-    data.subscription?.status === "trialing";
+    state === "changed" && targetPlan
+      ? data.plan.tier === targetPlan
+      : (PAID_TIERS as readonly string[]).includes(data.plan.tier) ||
+        data.subscription?.status === "active" ||
+        data.subscription?.status === "trialing";
   const [slow, setSlow] = useState(false);
   const attempts = useRef(0);
 
@@ -449,19 +466,37 @@ function CheckoutReturnBanner({
     refetchRef.current = refetch;
   });
 
+  const polling = state === "success" || state === "changed";
   useEffect(() => {
-    if (state !== "success" || landed) return;
+    if (!polling || landed) return;
     const interval = setInterval(() => {
       attempts.current += 1;
-      if (attempts.current > 12) {
+      if (attempts.current > POLL_MAX_ATTEMPTS) {
         setSlow(true);
         clearInterval(interval);
         return;
       }
       refetchRef.current();
-    }, 2500);
+    }, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [state, landed]);
+  }, [polling, landed]);
+
+  if (state === "scheduled") {
+    return (
+      <div
+        role="status"
+        className="flex items-center justify-between gap-4 rounded-lg border bg-muted/30 px-4 py-3 text-sm"
+      >
+        <p className="text-muted-foreground">
+          Plan change scheduled — {data.plan.displayName} stays active until the
+          end of the current billing period.
+        </p>
+        <Button size="sm" variant="ghost" onClick={onDone}>
+          Dismiss
+        </Button>
+      </div>
+    );
+  }
 
   if (state === "cancelled") {
     return (
@@ -488,7 +523,9 @@ function CheckoutReturnBanner({
       >
         <p className="flex items-center gap-2 font-medium">
           <CheckCircle2 className="size-4 shrink-0" aria-hidden />
-          Subscription active — welcome to {data.plan.displayName}.
+          {state === "changed"
+            ? `Plan updated — you're now on ${data.plan.displayName}.`
+            : `Subscription active — welcome to ${data.plan.displayName}.`}
         </p>
         <Button size="sm" variant="ghost" onClick={onDone}>
           Dismiss
@@ -521,8 +558,14 @@ function CheckoutReturnBanner({
 
 // ── Plan picker (#3418) ───────────────────────────────────────────
 
-/** Order used to classify a plan change as upgrade vs downgrade. */
-const TIER_RANK: Record<string, number> = { starter: 1, pro: 2, business: 3 };
+/**
+ * Order used to classify a plan change as upgrade vs downgrade. Derived
+ * from PAID_TIERS (the web-side tier source of truth in plan-intent.ts)
+ * so a new tier can't silently rank as 0 here while the picker shows it.
+ */
+const TIER_RANK: Record<string, number> = Object.fromEntries(
+  PAID_TIERS.map((tier, i) => [tier, i + 1]),
+);
 
 function PlanPicker({
   data,

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { useQueryStates } from "nuqs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -26,6 +28,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { useBillingPortal } from "@/ui/hooks/use-billing-portal";
+import { usePlanCheckout } from "@/ui/hooks/use-plan-checkout";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
@@ -35,10 +38,13 @@ import {
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
 import { formatDate, formatNumber } from "@/lib/format";
+import { consumePlanIntent } from "@/lib/billing/plan-intent";
 import { cn } from "@/lib/utils";
+import { billingSearchParams } from "./search-params";
 import type { BillingStatus } from "@useatlas/schemas";
 import {
   Bot,
+  CheckCircle2,
   Coins,
   CreditCard,
   DollarSign,
@@ -124,6 +130,18 @@ export default function BillingPage() {
     schema: BillingStatusSchema,
   });
   const { deployMode, error: modeError, resolved: modeResolved } = useDeployMode();
+  const [{ checkout, plan: planParam }, setParams] = useQueryStates(billingSearchParams);
+
+  // Pricing-page plan intent (#3418): /signup?plan=… stashes the choice in
+  // localStorage (the signup flow spans five hard navs); surface it here as
+  // the ?plan= URL param so the picker preselects and the URL is shareable.
+  useEffect(() => {
+    if (planParam) return;
+    const intent = consumePlanIntent();
+    if (intent) void setParams({ plan: intent });
+    // Mount-only: consumePlanIntent is one-shot (read-and-clear), so the
+    // effect must not re-run when planParam/setParams identities change.
+  }, []);
 
   // Framework-level 404 (billing routes not mounted) means self-hosted / no Stripe.
   // API-level 404s ("Workspace not found", "no internal database") have descriptive
@@ -180,12 +198,32 @@ export default function BillingPage() {
           {data && (
             <div className="space-y-10">
               <TrialCountdownBanner plan={data.plan} />
+              {checkout && (
+                <CheckoutReturnBanner
+                  state={checkout}
+                  data={data}
+                  refetch={refetch}
+                  onDone={() => void setParams({ checkout: null })}
+                />
+              )}
               <section id={TRIAL_BANNER_PLAN_ANCHOR_ID} className="scroll-mt-6">
                 <SectionHeading
                   title="Plan"
                   description="Your current subscription and limits"
                 />
                 <PlanShell data={data} />
+              </section>
+
+              <section>
+                <SectionHeading
+                  title={data.subscription ? "Change plan" : "Choose a plan"}
+                  description={
+                    data.subscription
+                      ? "Upgrades apply immediately (prorated); downgrades take effect at the end of the billing period"
+                      : "Subscribe to keep using Atlas after your trial"
+                  }
+                />
+                <PlanPicker data={data} highlight={planParam} />
               </section>
 
               <section>
@@ -372,6 +410,215 @@ function PlanShell({ data }: { data: BillingStatus }) {
         </p>
       )}
     </Shell>
+  );
+}
+
+// ── Checkout return banner (#3418) ────────────────────────────────
+
+/**
+ * Shown after the user returns from Stripe Checkout. The plan tier is
+ * written by the checkout.session.completed webhook, which races the
+ * redirect — so on `success` this polls the billing endpoint until the
+ * paid tier (or an active/trialing subscription) appears, then clears
+ * the URL param. If the webhook is slow (~30s of polling), the copy
+ * degrades to "refresh in a minute" instead of spinning forever.
+ */
+function CheckoutReturnBanner({
+  state,
+  data,
+  refetch,
+  onDone,
+}: {
+  state: "success" | "cancelled";
+  data: BillingStatus;
+  refetch: () => void;
+  onDone: () => void;
+}) {
+  const PAID_TIERS = ["starter", "pro", "business"];
+  const landed =
+    PAID_TIERS.includes(data.plan.tier) ||
+    data.subscription?.status === "active" ||
+    data.subscription?.status === "trialing";
+  const [slow, setSlow] = useState(false);
+  const attempts = useRef(0);
+
+  useEffect(() => {
+    if (state !== "success" || landed) return;
+    const interval = setInterval(() => {
+      attempts.current += 1;
+      if (attempts.current > 12) {
+        setSlow(true);
+        clearInterval(interval);
+        return;
+      }
+      refetch();
+    }, 2500);
+    return () => clearInterval(interval);
+  }, [state, landed, refetch]);
+
+  if (state === "cancelled") {
+    return (
+      <div
+        role="status"
+        className="flex items-center justify-between gap-4 rounded-lg border bg-muted/30 px-4 py-3 text-sm"
+      >
+        <p className="text-muted-foreground">
+          Checkout cancelled — no charges were made. Pick a plan below whenever
+          you&apos;re ready.
+        </p>
+        <Button size="sm" variant="ghost" onClick={onDone}>
+          Dismiss
+        </Button>
+      </div>
+    );
+  }
+
+  if (landed) {
+    return (
+      <div
+        role="status"
+        className="flex items-center justify-between gap-4 rounded-lg border border-emerald-500/40 bg-emerald-500/5 px-4 py-3 text-sm text-emerald-900 dark:text-emerald-200"
+      >
+        <p className="flex items-center gap-2 font-medium">
+          <CheckCircle2 className="size-4 shrink-0" aria-hidden />
+          Subscription active — welcome to {data.plan.displayName}.
+        </p>
+        <Button size="sm" variant="ghost" onClick={onDone}>
+          Dismiss
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-4 rounded-lg border border-blue-500/30 bg-blue-500/5 px-4 py-3 text-sm text-blue-900 dark:text-blue-200"
+    >
+      <p className="flex items-center gap-2 font-medium">
+        {slow ? (
+          <>Payment received — your plan will update shortly. Refresh in a minute.</>
+        ) : (
+          <>
+            <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+            Finalizing your subscription…
+          </>
+        )}
+      </p>
+      <Button size="sm" variant="ghost" onClick={onDone}>
+        Dismiss
+      </Button>
+    </div>
+  );
+}
+
+// ── Plan picker (#3418) ───────────────────────────────────────────
+
+/** Order used to classify a plan change as upgrade vs downgrade. */
+const TIER_RANK: Record<string, number> = { starter: 1, pro: 2, business: 3 };
+
+function PlanPicker({
+  data,
+  highlight,
+}: {
+  data: BillingStatus;
+  highlight: string | null;
+}) {
+  const { startCheckout, pendingPlan, error, clearError } = usePlanCheckout();
+  const plans = data.availablePlans ?? [];
+  // An older published schema (scaffolds pinned to a pre-#3418
+  // @useatlas/schemas) strips availablePlans at parse time — hide the
+  // picker rather than render an empty grid.
+  if (plans.length === 0) return null;
+
+  const currentTier = data.plan.tier;
+  const hasSubscription = data.subscription != null;
+  const currentRank = TIER_RANK[currentTier] ?? 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-3">
+        {plans.map((plan) => {
+          const isCurrent = hasSubscription && plan.tier === currentTier;
+          const isDowngrade = hasSubscription && TIER_RANK[plan.tier] < currentRank;
+          const busy = pendingPlan === plan.tier;
+          const label = isCurrent
+            ? "Current plan"
+            : !hasSubscription
+              ? "Subscribe"
+              : isDowngrade
+                ? "Downgrade"
+                : "Upgrade";
+          return (
+            <div
+              key={plan.tier}
+              data-testid={`plan-card-${plan.tier}`}
+              className={cn(
+                "flex flex-col gap-3 rounded-xl border bg-card/40 p-4",
+                highlight === plan.tier && "border-primary ring-1 ring-primary",
+                isCurrent && "border-primary/40",
+              )}
+            >
+              <div className="flex items-baseline justify-between">
+                <h3 className="text-sm font-semibold tracking-tight">{plan.displayName}</h3>
+                {isCurrent && (
+                  <Badge variant="secondary" className="text-[10px]">
+                    Current
+                  </Badge>
+                )}
+              </div>
+              <p>
+                <span className="text-2xl font-semibold tabular-nums">${plan.pricePerSeat}</span>
+                <span className="text-xs text-muted-foreground"> /seat/mo</span>
+              </p>
+              <ul className="space-y-1 text-xs text-muted-foreground">
+                <li>
+                  {plan.tokenBudgetPerSeat === null
+                    ? "Unlimited tokens"
+                    : `${formatNumber(plan.tokenBudgetPerSeat)} tokens/seat/mo`}
+                </li>
+                <li>{plan.maxSeats === null ? "Unlimited seats" : `Up to ${plan.maxSeats} seats`}</li>
+                <li>
+                  {plan.maxConnections === null
+                    ? "Unlimited connections"
+                    : `${plan.maxConnections} ${plan.maxConnections === 1 ? "connection" : "connections"}`}
+                </li>
+              </ul>
+              <Button
+                size="sm"
+                variant={isCurrent ? "outline" : isDowngrade ? "outline" : "default"}
+                disabled={isCurrent || !plan.configured || pendingPlan !== null}
+                onClick={() =>
+                  startCheckout({ plan: plan.tier, scheduleAtPeriodEnd: isDowngrade })
+                }
+                className="mt-auto"
+              >
+                {busy ? (
+                  <>
+                    <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                    Redirecting…
+                  </>
+                ) : (
+                  label
+                )}
+              </Button>
+              {!plan.configured && (
+                <p className="text-[11px] text-muted-foreground">
+                  Not available on this deployment.
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {error && <ErrorBanner message={error} onRetry={clearError} />}
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Billing is per seat ({data.seats?.count ?? data.usage.seatCount}{" "}
+        {(data.seats?.count ?? data.usage.seatCount) === 1 ? "member" : "members"} today) and the
+        seat count stays in sync as members join or leave. Upgrades are prorated immediately;
+        downgrades take effect at the end of the current billing period.
+      </p>
+    </div>
   );
 }
 

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -38,7 +38,7 @@ import {
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
 import { formatDate, formatNumber } from "@/lib/format";
-import { consumePlanIntent } from "@/lib/billing/plan-intent";
+import { consumePlanIntent, PAID_TIERS } from "@/lib/billing/plan-intent";
 import { cn } from "@/lib/utils";
 import { billingSearchParams } from "./search-params";
 import type { BillingStatus } from "@useatlas/schemas";
@@ -434,13 +434,20 @@ function CheckoutReturnBanner({
   refetch: () => void;
   onDone: () => void;
 }) {
-  const PAID_TIERS = ["starter", "pro", "business"];
   const landed =
-    PAID_TIERS.includes(data.plan.tier) ||
+    (PAID_TIERS as readonly string[]).includes(data.plan.tier) ||
     data.subscription?.status === "active" ||
     data.subscription?.status === "trialing";
   const [slow, setSlow] = useState(false);
   const attempts = useRef(0);
+
+  // refetch's identity changes per render (useAdminFetch recreates it), so
+  // depending on it directly would tear down and restart the interval on
+  // every poll-driven render. Route through a ref kept fresh each render.
+  const refetchRef = useRef(refetch);
+  useEffect(() => {
+    refetchRef.current = refetch;
+  });
 
   useEffect(() => {
     if (state !== "success" || landed) return;
@@ -451,10 +458,10 @@ function CheckoutReturnBanner({
         clearInterval(interval);
         return;
       }
-      refetch();
+      refetchRef.current();
     }, 2500);
     return () => clearInterval(interval);
-  }, [state, landed, refetch]);
+  }, [state, landed]);
 
   if (state === "cancelled") {
     return (

--- a/packages/web/src/app/admin/billing/search-params.ts
+++ b/packages/web/src/app/admin/billing/search-params.ts
@@ -1,0 +1,18 @@
+import { parseAsStringEnum } from "nuqs";
+
+/**
+ * URL state for the billing page (#3418).
+ *
+ * `checkout` is stamped by the Stripe Checkout return URLs
+ * (`?checkout=success` / `?checkout=cancelled`) — `success` drives the
+ * "finalizing your subscription" poll until the webhook lands the new
+ * tier; `cancelled` shows a dismissable notice.
+ *
+ * `plan` preselects a plan-picker card. Set by the pricing page intent
+ * (`/signup?plan=…`, carried via `lib/billing/plan-intent`) or shared
+ * directly as a deep link.
+ */
+export const billingSearchParams = {
+  checkout: parseAsStringEnum(["success", "cancelled"]),
+  plan: parseAsStringEnum(["starter", "pro", "business"]),
+};

--- a/packages/web/src/app/admin/billing/search-params.ts
+++ b/packages/web/src/app/admin/billing/search-params.ts
@@ -1,18 +1,23 @@
 import { parseAsStringEnum } from "nuqs";
+import { PAID_TIERS } from "@/lib/billing/plan-intent";
 
 /**
  * URL state for the billing page (#3418).
  *
- * `checkout` is stamped by the Stripe Checkout return URLs
- * (`?checkout=success` / `?checkout=cancelled`) — `success` drives the
- * "finalizing your subscription" poll until the webhook lands the new
- * tier; `cancelled` shows a dismissable notice.
+ * `checkout` is stamped by the post-Stripe return URLs:
+ *   - `success` / `cancelled` — Stripe Checkout (first subscription);
+ *     `success` drives the "finalizing your subscription" poll until the
+ *     webhook lands the new tier.
+ *   - `changed` — an immediate plan change on an existing subscription
+ *     (portal `subscription_update_confirm` or direct update); polls
+ *     until the target tier appears.
+ *   - `scheduled` — a downgrade scheduled for period end; static notice,
+ *     nothing to poll for.
  *
- * `plan` preselects a plan-picker card. Set by the pricing page intent
- * (`/signup?plan=…`, carried via `lib/billing/plan-intent`) or shared
- * directly as a deep link.
+ * `plan` preselects a plan-picker card (pricing-page intent or deep
+ * link) AND names the target tier the `changed` poll waits for.
  */
 export const billingSearchParams = {
-  checkout: parseAsStringEnum(["success", "cancelled"]),
-  plan: parseAsStringEnum(["starter", "pro", "business"]),
+  checkout: parseAsStringEnum(["success", "cancelled", "changed", "scheduled"]),
+  plan: parseAsStringEnum([...PAID_TIERS]),
 };

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { savePlanIntent } from "@/lib/billing/plan-intent";
 import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { getApiUrl } from "@/lib/api-url";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,15 @@ export default function SignupPage() {
   // rather than creating their own).
   const searchParams = useSearchParams();
   const invitationId = searchParams.get("invitationId");
+  // `?plan=…` is the pricing-page CTA intent (#3418). The signup flow
+  // spans five hard-navigated steps plus optional OAuth redirects, so the
+  // param can't survive as URL state — stash it; the billing plan picker
+  // consumes it for preselection. Saved in an effect (not render) so
+  // React strict-mode double-render doesn't double-write.
+  const planParam = searchParams.get("plan");
+  useEffect(() => {
+    savePlanIntent(planParam);
+  }, [planParam]);
   const postSignupPath = invitationId
     ? `/accept-invitation/${encodeURIComponent(invitationId)}`
     : "/signup/workspace";

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -256,6 +256,26 @@ type OrgClient = Omit<typeof _authClient, "useSession"> & {
       data?: { url: string; redirect: boolean } | null;
       error?: { message?: string; code?: string; status?: number } | null;
     }>;
+    // First subscription → Stripe Checkout redirect URL; plan change on an
+    // existing subscription → Billing Portal subscription_update_confirm
+    // URL (or the returnUrl when the plugin applied the change directly).
+    // Pass scheduleAtPeriodEnd for downgrades so the switch lands at the
+    // period boundary via a Subscription Schedule (#3418).
+    upgrade?: (opts: {
+      plan: string;
+      referenceId?: string;
+      customerType?: "user" | "organization";
+      annual?: boolean;
+      seats?: number;
+      successUrl?: string;
+      cancelUrl?: string;
+      returnUrl?: string;
+      scheduleAtPeriodEnd?: boolean;
+      disableRedirect?: boolean;
+    }) => Promise<{
+      data?: { url?: string | null; redirect: boolean } | null;
+      error?: { message?: string; code?: string; status?: number } | null;
+    }>;
   };
 };
 export const authClient: OrgClient = _authClient as OrgClient;

--- a/packages/web/src/lib/billing/__tests__/plan-intent.test.ts
+++ b/packages/web/src/lib/billing/__tests__/plan-intent.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Plan-intent storage contract (#3418): saved on /signup?plan=…, consumed
+ * once by the billing plan picker. localStorage-backed so it survives the
+ * signup flow's hard navigations and OAuth redirects.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { savePlanIntent, consumePlanIntent, isPlanIntent } from "../plan-intent";
+
+const KEY = "atlas.plan-intent";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("isPlanIntent", () => {
+  it("accepts exactly the three paid tiers", () => {
+    expect(isPlanIntent("starter")).toBe(true);
+    expect(isPlanIntent("pro")).toBe(true);
+    expect(isPlanIntent("business")).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    for (const v of ["trial", "free", "STARTER", "", null, undefined]) {
+      expect(isPlanIntent(v)).toBe(false);
+    }
+  });
+});
+
+describe("savePlanIntent / consumePlanIntent", () => {
+  it("round-trips a valid plan and clears on consumption (one-shot)", () => {
+    savePlanIntent("pro");
+    expect(consumePlanIntent()).toBe("pro");
+    expect(consumePlanIntent()).toBeNull();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("ignores invalid plans at save time", () => {
+    savePlanIntent("enterprise");
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+    expect(consumePlanIntent()).toBeNull();
+  });
+
+  it("expires intents older than 7 days", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ plan: "starter", savedAt: Date.now() - 8 * 24 * 60 * 60 * 1000 }),
+    );
+    expect(consumePlanIntent()).toBeNull();
+  });
+
+  it("survives malformed storage payloads (clears, returns null)", () => {
+    window.localStorage.setItem(KEY, "{not json");
+    expect(consumePlanIntent()).toBeNull();
+    window.localStorage.setItem(KEY, JSON.stringify({ plan: 42 }));
+    expect(consumePlanIntent()).toBeNull();
+  });
+});

--- a/packages/web/src/lib/billing/plan-intent.ts
+++ b/packages/web/src/lib/billing/plan-intent.ts
@@ -17,7 +17,9 @@
 const STORAGE_KEY = "atlas.plan-intent";
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
-const PAID_TIERS = ["starter", "pro", "business"] as const;
+/** The paid tiers, in upgrade order. Shared web-side source of truth
+ * (the web cannot import the API's plans.ts — pure HTTP client rule). */
+export const PAID_TIERS = ["starter", "pro", "business"] as const;
 export type PlanIntent = (typeof PAID_TIERS)[number];
 
 export function isPlanIntent(value: string | null | undefined): value is PlanIntent {

--- a/packages/web/src/lib/billing/plan-intent.ts
+++ b/packages/web/src/lib/billing/plan-intent.ts
@@ -1,0 +1,52 @@
+/**
+ * Plan intent carried from the marketing pricing page into the app (#3418).
+ *
+ * /pricing CTAs link to `/signup?plan=starter|pro|business`. The signup
+ * flow spans five hard-navigated steps (account → workspace → region →
+ * connect → success) plus optional OAuth round-trips, so threading the
+ * query param through every hop is brittle — instead the signup page
+ * stashes the intent here and the billing plan picker consumes it to
+ * preselect the card. localStorage (not zustand) because the value must
+ * survive `window.location.assign` hard navs and OAuth redirects.
+ *
+ * Best-effort by design: a user who lands on a different device simply
+ * sees no preselection. Intent expires after 7 days so a stale choice
+ * from an abandoned signup doesn't resurface weeks later.
+ */
+
+const STORAGE_KEY = "atlas.plan-intent";
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const PAID_TIERS = ["starter", "pro", "business"] as const;
+export type PlanIntent = (typeof PAID_TIERS)[number];
+
+export function isPlanIntent(value: string | null | undefined): value is PlanIntent {
+  return value != null && (PAID_TIERS as readonly string[]).includes(value);
+}
+
+export function savePlanIntent(plan: string | null | undefined): void {
+  if (typeof window === "undefined" || !isPlanIntent(plan)) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ plan, savedAt: Date.now() }));
+  } catch (err) {
+    // Private-mode / quota failures only cost the preselection nicety.
+    console.debug("plan-intent: save skipped", err instanceof Error ? err.message : String(err));
+  }
+}
+
+/** Read AND clear the stored intent (one-shot consumption). */
+export function consumePlanIntent(): PlanIntent | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    window.localStorage.removeItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw) as { plan?: unknown; savedAt?: unknown };
+    if (!isPlanIntent(typeof parsed.plan === "string" ? parsed.plan : null)) return null;
+    if (typeof parsed.savedAt !== "number" || Date.now() - parsed.savedAt > MAX_AGE_MS) return null;
+    return parsed.plan as PlanIntent;
+  } catch (err) {
+    console.debug("plan-intent: read skipped", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}

--- a/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
@@ -1,6 +1,14 @@
-import { describe, expect, test } from "bun:test";
-import { render } from "@testing-library/react";
-import { TrialCountdownBanner } from "../trial-countdown-banner";
+import { describe, expect, test, beforeEach, mock, type Mock } from "bun:test";
+import { render, fireEvent } from "@testing-library/react";
+
+// The Upgrade CTA navigates via next's router when the plan-picker anchor
+// isn't on the current page (#3418).
+const mockPush: Mock<(href: string) => void> = mock(() => {});
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { TrialCountdownBanner, TRIAL_BANNER_PLAN_ANCHOR_ID } from "../trial-countdown-banner";
 import type { BillingPlan } from "@useatlas/schemas";
 
 /**
@@ -151,5 +159,37 @@ describe("TrialCountdownBanner", () => {
     expect(container.textContent).toContain("Your trial has expired. Upgrade to keep using Atlas.");
     const button = container.querySelector("button");
     expect(button?.className).toContain("bg-primary");
+  });
+});
+
+describe("TrialCountdownBanner — Upgrade CTA navigation (#3418)", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  test("navigates to /admin/billing#anchor when the plan-picker anchor is absent (e.g. /admin)", () => {
+    const { getByRole } = render(
+      <TrialCountdownBanner plan={plan({})} now={NOW} />,
+    );
+    fireEvent.click(getByRole("button", { name: "Upgrade" }));
+    expect(mockPush).toHaveBeenCalledWith(`/admin/billing#${TRIAL_BANNER_PLAN_ANCHOR_ID}`);
+  });
+
+  test("scrolls in place when the anchor exists on the page (/admin/billing)", () => {
+    const anchor = document.createElement("section");
+    anchor.id = TRIAL_BANNER_PLAN_ANCHOR_ID;
+    const scrollSpy = mock(() => {});
+    anchor.scrollIntoView = scrollSpy as unknown as typeof anchor.scrollIntoView;
+    document.body.appendChild(anchor);
+    try {
+      const { getByRole } = render(
+        <TrialCountdownBanner plan={plan({})} now={NOW} />,
+      );
+      fireEvent.click(getByRole("button", { name: "Upgrade" }));
+      expect(scrollSpy).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    } finally {
+      anchor.remove();
+    }
   });
 });

--- a/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
+++ b/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { AlertTriangle, Clock, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -18,8 +19,11 @@ import type { BillingPlan } from "@useatlas/schemas";
  *
  * Hidden for any non-trial tier so paid workspaces don't see trial copy.
  *
- * The Upgrade CTA is intentionally a v1 placeholder — it scrolls to the
- * plan card already on the page. Stripe Checkout wiring is v2.
+ * The Upgrade CTA scrolls to the plan picker when its anchor is on the
+ * current page (/admin/billing), and otherwise navigates to
+ * /admin/billing with the anchor hash — the banner is also mounted on
+ * /admin, where the anchor doesn't exist and the old scroll-only CTA was
+ * a literal no-op click (#3418).
  *
  * Visual chrome matches the raw-div + tone-classed pattern used by
  * IncidentBanner and BackupMethodBanner; the shadcn Alert primitive pins
@@ -50,10 +54,18 @@ function resolveState(trialEndsAt: string, now: number): BannerState {
   return { kind: "early", daysLeft };
 }
 
-function scrollToPlanCard() {
+/**
+ * Scroll to the plan picker if it's on this page; otherwise route to the
+ * billing page with the anchor hash (Next scrolls to it after nav).
+ */
+function goToPlanPicker(push: (href: string) => void) {
   if (typeof document === "undefined") return;
   const el = document.getElementById(TRIAL_BANNER_PLAN_ANCHOR_ID);
-  el?.scrollIntoView({ behavior: "smooth", block: "start" });
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  } else {
+    push(`/admin/billing#${TRIAL_BANNER_PLAN_ANCHOR_ID}`);
+  }
 }
 
 export interface TrialCountdownBannerProps {
@@ -119,6 +131,7 @@ function BannerShell({
   title: string;
   buttonVariant: "default" | "secondary";
 }) {
+  const router = useRouter();
   return (
     <div
       role="alert"
@@ -136,7 +149,7 @@ function BannerShell({
       <Button
         size="sm"
         variant={buttonVariant}
-        onClick={scrollToPlanCard}
+        onClick={() => goToPlanPicker(router.push)}
         className="shrink-0"
       >
         Upgrade

--- a/packages/web/src/ui/hooks/use-plan-checkout.ts
+++ b/packages/web/src/ui/hooks/use-plan-checkout.ts
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Self-serve plan checkout / plan change via the Better Auth Stripe
+ * plugin (#3418).
+ *
+ * `authClient.subscription.upgrade` covers both journeys:
+ *   - First subscription → the plugin creates a Stripe Checkout session
+ *     and returns its URL (we redirect; the session's success URL routes
+ *     back through the plugin's /subscription/success sync endpoint to
+ *     `/admin/billing?checkout=success`).
+ *   - Existing subscription → the plugin returns a Billing Portal
+ *     `subscription_update_confirm` URL, or applies the change directly
+ *     and returns the `returnUrl`. Downgrades pass
+ *     `scheduleAtPeriodEnd: true` so the cheaper plan lands at the period
+ *     boundary via a Subscription Schedule instead of mid-cycle.
+ *
+ * Always org-scoped (`customerType: "organization"`); the server's
+ * `authorizeReference` requires an admin/owner of the active org.
+ * Success/cancel URLs are absolute against the WEB origin — the API may
+ * live on another host, and the plugin resolves relative URLs against its
+ * own baseURL (the API origin). The web origin must therefore be listed
+ * in BETTER_AUTH_TRUSTED_ORIGINS (already required for cross-origin auth).
+ */
+
+import { useState } from "react";
+import { authClient } from "@/lib/auth/client";
+
+function checkoutErrorMessage(error: { code?: string; message?: string } | null | undefined): string {
+  switch (error?.code) {
+    case "UNAUTHORIZED":
+      return "Only workspace admins and owners can change the plan.";
+    case "ALREADY_SUBSCRIBED_PLAN":
+      return "This workspace is already on that plan.";
+    case "SUBSCRIPTION_PLAN_NOT_FOUND":
+      return "That plan is not available on this deployment. Please contact support.";
+    case "EMAIL_VERIFICATION_REQUIRED":
+      return "Verify your email address before subscribing.";
+    default:
+      return error?.message || "Could not start checkout. Please try again.";
+  }
+}
+
+export function usePlanCheckout(): {
+  /** Start checkout (no subscription) or a plan change (subscribed). */
+  startCheckout: (opts: { plan: string; scheduleAtPeriodEnd?: boolean }) => Promise<void>;
+  /** The plan a request is currently in flight for, or null. */
+  pendingPlan: string | null;
+  error: string | null;
+  clearError: () => void;
+} {
+  const [pendingPlan, setPendingPlan] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function startCheckout(opts: { plan: string; scheduleAtPeriodEnd?: boolean }): Promise<void> {
+    setPendingPlan(opts.plan);
+    setError(null);
+    try {
+      const upgrade = authClient.subscription?.upgrade;
+      if (!upgrade) {
+        setError("Checkout is unavailable in this build. Please contact support.");
+        setPendingPlan(null);
+        return;
+      }
+      const origin = window.location.origin;
+      const res = await upgrade({
+        plan: opts.plan,
+        customerType: "organization",
+        successUrl: `${origin}/admin/billing?checkout=success`,
+        cancelUrl: `${origin}/admin/billing?checkout=cancelled`,
+        returnUrl: `${origin}/admin/billing`,
+        scheduleAtPeriodEnd: opts.scheduleAtPeriodEnd ?? false,
+        disableRedirect: true,
+      });
+      const url = res?.data?.url;
+      if (url) {
+        window.location.assign(url);
+        return; // keep pendingPlan set until the browser navigates
+      }
+      console.warn("Plan checkout: no URL returned", res?.error ?? res?.data);
+      setError(checkoutErrorMessage(res?.error));
+      setPendingPlan(null);
+    } catch (err) {
+      console.warn(
+        "Plan checkout request failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setError("Could not reach the billing service. Check your connection and try again.");
+      setPendingPlan(null);
+    }
+  }
+
+  return { startCheckout, pendingPlan, error, clearError: () => setError(null) };
+}

--- a/packages/web/src/ui/hooks/use-plan-checkout.ts
+++ b/packages/web/src/ui/hooks/use-plan-checkout.ts
@@ -63,12 +63,19 @@ export function usePlanCheckout(): {
         return;
       }
       const origin = window.location.origin;
+      // successUrl/cancelUrl serve the FIRST-subscription Checkout journey;
+      // returnUrl serves the change-plan journey (portal confirm / direct
+      // update). The latter previously returned bare — no ?checkout param —
+      // so the page rendered the stale tier with no lag handling at all
+      // (internal review on #3442). `changed` polls for the target tier
+      // (carried in ?plan=); `scheduled` is a static period-end notice.
+      const changedState = opts.scheduleAtPeriodEnd ? "scheduled" : "changed";
       const res = await upgrade({
         plan: opts.plan,
         customerType: "organization",
         successUrl: `${origin}/admin/billing?checkout=success`,
         cancelUrl: `${origin}/admin/billing?checkout=cancelled`,
-        returnUrl: `${origin}/admin/billing`,
+        returnUrl: `${origin}/admin/billing?checkout=${changedState}&plan=${opts.plan}`,
         scheduleAtPeriodEnd: opts.scheduleAtPeriodEnd ?? false,
         disableRedirect: true,
       });

--- a/packages/web/src/ui/hooks/use-plan-checkout.ts
+++ b/packages/web/src/ui/hooks/use-plan-checkout.ts
@@ -75,7 +75,11 @@ export function usePlanCheckout(): {
       const url = res?.data?.url;
       if (url) {
         window.location.assign(url);
-        return; // keep pendingPlan set until the browser navigates
+        // Keep pendingPlan set while the browser navigates; if navigation
+        // is blocked (popup blocker, intercepted test env) re-enable the
+        // grid after 10s instead of leaving it disabled forever.
+        setTimeout(() => setPendingPlan(null), 10_000);
+        return;
       }
       console.warn("Plan checkout: no URL returned", res?.error ?? res?.data);
       setError(checkoutErrorMessage(res?.error));


### PR DESCRIPTION
Closes #3418. Third PR of the P0 checkout-enabling cluster (#3415). **Stacked on #3441** (base = `claude/3417-org-stripe-customer-id`); retarget after the stack merges. All checkout goes through the `@better-auth/stripe` plugin — no hand-rolled Checkout or webhook routes.

## What

There was no purchase path anywhere: the trial banner's Upgrade CTA was a placeholder scroll (a literal no-op on `/admin` where its anchor doesn't exist), the billing page had no plan picker, the registered `stripeClient({ subscription: true })` was never called, and enforcement hard-403'd expired trials with copy pointing at an upgrade that didn't exist.

### API
- **`seatPriceId = priceId`** on every plan — the plugin's "seat-only plan" shape (verified in source: `isSeatOnlyPlan`): checkout emits **one per-seat line item with quantity = member count**, and the plugin's member add/remove/invite-accept hooks keep the Stripe quantity synced to membership automatically. One seat definition, same member-count basis enforcement uses.
- **Double-trial suppression** in `getCheckoutSessionParams` (#3426 one-trial decision): orgs that consumed the Atlas pre-checkout trial (`trial_ends_at` set — `assignSaasTrial` stamps every SaaS org) get `subscription_data: { trial_period_days: undefined }`, which overrides the plugin's `freeTrial` spread (our params spread after it; the Stripe SDK drops undefined keys). Fails toward suppression on lookup errors.
- **`GET /api/v1/billing` gains `availablePlans`** (tier, displayName, pricePerSeat, limits, `configured`) — the picker's source of truth. `BillingStatusSchema` widened with an **optional** `availablePlans` so a bundle pinned to an older published schema keeps parsing (the picker hides itself when absent). `@useatlas/schemas` bumped 0.0.3 → 0.0.4 in this PR; dependency refs stay at the published pin until the post-merge publish, per the publishing rule. The `subscription` object is untouched (#3429's surface not regressed).

### Web
- **Plan picker** on `/admin/billing`: first subscription = Stripe Checkout via `authClient.subscription.upgrade` (`customerType: "organization"`); plan changes ride the plugin's portal `subscription_update_confirm` / direct-update paths; **downgrades pass `scheduleAtPeriodEnd: true`** so the cheaper plan lands at the period boundary via a Subscription Schedule.
- **Checkout return UX**: `?checkout=success` polls past the webhook race ("Finalizing…" → success banner; degrades to "refresh in a minute" after ~30s of polling); `?checkout=cancelled` shows a dismissable notice. nuqs parsers in `search-params.ts`.
- **`?plan=` carry-through**: the pricing-page param survives the five-hard-nav signup flow via a localStorage intent (`lib/billing/plan-intent.ts`, 7-day expiry, one-shot consume) and preselects the picker card through the `?plan=` URL param (shareable deep link too).
- **Banner CTA fixed**: scrolls in place on `/admin/billing`, navigates to `/admin/billing#<anchor>` from `/admin` — the expired-trial 403 path now lands on a working picker.

## Notes
- Annual prices stay configured server-side but the picker is monthly-only: with seat-only plans the plugin's checkout would emit the monthly seat price even when `annual: true` (no `annualSeatPriceId` in 1.6.x) — revisit when upstream grows annual seat support.
- Checkout success/cancel URLs are absolute against the web origin; cross-origin deployments need the app origin in `BETTER_AUTH_TRUSTED_ORIGINS` (already required for auth itself).

## Tests
- **`stripe-checkout.test.ts`** (new E2E): drives the plugin's `/subscription/upgrade` with a real session against the production options — seat-only line items (`[{ price, quantity: 3 }]` for a 3-member org), `client_reference_id = orgId`, trial suppressed for trial-consumed orgs and kept (`trial_period_days: 14`) for never-trialed orgs, lazy org customer created with `metadata.organizationId` and persisted to `organization."stripeCustomerId"`, 401 for plain members, 400 for bare user-mode upgrades.
- Trial-suppression unit tests in the lifecycle suite; `seatPriceId === priceId` pinned in `plans.test.ts`; `availablePlans` wire assertions; banner navigation tests (scroll vs navigate); plan-intent storage contract tests.

`/ci` local gates all green (lint, type, full suite incl. web + schemas, syncpack, all drift checks incl. openapi regen, published-symbols).

https://claude.ai/code/session_01UxJHbiXemc9PRY1MX44i2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxJHbiXemc9PRY1MX44i2r)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783847241&installation_id=135337507&pr_number=3442&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3442&signature=c6d0b7f131286553f9452af38554f0b5f5aaa5021c658c0d2a8aca6670bcaec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added available plans display in billing dashboard, enabling users to view configured plans with pricing and limits
  * Implemented plan selection and checkout flow for upgrading or changing subscription tiers
  * Added plan intent persistence across navigations and sign-up flows

* **Bug Fixes**
  * Fixed duplicate trial issuance when upgrading organizations that already consumed trial period

* **Tests**
  * Expanded test coverage for Stripe checkout, subscription upgrades, and plan intent persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->