### PR TITLE
fix(billing): single shared seat-count source for token budget parity (#3430)

### DIFF
--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -98,6 +98,8 @@ mock.module("@atlas/api/lib/metering", () => ({
 
 let mockHasInternalDB = true;
 const mockInternalQueryUsage: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() => Promise.resolve([]));
+/** Workspace row for the summary route (defaults to free tier → null row). */
+const mockGetWorkspaceDetailsUsage: Mock<(orgId: string) => Promise<unknown>> = mock(() => Promise.resolve(null));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   InternalDB: MockInternalDB,
@@ -137,7 +139,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   deleteSuggestion: mock(() => Promise.resolve(false)),
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(() => Promise.resolve(null)),
-  getWorkspaceDetails: mock(() => Promise.resolve(null)),
+  getWorkspaceDetails: mockGetWorkspaceDetailsUsage,
   getWorkspaceNamesByIds: mock(() => Promise.resolve(new Map<string, string | null>())),
   updateWorkspaceStatus: mock(() => Promise.resolve(false)),
   updateWorkspacePlanTier: mock(() => Promise.resolve(false)),
@@ -259,6 +261,7 @@ mock.module("@atlas/api/lib/semantic/diff", () => ({
 // --- Import app after mocks ---
 
 const { app } = await import("../index");
+const { _resetSeatCountCache } = await import("@atlas/api/lib/billing/seat-count");
 
 // --- Helper ---
 
@@ -287,6 +290,11 @@ describe("Admin Usage API", () => {
     mockGetUsageHistory.mockImplementation(() => Promise.resolve([...mockHistorySummaries]));
     mockGetUsageBreakdown.mockImplementation(() => Promise.resolve([...mockBreakdownUsers]));
     mockAggregateUsageSummary.mockImplementation(() => Promise.resolve());
+    mockGetWorkspaceDetailsUsage.mockImplementation(() => Promise.resolve(null));
+    mockInternalQueryUsage.mockImplementation(() => Promise.resolve([]));
+    // Shared seat-count source (#3430) — clear its module-level last-known cache
+    // between tests so one test's member count can't leak into the next.
+    _resetSeatCountCache();
   });
 
   // --- GET /api/v1/admin/usage ---
@@ -339,6 +347,62 @@ describe("Admin Usage API", () => {
       const body = await res.json() as Record<string, unknown>;
       expect(body.error).toBe("internal_error");
       expect(body.requestId).toBeTruthy();
+    });
+  });
+
+  // --- GET /api/v1/admin/usage/summary ---
+
+  describe("GET /api/v1/admin/usage/summary", () => {
+    it("computes the token budget from the member count, not activeUsers (#3430)", async () => {
+      // Starter workspace with 10 members but only 2 active logins this month.
+      mockGetWorkspaceDetailsUsage.mockImplementation(() =>
+        Promise.resolve({
+          id: "org-1",
+          plan_tier: "starter",
+          byot: false,
+          trial_ends_at: null,
+          stripe_customer_id: null,
+          createdAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      mockGetCurrentPeriodUsage.mockImplementation(() =>
+        Promise.resolve({ ...mockCurrentUsage, activeUsers: 2 }),
+      );
+      mockInternalQueryUsage.mockImplementation((sql: string) =>
+        typeof sql === "string" && sql.includes("member")
+          ? Promise.resolve([{ count: 10 }])
+          : Promise.resolve([]),
+      );
+
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/summary"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { limits: { totalTokenBudget: number }; current: { activeUsers: number } };
+      // 2M/seat * 10 members = 20M — NOT 2M/seat * 2 active logins = 4M.
+      expect(body.limits.totalTokenBudget).toBe(20_000_000);
+      expect(body.current.activeUsers).toBe(2);
+    });
+
+    it("degrades to a 1-seat budget when the member query fails with nothing known (#3430)", async () => {
+      mockGetWorkspaceDetailsUsage.mockImplementation(() =>
+        Promise.resolve({
+          id: "org-1",
+          plan_tier: "starter",
+          byot: false,
+          trial_ends_at: null,
+          stripe_customer_id: null,
+          createdAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      mockInternalQueryUsage.mockImplementation((sql: string) =>
+        typeof sql === "string" && sql.includes("member")
+          ? Promise.reject(new Error("relation does not exist"))
+          : Promise.resolve([]),
+      );
+
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/summary"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { limits: { totalTokenBudget: number } };
+      expect(body.limits.totalTokenBudget).toBe(2_000_000);
     });
   });
 

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -164,6 +164,7 @@ import { billing } from "../routes/billing";
 // loop share. Tests assert the endpoint reports exactly what this resolves so
 // the picker default can't drift from the billed default (#3098).
 import { resolveModelId } from "@atlas/api/lib/providers";
+import { _resetSeatCountCache } from "@atlas/api/lib/billing/seat-count";
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 const app = new OpenAPIHono();
@@ -189,6 +190,10 @@ describe("billing routes", () => {
     mockGetWorkspaceDetails.mockImplementation(() => Promise.resolve({ ...mockWorkspace }));
     mockUpdateWorkspaceByot.mockImplementation(() => Promise.resolve(true));
     mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    // The shared seat-count source (#3430) keeps a module-level last-known
+    // cache. Reset it so one test's member count can't leak into the next as a
+    // last-known fallback.
+    _resetSeatCountCache();
   });
 
   // ── GET /billing ──────────────────────────────────────────────────
@@ -286,7 +291,10 @@ describe("billing routes", () => {
       expect(body.plan.trialEndsAtEffective).toBe("2026-01-15T00:00:00.000Z");
     });
 
-    it("defaults seat count to 1 when member query fails", async () => {
+    it("degrades seat count to 1 when the member query fails and nothing is known (#3430)", async () => {
+      // No prior successful read this run (cache reset in beforeEach), so the
+      // shared source has no last-known value to serve. A read page degrades to
+      // 1 rather than failing the whole response.
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
         const sql = args[0];
         if (typeof sql === "string" && sql.includes("member")) {
@@ -302,6 +310,37 @@ describe("billing routes", () => {
       expect(body.seats.count).toBe(1);
       // Budget should be tokenBudgetPerSeat * 1 = 2M
       expect(body.limits.totalTokenBudget).toBe(2_000_000);
+    });
+
+    it("serves the last-known seat count when the member query fails after a prior success (#3430)", async () => {
+      // First read succeeds with 5 members — caches the last-known value.
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 5 }]);
+        }
+        return Promise.resolve([]);
+      });
+      const first = await (await request("/api/v1/billing")).json() as { seats: { count: number } };
+      expect(first.seats.count).toBe(5);
+
+      // The member query now fails transiently — the budget must NOT collapse to
+      // 1 seat (which would 5× shrink it and disagree with enforcement). It
+      // serves the last-known 5.
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.reject(new Error("relation does not exist"));
+        }
+        return Promise.resolve([]);
+      });
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.seats.count).toBe(5);
+      // Budget holds at tokenBudgetPerSeat * 5 = 10M, not the 1-seat 2M.
+      expect(body.limits.totalTokenBudget).toBe(10_000_000);
     });
 
     it("defaults connection count to 0 when connections query fails", async () => {

--- a/packages/api/src/api/routes/admin-usage.ts
+++ b/packages/api/src/api/routes/admin-usage.ts
@@ -19,6 +19,7 @@ import {
   aggregateUsageSummary,
 } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, computeTokenBudget, isUnlimited } from "@atlas/api/lib/billing/plans";
+import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -216,11 +217,25 @@ adminUsage.openapi(getUsageSummaryRoute, async (c) => {
     // 30 days ago
     const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
 
-    const [usage, workspace, history, users] = yield* Effect.promise(() => Promise.all([
+    const [usage, workspace, history, users, seatCount] = yield* Effect.promise(() => Promise.all([
       getCurrentPeriodUsage(orgId!),
       getWorkspaceDetails(orgId!),
       getUsageHistory(orgId!, "daily", thirtyDaysAgo.toISOString(), undefined, 31),
       getUsageBreakdown(orgId!, undefined, undefined, 50),
+      // Seat count from the SHARED source (#3430) — the same `member` count
+      // enforcement and /billing read. The budget used to come from
+      // Math.max(1, usage.activeUsers) (distinct logins this month), which a
+      // 10-member/2-login workspace under-reported 5×, disagreeing with the
+      // actual 429 threshold. getSeatCount serves the last-known value on a
+      // transient blip; only when nothing is known does it throw, and this read
+      // page degrades to 1 (logged) rather than failing the whole response.
+      getSeatCount(orgId!).catch((err) => {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), orgId, requestId },
+          "Failed to resolve seat count for usage summary — defaulting to 1",
+        );
+        return 1;
+      }),
     ]));
 
     if (!workspace) {
@@ -229,7 +244,6 @@ adminUsage.openapi(getUsageSummaryRoute, async (c) => {
     const planTier = workspace?.plan_tier ?? "free";
     const plan = getPlanDefinition(planTier);
     const limits = getPlanLimits(planTier);
-    const seatCount = Math.max(1, usage.activeUsers);
     const totalTokenBudget = computeTokenBudget(planTier, seatCount);
 
     return c.json({

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -33,6 +33,7 @@ import {
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, getStripePlans, computeTokenBudget, isUnlimited, type PaidPlanTier } from "@atlas/api/lib/billing/plans";
 import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
+import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import { effectiveTrialEndsAt } from "@atlas/api/lib/billing/trial-expiry";
 import { getSettingLive } from "@atlas/api/lib/settings";
 import { resolveModelId } from "@atlas/api/lib/providers";
@@ -226,17 +227,18 @@ billing.openapi(getBillingStatusRoute, async (c) => {
 
     // Fetch seat count, connection count, subscription, and the saved model +
     // provider settings in parallel
-    const [seatCountResult, connectionCountResult, subResult, currentModelSetting, providerSetting] = yield* Effect.promise(() => Promise.all([
-      // Actual member count from Better Auth's member table
-      internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int AS count FROM member WHERE "organizationId" = $1`,
-        [orgId],
-      ).catch((err) => {
+    const [seatCount, connectionCountResult, subResult, currentModelSetting, providerSetting] = yield* Effect.promise(() => Promise.all([
+      // Seat count from the SHARED source (#3430) — the same `member` count
+      // enforcement and /admin/usage read, so the budget shown here matches the
+      // actual 429 threshold. getSeatCount serves the last-known value on a
+      // transient blip; only when nothing is known does it throw, and a read
+      // page degrades to 1 (logged) rather than failing the whole response.
+      getSeatCount(orgId).catch((err) => {
         log.warn(
           { err: err instanceof Error ? err.message : String(err), orgId },
-          "Failed to query member table for seat count — defaulting to 1",
+          "Failed to resolve seat count for billing page — defaulting to 1",
         );
-        return [{ count: 1 }] as Array<{ count: number }>;
+        return 1;
       }),
       // Connection count for this workspace. Exclude per-workspace
       // archive tombstones so a hidden demo install doesn't inflate the
@@ -289,7 +291,6 @@ billing.openapi(getBillingStatusRoute, async (c) => {
       }),
     ]));
 
-    const seatCount = Math.max(1, seatCountResult[0]?.count ?? 1);
     const connectionCount = connectionCountResult[0]?.count ?? 0;
     const subscription = subResult.length > 0 ? subResult[0] : null;
     // SSOT (#3098): currentModel is exactly what the agent loop resolves for

--- a/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Budget-parity regression test (#3430).
+ *
+ * The per-seat token budget is computed on three surfaces that must agree:
+ *   - enforcement (`checkPlanLimits`) — decides the actual 429 threshold,
+ *   - GET /billing — the billing page figure,
+ *   - GET /admin/usage/summary — the usage page figure.
+ *
+ * The bug: enforcement and /billing counted `member` rows while /admin/usage
+ * used `Math.max(1, activeUsers)` (distinct logins this month). A 10-member
+ * workspace with 2 active logins advertised a 4M budget on /admin/usage while
+ * enforcement and /billing used 20M — the usage page disagreed with the 429
+ * threshold.
+ *
+ * This pins that all three derive their seat count from the SAME shared
+ * `getSeatCount` source, so the budgets are identical regardless of
+ * `activeUsers`.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// --- Mocks ---
+
+/** Member rows returned by the seat-count query (the SHARED source). */
+let mockSeatRows: unknown[] = [{ count: 10 }];
+/** Usage returned by the metering layer — note the LOW activeUsers. */
+let mockUsage = {
+  queryCount: 0,
+  tokenCount: 0,
+  activeUsers: 2,
+  periodStart: "",
+  periodEnd: "",
+};
+let mockWorkspace: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getWorkspaceDetails: async (orgId: string) => (orgId ? mockWorkspace : null),
+  getWorkspaceStatus: async () => mockWorkspace?.workspace_status ?? null,
+  getInternalDB: () => ({
+    query: mock(() => Promise.resolve({ rows: [] })),
+    connect: () => Promise.reject(new Error("not configured")),
+    end: mock(() => {}),
+    on: mock(() => {}),
+  }),
+  // Both the seat-count query (member COUNT) and any other internalQuery
+  // consumer route through here; the parity test only triggers the seat-count
+  // path, so returning the member rows is sufficient.
+  internalQuery: async () => mockSeatRows,
+  internalExecute: () => {},
+  updateWorkspacePlanTier: async () => true,
+  updateWorkspaceByot: async () => true,
+  setWorkspaceTrialEndsAt: async () => true,
+  setWorkspaceRegion: async () => {},
+  insertSemanticAmendment: async () => "mock-amendment-id",
+  getPendingAmendmentCount: async () => 0,
+}));
+
+mock.module("@atlas/api/lib/metering", () => ({
+  getCurrentPeriodUsage: async () => mockUsage,
+  logUsageEvent: () => {},
+  aggregateUsageSummary: async () => {},
+  getUsageHistory: async () => [],
+  getUsageBreakdown: async () => [],
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () => null,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+// --- Import under test ---
+
+import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
+import { getSeatCount, _resetSeatCountCache } from "@atlas/api/lib/billing/seat-count";
+import { computeTokenBudget, getPlanLimits } from "@atlas/api/lib/billing/plans";
+import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+
+/**
+ * The exact budget expression the billing and usage routes compute:
+ * `computeTokenBudget(tier, getSeatCount(orgId))`.
+ */
+async function pageBudget(orgId: string, tier: "starter" | "pro" | "business"): Promise<number> {
+  const seatCount = await getSeatCount(orgId);
+  return computeTokenBudget(tier, seatCount);
+}
+
+const SEATS = 10;
+const STARTER_PER_SEAT = getPlanLimits("starter").tokenBudgetPerSeat;
+const TEN_SEAT_BUDGET = STARTER_PER_SEAT * SEATS; // 20,000,000
+const ONE_SEAT_BUDGET = STARTER_PER_SEAT; // 2,000,000 — the old activeUsers=1 collapse
+
+describe("token budget parity across surfaces (#3430)", () => {
+  beforeEach(() => {
+    mockSeatRows = [{ count: SEATS }];
+    mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 2, periodStart: "", periodEnd: "" };
+    mockWorkspace = {
+      id: "org-1",
+      plan_tier: "starter",
+      byot: false,
+      trial_ends_at: null,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    _resetSeatCountCache();
+    invalidatePlanCache();
+  });
+
+  it("billing and usage pages compute the same budget from the member count, not activeUsers", async () => {
+    // Both pages run `computeTokenBudget(tier, getSeatCount(orgId))`.
+    const billingBudget = await pageBudget("org-1", "starter");
+    const usageBudget = await pageBudget("org-1", "starter");
+
+    expect(billingBudget).toBe(TEN_SEAT_BUDGET);
+    expect(usageBudget).toBe(TEN_SEAT_BUDGET);
+    expect(billingBudget).toBe(usageBudget);
+
+    // Proves the figure no longer keys off the 2 active logins (would be 4M).
+    expect(usageBudget).not.toBe(STARTER_PER_SEAT * mockUsage.activeUsers);
+  });
+
+  it("enforcement uses the same member-derived budget as the pages", async () => {
+    // Usage just under the 10-seat hard limit (110% of 20M = 22M) but FAR over
+    // the old 1-seat budget's hard limit (110% of 2M = 2.2M). If enforcement
+    // were still keyed off a smaller seat count, this would 429.
+    mockUsage.tokenCount = 19_000_000;
+
+    const result = await checkPlanLimits("org-1"); // seatCount omitted → shared source
+    expect(result.allowed).toBe(true);
+
+    // And the limit enforcement reports is exactly the page budget.
+    const pageLimit = await pageBudget("org-1", "starter");
+    expect(pageLimit).toBe(TEN_SEAT_BUDGET);
+  });
+
+  it("blocks only when usage exceeds the member-derived budget, not the 1-seat budget", async () => {
+    // Over the 10-seat hard limit (> 22M).
+    mockUsage.tokenCount = 23_000_000;
+
+    const result = await checkPlanLimits("org-1");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed && result.errorCode === "plan_limit_exceeded") {
+      // The reported limit is the full 10-seat budget, not the collapsed 1-seat one.
+      expect(result.usage.limit).toBe(TEN_SEAT_BUDGET);
+      expect(result.usage.limit).not.toBe(ONE_SEAT_BUDGET);
+    } else {
+      throw new Error(`expected plan_limit_exceeded, got ${JSON.stringify(result)}`);
+    }
+  });
+
+  it("a seat-count blip serves the last-known budget, never collapsing to 1 seat", async () => {
+    // Warm the cache with the live count.
+    expect(await pageBudget("org-1", "starter")).toBe(TEN_SEAT_BUDGET);
+
+    // Now the member query returns nothing (transient blip). The budget must
+    // hold at the 10-seat value, not collapse to the 1-seat budget.
+    mockSeatRows = [];
+    expect(await pageBudget("org-1", "starter")).toBe(TEN_SEAT_BUDGET);
+
+    // Enforcement, too, keeps the 10-seat threshold under the blip.
+    mockUsage.tokenCount = 19_000_000;
+    const result = await checkPlanLimits("org-1");
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/seat-count.test.ts
+++ b/packages/api/src/lib/billing/__tests__/seat-count.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the shared seat-count source (#3430).
+ *
+ * The per-seat token budget is read on three surfaces — enforcement,
+ * GET /billing, GET /admin/usage/summary — that must agree on "seats" or the
+ * usage page advertises a budget the 429 threshold doesn't enforce. This pins
+ * the helper's contract: live count on success, last-known value on a transient
+ * blip, explicit failure (never a silent collapse to 1 seat) when nothing is
+ * known.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// --- Mocks ---
+
+/** Rows the `internalQuery` mock returns for the seat-count query. */
+let mockSeatRows: unknown[] = [];
+/** When true, the `internalQuery` mock throws (DB blip path). */
+let mockSeatQueryShouldThrow = false;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: async () => {
+    if (mockSeatQueryShouldThrow) throw new Error("db error");
+    return mockSeatRows;
+  },
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () => null,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+// --- Import under test ---
+
+import {
+  getSeatCount,
+  SeatCountUnavailableError,
+  _resetSeatCountCache,
+} from "@atlas/api/lib/billing/seat-count";
+
+describe("getSeatCount", () => {
+  beforeEach(() => {
+    mockSeatRows = [];
+    mockSeatQueryShouldThrow = false;
+    _resetSeatCountCache();
+  });
+
+  it("returns the live member count on success", async () => {
+    mockSeatRows = [{ count: 10 }];
+    expect(await getSeatCount("org-1")).toBe(10);
+  });
+
+  it("serves the last-known value when a later query fails (no collapse to 1)", async () => {
+    mockSeatRows = [{ count: 10 }];
+    expect(await getSeatCount("org-1")).toBe(10);
+
+    // Transient DB blip — must NOT shrink the budget to 1 seat.
+    mockSeatQueryShouldThrow = true;
+    expect(await getSeatCount("org-1")).toBe(10);
+  });
+
+  it("throws SeatCountUnavailableError when the query fails with no last-known value", async () => {
+    mockSeatQueryShouldThrow = true;
+    await expect(getSeatCount("org-cold")).rejects.toBeInstanceOf(SeatCountUnavailableError);
+  });
+
+  it("treats an empty result as a lookup failure rather than 0 seats", async () => {
+    mockSeatRows = [];
+    await expect(getSeatCount("org-empty")).rejects.toBeInstanceOf(SeatCountUnavailableError);
+  });
+
+  it("falls back to last-known value when a later query returns an empty result", async () => {
+    mockSeatRows = [{ count: 7 }];
+    expect(await getSeatCount("org-1")).toBe(7);
+
+    mockSeatRows = [];
+    expect(await getSeatCount("org-1")).toBe(7);
+  });
+
+  it("keeps last-known values per organization", async () => {
+    mockSeatRows = [{ count: 3 }];
+    expect(await getSeatCount("org-a")).toBe(3);
+    mockSeatRows = [{ count: 12 }];
+    expect(await getSeatCount("org-b")).toBe(12);
+
+    // A blip serves each org its own last-known value.
+    mockSeatQueryShouldThrow = true;
+    expect(await getSeatCount("org-a")).toBe(3);
+    expect(await getSeatCount("org-b")).toBe(12);
+  });
+
+  it("refreshes the live count when the query recovers", async () => {
+    mockSeatRows = [{ count: 4 }];
+    expect(await getSeatCount("org-1")).toBe(4);
+    mockSeatRows = [{ count: 9 }];
+    expect(await getSeatCount("org-1")).toBe(9);
+  });
+});

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -31,6 +31,7 @@ import {
   type WorkspaceRow,
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
+import { getSeatCount, SeatCountUnavailableError } from "./seat-count";
 import { computeTokenBudget, getPlanLimits, isUnlimited, TRIAL_DAYS } from "./plans";
 import type { OverageStatus, PlanLimitStatus } from "@useatlas/types";
 
@@ -118,7 +119,11 @@ export function invalidatePlanCache(orgId?: string): void {
  * Check if the workspace's current usage is within its plan limits.
  *
  * @param orgId - The organization/workspace ID.
- * @param seatCount - Number of seats (members) in the org. Defaults to 1.
+ * @param seatCount - Number of seats (members) in the org. When omitted it is
+ *   resolved via the shared {@link getSeatCount} source — the SAME `member`
+ *   count the billing and usage pages read — so the enforced budget can never
+ *   diverge from the advertised one (#3430). A seat-count lookup failure with
+ *   no last-known value fails the check closed (503), never silently 1 seat.
  *
  * Returns `{ allowed: true }` (with optional `warning`) when the request
  * may proceed. Returns `{ allowed: false, ... }` when the workspace has
@@ -131,23 +136,6 @@ export async function checkPlanLimits(
   // Self-hosted / no org — no enforcement
   if (!orgId || !hasInternalDB()) {
     return { allowed: true };
-  }
-
-  // Fetch seat count from member table if not provided
-  if (seatCount === undefined) {
-    try {
-      const rows = await internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int as count FROM member WHERE "organizationId" = $1`,
-        [orgId],
-      );
-      seatCount = rows[0]?.count ?? 1;
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err), orgId },
-        "Failed to query member count for plan enforcement — defaulting to 1 seat",
-      );
-      seatCount = 1;
-    }
   }
 
   let workspace: WorkspaceRow | null;
@@ -211,8 +199,35 @@ export async function checkPlanLimits(
     }
   }
 
+  // Resolve the seat count the budget scales with — the SAME shared source the
+  // billing and usage pages read, so the advertised budget and the actual 429
+  // threshold can never disagree (#3430). A seat-count blip does NOT collapse
+  // the budget to 1 seat: getSeatCount serves the last-known value when it has
+  // one, and throws SeatCountUnavailableError only when it has nothing. In that
+  // case we fail the check closed (503 "try again") rather than understate the
+  // budget 10× and fire a spurious 429.
+  if (seatCount === undefined) {
+    try {
+      seatCount = await getSeatCount(orgId);
+    } catch (err) {
+      if (err instanceof SeatCountUnavailableError) {
+        log.error(
+          { orgId },
+          "Seat count unavailable for plan enforcement and no last-known value — blocking as precaution",
+        );
+        return {
+          allowed: false,
+          errorCode: "billing_check_failed",
+          errorMessage: "Unable to verify billing status. Please try again.",
+          httpStatus: 503,
+        };
+      }
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
   // Token budget check — budget scales with seat count
-  const totalBudget = computeTokenBudget(tier, seatCount ?? 1);
+  const totalBudget = computeTokenBudget(tier, seatCount);
   if (!isUnlimited(totalBudget)) {
     try {
       const usage = await getCurrentPeriodUsage(orgId);

--- a/packages/api/src/lib/billing/seat-count.ts
+++ b/packages/api/src/lib/billing/seat-count.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared seat-count source for the per-seat token budget.
+ *
+ * The per-seat token budget (`computeTokenBudget(tier, seatCount)`) is read on
+ * three surfaces that must agree, or `/admin/usage` shows a budget the 429
+ * threshold doesn't enforce (#3430):
+ *
+ *  - Enforcement (`checkPlanLimits`) — gates the agent loop; its seat count
+ *    decides the actual 429 threshold.
+ *  - `GET /billing` — the billing page's "Token Budget" figure.
+ *  - `GET /admin/usage/summary` — the usage page's "Token Budget" figure.
+ *
+ * Before this module, enforcement and `/billing` both counted `member` rows
+ * while `/admin/usage` used `Math.max(1, activeUsers)` (distinct login events
+ * this month), so a 10-member workspace with 2 active logins advertised a 5×
+ * smaller budget on `/admin/usage` than enforcement actually allowed. This is
+ * the ONE definition of "seats" all three consume.
+ *
+ * Seats = the count of Better-Auth `member` rows for the organization. A
+ * transient lookup failure does NOT collapse the budget to 1 seat — that would
+ * shrink a 10-seat budget 10× and fire spurious "budget exceeded" 429s during a
+ * DB blip (CLAUDE.md: "prefer errors over silent fallbacks"). Instead we serve
+ * the last-known good value when we have one, and fail explicitly when we don't.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+
+const log = createLogger("billing:seat-count");
+
+/**
+ * The authoritative seat-count query — `member` rows for the organization.
+ * Exported so a real-Postgres test can exercise the exact aggregate the budget
+ * decision runs on. `$1` = organization id.
+ */
+export const SEAT_COUNT_SQL = `SELECT COUNT(*)::int AS count FROM member WHERE "organizationId" = $1`;
+
+/**
+ * Thrown when the seat count can't be determined and no last-known value is
+ * cached. Callers that gate access (enforcement) should fail the check; callers
+ * rendering a read-only page may catch this and degrade transparently rather
+ * than silently understate the budget.
+ */
+export class SeatCountUnavailableError extends Error {
+  readonly orgId: string;
+  constructor(orgId: string, cause?: unknown) {
+    super(`Seat count unavailable for organization ${orgId}`);
+    this.name = "SeatCountUnavailableError";
+    this.orgId = orgId;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+/**
+ * Last-known good seat count per organization. A transient `member`-count query
+ * failure serves this instead of collapsing to 1 seat. Unbounded growth is a
+ * non-issue: one small integer per organization, and organizations are few
+ * relative to requests.
+ */
+const lastKnownSeatCount = new Map<string, number>();
+
+/**
+ * Resolve the seat count for the per-seat token budget.
+ *
+ * Returns the live `member` count on success, caching it as the last-known
+ * value. On a query failure, serves the last-known value if one exists;
+ * otherwise throws {@link SeatCountUnavailableError} so the caller decides
+ * whether to fail closed (enforcement) or degrade transparently (read pages) —
+ * never silently substituting 1 seat.
+ *
+ * @param orgId - The organization/workspace id.
+ * @throws {SeatCountUnavailableError} when the lookup fails and no last-known
+ *   value is cached.
+ */
+export async function getSeatCount(orgId: string): Promise<number> {
+  try {
+    const rows = await internalQuery<{ count: number }>(SEAT_COUNT_SQL, [orgId]);
+    const count = rows[0]?.count;
+    if (typeof count === "number" && count > 0) {
+      lastKnownSeatCount.set(orgId, count);
+      return count;
+    }
+    // A workspace always has at least its owner as a member; a zero/absent count
+    // means the row contract was violated (empty result) rather than a genuine
+    // zero. Treat it as a lookup failure so we fall through to last-known /
+    // explicit-failure rather than budgeting for 0 seats.
+    log.warn(
+      { orgId, count },
+      "Seat-count query returned no usable count — falling back to last-known value",
+    );
+    const lastKnown = lastKnownSeatCount.get(orgId);
+    if (lastKnown !== undefined) {
+      return lastKnown;
+    }
+    throw new SeatCountUnavailableError(orgId);
+  } catch (err) {
+    if (err instanceof SeatCountUnavailableError) {
+      throw err;
+    }
+    const lastKnown = lastKnownSeatCount.get(orgId);
+    if (lastKnown !== undefined) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), orgId, lastKnown },
+        "Failed to query seat count — serving last-known value",
+      );
+      return lastKnown;
+    }
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to query seat count and no last-known value cached — failing the lookup",
+    );
+    throw new SeatCountUnavailableError(orgId, err);
+  }
+}
+
+/** Clear the last-known seat-count cache. Tests only. */
+export function _resetSeatCountCache(orgId?: string): void {
+  if (orgId) {
+    lastKnownSeatCount.delete(orgId);
+  } else {
+    lastKnownSeatCount.clear();
+  }
+}


### PR DESCRIPTION
Closes #3430.

## Problem
`computeTokenBudget(tier, seatCount)` was fed two different definitions of "seats" across three surfaces:
- Enforcement (`checkPlanLimits`) — `COUNT(member)`
- `GET /billing` — `COUNT(member)`
- `GET /admin/usage/summary` — `Math.max(1, usage.activeUsers)` (distinct logins this month) ← the bug

A 10-member workspace with 2 active logins advertised a 5× smaller budget on `/admin/usage` (4M) than enforcement actually allowed (20M), so the usage page disagreed with the real 429 threshold. Separately, enforcement's `seatCount = 1` fallback on a transient member-count failure shrank budgets up to 10× and fired spurious 429s during a DB blip.

## Change
- **New shared helper** `packages/api/src/lib/billing/seat-count.ts` — `getSeatCount(orgId)`, the single `COUNT(member)` source all three surfaces consume. Lives in the `lib/` data layer so routes import it (no `lib/ → api/routes/` inversion).
- **No fail-to-1-seat collapse** — per-org last-known cache: a transient query blip serves the last-known value; only a cold failure (nothing known) throws `SeatCountUnavailableError`. Enforcement then fails **closed** (503 "try again") instead of silently shrinking the budget; read pages degrade to 1 with a log.
- **Wired all three callers** — `admin-usage.ts`, `billing.ts`, `enforcement.ts` now call `getSeatCount`.

## Test plan
- `seat-count.test.ts` — helper contract (live count, last-known fallback, explicit cold failure, empty-row guard, per-org isolation).
- `seat-count-parity.test.ts` — pins identical budgets across billing/usage/enforcement from the same member count regardless of `activeUsers`; blip-holds-last-known behavior.
- Updated `billing.test.ts` (replaced obsolete "defaults to 1" test) + new `/admin/usage/summary` route tests asserting budget tracks members, not `activeUsers`.

## CI
The implementing agent ran the full `/ci` gate — lint, type, full `bun run test`, syncpack, template/security-headers/schema/oauth-helper drift, railway-watch, test-discipline, twenty-resolver, settings-readers, published-symbols — all green. (Two unrelated pre-existing flakes in `teams*.test.ts` on the chat-integration-cap path; the gate run still exited 0 and they pass in isolation — untouched by this change.)

https://claude.ai/code/session_01WDTKdKi1QJvCTuHY8wW3Py

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDTKdKi1QJvCTuHY8wW3Py)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783935805&installation_id=135337507&pr_number=3477&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3477&signature=954c3c552c56e5140b97d889feffaab166462e9dc5e880ae4701d049673c2885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->