### PR TITLE
fix(billing): Stripe teardown on workspace suspend/delete/purge — cancel on delete, customer deletion on GDPR purge, pause-collection on suspend (#3425)

### DIFF
--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -189,6 +189,19 @@ Webhook processing is idempotent and ordered: Atlas keeps a 30-day ledger of pro
 
 As a safety net for events lost beyond that window (for example after a webhook secret rotation), a background sweep runs every 6 hours and heals the workspace tier from the subscription table. Workspaces on a paid tier with no live subscription are logged but never downgraded automatically.
 
+## Workspace Lifecycle and Billing
+
+Platform-admin workspace lifecycle actions keep Stripe in sync automatically:
+
+| Action | Stripe behavior |
+|--------|-----------------|
+| Suspend | Payment collection is **paused** (`pause_collection: void`) — a suspended workspace can't use the product, so it isn't invoiced or dunned while suspended. The subscription stays alive |
+| Unsuspend | Payment collection resumes — normal invoicing restarts on the existing subscription |
+| Delete | The Stripe subscription is **canceled** before the data cascade runs — a deleted workspace never keeps invoicing |
+| Purge (GDPR) | Any remaining subscriptions are canceled and the **Stripe customer is permanently deleted** — no billable Stripe linkage survives a purge |
+
+If a Stripe call fails during one of these actions, the operation still completes; the failure is logged and returned as a `warnings` field on the admin response (and shown in the platform console) so the operator can follow up manually in the Stripe dashboard. Self-hosted deployments without Stripe configured skip these calls entirely.
+
 ---
 
 ## Stripe Setup (Self-Hosted)

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -65541,6 +65541,12 @@
                         "suggestions",
                         "scheduledTasks"
                       ]
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -65673,6 +65679,12 @@
                     },
                     "workspaceId": {
                       "type": "string"
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -65804,6 +65816,12 @@
                     },
                     "workspaceId": {
                       "type": "string"
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -65944,6 +65962,12 @@
                     },
                     "totalRows": {
                       "type": "number"
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [

--- a/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Platform-admin workspace lifecycle × Stripe teardown wiring (#3425).
+ *
+ * Route-level tests that the suspend/unsuspend/delete/purge handlers call
+ * into `lib/billing/workspace-teardown` (mocked here) with the right
+ * arguments and ordering, and that Stripe failures surface to the operator
+ * as a `warnings` field on the 200 response instead of stranding silently:
+ *
+ *   - DELETE  → cancelStripeSubscriptionsForWorkspace BEFORE the DB cascade
+ *   - purge   → purgeStripeBillingForWorkspace(orgId, stripeCustomerId)
+ *               BEFORE hardDeleteWorkspace (the cascade destroys the row
+ *               carrying the customer id)
+ *   - suspend → pauseStripeCollectionForWorkspace
+ *   - unsuspend → resumeStripeCollectionForWorkspace
+ *   - teardown warnings → `warnings` on the response + audit metadata
+ *   - no-op teardown (self-hosted) → no `warnings` key, no `stripe` audit key
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import type { StripeTeardownOutcome } from "@atlas/api/lib/billing/workspace-teardown";
+
+// ── Mockable state ──────────────────────────────────────────────────
+
+/** Cross-module call order — proves Stripe teardown runs before the cascade. */
+let callOrder: string[] = [];
+
+function wsRow(status: string): Record<string, unknown> {
+  return {
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    workspace_status: status,
+    plan_tier: "pro",
+    byot: false,
+    stripe_customer_id: "cus_acme",
+    trial_ends_at: null,
+    suspended_at: null,
+    deleted_at: null,
+    region: null,
+    region_assigned_at: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+let workspaceStatus = "active";
+
+const mockGetWorkspaceDetails = mock(async () => wsRow(workspaceStatus));
+const mockUpdateWorkspaceStatus = mock(async () => {
+  callOrder.push("updateStatus");
+  return true;
+});
+const mockCascade = mock(async () => {
+  callOrder.push("cascade");
+  return {
+    conversations: 1,
+    semanticEntities: 0,
+    learnedPatterns: 0,
+    suggestions: 0,
+    scheduledTasks: 0,
+    settings: 0,
+  };
+});
+const mockHardDelete = mock(async () => {
+  callOrder.push("hardDelete");
+  return { conversations: 3, subscriptions: 1, organization: 1 };
+});
+
+const mocks = createApiTestMocks({
+  internal: {
+    getWorkspaceDetails: mockGetWorkspaceDetails,
+    updateWorkspaceStatus: mockUpdateWorkspaceStatus,
+    cascadeWorkspaceDelete: mockCascade,
+    hardDeleteWorkspace: mockHardDelete,
+  },
+});
+
+// ── Stripe teardown module mock (all exports) ───────────────────────
+
+let teardownOutcome: StripeTeardownOutcome = { attempted: true, actions: [], warnings: [] };
+
+const mockCancelSubs = mock(async (_orgId: string) => {
+  callOrder.push("stripe:cancel");
+  return teardownOutcome;
+});
+const mockPurgeBilling = mock(async (_orgId: string, _customerId: string | null) => {
+  callOrder.push("stripe:purge");
+  return teardownOutcome;
+});
+const mockPause = mock(async (_orgId: string) => {
+  callOrder.push("stripe:pause");
+  return teardownOutcome;
+});
+const mockResume = mock(async (_orgId: string) => {
+  callOrder.push("stripe:resume");
+  return teardownOutcome;
+});
+
+mock.module("@atlas/api/lib/billing/workspace-teardown", () => ({
+  cancelStripeSubscriptionsForWorkspace: mockCancelSubs,
+  purgeStripeBillingForWorkspace: mockPurgeBilling,
+  pauseStripeCollectionForWorkspace: mockPause,
+  resumeStripeCollectionForWorkspace: mockResume,
+}));
+
+// ── Audit capture ───────────────────────────────────────────────────
+
+interface CapturedAudit {
+  actionType: string;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+let auditCalls: CapturedAudit[] = [];
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mock((entry: CapturedAudit) => {
+    auditCalls.push(entry);
+  }),
+  logAdminActionAwait: mock(async (entry: CapturedAudit) => {
+    auditCalls.push(entry);
+  }),
+  ADMIN_ACTIONS: {
+    workspace: {
+      suspend: "workspace.suspend",
+      unsuspend: "workspace.unsuspend",
+      delete: "workspace.delete",
+      purge: "workspace.purge",
+      changePlan: "workspace.change_plan",
+    },
+  },
+}));
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+function platformRequest(method: string, path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
+  });
+}
+
+beforeEach(() => {
+  mocks.setPlatformAdmin();
+  callOrder = [];
+  auditCalls = [];
+  workspaceStatus = "active";
+  teardownOutcome = { attempted: true, actions: ["canceled Stripe subscription sub_1"], warnings: [] };
+  mockCancelSubs.mockClear();
+  mockPurgeBilling.mockClear();
+  mockPause.mockClear();
+  mockResume.mockClear();
+  mockCascade.mockClear();
+  mockHardDelete.mockClear();
+  mockUpdateWorkspaceStatus.mockClear();
+});
+
+// ── Delete ──────────────────────────────────────────────────────────
+
+describe("DELETE /api/v1/platform/workspaces/:id — Stripe teardown", () => {
+  it("cancels Stripe subscriptions BEFORE the DB cascade", async () => {
+    const res = await app.fetch(platformRequest("DELETE", "/api/v1/platform/workspaces/org-1"));
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).toHaveBeenCalledTimes(1);
+    expect(mockCancelSubs.mock.calls[0][0]).toBe("org-1");
+    expect(callOrder.indexOf("stripe:cancel")).toBeLessThan(callOrder.indexOf("cascade"));
+  });
+
+  it("surfaces Stripe failures as warnings on the response and in audit metadata — delete proceeds", async () => {
+    teardownOutcome = {
+      attempted: true,
+      actions: [],
+      warnings: ["Failed to cancel Stripe subscription sub_1: stripe is down. Cancel it manually in the Stripe dashboard."],
+    };
+
+    const res = await app.fetch(platformRequest("DELETE", "/api/v1/platform/workspaces/org-1"));
+    const body = (await res.json()) as { warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.warnings).toHaveLength(1);
+    expect(body.warnings?.[0]).toContain("sub_1");
+    // Delete still completed.
+    expect(mockCascade).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledTimes(1);
+    // Audit metadata records the Stripe outcome.
+    const deleteAudit = auditCalls.find((a) => a.actionType === "workspace.delete");
+    expect(deleteAudit?.metadata?.stripe).toEqual({
+      actions: [],
+      warnings: teardownOutcome.warnings,
+    });
+  });
+
+  it("omits warnings + stripe audit key when teardown is a no-op (self-hosted)", async () => {
+    teardownOutcome = { attempted: false, actions: [], warnings: [] };
+
+    const res = await app.fetch(platformRequest("DELETE", "/api/v1/platform/workspaces/org-1"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect("warnings" in body).toBe(false);
+    const deleteAudit = auditCalls.find((a) => a.actionType === "workspace.delete");
+    expect(deleteAudit?.metadata && "stripe" in deleteAudit.metadata).toBe(false);
+  });
+});
+
+// ── Purge ───────────────────────────────────────────────────────────
+
+describe("POST /api/v1/platform/workspaces/:id/purge — Stripe teardown", () => {
+  beforeEach(() => {
+    workspaceStatus = "deleted"; // purge requires a soft-deleted workspace
+  });
+
+  it("tears down Stripe billing (with the org's customer id) BEFORE the hard-delete cascade", async () => {
+    const res = await app.fetch(platformRequest("POST", "/api/v1/platform/workspaces/org-1/purge"));
+
+    expect(res.status).toBe(200);
+    expect(mockPurgeBilling).toHaveBeenCalledTimes(1);
+    expect(mockPurgeBilling.mock.calls[0][0]).toBe("org-1");
+    expect(mockPurgeBilling.mock.calls[0][1]).toBe("cus_acme");
+    expect(callOrder.indexOf("stripe:purge")).toBeLessThan(callOrder.indexOf("hardDelete"));
+  });
+
+  it("surfaces Stripe failures as warnings — purge proceeds", async () => {
+    teardownOutcome = {
+      attempted: true,
+      actions: [],
+      warnings: ["Failed to delete Stripe customer cus_acme: api_error. Delete it manually in the Stripe dashboard — a GDPR purge must not leave a billable customer record."],
+    };
+
+    const res = await app.fetch(platformRequest("POST", "/api/v1/platform/workspaces/org-1/purge"));
+    const body = (await res.json()) as { warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.warnings).toHaveLength(1);
+    expect(body.warnings?.[0]).toContain("cus_acme");
+    expect(mockHardDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Suspend / unsuspend ─────────────────────────────────────────────
+
+describe("POST /api/v1/platform/workspaces/:id/suspend|unsuspend — pause/resume collection", () => {
+  it("suspend pauses Stripe collection", async () => {
+    const res = await app.fetch(platformRequest("POST", "/api/v1/platform/workspaces/org-1/suspend"));
+
+    expect(res.status).toBe(200);
+    expect(mockPause).toHaveBeenCalledTimes(1);
+    expect(mockPause.mock.calls[0][0]).toBe("org-1");
+    expect(mockResume).not.toHaveBeenCalled();
+  });
+
+  it("unsuspend resumes Stripe collection", async () => {
+    workspaceStatus = "suspended";
+
+    const res = await app.fetch(platformRequest("POST", "/api/v1/platform/workspaces/org-1/unsuspend"));
+
+    expect(res.status).toBe(200);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+    expect(mockResume.mock.calls[0][0]).toBe("org-1");
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it("suspend surfaces pause failures as warnings — suspend stands", async () => {
+    teardownOutcome = {
+      attempted: true,
+      actions: [],
+      warnings: ["Failed to pause collection on Stripe subscription sub_1: rate_limited. Pause it manually in the Stripe dashboard so the suspended workspace isn't invoiced."],
+    };
+
+    const res = await app.fetch(platformRequest("POST", "/api/v1/platform/workspaces/org-1/suspend"));
+    const body = (await res.json()) as { warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.warnings).toHaveLength(1);
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -45,6 +45,13 @@ import {
 } from "@useatlas/types";
 import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import {
+  cancelStripeSubscriptionsForWorkspace,
+  purgeStripeBillingForWorkspace,
+  pauseStripeCollectionForWorkspace,
+  resumeStripeCollectionForWorkspace,
+  type StripeTeardownOutcome,
+} from "@atlas/api/lib/billing/workspace-teardown";
 import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
   ABUSE_RESTORE_STATUSES,
@@ -70,6 +77,25 @@ import {
 const log = createLogger("platform-admin");
 
 const VALID_PLAN_TIERS = new Set<string>(PLAN_TIERS);
+
+/**
+ * Audit metadata for a Stripe teardown outcome (#3425) — empty when the
+ * teardown was a no-op (Stripe not configured), so self-hosted audit rows
+ * don't grow a misleading `stripe` key.
+ */
+function stripeAuditMetadata(billing: StripeTeardownOutcome): Record<string, unknown> {
+  return billing.attempted
+    ? { stripe: { actions: billing.actions, warnings: billing.warnings } }
+    : {};
+}
+
+/**
+ * Response fragment surfacing Stripe teardown failures to the operator —
+ * a Stripe API failure must never strand the operation silently (#3425).
+ */
+function withWarnings(billing: StripeTeardownOutcome): { warnings?: string[] } {
+  return billing.warnings.length > 0 ? { warnings: billing.warnings } : {};
+}
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -154,7 +180,7 @@ const suspendWorkspaceRoute = createRoute({
   responses: {
     200: {
       description: "Workspace suspended",
-      content: { "application/json": { schema: z.object({ message: z.string(), workspaceId: z.string() }) } },
+      content: { "application/json": { schema: z.object({ message: z.string(), workspaceId: z.string(), warnings: z.array(z.string()).optional() }) } },
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -173,7 +199,7 @@ const unsuspendWorkspaceRoute = createRoute({
   responses: {
     200: {
       description: "Workspace reactivated",
-      content: { "application/json": { schema: z.object({ message: z.string(), workspaceId: z.string() }) } },
+      content: { "application/json": { schema: z.object({ message: z.string(), workspaceId: z.string(), warnings: z.array(z.string()).optional() }) } },
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -204,6 +230,7 @@ const deleteWorkspaceRoute = createRoute({
               suggestions: z.number(),
               scheduledTasks: z.number(),
             }),
+            warnings: z.array(z.string()).optional(),
           }),
         },
       },
@@ -232,6 +259,7 @@ const purgeWorkspaceRoute = createRoute({
             workspaceId: z.string(),
             purged: z.record(z.string(), z.number()),
             totalRows: z.number(),
+            warnings: z.array(z.string()).optional(),
           }),
         },
       },
@@ -590,17 +618,26 @@ platformAdmin.openapi(suspendWorkspaceRoute, async (c) => {
     // Drop the cached `getCachedWorkspace` entry so the next user-side
     // request sees the new status within its TTL window (#2165).
     invalidatePlanCache(workspaceId);
-    log.info({ workspaceId, requestId }, "Workspace suspended by platform admin");
+
+    // Suspension billing policy (#3425): pause Stripe payment collection
+    // (`pause_collection: { behavior: "void" }`) — a suspended workspace
+    // can't use the product, so it must not keep being invoiced/dunned.
+    // The subscription stays alive so unsuspending restores billing.
+    // Stripe failures surface as operator warnings; the suspend stands.
+    const billing = yield* Effect.promise(() => pauseStripeCollectionForWorkspace(workspaceId));
+
+    log.info({ workspaceId, requestId, stripe: billing }, "Workspace suspended by platform admin");
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.suspend,
       targetType: "workspace",
       targetId: workspaceId,
       scope: "platform",
+      metadata: stripeAuditMetadata(billing),
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
-    return c.json({ message: "Workspace suspended.", workspaceId }, 200);
+    return c.json({ message: "Workspace suspended.", workspaceId, ...withWarnings(billing) }, 200);
   }), { label: "suspend workspace" });
 });
 
@@ -627,17 +664,23 @@ platformAdmin.openapi(unsuspendWorkspaceRoute, async (c) => {
 
     yield* Effect.promise(() => updateWorkspaceStatus(workspaceId, "active"));
     invalidatePlanCache(workspaceId); // #2165 — see suspend handler above
-    log.info({ workspaceId, requestId }, "Workspace unsuspended by platform admin");
+
+    // Resume Stripe payment collection paused at suspension time (#3425) —
+    // see the suspend handler above for the pause-collection policy.
+    const billing = yield* Effect.promise(() => resumeStripeCollectionForWorkspace(workspaceId));
+
+    log.info({ workspaceId, requestId, stripe: billing }, "Workspace unsuspended by platform admin");
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.unsuspend,
       targetType: "workspace",
       targetId: workspaceId,
       scope: "platform",
+      metadata: stripeAuditMetadata(billing),
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
-    return c.json({ message: "Workspace reactivated.", workspaceId }, 200);
+    return c.json({ message: "Workspace reactivated.", workspaceId, ...withWarnings(billing) }, 200);
   }), { label: "unsuspend workspace" });
 });
 
@@ -662,6 +705,14 @@ platformAdmin.openapi(deleteWorkspaceRoute, async (c) => {
       return c.json({ error: "conflict", message: "Workspace is already deleted.", requestId }, 409);
     }
 
+    // Cancel Stripe billing FIRST, then cascade (#3425): a deleted org
+    // must stop invoicing even if the cascade below fails, and the
+    // @better-auth/stripe plugin's own guard blocks user-initiated org
+    // deletion while subscriptions exist — this direct-DB path honors the
+    // same ordering rather than bypassing it. Stripe failures surface as
+    // operator warnings on the response; the delete proceeds.
+    const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(workspaceId));
+
     // Cascade cleanup first, then mark as deleted — if cleanup fails,
     // the workspace remains in its current state and can be retried.
     const cleanup = yield* Effect.tryPromise({
@@ -674,14 +725,14 @@ platformAdmin.openapi(deleteWorkspaceRoute, async (c) => {
     });
     invalidatePlanCache(workspaceId); // #2165 — see suspend handler above
 
-    log.info({ workspaceId, cleanup, requestId }, "Workspace deleted by platform admin");
+    log.info({ workspaceId, cleanup, stripe: billing, requestId }, "Workspace deleted by platform admin");
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.delete,
       targetType: "workspace",
       targetId: workspaceId,
       scope: "platform",
-      metadata: { cleanup },
+      metadata: { cleanup, ...stripeAuditMetadata(billing) },
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
@@ -689,6 +740,7 @@ platformAdmin.openapi(deleteWorkspaceRoute, async (c) => {
       message: "Workspace deleted.",
       workspaceId,
       cleanup,
+      ...withWarnings(billing),
     }, 200);
   }), { label: "delete workspace" });
 });
@@ -718,6 +770,16 @@ platformAdmin.openapi(purgeWorkspaceRoute, async (c) => {
       }, 409);
     }
 
+    // Stripe teardown BEFORE the purge cascade (#3425): the cascade
+    // destroys the organization row carrying the plugin-owned
+    // stripeCustomerId (#3417), so the customer must be deleted while the
+    // linkage still exists — a GDPR purge must leave no billable Stripe
+    // linkage behind. Stripe failures surface as operator warnings (with
+    // the raw Stripe ids for manual follow-up); the purge proceeds.
+    const billing = yield* Effect.promise(() =>
+      purgeStripeBillingForWorkspace(workspaceId, workspace.stripe_customer_id),
+    );
+
     const purged = yield* Effect.tryPromise({
       try: () => hardDeleteWorkspace(workspaceId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
@@ -725,14 +787,14 @@ platformAdmin.openapi(purgeWorkspaceRoute, async (c) => {
 
     const totalRows = Object.values(purged).reduce((sum, n) => sum + n, 0);
 
-    log.info({ workspaceId, totalRows, requestId }, "Workspace purged (GDPR hard delete)");
+    log.info({ workspaceId, totalRows, stripe: billing, requestId }, "Workspace purged (GDPR hard delete)");
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.purge,
       targetType: "workspace",
       targetId: workspaceId,
       scope: "platform",
-      metadata: { purged, totalRows },
+      metadata: { purged, totalRows, ...stripeAuditMetadata(billing) },
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
@@ -741,6 +803,7 @@ platformAdmin.openapi(purgeWorkspaceRoute, async (c) => {
       workspaceId,
       purged: purged as unknown as Record<string, number>,
       totalRows,
+      ...withWarnings(billing),
     }, 200);
   }), { label: "purge workspace (GDPR)" });
 });

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -60,7 +60,7 @@ import { blockNativeMemberRoleUpdate, blockNativeMemberRemoval } from "@atlas/ap
 import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
-import { STRIPE_API_VERSION } from "@atlas/api/lib/billing/stripe-api-version";
+import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import {
   classifyStripeEvent,
@@ -2248,7 +2248,13 @@ export function buildPlugins() {
       );
     } else {
       try {
-        const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: STRIPE_API_VERSION });
+        // Shared accessor (#3425) — same client instance + pinned apiVersion
+        // as the workspace billing teardown in lib/billing/workspace-teardown.ts.
+        const stripeClient = getStripeClient();
+        if (!stripeClient) {
+          // Unreachable: the STRIPE_SECRET_KEY check above guarantees a client.
+          throw new Error("getStripeClient() returned null despite STRIPE_SECRET_KEY being set");
+        }
 
         plugins.push(
           stripePlugin(buildStripePluginOptions({ stripeClient, webhookSecret })),

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Stripe billing teardown tests (#3425).
+ *
+ * Drives the four workspace-lifecycle teardown helpers against a mocked
+ * Stripe client + mocked internal DB:
+ *   - delete  → cancels every non-terminal subscription
+ *   - purge   → cancels subscriptions AND deletes the Stripe customer(s)
+ *   - suspend → pauses collection (`pause_collection: { behavior: "void" }`)
+ *   - unsuspend → resumes collection (clears `pause_collection`)
+ *   - Stripe failure → helper returns (never throws), warning surfaced, logged
+ *   - resource_missing → treated as already-gone (action, not warning)
+ *   - no Stripe configured / no internal DB → clean no-op
+ *   - subscription table missing (42P01) → no subscriptions, no warning
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+// ── Mockable state ──────────────────────────────────────────────────
+
+let hasDB = true;
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
+  mock(() => Promise.resolve([]));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({
+    internalQuery: mockInternalQuery,
+    hasInternalDB: () => hasDB,
+  }),
+}));
+
+// Logger spy — failure paths must log, not silently swallow.
+const mockLogError = mock((..._args: unknown[]) => {});
+const stubLogger = {
+  info: () => {},
+  warn: () => {},
+  error: mockLogError,
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  setLogLevel: () => false,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [] as string[],
+  hashShareToken: (token: string) => token,
+}));
+
+// ── Mocked Stripe client ────────────────────────────────────────────
+
+/** Records call order across the stub so ordering can be asserted. */
+let callOrder: string[] = [];
+
+const subscriptionsCancel: Mock<(id: string) => Promise<unknown>> = mock(
+  async (id: string) => {
+    callOrder.push(`cancel:${id}`);
+    return { id, status: "canceled" };
+  },
+);
+const subscriptionsUpdate: Mock<(id: string, params: Record<string, unknown>) => Promise<unknown>> =
+  mock(async (id: string, _params: Record<string, unknown>) => {
+    callOrder.push(`update:${id}`);
+    return { id };
+  });
+const customersDel: Mock<(id: string) => Promise<unknown>> = mock(async (id: string) => {
+  callOrder.push(`customer.del:${id}`);
+  return { id, deleted: true };
+});
+
+let stripeAvailable = true;
+function makeStripeStub() {
+  return {
+    subscriptions: { cancel: subscriptionsCancel, update: subscriptionsUpdate },
+    customers: { del: customersDel },
+  };
+}
+
+mock.module("@atlas/api/lib/billing/stripe-client", () => ({
+  getStripeClient: () => (stripeAvailable ? makeStripeStub() : null),
+  _resetStripeClientCache: () => {},
+}));
+
+const {
+  cancelStripeSubscriptionsForWorkspace,
+  purgeStripeBillingForWorkspace,
+  pauseStripeCollectionForWorkspace,
+  resumeStripeCollectionForWorkspace,
+} = await import("../workspace-teardown");
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const ORG = "org-acme";
+
+function subRow(
+  id: string,
+  status: string,
+  customerId: string | null = "cus_acme",
+): Record<string, unknown> {
+  return { stripeSubscriptionId: id, stripeCustomerId: customerId, status };
+}
+
+function mockSubscriptionRows(rows: Record<string, unknown>[]): void {
+  mockInternalQuery.mockImplementation(async (sql: string) => {
+    if (sql.includes("FROM subscription")) return rows;
+    return [];
+  });
+}
+
+class FakeStripeError extends Error {
+  code: string | undefined;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+beforeEach(() => {
+  hasDB = true;
+  stripeAvailable = true;
+  callOrder = [];
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  subscriptionsCancel.mockClear();
+  subscriptionsUpdate.mockClear();
+  customersDel.mockClear();
+  mockLogError.mockClear();
+  // Restore default success implementations after failure-path tests.
+  subscriptionsCancel.mockImplementation(async (id: string) => {
+    callOrder.push(`cancel:${id}`);
+    return { id, status: "canceled" };
+  });
+  subscriptionsUpdate.mockImplementation(async (id: string, _params: Record<string, unknown>) => {
+    callOrder.push(`update:${id}`);
+    return { id };
+  });
+  customersDel.mockImplementation(async (id: string) => {
+    callOrder.push(`customer.del:${id}`);
+    return { id, deleted: true };
+  });
+});
+
+// ── Delete: cancel subscriptions ────────────────────────────────────
+
+describe("cancelStripeSubscriptionsForWorkspace (delete path)", () => {
+  it("cancels every non-terminal subscription", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active"), subRow("sub_2", "trialing")]);
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome.attempted).toBe(true);
+    expect(subscriptionsCancel.mock.calls.map((c) => c[0])).toEqual(["sub_1", "sub_2"]);
+    expect(outcome.actions).toHaveLength(2);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("skips rows already terminal in the local subscription table", async () => {
+    mockSubscriptionRows([
+      subRow("sub_live", "active"),
+      subRow("sub_done", "canceled"),
+      subRow("sub_dead", "incomplete_expired"),
+    ]);
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(subscriptionsCancel.mock.calls.map((c) => c[0])).toEqual(["sub_live"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("surfaces a warning (and logs) when Stripe cancel fails — never throws", async () => {
+    mockSubscriptionRows([subRow("sub_boom", "active")]);
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("stripe is down");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome.attempted).toBe(true);
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("sub_boom");
+    expect(outcome.warnings[0]).toContain("stripe is down");
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("treats resource_missing as already-gone (action, not warning)", async () => {
+    mockSubscriptionRows([subRow("sub_gone", "active")]);
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("No such subscription", "resource_missing");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome.warnings).toEqual([]);
+    expect(outcome.actions).toHaveLength(1);
+    expect(outcome.actions[0]).toContain("already absent");
+  });
+
+  it("no-ops cleanly when Stripe is not configured", async () => {
+    stripeAvailable = false;
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome).toEqual({ attempted: false, actions: [], warnings: [] });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("no-ops cleanly when there is no internal DB", async () => {
+    hasDB = false;
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome).toEqual({ attempted: false, actions: [], warnings: [] });
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing subscription table (42P01) as no subscriptions", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new FakeStripeError('relation "subscription" does not exist', "42P01");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome).toEqual({ attempted: true, actions: [], warnings: [] });
+  });
+
+  it("surfaces a warning when the subscription read fails for a real reason", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("connection refused");
+    expect(mockLogError).toHaveBeenCalled();
+  });
+});
+
+// ── Purge: cancel + delete customer ─────────────────────────────────
+
+describe("purgeStripeBillingForWorkspace (GDPR purge path)", () => {
+  it("cancels remaining subscriptions then deletes the Stripe customer", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active", "cus_acme")]);
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_acme");
+
+    expect(outcome.attempted).toBe(true);
+    expect(subscriptionsCancel).toHaveBeenCalledTimes(1);
+    expect(customersDel).toHaveBeenCalledTimes(1);
+    expect(customersDel.mock.calls[0][0]).toBe("cus_acme");
+    // Ordering: subscription cancel BEFORE customer deletion.
+    expect(callOrder).toEqual(["cancel:sub_1", "customer.del:cus_acme"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("deletes the customer even when all subscriptions are already terminal", async () => {
+    mockSubscriptionRows([subRow("sub_old", "canceled", "cus_acme")]);
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_acme");
+
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+    expect(customersDel.mock.calls.map((c) => c[0])).toEqual(["cus_acme"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("unions customer ids from the org column and subscription rows", async () => {
+    mockSubscriptionRows([subRow("sub_old", "canceled", "cus_drifted")]);
+
+    await purgeStripeBillingForWorkspace(ORG, "cus_org");
+
+    expect(customersDel.mock.calls.map((c) => c[0]).toSorted()).toEqual([
+      "cus_drifted",
+      "cus_org",
+    ]);
+  });
+
+  it("makes no customer call when there is no Stripe customer linkage", async () => {
+    mockSubscriptionRows([]);
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, null);
+
+    expect(outcome.attempted).toBe(true);
+    expect(customersDel).not.toHaveBeenCalled();
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("surfaces a warning (and logs) when customer deletion fails — purge proceeds", async () => {
+    mockSubscriptionRows([]);
+    customersDel.mockImplementation(async () => {
+      throw new FakeStripeError("api_error");
+    });
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_acme");
+
+    expect(outcome.attempted).toBe(true);
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("cus_acme");
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("treats a resource_missing customer as already-gone", async () => {
+    mockSubscriptionRows([]);
+    customersDel.mockImplementation(async () => {
+      throw new FakeStripeError("No such customer", "resource_missing");
+    });
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_gone");
+
+    expect(outcome.warnings).toEqual([]);
+    expect(outcome.actions.some((a) => a.includes("already absent"))).toBe(true);
+  });
+
+  it("no-ops cleanly when Stripe is not configured", async () => {
+    stripeAvailable = false;
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_acme");
+
+    expect(outcome).toEqual({ attempted: false, actions: [], warnings: [] });
+    expect(customersDel).not.toHaveBeenCalled();
+  });
+});
+
+// ── Suspend / unsuspend: pause / resume collection ──────────────────
+
+describe("pause/resumeStripeCollectionForWorkspace (suspend policy)", () => {
+  it("suspend pauses collection with behavior: void", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome.attempted).toBe(true);
+    expect(subscriptionsUpdate).toHaveBeenCalledTimes(1);
+    expect(subscriptionsUpdate.mock.calls[0][0]).toBe("sub_1");
+    expect(subscriptionsUpdate.mock.calls[0][1]).toEqual({
+      pause_collection: { behavior: "void" },
+    });
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("unsuspend clears pause_collection", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+
+    const outcome = await resumeStripeCollectionForWorkspace(ORG);
+
+    expect(subscriptionsUpdate).toHaveBeenCalledTimes(1);
+    expect(subscriptionsUpdate.mock.calls[0][1]).toEqual({ pause_collection: "" });
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("skips terminal subscriptions", async () => {
+    mockSubscriptionRows([subRow("sub_done", "canceled")]);
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(subscriptionsUpdate).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ attempted: true, actions: [], warnings: [] });
+  });
+
+  it("surfaces a warning (and logs) when the pause fails — suspend proceeds", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    subscriptionsUpdate.mockImplementation(async () => {
+      throw new FakeStripeError("rate_limited");
+    });
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome.attempted).toBe(true);
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("sub_1");
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("no-ops cleanly when Stripe is not configured", async () => {
+    stripeAvailable = false;
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome).toEqual({ attempted: false, actions: [], warnings: [] });
+    expect(subscriptionsUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/billing/stripe-client.ts
+++ b/packages/api/src/lib/billing/stripe-client.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared Stripe client accessor (#3425).
+ *
+ * Single construction point for the Stripe SDK client so every caller —
+ * the @better-auth/stripe plugin wiring in `lib/auth/server.ts` and the
+ * workspace billing teardown in `lib/billing/workspace-teardown.ts` —
+ * uses the same secret key and the same pinned `apiVersion`
+ * ({@link STRIPE_API_VERSION}). Constructing ad-hoc clients elsewhere
+ * risks drifting the wire schema on the billing path (see #3129).
+ *
+ * Returns `null` when `STRIPE_SECRET_KEY` is unset (self-hosted /
+ * no-Stripe deployments) so callers can no-op cleanly. The instance is
+ * cached per secret key — tests that swap the env var get a fresh client.
+ */
+import Stripe from "stripe";
+import { STRIPE_API_VERSION } from "./stripe-api-version";
+
+let cachedClient: Stripe | null = null;
+let cachedKey: string | null = null;
+
+export function getStripeClient(): Stripe | null {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) return null;
+  if (cachedClient && cachedKey === key) return cachedClient;
+  cachedClient = new Stripe(key, { apiVersion: STRIPE_API_VERSION });
+  cachedKey = key;
+  return cachedClient;
+}
+
+/** Test-only: drop the cached client so env changes take effect. */
+export function _resetStripeClientCache(): void {
+  cachedClient = null;
+  cachedKey = null;
+}

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -1,0 +1,347 @@
+/**
+ * Stripe billing teardown for platform-admin workspace lifecycle ops (#3425).
+ *
+ * Platform-admin suspend/unsuspend/delete/purge historically performed no
+ * Stripe interaction at all — a deleted (or GDPR-purged) org left its Stripe
+ * subscription live and invoicing. This module is the single seam between
+ * those lifecycle operations and Stripe:
+ *
+ * - **Delete** → {@link cancelStripeSubscriptionsForWorkspace}: cancel every
+ *   live Stripe subscription for the org. Runs BEFORE the DB cascade — the
+ *   @better-auth/stripe plugin (org mode, #3416) blocks better-auth org
+ *   deletion while subscriptions exist, and platform-admin's direct-DB
+ *   cascade must honor the same ordering rather than bypass it.
+ * - **Purge (GDPR)** → {@link purgeStripeBillingForWorkspace}: cancel any
+ *   remaining subscriptions AND permanently delete the Stripe customer —
+ *   no billable Stripe linkage may survive a GDPR purge.
+ * - **Suspend / unsuspend** → {@link pauseStripeCollectionForWorkspace} /
+ *   {@link resumeStripeCollectionForWorkspace}: see the policy note on the
+ *   pause function.
+ *
+ * Failure semantics: Stripe API failures must never strand the admin
+ * operation silently. Every helper is total — it catches each Stripe error,
+ * logs it with context, and returns it as an operator-facing `warnings`
+ * entry that the route surfaces in the admin response for manual follow-up.
+ * The lifecycle operation itself always proceeds.
+ *
+ * No-Stripe deployments (self-hosted, no `STRIPE_SECRET_KEY`) and
+ * deployments without an internal DB no-op cleanly (`attempted: false`).
+ *
+ * Repo seam rule: this is `lib/` code — it must never import from
+ * `api/routes/`. Routes call down into it.
+ */
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getStripeClient } from "./stripe-client";
+
+const log = createLogger("billing:workspace-teardown");
+
+/** Outcome of one Stripe teardown helper invocation. */
+export interface StripeTeardownOutcome {
+  /**
+   * `false` when nothing was attempted — Stripe isn't configured
+   * (`STRIPE_SECRET_KEY` unset) or there is no internal DB. The caller can
+   * treat this as a clean no-op.
+   */
+  attempted: boolean;
+  /** Human-readable notes about each Stripe action taken (for audit metadata). */
+  actions: string[];
+  /**
+   * Operator-facing failure messages. Non-empty means at least one Stripe
+   * call failed and needs manual follow-up in the Stripe dashboard —
+   * surface these in the admin response, never swallow them.
+   */
+  warnings: string[];
+}
+
+/** Fresh no-op outcome — Stripe not configured / no internal DB. */
+function noopOutcome(): StripeTeardownOutcome {
+  return { attempted: false, actions: [], warnings: [] };
+}
+
+/**
+ * Subscription statuses that need no remote action — Stripe already
+ * considers them terminated.
+ */
+const TERMINAL_STATUSES = new Set(["canceled", "incomplete_expired"]);
+
+interface SubscriptionRow {
+  stripeSubscriptionId: string;
+  stripeCustomerId: string | null;
+  status: string | null;
+  [key: string]: unknown;
+}
+
+/** Stripe "the object no longer exists" — treat as already torn down. */
+function isResourceMissing(err: unknown): boolean {
+  return (
+    typeof err === "object"
+    && err !== null
+    && (err as { code?: unknown }).code === "resource_missing"
+  );
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Read the org's subscription rows from the @better-auth/stripe plugin's
+ * `subscription` table. The table only exists once the plugin has run its
+ * migrations, so `undefined_table` (42P01) means "no subscriptions", while
+ * any other DB error is surfaced as a warning — silently returning an empty
+ * list on a real failure would strand live subscriptions invisibly.
+ */
+async function listStripeSubscriptions(
+  orgId: string,
+): Promise<{ rows: SubscriptionRow[]; warning: string | null }> {
+  try {
+    const rows = await internalQuery<SubscriptionRow>(
+      `SELECT "stripeSubscriptionId", "stripeCustomerId", status
+         FROM subscription
+        WHERE "referenceId" = $1 AND "stripeSubscriptionId" IS NOT NULL`,
+      [orgId],
+    );
+    return { rows, warning: null };
+  } catch (err) {
+    if ((err as { code?: unknown }).code === "42P01") {
+      log.debug(
+        { orgId },
+        "subscription table does not exist — no Stripe subscriptions to tear down",
+      );
+      return { rows: [], warning: null };
+    }
+    const msg = errMessage(err);
+    log.error(
+      { orgId, err: msg },
+      "Failed to read subscription rows for Stripe teardown — live subscriptions may remain",
+    );
+    return {
+      rows: [],
+      warning:
+        `Could not read this workspace's subscription records (${msg}). `
+        + "Check the Stripe dashboard for live subscriptions belonging to this workspace.",
+    };
+  }
+}
+
+/** Cancel one Stripe subscription, folding the result into actions/warnings. */
+async function cancelOneSubscription(
+  orgId: string,
+  stripeSubscriptionId: string,
+  actions: string[],
+  warnings: string[],
+): Promise<void> {
+  const stripe = getStripeClient();
+  if (!stripe) return; // callers gate before reaching here
+  try {
+    await stripe.subscriptions.cancel(stripeSubscriptionId);
+    actions.push(`canceled Stripe subscription ${stripeSubscriptionId}`);
+    log.info(
+      { orgId, stripeSubscriptionId },
+      "Canceled Stripe subscription during workspace teardown",
+    );
+  } catch (err) {
+    if (isResourceMissing(err)) {
+      actions.push(`Stripe subscription ${stripeSubscriptionId} already absent in Stripe`);
+      log.info(
+        { orgId, stripeSubscriptionId },
+        "Stripe subscription already absent during workspace teardown",
+      );
+      return;
+    }
+    const msg = errMessage(err);
+    log.error(
+      { orgId, stripeSubscriptionId, err: msg },
+      "Failed to cancel Stripe subscription during workspace teardown",
+    );
+    warnings.push(
+      `Failed to cancel Stripe subscription ${stripeSubscriptionId}: ${msg}. `
+      + "Cancel it manually in the Stripe dashboard.",
+    );
+  }
+}
+
+/**
+ * Workspace delete: cancel every non-terminal Stripe subscription for the
+ * org. Call BEFORE the DB cascade (see module doc for the ordering
+ * rationale). Total — never throws; failures land in `warnings`.
+ */
+export async function cancelStripeSubscriptionsForWorkspace(
+  orgId: string,
+): Promise<StripeTeardownOutcome> {
+  if (!hasInternalDB() || !getStripeClient()) return noopOutcome();
+
+  const actions: string[] = [];
+  const warnings: string[] = [];
+  const { rows, warning } = await listStripeSubscriptions(orgId);
+  if (warning) warnings.push(warning);
+
+  for (const row of rows) {
+    if (row.status && TERMINAL_STATUSES.has(row.status)) continue;
+    await cancelOneSubscription(orgId, row.stripeSubscriptionId, actions, warnings);
+  }
+
+  return { attempted: true, actions, warnings };
+}
+
+/**
+ * GDPR purge: cancel any remaining subscriptions, then permanently delete
+ * the Stripe customer(s) linked to the org — a purged workspace must retain
+ * no billable Stripe linkage.
+ *
+ * `stripeCustomerId` is the plugin-owned `organization."stripeCustomerId"`
+ * value (#3417) read by the caller BEFORE the purge cascade destroys the
+ * organization row. Customer ids found on subscription rows are unioned in
+ * defensively, so a drifted org column can't leave a customer behind.
+ *
+ * Total — never throws; failures land in `warnings`.
+ */
+export async function purgeStripeBillingForWorkspace(
+  orgId: string,
+  stripeCustomerId: string | null,
+): Promise<StripeTeardownOutcome> {
+  if (!hasInternalDB()) return noopOutcome();
+  const stripe = getStripeClient();
+  if (!stripe) return noopOutcome();
+
+  const actions: string[] = [];
+  const warnings: string[] = [];
+  const { rows, warning } = await listStripeSubscriptions(orgId);
+  if (warning) warnings.push(warning);
+
+  // Cancel subscriptions first, then delete the customer — mirrors the
+  // ordering the @better-auth/stripe plugin enforces for user-initiated
+  // org deletion (#3425 plugin-review note).
+  for (const row of rows) {
+    if (row.status && TERMINAL_STATUSES.has(row.status)) continue;
+    await cancelOneSubscription(orgId, row.stripeSubscriptionId, actions, warnings);
+  }
+
+  const customerIds = new Set<string>();
+  if (stripeCustomerId) customerIds.add(stripeCustomerId);
+  for (const row of rows) {
+    if (row.stripeCustomerId) customerIds.add(row.stripeCustomerId);
+  }
+
+  for (const customerId of customerIds) {
+    try {
+      await stripe.customers.del(customerId);
+      actions.push(`deleted Stripe customer ${customerId}`);
+      log.info(
+        { orgId, stripeCustomerId: customerId },
+        "Deleted Stripe customer during GDPR purge",
+      );
+    } catch (err) {
+      if (isResourceMissing(err)) {
+        actions.push(`Stripe customer ${customerId} already absent in Stripe`);
+        log.info(
+          { orgId, stripeCustomerId: customerId },
+          "Stripe customer already absent during GDPR purge",
+        );
+        continue;
+      }
+      const msg = errMessage(err);
+      log.error(
+        { orgId, stripeCustomerId: customerId, err: msg },
+        "Failed to delete Stripe customer during GDPR purge",
+      );
+      warnings.push(
+        `Failed to delete Stripe customer ${customerId}: ${msg}. `
+        + "Delete it manually in the Stripe dashboard — a GDPR purge must not leave a billable customer record.",
+      );
+    }
+  }
+
+  return { attempted: true, actions, warnings };
+}
+
+/**
+ * Shared pause/resume implementation — both flip `pause_collection` on the
+ * org's non-terminal subscriptions.
+ */
+async function updateCollectionForWorkspace(
+  orgId: string,
+  mode: "pause" | "resume",
+): Promise<StripeTeardownOutcome> {
+  if (!hasInternalDB()) return noopOutcome();
+  const stripe = getStripeClient();
+  if (!stripe) return noopOutcome();
+
+  const actions: string[] = [];
+  const warnings: string[] = [];
+  const { rows, warning } = await listStripeSubscriptions(orgId);
+  if (warning) warnings.push(warning);
+
+  for (const row of rows) {
+    if (row.status && TERMINAL_STATUSES.has(row.status)) continue;
+    const id = row.stripeSubscriptionId;
+    try {
+      await stripe.subscriptions.update(
+        id,
+        // "" is Stripe's typed Emptyable — clears pause_collection entirely.
+        mode === "pause"
+          ? { pause_collection: { behavior: "void" } }
+          : { pause_collection: "" },
+      );
+      actions.push(
+        mode === "pause"
+          ? `paused collection on Stripe subscription ${id}`
+          : `resumed collection on Stripe subscription ${id}`,
+      );
+      log.info(
+        { orgId, stripeSubscriptionId: id, mode },
+        "Updated Stripe pause_collection during workspace suspend/unsuspend",
+      );
+    } catch (err) {
+      if (isResourceMissing(err)) {
+        actions.push(`Stripe subscription ${id} already absent in Stripe`);
+        log.info(
+          { orgId, stripeSubscriptionId: id, mode },
+          "Stripe subscription already absent during suspend/unsuspend",
+        );
+        continue;
+      }
+      const msg = errMessage(err);
+      log.error(
+        { orgId, stripeSubscriptionId: id, mode, err: msg },
+        "Failed to update Stripe pause_collection during workspace suspend/unsuspend",
+      );
+      warnings.push(
+        mode === "pause"
+          ? `Failed to pause collection on Stripe subscription ${id}: ${msg}. `
+            + "Pause it manually in the Stripe dashboard so the suspended workspace isn't invoiced."
+          : `Failed to resume collection on Stripe subscription ${id}: ${msg}. `
+            + "Resume it manually in the Stripe dashboard or the workspace won't be invoiced.",
+      );
+    }
+  }
+
+  return { attempted: true, actions, warnings };
+}
+
+/**
+ * Suspension billing policy (#3425, recorded in the issue triage note):
+ * **pause payment collection** (`pause_collection: { behavior: "void" }`)
+ * rather than cancel the subscription or let dunning continue — a suspended
+ * workspace can't use the product, so invoices generated while suspended
+ * are voided. The subscription itself stays alive, so unsuspending restores
+ * billing without a new checkout. `behavior: "void"` (not `"keep_as_draft"`)
+ * because we don't intend to retroactively collect for the suspension
+ * window.
+ */
+export async function pauseStripeCollectionForWorkspace(
+  orgId: string,
+): Promise<StripeTeardownOutcome> {
+  return updateCollectionForWorkspace(orgId, "pause");
+}
+
+/**
+ * Unsuspend: clear `pause_collection` so normal invoicing resumes. See
+ * {@link pauseStripeCollectionForWorkspace} for the policy rationale.
+ */
+export async function resumeStripeCollectionForWorkspace(
+  orgId: string,
+): Promise<StripeTeardownOutcome> {
+  return updateCollectionForWorkspace(orgId, "resume");
+}

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -952,6 +952,90 @@ describe("hardDeleteWorkspace()", () => {
     expect(result.integrationCredentials).toBe(2);
     expect(result.twentyIntegrations).toBe(3);
   });
+
+  it("purges Stripe billing linkage rows when the plugin's subscription table exists (#3425)", async () => {
+    // GDPR completeness: a purged workspace must retain no billable Stripe
+    // linkage — local `subscription` rows and the org's
+    // stripe_webhook_events ledger rows are deleted inside the cascade.
+    const { pool: basePool } = createMockPool();
+    const queries: string[] = [];
+    const client = {
+      async query(sql: string) {
+        queries.push(sql);
+        const upper = sql.trim().toUpperCase();
+        if (upper.startsWith("SELECT WORKSPACE_STATUS")) {
+          return { rows: [{ workspace_status: "deleted" }] };
+        }
+        if (sql.includes("to_regclass")) {
+          return { rows: [{ table_exists: true }] };
+        }
+        if (sql.includes("FROM member m")) return { rows: [] };
+        if (sql.includes("DELETE FROM stripe_webhook_events")) {
+          return { rows: [{ ok: 1 }, { ok: 1 }] }; // 2 ledger rows
+        }
+        if (sql.includes("DELETE FROM subscription")) {
+          return { rows: [{ ok: 1 }] }; // 1 subscription row
+        }
+        if (upper.startsWith("DELETE")) return { rows: [{ ok: 1 }] };
+        return { rows: [] };
+      },
+      release() {},
+    };
+    const pool = {
+      ...basePool,
+      async connect() {
+        return client;
+      },
+    };
+    _resetPool(pool);
+
+    const result = await hardDeleteWorkspace("org-1");
+
+    expect(
+      queries.some((q) => /DELETE FROM subscription WHERE "referenceId" = \$1/.test(q)),
+    ).toBe(true);
+    expect(queries.some((q) => q.includes("DELETE FROM stripe_webhook_events"))).toBe(true);
+    expect(result.subscriptions).toBe(1);
+    expect(result.stripeWebhookEvents).toBe(2);
+  });
+
+  it("skips Stripe linkage deletes when the plugin's subscription table is absent (self-hosted)", async () => {
+    // The @better-auth/stripe plugin's table only exists on Stripe-enabled
+    // deployments — the to_regclass probe must keep non-Stripe purges from
+    // aborting the transaction with `relation "subscription" does not exist`.
+    const { pool: basePool } = createMockPool();
+    const queries: string[] = [];
+    const client = {
+      async query(sql: string) {
+        queries.push(sql);
+        const upper = sql.trim().toUpperCase();
+        if (upper.startsWith("SELECT WORKSPACE_STATUS")) {
+          return { rows: [{ workspace_status: "deleted" }] };
+        }
+        if (sql.includes("to_regclass")) {
+          return { rows: [{ table_exists: false }] };
+        }
+        if (sql.includes("FROM member m")) return { rows: [] };
+        if (upper.startsWith("DELETE")) return { rows: [{ ok: 1 }] };
+        return { rows: [] };
+      },
+      release() {},
+    };
+    const pool = {
+      ...basePool,
+      async connect() {
+        return client;
+      },
+    };
+    _resetPool(pool);
+
+    const result = await hardDeleteWorkspace("org-1");
+
+    expect(queries.some((q) => q.includes("DELETE FROM subscription"))).toBe(false);
+    expect(queries.some((q) => q.includes("DELETE FROM stripe_webhook_events"))).toBe(false);
+    expect(result.subscriptions).toBe(0);
+    expect(result.stripeWebhookEvents).toBe(0);
+  });
 });
 
 describe("connection URL encryption", () => {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2270,6 +2270,11 @@ export interface HardDeleteResult {
   // twenty_integrations: Twenty CRM API key.
   integrationCredentials: number;
   twentyIntegrations: number;
+  // Stripe billing linkage (#3425): @better-auth/stripe `subscription` rows
+  // (0 when the plugin's table doesn't exist) + Atlas's stripe_webhook_events
+  // dedupe-ledger rows for the org's subscription ids.
+  subscriptions: number;
+  stripeWebhookEvents: number;
   // Better Auth tables
   members: number;
   betterAuthInvitations: number;
@@ -2433,6 +2438,33 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const integrationCredentials = await del(`DELETE FROM integration_credentials WHERE workspace_id = $1`);
     const twentyIntegrations = await del(`DELETE FROM twenty_integrations WHERE workspace_id = $1`);
 
+    // ── Phase 3b: Stripe billing linkage rows (#3425) ──
+    // The @better-auth/stripe plugin's `subscription` table only exists when
+    // the plugin has run its migrations (STRIPE_SECRET_KEY deployments) —
+    // probe with to_regclass so non-Stripe deployments don't abort the purge
+    // transaction. The REMOTE teardown (cancel subscription, delete the
+    // Stripe customer) runs in lib/billing/workspace-teardown.ts BEFORE this
+    // cascade; these deletes remove the local billable linkage for GDPR
+    // completeness. The stripe_webhook_events dedupe ledger rows are matched
+    // via the org's subscription ids, so they must go before the
+    // subscription rows.
+    let subscriptions = 0;
+    let stripeWebhookEvents = 0;
+    const subscriptionTableProbe = await client.query(
+      `SELECT to_regclass('public.subscription') IS NOT NULL AS table_exists`,
+    );
+    const subscriptionTableExists =
+      (subscriptionTableProbe.rows[0] as { table_exists?: boolean } | undefined)?.table_exists === true;
+    if (subscriptionTableExists) {
+      stripeWebhookEvents = await delRaw(
+        `DELETE FROM stripe_webhook_events WHERE stripe_subscription_id IN (
+           SELECT "stripeSubscriptionId" FROM subscription
+            WHERE "referenceId" = $1 AND "stripeSubscriptionId" IS NOT NULL
+         ) RETURNING 1`,
+      );
+      subscriptions = await del(`DELETE FROM subscription WHERE "referenceId" = $1`);
+    }
+
     // ── Phase 4: Better Auth — members + orphaned users ──
 
     // Find users who are ONLY in this org (no other memberships)
@@ -2535,6 +2567,8 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
       workspacePlugins,
       integrationCredentials,
       twentyIntegrations,
+      subscriptions,
+      stripeWebhookEvents,
       members,
       betterAuthInvitations,
       orphanedUsers,

--- a/packages/web/src/app/platform/page.tsx
+++ b/packages/web/src/app/platform/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import { toast } from "sonner";
 import { parseAsString, parseAsStringEnum, useQueryState } from "nuqs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -261,6 +262,13 @@ function PlatformPageContent() {
     if (result.ok) {
       setConfirmAction(null);
       setPurgeConfirmName("");
+      // Stripe teardown failures (#3425): the operation succeeded but a
+      // billing call needs manual follow-up — surface each warning so the
+      // operator doesn't discover a still-live subscription at invoice time.
+      const warnings = (result.data as { warnings?: string[] } | undefined)?.warnings;
+      for (const warning of warnings ?? []) {
+        toast.warning("Billing follow-up needed", { description: warning, duration: 12000 });
+      }
     }
     inProgress.stop(workspaceId);
   }


### PR DESCRIPTION
Closes #3425

## What

Platform-admin workspace lifecycle ops (suspend / unsuspend / delete / purge) performed **no Stripe interaction** — a deleted or GDPR-purged org left its Stripe subscription live and invoicing, and a purge retained a billable Stripe customer (compliance smell). This PR adds a billing teardown seam and wires all four operations to it.

## Suspension policy decision (recorded per the issue)

**Pause collection, don't cancel and don't keep dunning.** Suspend sets `pause_collection: { behavior: "void" }` on the org's live subscriptions; unsuspend clears it. Rationale: a suspended workspace can't use the product, so it must not be invoiced for it — but the subscription stays alive so reactivation restores billing without a new checkout. `void` (not `keep_as_draft`) because we don't retroactively collect for the suspension window.

**Wrinkle (noted on #3425):** this applies to *operator-initiated* suspension only. The `invoice.payment_failed` auto-suspension ladder intentionally keeps dunning — pausing collection there would stop Stripe's retry cycle, the only path back to a recovered payment.

## How

- **`lib/billing/workspace-teardown.ts`** (new) — single seam, never inlined in routes or `db/internal.ts`:
  - delete → `cancelStripeSubscriptionsForWorkspace` — cancels every non-terminal subscription **before** the DB cascade (mirrors the @better-auth/stripe plugin's own org-deletion guard ordering, per the issue's plugin-review note)
  - purge → `purgeStripeBillingForWorkspace(orgId, stripeCustomerId)` — cancels remaining subscriptions then **deletes the Stripe customer(s)**; runs before `hardDeleteWorkspace` since the cascade destroys the organization row carrying the plugin-owned `stripeCustomerId` (#3417). Customer ids on subscription rows are unioned in defensively
  - suspend/unsuspend → pause/resume collection
- **Failure semantics:** every helper is total — Stripe errors are logged with context and returned as operator-facing `warnings` surfaced on the 200 response, in audit metadata, and as a toast in the platform console. The lifecycle operation always proceeds; nothing strands silently. `resource_missing` is treated as already-torn-down.
- **No-Stripe / self-hosted:** clean no-op (`attempted: false`) when `STRIPE_SECRET_KEY` is unset or there's no internal DB; a missing `subscription` table (plugin never migrated) reads as "no subscriptions".
- **`lib/billing/stripe-client.ts`** (new) — shared `getStripeClient()` accessor, single construction point with the pinned `STRIPE_API_VERSION`; `auth/server.ts` plugin wiring now uses it instead of constructing its own client.
- **`hardDeleteWorkspace`** — GDPR completeness: also deletes local `subscription` rows and the org's `stripe_webhook_events` ledger rows, gated by a `to_regclass` probe so non-Stripe deployments don't abort the purge transaction.
- **Docs** — `billing-and-plans.mdx` gains a "Workspace Lifecycle and Billing" table documenting the new behavior.

## Tests

- `lib/billing/__tests__/workspace-teardown.test.ts` (20 tests) — mocked Stripe client: delete cancels; purge cancels + deletes customer (with id-union + ordering); suspend pauses / unsuspend resumes with exact params; Stripe failure → operation completes + warning + `log.error`; `resource_missing` → action not warning; no-Stripe / no-DB no-op; 42P01 table-missing; real DB read failure → warning.
- `api/__tests__/platform-admin-stripe-teardown.test.ts` (8 tests) — route-level: teardown called with right args, **ordering asserted** (Stripe before cascade / hard-delete), warnings surfaced on responses + audit metadata, no-op omits both.
- `lib/db/__tests__/internal.test.ts` — purge cascade deletes subscription + ledger rows when the table exists; skips cleanly when absent.

## CI evidence

- `bun run lint` ✓
- `bun run type` ✓
- `bun run test` (full suite): 595/603 files on first pass; the 8 failures (sql-approval, python-nsjail/byoc/rest-egress, discord, teams, teams-discord-always-mount, saas-guards) are local WSL load flakes — none are in this change's dependency graph, all 8 pass individually on this branch, and the env-sensitive four also pass at the base commit in the same worktree. CI is authoritative.
- `bun run scripts/test-isolated.ts --affected` (242 files) ✓
- `bun x syncpack lint` ✓
- `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` ✓ (800 files)
- `bash scripts/check-railway-watch.sh` ✓

## Out of scope (filed)

- #3459 — the parallel admin-orgs surface (`/api/v1/admin/organizations/:id/{suspend,activate}`, `DELETE /:id`) has the identical gap and is what the web `/platform/organizations` page calls; wiring it to the new helper is a small follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783886271&installation_id=135337507&pr_number=3464&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3464&signature=73a6362dca196ccde5ebbcccbe332f31e17e5b4a0564fc7459e7e6ab389eec2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace lifecycle actions (suspend, unsuspend, delete, purge) now automatically sync with Stripe billing—pausing/resuming payment collection, canceling subscriptions, and removing billing data as appropriate.
  * Warning notifications inform admins when billing follow-up is required after workspace operations complete successfully.

* **Documentation**
  * Added comprehensive documentation for workspace lifecycle and billing integration, detailing Stripe behaviors for each action and failure-handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->