### PR TITLE
fix(billing): surface past_due/canceled subscriptions + portal (#3429)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -73360,6 +73360,15 @@
                         },
                         "status": {
                           "type": "string"
+                        },
+                        "cancelAtPeriodEnd": {
+                          "type": "boolean"
+                        },
+                        "periodEnd": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         }
                       },
                       "required": [

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -371,6 +371,100 @@ describe("billing routes", () => {
       expect(body.currentModel).toBe("anthropic/claude-opus-4.8");
     });
 
+    // ── Subscription visibility (#3429) ────────────────────────────
+    //
+    // The subscription select must NOT filter to status IN
+    // ('active','trialing'): a delinquent customer needs the row (and thus
+    // the portal CTA) precisely when their sub is past_due / canceled.
+
+    function mockSubscriptionRow(row: Record<string, unknown> | null) {
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 1 }]);
+        }
+        if (typeof sql === "string" && sql.includes("FROM subscription")) {
+          return Promise.resolve(row ? [row] : []);
+        }
+        return Promise.resolve([]);
+      });
+    }
+
+    it("does NOT filter the subscription query to active/trialing (#3429)", async () => {
+      mockSubscriptionRow(null);
+      await request("/api/v1/billing");
+      const subCall = mockInternalQuery.mock.calls.find(
+        (call) => typeof call[0] === "string" && (call[0] as string).includes("FROM subscription"),
+      );
+      expect(subCall).toBeDefined();
+      const sql = subCall?.[0] as string;
+      // The bug was an `AND status IN ('active', 'trialing')` WHERE filter.
+      // The ORDER BY CASE may still reference those states for prioritization,
+      // so assert specifically that there is no `AND status IN (...)` filter.
+      expect(sql).not.toMatch(/AND\s+status\s+IN/);
+    });
+
+    it.each([
+      ["past_due"],
+      ["unpaid"],
+      ["canceled"],
+    ])("surfaces a %s subscription instead of null (#3429)", async (status) => {
+      mockSubscriptionRow({
+        stripeSubscriptionId: "sub_delinquent",
+        plan: "starter",
+        status,
+        cancelAtPeriodEnd: false,
+        periodEnd: null,
+      });
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.subscription).not.toBeNull();
+      expect(body.subscription.status).toBe(status);
+      expect(body.subscription.stripeSubscriptionId).toBe("sub_delinquent");
+    });
+
+    it("serializes cancelAtPeriodEnd + periodEnd for a pending-cancel sub (#3429)", async () => {
+      mockSubscriptionRow({
+        stripeSubscriptionId: "sub_pending",
+        plan: "pro",
+        status: "active",
+        cancelAtPeriodEnd: true,
+        periodEnd: new Date("2026-07-15T00:00:00.000Z"),
+      });
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.subscription.cancelAtPeriodEnd).toBe(true);
+      // pg Date is normalized to an ISO string on the wire.
+      expect(body.subscription.periodEnd).toBe("2026-07-15T00:00:00.000Z");
+    });
+
+    it("normalizes a NULL cancelAtPeriodEnd column to false (#3429)", async () => {
+      mockSubscriptionRow({
+        stripeSubscriptionId: "sub_legacy",
+        plan: "starter",
+        status: "active",
+        cancelAtPeriodEnd: null,
+        periodEnd: null,
+      });
+      const res = await request("/api/v1/billing");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.subscription.cancelAtPeriodEnd).toBe(false);
+      expect(body.subscription.periodEnd).toBeNull();
+    });
+
+    it("returns null subscription only when no row exists at all (#3429)", async () => {
+      mockSubscriptionRow(null);
+      const res = await request("/api/v1/billing");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.subscription).toBeNull();
+    });
+
     it("returns 401 when unauthenticated", async () => {
       mockAuthenticateRequest.mockImplementation(() =>
         Promise.resolve({ authenticated: false, error: "No credentials", status: 401 }),

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -253,13 +253,38 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         );
         return [{ count: 0 }] as Array<{ count: number }>;
       }),
-      // Active subscription from Better Auth's subscription table
+      // Subscription from Better Auth's subscription table.
+      //
+      // #3429: do NOT filter to status IN ('active','trialing'). A
+      // past_due / unpaid / canceled subscription is exactly when the user
+      // must reach the billing portal to fix payment — filtering it out
+      // serialized `subscription: null` and the UI hid the portal. Return
+      // whatever row exists and let the web present the state.
+      //
+      // A workspace can carry more than one row (an old canceled sub plus a
+      // fresh active one after resubscribe). Prefer a live row over a dead
+      // one so a stale canceled record doesn't shadow the real subscription:
+      // order healthy statuses first, then most-recently-updated. We also
+      // surface cancelAtPeriodEnd / periodEnd so the UI can show a
+      // pending-cancel end-date notice.
       internalQuery<{
         stripeSubscriptionId: string;
         plan: string;
         status: string;
+        cancelAtPeriodEnd: boolean | null;
+        periodEnd: Date | string | null;
       }>(
-        `SELECT "stripeSubscriptionId", plan, status FROM subscription WHERE "referenceId" = $1 AND status IN ('active', 'trialing') LIMIT 1`,
+        `SELECT "stripeSubscriptionId", plan, status, "cancelAtPeriodEnd", "periodEnd"
+           FROM subscription
+          WHERE "referenceId" = $1
+          ORDER BY
+            CASE
+              WHEN status IN ('active', 'trialing') THEN 0
+              WHEN status IN ('past_due', 'unpaid', 'incomplete') THEN 1
+              ELSE 2
+            END,
+            "updatedAt" DESC NULLS LAST
+          LIMIT 1`,
         [orgId],
       ).catch((err) => {
         // Subscription table may not exist if Stripe plugin hasn't run migrations yet.
@@ -267,7 +292,13 @@ billing.openapi(getBillingStatusRoute, async (c) => {
           { err: err instanceof Error ? err.message : String(err), orgId },
           "Failed to query subscription table — may not exist yet",
         );
-        return [] as Array<{ stripeSubscriptionId: string; plan: string; status: string }>;
+        return [] as Array<{
+          stripeSubscriptionId: string;
+          plan: string;
+          status: string;
+          cancelAtPeriodEnd: boolean | null;
+          periodEnd: Date | string | null;
+        }>;
       }),
       // Current model setting (live read for accuracy)
       getSettingLive("ATLAS_MODEL", orgId).catch((err) => {
@@ -366,6 +397,16 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         stripeSubscriptionId: subscription.stripeSubscriptionId,
         plan: subscription.plan,
         status: subscription.status,
+        // Coerce to a plain boolean — pg returns true/false, but a legacy
+        // NULL column reads as a pending-cancel of "no".
+        cancelAtPeriodEnd: subscription.cancelAtPeriodEnd === true,
+        // pg hands back a Date for timestamptz; the metering reads use
+        // .toISOString() likewise. Normalize so the wire is always an ISO
+        // string (or null), never a serialized Date object.
+        periodEnd:
+          subscription.periodEnd instanceof Date
+            ? subscription.periodEnd.toISOString()
+            : subscription.periodEnd ?? null,
       } : null,
       availablePlans: buildAvailablePlans(),
     }, 200);

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -40,6 +40,8 @@ const validStatus = {
     stripeSubscriptionId: "sub_123",
     plan: "starter_monthly",
     status: "active",
+    cancelAtPeriodEnd: false,
+    periodEnd: "2026-05-01T00:00:00.000Z",
   },
 };
 
@@ -147,6 +149,64 @@ describe("enum strict rejection", () => {
 
   test("canonical tuples match expected values", () => {
     expect(OVERAGE_STATUSES).toEqual(["ok", "warning", "soft_limit", "hard_limit"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subscription visibility (#3429) — the wire shape must carry delinquent /
+// pending-cancel states, not just active/trialing, and expose the
+// cancel-at-period-end fields the UI needs to render an end-date notice.
+// ---------------------------------------------------------------------------
+
+describe("subscription visibility (#3429)", () => {
+  const DELINQUENT_STATES = ["past_due", "unpaid", "canceled", "incomplete"];
+
+  test.each(DELINQUENT_STATES)(
+    "parses a %s subscription (not filtered to active/trialing)",
+    (status) => {
+      const parsed = BillingStatusSchema.parse({
+        ...validStatus,
+        subscription: { ...validStatus.subscription, status },
+      });
+      expect(parsed.subscription?.status).toBe(status);
+    },
+  );
+
+  test("parses trialing as a healthy subscription", () => {
+    const parsed = BillingStatusSchema.parse({
+      ...validStatus,
+      subscription: { ...validStatus.subscription, status: "trialing" },
+    });
+    expect(parsed.subscription?.status).toBe("trialing");
+  });
+
+  test("carries cancelAtPeriodEnd + periodEnd for a pending-cancel subscription", () => {
+    const parsed = BillingStatusSchema.parse({
+      ...validStatus,
+      subscription: {
+        ...validStatus.subscription,
+        status: "active",
+        cancelAtPeriodEnd: true,
+        periodEnd: "2026-07-15T00:00:00.000Z",
+      },
+    });
+    expect(parsed.subscription?.cancelAtPeriodEnd).toBe(true);
+    expect(parsed.subscription?.periodEnd).toBe("2026-07-15T00:00:00.000Z");
+  });
+
+  test("accepts a null periodEnd (plugin hasn't recorded one yet)", () => {
+    const parsed = BillingStatusSchema.parse({
+      ...validStatus,
+      subscription: { ...validStatus.subscription, periodEnd: null },
+    });
+    expect(parsed.subscription?.periodEnd).toBeNull();
+  });
+
+  test("tolerates an older bundle that omits cancelAtPeriodEnd / periodEnd", () => {
+    const { cancelAtPeriodEnd: _c, periodEnd: _p, ...legacySub } = validStatus.subscription;
+    const parsed = BillingStatusSchema.parse({ ...validStatus, subscription: legacySub });
+    expect(parsed.subscription?.cancelAtPeriodEnd).toBeUndefined();
+    expect(parsed.subscription?.periodEnd).toBeUndefined();
   });
 });
 

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -109,14 +109,33 @@ export interface BillingConnectionCount {
 }
 
 /**
- * Active Stripe subscription summary, or `null` when the workspace has no
- * active or trialing subscription. `plan` and `status` come directly from
- * Stripe / Better Auth and are intentionally free-form strings.
+ * Stripe subscription summary, or `null` only when the workspace has never
+ * had a subscription row at all. Critically this is NOT gated on status:
+ * `past_due`, `unpaid`, and `canceled` subscriptions are returned too
+ * (#3429) — those are exactly the states where the user must reach the
+ * billing portal to fix payment, so hiding them strands a delinquent
+ * customer. `plan` and `status` come directly from Stripe / Better Auth
+ * and are intentionally free-form strings (a new Stripe status must not
+ * fail parse).
  */
 export interface BillingSubscription {
   stripeSubscriptionId: string;
   plan: string;
   status: string;
+  /**
+   * True when the subscription is set to cancel at the end of the current
+   * period — still active/paid until then. The UI surfaces an end-date
+   * notice instead of a plain "active" badge (#3429). Optional for
+   * older-bundle tolerance; the API always sends it (default `false`).
+   */
+  cancelAtPeriodEnd?: boolean;
+  /**
+   * ISO end of the current billing period (the Better Auth Stripe plugin's
+   * persisted `periodEnd`). Drives the cancel-at-period-end "ends on" copy.
+   * Null when the plugin hasn't recorded one yet; optional for older-bundle
+   * tolerance.
+   */
+  periodEnd?: string | null;
 }
 
 /**
@@ -199,6 +218,8 @@ export const BillingSubscriptionSchema = z.object({
   stripeSubscriptionId: z.string(),
   plan: z.string(),
   status: z.string(),
+  cancelAtPeriodEnd: z.boolean().optional(),
+  periodEnd: z.string().nullable().optional(),
 }) satisfies z.ZodType<BillingSubscription>;
 
 export const BillingAvailablePlanSchema = z.object({

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -40,6 +40,11 @@ import { ModelProviderSection } from "@/ui/components/admin/model-provider-secti
 import { formatDate, formatNumber } from "@/lib/format";
 import { consumePlanIntent, PAID_TIERS } from "@/lib/billing/plan-intent";
 import { effectiveTrialEnd, isTrialEndPast } from "@/lib/billing/trial-copy";
+import {
+  cancelAtPeriodEndNotice,
+  hasActiveSubscription,
+  subscriptionPresentation,
+} from "@/lib/billing/subscription-status";
 import { cn } from "@/lib/utils";
 import { billingSearchParams } from "./search-params";
 import type { BillingStatus } from "@useatlas/schemas";
@@ -221,9 +226,9 @@ export default function BillingPage() {
 
               <section>
                 <SectionHeading
-                  title={data.subscription ? "Change plan" : "Choose a plan"}
+                  title={hasActiveSubscription(data.subscription) ? "Change plan" : "Choose a plan"}
                   description={
-                    data.subscription
+                    hasActiveSubscription(data.subscription)
                       ? "Upgrades apply immediately (prorated); downgrades take effect at the end of the billing period"
                       : "Subscribe to keep using Atlas after your trial"
                   }
@@ -333,7 +338,23 @@ function PlanShell({ data }: { data: BillingStatus }) {
   // endpoint, so a plain ErrorBanner suffices.
   const { openPortal, opening, error: portalError } = useBillingPortal();
 
-  const status: StatusKind = subscription?.status === "active" ? "connected" : "disconnected";
+  // #3429 — present the subscription state instead of treating anything
+  // that isn't "active" as broken/hidden. past_due / unpaid → "Fix payment"
+  // CTA via the portal; canceled stays visible; trialing reads as healthy.
+  // `null` only when the workspace has never subscribed.
+  const sub = subscription ? subscriptionPresentation(subscription) : null;
+  const cancelNotice = subscription
+    ? cancelAtPeriodEndNotice(subscription, formatDate)
+    : null;
+
+  // The plan-card status dot: prefer the subscription's derived state; with
+  // no subscription, fall back to "connected" for a self-hosted/free tier so
+  // the card doesn't read as disconnected when nothing is wrong.
+  const status: StatusKind = sub
+    ? sub.statusKind
+    : plan.pricePerSeat > 0
+      ? "disconnected"
+      : "connected";
 
   // Trial gets its own description (#3434) — the pricePerSeat === 0 copy
   // ("No charges — all features included") is true for the self-hosted free
@@ -359,10 +380,15 @@ function PlanShell({ data }: { data: BillingStatus }) {
       description={planDescription}
       status={status}
       actions={
-        subscription ? (
-          <Button onClick={openPortal} disabled={opening} size="sm">
+        sub?.showPortal ? (
+          <Button
+            onClick={openPortal}
+            disabled={opening}
+            size="sm"
+            variant={sub.isDelinquent ? "destructive" : "default"}
+          >
             <CreditCard className="mr-1.5 size-3.5" />
-            {opening ? "Opening…" : "Open billing portal"}
+            {opening ? "Opening…" : sub.portalLabel}
             <ExternalLink className="ml-1.5 size-3" />
           </Button>
         ) : undefined
@@ -404,18 +430,18 @@ function PlanShell({ data }: { data: BillingStatus }) {
             value={formatDate(trialEnds)}
           />
         )}
-        {subscription && (
+        {subscription && sub && (
           <DetailRow
             label="Subscription"
             value={
-              <Badge
-                variant={subscription.status === "active" ? "secondary" : "outline"}
-                className="text-[10px]"
-              >
+              <Badge variant={sub.badgeVariant} className="text-[10px]">
                 {subscription.status}
               </Badge>
             }
           />
+        )}
+        {cancelNotice && (
+          <DetailRow label="Scheduled" value={cancelNotice} />
         )}
         {overage > 0 && (
           <DetailRow
@@ -430,6 +456,23 @@ function PlanShell({ data }: { data: BillingStatus }) {
         )}
       </DetailList>
 
+      {/* #3429 — a delinquent subscription must shout: the customer has to
+          reach the portal to fix payment, and the old UI hid it. */}
+      {sub?.isDelinquent && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          <CreditCard className="size-3.5 shrink-0" aria-hidden />
+          <span>
+            Payment failed — your subscription is {subscription?.status}. Open the
+            billing portal to update your payment method and restore access.
+          </span>
+        </div>
+      )}
+      {sub?.isEnded && (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Your subscription has ended. Choose a plan below to resubscribe, or
+          open the billing portal to view past invoices.
+        </p>
+      )}
       {portalError && <ErrorBanner message={portalError} />}
       {!subscription && plan.pricePerSeat > 0 && (
         <p className="text-[11px] leading-relaxed text-muted-foreground">
@@ -608,7 +651,10 @@ function PlanPicker({
   if (plans.length === 0) return null;
 
   const currentTier = data.plan.tier;
-  const hasSubscription = data.subscription != null;
+  // A canceled / expired subscription is visible (#3429) but isn't a live
+  // plan to change — treat it as "no subscription" so the picker offers
+  // Subscribe rather than Upgrade/Downgrade against a dead plan.
+  const hasSubscription = hasActiveSubscription(data.subscription);
   const currentRank = TIER_RANK[currentTier] ?? 0;
 
   return (

--- a/packages/web/src/lib/billing/__tests__/subscription-status.test.ts
+++ b/packages/web/src/lib/billing/__tests__/subscription-status.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import type { BillingSubscription } from "@useatlas/schemas";
+import {
+  cancelAtPeriodEndNotice,
+  hasActiveSubscription,
+  subscriptionPresentation,
+} from "../subscription-status";
+
+function sub(overrides: Partial<BillingSubscription> = {}): BillingSubscription {
+  return {
+    stripeSubscriptionId: "sub_1",
+    plan: "starter",
+    status: "active",
+    cancelAtPeriodEnd: false,
+    periodEnd: null,
+    ...overrides,
+  };
+}
+
+// Identity formatter so date assertions are exact, not locale-dependent.
+const fmt = (v: string) => v;
+
+describe("subscriptionPresentation (#3429)", () => {
+  test("active → healthy, secondary badge, normal portal label", () => {
+    const p = subscriptionPresentation(sub({ status: "active" }));
+    expect(p.statusKind).toBe("connected");
+    expect(p.badgeVariant).toBe("secondary");
+    expect(p.showPortal).toBe(true);
+    expect(p.portalLabel).toBe("Open billing portal");
+    expect(p.isDelinquent).toBe(false);
+  });
+
+  test("trialing renders as healthy, not disconnected", () => {
+    const p = subscriptionPresentation(sub({ status: "trialing" }));
+    expect(p.statusKind).toBe("connected");
+    expect(p.isTrialing).toBe(true);
+    expect(p.badgeVariant).toBe("secondary");
+  });
+
+  test.each(["past_due", "unpaid", "incomplete"])(
+    "%s → unhealthy dot, destructive badge, 'Fix payment' CTA, portal shown",
+    (status) => {
+      const p = subscriptionPresentation(sub({ status }));
+      expect(p.statusKind).toBe("unhealthy");
+      expect(p.badgeVariant).toBe("destructive");
+      expect(p.isDelinquent).toBe(true);
+      expect(p.showPortal).toBe(true);
+      expect(p.portalLabel).toBe("Fix payment");
+    },
+  );
+
+  test.each(["canceled", "incomplete_expired"])(
+    "%s → ended, outline badge, portal still reachable",
+    (status) => {
+      const p = subscriptionPresentation(sub({ status }));
+      expect(p.isEnded).toBe(true);
+      expect(p.statusKind).toBe("disconnected");
+      expect(p.badgeVariant).toBe("outline");
+      // Portal reachable whenever a subscription row exists — a canceled
+      // customer may still want to resubscribe / view invoices.
+      expect(p.showPortal).toBe(true);
+    },
+  );
+
+  test("unknown Stripe status presents neutrally (not broken)", () => {
+    const p = subscriptionPresentation(sub({ status: "paused_2027" }));
+    expect(p.statusKind).toBe("connected");
+    expect(p.isDelinquent).toBe(false);
+    expect(p.showPortal).toBe(true);
+  });
+});
+
+describe("hasActiveSubscription (#3429)", () => {
+  test("null → false", () => {
+    expect(hasActiveSubscription(null)).toBe(false);
+  });
+
+  test.each(["active", "trialing", "past_due", "unpaid"])(
+    "%s is active for the picker (a live plan to change)",
+    (status) => {
+      expect(hasActiveSubscription(sub({ status }))).toBe(true);
+    },
+  );
+
+  test.each(["canceled", "incomplete_expired"])(
+    "%s is NOT active — picker offers Subscribe, not Upgrade",
+    (status) => {
+      expect(hasActiveSubscription(sub({ status }))).toBe(false);
+    },
+  );
+});
+
+describe("cancelAtPeriodEndNotice (#3429)", () => {
+  test("returns null when not scheduled to cancel", () => {
+    expect(cancelAtPeriodEndNotice(sub({ cancelAtPeriodEnd: false }), fmt)).toBeNull();
+  });
+
+  test("includes the end date when periodEnd is present", () => {
+    const notice = cancelAtPeriodEndNotice(
+      sub({ cancelAtPeriodEnd: true, periodEnd: "2026-07-15T00:00:00.000Z" }),
+      fmt,
+    );
+    expect(notice).toContain("2026-07-15T00:00:00.000Z");
+    expect(notice).toContain("access ends");
+  });
+
+  test("falls back to generic copy when periodEnd is absent", () => {
+    const notice = cancelAtPeriodEndNotice(
+      sub({ cancelAtPeriodEnd: true, periodEnd: null }),
+      fmt,
+    );
+    expect(notice).toBe("Cancels at the end of the current billing period");
+  });
+
+  test("tolerates an older bundle where cancelAtPeriodEnd is undefined", () => {
+    const { cancelAtPeriodEnd: _c, ...legacy } = sub();
+    expect(cancelAtPeriodEndNotice(legacy as BillingSubscription, fmt)).toBeNull();
+  });
+});

--- a/packages/web/src/lib/billing/subscription-status.ts
+++ b/packages/web/src/lib/billing/subscription-status.ts
@@ -1,0 +1,123 @@
+/**
+ * Subscription-state presentation helpers for the billing page (#3429).
+ *
+ * The single web-side statement of "how do we present this Stripe
+ * subscription state" — shared by the plan card's status dot, badge, and
+ * portal CTA so they can't disagree. The API now returns the subscription
+ * for ALL statuses (past_due / unpaid / canceled included, not just
+ * active/trialing — #3429), so the UI is responsible for presenting each
+ * state instead of the previous "subscription === null → hide everything".
+ *
+ * Stripe owns the status vocabulary, so this module classifies by membership
+ * rather than enumerating an exhaustive union — an unrecognized status falls
+ * through to a neutral "active-ish" presentation rather than reading as
+ * broken.
+ */
+
+import type { StatusKind } from "@/ui/components/admin/compact";
+import type { BillingSubscription } from "@useatlas/schemas";
+
+/**
+ * Stripe statuses that mean the customer must act to fix payment. These get
+ * a destructive badge + a "Fix payment" portal CTA — the portal is exactly
+ * what they need to reach, and the old code hid it.
+ */
+const DELINQUENT_STATUSES = new Set(["past_due", "unpaid", "incomplete"]);
+
+/** Stripe statuses for a subscription that has ended (no longer billing). */
+const ENDED_STATUSES = new Set(["canceled", "incomplete_expired"]);
+
+/** Healthy, currently-billing (or trialing) states. */
+const HEALTHY_STATUSES = new Set(["active", "trialing"]);
+
+export interface SubscriptionPresentation {
+  /** Status dot kind for the plan-card Shell. */
+  statusKind: StatusKind;
+  /** shadcn Badge variant for the status pill. */
+  badgeVariant: "default" | "secondary" | "outline" | "destructive";
+  /** Whether to render the billing-portal button. */
+  showPortal: boolean;
+  /** Portal button copy — "Fix payment" when delinquent, else "Open billing portal". */
+  portalLabel: string;
+  /**
+   * Delinquent (past_due / unpaid / incomplete) — the user must reach the
+   * portal to restore service. Drives the warning notice + CTA emphasis.
+   */
+  isDelinquent: boolean;
+  /** Trialing — healthy, must not read as "disconnected"/broken (#3429). */
+  isTrialing: boolean;
+  /** Subscription has ended (canceled). */
+  isEnded: boolean;
+}
+
+/**
+ * Derive how to present a subscription state. `subscription === null` means
+ * the workspace has no subscription at all (never subscribed) — callers
+ * handle that separately; this assumes a row is present.
+ */
+export function subscriptionPresentation(
+  subscription: BillingSubscription,
+): SubscriptionPresentation {
+  const status = subscription.status;
+  const isDelinquent = DELINQUENT_STATUSES.has(status);
+  const isEnded = ENDED_STATUSES.has(status);
+  const isTrialing = status === "trialing";
+  const isHealthy = HEALTHY_STATUSES.has(status);
+
+  const statusKind: StatusKind = isDelinquent
+    ? "unhealthy"
+    : isEnded
+      ? "disconnected"
+      : isHealthy
+        ? "connected"
+        : // Unknown Stripe status — present neutrally as connected rather
+          // than flagging a healthy-but-unenumerated state as broken.
+          "connected";
+
+  const badgeVariant: SubscriptionPresentation["badgeVariant"] = isDelinquent
+    ? "destructive"
+    : isEnded
+      ? "outline"
+      : "secondary";
+
+  return {
+    statusKind,
+    badgeVariant,
+    // Portal is reachable whenever a subscription row exists (a
+    // stripe_customer_id is implied). The delinquent customer needs it most.
+    showPortal: true,
+    portalLabel: isDelinquent ? "Fix payment" : "Open billing portal",
+    isDelinquent,
+    isTrialing,
+    isEnded,
+  };
+}
+
+/**
+ * Whether the workspace has a subscription that should be treated as
+ * "existing" by the plan picker (Change plan vs Choose a plan). A canceled /
+ * expired subscription is visible (#3429) but is NOT a live plan to change —
+ * the user needs to resubscribe, so the picker should offer "Subscribe", not
+ * "Upgrade/Downgrade". `null` (never subscribed) is likewise not active.
+ */
+export function hasActiveSubscription(
+  subscription: BillingSubscription | null,
+): boolean {
+  if (!subscription) return false;
+  return !ENDED_STATUSES.has(subscription.status);
+}
+
+/**
+ * Copy for a pending cancel-at-period-end notice, or null when the
+ * subscription is not scheduled to cancel. `formatDate` is injected so this
+ * stays pure and testable (the page passes its shared `formatDate`).
+ */
+export function cancelAtPeriodEndNotice(
+  subscription: BillingSubscription,
+  formatDate: (value: string) => string,
+): string | null {
+  if (!subscription.cancelAtPeriodEnd) return null;
+  return subscription.periodEnd
+    ? `Cancels at the end of the current period · access ends ${formatDate(subscription.periodEnd)}`
+    : "Cancels at the end of the current billing period";
+}


### PR DESCRIPTION
Closes #3429.

## Problem
`GET /api/v1/billing` filtered the subscription select to `status IN ('active','trialing')`, so `past_due` / `unpaid` / `canceled` subscriptions serialized as `subscription: null`. The billing page then hid "Open billing portal" and showed "No active subscription" — exactly when a delinquent customer must reach the portal to fix payment. Cancel-at-period-end was unrepresentable (no wire fields), and `trialing` rendered as a "disconnected"/broken state.

## Change
- **api** (`routes/billing.ts`) — widen the subscription query to return any row regardless of status, ordered so healthy states (active/trialing) win over delinquent (past_due/unpaid/incomplete) over ended (canceled), tie-broken by `updatedAt DESC` so a stale canceled row can't shadow a live resubscribe. Serialize `cancelAtPeriodEnd` (NULL→false) and `periodEnd` (pg `Date`→ISO).
- **schemas** (`billing.ts`) — add optional `cancelAtPeriodEnd: boolean` + `periodEnd: string | null` to `BillingSubscription` (wire SSOT, interface + Zod, `satisfies`-guarded); status stays free-form per Stripe.
- **web** (`admin/billing/page.tsx` + new `lib/billing/subscription-status.ts`) — state-aware `PlanShell`: trialing reads healthy, past_due/unpaid get a destructive badge + "Fix payment" portal CTA + warning notice, canceled stays visible, cancel-at-period-end shows the end date. Portal reachable whenever a subscription row exists. Presentation logic extracted to a pure, tested helper. Picker treats canceled/expired as resubscribe (Choose a plan), not Upgrade/Downgrade.
- **docs** — regenerate `apps/docs/openapi.json` for the new wire fields.

## Test plan
Schema + API + UI-helper tests cover each state: active, trialing, past_due, unpaid, canceled, incomplete, pending-cancel, unknown-status, older-bundle tolerance.

## CI
The implementing agent ran the full `/ci` gate — lint, type (tsgo + web), syncpack, template drift (804 files), schema drift (77 tables), railway-watch, openapi drift (regenerated), and full `bun run test` — all green. One unrelated pre-existing flake (`starter-prompts-cache-contract.test.tsx`, tracked as #3455) failed once under the parallel run but passes in isolation and touches none of this code.

8 files, +531/−18.

https://claude.ai/code/session_01WDTKdKi1QJvCTuHY8wW3Py

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDTKdKi1QJvCTuHY8wW3Py)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783935499&installation_id=135337507&pr_number=3476&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3476&signature=a8e0ad9d5e877b61eab259e5068ea04c8f8e6465d5dd30191784aceaaf2f2966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing page now displays comprehensive subscription states including delinquent, past due, and canceled subscriptions
  * Added scheduled cancellation notices indicating when pending cancellations take effect
  * Improved payment failure alerts with direct billing portal access options

* **Documentation**
  * Updated API schema to expose subscription cancellation status and period-end date fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->