### PR TITLE
docs(mcp): MCP V2 planning — agent-governance glossary + ADR-0015/0016

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,3 +190,6 @@ The MCP server runs the same agent tools as the chat app, so the same governance
 
 - **MCP admin tool** — an MCP tool that *configures* Atlas (creates a Datasource, connects an integration, raises a policy) rather than reading data — as opposed to the read-only query tools (`executeSQL`, `explore`, the semantic-layer tools).
   _Avoid_: "configuration surface" (bare "surface" is the pillar admin page).
+
+- **MCP action policy** — the per-workspace, customer-admin allow/deny over MCP action *categories* (e.g. "no datasource creation via MCP at all"). Evaluated first in the dispatch gate order and short-circuits before scope / RBAC / approval. Distinct from the **origin ceiling** — the non-configurable product invariant that MCP may never *lower* governance (disable RLS, the table whitelist, an approval rule, etc.). See [ADR-0016](./docs/adr/0016-mcp-v2-security-model.md).
+  _Avoid_: conflating it with the origin ceiling — the action policy is customer-configurable; the ceiling is not.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,3 +177,16 @@ The semantic layer (entity YAMLs, glossary, metrics) describes the schema of a *
 ### Flagged ambiguities
 
 - "source" / `connection:` / `--source` — historically the entity-group scope wore three different names: the YAML `connection:` field, the CLI `--source` flag, and the admin/API `source` (computed as the group id, defaulting to `"default"`). All three denote the **Connection group**. Canonical surface term: **group**; the aliases are deprecated and being unified.
+
+## MCP & agent governance
+
+The MCP server runs the same agent tools as the chat app, so the same governance (RBAC, approval rules, audit) must apply. These terms pin *who* is acting and *through what channel*.
+
+- **MCP actor** — the identity an MCP request is attributed to and authorized as. Three kinds: *governed* (bound to a real user + org via `ATLAS_MCP_USER_ID` / `ATLAS_MCP_ORG_ID`), *trusted* (synthetic `system:mcp`, carrying no real identity), and *hosted* (resolved per OAuth bearer).
+  _Avoid_: "MCP user" (the trusted actor is not a user).
+
+- **Agent origin** — the invocation channel a query or mutation reached the agent through: `chat` / `mcp` / `scheduler` / `slack`. Approval rules match on it and the audit log records it. See [ADR-0015](./docs/adr/0015-agent-origin-not-surface.md).
+  _Avoid_: "approval surface" and bare "surface" (reserved for the pillar admin page); "source" (a deprecated alias for Connection group).
+
+- **MCP admin tool** — an MCP tool that *configures* Atlas (creates a Datasource, connects an integration, raises a policy) rather than reading data — as opposed to the read-only query tools (`executeSQL`, `explore`, the semantic-layer tools).
+  _Avoid_: "configuration surface" (bare "surface" is the pillar admin page).

--- a/docs/adr/0015-agent-origin-not-surface.md
+++ b/docs/adr/0015-agent-origin-not-surface.md
@@ -1,0 +1,5 @@
+# Agent invocation origin is named "origin", not "surface"
+
+The channel an agent query/mutation arrives through — `chat` / `mcp` / `scheduler` / `slack`, which approval rules match on and the audit log records — was historically called the "approval surface" (`approvalSurface` in code, the `surface` column on `approval_rules` / `approval_queue`, migrations 0049/0052). But "surface" is already the canonical glossary term for a pillar's user-facing admin page ("one surface per pillar"), so the two collided in prose and would have collided harder once MCP added config tools ("configuration surface"). We renamed the invocation-channel concept to **agent origin** (`origin` column, `agentOrigin` in code) and reserved "surface" for the pillar page.
+
+Done as a one-shot breaking rename during the pre-customer clean-break window (see CONTEXT.md "Deployment posture") — no expand-contract migration needed. "channel" and "source" were rejected as themselves overloaded (Slack/proactive channels; "source" is the deprecated alias for Connection group being unified away).

--- a/docs/adr/0016-mcp-v2-security-model.md
+++ b/docs/adr/0016-mcp-v2-security-model.md
@@ -1,0 +1,38 @@
+# MCP V2 security model: RBAC-gated, origin-ceilinged, customer-governed config tools
+
+MCP V2 lets an authorized agent *configure* Atlas (provision datasources, connect integrations, raise governance), not just query it. Allowing config mutations over an autonomous, prompt-injectable channel demanded an explicit, layered authorization model rather than extending V1's read-only assumptions. Decided in the grill of PRD #3483.
+
+## Decision — the dispatch gate order
+
+Every MCP tool dispatch passes a fixed gate order; a mutation must clear all of them:
+
+1. **MCP action policy** (per-workspace kill-switch) — a customer admin can disable whole MCP action *categories* for their workspace from the dashboard; blocked categories short-circuit before anything else runs.
+2. **`mcp:write` scope** (hosted only) — carried on the OAuth bearer, granted at consent. stdio has no third-party client, so no scope term applies there.
+3. **RBAC role** — authority is the bound **MCP actor**'s role, resolved by a **live DB lookup at bearer-verify time** (mirroring the existing `member` / `oauth_client_workspace_grants` pattern), never from a token claim — so demotion/revocation takes effect immediately, not on token refresh.
+4. **Approval flow** — destructive actions route through Atlas's existing approval gate, keyed on `origin=mcp`. The approval *policy* is a per-workspace customer-admin decision (default: approval required), never an operator one.
+5. **Inline confirm** — the `destructiveHint` annotation (advisory, client-rendered) plus an elicitation confirm.
+
+## Two hard invariants above the configurable layers
+
+- **Origin ceiling (product invariant, configurable by no one):** MCP may *provision* resources and *raise* governance, but may **never lower** it — no tool that disables RLS, the table whitelist, an approval rule, PII masking, audit retention, plan tier, etc. exists for `origin=mcp`. "Lower" = disarming a control; "provision/raise" = adding a resource or tightening a control. Enforced **structurally** (the tool doesn't exist), so there is no hidden approval layer that can act without an RBAC identity.
+- **RBAC is the only source of authority.** Authority is never a property of the transport. The stdio **trusted** actor (`system:mcp`, no identity) is therefore permanently admin-incapable; admin tools always register but only a real bound admin identity can clear gate 3.
+
+## Credentials and plugin tools
+
+Credentials are supplied via **masked form-mode elicitation** — elicitation responses travel client→server and never enter the agent/LLM context, which is the actual goal (keep the secret out of context), achieved without a per-credential URL round-trip. **URL-mode elicitation is reserved as a future step-up ("super approval") re-auth** for the highest-risk actions (maps to incremental scope consent, SEP-835). Plugin-contributed MCP tools are **first-class** under this model: a mutating plugin tool obeys the same gate order and carries `origin=mcp`.
+
+## SaaS-first principle
+
+Gate capability through runtime, per-identity / per-action mechanisms (scope, RBAC, DB-backed workspace policy) — never operator-only env vars or `atlas.config.ts`. The `ATLAS_DEPLOY_MODE` flag (SaaS-vs-self-host *infrastructure*) is fine; gating a *capability decision* behind env is the self-host-shape-into-SaaS leak that CONTEXT.md's "The seam" warns against. Design SaaS-first and self-host inherits it (it drops the third-party scope term, keeps RBAC + approval). The destructive-action decision belongs to the **customer admin**, not the operator.
+
+## Foundation
+
+Atlas already runs Better Auth's `@better-auth/oauth-provider` — the path Better Auth now recommends (its standalone `mcp` plugin is deprecated) — and `mcp:write` is already a declared scope, so V2 *flips an existing gate* rather than adding auth infrastructure. Verification stays on JWKS-based `verifyMcpBearer` (topology-independent, revocation-immediate via the grants table), not `withMcpAuth` (same-process only).
+
+## Considered and rejected
+
+- **Authority from the transport** (hosted-can-admin / stdio-cannot) — rejected; authority is RBAC, full stop.
+- **Operator env flag to enable admin tools** (`ATLAS_MCP_ADMIN_TOOLS`) — rejected as a SaaS-seam leak; admin tools always register and are gated at dispatch.
+- **Role stamped into the JWT** — rejected; goes stale until refresh. Live DB lookup instead.
+- **Loopback HTTP proxy to the admin REST API** — rejected; credential-laundering surface + token-audience mismatch. Call the lib layer directly.
+- **URL-mode elicitation for every credential** — rejected as a UX anti-pattern; masked form-mode keeps secrets out of the agent context without the round-trip. URL-mode survives only as future step-up.


### PR DESCRIPTION
Planning artifacts from the MCP V2 ("Prime-Time MCP Server") review + grill. **Docs only** — no code changes.

## What's here
- **CONTEXT.md** — new *MCP & agent governance* glossary section: **MCP actor**, **Agent origin**, **MCP admin tool**, **MCP action policy**.
- **ADR-0015** — rename the agent-invocation-channel concept `surface` → **origin**, freeing "surface" for the pillar admin page (one-shot, pre-customer clean-break).
- **ADR-0016** — the MCP V2 security model: the dispatch gate order (action-policy → `mcp:write` → RBAC-via-live-DB-lookup → approval → confirm), the non-configurable **origin ceiling** (MCP may raise but never lower governance), the customer-owned MCP action policy, the SaaS-first principle, and credentials via masked form-mode elicitation.

## Why
These lock the decisions that PRD #3483 and its 24 implementation issues (#3491–#3514) reference. Merging puts the ADRs/glossary on `main` so those cross-links resolve and the implementation slices have a stable source of truth.

## Risk
Documentation only; no runtime, schema, or API changes.

Refs #3483.

https://claude.ai/code/session_01Ksr9Ff4V4VRpQRAbZdphtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksr9Ff4V4VRpQRAbZdphtK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955145&installation_id=135337507&pr_number=3516&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3516&signature=5208cbb3404e7b8abc20b6f679268dc7ce1f02d4eb1e3a052c8f44613eef00ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added glossary definitions clarifying MCP governance frameworks, agent origin taxonomy, and MCP action policy specifications
  * Documented agent origin terminology standardization and MCP V2 security model architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->