### PR TITLE
Fix Stripe teardown on admin-orgs surface + harden trial atomicity

### DIFF
--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -195,8 +195,8 @@ Platform-admin workspace lifecycle actions keep Stripe in sync automatically:
 
 | Action | Stripe behavior |
 |--------|-----------------|
-| Suspend | Payment collection is **paused** (`pause_collection: void`) — a suspended workspace can't use the product, so it isn't invoiced or dunned while suspended. The subscription stays alive |
-| Unsuspend | Payment collection resumes — normal invoicing restarts on the existing subscription |
+| Suspend | Payment collection is **paused** (`pause_collection: void`) and any invoices already open (including past-due invoices mid-dunning) are **voided** — a suspended workspace can't use the product, so it isn't invoiced, dunned, or charged while suspended. The subscription stays alive |
+| Unsuspend | Payment collection resumes — normal invoicing restarts on the existing subscription. Invoices voided at suspension time are not resurrected; the next billing cycle bills normally |
 | Delete | The Stripe subscription is **canceled** before the data cascade runs — a deleted workspace never keeps invoicing |
 | Purge (GDPR) | Any remaining subscriptions are canceled and the **Stripe customer is permanently deleted** — no billable Stripe linkage survives a purge |
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -20824,7 +20824,13 @@
                     "message": {
                       "type": "string"
                     },
-                    "organization": {}
+                    "organization": {},
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   },
                   "required": [
                     "message"
@@ -20998,7 +21004,13 @@
                     "message": {
                       "type": "string"
                     },
-                    "organization": {}
+                    "organization": {},
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   },
                   "required": [
                     "message"
@@ -21389,7 +21401,13 @@
                     "message": {
                       "type": "string"
                     },
-                    "organization": {}
+                    "organization": {},
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   },
                   "required": [
                     "message"

--- a/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Admin-orgs workspace lifecycle × Stripe teardown wiring (#3459).
+ *
+ * The admin-orgs surface (`/api/v1/admin/organizations/...`) performs the
+ * same suspend/activate/delete mutations as the platform-admin surface but
+ * historically with NO Stripe interaction — the exact bug class #3425
+ * fixed, still live on the surface the web UI actually calls. Mirrors
+ * `platform-admin-stripe-teardown.test.ts`:
+ *
+ *   - PATCH :id/suspend  → pauseStripeCollectionForWorkspace
+ *   - PATCH :id/activate → resumeStripeCollectionForWorkspace
+ *   - DELETE :id         → cancelStripeSubscriptionsForWorkspace BEFORE
+ *                          the DB cascade
+ *   - teardown warnings  → `warnings` on the response + audit metadata
+ *   - no-op teardown (self-hosted) → no `warnings` key, no `stripe` audit key
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import type { StripeTeardownOutcome } from "@atlas/api/lib/billing/workspace-teardown";
+
+// ── Mockable state ──────────────────────────────────────────────────
+
+/** Cross-module call order — proves Stripe teardown runs before the cascade. */
+let callOrder: string[] = [];
+
+function wsRow(status: string): Record<string, unknown> {
+  return {
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    workspace_status: status,
+    plan_tier: "pro",
+    byot: false,
+    stripe_customer_id: "cus_acme",
+    trial_ends_at: null,
+    suspended_at: null,
+    deleted_at: null,
+    region: null,
+    region_assigned_at: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+let workspaceStatus = "active";
+
+const mockGetWorkspaceDetails = mock(async () => wsRow(workspaceStatus));
+const mockUpdateWorkspaceStatus = mock(async () => {
+  callOrder.push("updateStatus");
+  return true;
+});
+const mockCascade = mock(async () => {
+  callOrder.push("cascade");
+  return {
+    conversations: 1,
+    semanticEntities: 0,
+    learnedPatterns: 0,
+    suggestions: 0,
+    scheduledTasks: 0,
+    settings: 0,
+  };
+});
+
+const mocks = createApiTestMocks({
+  internal: {
+    getWorkspaceDetails: mockGetWorkspaceDetails,
+    updateWorkspaceStatus: mockUpdateWorkspaceStatus,
+    cascadeWorkspaceDelete: mockCascade,
+  },
+});
+
+// ── Stripe teardown module mock (all exports) ───────────────────────
+
+let teardownOutcome: StripeTeardownOutcome = { attempted: true, actions: [], warnings: [] };
+
+const mockCancelSubs = mock(async (_orgId: string) => {
+  callOrder.push("stripe:cancel");
+  return teardownOutcome;
+});
+const mockPurgeBilling = mock(async (_orgId: string, _customerId: string | null) => {
+  callOrder.push("stripe:purge");
+  return teardownOutcome;
+});
+const mockPause = mock(async (_orgId: string) => {
+  callOrder.push("stripe:pause");
+  return teardownOutcome;
+});
+const mockResume = mock(async (_orgId: string) => {
+  callOrder.push("stripe:resume");
+  return teardownOutcome;
+});
+
+mock.module("@atlas/api/lib/billing/workspace-teardown", () => ({
+  cancelStripeSubscriptionsForWorkspace: mockCancelSubs,
+  purgeStripeBillingForWorkspace: mockPurgeBilling,
+  pauseStripeCollectionForWorkspace: mockPause,
+  resumeStripeCollectionForWorkspace: mockResume,
+  stripeAuditMetadata: (billing: StripeTeardownOutcome) =>
+    billing.attempted
+      ? { stripe: { actions: billing.actions, warnings: billing.warnings } }
+      : {},
+  withWarnings: (billing: StripeTeardownOutcome) =>
+    billing.warnings.length > 0 ? { warnings: billing.warnings } : {},
+}));
+
+// ── Audit capture ───────────────────────────────────────────────────
+
+interface CapturedAudit {
+  actionType: string;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+let auditCalls: CapturedAudit[] = [];
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mock((entry: CapturedAudit) => {
+    auditCalls.push(entry);
+  }),
+  logAdminActionAwait: mock(async (entry: CapturedAudit) => {
+    auditCalls.push(entry);
+  }),
+  ADMIN_ACTIONS: {
+    workspace: {
+      suspend: "workspace.suspend",
+      unsuspend: "workspace.unsuspend",
+      delete: "workspace.delete",
+      purge: "workspace.purge",
+      changePlan: "workspace.change_plan",
+    },
+  },
+}));
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+function adminRequest(method: string, path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
+  });
+}
+
+beforeEach(() => {
+  mocks.setPlatformAdmin();
+  callOrder = [];
+  auditCalls = [];
+  workspaceStatus = "active";
+  teardownOutcome = { attempted: true, actions: ["paused collection on Stripe subscription sub_1"], warnings: [] };
+  mockCancelSubs.mockClear();
+  mockPurgeBilling.mockClear();
+  mockPause.mockClear();
+  mockResume.mockClear();
+  mockCascade.mockClear();
+  mockUpdateWorkspaceStatus.mockClear();
+});
+
+// ── Suspend / activate ──────────────────────────────────────────────
+
+describe("PATCH /api/v1/admin/organizations/:id/suspend|activate — pause/resume collection", () => {
+  it("suspend pauses Stripe collection", async () => {
+    const res = await app.fetch(adminRequest("PATCH", "/api/v1/admin/organizations/org-1/suspend"));
+
+    expect(res.status).toBe(200);
+    expect(mockPause).toHaveBeenCalledTimes(1);
+    expect(mockPause.mock.calls[0][0]).toBe("org-1");
+    expect(mockResume).not.toHaveBeenCalled();
+    const suspendAudit = auditCalls.find((a) => a.actionType === "workspace.suspend");
+    expect(suspendAudit?.metadata?.stripe).toEqual({
+      actions: teardownOutcome.actions,
+      warnings: [],
+    });
+  });
+
+  it("activate resumes Stripe collection", async () => {
+    workspaceStatus = "suspended";
+
+    const res = await app.fetch(adminRequest("PATCH", "/api/v1/admin/organizations/org-1/activate"));
+
+    expect(res.status).toBe(200);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+    expect(mockResume.mock.calls[0][0]).toBe("org-1");
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it("suspend surfaces pause failures as warnings — suspend stands", async () => {
+    teardownOutcome = {
+      attempted: true,
+      actions: [],
+      warnings: ["Failed to pause collection on Stripe subscription sub_1: rate_limited. Pause it manually in the Stripe dashboard so the suspended workspace isn't invoiced."],
+    };
+
+    const res = await app.fetch(adminRequest("PATCH", "/api/v1/admin/organizations/org-1/suspend"));
+    const body = (await res.json()) as { warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.warnings).toHaveLength(1);
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits warnings + stripe audit key when teardown is a no-op (self-hosted)", async () => {
+    teardownOutcome = { attempted: false, actions: [], warnings: [] };
+
+    const res = await app.fetch(adminRequest("PATCH", "/api/v1/admin/organizations/org-1/suspend"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect("warnings" in body).toBe(false);
+    const suspendAudit = auditCalls.find((a) => a.actionType === "workspace.suspend");
+    expect(suspendAudit?.metadata && "stripe" in suspendAudit.metadata).toBe(false);
+  });
+});
+
+// ── Delete ──────────────────────────────────────────────────────────
+
+describe("DELETE /api/v1/admin/organizations/:id — Stripe teardown", () => {
+  it("cancels Stripe subscriptions BEFORE the DB cascade", async () => {
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/organizations/org-1"));
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).toHaveBeenCalledTimes(1);
+    expect(mockCancelSubs.mock.calls[0][0]).toBe("org-1");
+    expect(callOrder.indexOf("stripe:cancel")).toBeLessThan(callOrder.indexOf("cascade"));
+  });
+
+  it("surfaces Stripe failures as warnings on the response and in audit metadata — delete proceeds", async () => {
+    teardownOutcome = {
+      attempted: true,
+      actions: [],
+      warnings: ["Failed to cancel Stripe subscription sub_1: stripe is down. Cancel it manually in the Stripe dashboard."],
+    };
+
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/organizations/org-1"));
+    const body = (await res.json()) as { warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.warnings).toHaveLength(1);
+    expect(body.warnings?.[0]).toContain("sub_1");
+    // Delete still completed.
+    expect(mockCascade).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledTimes(1);
+    // Audit metadata records the Stripe outcome.
+    const deleteAudit = auditCalls.find((a) => a.actionType === "workspace.delete");
+    expect(deleteAudit?.metadata?.stripe).toEqual({
+      actions: [],
+      warnings: teardownOutcome.warnings,
+    });
+  });
+
+  it("omits the stripe audit key when teardown is a no-op (self-hosted)", async () => {
+    teardownOutcome = { attempted: false, actions: [], warnings: [] };
+
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/organizations/org-1"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect("warnings" in body).toBe(false);
+    const deleteAudit = auditCalls.find((a) => a.actionType === "workspace.delete");
+    expect(deleteAudit?.metadata && "stripe" in deleteAudit.metadata).toBe(false);
+  });
+});

--- a/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
@@ -101,6 +101,14 @@ mock.module("@atlas/api/lib/billing/workspace-teardown", () => ({
   purgeStripeBillingForWorkspace: mockPurgeBilling,
   pauseStripeCollectionForWorkspace: mockPause,
   resumeStripeCollectionForWorkspace: mockResume,
+  // Shared response/audit helpers (#3459) — mirror the real implementations
+  // so the warnings/audit assertions below exercise the same shapes.
+  stripeAuditMetadata: (billing: StripeTeardownOutcome) =>
+    billing.attempted
+      ? { stripe: { actions: billing.actions, warnings: billing.warnings } }
+      : {},
+  withWarnings: (billing: StripeTeardownOutcome) =>
+    billing.warnings.length > 0 ? { warnings: billing.warnings } : {},
 }));
 
 // ── Audit capture ───────────────────────────────────────────────────

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -24,6 +24,13 @@ import {
 import { connections } from "@atlas/api/lib/db/connection";
 import { flushCache } from "@atlas/api/lib/cache/index";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import {
+  cancelStripeSubscriptionsForWorkspace,
+  pauseStripeCollectionForWorkspace,
+  resumeStripeCollectionForWorkspace,
+  stripeAuditMetadata,
+  withWarnings,
+} from "@atlas/api/lib/billing/workspace-teardown";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -111,6 +118,9 @@ const OrgStatsSchema = z.object({
 const WorkspaceActionResponseSchema = z.object({
   message: z.string(),
   organization: z.unknown(),
+  // Stripe teardown failures surface to the operator for manual follow-up
+  // in the Stripe dashboard (#3459) — never stranded silently.
+  warnings: z.array(z.string()).optional(),
 });
 
 const DeleteCascadeSchema = z.object({
@@ -623,6 +633,12 @@ adminOrgs.openapi(suspendOrgRoute, async (c) => {
     // Drop the cached `getCachedWorkspace` entry so the next user-side
     // request sees the new status within its TTL window (#2165).
     invalidatePlanCache(orgId);
+    // Suspension billing policy (#3425, wired here by #3459): pause Stripe
+    // payment collection — a suspended workspace can't use the product, so
+    // it must not keep being invoiced/dunned. The subscription stays alive
+    // so activating restores billing. Stripe failures surface as operator
+    // warnings; the suspend stands.
+    const billing = yield* Effect.promise(() => pauseStripeCollectionForWorkspace(orgId));
     // Audit the mutation commit BEFORE the pool drain — a transient
     // `drainOrg` rejection must not silently drop the audit row after
     // the DB already flipped to suspended. Drain failure still fails
@@ -632,13 +648,14 @@ adminOrgs.openapi(suspendOrgRoute, async (c) => {
       targetType: "workspace",
       targetId: orgId,
       scope: "platform",
+      metadata: stripeAuditMetadata(billing),
       ipAddress: clientIpFor(c),
     });
     if (connections.isOrgPoolingEnabled()) yield* Effect.promise(() => connections.drainOrg(orgId));
 
-    log.info({ orgId, requestId, admin: user?.id }, "Workspace suspended");
+    log.info({ orgId, requestId, admin: user?.id, stripe: billing }, "Workspace suspended");
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
-    return c.json({ message: "Workspace suspended. All queries are blocked until reactivation.", organization: updated }, 200);
+    return c.json({ message: "Workspace suspended. All queries are blocked until reactivation.", organization: updated, ...withWarnings(billing) }, 200);
   }), { label: "suspend workspace" });
 });
 
@@ -657,7 +674,10 @@ adminOrgs.openapi(activateOrgRoute, async (c) => {
 
     yield* Effect.promise(() => updateWorkspaceStatus(orgId, "active"));
     invalidatePlanCache(orgId); // #2165 — see suspend handler above
-    log.info({ orgId, requestId, admin: user?.id }, "Workspace activated");
+    // Resume Stripe payment collection paused at suspension time (#3459) —
+    // see the suspend handler above for the pause-collection policy.
+    const billing = yield* Effect.promise(() => resumeStripeCollectionForWorkspace(orgId));
+    log.info({ orgId, requestId, admin: user?.id, stripe: billing }, "Workspace activated");
     // Canonical action_type is `workspace.unsuspend` (not
     // `workspace.activate`) — the endpoint path deliberately differs
     // from the audit event so compliance queries filtering on a single
@@ -667,10 +687,11 @@ adminOrgs.openapi(activateOrgRoute, async (c) => {
       targetType: "workspace",
       targetId: orgId,
       scope: "platform",
+      metadata: stripeAuditMetadata(billing),
       ipAddress: clientIpFor(c),
     });
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
-    return c.json({ message: "Workspace activated. Normal operations resumed.", organization: updated }, 200);
+    return c.json({ message: "Workspace activated. Normal operations resumed.", organization: updated, ...withWarnings(billing) }, 200);
   }), { label: "activate workspace" });
 });
 
@@ -707,6 +728,15 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     }
     flushCache();
 
+    // Cancel Stripe billing BEFORE the cascade (#3425, wired here by
+    // #3459): a deleted org must stop invoicing even if the cascade below
+    // fails, and the @better-auth/stripe plugin's own guard blocks
+    // user-initiated org deletion while subscriptions exist — this
+    // direct-DB path honors the same ordering rather than bypassing it.
+    // Stripe failures join the existing `warnings` array; delete proceeds.
+    const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(orgId));
+    warnings.push(...billing.warnings);
+
     const cascade = yield* Effect.tryPromise({
       try: () => cascadeWorkspaceDelete(orgId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
@@ -717,7 +747,7 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     });
     invalidatePlanCache(orgId); // #2165 — see suspend handler above
 
-    log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained, warnings }, "Workspace soft-deleted with cascading cleanup");
+    log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained, warnings, stripe: billing }, "Workspace soft-deleted with cascading cleanup");
     // `cleanup` mirrors platform-admin.ts. `poolsDrained`/`warnings`
     // are additive — admin-orgs drains pools, platform-admin doesn't.
     logAdminAction({
@@ -728,6 +758,7 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
       metadata: {
         cleanup: cascade,
         poolsDrained,
+        ...stripeAuditMetadata(billing),
         ...(warnings.length > 0 ? { warnings } : {}),
       },
       ipAddress: clientIpFor(c),

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -50,7 +50,8 @@ import {
   purgeStripeBillingForWorkspace,
   pauseStripeCollectionForWorkspace,
   resumeStripeCollectionForWorkspace,
-  type StripeTeardownOutcome,
+  stripeAuditMetadata,
+  withWarnings,
 } from "@atlas/api/lib/billing/workspace-teardown";
 import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
@@ -77,25 +78,6 @@ import {
 const log = createLogger("platform-admin");
 
 const VALID_PLAN_TIERS = new Set<string>(PLAN_TIERS);
-
-/**
- * Audit metadata for a Stripe teardown outcome (#3425) — empty when the
- * teardown was a no-op (Stripe not configured), so self-hosted audit rows
- * don't grow a misleading `stripe` key.
- */
-function stripeAuditMetadata(billing: StripeTeardownOutcome): Record<string, unknown> {
-  return billing.attempted
-    ? { stripe: { actions: billing.actions, warnings: billing.warnings } }
-    : {};
-}
-
-/**
- * Response fragment surfacing Stripe teardown failures to the operator —
- * a Stripe API failure must never strand the operation silently (#3425).
- */
-function withWarnings(billing: StripeTeardownOutcome): { warnings?: string[] } {
-  return billing.warnings.length > 0 ? { warnings: billing.warnings } : {};
-}
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
+++ b/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
@@ -51,13 +51,34 @@ function makeMockPool(opts: {
   trialConsumedElsewhere?: boolean;
   /** Eligibility lookup throws (DB blip mid-hook). */
   eligibilityThrows?: boolean;
+  /**
+   * Atomic claim (#3469): the `ON CONFLICT DO NOTHING` insert returns no
+   * row and the user's existing grant points at this org id (or a
+   * different one — the lost-race shape).
+   */
+  claimExistingOrgId?: string;
 }): MockPool {
   const queries: Array<{ sql: string; params?: unknown[] }> = [];
   const pool = {
     query: async (sql: string, params?: unknown[]) => {
       queries.push({ sql, params });
-      // The #3426 eligibility lookup joins member → organization on the
-      // trial-consumed stamp. Dispatch it before the generic SELECT arm.
+      // #3469 atomic claim — dispatch before the eligibility arm (both
+      // mention user_trial_grants).
+      if (/INSERT INTO user_trial_grants/i.test(sql)) {
+        if (opts.updateThrows) throw new Error("INSERT failed");
+        return opts.claimExistingOrgId !== undefined
+          ? { rows: [], rowCount: 0 } // conflict — someone holds the grant
+          : { rows: [{ user_id: params?.[0] }], rowCount: 1 };
+      }
+      if (/SELECT org_id FROM user_trial_grants/i.test(sql)) {
+        return {
+          rows: opts.claimExistingOrgId !== undefined ? [{ org_id: opts.claimExistingOrgId }] : [],
+          rowCount: opts.claimExistingOrgId !== undefined ? 1 : 0,
+        };
+      }
+      // The #3426 eligibility lookup ORs the durable grant marker with
+      // the member → organization trial-consumed stamp. Dispatch it
+      // before the generic SELECT arm.
       if (/FROM\s+member/i.test(sql)) {
         if (opts.eligibilityThrows) throw new Error("eligibility lookup failed");
         return {
@@ -120,21 +141,28 @@ describe("assignSaasTrial — body", () => {
     await assignSaasTrial({ user: USER, organization: ORG });
     const after = Date.now();
 
-    expect(queries).toHaveLength(3);
+    expect(queries).toHaveLength(4);
     expect(queries[0].sql).toMatch(/SELECT plan_tier FROM organization/);
     // #3426 eligibility lookup: keyed on the CREATING user, excluding the
     // just-created org (its owner-member row already exists when the
-    // afterCreateOrganization hook fires).
+    // afterCreateOrganization hook fires). Durable grant marker (#3470)
+    // OR-joined with the legacy owner-membership proxy.
+    expect(queries[1].sql).toMatch(/user_trial_grants/);
     expect(queries[1].sql).toMatch(/FROM member/);
     expect(queries[1].sql).toMatch(/trial_ends_at IS NOT NULL/);
     expect(queries[1].params).toEqual([USER.id, ORG.id]);
-    expect(queries[2].sql).toMatch(
+    // #3469 atomic claim: ON CONFLICT (user_id) DO NOTHING — exactly one
+    // concurrent creation can win.
+    expect(queries[2].sql).toMatch(/INSERT INTO user_trial_grants/);
+    expect(queries[2].sql).toMatch(/ON CONFLICT \(user_id\) DO NOTHING/);
+    expect(queries[2].params).toEqual([USER.id, ORG.id]);
+    expect(queries[3].sql).toMatch(
       /UPDATE organization SET plan_tier = 'trial', trial_ends_at/,
     );
     // Belt-and-suspenders: the UPDATE re-asserts the free guard.
-    expect(queries[2].sql).toMatch(/AND plan_tier = 'free'/);
+    expect(queries[3].sql).toMatch(/AND plan_tier = 'free'/);
 
-    const [trialEndsAtParam, orgIdParam] = queries[2].params ?? [];
+    const [trialEndsAtParam, orgIdParam] = queries[3].params ?? [];
     expect(orgIdParam).toBe(ORG.id);
     const trialEndsAt = new Date(String(trialEndsAtParam)).getTime();
     const target = before + TRIAL_DAYS * DAY_MS;
@@ -168,6 +196,64 @@ describe("assignSaasTrial — body", () => {
     expect(
       queries.some((q) => /plan_tier = 'trial'/i.test(q.sql) && /^\s*UPDATE/i.test(q.sql)),
       "a trial-consumed creator must never receive a second trial",
+    ).toBe(false);
+  });
+
+  it("locks the loser of a concurrent claim race (#3469) — exactly one trial is minted", async () => {
+    // Both concurrent creations passed the read-side eligibility check
+    // (trialConsumedElsewhere: false), but this request's atomic claim
+    // hit the conflict: the user's grant already points at the SIBLING
+    // org. The loser must land on 'locked' with the consumed-now stamp.
+    const { pool, queries } = makeMockPool({
+      selectTier: "free",
+      trialConsumedElsewhere: false,
+      claimExistingOrgId: "org_sibling_race_winner",
+    });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(
+      queries.some((q) => /UPDATE organization SET plan_tier = 'locked'/i.test(q.sql)),
+      "the claim-race loser must land on 'locked'",
+    ).toBe(true);
+    expect(
+      queries.some((q) => /plan_tier = 'trial'/i.test(q.sql) && /^\s*UPDATE/i.test(q.sql)),
+      "the claim-race loser must never receive a trial",
+    ).toBe(false);
+  });
+
+  it("proceeds with the trial when the existing grant already points at THIS org (crash-heal retry)", async () => {
+    // A previous attempt claimed the grant but crashed before the tier
+    // write. The retry's insert conflicts, but the grant belongs to this
+    // very org — idempotent re-run, not a lost race.
+    const { pool, queries } = makeMockPool({
+      selectTier: "free",
+      trialConsumedElsewhere: false,
+      claimExistingOrgId: ORG.id,
+    });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(
+      queries.some((q) => /UPDATE organization SET plan_tier = 'trial'/i.test(q.sql)),
+      "a retry holding its own grant must still receive the trial",
+    ).toBe(true);
+    expect(
+      queries.some((q) => /plan_tier = 'locked'/i.test(q.sql) && /^\s*UPDATE/i.test(q.sql)),
+    ).toBe(false);
+  });
+
+  it("skips the claim entirely when eligibility already says consumed — no grant row is written", async () => {
+    const { pool, queries } = makeMockPool({ selectTier: "free", trialConsumedElsewhere: true });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(
+      queries.some((q) => /INSERT INTO user_trial_grants/i.test(q.sql)),
+      "grant rows record actual grants — a consumed-elsewhere creator writes none",
     ).toBe(false);
   });
 

--- a/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
+++ b/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
@@ -47,6 +47,9 @@ function makeMockPool(opts: {
   selectTier?: string | null;
   selectThrows?: boolean;
   updateThrows?: boolean;
+  /** Atomic-claim INSERT throws (separate from updateThrows so the
+   * UPDATE-failure path is testable independently — CodeRabbit on #3475). */
+  claimThrows?: boolean;
   /** Eligibility lookup (#3426): creator already owns a trialed org. */
   trialConsumedElsewhere?: boolean;
   /** Eligibility lookup throws (DB blip mid-hook). */
@@ -65,7 +68,7 @@ function makeMockPool(opts: {
       // #3469 atomic claim — dispatch before the eligibility arm (both
       // mention user_trial_grants).
       if (/INSERT INTO user_trial_grants/i.test(sql)) {
-        if (opts.updateThrows) throw new Error("INSERT failed");
+        if (opts.claimThrows) throw new Error("INSERT failed");
         return opts.claimExistingOrgId !== undefined
           ? { rows: [], rowCount: 0 } // conflict — someone holds the grant
           : { rows: [{ user_id: params?.[0] }], rowCount: 1 };
@@ -245,7 +248,12 @@ describe("assignSaasTrial — body", () => {
     ).toBe(false);
   });
 
-  it("skips the claim entirely when eligibility already says consumed — no grant row is written", async () => {
+  it("stamps a durable marker on the locked path when consumed only via the legacy proxy (#3470)", async () => {
+    // A user made owner of a trialed org after migration 0130 has no
+    // user_trial_grants row, so `consumed` is true only via the legacy
+    // proxy. The locked path must still claim a durable marker (idempotent,
+    // ON CONFLICT DO NOTHING) — otherwise a later owner demotion would
+    // erase the proxy match and reopen trial eligibility (#3470 hole).
     const { pool, queries } = makeMockPool({ selectTier: "free", trialConsumedElsewhere: true });
     _resetPool(pool);
 
@@ -253,7 +261,14 @@ describe("assignSaasTrial — body", () => {
 
     expect(
       queries.some((q) => /INSERT INTO user_trial_grants/i.test(q.sql)),
-      "grant rows record actual grants — a consumed-elsewhere creator writes none",
+      "the locked path must durably record consumption so demotion can't reopen eligibility",
+    ).toBe(true);
+    // Still locked, never a second trial.
+    expect(
+      queries.some((q) => /UPDATE organization SET plan_tier = 'locked'/i.test(q.sql)),
+    ).toBe(true);
+    expect(
+      queries.some((q) => /plan_tier = 'trial'/i.test(q.sql) && /^\s*UPDATE/i.test(q.sql)),
     ).toBe(false);
   });
 
@@ -354,7 +369,21 @@ describe("assignSaasTrial — body", () => {
   });
 
   it("does not throw when the UPDATE fails", async () => {
-    const { pool } = makeMockPool({ selectTier: "free", updateThrows: true });
+    const { pool, queries } = makeMockPool({ selectTier: "free", updateThrows: true });
+    _resetPool(pool);
+
+    await expect(
+      assignSaasTrial({ user: USER, organization: ORG }),
+    ).resolves.toBeUndefined();
+
+    // The claim INSERT must have run (and not thrown) so the UPDATE arm is
+    // the one that failed — proves updateThrows isolates the UPDATE path.
+    expect(queries.some((q) => /INSERT INTO user_trial_grants/i.test(q.sql))).toBe(true);
+    expect(queries.some((q) => /^\s*UPDATE/i.test(q.sql))).toBe(true);
+  });
+
+  it("does not throw when the atomic claim INSERT fails", async () => {
+    const { pool } = makeMockPool({ selectTier: "free", claimThrows: true });
     _resetPool(pool);
 
     await expect(

--- a/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
@@ -141,6 +141,11 @@ function makeRecordingPool(): InternalPool {
       // "no trial consumed" so assignSaasTrial takes the trial branch the
       // wiring assertion pins.
       if (/trial_ends_at\s+IS\s+NOT\s+NULL/i.test(sql)) return rows([]);
+      // #3469 atomic trial claim: return the inserted row (claim won) so
+      // the hook proceeds to the trial UPDATE the wiring assertion pins.
+      if (/INSERT\s+INTO\s+user_trial_grants/i.test(sql)) {
+        return rows([{ user_id: params?.[0] }]);
+      }
       if (/FROM\s+member/i.test(sql)) return rows([{ organizationId: "org_welcome" }]);
       return rows([]);
     },

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -373,9 +373,10 @@ describe("migrateAuthTables", () => {
             { name: "0123_elasticsearch_datasource_catalog.sql" },
             { name: "0124_duckdb_not_saas_eligible.sql" },
             { name: "0125_elasticsearch_auth_modes_config_schema.sql" },
-            // 0126/0127 are MANAGED_AUTH_MIGRATIONS (skipped outside managed
-            // mode), so they don't need to appear here.
+            // 0126/0127/0130 are MANAGED_AUTH_MIGRATIONS (skipped outside
+            // managed mode), so they don't need to appear here.
             { name: "0128_stripe_webhook_event_ledger.sql" },
+            { name: "0129_stripe_purged_subscriptions.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -118,6 +118,9 @@ interface LedgerRow {
 
 let ledgerRows: LedgerRow[] = [];
 
+/** GDPR purge tombstones (#3468) — answered for the classify probe. */
+let purgedSubscriptionIds = new Set<string>();
+
 // The production allowlist, so the sim can't drift from the real
 // ordering model if TIER_LIFECYCLE_EVENT_TYPES changes.
 const LIFECYCLE_TYPES: readonly string[] = TIER_LIFECYCLE_EVENT_TYPES;
@@ -128,6 +131,13 @@ function ledgerAwareQuery(
   return (sql: string, params?: unknown[]) => {
     if (sql.includes("FROM stripe_webhook_events WHERE event_id")) {
       return Promise.resolve(ledgerRows.filter((r) => r.event_id === params?.[0]));
+    }
+    if (sql.includes("FROM stripe_purged_subscriptions")) {
+      return Promise.resolve(
+        purgedSubscriptionIds.has(String(params?.[0]))
+          ? [{ stripe_subscription_id: params?.[0] }]
+          : [],
+      );
     }
     if (sql.includes("FROM stripe_webhook_events") && sql.includes("event_created > $2")) {
       // Mirrors the production stale probe: lifecycle rows only; newer
@@ -311,6 +321,7 @@ beforeEach(() => {
   mockGetWorkspaceDetails.mockReset();
   mockGetWorkspaceDetails.mockImplementation(() => Promise.resolve(null));
   ledgerRows = [];
+  purgedSubscriptionIds = new Set();
   mockInternalQuery.mockReset();
   mockInternalQuery.mockImplementation(ledgerAwareQuery());
   subscriptionsRetrieve.mockClear();
@@ -577,6 +588,27 @@ describe("customer.subscription.deleted", () => {
 
     expect(res.status).toBe(200);
     expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("skips and does NOT record deliveries for a GDPR-purged subscription (#3468)", async () => {
+    // Purge already ran: hardDeleteWorkspace tombstoned the subscription
+    // id and removed the local subscription + ledger rows. The purge's
+    // own Stripe cancellation now delivers customer.subscription.deleted
+    // — it must neither sync nor regrow stripe_webhook_events.
+    purgedSubscriptionIds = new Set(["sub_stripe_1"]);
+    const auth = makeAuth(emptyDB());
+
+    const res = await postWebhook(auth, {
+      id: "evt_post_purge",
+      type: "customer.subscription.deleted",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "canceled" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+    expect(mockUpdateWorkspaceStatus).not.toHaveBeenCalled();
+    expect(ledgerRows).toEqual([]);
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -132,7 +132,9 @@ function ledgerAwareQuery(
     if (sql.includes("FROM stripe_webhook_events WHERE event_id")) {
       return Promise.resolve(ledgerRows.filter((r) => r.event_id === params?.[0]));
     }
-    if (sql.includes("FROM stripe_purged_subscriptions")) {
+    // classify-time tombstone probe (#3468) — match the SELECT shape only,
+    // NOT the record INSERT's `NOT EXISTS (SELECT 1 FROM ...)` guard below.
+    if (sql.includes("SELECT stripe_subscription_id FROM stripe_purged_subscriptions")) {
       return Promise.resolve(
         purgedSubscriptionIds.has(String(params?.[0]))
           ? [{ stripe_subscription_id: params?.[0] }]
@@ -161,6 +163,11 @@ function ledgerAwareQuery(
         string | null,
         string | null,
       ];
+      // Model the record-time `WHERE NOT EXISTS (... stripe_purged_subscriptions ...)`
+      // guard (#3468): a tombstoned subscription's event is never recorded.
+      if (subId !== null && purgedSubscriptionIds.has(subId)) {
+        return Promise.resolve([]);
+      }
       if (!ledgerRows.some((r) => r.event_id === id)) {
         ledgerRows.push({
           event_id: id,

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -242,16 +242,27 @@ export async function assignSaasTrial(args: {
     //     first-workspace creations both pass gate 1, but the
     //     `ON CONFLICT (user_id) DO NOTHING` insert lets exactly one
     //     win; the loser lands on the locked arm with consumed-now.
+    //
+    // The claim runs UNCONDITIONALLY (not short-circuited on `consumed`)
+    // so the locked path also leaves a durable marker (#3470): when
+    // `consumed` matched only via the legacy owner-of-a-trialed-org proxy
+    // there is no `user_trial_grants` row yet, and a later demotion or
+    // deletion of that proxy org would otherwise reopen eligibility.
+    // `ON CONFLICT DO NOTHING` preserves any existing grant, so a user
+    // whose marker already points at an earlier org keeps it. The grant
+    // gets the trial only when the user hadn't consumed one AND this org
+    // won the claim.
     const consumed = await userHasConsumedTrial(user.id, org.id);
-    const won = !consumed && (await claimTrialGrant(user.id, org.id));
-    if (!won) {
+    const claimedThisOrg = await claimTrialGrant(user.id, org.id);
+    const grantTrial = !consumed && claimedThisOrg;
+    if (!grantTrial) {
       await internalQuery(
         `UPDATE organization SET plan_tier = 'locked', trial_ends_at = $1
          WHERE id = $2 AND plan_tier = 'free'`,
         [new Date().toISOString(), org.id],
       );
       log.info(
-        { userId: user.id, orgId: org.id, lostConcurrentClaim: !consumed },
+        { userId: user.id, orgId: org.id, lostConcurrentClaim: !consumed && !claimedThisOrg },
         "Workspace creator already consumed a SaaS trial — new workspace starts locked (one trial per user, #3426/#3469)",
       );
       return;

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -60,7 +60,7 @@ import { blockNativeMemberRoleUpdate, blockNativeMemberRemoval } from "@atlas/ap
 import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
-import { userHasConsumedTrial } from "@atlas/api/lib/billing/trial-eligibility";
+import { userHasConsumedTrial, claimTrialGrant } from "@atlas/api/lib/billing/trial-eligibility";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import {
@@ -224,8 +224,8 @@ export async function assignSaasTrial(args: {
     );
     if (existing[0]?.plan_tier !== "free") return;
 
-    // One trial per user (#3426): a creator who already owns a trialed
-    // workspace gets NO fresh trial — the new org lands directly on the
+    // One trial per user (#3426): a creator who already consumed a trial
+    // gets NO fresh one — the new org lands directly on the
     // zero-entitlement 'locked' churn tier (#3421), where enforcement
     // blocks gated actions exactly like an ended subscription and the
     // billing page offers the upgrade path. The org IS still created (no
@@ -233,15 +233,26 @@ export async function assignSaasTrial(args: {
     // customers). `trial_ends_at = NOW()` stamps the trial as consumed so
     // `getCheckoutSessionParams`' double-trial suppression also withholds
     // the Stripe-side trial at first checkout.
-    if (await userHasConsumedTrial(user.id, org.id)) {
+    //
+    // Two gates, both in trial-eligibility.ts:
+    //  1. userHasConsumedTrial — durable per-user grant marker (#3470)
+    //     OR the legacy owner-of-a-trialed-org proxy (received-ownership
+    //     posture: fail toward no-second-trial).
+    //  2. claimTrialGrant — the ATOMIC claim (#3469): two concurrent
+    //     first-workspace creations both pass gate 1, but the
+    //     `ON CONFLICT (user_id) DO NOTHING` insert lets exactly one
+    //     win; the loser lands on the locked arm with consumed-now.
+    const consumed = await userHasConsumedTrial(user.id, org.id);
+    const won = !consumed && (await claimTrialGrant(user.id, org.id));
+    if (!won) {
       await internalQuery(
         `UPDATE organization SET plan_tier = 'locked', trial_ends_at = $1
          WHERE id = $2 AND plan_tier = 'free'`,
         [new Date().toISOString(), org.id],
       );
       log.info(
-        { userId: user.id, orgId: org.id },
-        "Workspace creator already consumed a SaaS trial — new workspace starts locked (one trial per user, #3426)",
+        { userId: user.id, orgId: org.id, lostConcurrentClaim: !consumed },
+        "Workspace creator already consumed a SaaS trial — new workspace starts locked (one trial per user, #3426/#3469)",
       );
       return;
     }

--- a/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
+++ b/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
@@ -89,13 +89,15 @@ describe("backfillSaasTrial", () => {
     expect(result.updatedCount).toBe(2);
     expect(result.orgIds).toEqual(["org_dogfood", "org_acme"]);
     expect(result.lockedOrgIds).toEqual([]);
-    expect(queries).toHaveLength(2);
+    expect(queries).toHaveLength(3);
 
     // Statement 1 — the #3426 lock arm runs FIRST so the promote arm can
     // never see a trial-consumed owner's org.
     expect(queries[0].sql).toMatch(/plan_tier = 'locked'/);
     expect(queries[0].sql).toMatch(/trial_ends_at IS NOT NULL/);
-    // Eligibility keys on owner membership, mirroring trial-eligibility.ts.
+    // Eligibility keys on the durable grant marker (#3470) OR the legacy
+    // owner-membership proxy, mirroring trial-eligibility.ts.
+    expect(queries[0].sql).toMatch(/user_trial_grants/);
     expect(queries[0].sql).toMatch(/role = 'owner'/);
 
     // Statement 2 — the promote arm.
@@ -103,6 +105,12 @@ describe("backfillSaasTrial", () => {
     // The idempotency guards must survive any future rewrite.
     expect(queries[1].sql).toMatch(/plan_tier = 'free'/);
     expect(queries[1].sql).toMatch(/trial_ends_at IS NULL/);
+
+    // Statement 3 — healed grants are recorded through the same durable
+    // marker the signup hook claims (#3469/#3470).
+    expect(queries[2].sql).toMatch(/INSERT INTO user_trial_grants/);
+    expect(queries[2].sql).toMatch(/ON CONFLICT \(user_id\) DO NOTHING/);
+    expect(queries[2].params).toEqual([["org_dogfood", "org_acme"]]);
 
     const [trialEndsAtParam] = queries[1].params ?? [];
     const trialEndsAt = new Date(String(trialEndsAtParam)).getTime();
@@ -155,7 +163,7 @@ describe("backfillSaasTrial", () => {
     const pool = {
       query: async (sql: string, params?: unknown[]) => {
         queries.push({ sql, params });
-        if (/plan_tier = 'locked'/.test(sql)) {
+        if (/plan_tier = 'locked'/.test(sql) || /INSERT INTO user_trial_grants/.test(sql)) {
           return { rows: [], rowCount: 0 };
         }
         promoteCalls += 1;
@@ -175,7 +183,9 @@ describe("backfillSaasTrial", () => {
     expect(second.updatedCount).toBe(0);
     expect(second.orgIds).toEqual([]);
 
-    expect(queries).toHaveLength(4);
+    // Boot 1: lock + promote + grant stamp; boot 2: lock + promote only
+    // (zero promoted rows → no grant insert).
+    expect(queries).toHaveLength(5);
   });
 
   it("skips on self-hosted — no UPDATE", async () => {

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
@@ -58,6 +58,7 @@ describe("reconcilePlanTiers", () => {
       healed: 0,
       flagged: 0,
       prunedLedger: 0,
+      prunedTombstones: 0,
     });
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
@@ -105,6 +106,7 @@ describe("reconcilePlanTiers", () => {
       healed: 0,
       flagged: 0,
       prunedLedger: 0,
+      prunedTombstones: 0,
     });
     expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
   });
@@ -178,6 +180,18 @@ describe("reconcilePlanTiers", () => {
 
     const result = await reconcilePlanTiers();
     expect(result.prunedLedger).toBe(2);
+  });
+
+  it("prunes GDPR purge tombstones past retention and reports the count (#3468)", async () => {
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM organization o")) return Promise.resolve([]);
+      if (sql.includes("DELETE FROM stripe_purged_subscriptions"))
+        return Promise.resolve([{ stripe_subscription_id: "sub_purged_old" }]);
+      return Promise.resolve([]);
+    });
+
+    const result = await reconcilePlanTiers();
+    expect(result.prunedTombstones).toBe(1);
   });
 
   it("propagates internal-DB failures so the scheduler tick logs and retries", async () => {

--- a/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
+++ b/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
@@ -26,7 +26,9 @@ const {
   classifyStripeEvent,
   recordStripeEvent,
   pruneStripeEventLedger,
+  pruneStripePurgedSubscriptions,
   STRIPE_EVENT_LEDGER_RETENTION_DAYS,
+  STRIPE_PURGE_TOMBSTONE_RETENTION_DAYS,
 } = await import("../stripe-event-ledger");
 
 const EVENT = {
@@ -45,12 +47,16 @@ beforeEach(() => {
 describe("classifyStripeEvent", () => {
   it("returns fresh when neither the id nor a newer same-subscription event is recorded", async () => {
     await expect(classifyStripeEvent(EVENT)).resolves.toBe("fresh");
-    // Two probes: dedup by event id, then ordering by subscription id.
-    expect(mockInternalQuery).toHaveBeenCalledTimes(2);
+    // Three probes: dedup by event id, purge tombstone (#3468), then
+    // ordering by subscription id.
+    expect(mockInternalQuery).toHaveBeenCalledTimes(3);
     const [dupSql, dupParams] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
     expect(dupSql).toContain("WHERE event_id = $1");
     expect(dupParams).toEqual(["evt_1"]);
-    const [staleSql, staleParams] = mockInternalQuery.mock.calls[1] as [string, unknown[]];
+    const [tombstoneSql, tombstoneParams] = mockInternalQuery.mock.calls[1] as [string, unknown[]];
+    expect(tombstoneSql).toContain("FROM stripe_purged_subscriptions");
+    expect(tombstoneParams).toEqual(["sub_1"]);
+    const [staleSql, staleParams] = mockInternalQuery.mock.calls[2] as [string, unknown[]];
     expect(staleSql).toContain("event_created > $2");
     // Only lifecycle events may block (payment failures excluded) …
     expect(staleSql).toContain("event_type IN (");
@@ -67,8 +73,28 @@ describe("classifyStripeEvent", () => {
     ).resolves.toBe("fresh");
     // A payment failure recorded first must never make a delayed
     // lifecycle sync look stale, and vice versa — it skips the
-    // ordering probe entirely.
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    // ordering probe entirely (the dedup + tombstone probes still run).
+    expect(mockInternalQuery).toHaveBeenCalledTimes(2);
+    const sqls = mockInternalQuery.mock.calls.map((c) => c[0] as string);
+    expect(sqls.some((s) => s.includes("event_created > $2"))).toBe(false);
+  });
+
+  it("returns purged when the subscription id is tombstoned by a GDPR purge (#3468)", async () => {
+    mockInternalQuery.mockImplementation((sql) =>
+      Promise.resolve(
+        sql.includes("FROM stripe_purged_subscriptions")
+          ? [{ stripe_subscription_id: "sub_1" }]
+          : [],
+      ),
+    );
+    await expect(
+      classifyStripeEvent({ ...EVENT, type: "customer.subscription.deleted" }),
+    ).resolves.toBe("purged");
+    // Non-lifecycle deliveries for the purged subscription are equally
+    // terminal — they must not regrow the ledger either.
+    await expect(
+      classifyStripeEvent({ ...EVENT, id: "evt_2", type: "invoice.payment_failed" }),
+    ).resolves.toBe("purged");
   });
 
   it("returns duplicate when the event id is already recorded (replay)", async () => {
@@ -159,6 +185,30 @@ describe("pruneStripeEventLedger", () => {
   it("rejects negative/non-finite retention before touching the DB (would invert the cutoff)", async () => {
     await expect(pruneStripeEventLedger(-1)).rejects.toThrow(/Invalid/);
     await expect(pruneStripeEventLedger(Number.NaN)).rejects.toThrow(/Invalid/);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("pruneStripePurgedSubscriptions (#3468)", () => {
+  it("deletes tombstones past the default retention and returns the count", async () => {
+    mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ stripe_subscription_id: "sub_old" }]),
+    );
+    await expect(pruneStripePurgedSubscriptions()).resolves.toBe(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("DELETE FROM stripe_purged_subscriptions");
+    expect(params).toEqual([String(STRIPE_PURGE_TOMBSTONE_RETENTION_DAYS)]);
+  });
+
+  it("returns 0 without an internal DB", async () => {
+    hasDb = false;
+    await expect(pruneStripePurgedSubscriptions()).resolves.toBe(0);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects negative/non-finite retention before touching the DB (would invert the cutoff)", async () => {
+    await expect(pruneStripePurgedSubscriptions(-1)).rejects.toThrow(/Invalid/);
+    await expect(pruneStripePurgedSubscriptions(Number.NaN)).rejects.toThrow(/Invalid/);
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
+++ b/packages/api/src/lib/billing/__tests__/stripe-event-ledger.test.ts
@@ -138,6 +138,10 @@ describe("recordStripeEvent", () => {
     expect(sql).toContain("INSERT INTO stripe_webhook_events");
     expect(sql).toContain("applied_plan_tier");
     expect(sql).toContain("ON CONFLICT (event_id) DO NOTHING");
+    // Record-time tombstone guard (#3468): the insert is skipped if the
+    // subscription was purged after classify but before record.
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain("stripe_purged_subscriptions");
     expect(params).toEqual([
       "evt_1",
       "customer.subscription.updated",

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -70,11 +70,27 @@ const customersDel: Mock<(id: string) => Promise<unknown>> = mock(async (id: str
   return { id, deleted: true };
 });
 
+/** Open invoices returned by `invoices.list` per subscription id (#3467). */
+let openInvoices: Record<string, string[]> = {};
+
+const invoicesList: Mock<(params: Record<string, unknown>) => Promise<unknown>> = mock(
+  async (params: Record<string, unknown>) => {
+    callOrder.push(`invoices.list:${String(params.subscription)}`);
+    const ids = openInvoices[String(params.subscription)] ?? [];
+    return { data: ids.map((id) => ({ id, status: "open" })) };
+  },
+);
+const invoicesVoid: Mock<(id: string) => Promise<unknown>> = mock(async (id: string) => {
+  callOrder.push(`invoices.void:${id}`);
+  return { id, status: "void" };
+});
+
 let stripeAvailable = true;
 function makeStripeStub() {
   return {
     subscriptions: { cancel: subscriptionsCancel, update: subscriptionsUpdate },
     customers: { del: customersDel },
+    invoices: { list: invoicesList, voidInvoice: invoicesVoid },
   };
 }
 
@@ -121,11 +137,14 @@ beforeEach(() => {
   hasDB = true;
   stripeAvailable = true;
   callOrder = [];
+  openInvoices = {};
   mockInternalQuery.mockReset();
   mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   subscriptionsCancel.mockClear();
   subscriptionsUpdate.mockClear();
   customersDel.mockClear();
+  invoicesList.mockClear();
+  invoicesVoid.mockClear();
   mockLogError.mockClear();
   // Restore default success implementations after failure-path tests.
   subscriptionsCancel.mockImplementation(async (id: string) => {
@@ -139,6 +158,15 @@ beforeEach(() => {
   customersDel.mockImplementation(async (id: string) => {
     callOrder.push(`customer.del:${id}`);
     return { id, deleted: true };
+  });
+  invoicesList.mockImplementation(async (params: Record<string, unknown>) => {
+    callOrder.push(`invoices.list:${String(params.subscription)}`);
+    const ids = openInvoices[String(params.subscription)] ?? [];
+    return { data: ids.map((id) => ({ id, status: "open" })) };
+  });
+  invoicesVoid.mockImplementation(async (id: string) => {
+    callOrder.push(`invoices.void:${id}`);
+    return { id, status: "void" };
   });
 });
 
@@ -381,5 +409,88 @@ describe("pause/resumeStripeCollectionForWorkspace (suspend policy)", () => {
 
     expect(outcome).toEqual({ attempted: false, actions: [], warnings: [] });
     expect(subscriptionsUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Suspend: void invoices already open at pause time (#3467) ───────
+
+describe("pauseStripeCollectionForWorkspace — voids open invoices (#3467)", () => {
+  it("voids every open invoice on the paused subscription, after the pause", async () => {
+    mockSubscriptionRows([subRow("sub_1", "past_due")]);
+    openInvoices = { sub_1: ["in_1", "in_2"] };
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(invoicesVoid.mock.calls.map((c) => c[0])).toEqual(["in_1", "in_2"]);
+    // Pause lands before the invoice sweep for the same subscription.
+    expect(callOrder.indexOf("update:sub_1")).toBeLessThan(callOrder.indexOf("invoices.void:in_1"));
+    expect(outcome.actions.filter((a) => a.includes("voided open invoice"))).toHaveLength(2);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it("resume never touches invoices — voiding is terminal, next cycle bills fresh", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    openInvoices = { sub_1: ["in_1"] };
+
+    await resumeStripeCollectionForWorkspace(ORG);
+
+    expect(invoicesList).not.toHaveBeenCalled();
+    expect(invoicesVoid).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a warning (and logs) when the invoice list fails — pause stands", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    invoicesList.mockImplementation(async () => {
+      throw new FakeStripeError("api_error");
+    });
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome.actions.some((a) => a.includes("paused collection"))).toBe(true);
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("list open invoices");
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("surfaces a per-invoice warning when a void fails — other invoices still voided", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    openInvoices = { sub_1: ["in_bad", "in_ok"] };
+    invoicesVoid.mockImplementation(async (id: string) => {
+      if (id === "in_bad") throw new FakeStripeError("invoice_locked");
+      callOrder.push(`invoices.void:${id}`);
+      return { id, status: "void" };
+    });
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain("in_bad");
+    expect(outcome.actions.some((a) => a.includes("in_ok"))).toBe(true);
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("treats a resource_missing invoice as already-gone (action, not warning)", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    openInvoices = { sub_1: ["in_gone"] };
+    invoicesVoid.mockImplementation(async () => {
+      throw new FakeStripeError("No such invoice", "resource_missing");
+    });
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(outcome.warnings).toEqual([]);
+    expect(outcome.actions.some((a) => a.includes("already absent"))).toBe(true);
+  });
+
+  it("skips the invoice sweep when the pause itself failed", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    subscriptionsUpdate.mockImplementation(async () => {
+      throw new FakeStripeError("rate_limited");
+    });
+
+    await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(invoicesList).not.toHaveBeenCalled();
+    expect(invoicesVoid).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -428,6 +428,31 @@ describe("pauseStripeCollectionForWorkspace — voids open invoices (#3467)", ()
     expect(outcome.warnings).toEqual([]);
   });
 
+  it("pages through ALL open invoices, not just the first page (#3475 review)", async () => {
+    mockSubscriptionRows([subRow("sub_1", "active")]);
+    // Two pages: the first reports has_more, the second closes it out.
+    let call = 0;
+    invoicesList.mockImplementation(async (params: Record<string, unknown>) => {
+      callOrder.push(`invoices.list:${String(params.subscription)}`);
+      call += 1;
+      if (call === 1) {
+        return {
+          data: [{ id: "in_p1a", status: "open" }, { id: "in_p1b", status: "open" }],
+          has_more: true,
+        };
+      }
+      return { data: [{ id: "in_p2a", status: "open" }], has_more: false };
+    });
+
+    const outcome = await pauseStripeCollectionForWorkspace(ORG);
+
+    expect(invoicesList).toHaveBeenCalledTimes(2);
+    // Second page request is anchored on the last id of the first page.
+    expect((invoicesList.mock.calls[1][0] as Record<string, unknown>).starting_after).toBe("in_p1b");
+    expect(invoicesVoid.mock.calls.map((c) => c[0])).toEqual(["in_p1a", "in_p1b", "in_p2a"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
   it("resume never touches invoices — voiding is terminal, next cycle bills fresh", async () => {
     mockSubscriptionRows([subRow("sub_1", "active")]);
     openInvoices = { sub_1: ["in_1"] };

--- a/packages/api/src/lib/billing/backfill-saas-trial.ts
+++ b/packages/api/src/lib/billing/backfill-saas-trial.ts
@@ -22,15 +22,22 @@
  * workspaces get a fresh window rather than landing pre-expired the
  * moment this code deploys.
  *
- * Two statements, lock-first: orgs with a trial-consumed owner are
+ * Three statements, lock-first: orgs with a trial-consumed owner are
  * demoted to 'locked' before the promote statement runs, so the promote
  * (`plan_tier = 'free'` guard) can never see them. The eligibility
- * predicate mirrors `userHasConsumedTrial` but keys on ANY owner — the
- * creator isn't recorded, so we fail toward no-second-trial. Two free
- * orgs sharing a never-trialed owner both promote in the same pass
- * (neither has `trial_ends_at` when the statement snapshots) — that
- * matches the pre-#3426 behaviour for legacy rows and is not reachable
- * by farming (the signup hook serializes new orgs).
+ * predicate mirrors `userHasConsumedTrial` — the durable
+ * `user_trial_grants` marker (#3470, a grant for a DIFFERENT org)
+ * OR-joined with the legacy any-owner-of-a-trialed-org proxy — so we
+ * fail toward no-second-trial. A grant pointing AT the org itself does
+ * NOT lock it: that's the crash-heal shape (#3469 claimed the grant but
+ * the tier write failed), and the promote arm finishes the job. After
+ * promoting, owners of the promoted orgs are stamped into
+ * `user_trial_grants` (ON CONFLICT DO NOTHING) so the heal records
+ * consumption through the same marker the hook reads. Two free orgs
+ * sharing a never-trialed owner both promote in the same pass (neither
+ * has `trial_ends_at` when the statement snapshots) — that matches the
+ * pre-#3426 behaviour for legacy rows and is not reachable by farming
+ * (the signup hook claims atomically per user).
  *
  * Wired through `BackfillSaasTrialLive` in
  * `packages/api/src/lib/effect/layers.ts`, which depends on `Migration`
@@ -72,7 +79,10 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
   try {
     // 1) One-trial-per-user arm (#3426): free orgs with an owner who
     //    already consumed a trial land on 'locked', trial stamped as
-    //    consumed-now. Must run BEFORE the promote arm.
+    //    consumed-now. Must run BEFORE the promote arm. "Consumed" =
+    //    the durable grant marker for a DIFFERENT org (#3470) or the
+    //    legacy owner-of-a-trialed-org proxy — mirror of
+    //    `userHasConsumedTrial`.
     const lockedRows = await internalQuery<{ id: string }>(
       `UPDATE organization o
           SET plan_tier = 'locked',
@@ -82,13 +92,24 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
           AND EXISTS (
             SELECT 1
               FROM member m_new
-              JOIN member m_prior ON m_prior."userId" = m_new."userId"
-              JOIN organization o_prior ON o_prior.id = m_prior."organizationId"
              WHERE m_new."organizationId" = o.id
                AND m_new.role = 'owner'
-               AND m_prior.role = 'owner'
-               AND o_prior.id <> o.id
-               AND o_prior.trial_ends_at IS NOT NULL
+               AND (
+                 EXISTS (
+                   SELECT 1 FROM user_trial_grants g
+                    WHERE g.user_id = m_new."userId"
+                      AND g.org_id <> o.id
+                 )
+                 OR EXISTS (
+                   SELECT 1
+                     FROM member m_prior
+                     JOIN organization o_prior ON o_prior.id = m_prior."organizationId"
+                    WHERE m_prior."userId" = m_new."userId"
+                      AND m_prior.role = 'owner'
+                      AND o_prior.id <> o.id
+                      AND o_prior.trial_ends_at IS NOT NULL
+                 )
+               )
           )
         RETURNING id`,
     );
@@ -105,6 +126,22 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
       [trialEndsAt.toISOString()],
     );
     const orgIds = rows.map((r) => r.id);
+
+    // 3) Record consumption for the healed grants through the same
+    //    durable marker the signup hook claims (#3469/#3470), so a
+    //    later owner demotion can't reopen eligibility. ON CONFLICT
+    //    keeps a crash-healed org's existing claim intact.
+    if (orgIds.length > 0) {
+      await internalQuery(
+        `INSERT INTO user_trial_grants (user_id, org_id)
+         SELECT m."userId", m."organizationId"
+           FROM member m
+          WHERE m."organizationId" = ANY($1)
+            AND m.role = 'owner'
+         ON CONFLICT (user_id) DO NOTHING`,
+        [orgIds],
+      );
+    }
     log.info(
       { updatedCount: orgIds.length, orgIds, lockedOrgIds, trialEndsAt: trialEndsAt.toISOString() },
       orgIds.length === 0 && lockedOrgIds.length === 0

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -37,7 +37,10 @@ import {
   updateWorkspacePlanTier,
 } from "@atlas/api/lib/db/internal";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
-import { pruneStripeEventLedger } from "@atlas/api/lib/billing/stripe-event-ledger";
+import {
+  pruneStripeEventLedger,
+  pruneStripePurgedSubscriptions,
+} from "@atlas/api/lib/billing/stripe-event-ledger";
 import { parsePlanTier } from "@atlas/api/lib/integrations/install/plan-rank";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { PlanTier } from "@useatlas/types";
@@ -54,6 +57,8 @@ export interface PlanTierReconcileResult {
   flagged: number;
   /** Webhook-ledger rows pruned past retention. */
   prunedLedger: number;
+  /** GDPR purge tombstones pruned past retention (#3468). */
+  prunedTombstones: number;
 }
 
 // Type alias, not interface: internalQuery's generic is constrained to
@@ -74,7 +79,7 @@ type ReconcileRow = {
  * interval.
  */
 export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
-  if (!hasInternalDB()) return { healed: 0, flagged: 0, prunedLedger: 0 };
+  if (!hasInternalDB()) return { healed: 0, flagged: 0, prunedLedger: 0, prunedTombstones: 0 };
 
   // Newest live subscription per org, joined against the org's current
   // tier AND the ledger's newest APPLIED tier for that subscription.
@@ -167,9 +172,10 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
   }
 
   const prunedLedger = await pruneStripeEventLedger();
+  const prunedTombstones = await pruneStripePurgedSubscriptions();
 
-  if (healed > 0 || flagged > 0 || prunedLedger > 0) {
-    log.info({ healed, flagged, prunedLedger, orgsScanned: rows.length }, "Plan-tier reconciliation pass complete");
+  if (healed > 0 || flagged > 0 || prunedLedger > 0 || prunedTombstones > 0) {
+    log.info({ healed, flagged, prunedLedger, prunedTombstones, orgsScanned: rows.length }, "Plan-tier reconciliation pass complete");
   }
-  return { healed, flagged, prunedLedger };
+  return { healed, flagged, prunedLedger, prunedTombstones };
 }

--- a/packages/api/src/lib/billing/stripe-event-ledger.ts
+++ b/packages/api/src/lib/billing/stripe-event-ledger.ts
@@ -151,9 +151,22 @@ export async function recordStripeEvent(
   appliedPlanTier: PlanTier | null,
 ): Promise<void> {
   if (!hasInternalDB()) return;
+  // The `WHERE NOT EXISTS (... stripe_purged_subscriptions ...)` guard
+  // closes the in-flight race the classify-time check can't (#3468
+  // review): a GDPR purge cancels the subscription remotely BEFORE it
+  // stamps the tombstone, so a `customer.subscription.deleted` delivery
+  // can classify `fresh` (pre-tombstone) and reach this record step
+  // AFTER the purge transaction commits the tombstone. Re-checking at
+  // record time means the row is never reinserted once the tombstone
+  // exists. NULL subscription ids match no tombstone, so non-subscription
+  // events still record. `ON CONFLICT DO NOTHING` keeps the idempotent
+  // record-last protocol intact.
   await internalQuery(
     `INSERT INTO stripe_webhook_events (event_id, event_type, event_created, stripe_subscription_id, applied_plan_tier)
-     VALUES ($1, $2, $3, $4, $5)
+     SELECT $1, $2, $3, $4, $5
+      WHERE NOT EXISTS (
+        SELECT 1 FROM stripe_purged_subscriptions WHERE stripe_subscription_id = $4
+      )
      ON CONFLICT (event_id) DO NOTHING`,
     [
       event.id,

--- a/packages/api/src/lib/billing/stripe-event-ledger.ts
+++ b/packages/api/src/lib/billing/stripe-event-ledger.ts
@@ -34,6 +34,13 @@ const log = createLogger("billing:event-ledger");
 /** Ledger retention — past Stripe's ~3-week retry horizon. */
 export const STRIPE_EVENT_LEDGER_RETENTION_DAYS = 30;
 
+/**
+ * Purge-tombstone retention (#3468) — same horizon rationale as the
+ * ledger: Stripe stops retrying after ~3 weeks, so after 30 days no
+ * delivery for a purged subscription id can still arrive.
+ */
+export const STRIPE_PURGE_TOMBSTONE_RETENTION_DAYS = 30;
+
 export interface StripeLedgerEvent {
   /** Stripe event id (`evt_…`). */
   id: string;
@@ -47,7 +54,7 @@ export interface StripeLedgerEvent {
   stripeSubscriptionId: string | null;
 }
 
-export type StripeEventDisposition = "fresh" | "duplicate" | "stale";
+export type StripeEventDisposition = "fresh" | "duplicate" | "stale" | "purged";
 
 /**
  * The event types whose relative order determines the workspace tier.
@@ -85,6 +92,13 @@ const LIFECYCLE_LIST_SQL = TIER_LIFECYCLE_EVENT_TYPES.map((t) => `'${t}'`).join(
  *    events — deletion is terminal (Stripe never resurrects a
  *    subscription id), so nothing sharing its second may run after it
  *    and write a paid tier back onto a locked workspace.
+ *  - `purged` — the subscription belonged to a GDPR-purged workspace
+ *    (#3468). The purge's own Stripe cancellation generates
+ *    `customer.subscription.deleted` deliveries that arrive AFTER the
+ *    purge transaction; without this branch, recording them would
+ *    regrow `stripe_webhook_events` rows for a purged workspace. A
+ *    purge must be terminal — skip without side effects (and without
+ *    recording, since `onEvent` only records `fresh` events).
  *  - `fresh` — process it.
  */
 export async function classifyStripeEvent(
@@ -97,6 +111,15 @@ export async function classifyStripeEvent(
     [event.id],
   );
   if (dup.length > 0) return "duplicate";
+
+  if (event.stripeSubscriptionId) {
+    const tombstone = await internalQuery<{ stripe_subscription_id: string }>(
+      `SELECT stripe_subscription_id FROM stripe_purged_subscriptions
+        WHERE stripe_subscription_id = $1 LIMIT 1`,
+      [event.stripeSubscriptionId],
+    );
+    if (tombstone.length > 0) return "purged";
+  }
 
   if (event.stripeSubscriptionId && isTierLifecycleEventType(event.type)) {
     const newer = await internalQuery<{ event_id: string }>(
@@ -163,6 +186,32 @@ export async function pruneStripeEventLedger(
   );
   if (rows.length > 0) {
     log.info({ pruned: rows.length, retentionDays }, "Pruned Stripe webhook event ledger");
+  }
+  return rows.length;
+}
+
+/**
+ * Drop purge tombstones past retention (#3468), so the tombstone table
+ * itself stays bounded rather than becoming a new unbounded GDPR
+ * surface. Returns the number pruned. Called by the reconciliation
+ * sweep alongside {@link pruneStripeEventLedger}.
+ */
+export async function pruneStripePurgedSubscriptions(
+  retentionDays: number = STRIPE_PURGE_TOMBSTONE_RETENTION_DAYS,
+): Promise<number> {
+  // Same inverted-cutoff guard as the ledger prune (CodeRabbit on #3444).
+  if (!Number.isFinite(retentionDays) || retentionDays < 0) {
+    throw new Error(`Invalid stripe purge tombstone retentionDays: ${retentionDays}`);
+  }
+  if (!hasInternalDB()) return 0;
+  const rows = await internalQuery<{ stripe_subscription_id: string }>(
+    `DELETE FROM stripe_purged_subscriptions
+      WHERE purged_at < now() - ($1 || ' days')::interval
+      RETURNING stripe_subscription_id`,
+    [String(retentionDays)],
+  );
+  if (rows.length > 0) {
+    log.info({ pruned: rows.length, retentionDays }, "Pruned Stripe purge tombstones");
   }
   return rows.length;
 }

--- a/packages/api/src/lib/billing/trial-eligibility.ts
+++ b/packages/api/src/lib/billing/trial-eligibility.ts
@@ -1,5 +1,5 @@
 /**
- * One-trial-per-user eligibility (#3426).
+ * One-trial-per-user eligibility (#3426, hardened by #3469/#3470).
  *
  * ── Policy (recorded on #3426, maintainer triage 2026-06-12) ─────────
  * Trial eligibility keys on the CREATING USER, not the org: a user's
@@ -12,20 +12,21 @@
  * module.
  *
  * ── Eligibility key ──────────────────────────────────────────────────
- * "Has this user already consumed a trial?" = the user is an OWNER
- * member of any other organization whose `trial_ends_at` is set.
- * `assignSaasTrial` stamps `trial_ends_at` the moment a trial is
- * granted (and the locked-at-birth branch stamps it too), and nothing
- * ever clears it — paid conversions keep the stamp — so the column
- * doubles as a durable "trial consumed" marker. Owner membership is the
- * closest queryable proxy for "creator": Better Auth inserts the
- * creator as `member.role = 'owner'` and stores no separate creator
- * column. A user who *received* ownership of a trialed org without
- * creating it is treated as having consumed a trial — we deliberately
- * fail toward no-second-trial rather than tracking creators in a new
- * column.
+ * The durable marker is a `user_trial_grants` row (#3470) — one row per
+ * user, stamped at grant time, immune to membership/role changes and
+ * org deletion. The legacy proxy (the user is an OWNER member of any
+ * other organization whose `trial_ends_at` is set) is kept as an OR-arm:
+ * it covers users who *received* ownership of a trialed org without
+ * creating it — we deliberately fail toward no-second-trial.
  *
- * The set-based mirror of this predicate lives in
+ * ── Atomicity ────────────────────────────────────────────────────────
+ * The grant itself is claimed via {@link claimTrialGrant} — a single
+ * `INSERT ... ON CONFLICT (user_id) DO NOTHING` (#3469), so two
+ * concurrent first-workspace creations by the same user mint exactly
+ * one trial; the loser's org lands `'locked'`. The check-then-claim
+ * pair lives in `assignSaasTrial` (`lib/auth/server.ts`).
+ *
+ * The set-based mirror of the eligibility predicate lives in
  * `backfill-saas-trial.ts` (boot-time heal) — keep the two in sync.
  */
 
@@ -34,7 +35,8 @@ import { internalQuery } from "@atlas/api/lib/db/internal";
 /**
  * Whether `userId` has already consumed a SaaS trial via some org other
  * than `excludeOrgId` (pass the just-created org so its own owner row —
- * inserted before `afterCreateOrganization` fires — can't count).
+ * inserted before `afterCreateOrganization` fires — and a crash-orphaned
+ * grant pointing at it can't count against itself).
  *
  * Throws on query failure — the caller owns the failure posture
  * (`assignSaasTrial` logs and leaves the org on `'free'` for the boot
@@ -46,14 +48,56 @@ export async function userHasConsumedTrial(
 ): Promise<boolean> {
   const rows = await internalQuery<{ consumed: number }>(
     `SELECT 1 AS consumed
-       FROM member m
-       JOIN organization o ON o.id = m."organizationId"
-      WHERE m."userId" = $1
-        AND m.role = 'owner'
-        AND o.id <> $2
-        AND o.trial_ends_at IS NOT NULL
-      LIMIT 1`,
+      WHERE EXISTS (
+              SELECT 1 FROM user_trial_grants g
+               WHERE g.user_id = $1 AND g.org_id <> $2
+            )
+         OR EXISTS (
+              SELECT 1
+                FROM member m
+                JOIN organization o ON o.id = m."organizationId"
+               WHERE m."userId" = $1
+                 AND m.role = 'owner'
+                 AND o.id <> $2
+                 AND o.trial_ends_at IS NOT NULL
+            )`,
     [userId, excludeOrgId],
   );
   return rows.length > 0;
+}
+
+/**
+ * Atomically claim the user's one trial for `orgId` (#3469). Returns
+ * `true` when this org holds the user's grant — either this call
+ * inserted it (won the claim) or a previous attempt for the SAME org
+ * already had (idempotent retry after a crash between claim and the
+ * tier write, which the boot backfill heals). Returns `false` when the
+ * user's grant belongs to a different org — the caller must take the
+ * locked arm.
+ *
+ * The PRIMARY KEY on `user_id` is what makes this race-free: under two
+ * concurrent first-workspace creations, exactly one INSERT returns a
+ * row. Locks nothing across users.
+ *
+ * Throws on query failure — same caller-owned posture as
+ * {@link userHasConsumedTrial}.
+ */
+export async function claimTrialGrant(
+  userId: string,
+  orgId: string,
+): Promise<boolean> {
+  const inserted = await internalQuery<{ user_id: string }>(
+    `INSERT INTO user_trial_grants (user_id, org_id)
+     VALUES ($1, $2)
+     ON CONFLICT (user_id) DO NOTHING
+     RETURNING user_id`,
+    [userId, orgId],
+  );
+  if (inserted.length > 0) return true;
+
+  const existing = await internalQuery<{ org_id: string }>(
+    `SELECT org_id FROM user_trial_grants WHERE user_id = $1 LIMIT 1`,
+    [userId],
+  );
+  return existing[0]?.org_id === orgId;
 }

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -278,6 +278,83 @@ export async function purgeStripeBillingForWorkspace(
 }
 
 /**
+ * Void the invoices already open (incl. past-due) on a subscription at
+ * pause time (#3467). `pause_collection: { behavior: "void" }` only
+ * affects invoices generated AFTER the pause — Stripe keeps retrying
+ * invoices that were open before it, so a workspace suspended mid-dunning
+ * would still get charged. Policy decision (recorded on #3467): VOID them
+ * — suspension means "stop invoicing/dunning for the suspension window",
+ * and we don't intend to retroactively collect (same rationale as
+ * `behavior: "void"` itself). Voiding is terminal in Stripe, so resume
+ * never resurrects these; the next cycle bills normally.
+ *
+ * Total — failures (list or per-invoice void) land in `warnings`.
+ */
+async function voidOpenInvoicesForSubscription(
+  orgId: string,
+  stripeSubscriptionId: string,
+  actions: string[],
+  warnings: string[],
+): Promise<void> {
+  const stripe = getStripeClient();
+  if (!stripe) return; // callers gate before reaching here
+
+  let openInvoiceIds: string[] = [];
+  try {
+    // One page of 100 — a single subscription cannot accumulate more
+    // open invoices than that within Stripe's ~3-week dunning horizon.
+    const invoices = await stripe.invoices.list({
+      subscription: stripeSubscriptionId,
+      status: "open",
+      limit: 100,
+    });
+    openInvoiceIds = invoices.data
+      .map((inv) => inv.id)
+      .filter((id): id is string => typeof id === "string");
+  } catch (err) {
+    const msg = errMessage(err);
+    log.error(
+      { orgId, stripeSubscriptionId, err: msg },
+      "Failed to list open invoices during workspace suspend",
+    );
+    warnings.push(
+      `Failed to list open invoices on Stripe subscription ${stripeSubscriptionId}: ${msg}. `
+      + "Check the Stripe dashboard and void any open invoices manually so the suspended workspace isn't charged.",
+    );
+    return;
+  }
+
+  for (const invoiceId of openInvoiceIds) {
+    try {
+      await stripe.invoices.voidInvoice(invoiceId);
+      actions.push(`voided open invoice ${invoiceId} on Stripe subscription ${stripeSubscriptionId}`);
+      log.info(
+        { orgId, stripeSubscriptionId, invoiceId },
+        "Voided open invoice during workspace suspend",
+      );
+    } catch (err) {
+      if (isResourceMissing(err)) {
+        actions.push(`invoice ${invoiceId} already absent in Stripe`);
+        log.info(
+          { orgId, stripeSubscriptionId, invoiceId },
+          "Invoice already absent during workspace suspend",
+        );
+        continue;
+      }
+      const msg = errMessage(err);
+      log.error(
+        { orgId, stripeSubscriptionId, invoiceId, err: msg },
+        "Failed to void open invoice during workspace suspend",
+      );
+      warnings.push(
+        `Failed to void open invoice ${invoiceId} on Stripe subscription ${stripeSubscriptionId}: ${msg}. `
+        + "Void it manually in the Stripe dashboard so the suspended workspace isn't charged.",
+      );
+    }
+  }
+}
+
+/**
  * Shared pause/resume implementation — both flip `pause_collection` on the
  * org's non-terminal subscriptions.
  */
@@ -314,6 +391,12 @@ async function updateCollectionForWorkspace(
         { orgId, stripeSubscriptionId: id, mode },
         "Updated Stripe pause_collection during workspace suspend/unsuspend",
       );
+      // Pause only stops FUTURE invoices — invoices already open keep
+      // dunning, so void them too (#3467). Resume deliberately does not
+      // touch invoices: voiding is terminal, the next cycle bills fresh.
+      if (mode === "pause") {
+        await voidOpenInvoicesForSubscription(orgId, id, actions, warnings);
+      }
     } catch (err) {
       if (isResourceMissing(err)) {
         actions.push(`Stripe subscription ${id} already absent in Stripe`);
@@ -350,6 +433,13 @@ async function updateCollectionForWorkspace(
  * billing without a new checkout. `behavior: "void"` (not `"keep_as_draft"`)
  * because we don't intend to retroactively collect for the suspension
  * window.
+ *
+ * Invoices already open at pause time keep dunning despite the pause
+ * (Stripe pauses future invoice GENERATION only), so they are voided as
+ * part of the same operation — see
+ * {@link voidOpenInvoicesForSubscription} (#3467). The
+ * `invoice.payment_failed` auto-suspension ladder does NOT go through
+ * this helper — it intentionally keeps dunning so payment can recover.
  */
 export async function pauseStripeCollectionForWorkspace(
   orgId: string,

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -299,18 +299,29 @@ async function voidOpenInvoicesForSubscription(
   const stripe = getStripeClient();
   if (!stripe) return; // callers gate before reaching here
 
-  let openInvoiceIds: string[];
+  const openInvoiceIds: string[] = [];
   try {
-    // One page of 100 — a single subscription cannot accumulate more
-    // open invoices than that within Stripe's ~3-week dunning horizon.
-    const invoices = await stripe.invoices.list({
-      subscription: stripeSubscriptionId,
-      status: "open",
-      limit: 100,
-    });
-    openInvoiceIds = invoices.data
-      .map((inv) => inv.id)
-      .filter((id): id is string => typeof id === "string");
+    // Page through ALL open invoices, not just the first 100 — a
+    // long-delinquent or manually-invoiced subscription can carry more
+    // than one page, and any unvoided page keeps dunning the suspended
+    // workspace (#3467 review). Cap the page walk defensively so a
+    // mis-paging Stripe response can't spin forever.
+    let startingAfter: string | undefined;
+    for (let page = 0; page < 1000; page++) {
+      const invoices = await stripe.invoices.list({
+        subscription: stripeSubscriptionId,
+        status: "open",
+        limit: 100,
+        ...(startingAfter ? { starting_after: startingAfter } : {}),
+      });
+      for (const inv of invoices.data) {
+        if (typeof inv.id === "string") openInvoiceIds.push(inv.id);
+      }
+      if (!invoices.has_more || invoices.data.length === 0) break;
+      const lastId = invoices.data[invoices.data.length - 1]?.id;
+      if (typeof lastId !== "string") break;
+      startingAfter = lastId;
+    }
   } catch (err) {
     const msg = errMessage(err);
     log.error(

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -60,6 +60,27 @@ function noopOutcome(): StripeTeardownOutcome {
 }
 
 /**
+ * Audit-metadata fragment recording the Stripe teardown outcome on the
+ * admin action row — empty when nothing was attempted (self-hosted /
+ * no-Stripe), so no-op deployments don't grow a misleading `stripe` key.
+ * Shared by the platform-admin and admin-orgs lifecycle routes (#3459).
+ */
+export function stripeAuditMetadata(billing: StripeTeardownOutcome): Record<string, unknown> {
+  return billing.attempted
+    ? { stripe: { actions: billing.actions, warnings: billing.warnings } }
+    : {};
+}
+
+/**
+ * Response fragment surfacing Stripe teardown failures to the operator —
+ * a Stripe API failure must never strand the operation silently (#3425).
+ * Shared by the platform-admin and admin-orgs lifecycle routes (#3459).
+ */
+export function withWarnings(billing: StripeTeardownOutcome): { warnings?: string[] } {
+  return billing.warnings.length > 0 ? { warnings: billing.warnings } : {};
+}
+
+/**
  * Subscription statuses that need no remote action — Stripe already
  * considers them terminated.
  */

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -299,7 +299,7 @@ async function voidOpenInvoicesForSubscription(
   const stripe = getStripeClient();
   if (!stripe) return; // callers gate before reaching here
 
-  let openInvoiceIds: string[] = [];
+  let openInvoiceIds: string[];
   try {
     // One page of 100 — a single subscription cannot accumulate more
     // open invoices than that within Stripe's ~3-week dunning horizon.

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -999,6 +999,53 @@ describe("hardDeleteWorkspace()", () => {
     expect(result.stripeWebhookEvents).toBe(2);
   });
 
+  it("tombstones the purged subscription ids BEFORE deleting their ledger rows (#3468)", async () => {
+    // The purge's own Stripe cancellation generates
+    // customer.subscription.deleted webhooks that arrive after this
+    // transaction — without a tombstone the webhook path regrows
+    // stripe_webhook_events rows for the purged workspace. The stamp must
+    // run inside the transaction, before the rows it protects are gone,
+    // and be idempotent (ON CONFLICT DO NOTHING).
+    const { pool: basePool } = createMockPool();
+    const queries: string[] = [];
+    const client = {
+      async query(sql: string) {
+        queries.push(sql);
+        const upper = sql.trim().toUpperCase();
+        if (upper.startsWith("SELECT WORKSPACE_STATUS")) {
+          return { rows: [{ workspace_status: "deleted" }] };
+        }
+        if (sql.includes("to_regclass")) {
+          return { rows: [{ table_exists: true }] };
+        }
+        if (sql.includes("FROM member m")) return { rows: [] };
+        if (upper.startsWith("DELETE")) return { rows: [{ ok: 1 }] };
+        return { rows: [] };
+      },
+      release() {},
+    };
+    const pool = {
+      ...basePool,
+      async connect() {
+        return client;
+      },
+    };
+    _resetPool(pool);
+
+    await hardDeleteWorkspace("org-1");
+
+    const tombstoneIdx = queries.findIndex((q) =>
+      q.includes("INSERT INTO stripe_purged_subscriptions"),
+    );
+    const ledgerDeleteIdx = queries.findIndex((q) =>
+      q.includes("DELETE FROM stripe_webhook_events"),
+    );
+    expect(tombstoneIdx).toBeGreaterThan(-1);
+    expect(ledgerDeleteIdx).toBeGreaterThan(-1);
+    expect(tombstoneIdx).toBeLessThan(ledgerDeleteIdx);
+    expect(queries[tombstoneIdx]).toContain("ON CONFLICT (stripe_subscription_id) DO NOTHING");
+  });
+
   it("skips Stripe linkage deletes when the plugin's subscription table is absent (self-hosted)", async () => {
     // The @better-auth/stripe plugin's table only exists on Stripe-enabled
     // deployments — the to_regclass probe must keep non-Stripe purges from

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -1040,9 +1040,18 @@ describe("hardDeleteWorkspace()", () => {
     const ledgerDeleteIdx = queries.findIndex((q) =>
       q.includes("DELETE FROM stripe_webhook_events"),
     );
+    // Pin the insert before BOTH the ledger delete and the subscription
+    // delete — otherwise the tombstone SELECT (which reads the subscription
+    // table) could be reordered after the subscription rows are gone and
+    // silently stamp zero tombstones (CodeRabbit on #3475).
+    const subscriptionDeleteIdx = queries.findIndex((q) =>
+      /DELETE FROM subscription WHERE "referenceId"/.test(q),
+    );
     expect(tombstoneIdx).toBeGreaterThan(-1);
     expect(ledgerDeleteIdx).toBeGreaterThan(-1);
+    expect(subscriptionDeleteIdx).toBeGreaterThan(-1);
     expect(tombstoneIdx).toBeLessThan(ledgerDeleteIdx);
+    expect(tombstoneIdx).toBeLessThan(subscriptionDeleteIdx);
     expect(queries[tombstoneIdx]).toContain("ON CONFLICT (stripe_subscription_id) DO NOTHING");
   });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -148,7 +148,9 @@ describe("runMigrations", () => {
     //   Plus 0126 (plugin-owned organization."stripeCustomerId", #3417) = 127.
     //   Plus 0127 (chk_plan_tier widened with 'locked', #3421) = 128.
     //   Plus 0128 (stripe_webhook_events ledger, #3423) = 129.
-    expect(count).toBe(129);
+    //   Plus 0129 (stripe_purged_subscriptions tombstones, #3468) = 130.
+    //   Plus 0130 (user_trial_grants one-trial marker, #3469/#3470) = 131.
+    expect(count).toBe(131);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -306,6 +308,8 @@ describe("runMigrations", () => {
         "0126_org_stripe_customer_id_plugin_column.sql",
         "0127_plan_tier_locked.sql",
         "0128_stripe_webhook_event_ledger.sql",
+        "0129_stripe_purged_subscriptions.sql",
+        "0130_user_trial_grants.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2624,6 +2624,21 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const subscriptionTableExists =
       (subscriptionTableProbe.rows[0] as { table_exists?: boolean } | undefined)?.table_exists === true;
     if (subscriptionTableExists) {
+      // Tombstone the purged subscription ids FIRST (#3468): the remote
+      // teardown's cancellations generate `customer.subscription.deleted`
+      // webhooks that arrive after this transaction commits, and the
+      // webhook ledger records events keyed on the subscription id even
+      // when no org resolves — without the tombstone, a completed purge
+      // immediately regrows `stripe_webhook_events` rows. Stamped inside
+      // the purge transaction (same atomicity as the deletes below);
+      // consulted by `classifyStripeEvent`; pruned after 30 days.
+      await client.query(
+        `INSERT INTO stripe_purged_subscriptions (stripe_subscription_id)
+         SELECT "stripeSubscriptionId" FROM subscription
+          WHERE "referenceId" = $1 AND "stripeSubscriptionId" IS NOT NULL
+         ON CONFLICT (stripe_subscription_id) DO NOTHING`,
+        [orgId],
+      );
       stripeWebhookEvents = await delRaw(
         `DELETE FROM stripe_webhook_events WHERE stripe_subscription_id IN (
            SELECT "stripeSubscriptionId" FROM subscription

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -965,6 +965,9 @@ export const MANAGED_AUTH_MIGRATIONS = [
   "0126_org_stripe_customer_id_plugin_column.sql",
   // Widens organization.chk_plan_tier with the 'locked' churn tier (#3421).
   "0127_plan_tier_locked.sql",
+  // FK to Better Auth's "user" + backfill against "member"/"organization"
+  // (#3469/#3470 one-trial-per-user durable marker).
+  "0130_user_trial_grants.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/migrations/0129_stripe_purged_subscriptions.sql
+++ b/packages/api/src/lib/db/migrations/0129_stripe_purged_subscriptions.sql
@@ -1,0 +1,26 @@
+-- 0129: Tombstones for Stripe subscriptions erased by GDPR purge (#3468).
+--
+-- `purgeStripeBillingForWorkspace` cancels the org's subscriptions and
+-- `hardDeleteWorkspace` removes the local `subscription` +
+-- `stripe_webhook_events` rows — but those cancellations themselves
+-- generate `customer.subscription.deleted` webhooks that arrive AFTER
+-- the purge transaction. The webhook path records events in
+-- `stripe_webhook_events` keyed on the Stripe subscription id even when
+-- no org resolves, so a completed purge immediately regrew ledger rows.
+-- A purge must be terminal: `hardDeleteWorkspace` stamps a tombstone per
+-- purged subscription id inside the purge transaction, and
+-- `classifyStripeEvent` skips (and never records) deliveries for
+-- tombstoned ids.
+--
+-- Bounded surface: rows carry only the Stripe subscription id (no tenant
+-- data) and are pruned by the reconciliation sweep after 30 days —
+-- Stripe's own retry horizon is ~3 weeks, so no post-purge delivery for
+-- the id can outlive its tombstone.
+CREATE TABLE IF NOT EXISTS stripe_purged_subscriptions (
+  stripe_subscription_id TEXT PRIMARY KEY,
+  purged_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Retention pruning scans.
+CREATE INDEX IF NOT EXISTS idx_stripe_purged_subscriptions_purged_at
+  ON stripe_purged_subscriptions (purged_at);

--- a/packages/api/src/lib/db/migrations/0130_user_trial_grants.sql
+++ b/packages/api/src/lib/db/migrations/0130_user_trial_grants.sql
@@ -1,0 +1,39 @@
+-- 0130: Durable + atomic one-trial-per-user marker (#3469, #3470).
+--
+-- The #3426/#3460 eligibility check keyed "has this user consumed a
+-- trial?" on CURRENT owner membership of an org with trial_ends_at set.
+-- Two holes:
+--   • durability (#3470): owner demotion (a supported admin flow) erases
+--     the match — a demoted user could create a new workspace and
+--     receive a fresh trial. Same for org deletion.
+--   • atomicity (#3469): two concurrent create-workspace requests by the
+--     same user could both pass the read-side check before either
+--     stamped trial_ends_at, minting two trials.
+-- One row per user, stamped at grant time, fixes both: the PRIMARY KEY
+-- makes `INSERT ... ON CONFLICT (user_id) DO NOTHING` an atomic claim
+-- (exactly one concurrent creation wins), and the row survives
+-- membership/role changes and org deletion (org_id is deliberately NOT
+-- an FK — the marker must outlive the org).
+--
+-- The FK to "user" is ON DELETE CASCADE: when the user row itself is
+-- erased (GDPR purge of their last workspace), the marker goes with it —
+-- a purged identity holds no billing history to key on.
+CREATE TABLE IF NOT EXISTS user_trial_grants (
+  user_id    TEXT        PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  -- The org the trial was granted to (informational + idempotent-retry
+  -- detection in claimTrialGrant). Not an FK by design — see above.
+  org_id     TEXT        NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed from the owner-membership heuristic the read-side check used
+-- (#3460): every current owner of a trial-stamped org has consumed a
+-- trial. Oldest trialed org per user wins as the recorded grant target.
+INSERT INTO user_trial_grants (user_id, org_id)
+SELECT DISTINCT ON (m."userId") m."userId", o.id
+  FROM member m
+  JOIN organization o ON o.id = m."organizationId"
+ WHERE m.role = 'owner'
+   AND o.trial_ends_at IS NOT NULL
+ ORDER BY m."userId", o."createdAt" ASC
+ON CONFLICT (user_id) DO NOTHING;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2368,3 +2368,22 @@ export const stripeWebhookEvents = pgTable(
     index("idx_stripe_webhook_events_processed").on(t.processedAt),
   ],
 );
+
+/**
+ * Tombstones for Stripe subscription ids erased by GDPR purge (#3468) —
+ * the purge's own cancellation generates `customer.subscription.deleted`
+ * webhooks that arrive AFTER the purge transaction; without the
+ * tombstone, recording them regrows `stripe_webhook_events` rows for a
+ * purged workspace. Stamped inside the `hardDeleteWorkspace`
+ * transaction; consulted by `classifyStripeEvent`; pruned by the
+ * reconciliation sweep after 30 days (past Stripe's ~3-week retry
+ * horizon). Mirrors `migrations/0129_stripe_purged_subscriptions.sql`.
+ */
+export const stripePurgedSubscriptions = pgTable(
+  "stripe_purged_subscriptions",
+  {
+    stripeSubscriptionId: text("stripe_subscription_id").primaryKey(),
+    purgedAt: timestamp("purged_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("idx_stripe_purged_subscriptions_purged_at").on(t.purgedAt)],
+);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2387,3 +2387,21 @@ export const stripePurgedSubscriptions = pgTable(
   },
   (t) => [index("idx_stripe_purged_subscriptions_purged_at").on(t.purgedAt)],
 );
+
+/**
+ * Durable + atomic one-trial-per-user marker (#3469/#3470) — one row per
+ * user, stamped at grant time. The PRIMARY KEY makes
+ * `INSERT ... ON CONFLICT (user_id) DO NOTHING` an atomic claim under
+ * concurrent workspace creation; the row survives owner demotion and org
+ * deletion (org_id is deliberately NOT an FK). Mirrors
+ * `migrations/0130_user_trial_grants.sql`.
+ */
+export const userTrialGrants = pgTable("user_trial_grants", {
+  // FK to Better Auth's "user"(id) ON DELETE CASCADE is enforced in the
+  // migration — Drizzle's `references()` would require the Better Auth
+  // `user` table in this schema, which it isn't. Plain text() matches
+  // (same pattern as trusted_device above).
+  userId: text("user_id").primaryKey(),
+  orgId: text("org_id").notNull(),
+  grantedAt: timestamp("granted_at", { withTimezone: true }).notNull().defaultNow(),
+});


### PR DESCRIPTION
## Summary

Fixes two critical billing bugs and hardens trial grant atomicity:

1. **Admin-orgs Stripe teardown (#3459)**: The `/api/v1/admin/organizations/...` surface (used by the web UI) was missing Stripe integration on suspend/activate/delete operations — the exact bug class #3425 fixed on platform-admin but never wired here. Now:
   - `PATCH :id/suspend` → pauses Stripe collection + voids open invoices (#3467)
   - `PATCH :id/activate` → resumes Stripe collection
   - `DELETE :id` → cancels Stripe subscriptions BEFORE the DB cascade
   - Stripe failures surface as operator warnings; operations proceed (never stranded)
   - No-op teardown (self-hosted) omits `warnings` and `stripe` audit keys

2. **Trial grant atomicity (#3469)**: Two concurrent workspace creations by the same user could both pass the eligibility check and mint two trials. Fixed via:
   - New `user_trial_grants` table with `PRIMARY KEY (user_id)` for atomic `INSERT ... ON CONFLICT (user_id) DO NOTHING` claiming
   - `claimTrialGrant()` function in trial-eligibility module
   - Loser of the race gets their org locked to `'locked'` tier

3. **Trial grant durability (#3470)**: Owner demotion or org deletion could erase the trial-consumed marker. Fixed by:
   - `user_trial_grants` row survives membership/role changes and org deletion (org_id is NOT an FK)
   - Eligibility check OR-joins the durable marker with legacy owner-of-trialed-org proxy
   - Backfill stamps consumed users into the marker table

4. **GDPR purge webhook safety (#3468)**: Stripe's own cancellation webhooks for purged subscriptions arrived AFTER the purge transaction and regrew ledger rows. Fixed via:
   - New `stripe_purged_subscriptions` tombstone table stamped inside `hardDeleteWorkspace`
   - `classifyStripeEvent` skips (never records) deliveries for tombstoned subscription ids
   - Tombstones pruned after 30 days (past Stripe's ~3-week retry horizon)

Closes #3425, #3459, #3467, #3468, #3469, #3470.

## Test Plan

- Added comprehensive test suite for admin-orgs Stripe teardown (`admin-orgs-stripe-teardown.test.ts`) mirroring platform-admin tests
- Extended workspace-teardown tests to cover invoice voiding on suspend (#3467)
- Added trial atomicity tests (`assign-saas-trial.test.ts`) covering concurrent claim races and loser locking
- Added GDPR purge tombstone tests (`stripe-event-ledger.test.ts`, `internal.test.ts`) verifying ordering and webhook filtering
- Updated backfill tests to verify durable marker stamping
- All existing tests pass; new migrations tested via `migrate.test.ts`

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Drizzle schema mirrors migrations (0129, 0130)
- [x] Labels: type:bug, area:billing
- [x] CHANGELOG.md updated (user-facing: web UI now correctly pauses billing on suspend)

https://claude.ai/code/session_019seNT5ANFjxNbdKm8oYTwG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783929418&installation_id=135337507&pr_number=3475&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3475&signature=250302f5bd7aa4495bfde61885693a63da7e73da290ac44fd8d7294bf46cba51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented trial grant enforcement to limit users to one trial per account
  * Added automatic invoice voiding when workspaces are suspended

* **Bug Fixes**
  * Improved GDPR compliance with subscription purge tracking to prevent reactivation of deleted subscriptions

* **Documentation**
  * Updated billing documentation to clarify suspension behavior and invoice handling

* **Tests**
  * Added comprehensive test coverage for trial grants, Stripe lifecycle operations, and suspension/deletion workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->