### PR TITLE
fix(billing): single enforcement seam in executeAgentQuery covers chat platforms and scheduler

### DIFF
--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -133,6 +133,14 @@ Trial workspaces have a separate check: if the trial has expired (14 days from c
 
 If workspace or plan data cannot be fetched, the request is **blocked** with HTTP 503 as a security precaution. If usage metering data specifically cannot be read (e.g., metering database is temporarily unavailable), the request is **allowed** with a warning that usage tracking may be inaccurate. Enforcement is best-effort for metering — Atlas prefers availability over strict enforcement.
 
+### Enforcement Surfaces
+
+Enforcement applies on **every** path that runs the Atlas agent — not just web chat and the API:
+
+- **Web chat and `POST /api/v1/query`** — blocked requests return the HTTP error envelope above (403/429/503 with an upgrade or retry CTA). The 80–109% warning band is attached to successful responses as `planWarning`.
+- **Chat platforms** (Slack, Discord, Telegram, Teams, Google Chat, WhatsApp) — a blocked workspace receives an **in-thread reply** explaining why the request was refused (e.g. "Your free trial has expired. Upgrade to a paid plan to continue using Atlas."), the same way rate-limit refusals are delivered. Requests are never silently dropped. The 80–109% warning band does **not** post warnings into chat threads — it's visible on the billing dashboard and in successful web/API responses instead.
+- **Scheduled tasks** — a blocked run is recorded as **failed in the task's run history** with the billing reason (e.g. `Blocked by billing enforcement [trial_expired]: …`), visible to the task owner. Runs resume automatically on the next schedule once the workspace is back in good standing — tasks are not auto-paused.
+
 ---
 
 ## Customer Portal

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -1557,6 +1557,55 @@
                           "denyUrl"
                         ]
                       }
+                    },
+                    "planWarning": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "plan_limit_warning"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "metrics": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              },
+                              "currentUsage": {
+                                "type": "number"
+                              },
+                              "limit": {
+                                "type": "number"
+                              },
+                              "usagePercent": {
+                                "type": "number"
+                              },
+                              "status": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metric",
+                              "currentUsage",
+                              "limit",
+                              "usagePercent",
+                              "status"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "metrics"
+                      ]
                     }
                   },
                   "required": [

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -1636,7 +1636,28 @@ describe("POST /api/v1/chat", () => {
       return frames;
     }
 
+    // #3451 — the warning now arrives via the shared billing gate
+    // (checkAgentBillingGate), which only consults checkPlanLimits when
+    // the request carries an org. Bind one so the warning path is
+    // reachable (the pre-gate route called the mocked checkPlanLimits
+    // unconditionally, which masked the no-org short-circuit).
+    function bindPlanWarningOrg(): void {
+      mockAuthenticateRequest.mockResolvedValue({
+        authenticated: true as const,
+        mode: "managed" as const,
+        user: {
+          id: "user-plan-warning",
+          mode: "managed" as const,
+          label: "plan-warning@useatlas.dev",
+          role: "admin",
+          activeOrganizationId: "org-plan-warning",
+          claims: { twoFactorEnabled: true },
+        },
+      });
+    }
+
     it("folds checkPlanLimits warning into the data-context-warning channel", async () => {
+      bindPlanWarningOrg();
       mockCheckPlanLimits.mockResolvedValueOnce({
         allowed: true,
         warning: {
@@ -1659,6 +1680,7 @@ describe("POST /api/v1/chat", () => {
     });
 
     it("plan_limit_warning frame is unshifted ahead of preflight degradations", async () => {
+      bindPlanWarningOrg();
       mockCheckPlanLimits.mockResolvedValueOnce({
         allowed: true,
         warning: {
@@ -1687,6 +1709,7 @@ describe("POST /api/v1/chat", () => {
     });
 
     it("never emits a legacy data-plan-warning frame even when a plan warning is present", async () => {
+      bindPlanWarningOrg();
       mockCheckPlanLimits.mockResolvedValueOnce({
         allowed: true,
         warning: {
@@ -1704,6 +1727,7 @@ describe("POST /api/v1/chat", () => {
     });
 
     it("never sets the legacy x-plan-limit-warning response header", async () => {
+      bindPlanWarningOrg();
       mockCheckPlanLimits.mockResolvedValueOnce({
         allowed: true,
         warning: {
@@ -1714,6 +1738,24 @@ describe("POST /api/v1/chat", () => {
       });
       const response = await app.fetch(makeRequest());
       expect(response.headers.get("x-plan-limit-warning")).toBeNull();
+    });
+
+    it("#3451 — a plan-limit block from the billing gate returns the chat error envelope (no stream)", async () => {
+      bindPlanWarningOrg();
+      mockCheckPlanLimits.mockResolvedValueOnce({
+        allowed: false,
+        errorCode: "trial_expired",
+        errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+        httpStatus: 403,
+      });
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("trial_expired");
+      expect(body.message).toContain("trial has expired");
+      expect(body.retryable).toBe(false);
+      expect(typeof body.requestId).toBe("string");
+      expect(mockRunAgent).not.toHaveBeenCalled();
     });
 
     it("emits no plan_limit_warning frame when checkPlanLimits returns no warning", async () => {

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -164,6 +164,53 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
+// #3419/#3420 — the billing seam lives inside `executeAgentQuery`; the
+// route's job is mapping `BillingBlockedError` to the HTTP envelope.
+// Mock the gate module so tests control the verdict; the stub error
+// class mirrors the real one (the route narrows via `instanceof`).
+class BillingBlockedErrorStub extends Error {
+  override readonly name = "BillingBlockedError";
+  readonly errorCode: string;
+  readonly httpStatus: number;
+  readonly retryable: boolean;
+  readonly retryAfterSeconds: number | undefined;
+  readonly usage: { currentUsage: number; limit: number; metric: string } | undefined;
+  constructor(block: {
+    errorCode: string;
+    errorMessage: string;
+    httpStatus: number;
+    retryable: boolean;
+    retryAfterSeconds?: number;
+    usage?: { currentUsage: number; limit: number; metric: string };
+  }) {
+    super(block.errorMessage);
+    this.errorCode = block.errorCode;
+    this.httpStatus = block.httpStatus;
+    this.retryable = block.retryable;
+    this.retryAfterSeconds = block.retryAfterSeconds;
+    this.usage = block.usage;
+  }
+}
+
+type BillingGateVerdict =
+  | { allowed: true; warning?: { code: "plan_limit_warning"; message: string; metrics: unknown[] } }
+  | {
+      allowed: false;
+      errorCode: string;
+      errorMessage: string;
+      httpStatus: number;
+      retryable: boolean;
+      retryAfterSeconds?: number;
+      usage?: { currentUsage: number; limit: number; metric: string };
+    };
+let billingGateVerdict: BillingGateVerdict = { allowed: true };
+const mockCheckAgentBillingGate = mock(async (_orgId: string | undefined) => billingGateVerdict);
+
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: BillingBlockedErrorStub,
+}));
+
 // Import after mocks are registered
 const { app } = await import("../index");
 
@@ -206,6 +253,8 @@ describe("POST /api/v1/query", () => {
     mockAddMessageQuery.mockReset();
     mockGetConversationQuery.mockReset();
     mockGetConversationQuery.mockResolvedValue({ ok: false, reason: "not_found" });
+    billingGateVerdict = { allowed: true };
+    mockCheckAgentBillingGate.mockClear();
   });
 
   afterEach(() => {
@@ -227,6 +276,75 @@ describe("POST /api/v1/query", () => {
     expect(body.data).toEqual([{ columns: ["count"], rows: [{ count: 42 }] }]);
     expect(body.steps).toBe(1);
     expect(body.usage).toEqual({ totalTokens: 150 });
+  });
+
+  // ── #3419/#3420: billing blocks from the seam map to the HTTP envelope ──
+
+  it("maps a trial_expired billing block to a 403 envelope with requestId", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+      httpStatus: 403,
+      retryable: false,
+    };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("trial_expired");
+    expect(body.message).toContain("trial has expired");
+    expect(body.retryable).toBe(false);
+    expect(typeof body.requestId).toBe("string");
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  it("maps an abuse-throttle billing block to 429 with a Retry-After header", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "workspace_throttled",
+      errorMessage: "Workspace is temporarily throttled due to high usage. Please retry shortly.",
+      httpStatus: 429,
+      retryable: true,
+      retryAfterSeconds: 5,
+    };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("5");
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("workspace_throttled");
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfterSeconds).toBe(5);
+  });
+
+  it("maps a hard-cap billing block to 429 with usage details", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "plan_limit_exceeded",
+      errorMessage: "You have exceeded your plan's token budget.",
+      httpStatus: 429,
+      retryable: false,
+      usage: { currentUsage: 2_300_000, limit: 2_000_000, metric: "tokens" },
+    };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(429);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("plan_limit_exceeded");
+    expect(body.usage).toEqual({ currentUsage: 2_300_000, limit: 2_000_000, metric: "tokens" });
+  });
+
+  it("attaches the 80–109% planWarning to a successful response without blocking", async () => {
+    billingGateVerdict = {
+      allowed: true,
+      warning: {
+        code: "plan_limit_warning",
+        message: "You are approaching your plan's token budget",
+        metrics: [],
+      },
+    };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect((body.planWarning as Record<string, unknown>).code).toBe("plan_limit_warning");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -15,7 +15,7 @@ import { withRequestId, resolveMode, type AuthEnv } from "./middleware";
 import { z } from "zod";
 import { type UIMessage, createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
-import { matchError, isRetryableError, isChatErrorCode, type ChatContextWarning } from "@useatlas/types";
+import { matchError, isRetryableError, type ChatContextWarning } from "@useatlas/types";
 import { runAgent } from "@atlas/api/lib/agent";
 import { corsResponseHeaders } from "@atlas/api/lib/cors";
 import { validateEnvironment } from "@atlas/api/lib/startup";
@@ -29,9 +29,7 @@ import {
 } from "@atlas/api/lib/auth/middleware";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { markOrgActive } from "@atlas/api/lib/db/org-activity";
-import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
-import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
-import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
+import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
 import {
   createConversation,
   verifyGroupBelongsToOrg,
@@ -605,13 +603,35 @@ chat.openapi(chatRoute, async (c) => {
       }
     }
   
-    // Workspace status check — block suspended/deleted workspaces
-    const wsCheck = yield* Effect.promise(() => checkWorkspaceStatus(authResult.user?.activeOrganizationId));
-    if (!wsCheck.allowed) {
-      return c.json(
-        { error: wsCheck.errorCode, message: wsCheck.errorMessage, retryable: wsCheck.errorCode && isChatErrorCode(wsCheck.errorCode) ? isRetryableError(wsCheck.errorCode) : false, requestId },
-        wsCheck.httpStatus ?? 403,
+    // #3451 — workspace status, abuse, and plan-limit enforcement via the
+    // shared billing gate (lib/billing/agent-gate.ts): the same composition
+    // the `executeAgentQuery` seam runs for /query, chat platforms, and the
+    // scheduler, so web chat can never drift from those surfaces. This
+    // route streams via `runAgent` directly and never reaches the seam, so
+    // it calls the gate here and maps the block to the chat error envelope.
+    // The 80–109% warning arrives on the allowed arm and is folded into the
+    // `data-context-warning` stream at the writer below.
+    const gateCheck = yield* Effect.promise(() => checkAgentBillingGate(authResult.user?.activeOrganizationId));
+    if (!gateCheck.allowed) {
+      log.warn(
+        { requestId, orgId: authResult.user?.activeOrganizationId, errorCode: gateCheck.errorCode },
+        "Chat blocked by billing enforcement",
       );
+      const blockBody = {
+        error: gateCheck.errorCode,
+        message: gateCheck.errorMessage,
+        retryable: gateCheck.retryable,
+        requestId,
+        ...(gateCheck.retryAfterSeconds !== undefined && { retryAfterSeconds: gateCheck.retryAfterSeconds }),
+        ...(gateCheck.usage && { usage: gateCheck.usage }),
+      };
+      if (gateCheck.retryAfterSeconds !== undefined) {
+        return c.json(blockBody, {
+          status: gateCheck.httpStatus,
+          headers: { "Retry-After": String(gateCheck.retryAfterSeconds) },
+        });
+      }
+      return c.json(blockBody, gateCheck.httpStatus);
     }
 
     // #2377 — stamp workspace activity now that the org is authenticated and
@@ -651,51 +671,9 @@ chat.openapi(chatRoute, async (c) => {
       }
     }
 
-    // Abuse check — block suspended workspaces, reject throttled ones with 429
-    const abuseOrgId = authResult.user?.activeOrganizationId;
-    if (abuseOrgId) {
-      const abuse = checkAbuseStatus(abuseOrgId);
-      if (abuse.level === "suspended") {
-        log.warn({ requestId, orgId: abuseOrgId }, "Workspace suspended due to abuse");
-        return c.json(
-          { error: "workspace_suspended", message: "Workspace suspended due to unusual activity. Contact your administrator.", retryable: false, requestId },
-          403,
-        );
-      }
-      if (abuse.level === "throttled" && abuse.throttleDelayMs) {
-        const retryAfterSeconds = Math.ceil(abuse.throttleDelayMs / 1000);
-        log.warn({ requestId, orgId: abuseOrgId, delayMs: abuse.throttleDelayMs }, "Workspace throttled due to abuse");
-        return c.json(
-          {
-            error: "workspace_throttled",
-            message: "Workspace is temporarily throttled due to high usage. Please retry shortly.",
-            retryable: true,
-            retryAfterSeconds,
-            requestId,
-          },
-          { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } },
-        );
-      }
-    }
-  
-    // Plan limit check — block or warn when usage approaches/exceeds plan limits
-    const planCheck = yield* Effect.promise(() => checkPlanLimits(authResult.user?.activeOrganizationId));
-    if (!planCheck.allowed) {
-      return c.json(
-        {
-          error: planCheck.errorCode,
-          message: planCheck.errorMessage,
-          retryable: isChatErrorCode(planCheck.errorCode) ? isRetryableError(planCheck.errorCode) : false,
-          requestId,
-          ...(planCheck.errorCode === "plan_limit_exceeded" && { usage: planCheck.usage }),
-        },
-        planCheck.httpStatus,
-      );
-    }
-  
-    // Captured here; folded into the unified `data-context-warning`
-    // stream at the writer below.
-    const planWarning = planCheck.allowed ? planCheck.warning : undefined;
+    // Captured from the billing gate above; folded into the unified
+    // `data-context-warning` stream at the writer below.
+    const planWarning = gateCheck.warning;
   
     // Resolve atlas mode for this request (published vs developer)
     const atlasMode = resolveMode(

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -19,14 +19,11 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
-import { isRetryableError, isChatErrorCode } from "@useatlas/types";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
+import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
-import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
-import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
-import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import {
   createConversation,
   addMessage,
@@ -203,70 +200,14 @@ query.openapi(
         { requestId, user: authResult.user, approvalSurface: "chat" },
         async () => {
 
-        // Workspace status check — block suspended/deleted workspaces
-        const wsCheck = await checkWorkspaceStatus(authResult.user?.activeOrganizationId);
-        if (!wsCheck.allowed) {
-          const wsError = wsCheck.errorCode ?? "workspace_error";
-          const wsMessage = wsCheck.errorMessage ?? "Workspace access denied.";
-          const wsStatus = wsCheck.httpStatus ?? 403;
-          throw new HTTPException(wsStatus as 403, {
-            res: Response.json(
-              { error: wsError, message: wsMessage, retryable: isChatErrorCode(wsError) ? isRetryableError(wsError) : false, requestId },
-              { status: wsStatus },
-            ),
-          });
-        }
-    
-        // Abuse check — block suspended workspaces, reject throttled ones with 429
-        const abuseOrgId = authResult.user?.activeOrganizationId;
-        if (abuseOrgId) {
-          const abuse = checkAbuseStatus(abuseOrgId);
-          if (abuse.level === "suspended") {
-            log.warn({ requestId, orgId: abuseOrgId }, "Workspace suspended due to abuse");
-            throw new HTTPException(403, {
-              res: Response.json(
-                { error: "workspace_suspended", message: "Workspace suspended due to unusual activity. Contact your administrator.", retryable: false, requestId },
-                { status: 403 },
-              ),
-            });
-          }
-          if (abuse.level === "throttled" && abuse.throttleDelayMs) {
-            const retryAfterSeconds = Math.ceil(abuse.throttleDelayMs / 1000);
-            log.warn({ requestId, orgId: abuseOrgId, delayMs: abuse.throttleDelayMs }, "Workspace throttled due to abuse");
-            throw new HTTPException(429, {
-              // Use raw Response (not Response.json) to include Retry-After header
-              res: new Response(
-                JSON.stringify({
-                  error: "workspace_throttled",
-                  message: "Workspace is temporarily throttled due to high usage. Please retry shortly.",
-                  retryable: true,
-                  retryAfterSeconds,
-                  requestId,
-                }),
-                { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(retryAfterSeconds) } },
-              ),
-            });
-          }
-        }
-    
-        // Plan limit check — block or warn when usage approaches/exceeds plan limits
-        const planCheck = await checkPlanLimits(authResult.user?.activeOrganizationId);
-        if (!planCheck.allowed) {
-          return c.json(
-            {
-              error: planCheck.errorCode,
-              message: planCheck.errorMessage,
-              retryable: isChatErrorCode(planCheck.errorCode) ? isRetryableError(planCheck.errorCode) : false,
-              requestId,
-              ...(planCheck.errorCode === "plan_limit_exceeded" && { usage: planCheck.usage }),
-            },
-            planCheck.httpStatus,
-          );
-        }
-    
-        // Capture plan warning for JSON response
-        const planWarning = planCheck.allowed ? planCheck.warning : undefined;
-    
+        // #3419/#3420 — workspace status, abuse, and plan-limit
+        // enforcement converged onto the shared seam inside
+        // `executeAgentQuery` (lib/billing/agent-gate.ts), so this route
+        // can't drift from the chat-platform and scheduler surfaces. A
+        // block surfaces as `BillingBlockedError` and is mapped to the
+        // HTTP envelope in the catch below; the 80–109% warning band
+        // arrives on `queryResult.planWarning`.
+
         // --- Startup diagnostics ---
         const diagnostics = await validateEnvironment();
         if (diagnostics.length > 0) {
@@ -347,15 +288,50 @@ query.openapi(
             }));
           }
     
+          // `restResult` carries `planWarning` (the 80–109% band) when
+          // the billing gate attached one — no separate plumbing needed.
           return c.json({
             ...restResult,
             ...(conversationId && { conversationId }),
             ...(enrichedPendingActions && { pendingActions: enrichedPendingActions }),
-            ...(planWarning && { planWarning }),
           }, 200);
         } catch (err) {
           if (err instanceof HTTPException) throw err;
-    
+
+          // #3419/#3420 — billing-enforcement block from the seam in
+          // `executeAgentQuery`. Map to the same envelope the inline
+          // checks used to produce, including Retry-After on throttles.
+          if (err instanceof BillingBlockedError) {
+            log.warn(
+              { requestId, errorCode: err.errorCode, category: "billing_blocked" },
+              "Query blocked by billing enforcement",
+            );
+            const body = {
+              error: err.errorCode,
+              message: err.message,
+              retryable: err.retryable,
+              requestId,
+              ...(err.retryAfterSeconds !== undefined && { retryAfterSeconds: err.retryAfterSeconds }),
+              ...(err.usage && { usage: err.usage }),
+            };
+            // HTTPException with an embedded Response (rather than
+            // c.json) because the block statuses aren't part of the
+            // OpenAPI route's typed responses — same pattern the
+            // pre-seam inline checks used, and the only way to attach
+            // a Retry-After header on the throttle arm.
+            throw new HTTPException(err.httpStatus as 403, {
+              res: new Response(JSON.stringify(body), {
+                status: err.httpStatus,
+                headers: {
+                  "Content-Type": "application/json",
+                  ...(err.retryAfterSeconds !== undefined
+                    ? { "Retry-After": String(err.retryAfterSeconds) }
+                    : {}),
+                },
+              }),
+            });
+          }
+
           const message = err instanceof Error ? err.message : "";
     
           // --- Structured AI SDK error types ---

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -67,6 +67,24 @@ export const QueryResponseSchema = z.object({
       }),
     )
     .optional(),
+  // #3452 — the 80–109% plan-usage warning band attached by the billing
+  // gate (see lib/billing/agent-gate.ts). Mirrors PlanLimitWarning /
+  // PlanLimitStatus from @useatlas/types.
+  planWarning: z
+    .object({
+      code: z.literal("plan_limit_warning"),
+      message: z.string(),
+      metrics: z.array(
+        z.object({
+          metric: z.string(),
+          currentUsage: z.number(),
+          limit: z.number(),
+          usagePercent: z.number(),
+          status: z.string(),
+        }),
+      ),
+    })
+    .optional(),
 });
 
 

--- a/packages/api/src/lib/__tests__/agent-query-billing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-billing.test.ts
@@ -98,12 +98,16 @@ describe("executeAgentQuery billing seam", () => {
     const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
       activeOrganizationId: "org-expired",
     });
-    const promise = executeAgentQuery("question", "req-2", { actor });
-    await expect(promise).rejects.toBeInstanceOf(BillingBlockedErrorStub);
-    await promise.catch((err: unknown) => {
-      expect((err as Error).message).toContain("trial has expired");
-      expect((err as BillingBlockedErrorStub).errorCode).toBe("trial_expired");
-    });
+    const err: unknown = await executeAgentQuery("question", "req-2", { actor }).then(
+      () => {
+        throw new Error("expected executeAgentQuery to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(BillingBlockedErrorStub);
+    if (!(err instanceof BillingBlockedErrorStub)) throw new Error("unreachable");
+    expect(err.message).toContain("trial has expired");
+    expect(err.errorCode).toBe("trial_expired");
     expect(mockRunAgent).not.toHaveBeenCalled();
   });
 

--- a/packages/api/src/lib/__tests__/agent-query-billing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-billing.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the billing-enforcement seam in `executeAgentQuery`
+ * (#3419 / #3420).
+ *
+ * Pins the seam contract:
+ *  - The gate is consulted with the bound actor's org BEFORE the agent
+ *    runs — a blocked workspace produces ZERO LLM spend.
+ *  - A block surfaces as `BillingBlockedError` whose `message` is the
+ *    user-safe text (chat platforms deliver it verbatim; the scheduler
+ *    records it on the run row).
+ *  - The 80–109% warning band never blocks; it lands on
+ *    `result.planWarning` for surfaces that render it.
+ *  - Runs with no org (self-hosted, CLI tooling) pass through.
+ *
+ * The gate's own composition logic is covered in
+ * `billing/__tests__/agent-gate.test.ts`; here it is mocked at the
+ * module boundary.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockRunAgent = mock(async () => ({
+  text: Promise.resolve("answer"),
+  steps: Promise.resolve([]),
+  totalUsage: Promise.resolve({ inputTokens: 10, outputTokens: 5 }),
+}));
+
+mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: mockRunAgent,
+}));
+
+// Faithful stand-in for the real class — `executeAgentQuery` constructs
+// it from the gate's block result, and callers narrow via `instanceof`.
+class BillingBlockedErrorStub extends Error {
+  override readonly name = "BillingBlockedError";
+  readonly errorCode: string;
+  readonly httpStatus: number;
+  readonly retryable: boolean;
+  readonly retryAfterSeconds: number | undefined;
+  readonly usage: { currentUsage: number; limit: number; metric: string } | undefined;
+  constructor(block: {
+    errorCode: string;
+    errorMessage: string;
+    httpStatus: number;
+    retryable: boolean;
+    retryAfterSeconds?: number;
+    usage?: { currentUsage: number; limit: number; metric: string };
+  }) {
+    super(block.errorMessage);
+    this.errorCode = block.errorCode;
+    this.httpStatus = block.httpStatus;
+    this.retryable = block.retryable;
+    this.retryAfterSeconds = block.retryAfterSeconds;
+    this.usage = block.usage;
+  }
+}
+
+type GateResult =
+  | { allowed: true; warning?: { code: "plan_limit_warning"; message: string; metrics: unknown[] } }
+  | { allowed: false; errorCode: string; errorMessage: string; httpStatus: number; retryable: boolean };
+let gateResult: GateResult = { allowed: true };
+const mockCheckAgentBillingGate = mock(async (_orgId: string | undefined) => gateResult);
+
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: BillingBlockedErrorStub,
+}));
+
+const { executeAgentQuery } = await import("@atlas/api/lib/agent-query");
+const { withRequestContext } = await import("@atlas/api/lib/logger");
+const { createAtlasUser } = await import("@atlas/api/lib/auth/types");
+
+describe("executeAgentQuery billing seam", () => {
+  beforeEach(() => {
+    gateResult = { allowed: true };
+    mockRunAgent.mockClear();
+    mockCheckAgentBillingGate.mockClear();
+  });
+
+  it("consults the gate with the actor's org before running the agent", async () => {
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-1",
+    });
+    await executeAgentQuery("how many customers?", "req-1", { actor });
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledTimes(1);
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org-1");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws BillingBlockedError and never runs the agent when blocked", async () => {
+    gateResult = {
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+      httpStatus: 403,
+      retryable: false,
+    };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-expired",
+    });
+    const promise = executeAgentQuery("question", "req-2", { actor });
+    await expect(promise).rejects.toBeInstanceOf(BillingBlockedErrorStub);
+    await promise.catch((err: unknown) => {
+      expect((err as Error).message).toContain("trial has expired");
+      expect((err as BillingBlockedErrorStub).errorCode).toBe("trial_expired");
+    });
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  it("uses the inherited RequestContext user's org when no actor is passed", async () => {
+    const user = createAtlasUser("user-parent", "managed", "user-parent@example.com", {
+      activeOrganizationId: "org-parent",
+    });
+    await withRequestContext({ requestId: "outer", user }, async () => {
+      await executeAgentQuery("question", "req-3");
+    });
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org-parent");
+  });
+
+  it("passes the gate undefined when no actor or inherited user exists (self-hosted/CLI)", async () => {
+    await executeAgentQuery("question", "req-4");
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith(undefined);
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the 80–109% warning band as planWarning without blocking", async () => {
+    gateResult = {
+      allowed: true,
+      warning: {
+        code: "plan_limit_warning",
+        message: "You are approaching your plan's token budget",
+        metrics: [],
+      },
+    };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-warn",
+    });
+    const result = await executeAgentQuery("question", "req-5", { actor });
+    expect(result.planWarning?.code).toBe("plan_limit_warning");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits planWarning when the gate allows cleanly", async () => {
+    const result = await executeAgentQuery("question", "req-6");
+    expect(result.planWarning).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -8,6 +8,8 @@
 
 import { runAgent } from "@atlas/api/lib/agent";
 import { createLogger, getRequestContext, withRequestContext } from "@atlas/api/lib/logger";
+import { checkAgentBillingGate, BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
+import type { PlanLimitWarning } from "@atlas/api/lib/billing/enforcement";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import type { ApprovalRequestSurface } from "@useatlas/types";
 
@@ -50,6 +52,15 @@ export interface AgentQueryResult {
    * F-54 / F-55 closed the regression where this was silently bypassed.
    */
   pendingApproval?: PendingApproval;
+  /**
+   * #3419/#3420 — the 80–109% plan-usage warning band from the billing
+   * gate. Never blocks the run. Surfaces that render usage warnings
+   * (the `/api/v1/query` JSON envelope) attach it to their response;
+   * machine-initiated surfaces (chat platforms, scheduler) deliberately
+   * leave it unrendered — the band is logged by `billing/enforcement.ts`
+   * and visible in the admin billing page.
+   */
+  planWarning?: PlanLimitWarning;
 }
 
 export interface ExecuteAgentQueryOptions {
@@ -99,6 +110,15 @@ export interface ExecuteAgentQueryOptions {
  *
  * Creates a UIMessage from the question, invokes the agent loop, and
  * extracts SQL queries, data, and the final answer from tool results.
+ *
+ * **Billing enforcement seam (#3419/#3420):** before the agent runs,
+ * the bound actor's workspace is checked against
+ * {@link checkAgentBillingGate} (workspace status → abuse status →
+ * plan limits). A blocked workspace throws {@link BillingBlockedError}
+ * — whose `message` is user-safe — with ZERO LLM spend. Putting the
+ * gate here (rather than per-callsite) means every current and future
+ * caller is covered by construction. Self-hosted deployments and runs
+ * without an org pass through untouched.
  */
 export async function executeAgentQuery(
   question: string,
@@ -135,6 +155,26 @@ export async function executeAgentQuery(
       ...(connectionGroupId ? { connectionGroupId } : {}),
     },
     async () => {
+    // #3419/#3420 — the single billing-enforcement seam for agent runs.
+    // Blocks before any tool registry / LLM work so a suspended,
+    // trial-expired, hard-capped, or abuse-flagged workspace consumes
+    // zero platform-paid tokens regardless of which surface called.
+    const gateOrgId = boundUser?.activeOrganizationId;
+    const gate = await checkAgentBillingGate(gateOrgId);
+    if (!gate.allowed) {
+      log.warn(
+        {
+          requestId: id,
+          orgId: gateOrgId,
+          errorCode: gate.errorCode,
+          httpStatus: gate.httpStatus,
+          ...(surface ? { surface } : {}),
+        },
+        "Agent run blocked by billing enforcement",
+      );
+      throw new BillingBlockedError(gate);
+    }
+
     const priorUIMessages = (options?.priorMessages ?? []).map((m, i) => ({
       id: `${id}-prior-${i}`,
       role: m.role as "user" | "assistant",
@@ -284,6 +324,7 @@ export async function executeAgentQuery(
       },
       ...(pendingActions.length > 0 && { pendingActions }),
       ...(pendingApproval ? { pendingApproval } : {}),
+      ...(gate.warning ? { planWarning: gate.warning } : {}),
     };
   });
 }

--- a/packages/api/src/lib/billing/__tests__/agent-gate.self-hosted.test.ts
+++ b/packages/api/src/lib/billing/__tests__/agent-gate.self-hosted.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Self-hosted passthrough test for the agent billing gate (#3419/#3420
+ * acceptance criterion: "Self-hosted mode (no billing) is a no-op
+ * passthrough").
+ *
+ * Unlike `agent-gate.test.ts` (which mocks the three underlying checks
+ * to pin the gate's composition), this file runs the REAL
+ * `checkWorkspaceStatus` / `checkAbuseStatus` / `checkPlanLimits`
+ * against a self-hosted environment: no internal DB
+ * (`hasInternalDB() === false`) and no `ATLAS_DEPLOY_MODE=saas`. Every
+ * check must short-circuit to allowed — even with an orgId bound — so
+ * chat-platform and scheduler runs on self-hosted deployments are
+ * never gated.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+// Self-hosted: no internal DB. Stub list mirrors `lib/__tests__/workspace.test.ts`.
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => false,
+  getWorkspaceStatus: async () => null,
+  getWorkspaceDetails: async () => null,
+  internalQuery: async () => [],
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+  closeInternalDB: async () => {},
+  migrateInternalDB: async () => {},
+  loadSavedConnections: async () => 0,
+  _resetPool: () => {},
+  _resetCircuitBreaker: () => {},
+  encryptSecret: (url: string) => url,
+  decryptSecret: (url: string) => url,
+  getEncryptionKey: () => null,
+  isPlaintextUrl: (v: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(v),
+  _resetEncryptionKeyCache: () => {},
+  findPatternBySQL: async () => null,
+  insertLearnedPattern: () => {},
+  incrementPatternCount: () => {},
+  getApprovedPatterns: async () => [],
+  upsertSuggestion: async () => "created" as const,
+  getSuggestionsByTables: async () => [],
+  getPopularSuggestions: async () => [],
+  incrementSuggestionClick: () => {},
+  deleteSuggestion: async () => false,
+  getAuditLogQueries: async () => [],
+  updateWorkspaceStatus: async () => true,
+  updateWorkspacePlanTier: async () => true,
+  cascadeWorkspaceDelete: async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 }),
+  getWorkspaceHealthSummary: async () => null,
+  getWorkspaceRegion: async () => null,
+  setWorkspaceRegion: async () => {},
+  insertSemanticAmendment: async () => "mock-amendment-id",
+  getPendingAmendmentCount: async () => 0,
+}));
+
+const { checkAgentBillingGate } = await import("@atlas/api/lib/billing/agent-gate");
+
+describe("checkAgentBillingGate — self-hosted (no internal DB, non-SaaS)", () => {
+  it("is a no-op passthrough even when an orgId is bound", async () => {
+    const result = await checkAgentBillingGate("org-self-hosted");
+    expect(result.allowed).toBe(true);
+    if (!result.allowed) throw new Error("expected allow");
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("is a no-op passthrough when no orgId is bound (CLI tooling, anonymous)", async () => {
+    const result = await checkAgentBillingGate(undefined);
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/agent-gate.self-hosted.test.ts
+++ b/packages/api/src/lib/billing/__tests__/agent-gate.self-hosted.test.ts
@@ -15,6 +15,11 @@
 
 import { describe, it, expect, mock } from "bun:test";
 
+// Pin a non-SaaS deploy mode BEFORE the gate module graph loads, so the
+// abuse check's isSaasDeployment() read can't be flipped by external CI
+// env state. `??=` hoist per docs/development/testing.md (never `=`).
+process.env.ATLAS_DEPLOY_MODE ??= "self-hosted";
+
 // Self-hosted: no internal DB. Stub list mirrors `lib/__tests__/workspace.test.ts`.
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => false,

--- a/packages/api/src/lib/billing/__tests__/agent-gate.test.ts
+++ b/packages/api/src/lib/billing/__tests__/agent-gate.test.ts
@@ -168,6 +168,15 @@ describe("checkAgentBillingGate", () => {
     expect(result.retryAfterSeconds).toBe(5);
   });
 
+  it("blocks a throttled workspace even when throttleDelayMs is missing (fail-closed, 1s floor)", async () => {
+    abuseVerdict = { level: "throttled" };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_throttled");
+    expect(result.retryAfterSeconds).toBe(1);
+  });
+
   it("blocks a trial-expired workspace with 403 trial_expired", async () => {
     planVerdict = {
       allowed: false,

--- a/packages/api/src/lib/billing/__tests__/agent-gate.test.ts
+++ b/packages/api/src/lib/billing/__tests__/agent-gate.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the shared agent billing gate (#3419 / #3420).
+ *
+ * `checkAgentBillingGate` is the single enforcement seam consulted by
+ * `executeAgentQuery` before any LLM spend. It composes the three
+ * existing checks — `checkWorkspaceStatus`, `checkAbuseStatus`,
+ * `checkPlanLimits` — in that order, short-circuiting on the first
+ * block. These tests pin the composition contract (which check wins,
+ * what envelope fields each block carries), not the internals of the
+ * underlying checks — those have their own suites
+ * (`workspace.test.ts`, `abuse.test.ts`, `enforcement.test.ts`).
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// --- Controllable verdicts for the three underlying checks ---
+
+type WorkspaceVerdict = {
+  allowed: boolean;
+  status?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  httpStatus?: 403 | 404 | 503;
+};
+let workspaceVerdict: WorkspaceVerdict = { allowed: true };
+const mockCheckWorkspaceStatus = mock(async (_orgId: string | undefined) => workspaceVerdict);
+
+let abuseVerdict: { level: string; throttleDelayMs?: number } = { level: "none" };
+const mockCheckAbuseStatus = mock((_workspaceId: string) => abuseVerdict);
+
+type PlanVerdict =
+  | { allowed: true; warning?: { code: "plan_limit_warning"; message: string; metrics: unknown[] } }
+  | { allowed: false; errorCode: string; errorMessage: string; httpStatus: 403 | 429 | 503; usage?: { currentUsage: number; limit: number; metric: string } };
+let planVerdict: PlanVerdict = { allowed: true };
+const mockCheckPlanLimits = mock(async (_orgId: string | undefined) => planVerdict);
+
+mock.module("@atlas/api/lib/workspace", () => ({
+  checkWorkspaceStatus: mockCheckWorkspaceStatus,
+}));
+
+mock.module("@atlas/api/lib/security/abuse", () => ({
+  checkAbuseStatus: mockCheckAbuseStatus,
+  // Unused by the gate but mock.module replaces the whole module —
+  // stub every value export so unrelated importers in the graph load.
+  ABUSE_RESTORE_STATUSES: ["pending", "complete", "failed", "skipped"],
+  getAbuseConfig: mock(() => ({ throttleDelayMs: 5000 })),
+  getAbuseRestoreStatus: mock(() => "complete"),
+  _resetAbuseState: mock(() => {}),
+  recordQueryEvent: mock(() => {}),
+  listFlaggedWorkspaces: mock(() => []),
+  getAbuseDetail: mock(async () => null),
+  reinstateWorkspace: mock(() => false),
+  getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+  restoreAbuseState: mock(async () => {}),
+  ABUSE_CLEANUP_INTERVAL_MS: 300_000,
+  abuseCleanupTick: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkPlanLimits: mockCheckPlanLimits,
+  // Unused by the gate — stubbed for module-graph completeness.
+  getCachedWorkspace: mock(async () => null),
+  invalidatePlanCache: mock(() => {}),
+  buildMetricStatus: mock(() => ({ metric: "tokens", currentUsage: 0, limit: 1, usagePercent: 0, status: "ok" })),
+  severityOf: mock(() => 0),
+  checkResourceLimit: mock(async () => ({ allowed: true })),
+  CHAT_INTEGRATION_COUNT_SQL: "",
+  checkChatIntegrationLimit: mock(async () => ({ allowed: true })),
+  checkChatIntegrationLimitAndInstall: mock(async () => ({ allowed: true, rows: [] })),
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { checkAgentBillingGate } = await import("@atlas/api/lib/billing/agent-gate");
+
+describe("checkAgentBillingGate", () => {
+  beforeEach(() => {
+    workspaceVerdict = { allowed: true };
+    abuseVerdict = { level: "none" };
+    planVerdict = { allowed: true };
+    mockCheckWorkspaceStatus.mockClear();
+    mockCheckAbuseStatus.mockClear();
+    mockCheckPlanLimits.mockClear();
+  });
+
+  it("blocks a suspended workspace with 403 workspace_suspended", async () => {
+    workspaceVerdict = {
+      allowed: false,
+      status: "suspended",
+      errorCode: "workspace_suspended",
+      errorMessage: "This workspace has been suspended. Please update your payment method or contact support.",
+      httpStatus: 403,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_suspended");
+    expect(result.httpStatus).toBe(403);
+    expect(result.retryable).toBe(false);
+    expect(result.errorMessage).toContain("suspended");
+  });
+
+  it("blocks a deleted workspace with 404 workspace_deleted", async () => {
+    workspaceVerdict = {
+      allowed: false,
+      status: "deleted",
+      errorCode: "workspace_deleted",
+      errorMessage: "This workspace has been deleted.",
+      httpStatus: 404,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_deleted");
+    expect(result.httpStatus).toBe(404);
+    expect(result.retryable).toBe(false);
+  });
+
+  it("fails closed (503, retryable) when the workspace lookup fails", async () => {
+    workspaceVerdict = {
+      allowed: false,
+      errorCode: "workspace_check_failed",
+      errorMessage: "Unable to verify workspace status. Please try again.",
+      httpStatus: 503,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_check_failed");
+    expect(result.httpStatus).toBe(503);
+    expect(result.retryable).toBe(true);
+  });
+
+  it("short-circuits on a workspace block — abuse and plan checks never run", async () => {
+    workspaceVerdict = {
+      allowed: false,
+      errorCode: "workspace_suspended",
+      errorMessage: "suspended",
+      httpStatus: 403,
+    };
+    await checkAgentBillingGate("org-1");
+    expect(mockCheckAbuseStatus).not.toHaveBeenCalled();
+    expect(mockCheckPlanLimits).not.toHaveBeenCalled();
+  });
+
+  it("blocks an abuse-suspended workspace with 403 (plan check never runs)", async () => {
+    abuseVerdict = { level: "suspended" };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_suspended");
+    expect(result.httpStatus).toBe(403);
+    expect(result.retryable).toBe(false);
+    expect(result.errorMessage).toContain("unusual activity");
+    expect(mockCheckPlanLimits).not.toHaveBeenCalled();
+  });
+
+  it("blocks an abuse-throttled workspace with 429 + retryAfterSeconds", async () => {
+    abuseVerdict = { level: "throttled", throttleDelayMs: 5000 };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("workspace_throttled");
+    expect(result.httpStatus).toBe(429);
+    expect(result.retryable).toBe(true);
+    expect(result.retryAfterSeconds).toBe(5);
+  });
+
+  it("blocks a trial-expired workspace with 403 trial_expired", async () => {
+    planVerdict = {
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+      httpStatus: 403,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("trial_expired");
+    expect(result.httpStatus).toBe(403);
+    expect(result.retryable).toBe(false);
+    expect(result.errorMessage).toContain("trial has expired");
+  });
+
+  it("blocks a hard-capped workspace with 429 plan_limit_exceeded + usage", async () => {
+    planVerdict = {
+      allowed: false,
+      errorCode: "plan_limit_exceeded",
+      errorMessage: "You have exceeded your plan's token budget.",
+      httpStatus: 429,
+      usage: { currentUsage: 2_300_000, limit: 2_000_000, metric: "tokens" },
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("plan_limit_exceeded");
+    expect(result.httpStatus).toBe(429);
+    expect(result.usage).toEqual({ currentUsage: 2_300_000, limit: 2_000_000, metric: "tokens" });
+  });
+
+  it("blocks a churned (locked) workspace with 403 subscription_required", async () => {
+    planVerdict = {
+      allowed: false,
+      errorCode: "subscription_required",
+      errorMessage: "Your subscription has ended. Resubscribe from the billing page to continue using Atlas.",
+      httpStatus: 403,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("subscription_required");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("fails closed (503, retryable) when the plan check itself fails", async () => {
+    planVerdict = {
+      allowed: false,
+      errorCode: "billing_check_failed",
+      errorMessage: "Unable to verify billing status. Please try again.",
+      httpStatus: 503,
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.errorCode).toBe("billing_check_failed");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("allows and passes the 80–109% warning band through without blocking", async () => {
+    planVerdict = {
+      allowed: true,
+      warning: { code: "plan_limit_warning", message: "You are approaching your plan's token budget", metrics: [] },
+    };
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(true);
+    if (!result.allowed) throw new Error("expected allow");
+    expect(result.warning?.code).toBe("plan_limit_warning");
+  });
+
+  it("allows a healthy workspace, consulting all three checks", async () => {
+    const result = await checkAgentBillingGate("org-1");
+    expect(result.allowed).toBe(true);
+    expect(mockCheckWorkspaceStatus).toHaveBeenCalledWith("org-1");
+    expect(mockCheckAbuseStatus).toHaveBeenCalledWith("org-1");
+    expect(mockCheckPlanLimits).toHaveBeenCalledWith("org-1");
+  });
+
+  it("allows with no orgId without consulting abuse or plan checks", async () => {
+    const result = await checkAgentBillingGate(undefined);
+    expect(result.allowed).toBe(true);
+    expect(mockCheckAbuseStatus).not.toHaveBeenCalled();
+    expect(mockCheckPlanLimits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/billing/agent-gate.ts
+++ b/packages/api/src/lib/billing/agent-gate.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared billing-enforcement gate for agent runs (#3419 / #3420).
+ *
+ * One seam, consulted by `executeAgentQuery` before any LLM spend, so
+ * every caller — web `/api/v1/query`, all six chat-platform webhook
+ * paths, the scheduler executor, and any future caller — is covered by
+ * construction rather than by per-callsite discipline.
+ *
+ * Composes the three existing checks in order, short-circuiting on the
+ * first block:
+ *
+ *   1. `checkWorkspaceStatus` — suspended / deleted workspaces (and
+ *      fail-closed on lookup errors → 503).
+ *   2. `checkAbuseStatus` — abuse-suspended (403) and abuse-throttled
+ *      (429 + Retry-After) workspaces.
+ *   3. `checkPlanLimits` — trial expiry, churned (`locked`) tier, and
+ *      the token hard cap (110%+); fail-closed on workspace lookup
+ *      errors (503).
+ *
+ * This module REUSES the tested fail-closed lookups and threshold
+ * boundaries in `enforcement.ts` / `workspace.ts` / `abuse.ts` — it
+ * adds no policy of its own, only composition and a transport-agnostic
+ * envelope (`errorCode` + user-safe `errorMessage` + `httpStatus` +
+ * `retryable`), so each surface can shape the block appropriately:
+ * HTTP routes map it to their JSON envelope, chat platforms surface
+ * `BillingBlockedError.message` as an in-thread reply, and the
+ * scheduler records it on the task run.
+ *
+ * **80–109% warning band:** never blocks. The gate passes the
+ * `checkPlanLimits` warning through on the allowed arm; callers that
+ * render warnings (the web/API surfaces) attach it to their response,
+ * while machine-initiated surfaces (chat platforms, scheduler)
+ * intentionally do not render it — the band is already logged by
+ * `enforcement.ts` and visible in the admin billing page.
+ *
+ * **Self-hosted / no billing:** every underlying check short-circuits
+ * to allowed when there is no internal DB, no orgId, or (for abuse)
+ * a non-SaaS deploy mode — the gate is a no-op passthrough.
+ */
+
+import { isChatErrorCode, isRetryableError } from "@useatlas/types";
+import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
+import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
+import { checkPlanLimits, type PlanLimitWarning } from "./enforcement";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("billing:agent-gate");
+
+export interface AgentBillingBlock {
+  allowed: false;
+  /** Machine-readable code (a `ChatErrorCode` — e.g. `trial_expired`). */
+  errorCode: string;
+  /** User-safe message — surfaced verbatim on chat platforms and run rows. */
+  errorMessage: string;
+  httpStatus: 403 | 404 | 429 | 503;
+  /** Whether retrying (without operator action) may succeed. */
+  retryable: boolean;
+  /** Set on abuse-throttle blocks so HTTP surfaces can emit Retry-After. */
+  retryAfterSeconds?: number;
+  /** Set on `plan_limit_exceeded` blocks. */
+  usage?: { currentUsage: number; limit: number; metric: string };
+}
+
+export type AgentBillingGateResult =
+  | { allowed: true; warning?: PlanLimitWarning }
+  | AgentBillingBlock;
+
+/**
+ * Thrown by `executeAgentQuery` when the gate blocks a run. `message`
+ * is the user-safe `errorMessage`, so surfaces that deliver raw error
+ * messages to end users (the chat-plugin bridge's error card, the
+ * scheduler's run row) are safe by construction.
+ *
+ * Deliberately a plain `Error` subclass rather than a
+ * `Data.TaggedError`: `executeAgentQuery` and its callers are plain
+ * async (no Effect context), and the established pattern for errors on
+ * that path is `instanceof` sentinels (see the UnknownTenantError
+ * family in `lib/chat-plugin/executeQuery.ts`).
+ */
+export class BillingBlockedError extends Error {
+  override readonly name = "BillingBlockedError";
+  readonly errorCode: string;
+  readonly httpStatus: 403 | 404 | 429 | 503;
+  readonly retryable: boolean;
+  readonly retryAfterSeconds: number | undefined;
+  readonly usage: { currentUsage: number; limit: number; metric: string } | undefined;
+
+  constructor(block: AgentBillingBlock) {
+    super(block.errorMessage);
+    this.errorCode = block.errorCode;
+    this.httpStatus = block.httpStatus;
+    this.retryable = block.retryable;
+    this.retryAfterSeconds = block.retryAfterSeconds;
+    this.usage = block.usage;
+  }
+}
+
+/** Retryable classification, mirroring the web routes' envelope logic. */
+function retryableFor(errorCode: string): boolean {
+  return isChatErrorCode(errorCode) ? isRetryableError(errorCode) : false;
+}
+
+/**
+ * Run the full billing gate for an agent invocation.
+ *
+ * `orgId` is the workspace of the bound actor (undefined when the run
+ * has no org — self-hosted, CLI eval tooling — which always allows).
+ * Returns the first block encountered, or `{ allowed: true }` with the
+ * optional plan-limit warning (80–109% band) passed through.
+ */
+export async function checkAgentBillingGate(
+  orgId: string | undefined,
+): Promise<AgentBillingGateResult> {
+  // 1. Workspace status — suspended / deleted / lookup failure.
+  const wsCheck = await checkWorkspaceStatus(orgId);
+  if (!wsCheck.allowed) {
+    const errorCode = wsCheck.errorCode ?? "workspace_check_failed";
+    return {
+      allowed: false,
+      errorCode,
+      errorMessage: wsCheck.errorMessage ?? "Workspace access denied.",
+      httpStatus: wsCheck.httpStatus ?? 403,
+      retryable: retryableFor(errorCode),
+    };
+  }
+
+  if (!orgId) {
+    return { allowed: true };
+  }
+
+  // 2. Abuse status — in-memory, SaaS-only (returns "none" elsewhere).
+  const abuse = checkAbuseStatus(orgId);
+  if (abuse.level === "suspended") {
+    log.warn({ orgId }, "Agent run blocked: workspace suspended due to abuse");
+    return {
+      allowed: false,
+      errorCode: "workspace_suspended",
+      errorMessage:
+        "Workspace suspended due to unusual activity. Contact your administrator.",
+      httpStatus: 403,
+      retryable: false,
+    };
+  }
+  if (abuse.level === "throttled" && abuse.throttleDelayMs) {
+    const retryAfterSeconds = Math.ceil(abuse.throttleDelayMs / 1000);
+    log.warn(
+      { orgId, delayMs: abuse.throttleDelayMs },
+      "Agent run blocked: workspace throttled due to abuse",
+    );
+    return {
+      allowed: false,
+      errorCode: "workspace_throttled",
+      errorMessage:
+        "Workspace is temporarily throttled due to high usage. Please retry shortly.",
+      httpStatus: 429,
+      retryable: true,
+      retryAfterSeconds,
+    };
+  }
+
+  // 3. Plan limits — trial expiry, locked tier, token hard cap.
+  const planCheck = await checkPlanLimits(orgId);
+  if (!planCheck.allowed) {
+    return {
+      allowed: false,
+      errorCode: planCheck.errorCode,
+      errorMessage: planCheck.errorMessage,
+      httpStatus: planCheck.httpStatus,
+      retryable: retryableFor(planCheck.errorCode),
+      ...(planCheck.errorCode === "plan_limit_exceeded" ? { usage: planCheck.usage } : {}),
+    };
+  }
+
+  return {
+    allowed: true,
+    ...(planCheck.warning ? { warning: planCheck.warning } : {}),
+  };
+}

--- a/packages/api/src/lib/billing/agent-gate.ts
+++ b/packages/api/src/lib/billing/agent-gate.ts
@@ -38,7 +38,7 @@
  * a non-SaaS deploy mode — the gate is a no-op passthrough.
  */
 
-import { isChatErrorCode, isRetryableError } from "@useatlas/types";
+import { isRetryableError, type ChatErrorCode } from "@useatlas/types";
 import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
 import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import { checkPlanLimits, type PlanLimitWarning } from "./enforcement";
@@ -48,8 +48,8 @@ const log = createLogger("billing:agent-gate");
 
 export interface AgentBillingBlock {
   allowed: false;
-  /** Machine-readable code (a `ChatErrorCode` — e.g. `trial_expired`). */
-  errorCode: string;
+  /** Machine-readable code — e.g. `trial_expired`, `workspace_suspended`. */
+  errorCode: ChatErrorCode;
   /** User-safe message — surfaced verbatim on chat platforms and run rows. */
   errorMessage: string;
   httpStatus: 403 | 404 | 429 | 503;
@@ -79,7 +79,7 @@ export type AgentBillingGateResult =
  */
 export class BillingBlockedError extends Error {
   override readonly name = "BillingBlockedError";
-  readonly errorCode: string;
+  readonly errorCode: ChatErrorCode;
   readonly httpStatus: 403 | 404 | 429 | 503;
   readonly retryable: boolean;
   readonly retryAfterSeconds: number | undefined;
@@ -95,10 +95,6 @@ export class BillingBlockedError extends Error {
   }
 }
 
-/** Retryable classification, mirroring the web routes' envelope logic. */
-function retryableFor(errorCode: string): boolean {
-  return isChatErrorCode(errorCode) ? isRetryableError(errorCode) : false;
-}
 
 /**
  * Run the full billing gate for an agent invocation.
@@ -120,7 +116,7 @@ export async function checkAgentBillingGate(
       errorCode,
       errorMessage: wsCheck.errorMessage ?? "Workspace access denied.",
       httpStatus: wsCheck.httpStatus ?? 403,
-      retryable: retryableFor(errorCode),
+      retryable: isRetryableError(errorCode),
     };
   }
 
@@ -166,7 +162,7 @@ export async function checkAgentBillingGate(
       errorCode: planCheck.errorCode,
       errorMessage: planCheck.errorMessage,
       httpStatus: planCheck.httpStatus,
-      retryable: retryableFor(planCheck.errorCode),
+      retryable: isRetryableError(planCheck.errorCode),
       ...(planCheck.errorCode === "plan_limit_exceeded" ? { usage: planCheck.usage } : {}),
     };
   }

--- a/packages/api/src/lib/billing/agent-gate.ts
+++ b/packages/api/src/lib/billing/agent-gate.ts
@@ -137,8 +137,12 @@ export async function checkAgentBillingGate(
       retryable: false,
     };
   }
-  if (abuse.level === "throttled" && abuse.throttleDelayMs) {
-    const retryAfterSeconds = Math.ceil(abuse.throttleDelayMs / 1000);
+  if (abuse.level === "throttled") {
+    // Defensive: checkAbuseStatus always supplies throttleDelayMs on the
+    // throttled arm (its config floor is > 0), but if a future variant
+    // omitted it, still BLOCK with a 1s floor — falling open on an abuse
+    // verdict would be a silent fallback on a security check (CLAUDE.md).
+    const retryAfterSeconds = Math.max(1, Math.ceil((abuse.throttleDelayMs ?? 1000) / 1000));
     log.warn(
       { orgId, delayMs: abuse.throttleDelayMs },
       "Agent run blocked: workspace throttled due to abuse",

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -1298,4 +1298,129 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(mockInternalQuery).not.toHaveBeenCalled();
     expect(capturedAgentCalls).toHaveLength(0);
   });
+
+  // -------------------------------------------------------------------------
+  // #3419 — billing enforcement blocks surface as user-visible platform
+  // replies on every chat-platform path.
+  //
+  // The seam lives inside `executeAgentQuery` (mocked here, covered by
+  // `lib/__tests__/agent-query-billing.test.ts`); what THIS file pins is
+  // the delivery contract: when the seam throws `BillingBlockedError`,
+  // every platform branch rethrows it unchanged — same user-safe message,
+  // same type — so the chat bridge renders it as an in-thread error card
+  // exactly like the rate-limit reply (never a silent drop, never a
+  // scrubbed-away "agent run failed").
+  // -------------------------------------------------------------------------
+
+  describe("billing enforcement blocks (#3419)", () => {
+    const TRIAL_EXPIRED_MSG =
+      "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.";
+
+    const platformContexts: Array<{
+      platform: string;
+      ctx: Parameters<typeof import("../executeQuery").runExecuteQuery>[1];
+    }> = [
+      {
+        platform: "slack",
+        ctx: {
+          threadId: "slack:C1-1.2",
+          adapter: { name: "slack" },
+          rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", ts: "1.2" },
+        },
+      },
+      {
+        platform: "telegram",
+        ctx: {
+          threadId: "telegram:12345-7",
+          adapter: { name: "telegram" },
+          rawMessage: { message_id: 7, chat: { id: 12345 }, from: { id: 99 } },
+        },
+      },
+      {
+        platform: "discord",
+        ctx: {
+          threadId: "discord:g123-c456",
+          adapter: { name: "discord" },
+          rawMessage: {
+            id: "111111111111111111",
+            type: 2,
+            guild_id: "123456789012345678",
+            channel_id: "456",
+            member: { user: { id: "U_DC" } },
+          },
+        },
+      },
+      {
+        platform: "whatsapp",
+        ctx: {
+          threadId: "whatsapp:1098765432109876:16315551234",
+          adapter: { name: "whatsapp" },
+          rawMessage: {
+            phoneNumberId: "1098765432109876",
+            contact: { wa_id: "16315551234" },
+            message: { id: "m1", from: "16315551234", type: "text", text: { body: "q" } },
+          },
+        },
+      },
+      {
+        platform: "gchat",
+        ctx: {
+          threadId: "gchat:spaces/AAA-AAA",
+          adapter: { name: "gchat" },
+          rawMessage: {
+            eventType: "MESSAGE",
+            space: { name: "spaces/AAA-AAA", customer: "C01abc234" },
+            message: {
+              name: "spaces/AAA-AAA/messages/M1",
+              thread: { name: "spaces/AAA-AAA/threads/T1" },
+            },
+            user: { name: "users/12345" },
+          },
+        },
+      },
+      {
+        platform: "teams",
+        ctx: {
+          threadId: "teams:19:meeting_abc",
+          adapter: { name: "teams" },
+          rawMessage: {
+            channelData: { tenant: { id: "72f988bf-86f1-41af-91ab-2d7cd011db47" } },
+            conversation: { id: "19:meeting_abc@thread.v2" },
+            from: { id: "29:1abc", aadObjectId: "aad-obj-1" },
+          },
+        },
+      },
+    ];
+
+    for (const { platform, ctx } of platformContexts) {
+      it(`${platform}: a billing block from the seam propagates typed with its user-safe message`, async () => {
+        // Non-Slack branches resolve their tenant via workspace_plugins.
+        mockInternalQuery.mockImplementation((sql: string) => {
+          if (sql.includes("workspace_plugins")) {
+            return Promise.resolve([{ workspace_id: `org-${platform}-tenant` }]);
+          }
+          return Promise.resolve([]);
+        });
+        const { BillingBlockedError } = await import("@atlas/api/lib/billing/agent-gate");
+        mockExecuteAgentQuery.mockImplementationOnce(() =>
+          Promise.reject(
+            new BillingBlockedError({
+              allowed: false,
+              errorCode: "trial_expired",
+              errorMessage: TRIAL_EXPIRED_MSG,
+              httpStatus: 403,
+              retryable: false,
+            }),
+          ),
+        );
+        const { runExecuteQuery } = await import("../executeQuery");
+
+        const promise = runExecuteQuery("q", ctx);
+        await expect(promise).rejects.toThrow(TRIAL_EXPIRED_MSG);
+        await promise.catch((err: unknown) => {
+          expect(err).toBeInstanceOf(BillingBlockedError);
+        });
+      });
+    }
+  });
 });

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -62,6 +62,7 @@ import type {
 } from "@useatlas/chat";
 import type { ApprovalRequestSurface } from "@useatlas/types";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
+import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import { createLogger } from "@atlas/api/lib/logger";
 import { checkRateLimit } from "@atlas/api/lib/auth/middleware";
 import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
@@ -1403,6 +1404,19 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
       presentationMode: presentationMode ?? "conversational",
     });
   } catch (err) {
+    // #3419 — a billing-enforcement block from the seam in
+    // `executeAgentQuery` is an expected policy outcome, not an agent
+    // failure: log at warn (the seam already warned with org context)
+    // and rethrow UNCHANGED. Its `message` is user-safe by construction,
+    // so the bridge delivers it as the in-thread platform reply — the
+    // same path the rate-limit refusal takes, never a silent drop.
+    if (err instanceof BillingBlockedError) {
+      log.warn(
+        { errorCode: err.errorCode, requestId, ...tenantLabel },
+        "Chat plugin executeQuery blocked by billing enforcement",
+      );
+      throw err;
+    }
     // Log the original `err` (with stack trace) so Sentry sees the
     // unscrubbed version. The re-thrown message stays unscrubbed too —
     // the bridge's `scrubErrorMessage` is the single source of truth

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -253,6 +253,33 @@ describe("executor", () => {
     );
   });
 
+  // ── #3420: billing enforcement blocks ──────────────────────────────
+
+  it("records a billing block on the run with the user-safe reason and never delivers (#3420)", async () => {
+    const { BillingBlockedError } = await import("@atlas/api/lib/billing/agent-gate");
+    mockExecuteAgentQuery.mockImplementationOnce(() =>
+      Promise.reject(
+        new BillingBlockedError({
+          allowed: false,
+          errorCode: "trial_expired",
+          errorMessage:
+            "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+          httpStatus: 403,
+          retryable: false,
+        }),
+      ),
+    );
+    // The thrown message is what engine.ts records on the run row via
+    // completeTaskRun(runId, "failed", { error }) — it must name billing
+    // enforcement AND carry the user-safe reason so the task owner sees
+    // exactly why the run was blocked in run history.
+    const promise = executeScheduledTask("task-1", "run-1", 30_000);
+    await expect(promise).rejects.toThrow(/Blocked by billing enforcement/);
+    await expect(promise).rejects.toThrow(/trial has expired/);
+    expect(mockDeliverResult).not.toHaveBeenCalled();
+    expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
+  });
+
   it("skips delivery status when no recipients attempted", async () => {
     mockDeliverResult.mockResolvedValueOnce({ attempted: 0, succeeded: 0, failed: 0, permanentFailures: 0, firstPermanentError: null });
     await executeScheduledTask("task-1", "run-1", 30_000);

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -21,6 +21,7 @@ import { Effect, Duration, Exit, Cause } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getScheduledTask, updateRunDeliveryStatus } from "@atlas/api/lib/scheduled-tasks";
 import { executeAgentQuery, type AgentQueryResult } from "@atlas/api/lib/agent-query";
+import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import { loadActorUser } from "@atlas/api/lib/auth/actor";
 import { SchedulerTaskTimeoutError, SchedulerExecutionError } from "@atlas/api/lib/effect/errors";
 import { causeToError } from "@atlas/api/lib/audit/error-scrub";
@@ -50,9 +51,20 @@ function agentQueryEffect(
 ) {
   return Effect.tryPromise({
     try: () => executeAgentQuery(question, requestId, options),
+    // #3420 — a billing-enforcement block from the seam in
+    // `executeAgentQuery` is recorded on the run row verbatim (engine.ts
+    // calls `completeTaskRun(runId, "failed", { error: message })`), so
+    // the message must name billing enforcement AND carry the user-safe
+    // reason for the task owner's run history. Never a silent skip: the
+    // seam already logged the block with org context.
     catch: (err) =>
       new SchedulerExecutionError({
-        message: err instanceof Error ? err.message : String(err),
+        message:
+          err instanceof BillingBlockedError
+            ? `Blocked by billing enforcement [${err.errorCode}]: ${err.message}`
+            : err instanceof Error
+              ? err.message
+              : String(err),
         taskId,
       }),
   }).pipe(

--- a/packages/api/src/lib/workspace.ts
+++ b/packages/api/src/lib/workspace.ts
@@ -24,7 +24,12 @@ const log = createLogger("workspace");
 export interface WorkspaceCheckResult {
   allowed: boolean;
   status?: WorkspaceStatus;
-  errorCode?: string;
+  /**
+   * Literal union (not `string`) so downstream envelopes — notably the
+   * billing gate's `ChatErrorCode`-typed block (#3451 review) — stay
+   * exhaustively typed without casts.
+   */
+  errorCode?: "workspace_suspended" | "workspace_deleted" | "workspace_check_failed";
   errorMessage?: string;
   httpStatus?: 403 | 404 | 503;
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -46,6 +46,7 @@ import type {
   DeliveryChannel,
   ActionApprovalMode,
   ActionStatus,
+  PlanLimitStatus,
   RollbackInfo,
   Recipient,
   ScheduledTask,
@@ -162,6 +163,16 @@ export interface QueryResponse {
     approveUrl: string;
     denyUrl: string;
   }>;
+  /**
+   * 80–109% plan-usage warning band (#3452). Present when the workspace
+   * is approaching or in grace against its token budget; omitted below
+   * 80% and on self-hosted deployments.
+   */
+  planWarning?: {
+    code: "plan_limit_warning";
+    message: string;
+    metrics: PlanLimitStatus[];
+  };
 }
 
 export interface ListConversationsResponse {


### PR DESCRIPTION
Fixes #3419, fixes #3420. Also fixes #3451 and fixes #3452 (self-review follow-ups, applied in-PR). Parent audit #3415.

## Problem

All six chat-platform paths in `lib/chat-plugin/executeQuery.ts` and the scheduler's `executeScheduledTask` reached `executeAgentQuery` → `runAgent` with **zero** calls to `checkPlanLimits` / `checkWorkspaceStatus` / `checkAbuseStatus`. A suspended, trial-expired, or hard-capped workspace kept consuming platform-paid LLM tokens indefinitely via @mentions and scheduled tasks.

## Approach: one seam, covered by construction

- **New `lib/billing/agent-gate.ts`** — `checkAgentBillingGate(orgId)` composes the existing, already-tested checks in order (`checkWorkspaceStatus` → `checkAbuseStatus` → `checkPlanLimits`), short-circuiting on the first block. It adds no policy of its own — fail-closed lookups and threshold boundaries stay in `enforcement.ts`/`workspace.ts`/`abuse.ts`. Blocks throw `BillingBlockedError` (typed `ChatErrorCode`, user-safe `message`).
- **`executeAgentQuery` consults the gate before any LLM spend** — every current and future caller (web `/query`, all six chat platforms, scheduler) is covered without per-callsite discipline.
- **Web `chat.ts` converged too (#3451)** — it streams via `runAgent` and never reaches the seam, so it calls `checkAgentBillingGate` directly and maps the block to its envelope. The inline three-check trio is gone; the enforcement perimeter is now exactly one composition.

## Surface-appropriate failure shaping

- **Chat platforms (Slack/Discord/Telegram/Teams/GChat/WhatsApp):** the block propagates typed and unmangled through `runAgentAndMap` to the chat bridge, which renders it as an **in-thread error card** — the same delivery path as rate-limit refusals. Never a silent drop. Logged at warn (policy outcome, not an agent failure).
- **Scheduler:** the run is recorded as failed with `Blocked by billing enforcement [code]: ``&lt;user-safe reason&gt;'`` — `engine.ts` writes it to the run row via `completeTaskRun`, owner-visible in run history. Delivery is never attempted. Tasks are not auto-paused; they resume on the next tick once the workspace is back in good standing.
- **`POST /api/v1/query`:** inline checks removed; the route maps `BillingBlockedError` to its existing envelope (403/404/429/503, `Retry-After` on throttles, `usage` on hard caps, `requestId` always). **No double enforcement anywhere.**

## 80–109% warning band (documented decision)

Never blocks. The gate passes the warning through; `/query` includes it as `planWarning` (now declared on the OpenAPI 200 schema and SDK `QueryResponse` — #3452), web chat folds it into the `data-context-warning` stream as before. Chat threads and scheduler runs intentionally do **not** render it. Documented in `billing-and-plans.mdx` → "Enforcement Surfaces".

## Self-hosted

No-op passthrough — pinned by `agent-gate.self-hosted.test.ts` against the **real** checks with `hasInternalDB() === false` and non-SaaS deploy mode, including with an orgId bound.

## Behavior notes (from self-review)

- On `/api/v1/query`, billing enforcement now runs **after** body validation, env diagnostics, and the datasource check (it lives inside `executeAgentQuery`). A request failing one of those **and** billing-blocked gets the earlier error (422/400) instead of the billing error. The gate still always runs before any LLM spend.
- On web chat, abuse/plan blocks now take precedence over the migration write-lock check (the gate is atomic; workspace-status precedence unchanged), and `markOrgActive` no longer stamps activity for billing-blocked turns.

## #3437 (MCP executeSQL, admin semantic-improve)

Assessed: neither path flows through the seam. Left open with [a comment](https://github.com/AtlasDevHQ/atlas/issues/3437#issuecomment-4693154032) describing the gaps — the gate makes those fixes one-call wiring.

## Tests (TDD: red → green per path)

- `agent-gate.test.ts` (13) — composition arms: suspended/deleted/check-failed, abuse suspended/throttled (+`retryAfterSeconds`), trial-expired/locked/hard-cap (+`usage`)/billing-check-failed, warning passthrough, short-circuit order, no-org passthrough
- `agent-query-billing.test.ts` (6) — gate consulted with the bound actor's org **before** `runAgent`; blocked → typed throw + zero agent calls; `planWarning` attach; inherited-context org; undefined-org passthrough
- `execute-query.test.ts` (+6) — all six platforms: block propagates typed with its user-safe message
- `executor.test.ts` (+1) — billing reason recorded on the run, delivery never attempted
- `query.test.ts` (+4) — route envelope mapping: 403 + `requestId`, 429 + `Retry-After`, 429 + `usage`, 200 + `planWarning`
- `chat.test.ts` (+1, 4 hardened) — blocked-path envelope via the gate; plan-warning tests now bind an org (the pre-gate route called the mocked `checkPlanLimits` unconditionally, masking the no-org short-circuit)
- `agent-gate.self-hosted.test.ts` (2) — real-modules no-op passthrough

## CI

`/ci` all green locally (both rounds): lint, type, **full** `bun run test`, syncpack, template drift, security-headers, railway-watch, schema-drift, oauth-helper drift, test discipline, twenty-resolver, settings-readers, published-symbols, ee-imports.

https://claude.ai/code/session_01WkiyzL3qot9eJs9kz5E9mv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized billing enforcement across agent paths with platform-specific behaviors: web/API return structured HTTP errors, chat shows in-thread refusals, scheduled tasks mark blocked runs failed and retry on next schedule.
  * Responses may include a plan-usage warning (80–109% band) surfaced as a `planWarning` object.

* **Documentation**
  * Added "Enforcement Surfaces" guidance describing where billing enforcement applies and platform behaviors.

* **Tests**
  * Expanded test coverage validating billing gate behavior across APIs, chat plugins, scheduler, and SDK responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->