### PR TITLE
fix(billing): operator plan-override precedence vs Stripe + trial extension (#3427)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -21381,6 +21381,19 @@
                   "planTier": {
                     "type": "string",
                     "example": "starter"
+                  },
+                  "overrideDays": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 365,
+                    "description": "Days the operator grant takes precedence over Stripe before auto-healing. Defaults to 90. Pass 0 to clear the override.",
+                    "example": 90
+                  },
+                  "trialEndsAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Required when planTier is 'trial' — new trial end date (ISO 8601). Ignored otherwise.",
+                    "example": "2026-08-01T00:00:00.000Z"
                   }
                 },
                 "required": [
@@ -66241,6 +66254,19 @@
                     ],
                     "description": "The new plan tier for the workspace.",
                     "example": "starter"
+                  },
+                  "overrideDays": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 365,
+                    "description": "Days the operator grant takes precedence over Stripe before auto-healing. Defaults to 90. Pass 0 to clear the override and let Stripe reassert control immediately.",
+                    "example": 90
+                  },
+                  "trialEndsAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Required when planTier is 'trial' — the new trial end date (ISO 8601). Ignored for other tiers.",
+                    "example": "2026-08-01T00:00:00.000Z"
                   }
                 },
                 "required": [
@@ -66266,19 +66292,38 @@
                     },
                     "planTier": {
                       "type": "string"
+                    },
+                    "planOverrideUntil": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "trialEndsAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
                     "message",
                     "workspaceId",
-                    "planTier"
+                    "planTier",
+                    "planOverrideUntil"
                   ]
                 }
               }
             }
           },
           "400": {
-            "description": "Invalid plan tier",
+            "description": "Invalid plan tier or missing trialEndsAt",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -216,6 +216,14 @@ export function buildInternalDbMockDefaults(deps: {
     setWorkspaceRegion: mock(async () => ({ assigned: true })),
     updateWorkspaceByot: mock(async () => true),
     setWorkspaceTrialEndsAt: mock(async () => true),
+    // #3427 — pure predicate; default mock mirrors the real semantics
+    // (active when plan_override_until is set and in the future) so callers
+    // that don't override it still behave correctly.
+    isPlanOverrideActive: mock((until?: string | null, now: Date = new Date()) => {
+      if (!until) return false;
+      const t = new Date(until);
+      return !Number.isNaN(t.getTime()) && t.getTime() > now.getTime();
+    }),
     getAutoApproveThreshold: mock(() => 2),
     getAutoApproveTypes: mock(() => new Set(["update_description", "add_dimension"])),
     insertSemanticAmendment: mock(async () => ({ id: "mock-amendment-id", status: "pending" as const })),

--- a/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
@@ -373,8 +373,10 @@ describe("admin-orgs PATCH /:id/plan — audit emission (F-31)", () => {
       targetId: "org-parity",
     });
     // Metadata shape mirrors platform-admin.ts:
-    //   { previousPlan: <old tier>, newPlan: <new tier> }
-    expect(entry.metadata).toEqual({ previousPlan: "starter", newPlan: "pro" });
+    //   { previousPlan, newPlan, planOverrideUntil } (#3427 — an operator
+    //   plan change stamps a precedence window the next Stripe webhook honors).
+    expect(entry.metadata).toMatchObject({ previousPlan: "starter", newPlan: "pro" });
+    expect(typeof entry.metadata?.planOverrideUntil).toBe("string");
   });
 
   it("does not emit on invalid plan tier (400)", async () => {

--- a/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
@@ -61,11 +61,17 @@ const mockCascade = mock(async () => {
   };
 });
 
+// #3427 — spies for the plan-override + trial-extension behavior.
+const mockUpdatePlanTier = mock(async (_orgId: string, _tier: string, _override?: unknown) => true);
+const mockSetTrialEndsAt = mock(async (_orgId: string, _date: Date) => true);
+
 const mocks = createApiTestMocks({
   internal: {
     getWorkspaceDetails: mockGetWorkspaceDetails,
     updateWorkspaceStatus: mockUpdateWorkspaceStatus,
     cascadeWorkspaceDelete: mockCascade,
+    updateWorkspacePlanTier: mockUpdatePlanTier,
+    setWorkspaceTrialEndsAt: mockSetTrialEndsAt,
   },
 });
 
@@ -134,11 +140,13 @@ const { app } = await import("../index");
 
 afterAll(() => mocks.cleanup());
 
-function adminRequest(method: string, path: string): Request {
-  return new Request(`http://localhost${path}`, {
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const init: RequestInit = {
     method,
     headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, init);
 }
 
 beforeEach(() => {
@@ -153,6 +161,8 @@ beforeEach(() => {
   mockResume.mockClear();
   mockCascade.mockClear();
   mockUpdateWorkspaceStatus.mockClear();
+  mockUpdatePlanTier.mockClear();
+  mockSetTrialEndsAt.mockClear();
 });
 
 // ── Suspend / activate ──────────────────────────────────────────────
@@ -257,5 +267,100 @@ describe("DELETE /api/v1/admin/organizations/:id — Stripe teardown", () => {
     expect("warnings" in body).toBe(false);
     const deleteAudit = auditCalls.find((a) => a.actionType === "workspace.delete");
     expect(deleteAudit?.metadata && "stripe" in deleteAudit.metadata).toBe(false);
+  });
+});
+
+// ── Plan change: operator override + trial extension + free→cancel (#3427) ──
+
+describe("PATCH /api/v1/admin/organizations/:id/plan — operator override precedence (#3427)", () => {
+  it("stamps a plan-override window (default 90d) so the next webhook can't clobber the grant", async () => {
+    const before = Date.now();
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", { planTier: "pro" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdatePlanTier).toHaveBeenCalledTimes(1);
+    const [orgId, tier, override] = mockUpdatePlanTier.mock.calls[0] as [string, string, { until: Date }];
+    expect(orgId).toBe("org-1");
+    expect(tier).toBe("pro");
+    // A future override window was stamped (≈ 90 days out).
+    expect(override).toHaveProperty("until");
+    const ms = override.until.getTime() - before;
+    expect(ms).toBeGreaterThan(89 * 86_400_000);
+    expect(ms).toBeLessThan(91 * 86_400_000);
+    const audit = auditCalls.find((a) => a.actionType === "workspace.change_plan");
+    expect(audit?.metadata?.planOverrideUntil).toBe(override.until.toISOString());
+  });
+
+  it("clears the override (releases control to Stripe) when overrideDays is 0", async () => {
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", { planTier: "starter", overrideDays: 0 }),
+    );
+
+    expect(res.status).toBe(200);
+    const [, , override] = mockUpdatePlanTier.mock.calls[0] as [string, string, unknown];
+    expect(override).toBe("clear");
+    const audit = auditCalls.find((a) => a.actionType === "workspace.change_plan");
+    expect(audit?.metadata?.planOverrideUntil).toBeNull();
+  });
+
+  it("rejects setting the 'trial' tier with no trialEndsAt (no stale reuse)", async () => {
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", { planTier: "trial" }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("trialEndsAt");
+    expect(mockUpdatePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("rejects a trialEndsAt in the past", async () => {
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", {
+        planTier: "trial",
+        trialEndsAt: new Date(Date.now() - 86_400_000).toISOString(),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockUpdatePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("extends a trial: wires setWorkspaceTrialEndsAt with an explicit future date", async () => {
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", {
+        planTier: "trial",
+        trialEndsAt: future,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdatePlanTier).toHaveBeenCalledWith("org-1", "trial", expect.anything());
+    expect(mockSetTrialEndsAt).toHaveBeenCalledTimes(1);
+    const [orgId, date] = mockSetTrialEndsAt.mock.calls[0] as [string, Date];
+    expect(orgId).toBe("org-1");
+    expect(date.toISOString()).toBe(future);
+  });
+
+  it("cancels Stripe subscriptions when downgrading a paying org to free", async () => {
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", { planTier: "free" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).toHaveBeenCalledTimes(1);
+    expect(mockCancelSubs.mock.calls[0][0]).toBe("org-1");
+  });
+
+  it("does NOT touch Stripe when moving to a paid tier", async () => {
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/organizations/org-1/plan", { planTier: "pro" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-stripe-teardown.test.ts
@@ -338,7 +338,12 @@ describe("PATCH /api/v1/admin/organizations/:id/plan — operator override prece
     );
 
     expect(res.status).toBe(200);
-    expect(mockUpdatePlanTier).toHaveBeenCalledWith("org-1", "trial", expect.anything());
+    // #3427 review: a trial grant must CLEAR the override (a trialing org has no
+    // competing subscription; an override would only block the customer's own
+    // paid conversion), not stamp a comp window.
+    const [, tier, override] = mockUpdatePlanTier.mock.calls[0] as [string, string, unknown];
+    expect(tier).toBe("trial");
+    expect(override).toBe("clear");
     expect(mockSetTrialEndsAt).toHaveBeenCalledTimes(1);
     const [orgId, date] = mockSetTrialEndsAt.mock.calls[0] as [string, Date];
     expect(orgId).toBe("org-1");

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -115,6 +115,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
+  setWorkspaceTrialEndsAt: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),
   getWorkspaceHealthSummary: mock(async () => null),
   getWorkspaceRegion: mock(async () => null),

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -143,6 +143,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getWorkspaceNamesByIds: mock(() => Promise.resolve(new Map<string, string | null>())),
   updateWorkspaceStatus: mock(() => Promise.resolve(false)),
   updateWorkspacePlanTier: mock(() => Promise.resolve(false)),
+  setWorkspaceTrialEndsAt: mock(() => Promise.resolve(true)),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),
   getWorkspaceHealthSummary: mock(() => Promise.resolve(null)),
   getWorkspaceRegion: mock(async () => null),

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -204,6 +204,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mockUpdateWorkspaceStatus,
   updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
+  setWorkspaceTrialEndsAt: mock(async () => true),
   cascadeWorkspaceDelete: mockCascadeWorkspaceDelete,
   getWorkspaceHealthSummary: mockGetWorkspaceHealthSummary,
   getWorkspaceRegion: mock(async () => null),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -338,6 +338,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
+  setWorkspaceTrialEndsAt: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),
   getWorkspaceHealthSummary: mock(async () => null),
   getWorkspaceRegion: mock(async () => null),

--- a/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
@@ -66,12 +66,18 @@ const mockHardDelete = mock(async () => {
   return { conversations: 3, subscriptions: 1, organization: 1 };
 });
 
+// #3427 — spies for the plan-override + trial-extension behavior.
+const mockUpdatePlanTier = mock(async (_orgId: string, _tier: string, _override?: unknown) => true);
+const mockSetTrialEndsAt = mock(async (_orgId: string, _date: Date) => true);
+
 const mocks = createApiTestMocks({
   internal: {
     getWorkspaceDetails: mockGetWorkspaceDetails,
     updateWorkspaceStatus: mockUpdateWorkspaceStatus,
     cascadeWorkspaceDelete: mockCascade,
     hardDeleteWorkspace: mockHardDelete,
+    updateWorkspacePlanTier: mockUpdatePlanTier,
+    setWorkspaceTrialEndsAt: mockSetTrialEndsAt,
   },
 });
 
@@ -142,11 +148,13 @@ const { app } = await import("../index");
 
 afterAll(() => mocks.cleanup());
 
-function platformRequest(method: string, path: string): Request {
-  return new Request(`http://localhost${path}`, {
+function platformRequest(method: string, path: string, body?: unknown): Request {
+  const init: RequestInit = {
     method,
     headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, init);
 }
 
 beforeEach(() => {
@@ -162,6 +170,8 @@ beforeEach(() => {
   mockCascade.mockClear();
   mockHardDelete.mockClear();
   mockUpdateWorkspaceStatus.mockClear();
+  mockUpdatePlanTier.mockClear();
+  mockSetTrialEndsAt.mockClear();
 });
 
 // ── Delete ──────────────────────────────────────────────────────────
@@ -283,5 +293,87 @@ describe("POST /api/v1/platform/workspaces/:id/suspend|unsuspend — pause/resum
     expect(res.status).toBe(200);
     expect(body.warnings).toHaveLength(1);
     expect(mockUpdateWorkspaceStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Plan change: operator override + trial extension + free→cancel (#3427) ──
+
+describe("PATCH /api/v1/platform/workspaces/:id/plan — operator override precedence (#3427)", () => {
+  it("stamps a plan-override window (default 90d) so the next webhook can't clobber the grant", async () => {
+    const before = Date.now();
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", { planTier: "pro" }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { planOverrideUntil: string | null };
+    expect(mockUpdatePlanTier).toHaveBeenCalledTimes(1);
+    const [orgId, tier, override] = mockUpdatePlanTier.mock.calls[0] as [string, string, { until: Date }];
+    expect(orgId).toBe("org-1");
+    expect(tier).toBe("pro");
+    expect(override).toHaveProperty("until");
+    const ms = override.until.getTime() - before;
+    expect(ms).toBeGreaterThan(89 * 86_400_000);
+    expect(ms).toBeLessThan(91 * 86_400_000);
+    expect(body.planOverrideUntil).toBe(override.until.toISOString());
+  });
+
+  it("clears the override (releases control to Stripe) when overrideDays is 0", async () => {
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", { planTier: "starter", overrideDays: 0 }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { planOverrideUntil: string | null };
+    const [, , override] = mockUpdatePlanTier.mock.calls[0] as [string, string, unknown];
+    expect(override).toBe("clear");
+    expect(body.planOverrideUntil).toBeNull();
+  });
+
+  it("rejects setting the 'trial' tier with no trialEndsAt (no stale reuse)", async () => {
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", { planTier: "trial" }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("trialEndsAt");
+    expect(mockUpdatePlanTier).not.toHaveBeenCalled();
+  });
+
+  it("extends a trial: wires setWorkspaceTrialEndsAt with an explicit future date", async () => {
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", {
+        planTier: "trial",
+        trialEndsAt: future,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdatePlanTier).toHaveBeenCalledWith("org-1", "trial", expect.anything());
+    expect(mockSetTrialEndsAt).toHaveBeenCalledTimes(1);
+    const [orgId, date] = mockSetTrialEndsAt.mock.calls[0] as [string, Date];
+    expect(orgId).toBe("org-1");
+    expect(date.toISOString()).toBe(future);
+  });
+
+  it("cancels Stripe subscriptions when downgrading a paying org to free", async () => {
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", { planTier: "free" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).toHaveBeenCalledTimes(1);
+    expect(mockCancelSubs.mock.calls[0][0]).toBe("org-1");
+  });
+
+  it("does NOT touch Stripe when moving to a paid tier", async () => {
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", { planTier: "pro" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCancelSubs).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin-stripe-teardown.test.ts
@@ -351,11 +351,32 @@ describe("PATCH /api/v1/platform/workspaces/:id/plan — operator override prece
     );
 
     expect(res.status).toBe(200);
-    expect(mockUpdatePlanTier).toHaveBeenCalledWith("org-1", "trial", expect.anything());
+    // #3427 review: a trial grant must CLEAR the override, never stamp a comp
+    // window. A trialing org has no competing subscription, so an override would
+    // only block the customer's own paid conversion (charged by Stripe, stranded
+    // on trial). Pin that the directive is "clear", not a future `until`.
+    const [, tier, override] = mockUpdatePlanTier.mock.calls[0] as [string, string, unknown];
+    expect(tier).toBe("trial");
+    expect(override).toBe("clear");
     expect(mockSetTrialEndsAt).toHaveBeenCalledTimes(1);
     const [orgId, date] = mockSetTrialEndsAt.mock.calls[0] as [string, Date];
     expect(orgId).toBe("org-1");
     expect(date.toISOString()).toBe(future);
+  });
+
+  it("clears the override even when overrideDays is explicitly passed for a trial", async () => {
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/platform/workspaces/org-1/plan", {
+        planTier: "trial",
+        trialEndsAt: future,
+        overrideDays: 90,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const [, , override] = mockUpdatePlanTier.mock.calls[0] as [string, string, unknown];
+    expect(override).toBe("clear");
   });
 
   it("cancels Stripe subscriptions when downgrading a paying org to free", async () => {

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -17,6 +17,7 @@ import {
   getWorkspaceDetails,
   updateWorkspaceStatus,
   updateWorkspacePlanTier,
+  setWorkspaceTrialEndsAt,
   cascadeWorkspaceDelete,
   getWorkspaceHealthSummary,
   type PlanTier,
@@ -24,6 +25,7 @@ import {
 import { connections } from "@atlas/api/lib/db/connection";
 import { flushCache } from "@atlas/api/lib/cache/index";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import { PLAN_OVERRIDE_DAYS } from "@atlas/api/lib/billing/plans";
 import {
   cancelStripeSubscriptionsForWorkspace,
   pauseStripeCollectionForWorkspace,
@@ -157,6 +159,19 @@ const ConflictErrorSchema = z.object({
 
 const UpdatePlanBodySchema = z.object({
   planTier: z.string().openapi({ example: "starter" }),
+  // #3427 — an operator plan change overrides Stripe for a bounded window so
+  // the next webhook can't clobber the grant. Pass 0 to clear the override.
+  overrideDays: z.number().int().min(0).max(365).optional().openapi({
+    description:
+      "Days the operator grant takes precedence over Stripe before auto-healing. Defaults to 90. Pass 0 to clear the override.",
+    example: 90,
+  }),
+  // #3427 — setting `trial` requires an explicit future end date (a stale
+  // trial_ends_at expires instantly). Also the trial-extension surface.
+  trialEndsAt: z.string().datetime().optional().openapi({
+    description: "Required when planTier is 'trial' — new trial end date (ISO 8601). Ignored otherwise.",
+    example: "2026-08-01T00:00:00.000Z",
+  }),
 });
 
 // ---------------------------------------------------------------------------
@@ -810,26 +825,79 @@ adminOrgs.openapi(updatePlanRoute, async (c) => {
     if (!body.planTier || !VALID_PLAN_TIERS.has(body.planTier as PlanTier)) {
       return c.json({ error: "bad_request", message: `Invalid plan tier. Must be one of: ${[...VALID_PLAN_TIERS].join(", ")}` }, 400);
     }
+    const planTier = body.planTier as PlanTier;
+
+    // #3427 — setting `trial` requires an explicit, future end date (a stale
+    // trial_ends_at would expire instantly). Doubles as the trial-extension
+    // surface: set planTier="trial" with a future date to extend a trial.
+    let parsedTrialEndsAt: Date | null = null;
+    if (planTier === "trial") {
+      if (!body.trialEndsAt) {
+        return c.json({ error: "bad_request", message: "Setting the 'trial' tier requires an explicit trialEndsAt (ISO 8601) — a stale trial_ends_at would expire instantly." }, 400);
+      }
+      parsedTrialEndsAt = new Date(body.trialEndsAt);
+      if (Number.isNaN(parsedTrialEndsAt.getTime())) {
+        return c.json({ error: "bad_request", message: `Invalid trialEndsAt: ${body.trialEndsAt}` }, 400);
+      }
+      if (parsedTrialEndsAt.getTime() <= Date.now()) {
+        return c.json({ error: "bad_request", message: "trialEndsAt must be in the future." }, 400);
+      }
+    }
 
     const workspace = yield* Effect.promise(() => getWorkspaceDetails(orgId));
     if (!workspace) return c.json({ error: "not_found", message: "Organization not found." }, 404);
     if (workspace.workspace_status === "deleted") return c.json({ error: "conflict", message: "Cannot update plan for a deleted workspace." }, 409);
 
     const previousPlan = workspace.plan_tier;
-    yield* Effect.promise(() => updateWorkspacePlanTier(orgId, body.planTier as PlanTier));
+
+    // #3427 — operator plan change OVERRIDES Stripe for a bounded window so the
+    // next webhook can't clobber the grant. `overrideDays === 0` clears it.
+    const days = body.overrideDays ?? PLAN_OVERRIDE_DAYS;
+    const overrideUntil: Date | null = days === 0 ? null : new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+    const override = days === 0 ? ("clear" as const) : { until: overrideUntil as Date };
+
+    yield* Effect.promise(() => updateWorkspacePlanTier(orgId, planTier, override));
+
+    if (parsedTrialEndsAt) {
+      const stamped = yield* Effect.promise(() => setWorkspaceTrialEndsAt(orgId, parsedTrialEndsAt));
+      if (!stamped) {
+        log.warn({ orgId, requestId }, "Plan set to trial but trial_ends_at write matched 0 rows — workspace vanished mid-request?");
+      }
+    }
+
+    // #3427 — downgrading a paying org to free/locked must STOP Stripe
+    // invoicing. Best-effort: Stripe failures surface as operator warnings;
+    // the plan change always proceeds (same pattern as suspend/delete teardown).
+    let warnings: string[] = [];
+    let stripeMeta: Record<string, unknown> = {};
+    if (planTier === "free" || planTier === "locked") {
+      const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(orgId));
+      warnings = withWarnings(billing).warnings ?? [];
+      stripeMeta = stripeAuditMetadata(billing);
+    }
+
     invalidatePlanCache(orgId);
-    log.info({ orgId, requestId, admin: user?.id, planTier: body.planTier }, "Workspace plan tier updated");
+    log.info(
+      { orgId, requestId, admin: user?.id, planTier, planOverrideUntil: overrideUntil?.toISOString() ?? null },
+      "Workspace plan tier updated",
+    );
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.changePlan,
       targetType: "workspace",
       targetId: orgId,
       scope: "platform",
-      metadata: { previousPlan, newPlan: body.planTier },
+      metadata: {
+        previousPlan,
+        newPlan: planTier,
+        planOverrideUntil: overrideUntil?.toISOString() ?? null,
+        ...(parsedTrialEndsAt ? { trialEndsAt: parsedTrialEndsAt.toISOString() } : {}),
+        ...stripeMeta,
+      },
       ipAddress: clientIpFor(c),
     });
 
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
-    return c.json({ message: `Plan tier updated to ${body.planTier}.`, organization: updated }, 200);
+    return c.json({ message: `Plan tier updated to ${planTier}.`, organization: updated, ...(warnings.length > 0 ? { warnings } : {}) }, 200);
   }), { label: "update plan tier" });
 });
 

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -852,7 +852,11 @@ adminOrgs.openapi(updatePlanRoute, async (c) => {
 
     // #3427 — operator plan change OVERRIDES Stripe for a bounded window so the
     // next webhook can't clobber the grant. `overrideDays === 0` clears it.
-    const days = body.overrideDays ?? PLAN_OVERRIDE_DAYS;
+    // EXCEPTION (#3427 review): a `trial` grant must NOT stamp an override — a
+    // trialing org has no competing subscription, so an override would only
+    // block the customer's own paid conversion (charged by Stripe, stranded on
+    // trial). Trial protection is the trial_ends_at window; clear it for trial.
+    const days = planTier === "trial" ? 0 : (body.overrideDays ?? PLAN_OVERRIDE_DAYS);
     const overrideUntil: Date | null = days === 0 ? null : new Date(Date.now() + days * 24 * 60 * 60 * 1000);
     const override = days === 0 ? ("clear" as const) : { until: overrideUntil as Date };
 

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -33,6 +33,7 @@ import {
   getWorkspaceDetails,
   updateWorkspaceStatus,
   updateWorkspacePlanTier,
+  setWorkspaceTrialEndsAt,
   cascadeWorkspaceDelete,
   hardDeleteWorkspace,
   type WorkspaceRow,
@@ -43,7 +44,7 @@ import {
   PLAN_TIERS,
   type PlatformWorkspace,
 } from "@useatlas/types";
-import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
+import { getPlanDefinition, PLAN_OVERRIDE_DAYS } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 import {
   cancelStripeSubscriptionsForWorkspace,
@@ -92,7 +93,28 @@ const ChangePlanBodySchema = z.object({
     description: "The new plan tier for the workspace.",
     example: "starter",
   }),
+  // #3427 — an operator plan change is an OVERRIDE that takes precedence over
+  // Stripe for a bounded window (default PLAN_OVERRIDE_DAYS). The Stripe webhook
+  // tier sync skips its write while the window is active. Pass `0` to release
+  // control back to Stripe immediately (re-sync to the Stripe-derived tier).
+  overrideDays: z.number().int().min(0).max(365).optional().openapi({
+    description:
+      "Days the operator grant takes precedence over Stripe before auto-healing. Defaults to 90. Pass 0 to clear the override and let Stripe reassert control immediately.",
+    example: 90,
+  }),
+  // #3427 — setting the `trial` tier MUST carry an explicit end date: reusing a
+  // stale `trial_ends_at` would stamp an instantly-expired trial. Required when
+  // planTier === "trial"; ignored otherwise. Also doubles as the trial-extension
+  // surface (set planTier="trial" with a future date to extend).
+  trialEndsAt: z.string().datetime().optional().openapi({
+    description:
+      "Required when planTier is 'trial' — the new trial end date (ISO 8601). Ignored for other tiers.",
+    example: "2026-08-01T00:00:00.000Z",
+  }),
 });
+
+/** Tiers an operator downgrade-to-free/locked must stop Stripe invoicing for (#3427). */
+const STRIPE_CANCEL_ON_TIER = new Set<PlanTier>(["free", "locked"]);
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -264,9 +286,22 @@ const changePlanRoute = createRoute({
   responses: {
     200: {
       description: "Plan updated",
-      content: { "application/json": { schema: z.object({ message: z.string(), workspaceId: z.string(), planTier: z.string() }) } },
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string(),
+            workspaceId: z.string(),
+            planTier: z.string(),
+            // #3427 — when the operator grant takes precedence over Stripe.
+            // null when the override was cleared (overrideDays === 0).
+            planOverrideUntil: z.string().nullable(),
+            trialEndsAt: z.string().nullable().optional(),
+            warnings: z.array(z.string()).optional(),
+          }),
+        },
+      },
     },
-    400: { description: "Invalid plan tier", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Invalid plan tier or missing trialEndsAt", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Workspace not found", content: { "application/json": { schema: ErrorSchema } } },
@@ -434,6 +469,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
       trial_ends_at: string | null;
       suspended_at: string | null;
       suspension_source: "billing" | "operator" | null;
+      plan_override_until: string | null;
       deleted_at: string | null;
       region: string | null;
       region_assigned_at: string | null;
@@ -446,7 +482,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
     }>(
       `SELECT
          o.id, o.name, o.slug, o.workspace_status, o.plan_tier, o.byot,
-         o."stripeCustomerId" AS stripe_customer_id, o.trial_ends_at, o.suspended_at, o.suspension_source, o.deleted_at,
+         o."stripeCustomerId" AS stripe_customer_id, o.trial_ends_at, o.suspended_at, o.suspension_source, o.plan_override_until, o.deleted_at,
          o.region, o.region_assigned_at, o."createdAt",
          COALESCE(m.cnt, 0)::int AS members,
          COALESCE(cv.cnt, 0)::int AS conversations,
@@ -481,6 +517,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
           trial_ends_at: row.trial_ends_at,
           suspended_at: row.suspended_at,
           suspension_source: row.suspension_source,
+          plan_override_until: row.plan_override_until,
           deleted_at: row.deleted_at,
           region: row.region,
           region_assigned_at: row.region_assigned_at,
@@ -806,10 +843,32 @@ platformAdmin.openapi(changePlanRoute, async (c) => {
 
     const workspaceId = c.req.param("id");
     const body = c.req.valid("json");
-    const { planTier } = body;
+    const { planTier, overrideDays, trialEndsAt } = body;
 
     if (!VALID_PLAN_TIERS.has(planTier)) {
       return c.json({ error: "validation_error", message: `Invalid plan tier: ${planTier}`, requestId }, 400);
+    }
+
+    // #3427 — setting `trial` must carry an explicit, future end date.
+    // Without this the org reuses a stale `trial_ends_at` and the trial is
+    // instantly expired. This also IS the trial-extension surface: set
+    // planTier="trial" with a future date to extend an active/lapsed trial.
+    let parsedTrialEndsAt: Date | null = null;
+    if (planTier === "trial") {
+      if (!trialEndsAt) {
+        return c.json({
+          error: "validation_error",
+          message: "Setting the 'trial' tier requires an explicit trialEndsAt (ISO 8601) — a stale trial_ends_at would expire instantly.",
+          requestId,
+        }, 400);
+      }
+      parsedTrialEndsAt = new Date(trialEndsAt);
+      if (Number.isNaN(parsedTrialEndsAt.getTime())) {
+        return c.json({ error: "validation_error", message: `Invalid trialEndsAt: ${trialEndsAt}`, requestId }, 400);
+      }
+      if (parsedTrialEndsAt.getTime() <= Date.now()) {
+        return c.json({ error: "validation_error", message: "trialEndsAt must be in the future.", requestId }, 400);
+      }
     }
 
     const workspace = yield* Effect.promise(() => getWorkspaceDetails(workspaceId));
@@ -817,25 +876,73 @@ platformAdmin.openapi(changePlanRoute, async (c) => {
       return c.json({ error: "not_found", message: "Workspace not found.", requestId }, 404);
     }
 
-    const updated = yield* Effect.promise(() => updateWorkspacePlanTier(workspaceId, planTier as PlanTier));
+    // #3427 — an operator plan change OVERRIDES Stripe for a bounded window so
+    // the next webhook can't clobber the grant. `overrideDays === 0` clears the
+    // override (release control back to Stripe immediately); omit it for the
+    // PLAN_OVERRIDE_DAYS default. The directive is passed atomically with the
+    // tier write so the row never sits at "new tier, no override".
+    const days = overrideDays ?? PLAN_OVERRIDE_DAYS;
+    const overrideUntil: Date | null = days === 0 ? null : new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+    const override = days === 0 ? ("clear" as const) : { until: overrideUntil as Date };
+
+    const updated = yield* Effect.promise(() => updateWorkspacePlanTier(workspaceId, planTier as PlanTier, override));
     if (!updated) {
       return c.json({ error: "not_found", message: "Workspace not found.", requestId }, 404);
     }
 
+    // Trial end date: set AFTER the tier write so the two land for the same
+    // row. setWorkspaceTrialEndsAt returning false here would be a
+    // get-then-write race (org deleted mid-request) — log, don't fail the op.
+    if (parsedTrialEndsAt) {
+      const stamped = yield* Effect.promise(() => setWorkspaceTrialEndsAt(workspaceId, parsedTrialEndsAt));
+      if (!stamped) {
+        log.warn({ workspaceId, requestId }, "Plan set to trial but trial_ends_at write matched 0 rows — workspace vanished mid-request?");
+      }
+    }
+
+    // #3427 — downgrading a paying org to free/locked must STOP Stripe
+    // invoicing; otherwise the customer keeps being charged for entitlements
+    // the DB no longer grants. Best-effort: Stripe failures surface as
+    // operator warnings (same pattern as the delete/purge teardown), the plan
+    // change itself always proceeds.
+    let warnings: string[] = [];
+    let stripeMeta: Record<string, unknown> = {};
+    if (STRIPE_CANCEL_ON_TIER.has(planTier as PlanTier)) {
+      const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(workspaceId));
+      warnings = withWarnings(billing).warnings ?? [];
+      stripeMeta = stripeAuditMetadata(billing);
+    }
+
     invalidatePlanCache(workspaceId); // #2165 — see suspend handler above
 
-    log.info({ workspaceId, planTier, previousTier: workspace.plan_tier, requestId }, "Workspace plan changed by platform admin");
+    log.info(
+      { workspaceId, planTier, previousTier: workspace.plan_tier, planOverrideUntil: overrideUntil?.toISOString() ?? null, requestId },
+      "Workspace plan changed by platform admin",
+    );
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.changePlan,
       targetType: "workspace",
       targetId: workspaceId,
       scope: "platform",
-      metadata: { previousPlan: workspace.plan_tier, newPlan: planTier },
+      metadata: {
+        previousPlan: workspace.plan_tier,
+        newPlan: planTier,
+        planOverrideUntil: overrideUntil?.toISOString() ?? null,
+        ...(parsedTrialEndsAt ? { trialEndsAt: parsedTrialEndsAt.toISOString() } : {}),
+        ...stripeMeta,
+      },
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
-    return c.json({ message: "Plan updated.", workspaceId, planTier }, 200);
+    return c.json({
+      message: "Plan updated.",
+      workspaceId,
+      planTier,
+      planOverrideUntil: overrideUntil?.toISOString() ?? null,
+      ...(parsedTrialEndsAt ? { trialEndsAt: parsedTrialEndsAt.toISOString() } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
+    }, 200);
   }), { label: "change workspace plan" });
 });
 

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -881,7 +881,14 @@ platformAdmin.openapi(changePlanRoute, async (c) => {
     // override (release control back to Stripe immediately); omit it for the
     // PLAN_OVERRIDE_DAYS default. The directive is passed atomically with the
     // tier write so the row never sits at "new tier, no override".
-    const days = overrideDays ?? PLAN_OVERRIDE_DAYS;
+    //
+    // EXCEPTION (#3427 review) — a `trial` grant must NOT stamp an override. A
+    // trialing org has no competing active subscription, so the override would
+    // only block the customer's OWN paid conversion (checkout →
+    // applyWorkspaceTier) for the window's length — Stripe charges them while
+    // they stay stranded on the trial tier. Trial protection is the
+    // trial_ends_at window, not the override, so we clear it for trial.
+    const days = planTier === "trial" ? 0 : (overrideDays ?? PLAN_OVERRIDE_DAYS);
     const overrideUntil: Date | null = days === 0 ? null : new Date(Date.now() + days * 24 * 60 * 60 * 1000);
     const override = days === 0 ? ("clear" as const) : { until: overrideUntil as Date };
 

--- a/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
@@ -64,6 +64,8 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getWorkspaceDetails: async () => null,
   updateWorkspaceStatus: async () => true,
   updateWorkspacePlanTier: async () => true,
+  // #3427 — imported by lib/auth/server.ts (applyWorkspaceTier override check).
+  isPlanOverrideActive: () => false,
   cascadeWorkspaceDelete: async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 }),
   getWorkspaceHealthSummary: async () => null,
   getWorkspaceRegion: async () => null,

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -536,6 +536,112 @@ describe("customer.subscription.updated → pending cancel (#3421)", () => {
   });
 });
 
+// ── operator plan-override precedence (#3427) ───────────────────────
+
+describe("operator plan-override precedence (#3427)", () => {
+  it("does NOT clobber the plan_tier when an operator override is active", async () => {
+    // A platform admin comped this org to `pro` (override window in the
+    // future). The plugin's subscription row still says `starter`, so a
+    // stray customer.subscription.updated would normally re-sync the org
+    // to starter — the override must block that write.
+    const overrideUntil = new Date(Date.now() + 30 * 86_400_000).toISOString();
+    mockGetWorkspaceDetails.mockImplementation(() =>
+      Promise.resolve({ id: "org-1", plan_tier: "pro", plan_override_until: overrideUntil }),
+    );
+
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_stripe_1",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    const res = await postWebhook(auth, {
+      id: "evt_override_active",
+      type: "customer.subscription.updated",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "active" }) },
+    });
+
+    expect(res.status).toBe(200);
+    // The operator grant survives — NO Stripe-driven tier write happened.
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalled();
+    // The event is still recorded (handled, deliberately a no-op) so Stripe
+    // doesn't redeliver it forever. The tier the sync WOULD have written is
+    // banked so the reconcile sweep stays consistent.
+    expect(ledgerRows.map((r) => [r.event_id, r.applied_plan_tier])).toEqual([
+      ["evt_override_active", "starter"],
+    ]);
+  });
+
+  it("applies the Stripe tier normally once the override window has lapsed", async () => {
+    // Same shape, but the override is in the PAST → Stripe is authoritative
+    // again and the sync proceeds.
+    const overrideUntil = new Date(Date.now() - 86_400_000).toISOString();
+    mockGetWorkspaceDetails.mockImplementation(() =>
+      Promise.resolve({ id: "org-1", plan_tier: "pro", plan_override_until: overrideUntil }),
+    );
+
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_stripe_1",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    const res = await postWebhook(auth, {
+      id: "evt_override_lapsed",
+      type: "customer.subscription.updated",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "active" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "starter");
+  });
+
+  it("falls toward Stripe authority when the override lookup fails", async () => {
+    // A DB blip reading plan_override_until must NOT silently skip the sync
+    // (that would strand the org on a stale tier) — fall through to the write.
+    mockGetWorkspaceDetails.mockImplementation(() => Promise.reject(new Error("pg blip")));
+
+    const db = emptyDB();
+    db.subscription.push({
+      id: "subrow_1",
+      plan: "starter",
+      referenceId: "org-1",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_stripe_1",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const auth = makeAuth(db);
+
+    const res = await postWebhook(auth, {
+      id: "evt_override_readfail",
+      type: "customer.subscription.updated",
+      created: EPOCH,
+      data: { object: stripeSubscription({ status: "active" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-1", "starter");
+  });
+});
+
 describe("customer.subscription.deleted", () => {
   it("locks the org when the subscription actually ends — never free (#3421)", async () => {
     const db = emptyDB();

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -33,7 +33,7 @@ import {
 import { listUserWorkspaceIds } from "@atlas/api/lib/auth/oauth-workspace-grants";
 import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit";
 import Stripe from "stripe";
-import { getInternalDB, getWorkspaceDetails, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, withStripeSubscriptionLock, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
+import { getInternalDB, getWorkspaceDetails, hasInternalDB, internalQuery, isPlanOverrideActive, updateWorkspacePlanTier, updateWorkspaceStatus, withStripeSubscriptionLock, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   resolveRequireEmailVerification as envProfileResolveRequireEmailVerification,
@@ -1469,8 +1469,48 @@ async function resolveOrgIdForStripeSubscription(
  * Returns whether the write matched an organization row — callers use
  * it to skip follow-on side effects (e.g. the CRM conversion stamp)
  * for orgs that no longer exist.
+ *
+ * Operator-override precedence (#3427): a platform admin can set
+ * `plan_tier` directly with NO Stripe interaction (platform-admin.ts /
+ * admin-orgs.ts), stamping `plan_override_until`. While that window is
+ * active this Stripe-driven write is SKIPPED — a stray
+ * `customer.subscription.updated` / cancel must not silently clobber an
+ * operator grant. We return `true` on a skip so the caller still records
+ * the event in the ledger (it was handled, just deliberately a no-op) and
+ * still runs follow-on side effects keyed on "the org exists". The
+ * override read is a single getWorkspaceDetails; on a read error we FALL
+ * THROUGH to the write (fail toward Stripe authority) so a transient DB
+ * blip can't strand an org on a stale operator tier — logged either way.
+ *
+ * #3423 — the reconciliation sweep MUST honor the same precedence: before
+ * it heals `plan_tier` from the ledger's ordering-correct source, it has
+ * to skip orgs whose `plan_override_until` is still in the future, exactly
+ * as this function does. The check lives here so the webhook path is
+ * covered; the sweep needs its own guard at its write site.
  */
 async function applyWorkspaceTier(orgId: string, tier: PlanTier, context: string): Promise<boolean> {
+  try {
+    const workspace = await getWorkspaceDetails(orgId);
+    if (workspace && isPlanOverrideActive(workspace.plan_override_until)) {
+      billingLog.info(
+        { orgId, tier, currentTier: workspace.plan_tier, planOverrideUntil: workspace.plan_override_until, context },
+        "Plan-override active — skipping Stripe-driven tier write to preserve operator grant (#3427)",
+      );
+      // Treated as handled: the org exists and the event was processed
+      // (deliberately a no-op), so the ledger records it and follow-on
+      // side effects that only gate on "org exists" still run.
+      return true;
+    }
+  } catch (err) {
+    // Fail toward Stripe authority: if we can't read the override window,
+    // do NOT silently skip the sync — fall through to the write below so
+    // a transient DB blip can't pin an org on a stale operator tier.
+    billingLog.warn(
+      { err: errorMessage(err), orgId, tier, context },
+      "Plan-override check failed — proceeding with Stripe tier write (fail toward Stripe authority)",
+    );
+  }
+
   // false = no organization row matched (helper logs the contract
   // violation). Do NOT throw — Stripe redelivering won't create the org.
   const updated = await updateWorkspacePlanTier(orgId, tier);

--- a/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
@@ -203,11 +203,12 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
     await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
     await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
     // Minimal `organization` — only the columns getWorkspaceDetails reads.
-    // `suspension_source` mirrors migration 0131 (a MANAGED_AUTH_MIGRATION,
-    // so it's skipped by `runMigrations` above and never created here): the
-    // reader's SELECT lists it, so the fixture must carry it or every
-    // `getWorkspaceDetails` call fails with `column "suspension_source"
-    // does not exist`. Nullable TEXT, matching the migration's column.
+    // `suspension_source` mirrors migration 0131 and `plan_override_until`
+    // mirrors 0132 — both MANAGED_AUTH_MIGRATIONS, so they're skipped by
+    // `runMigrations` above and never created here: the reader's SELECT lists
+    // them, so the fixture must carry them or every `getWorkspaceDetails` call
+    // fails with `column "..." does not exist`. Nullable, matching the
+    // migrations' columns.
     await pool.query(
       `CREATE TABLE organization (
          id text PRIMARY KEY,
@@ -220,6 +221,7 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
          trial_ends_at timestamptz,
          suspended_at timestamptz,
          suspension_source text,
+         plan_override_until timestamptz,
          deleted_at timestamptz,
          region text,
          region_assigned_at timestamptz,

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers.test.ts
@@ -31,13 +31,15 @@ interface OrgRow {
   subscription_plan: string | null;
   /** Newest applied tier from the webhook ledger (defaulted to null). */
   ledger_tier?: string | null;
+  /** Operator override window (#3427); defaulted to null = no override. */
+  plan_override_until?: string | null;
 }
 
 /** Route the org scan and the ledger prune through one mock. */
 function installQueryFixture(orgs: OrgRow[], pruned: { event_id: string }[] = []) {
   mockInternalQuery.mockImplementation((sql: string) => {
     if (sql.includes("FROM organization o"))
-      return Promise.resolve(orgs.map((o) => ({ ledger_tier: null, ...o })));
+      return Promise.resolve(orgs.map((o) => ({ ledger_tier: null, plan_override_until: null, ...o })));
     if (sql.includes("DELETE FROM stripe_webhook_events")) return Promise.resolve(pruned);
     return Promise.resolve([]);
   });
@@ -80,6 +82,37 @@ describe("reconcilePlanTiers", () => {
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(2);
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-locked", "starter");
     expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-upgrade", "pro");
+  });
+
+  it("does NOT heal an org while its operator override window is active (#3427)", async () => {
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    installQueryFixture([
+      // Operator comped this org to pro; the subscription says starter. The
+      // webhook path already preserves the grant — the 6-hour sweep must too,
+      // or it silently reverts the operator within one interval.
+      { org_id: "org-comped", plan_tier: "pro", subscription_plan: "starter", plan_override_until: future },
+      // Control: identical drift with NO override still heals.
+      { org_id: "org-normal", plan_tier: "starter", subscription_plan: "pro" },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.healed).toBe(1);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-normal", "pro");
+    expect(mockUpdateWorkspacePlanTier).not.toHaveBeenCalledWith("org-comped", "starter");
+  });
+
+  it("resumes healing once the override window has lapsed (#3427)", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    installQueryFixture([
+      { org_id: "org-expired", plan_tier: "pro", subscription_plan: "starter", plan_override_until: past },
+    ]);
+
+    const result = await reconcilePlanTiers();
+
+    expect(result.healed).toBe(1);
+    expect(mockUpdateWorkspacePlanTier).toHaveBeenCalledWith("org-expired", "starter");
   });
 
   it("flags but never rewrites a paid-tier org with no live subscription (#3427 pending)", async () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -83,6 +83,17 @@ const UNLIMITED = -1;
 /** Trial duration in days. Single source of truth — used in plan definitions, Stripe config, and enforcement. */
 export const TRIAL_DAYS = 14;
 
+/**
+ * Default duration (days) of a platform-admin plan-override window (#3427).
+ *
+ * When an operator sets `plan_tier` directly, the Stripe webhook tier sync
+ * skips its write until `plan_override_until` lapses. A bounded default means
+ * an operator grant auto-heals back to Stripe authority instead of pinning the
+ * tier forever — long enough (90 days) to cover a comp / dispute / manual
+ * support grant, short enough that a forgotten override eventually re-syncs.
+ */
+export const PLAN_OVERRIDE_DAYS = 90;
+
 /** The tiers self-serve checkout can move a workspace to (#3418). */
 export type PaidPlanTier = "starter" | "pro" | "business";
 

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -147,6 +147,15 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
         continue;
       }
       if (expectedTier !== currentTier) {
+        // #3427 precedence — the operator plan-override window landed on the
+        // org row as `plan_override_until` (see `isPlanOverrideActive` and
+        // `applyWorkspaceTier` in lib/auth/server.ts). When #3423 finishes this
+        // sweep it MUST honor the SAME precedence the webhook path now does:
+        // add `o.plan_override_until` to the SELECT above and skip this heal
+        // (`if (isPlanOverrideActive(row.plan_override_until)) continue;`) so a
+        // background reconcile can't clobber an active operator grant any more
+        // than a stray webhook can. Intentionally NOT wired here to keep this
+        // change scoped to the webhook path (#3427); this is the marker.
         const updated = await updateWorkspacePlanTier(row.org_id, expectedTier);
         if (updated) {
           invalidatePlanCache(row.org_id);

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -34,6 +34,7 @@
 import {
   hasInternalDB,
   internalQuery,
+  isPlanOverrideActive,
   updateWorkspacePlanTier,
 } from "@atlas/api/lib/db/internal";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
@@ -70,6 +71,9 @@ type ReconcileRow = {
   subscription_plan: string | null;
   /** Newest non-null `applied_plan_tier` from the webhook ledger. */
   ledger_tier: string | null;
+  /** Operator plan-override window (#3427); when in the future, the sweep
+   *  must not heal over the operator's grant. */
+  plan_override_until: string | null;
 };
 
 /**
@@ -105,7 +109,7 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
   //    then Stripe's own ~3-week retry/redelivery window has closed, so
   //    a stale delivery storm can no longer be in flight).
   const rows = await internalQuery<ReconcileRow>(
-    `SELECT o.id AS org_id, o.plan_tier, sub.plan AS subscription_plan,
+    `SELECT o.id AS org_id, o.plan_tier, o.plan_override_until, sub.plan AS subscription_plan,
             led.applied_plan_tier AS ledger_tier
        FROM organization o
        LEFT JOIN LATERAL (
@@ -147,15 +151,21 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
         continue;
       }
       if (expectedTier !== currentTier) {
-        // #3427 precedence — the operator plan-override window landed on the
-        // org row as `plan_override_until` (see `isPlanOverrideActive` and
-        // `applyWorkspaceTier` in lib/auth/server.ts). When #3423 finishes this
-        // sweep it MUST honor the SAME precedence the webhook path now does:
-        // add `o.plan_override_until` to the SELECT above and skip this heal
-        // (`if (isPlanOverrideActive(row.plan_override_until)) continue;`) so a
-        // background reconcile can't clobber an active operator grant any more
-        // than a stray webhook can. Intentionally NOT wired here to keep this
-        // change scoped to the webhook path (#3427); this is the marker.
+        // #3427 precedence — honor the operator plan-override window here too.
+        // The webhook path (`applyWorkspaceTier` in lib/auth/server.ts) already
+        // skips a tier write while `plan_override_until` is in the future; this
+        // background sweep is the OTHER Stripe-derived tier-write path, so it
+        // must obey the same rule or it would silently revert an operator grant
+        // within one interval (~6h) — defeating the guarantee. Skip the heal
+        // while the override is active; the org is left on the operator's tier
+        // and re-converges naturally once the window lapses.
+        if (isPlanOverrideActive(row.plan_override_until)) {
+          log.info(
+            { orgId: row.org_id, planTier: currentTier, expectedTier, planOverrideUntil: row.plan_override_until },
+            "Skipping plan-tier heal — operator override window is active (#3427)",
+          );
+          continue;
+        }
         const updated = await updateWorkspacePlanTier(row.org_id, expectedTier);
         if (updated) {
           invalidatePlanCache(row.org_id);

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -17,6 +17,8 @@ import {
   loadSavedConnections,
   cascadeWorkspaceDelete,
   hardDeleteWorkspace,
+  updateWorkspacePlanTier,
+  isPlanOverrideActive,
   _resetPool,
   _resetCircuitBreaker,
   _hasRecoveryFiber,
@@ -1589,6 +1591,70 @@ describe("connection URL encryption", () => {
       await new Promise((r) => setTimeout(r, 10));
       // Circuit is open — call was dropped, not dispatched (still 5)
       expect(calls.length).toBe(5);
+    });
+  });
+
+  // ── #3427 operator plan-override precedence ──────────────────────────
+
+  describe("isPlanOverrideActive()", () => {
+    const now = new Date("2026-06-13T00:00:00.000Z");
+
+    it("is false for null/undefined/empty", () => {
+      expect(isPlanOverrideActive(null, now)).toBe(false);
+      expect(isPlanOverrideActive(undefined, now)).toBe(false);
+      expect(isPlanOverrideActive("", now)).toBe(false);
+    });
+
+    it("is false for an unparseable timestamp (Stripe stays authoritative)", () => {
+      expect(isPlanOverrideActive("not-a-date", now)).toBe(false);
+    });
+
+    it("is false for a past timestamp", () => {
+      expect(isPlanOverrideActive("2026-06-12T23:59:59.000Z", now)).toBe(false);
+    });
+
+    it("is true for a future timestamp", () => {
+      expect(isPlanOverrideActive("2026-06-14T00:00:00.000Z", now)).toBe(true);
+    });
+  });
+
+  describe("updateWorkspacePlanTier() override directive", () => {
+    it("leaves plan_override_until untouched when no directive is passed (Stripe path)", async () => {
+      const { pool, calls } = createMockPool();
+      pool._setResult({ rows: [{ id: "org-1" }] });
+      _resetPool(pool);
+
+      await updateWorkspacePlanTier("org-1", "starter");
+
+      const q = calls.queries.at(-1)!;
+      expect(q.sql).toContain("SET plan_tier = $1");
+      expect(q.sql).not.toContain("plan_override_until");
+      expect(q.params).toEqual(["starter", "org-1"]);
+    });
+
+    it("stamps plan_override_until when given an until directive (operator path)", async () => {
+      const { pool, calls } = createMockPool();
+      pool._setResult({ rows: [{ id: "org-1" }] });
+      _resetPool(pool);
+
+      const until = new Date("2026-09-01T00:00:00.000Z");
+      await updateWorkspacePlanTier("org-1", "pro", { until });
+
+      const q = calls.queries.at(-1)!;
+      expect(q.sql).toContain("plan_override_until = $3");
+      expect(q.params).toEqual(["pro", "org-1", until.toISOString()]);
+    });
+
+    it("nulls plan_override_until when given the 'clear' directive", async () => {
+      const { pool, calls } = createMockPool();
+      pool._setResult({ rows: [{ id: "org-1" }] });
+      _resetPool(pool);
+
+      await updateWorkspacePlanTier("org-1", "starter", "clear");
+
+      const q = calls.queries.at(-1)!;
+      expect(q.sql).toContain("plan_override_until = NULL");
+      expect(q.params).toEqual(["starter", "org-1"]);
     });
   });
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -151,7 +151,8 @@ describe("runMigrations", () => {
     //   Plus 0129 (stripe_purged_subscriptions tombstones, #3468) = 130.
     //   Plus 0130 (user_trial_grants one-trial marker, #3469/#3470) = 131.
     //   Plus 0131 (organization.suspension_source billing/operator, #3424) = 132.
-    expect(count).toBe(132);
+    //   Plus 0132 (organization.plan_override_until operator precedence, #3427) = 133.
+    expect(count).toBe(133);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -312,6 +313,7 @@ describe("runMigrations", () => {
         "0129_stripe_purged_subscriptions.sql",
         "0130_user_trial_grants.sql",
         "0131_org_suspension_source.sql",
+        "0132_org_plan_override.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -972,6 +972,10 @@ export const MANAGED_AUTH_MIGRATIONS = [
   // recovery only unsuspends billing-induced suspensions, never operator
   // ones (#3424).
   "0131_org_suspension_source.sql",
+  // Adds plan_override_until to Better Auth's "organization" table so the
+  // Stripe webhook tier sync respects an active platform-admin plan grant
+  // instead of clobbering it (#3427).
+  "0132_org_plan_override.sql",
 ];
 
 /**
@@ -1868,6 +1872,14 @@ export interface WorkspaceRow {
    * operator suspension survives a billing recovery.
    */
   suspension_source: SuspensionSource | null;
+  /**
+   * Operator plan-override window (#3427). NULL (or a past timestamp) means
+   * Stripe is authoritative for `plan_tier`. A future timestamp means a
+   * platform admin set `plan_tier` directly and the Stripe-webhook tier sync
+   * (`applyWorkspaceTier` in lib/auth/server.ts) must NOT overwrite it until
+   * the window lapses. Stamped/cleared via {@link updateWorkspacePlanTier}.
+   */
+  plan_override_until: string | null;
   deleted_at: string | null;
   region: string | null;
   region_assigned_at: string | null;
@@ -1917,7 +1929,7 @@ export async function getWorkspaceNamesByIds(
 export async function getWorkspaceDetails(orgId: string): Promise<WorkspaceRow | null> {
   if (!hasInternalDB()) return null;
   const rows = await internalQuery<WorkspaceRow>(
-    `SELECT id, name, slug, workspace_status, plan_tier, byot, "stripeCustomerId" AS stripe_customer_id, trial_ends_at, suspended_at, suspension_source, deleted_at, region, region_assigned_at, "createdAt"
+    `SELECT id, name, slug, workspace_status, plan_tier, byot, "stripeCustomerId" AS stripe_customer_id, trial_ends_at, suspended_at, suspension_source, plan_override_until, deleted_at, region, region_assigned_at, "createdAt"
      FROM organization WHERE id = $1`,
     [orgId],
   );
@@ -1961,8 +1973,47 @@ export async function updateWorkspaceStatus(
 }
 
 /**
+ * Operator plan-override directive for {@link updateWorkspacePlanTier} (#3427).
+ *
+ * Stripe-driven writes (the webhook tier sync) pass NO `override` and leave
+ * `plan_override_until` untouched — a future operator window keeps protecting
+ * the grant, and once it lapses Stripe writes flow through normally.
+ *
+ * Operator-driven writes (platform-admin / admin-orgs plan changes) pass an
+ * explicit directive:
+ *  - `{ until: Date }` — stamp the precedence window so the next Stripe webhook
+ *    skips its tier write until `until`.
+ *  - `"clear"` — release control back to Stripe immediately (NULL the column),
+ *    e.g. when an operator deliberately re-syncs an org to its Stripe state.
+ */
+export type PlanOverrideDirective = { readonly until: Date } | "clear";
+
+/**
+ * Whether a workspace's operator plan-override window is currently active
+ * (#3427) — i.e. `plan_override_until` is set and in the future. When true,
+ * the Stripe-webhook tier sync must NOT overwrite `plan_tier`. A NULL,
+ * unparseable, or past timestamp returns false (Stripe is authoritative).
+ *
+ * @param planOverrideUntil the org row's `plan_override_until` value
+ * @param now injectable clock for testing (defaults to wall-clock)
+ */
+export function isPlanOverrideActive(
+  planOverrideUntil: string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!planOverrideUntil) return false;
+  const until = new Date(planOverrideUntil);
+  if (Number.isNaN(until.getTime())) return false;
+  return until.getTime() > now.getTime();
+}
+
+/**
  * Update workspace plan tier. Returns true if the org was found and updated,
  * false if no row matched the given orgId.
+ *
+ * `override` (#3427) controls the operator precedence window. Omit it on the
+ * Stripe-webhook path (`plan_override_until` is left as-is); pass a directive on
+ * operator paths to stamp or clear the window. See {@link PlanOverrideDirective}.
  *
  * The 0-row arm logs at error level: every caller passes an orgId that is
  * supposed to exist (Stripe webhook `referenceId`, platform-admin override),
@@ -1972,11 +2023,21 @@ export async function updateWorkspaceStatus(
 export async function updateWorkspacePlanTier(
   orgId: string,
   planTier: PlanTier,
+  override?: PlanOverrideDirective,
 ): Promise<boolean> {
-  const rows = await internalQuery<{ id: string }>(
-    `UPDATE organization SET plan_tier = $1 WHERE id = $2 RETURNING id`,
-    [planTier, orgId],
-  );
+  let sqlStr: string;
+  let params: unknown[];
+  if (override === undefined) {
+    sqlStr = `UPDATE organization SET plan_tier = $1 WHERE id = $2 RETURNING id`;
+    params = [planTier, orgId];
+  } else if (override === "clear") {
+    sqlStr = `UPDATE organization SET plan_tier = $1, plan_override_until = NULL WHERE id = $2 RETURNING id`;
+    params = [planTier, orgId];
+  } else {
+    sqlStr = `UPDATE organization SET plan_tier = $1, plan_override_until = $3 WHERE id = $2 RETURNING id`;
+    params = [planTier, orgId, override.until.toISOString()];
+  }
+  const rows = await internalQuery<{ id: string }>(sqlStr, params);
   if (rows.length === 0) {
     log.error(
       { orgId, planTier },

--- a/packages/api/src/lib/db/migrations/0132_org_plan_override.sql
+++ b/packages/api/src/lib/db/migrations/0132_org_plan_override.sql
@@ -1,0 +1,38 @@
+-- 0132 — Platform-admin plan override window vs Stripe (#3427).
+--
+-- Platform admins set `plan_tier` directly (platform-admin.ts / admin-orgs.ts)
+-- with no Stripe interaction. Before this column there was no precedence rule
+-- between the two sources of truth, so an operator grant of `pro` was silently
+-- overwritten by the next Stripe webhook for that org (a stray
+-- `customer.subscription.updated`, a cancel, the reconciliation sweep, …).
+--
+-- `plan_override_until` records an OPERATOR-OWNED precedence window. When it is
+-- non-NULL and in the future, the org's `plan_tier` was set by an operator and
+-- the Stripe-webhook tier sync (`applyWorkspaceTier` in lib/auth/server.ts)
+-- skips its write rather than clobbering the grant. NULL (or an expired
+-- timestamp) means Stripe is authoritative again — the normal case.
+--
+-- Why a flag/expiry on the org rather than routing operator changes through
+-- Stripe: an operator grant is frequently a SUPPORT action with no Stripe
+-- counterpart (comp a customer, extend a trial, lock for ToS), so there is
+-- often no Stripe object to mutate. A bounded expiry also auto-heals — once it
+-- lapses, Stripe reasserts control with no operator cleanup needed.
+--
+-- This ALTERs the Better Auth `organization` table, so (like 0027/0126/0127/
+-- 0131) it joins MANAGED_AUTH_MIGRATIONS in db/internal.ts and is skipped by the
+-- runner in non-managed auth modes (where Better Auth never creates
+-- `organization`). The `organization` table is NOT a Drizzle-managed table (not
+-- in schema.ts), so there is no schema.ts mirror to update — its columns live
+-- only in raw migrations (see 0027_organization_saas_columns.sql). Additive
+-- column only (no drop), so no two-phase discipline applies.
+
+DO $$ BEGIN
+  -- Scope the existence check to the caller's search_path via to_regclass
+  -- (same rationale as 0027 / 0131 — a sibling-schema match would pass
+  -- information_schema then fail the ALTER).
+  IF to_regclass('organization') IS NULL THEN
+    RAISE EXCEPTION 'Atlas migration 0132 requires the "organization" table to exist. In managed auth mode, Better Auth migrations must run before Atlas migrations (#1472). Migration 0132 is registered in MANAGED_AUTH_MIGRATIONS so non-managed deploys skip it.';
+  END IF;
+END $$;
+
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS plan_override_until TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

Platform admins could set `plan_tier` directly (`platform-admin.ts` / `admin-orgs.ts`) with **no Stripe interaction and no precedence rule** between the two sources of truth. Three concrete bugs:

1. An operator grant of `pro` was silently overwritten by the next Stripe webhook (a stray `customer.subscription.updated` / cancel).
2. Downgrading a paying org to `free` didn't cancel their Stripe invoices — they kept being charged for entitlements the DB no longer granted.
3. Setting a tier back to `trial` reused the stale `trial_ends_at` (instantly expired), and `setWorkspaceTrialEndsAt` had **zero callers** — no way to extend a trial existed.

Closes #3427.

## Precedence model chosen — flag/expiry on the org row

I record an **operator-override window** on the organization row: `plan_override_until TIMESTAMPTZ` (migration `0132`, additive). When it is set and in the future, `applyWorkspaceTier` — the single choke point through which **every** Stripe-webhook tier write passes — **skips its write** to preserve the operator grant. The event is still recorded in the webhook ledger (it was handled, deliberately a no-op) so Stripe stops redelivering, and follow-on side effects keyed on "the org exists" still run. On a read error it **falls toward Stripe authority** (proceeds with the write) so a transient DB blip can't strand an org on a stale operator tier.

**Why flag/expiry over routing operator changes through Stripe:** an operator grant is frequently a support action with no Stripe counterpart (comp a customer, lock for ToS, extend a trial), so there's often no Stripe object to mutate. A bounded window (default 90 days, `PLAN_OVERRIDE_DAYS`) also **auto-heals** — once it lapses Stripe reasserts control with no operator cleanup needed. `overrideDays: 0` clears the window immediately (`plan_override_until = NULL`, "re-sync to Stripe").

## Changes

- **Migration `0132_org_plan_override.sql`** — adds `plan_override_until` to the Better-Auth-managed `organization` table; registered in `MANAGED_AUTH_MIGRATIONS` (skipped in non-managed auth modes), exactly like `0131`. No `schema.ts` mirror — `organization` is not a Drizzle-managed table (its columns live only in raw migrations). Additive, no drop.
- **`db/internal.ts`** — `WorkspaceRow.plan_override_until` + `getWorkspaceDetails` SELECT; `updateWorkspacePlanTier` gains an optional `PlanOverrideDirective` (`{ until }` to stamp, `"clear"` to NULL, omitted on the Stripe path to leave untouched); new pure `isPlanOverrideActive()` helper.
- **`auth/server.ts`** — `applyWorkspaceTier` honors the override window before any Stripe-driven tier write.
- **Operator plan routes** (`platform-admin.ts` + `admin-orgs.ts`) — stamp the override window on every operator plan change; **require an explicit future `trialEndsAt`** when setting `trial` (this wires up `setWorkspaceTrialEndsAt` as the **trial-extension surface**); **cancel Stripe invoices** when downgrading to `free`/`locked` (best-effort, warnings surfaced — same pattern as the existing delete/suspend teardown).
- **`reconcile-plan-tiers.ts`** — left a clear precedence marker at the #3423 heal site (deliberately **not** wired into the reconciler, to keep this PR scoped to the webhook path) so #3423 can honor the same `plan_override_until` precedence.

## Tests

- `stripe-webhook-lifecycle.test.ts`: **a `customer.subscription.updated` does NOT clobber an active operator override**; a lapsed window applies the Stripe tier normally; an override read-failure falls through to the write.
- `internal.test.ts`: `isPlanOverrideActive` truth table + `updateWorkspacePlanTier` override-directive SQL shapes.
- `admin-orgs-stripe-teardown.test.ts` / `platform-admin-stripe-teardown.test.ts`: operator-route behavior on both surfaces — override stamping (default 90d), `overrideDays:0` clears, `trial` requires `trialEndsAt`, trial extension wires `setWorkspaceTrialEndsAt`, `free` cancels Stripe, paid tiers don't.
- `migrate.test.ts` count + applied-list bumped; `admin-orgs-audit.test.ts` metadata assertion updated for the new `planOverrideUntil` key; "Mock all exports" fixups in the hand-mocked internal-DB test files.

## CI

Local `/ci` gates all green: lint, type, full test (api 611/611 + test:others), syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift, test-discipline, settings-readers, twenty-resolver, published-symbols.

Disjoint from the parallel billing sessions — did not touch `metering.ts`, `enforcement.ts`, `middleware.ts`, or web pages (#3431 / #3432 own those).

https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvYwwQbYVypockmv72WPNj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783942078&installation_id=135337507&pr_number=3481&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3481&signature=e3ee8994e945f41382d49695f45c03bd1b68bcb83a2a35dfe18f8af56119a15d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->