### PR TITLE
docs(billing): describe the real token hard-cap; stop advertising unimplemented metered overage (#3422)

### DIFF
--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -1,12 +1,12 @@
 ---
 title: Billing & Plans
-description: Per-seat pricing tiers, query budgets, overage handling, Stripe setup, and the billing dashboard.
+description: Per-seat pricing tiers, token budgets, the warn → grace → pause hard cap, Stripe setup, and the billing dashboard.
 icon: CreditCard
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Atlas uses per-seat billing. On [app.useatlas.dev](https://app.useatlas.dev), the first workspace you create starts with a 14-day trial (one trial per user), then requires a paid plan; additional workspaces you create start locked until they're subscribed. Self-hosted deployments are free with no enforcement. Billing includes automatic usage metering, per-seat query budgets, and graceful overage handling.
+Atlas uses per-seat billing. On [app.useatlas.dev](https://app.useatlas.dev), the first workspace you create starts with a 14-day trial (one trial per user), then requires a paid plan; additional workspaces you create start locked until they're subscribed. Self-hosted deployments are free with no enforcement. Billing includes automatic usage metering, per-seat token budgets, and a graceful warn → grace → pause hard cap (there is no metered pay-as-you-go overage charge).
 
 <Callout type="info" title="SaaS">
 On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View your usage, manage your plan, and update payment methods from **Admin > Billing** — no Stripe setup required on your end.
@@ -28,7 +28,7 @@ On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View 
 | **AI queries / seat / mo** | ~100 | ~250 | ~750 | Unlimited |
 | **Max seats** | 10 | 25 | Unlimited | Unlimited |
 | **Datasource connections** | 1 | 3 | Unlimited | Unlimited |
-| **Extra connections** | +$10/mo each | +$10/mo each | Included | N/A |
+| **Extra connections** | Upgrade plan | Upgrade plan | Included | N/A |
 | **Default model** | claude-haiku-4-5 | claude-sonnet-4-6 | claude-sonnet-4-6 | BYOK |
 | **Custom domain** | — | ✓ | ✓ | N/A |
 | **SSO / SCIM** | — | — | ✓ | N/A |
@@ -86,7 +86,7 @@ The admin billing dashboard is available at **Admin > Billing** (`/admin/billing
 - **Query usage** — AI queries consumed vs. computed budget, with progress bar
 - **Seat usage** — actual member count vs. tier maximum
 - **Connection usage** — datasource connections vs. tier limit
-- **Overage status** — current enforcement tier (ok / warning / soft limit / hard limit)
+- **Budget status** — current enforcement tier (ok / warning / grace / paused)
 - **Default model** — current LLM model with override capability
 - **BYOT toggle** — enable/disable bring-your-own-token (admin/owner only)
 - **Stripe portal link** — self-service plan changes, payment methods, invoices
@@ -97,24 +97,20 @@ Usage data is also available programmatically via the admin API. See [Usage Mete
 
 ---
 
-## Overage Handling
+## Token Budget & the Warn → Grace → Pause Hard Cap
 
-Atlas uses a 4-tier degradation model instead of a hard cutoff. Enforcement runs before every agent execution, checking query usage against the workspace's computed budget.
+Each paid plan includes a per-seat monthly **token budget** that scales with the workspace's seat count. Enforcement runs before every agent execution, checking usage against that computed budget and degrading through four tiers rather than cutting off abruptly:
 
 | Tier | Usage | Behavior |
 |------|-------|----------|
 | **OK** | 0–79% | No warning. Request proceeds normally |
 | **Warning** | 80–99% | Request proceeds. Warning metadata attached to the response |
-| **Soft limit** | 100–109% | 10% grace buffer. Request allowed with overage warning |
-| **Hard limit** | 110%+ | Request blocked with HTTP 429. Upgrade or add-seats CTA in error message |
+| **Grace** | 100–109% | 10% grace buffer. Request still allowed, with a usage warning |
+| **Paused (hard cap)** | 110%+ | Request blocked with HTTP 429. Upgrade or add-seats CTA in error message |
 
-When usage exceeds the included token budget, overage charges apply at a flat rate across all paid plans:
+This is a **hard cap with a grace buffer, not pay-as-you-go**. There is no metered per-token overage charge — Atlas does not bill for usage beyond the included budget. Once a workspace crosses 110%, new agent requests are paused until you upgrade your plan, add seats, or the billing period resets. Every token counts the same toward the budget regardless of which model produced it; there is no model-weighted or "output-equivalent" normalization.
 
-| Rate | Description |
-|------|-------------|
-| **$1.00 / 1M tokens** | Applies to Starter, Pro, and Business plans equally |
-
-To avoid overages entirely, enable [BYOT](#byot-bring-your-own-token) and use your own API keys.
+To remove token limits entirely, enable [BYOT](#byot-bring-your-own-token) and use your own API keys.
 
 ### Enforcement Skipped
 

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -152,7 +152,7 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
       { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
       { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
       { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 8" },
-      { feature: "Overage rate", selfHosted: false, starter: "$1 / 1M tokens", pro: "$1 / 1M tokens", business: "$1 / 1M tokens" },
+      { feature: "When you hit the budget", selfHosted: "No limit (BYOK)", starter: "Warn → 10% grace → pause", pro: "Warn → 10% grace → pause", business: "Warn → 10% grace → pause" },
     ],
   },
   {
@@ -198,12 +198,12 @@ const FAQS: FAQ[] = [
   {
     question: "Can I switch models?",
     answer:
-      "Yes. Every plan lets you choose any supported model (Claude, GPT, etc.). On paid plans, your per-seat query budget adjusts automatically based on the model's cost — a more expensive model uses more budget per query, a cheaper one uses less.",
+      "Yes. Every plan lets you choose any supported model (Claude, GPT, etc.). Your per-seat budget is a flat token count — every token counts the same regardless of which model produced it, so a more capable model simply consumes the shared budget faster. Switch to BYOK to remove token limits entirely.",
   },
   {
-    question: "What happens when I hit my query limit?",
+    question: "What happens when I hit my token budget?",
     answer:
-      "You'll get warnings as you approach your limit. You have a 10% grace buffer beyond your included token budget; usage past that is billed at $1 per 1M output-equivalent tokens (roughly $0.10 per typical query, depending on the model). To avoid overages entirely, switch to BYOK at any time — your own API key means unlimited queries.",
+      "Each paid plan includes a per-seat monthly token budget that scales with your seat count. As you approach it you'll get a usage warning (from ~80%), and you keep working through a 10% grace buffer past 100%. At 110% new requests are paused until you upgrade, add seats, or your billing period resets. There is no metered per-token overage charge — it's a hard cap with a grace buffer, not pay-as-you-go. To remove token limits entirely, switch to BYOK at any time and use your own API key.",
   },
   {
     question: "Is there a free option?",

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -53,7 +53,6 @@ import {
   CheckCircle2,
   Coins,
   CreditCard,
-  DollarSign,
   ExternalLink,
   Loader2,
   Plus,
@@ -364,7 +363,6 @@ function PlanShell({ data }: { data: BillingStatus }) {
   const { plan, usage, subscription } = data;
   const seatCount = data.seats?.count ?? usage.seatCount;
   const totalMonthly = plan.pricePerSeat * seatCount;
-  const overage = data.overagePerMillionTokens ?? 0;
 
   // #3417 — the portal goes through the Better Auth Stripe plugin
   // (authClient.subscription.billingPortal), not an Atlas route. The
@@ -478,17 +476,15 @@ function PlanShell({ data }: { data: BillingStatus }) {
         {cancelNotice && (
           <DetailRow label="Scheduled" value={cancelNotice} />
         )}
-        {overage > 0 && (
-          <DetailRow
-            label="Overage"
-            value={
-              <span className="inline-flex items-center gap-1">
-                <DollarSign className="size-3 text-muted-foreground" />
-                {overage.toFixed(2)}/M tokens
-              </span>
-            }
-          />
-        )}
+        {/*
+         * #3422 — `overagePerMillionTokens` is a display-only wire field that
+         * is NOT charged: enforcement is a hard cap with a 10% grace buffer,
+         * not metered pay-as-you-go billing. Rendering it as "$X/M tokens"
+         * implied an active per-token charge that does not exist, so the row
+         * is intentionally not surfaced. The field stays in the wire schema
+         * (removal has publish-sequencing implications); real metered billing
+         * is parked in #3515.
+         */}
       </DetailList>
 
       {/* #3429 — a delinquent subscription must shout: the customer has to


### PR DESCRIPTION
## Decision (Approach B)

#3422 found that the product **advertised** metered token overage — "$1 per 1M output-equivalent tokens", model-aware/output-equivalent per-seat budgets — but none of it is implemented. The real behavior (verified in `enforcement.ts` `evaluateUsage`) is a per-seat monthly token budget with a **warn → 10% grace → pause** hard cap:

- **80–99%** → usage warning (still served)
- **100–109%** → 10% grace buffer (still served, with warning)
- **≥110%** → requests paused / blocked (HTTP 429) until upgrade / add seats / billing-period reset
- BYOT removes token limits entirely; extra connections/chats are **not** purchasable à la carte — the only lever is a plan upgrade.

This PR is **copy/docs only** — it amends every customer-facing surface to describe that real behavior honestly. The implementation path (real Stripe metered billing + model-weighted accounting + soft-limit semantics) is **deferred to #3515**. No Stripe/metering/enforcement/model-weighting code is touched here.

## Surfaces fixed

1. **`apps/www/.../pricing/pricing-content.tsx`**
   - Comparison "Overage rate ($1 / 1M tokens)" row → **"When you hit the budget"** = `No limit (BYOK)` / `Warn → 10% grace → pause`.
   - FAQ "Can I switch models?" — removed the unimplemented "per-seat budget adjusts automatically based on the model's cost" (model-aware) claim; rewritten to flat token counting + BYOK escape. Not promised as "coming soon".
   - FAQ "What happens when I hit my query limit?" → "…token budget?" — removed "billed at $1 per 1M output-equivalent tokens"; now states the 80/100/110 warn → grace → pause hard cap explicitly and that there is **no** metered pay-as-you-go charge.

2. **`apps/docs/content/docs/guides/billing-and-plans.mdx`**
   - Front-matter description + intro reconciled (per-seat token budgets, warn → grace → pause; no metered pay-as-you-go).
   - "Overage Handling" section retitled **"Token Budget & the Warn → Grace → Pause Hard Cap"**; the false **"$1.00 / 1M tokens" flat-rate overage table removed**; tier table relabeled (OK / Warning / **Grace** / **Paused (hard cap)**) with explicit 80/100/110 semantics + an explicit "hard cap with a grace buffer, not pay-as-you-go / no model-weighting" paragraph.
   - Dashboard bullet "Overage status" → "Budget status (ok / warning / grace / paused)".
   - "Extra connections: +$10/mo each" comparison cell → "Upgrade plan" (no à la carte).

3. **`/admin/billing` (`packages/web/.../admin/billing/page.tsx`)**
   - The **"Overage" `$X/M tokens` DetailRow** (rendered with a `DollarSign`, which implied an active metered charge) is **removed**, with an inline `#3422`/`#3515` comment explaining why. The `overagePerMillionTokens` **wire field is left intact** (a display-only value) — removing it is a wire-schema change with publish-sequencing implications, noted for #3515. Removed the now-unused `overage` local and `DollarSign` import.

## Sibling-drift sweep

Grepped `apps/www`, `apps/docs`, `packages/web` for `$1` / `per 1M` / `overage` / `output-equivalent` / `model-aware` / `adjusts automatically` / `pay-as-you-go` / `+$10/mo` billing copy. The only remaining matches are the corrected lines above plus legitimate non-billing uses (`metered for analytics`, `metered against the workspace budget`, `overageColor(tokenOverageStatus)` enforcement-tier coloring, historical changelog entries). No billing/overage drift left unfixed and no out-of-scope drift requiring a separate issue was found.

## Out of scope (intentionally not done)

- `overagePerMillionTokens` left in `plans.ts` / `packages/schemas/src/billing.ts` / the billing route (wire-schema removal → #3515).
- No Stripe / metering / enforcement / model-weighting code.

## CI gates (all green locally)

- `bun run lint` ✅
- `bun run type` ✅ (`@atlas/web type: Exited with code 0`)
- `bun x syncpack lint` ✅ (No issues found)
- `check-template-drift.sh` ✅ (809 files verified)
- `check-railway-watch.sh` ✅
- OpenAPI drift: none — no API route schemas touched.
- `@atlas/web` full isolated test suite ✅ (211/211 files pass, incl. the `model-config` test that exercises `overagePerMillionTokens`). No test asserted the changed pricing/FAQ/docs copy strings (grep-verified).

Closes #3422

https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUNyuKZGWop5EAhxd46yJa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955360&installation_id=135337507&pr_number=3517&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3517&signature=7314599dfc0b22be06a34ca331d0fc1a7bbaa3c356fa2824be25a16142614af2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->