### PR TITLE
fix(billing): document per-replica plan-cache + rate-limit staleness contract (#3432)

### DIFF
--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -28,10 +28,29 @@ const log = createLogger("auth");
 // ---------------------------------------------------------------------------
 // Rate limiting — in-memory sliding window
 // ---------------------------------------------------------------------------
+//
+// PER-REPLICA / IN-MEMORY (#3432). `windows` lives in this process only; it is
+// NOT a shared store. Under a multi-replica SaaS deployment the effective
+// ceiling is N × the nominal limit: each of N replicas independently admits up
+// to `limit` requests per WINDOW_MS for the same caller, and a load balancer
+// can spread a caller's burst across all of them. So `ATLAS_RATE_LIMIT_RPM=120`
+// across 3 replicas tolerates up to ~360 rpm/caller in the worst case.
+//
+// Recorded decision (#3432 triage): documented as per-replica for v1 rather
+// than moved to a shared store (e.g. Redis). The limiter is an abuse/cost
+// backstop, not a hard quota — plan/token budgets (checkPlanLimits) are the
+// real spend ceiling and ARE globally consistent (they read the internal DB).
+// Revisit (shared store) only if a single caller's cross-replica burst proves
+// to be a real abuse vector.
 
 const WINDOW_MS = 60_000; // 60 seconds
 
-/** Map of rate-limit key → array of request timestamps (ms). */
+/**
+ * Map of rate-limit key → array of request timestamps (ms).
+ *
+ * PER-REPLICA (#3432): in-memory to THIS process. See the block comment above —
+ * with N replicas the real ceiling is N × the configured per-bucket limit.
+ */
 const windows = new Map<string, number[]>();
 
 let lastWarnedRpmValue: string | undefined;
@@ -199,6 +218,10 @@ export function getClientIP(req: Request): string | null {
  *
  * Note: this still limits API *requests*, not agent steps. Per-conversation
  * step accounting (F-77) is enforced separately on the chat handler.
+ *
+ * PER-REPLICA (#3432): the sliding window is in-memory to the calling process,
+ * so under N replicas the effective ceiling is N × the per-bucket limit — see
+ * the block comment on `windows`. This is the accepted v1 contract.
  */
 export function checkRateLimit(
   key: string,

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -19,6 +19,10 @@ let mockHasInternalDB = true;
 let mockWorkspace: Record<string, unknown> | null = null;
 let mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
 let mockWorkspaceDetailsShouldThrow = false;
+/** Count of `getWorkspaceDetails` invocations — i.e. internal-DB plan reads
+ *  that the per-replica planCache did NOT absorb. Used by the #3432
+ *  per-replica staleness-contract test. */
+let mockWorkspaceReadCount = 0;
 let mockUsageShouldThrow = false;
 /** Rows returned by the `internalQuery` mock (chat-integration count query). */
 let mockInternalQueryResult: unknown[] = [];
@@ -38,6 +42,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   getWorkspaceDetails: async (orgId: string) => {
     if (mockWorkspaceDetailsShouldThrow) throw new Error("db error");
+    mockWorkspaceReadCount++;
     return orgId ? mockWorkspace : null;
   },
   getWorkspaceStatus: async () => mockWorkspace?.workspace_status ?? null,
@@ -219,6 +224,7 @@ describe("billing/enforcement", () => {
     mockUsageShouldThrow = false;
     mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
     mockWorkspace = null;
+    mockWorkspaceReadCount = 0;
     invalidatePlanCache();
   });
 
@@ -532,6 +538,53 @@ describe("billing/enforcement", () => {
     const result = await checkPlanLimits("org-1", SEATS);
     expect(result.allowed).toBe(true);
     // After invalidation, it should have re-fetched and gotten "free" tier
+  });
+
+  // ── Per-replica staleness contract (#3432) ────────────────────────
+  //
+  // The planCache is in-memory PER PROCESS: invalidatePlanCache only clears
+  // the calling replica's Map. A Stripe webhook on "replica A" cannot reach
+  // "replica B"'s cache, so B serves the stale tier until its own TTL lapses.
+  // These tests pin that documented contract via the internal-DB read count
+  // (a re-read == a cache miss).
+
+  it("serves the cached tier within TTL without re-reading the internal DB (warm cache)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockUsage = { queryCount: 0, tokenCount: 500_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+
+    // First call populates the cache — one internal-DB read.
+    await checkPlanLimits("org-1", SEATS);
+    expect(mockWorkspaceReadCount).toBe(1);
+
+    // Tier flips at the source (as a Stripe webhook on ANOTHER replica would
+    // land it), but THIS process was not invalidated.
+    mockWorkspace = makeWorkspace({ plan_tier: "free" });
+
+    // Second call within TTL is served from the warm cache — no re-read, so
+    // the stale "starter" tier is still enforced. This IS the ≤60s window.
+    await checkPlanLimits("org-1", SEATS);
+    expect(mockWorkspaceReadCount).toBe(1);
+  });
+
+  it("invalidatePlanCache only clears the LOCAL process cache — proven by the re-read", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockUsage = { queryCount: 0, tokenCount: 500_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+
+    // Warm the cache for two distinct orgs — one DB read each.
+    await checkPlanLimits("org-1", SEATS);
+    await checkPlanLimits("org-2", SEATS);
+    expect(mockWorkspaceReadCount).toBe(2);
+
+    // Local invalidation models the webhook firing on THIS replica for org-1.
+    invalidatePlanCache("org-1");
+
+    // org-1 re-reads (cache cleared locally → DB hit); org-2 stays warm. There
+    // is no shared store, so a sibling replica's cache would be untouched by
+    // this call — exactly the cross-replica staleness #3432 accepts.
+    await checkPlanLimits("org-1", SEATS);
+    expect(mockWorkspaceReadCount).toBe(3);
+    await checkPlanLimits("org-2", SEATS);
+    expect(mockWorkspaceReadCount).toBe(3);
   });
 });
 

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -67,6 +67,35 @@ export type PlanCheckResult =
 // ---------------------------------------------------------------------------
 // Plan limit cache
 // ---------------------------------------------------------------------------
+//
+// PER-REPLICA / IN-MEMORY — documented staleness contract (#3432).
+//
+// `planCache` is a plain in-process Map: each API replica holds its OWN copy.
+// A Stripe webhook handled on replica A calls invalidatePlanCache(orgId) on A
+// ONLY — replicas B..N keep serving their cached WorkspaceRow until their own
+// PLAN_CACHE_TTL_MS entry expires. So after a tier change (upgrade/downgrade)
+// OR a suspension/status flip (checkWorkspaceStatus in lib/workspace.ts reads
+// the SAME cache via getCachedWorkspace), replicas that didn't handle the
+// webhook can be stale for up to PLAN_CACHE_TTL_MS (60s).
+//
+// Recorded decision (#3432 triage): we ACCEPT this 60s window as the v1
+// staleness SLA rather than build cross-replica pub/sub. Two things make that
+// safe:
+//   1. The post-checkout UI (#3418, CheckoutReturnBanner in
+//      packages/web/src/app/admin/billing/page.tsx) polls /api/v1/billing for
+//      25 × 3s = 75s — deliberately longer than this TTL — so a webhook landing
+//      against a warm cache on whichever replica the user hits is guaranteed to
+//      clear (TTL expiry) before the poll gives up. That closes the
+//      user-visible "I paid and it's still blocked" gap: the staleness never
+//      outlives the poll window.
+//   2. The window is bounded and self-healing (TTL expiry); for a brand-new
+//      subscriber the stale direction is fail-OPEN at worst, and only for <60s.
+//
+// Revisit trigger: if the 60s window ever proves user-visible BEYOND the
+// post-checkout poll (e.g. a mid-session suspension that must take effect
+// cross-replica in <60s), replace this with Postgres LISTEN/NOTIFY pub-sub
+// invalidation (broadcast invalidatePlanCache over a `plan_cache_invalidate`
+// channel) rather than shortening the TTL globally.
 
 interface CachedPlanData {
   workspace: WorkspaceRow;
@@ -84,6 +113,10 @@ const PLAN_CACHE_TTL_MS = 60_000;
  *
  * Exported so that workspace status checks can reuse the same cache
  * instead of making a separate DB query per request.
+ *
+ * NOTE (#3432): this cache is per-replica/in-memory — see the block comment
+ * above. A value read here can be up to PLAN_CACHE_TTL_MS (60s) behind a tier
+ * or suspension change applied via a Stripe webhook on a DIFFERENT replica.
  */
 export async function getCachedWorkspace(
   orgId: string,
@@ -102,7 +135,15 @@ export async function getCachedWorkspace(
   return workspace;
 }
 
-/** Clear cached workspace data. Called after plan tier changes (e.g. Stripe webhook) to force a fresh DB read. */
+/**
+ * Clear cached workspace data. Called after plan tier changes (e.g. Stripe
+ * webhook) to force a fresh DB read.
+ *
+ * PER-REPLICA (#3432): this clears ONLY the calling process's `planCache`. The
+ * webhook fires on one replica, so the other replicas are NOT invalidated here
+ * — they self-heal on TTL expiry (≤60s). See the block comment on `planCache`
+ * for the accepted staleness contract and the PG LISTEN/NOTIFY revisit trigger.
+ */
 export function invalidatePlanCache(orgId?: string): void {
   if (orgId) {
     planCache.delete(orgId);


### PR DESCRIPTION
Closes #3432.

## What

Per the recorded triage decision, **accepts the 60s per-replica `planCache` TTL as the documented v1 staleness contract** rather than building cross-replica pub/sub. Documents the in-memory plan cache and rate limiters as per-replica, and pins the contract with tests.

## Changes

- **`lib/billing/enforcement.ts`** — block comment on `planCache` / `getCachedWorkspace` / `invalidatePlanCache` explaining the cache is in-process per replica: a Stripe webhook on replica A only invalidates A; B..N self-heal on TTL expiry (≤60s), covering both tier flips and suspension state (shared via `lib/workspace.ts`). Records the PG `LISTEN/NOTIFY` revisit trigger.
- **`lib/auth/middleware.ts`** — documents `checkRateLimit`'s sliding window as per-replica: under N replicas the effective ceiling is N× the nominal limit. Notes that plan/token budgets (`checkPlanLimits`) are the real, globally-consistent spend ceiling.
- **`lib/billing/__tests__/enforcement.test.ts`** — two tests proving `invalidatePlanCache` clears only the local process cache (a re-read == cross-replica staleness), via an internal-DB read counter.

## #3418 verification (the user-visible gap)

The post-checkout UI (`CheckoutReturnBanner`, shipped in closed #3418) polls `/api/v1/billing` for **25 × 3s = 75s**, deliberately longer than the 60s TTL — so a warm-cache webhook is guaranteed to clear before the poll gives up. The "I paid and it's still blocked" gap never outlives the poll window. No web-page edits needed (and `billing/page.tsx` is owned by the parallel #3431 PR).

## Note on the stale issue reference

The issue cited a portal limiter at `billing.ts:54`; that hand-rolled `POST /portal` route was deleted in #3417 (portal now goes through the plugin's `/api/auth/subscription/billing-portal`). All remaining billing rate-limiting flows through the now-documented `checkRateLimit`, so no `billing.ts` change is required.

## Tests

`enforcement.test.ts` 86 pass / 0 fail. Lint + type-check clean. Docs/comments + tests only — no logic change, no schema change, no new dependency.

https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783941102&installation_id=135337507&pr_number=3479&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3479&signature=f85ae498a6679feccd8af6550cd3b2df5f9e6e8b5c06a8eeb4bce62f61f2d282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rate limiter and plan cache behavior documentation.

* **Tests**
  * Added tests to validate plan cache behavior and invalidation contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->