### PR TITLE
chore(billing): close wire-schema gaps, dedupe business limits, parse portal mutations (#3438)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -73315,13 +73315,20 @@
                             "number",
                             "null"
                           ]
+                        },
+                        "maxChatIntegrations": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
                         }
                       },
                       "required": [
                         "tokenBudgetPerSeat",
                         "totalTokenBudget",
                         "maxSeats",
-                        "maxConnections"
+                        "maxConnections",
+                        "maxChatIntegrations"
                       ]
                     },
                     "usage": {

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -223,6 +223,9 @@ describe("billing routes", () => {
       expect(body.plan.byot).toBe(false);
       expect(body.plan.pricePerSeat).toBe(29);
       expect(body.limits.tokenBudgetPerSeat).toBeGreaterThan(0);
+      // #3438 — the chat-integration cap the install gate enforces must reach
+      // the wire so the billing page can display it (Starter = 1).
+      expect(body.limits.maxChatIntegrations).toBe(1);
       expect(body.usage.queryCount).toBe(500);
       // Per-seat pricing fields
       expect(body.seats).toEqual({ count: 3, max: 10 });

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -374,6 +374,7 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         totalTokenBudget: tokenLimit,
         maxSeats: isUnlimited(limits.maxSeats) ? null : limits.maxSeats,
         maxConnections: isUnlimited(limits.maxConnections) ? null : limits.maxConnections,
+        maxChatIntegrations: isUnlimited(limits.maxChatIntegrations) ? null : limits.maxChatIntegrations,
       },
       usage: {
         queryCount: usage.queryCount,

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -221,6 +221,23 @@ describe("billing/plans", () => {
       expect(plans.map((p) => p.name)).toEqual(["starter", "pro", "business"]);
     });
 
+    it("business plan limits reference PLANS.business.limits, not hardcoded UNLIMITED (#3438)", () => {
+      // Drift trap: the business stripe-plan limits previously hardcoded
+      // seats/connections/chatIntegrations: -1 instead of reading from the
+      // canonical PLANS definition like starter/pro do. Assert they track
+      // the source of truth so a future cap change in PLANS.business can't
+      // silently diverge from what Stripe advertises.
+      process.env.STRIPE_BUSINESS_PRICE_ID = "price_biz_789";
+      const business = getStripePlans().find((p) => p.name === "business");
+      const limits = getPlanLimits("business");
+      expect(business?.limits).toEqual({
+        tokenBudgetPerSeat: limits.tokenBudgetPerSeat,
+        seats: limits.maxSeats,
+        connections: limits.maxConnections,
+        chatIntegrations: limits.maxChatIntegrations,
+      });
+    });
+
     it("sets seatPriceId === priceId on every plan (seat-only auto-managed seats, #3418)", () => {
       // seatPriceId === priceId is the plugin's "seat-only plan" shape:
       // checkout emits a single per-seat line item with quantity = member

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -316,9 +316,9 @@ export function getStripePlans(): Array<{
       annualDiscountPriceId: process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID,
       limits: {
         tokenBudgetPerSeat: PLANS.business.limits.tokenBudgetPerSeat,
-        seats: UNLIMITED,
-        connections: UNLIMITED,
-        chatIntegrations: UNLIMITED,
+        seats: PLANS.business.limits.maxSeats,
+        connections: PLANS.business.limits.maxConnections,
+        chatIntegrations: PLANS.business.limits.maxChatIntegrations,
       },
       freeTrial: { days: TRIAL_DAYS },
     });

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/schemas",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Shared Zod schemas for Atlas wire format — single source of truth for API route validation and web response parsing",
   "type": "module",
   "private": true,

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -22,6 +22,7 @@ const validStatus = {
     totalTokenBudget: 20_000_000,
     maxSeats: 10,
     maxConnections: 1,
+    maxChatIntegrations: 1,
   },
   usage: {
     queryCount: 423,
@@ -53,6 +54,7 @@ const selfHostedStatus = {
     totalTokenBudget: null,
     maxSeats: null,
     maxConnections: null,
+    maxChatIntegrations: null,
   },
   seats: { count: 1, max: null },
   connections: { count: 0, max: null },
@@ -207,6 +209,30 @@ describe("subscription visibility (#3429)", () => {
     const parsed = BillingStatusSchema.parse({ ...validStatus, subscription: legacySub });
     expect(parsed.subscription?.cancelAtPeriodEnd).toBeUndefined();
     expect(parsed.subscription?.periodEnd).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat-integration cap (#3438) — BillingLimitsSchema must carry
+// maxChatIntegrations so the billing page can display the cap the install
+// gate already enforces (PlanLimits.maxChatIntegrations).
+// ---------------------------------------------------------------------------
+
+describe("chat-integration cap (#3438)", () => {
+  test("parses a numeric maxChatIntegrations cap", () => {
+    const parsed = BillingStatusSchema.parse(validStatus);
+    expect(parsed.limits.maxChatIntegrations).toBe(1);
+  });
+
+  test("parses a null maxChatIntegrations (unlimited)", () => {
+    const parsed = BillingStatusSchema.parse(selfHostedStatus);
+    expect(parsed.limits.maxChatIntegrations).toBeNull();
+  });
+
+  test("rejects a status whose limits omit maxChatIntegrations", () => {
+    const { maxChatIntegrations: _m, ...partialLimits } = validStatus.limits;
+    const drifted = { ...validStatus, limits: partialLimits };
+    expect(BillingStatusSchema.safeParse(drifted).success).toBe(false);
   });
 });
 

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -83,6 +83,13 @@ export interface BillingLimits {
   totalTokenBudget: number | null;
   maxSeats: number | null;
   maxConnections: number | null;
+  /**
+   * Max distinct chat-pillar integrations the workspace may install (null =
+   * unlimited). Enforced server-side by `checkChatIntegrationLimitAndInstall`
+   * via `PlanLimits.maxChatIntegrations` (#2953, #3001); surfaced here so the
+   * billing page can display the cap alongside seats / connections (#3438).
+   */
+  maxChatIntegrations: number | null;
 }
 
 /** Current-period usage counters. */
@@ -199,6 +206,7 @@ export const BillingLimitsSchema = z.object({
   totalTokenBudget: z.number().nullable(),
   maxSeats: z.number().nullable(),
   maxConnections: z.number().nullable(),
+  maxChatIntegrations: z.number().nullable(),
 }) satisfies z.ZodType<BillingLimits>;
 
 export const BillingUsageSchema = z.object({

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -110,9 +110,12 @@ function tierVariant(tier: string): "default" | "secondary" | "outline" | "destr
   }
 }
 
-function overageColor(status: string): string {
+// Param is typed to the wire enum (not bare `string`) so an OverageStatus
+// member added in @useatlas/schemas surfaces here as a missing case rather
+// than silently falling through to the muted default. The dead "exceeded"
+// arm — never a member of OverageStatus — was removed in #3438.
+function overageColor(status: BillingStatus["usage"]["tokenOverageStatus"]): string {
   switch (status) {
-    case "exceeded":
     case "hard_limit":
       return "text-destructive";
     case "warning":
@@ -845,9 +848,27 @@ function UsageShell({ data }: { data: BillingStatus }) {
           label="Connections"
           value={<ResourceValue count={connections.count} max={connections.max} />}
         />
+        {/* Chat-integration cap (#3438). The wire shape carries only the cap
+            (`limits.maxChatIntegrations`), not a current count — the install
+            gate enforces it server-side — so render the limit alone rather
+            than a count/max ratio. */}
+        <DetailRow label="Chat integrations" value={<CapValue max={limits.maxChatIntegrations} />} />
       </DetailList>
     </Shell>
   );
+}
+
+/**
+ * Render a plan cap that has no current-count companion in the wire shape
+ * (e.g. chat integrations, #3438): "Unlimited" when null, otherwise the
+ * bare limit. Unlike {@link ResourceValue} there is no count/max ratio or
+ * near-limit warning — enforcement happens server-side at install time.
+ */
+function CapValue({ max }: { max: number | null }) {
+  if (max === null) {
+    return <span className="text-muted-foreground">Unlimited</span>;
+  }
+  return <span className="font-mono tabular-nums">{max}</span>;
 }
 
 function ResourceValue({ count, max }: { count: number; max: number | null }) {


### PR DESCRIPTION
P2/P3 billing maintenance batch — drift traps and pattern violations, no user-facing breakage. Closes #3438.

## Items

- [x] **1. `BillingLimitsSchema` carries `maxChatIntegrations`.** Added `maxChatIntegrations: number | null` to `BillingLimits` + `BillingLimitsSchema` (`packages/schemas/src/billing.ts`), emitted it from the billing route (`packages/api/src/api/routes/billing.ts`), and surfaced the cap on the billing page (`UsageShell`) via a new `CapValue` helper — cap-only, since the wire shape has no current count (enforcement is server-side at install time). Private `@useatlas/schemas` bumped `0.0.5 → 0.0.6`.
- [x] **2. Business limits referenced from `PLANS`, not duplicated.** `getStripePlans` business tier now reads `PLANS.business.limits.{maxSeats,maxConnections,maxChatIntegrations}` like starter/pro, instead of hardcoding `UNLIMITED`. Diff kept tight to the business-tier limits block (~318–322) — the price-ID region is untouched. A new test asserts the business stripe-plan limits track `getPlanLimits("business")`.
- [x] **3. Portal mutations — already resolved upstream.** The hand-rolled `POST /api/v1/billing/portal` route was **deleted in #3417**. Both `/admin/billing` and `/admin/usage` now open the portal through the Better Auth Stripe plugin client (`authClient.subscription.billingPortal`) via the shared `useBillingPortal` hook — there is no Atlas wire body to Zod-parse anymore (`res.data.url` is a Better Auth client type). No schema-less Atlas fetch remains on either page. No change required.
- [x] **4. Dead `"exceeded"` arm removed.** `overageColor("exceeded")` switched on a non-member of `OverageStatus`. Removed the dead arm and narrowed the param from `string` to the wire enum (`BillingStatus["usage"]["tokenOverageStatus"]`) so a future `OverageStatus` member surfaces as a missing-case compile error instead of silently hitting the muted default.
- [x] **5. Period header TZ-stable — already resolved upstream.** Both `formatBillingPeriod` (billing) and `formatPeriod` (usage) already format `utc-month` windows in UTC and Stripe windows in local time (`#3431`), so "May 31 – Jun 30" can no longer slip a boundary. No change required.

## Acceptance criteria

- [x] Wire schema carries every enforced limit; UI shows the chat-integration cap
- [x] Business limits referenced from `PLANS`, not duplicated
- [x] Portal mutations parsed with a shared Zod schema (N/A — route deleted in #3417; client-hook path has no Atlas wire body)
- [x] Dead `"exceeded"` arm removed; period header TZ-stable

## Tests

- `packages/schemas/src/__tests__/billing.test.ts` — parses numeric / null `maxChatIntegrations`, rejects when omitted.
- `packages/api/src/api/__tests__/billing.test.ts` — billing route emits the cap (Starter = 1).
- `packages/api/src/lib/billing/__tests__/plans.test.ts` — business stripe-plan limits track `PLANS.business.limits.*`.

## CI gates

Full `bun run test` (api 612 / web 211 / cli 30 / mcp 18 / ee 27 / schemas 360 — all green), `bun run lint`, `bun run type`, `bun x syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh`, `check-published-symbols.ts` — all pass.

https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783947507&installation_id=135337507&pr_number=3488&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3488&signature=b7dbb38dd3875897bbefcfeee0b3bb2d6040f2257610862eaf77ea9534f5a175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->