### PR TITLE
fix(api): proactive classifier quota derives from plan tier when no override is set

### DIFF
--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -31,6 +31,7 @@ describe("billing/plans", () => {
       expect(isUnlimited(limits.maxSeats)).toBe(true);
       expect(isUnlimited(limits.maxConnections)).toBe(true);
       expect(isUnlimited(limits.maxChatIntegrations)).toBe(true);
+      expect(isUnlimited(limits.monthlyProactiveClassifierCap)).toBe(true);
     });
 
     it("business tier has unlimited seats and connections", () => {
@@ -49,6 +50,20 @@ describe("billing/plans", () => {
       expect(trial.maxSeats).toBe(starter.maxSeats);
       expect(trial.maxConnections).toBe(starter.maxConnections);
       expect(trial.maxChatIntegrations).toBe(starter.maxChatIntegrations);
+      expect(trial.monthlyProactiveClassifierCap).toBe(
+        starter.monthlyProactiveClassifierCap,
+      );
+    });
+
+    it("every paid/SaaS tier bounds the proactive classifier cap (#3436)", () => {
+      // NULL workspace column = this tier default; only self-hosted is
+      // unlimited, so a Starter workspace's classifier spend is bounded
+      // out of the box instead of requiring an operator-set column.
+      expect(getPlanLimits("trial").monthlyProactiveClassifierCap).toBe(5_000);
+      expect(getPlanLimits("starter").monthlyProactiveClassifierCap).toBe(5_000);
+      expect(getPlanLimits("pro").monthlyProactiveClassifierCap).toBe(20_000);
+      expect(getPlanLimits("business").monthlyProactiveClassifierCap).toBe(100_000);
+      expect(getPlanLimits("locked").monthlyProactiveClassifierCap).toBe(0);
     });
 
     it("starter tier has finite limits", () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -46,6 +46,18 @@ export interface PlanLimits {
    * `checkChatIntegrationLimitAndInstall` (#2953, #3001).
    */
   maxChatIntegrations: number;
+  /**
+   * Included proactive-chat classifier invocations per workspace per
+   * month (#3436). -1 = unlimited. This is the tier-derived default for
+   * `workspace_proactive_config.monthly_classifier_cap` — when that
+   * column is NULL the quota gate falls back to this value (the column
+   * is an operator/admin override, not the only cap). Sizing: a
+   * classify is one small haiku-class call (~$0.0005), so even the
+   * Business cap bounds worst-case spend at low tens of dollars while
+   * staying invisible to legitimate usage. Enforced in
+   * `lib/proactive/quota.ts:getEffectiveMonthlyClassifierCap`.
+   */
+  monthlyProactiveClassifierCap: number;
 }
 
 export interface PlanDefinition {
@@ -93,6 +105,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: UNLIMITED,
       maxConnections: UNLIMITED,
       maxChatIntegrations: UNLIMITED,
+      monthlyProactiveClassifierCap: UNLIMITED,
     },
     features: { ...NO_FEATURES },
   },
@@ -112,6 +125,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: 10,
       maxConnections: 1,
       maxChatIntegrations: 1,
+      monthlyProactiveClassifierCap: 5_000,
     },
     features: { ...NO_FEATURES },
   },
@@ -126,6 +140,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: 10,
       maxConnections: 1,
       maxChatIntegrations: 1,
+      monthlyProactiveClassifierCap: 5_000,
     },
     features: { ...NO_FEATURES },
   },
@@ -140,6 +155,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: 25,
       maxConnections: 3,
       maxChatIntegrations: 3,
+      monthlyProactiveClassifierCap: 20_000,
     },
     features: {
       customDomain: true,
@@ -164,6 +180,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: 0,
       maxConnections: 0,
       maxChatIntegrations: 0,
+      monthlyProactiveClassifierCap: 0,
     },
     features: { ...NO_FEATURES },
   },
@@ -178,6 +195,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxSeats: UNLIMITED,
       maxConnections: UNLIMITED,
       maxChatIntegrations: UNLIMITED,
+      monthlyProactiveClassifierCap: 100_000,
     },
     features: {
       customDomain: true,

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -647,7 +647,7 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(err?.message).toMatch(/chk_workspace_proactive_monthly_cap_nonneg|23514|check constraint/i);
   }, PG_TEST_TIMEOUT_MS);
 
-  it("workspace_proactive_config: CHECK accepts NULL monthly_classifier_cap (unlimited) (#2294)", async () => {
+  it("workspace_proactive_config: CHECK accepts NULL monthly_classifier_cap (no override — plan-tier default since #3436) (#2294)", async () => {
     const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
     const ws = `ws-wpc-cap-null-${stamp}`;
     await pool.query(

--- a/packages/api/src/lib/proactive/__tests__/quota.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/quota.test.ts
@@ -35,6 +35,27 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     mockInternalQuery(sql, params),
 }));
 
+// Billing seam for the plan-tier default cap (#3436). Only
+// `getCachedWorkspace` matters here, but ALL value exports must be
+// stubbed — a partial mock.module fails at module load.
+type MockWorkspaceRow = { plan_tier: string; byot: boolean } | null;
+let mockWorkspaceRow: MockWorkspaceRow = null;
+const mockGetCachedWorkspace: Mock<(orgId: string) => Promise<MockWorkspaceRow>> = mock(
+  async () => mockWorkspaceRow,
+);
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  getCachedWorkspace: mockGetCachedWorkspace,
+  invalidatePlanCache: () => {},
+  checkPlanLimits: async () => ({ allowed: true }),
+  buildMetricStatus: () => ({}),
+  severityOf: () => 0,
+  checkResourceLimit: async () => ({ allowed: true }),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkChatIntegrationLimit: async () => ({ allowed: true }),
+  checkChatIntegrationLimitAndInstall: async () => ({ installed: true }),
+}));
+
 const quota = await import("../quota");
 
 // ---------------------------------------------------------------------------
@@ -143,6 +164,73 @@ describe("getMonthlyClassifierCap", () => {
   });
 });
 
+describe("getEffectiveMonthlyClassifierCap (#3436)", () => {
+  beforeEach(() => {
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockClear();
+    mockGetCachedWorkspace.mockClear();
+    mockWorkspaceRow = null;
+  });
+
+  it("the override column wins when set — even over a lower tier default", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: 42 },
+    ]);
+    mockWorkspaceRow = { plan_tier: "starter", byot: false };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBe(42);
+    // Plan lookup is skipped entirely when the override resolves.
+    expect(mockGetCachedWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("an override of 0 is respected (stop immediately), not treated as unset", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: 0 },
+    ]);
+    mockWorkspaceRow = { plan_tier: "business", byot: false };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBe(0);
+  });
+
+  it.each([
+    ["trial", 5_000],
+    ["starter", 5_000],
+    ["pro", 20_000],
+    ["business", 100_000],
+    ["locked", 0],
+  ] as const)("NULL column derives the %s tier default (%i)", async (tier, expected) => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: null },
+    ]);
+    mockWorkspaceRow = { plan_tier: tier, byot: false };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBe(expected);
+  });
+
+  it("free (self-hosted) tier stays unlimited", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    mockWorkspaceRow = { plan_tier: "free", byot: false };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBeNull();
+  });
+
+  it("BYOT bypasses the tier default — classifier runs on the customer's key", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: null },
+    ]);
+    mockWorkspaceRow = { plan_tier: "starter", byot: true };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBeNull();
+  });
+
+  it("no workspace row → null (pre-#3436 behavior preserved)", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    mockWorkspaceRow = null;
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBeNull();
+  });
+
+  it("no internal DB → null without touching the plan cache", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBeNull();
+    expect(mockGetCachedWorkspace).not.toHaveBeenCalled();
+  });
+});
+
 describe("getClassifyCountThisMonth", () => {
   beforeEach(() => {
     mockHasInternalDB.mockImplementation(() => true);
@@ -184,6 +272,20 @@ describe("getWorkspaceQuotaStatus", () => {
   beforeEach(() => {
     mockHasInternalDB.mockImplementation(() => true);
     mockInternalQuery.mockClear();
+    mockWorkspaceRow = null;
+  });
+
+  it("enforces the plan-tier default when the override column is NULL (#3436)", async () => {
+    mockWorkspaceRow = { plan_tier: "starter", byot: false };
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("monthly_classifier_cap")) {
+        return [{ monthly_classifier_cap: null }];
+      }
+      return [{ count: 5_000 }];
+    });
+    const out = await quota.getWorkspaceQuotaStatus("ws-1");
+    expect(out.monthlyClassifierCap).toBe(5_000);
+    expect(out.capReached).toBe(true);
   });
 
   it("returns capReached=false when cap is null (unlimited)", async () => {

--- a/packages/api/src/lib/proactive/__tests__/quota.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/quota.test.ts
@@ -218,6 +218,16 @@ describe("getEffectiveMonthlyClassifierCap (#3436)", () => {
     expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBeNull();
   });
 
+  it("an explicit override still caps a BYOT workspace — BYOT only changes the unset default", async () => {
+    // Pre-#3436 the column applied to every workspace, BYOT included; an
+    // admin deliberately setting a cap must keep winning over the bypass.
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: 100 },
+    ]);
+    mockWorkspaceRow = { plan_tier: "starter", byot: true };
+    expect(await quota.getEffectiveMonthlyClassifierCap("ws-1")).toBe(100);
+  });
+
   it("no workspace row → null (pre-#3436 behavior preserved)", async () => {
     mockInternalQuery.mockImplementation(async () => []);
     mockWorkspaceRow = null;

--- a/packages/api/src/lib/proactive/quota.ts
+++ b/packages/api/src/lib/proactive/quota.ts
@@ -8,7 +8,14 @@
  *
  * Source of truth:
  *   - cap value     →  `workspace_proactive_config.monthly_classifier_cap`
- *                      (added by #2294, null = unlimited).
+ *                      (added by #2294) when set — an operator/admin
+ *                      **override**. When NULL, the cap derives from the
+ *                      workspace's plan tier
+ *                      (`plans.ts:monthlyProactiveClassifierCap`, #3436) —
+ *                      previously NULL meant unlimited, which left a
+ *                      Starter workspace's classifier spend unbounded
+ *                      unless an operator hand-set the column. Self-hosted
+ *                      (`free` tier) and BYOT workspaces stay unlimited.
  *   - usage count   →  `proactive_meter_events` rows with
  *                      `event_type = 'classify'` and
  *                      `created_at >= start_of_current_month_utc`.
@@ -29,6 +36,8 @@
  */
 
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getCachedWorkspace } from "@atlas/api/lib/billing/enforcement";
+import { getPlanLimits, isUnlimited } from "@atlas/api/lib/billing/plans";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { ProactiveQuotaStatus } from "@useatlas/types";
 
@@ -88,9 +97,10 @@ export function isOverQuota(count: number, cap: number | null | undefined): bool
 // was removed in the post-1.5.0 polish so plugin + API can't drift.
 
 /**
- * Read the workspace's cap value. Returns `null` when the workspace
- * has never had its proactive config materialised — matches the
- * "no cap" semantic for `monthly_classifier_cap = NULL`.
+ * Read the workspace's raw **override** cap column. Returns `null` when
+ * the workspace has never had its proactive config materialised or the
+ * column is NULL — meaning "no override; the plan-tier default applies"
+ * (see {@link getEffectiveMonthlyClassifierCap}).
  */
 export async function getMonthlyClassifierCap(
   workspaceId: string,
@@ -104,6 +114,39 @@ export async function getMonthlyClassifierCap(
   );
   if (rows.length === 0) return null;
   return rows[0]!.monthly_classifier_cap;
+}
+
+/**
+ * Resolve the cap the quota gate actually enforces (#3436):
+ *
+ *   1. `workspace_proactive_config.monthly_classifier_cap` when set —
+ *      the operator/admin override wins in either direction (a Starter
+ *      workspace can be granted more, a Business one clamped down).
+ *   2. Otherwise the workspace's plan-tier default
+ *      (`plans.ts:monthlyProactiveClassifierCap`); `-1` → `null`
+ *      (unlimited — the `free`/self-hosted tier).
+ *   3. BYOT workspaces are unlimited regardless of tier — classifier
+ *      calls run on their own key, mirroring the token-budget bypass.
+ *   4. No workspace row (org id unknown to billing — e.g. managed-auth
+ *      table not present) → `null`, preserving the pre-#3436 behavior
+ *      for deployments without the billing surface.
+ *
+ * The plan read goes through `getCachedWorkspace` (60s TTL), so the
+ * per-message listener path costs at most one extra cached lookup.
+ */
+export async function getEffectiveMonthlyClassifierCap(
+  workspaceId: string,
+): Promise<number | null> {
+  const override = await getMonthlyClassifierCap(workspaceId);
+  if (override !== null) return override;
+  if (!hasInternalDB()) return null;
+
+  const workspace = await getCachedWorkspace(workspaceId);
+  if (!workspace) return null;
+  if (workspace.byot) return null;
+
+  const tierCap = getPlanLimits(workspace.plan_tier).monthlyProactiveClassifierCap;
+  return isUnlimited(tierCap) ? null : tierCap;
 }
 
 /**
@@ -142,15 +185,15 @@ export async function getClassifyCountThisMonth(
  * every render. Both are cheap thanks to the 0078 index.
  *
  * Fails open on read errors — `capReached: false` keeps Atlas
- * answering when the meter table hiccups. Logs at `error` for
- * log-scrape dashboards (the workspace's monthly cap is silently
- * bypassed during the outage window, so the billing tail is
- * exposed — operators need to see it). Note: the API logger is
- * plain pino; there's no Sentry/PagerDuty wired on the catch path,
- * so "alerting" is operator-initiated via log streams. The listener
- * stamps `metadata.quotaReadFailed: true` on the post-classification
- * meter row so the per-workspace analytics rollup shows the per-
- * message bypass count too.
+ * answering when the meter table hiccups. Reviewed and kept in #3436:
+ * the failure window is one request, the `error`-level log is the
+ * operator alert (plain pino — log-scrape dashboards, no
+ * Sentry/PagerDuty on this path), and the listener stamps
+ * `metadata.quotaReadFailed: true` on the post-classification meter
+ * row so the per-workspace analytics rollup shows the per-message
+ * bypass count too. A fail-closed alternative would turn an internal
+ * DB blip into a silent product outage for every proactive workspace,
+ * which is the worse trade for a quota-not-billing gate.
  */
 export async function getWorkspaceQuotaStatus(
   workspaceId: string,
@@ -161,8 +204,11 @@ export async function getWorkspaceQuotaStatus(
     // the count is index-scanned. Splitting keeps the SQL readable +
     // lets `getMonthlyClassifierCap` be reused for the workspace-config
     // view in `admin-proactive.ts` later without re-deriving the cap.
+    // The cap is the *effective* one (override-or-plan-tier, #3436), so
+    // `monthlyClassifierCap` on the wire now reflects what the gate
+    // enforces — admin usage bars show the plan default, not blank.
     const [cap, count] = await Promise.all([
-      getMonthlyClassifierCap(workspaceId),
+      getEffectiveMonthlyClassifierCap(workspaceId),
       getClassifyCountThisMonth(workspaceId, now),
     ]);
     return {

--- a/packages/api/src/lib/proactive/quota.ts
+++ b/packages/api/src/lib/proactive/quota.ts
@@ -122,11 +122,15 @@ export async function getMonthlyClassifierCap(
  *   1. `workspace_proactive_config.monthly_classifier_cap` when set —
  *      the operator/admin override wins in either direction (a Starter
  *      workspace can be granted more, a Business one clamped down).
+ *      Deliberately checked BEFORE the BYOT bypass: the column applied
+ *      to every workspace (BYOT included) before #3436, and an
+ *      explicitly-set cap is a deliberate admin decision — BYOT only
+ *      changes what an *unset* column defaults to.
  *   2. Otherwise the workspace's plan-tier default
  *      (`plans.ts:monthlyProactiveClassifierCap`); `-1` → `null`
  *      (unlimited — the `free`/self-hosted tier).
- *   3. BYOT workspaces are unlimited regardless of tier — classifier
- *      calls run on their own key, mirroring the token-budget bypass.
+ *   3. BYOT workspaces default to unlimited — classifier calls run on
+ *      their own key, mirroring the token-budget bypass.
  *   4. No workspace row (org id unknown to billing — e.g. managed-auth
  *      table not present) → `null`, preserving the pre-#3436 behavior
  *      for deployments without the billing surface.

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -574,9 +574,10 @@ function MonthlyCapField({
 //   - 100%  red    (exhausted — proactive is silently short-circuiting)
 //
 // Rendered inline under the cap input so the admin can see the impact of
-// the value they just typed. Hides itself when the workspace has never
-// set a cap (`monthlyClassifierCap === null`) — there's nothing to
-// usage-bar against.
+// the value they just typed. Hides itself when the effective cap is
+// unlimited (`monthlyClassifierCap === null` — self-hosted/BYOT, since
+// #3436 a NULL column otherwise resolves to the plan-tier default) —
+// there's nothing to usage-bar against.
 // ---------------------------------------------------------------------------
 
 // Both `QuotaUsageIndicator` and `DecisionDrillDownPanel` read this same

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -542,10 +542,11 @@ function MonthlyCapField({
         Monthly classifier cap
       </Label>
       <p className="text-[12px] text-muted-foreground">
-        Optional. Hard cap on classifier invocations per calendar month. When
-        the cap is reached, proactive chat short-circuits before the
-        classifier runs until the next reset (calendar month, UTC). Leave
-        blank for no cap.
+        Optional override. Hard cap on classifier invocations per calendar
+        month. When the cap is reached, proactive chat short-circuits before
+        the classifier runs until the next reset (calendar month, UTC).
+        Leave blank to use your plan&apos;s included allowance — self-hosted
+        deployments have no cap.
       </p>
       <Input
         id="proactive-monthly-cap"


### PR DESCRIPTION
Closes #3436 (v0.0.14 — Billing Hardening, thread 3).

The proactive answering meter was billing-adjacent but disconnected from plans: `workspace_proactive_config.monthly_classifier_cap` defaulted to NULL = **unlimited**, so a Starter workspace's classifier spend was unbounded unless an operator hand-set the column.

## What changed

- **`PlanLimits.monthlyProactiveClassifierCap`** — new per-tier default: trial/starter **5,000**, pro **20,000**, business **100,000**, locked **0**, free/self-hosted **unlimited**. Trial mirrors starter per the existing "trial has same limits as starter" contract. Sizing rationale in the field doc: one classify ≈ one haiku-class call (~$0.0005), so even the Business cap bounds worst-case spend at low tens of dollars while staying invisible to legitimate usage.
- **`getEffectiveMonthlyClassifierCap`** (new, `lib/proactive/quota.ts`) — the column becomes an operator/admin **override** (wins in either direction, including an explicit `0`); NULL falls back to the plan-tier default via `getCachedWorkspace` (60s TTL — the per-message listener path costs at most one cached lookup). **BYOT** workspaces stay unlimited (classifier runs on their key, mirroring the token-budget bypass). Workspaces unknown to billing keep the pre-#3436 unlimited behavior, so deployments without the billing surface are unaffected.
- **`getWorkspaceQuotaStatus`** now enforces and reports the effective cap — the chat-plugin quota gate and the admin analytics usage bar both pick up tier defaults with no wire-shape change.
- **Fail-open AC** — reviewed and kept, with the trade-off now documented at the source: the `error`-level log is the operator alert and the listener stamps `metadata.quotaReadFailed: true` on the meter row; fail-closed would turn an internal-DB blip into a silent product outage for every proactive workspace.
- **Admin page copy** — the cap field now says blank = "your plan's included allowance" instead of "no cap".

## Tests

- `quota.test.ts` — tier-derived defaults for every tier, override precedence (including `0`), BYOT bypass, missing-workspace and no-internal-DB fallbacks, and a `getWorkspaceQuotaStatus` integration case (NULL column + starter tier → capReached at 5,000).
- `plans.test.ts` — pins the new limit per tier + free-unlimited + trial≡starter.

## CI

All local gates pass: lint, type, full test suite, syncpack, template drift, security-headers drift, railway-watch, schema drift, oauth-helper drift, test discipline, twenty-resolver, settings-readers, published-symbols, OpenAPI drift (no route-schema change).

Note: the `Deploy Validation` scaffold jobs are currently failing repo-wide on an upstream npm phantom (`ai@6.0.204` advertised then unpublished) — tracked in #3472, unrelated to this diff.

https://claude.ai/code/session_01RmdwaTaEu5XhMxFaAHhpN6

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmdwaTaEu5XhMxFaAHhpN6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783891816&installation_id=135337507&pr_number=3473&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3473&signature=936e314f5e434ae237295568b43031e7071d02ea7d98199ae2999d6dce500bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly proactive classifier cap now uses tier-based defaults (free = unlimited; trial/starter/pro/business/locked have defined numeric caps) and a per-workspace optional override. The effective cap is what admins and the quota gate observe.

* **Tests**
  * Expanded coverage for tier defaults, workspace overrides (including zero/null), BYOT, and failure/read-fallback scenarios.

* **Documentation**
  * Clarified admin UI helper text for the Monthly classifier cap (optional override, UTC monthly reset, blank = no cap).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->