### PR TITLE
fix(billing): anchor token metering on the Stripe subscription period (#3431)

### DIFF
--- a/apps/docs/content/docs/guides/usage-metering.mdx
+++ b/apps/docs/content/docs/guides/usage-metering.mdx
@@ -47,6 +47,15 @@ Usage endpoints are mounted at `/api/v1/admin/usage`. All require the `admin` ro
 
 Returns real-time counts from raw usage events for the current billing period.
 
+The metering window is the workspace's **Stripe subscription period** (the
+invoice cycle's `current_period_start` … `current_period_end`) when an active
+subscription exists, so the token budget resets in lockstep with the invoice —
+a workspace that subscribed on the 25th resets on the 25th, not the 1st.
+Workspaces without an active subscription (trialing, past-due, or unsubscribed)
+fall back to the **UTC calendar month**, matching the proactive-chat quota
+window. The `periodSource` field reports which window applies (`"stripe"` or
+`"utc-month"`).
+
 ```bash
 curl https://your-atlas.example.com/api/v1/admin/usage \
   -H "Authorization: Bearer <admin-token>"
@@ -60,8 +69,9 @@ Response:
   "queryCount": 1842,
   "tokenCount": 245000,
   "activeUsers": 12,
-  "periodStart": "2026-03-01T00:00:00.000Z",
-  "periodEnd": "2026-04-01T00:00:00.000Z"
+  "periodStart": "2026-03-25T00:00:00.000Z",
+  "periodEnd": "2026-04-25T00:00:00.000Z",
+  "periodSource": "stripe"
 }
 ```
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -27608,6 +27608,13 @@
                     },
                     "periodEnd": {
                       "type": "string"
+                    },
+                    "periodSource": {
+                      "type": "string",
+                      "enum": [
+                        "stripe",
+                        "utc-month"
+                      ]
                     }
                   },
                   "required": [
@@ -27616,7 +27623,8 @@
                     "tokenCount",
                     "activeUsers",
                     "periodStart",
-                    "periodEnd"
+                    "periodEnd",
+                    "periodSource"
                   ]
                 }
               }
@@ -27769,6 +27777,13 @@
                         },
                         "periodEnd": {
                           "type": "string"
+                        },
+                        "periodSource": {
+                          "type": "string",
+                          "enum": [
+                            "stripe",
+                            "utc-month"
+                          ]
                         }
                       },
                       "required": [
@@ -27776,7 +27791,8 @@
                         "tokenCount",
                         "activeUsers",
                         "periodStart",
-                        "periodEnd"
+                        "periodEnd",
+                        "periodSource"
                       ]
                     },
                     "plan": {
@@ -73292,6 +73308,13 @@
                         },
                         "periodEnd": {
                           "type": "string"
+                        },
+                        "periodSource": {
+                          "type": "string",
+                          "enum": [
+                            "stripe",
+                            "utc-month"
+                          ]
                         }
                       },
                       "required": [

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -59,6 +59,7 @@ const mockCurrentUsage = {
   activeUsers: 3,
   periodStart: "2026-03-01T00:00:00.000Z",
   periodEnd: "2026-04-01T00:00:00.000Z",
+  periodSource: "utc-month" as const,
 };
 
 const mockHistorySummaries: unknown[] = [

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -103,6 +103,7 @@ const mockUsage = {
   activeUsers: 3,
   periodStart: "2026-03-01T00:00:00.000Z",
   periodEnd: "2026-04-01T00:00:00.000Z",
+  periodSource: "utc-month" as const,
 };
 
 mock.module("@atlas/api/lib/metering", () => ({

--- a/packages/api/src/api/routes/admin-usage.ts
+++ b/packages/api/src/api/routes/admin-usage.ts
@@ -42,6 +42,9 @@ const CurrentPeriodUsageResponseSchema = z.object({
   activeUsers: z.number(),
   periodStart: z.string(),
   periodEnd: z.string(),
+  // #3431: "stripe" when the window is anchored on the org's active
+  // subscription period, "utc-month" for the calendar-month fallback.
+  periodSource: z.enum(["stripe", "utc-month"]),
 });
 
 const UsageSummaryRowSchema = z.object({
@@ -71,6 +74,7 @@ const SummaryResponseSchema = z.object({
     activeUsers: z.number(),
     periodStart: z.string(),
     periodEnd: z.string(),
+    periodSource: z.enum(["stripe", "utc-month"]),
   }),
   plan: z.object({
     tier: z.string(),
@@ -254,6 +258,7 @@ adminUsage.openapi(getUsageSummaryRoute, async (c) => {
         activeUsers: usage.activeUsers,
         periodStart: usage.periodStart,
         periodEnd: usage.periodEnd,
+        periodSource: usage.periodSource,
       },
       plan: {
         tier: planTier,

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -383,6 +383,7 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         tokenOverageStatus: tokenOverage.status,
         periodStart: usage.periodStart,
         periodEnd: usage.periodEnd,
+        periodSource: usage.periodSource,
       },
       seats: {
         count: seatCount,

--- a/packages/api/src/lib/__tests__/metering.test.ts
+++ b/packages/api/src/lib/__tests__/metering.test.ts
@@ -125,8 +125,14 @@ describe("metering", () => {
   });
 
   describe("getCurrentPeriodUsage", () => {
-    it("returns current period aggregates", async () => {
+    // #3431: getCurrentPeriodUsage now issues TWO queries — first the
+    // active-subscription period lookup (billing/period.ts), then the
+    // usage aggregate. The first queryResults entry feeds the subscription
+    // lookup; an empty array there means "no active subscription → UTC
+    // calendar-month fallback".
+    it("returns current period aggregates (UTC-month fallback, no subscription)", async () => {
       queryResults = [
+        [], // no active subscription row → UTC month
         [{ query_count: 42, token_count: 10000, active_users: 3 }],
       ];
 
@@ -137,10 +143,35 @@ describe("metering", () => {
       expect(result.activeUsers).toBe(3);
       expect(result.periodStart).toBeTruthy();
       expect(result.periodEnd).toBeTruthy();
+      expect(result.periodSource).toBe("utc-month");
+    });
+
+    it("anchors on the Stripe period when an active subscription exists", async () => {
+      const start = "2026-05-25T00:00:00.000Z";
+      const end = "2026-06-25T00:00:00.000Z";
+      queryResults = [
+        [{ periodStart: start, periodEnd: end }], // active subscription
+        [{ query_count: 7, token_count: 700, active_users: 1 }],
+      ];
+
+      const result = await getCurrentPeriodUsage(
+        "org-sub",
+        new Date("2026-06-10T12:00:00.000Z"),
+      );
+
+      expect(result.periodSource).toBe("stripe");
+      expect(result.periodStart).toBe(start);
+      expect(result.periodEnd).toBe(end);
+      // The usage aggregate must be windowed on the Stripe bounds.
+      const usageCall = queryCalls.find((c) => c.sql.includes("usage_events"));
+      expect(usageCall?.params).toEqual(["org-sub", start, end]);
     });
 
     it("returns zeros when no data", async () => {
-      queryResults = [[{ query_count: 0, token_count: 0, active_users: 0 }]];
+      queryResults = [
+        [], // no active subscription
+        [{ query_count: 0, token_count: 0, active_users: 0 }],
+      ];
 
       const result = await getCurrentPeriodUsage("org-empty");
 
@@ -153,11 +184,15 @@ describe("metering", () => {
       mockHasInternalDB = false;
       const result = await getCurrentPeriodUsage("org-1");
       expect(result.queryCount).toBe(0);
+      expect(result.periodSource).toBe("utc-month");
       expect(queryCalls).toHaveLength(0);
     });
 
     it("returns zeros when query returns empty result set", async () => {
-      queryResults = [[]]; // empty array — rows[0] is undefined
+      queryResults = [
+        [], // no active subscription
+        [], // empty aggregate — rows[0] is undefined
+      ];
 
       const result = await getCurrentPeriodUsage("org-1");
 

--- a/packages/api/src/lib/billing/__tests__/period.test.ts
+++ b/packages/api/src/lib/billing/__tests__/period.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for billing-period resolution (#3431).
+ *
+ * Covers:
+ *   - `startOfMonthUTC` / `endOfMonthUTC` boundary + rollover semantics.
+ *   - `resolveBillingPeriod`: Stripe anchoring for active subscriptions,
+ *     UTC calendar-month fallback for trial / past_due / unsubscribed /
+ *     no-DB, and missing-bounds degradation.
+ *   - A TZ-offset server must not shift the UTC-month boundary by its
+ *     local offset (set via process.env.TZ — `??=` hoist per testing
+ *     rules, no top-level reassignment of an existing var).
+ */
+
+// A non-UTC server timezone is the whole point of the regression: if the
+// month math read local fields the boundary would shift by the offset.
+// `??=` so we never clobber a TZ the CI runner already pinned.
+process.env.TZ ??= "America/Los_Angeles";
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// --- Internal DB mock ---
+
+let mockHasInternalDB = true;
+let mockQueryShouldThrow = false;
+let queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryResults: unknown[] = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: async (sql: string, params?: unknown[]) => {
+    if (mockQueryShouldThrow) throw new Error("relation \"subscription\" does not exist");
+    queryCalls.push({ sql, params });
+    const result = queryResults.shift();
+    return result ?? [];
+  },
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import {
+  startOfMonthUTC,
+  endOfMonthUTC,
+  resolveBillingPeriod,
+} from "@atlas/api/lib/billing/period";
+
+describe("billing/period", () => {
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    mockHasInternalDB = true;
+    mockQueryShouldThrow = false;
+  });
+
+  describe("startOfMonthUTC / endOfMonthUTC", () => {
+    it("truncates to the first of the UTC month at 00:00:00.000Z", () => {
+      const now = new Date("2026-06-25T18:30:00.000Z");
+      expect(startOfMonthUTC(now).toISOString()).toBe("2026-06-01T00:00:00.000Z");
+      expect(endOfMonthUTC(now).toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    });
+
+    it("rolls December → January of the next year", () => {
+      const now = new Date("2026-12-15T00:00:00.000Z");
+      expect(startOfMonthUTC(now).toISOString()).toBe("2026-12-01T00:00:00.000Z");
+      expect(endOfMonthUTC(now).toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    });
+
+    it("does NOT shift the boundary by the server's local TZ offset", () => {
+      // 2026-06-01T03:00:00Z is still May 31 in America/Los_Angeles. A
+      // local-field implementation would bucket this into May; UTC keeps
+      // it in June.
+      const justAfterUtcMonthStart = new Date("2026-06-01T03:00:00.000Z");
+      expect(startOfMonthUTC(justAfterUtcMonthStart).toISOString()).toBe(
+        "2026-06-01T00:00:00.000Z",
+      );
+    });
+  });
+
+  describe("resolveBillingPeriod", () => {
+    it("anchors on an active subscription's Stripe period", async () => {
+      const periodStart = new Date("2026-05-25T00:00:00.000Z");
+      const periodEnd = new Date("2026-06-25T00:00:00.000Z");
+      queryResults = [[{ periodStart, periodEnd }]];
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("stripe");
+      expect(period.start.toISOString()).toBe(periodStart.toISOString());
+      expect(period.end.toISOString()).toBe(periodEnd.toISOString());
+      // Only active rows anchor.
+      expect(queryCalls[0]?.sql).toContain("status = 'active'");
+    });
+
+    it("accepts ISO-string period columns (pg may hand back strings)", async () => {
+      queryResults = [[
+        { periodStart: "2026-05-25T00:00:00.000Z", periodEnd: "2026-06-25T00:00:00.000Z" },
+      ]];
+
+      const period = await resolveBillingPeriod("org-1", new Date("2026-06-10T00:00:00.000Z"));
+
+      expect(period.source).toBe("stripe");
+      expect(period.start.toISOString()).toBe("2026-05-25T00:00:00.000Z");
+      expect(period.end.toISOString()).toBe("2026-06-25T00:00:00.000Z");
+    });
+
+    it("falls back to the UTC calendar month when no active subscription exists", async () => {
+      queryResults = [[]]; // trialing/past_due/canceled/unsubscribed all filtered out
+
+      const period = await resolveBillingPeriod(
+        "org-trial",
+        new Date("2026-06-10T18:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(period.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+      expect(period.end.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    });
+
+    it("falls back when the active row is missing period bounds", async () => {
+      queryResults = [[{ periodStart: null, periodEnd: null }]];
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(period.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    });
+
+    it("falls back without querying when no internal DB is configured", async () => {
+      mockHasInternalDB = false;
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it("falls back (not throws) when the subscription table read fails", async () => {
+      mockQueryShouldThrow = true;
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(period.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    });
+
+    it("agrees with proactive's startOfMonthUTC on the month boundary", async () => {
+      // The proactive quota module re-exports startOfMonthUTC from this
+      // module, so the fallback start must equal the proactive cutoff.
+      const { startOfMonthUTC: proactiveStart } = await import(
+        "@atlas/api/lib/proactive/quota"
+      );
+      queryResults = [[]];
+      const now = new Date("2026-06-10T07:00:00.000Z");
+
+      const period = await resolveBillingPeriod("org-1", now);
+
+      expect(period.start.toISOString()).toBe(proactiveStart(now).toISOString());
+    });
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/period.test.ts
+++ b/packages/api/src/lib/billing/__tests__/period.test.ts
@@ -125,6 +125,53 @@ describe("billing/period", () => {
       expect(period.end.toISOString()).toBe("2026-07-01T00:00:00.000Z");
     });
 
+    it("falls back to the UTC month when the active period is STALE (now past periodEnd)", async () => {
+      // Renewal webhook lag: the stored bounds still describe the previous
+      // cycle, and `now` has advanced past `periodEnd`. Anchoring here would
+      // window usage over a dead past range → 0 usage + under-counted budget.
+      const periodStart = new Date("2026-04-25T00:00:00.000Z");
+      const periodEnd = new Date("2026-05-25T00:00:00.000Z");
+      queryResults = [[{ periodStart, periodEnd }]];
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"), // a full cycle past periodEnd
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(period.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+      expect(period.end.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    });
+
+    it("falls back to the UTC month when now is BEFORE the active period start", async () => {
+      // Defensive symmetry: a future-dated period would otherwise window over
+      // a range that doesn't yet contain `now`.
+      queryResults = [[
+        { periodStart: "2026-07-01T00:00:00.000Z", periodEnd: "2026-08-01T00:00:00.000Z" },
+      ]];
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-10T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("utc-month");
+      expect(period.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    });
+
+    it("anchors when now is exactly at periodStart (inclusive lower bound)", async () => {
+      queryResults = [[
+        { periodStart: "2026-06-01T00:00:00.000Z", periodEnd: "2026-07-01T00:00:00.000Z" },
+      ]];
+
+      const period = await resolveBillingPeriod(
+        "org-1",
+        new Date("2026-06-01T00:00:00.000Z"),
+      );
+
+      expect(period.source).toBe("stripe");
+    });
+
     it("falls back when the active row is missing period bounds", async () => {
       queryResults = [[{ periodStart: null, periodEnd: null }]];
 

--- a/packages/api/src/lib/billing/period.ts
+++ b/packages/api/src/lib/billing/period.ts
@@ -155,5 +155,29 @@ export async function resolveBillingPeriod(
   // the UTC month is a safe window until the next webhook fills them in.
   if (!start || !end) return fallback;
 
+  // A present-but-STALE period must not anchor the meter. At renewal there is
+  // a window where the stored bounds still describe the *previous* cycle —
+  // the `customer.subscription.updated` webhook that advances
+  // `current_period_start`/`_end` can lag (retries span hours/days). If `now`
+  // is outside `[start, end)`, windowing usage over that dead range would
+  // exclude the entire current cycle: `getCurrentPeriodUsage` returns 0, the
+  // UI shows no usage, and `enforcement.ts` under-counts the budget (unlimited
+  // spend until the webhook lands). Fall back to the UTC month, which always
+  // contains `now`, until the bounds are refreshed. (Rolling the window
+  // forward by a month would mis-handle annual subscriptions, whose period is
+  // a year — the UTC month is the safe, cadence-agnostic choice.)
+  if (now < start || now >= end) {
+    log.debug(
+      {
+        workspaceId,
+        periodStart: start.toISOString(),
+        periodEnd: end.toISOString(),
+        now: now.toISOString(),
+      },
+      "Active subscription period does not contain now (stale bounds) — falling back to UTC calendar month",
+    );
+    return fallback;
+  }
+
   return { start, end, source: "stripe" };
 }

--- a/packages/api/src/lib/billing/period.ts
+++ b/packages/api/src/lib/billing/period.ts
@@ -1,0 +1,159 @@
+/**
+ * Billing-period resolution (#3431).
+ *
+ * The token meter windows usage over a billing period. Two distinct
+ * clocks were drifting apart before this module existed:
+ *
+ *   - `metering.ts:getCurrentPeriodUsage` used the **server-local**
+ *     calendar month (`new Date(y, m, 1)`) — wrong on any non-UTC host,
+ *     and never aligned to the customer's Stripe invoice anchor. A
+ *     customer who subscribes on the 25th saw their token budget reset
+ *     on the 1st, mid-invoice-cycle.
+ *   - `proactive/quota.ts` deliberately used a **UTC** calendar month.
+ *
+ * This module is the single source of truth for both:
+ *
+ *   - `startOfMonthUTC` / `endOfMonthUTC` — the UTC calendar-month
+ *     boundary (the fallback window for trial / unsubscribed orgs).
+ *     `proactive/quota.ts` re-exports `startOfMonthUTC` from here so the
+ *     two subsystems can never disagree on where a month starts.
+ *   - `resolveBillingPeriod` — anchors on the Stripe subscription's
+ *     `periodStart` / `periodEnd` when the org has an **active**
+ *     subscription row, falling back to the UTC calendar month
+ *     otherwise (trial, past_due, canceled, unsubscribed, or no
+ *     internal DB).
+ *
+ * `lib/` discipline: this module lives in `lib/` and never imports from
+ * `api/routes/`. It reads the Better-Auth `subscription` table directly
+ * via `internalQuery` rather than through `billing/enforcement.ts`, so
+ * `metering.ts` can consume it without pulling enforcement (and its
+ * `getCurrentPeriodUsage` import) into a cycle.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("billing:period");
+
+// ---------------------------------------------------------------------------
+// Pure UTC calendar-month helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * UTC `Date` for the start of the calendar month containing `now`.
+ * Caller passes `now` so tests can pin the rollover boundary without
+ * faking `Date.now()` globally.
+ *
+ * UTC by design — a non-UTC server must not shift the month boundary by
+ * its local offset. `proactive/quota.ts` re-exports this so the proactive
+ * cap and the token meter agree to the millisecond.
+ */
+export function startOfMonthUTC(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+}
+
+/**
+ * UTC `Date` for the start of the month AFTER the one containing `now`
+ * (i.e. the exclusive end of the current calendar month). `getUTCMonth()
+ * + 1` rolls December → January of the next year correctly because
+ * `Date.UTC` normalizes the overflow.
+ */
+export function endOfMonthUTC(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Resolved period
+// ---------------------------------------------------------------------------
+
+export interface BillingPeriod {
+  /** Inclusive start of the metering window. */
+  start: Date;
+  /** Exclusive end of the metering window — the moment usage resets. */
+  end: Date;
+  /**
+   * Where the window came from:
+   *   - `"stripe"` — anchored on an active subscription's period.
+   *   - `"utc-month"` — UTC calendar-month fallback (trial / unsubscribed).
+   */
+  source: "stripe" | "utc-month";
+}
+
+/** Coerce a `pg` timestamptz (Date or ISO string) to a `Date`, or null. */
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Resolve the billing period to meter `workspaceId` over.
+ *
+ * Anchors on the Stripe subscription's `periodStart` / `periodEnd` when
+ * an **active** subscription row exists (the row the Better-Auth Stripe
+ * plugin populates from `current_period_start` / `current_period_end`).
+ * Only `status = 'active'` anchors — `trialing`, `past_due`, `unpaid`,
+ * `canceled`, etc. fall back to the UTC calendar month so a trialing or
+ * delinquent org meters on the same well-defined window as an
+ * unsubscribed one.
+ *
+ * Fallback (UTC calendar month) applies when:
+ *   - no internal DB is configured,
+ *   - the `subscription` table doesn't exist yet (plugin not migrated),
+ *   - no active row exists for the org, or
+ *   - an active row exists but is missing period bounds.
+ *
+ * Read failures fall back rather than throw: metering is best-effort and
+ * a UTC month is always a safe, well-defined window.
+ *
+ * @param workspaceId - The org / workspace id (Stripe `referenceId`).
+ * @param now - Current time; injected so tests can pin boundaries.
+ */
+export async function resolveBillingPeriod(
+  workspaceId: string,
+  now: Date = new Date(),
+): Promise<BillingPeriod> {
+  const fallback: BillingPeriod = {
+    start: startOfMonthUTC(now),
+    end: endOfMonthUTC(now),
+    source: "utc-month",
+  };
+
+  if (!hasInternalDB()) return fallback;
+
+  let rows: Array<{ periodStart: Date | string | null; periodEnd: Date | string | null }>;
+  try {
+    rows = await internalQuery<{
+      periodStart: Date | string | null;
+      periodEnd: Date | string | null;
+    }>(
+      `SELECT "periodStart", "periodEnd"
+         FROM subscription
+        WHERE "referenceId" = $1
+          AND status = 'active'
+        ORDER BY "updatedAt" DESC NULLS LAST
+        LIMIT 1`,
+      [workspaceId],
+    );
+  } catch (err) {
+    // Subscription table may not exist (Stripe plugin not migrated) or the
+    // read may have hiccupped — fall back to the UTC month rather than fail
+    // a best-effort meter read.
+    log.debug(
+      { err: err instanceof Error ? err.message : String(err), workspaceId },
+      "Subscription period lookup failed — falling back to UTC calendar month",
+    );
+    return fallback;
+  }
+
+  const row = rows[0];
+  if (!row) return fallback;
+
+  const start = toDate(row.periodStart);
+  const end = toDate(row.periodEnd);
+  // An active row with missing/invalid bounds is treated as un-anchored —
+  // the UTC month is a safe window until the next webhook fills them in.
+  if (!start || !end) return fallback;
+
+  return { start, end, source: "stripe" };
+}

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -18,6 +18,7 @@ import {
   internalExecute,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
+import { resolveBillingPeriod } from "@atlas/api/lib/billing/period";
 
 const log = createLogger("metering");
 
@@ -193,24 +194,49 @@ export interface UsageCurrentPeriod {
   queryCount: number;
   tokenCount: number;
   activeUsers: number;
+  /** Inclusive ISO start of the metering window. */
   periodStart: string;
+  /** Exclusive ISO end of the window — the moment usage resets. */
   periodEnd: string;
+  /**
+   * Where the window came from (#3431):
+   *   - `"stripe"`    — anchored on the org's active Stripe subscription
+   *                     period (`current_period_start`/`_end`).
+   *   - `"utc-month"` — UTC calendar-month fallback (trial / unsubscribed
+   *                     / no internal DB). Agrees with `proactive/quota.ts`.
+   * Lets the billing/usage UI and the 429 copy label the reset accurately.
+   */
+  periodSource: "stripe" | "utc-month";
 }
 
 /**
  * Get the current period summary for a workspace by querying usage_events
  * directly (real-time, not from pre-aggregated summaries).
+ *
+ * The window is the org's Stripe billing period when an active
+ * subscription exists, else the UTC calendar month (#3431) — resolved by
+ * {@link resolveBillingPeriod}. This replaced a server-local-timezone
+ * calendar month that drifted from the invoice anchor and from the
+ * proactive subsystem's UTC month.
+ *
+ * @param now - Current time; injected so tests can pin the boundary.
  */
 export async function getCurrentPeriodUsage(
   workspaceId: string,
+  now: Date = new Date(),
 ): Promise<UsageCurrentPeriod> {
   if (!hasInternalDB()) {
-    return { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
+    return {
+      queryCount: 0,
+      tokenCount: 0,
+      activeUsers: 0,
+      periodStart: "",
+      periodEnd: "",
+      periodSource: "utc-month",
+    };
   }
 
-  const now = new Date();
-  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
-  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  const period = await resolveBillingPeriod(workspaceId, now);
 
   const rows = await internalQuery<{
     query_count: number;
@@ -225,7 +251,7 @@ export async function getCurrentPeriodUsage(
      WHERE workspace_id = $1
        AND created_at >= $2
        AND created_at < $3`,
-    [workspaceId, periodStart.toISOString(), periodEnd.toISOString()],
+    [workspaceId, period.start.toISOString(), period.end.toISOString()],
   );
 
   const row = rows[0];
@@ -233,8 +259,9 @@ export async function getCurrentPeriodUsage(
     queryCount: row?.query_count ?? 0,
     tokenCount: row?.token_count ?? 0,
     activeUsers: row?.active_users ?? 0,
-    periodStart: periodStart.toISOString(),
-    periodEnd: periodEnd.toISOString(),
+    periodStart: period.start.toISOString(),
+    periodEnd: period.end.toISOString(),
+    periodSource: period.source,
   };
 }
 

--- a/packages/api/src/lib/proactive/quota.ts
+++ b/packages/api/src/lib/proactive/quota.ts
@@ -38,6 +38,7 @@
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getCachedWorkspace } from "@atlas/api/lib/billing/enforcement";
 import { getPlanLimits, isUnlimited } from "@atlas/api/lib/billing/plans";
+import { startOfMonthUTC } from "@atlas/api/lib/billing/period";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { ProactiveQuotaStatus } from "@useatlas/types";
 
@@ -56,22 +57,15 @@ export type WorkspaceQuotaStatus = ProactiveQuotaStatus;
 // ---------------------------------------------------------------------------
 
 /**
- * Return the UTC `Date` for the start of the calendar month containing
- * `now`. Caller passes `now` (rather than us reading `Date.now()`) so
- * unit tests can pin the rollover boundary deterministically — bug
- * fixed in flight: the alternative "compute on call" version made
- * the month-rollover test impossible to write without faking
- * `Date.now()` globally.
+ * UTC start-of-calendar-month — re-exported from the shared billing-period
+ * helper (#3431) so the proactive cap and the token meter
+ * (`metering.ts` → `billing/period.ts`) can never drift on where a month
+ * starts. The canonical definition + rationale live in `billing/period.ts`.
  *
- * UTC by design: a workspace-local timezone column lives in a future
- * 1.5.x slice. For 1.5.0 we ship UTC so the cap is well-defined the
- * second the meter is wired across SaaS regions; the visible drift
- * (an admin in PST sees the cap reset at 16:00 local on the last day
- * of the month) is fine for a quota-not-billing surface.
+ * Preserved as a named export here for back-compat: the admin proactive
+ * route and the quota unit tests import `startOfMonthUTC` from this module.
  */
-export function startOfMonthUTC(now: Date): Date {
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
-}
+export { startOfMonthUTC };
 
 /**
  * Pure cap check.

--- a/packages/schemas/src/analytics.ts
+++ b/packages/schemas/src/analytics.ts
@@ -246,6 +246,10 @@ export const UsageSummarySchema = z.object({
     activeUsers: z.number(),
     periodStart: IsoTimestampSchema,
     periodEnd: IsoTimestampSchema,
+    // #3431: "stripe" when the metering window is anchored on the org's
+    // active subscription period, "utc-month" for the calendar-month
+    // fallback. Optional for older-bundle tolerance — the API always sends it.
+    periodSource: z.enum(["stripe", "utc-month"]).optional(),
   }),
   plan: z.object({
     tier: z.string(),

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -94,6 +94,13 @@ export interface BillingUsage {
   tokenOverageStatus: OverageStatus;
   periodStart: string;
   periodEnd: string;
+  /**
+   * #3431: where the metering window came from — `"stripe"` when anchored
+   * on the org's active subscription period, `"utc-month"` for the UTC
+   * calendar-month fallback (trial / unsubscribed). Lets the billing page
+   * label "Current period" honestly. Optional for older-bundle tolerance.
+   */
+  periodSource?: "stripe" | "utc-month";
 }
 
 /** Seat limit / current count. */
@@ -202,6 +209,7 @@ export const BillingUsageSchema = z.object({
   tokenOverageStatus: OverageStatusEnum,
   periodStart: z.string(),
   periodEnd: z.string(),
+  periodSource: z.enum(["stripe", "utc-month"]).optional(),
 }) satisfies z.ZodType<BillingUsage>;
 
 export const BillingSeatCountSchema = z.object({

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -63,6 +63,38 @@ import {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
+/**
+ * Label the metering window under the Usage section (#3431).
+ *
+ * `periodEnd` is the **exclusive** upper bound, so the displayed range ends
+ * the day before. UTC-month windows render in UTC so a browser west of UTC
+ * doesn't slip the boundary back a day; Stripe-anchored windows are real
+ * invoice-clock instants and render in local time. The leading label says
+ * "Billing period" only when actually anchored on the subscription —
+ * otherwise "Current period", so the copy never implies invoice alignment
+ * the meter isn't honoring.
+ */
+function formatBillingPeriod(
+  start: string,
+  end: string,
+  source: "stripe" | "utc-month" | undefined,
+): string {
+  if (!start || !end) return "Current period";
+  const s = new Date(start);
+  const e = new Date(end);
+  if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime())) return "Current period";
+  const lastDay = new Date(e.getTime() - 1);
+  const tz = source === "stripe" ? undefined : "UTC";
+  const opts: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: tz,
+  };
+  const label = source === "stripe" ? "Billing period" : "Current period";
+  return `${label} · ${s.toLocaleDateString(undefined, opts)} – ${lastDay.toLocaleDateString(undefined, opts)}`;
+}
+
 function tierVariant(tier: string): "default" | "secondary" | "outline" | "destructive" {
   switch (tier) {
     case "business":
@@ -239,7 +271,7 @@ export default function BillingPage() {
               <section>
                 <SectionHeading
                   title="Usage"
-                  description={`Current period · ${formatDate(data.usage.periodStart)} – ${formatDate(data.usage.periodEnd)}`}
+                  description={formatBillingPeriod(data.usage.periodStart, data.usage.periodEnd, data.usage.periodSource)}
                 />
                 <UsageShell data={data} />
               </section>

--- a/packages/web/src/app/admin/usage/page.tsx
+++ b/packages/web/src/app/admin/usage/page.tsx
@@ -55,10 +55,34 @@ function pct(used: number, limit: number | null): number | null {
   return Math.min(Math.round((used / limit) * 100), 100);
 }
 
-function formatPeriod(start: string, end: string): string {
+/**
+ * Render the metering window (#3431).
+ *
+ * The `end` we receive is the **exclusive** upper bound of the window, so
+ * the human-facing range ends the day before (the last day usage counts).
+ *
+ * UTC-month windows are formatted in **UTC** — the boundary is defined in
+ * UTC, so rendering `2026-06-01T00:00:00Z` in a browser west of UTC must
+ * not slip the label back to "May 31". Stripe-anchored windows are real
+ * instants tied to the customer's invoice clock, so they render in the
+ * viewer's local timezone, matching the rest of the billing UI.
+ */
+function formatPeriod(
+  start: string,
+  end: string,
+  source: "stripe" | "utc-month" | undefined,
+): string {
+  if (!start || !end) return "Current period";
   const s = new Date(start);
   const e = new Date(end);
-  return `${s.toLocaleDateString(undefined, { month: "long", year: "numeric" })} (${s.toLocaleDateString(undefined, { month: "short", day: "numeric" })} – ${e.toLocaleDateString(undefined, { month: "short", day: "numeric" })})`;
+  // Inclusive last day = exclusive end − 1ms.
+  const lastDay = new Date(e.getTime() - 1);
+  const tz = source === "stripe" ? undefined : "UTC";
+  const monthYear = s.toLocaleDateString(undefined, { month: "long", year: "numeric", timeZone: tz });
+  const from = s.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: tz });
+  const to = lastDay.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: tz });
+  const label = source === "stripe" ? "Billing period" : monthYear;
+  return `${label} (${from} – ${to})`;
 }
 
 // ── Component ─────────────────────────────────────────────────────
@@ -101,7 +125,7 @@ export default function UsageDashboardPage() {
           <h1 className="text-2xl font-bold tracking-tight">Usage</h1>
           <p className="text-sm text-muted-foreground">
             {data
-              ? `${data.plan.displayName} plan — ${formatPeriod(data.current.periodStart, data.current.periodEnd)}`
+              ? `${data.plan.displayName} plan — ${formatPeriod(data.current.periodStart, data.current.periodEnd, data.current.periodSource)}`
               : "Monitor workspace consumption relative to plan limits."}
           </p>
         </div>


### PR DESCRIPTION
## Summary

`getCurrentPeriodUsage` (`packages/api/src/lib/metering.ts`) computed the token-metering window as `new Date(now.getFullYear(), now.getMonth(), 1)` — the **server-local-timezone calendar month**. That was never aligned to the customer's Stripe invoice anchor and disagreed with the proactive subsystem, which deliberately uses a **UTC** month (`lib/proactive/quota.ts`). A workspace that subscribed on the 25th had its token budget reset on the 1st, mid-invoice-cycle, and the billing/usage pages mislabeled the window (a non-UTC server also shifted the boundary by hours).

## What changed

- **New `packages/api/src/lib/billing/period.ts`** — single source of truth for the metering window:
  - `startOfMonthUTC` / `endOfMonthUTC` — UTC calendar-month helpers.
  - `resolveBillingPeriod(workspaceId, now)` — anchors on an **active** subscription's `periodStart`/`periodEnd` (the Better-Auth Stripe plugin's persisted `current_period_start`/`current_period_end`), else falls back to the UTC calendar month. Reads the `subscription` table directly via `internalQuery` (no `enforcement.ts` import → no cycle). Lives in `lib/`, never imports from `api/routes/`.
- **`metering.ts`** consumes `resolveBillingPeriod`; `UsageCurrentPeriod` gains a `periodSource` field (`"stripe"` | `"utc-month"`) so downstream can label the real reset moment. `getCurrentPeriodUsage` now takes an injectable `now` for testing.
- **`proactive/quota.ts`** re-exports `startOfMonthUTC` from the shared helper, so the proactive cap and the token meter can never drift on where a month starts.
- **Billing + usage pages** (`admin/billing/page.tsx`, `admin/usage/page.tsx`) render UTC-month windows in **UTC** (no server/browser local-month slip), only say "Billing period" when actually subscription-anchored, and display the inclusive last day of the window.
- **Wire schemas** (`@useatlas/schemas` analytics + billing) carry `periodSource` (optional for older-bundle tolerance); API routes (`admin-usage.ts`, `billing.ts`) surface it.
- **Docs** — `guides/usage-metering.mdx` now documents the Stripe-period vs UTC-month behavior and the `periodSource` field.

## Precedence

| Condition | Window | `periodSource` |
|-----------|--------|----------------|
| ACTIVE subscription row with valid period bounds | Stripe `periodStart`…`periodEnd` | `"stripe"` |
| trialing / past_due / canceled / unsubscribed / no active row / missing bounds / no internal DB / read failure | UTC calendar month (matches `quota.ts`) | `"utc-month"` |

Only `status = 'active'` anchors — trial falls back, per the recorded triage decision.

## 429 copy

The hard-limit 429 message ("…wait until the next billing period") lives in `packages/api/src/lib/billing/enforcement.ts`, owned by the parallel **#3432** session — left untouched here. This fix makes that message's reset moment **real** (subscribed orgs now meter against the actual invoice period, and `getCurrentPeriodUsage` returns the accurate `periodEnd` + `periodSource`). Interpolating the literal reset date into the 429 string is a one-line follow-up for #3432, which owns the file.

## Tests

- `lib/billing/__tests__/period.test.ts` (new): UTC boundary + Dec→Jan rollover, Stripe anchoring (Date + ISO-string columns), UTC fallback for no-subscription / missing-bounds / no-DB / read-failure, agreement with `proactive`'s `startOfMonthUTC`, and a **TZ-offset server** (`process.env.TZ ??= "America/Los_Angeles"`) proving the boundary doesn't shift by the local offset.
- `lib/__tests__/metering.test.ts`: updated for the two-query flow + new Stripe-anchored case.
- Route/schema test fixtures updated for `periodSource`.

All `/ci` gates pass locally: lint, type, full test suite (0 failures), syncpack, template/security-header/railway/schema/oauth/test-discipline/twenty-resolver/settings-readers drift, published-symbols.

Closes #3431

https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783941868&installation_id=135337507&pr_number=3480&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3480&signature=0d68de303d70dc3a458bedce14878452de1340338ed021fee67cb4fd0739f392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->