### PR TITLE
feat(billing): durable Stripe webhook sync via onEvent + event ledger (#3423)

### DIFF
--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -173,6 +173,12 @@ Atlas handles Stripe subscription lifecycle events via the Better Auth Stripe pl
 
 Plan tier changes take effect immediately — the plan cache is invalidated on webhook receipt so the next request reads fresh data from the database.
 
+### Delivery reliability
+
+Webhook processing is idempotent and ordered: Atlas keeps a 30-day ledger of processed Stripe event IDs, so replayed deliveries are acknowledged without re-running side effects, and an out-of-order older event for a subscription is skipped instead of regressing the plan. If the internal database is unavailable when an event arrives, Atlas returns an error so Stripe retries the delivery (Stripe retries for roughly three weeks).
+
+As a safety net for events lost beyond that window (for example after a webhook secret rotation), a background sweep runs every 6 hours and heals the workspace tier from the subscription table. Workspaces on a paid tier with no live subscription are logged but never downgraded automatically.
+
 ---
 
 ## Stripe Setup (Self-Hosted)

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -373,6 +373,9 @@ describe("migrateAuthTables", () => {
             { name: "0123_elasticsearch_datasource_catalog.sql" },
             { name: "0124_duckdb_not_saas_eligible.sql" },
             { name: "0125_elasticsearch_auth_modes_config_schema.sql" },
+            // 0126/0127 are MANAGED_AUTH_MIGRATIONS (skipped outside managed
+            // mode), so they don't need to appear here.
+            { name: "0128_stripe_webhook_event_ledger.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -60,6 +60,7 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
 }));
 
 const { buildStripePluginOptions } = await import("../server");
+const { TIER_LIFECYCLE_EVENT_TYPES } = await import("@atlas/api/lib/billing/stripe-event-ledger");
 const { betterAuth } = await import("better-auth");
 const { memoryAdapter } = await import("better-auth/adapters/memory");
 const { organization } = await import("better-auth/plugins");
@@ -81,12 +82,9 @@ interface LedgerRow {
 
 let ledgerRows: LedgerRow[] = [];
 
-const LIFECYCLE_TYPES = [
-  "checkout.session.completed",
-  "customer.subscription.created",
-  "customer.subscription.updated",
-  "customer.subscription.deleted",
-];
+// The production allowlist, so the sim can't drift from the real
+// ordering model if TIER_LIFECYCLE_EVENT_TYPES changes.
+const LIFECYCLE_TYPES: readonly string[] = TIER_LIFECYCLE_EVENT_TYPES;
 
 function ledgerAwareQuery(
   extra?: (sql: string, params?: unknown[]) => unknown[] | null,
@@ -631,6 +629,9 @@ describe("event ledger (#3423)", () => {
     });
     expect(tied.status).toBe(200);
     expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+    // The stale event must not land in the ledger either — only
+    // processed events are recorded.
+    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_tie"]);
   });
 
   it("returns 400 and does NOT record the event when the sync fails, so a redelivery re-runs it", async () => {
@@ -657,9 +658,13 @@ describe("event ledger (#3423)", () => {
     // retry below is classified fresh instead of duplicate.
     expect(ledgerRows).toHaveLength(0);
 
+    // Clear so the assertions below prove the REDELIVERY reran the sync,
+    // not just that the failed first attempt reached the write.
+    mockUpdateWorkspacePlanTier.mockClear();
     mockUpdateWorkspacePlanTier.mockImplementation(() => Promise.resolve(true));
     const retry = await postWebhook(auth, checkoutCompletedEvent());
     expect(retry.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "starter");
     expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_checkout_1"]);
   });

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -81,6 +81,13 @@ interface LedgerRow {
 
 let ledgerRows: LedgerRow[] = [];
 
+const LIFECYCLE_TYPES = [
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+];
+
 function ledgerAwareQuery(
   extra?: (sql: string, params?: unknown[]) => unknown[] | null,
 ): (sql: string, params?: unknown[]) => Promise<unknown[]> {
@@ -89,11 +96,16 @@ function ledgerAwareQuery(
       return Promise.resolve(ledgerRows.filter((r) => r.event_id === params?.[0]));
     }
     if (sql.includes("FROM stripe_webhook_events") && sql.includes("event_created > $2")) {
+      // Mirrors the production stale probe: lifecycle rows only; newer
+      // wins, and a same-second recorded deletion also blocks (tie-break).
       return Promise.resolve(
         ledgerRows.filter(
           (r) =>
             r.stripe_subscription_id === params?.[0] &&
-            r.event_created > String(params?.[1]),
+            LIFECYCLE_TYPES.includes(r.event_type) &&
+            (r.event_created > String(params?.[1]) ||
+              (r.event_created === String(params?.[1]) &&
+                r.event_type === "customer.subscription.deleted")),
         ),
       );
     }
@@ -582,6 +594,43 @@ describe("event ledger (#3423)", () => {
     expect(stale.status).toBe(200);
     expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
     expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_new"]);
+  });
+
+  it("skips a SAME-second older event after a deletion (1s-granularity tie-break)", async () => {
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_stripe_1",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    // Deleted and updated share the same Stripe `created` second —
+    // strictly-greater ordering alone would let the late updated event
+    // resurrect the paid tier on the locked workspace (Codex on #3444).
+    const deleted = await postWebhook(auth, {
+      id: "evt_deleted_tie",
+      type: "customer.subscription.deleted",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "canceled" }) },
+    });
+    expect(deleted.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "locked");
+    mockUpdateWorkspacePlanTier.mockClear();
+
+    const tied = await postWebhook(auth, {
+      id: "evt_updated_tie",
+      type: "customer.subscription.updated",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "active" }) },
+    });
+    expect(tied.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
   });
 
   it("returns 400 and does NOT record the event when the sync fails, so a redelivery re-runs it", async () => {

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -78,6 +78,8 @@ interface LedgerRow {
   event_type: string;
   event_created: string;
   stripe_subscription_id: string | null;
+  /** Tier the sync actually wrote for this event (null when none). */
+  applied_plan_tier: string | null;
 }
 
 let ledgerRows: LedgerRow[] = [];
@@ -108,13 +110,20 @@ function ledgerAwareQuery(
       );
     }
     if (sql.includes("INSERT INTO stripe_webhook_events")) {
-      const [id, type, created, subId] = params as [string, string, string, string | null];
+      const [id, type, created, subId, appliedTier] = params as [
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+      ];
       if (!ledgerRows.some((r) => r.event_id === id)) {
         ledgerRows.push({
           event_id: id,
           event_type: type,
           event_created: created,
           stripe_subscription_id: subId,
+          applied_plan_tier: appliedTier,
         });
       }
       return Promise.resolve([]);
@@ -413,8 +422,12 @@ describe("checkout.session.completed", () => {
     // The plugin's own row sync ran too: status + stripeSubscriptionId persisted.
     expect(db.subscription[0].status).toBe("active");
     expect(db.subscription[0].stripeSubscriptionId).toBe("sub_stripe_1");
-    // #3423 — the sync succeeded, so the event id landed in the ledger.
-    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_checkout_1"]);
+    // #3423 — the sync succeeded, so the event id landed in the ledger
+    // together with the tier it applied (the sweep's ordering-correct
+    // source of truth).
+    expect(ledgerRows.map((r) => [r.event_id, r.applied_plan_tier])).toEqual([
+      ["evt_checkout_1", "starter"],
+    ]);
   });
 });
 
@@ -490,7 +503,9 @@ describe("customer.subscription.deleted", () => {
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "locked");
     expect(db.subscription[0].status).toBe("canceled");
-    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_1"]);
+    expect(ledgerRows.map((r) => [r.event_id, r.applied_plan_tier])).toEqual([
+      ["evt_deleted_1", "locked"],
+    ]);
   });
 
   it("skips the lock when another active subscription exists (stale deletion guard)", async () => {
@@ -632,6 +647,44 @@ describe("event ledger (#3423)", () => {
     // The stale event must not land in the ledger either — only
     // processed events are recorded.
     expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_tie"]);
+  });
+
+  it("treats an unrecognized price as retryable — 400 and NOT recorded (env misconfig)", async () => {
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      status: "incomplete",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+    // STRIPE_*_PRICE_ID misconfig: the subscription's price maps to no
+    // Atlas tier. Recording the event would permanently no-op Stripe's
+    // replays; throwing keeps the ~3-week retry window open for the
+    // operator to fix the env.
+    subscriptionsRetrieve.mockImplementation(() =>
+      Promise.resolve(stripeSubscription({
+        items: {
+          data: [
+            {
+              id: "si_1",
+              quantity: 1,
+              current_period_start: EPOCH,
+              current_period_end: EPOCH + 30 * 86_400,
+              price: { id: "price_not_configured", recurring: { interval: "month" } },
+            },
+          ],
+        },
+      })),
+    );
+
+    const res = await postWebhook(auth, checkoutCompletedEvent());
+    expect(res.status).toBe(400);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+    expect(ledgerRows).toHaveLength(0);
   });
 
   it("returns 400 and does NOT record the event when the sync fails, so a redelivery re-runs it", async () => {

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -1,5 +1,6 @@
 /**
- * Webhook-lifecycle tests for the Stripe billing plugin wiring (#3416).
+ * Webhook-lifecycle tests for the Stripe billing plugin wiring
+ * (#3416/#3421/#3423).
  *
  * These drive a REAL Better Auth instance (memory adapter) configured with
  * the REAL production plugin options ({@link buildStripePluginOptions})
@@ -7,15 +8,23 @@
  * `/api/auth/stripe/webhook`. This closes the gap noted in
  * dispatch-conversion-crm-stamp.test.ts: the hooks are no longer
  * untestable closures — the referenceId→orgId contract is exercised
- * end-to-end (event → plugin handler → Atlas hook → plan-tier write).
+ * end-to-end (event → plugin handler → `onEvent` sync → plan-tier write).
  *
  * Covered:
  *   - config shape: org mode on, authorizeReference defined (regression
  *     guard — removing either silently reverts to user-scoped subs)
  *   - checkout.session.completed → `updateWorkspacePlanTier(orgId, plan)`
- *   - customer.subscription.deleted → downgrade write for the same orgId
+ *   - customer.subscription.deleted → locked write for the same orgId,
+ *     plus the stale-deletion guard (another active sub → skip)
  *   - invoice.payment_failed (attempt 3) → workspace suspended via the
  *     subscription-table referenceId lookup
+ *   - event ledger (#3423): replays skipped, out-of-order deliveries for
+ *     the same subscription skipped, failed sync → 400 + NOT recorded so
+ *     Stripe's redelivery re-runs the sync (record-last protocol)
+ *
+ * The internalQuery mock embeds a stateful in-memory `stripe_webhook_events`
+ * sim (SQL-discriminated) so ledger semantics are tested for real instead
+ * of being stubbed to "fresh".
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, mock, type Mock } from "bun:test";
@@ -56,6 +65,54 @@ const { memoryAdapter } = await import("better-auth/adapters/memory");
 const { organization } = await import("better-auth/plugins");
 const { stripe: stripePlugin } = await import("@better-auth/stripe");
 
+// ── Event-ledger sim (#3423) ────────────────────────────────────────
+//
+// The ledger module issues three SQL shapes against the internal DB;
+// this in-memory table answers them so the dedup/stale/record protocol
+// runs for real. Subscription-table queries fall through to the
+// per-test `extra` handler.
+
+interface LedgerRow {
+  event_id: string;
+  event_type: string;
+  event_created: string;
+  stripe_subscription_id: string | null;
+}
+
+let ledgerRows: LedgerRow[] = [];
+
+function ledgerAwareQuery(
+  extra?: (sql: string, params?: unknown[]) => unknown[] | null,
+): (sql: string, params?: unknown[]) => Promise<unknown[]> {
+  return (sql: string, params?: unknown[]) => {
+    if (sql.includes("FROM stripe_webhook_events WHERE event_id")) {
+      return Promise.resolve(ledgerRows.filter((r) => r.event_id === params?.[0]));
+    }
+    if (sql.includes("FROM stripe_webhook_events") && sql.includes("event_created > $2")) {
+      return Promise.resolve(
+        ledgerRows.filter(
+          (r) =>
+            r.stripe_subscription_id === params?.[0] &&
+            r.event_created > String(params?.[1]),
+        ),
+      );
+    }
+    if (sql.includes("INSERT INTO stripe_webhook_events")) {
+      const [id, type, created, subId] = params as [string, string, string, string | null];
+      if (!ledgerRows.some((r) => r.event_id === id)) {
+        ledgerRows.push({
+          event_id: id,
+          event_type: type,
+          event_created: created,
+          stripe_subscription_id: subId,
+        });
+      }
+      return Promise.resolve([]);
+    }
+    return Promise.resolve(extra?.(sql, params) ?? []);
+  };
+}
+
 // ── Stripe client double ────────────────────────────────────────────
 //
 // `constructEventAsync` echoes the request body back as the event, so each
@@ -63,6 +120,7 @@ const { stripe: stripePlugin } = await import("@better-auth/stripe");
 
 const STARTER_PRICE = "price_starter_test";
 const PRO_PRICE = "price_pro_test";
+const EPOCH = Math.floor(Date.now() / 1000);
 
 const subscriptionsRetrieve: Mock<(id: string) => Promise<unknown>> = mock(() =>
   Promise.resolve(stripeSubscription()),
@@ -87,7 +145,6 @@ function makeStripeClient() {
 }
 
 function stripeSubscription(overrides: Record<string, unknown> = {}) {
-  const epoch = Math.floor(Date.now() / 1000);
   return {
     id: "sub_stripe_1",
     customer: "cus_1",
@@ -99,13 +156,17 @@ function stripeSubscription(overrides: Record<string, unknown> = {}) {
     trial_start: null,
     trial_end: null,
     schedule: null,
+    // Checkout-created subscriptions carry the plugin's referenceId stamp;
+    // resolveOrgIdForStripeSubscription reads it before falling back to
+    // the subscription-table lookup.
+    metadata: { referenceId: "org-1", subscriptionId: "subrow_1" },
     items: {
       data: [
         {
           id: "si_1",
           quantity: 1,
-          current_period_start: epoch,
-          current_period_end: epoch + 30 * 86_400,
+          current_period_start: EPOCH,
+          current_period_end: EPOCH + 30 * 86_400,
           price: { id: STARTER_PRICE, recurring: { interval: "month" } },
         },
       ],
@@ -158,6 +219,22 @@ async function postWebhook(
   );
 }
 
+function checkoutCompletedEvent(id = "evt_checkout_1", created = EPOCH) {
+  return {
+    id,
+    type: "checkout.session.completed",
+    created,
+    data: {
+      object: {
+        mode: "subscription",
+        subscription: "sub_stripe_1",
+        client_reference_id: "org-1",
+        metadata: { referenceId: "org-1", subscriptionId: "subrow_1", userId: "user-1" },
+      },
+    },
+  };
+}
+
 const ENV_KEYS = ["STRIPE_STARTER_PRICE_ID", "STRIPE_PRO_PRICE_ID"] as const;
 const savedEnv: Record<string, string | undefined> = {};
 
@@ -175,12 +252,14 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  mockUpdateWorkspacePlanTier.mockClear();
+  mockUpdateWorkspacePlanTier.mockReset();
+  mockUpdateWorkspacePlanTier.mockImplementation(() => Promise.resolve(true));
   mockUpdateWorkspaceStatus.mockClear();
   mockGetWorkspaceDetails.mockReset();
   mockGetWorkspaceDetails.mockImplementation(() => Promise.resolve(null));
+  ledgerRows = [];
   mockInternalQuery.mockReset();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mockInternalQuery.mockImplementation(ledgerAwareQuery());
   subscriptionsRetrieve.mockClear();
   subscriptionsRetrieve.mockImplementation(() => Promise.resolve(stripeSubscription()));
 });
@@ -303,7 +382,7 @@ describe("getCheckoutSessionParams — org-scope guard", () => {
 // ── checkout.session.completed → plan-tier sync ─────────────────────
 
 describe("checkout.session.completed", () => {
-  it("updates organization.plan_tier for the org referenceId", async () => {
+  it("updates organization.plan_tier for the org referenceId and records the event", async () => {
     const db = emptyDB();
     db.subscription.push({
       id: "subrow_1",
@@ -316,18 +395,7 @@ describe("checkout.session.completed", () => {
     });
     const auth = makeAuth(db);
 
-    const res = await postWebhook(auth, {
-      id: "evt_checkout_1",
-      type: "checkout.session.completed",
-      data: {
-        object: {
-          mode: "subscription",
-          subscription: "sub_stripe_1",
-          client_reference_id: "org-1",
-          metadata: { referenceId: "org-1", subscriptionId: "subrow_1", userId: "user-1" },
-        },
-      },
-    });
+    const res = await postWebhook(auth, checkoutCompletedEvent());
 
     expect(res.status).toBe(200);
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
@@ -335,6 +403,8 @@ describe("checkout.session.completed", () => {
     // The plugin's own row sync ran too: status + stripeSubscriptionId persisted.
     expect(db.subscription[0].status).toBe("active");
     expect(db.subscription[0].stripeSubscriptionId).toBe("sub_stripe_1");
+    // #3423 — the sync succeeded, so the event id landed in the ledger.
+    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_checkout_1"]);
   });
 });
 
@@ -362,6 +432,7 @@ describe("customer.subscription.updated → pending cancel (#3421)", () => {
     const res = await postWebhook(auth, {
       id: "evt_cancel_scheduled_1",
       type: "customer.subscription.updated",
+      created: EPOCH,
       data: {
         object: stripeSubscription({
           status: "active",
@@ -372,8 +443,8 @@ describe("customer.subscription.updated → pending cancel (#3421)", () => {
 
     expect(res.status).toBe(200);
     // The customer is paid up — entitlements retained until period end.
-    // (onSubscriptionUpdate still runs plan sync against the same tier,
-    // so any write must be to "starter", never a downgrade.)
+    // (The onEvent sync still writes the same tier, so any write must be
+    // to "starter", never a downgrade.)
     for (const call of mockUpdateWorkspacePlanTier.mock.calls) {
       const [, tier] = call as [string, string];
       expect(tier).toBe("starter");
@@ -401,6 +472,7 @@ describe("customer.subscription.deleted", () => {
     const res = await postWebhook(auth, {
       id: "evt_deleted_1",
       type: "customer.subscription.deleted",
+      created: EPOCH,
       data: { object: stripeSubscription({ status: "canceled" }) },
     });
 
@@ -408,6 +480,7 @@ describe("customer.subscription.deleted", () => {
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "locked");
     expect(db.subscription[0].status).toBe("canceled");
+    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_1"]);
   });
 
   it("skips the lock when another active subscription exists (stale deletion guard)", async () => {
@@ -425,21 +498,121 @@ describe("customer.subscription.deleted", () => {
     const auth = makeAuth(db);
     // The org resubscribed: a DIFFERENT subscription row is active in the
     // internal DB. A delayed deleted event for the old subscription must
-    // not revoke the paying customer's access.
-    mockInternalQuery.mockImplementation((sql: string) =>
-      Promise.resolve(
-        sql.includes("status IN ('active', 'trialing')") ? [{ id: "subrow_new" }] : [],
+    // not revoke the paying customer's access. (The ledger's stale check
+    // can't catch this case — the two events concern different
+    // subscription ids — hence the explicit guard.)
+    mockInternalQuery.mockImplementation(
+      ledgerAwareQuery((sql) =>
+        sql.includes("status IN ('active', 'trialing')") ? [{ id: "subrow_new" }] : null,
       ),
     );
 
     const res = await postWebhook(auth, {
       id: "evt_deleted_stale",
       type: "customer.subscription.deleted",
+      created: EPOCH,
       data: { object: stripeSubscription({ status: "canceled" }) },
     });
 
     expect(res.status).toBe(200);
     expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+  });
+});
+
+// ── event ledger (#3423): replay, ordering, record-last ─────────────
+
+describe("event ledger (#3423)", () => {
+  it("skips a replayed delivery of an already-processed event id", async () => {
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      status: "incomplete",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    const first = await postWebhook(auth, checkoutCompletedEvent());
+    expect(first.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
+
+    const replay = await postWebhook(auth, checkoutCompletedEvent());
+    expect(replay.status).toBe(200);
+    // The duplicate was ACKed without re-running the sync.
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
+    expect(ledgerRows).toHaveLength(1);
+  });
+
+  it("skips an out-of-order older event for a subscription that already has a newer one applied", async () => {
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_stripe_1",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    // The subscription ended (event_created = EPOCH + 100) → locked.
+    const deleted = await postWebhook(auth, {
+      id: "evt_deleted_new",
+      type: "customer.subscription.deleted",
+      created: EPOCH + 100,
+      data: { object: stripeSubscription({ status: "canceled" }) },
+    });
+    expect(deleted.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "locked");
+    mockUpdateWorkspacePlanTier.mockClear();
+
+    // A delayed OLDER updated event (still "active") arrives afterwards.
+    // Applying it would resurrect the tier on a locked workspace.
+    const stale = await postWebhook(auth, {
+      id: "evt_updated_old",
+      type: "customer.subscription.updated",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "active" }) },
+    });
+    expect(stale.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_deleted_new"]);
+  });
+
+  it("returns 400 and does NOT record the event when the sync fails, so a redelivery re-runs it", async () => {
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      status: "incomplete",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+    mockUpdateWorkspacePlanTier.mockImplementation(() =>
+      Promise.reject(new Error("internal db down")),
+    );
+
+    const failed = await postWebhook(auth, checkoutCompletedEvent());
+    // onEvent throws propagate (the plugin's named hooks swallow; onEvent
+    // does not) → 400 → Stripe retries.
+    expect(failed.status).toBe(400);
+    // Record-last protocol: the failed event is NOT in the ledger, so the
+    // retry below is classified fresh instead of duplicate.
+    expect(ledgerRows).toHaveLength(0);
+
+    mockUpdateWorkspacePlanTier.mockImplementation(() => Promise.resolve(true));
+    const retry = await postWebhook(auth, checkoutCompletedEvent());
+    expect(retry.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "starter");
+    expect(ledgerRows.map((r) => r.event_id)).toEqual(["evt_checkout_1"]);
   });
 });
 
@@ -450,6 +623,7 @@ describe("invoice.payment_failed", () => {
     return {
       id: `evt_pf_${attemptCount}`,
       type: "invoice.payment_failed",
+      created: EPOCH,
       data: {
         object: {
           id: "in_1",
@@ -462,8 +636,10 @@ describe("invoice.payment_failed", () => {
   }
 
   it("suspends the workspace resolved via the subscription table on attempt 3", async () => {
-    mockInternalQuery.mockImplementation(() =>
-      Promise.resolve([{ referenceId: "org-1" }]),
+    mockInternalQuery.mockImplementation(
+      ledgerAwareQuery((sql) =>
+        sql.includes(`"stripeSubscriptionId" = $1`) ? [{ referenceId: "org-1" }] : null,
+      ),
     );
     const auth = makeAuth(emptyDB());
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1362,6 +1362,11 @@ export { assertInvitationRoleAllowed, isTransportError } from "@atlas/api/lib/au
  * per-subscription ordering guard (#3423). Returns null for events with
  * no subscription scope (ledger still dedupes them by event id).
  *
+ * `invoice.payment_failed` reports its subscription id too, but only
+ * TIER_LIFECYCLE_EVENT_TYPES participate in the ordering guard (see
+ * classifyStripeEvent) — a payment failure recorded first must never
+ * make a delayed `updated`/`deleted` lifecycle sync look stale.
+ *
  * @internal — exported for testing.
  */
 export function stripeEventSubscriptionId(event: Stripe.Event): string | null {
@@ -1404,14 +1409,20 @@ async function resolveOrgIdForStripeSubscription(
   return rows[0]?.referenceId ?? null;
 }
 
-/** Tier write + cache invalidation shared by the sync arms below. */
-async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string): Promise<void> {
+/**
+ * Tier write + cache invalidation shared by the sync arms below.
+ * Returns whether the write matched an organization row — callers use
+ * it to skip follow-on side effects (e.g. the CRM conversion stamp)
+ * for orgs that no longer exist.
+ */
+async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string): Promise<boolean> {
   // false = no organization row matched (helper logs the contract
   // violation). Do NOT throw — Stripe redelivering won't create the org.
   const updated = await updateWorkspacePlanTier(orgId, tier);
-  if (!updated) return;
+  if (!updated) return false;
   invalidatePlanCache(orgId);
   billingLog.info({ orgId, tier }, "%s — plan tier synced", context);
+  return true;
 }
 
 /**
@@ -1454,8 +1465,15 @@ export async function syncStripeEventToWorkspace(
       const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
       const tier = priceId ? resolvePlanTierFromPriceId(priceId) : null;
       if (tier) {
-        await applyWorkspaceTier(orgId, tier, "Checkout completed");
+        const applied = await applyWorkspaceTier(orgId, tier, "Checkout completed");
+        // Org row gone (stale checkout for a deleted workspace): the
+        // tier write missed, so don't record a paid conversion for a
+        // nonexistent workspace either (Codex review on #3444).
+        if (!applied) return;
       } else {
+        // Unrecognized price (env misconfig) still stamps below: the
+        // checkout DID complete and money moved — dropping the
+        // conversion record would understate real revenue.
         billingLog.warn(
           { orgId, priceId, eventId: event.id },
           "Checkout completed with unrecognized price ID — cannot map to Atlas plan tier",
@@ -1500,27 +1518,6 @@ export async function syncStripeEventToWorkspace(
         return;
       }
 
-      // #2737 — trial → active is the real "paid" signal (first
-      // post-trial invoice paid). Only fires for `updated` events with
-      // the right previous_attributes transition.
-      if (event.type === "customer.subscription.updated") {
-        const customerId = typeof stripeSubscription.customer === "string"
-          ? stripeSubscription.customer
-          : stripeSubscription.customer?.id;
-        const updateDirective = planConversionStamp({
-          trigger: "update",
-          subscription: { stripeCustomerId: customerId },
-          event: event as unknown as { type: string; data: { previous_attributes?: { status?: string | null } | null; object: { status?: string | null } } },
-        });
-        if (updateDirective.kind === "dispatch") {
-          await dispatchConversionCrmStamp({
-            stripeClient,
-            stripeCustomerId: updateDirective.stripeCustomerId,
-            orgId,
-          });
-        }
-      }
-
       const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
       if (!priceId) {
         billingLog.warn(
@@ -1537,7 +1534,32 @@ export async function syncStripeEventToWorkspace(
         );
         return;
       }
-      await applyWorkspaceTier(orgId, tier, "Subscription updated");
+      const applied = await applyWorkspaceTier(orgId, tier, "Subscription updated");
+
+      // #2737 — trial → active is the real "paid" signal (first
+      // post-trial invoice paid). Only fires for `updated` events with
+      // the right previous_attributes transition. Stamped AFTER the
+      // tier write succeeds (CodeRabbit on #3444): if the write throws,
+      // onEvent 400s and Stripe redelivers — stamping first would
+      // enqueue a duplicate conversion on every failed attempt. Skipped
+      // when the org row is gone, matching the checkout arm.
+      if (applied && event.type === "customer.subscription.updated") {
+        const customerId = typeof stripeSubscription.customer === "string"
+          ? stripeSubscription.customer
+          : stripeSubscription.customer?.id;
+        const updateDirective = planConversionStamp({
+          trigger: "update",
+          subscription: { stripeCustomerId: customerId },
+          event: event as unknown as { type: string; data: { previous_attributes?: { status?: string | null } | null; object: { status?: string | null } } },
+        });
+        if (updateDirective.kind === "dispatch") {
+          await dispatchConversionCrmStamp({
+            stripeClient,
+            stripeCustomerId: updateDirective.stripeCustomerId,
+            orgId,
+          });
+        }
+      }
       return;
     }
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1432,6 +1432,21 @@ async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string
  * failures THROW and surface as webhook 400s — Stripe redelivers instead
  * of the failure being swallowed like in the onSubscription* hooks.
  *
+ * Returns the plan tier this event actually WROTE (null when none) —
+ * recorded into the ledger's `applied_plan_tier` so the reconciliation
+ * sweep can heal from ordering-correct data instead of the plugin's
+ * last-delivered-wins subscription row.
+ *
+ * Skip vs throw discipline:
+ *  - PERMANENT conditions return null and get recorded (replaying the
+ *    identical event could never succeed): non-Atlas checkouts/
+ *    subscriptions (no referenceId), deleted orgs, setup-mode sessions.
+ *  - RETRYABLE conditions THROW (→ 400 → Stripe retries for ~3 weeks):
+ *    an unrecognized price id is an env misconfiguration — once the
+ *    operator fixes STRIPE_*_PRICE_ID, the redelivery applies the tier
+ *    (and stamps the conversion) instead of the event being permanently
+ *    no-op'd by the dedup guard.
+ *
  * The CRM stamp itself stays best-effort at the dispatch boundary
  * (`dispatchConversionCrmStamp` swallows internally): once enqueued the
  * `crm_outbox` provides its durability, and a Twenty outage must not
@@ -1442,11 +1457,11 @@ async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string
 export async function syncStripeEventToWorkspace(
   event: Stripe.Event,
   stripeClient: Stripe,
-): Promise<void> {
+): Promise<PlanTier | null> {
   switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object as Stripe.Checkout.Session;
-      if (session.mode === "setup") return;
+      if (session.mode === "setup") return null;
       const orgId = session.client_reference_id ?? session.metadata?.referenceId ?? null;
       const subId = typeof session.subscription === "string"
         ? session.subscription
@@ -1456,7 +1471,7 @@ export async function syncStripeEventToWorkspace(
           { eventId: event.id, orgId, subId },
           "checkout.session.completed without referenceId/subscription — skipping sync",
         );
-        return;
+        return null;
       }
       // The plugin's own handler retrieved the subscription too, but its
       // copy is closed over — one extra retrieve per checkout is the
@@ -1464,21 +1479,20 @@ export async function syncStripeEventToWorkspace(
       const stripeSubscription = await stripeClient.subscriptions.retrieve(subId);
       const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
       const tier = priceId ? resolvePlanTierFromPriceId(priceId) : null;
-      if (tier) {
-        const applied = await applyWorkspaceTier(orgId, tier, "Checkout completed");
-        // Org row gone (stale checkout for a deleted workspace): the
-        // tier write missed, so don't record a paid conversion for a
-        // nonexistent workspace either (Codex review on #3444).
-        if (!applied) return;
-      } else {
-        // Unrecognized price (env misconfig) still stamps below: the
-        // checkout DID complete and money moved — dropping the
-        // conversion record would understate real revenue.
-        billingLog.warn(
-          { orgId, priceId, eventId: event.id },
-          "Checkout completed with unrecognized price ID — cannot map to Atlas plan tier",
+      if (!tier) {
+        // Retryable: money moved but the price env mapping is broken.
+        // Throwing keeps Stripe redelivering until the operator fixes
+        // STRIPE_*_PRICE_ID — the redelivery then applies the tier AND
+        // enqueues the conversion stamp below.
+        throw new Error(
+          `checkout.session.completed for org ${orgId} carries unrecognized price "${priceId ?? "<none>"}" — fix STRIPE_*_PRICE_ID; Stripe will retry`,
         );
       }
+      const applied = await applyWorkspaceTier(orgId, tier, "Checkout completed");
+      // Org row gone (stale checkout for a deleted workspace): the
+      // tier write missed, so don't record a paid conversion for a
+      // nonexistent workspace either (Codex review on #3444).
+      if (!applied) return null;
 
       // #2737 — Twenty CRM conversion stamp. Trialing checkouts are
       // skipped (would overcount unpaid trials); the trial → active
@@ -1503,7 +1517,7 @@ export async function syncStripeEventToWorkspace(
           orgId,
         });
       }
-      return;
+      return tier;
     }
 
     case "customer.subscription.created":
@@ -1511,11 +1525,13 @@ export async function syncStripeEventToWorkspace(
       const stripeSubscription = event.data.object as Stripe.Subscription;
       const orgId = await resolveOrgIdForStripeSubscription(stripeSubscription);
       if (!orgId) {
+        // Permanent: no referenceId metadata and no subscription row —
+        // a non-Atlas subscription in a shared Stripe account.
         billingLog.warn(
           { eventId: event.id, stripeSubscriptionId: stripeSubscription.id },
           "Subscription event has no resolvable org referenceId — skipping sync",
         );
-        return;
+        return null;
       }
 
       const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
@@ -1524,15 +1540,14 @@ export async function syncStripeEventToWorkspace(
           { orgId, stripeSubscriptionId: stripeSubscription.id },
           "Subscription event has no price ID on items — skipping plan sync",
         );
-        return;
+        return null;
       }
       const tier = resolvePlanTierFromPriceId(priceId);
       if (!tier) {
-        billingLog.warn(
-          { orgId, priceId },
-          "Subscription event with unrecognized price ID — cannot map to Atlas plan tier",
+        // Retryable env misconfig — see the checkout arm.
+        throw new Error(
+          `Subscription event for org ${orgId} carries unrecognized price "${priceId}" — fix STRIPE_*_PRICE_ID; Stripe will retry`,
         );
-        return;
       }
       const applied = await applyWorkspaceTier(orgId, tier, "Subscription updated");
 
@@ -1560,7 +1575,7 @@ export async function syncStripeEventToWorkspace(
           });
         }
       }
-      return;
+      return applied ? tier : null;
     }
 
     case "customer.subscription.deleted": {
@@ -1573,7 +1588,7 @@ export async function syncStripeEventToWorkspace(
           { eventId: event.id, stripeSubscriptionId: stripeSubscription.id },
           "Subscription deleted with no resolvable org referenceId — skipping lock",
         );
-        return;
+        return null;
       }
       // Stale-deletion guard (Codex review on #3443): webhook delivery is
       // unordered, so a delayed deleted event for an OLD subscription can
@@ -1596,14 +1611,14 @@ export async function syncStripeEventToWorkspace(
           { orgId, deletedSubscriptionId: stripeSubscription.id },
           "Subscription deleted but another active subscription exists — skipping lock",
         );
-        return;
+        return null;
       }
-      await applyWorkspaceTier(orgId, "locked", "Subscription deleted — workspace locked");
-      return;
+      const applied = await applyWorkspaceTier(orgId, "locked", "Subscription deleted — workspace locked");
+      return applied ? "locked" : null;
     }
 
     default:
-      return;
+      return null;
   }
 }
 
@@ -1786,7 +1801,7 @@ export function buildStripePluginOptions(deps: {
         return;
       }
 
-      await syncStripeEventToWorkspace(event, stripeClient);
+      const appliedTier = await syncStripeEventToWorkspace(event, stripeClient);
 
       if (event.type === "invoice.payment_failed") {
         const invoice = event.data.object as Stripe.Invoice;
@@ -1850,7 +1865,7 @@ export function buildStripePluginOptions(deps: {
         }
       }
 
-      await recordStripeEvent(ledgerEvent);
+      await recordStripeEvent(ledgerEvent, appliedTier);
     },
   };
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -62,6 +62,11 @@ import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { STRIPE_API_VERSION } from "@atlas/api/lib/billing/stripe-api-version";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
+import {
+  classifyStripeEvent,
+  recordStripeEvent,
+  type StripeLedgerEvent,
+} from "@atlas/api/lib/billing/stripe-event-ledger";
 import { getConfig } from "@atlas/api/lib/config";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
@@ -1353,6 +1358,234 @@ export { assertInvitationRoleAllowed, isTransportError } from "@atlas/api/lib/au
 
 /** @internal — exported for wiring assertions in tests. */
 /**
+ * Stripe subscription id an event concerns, for the event ledger's
+ * per-subscription ordering guard (#3423). Returns null for events with
+ * no subscription scope (ledger still dedupes them by event id).
+ *
+ * @internal — exported for testing.
+ */
+export function stripeEventSubscriptionId(event: Stripe.Event): string | null {
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      return typeof session.subscription === "string"
+        ? session.subscription
+        : session.subscription?.id ?? null;
+    }
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted":
+      return (event.data.object as Stripe.Subscription).id ?? null;
+    case "invoice.payment_failed": {
+      const invoice = event.data.object as Stripe.Invoice;
+      const parentSub = invoice.parent?.subscription_details?.subscription;
+      return typeof parentSub === "string" ? parentSub : parentSub?.id ?? null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve the Atlas orgId a Stripe subscription belongs to. Checkout-
+ * created subscriptions carry `metadata.referenceId` (stamped by the
+ * plugin's upgrade flow); dashboard-created ones are resolved through
+ * the plugin's subscription table.
+ */
+async function resolveOrgIdForStripeSubscription(
+  subscription: Stripe.Subscription,
+): Promise<string | null> {
+  const metaRef = subscription.metadata?.referenceId;
+  if (typeof metaRef === "string" && metaRef.length > 0) return metaRef;
+  const rows = await internalQuery<{ referenceId: string }>(
+    `SELECT "referenceId" FROM subscription WHERE "stripeSubscriptionId" = $1 LIMIT 1`,
+    [subscription.id],
+  );
+  return rows[0]?.referenceId ?? null;
+}
+
+/** Tier write + cache invalidation shared by the sync arms below. */
+async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string): Promise<void> {
+  // false = no organization row matched (helper logs the contract
+  // violation). Do NOT throw — Stripe redelivering won't create the org.
+  const updated = await updateWorkspacePlanTier(orgId, tier);
+  if (!updated) return;
+  invalidatePlanCache(orgId);
+  billingLog.info({ orgId, tier }, "%s — plan tier synced", context);
+}
+
+/**
+ * The must-not-be-lost Stripe sync (#3423): plan-tier writes + the Twenty
+ * CRM conversion stamp, keyed on the four subscription-lifecycle event
+ * types. Runs inside `onEvent` (behind the event ledger), so internal-DB
+ * failures THROW and surface as webhook 400s — Stripe redelivers instead
+ * of the failure being swallowed like in the onSubscription* hooks.
+ *
+ * The CRM stamp itself stays best-effort at the dispatch boundary
+ * (`dispatchConversionCrmStamp` swallows internally): once enqueued the
+ * `crm_outbox` provides its durability, and a Twenty outage must not
+ * block the tier sync retry loop.
+ *
+ * @internal — exported for testing.
+ */
+export async function syncStripeEventToWorkspace(
+  event: Stripe.Event,
+  stripeClient: Stripe,
+): Promise<void> {
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (session.mode === "setup") return;
+      const orgId = session.client_reference_id ?? session.metadata?.referenceId ?? null;
+      const subId = typeof session.subscription === "string"
+        ? session.subscription
+        : session.subscription?.id;
+      if (!orgId || !subId) {
+        billingLog.warn(
+          { eventId: event.id, orgId, subId },
+          "checkout.session.completed without referenceId/subscription — skipping sync",
+        );
+        return;
+      }
+      // The plugin's own handler retrieved the subscription too, but its
+      // copy is closed over — one extra retrieve per checkout is the
+      // price of a durable, independently-retryable sync.
+      const stripeSubscription = await stripeClient.subscriptions.retrieve(subId);
+      const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
+      const tier = priceId ? resolvePlanTierFromPriceId(priceId) : null;
+      if (tier) {
+        await applyWorkspaceTier(orgId, tier, "Checkout completed");
+      } else {
+        billingLog.warn(
+          { orgId, priceId, eventId: event.id },
+          "Checkout completed with unrecognized price ID — cannot map to Atlas plan tier",
+        );
+      }
+
+      // #2737 — Twenty CRM conversion stamp. Trialing checkouts are
+      // skipped (would overcount unpaid trials); the trial → active
+      // transition is picked up by customer.subscription.updated below.
+      // Gating centralised in `planConversionStamp`.
+      const customerId = typeof stripeSubscription.customer === "string"
+        ? stripeSubscription.customer
+        : stripeSubscription.customer?.id;
+      const directive = planConversionStamp({
+        trigger: "complete",
+        subscription: { status: stripeSubscription.status, stripeCustomerId: customerId },
+      });
+      if (directive.kind === "log-and-skip") {
+        log.warn(
+          { orgId, eventId: event.id, event: "conversion_crm.no_stripe_customer_id" },
+          "Subscription completed without stripeCustomerId — skipping Twenty conversion stamp",
+        );
+      } else if (directive.kind === "dispatch") {
+        await dispatchConversionCrmStamp({
+          stripeClient,
+          stripeCustomerId: directive.stripeCustomerId,
+          orgId,
+        });
+      }
+      return;
+    }
+
+    case "customer.subscription.created":
+    case "customer.subscription.updated": {
+      const stripeSubscription = event.data.object as Stripe.Subscription;
+      const orgId = await resolveOrgIdForStripeSubscription(stripeSubscription);
+      if (!orgId) {
+        billingLog.warn(
+          { eventId: event.id, stripeSubscriptionId: stripeSubscription.id },
+          "Subscription event has no resolvable org referenceId — skipping sync",
+        );
+        return;
+      }
+
+      // #2737 — trial → active is the real "paid" signal (first
+      // post-trial invoice paid). Only fires for `updated` events with
+      // the right previous_attributes transition.
+      if (event.type === "customer.subscription.updated") {
+        const customerId = typeof stripeSubscription.customer === "string"
+          ? stripeSubscription.customer
+          : stripeSubscription.customer?.id;
+        const updateDirective = planConversionStamp({
+          trigger: "update",
+          subscription: { stripeCustomerId: customerId },
+          event: event as unknown as { type: string; data: { previous_attributes?: { status?: string | null } | null; object: { status?: string | null } } },
+        });
+        if (updateDirective.kind === "dispatch") {
+          await dispatchConversionCrmStamp({
+            stripeClient,
+            stripeCustomerId: updateDirective.stripeCustomerId,
+            orgId,
+          });
+        }
+      }
+
+      const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
+      if (!priceId) {
+        billingLog.warn(
+          { orgId, stripeSubscriptionId: stripeSubscription.id },
+          "Subscription event has no price ID on items — skipping plan sync",
+        );
+        return;
+      }
+      const tier = resolvePlanTierFromPriceId(priceId);
+      if (!tier) {
+        billingLog.warn(
+          { orgId, priceId },
+          "Subscription event with unrecognized price ID — cannot map to Atlas plan tier",
+        );
+        return;
+      }
+      await applyWorkspaceTier(orgId, tier, "Subscription updated");
+      return;
+    }
+
+    case "customer.subscription.deleted": {
+      // #3421 — the single churn landing point: the subscription actually
+      // ended. Locked (zero entitlements, resubscribe CTA), never free.
+      const stripeSubscription = event.data.object as Stripe.Subscription;
+      const orgId = await resolveOrgIdForStripeSubscription(stripeSubscription);
+      if (!orgId) {
+        billingLog.warn(
+          { eventId: event.id, stripeSubscriptionId: stripeSubscription.id },
+          "Subscription deleted with no resolvable org referenceId — skipping lock",
+        );
+        return;
+      }
+      // Stale-deletion guard (Codex review on #3443): webhook delivery is
+      // unordered, so a delayed deleted event for an OLD subscription can
+      // arrive after the org already resubscribed (a different
+      // subscription row, active/trialing). Locking then would revoke a
+      // paying customer's access. The plugin marked THIS subscription
+      // canceled before onEvent runs, so any remaining active/trialing
+      // row is a different, current subscription — skip the lock. (The
+      // ledger's per-subscription stale check can't catch this: the two
+      // events concern DIFFERENT subscription ids.)
+      const activeRows = await internalQuery<{ id: string }>(
+        `SELECT id FROM subscription
+          WHERE "referenceId" = $1 AND status IN ('active', 'trialing')
+            AND "stripeSubscriptionId" IS DISTINCT FROM $2
+          LIMIT 1`,
+        [orgId, stripeSubscription.id ?? null],
+      );
+      if (activeRows.length > 0) {
+        billingLog.info(
+          { orgId, deletedSubscriptionId: stripeSubscription.id },
+          "Subscription deleted but another active subscription exists — skipping lock",
+        );
+        return;
+      }
+      await applyWorkspaceTier(orgId, "locked", "Subscription deleted — workspace locked");
+      return;
+    }
+
+    default:
+      return;
+  }
+}
+
+/**
  * @better-auth/stripe plugin options — extracted from {@link buildPlugins}
  * so the exact production configuration (org scoping, authorizeReference,
  * webhook hooks) is constructible in tests against a mock Stripe client
@@ -1460,63 +1693,16 @@ export function buildStripePluginOptions(deps: {
         }
         return {};
       },
+      // #3423 — observability only. The must-not-be-lost sync (plan-tier
+      // write + CRM conversion stamp) lives in `onEvent` below, where
+      // throws propagate as webhook 400s and Stripe retries. This hook is
+      // wrapped in the plugin's catch-and-log, so anything here is
+      // best-effort by construction.
       async onSubscriptionComplete({ subscription, plan }) {
-        const orgId = subscription.referenceId;
-        if (orgId && (plan.name === "starter" || plan.name === "pro" || plan.name === "business")) {
-          try {
-            // false = no organization row matched the referenceId (the
-            // helper logs the contract violation). Skip the success path
-            // AND the CRM stamp below — stamping a conversion for a
-            // workspace that doesn't exist would pollute Twenty. ACK
-            // semantics are unchanged either way: the plugin swallows
-            // hook throws (#3423 owns durable retry).
-            const updated = await updateWorkspacePlanTier(orgId, plan.name as PlanTier);
-            if (!updated) return;
-            invalidatePlanCache(orgId);
-            log.info({ orgId, plan: plan.name }, "Subscription activated — plan tier synced");
-          } catch (err) {
-            log.error(
-              { err: errorMessage(err), orgId, plan: plan.name },
-              "Failed to sync plan tier on subscription activation — Stripe will retry webhook",
-            );
-            throw err;
-          }
-        }
-
-        // #2737 — fire-and-forget Twenty CRM conversion stamp.
-        // Awaited deliberately: the helper swallows every
-        // failure internally, so the await only blocks on the
-        // outbox INSERT (a few ms). Not awaiting risks an
-        // unhandled rejection if a future change widens the
-        // error channel.
-        //
-        // All paid plans ship with `freeTrial: { days: TRIAL_DAYS }`
-        // (see `lib/billing/plans.ts`), so this hook fires with
-        // status `"trialing"` on every checkout completion that
-        // entered a trial — stamping then would overcount unpaid
-        // trials as paid conversions in the #2728 read path. The
-        // trial → active transition is picked up by
-        // `onSubscriptionUpdate` below. Gating is centralised in
-        // `planConversionStamp` so the trial / no-customer-id /
-        // active permutations are unit-testable.
-        const directive = planConversionStamp({ trigger: "complete", subscription });
-        if (directive.kind === "log-and-skip") {
-          log.warn(
-            {
-              orgId,
-              plan: plan.name,
-              subscriptionId: subscription.id,
-              event: "conversion_crm.no_stripe_customer_id",
-            },
-            "Subscription completed without stripeCustomerId — skipping Twenty conversion stamp",
-          );
-        } else if (directive.kind === "dispatch") {
-          await dispatchConversionCrmStamp({
-            stripeClient,
-            stripeCustomerId: directive.stripeCustomerId,
-            orgId,
-          });
-        }
+        log.info(
+          { orgId: subscription.referenceId, plan: plan.name, subscriptionId: subscription.id },
+          "Checkout completed — subscription row synced by plugin",
+        );
       },
       // #3421 — fires ONCE at the active→pending-cancel transition
       // (schedule-time, verified in plugin source): the customer is paid
@@ -1531,115 +1717,55 @@ export function buildStripePluginOptions(deps: {
           "Subscription cancellation scheduled — entitlements retained until period end",
         );
       },
-      async onSubscriptionUpdate({ event, subscription }) {
-        const orgId = subscription.referenceId;
-        if (!orgId) return;
-
-        // Resolve the new plan tier from the Stripe subscription's price ID
-        const stripeSubscription = event.data.object as Stripe.Subscription;
-
-        // #2737 — Twenty CRM conversion stamp on trial → active.
-        // `onSubscriptionComplete` skips trialing subscriptions to
-        // avoid overcounting unpaid trials as paid conversions.
-        // The real "paid" signal is `customer.subscription.updated`
-        // with status transitioning from "trialing" to "active"
-        // (Stripe fires this when the first trial-end invoice is
-        // paid). Awaited for the same reason as the create-side
-        // dispatch (helper swallows internally; the await only
-        // blocks on the outbox INSERT).
-        const updateDirective = planConversionStamp({
-          trigger: "update",
-          subscription,
-          event: event as { type: string; data: { previous_attributes?: { status?: string | null } | null; object: { status?: string | null } } },
-        });
-        if (updateDirective.kind === "dispatch") {
-          await dispatchConversionCrmStamp({
-            stripeClient,
-            stripeCustomerId: updateDirective.stripeCustomerId,
-            orgId,
-          });
-        }
-
-        const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
-        if (!priceId) {
-          billingLog.warn(
-            { orgId, subscriptionId: subscription.id },
-            "Subscription updated but no price ID found on Stripe subscription items — skipping plan sync",
-          );
-          return;
-        }
-
-        const newTier = resolvePlanTierFromPriceId(priceId);
-        if (!newTier) {
-          billingLog.warn(
-            { orgId, priceId },
-            "Subscription updated with unrecognized price ID — cannot map to Atlas plan tier",
-          );
-          return;
-        }
-
-        try {
-          const updated = await updateWorkspacePlanTier(orgId, newTier);
-          if (!updated) return; // helper already logged the missing org
-          invalidatePlanCache(orgId);
-          billingLog.info(
-            { orgId, newTier, priceId },
-            "Subscription updated — plan tier synced",
-          );
-        } catch (err) {
-          billingLog.error(
-            { err: errorMessage(err), orgId, newTier, priceId },
-            "Failed to sync plan tier on subscription update — Stripe will retry webhook",
-          );
-          throw err;
-        }
+      // #3423 — observability only; see onSubscriptionComplete.
+      async onSubscriptionUpdate({ subscription }) {
+        billingLog.debug(
+          { orgId: subscription.referenceId, subscriptionId: subscription.id, status: subscription.status },
+          "Subscription updated — row synced by plugin",
+        );
       },
-      // #3421 — the single churn landing point: Stripe emits
-      // customer.subscription.deleted when the subscription actually ends
-      // (period end after a scheduled cancel, or immediate cancellation).
-      // Lands on "locked" (zero entitlements, resubscribe CTA) — NEVER
-      // "free", which on SaaS bypasses all enforcement.
+      // #3423 — observability only; the locked-tier downgrade (#3421)
+      // moved into `onEvent` with the rest of the must-not-be-lost sync.
       async onSubscriptionDeleted({ subscription }) {
-        const orgId = subscription.referenceId;
-        if (orgId) {
-          try {
-            // Stale-deletion guard (Codex review): webhook delivery is
-            // unordered, so a delayed deleted event for an OLD
-            // subscription can arrive after the org already resubscribed
-            // (a different subscription row, active/trialing). Locking
-            // then would revoke a paying customer's access. The plugin
-            // marked THIS subscription canceled before invoking the hook,
-            // so any remaining active/trialing row is a different,
-            // current subscription — skip the lock.
-            const activeRows = await internalQuery<{ id: string }>(
-              `SELECT id FROM subscription
-                WHERE "referenceId" = $1 AND status IN ('active', 'trialing')
-                  AND "stripeSubscriptionId" IS DISTINCT FROM $2
-                LIMIT 1`,
-              [orgId, subscription.stripeSubscriptionId ?? null],
-            );
-            if (activeRows.length > 0) {
-              log.info(
-                { orgId, deletedSubscriptionId: subscription.stripeSubscriptionId },
-                "Subscription deleted but another active subscription exists — skipping lock",
-              );
-              return;
-            }
-            const updated = await updateWorkspacePlanTier(orgId, "locked");
-            if (!updated) return; // helper already logged the missing org
-            invalidatePlanCache(orgId);
-            log.info({ orgId }, "Subscription deleted — workspace locked (resubscribe to restore access)");
-          } catch (err) {
-            log.error(
-              { err: errorMessage(err), orgId },
-              "Failed to lock workspace on subscription delete — Stripe will retry webhook",
-            );
-            throw err;
-          }
-        }
+        log.info(
+          { orgId: subscription.referenceId, subscriptionId: subscription.id },
+          "Subscription deleted — row synced by plugin",
+        );
       },
     },
+    // #3423 — the durable path. `onEvent` is the ONLY hook whose throws
+    // the plugin propagates (→ 400 STRIPE_WEBHOOK_ERROR → Stripe retries
+    // for ~3 weeks), so the must-not-be-lost sync lives here, wrapped in
+    // the event ledger:
+    //   1. classify — replays (same event id) and stale deliveries (an
+    //      older event arriving after a newer one for the same
+    //      subscription) are skipped without side effects.
+    //   2. sync — plan-tier write + CRM stamp. Internal-DB failures
+    //      THROW so Stripe redelivers; nothing is lost.
+    //   3. best-effort branches (payment-failure suspension) — never
+    //      throw; #3424 owns the delinquency ladder.
+    //   4. record the event id LAST — a crash before this point causes
+    //      one extra retry that re-runs an idempotent write (the safe
+    //      direction; recording first would make failures unrecoverable).
     async onEvent(event: Stripe.Event) {
+      const ledgerEvent: StripeLedgerEvent = {
+        id: event.id,
+        type: event.type,
+        created: event.created,
+        stripeSubscriptionId: stripeEventSubscriptionId(event),
+      };
+      const disposition = await classifyStripeEvent(ledgerEvent);
+      if (disposition !== "fresh") {
+        billingLog.info(
+          { eventId: event.id, eventType: event.type, disposition },
+          "Skipping Stripe webhook event (%s)",
+          disposition,
+        );
+        return;
+      }
+
+      await syncStripeEventToWorkspace(event, stripeClient);
+
       if (event.type === "invoice.payment_failed") {
         const invoice = event.data.object as Stripe.Invoice;
         const customerId = typeof invoice.customer === "string"
@@ -1694,11 +1820,15 @@ export function buildStripePluginOptions(deps: {
               { err: errorMessage(err), subscriptionId, attemptCount },
               "Failed to suspend workspace after repeated payment failures",
             );
-            // Do not re-throw — the onEvent handler should not cause Stripe to retry
-            // the entire webhook. The payment failure is already recorded by Stripe.
+            // Do not re-throw — suspension is the best-effort branch
+            // (#3424 owns the ladder); the payment failure is already
+            // recorded by Stripe, and a throw here would force a
+            // redelivery of an already-synced event.
           }
         }
       }
+
+      await recordStripeEvent(ledgerEvent);
     },
   };
 }

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
@@ -127,6 +127,21 @@ describe("reconcilePlanTiers", () => {
     expect(result.healed).toBe(0);
   });
 
+  it("ignores subscription rows whose stripe sub has a recorded deletion event (stale last-delivered rows)", async () => {
+    // The plugin writes its subscription table last-DELIVERED-wins, so a
+    // stale older `updated` after a processed `deleted` can leave the row
+    // "active". The scan must not treat such rows as live — otherwise the
+    // sweep would heal a locked org back to paid. Semantics live in SQL
+    // (NOT EXISTS against the ledger), so pin the query shape here; the
+    // behavior itself is covered by the ledger tie-break tests.
+    installQueryFixture([]);
+    await reconcilePlanTiers();
+    const [scanSql] = mockInternalQuery.mock.calls[0] as [string];
+    expect(scanSql).toContain("NOT EXISTS");
+    expect(scanSql).toContain("'customer.subscription.deleted'");
+    expect(scanSql).toContain("stripe_webhook_events");
+  });
+
   it("prunes the webhook event ledger and reports the count", async () => {
     installQueryFixture([], [{ event_id: "evt_old_1" }, { event_id: "evt_old_2" }]);
 

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the plan-tier reconciliation sweep (#3423).
+ *
+ * Pins the two deliberate asymmetries (heal toward the subscription
+ * table; flag-don't-heal paid orgs without a subscription — see #3427)
+ * and the normal-state exclusions (trial/free/locked with no sub).
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
+  mock(() => Promise.resolve([]));
+const mockUpdateWorkspacePlanTier: Mock<(orgId: string, tier: string) => Promise<boolean>> =
+  mock(() => Promise.resolve(true));
+let hasDb = true;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({
+    internalQuery: mockInternalQuery,
+    hasInternalDB: () => hasDb,
+  }),
+  updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
+}));
+
+const { reconcilePlanTiers } = await import("../reconcile-plan-tiers");
+
+interface OrgRow {
+  org_id: string;
+  plan_tier: string | null;
+  subscription_plan: string | null;
+}
+
+/** Route the org scan and the ledger prune through one mock. */
+function installQueryFixture(orgs: OrgRow[], pruned: { event_id: string }[] = []) {
+  mockInternalQuery.mockImplementation((sql: string) => {
+    if (sql.includes("FROM organization o")) return Promise.resolve(orgs);
+    if (sql.includes("DELETE FROM stripe_webhook_events")) return Promise.resolve(pruned);
+    return Promise.resolve([]);
+  });
+}
+
+beforeEach(() => {
+  hasDb = true;
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mockUpdateWorkspacePlanTier.mockReset();
+  mockUpdateWorkspacePlanTier.mockImplementation(() => Promise.resolve(true));
+});
+
+describe("reconcilePlanTiers", () => {
+  it("returns zeros without touching the DB when there is no internal DB", async () => {
+    hasDb = false;
+    await expect(reconcilePlanTiers()).resolves.toEqual({
+      healed: 0,
+      flagged: 0,
+      prunedLedger: 0,
+    });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("heals an org whose tier disagrees with its live subscription (incl. un-locking a resubscribe)", async () => {
+    installQueryFixture([
+      // Lost resubscribe webhook: locked org with an active starter sub.
+      { org_id: "org-locked", plan_tier: "locked", subscription_plan: "starter" },
+      // Lost upgrade webhook: starter org paying for pro.
+      { org_id: "org-upgrade", plan_tier: "starter", subscription_plan: "pro" },
+      // In sync — no write.
+      { org_id: "org-ok", plan_tier: "pro", subscription_plan: "pro" },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.healed).toBe(2);
+    expect(result.flagged).toBe(0);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(2);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-locked", "starter");
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-upgrade", "pro");
+  });
+
+  it("flags but never rewrites a paid-tier org with no live subscription (#3427 pending)", async () => {
+    installQueryFixture([
+      { org_id: "org-paid-nosub", plan_tier: "business", subscription_plan: null },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.flagged).toBe(1);
+    expect(result.healed).toBe(0);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("leaves trial, free, locked, and null-tier orgs without a subscription alone", async () => {
+    installQueryFixture([
+      { org_id: "org-trial", plan_tier: "trial", subscription_plan: null },
+      { org_id: "org-free", plan_tier: "free", subscription_plan: null },
+      { org_id: "org-churned", plan_tier: "locked", subscription_plan: null },
+      { org_id: "org-legacy", plan_tier: null, subscription_plan: null },
+    ]);
+
+    await expect(reconcilePlanTiers()).resolves.toEqual({
+      healed: 0,
+      flagged: 0,
+      prunedLedger: 0,
+    });
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("skips (does not write) a subscription whose plan name is outside the tier vocabulary", async () => {
+    installQueryFixture([
+      { org_id: "org-weird", plan_tier: "starter", subscription_plan: "enterprise" },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.healed).toBe(0);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("does not count a heal when the org row vanished under the write", async () => {
+    mockUpdateWorkspacePlanTier.mockImplementation(() => Promise.resolve(false));
+    installQueryFixture([
+      { org_id: "org-gone", plan_tier: "locked", subscription_plan: "starter" },
+    ]);
+
+    const result = await reconcilePlanTiers();
+    expect(result.healed).toBe(0);
+  });
+
+  it("prunes the webhook event ledger and reports the count", async () => {
+    installQueryFixture([], [{ event_id: "evt_old_1" }, { event_id: "evt_old_2" }]);
+
+    const result = await reconcilePlanTiers();
+    expect(result.prunedLedger).toBe(2);
+  });
+
+  it("propagates internal-DB failures so the scheduler tick logs and retries", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("pg down")));
+    await expect(reconcilePlanTiers()).rejects.toThrow("pg down");
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
@@ -29,12 +29,15 @@ interface OrgRow {
   org_id: string;
   plan_tier: string | null;
   subscription_plan: string | null;
+  /** Newest applied tier from the webhook ledger (defaulted to null). */
+  ledger_tier?: string | null;
 }
 
 /** Route the org scan and the ledger prune through one mock. */
 function installQueryFixture(orgs: OrgRow[], pruned: { event_id: string }[] = []) {
   mockInternalQuery.mockImplementation((sql: string) => {
-    if (sql.includes("FROM organization o")) return Promise.resolve(orgs);
+    if (sql.includes("FROM organization o"))
+      return Promise.resolve(orgs.map((o) => ({ ledger_tier: null, ...o })));
     if (sql.includes("DELETE FROM stripe_webhook_events")) return Promise.resolve(pruned);
     return Promise.resolve([]);
   });
@@ -127,6 +130,31 @@ describe("reconcilePlanTiers", () => {
     expect(result.healed).toBe(0);
   });
 
+  it("prefers the ledger's newest APPLIED tier over the plugin's last-delivered row plan", async () => {
+    // Stale older `updated` (plan=starter) delivered after a newer one
+    // (plan=pro): the ledger skipped the Atlas sync, but the plugin's
+    // row regressed to starter. Healing from the row would write
+    // pro→starter — exactly the regression the ledger rejected. The
+    // sweep must trust applied_plan_tier when present.
+    installQueryFixture([
+      { org_id: "org-1", plan_tier: "pro", subscription_plan: "starter", ledger_tier: "pro" },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.healed).toBe(0);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+
+    // And when the org ACTUALLY drifted from the ledger-applied tier
+    // (lost webhook), the heal targets the ledger tier, not the row.
+    installQueryFixture([
+      { org_id: "org-2", plan_tier: "starter", subscription_plan: "starter", ledger_tier: "pro" },
+    ]);
+    const second = await reconcilePlanTiers();
+    expect(second.healed).toBe(1);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-2", "pro");
+  });
+
   it("ignores subscription rows whose stripe sub has a recorded deletion event (stale last-delivered rows)", async () => {
     // The plugin writes its subscription table last-DELIVERED-wins, so a
     // stale older `updated` after a processed `deleted` can leave the row
@@ -140,6 +168,9 @@ describe("reconcilePlanTiers", () => {
     expect(scanSql).toContain("NOT EXISTS");
     expect(scanSql).toContain("'customer.subscription.deleted'");
     expect(scanSql).toContain("stripe_webhook_events");
+    // The ledger-applied-tier lateral must survive too — dropping it
+    // silently reverts the sweep to last-delivered-wins healing.
+    expect(scanSql).toContain("applied_plan_tier");
   });
 
   it("prunes the webhook event ledger and reports the count", async () => {

--- a/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
+++ b/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the Stripe webhook event ledger (#3423).
+ *
+ * The classify→process→record protocol itself is exercised end-to-end in
+ * stripe-webhook-lifecycle.test.ts; this file pins the per-function
+ * contracts: SQL shapes/params, the no-internal-DB bypass, and the
+ * throw-on-failure discipline that makes `onEvent` durable (a swallowed
+ * ledger error would re-create the silent-loss bug).
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
+  mock(() => Promise.resolve([]));
+let hasDb = true;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({
+    internalQuery: mockInternalQuery,
+    hasInternalDB: () => hasDb,
+  }),
+}));
+
+const {
+  classifyStripeEvent,
+  recordStripeEvent,
+  pruneStripeEventLedger,
+  STRIPE_EVENT_LEDGER_RETENTION_DAYS,
+} = await import("../stripe-event-ledger");
+
+const EVENT = {
+  id: "evt_1",
+  type: "customer.subscription.updated",
+  created: 1_750_000_000,
+  stripeSubscriptionId: "sub_1",
+};
+
+beforeEach(() => {
+  hasDb = true;
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+});
+
+describe("classifyStripeEvent", () => {
+  it("returns fresh when neither the id nor a newer same-subscription event is recorded", async () => {
+    await expect(classifyStripeEvent(EVENT)).resolves.toBe("fresh");
+    // Two probes: dedup by event id, then ordering by subscription id.
+    expect(mockInternalQuery).toHaveBeenCalledTimes(2);
+    const [dupSql, dupParams] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(dupSql).toContain("WHERE event_id = $1");
+    expect(dupParams).toEqual(["evt_1"]);
+    const [staleSql, staleParams] = mockInternalQuery.mock.calls[1] as [string, unknown[]];
+    expect(staleSql).toContain("event_created > $2");
+    expect(staleParams).toEqual(["sub_1", new Date(EVENT.created * 1000).toISOString()]);
+  });
+
+  it("returns duplicate when the event id is already recorded (replay)", async () => {
+    mockInternalQuery.mockImplementation((sql) =>
+      Promise.resolve(sql.includes("WHERE event_id = $1") ? [{ event_id: "evt_1" }] : []),
+    );
+    await expect(classifyStripeEvent(EVENT)).resolves.toBe("duplicate");
+  });
+
+  it("returns stale when a newer event for the same subscription was already applied", async () => {
+    mockInternalQuery.mockImplementation((sql) =>
+      Promise.resolve(sql.includes("event_created > $2") ? [{ event_id: "evt_newer" }] : []),
+    );
+    await expect(classifyStripeEvent(EVENT)).resolves.toBe("stale");
+  });
+
+  it("skips the ordering probe for events with no subscription scope", async () => {
+    await expect(
+      classifyStripeEvent({ ...EVENT, stripeSubscriptionId: null }),
+    ).resolves.toBe("fresh");
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns fresh without querying when there is no internal DB", async () => {
+    hasDb = false;
+    await expect(classifyStripeEvent(EVENT)).resolves.toBe("fresh");
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("propagates ledger query failures (onEvent must 400 so Stripe retries)", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("pg down")));
+    await expect(classifyStripeEvent(EVENT)).rejects.toThrow("pg down");
+  });
+});
+
+describe("recordStripeEvent", () => {
+  it("inserts the event with ON CONFLICT DO NOTHING (idempotent)", async () => {
+    await recordStripeEvent(EVENT);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO stripe_webhook_events");
+    expect(sql).toContain("ON CONFLICT (event_id) DO NOTHING");
+    expect(params).toEqual([
+      "evt_1",
+      "customer.subscription.updated",
+      new Date(EVENT.created * 1000).toISOString(),
+      "sub_1",
+    ]);
+  });
+
+  it("is a no-op without an internal DB", async () => {
+    hasDb = false;
+    await recordStripeEvent(EVENT);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("propagates insert failures", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("pg down")));
+    await expect(recordStripeEvent(EVENT)).rejects.toThrow("pg down");
+  });
+});
+
+describe("pruneStripeEventLedger", () => {
+  it("deletes rows past the default retention and returns the count", async () => {
+    mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ event_id: "evt_a" }, { event_id: "evt_b" }]),
+    );
+    await expect(pruneStripeEventLedger()).resolves.toBe(2);
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("DELETE FROM stripe_webhook_events");
+    expect(params).toEqual([String(STRIPE_EVENT_LEDGER_RETENTION_DAYS)]);
+  });
+
+  it("returns 0 without an internal DB", async () => {
+    hasDb = false;
+    await expect(pruneStripeEventLedger()).resolves.toBe(0);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
+++ b/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
@@ -52,7 +52,23 @@ describe("classifyStripeEvent", () => {
     expect(dupParams).toEqual(["evt_1"]);
     const [staleSql, staleParams] = mockInternalQuery.mock.calls[1] as [string, unknown[]];
     expect(staleSql).toContain("event_created > $2");
+    // Only lifecycle events may block (payment failures excluded) …
+    expect(staleSql).toContain("event_type IN (");
+    expect(staleSql).not.toContain("'invoice.payment_failed'");
+    // … and a recorded deletion also blocks SAME-second events (Stripe
+    // `created` is 1s-granular; deletion is terminal).
+    expect(staleSql).toContain("event_created = $2 AND event_type = 'customer.subscription.deleted'");
     expect(staleParams).toEqual(["sub_1", new Date(EVENT.created * 1000).toISOString()]);
+  });
+
+  it("dedupes non-lifecycle events by id only — no ordering probe for invoice.payment_failed", async () => {
+    await expect(
+      classifyStripeEvent({ ...EVENT, type: "invoice.payment_failed" }),
+    ).resolves.toBe("fresh");
+    // A payment failure recorded first must never make a delayed
+    // lifecycle sync look stale, and vice versa — it skips the
+    // ordering probe entirely.
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
   });
 
   it("returns duplicate when the event id is already recorded (replay)", async () => {
@@ -129,6 +145,12 @@ describe("pruneStripeEventLedger", () => {
   it("returns 0 without an internal DB", async () => {
     hasDb = false;
     await expect(pruneStripeEventLedger()).resolves.toBe(0);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects negative/non-finite retention before touching the DB (would invert the cutoff)", async () => {
+    await expect(pruneStripeEventLedger(-1)).rejects.toThrow(/Invalid/);
+    await expect(pruneStripeEventLedger(Number.NaN)).rejects.toThrow(/Invalid/);
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
+++ b/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
@@ -105,29 +105,37 @@ describe("classifyStripeEvent", () => {
 });
 
 describe("recordStripeEvent", () => {
-  it("inserts the event with ON CONFLICT DO NOTHING (idempotent)", async () => {
-    await recordStripeEvent(EVENT);
+  it("inserts the event + applied tier with ON CONFLICT DO NOTHING (idempotent)", async () => {
+    await recordStripeEvent(EVENT, "pro");
     expect(mockInternalQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("INSERT INTO stripe_webhook_events");
+    expect(sql).toContain("applied_plan_tier");
     expect(sql).toContain("ON CONFLICT (event_id) DO NOTHING");
     expect(params).toEqual([
       "evt_1",
       "customer.subscription.updated",
       new Date(EVENT.created * 1000).toISOString(),
       "sub_1",
+      "pro",
     ]);
+  });
+
+  it("records null when the sync applied no tier", async () => {
+    await recordStripeEvent(EVENT, null);
+    const [, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBeNull();
   });
 
   it("is a no-op without an internal DB", async () => {
     hasDb = false;
-    await recordStripeEvent(EVENT);
+    await recordStripeEvent(EVENT, "pro");
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 
   it("propagates insert failures", async () => {
     mockInternalQuery.mockImplementation(() => Promise.reject(new Error("pg down")));
-    await expect(recordStripeEvent(EVENT)).rejects.toThrow("pg down");
+    await expect(recordStripeEvent(EVENT, null)).rejects.toThrow("pg down");
   });
 });
 

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -63,6 +63,8 @@ type ReconcileRow = {
   org_id: string;
   plan_tier: string | null;
   subscription_plan: string | null;
+  /** Newest non-null `applied_plan_tier` from the webhook ledger. */
+  ledger_tier: string | null;
 };
 
 /**
@@ -75,26 +77,34 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
   if (!hasInternalDB()) return { healed: 0, flagged: 0, prunedLedger: 0 };
 
   // Newest live subscription per org, joined against the org's current
-  // tier. `subscription.plan` stores the plan NAME, which is the tier
+  // tier AND the ledger's newest APPLIED tier for that subscription.
+  // `subscription.plan` stores the plan NAME, which is the tier
   // vocabulary (plans.ts names plans after tiers); parsePlanTier guards
   // the trust boundary anyway.
   //
-  // The NOT EXISTS guard (Codex review on #3444): the plugin's own
-  // handlers write the subscription row last-DELIVERED-wins, so a stale
-  // older `updated` delivered after a processed `deleted` can flip the
-  // row back to "active" even though the ledger correctly skipped the
-  // Atlas side effects. Stripe never resurrects a subscription id, so
-  // any sub with a recorded deletion event is ended regardless of what
-  // the row claims — without this, the sweep would heal a locked
-  // workspace back to paid six hours after the stale delivery. (Ledger
-  // retention is 30 days; a row still stale-active after that has no
-  // ledger witness left, which is the residual risk we accept — the
-  // deleted event itself can no longer be replayed by then either.)
+  // The plugin writes its subscription row last-DELIVERED-wins, so a
+  // stale older delivery can regress the row even though the webhook
+  // ledger correctly skipped the Atlas-side sync (Codex review on
+  // #3444). Two defenses, one per failure shape:
+  //  - The NOT EXISTS guard: any sub with a recorded deletion event is
+  //    ended regardless of what the row claims (Stripe never resurrects
+  //    a subscription id) — without it, a stale `updated` flipping the
+  //    row back to "active" would heal a locked workspace back to paid.
+  //  - `led.applied_plan_tier` (preferred over `sub.plan` when present):
+  //    the tier the ORDERING-CORRECT sync last wrote. A stale older
+  //    `updated` (plan=starter) delivered after a newer one (plan=pro)
+  //    regresses the row to starter, but the ledger-latest applied tier
+  //    stays pro — healing from the row would undo the ledger's
+  //    protection. The row remains the fallback for rows that predate
+  //    the ledger or whose entries aged past the 30-day retention (by
+  //    then Stripe's own ~3-week retry/redelivery window has closed, so
+  //    a stale delivery storm can no longer be in flight).
   const rows = await internalQuery<ReconcileRow>(
-    `SELECT o.id AS org_id, o.plan_tier, sub.plan AS subscription_plan
+    `SELECT o.id AS org_id, o.plan_tier, sub.plan AS subscription_plan,
+            led.applied_plan_tier AS ledger_tier
        FROM organization o
        LEFT JOIN LATERAL (
-         SELECT s.plan FROM subscription s
+         SELECT s.plan, s."stripeSubscriptionId" FROM subscription s
           WHERE s."referenceId" = o.id AND s.status IN ('active', 'trialing')
             AND NOT EXISTS (
               SELECT 1 FROM stripe_webhook_events w
@@ -102,20 +112,31 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
                  AND w.event_type = 'customer.subscription.deleted')
           ORDER BY s."createdAt" DESC
           LIMIT 1
-       ) sub ON true`,
+       ) sub ON true
+       LEFT JOIN LATERAL (
+         SELECT w.applied_plan_tier FROM stripe_webhook_events w
+          WHERE w.stripe_subscription_id = sub."stripeSubscriptionId"
+            AND w.applied_plan_tier IS NOT NULL
+          ORDER BY w.event_created DESC
+          LIMIT 1
+       ) led ON true`,
   );
 
   let healed = 0;
   let flagged = 0;
 
+  // Sequential on purpose, not Promise.all: this is a 6-hour background
+  // sweep and heals are expected to be rare — serializing the writes
+  // keeps the sweep from bursting the internal pool alongside live
+  // request traffic for no latency benefit anyone observes.
   for (const row of rows) {
     const currentTier = parsePlanTier(row.plan_tier);
 
     if (row.subscription_plan != null) {
-      const expectedTier = parsePlanTier(row.subscription_plan);
+      const expectedTier = parsePlanTier(row.ledger_tier ?? row.subscription_plan);
       if (expectedTier === null) {
         log.warn(
-          { orgId: row.org_id, subscriptionPlan: row.subscription_plan },
+          { orgId: row.org_id, subscriptionPlan: row.subscription_plan, ledgerTier: row.ledger_tier },
           "Subscription row carries a plan name outside the tier vocabulary — cannot reconcile",
         );
         continue;

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -1,0 +1,138 @@
+/**
+ * Plan-tier reconciliation sweep (#3423) — the safety net under the
+ * webhook path.
+ *
+ * The webhook `onEvent` sync (lib/auth/server.ts) is durable against
+ * transient failures (throws → Stripe redelivers), but not against
+ * permanent loss: a webhook secret rotation, an endpoint outage past
+ * Stripe's ~3-week retry horizon, or an event class we don't handle can
+ * still leave `organization.plan_tier` divergent from the subscription
+ * the plugin's own table says the org is paying for. This sweep heals
+ * that drift from the same source of truth the webhooks write
+ * (`subscription`, owned by @better-auth/stripe) through the same write
+ * path (`updateWorkspacePlanTier` + plan-cache invalidation).
+ *
+ * Two deliberate asymmetries:
+ *
+ *  - Org HAS an active/trialing subscription but the tier disagrees →
+ *    HEAL (the subscription row is webhook-fed ground truth; this also
+ *    un-locks an org whose resubscribe webhook was lost).
+ *  - Org sits on a PAID tier with NO active/trialing subscription →
+ *    FLAG ONLY (log, never write). This shape is ambiguous: it can be a
+ *    lost `customer.subscription.deleted` (should lock) or a deliberate
+ *    operator grant via the admin plan endpoint. Until the billing
+ *    override flag lands (#3427) there is no way to tell them apart, so
+ *    the sweep refuses to guess — locking a comped design partner is
+ *    worse than a stale entitlement.
+ *
+ * `trial`, `free`, and `locked` orgs without a subscription are normal
+ * states (pre-checkout trial, legacy/self-hosted rows, churned) and are
+ * left alone. Runs from the scheduler fiber in `lib/effect/layers.ts`;
+ * also prunes the webhook event ledger past retention.
+ */
+
+import {
+  hasInternalDB,
+  internalQuery,
+  updateWorkspacePlanTier,
+} from "@atlas/api/lib/db/internal";
+import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import { pruneStripeEventLedger } from "@atlas/api/lib/billing/stripe-event-ledger";
+import { parsePlanTier } from "@atlas/api/lib/integrations/install/plan-rank";
+import { createLogger } from "@atlas/api/lib/logger";
+import type { PlanTier } from "@useatlas/types";
+
+const log = createLogger("billing:reconcile");
+
+/** Tiers that imply a live Stripe subscription should exist. */
+const PAID_TIERS: ReadonlySet<PlanTier> = new Set(["starter", "pro", "business"]);
+
+export interface PlanTierReconcileResult {
+  /** Orgs whose plan_tier was rewritten to match their subscription. */
+  healed: number;
+  /** Paid-tier orgs with no live subscription — logged, not changed. */
+  flagged: number;
+  /** Webhook-ledger rows pruned past retention. */
+  prunedLedger: number;
+}
+
+// Type alias, not interface: internalQuery's generic is constrained to
+// Record<string, unknown>, which only object-literal type aliases satisfy
+// via their implicit index signature.
+type ReconcileRow = {
+  org_id: string;
+  plan_tier: string | null;
+  subscription_plan: string | null;
+};
+
+/**
+ * One reconciliation pass. Idempotent; safe to run concurrently across
+ * instances (the heal write is a plain idempotent UPDATE). Throws on
+ * internal-DB failure so the scheduler tick logs it and retries next
+ * interval.
+ */
+export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
+  if (!hasInternalDB()) return { healed: 0, flagged: 0, prunedLedger: 0 };
+
+  // Newest live subscription per org, joined against the org's current
+  // tier. `subscription.plan` stores the plan NAME, which is the tier
+  // vocabulary (plans.ts names plans after tiers); parsePlanTier guards
+  // the trust boundary anyway.
+  const rows = await internalQuery<ReconcileRow>(
+    `SELECT o.id AS org_id, o.plan_tier, sub.plan AS subscription_plan
+       FROM organization o
+       LEFT JOIN LATERAL (
+         SELECT s.plan FROM subscription s
+          WHERE s."referenceId" = o.id AND s.status IN ('active', 'trialing')
+          ORDER BY s."createdAt" DESC
+          LIMIT 1
+       ) sub ON true`,
+  );
+
+  let healed = 0;
+  let flagged = 0;
+
+  for (const row of rows) {
+    const currentTier = parsePlanTier(row.plan_tier);
+
+    if (row.subscription_plan != null) {
+      const expectedTier = parsePlanTier(row.subscription_plan);
+      if (expectedTier === null) {
+        log.warn(
+          { orgId: row.org_id, subscriptionPlan: row.subscription_plan },
+          "Subscription row carries a plan name outside the tier vocabulary — cannot reconcile",
+        );
+        continue;
+      }
+      if (expectedTier !== currentTier) {
+        const updated = await updateWorkspacePlanTier(row.org_id, expectedTier);
+        if (updated) {
+          invalidatePlanCache(row.org_id);
+          healed += 1;
+          log.warn(
+            { orgId: row.org_id, from: row.plan_tier, to: expectedTier },
+            "Healed plan-tier drift from the subscription table (lost webhook?)",
+          );
+        }
+      }
+      continue;
+    }
+
+    // No live subscription. Paid tier → flag-don't-heal (see module doc:
+    // indistinguishable from an operator grant until #3427).
+    if (currentTier !== null && PAID_TIERS.has(currentTier)) {
+      flagged += 1;
+      log.warn(
+        { orgId: row.org_id, planTier: currentTier },
+        "Paid-tier org has no active subscription — possible lost deletion webhook or operator grant; NOT changing (see #3427)",
+      );
+    }
+  }
+
+  const prunedLedger = await pruneStripeEventLedger();
+
+  if (healed > 0 || flagged > 0 || prunedLedger > 0) {
+    log.info({ healed, flagged, prunedLedger, orgsScanned: rows.length }, "Plan-tier reconciliation pass complete");
+  }
+  return { healed, flagged, prunedLedger };
+}

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -78,12 +78,28 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
   // tier. `subscription.plan` stores the plan NAME, which is the tier
   // vocabulary (plans.ts names plans after tiers); parsePlanTier guards
   // the trust boundary anyway.
+  //
+  // The NOT EXISTS guard (Codex review on #3444): the plugin's own
+  // handlers write the subscription row last-DELIVERED-wins, so a stale
+  // older `updated` delivered after a processed `deleted` can flip the
+  // row back to "active" even though the ledger correctly skipped the
+  // Atlas side effects. Stripe never resurrects a subscription id, so
+  // any sub with a recorded deletion event is ended regardless of what
+  // the row claims — without this, the sweep would heal a locked
+  // workspace back to paid six hours after the stale delivery. (Ledger
+  // retention is 30 days; a row still stale-active after that has no
+  // ledger witness left, which is the residual risk we accept — the
+  // deleted event itself can no longer be replayed by then either.)
   const rows = await internalQuery<ReconcileRow>(
     `SELECT o.id AS org_id, o.plan_tier, sub.plan AS subscription_plan
        FROM organization o
        LEFT JOIN LATERAL (
          SELECT s.plan FROM subscription s
           WHERE s."referenceId" = o.id AND s.status IN ('active', 'trialing')
+            AND NOT EXISTS (
+              SELECT 1 FROM stripe_webhook_events w
+               WHERE w.stripe_subscription_id = s."stripeSubscriptionId"
+                 AND w.event_type = 'customer.subscription.deleted')
           ORDER BY s."createdAt" DESC
           LIMIT 1
        ) sub ON true`,

--- a/packages/api/src/lib/billing/stripe-event-ledger.ts
+++ b/packages/api/src/lib/billing/stripe-event-ledger.ts
@@ -22,6 +22,7 @@
  * swallowing would re-create the exact silent-loss bug this fixes.
  */
 
+import type { PlanTier } from "@useatlas/types";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 
@@ -110,14 +111,31 @@ export async function classifyStripeEvent(
   return "fresh";
 }
 
-/** Record a processed event. Idempotent (`ON CONFLICT DO NOTHING`). */
-export async function recordStripeEvent(event: StripeLedgerEvent): Promise<void> {
+/**
+ * Record a processed event. Idempotent (`ON CONFLICT DO NOTHING`).
+ *
+ * `appliedPlanTier` is the tier the sync actually WROTE for this event
+ * (null when it applied none). The reconciliation sweep prefers the
+ * newest non-null value per subscription over the plugin's
+ * last-delivered-wins `subscription.plan` column — see the sweep's
+ * module doc for the stale-row scenario this guards.
+ */
+export async function recordStripeEvent(
+  event: StripeLedgerEvent,
+  appliedPlanTier: PlanTier | null,
+): Promise<void> {
   if (!hasInternalDB()) return;
   await internalQuery(
-    `INSERT INTO stripe_webhook_events (event_id, event_type, event_created, stripe_subscription_id)
-     VALUES ($1, $2, $3, $4)
+    `INSERT INTO stripe_webhook_events (event_id, event_type, event_created, stripe_subscription_id, applied_plan_tier)
+     VALUES ($1, $2, $3, $4, $5)
      ON CONFLICT (event_id) DO NOTHING`,
-    [event.id, event.type, new Date(event.created * 1000).toISOString(), event.stripeSubscriptionId],
+    [
+      event.id,
+      event.type,
+      new Date(event.created * 1000).toISOString(),
+      event.stripeSubscriptionId,
+      appliedPlanTier,
+    ],
   );
 }
 

--- a/packages/api/src/lib/billing/stripe-event-ledger.ts
+++ b/packages/api/src/lib/billing/stripe-event-ledger.ts
@@ -46,13 +46,41 @@ export interface StripeLedgerEvent {
 export type StripeEventDisposition = "fresh" | "duplicate" | "stale";
 
 /**
+ * The event types whose relative order determines the workspace tier.
+ * ONLY these participate in the per-subscription ordering guard — both
+ * as the incoming side and as recorded blockers. Non-lifecycle events
+ * that still carry a subscription id (e.g. `invoice.payment_failed`)
+ * are deduped by event id but must never make a lifecycle event look
+ * stale: a payment failure recorded first would otherwise suppress a
+ * delayed `updated`/`deleted` sync entirely (Codex review on #3444).
+ */
+export const TIER_LIFECYCLE_EVENT_TYPES = [
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+] as const;
+
+export function isTierLifecycleEventType(type: string): boolean {
+  return (TIER_LIFECYCLE_EVENT_TYPES as readonly string[]).includes(type);
+}
+
+// Static, compile-time list — safe to inline into SQL.
+const LIFECYCLE_LIST_SQL = TIER_LIFECYCLE_EVENT_TYPES.map((t) => `'${t}'`).join(", ");
+
+/**
  * Classify a delivery before processing it.
  *
  *  - `duplicate` — this exact event id was already processed (replay).
- *  - `stale` — a strictly NEWER event for the same subscription was
- *    already applied; applying this one would regress status/plan
- *    (the plugin itself writes last-DELIVERED-wins, so the guard is the
- *    only out-of-order protection).
+ *  - `stale` — a strictly NEWER lifecycle event for the same
+ *    subscription was already applied; applying this one would regress
+ *    status/plan (the plugin itself writes last-DELIVERED-wins, so the
+ *    guard is the only out-of-order protection). Stripe `created` has
+ *    1-second granularity, so ties are broken conservatively: a
+ *    recorded `customer.subscription.deleted` also blocks SAME-second
+ *    events — deletion is terminal (Stripe never resurrects a
+ *    subscription id), so nothing sharing its second may run after it
+ *    and write a paid tier back onto a locked workspace.
  *  - `fresh` — process it.
  */
 export async function classifyStripeEvent(
@@ -66,10 +94,13 @@ export async function classifyStripeEvent(
   );
   if (dup.length > 0) return "duplicate";
 
-  if (event.stripeSubscriptionId) {
+  if (event.stripeSubscriptionId && isTierLifecycleEventType(event.type)) {
     const newer = await internalQuery<{ event_id: string }>(
       `SELECT event_id FROM stripe_webhook_events
-        WHERE stripe_subscription_id = $1 AND event_created > $2
+        WHERE stripe_subscription_id = $1
+          AND event_type IN (${LIFECYCLE_LIST_SQL})
+          AND (event_created > $2
+               OR (event_created = $2 AND event_type = 'customer.subscription.deleted'))
         LIMIT 1`,
       [event.stripeSubscriptionId, new Date(event.created * 1000).toISOString()],
     );
@@ -97,6 +128,11 @@ export async function recordStripeEvent(event: StripeLedgerEvent): Promise<void>
 export async function pruneStripeEventLedger(
   retentionDays: number = STRIPE_EVENT_LEDGER_RETENTION_DAYS,
 ): Promise<number> {
+  // A negative value would invert the cutoff into `< now() + interval`
+  // and wipe the live ledger (CodeRabbit on #3444).
+  if (!Number.isFinite(retentionDays) || retentionDays < 0) {
+    throw new Error(`Invalid stripe event ledger retentionDays: ${retentionDays}`);
+  }
   if (!hasInternalDB()) return 0;
   const rows = await internalQuery<{ event_id: string }>(
     `DELETE FROM stripe_webhook_events

--- a/packages/api/src/lib/billing/stripe-event-ledger.ts
+++ b/packages/api/src/lib/billing/stripe-event-ledger.ts
@@ -1,0 +1,111 @@
+/**
+ * Stripe webhook event ledger (#3423) — idempotency + ordering for the
+ * must-not-be-lost sync that lives in the Stripe plugin's `onEvent`.
+ *
+ * Protocol (the caller is `onEvent` in `lib/auth/server.ts`):
+ *   1. {@link classifyStripeEvent} BEFORE processing — `duplicate` and
+ *      `stale` deliveries are skipped without side effects.
+ *   2. Process the sync (plan-tier write, CRM stamp enqueue).
+ *   3. {@link recordStripeEvent} AFTER the sync succeeds.
+ *
+ * The classify→process→record order is deliberate: recording first would
+ * make a failed sync unrecoverable (Stripe's retry of the same event id
+ * would hit the duplicate guard and be skipped). Recording last means a
+ * crash between steps 2 and 3 causes one extra retry that re-runs an
+ * idempotent tier write — the safe direction. The residual race (two
+ * concurrent deliveries of the same event both passing step 1) has the
+ * same idempotent-rewrite outcome.
+ *
+ * Every function THROWS on ledger/DB failure. `onEvent` throws are the
+ * only ones the plugin propagates (→ 400 `STRIPE_WEBHOOK_ERROR` → Stripe
+ * retries), so failing loudly here is what makes the sync durable —
+ * swallowing would re-create the exact silent-loss bug this fixes.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("billing:event-ledger");
+
+/** Ledger retention — past Stripe's ~3-week retry horizon. */
+export const STRIPE_EVENT_LEDGER_RETENTION_DAYS = 30;
+
+export interface StripeLedgerEvent {
+  /** Stripe event id (`evt_…`). */
+  id: string;
+  type: string;
+  /** Stripe `event.created` — unix seconds. */
+  created: number;
+  /**
+   * Stripe subscription id the event concerns, or null for events with
+   * no subscription scope. Drives the per-subscription ordering guard.
+   */
+  stripeSubscriptionId: string | null;
+}
+
+export type StripeEventDisposition = "fresh" | "duplicate" | "stale";
+
+/**
+ * Classify a delivery before processing it.
+ *
+ *  - `duplicate` — this exact event id was already processed (replay).
+ *  - `stale` — a strictly NEWER event for the same subscription was
+ *    already applied; applying this one would regress status/plan
+ *    (the plugin itself writes last-DELIVERED-wins, so the guard is the
+ *    only out-of-order protection).
+ *  - `fresh` — process it.
+ */
+export async function classifyStripeEvent(
+  event: StripeLedgerEvent,
+): Promise<StripeEventDisposition> {
+  if (!hasInternalDB()) return "fresh"; // no ledger without an internal DB
+
+  const dup = await internalQuery<{ event_id: string }>(
+    `SELECT event_id FROM stripe_webhook_events WHERE event_id = $1 LIMIT 1`,
+    [event.id],
+  );
+  if (dup.length > 0) return "duplicate";
+
+  if (event.stripeSubscriptionId) {
+    const newer = await internalQuery<{ event_id: string }>(
+      `SELECT event_id FROM stripe_webhook_events
+        WHERE stripe_subscription_id = $1 AND event_created > $2
+        LIMIT 1`,
+      [event.stripeSubscriptionId, new Date(event.created * 1000).toISOString()],
+    );
+    if (newer.length > 0) return "stale";
+  }
+
+  return "fresh";
+}
+
+/** Record a processed event. Idempotent (`ON CONFLICT DO NOTHING`). */
+export async function recordStripeEvent(event: StripeLedgerEvent): Promise<void> {
+  if (!hasInternalDB()) return;
+  await internalQuery(
+    `INSERT INTO stripe_webhook_events (event_id, event_type, event_created, stripe_subscription_id)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (event_id) DO NOTHING`,
+    [event.id, event.type, new Date(event.created * 1000).toISOString(), event.stripeSubscriptionId],
+  );
+}
+
+/**
+ * Drop ledger rows past retention. Returns the number pruned. Called by
+ * the reconciliation sweep, not on the webhook path.
+ */
+export async function pruneStripeEventLedger(
+  retentionDays: number = STRIPE_EVENT_LEDGER_RETENTION_DAYS,
+): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  const rows = await internalQuery<{ event_id: string }>(
+    `DELETE FROM stripe_webhook_events
+      WHERE processed_at < now() - ($1 || ' days')::interval
+      RETURNING event_id`,
+    [String(retentionDays)],
+  );
+  if (rows.length > 0) {
+    log.info({ pruned: rows.length, retentionDays }, "Pruned Stripe webhook event ledger");
+  }
+  return rows.length;
+}

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -147,7 +147,8 @@ describe("runMigrations", () => {
     //   Plus 0125 (elasticsearch auth-modes config_schema update, #3263–#3266) = 126.
     //   Plus 0126 (plugin-owned organization."stripeCustomerId", #3417) = 127.
     //   Plus 0127 (chk_plan_tier widened with 'locked', #3421) = 128.
-    expect(count).toBe(128);
+    //   Plus 0128 (stripe_webhook_events ledger, #3423) = 129.
+    expect(count).toBe(129);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -304,6 +305,7 @@ describe("runMigrations", () => {
         "0125_elasticsearch_auth_modes_config_schema.sql",
         "0126_org_stripe_customer_id_plugin_column.sql",
         "0127_plan_tier_locked.sql",
+        "0128_stripe_webhook_event_ledger.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0128_stripe_webhook_event_ledger.sql
+++ b/packages/api/src/lib/db/migrations/0128_stripe_webhook_event_ledger.sql
@@ -18,6 +18,14 @@ CREATE TABLE IF NOT EXISTS stripe_webhook_events (
   event_type TEXT NOT NULL,
   event_created TIMESTAMPTZ NOT NULL,
   stripe_subscription_id TEXT,
+  -- Plan tier this event's sync actually WROTE to the org (NULL when the
+  -- event applied no tier). The reconciliation sweep prefers the newest
+  -- non-null value here over the plugin's `subscription.plan` column:
+  -- the plugin writes its row last-DELIVERED-wins, so a stale older
+  -- delivery can regress the row even though the ledger correctly
+  -- skipped the Atlas-side sync — healing from the row would undo the
+  -- ordering protection this ledger exists for.
+  applied_plan_tier TEXT,
   processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/packages/api/src/lib/db/migrations/0128_stripe_webhook_event_ledger.sql
+++ b/packages/api/src/lib/db/migrations/0128_stripe_webhook_event_ledger.sql
@@ -1,0 +1,30 @@
+-- 0128: Stripe webhook event ledger (#3423).
+--
+-- The @better-auth/stripe plugin ACKs 200 even when Atlas's
+-- onSubscription* hooks throw, and Stripe replays deliveries — so the
+-- must-not-be-lost sync (plan-tier write + CRM conversion stamp) moved
+-- into `onEvent`, where throws DO propagate as 400s and trigger Stripe's
+-- retry. This table gives that path:
+--   • idempotency — processed `event_id`s are recorded; replays no-op
+--   • ordering    — `event_created` per `stripe_subscription_id` lets a
+--     delayed older event be ignored instead of regressing status/plan
+--     (last-applied-wins, not last-delivered-wins)
+--
+-- Rows are pruned by the reconciliation sweep after STRIPE_EVENT_LEDGER
+-- retention (30 days) — Stripe's own retry horizon is ~3 weeks, so a
+-- pruned event can no longer be replayed by Stripe itself.
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  event_created TIMESTAMPTZ NOT NULL,
+  stripe_subscription_id TEXT,
+  processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Ordering lookups: newest applied event per subscription.
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_sub
+  ON stripe_webhook_events (stripe_subscription_id, event_created DESC);
+
+-- Retention pruning scans.
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_processed
+  ON stripe_webhook_events (processed_at);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2344,3 +2344,26 @@ export const emailOutbox = pgTable(
       .where(sql`status IN ('pending', 'in_flight')`),
   ],
 );
+
+/**
+ * Stripe webhook event ledger (#3423) — idempotency + ordering for the
+ * must-not-be-lost sync in the Stripe plugin's `onEvent`. `event_id` is
+ * the Stripe event id (replays no-op); `event_created` per
+ * `stripe_subscription_id` lets a delayed older event be ignored instead
+ * of regressing status/plan. Pruned by the reconciliation sweep after
+ * 30 days. Mirrors `migrations/0128_stripe_webhook_event_ledger.sql`.
+ */
+export const stripeWebhookEvents = pgTable(
+  "stripe_webhook_events",
+  {
+    eventId: text("event_id").primaryKey(),
+    eventType: text("event_type").notNull(),
+    eventCreated: timestamp("event_created", { withTimezone: true }).notNull(),
+    stripeSubscriptionId: text("stripe_subscription_id"),
+    processedAt: timestamp("processed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("idx_stripe_webhook_events_sub").on(t.stripeSubscriptionId, t.eventCreated),
+    index("idx_stripe_webhook_events_processed").on(t.processedAt),
+  ],
+);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2363,7 +2363,7 @@ export const stripeWebhookEvents = pgTable(
     processedAt: timestamp("processed_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
-    index("idx_stripe_webhook_events_sub").on(t.stripeSubscriptionId, t.eventCreated),
+    index("idx_stripe_webhook_events_sub").on(t.stripeSubscriptionId, t.eventCreated.desc()),
     index("idx_stripe_webhook_events_processed").on(t.processedAt),
   ],
 );

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2360,6 +2360,7 @@ export const stripeWebhookEvents = pgTable(
     eventType: text("event_type").notNull(),
     eventCreated: timestamp("event_created", { withTimezone: true }).notNull(),
     stripeSubscriptionId: text("stripe_subscription_id"),
+    appliedPlanTier: text("applied_plan_tier"),
     processedAt: timestamp("processed_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -371,6 +371,7 @@ describe("makeSchedulerLive", () => {
         "settings_refresh",
         "onboarding_email",
         "expert_scheduler",
+        "billing_reconcile",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1472,17 +1472,23 @@ export function makeSchedulerLive(
           if (!process.env.STRIPE_SECRET_KEY || !process.env.STRIPE_WEBHOOK_SECRET) {
             return false;
           }
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
           const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
             hasInternalDB: () => boolean;
           };
           return hasInternalDB();
         },
-        catch: (err) => {
-          log.debug({ err: errorMessage(err) }, "Billing reconcile gate check failed — skipping");
-          return false;
-        },
-      }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+        // Normalize to Error per the Effect.try/tryPromise rule; the
+        // catchAll below logs it and degrades to "fiber not started".
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.debug({ err: errorMessage(err) }, "Billing reconcile gate check failed — skipping");
+            return false;
+          }),
+        ),
+      );
 
       if (billingReconcileEnabled) {
         // 6h: drift heals well inside Stripe's ~3-week retry horizon

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -157,11 +157,12 @@ function withFiberDeathLog<A, E, R>(
 //     catalog-refresh fiber and the scheduler engine use that 4th arg
 //     elsewhere, inside their own modules).
 //
-//   • SCHEDULER_WORK_SPAN_NAMES — 4 background-work fibers (they perform
+//   • SCHEDULER_WORK_SPAN_NAMES — 5 background-work fibers (they perform
 //     recurring side-effecting work rather than evicting state):
 //     `sub_processor_publisher`, `settings_refresh`, `onboarding_email`,
-//     `expert_scheduler`. Spanned by #2987 — identical rationale and wrap
-//     shape, no result attributes (each tick returns void, matching the 8
+//     `expert_scheduler`, `billing_reconcile`. Spanned by #2987 (+#3423
+//     for billing_reconcile) — identical rationale and wrap shape, no
+//     result attributes (each tick returns void, matching the 8
 //     attribute-less cleanup fibers).
 //
 // Two records, not one: "cleanup sweep" vs "background work" is a real
@@ -213,6 +214,7 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   settings_refresh: "atlas.scheduler.settings_refresh",
   onboarding_email: "atlas.scheduler.onboarding_email",
   expert_scheduler: "atlas.scheduler.expert_scheduler",
+  billing_reconcile: "atlas.scheduler.billing_reconcile",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1458,6 +1460,71 @@ export function makeSchedulerLive(
         log.info({ intervalMs: getExpertSchedulerIntervalMs() }, "Semantic expert scheduler started");
       } else {
         log.debug("Semantic expert scheduler not started — feature disabled");
+      }
+
+      // ── Periodic fiber: plan-tier reconciliation sweep (#3423) ──────
+      // Safety net under the Stripe webhook path: heals plan_tier drift
+      // from the plugin's subscription table and prunes the webhook
+      // event ledger. Only meaningful when Stripe billing is wired AND
+      // an internal DB holds the org/subscription tables.
+      const billingReconcileEnabled = yield* Effect.try({
+        try: () => {
+          if (!process.env.STRIPE_SECRET_KEY || !process.env.STRIPE_WEBHOOK_SECRET) {
+            return false;
+          }
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+            hasInternalDB: () => boolean;
+          };
+          return hasInternalDB();
+        },
+        catch: (err) => {
+          log.debug({ err: errorMessage(err) }, "Billing reconcile gate check failed — skipping");
+          return false;
+        },
+      }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+      if (billingReconcileEnabled) {
+        // 6h: drift heals well inside Stripe's ~3-week retry horizon
+        // without adding meaningful load (one org-table scan per pass).
+        // `Effect.repeat` runs the tick once at boot, then on the spacing
+        // — so a deploy also doubles as an immediate reconcile.
+        const BILLING_RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+        const reconcileTick = Effect.tryPromise({
+          try: async () => {
+            const { reconcilePlanTiers } = await import(
+              "@atlas/api/lib/billing/reconcile-plan-tiers"
+            );
+            await reconcilePlanTiers();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn(
+                { err: errorMessage(err) },
+                "Plan-tier reconciliation tick failed — will retry next interval",
+              );
+            }),
+          ),
+        );
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
+          withFiberDeathLog(
+            "billing_reconcile",
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.billing_reconcile, {}, reconcileTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(BILLING_RECONCILE_INTERVAL_MS))),
+            ),
+          ),
+        );
+        log.info(
+          { intervalMs: BILLING_RECONCILE_INTERVAL_MS },
+          "Plan-tier reconciliation sweep started",
+        );
+      } else {
+        log.debug(
+          "Plan-tier reconciliation sweep not started — Stripe billing or internal DB not configured",
+        );
       }
 
       // Start audit purge scheduler via the `AuditPurgeScheduler` Tag


### PR DESCRIPTION
Closes #3423. **Stacked on #3443** (`claude/3421-locked-tier`) — retarget to `main` after #3443 merges; only the last commit (919bf65) is this PR's diff until then.

## Problem

The @better-auth/stripe plugin try/catches every `onSubscription*` hook and ACKs 200 even when the hook throws (verified in plugin dist source). A transient internal-DB failure during the plan-tier write or CRM stamp was silently lost — Stripe never retried, and the workspace stayed on the wrong tier until someone noticed.

## What this does

**Move the must-not-be-lost sync into `onEvent`** — the only hook whose throws propagate (→ 400 `STRIPE_WEBHOOK_ERROR` → Stripe retries for ~3 weeks):
- `syncStripeEventToWorkspace` handles `checkout.session.completed` / `customer.subscription.created|updated|deleted` (plan-tier write + Twenty CRM conversion stamp). The `onSubscription*` hooks are now observability-only logs.
- The #3421 stale-deletion guard (another active/trialing sub for the org → skip the lock) moves into the `deleted` arm — the ledger can't catch that case since the two events concern *different* subscription ids.
- The `invoice.payment_failed` suspension branch stays best-effort (never throws; #3424 owns the delinquency ladder).

**Event ledger** (`stripe_webhook_events`, migration 0128 + drizzle mirror) with a deliberate **classify → process → record-LAST** protocol:
- replayed deliveries (same event id) → ACKed without side effects
- out-of-order older events for the same subscription → skipped instead of regressing the tier (last-*applied*-wins, not last-delivered)
- a crash before recording costs one extra idempotent re-run — the safe direction; recording first would make a failed sync unrecoverable (the retry would hit the dedup guard)

**Reconciliation sweep** (`reconcilePlanTiers`, new `billing_reconcile` scheduler fiber: 6h interval + boot tick, gated on `STRIPE_SECRET_KEY`+`STRIPE_WEBHOOK_SECRET`+internal DB): heals `plan_tier` drift from the plugin's own `subscription` table through the same write path (`updateWorkspacePlanTier` + plan-cache invalidation) — the safety net for events lost past Stripe's retry horizon (e.g. webhook secret rotation). Paid-tier orgs with **no** live subscription are **flagged, never auto-downgraded**: indistinguishable from an operator grant until the billing-override flag (#3427) exists. Also prunes the ledger past 30-day retention.

## Tests

- `stripe-webhook-lifecycle.test.ts` now runs the ledger protocol **for real** (stateful in-memory `stripe_webhook_events` sim behind the internalQuery mock): replay-dedup, stale-ordering (late older `updated` can't resurrect a locked org), and failed-sync → 400 + *not* recorded → redelivery succeeds. All prior #3416/#3421 coverage retained.
- New unit tests for the ledger (`classify`/`record`/`prune` contracts, no-internal-DB bypass, throw-on-failure) and the sweep (heal/flag asymmetry, normal-state exclusions).
- Real-Postgres migration smoke updated (0128, count 129).

## CI

Local gates: lint, type, **full** test suite (591/591 api files + all other packages), syncpack, template/security-headers/railway/schema/oauth-helper drift, test discipline, twenty-resolver, settings readers — all pass. `check-published-symbols` fails on the **inherited** `MIN_PLAN_TIERS` value import from #3442/#3443 (pending the `@useatlas/types` 0.1.18 publish-then-bump sequencing already documented there) — not introduced by this branch.

## Post-merge notes (maintainer)

- Same publish sequencing as #3442/#3443: publish `@useatlas/types` 0.1.18 + `@useatlas/schemas` 0.0.4, then bump refs.
- #3427 (billing-override flag) unblocks letting the sweep heal/lock paid-tier-no-sub orgs instead of just flagging.

https://claude.ai/code/session_01UxJHbiXemc9PRY1MX44i2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxJHbiXemc9PRY1MX44i2r)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783851520&installation_id=135337507&pr_number=3444&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3444&signature=c9388fe3b2f058c6bd1f24bdb5f3b36e586eb038a1aea982e5f2987ea5eade72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Delivery reliability" details to Stripe webhook handling docs.

* **New Features**
  * Durable webhook event ledger for idempotent, per-subscription ordering and retention.
  * Durable sync path to reconcile Stripe lifecycle events to workspace plan tiers.
  * Scheduled plan-tier reconciliation every 6 hours; safe behavior when internal DB is unavailable.

* **Tests**
  * Expanded unit/integration tests covering ledger semantics, webhook lifecycle, reconciliation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->