### PR TITLE
fix(billing): map check_failed to 503 retry, not 429 plan-limit, in admin-connections + invitation seat limit

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -51087,7 +51087,7 @@
             }
           },
           "429": {
-            "description": "Rate limit exceeded",
+            "description": "Rate limit exceeded, or plan connection limit reached: `plan_limit_exceeded`",
             "content": {
               "application/json": {
                 "schema": {
@@ -51099,6 +51099,31 @@
           },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Billing/plan-limit check unavailable: `billing_check_failed`",
             "content": {
               "application/json": {
                 "schema": {
@@ -72704,7 +72729,7 @@
             }
           },
           "429": {
-            "description": "Seat limit reached",
+            "description": "Seat limit reached: `seat_limit`",
             "content": {
               "application/json": {
                 "schema": {
@@ -72730,6 +72755,31 @@
           },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Billing/plan-limit check unavailable: `billing_check_failed`",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the create-connection plan-limit gate's error-arm mapping (#3433).
+ *
+ * `POST /api/v1/admin/connections` runs `checkResourceLimit(orgId,
+ * "connections", count)` before installing. The `ResourceLimitResult`
+ * contract keeps its two `allowed: false` arms deliberately distinct:
+ *
+ *   - `cap_reached`  — genuine plan cap → 429 `plan_limit_exceeded` "upgrade"
+ *   - `check_failed` — infra fault (workspace lookup failed) → 503
+ *     `billing_check_failed` "try again"
+ *
+ * Both arms stay fail-closed (the connection is never created); only the
+ * status/code/message differs. Collapsing `check_failed` into the 429 arm
+ * shows an admin "plan limit exceeded — upgrade" during an internal-DB
+ * blip for a connection they're entitled to.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import type { ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+});
+
+// Billing enforcement — per-test arm selection via mockCheckResourceLimit.
+const mockCheckResourceLimit = mock<
+  (orgId: string | undefined, resource: string, count: number) => Promise<ResourceLimitResult>
+>(async () => ({ allowed: true }));
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkResourceLimit: mockCheckResourceLimit,
+  getCachedWorkspace: mock(async () => null),
+  invalidatePlanCache: mock(() => {}),
+  checkPlanLimits: mock(async () => ({ allowed: true, status: "ok" })),
+  buildMetricStatus: mock(() => "ok"),
+  severityOf: mock(() => 0),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkChatIntegrationLimit: mock(async () => ({ allowed: true })),
+  checkChatIntegrationLimitAndInstall: mock(async () => ({ outcome: "installed" })),
+}));
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockClear();
+  // The route's plan-limit COUNT against workspace_plugins.
+  mocks.mockInternalQuery.mockImplementation(async () => [{ count: 3 }]);
+  mockCheckResourceLimit.mockClear();
+  mockCheckResourceLimit.mockImplementation(async () => ({ allowed: true }));
+});
+
+function createRequest(): Request {
+  return new Request("http://localhost/api/v1/admin/connections", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ id: "warehouse", url: "postgresql://example/db" }),
+  });
+}
+
+describe("POST /api/v1/admin/connections resource-limit arms (#3433)", () => {
+  it("cap_reached → 429 plan_limit_exceeded with upgrade guidance", async () => {
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "cap_reached",
+      errorMessage: "Your starter plan allows up to 3 connections. Upgrade to add more.",
+      limit: 3,
+    }));
+
+    const res = await app.fetch(createRequest());
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: string; message: string; requestId?: string };
+    expect(body.error).toBe("plan_limit_exceeded");
+    expect(body.message).toContain("Upgrade");
+    expect(mockCheckResourceLimit).toHaveBeenCalledWith("org-alpha", "connections", 3);
+  });
+
+  it("check_failed → 503 billing_check_failed with retry guidance, NOT a plan-limit error", async () => {
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: "Unable to verify plan limits. Please try again.",
+    }));
+
+    const res = await app.fetch(createRequest());
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; message: string; requestId?: string };
+    expect(body.error).toBe("billing_check_failed");
+    expect(body.message).toMatch(/try again/i);
+    // The infra-failure arm must never masquerade as a plan-limit hit.
+    expect(body.error).not.toBe("plan_limit_exceeded");
+    expect(body.message).not.toMatch(/upgrade/i);
+    expect(typeof body.requestId).toBe("string");
+  });
+
+  it("stays fail-closed on check_failed — no install write reaches the DB", async () => {
+    const writes: string[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (/INSERT|UPDATE|DELETE/i.test(sql)) writes.push(sql);
+      return [{ count: 3 }];
+    });
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: "Unable to verify plan limits. Please try again.",
+    }));
+
+    const res = await app.fetch(createRequest());
+    expect(res.status).toBe(503);
+    expect(writes).toEqual([]);
+  });
+});

--- a/packages/api/src/api/__tests__/platform-invitations.test.ts
+++ b/packages/api/src/api/__tests__/platform-invitations.test.ts
@@ -63,7 +63,7 @@ mock.module("@atlas/api/lib/email/hooks", () => ({
 
 // Billing enforcement — by default allow every seat check.
 const mockCheckResourceLimit = mock<
-  (orgId: string, resource: string, count: number) => Promise<{ allowed: boolean; errorMessage?: string }>
+  (orgId: string, resource: string, count: number) => Promise<{ allowed: boolean; reason?: "cap_reached" | "check_failed"; errorMessage?: string; limit?: number }>
 >(async () => ({ allowed: true }));
 
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
@@ -374,7 +374,9 @@ describe("POST /api/v1/platform/invitations", () => {
     mocks.mockInternalQuery.mockImplementation(defaultQueryHandler({ seatCount: 5 }));
     mockCheckResourceLimit.mockImplementation(async () => ({
       allowed: false,
+      reason: "cap_reached",
       errorMessage: "Workspace seat limit reached.",
+      limit: 5,
     }));
 
     const res = await app.request(
@@ -387,6 +389,38 @@ describe("POST /api/v1/platform/invitations", () => {
     expect(res.status).toBe(429);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("seat_limit");
+  });
+
+  it("returns 503 billing_check_failed when the seat count can't be verified (#3433)", async () => {
+    // `checkResourceLimit` failed closed with `check_failed` — an infra
+    // fault, not a plan cap. The invite is still blocked, but the caller
+    // must see a transient "try again", never "seat limit — upgrade".
+    // Clear accumulated calls from earlier tests so the INSERT assertion
+    // below only sees this request's queries.
+    mocks.mockInternalQuery.mockClear();
+    mocks.mockInternalQuery.mockImplementation(defaultQueryHandler());
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: "Unable to verify plan limits. Please try again.",
+    }));
+
+    const res = await app.request(
+      platformRequest("POST", "/api/v1/platform/invitations", {
+        organizationId: "target-org",
+        email: "newuser@example.com",
+        role: "member",
+      }),
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("billing_check_failed");
+    expect(body.message).toMatch(/try again/i);
+    // Fail-closed: the invitation row was never inserted.
+    const insertCalls = mocks.mockInternalQuery.mock.calls.filter(
+      ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO invitation"),
+    );
+    expect(insertCalls.length).toBe(0);
   });
 
   it("normalizes email to lowercase before dedup + insert", async () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -381,8 +381,11 @@ const createConnectionRoute = createRoute({
     403: { description: "Forbidden — admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
     409: { description: "Connection already exists", content: { "application/json": { schema: ErrorSchema } } },
-    429: { description: "Rate limit exceeded", content: { "application/json": { schema: AuthErrorSchema } } },
+    429: { description: "Rate limit exceeded, or plan connection limit reached: `plan_limit_exceeded`", content: { "application/json": { schema: AuthErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    // The plan-limit count couldn't be verified (infra fault) — fail-closed
+    // with a transient "try again", not an upgrade prompt (#3433).
+    503: { description: "Billing/plan-limit check unavailable: `billing_check_failed`", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -786,6 +789,12 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
   const connCount = connCountRows[0]?.count ?? 0;
   const resourceCheck = await checkResourceLimit(orgId, "connections", connCount);
   if (!resourceCheck.allowed) {
+    // ResourceLimitResult error-arm contract (#3433): `check_failed` means
+    // the count couldn't be verified (infra fault) — still fail-closed, but
+    // surface 503 "try again", never a misleading 429 "upgrade your plan".
+    if (resourceCheck.reason === "check_failed") {
+      return c.json({ error: "billing_check_failed", message: resourceCheck.errorMessage, requestId }, 503);
+    }
     return c.json({ error: "plan_limit_exceeded", message: resourceCheck.errorMessage, requestId }, 429);
   }
 

--- a/packages/api/src/api/routes/platform-invitations.ts
+++ b/packages/api/src/api/routes/platform-invitations.ts
@@ -96,8 +96,11 @@ const createInvitationRoute = createRoute({
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
     409: { description: "User already a member or already invited", content: { "application/json": { schema: ErrorSchema } } },
-    429: { description: "Seat limit reached", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Seat limit reached: `seat_limit`", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    // The seat count couldn't be verified (infra fault) — fail-closed with
+    // a transient "try again", not an upgrade prompt (#3433).
+    503: { description: "Billing/plan-limit check unavailable: `billing_check_failed`", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -344,14 +347,25 @@ platformInvitations.openapi(createInvitationRoute, async (c) => {
     if (seatLimit._tag === "Left") {
       const err = seatLimit.left;
       if (err instanceof APIError) {
-        const status = err.status === "TOO_MANY_REQUESTS" ? 429 : 500;
+        // Mirror the helper's error-arm contract (#3433): TOO_MANY_REQUESTS
+        // is a genuine seat cap (429 "upgrade"); SERVICE_UNAVAILABLE means
+        // the count couldn't be verified (503 "try again"). Anything else
+        // is a programmer error → 500.
+        if (err.status === "TOO_MANY_REQUESTS") {
+          return c.json(
+            { error: "seat_limit", message: err.body?.message ?? "Workspace seat limit reached.", requestId },
+            429,
+          );
+        }
+        if (err.status === "SERVICE_UNAVAILABLE") {
+          return c.json(
+            { error: "billing_check_failed", message: err.body?.message ?? "Unable to verify plan limits. Please try again.", requestId },
+            503,
+          );
+        }
         return c.json(
-          {
-            error: status === 429 ? "seat_limit" : "internal_error",
-            message: err.body?.message ?? "Seat-limit check failed.",
-            requestId,
-          },
-          status,
+          { error: "internal_error", message: err.body?.message ?? "Seat-limit check failed.", requestId },
+          500,
         );
       }
       log.error({ err: errorMessage(err), organizationId, requestId }, "Seat-limit check threw unexpectedly");

--- a/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for `enforceInvitationSeatLimit`'s error-arm mapping (#3433).
+ *
+ * The `ResourceLimitResult` contract (`lib/billing/enforcement.ts`) keeps
+ * its two `allowed: false` arms deliberately distinct:
+ *
+ *   - `cap_reached`  — genuine plan cap → 429 "upgrade your plan"
+ *   - `check_failed` — infra fault (count unreadable) → 503 "try again"
+ *
+ * Both arms must stay fail-closed (the invitation is blocked either way);
+ * only the thrown `APIError` status/message differs. Collapsing
+ * `check_failed` into `TOO_MANY_REQUESTS` shows an admin "seat limit
+ * reached — upgrade" during an internal-DB blip for seats they're
+ * entitled to.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import type { ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
+
+const mocks = createApiTestMocks();
+
+// Billing enforcement — per-test arm selection via mockCheckResourceLimit.
+const mockCheckResourceLimit = mock<
+  (orgId: string | undefined, resource: string, count: number) => Promise<ResourceLimitResult>
+>(async () => ({ allowed: true }));
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkResourceLimit: mockCheckResourceLimit,
+  getCachedWorkspace: mock(async () => null),
+  invalidatePlanCache: mock(() => {}),
+  checkPlanLimits: mock(async () => ({ allowed: true, status: "ok" })),
+  buildMetricStatus: mock(() => "ok"),
+  severityOf: mock(() => 0),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkChatIntegrationLimit: mock(async () => ({ allowed: true })),
+  checkChatIntegrationLimitAndInstall: mock(async () => ({ outcome: "installed" })),
+}));
+
+const { enforceInvitationSeatLimit } = await import("@atlas/api/lib/auth/invitations");
+const { APIError } = await import("better-auth/api");
+
+afterAll(() => mocks.cleanup());
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockClear();
+  mocks.mockInternalQuery.mockImplementation(async () => [{ count: 5 }]);
+  mockCheckResourceLimit.mockClear();
+  mockCheckResourceLimit.mockImplementation(async () => ({ allowed: true }));
+});
+
+/** Run the gate and return the thrown APIError, failing if it resolves. */
+async function expectAPIError(): Promise<InstanceType<typeof APIError>> {
+  try {
+    await enforceInvitationSeatLimit("org-1");
+  } catch (err) {
+    expect(err).toBeInstanceOf(APIError);
+    return err as InstanceType<typeof APIError>;
+  }
+  throw new Error("expected enforceInvitationSeatLimit to throw, but it resolved");
+}
+
+describe("enforceInvitationSeatLimit error-arm mapping (#3433)", () => {
+  it("resolves when the seat check allows", async () => {
+    await expect(enforceInvitationSeatLimit("org-1")).resolves.toBeUndefined();
+    expect(mockCheckResourceLimit).toHaveBeenCalledWith("org-1", "seats", 5);
+  });
+
+  it("cap_reached → 429 TOO_MANY_REQUESTS with upgrade guidance", async () => {
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "cap_reached",
+      errorMessage: "Your starter plan allows up to 5 seats. Upgrade to add more.",
+      limit: 5,
+    }));
+
+    const err = await expectAPIError();
+    expect(err.status).toBe("TOO_MANY_REQUESTS");
+    expect(err.statusCode).toBe(429);
+    expect(err.body?.message).toContain("Upgrade");
+  });
+
+  it("check_failed → 503 SERVICE_UNAVAILABLE with retry guidance, NOT a plan-limit error", async () => {
+    mockCheckResourceLimit.mockImplementation(async () => ({
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: "Unable to verify plan limits. Please try again.",
+    }));
+
+    const err = await expectAPIError();
+    expect(err.status).toBe("SERVICE_UNAVAILABLE");
+    expect(err.statusCode).toBe(503);
+    expect(err.body?.message).toMatch(/try again/i);
+    // The infra-failure arm must never masquerade as a seat-limit hit.
+    expect(err.body?.message ?? "").not.toMatch(/upgrade|seat limit/i);
+  });
+});

--- a/packages/api/src/lib/auth/invitations.ts
+++ b/packages/api/src/lib/auth/invitations.ts
@@ -130,9 +130,18 @@ export function assertPlatformInvitationRole(role: unknown): void {
 
 /**
  * Seat-limit gate. Counts current members + pending invitations against
- * the target org's plan cap and throws `APIError("TOO_MANY_REQUESTS")` on
- * over-limit. TOCTOU is acceptable here — invitation creation is
- * low-frequency and the next call catches any overshoot.
+ * the target org's plan cap. Throws per the `ResourceLimitResult` error-arm
+ * contract (`lib/billing/enforcement.ts`), keeping the two `allowed: false`
+ * arms distinct (#3433):
+ *
+ *   - `cap_reached`  → `APIError("TOO_MANY_REQUESTS")` (429) — genuine plan
+ *     cap; the actionable response is "upgrade your plan".
+ *   - `check_failed` → `APIError("SERVICE_UNAVAILABLE")` (503) — the count
+ *     couldn't be verified (infra fault). Still fail-closed, but the
+ *     actionable response is "try again", never an upgrade prompt.
+ *
+ * TOCTOU is acceptable here — invitation creation is low-frequency and the
+ * next call catches any overshoot.
  *
  * Fails open on Postgres transport errors so a pool restart doesn't block
  * legitimate invites; escalates on programmer/SQL errors so they surface
@@ -150,6 +159,14 @@ export async function enforceInvitationSeatLimit(orgId: string): Promise<void> {
     const seatCount = rows[0]?.count ?? 0;
     const resourceCheck = await checkResourceLimit(orgId, "seats", seatCount);
     if (!resourceCheck.allowed) {
+      if (resourceCheck.reason === "check_failed") {
+        // Infra fault, not a plan cap — Better Auth surfaces the APIError's
+        // status directly, so the caller sees a 503 "try again" instead of
+        // a misleading 429 "upgrade your plan".
+        throw new APIError("SERVICE_UNAVAILABLE", {
+          message: resourceCheck.errorMessage ?? "Unable to verify plan limits. Please try again.",
+        });
+      }
       throw new APIError("TOO_MANY_REQUESTS", {
         message: resourceCheck.errorMessage ?? "Workspace seat limit reached.",
       });


### PR DESCRIPTION
## Summary

Two callers of the `ResourceLimitResult` contract (`lib/billing/enforcement.ts:384–402`) collapsed its two `allowed: false` arms, rendering infra failures (`check_failed`, should be 503 "try again") as plan limits (429 "upgrade"). During an internal-DB blip, admins saw "plan limit exceeded — upgrade" for resources they're entitled to.

Fail-closed behavior is unchanged — both arms still block the request. Only the status/code/message mapping changed, matching the chat-integration path (`integrations.ts:945,1540`).

## Changes

- **`api/routes/admin-connections.ts`** — `POST /api/v1/admin/connections` now returns 503 `billing_check_failed` ("Unable to verify plan limits. Please try again.") for the `check_failed` arm; 429 `plan_limit_exceeded` stays for `cap_reached`. 503 added to the OpenAPI route definition.
- **`lib/auth/invitations.ts`** — `enforceInvitationSeatLimit` throws `APIError("SERVICE_UNAVAILABLE")` (503) for `check_failed`; `TOO_MANY_REQUESTS` (429) stays for `cap_reached`. Better Auth surfaces the APIError status directly on the native `createInvitation` hook path.
- **`api/routes/platform-invitations.ts`** — the cross-org invite route's APIError mapping (a direct consumer of the helper's thrown contract) gains the `SERVICE_UNAVAILABLE` → 503 `billing_check_failed` branch; without it the newly-distinguished arm would have collapsed into 500 `internal_error`. 503 added to the OpenAPI route definition.

## Tests (TDD — red per arm per call site, then the fix)

- New `api/__tests__/admin-connections-resource-limit.test.ts` — both arms + a fail-closed assertion (no install write on `check_failed`).
- New `lib/auth/__tests__/invitations-seat-limit.test.ts` — both arms of `enforceInvitationSeatLimit` directly (status, statusCode, message guidance).
- `api/__tests__/platform-invitations.test.ts` — new 503 `billing_check_failed` case through the route; existing 429 case now pins `reason: "cap_reached"`.

## Third callers

Audited every `checkResourceLimit` consumer: the SSO auto-provisioning path (`lib/auth/server.ts:2457`) and the chat-integration gates already distinguish the arms correctly — no third collapsed caller found.

## Verification

- `bun run lint` ✅, `bun run type` ✅
- Full `bun run test`: 592/596 files pass; the 4 failures (`discord.test.ts`, `teams.test.ts`, `teams-discord-always-mount.test.ts`, `saas-guards.test.ts`) are load-induced local flakes — all 4 pass deterministically when re-run via the isolated runner, and none import the changed files.

Closes #3433

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783878887&installation_id=135337507&pr_number=3453&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3453&signature=2c05b7259bfb532a8ac5d56ea3160fbf9b63865c572ba1279d62bfc7e1e24ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct 503 error responses for billing verification failures, properly distinguished from plan limit errors (429).
  * Improved error responses with specific error codes for capacity limits and billing verification issues.

* **Bug Fixes**
  * Enhanced error handling for resource and seat limit checks with appropriate HTTP status codes and clearer user guidance on upgrade and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->