### PR TITLE
chore(api): swap MIN_PLAN_TIERS local tuple for the @useatlas/types value export

### DIFF
--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -27,7 +27,7 @@ import {
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { invokeOnUninstallHookForInstallRow } from "@atlas/api/lib/plugins/uninstall-hook";
 import { getConfig } from "@atlas/api/lib/config";
-import type { MinPlanTier, PlanTier } from "@useatlas/types";
+import { MIN_PLAN_TIERS, type PlanTier } from "@useatlas/types";
 import {
   isPlanEligible as planRankEligible,
   parsePlanTier,
@@ -48,20 +48,6 @@ const log = createLogger("admin-marketplace");
 
 const PLUGIN_TYPES = ["datasource", "context", "interaction", "action", "sandbox"] as const;
 type PluginType = (typeof PLUGIN_TYPES)[number];
-
-/**
- * Valid `min_plan` requirement values — every plan tier EXCEPT `locked`
- * (a churn state can never be a requirement; see plan-rank.ts).
- *
- * Local tuple rather than the `MIN_PLAN_TIERS` value export in
- * `@useatlas/types`: a braced VALUE import of a symbol that the pinned
- * published types version doesn't ship yet fails
- * `check-published-symbols` (publish-then-bump rule). The `satisfies`
- * ties it to the canonical `MinPlanTier` union (type-only imports are
- * exempt — they erase), so the two can't drift; swap to the value
- * import once types ≥0.1.18 is published and the refs are bumped.
- */
-const MIN_PLAN_TIERS = ["free", "trial", "starter", "pro", "business"] as const satisfies readonly MinPlanTier[];
 
 /**
  * Whether the workspace's tier admits installing a plugin requiring


### PR DESCRIPTION
## Summary
- `@useatlas/types` 0.1.18 (which ships the `MIN_PLAN_TIERS` value export) is now published, and all refs are `^0.1.0` so they resolve to it — the swap condition documented on the local tuple in `admin-marketplace.ts` is met
- Replaces the local tuple + workaround comment with the canonical value import; `check-published-symbols` passes (`@useatlas/types@^0.1.0 → 0.1.18 ok`)

Follow-up to the publish catch-up (types-v0.1.18, salesforce-v0.0.6, webhook-v0.0.8, elasticsearch-v0.0.4 rerun, railway-sandbox + obsidian-reader first publishes). Removes the workaround introduced with #3442.

## Test plan
- [x] `bun scripts/check-published-symbols.ts` green
- [x] `bun run type` green
- [x] `test-isolated.ts --affected` → admin-marketplace.test.ts passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783866640&installation_id=135337507&pr_number=3448&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3448&signature=27c75b92ab119c7931010afd2e0ef1c15b9be3f1ffc1ddbddc9c530b8abfb2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated plan tier validation configuration by centralizing the source of plan tier constants, improving code maintainability without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->