### PR TITLE
chore(billing): boot-time billing config validation — price IDs, key/price mode, subscription table (#3435)

### DIFF
--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -36,6 +36,7 @@ import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
 import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import { effectiveTrialEndsAt } from "@atlas/api/lib/billing/trial-expiry";
 import { getSettingLive } from "@atlas/api/lib/settings";
+import { getConfig } from "@atlas/api/lib/config";
 import { resolveModelId } from "@atlas/api/lib/providers";
 import { BillingStatusSchema } from "@useatlas/schemas";
 import { ADMIN_ROLES, type AdminRole } from "@useatlas/types/auth";
@@ -289,11 +290,39 @@ billing.openapi(getBillingStatusRoute, async (c) => {
           LIMIT 1`,
         [orgId],
       ).catch((err) => {
-        // Subscription table may not exist if Stripe plugin hasn't run migrations yet.
-        log.debug(
-          { err: err instanceof Error ? err.message : String(err), orgId },
-          "Failed to query subscription table — may not exist yet",
-        );
+        // The Better Auth `subscription` table is created by Better Auth's OWN
+        // migrator (`@better-auth/stripe`), NOT by an Atlas `db/migrations/*.sql`
+        // — so it sits OUTSIDE Atlas's migration + schema-drift discipline
+        // (`scripts/check-schema-drift.sh` never sees it, there's no `pgTable`
+        // mirror in `db/schema.ts`). On SaaS, where billing is live, a missing
+        // table is a real failure that masquerades as `subscription: null`
+        // ("not subscribed") and hides the billing portal (#3429 precedent).
+        // So: elevate a missing-table error (Postgres undefined_table, 42P01)
+        // to `log.error` on SaaS — the only place this carve-out can surface —
+        // while keeping every other case (and all of self-hosted) at debug,
+        // since self-hosted legitimately runs without the Stripe plugin's
+        // tables. See #3435.
+        const isSaas = getConfig()?.deployMode === "saas";
+        const code =
+          typeof err === "object" && err !== null && "code" in err
+            ? String((err as { code: unknown }).code)
+            : undefined;
+        const missingTable = code === "42P01";
+        const message = err instanceof Error ? err.message : String(err);
+        if (isSaas && missingTable) {
+          log.error(
+            { err: message, code, orgId, event: "billing.subscription_table_missing" },
+            "subscription table missing on SaaS — Better Auth's Stripe migrator has not run; " +
+              "the billing endpoint is reporting subscription: null (indistinguishable from " +
+              "'not subscribed') for every workspace. Run the @better-auth/stripe migrations. " +
+              "See #3435.",
+          );
+        } else {
+          log.debug(
+            { err: message, code, orgId },
+            "Failed to query subscription table — may not exist yet",
+          );
+        }
         return [] as Array<{
           stripeSubscriptionId: string;
           plan: string;

--- a/packages/api/src/lib/billing/__tests__/config-validation.test.ts
+++ b/packages/api/src/lib/billing/__tests__/config-validation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the pure billing-config validation primitives (#3435).
+ *
+ * Network-free: no Stripe SDK, no Layer DAG. The live price-resolution +
+ * livemode comparison lives in `BillingConfigGuardLive` and is exercised by
+ * `effect/__tests__/saas-guards.test.ts`.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  MONTHLY_PRICE_ID_ENV_VARS,
+  ANNUAL_PRICE_ID_ENV_VARS,
+  findMissingMonthlyPriceIdEnvVars,
+  detectStripeKeyMode,
+  isPriceModeConsistent,
+} from "@atlas/api/lib/billing/config-validation";
+
+describe("billing/config-validation", () => {
+  describe("MONTHLY_PRICE_ID_ENV_VARS", () => {
+    it("enumerates the three paid-tier monthly price vars", () => {
+      expect([...MONTHLY_PRICE_ID_ENV_VARS]).toEqual([
+        "STRIPE_STARTER_PRICE_ID",
+        "STRIPE_PRO_PRICE_ID",
+        "STRIPE_BUSINESS_PRICE_ID",
+      ]);
+    });
+
+    it("is disjoint from the annual vars", () => {
+      for (const monthly of MONTHLY_PRICE_ID_ENV_VARS) {
+        expect(ANNUAL_PRICE_ID_ENV_VARS).not.toContain(monthly);
+      }
+    });
+  });
+
+  describe("findMissingMonthlyPriceIdEnvVars", () => {
+    it("returns all three when env is empty", () => {
+      expect(findMissingMonthlyPriceIdEnvVars({})).toEqual([
+        "STRIPE_STARTER_PRICE_ID",
+        "STRIPE_PRO_PRICE_ID",
+        "STRIPE_BUSINESS_PRICE_ID",
+      ]);
+    });
+
+    it("returns empty when all three monthly vars are set", () => {
+      expect(
+        findMissingMonthlyPriceIdEnvVars({
+          STRIPE_STARTER_PRICE_ID: "price_a",
+          STRIPE_PRO_PRICE_ID: "price_b",
+          STRIPE_BUSINESS_PRICE_ID: "price_c",
+        }),
+      ).toEqual([]);
+    });
+
+    it("flags only the missing tier", () => {
+      expect(
+        findMissingMonthlyPriceIdEnvVars({
+          STRIPE_STARTER_PRICE_ID: "price_a",
+          STRIPE_BUSINESS_PRICE_ID: "price_c",
+        }),
+      ).toEqual(["STRIPE_PRO_PRICE_ID"]);
+    });
+
+    it("treats an empty string as missing", () => {
+      expect(
+        findMissingMonthlyPriceIdEnvVars({
+          STRIPE_STARTER_PRICE_ID: "",
+          STRIPE_PRO_PRICE_ID: "price_b",
+          STRIPE_BUSINESS_PRICE_ID: "price_c",
+        }),
+      ).toEqual(["STRIPE_STARTER_PRICE_ID"]);
+    });
+
+    it("does NOT require the optional annual vars", () => {
+      expect(
+        findMissingMonthlyPriceIdEnvVars({
+          STRIPE_STARTER_PRICE_ID: "price_a",
+          STRIPE_PRO_PRICE_ID: "price_b",
+          STRIPE_BUSINESS_PRICE_ID: "price_c",
+          // every annual var deliberately absent
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("detectStripeKeyMode", () => {
+    it("classifies a standard test key", () => {
+      expect(detectStripeKeyMode("sk_test_abc123")).toBe("test");
+    });
+
+    it("classifies a standard live key", () => {
+      expect(detectStripeKeyMode("sk_live_abc123")).toBe("live");
+    });
+
+    it("returns unknown for undefined / null / empty", () => {
+      expect(detectStripeKeyMode(undefined)).toBe("unknown");
+      expect(detectStripeKeyMode(null)).toBe("unknown");
+      expect(detectStripeKeyMode("")).toBe("unknown");
+    });
+
+    it("returns unknown for restricted, publishable, or typo keys", () => {
+      expect(detectStripeKeyMode("rk_live_abc")).toBe("unknown");
+      expect(detectStripeKeyMode("pk_test_abc")).toBe("unknown");
+      expect(detectStripeKeyMode("whatever")).toBe("unknown");
+    });
+  });
+
+  describe("isPriceModeConsistent", () => {
+    it("live key pairs with a livemode price", () => {
+      expect(isPriceModeConsistent("live", true)).toBe(true);
+      expect(isPriceModeConsistent("live", false)).toBe(false);
+    });
+
+    it("test key pairs with a non-livemode price", () => {
+      expect(isPriceModeConsistent("test", false)).toBe(true);
+      expect(isPriceModeConsistent("test", true)).toBe(false);
+    });
+
+    it("unknown key mode is never consistent", () => {
+      expect(isPriceModeConsistent("unknown", true)).toBe(false);
+      expect(isPriceModeConsistent("unknown", false)).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/lib/billing/config-validation.ts
+++ b/packages/api/src/lib/billing/config-validation.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure, network-free billing-config validation primitives (#3435).
+ *
+ * These back the boot-time `BillingConfigGuardLive` SaaS guard in
+ * `lib/effect/saas-guards.ts`. They are kept here — beside `plans.ts`, the
+ * single source of truth for which `STRIPE_*_PRICE_ID` env vars map to a plan
+ * tier — and free of any Stripe SDK / network dependency so they can be unit
+ * tested in isolation (no Layer DAG, no live Stripe account).
+ *
+ * Two classes of misconfig are detectable without touching Stripe and so are
+ * checked here:
+ *
+ *   1. **Missing monthly price IDs.** `getStripePlans()` (`plans.ts`) silently
+ *      omits a tier whose monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` is
+ *      unset — the plan never appears in checkout and the region looks healthy.
+ *      {@link findMissingMonthlyPriceIdEnvVars} names the absent vars.
+ *
+ *   2. **Secret-key mode.** `sk_test_…` vs `sk_live_…` is the only test/live
+ *      signal available locally — a Stripe *price* ID (`price_…`) carries no
+ *      mode in its string. {@link detectStripeKeyMode} extracts the key's mode
+ *      so the guard can (a) reject a malformed/restricted key shape at boot and
+ *      (b) hand the expected mode to the network-resolution warn-path, which
+ *      compares it against each resolved price's `livemode`.
+ *
+ * The "do these price IDs actually exist in the configured account, and does
+ * each price's `livemode` match the key mode?" check is inherently a network
+ * call and lives in the guard (a loud warn, never a boot crash — a Stripe
+ * outage must not wedge boot). It is NOT here because it isn't pure.
+ */
+
+/** Monthly price-ID env var for each paid tier — the SSOT `getStripePlans()` reads. */
+export const MONTHLY_PRICE_ID_ENV_VARS = [
+  "STRIPE_STARTER_PRICE_ID",
+  "STRIPE_PRO_PRICE_ID",
+  "STRIPE_BUSINESS_PRICE_ID",
+] as const;
+
+/** Annual (discount) price-ID env vars. Optional — absence is not a misconfig. */
+export const ANNUAL_PRICE_ID_ENV_VARS = [
+  "STRIPE_STARTER_ANNUAL_PRICE_ID",
+  "STRIPE_PRO_ANNUAL_PRICE_ID",
+  "STRIPE_BUSINESS_ANNUAL_PRICE_ID",
+] as const;
+
+export type MonthlyPriceIdEnvVar = (typeof MONTHLY_PRICE_ID_ENV_VARS)[number];
+
+/**
+ * Stripe secret-key mode, derived from the `sk_test_` / `sk_live_` prefix.
+ *
+ *   - `"test"` / `"live"` — a well-formed standard secret key.
+ *   - `"unknown"` — anything else: empty, a restricted key (`rk_…`, whose mode
+ *     isn't encoded in the prefix), a publishable key pasted by mistake
+ *     (`pk_…`), or an outright typo. The guard treats `"unknown"` as a
+ *     fail-fast boot error: a SaaS region must run on a standard secret key
+ *     whose mode we can pin against resolved prices.
+ */
+export type StripeKeyMode = "test" | "live" | "unknown";
+
+/**
+ * Return the subset of {@link MONTHLY_PRICE_ID_ENV_VARS} that are unset or
+ * empty in `env`. An empty string counts as missing — Stripe never issues an
+ * empty price ID, and `getStripePlans()` would push a plan with `priceId: ""`
+ * that 400s at checkout.
+ *
+ * Annual price IDs are intentionally excluded: they are an optional discount
+ * lever, and `getStripePlans()` passes `annualDiscountPriceId: undefined`
+ * cleanly when unset.
+ */
+export function findMissingMonthlyPriceIdEnvVars(
+  env: Record<string, string | undefined> = process.env,
+): MonthlyPriceIdEnvVar[] {
+  return MONTHLY_PRICE_ID_ENV_VARS.filter((key) => {
+    const value = env[key];
+    return value === undefined || value === "";
+  });
+}
+
+/**
+ * Classify a Stripe secret key by its mode prefix. See {@link StripeKeyMode}
+ * for the `"unknown"` semantics. The check is prefix-only and never logs or
+ * echoes the key (it is a secret — callers pass it but it never reaches a log
+ * line or error message).
+ */
+export function detectStripeKeyMode(
+  secretKey: string | undefined | null,
+): StripeKeyMode {
+  if (typeof secretKey !== "string" || secretKey.length === 0) return "unknown";
+  if (secretKey.startsWith("sk_test_")) return "test";
+  if (secretKey.startsWith("sk_live_")) return "live";
+  return "unknown";
+}
+
+/**
+ * Whether a resolved Stripe price's `livemode` is consistent with the secret
+ * key's mode. `livemode === true` ⇒ the price lives in the live account, which
+ * must pair with an `sk_live_` key; `false` ⇒ test account ⇒ `sk_test_`.
+ *
+ * Returns `false` (inconsistent) whenever `keyMode === "unknown"` — a key whose
+ * mode we can't determine can't be proven consistent with anything. Callers
+ * that reach this function have already passed the boot-time key-shape gate, so
+ * in practice `keyMode` is `"test"` or `"live"`; the `"unknown"` branch is a
+ * defensive total-function fallback.
+ */
+export function isPriceModeConsistent(
+  keyMode: StripeKeyMode,
+  priceLivemode: boolean,
+): boolean {
+  if (keyMode === "live") return priceLivemode === true;
+  if (keyMode === "test") return priceLivemode === false;
+  return false;
+}

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -255,6 +255,14 @@ export function computeTokenBudget(tier: PlanTier, seatCount: number): number {
  * member-count basis enforcement uses for token budgets. The pairing is
  * pinned by plans.test.ts — a drift would re-add a base line item on top
  * of the seat item (double billing).
+ *
+ * NOTE (#3435): each tier below is conditionally pushed only when its monthly
+ * `STRIPE_*_PRICE_ID` is set, so a missing one SILENTLY OMITS that tier from
+ * checkout. This function deliberately stays silent (it has many legitimate
+ * callers that don't want boot noise); the loud check lives at boot in
+ * `BillingConfigGuardLive` (`lib/effect/saas-guards.ts`), which fails a SaaS
+ * boot when any required monthly price ID is absent. The required-var SSOT
+ * is `MONTHLY_PRICE_ID_ENV_VARS` in `lib/billing/config-validation.ts`.
  */
 export function getStripePlans(): Array<{
   name: string;

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -889,6 +889,59 @@ describe("buildAppLayer", () => {
   // to it. Per-#1988-guard end-to-end tests would force the same
   // real-DB-URL workaround for marginal additional coverage beyond the
   // existing unit-level guard tests.
+
+  // #3435 — canary that `billingConfigGuardLayer` is actually wired into
+  // `Layer.mergeAll(...)`. Uses the PURE fail-fast path (missing monthly
+  // price ID) so it never reaches the network price-resolution branch — no
+  // Stripe SDK / mock needed. STRIPE_SECRET_KEY must be set (the guard gates
+  // on it) with at least one tier's price ID absent.
+  test("buildAppLayer wires BillingConfigGuardLive — missing price ID fails the layer in SaaS", async () => {
+    const savedDb = process.env.DATABASE_URL;
+    const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
+    const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+    const savedProvider = process.env.ATLAS_PROVIDER;
+    const savedStripeKey = process.env.STRIPE_SECRET_KEY;
+    const savedStarter = process.env.STRIPE_STARTER_PRICE_ID;
+    const savedPro = process.env.STRIPE_PRO_PRICE_ID;
+    const savedBusiness = process.env.STRIPE_BUSINESS_PRICE_ID;
+    // Satisfy the sibling SaaS guards so the cause carries exclusively the
+    // billing error.
+    process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
+    process.env.ATLAS_RATE_LIMIT_RPM = "300";
+    process.env.ATLAS_PROVIDER = "ollama"; // keyless provider
+    process.env.STRIPE_SECRET_KEY = "sk_test_wiring";
+    // All price IDs absent → fail-fast before any network call.
+    delete process.env.STRIPE_STARTER_PRICE_ID;
+    delete process.env.STRIPE_PRO_PRICE_ID;
+    delete process.env.STRIPE_BUSINESS_PRICE_ID;
+
+    try {
+      const config = { deployMode: "saas" } as Parameters<typeof buildAppLayer>[0];
+      const layer = buildAppLayer(config);
+
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(Effect.provide(layer)),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const text = String(Exit.isFailure(exit) ? exit.cause : "");
+      expect(text).toContain("BillingConfigInvalidError");
+    } finally {
+      const restore = (key: string, val: string | undefined) => {
+        if (val !== undefined) process.env[key] = val;
+        else delete process.env[key];
+      };
+      restore("DATABASE_URL", savedDb);
+      restore("ATLAS_ENCRYPTION_KEYS", savedKeys);
+      restore("ATLAS_RATE_LIMIT_RPM", savedRpm);
+      restore("ATLAS_PROVIDER", savedProvider);
+      restore("STRIPE_SECRET_KEY", savedStripeKey);
+      restore("STRIPE_STARTER_PRICE_ID", savedStarter);
+      restore("STRIPE_PRO_PRICE_ID", savedPro);
+      restore("STRIPE_BUSINESS_PRICE_ID", savedBusiness);
+    }
+  });
 });
 
 // ── ImplementationStatusOverrideLive (#2747 — 1.5.3 slice 9) ──────────

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -71,7 +71,33 @@ import type {
   ProviderUnsupportedError as TProviderUnsupportedError,
   RegionMisconfiguredError as TRegionMisconfiguredError,
   ChatAdapterEnvMissingError as TChatAdapterEnvMissingError,
+  BillingConfigInvalidError as TBillingConfigInvalidError,
 } from "../saas-guards";
+
+// ── Stripe client mock for BillingConfigGuardLive (#3435) ────────────
+// The guard lazy-imports `getStripeClient()` and calls `prices.retrieve`.
+// Drive both from these module-level controls so no test touches a real
+// Stripe account. `mockStripePrices` maps priceId → { livemode } (a
+// resolvable price); any priceId absent from the map throws "No such
+// price" (the unresolved path). `mockStripeClientNull` forces
+// getStripeClient() → null. Reset in each test's setup.
+let mockStripePrices: Record<string, { livemode: boolean }> = {};
+let mockStripeClientNull = false;
+mock.module("@atlas/api/lib/billing/stripe-client", () => ({
+  getStripeClient: () =>
+    mockStripeClientNull
+      ? null
+      : {
+          prices: {
+            retrieve: async (id: string) => {
+              const price = mockStripePrices[id];
+              if (!price) throw new Error(`No such price: '${id}'`);
+              return { id, livemode: price.livemode };
+            },
+          },
+        },
+  _resetStripeClientCache: () => {},
+}));
 
 const {
   EnterpriseGuardLive,
@@ -91,6 +117,8 @@ const {
   RegionMisconfiguredError,
   ChatAdapterEnvGuardLive,
   ChatAdapterEnvMissingError,
+  BillingConfigGuardLive,
+  BillingConfigInvalidError,
 } = await import("../saas-guards");
 const { Config, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
@@ -1502,5 +1530,184 @@ describe("ChatAdapterEnvGuardLive", () => {
       );
       expect(Exit.isSuccess(exit)).toBe(true);
     });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  BillingConfigGuardLive (#3435)
+// ══════════════════════════════════════════════════════════════════════
+
+// STRIPE_SECRET_KEY + the price-ID env vars are NOT in SAAS_ENV_KEYS (they
+// gate the conditional billing mount, not the SaaS boot contract), so
+// `withCleanEnv` doesn't manage them. Save/clear/restore them here.
+const BILLING_ENV_KEYS = [
+  "STRIPE_SECRET_KEY",
+  "STRIPE_STARTER_PRICE_ID",
+  "STRIPE_PRO_PRICE_ID",
+  "STRIPE_BUSINESS_PRICE_ID",
+  "STRIPE_STARTER_ANNUAL_PRICE_ID",
+  "STRIPE_PRO_ANNUAL_PRICE_ID",
+  "STRIPE_BUSINESS_ANNUAL_PRICE_ID",
+] as const;
+
+function withBillingEnv<T>(
+  vars: Partial<Record<(typeof BILLING_ENV_KEYS)[number], string>>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of BILLING_ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  mockStripePrices = {};
+  mockStripeClientNull = false;
+  for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+  return run().finally(() => {
+    for (const key of BILLING_ENV_KEYS) {
+      if (saved[key] !== undefined) process.env[key] = saved[key];
+      else delete process.env[key];
+    }
+  });
+}
+
+function runBillingGuard(deployMode: string) {
+  return Effect.runPromiseExit(
+    Effect.void.pipe(
+      Effect.provide(
+        BillingConfigGuardLive.pipe(
+          Layer.provide(makeTestConfigLayer({ deployMode })),
+        ),
+      ),
+    ),
+  );
+}
+
+describe("BillingConfigGuardLive", () => {
+  const ALL_PRICES = {
+    STRIPE_STARTER_PRICE_ID: "price_starter",
+    STRIPE_PRO_PRICE_ID: "price_pro",
+    STRIPE_BUSINESS_PRICE_ID: "price_business",
+  };
+
+  test("self-hosted is inert even with a broken billing config", async () => {
+    await withBillingEnv({ STRIPE_SECRET_KEY: "rk_broken" }, async () => {
+      const exit = await runBillingGuard("self-hosted");
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("SaaS without STRIPE_SECRET_KEY boots silently (pre-billing)", async () => {
+    await withBillingEnv({}, async () => {
+      const exit = await runBillingGuard("saas");
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("fails boot in SaaS when a monthly price ID is missing", async () => {
+    await withBillingEnv(
+      {
+        STRIPE_SECRET_KEY: "sk_test_abc",
+        STRIPE_STARTER_PRICE_ID: "price_starter",
+        STRIPE_BUSINESS_PRICE_ID: "price_business",
+        // STRIPE_PRO_PRICE_ID deliberately absent
+      },
+      async () => {
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(BillingConfigInvalidError);
+        const e = failure as TBillingConfigInvalidError;
+        expect(e._tag).toBe("BillingConfigInvalidError");
+        expect(e.missingPriceIdEnvVars).toEqual(["STRIPE_PRO_PRICE_ID"]);
+        expect(e.keyMode).toBe("test");
+        expect(e.message).toContain("#3435");
+      },
+    );
+  });
+
+  test("fails boot in SaaS on a non-standard secret-key mode", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "rk_live_restricted", ...ALL_PRICES },
+      async () => {
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(BillingConfigInvalidError);
+        const e = failure as TBillingConfigInvalidError;
+        expect(e.keyMode).toBe("unknown");
+        expect(e.missingPriceIdEnvVars).toEqual([]);
+      },
+    );
+  });
+
+  test("never leaks the secret key on the error", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_super_secret_value", STRIPE_STARTER_PRICE_ID: "price_x" },
+      async () => {
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        const e = failure as TBillingConfigInvalidError;
+        expect(e.message).not.toContain("sk_test_super_secret_value");
+      },
+    );
+  });
+
+  test("boots (warn-only) when all prices resolve consistently with the key mode", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      async () => {
+        // All three prices are test-mode (livemode false) — consistent with sk_test_.
+        mockStripePrices = {
+          price_starter: { livemode: false },
+          price_pro: { livemode: false },
+          price_business: { livemode: false },
+        };
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isSuccess(exit)).toBe(true);
+      },
+    );
+  });
+
+  test("does NOT fail boot when a configured price can't be resolved (warn, not crash)", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      async () => {
+        // price_pro absent from the mock → "No such price" → unresolved warn path.
+        mockStripePrices = {
+          price_starter: { livemode: false },
+          price_business: { livemode: false },
+        };
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isSuccess(exit)).toBe(true);
+      },
+    );
+  });
+
+  test("does NOT fail boot on a livemode↔key-mode mismatch (warn, not crash)", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      async () => {
+        // A live-mode price configured under a test key — the classic mixup.
+        mockStripePrices = {
+          price_starter: { livemode: true },
+          price_pro: { livemode: false },
+          price_business: { livemode: false },
+        };
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isSuccess(exit)).toBe(true);
+      },
+    );
+  });
+
+  test("does NOT fail boot when getStripeClient() returns null", async () => {
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      async () => {
+        mockStripeClientNull = true;
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isSuccess(exit)).toBe(true);
+      },
+    );
   });
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -56,6 +56,7 @@ import {
   RegionGuardLive,
   PluginConfigGuardLive,
   ChatAdapterEnvGuardLive,
+  BillingConfigGuardLive,
   MigrationsRequiredError,
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
@@ -2944,6 +2945,14 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // only on `Config` and reads env directly, so it runs in parallel with
   // the migration + sync layers alongside the other env-checking guards.
   const chatAdapterEnvGuardLayer = ChatAdapterEnvGuardLive.pipe(Layer.provide(configLayer));
+  // #3435 — billing config validation. Gated on `deployMode === "saas"` AND
+  // `STRIPE_SECRET_KEY` present, so self-hosted and pre-billing SaaS are inert.
+  // Fails boot on the two pure misconfigs (missing monthly price ID, non-standard
+  // key mode) and loudly warns (never crashes) on the network price-resolution /
+  // livemode-mismatch check. `Config`-only; lazy-imports the Stripe SDK + the
+  // config-validation SSOT inside its Effect body so it runs as an env-checking
+  // peer of the migration + sync layers.
+  const billingConfigGuardLayer = BillingConfigGuardLive.pipe(Layer.provide(configLayer));
   // #1988 C7 + C8 — region routing claim and stale plugin config checks.
   // Both depend only on `Config`. PluginConfigGuardLive lazy-imports the
   // plugin registry + InternalDB inside its Effect body so it can run as
@@ -2988,6 +2997,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     regionGuardLayer,
     pluginConfigGuardLayer,
     chatAdapterEnvGuardLayer,
+    billingConfigGuardLayer,
     migrationGuardLayer,
     EnterpriseLayer,
   );

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -97,6 +97,7 @@ const RATE_LIMIT_ISSUE_REF = "#1983";
 const ISSUE_REF_1988 = "#1988";
 const CHAT_ADAPTER_ISSUE_REF = "#2672";
 const PROVIDER_KEY_ISSUE_REF = "#3178";
+const BILLING_CONFIG_ISSUE_REF = "#3435";
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Tagged errors
@@ -326,6 +327,32 @@ export class ChatAdapterEnvMissingError extends Data.TaggedError("ChatAdapterEnv
 export class MigrationsRequiredError extends Data.TaggedError("MigrationsRequiredError")<{
   readonly message: string;
   readonly cause?: string;
+}> {}
+
+/**
+ * SaaS region booted with `STRIPE_SECRET_KEY` set but one or more paid-tier
+ * monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` env vars unset/empty, OR a
+ * secret key whose mode prefix isn't a standard `sk_test_` / `sk_live_`
+ * (#3435). Both are pure, network-free misconfigs caught at boot:
+ *
+ *   - A missing monthly price ID silently omits that tier from
+ *     `getStripePlans()` — the plan never appears in checkout, the region looks
+ *     healthy, and a customer who wanted that tier simply can't buy it.
+ *   - A non-standard key shape (`rk_…` restricted, `pk_…` publishable paste, a
+ *     typo) means we can't pin the test/live mode the price-resolution warn
+ *     path compares against, and a restricted key may lack `prices.retrieve`
+ *     scope outright.
+ *
+ * `missingPriceIdEnvVars` lists the absent monthly vars (empty when the failure
+ * is solely the key shape) and `keyMode` carries the detected mode so the
+ * boot-failure log is operator-actionable without re-parsing `message`. The key
+ * itself is NEVER placed on the error or in the message — only its mode
+ * classification. Self-hosted, and SaaS-without-Stripe, never construct this.
+ */
+export class BillingConfigInvalidError extends Data.TaggedError("BillingConfigInvalidError")<{
+  readonly message: string;
+  readonly missingPriceIdEnvVars: readonly string[];
+  readonly keyMode: "test" | "live" | "unknown";
 }> {}
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1076,6 +1103,198 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
           }),
         );
       }
+    }
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  BillingConfigGuardLive (#3435)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Fail boot in SaaS when Stripe billing is configured (`STRIPE_SECRET_KEY`
+ * set) but the price-ID / key-mode config is internally inconsistent — and
+ * loudly WARN (never crash) when the configured price IDs can't be resolved in
+ * the live Stripe account, or a resolved price's `livemode` doesn't match the
+ * key mode.
+ *
+ * Three ways a misconfigured prod looked healthy before this guard (#3435):
+ *
+ *   1. A missing monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` silently
+ *      omits that plan from `getStripePlans()` — no warning, the tier just
+ *      vanishes from checkout.
+ *   2. A test-mode price ID configured against a live key (or vice-versa)
+ *      produces valid-signature webhooks whose plan sync silently no-ops
+ *      (`resolvePlanTierFromPriceId` returns null in `auth/server.ts`).
+ *   3. (Companion fix, not here) `GET /api/v1/billing` reporting a missing
+ *      `subscription` table as `subscription: null` — addressed in `billing.ts`.
+ *
+ * **warn vs fail-fast decision (#3435).** Two pure, network-free checks
+ * FAIL-FAST (CLAUDE.md "prefer errors over silent fallbacks"):
+ *   - any missing monthly price ID, and
+ *   - a secret key whose mode prefix isn't a standard `sk_test_` / `sk_live_`.
+ * The "do these price IDs exist in the account, and does each price's
+ * `livemode` match the key mode?" check is a network call, so it is a loud
+ * `log.error` (with a per-price breakdown) but NEVER fails boot — a transient
+ * Stripe outage or rate-limit at deploy time must not wedge a region. The
+ * mismatch it detects is still operator-actionable from the log, and the
+ * webhook-sync no-op it guards against is itself retryable.
+ *
+ * Gate: `deployMode === "saas"` AND `STRIPE_SECRET_KEY` present. Self-hosted is
+ * untouched (no Stripe), and a SaaS region that hasn't turned on billing yet
+ * (no `STRIPE_SECRET_KEY`) boots silently — matching the existing conditional
+ * mount of the billing routes and the `@better-auth/stripe` plugin.
+ *
+ * The Stripe SDK + `config-validation` SSOT are lazy-imported (same wall-off
+ * pattern as `EncryptionKeyGuardLive`) so this module stays free of the `stripe`
+ * static graph. The network resolution is wrapped so an SDK/import rejection
+ * becomes a warn, not a boot-killing defect.
+ */
+export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidError, Config> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+
+    // Gate on Stripe being configured at all. A SaaS region can legitimately
+    // run pre-billing (no STRIPE_SECRET_KEY) — the billing routes and the
+    // Stripe auth plugin are themselves conditionally mounted on this var.
+    const secretKey = process.env.STRIPE_SECRET_KEY;
+    if (!secretKey) return;
+
+    const {
+      findMissingMonthlyPriceIdEnvVars,
+      detectStripeKeyMode,
+      isPriceModeConsistent,
+      MONTHLY_PRICE_ID_ENV_VARS,
+      ANNUAL_PRICE_ID_ENV_VARS,
+    } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/billing/config-validation"),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.orDie);
+
+    // ── Pure check 1: monthly price-ID presence (fail-fast) ──────────────
+    const missingPriceIdEnvVars = findMissingMonthlyPriceIdEnvVars();
+    const keyMode = detectStripeKeyMode(secretKey);
+
+    // ── Pure check 2: secret-key mode shape (fail-fast) ──────────────────
+    // Collected with the price-ID result so a region missing both gets one
+    // boot-failure log naming both, rather than fixing one then re-failing.
+    if (missingPriceIdEnvVars.length > 0 || keyMode === "unknown") {
+      const parts: string[] = [];
+      if (missingPriceIdEnvVars.length > 0) {
+        parts.push(
+          `missing required monthly price ID env var(s): [${missingPriceIdEnvVars.join(", ")}] — ` +
+            `getStripePlans() silently omits each absent tier from checkout`,
+        );
+      }
+      if (keyMode === "unknown") {
+        parts.push(
+          `STRIPE_SECRET_KEY is not a standard secret key (expected an sk_test_… or sk_live_… ` +
+            `prefix) — restricted (rk_…) or publishable (pk_…) keys can't be mode-checked against ` +
+            `the configured prices and may lack prices.retrieve scope`,
+        );
+      }
+      return yield* Effect.fail(
+        new BillingConfigInvalidError({
+          missingPriceIdEnvVars,
+          keyMode,
+          message:
+            `SaaS region booted with STRIPE_SECRET_KEY set but the billing config is invalid: ` +
+            `${parts.join("; ")}. Fix the env var(s) on every region's api service before booting. ` +
+            `See ${BILLING_CONFIG_ISSUE_REF}.`,
+        }),
+      );
+    }
+
+    // ── Network check: price existence + livemode↔key-mode (loud WARN) ───
+    // A transient Stripe error here must NOT crash boot, so everything below
+    // resolves to a logged warning. We resolve every CONFIGURED price ID
+    // (monthly — guaranteed present by the fail-fast above — plus any annual
+    // vars the operator set) and check each price's livemode against keyMode.
+    const configuredPriceVars = [
+      ...MONTHLY_PRICE_ID_ENV_VARS,
+      ...ANNUAL_PRICE_ID_ENV_VARS,
+    ]
+      .map((envVar): { envVar: string; priceId: string | undefined } => ({
+        envVar,
+        priceId: process.env[envVar],
+      }))
+      .filter((p): p is { envVar: string; priceId: string } => Boolean(p.priceId));
+
+    const resolution = yield* Effect.promise(
+      async (): Promise<
+        | { ok: true; mismatches: string[]; unresolved: string[] }
+        | { ok: false; error: string }
+      > => {
+        try {
+          const { getStripeClient } = await import(
+            "@atlas/api/lib/billing/stripe-client"
+          );
+          const stripe = getStripeClient();
+          // Unreachable: STRIPE_SECRET_KEY was non-empty above. Guard anyway so
+          // a future refactor of getStripeClient() can't turn this into a throw.
+          if (!stripe) return { ok: true, mismatches: [], unresolved: [] };
+
+          const mismatches: string[] = [];
+          const unresolved: string[] = [];
+          for (const { envVar, priceId } of configuredPriceVars) {
+            try {
+              const price = await stripe.prices.retrieve(priceId);
+              if (!isPriceModeConsistent(keyMode, price.livemode)) {
+                mismatches.push(
+                  `${envVar} (${priceId}) is livemode=${price.livemode} but the key is ${keyMode}-mode`,
+                );
+              }
+            } catch (priceErr) {
+              // Most commonly a "No such price" — the price doesn't exist in
+              // THIS account/mode (the classic test-price-in-prod mixup).
+              unresolved.push(
+                `${envVar} (${priceId}): ${priceErr instanceof Error ? priceErr.message : String(priceErr)}`,
+              );
+            }
+          }
+          return { ok: true, mismatches, unresolved };
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+      },
+    );
+
+    if (!resolution.ok) {
+      log.error(
+        { err: new Error(resolution.error), event: "billing_config.resolution_failed" },
+        `Could not verify Stripe price IDs against the configured account at boot ` +
+          `(network/SDK error) — proceeding, but a test/live price mixup would stay undetected ` +
+          `until a checkout no-ops. See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
+      return;
+    }
+
+    if (resolution.unresolved.length > 0) {
+      log.error(
+        {
+          unresolved: resolution.unresolved,
+          keyMode,
+          event: "billing_config.price_unresolved",
+        },
+        `One or more configured Stripe price IDs do not exist in the ${keyMode}-mode account — ` +
+          `a webhook carrying one of these prices would pass signature verification then no-op the ` +
+          `plan sync (resolvePlanTierFromPriceId → null). This is the classic test-price-in-prod ` +
+          `mixup. Fix the STRIPE_*_PRICE_ID values for the ${keyMode} account. See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
+    }
+
+    if (resolution.mismatches.length > 0) {
+      log.error(
+        {
+          mismatches: resolution.mismatches,
+          keyMode,
+          event: "billing_config.mode_mismatch",
+        },
+        `One or more configured Stripe prices resolved with a livemode inconsistent with the ` +
+          `secret key's ${keyMode} mode — checkout / webhook plan sync will silently no-op for the ` +
+          `affected tier(s). See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
     }
   }),
 );


### PR DESCRIPTION
Adds a `BillingConfigGuardLive` to the SaaS boot-guard family (`lib/effect/saas-guards.ts`) closing the three "misconfigured prod looks healthy" gaps from #3435, plus a new pure validation module and a `subscription`-table carve-out fix.

## warn vs fail-fast decision

The guard is gated on `deployMode === "saas"` **AND** `STRIPE_SECRET_KEY` present — so self-hosted, and a SaaS region that hasn't turned on billing yet, boot exactly as before (no new noise, no crash).

Within that gate I split by check class, per CLAUDE.md "prefer errors over silent fallbacks":

- **Fail-fast (pure, network-free):**
  - any missing monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` (each silently omits its tier from `getStripePlans()` / checkout), and
  - a secret key whose mode prefix isn't a standard `sk_test_…` / `sk_live_…` (a restricted `rk_…` / publishable `pk_…` / typo key can't be mode-checked and may lack `prices.retrieve` scope).

  These are local, deterministic misconfigs — boot fails with a tagged `BillingConfigInvalidError`.

- **Loud warn, never crash (network):** resolving each configured price ID against the live Stripe account and checking each price's `livemode` against the key mode. A Stripe outage / rate-limit at deploy time **must not** wedge a region, so an unresolved price (the classic test-price-in-prod mixup → valid-signature webhook that no-ops the plan sync) or a livemode↔key mismatch is logged at `log.error` (with a per-price breakdown), not a boot failure. The mismatch stays operator-actionable from the log, and the sync no-op it guards against is itself retryable.

The Stripe key is **never** placed on the error or in any log/message — only its `test`/`live`/`unknown` classification.

## Acceptance criteria

- [x] SaaS boot validates: all expected (monthly) price IDs present, resolvable in Stripe, key/price mode consistent — fail-fast on the two pure checks, loud warn on the network check (decision above)
- [x] Missing `subscription` table logs at `error` level on SaaS — `billing.ts` now elevates a Postgres `42P01` (undefined_table) to `log.error` only when `deployMode === "saas"`; every other case (and all of self-hosted) stays at `debug`. The Better-Auth-migrator carve-out is documented inline (the table is outside Atlas migration / schema-drift discipline).
- [x] Self-hosted (no Stripe / no `STRIPE_SECRET_KEY`) boots silently — guard returns early; no crash, no new logs

## Files changed

- `lib/billing/config-validation.ts` (new) — pure, network-free SSOT: `MONTHLY_PRICE_ID_ENV_VARS`, `findMissingMonthlyPriceIdEnvVars`, `detectStripeKeyMode`, `isPriceModeConsistent`
- `lib/effect/saas-guards.ts` — `BillingConfigInvalidError` tagged error + `BillingConfigGuardLive`
- `lib/effect/layers.ts` — wires `billingConfigGuardLayer` into `buildAppLayer`'s `mergeAll`
- `api/routes/billing.ts` — SaaS-gated `log.error` for the missing `subscription` table + carve-out doc
- `lib/billing/plans.ts` — docstring note on `getStripePlans`' silent-omission, pointing at the guard (kept clear of the BUSINESS-limits block #3438 edits)
- tests: `config-validation.test.ts` (14), `saas-guards.test.ts` (+8 incl. secret-key non-leak), `layers.test.ts` (+1 `buildAppLayer` wiring canary)

## CI

`lint`, `type`, `syncpack lint`, template-drift, railway-watch all green. OpenAPI-drift gate run — logging-only change produced **no** `apps/docs` drift. Affected isolated test runner: 39/39 files pass.

Closes #3435

https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783948581&installation_id=135337507&pr_number=3489&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3489&signature=f9f560e45d914a495b95168d523b9e65865cfca434cc71fb35ea796e03194f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stripe billing configuration validation during app startup in SaaS deployment mode
  * Enhanced error detection for missing or misconfigured billing settings

* **Bug Fixes**
  * Improved error logging for missing Better Auth Stripe migrations

* **Tests**
  * Added billing configuration validation test suite
  * Added SaaS boot integration tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->