### PR TITLE
chore(ci): add obsidian-reader-v* publish train

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ on:
       - 'webhook-action-v*'
       # Plugins — context
       - 'yaml-context-v*'
+      - 'obsidian-reader-v*'
       # Community
       - 'obsidian-v*'
 
@@ -198,6 +199,10 @@ jobs:
       - name: Publish @useatlas/yaml-context
         if: startsWith(github.ref, 'refs/tags/yaml-context-v')
         run: cd plugins/yaml-context && npm publish --access public --provenance
+
+      - name: Publish @useatlas/obsidian-reader
+        if: startsWith(github.ref, 'refs/tags/obsidian-reader-v')
+        run: cd plugins/obsidian-reader && npm publish --access public --provenance
 
       # Community
       - name: Publish obsidian-atlas


### PR DESCRIPTION
## Summary
- `@useatlas/obsidian-reader` 0.0.1 was bootstrap-published manually today, but `publish.yml` had no `obsidian-reader-v*` trigger or step — the existing `obsidian-v*` train publishes `plugins/obsidian` (`obsidian-atlas`), a different package
- Adds the trigger + a publish step mirroring the other raw-TS plugin steps, grouped with the context plugins

No glob ambiguity: `obsidian-v*` doesn't match `obsidian-reader-v*` tags (literal-prefix match).

## Test plan
- [x] Step conditions verified against both tag shapes
- [ ] Post-merge: `obsidian-reader-v0.0.1` bookkeeping tag doubles as the trusted-publisher smoke test (expect publish-over-existing conflict, not E404 — same as the railway-sandbox test in run 27422618185)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783867182&installation_id=135337507&pr_number=3449&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3449&signature=a61e8cc0bd9a3014f1f76f8d8b657f34cd6f2fcc7a52c63eef0a8c242b09d9c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release workflow configuration for improved publishing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->