### PR TITLE
refactor(approval): rename agent-invocation "surface" → "origin" (#3491)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -37048,7 +37048,7 @@
                               "enabled": {
                                 "type": "boolean"
                               },
-                              "surface": {
+                              "origin": {
                                 "type": "string",
                                 "enum": [
                                   "any",
@@ -37091,7 +37091,7 @@
                               "orgId",
                               "name",
                               "enabled",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "updatedAt",
                               "ruleType",
@@ -37114,7 +37114,7 @@
                               "enabled": {
                                 "type": "boolean"
                               },
-                              "surface": {
+                              "origin": {
                                 "type": "string",
                                 "enum": [
                                   "any",
@@ -37154,7 +37154,7 @@
                               "orgId",
                               "name",
                               "enabled",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "updatedAt",
                               "ruleType",
@@ -37177,7 +37177,7 @@
                               "enabled": {
                                 "type": "boolean"
                               },
-                              "surface": {
+                              "origin": {
                                 "type": "string",
                                 "enum": [
                                   "any",
@@ -37217,7 +37217,7 @@
                               "orgId",
                               "name",
                               "enabled",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "updatedAt",
                               "ruleType",
@@ -37383,7 +37383,7 @@
                         "description": "Whether the rule is active. Defaults to true.",
                         "example": true
                       },
-                      "surface": {
+                      "origin": {
                         "type": "string",
                         "enum": [
                           "any",
@@ -37398,7 +37398,7 @@
                           "gchat",
                           "webhook"
                         ],
-                        "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
+                        "description": "Agent origin this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072 / ADR-0015.",
                         "example": "any"
                       }
                     },
@@ -37442,7 +37442,7 @@
                         "description": "Whether the rule is active. Defaults to true.",
                         "example": true
                       },
-                      "surface": {
+                      "origin": {
                         "type": "string",
                         "enum": [
                           "any",
@@ -37457,7 +37457,7 @@
                           "gchat",
                           "webhook"
                         ],
-                        "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
+                        "description": "Agent origin this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072 / ADR-0015.",
                         "example": "any"
                       }
                     },
@@ -37497,7 +37497,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -37540,7 +37540,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -37563,7 +37563,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -37603,7 +37603,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -37626,7 +37626,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -37666,7 +37666,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -37815,7 +37815,7 @@
                   "enabled": {
                     "type": "boolean"
                   },
-                  "surface": {
+                  "origin": {
                     "type": "string",
                     "enum": [
                       "any",
@@ -37830,7 +37830,7 @@
                       "gchat",
                       "webhook"
                     ],
-                    "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
+                    "description": "Agent origin this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072 / ADR-0015.",
                     "example": "any"
                   }
                 }
@@ -37863,7 +37863,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -37906,7 +37906,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -37929,7 +37929,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -37969,7 +37969,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -37992,7 +37992,7 @@
                             "enabled": {
                               "type": "boolean"
                             },
-                            "surface": {
+                            "origin": {
                               "type": "string",
                               "enum": [
                                 "any",
@@ -38032,7 +38032,7 @@
                             "orgId",
                             "name",
                             "enabled",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "updatedAt",
                             "ruleType",
@@ -38365,7 +38365,7 @@
                                   "type": "string"
                                 }
                               },
-                              "surface": {
+                              "origin": {
                                 "type": [
                                   "string",
                                   "null"
@@ -38421,7 +38421,7 @@
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "expiresAt",
                               "status",
@@ -38482,7 +38482,7 @@
                                   "type": "string"
                                 }
                               },
-                              "surface": {
+                              "origin": {
                                 "type": [
                                   "string",
                                   "null"
@@ -38544,7 +38544,7 @@
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "expiresAt",
                               "status",
@@ -38605,7 +38605,7 @@
                                   "type": "string"
                                 }
                               },
-                              "surface": {
+                              "origin": {
                                 "type": [
                                   "string",
                                   "null"
@@ -38667,7 +38667,7 @@
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "expiresAt",
                               "status",
@@ -38728,7 +38728,7 @@
                                   "type": "string"
                                 }
                               },
-                              "surface": {
+                              "origin": {
                                 "type": [
                                   "string",
                                   "null"
@@ -38784,7 +38784,7 @@
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
-                              "surface",
+                              "origin",
                               "createdAt",
                               "expiresAt",
                               "status",
@@ -38999,7 +38999,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39055,7 +39055,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39116,7 +39116,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39178,7 +39178,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39239,7 +39239,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39301,7 +39301,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39362,7 +39362,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39418,7 +39418,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39634,7 +39634,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39690,7 +39690,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39751,7 +39751,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39813,7 +39813,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39874,7 +39874,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -39936,7 +39936,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",
@@ -39997,7 +39997,7 @@
                                 "type": "string"
                               }
                             },
-                            "surface": {
+                            "origin": {
                               "type": [
                                 "string",
                                 "null"
@@ -40053,7 +40053,7 @@
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
-                            "surface",
+                            "origin",
                             "createdAt",
                             "expiresAt",
                             "status",

--- a/bun.lock
+++ b/bun.lock
@@ -413,7 +413,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.19",
+      "version": "0.2.0",
       "devDependencies": {
         "typescript": "^6.0.3",
       },
@@ -4305,6 +4305,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.1.19", "", {}, "sha512-ACCUyc17LK+gTwrWfNUMWkFOaVjqM0rfV+z/a/qghJ2PcP6F8NwBRjm96l4EMdweDxBmlU0ccXlXCoZ67YO91A=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.1.19", "", {}, "sha512-ACCUyc17LK+gTwrWfNUMWkFOaVjqM0rfV+z/a/qghJ2PcP6F8NwBRjm96l4EMdweDxBmlU0ccXlXCoZ67YO91A=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -26,7 +26,7 @@
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.1.0",
+    "@useatlas/types": "^0.2.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "@better-auth/api-key": "^1.6.16",
     "@better-auth/oauth-provider": "^1.6.16",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -23,7 +23,7 @@
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.1.0",
+    "@useatlas/types": "^0.2.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "ai": "^6.0.193",
     "@better-auth/api-key": "^1.6.16",

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -885,7 +885,7 @@ export default defineConfig({
       ],
       state: { backend: "pg" },
       // Host-side executeQuery — preserves the F-55 actor binding,
-      // approvalSurface stamp, conversation persistence, rate-limit
+      // agentOrigin stamp, conversation persistence, rate-limit
       // key shape, and :lock: pending-approval flow that slack.ts's
       // legacy app_mention / thread-followup branches used to own.
       executeQuery: createChatPluginExecuteQuery(),

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -871,7 +871,7 @@ export default defineConfig({
       ],
       state: { backend: "pg" },
       // Host-side executeQuery — preserves the F-55 actor binding,
-      // approvalSurface stamp, conversation persistence, rate-limit
+      // agentOrigin stamp, conversation persistence, rate-limit
       // key shape, and :lock: pending-approval flow that slack.ts's
       // legacy app_mention / thread-followup branches used to own.
       executeQuery: createChatPluginExecuteQuery(),

--- a/e2e/browser/admin-approval-surface.spec.ts
+++ b/e2e/browser/admin-approval-surface.spec.ts
@@ -1,25 +1,25 @@
 import { test, expect, type Page, type Route } from "@playwright/test";
 
 /**
- * Admin approval rules — surface scoping (#2072) @llm
+ * Admin approval rules — origin scoping (#2072) @llm
  *
  * The rule-evaluation behavior (MCP-only rule fires for MCP queries but
  * not chat queries against the same shape) is exercised end-to-end by
  * `ee/src/governance/approval.test.ts` (DB-side filter + acceptance-
  * criteria scenarios) and `packages/api/src/lib/approvals/__tests__/
- * evaluate.test.ts` (pure surface-matching predicate). A true browser-
+ * evaluate.test.ts` (pure origin-matching predicate). A true browser-
  * driven "MCP transport queues a request, chat doesn't" path would
  * require a live MCP SDK with DCR-bootstrapping, which we cannot drive
  * headlessly.
  *
  * What this spec covers:
- *   1. The admin sees a Surface column on the rules list.
- *   2. Opening the editor shows the Surface dropdown defaulted to 'any'.
+ *   1. The admin sees an Origin column on the rules list.
+ *   2. Opening the editor shows the Origin dropdown defaulted to 'any'.
  *   3. Selecting "MCP only" and saving emits a POST whose body includes
- *      `surface: "mcp"` — pinning the wire-layer contract the rule
+ *      `origin: "mcp"` — pinning the wire-layer contract the rule
  *      evaluator's SQL filter relies on.
  *   4. The new row renders with the `mcp` badge so the admin can see at
- *      a glance which rules are surface-scoped.
+ *      a glance which rules are origin-scoped.
  *
  * The `@llm` tag opts this spec into the serial worker so the route
  * mocks aren't raced by other specs that also touch admin endpoints.
@@ -33,7 +33,7 @@ interface MockApprovalRule {
   pattern: string;
   threshold: number | null;
   enabled: boolean;
-  surface: "any" | "chat" | "mcp" | "scheduler" | "slack" | "teams" | "webhook";
+  origin: "any" | "chat" | "mcp" | "scheduler" | "slack" | "teams" | "webhook";
   createdAt: string;
   updatedAt: string;
 }
@@ -49,7 +49,7 @@ function buildFixture(): MockApprovalRule[] {
       threshold: null,
       enabled: true,
       // 'any' is the migration default — preserves the pre-2072 shape.
-      surface: "any",
+      origin: "any",
       createdAt: "2026-04-01T10:00:00.000Z",
       updatedAt: "2026-04-01T10:00:00.000Z",
     },
@@ -84,7 +84,7 @@ async function installMocks(
           pattern: typeof body.pattern === "string" ? body.pattern : "",
           threshold: typeof body.threshold === "number" ? body.threshold : null,
           enabled: body.enabled !== false,
-          surface: (body.surface as MockApprovalRule["surface"]) ?? "any",
+          origin: (body.origin as MockApprovalRule["origin"]) ?? "any",
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         };
@@ -128,10 +128,10 @@ async function installMocks(
   return { state, postCalls };
 }
 
-test.describe("Admin approval — surface scoping (#2072) @llm", () => {
+test.describe("Admin approval — origin scoping (#2072) @llm", () => {
   test.describe.configure({ timeout: 45_000 });
 
-  test("Surface column renders in the rules list", async ({ page }) => {
+  test("Origin column renders in the rules list", async ({ page }) => {
     await installMocks(page, buildFixture());
     await page.goto("/admin/approval");
 
@@ -139,13 +139,13 @@ test.describe("Admin approval — surface scoping (#2072) @llm", () => {
       timeout: 15_000,
     });
     // The new column header.
-    await expect(page.getByRole("columnheader", { name: "Surface" })).toBeVisible();
-    // The seeded `any` rule renders its surface badge — exact 'any'
+    await expect(page.getByRole("columnheader", { name: "Origin" })).toBeVisible();
+    // The seeded `any` rule renders its origin badge — exact 'any'
     // text confirms the lower-case enum value reaches the table cell.
     await expect(page.getByRole("cell", { name: "any" }).first()).toBeVisible();
   });
 
-  test("admin creates an MCP-only rule and the wire body carries surface: 'mcp'", async ({
+  test("admin creates an MCP-only rule and the wire body carries origin: 'mcp'", async ({
     page,
   }) => {
     const { postCalls } = await installMocks(page, buildFixture());
@@ -161,8 +161,8 @@ test.describe("Admin approval — surface scoping (#2072) @llm", () => {
     // Fill the basics.
     await page.getByLabel("Rule Name").fill("MCP-only PII gate");
 
-    // Surface dropdown — pick MCP only.
-    await page.getByRole("combobox", { name: "Approval rule surface" }).click();
+    // Origin dropdown — pick MCP only.
+    await page.getByRole("combobox", { name: "Approval rule origin" }).click();
     await page.getByRole("option", { name: /MCP only/ }).click();
 
     // Pattern (table rule type is the default — keep it).
@@ -178,7 +178,7 @@ test.describe("Admin approval — surface scoping (#2072) @llm", () => {
       name: "MCP-only PII gate",
       ruleType: "table",
       pattern: "customers",
-      surface: "mcp",
+      origin: "mcp",
     });
 
     // The new row should render with the mcp badge.

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -78,10 +78,10 @@ function makeRuleRow(overrides: Partial<Record<string, unknown>> = {}): Record<s
     pattern: "users",
     threshold: null,
     enabled: true,
-    // #2072 — default 'any' fires for every request surface, preserving
+    // #2072 — default 'any' fires for every request origin, preserving
     // the pre-2072 behavior every legacy test was written against.
-    // Surface-scoped tests override this explicitly.
-    surface: "any",
+    // Origin-scoped tests override this explicitly.
+    origin: "any",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,
@@ -109,9 +109,9 @@ function makeQueueRow(overrides: Partial<Record<string, unknown>> = {}): Record<
     reviewer_email: null,
     review_comment: null,
     reviewed_at: null,
-    // #2072 — null preserves the pre-2072 unstamped shape; the surface-
+    // #2072 — null preserves the pre-2072 unstamped shape; the origin-
     // isolation tests override explicitly.
-    surface: null,
+    origin: null,
     created_at: "2026-01-01T00:00:00Z",
     expires_at: "2030-01-01T00:00:00Z",
     ...overrides,
@@ -233,41 +233,41 @@ describe("createApprovalRule", () => {
     ).rejects.toThrow("unexpected rule_type");
   });
 
-  it("#2072: defaults surface to 'any' when admin doesn't pin one", async () => {
-    ee.queueMockRows([makeRuleRow({ surface: "any" })]);
+  it("#2072: defaults origin to 'any' when admin doesn't pin one", async () => {
+    ee.queueMockRows([makeRuleRow({ origin: "any" })]);
     const result = await run(createApprovalRule("org-1", {
       ruleType: "table",
       name: "PII tables",
       pattern: "users",
     }));
-    expect(result.surface).toBe("any");
+    expect(result.origin).toBe("any");
     const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_rules"));
     expect(insert).toBeDefined();
     expect(insert!.params).toContain("any");
   });
 
-  it("#2072: persists explicit surface (mcp) when admin pins it", async () => {
-    ee.queueMockRows([makeRuleRow({ surface: "mcp" })]);
+  it("#2072: persists explicit origin (mcp) when admin pins it", async () => {
+    ee.queueMockRows([makeRuleRow({ origin: "mcp" })]);
     const result = await run(createApprovalRule("org-1", {
       ruleType: "table",
       name: "MCP-only PII",
       pattern: "users",
-      surface: "mcp",
+      origin: "mcp",
     }));
-    expect(result.surface).toBe("mcp");
+    expect(result.origin).toBe("mcp");
     const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_rules"));
     expect(insert!.params).toContain("mcp");
   });
 
-  it("#2072: rejects an invalid surface value at validation", async () => {
+  it("#2072: rejects an invalid origin value at validation", async () => {
     try {
       await run(createApprovalRule("org-1", {
         ruleType: "table",
         name: "bad",
         pattern: "users",
-        surface: "msc" as never,
+        origin: "msc" as never,
       }));
-      expect.unreachable("expected ApprovalError for invalid surface");
+      expect.unreachable("expected ApprovalError for invalid origin");
     } catch (err) {
       expect(err).toBeInstanceOf(ApprovalError);
     }
@@ -435,40 +435,40 @@ describe("checkApprovalRequired", () => {
     expect(result.required).toBe(true);
   });
 
-  // ── #2072 surface scoping ──────────────────────────────────────────
+  // ── #2072 origin scoping ──────────────────────────────────────────
 
-  describe("#2072 surface scoping", () => {
-    it("pushes the request surface into the SQL filter (mcp request)", async () => {
-      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", surface: "mcp" })]);
+  describe("#2072 origin scoping", () => {
+    it("pushes the request origin into the SQL filter (mcp request)", async () => {
+      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", origin: "mcp" })]);
       const result = await run(checkApprovalRequired(
         "org-1",
         ["users"],
         ["id"],
-        { surface: "mcp" },
+        { origin: "mcp" },
       ));
       expect(result.required).toBe(true);
-      // Captured SQL contains the surface predicate so a future refactor
+      // Captured SQL contains the origin predicate so a future refactor
       // that drops it (and re-introduces the all-or-nothing pre-2072
       // shape) fails this test instead of silently regressing.
       const captured = ee.capturedQueries[ee.capturedQueries.length - 1];
-      expect(captured.sql).toContain("surface = 'any'");
-      expect(captured.sql).toContain("surface = $2");
+      expect(captured.sql).toContain("origin = 'any'");
+      expect(captured.sql).toContain("origin = $2");
       expect(captured.params).toEqual(["org-1", "mcp"]);
     });
 
     it("acceptance: MCP-only rule fires for MCP queries against the same shape", async () => {
       // Authoring an `mcp`-only rule and querying via the MCP transport
       // is the headline acceptance criterion in #2072.
-      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "customers", surface: "mcp" })]);
+      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "customers", origin: "mcp" })]);
       const result = await run(checkApprovalRequired(
         "org-1",
         ["customers"],
         ["id"],
-        { surface: "mcp" },
+        { origin: "mcp" },
       ));
       expect(result.required).toBe(true);
       expect(result.matchedRules).toHaveLength(1);
-      expect(result.matchedRules[0].surface).toBe("mcp");
+      expect(result.matchedRules[0].origin).toBe("mcp");
     });
 
     it("acceptance: same MCP-only rule does NOT fire for chat queries against the same shape", async () => {
@@ -480,37 +480,37 @@ describe("checkApprovalRequired", () => {
         "org-1",
         ["customers"],
         ["id"],
-        { surface: "chat" },
+        { origin: "chat" },
       ));
       expect(result.required).toBe(false);
       const captured = ee.capturedQueries[ee.capturedQueries.length - 1];
       expect(captured.params).toEqual(["org-1", "chat"]);
     });
 
-    it("'any' rule fires for every surface (preserves pre-2072 default)", async () => {
+    it("'any' rule fires for every origin (preserves pre-2072 default)", async () => {
       // The migration default sets every existing row to 'any'. This
       // non-destructive promise is the criterion most likely to regress.
-      for (const surface of ["chat", "mcp", "scheduler", "slack", "teams", "webhook"] as const) {
+      for (const origin of ["chat", "mcp", "scheduler", "slack", "teams", "webhook"] as const) {
         ee.reset();
         mockEnterpriseEnabled = true;
-        ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", surface: "any" })]);
+        ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", origin: "any" })]);
         const result = await run(checkApprovalRequired(
           "org-1",
           ["users"],
           ["id"],
-          { surface },
+          { origin },
         ));
-        expect(result.required, `'any' rule must fire for surface "${surface}"`).toBe(true);
+        expect(result.required, `'any' rule must fire for origin "${origin}"`).toBe(true);
       }
     });
 
-    it("passes NULL surface to SQL when the caller didn't stamp one (fail-closed for scoped rules)", async () => {
-      // Routes that haven't been retrofitted to stamp surface end up
+    it("passes NULL origin to SQL when the caller didn't stamp one (fail-closed for scoped rules)", async () => {
+      // Routes that haven't been retrofitted to stamp origin end up
       // here. The SQL filter still fires 'any' rules but skips
-      // surface-scoped ones — that's the fail-closed shape (a route
-      // forgetting to stamp can't accidentally trip a surface-scoped
+      // origin-scoped ones — that's the fail-closed shape (a route
+      // forgetting to stamp can't accidentally trip a origin-scoped
       // rule meant for a different transport).
-      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", surface: "any" })]);
+      ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users", origin: "any" })]);
       const result = await run(checkApprovalRequired("org-1", ["users"], ["id"]));
       expect(result.required).toBe(true);
       const captured = ee.capturedQueries[ee.capturedQueries.length - 1];
@@ -524,7 +524,7 @@ describe("checkApprovalRequired", () => {
         "org-1",
         ["payroll"],
         ["amount"],
-        { surface: "chat" },
+        { origin: "chat" },
       ));
       expect(result.required).toBe(false);
       expect(ee.capturedQueries[ee.capturedQueries.length - 1].params).toEqual(["org-1", "chat"]);
@@ -562,8 +562,8 @@ describe("createApprovalRequest", () => {
     expect(ee.capturedQueries.some((q) => q.sql.includes("INSERT INTO approval_queue"))).toBe(true);
   });
 
-  it("#2072: stamps surface on the queued row when caller provides it", async () => {
-    ee.queueMockRows([makeQueueRow({ surface: "mcp" })]);
+  it("#2072: stamps origin on the queued row when caller provides it", async () => {
+    ee.queueMockRows([makeQueueRow({ origin: "mcp" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -575,18 +575,18 @@ describe("createApprovalRequest", () => {
       connectionId: "default",
       tablesAccessed: ["customers"],
       columnsAccessed: ["id"],
-      surface: "mcp",
+      origin: "mcp",
     }));
-    expect(result.surface).toBe("mcp");
-    // The captured INSERT carries the surface in the parameter list so
+    expect(result.origin).toBe("mcp");
+    // The captured INSERT carries the origin in the parameter list so
     // a future refactor that drops the binding regresses this test.
     const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_queue"));
     expect(insert).toBeDefined();
     expect(insert!.params).toContain("mcp");
   });
 
-  it("#2072: stores surface as null when the caller does not provide it (legacy shape)", async () => {
-    ee.queueMockRows([makeQueueRow({ surface: null })]);
+  it("#2072: stores origin as null when the caller does not provide it (legacy shape)", async () => {
+    ee.queueMockRows([makeQueueRow({ origin: null })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -599,7 +599,7 @@ describe("createApprovalRequest", () => {
       tablesAccessed: ["users"],
       columnsAccessed: ["id"],
     }));
-    expect(result.surface).toBeNull();
+    expect(result.origin).toBeNull();
   });
 
   it("writes literal NULL when both connectionGroupId and connectionId are absent", async () => {
@@ -630,7 +630,7 @@ describe("createApprovalRequest", () => {
     expect(insert!.params[7]).toBeNull();
   });
 
-  it("#2072: rejects a surface value that isn't in the request enum (typo)", async () => {
+  it("#2072: rejects a origin value that isn't in the request enum (typo)", async () => {
     try {
       await run(createApprovalRequest({
         orgId: "org-1",
@@ -643,9 +643,9 @@ describe("createApprovalRequest", () => {
         connectionId: "default",
         tablesAccessed: ["users"],
         columnsAccessed: ["id"],
-        surface: "msc" as never,
+        origin: "msc" as never,
       }));
-      expect.unreachable("expected ApprovalError for invalid surface");
+      expect.unreachable("expected ApprovalError for invalid origin");
     } catch (err) {
       expect(err).toBeInstanceOf(ApprovalError);
     }

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -30,17 +30,17 @@ import { createLogger } from "@atlas/api/lib/logger";
 import type {
   ApprovalRule,
   ApprovalRuleType,
-  ApprovalRuleSurface,
+  ApprovalRuleOrigin,
   ApprovalRequest,
-  ApprovalRequestSurface,
+  ApprovalRequestOrigin,
   ApprovalStatus,
   CreateApprovalRuleRequest,
   UpdateApprovalRuleRequest,
 } from "@useatlas/types";
 import {
   APPROVAL_RULE_TYPES,
-  APPROVAL_RULE_SURFACES,
-  APPROVAL_REQUEST_SURFACES,
+  APPROVAL_RULE_ORIGINS,
+  APPROVAL_REQUEST_ORIGINS,
   APPROVAL_STATUSES,
 } from "@useatlas/types";
 import {
@@ -74,8 +74,8 @@ interface ApprovalRuleRow {
   pattern: string;
   threshold: number | null;
   enabled: boolean;
-  /** #2072 — surface scope. Defaults to 'any' via the migration. */
-  surface: string;
+  /** #2072 — origin scope. Defaults to 'any' via the migration. */
+  origin: string;
   created_at: string;
   updated_at: string;
   [key: string]: unknown;
@@ -99,8 +99,8 @@ interface ApprovalQueueRow {
   reviewer_email: string | null;
   review_comment: string | null;
   reviewed_at: string | null;
-  /** #2072 — origin surface stamped at request creation. NULL for legacy. */
-  surface: string | null;
+  /** #2072 — agent origin stamped at request creation. NULL for legacy. */
+  origin: string | null;
   created_at: string;
   expires_at: string;
   [key: string]: unknown;
@@ -116,12 +116,12 @@ function isValidStatus(status: string): status is ApprovalStatus {
   return (APPROVAL_STATUSES as readonly string[]).includes(status);
 }
 
-function isValidRuleSurface(surface: string): surface is ApprovalRuleSurface {
-  return (APPROVAL_RULE_SURFACES as readonly string[]).includes(surface);
+function isValidRuleOrigin(origin: string): origin is ApprovalRuleOrigin {
+  return (APPROVAL_RULE_ORIGINS as readonly string[]).includes(origin);
 }
 
-function isValidRequestSurface(surface: string): surface is ApprovalRequestSurface {
-  return (APPROVAL_REQUEST_SURFACES as readonly string[]).includes(surface);
+function isValidRequestOrigin(origin: string): origin is ApprovalRequestOrigin {
+  return (APPROVAL_REQUEST_ORIGINS as readonly string[]).includes(origin);
 }
 
 // Post-0096 cutover (#2744 / ADR-0007 pure-collapse): the legacy
@@ -137,28 +137,28 @@ function rowToRule(row: ApprovalRuleRow): ApprovalRule | null {
     log.warn({ ruleId: row.id, ruleType: row.rule_type }, "Approval rule has unexpected rule_type in database — skipping rule");
     return null;
   }
-  // #2072: fail-closed-strict on surface drift. The column is NOT NULL
+  // #2072: fail-closed-strict on origin drift. The column is NOT NULL
   // with DEFAULT 'any' post-0052, so a NULL/missing read indicates
   // schema drift (partial restore, hand-rolled migration, ORM
-  // misbehavior). Coercing to 'any' would silently broaden a surface-
+  // misbehavior). Coercing to 'any' would silently broaden an origin-
   // scoped rule that an admin authored to ALL surfaces — exactly the
   // governance bypass shape this column exists to prevent. Drop the
   // row instead so the operator sees the warning and the missing rule.
-  if (typeof row.surface !== "string") {
-    log.warn({ ruleId: row.id }, "Approval rule has missing/null surface in database — schema drift, skipping rule");
+  if (typeof row.origin !== "string") {
+    log.warn({ ruleId: row.id }, "Approval rule has missing/null origin in database — schema drift, skipping rule");
     return null;
   }
-  if (!isValidRuleSurface(row.surface)) {
-    log.warn({ ruleId: row.id, surface: row.surface }, "Approval rule has unexpected surface in database — skipping rule");
+  if (!isValidRuleOrigin(row.origin)) {
+    log.warn({ ruleId: row.id, origin: row.origin }, "Approval rule has unexpected origin in database — skipping rule");
     return null;
   }
-  const surfaceValue = row.surface;
+  const originValue = row.origin;
   const base = {
     id: row.id,
     orgId: row.org_id,
     name: row.name,
     enabled: row.enabled,
-    surface: surfaceValue,
+    origin: originValue,
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };
@@ -195,16 +195,16 @@ function rowToRequest(row: ApprovalQueueRow): ApprovalRequest | null {
     log.warn({ requestId: row.id, status: row.status }, "Approval request has unexpected status in database — skipping request");
     return null;
   }
-  // #2072: surface on a queued row is request-side (no 'any'). Drop on
-  // unknown values rather than coerce — a corrupt surface column means
+  // #2072: origin on a queued row is request-side (no 'any'). Drop on
+  // unknown values rather than coerce — a corrupt origin column means
   // the audit dimension would silently mis-bucket reports.
-  let surface: ApprovalRequestSurface | null = null;
-  if (row.surface !== null && row.surface !== undefined) {
-    if (!isValidRequestSurface(row.surface)) {
-      log.warn({ requestId: row.id, surface: row.surface }, "Approval request has unexpected surface in database — skipping request");
+  let origin: ApprovalRequestOrigin | null = null;
+  if (row.origin !== null && row.origin !== undefined) {
+    if (!isValidRequestOrigin(row.origin)) {
+      log.warn({ requestId: row.id, origin: row.origin }, "Approval request has unexpected origin in database — skipping request");
       return null;
     }
-    surface = row.surface;
+    origin = row.origin;
   }
   const base = {
     id: row.id,
@@ -223,7 +223,7 @@ function rowToRequest(row: ApprovalQueueRow): ApprovalRequest | null {
     connectionGroupId: row.connection_group_id ?? null,
     tablesAccessed: parseJsonArray(row.tables_accessed),
     columnsAccessed: parseJsonArray(row.columns_accessed),
-    surface,
+    origin,
     createdAt: String(row.created_at),
     expiresAt: String(row.expires_at),
   };
@@ -276,12 +276,12 @@ function validateRuleInput(input: CreateApprovalRuleRequest): Effect.Effect<void
   if (!isValidRuleType(input.ruleType as string)) {
     return Effect.fail(new ApprovalError({ message: `Invalid rule type "${input.ruleType as string}". Supported: ${APPROVAL_RULE_TYPES.join(", ")}`, code: "validation" }));
   }
-  // #2072 — surface is optional on create (defaults to 'any'). When
+  // #2072 — origin is optional on create (defaults to 'any'). When
   // present, validate against the canonical enum so a typo can't reach
   // the DB CHECK constraint as a 500.
-  if (input.surface !== undefined && !isValidRuleSurface(input.surface as string)) {
+  if (input.origin !== undefined && !isValidRuleOrigin(input.origin as string)) {
     return Effect.fail(new ApprovalError({
-      message: `Invalid surface "${input.surface as string}". Supported: ${APPROVAL_RULE_SURFACES.join(", ")}`,
+      message: `Invalid origin "${input.origin as string}". Supported: ${APPROVAL_RULE_ORIGINS.join(", ")}`,
       code: "validation",
     }));
   }
@@ -301,11 +301,11 @@ function validateRuleInput(input: CreateApprovalRuleRequest): Effect.Effect<void
 // SELECT, RETURNING (insert), and RETURNING (update) all carry the
 // new `connection_group_id` column without drifting from each other.
 // Drift was the exact #2191-class regression PR review caught on the
-// surface column rollout; centralizing here keeps the three sites in
+// origin column rollout; centralizing here keeps the three sites in
 // lockstep.
 const APPROVAL_QUEUE_COLUMNS = `id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
   explanation, connection_group_id, tables_accessed, columns_accessed, status,
-  reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at`;
+  reviewer_id, reviewer_email, review_comment, reviewed_at, origin, created_at, expires_at`;
 
 // ── Default expiry ──────────────────────────────────────────────────
 
@@ -330,7 +330,7 @@ export const listApprovalRules = (orgId: string): Effect.Effect<ApprovalRule[], 
     if (!hasInternalDB()) return [];
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
-      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, surface, created_at, updated_at
+      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at
        FROM approval_rules
        WHERE org_id = $1
        ORDER BY created_at ASC`,
@@ -346,7 +346,7 @@ export const getApprovalRule = (orgId: string, ruleId: string): Effect.Effect<Ap
     if (!hasInternalDB()) return null;
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
-      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, surface, created_at, updated_at
+      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at
        FROM approval_rules
        WHERE org_id = $1 AND id = $2
        LIMIT 1`,
@@ -373,9 +373,9 @@ export const createApprovalRule = (
     yield* validateRuleInput(input);
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
-      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled, surface)
+      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled, origin)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING id, org_id, name, rule_type, pattern, threshold, enabled, surface, created_at, updated_at`,
+       RETURNING id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at`,
       [
         orgId,
         input.name.trim(),
@@ -385,7 +385,7 @@ export const createApprovalRule = (
         input.ruleType === "cost" ? input.threshold : null,
         input.enabled ?? true,
         // #2072 — default 'any' preserves pre-2072 fires-everywhere behavior.
-        input.surface ?? "any",
+        input.origin ?? "any",
       ],
     ));
 
@@ -442,17 +442,17 @@ export const updateApprovalRule = (
       params.push(input.enabled);
       idx++;
     }
-    if (input.surface !== undefined) {
+    if (input.origin !== undefined) {
       // #2072 — validate before writing so a typo doesn't reach the DB
       // CHECK as a 500 with no diagnostic for the admin.
-      if (!isValidRuleSurface(input.surface as string)) {
+      if (!isValidRuleOrigin(input.origin as string)) {
         return yield* Effect.fail(new ApprovalError({
-          message: `Invalid surface "${input.surface as string}". Supported: ${APPROVAL_RULE_SURFACES.join(", ")}`,
+          message: `Invalid origin "${input.origin as string}". Supported: ${APPROVAL_RULE_ORIGINS.join(", ")}`,
           code: "validation",
         }));
       }
-      sets.push(`surface = $${idx}`);
-      params.push(input.surface);
+      sets.push(`origin = $${idx}`);
+      params.push(input.origin);
     }
 
     if (sets.length === 0) {
@@ -463,7 +463,7 @@ export const updateApprovalRule = (
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
       `UPDATE approval_rules SET ${sets.join(", ")} WHERE org_id = $1 AND id = $2
-       RETURNING id, org_id, name, rule_type, pattern, threshold, enabled, surface, created_at, updated_at`,
+       RETURNING id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at`,
       [orgId, ruleId, ...params],
     ));
 
@@ -526,8 +526,8 @@ const IDENTITY_MISSING_RULE: ApprovalRule = {
   threshold: null,
   enabled: true,
   // 'any' on the sentinel — this is the fail-closed shape and must fire
-  // regardless of which surface the unidentified caller came from.
-  surface: "any",
+  // regardless of which origin the unidentified caller came from.
+  origin: "any",
   createdAt: new Date(0).toISOString(),
   updatedAt: new Date(0).toISOString(),
 };
@@ -588,13 +588,13 @@ export const checkApprovalRequired = (
   options?: {
     requesterId?: string | undefined;
     /**
-     * #2072 — origin surface stamped by the calling route. The SQL filter
-     * applies `surface = $surface OR surface = 'any'`; passing `undefined`
+     * #2072 — agent origin stamped by the calling route. The SQL filter
+     * applies `origin = $origin OR origin = 'any'`; passing `undefined`
      * (legacy / unstamped routes) only fires `'any'` rules, which is the
-     * fail-closed shape — a route that forgets to stamp surface can't
-     * accidentally trip surface-scoped rules.
+     * fail-closed shape — a route that forgets to stamp origin can't
+     * accidentally trip origin-scoped rules.
      */
-    surface?: ApprovalRequestSurface | undefined;
+    origin?: ApprovalRequestOrigin | undefined;
   },
 ): Effect.Effect<ApprovalMatchResult, never> =>
   Effect.gen(function* () {
@@ -631,18 +631,18 @@ export const checkApprovalRequired = (
 
     yield* requireEnterpriseEffect("approval-workflows");
 
-    // #2072 — surface filter pushed into the SQL: rules pinned to a
-    // specific surface only fetch when the request stamped that surface.
-    // `surface = $2 OR surface = 'any'` with `$2 IS NULL` still fires
+    // #2072 — origin filter pushed into the SQL: rules pinned to a
+    // specific origin only fetch when the request stamped that origin.
+    // `origin = $2 OR origin = 'any'` with `$2 IS NULL` still fires
     // 'any' rules (NULL = 'any' is false in three-valued logic) — that's
     // the desired pre-2072 backwards-compat shape. The
     // `idx_approval_rules_org_surface` index covers both branches.
-    const requestSurface: string | null = options?.surface ?? null;
+    const requestOrigin: string | null = options?.origin ?? null;
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
-      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, surface, created_at, updated_at
+      `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at
        FROM approval_rules
-       WHERE org_id = $1 AND enabled = true AND (surface = 'any' OR surface = $2)`,
-      [orgId, requestSurface],
+       WHERE org_id = $1 AND enabled = true AND (origin = 'any' OR origin = $2)`,
+      [orgId, requestOrigin],
     ));
 
     if (rows.length === 0) {
@@ -718,12 +718,12 @@ export const createApprovalRequest = (opts: {
   tablesAccessed: string[];
   columnsAccessed: string[];
   /**
-   * #2072 — origin surface stamped on the queued row for audit. Optional
+   * #2072 — agent origin stamped on the queued row for audit. Optional
    * because legacy callers (and tests pinned to the old shape) don't
-   * stamp it; missing surface stores NULL and renders as "unknown
+   * stamp it; missing origin stores NULL and renders as "unknown
    * origin" in admin reports.
    */
-  surface?: ApprovalRequestSurface | null;
+  origin?: ApprovalRequestOrigin | null;
 }): Effect.Effect<ApprovalRequest, ApprovalError | EnterpriseError | Error> =>
   Effect.gen(function* () {
     yield* requireEnterpriseEffect("approval-workflows");
@@ -754,9 +754,9 @@ export const createApprovalRequest = (opts: {
     // #2072 — defensive validation. The DB CHECK enforces this too, but
     // surfacing the bad input as a typed ApprovalError beats a 500 from
     // the SQL layer with no diagnostic for the caller.
-    if (opts.surface != null && !isValidRequestSurface(opts.surface as string)) {
+    if (opts.origin != null && !isValidRequestOrigin(opts.origin as string)) {
       return yield* Effect.fail(new ApprovalError({
-        message: `Invalid request surface "${opts.surface as string}". Supported: ${APPROVAL_REQUEST_SURFACES.join(", ")}`,
+        message: `Invalid request origin "${opts.origin as string}". Supported: ${APPROVAL_REQUEST_ORIGINS.join(", ")}`,
         code: "validation",
       }));
     }
@@ -797,7 +797,7 @@ export const createApprovalRequest = (opts: {
     // the scalar subquery.
     const insertSql = `INSERT INTO approval_queue
          (org_id, rule_id, rule_name, requester_id, requester_email, query_sql, explanation,
-          connection_group_id, tables_accessed, columns_accessed, surface, expires_at)
+          connection_group_id, tables_accessed, columns_accessed, origin, expires_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7, ${groupExpression}, $9, $10, $11, now() + make_interval(hours => $12))
        RETURNING ${APPROVAL_QUEUE_COLUMNS}`;
 
@@ -814,7 +814,7 @@ export const createApprovalRequest = (opts: {
         groupParam,
         JSON.stringify(opts.tablesAccessed),
         JSON.stringify(opts.columnsAccessed),
-        opts.surface ?? null,
+        opts.origin ?? null,
         expiryHours,
       ],
     ));

--- a/packages/api/src/api/__tests__/admin-approval-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-approval-audit.test.ts
@@ -177,15 +177,15 @@ beforeEach(() => {
   mockLogAdminAction.mockClear();
   mockCreateApprovalRule.mockClear();
   mockCreateApprovalRule.mockImplementation(() =>
-    // #2072 — surface returned by the EE layer (default 'any'). Audit
+    // #2072 — origin returned by the EE layer (default 'any'). Audit
     // metadata mirrors this from the post-create rule.
-    Effect.succeed({ id: "rule-123", orgId: "org-alpha", ruleType: "cost", name: "Flag cost", enabled: true, surface: "any" }),
+    Effect.succeed({ id: "rule-123", orgId: "org-alpha", ruleType: "cost", name: "Flag cost", enabled: true, origin: "any" }),
   );
   mockUpdateApprovalRule.mockClear();
   mockUpdateApprovalRule.mockImplementation(() =>
     // #2072 — simulate an admin rescoping the rule from 'any' to 'mcp'
-    // so the rule_update audit metadata picks up the post-update surface.
-    Effect.succeed({ id: "rule-123", orgId: "org-alpha", ruleType: "cost", name: "Flag cost (updated)", enabled: true, surface: "mcp" }),
+    // so the rule_update audit metadata picks up the post-update origin.
+    Effect.succeed({ id: "rule-123", orgId: "org-alpha", ruleType: "cost", name: "Flag cost (updated)", enabled: true, origin: "mcp" }),
   );
   mockDeleteApprovalRule.mockClear();
   mockDeleteApprovalRule.mockImplementation(() => Effect.succeed(true));
@@ -213,11 +213,11 @@ describe("POST /api/v1/admin/approval/rules — audit emission (F-29)", () => {
     expect(entry.actionType).toBe("approval.rule_create");
     expect(entry.targetType).toBe("approval");
     expect(entry.targetId).toBe("rule-123");
-    // #2072 — surface stamped from the post-create rule. Pinning this
-    // catches a regression that drops surface from the rule_create
+    // #2072 — origin stamped from the post-create rule. Pinning this
+    // catches a regression that drops origin from the rule_create
     // metadata builder (admin-approval.ts) — a compliance reviewer would
     // otherwise lose the audit dimension silently.
-    expect(entry.metadata).toMatchObject({ name: "Flag cost", ruleType: "cost", surface: "any" });
+    expect(entry.metadata).toMatchObject({ name: "Flag cost", ruleType: "cost", origin: "any" });
   });
 });
 
@@ -242,10 +242,10 @@ describe("PUT /api/v1/admin/approval/rules/:id — audit emission (F-29)", () =>
     const keys = entry.metadata?.keysChanged;
     expect(Array.isArray(keys)).toBe(true);
     expect((keys as string[]).sort()).toEqual(["enabled", "name"]);
-    // #2072 — surface stamped from the post-update rule so a reviewer
+    // #2072 — origin stamped from the post-update rule so a reviewer
     // can see when a rule's scope changed (e.g. 'any' → 'mcp')
     // alongside the keysChanged list.
-    expect(entry.metadata?.surface).toBe("mcp");
+    expect(entry.metadata?.origin).toBe("mcp");
   });
 
   it("does not emit when the rule does not exist (404)", async () => {

--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -18,7 +18,7 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { APPROVAL_STATUSES, APPROVAL_RULE_SURFACES } from "@useatlas/types";
+import { APPROVAL_STATUSES, APPROVAL_RULE_ORIGINS } from "@useatlas/types";
 import { ApprovalRuleSchema, ApprovalRequestSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
@@ -37,15 +37,15 @@ const approvalDomainError = domainError(ApprovalError, { validation: 400, not_fo
 // Request body schemas — response shapes live in @useatlas/schemas.
 // ---------------------------------------------------------------------------
 
-// #2072 — surface scope is shared across rule types. `'any'` (default)
+// #2072 — agent origin scope is shared across rule types. `'any'` (default)
 // preserves pre-2072 fires-everywhere semantics; the others pin a rule
 // to a single transport. The field is `.optional()` because the EE
 // layer applies the `'any'` default — the strict `z.enum(...)` on the
 // inner type still rejects typos at the route boundary as a 400
 // rather than letting them land in `validateRuleInput` as a 500.
-const SurfaceField = z.enum(APPROVAL_RULE_SURFACES).optional().openapi({
+const OriginField = z.enum(APPROVAL_RULE_ORIGINS).optional().openapi({
   description:
-    "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
+    "Agent origin this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072 / ADR-0015.",
   example: "any",
 });
 
@@ -71,7 +71,7 @@ const CostRuleBodySchema = z.object({
     description: "Whether the rule is active. Defaults to true.",
     example: true,
   }),
-  surface: SurfaceField,
+  origin: OriginField,
 });
 
 const NamedRuleBodySchema = z.object({
@@ -95,7 +95,7 @@ const NamedRuleBodySchema = z.object({
     description: "Whether the rule is active. Defaults to true.",
     example: true,
   }),
-  surface: SurfaceField,
+  origin: OriginField,
 });
 
 const CreateRuleBodySchema = z.discriminatedUnion("ruleType", [
@@ -108,7 +108,7 @@ const UpdateRuleBodySchema = z.object({
   pattern: z.string().optional(),
   threshold: z.number().nullable().optional(),
   enabled: z.boolean().optional(),
-  surface: SurfaceField,
+  origin: OriginField,
 });
 
 const ReviewBodySchema = z.object({
@@ -364,10 +364,10 @@ adminApproval.openapi(createRuleRoute, async (c) => {
 
     // `body` is narrowed by the discriminated union (#1660); pass it
     // through as the matching CreateApprovalRuleRequest variant.
-    // #2072 — surface (optional) flows on every variant.
+    // #2072 — origin (optional) flows on every variant.
     const input = body.ruleType === "cost"
-      ? { ruleType: "cost" as const, name: body.name, threshold: body.threshold, enabled: body.enabled, surface: body.surface }
-      : { ruleType: body.ruleType, name: body.name, pattern: body.pattern, enabled: body.enabled, surface: body.surface };
+      ? { ruleType: "cost" as const, name: body.name, threshold: body.threshold, enabled: body.enabled, origin: body.origin }
+      : { ruleType: body.ruleType, name: body.name, pattern: body.pattern, enabled: body.enabled, origin: body.origin };
 
     const rule = yield* (yield* ApprovalGate).createApprovalRule(orgId!, input);
 
@@ -381,9 +381,9 @@ adminApproval.openapi(createRuleRoute, async (c) => {
       targetType: "approval",
       targetId: rule.id,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-      // #2072 — surface stamped in admin-action metadata so /admin/audit
+      // #2072 — origin stamped in admin-action metadata so /admin/audit
       // shows the new dimension on rule-creation events.
-      metadata: { name: body.name, ruleType: body.ruleType, surface: rule.surface },
+      metadata: { name: body.name, ruleType: body.ruleType, origin: rule.origin },
     });
 
     return c.json({ rule }, 201);
@@ -403,17 +403,17 @@ adminApproval.openapi(updateRuleRoute, async (c) => {
     // semantic-diff signal — records WHICH fields the admin touched
     // without recording the values, since pattern/threshold may
     // themselves be sensitive shape data for a compromised admin
-    // mapping the approval surface.
+    // mapping the approval gate.
     logAdminAction({
       actionType: ADMIN_ACTIONS.approval.ruleUpdate,
       targetType: "approval",
       targetId: ruleId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-      // #2072 — record the post-update surface alongside the keysChanged
+      // #2072 — record the post-update origin alongside the keysChanged
       // diff so a compliance reviewer can see when a rule was rescoped
       // (e.g. mcp-only → any) without having to cross-reference the rule
       // table at the timestamp.
-      metadata: { keysChanged: Object.keys(body), surface: rule.surface },
+      metadata: { keysChanged: Object.keys(body), origin: rule.origin },
     });
 
     return c.json({ rule }, 200);
@@ -498,13 +498,13 @@ adminApproval.openapi(reviewRoute, async (c) => {
       targetType: "approval",
       targetId: itemId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-      // #2072 — surface comes from the queued row (stamped at request
+      // #2072 — origin comes from the queued row (stamped at request
       // creation by lib/tools/sql.ts). NULL on the queue row means
       // either a legacy pre-2072 request or a route that didn't stamp
-      // surface; surface those distinctly as "unknown_origin" rather
+      // an origin; record those distinctly as "unknown_origin" rather
       // than a literal null so compliance reviewers can tell them
       // apart from a forensics query that explicitly wrote null.
-      metadata: { requestId: itemId, surface: result.surface ?? "unknown_origin" },
+      metadata: { requestId: itemId, origin: result.origin ?? "unknown_origin" },
     });
 
     return c.json({ request: result }, 200);

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -685,8 +685,8 @@ chat.openapi(chatRoute, async (c) => {
     // Bind user to AsyncLocalStorage so downstream code (logQueryAudit, etc.)
     // has access to user identity. The middleware already set up requestId context;
     // this nested call adds the user after inline auth completes.
-    // #2072 — stamp 'chat' on the surface so chat-only approval rules
-    // fire here but mcp/scheduler/slack-only rules do not.
+    // #2072 — stamp 'chat' as the agent origin so chat-only approval
+    // rules fire here but mcp/scheduler/slack-only rules do not.
     //
     // #2345 — the routing fields are resolved INSIDE this callback
     // because they depend on the parsed body + the persisted
@@ -694,7 +694,7 @@ chat.openapi(chatRoute, async (c) => {
     // known so plugin tools / agent helpers see them in AsyncLocalStorage
     // without a second middleware pass.
     return withRequestContext(
-      { requestId, user: authResult.user, atlasMode, approvalSurface: "chat" },
+      { requestId, user: authResult.user, atlasMode, agentOrigin: "chat" },
       async () => {
         // Startup diagnostics — fast-fail with actionable errors
         const diagnostics = await validateEnvironment();
@@ -1343,7 +1343,7 @@ chat.openapi(chatRoute, async (c) => {
               requestId,
               user: authResult.user,
               atlasMode,
-              approvalSurface: "chat",
+              agentOrigin: "chat",
               ...(effectiveConnectionId !== undefined && {
                 connectionId: effectiveConnectionId,
               }),

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -529,7 +529,7 @@ demo.openapi(demoChatRoute, async (c) => {
   // #2072 — demo runs the same flow as chat from the user's POV.
   const demoUser = createAtlasUser(userId, "simple-key", `demo:${email}`);
   return withRequestContext(
-    { requestId, user: demoUser, approvalSurface: "chat" },
+    { requestId, user: demoUser, agentOrigin: "chat" },
     async () => {
       // Startup diagnostics
       const diagnostics = await validateEnvironment();

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -212,10 +212,10 @@ query.openapi(
       const { authResult } = preamble;
 
       // Bind user identity into AsyncLocalStorage for downstream logging/audit.
-      // #2072 — `/api/v1/query` is the API form of chat; surface-scoped
+      // #2072 — `/api/v1/query` is the API form of chat; origin-scoped
       // approval rules treat it identically to the chat UI.
       return withRequestContext(
-        { requestId, user: authResult.user, approvalSurface: "chat" },
+        { requestId, user: authResult.user, agentOrigin: "chat" },
         async () => {
 
         // #3419/#3420 — workspace status, abuse, and plan-limit

--- a/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
+++ b/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
@@ -53,7 +53,7 @@ const KNOWN_AGENT_CALLERS: AgentCallerSpec[] = [
   {
     file: "packages/api/src/lib/scheduler/executor.ts",
     // F-54: resolves the task creator and passes as actor.
-    // #2072: also stamps approvalSurface for surface-scoped rules — the
+    // #2072: also stamps agentOrigin for origin-scoped rules — the
     // regex covers either the bare `{ actor }` shape OR an options bag
     // that includes both fields, so future option additions don't trip
     // this guardrail.
@@ -93,33 +93,33 @@ async function readRepoFile(relPath: string): Promise<string> {
 }
 
 /**
- * #2072 surface-stamp registry — symmetric guardrail to the F-54/F-55
+ * #2072 origin-stamp registry — symmetric guardrail to the F-54/F-55
  * binding registry above. Every agent caller (or its parent transport
- * frame) must stamp the request's origin on `RequestContext.approvalSurface`,
- * either inline via `withRequestContext({ ..., approvalSurface: "..." })` or
- * by passing `approvalSurface` to `executeAgentQuery`. A route that omits
- * the stamp silently degrades surface-scoped approval rules to no-op for
+ * frame) must stamp the request's origin on `RequestContext.agentOrigin`,
+ * either inline via `withRequestContext({ ..., agentOrigin: "..." })` or
+ * by passing `agentOrigin` to `executeAgentQuery`. A route that omits
+ * the stamp silently degrades origin-scoped approval rules to no-op for
  * that transport — the same class of silent governance regression F-54/F-55
  * closed for the actor binding.
  */
-interface SurfaceStamperSpec {
+interface OriginStamperSpec {
   file: string;
   /** Regex that must appear in the file. Use `\b<value>\b` to pin the literal. */
-  surfaceProof: RegExp;
+  originProof: RegExp;
 }
 
-const KNOWN_SURFACE_STAMPERS: SurfaceStamperSpec[] = [
+const KNOWN_ORIGIN_STAMPERS: OriginStamperSpec[] = [
   // Web chat surface — chat / query / demo / API form all stamp 'chat'.
-  { file: "packages/api/src/api/routes/chat.ts", surfaceProof: /approvalSurface:\s*"chat"/ },
-  { file: "packages/api/src/api/routes/query.ts", surfaceProof: /approvalSurface:\s*"chat"/ },
-  { file: "packages/api/src/api/routes/demo.ts", surfaceProof: /approvalSurface:\s*"chat"/ },
+  { file: "packages/api/src/api/routes/chat.ts", originProof: /agentOrigin:\s*"chat"/ },
+  { file: "packages/api/src/api/routes/query.ts", originProof: /agentOrigin:\s*"chat"/ },
+  { file: "packages/api/src/api/routes/demo.ts", originProof: /agentOrigin:\s*"chat"/ },
   // Scheduler executor stamps 'scheduler' on every scheduled run.
-  { file: "packages/api/src/lib/scheduler/executor.ts", surfaceProof: /approvalSurface:\s*"scheduler"/ },
+  { file: "packages/api/src/lib/scheduler/executor.ts", originProof: /agentOrigin:\s*"scheduler"/ },
   // MCP — both the per-tool dispatch frames and the outer hosted-MCP
   // session frame stamp 'mcp'.
-  { file: "packages/mcp/src/tools.ts", surfaceProof: /approvalSurface:\s*"mcp"/ },
-  { file: "packages/mcp/src/semantic-tools.ts", surfaceProof: /approvalSurface:\s*"mcp"/ },
-  { file: "packages/mcp/src/hosted.ts", surfaceProof: /approvalSurface:\s*"mcp"/ },
+  { file: "packages/mcp/src/tools.ts", originProof: /agentOrigin:\s*"mcp"/ },
+  { file: "packages/mcp/src/semantic-tools.ts", originProof: /agentOrigin:\s*"mcp"/ },
+  { file: "packages/mcp/src/hosted.ts", originProof: /agentOrigin:\s*"mcp"/ },
 ];
 
 describe("F-54/F-55 agent-surface registry", () => {
@@ -131,13 +131,13 @@ describe("F-54/F-55 agent-surface registry", () => {
     }
   });
 
-  it("#2072: every known surface-stamping caller writes approvalSurface with the expected value", async () => {
-    for (const spec of KNOWN_SURFACE_STAMPERS) {
+  it("#2072: every known surface-stamping caller writes agentOrigin with the expected value", async () => {
+    for (const spec of KNOWN_ORIGIN_STAMPERS) {
       const source = await readRepoFile(spec.file);
       expect(
         source,
-        `${spec.file} must stamp approvalSurface (regex ${spec.surfaceProof}). A route that skips this silently downgrades surface-scoped approval rules for that transport.`,
-      ).toMatch(spec.surfaceProof);
+        `${spec.file} must stamp agentOrigin (regex ${spec.originProof}). A route that skips this silently downgrades origin-scoped approval rules for that transport.`,
+      ).toMatch(spec.originProof);
     }
   });
 

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -11,7 +11,7 @@ import { createLogger, getRequestContext, withRequestContext } from "@atlas/api/
 import { checkAgentBillingGate, BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import type { PlanLimitWarning } from "@atlas/api/lib/billing/enforcement";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
-import type { ApprovalRequestSurface } from "@useatlas/types";
+import type { ApprovalRequestOrigin } from "@useatlas/types";
 
 const log = createLogger("agent-query");
 
@@ -79,14 +79,14 @@ export interface ExecuteAgentQueryOptions {
    */
   actor?: AtlasUser;
   /**
-   * #2072 — origin surface for surface-scoped approval rules. System
+   * #2072 — agent origin for origin-scoped approval rules. System
    * callers (scheduler, chat-platform receivers) MUST pass this so an
    * "MCP-only" or "scheduler-only" rule fires for the correct transport.
-   * When omitted, falls back to whatever surface the parent
+   * When omitted, falls back to whatever origin the parent
    * RequestContext stamped (or undefined if neither is set, in which
    * case only `'any'` rules match — fail-closed).
    */
-  approvalSurface?: ApprovalRequestSurface;
+  agentOrigin?: ApprovalRequestOrigin;
   /** Execution target for this agent run. */
   connectionId?: string;
   /** Content scope for group-aware semantic overlays. */
@@ -133,7 +133,7 @@ export async function executeAgentQuery(
   // parent RequestContext stamped. System-initiated callers (scheduler,
   // Slack, Teams) pass this explicitly because they don't run inside a
   // route-level `withRequestContext` that would have set it.
-  const surface = options?.approvalSurface ?? inheritedCtx?.approvalSurface;
+  const origin = options?.agentOrigin ?? inheritedCtx?.agentOrigin;
   const connectionId = options?.connectionId ?? inheritedCtx?.connectionId;
   const connectionGroupId = options?.connectionGroupId ?? inheritedCtx?.connectionGroupId;
 
@@ -150,7 +150,7 @@ export async function executeAgentQuery(
       requestId: id,
       ...(boundUser ? { user: boundUser } : {}),
       ...(inheritedMode ? { atlasMode: inheritedMode } : {}),
-      ...(surface ? { approvalSurface: surface } : {}),
+      ...(origin ? { agentOrigin: origin } : {}),
       ...(connectionId ? { connectionId } : {}),
       ...(connectionGroupId ? { connectionGroupId } : {}),
     },
@@ -158,7 +158,7 @@ export async function executeAgentQuery(
     // #3419/#3420 — the single billing-enforcement seam for agent runs.
     // Blocks before any tool registry / LLM work so a suspended,
     // trial-expired, hard-capped, or abuse-flagged workspace consumes
-    // zero platform-paid tokens regardless of which surface called.
+    // zero platform-paid tokens regardless of which origin called.
     const gateOrgId = boundUser?.activeOrganizationId;
     const gate = await checkAgentBillingGate(gateOrgId);
     if (!gate.allowed) {
@@ -168,7 +168,7 @@ export async function executeAgentQuery(
           orgId: gateOrgId,
           errorCode: gate.errorCode,
           httpStatus: gate.httpStatus,
-          ...(surface ? { surface } : {}),
+          ...(origin ? { agentOrigin: origin } : {}),
         },
         "Agent run blocked by billing enforcement",
       );

--- a/packages/api/src/lib/approvals/__tests__/evaluate.test.ts
+++ b/packages/api/src/lib/approvals/__tests__/evaluate.test.ts
@@ -1,75 +1,75 @@
 /**
- * Surface-scoping predicate tests (#2072).
+ * Origin-scoping predicate tests (#2072).
  *
- * Pins the matching semantics for `surfaceMatchesRule`: a rule fires for a
- * request when the rule's surface is `'any'` OR equals the request's
- * surface. Unknown request surface (route forgot to stamp) fails-closed for
- * non-`any` rules so a rule with `surface = 'mcp'` never matches a request
+ * Pins the matching semantics for `originMatchesRule`: a rule fires for a
+ * request when the rule's origin is `'any'` OR equals the request's
+ * origin. Unknown request origin (route forgot to stamp) fails-closed for
+ * non-`any` rules so a rule with `origin = 'mcp'` never matches a request
  * whose origin we couldn't identify.
  */
 
 import { describe, it, expect } from "bun:test";
-import { surfaceMatchesRule, REQUEST_SURFACES, APPROVAL_RULE_SURFACES } from "../evaluate";
-import type { RequestSurface } from "../types";
+import { originMatchesRule, REQUEST_ORIGINS, APPROVAL_RULE_ORIGINS } from "../evaluate";
+import type { RequestOrigin } from "../types";
 
-describe("surfaceMatchesRule (#2072)", () => {
-  describe("rule.surface = 'any' — preserves pre-2072 behavior", () => {
-    it("matches every defined request surface", () => {
-      for (const reqSurface of REQUEST_SURFACES) {
+describe("originMatchesRule (#2072)", () => {
+  describe("rule.origin = 'any' — preserves pre-2072 behavior", () => {
+    it("matches every defined request origin", () => {
+      for (const reqOrigin of REQUEST_ORIGINS) {
         expect(
-          surfaceMatchesRule("any", reqSurface),
-          `'any' rule must match request surface "${reqSurface}"`,
+          originMatchesRule("any", reqOrigin),
+          `'any' rule must match request origin "${reqOrigin}"`,
         ).toBe(true);
       }
     });
 
-    it("matches when the request surface is unknown (legacy / unstamped routes)", () => {
-      // Pre-2072 callers don't stamp surface. An 'any' rule must still
+    it("matches when the request origin is unknown (legacy / unstamped routes)", () => {
+      // Pre-2072 callers don't stamp origin. An 'any' rule must still
       // fire for them — that's the migration's "non-destructive" promise.
-      expect(surfaceMatchesRule("any", undefined)).toBe(true);
+      expect(originMatchesRule("any", undefined)).toBe(true);
     });
   });
 
-  describe("rule.surface = 'mcp' — surface isolation", () => {
+  describe("rule.origin = 'mcp' — origin isolation", () => {
     it("fires for an MCP-bound request", () => {
-      expect(surfaceMatchesRule("mcp", "mcp")).toBe(true);
+      expect(originMatchesRule("mcp", "mcp")).toBe(true);
     });
 
     it("does not fire for chat-bound requests with the same query shape", () => {
       // Acceptance criterion from #2072: 'MCP-only rule that fires for MCP
       // queries but not chat queries against the same query shape'.
-      expect(surfaceMatchesRule("mcp", "chat")).toBe(false);
+      expect(originMatchesRule("mcp", "chat")).toBe(false);
     });
 
-    it("does not fire for any other surface", () => {
-      const others = REQUEST_SURFACES.filter((s) => s !== "mcp");
-      for (const reqSurface of others) {
+    it("does not fire for any other origin", () => {
+      const others = REQUEST_ORIGINS.filter((s) => s !== "mcp");
+      for (const reqOrigin of others) {
         expect(
-          surfaceMatchesRule("mcp", reqSurface),
-          `'mcp' rule must NOT match request surface "${reqSurface}"`,
+          originMatchesRule("mcp", reqOrigin),
+          `'mcp' rule must NOT match request origin "${reqOrigin}"`,
         ).toBe(false);
       }
     });
 
-    it("does not fire when request surface is unknown (fail-closed)", () => {
-      // Non-'any' rules require an identified surface. Unknown surface
-      // means the route forgot to stamp; we don't want surface-scoped
+    it("does not fire when request origin is unknown (fail-closed)", () => {
+      // Non-'any' rules require an identified origin. Unknown origin
+      // means the route forgot to stamp; we don't want origin-scoped
       // rules accidentally firing because the binding was missed.
-      expect(surfaceMatchesRule("mcp", undefined)).toBe(false);
+      expect(originMatchesRule("mcp", undefined)).toBe(false);
     });
   });
 
-  describe("rule.surface = 'chat' — symmetric isolation", () => {
+  describe("rule.origin = 'chat' — symmetric isolation", () => {
     it("fires for a chat-bound request", () => {
-      expect(surfaceMatchesRule("chat", "chat")).toBe(true);
+      expect(originMatchesRule("chat", "chat")).toBe(true);
     });
 
     it("does not fire for an MCP-bound request with the same query shape", () => {
-      expect(surfaceMatchesRule("chat", "mcp")).toBe(false);
+      expect(originMatchesRule("chat", "mcp")).toBe(false);
     });
 
-    it("does not fire when request surface is unknown", () => {
-      expect(surfaceMatchesRule("chat", undefined)).toBe(false);
+    it("does not fire when request origin is unknown", () => {
+      expect(originMatchesRule("chat", undefined)).toBe(false);
     });
   });
 
@@ -77,7 +77,7 @@ describe("surfaceMatchesRule (#2072)", () => {
     // Defensive enumeration — a future refactor that drops one of the
     // surfaces from the union must surface as a compile error in this
     // exhaustive list, not as a silent runtime gap.
-    const cases: { rule: typeof APPROVAL_RULE_SURFACES[number]; req: RequestSurface }[] = [
+    const cases: { rule: typeof APPROVAL_RULE_ORIGINS[number]; req: RequestOrigin }[] = [
       { rule: "scheduler", req: "scheduler" },
       { rule: "slack", req: "slack" },
       { rule: "teams", req: "teams" },
@@ -86,29 +86,29 @@ describe("surfaceMatchesRule (#2072)", () => {
 
     for (const { rule, req } of cases) {
       it(`'${rule}' rule fires for '${req}' request`, () => {
-        expect(surfaceMatchesRule(rule, req)).toBe(true);
+        expect(originMatchesRule(rule, req)).toBe(true);
       });
 
       it(`'${rule}' rule does not fire for 'mcp' request`, () => {
-        expect(surfaceMatchesRule(rule, "mcp")).toBe(false);
+        expect(originMatchesRule(rule, "mcp")).toBe(false);
       });
 
       it(`'${rule}' rule does not fire for 'chat' request`, () => {
-        expect(surfaceMatchesRule(rule, "chat")).toBe(false);
+        expect(originMatchesRule(rule, "chat")).toBe(false);
       });
     }
   });
 
   describe("enum exhaustiveness (catches enum drift)", () => {
-    it("APPROVAL_RULE_SURFACES contains 'any' plus every REQUEST_SURFACES value", () => {
+    it("APPROVAL_RULE_ORIGINS contains 'any' plus every REQUEST_ORIGINS value", () => {
       // The rule enum is the request enum + 'any'. If a new request
-      // surface lands without a matching rule entry, surface-scoped rules
+      // origin lands without a matching rule entry, origin-scoped rules
       // for it cannot be authored — this assertion fails so the schema /
       // migration / type drift is caught at the test layer.
-      for (const reqSurface of REQUEST_SURFACES) {
-        expect(APPROVAL_RULE_SURFACES).toContain(reqSurface);
+      for (const reqOrigin of REQUEST_ORIGINS) {
+        expect(APPROVAL_RULE_ORIGINS).toContain(reqOrigin);
       }
-      expect(APPROVAL_RULE_SURFACES).toContain("any");
+      expect(APPROVAL_RULE_ORIGINS).toContain("any");
     });
   });
 });

--- a/packages/api/src/lib/approvals/evaluate.ts
+++ b/packages/api/src/lib/approvals/evaluate.ts
@@ -1,58 +1,59 @@
 /**
- * Surface-scoping match predicate for approval rules (#2072).
+ * Origin-scoping match predicate for approval rules (#2072; "surface"
+ * renamed to "origin" in ADR-0015).
  *
  * The DB-side filter in `ee/governance/approval.ts` uses
- *   WHERE org_id = $1 AND enabled = true AND (surface = 'any' OR surface = $2)
- * with `$2` set to the request's surface (or NULL when unknown). This file
+ *   WHERE org_id = $1 AND enabled = true AND (origin = 'any' OR origin = $2)
+ * with `$2` set to the request's origin (or NULL when unknown). This file
  * exists so the same matching contract lives in code we can unit-test
  * directly without a DB mock — and so post-fetch filtering (defense in
  * depth) shares one source of truth with the SQL filter.
  *
  * Semantics:
- *   - `surface = 'any'` rule  →  fires for every request (preserves
+ *   - `origin = 'any'` rule  →  fires for every request (preserves
  *     pre-2072 behavior; this is the migration default).
- *   - `surface = '<value>'` rule  →  fires only when the request stamped
- *     that exact surface on its RequestContext.
- *   - Unknown request surface  →  only `'any'` rules match. A rule pinned
- *     to a specific surface (e.g. `'mcp'`) does NOT match an unknown-
- *     surface request. This is *scope isolation*, not the F-54/F-55
- *     governance fail-closed: if a route forgets to stamp surface, an
+ *   - `origin = '<value>'` rule  →  fires only when the request stamped
+ *     that exact origin on its RequestContext.
+ *   - Unknown request origin  →  only `'any'` rules match. A rule pinned
+ *     to a specific origin (e.g. `'mcp'`) does NOT match an unknown-
+ *     origin request. This is *scope isolation*, not the F-54/F-55
+ *     governance fail-closed: if a route forgets to stamp an origin, an
  *     `'any'` rule still fires (so governance is preserved); only the
- *     surface-scoped rules become dormant for that caller. The true
+ *     origin-scoped rules become dormant for that caller. The true
  *     governance fail-closed lives in `checkApprovalRequired`'s
  *     `identityMissing` path.
  */
 
 import {
-  APPROVAL_RULE_SURFACES,
-  REQUEST_SURFACES,
-  type ApprovalRuleSurface,
-  type RequestSurface,
+  APPROVAL_RULE_ORIGINS,
+  REQUEST_ORIGINS,
+  type ApprovalRuleOrigin,
+  type RequestOrigin,
 } from "./types";
 
-export { APPROVAL_RULE_SURFACES, REQUEST_SURFACES };
-export type { ApprovalRuleSurface, RequestSurface };
+export { APPROVAL_RULE_ORIGINS, REQUEST_ORIGINS };
+export type { ApprovalRuleOrigin, RequestOrigin };
 
 /**
- * True when a rule with `ruleSurface` matches a request originating from
- * `requestSurface`. See module-level comment for the matching contract.
+ * True when a rule with `ruleOrigin` matches a request originating from
+ * `requestOrigin`. See module-level comment for the matching contract.
  */
-export function surfaceMatchesRule(
-  ruleSurface: ApprovalRuleSurface,
-  requestSurface: RequestSurface | undefined,
+export function originMatchesRule(
+  ruleOrigin: ApprovalRuleOrigin,
+  requestOrigin: RequestOrigin | undefined,
 ): boolean {
-  if (ruleSurface === "any") return true;
-  return ruleSurface === requestSurface;
+  if (ruleOrigin === "any") return true;
+  return ruleOrigin === requestOrigin;
 }
 
 /**
- * Filter an in-memory rule array by surface. Mirrors the SQL-side filter
+ * Filter an in-memory rule array by origin. Mirrors the SQL-side filter
  * exactly so callers can post-verify or test the matching without
  * round-tripping the DB.
  */
-export function selectMatchingRulesBySurface<T extends { surface: ApprovalRuleSurface }>(
+export function selectMatchingRulesByOrigin<T extends { origin: ApprovalRuleOrigin }>(
   rules: readonly T[],
-  requestSurface: RequestSurface | undefined,
+  requestOrigin: RequestOrigin | undefined,
 ): T[] {
-  return rules.filter((rule) => surfaceMatchesRule(rule.surface, requestSurface));
+  return rules.filter((rule) => originMatchesRule(rule.origin, requestOrigin));
 }

--- a/packages/api/src/lib/approvals/types.ts
+++ b/packages/api/src/lib/approvals/types.ts
@@ -1,5 +1,6 @@
 /**
- * Surface-scoping helpers for approval rules (#2072).
+ * Origin-scoping helpers for approval rules (#2072; "surface" renamed to
+ * "origin" in ADR-0015).
  *
  * The canonical enums live in `@useatlas/types/approval` so the SQL
  * route layer, the wire schemas, the web admin types, and this module
@@ -12,17 +13,17 @@
  */
 
 import {
-  APPROVAL_RULE_SURFACES,
-  APPROVAL_REQUEST_SURFACES,
-  type ApprovalRuleSurface,
-  type ApprovalRequestSurface,
+  APPROVAL_RULE_ORIGINS,
+  APPROVAL_REQUEST_ORIGINS,
+  type ApprovalRuleOrigin,
+  type ApprovalRequestOrigin,
 } from "@useatlas/types";
 
 export {
-  APPROVAL_RULE_SURFACES,
-  APPROVAL_REQUEST_SURFACES,
-  type ApprovalRuleSurface,
-  type ApprovalRequestSurface,
+  APPROVAL_RULE_ORIGINS,
+  APPROVAL_REQUEST_ORIGINS,
+  type ApprovalRuleOrigin,
+  type ApprovalRequestOrigin,
 };
 
 /**
@@ -30,13 +31,13 @@ export {
  * shorter names. Anyone reading `evaluate.ts` is already inside the
  * approval-rules namespace; the prefix is redundant noise there.
  */
-export const REQUEST_SURFACES = APPROVAL_REQUEST_SURFACES;
-export type RequestSurface = ApprovalRequestSurface;
+export const REQUEST_ORIGINS = APPROVAL_REQUEST_ORIGINS;
+export type RequestOrigin = ApprovalRequestOrigin;
 
-export function isApprovalRuleSurface(value: string): value is ApprovalRuleSurface {
-  return (APPROVAL_RULE_SURFACES as readonly string[]).includes(value);
+export function isApprovalRuleOrigin(value: string): value is ApprovalRuleOrigin {
+  return (APPROVAL_RULE_ORIGINS as readonly string[]).includes(value);
 }
 
-export function isRequestSurface(value: string): value is ApprovalRequestSurface {
-  return (APPROVAL_REQUEST_SURFACES as readonly string[]).includes(value);
+export function isRequestOrigin(value: string): value is ApprovalRequestOrigin {
+  return (APPROVAL_REQUEST_ORIGINS as readonly string[]).includes(value);
 }

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -373,10 +373,11 @@ describe("migrateAuthTables", () => {
             { name: "0123_elasticsearch_datasource_catalog.sql" },
             { name: "0124_duckdb_not_saas_eligible.sql" },
             { name: "0125_elasticsearch_auth_modes_config_schema.sql" },
-            // 0126/0127/0130 are MANAGED_AUTH_MIGRATIONS (skipped outside
-            // managed mode), so they don't need to appear here.
+            // 0126/0127/0130/0131/0132 are MANAGED_AUTH_MIGRATIONS (skipped
+            // outside managed mode), so they don't need to appear here.
             { name: "0128_stripe_webhook_event_ledger.sql" },
             { name: "0129_stripe_purged_subscriptions.sql" },
+            { name: "0133_approval_origin_rename.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -4,12 +4,12 @@
  * Feeds a synthetic Slack `app_mention` payload (the same shape Slack's
  * Events API delivers) through `runExecuteQuery` and asserts the agent
  * sees the legacy slack.ts envelope: `orgId` via `botActorUser`,
- * `approvalSurface: "slack"`, conversation persistence by
+ * `agentOrigin: "slack"`, conversation persistence by
  * (channel, thread_ts), and rate-limit key `slack:${teamId}`.
  *
  * The agent + Slack store + conversation persistence are mocked at the
  * module boundary. `executeAgentQuery` is captured so its `actor` /
- * `approvalSurface` arguments are asserted directly — that's the F-55
+ * `agentOrigin` arguments are asserted directly — that's the F-55
  * gate this slice has to preserve.
  */
 
@@ -29,7 +29,7 @@ interface CapturedAgentCall {
   requestId?: string;
   options?: {
     actor?: { id: string; activeOrganizationId?: string };
-    approvalSurface?: string;
+    agentOrigin?: string;
     conversationId?: string;
     priorMessages?: Array<{ role: string; content: string }>;
   };
@@ -42,7 +42,7 @@ const mockExecuteAgentQuery: Mock<
     requestId?: string,
     options?: {
       actor?: { id: string; activeOrganizationId?: string };
-      approvalSurface?: string;
+      agentOrigin?: string;
       conversationId?: string;
       priorMessages?: Array<{ role: string; content: string }>;
     },
@@ -219,7 +219,7 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(actor!.activeOrganizationId).toBe("org-xyz");
   });
 
-  it("stamps approvalSurface='slack' on every agent invocation", async () => {
+  it("stamps agentOrigin='slack' on every agent invocation", async () => {
     const { runExecuteQuery } = await import("../executeQuery");
 
     await runExecuteQuery("test question", {
@@ -233,7 +233,7 @@ describe("chat-plugin executeQuery host helper", () => {
       },
     });
 
-    expect(capturedAgentCalls[0]!.options?.approvalSurface).toBe("slack");
+    expect(capturedAgentCalls[0]!.options?.agentOrigin).toBe("slack");
   });
 
   it("rate-limit key for thread follow-up is team-wide `slack:<teamId>` — matches slack.ts:491", async () => {
@@ -658,7 +658,7 @@ describe("chat-plugin executeQuery host helper", () => {
   // Discord branch — 1.5.3 #2749 (Phase D)
   // -------------------------------------------------------------------------
 
-  it("Discord happy path: resolves guild_id → workspace + binds discord actor + stamps approvalSurface='discord'", async () => {
+  it("Discord happy path: resolves guild_id → workspace + binds discord actor + stamps agentOrigin='discord'", async () => {
     mockInternalQuery.mockImplementation((sql: string) => {
       if (sql.includes("workspace_plugins")) {
         return Promise.resolve([{ workspace_id: "org-discord-tenant" }]);
@@ -683,7 +683,7 @@ describe("chat-plugin executeQuery host helper", () => {
     const call = capturedAgentCalls[0]!;
     expect(call.options?.actor?.id).toBe("discord-bot:123456789012345678:U_DC");
     expect(call.options?.actor?.activeOrganizationId).toBe("org-discord-tenant");
-    expect(call.options?.approvalSurface).toBe("discord");
+    expect(call.options?.agentOrigin).toBe("discord");
     // Rate-limit key shape is `discord:${guildId}` (per-server bucket).
     expect(observedRateLimitKeys).toContain("discord:123456789012345678");
   });
@@ -797,7 +797,7 @@ describe("chat-plugin executeQuery host helper", () => {
   // hand the host callback in production.
   // ---------------------------------------------------------------------------
 
-  it("WhatsApp happy path: resolves phone_number_id → workspace + binds whatsapp actor + stamps approvalSurface='whatsapp'", async () => {
+  it("WhatsApp happy path: resolves phone_number_id → workspace + binds whatsapp actor + stamps agentOrigin='whatsapp'", async () => {
     mockInternalQuery.mockImplementation((sql: string) => {
       if (sql.includes("workspace_plugins")) {
         return Promise.resolve([{ workspace_id: "org-whatsapp-tenant" }]);
@@ -825,7 +825,7 @@ describe("chat-plugin executeQuery host helper", () => {
     const call = capturedAgentCalls[0];
     expect(call.options?.actor?.id).toBe("whatsapp-bot:1098765432109876:16315551234");
     expect(call.options?.actor?.activeOrganizationId).toBe("org-whatsapp-tenant");
-    expect(call.options?.approvalSurface).toBe("whatsapp");
+    expect(call.options?.agentOrigin).toBe("whatsapp");
     // Rate-limit key shape is `whatsapp:${phoneNumberId}` (per-number bucket).
     expect(observedRateLimitKeys).toContain("whatsapp:1098765432109876");
     // DB lookup against the catalog row's stable id with config->>'phone_number_id'.
@@ -949,7 +949,7 @@ describe("chat-plugin executeQuery host helper", () => {
   // Google Chat branch — 1.5.3 #2754 (Phase D)
   // -------------------------------------------------------------------------
 
-  it("Google Chat happy path: resolves workspace_id → workspace + binds gchat actor + stamps approvalSurface='gchat'", async () => {
+  it("Google Chat happy path: resolves workspace_id → workspace + binds gchat actor + stamps agentOrigin='gchat'", async () => {
     mockInternalQuery.mockImplementation((sql: string) => {
       if (sql.includes("workspace_plugins")) {
         return Promise.resolve([{ workspace_id: "org-gchat-tenant" }]);
@@ -977,7 +977,7 @@ describe("chat-plugin executeQuery host helper", () => {
     const call = capturedAgentCalls[0]!;
     expect(call.options?.actor?.id).toBe("gchat-bot:C01abc234:users/12345");
     expect(call.options?.actor?.activeOrganizationId).toBe("org-gchat-tenant");
-    expect(call.options?.approvalSurface).toBe("gchat");
+    expect(call.options?.agentOrigin).toBe("gchat");
     // Rate-limit key shape is `gchat:${workspaceId}` (per-Workspace bucket).
     expect(observedRateLimitKeys).toContain("gchat:C01abc234");
   });
@@ -1121,7 +1121,7 @@ describe("chat-plugin executeQuery host helper", () => {
 
   const TEAMS_TENANT = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
-  it("Teams happy path: resolves tenant_id → workspace + binds teams actor + stamps approvalSurface='teams'", async () => {
+  it("Teams happy path: resolves tenant_id → workspace + binds teams actor + stamps agentOrigin='teams'", async () => {
     mockInternalQuery.mockImplementation((sql: string) => {
       if (sql.includes("workspace_plugins")) {
         return Promise.resolve([{ workspace_id: "org-teams-tenant" }]);
@@ -1146,7 +1146,7 @@ describe("chat-plugin executeQuery host helper", () => {
     // externalId is the tenant GUID; externalUserId prefers the AAD object id.
     expect(call.options?.actor?.id).toBe(`teams-bot:${TEAMS_TENANT}:aad-obj-1`);
     expect(call.options?.actor?.activeOrganizationId).toBe("org-teams-tenant");
-    expect(call.options?.approvalSurface).toBe("teams");
+    expect(call.options?.agentOrigin).toBe("teams");
     // Rate-limit key shape is `teams:${tenantId}` (per-tenant bucket).
     expect(observedRateLimitKeys).toContain(`teams:${TEAMS_TENANT}`);
     // DB lookup against the catalog row's stable id with config->>'tenant_id'.

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -32,7 +32,7 @@
  *   - `getBotToken(teamId)` / `getInstallation(teamId)` for tenancy (Slack)
  *   - `workspace_plugins.config->>'chat_id'` lookup (Telegram)
  *   - `botActorUser({ platform, externalId, orgId, ... })` for F-55 identity
- *   - `executeAgentQuery(question, undefined, { actor, approvalSurface, priorMessages })`
+ *   - `executeAgentQuery(question, undefined, { actor, agentOrigin, priorMessages })`
  *   - `getConversationId` / `setConversationId` for thread → conversation mapping
  *   - `createConversation` / `addMessage` for multi-turn persistence
  *   - `checkRateLimit("&lt;platform&gt;:${tenantKey}")` for per-tenant rate limiting
@@ -60,7 +60,7 @@ import type {
   ChatQueryResult,
   ChatPluginConfig,
 } from "@useatlas/chat";
-import type { ApprovalRequestSurface } from "@useatlas/types";
+import type { ApprovalRequestOrigin } from "@useatlas/types";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -363,7 +363,7 @@ function extractTeamsTenantId(raw: TeamsRawEvent): string | undefined {
  *
  * Multi-platform dispatch lives inside `runExecuteQuery`. Each chat
  * Platform gets its own tenant resolver, rate-limit key shape, and
- * approval-surface stamp. The `unsupported platform` branch throws a
+ * agent-origin stamp. The `unsupported platform` branch throws a
  * user-safe error so the plugin's `buildErrorCard` path stays graceful.
  *
  * The returned callback is plain async — no `Effect` / `ManagedRuntime`
@@ -533,7 +533,7 @@ async function runSlackExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "slack",
+    agentOrigin: "slack",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
@@ -639,7 +639,7 @@ async function runTelegramExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "telegram",
+    agentOrigin: "telegram",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
@@ -834,7 +834,7 @@ async function runDiscordExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "discord",
+    agentOrigin: "discord",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
@@ -1005,7 +1005,7 @@ async function runGchatExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "gchat",
+    agentOrigin: "gchat",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
@@ -1181,7 +1181,7 @@ async function runTeamsExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "teams",
+    agentOrigin: "teams",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
@@ -1328,7 +1328,7 @@ interface RunAgentArgs {
   readonly question: string;
   readonly requestId: string;
   readonly actor: ReturnType<typeof botActorUser>;
-  readonly approvalSurface: ApprovalRequestSurface;
+  readonly agentOrigin: ApprovalRequestOrigin;
   readonly conversationId: string | null;
   readonly priorMessages: ChatExecuteQueryContext["priorMessages"] | null;
   readonly presentationMode: ChatExecuteQueryContext["presentationMode"];
@@ -1349,7 +1349,7 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
     question,
     requestId,
     actor,
-    approvalSurface,
+    agentOrigin,
     conversationId,
     priorMessages,
     presentationMode,
@@ -1393,7 +1393,7 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
     queryResult = await executeAgentQuery(question, requestId, {
       ...(history ? { priorMessages: history } : {}),
       actor,
-      approvalSurface,
+      agentOrigin,
       ...(conversationId ? { conversationId } : {}),
       // #2705 — propagate the bridge's presentation-mode signal so the
       // chat path produces the conversational shape. Default to
@@ -1623,7 +1623,7 @@ async function runWhatsAppExecuteQuery(
     question,
     requestId,
     actor,
-    approvalSurface: "whatsapp",
+    agentOrigin: "whatsapp",
     conversationId,
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -152,7 +152,8 @@ describe("runMigrations", () => {
     //   Plus 0130 (user_trial_grants one-trial marker, #3469/#3470) = 131.
     //   Plus 0131 (organization.suspension_source billing/operator, #3424) = 132.
     //   Plus 0132 (organization.plan_override_until operator precedence, #3427) = 133.
-    expect(count).toBe(133);
+    //   Plus 0133 (approval surface→origin rename, #3491) = 134.
+    expect(count).toBe(134);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -314,6 +315,7 @@ describe("runMigrations", () => {
         "0130_user_trial_grants.sql",
         "0131_org_suspension_source.sql",
         "0132_org_plan_override.sql",
+        "0133_approval_origin_rename.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0133_approval_origin_rename.sql
+++ b/packages/api/src/lib/db/migrations/0133_approval_origin_rename.sql
@@ -12,20 +12,27 @@
 -- overlap to protect and no data to backfill — RENAME COLUMN is in-place
 -- and preserves every existing row's value.
 --
--- Idempotent: each rename is guarded so a re-run (or a deploy that
--- partially applied) is a no-op rather than an error. Postgres has no
--- `ALTER ... RENAME ... IF EXISTS` for columns/constraints, so we gate on
--- the catalog. `ALTER INDEX ... RENAME` does support `IF EXISTS`.
+-- Idempotent AND schema-scoped: each rename is guarded so a re-run (or a
+-- deploy that partially applied) is a no-op rather than an error. Every
+-- existence check is pinned to `current_schema()` — the migrate-pg /
+-- rotate-encryption-key tests run migrations under per-test schemas, and
+-- an unscoped `information_schema`/`pg_constraint` probe would see another
+-- schema's already-renamed `origin` column, skip the rename here, then
+-- trip the unconditional COMMENT with "column origin does not exist".
+-- Postgres has no `ALTER ... RENAME ... IF EXISTS` for columns/constraints,
+-- hence the DO-block guards; `ALTER INDEX ... RENAME` does support IF EXISTS.
 
 -- ── approval_rules.surface → origin ──────────────────────────────────
 
 DO $$ BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'approval_rules' AND column_name = 'surface'
+    WHERE table_schema = current_schema()
+      AND table_name = 'approval_rules' AND column_name = 'surface'
   ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'approval_rules' AND column_name = 'origin'
+    WHERE table_schema = current_schema()
+      AND table_name = 'approval_rules' AND column_name = 'origin'
   ) THEN
     ALTER TABLE approval_rules RENAME COLUMN surface TO origin;
   END IF;
@@ -36,7 +43,9 @@ END $$;
 -- identifier so it reads `chk_approval_rule_origin` to match.
 DO $$ BEGIN
   IF EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'chk_approval_rule_surface'
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_approval_rule_surface'
+      AND connamespace = current_schema()::regnamespace
   ) THEN
     ALTER TABLE approval_rules
       RENAME CONSTRAINT chk_approval_rule_surface TO chk_approval_rule_origin;
@@ -54,10 +63,12 @@ COMMENT ON COLUMN approval_rules.origin IS
 DO $$ BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'approval_queue' AND column_name = 'surface'
+    WHERE table_schema = current_schema()
+      AND table_name = 'approval_queue' AND column_name = 'surface'
   ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'approval_queue' AND column_name = 'origin'
+    WHERE table_schema = current_schema()
+      AND table_name = 'approval_queue' AND column_name = 'origin'
   ) THEN
     ALTER TABLE approval_queue RENAME COLUMN surface TO origin;
   END IF;
@@ -65,7 +76,9 @@ END $$;
 
 DO $$ BEGIN
   IF EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'chk_approval_request_surface'
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_approval_request_surface'
+      AND connamespace = current_schema()::regnamespace
   ) THEN
     ALTER TABLE approval_queue
       RENAME CONSTRAINT chk_approval_request_surface TO chk_approval_request_origin;

--- a/packages/api/src/lib/db/migrations/0133_approval_origin_rename.sql
+++ b/packages/api/src/lib/db/migrations/0133_approval_origin_rename.sql
@@ -1,0 +1,76 @@
+-- Migration 0133: Rename the approval "surface" column to "origin" (#3491).
+--
+-- ADR-0015 renames the agent-invocation-channel concept (chat / mcp /
+-- scheduler / slack / …) from "surface" to "agent origin", freeing the
+-- bare word "surface" for the pillar admin-page concept. The enum VALUES
+-- are unchanged — only the column, its CHECK constraints, and the lookup
+-- index are renamed.
+--
+-- One-shot breaking rename, NOT an expand/contract dance: we are in the
+-- pre-customer clean-break window (CONTEXT.md "Deployment posture";
+-- ADR-0015 explicitly authorizes this), so there is no N-1↔N deploy
+-- overlap to protect and no data to backfill — RENAME COLUMN is in-place
+-- and preserves every existing row's value.
+--
+-- Idempotent: each rename is guarded so a re-run (or a deploy that
+-- partially applied) is a no-op rather than an error. Postgres has no
+-- `ALTER ... RENAME ... IF EXISTS` for columns/constraints, so we gate on
+-- the catalog. `ALTER INDEX ... RENAME` does support `IF EXISTS`.
+
+-- ── approval_rules.surface → origin ──────────────────────────────────
+
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_rules' AND column_name = 'surface'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_rules' AND column_name = 'origin'
+  ) THEN
+    ALTER TABLE approval_rules RENAME COLUMN surface TO origin;
+  END IF;
+END $$;
+
+-- Rename the CHECK constraint. Renaming the column above auto-updates the
+-- constraint's stored column reference; this only renames the constraint
+-- identifier so it reads `chk_approval_rule_origin` to match.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_approval_rule_surface'
+  ) THEN
+    ALTER TABLE approval_rules
+      RENAME CONSTRAINT chk_approval_rule_surface TO chk_approval_rule_origin;
+  END IF;
+END $$;
+
+ALTER INDEX IF EXISTS idx_approval_rules_org_surface
+  RENAME TO idx_approval_rules_org_origin;
+
+COMMENT ON COLUMN approval_rules.origin IS
+  'Agent origin this rule applies to (renamed from "surface" in ADR-0015 / #3491). ''any'' fires for every request (pre-2072 default); ''chat'' / ''mcp'' / ''scheduler'' / ''slack'' / ''teams'' / ''telegram'' / ''discord'' / ''whatsapp'' / ''gchat'' / ''webhook'' scope to the named transport. See packages/api/src/lib/approvals/evaluate.ts.';
+
+-- ── approval_queue.surface → origin ──────────────────────────────────
+
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_queue' AND column_name = 'surface'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_queue' AND column_name = 'origin'
+  ) THEN
+    ALTER TABLE approval_queue RENAME COLUMN surface TO origin;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_approval_request_surface'
+  ) THEN
+    ALTER TABLE approval_queue
+      RENAME CONSTRAINT chk_approval_request_surface TO chk_approval_request_origin;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN approval_queue.origin IS
+  'Agent origin of the request that produced this approval row (renamed from "surface" in ADR-0015 / #3491). NULL for legacy rows or callers that did not stamp an origin.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -982,21 +982,22 @@ export const approvalRules = pgTable(
     pattern: text("pattern").notNull().default(""),
     threshold: integer("threshold"),
     enabled: boolean("enabled").notNull().default(true),
-    // #2072 — surface scoping. 'any' preserves pre-2072 fires-everywhere
-    // semantics; the other values pin a rule to a single transport.
-    surface: text("surface").notNull().default("any"),
+    // #2072 — agent-origin scoping (renamed from "surface" in ADR-0015).
+    // 'any' preserves pre-2072 fires-everywhere semantics; the other
+    // values pin a rule to a single transport.
+    origin: text("origin").notNull().default("any"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     check("chk_approval_rule_type", sql`rule_type IN ('table', 'column', 'cost')`),
     check(
-      "chk_approval_rule_surface",
-      sql`surface IN ('any', 'chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'gchat', 'webhook')`,
+      "chk_approval_rule_origin",
+      sql`origin IN ('any', 'chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'gchat', 'webhook')`,
     ),
     index("idx_approval_rules_org").on(t.orgId),
     index("idx_approval_rules_org_enabled").on(t.orgId).where(sql`enabled = true`),
-    index("idx_approval_rules_org_surface").on(t.orgId, t.surface),
+    index("idx_approval_rules_org_origin").on(t.orgId, t.origin),
   ],
 );
 
@@ -1025,18 +1026,19 @@ export const approvalQueue = pgTable(
     reviewerEmail: text("reviewer_email"),
     reviewComment: text("review_comment"),
     reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
-    // #2072 — origin surface stamped at request creation. NULL for legacy
-    // rows / callers that didn't bind a surface; only chat / mcp / scheduler
-    // / slack / teams / webhook for new rows.
-    surface: text("surface"),
+    // #2072 — agent origin stamped at request creation (renamed from
+    // "surface" in ADR-0015). NULL for legacy rows / callers that didn't
+    // bind an origin; only chat / mcp / scheduler / slack / teams /
+    // webhook for new rows.
+    origin: text("origin"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull().default(sql`now() + interval '24 hours'`),
   },
   (t) => [
     check("chk_approval_status", sql`status IN ('pending', 'approved', 'denied', 'expired')`),
     check(
-      "chk_approval_request_surface",
-      sql`surface IS NULL OR surface IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'gchat', 'webhook')`,
+      "chk_approval_request_origin",
+      sql`origin IS NULL OR origin IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'gchat', 'webhook')`,
     ),
     // 0094 / #2744 — composite FK to `connection_groups (id, org_id)`
     // dropped with the table. `connection_group_id` stays as a

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1260,7 +1260,7 @@ export const NoopComplianceReportsLayer: Layer.Layer<ComplianceReports> =
 type ApprovalRule = import("@useatlas/types").ApprovalRule;
 type ApprovalRequest = import("@useatlas/types").ApprovalRequest;
 type ApprovalStatus = import("@useatlas/types").ApprovalStatus;
-type ApprovalRequestSurface = import("@useatlas/types").ApprovalRequestSurface;
+type ApprovalRequestOrigin = import("@useatlas/types").ApprovalRequestOrigin;
 type CreateApprovalRuleRequest = import("@useatlas/types").CreateApprovalRuleRequest;
 type UpdateApprovalRuleRequest = import("@useatlas/types").UpdateApprovalRuleRequest;
 type ApprovalError = import("@atlas/api/lib/governance/errors").ApprovalError;
@@ -1284,7 +1284,7 @@ export interface CreateApprovalRequestInput {
   readonly connectionGroupId?: string | null;
   readonly tablesAccessed: string[];
   readonly columnsAccessed: string[];
-  readonly surface?: ApprovalRequestSurface | null;
+  readonly origin?: ApprovalRequestOrigin | null;
 }
 
 export interface ApprovalGateShape {
@@ -1304,7 +1304,7 @@ export interface ApprovalGateShape {
     columnsAccessed: string[],
     options?: {
       requesterId?: string | undefined;
-      surface?: ApprovalRequestSurface | undefined;
+      origin?: ApprovalRequestOrigin | undefined;
     },
   ) => Effect.Effect<ApprovalMatchResult, never>;
   /** Has the requester already had an identical query approved? */

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -51,14 +51,15 @@ interface RequestContext {
   /** #2067 — request-shape discriminator persisted to `audit_log.{actor_kind, client_id, tool_name}`. */
   actor?: RequestActor;
   /**
-   * #2072 — origin surface for surface-scoped approval rule matching.
-   * Stamped by every agent-facing route (chat / query / slack / teams /
-   * webhook / mcp / scheduler) so `checkApprovalRequired` can apply
-   * `WHERE surface = $req OR surface = 'any'`. Distinct from
-   * `actor.kind` (which is the audit-log discriminator and uses a
-   * different value space — `human` / `agent` / `mcp` / `scheduler`).
+   * #2072 — agent origin for origin-scoped approval rule matching
+   * (renamed from "surface" in ADR-0015). Stamped by every agent-facing
+   * route (chat / query / slack / teams / webhook / mcp / scheduler) so
+   * `checkApprovalRequired` can apply `WHERE origin = $req OR origin =
+   * 'any'`. Distinct from `actor.kind` (which is the audit-log
+   * discriminator and uses a different value space — `human` / `agent` /
+   * `mcp` / `scheduler`).
    */
-  approvalSurface?: import("@useatlas/types").ApprovalRequestSurface;
+  agentOrigin?: import("@useatlas/types").ApprovalRequestOrigin;
   /**
    * #2345 — group-aware chat routing.
    *

--- a/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
@@ -39,7 +39,7 @@ interface ObservedRunAgentCall {
   question: string;
   userId?: string;
   orgId?: string | null;
-  approvalSurface?: string;
+  agentOrigin?: string;
   requestId?: string;
   hasCustomToolRegistry: boolean;
 }
@@ -77,7 +77,7 @@ mock.module("@atlas/api/lib/agent", () => ({
       getRequestContext: () => {
         requestId: string;
         user?: { id: string; activeOrganizationId?: string };
-        approvalSurface?: string;
+        agentOrigin?: string;
       } | undefined;
     };
     const ctx = getRequestContext();
@@ -86,7 +86,7 @@ mock.module("@atlas/api/lib/agent", () => ({
       question,
       userId: ctx?.user?.id,
       orgId: ctx?.user?.activeOrganizationId ?? null,
-      approvalSurface: ctx?.approvalSurface,
+      agentOrigin: ctx?.agentOrigin,
       requestId: ctx?.requestId,
       // Non-null when the adapter built a restricted registry for the
       // unlinked-asker path. The unlinked path test asserts truthy;
@@ -227,7 +227,7 @@ describe("createProactiveAnswerAdapter — linked path", () => {
     expect(observedRunAgentCalls).toHaveLength(1);
     expect(observedRunAgentCalls[0].userId).toBe("user-linked");
     expect(observedRunAgentCalls[0].orgId).toBe("org-linked");
-    expect(observedRunAgentCalls[0].approvalSurface).toBe("slack");
+    expect(observedRunAgentCalls[0].agentOrigin).toBe("slack");
     expect(observedRunAgentCalls[0].question).toBe("how many customers?");
     // Linked askers get the default ToolRegistry — no `tools` arg
     // passed through to runAgent.

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -297,7 +297,7 @@ export function createProactiveAnswerAdapter(
         {
           requestId,
           user: actor,
-          approvalSurface: "slack",
+          agentOrigin: "slack",
         },
         () =>
           runAgent({

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -188,10 +188,10 @@ export async function executeScheduledTask(
     // fire only on scheduled runs, leaving chat / mcp queries against
     // the same tables unaffected. (Approval rules are additive; they
     // can only require approval, never waive it — to exempt the
-    // scheduler from a broad rule, narrow that rule's surface.)
+    // scheduler from a broad rule, narrow that rule's origin.)
     agentQueryEffect(task.question, requestId, taskId, timeoutMs, {
       actor,
-      approvalSurface: "scheduler",
+      agentOrigin: "scheduler",
       ...(resolvedConnectionId ? { connectionId: resolvedConnectionId } : {}),
       ...(task.connectionGroupId ? { connectionGroupId: task.connectionGroupId } : {}),
     }),

--- a/packages/api/src/lib/tools/__tests__/sql-approval.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-approval.test.ts
@@ -116,8 +116,8 @@ mock.module("@atlas/api/lib/rls", () => ({
 let requestContextValue: {
   requestId: string;
   user?: { id: string; activeOrganizationId?: string; label?: string; claims?: Record<string, unknown> };
-  // #2072 — surface stamped by route-level withRequestContext frames.
-  approvalSurface?: "chat" | "mcp" | "scheduler" | "slack" | "teams" | "webhook";
+  // #2072 — origin stamped by route-level withRequestContext frames.
+  agentOrigin?: "chat" | "mcp" | "scheduler" | "slack" | "teams" | "webhook";
 } = {
   requestId: "test-approval",
   user: { id: "user-1", activeOrganizationId: "org-1", label: "user-1@example.com" },
@@ -148,7 +148,7 @@ const mockCheckApprovalRequired = mock<
 >(() => Effect.succeed({ required: false, matchedRules: [] }));
 const mockCreateApprovalRequest = mock<
   // #2072 — typed signature so per-test `mockImplementation((opts) => ...)`
-  // can assert the surface field on the payload without a `(opts: unknown)`
+  // can assert the origin field on the payload without a `(opts: unknown)`
   // cast that TypeScript narrows away from the original mock factory.
   (opts: unknown) => import("effect").Effect.Effect<{ id: string; status: string }, never, never>
 >(() => Effect.succeed({ id: "req-test", status: "pending" }));
@@ -347,24 +347,24 @@ describe("F-54/F-55 executeSQL approval gate", () => {
     expect(mockCheckApprovalRequired).toHaveBeenCalled();
   });
 
-  // ── #2072 surface forwarding ─────────────────────────────────────────
-  // Pin the wire from RequestContext.approvalSurface into
+  // ── #2072 origin forwarding ─────────────────────────────────────────
+  // Pin the wire from RequestContext.agentOrigin into
   // checkApprovalRequired's options bag and through to the createApprovalRequest
   // payload. The DB-side filter is unit-tested in
   // ee/src/governance/approval.test.ts, but a refactor that drops the
-  // `surface: checkSurface` spread in lib/tools/sql.ts would silently
-  // degrade every surface-scoped rule to no-op against the corresponding
+  // `origin: checkOrigin` spread in lib/tools/sql.ts would silently
+  // degrade every origin-scoped rule to no-op against the corresponding
   // transport without those tests failing.
 
-  it("#2072: forwards approvalSurface from RequestContext into checkApprovalRequired", async () => {
+  it("#2072: forwards agentOrigin from RequestContext into checkApprovalRequired", async () => {
     requestContextValue = {
       requestId: "test-approval",
       user: { id: "user-1", activeOrganizationId: "org-1", label: "user-1@example.com" },
-      approvalSurface: "mcp",
+      agentOrigin: "mcp",
     };
     mockCheckApprovalRequired.mockImplementation((_orgId: unknown, _t: unknown, _c: unknown, options?: unknown) => {
-      const opts = options as { surface?: string } | undefined;
-      expect(opts?.surface).toBe("mcp");
+      const opts = options as { origin?: string } | undefined;
+      expect(opts?.origin).toBe("mcp");
       return Effect.succeed({ required: false, matchedRules: [] });
     });
 
@@ -376,15 +376,15 @@ describe("F-54/F-55 executeSQL approval gate", () => {
     expect(mockCheckApprovalRequired).toHaveBeenCalled();
   });
 
-  it("#2072: omits surface from checkApprovalRequired options when RequestContext doesn't stamp one", async () => {
+  it("#2072: omits origin from checkApprovalRequired options when RequestContext doesn't stamp one", async () => {
     requestContextValue = {
       requestId: "test-approval",
       user: { id: "user-1", activeOrganizationId: "org-1", label: "user-1@example.com" },
-      // approvalSurface deliberately absent — legacy / unstamped path.
+      // agentOrigin deliberately absent — legacy / unstamped path.
     };
     mockCheckApprovalRequired.mockImplementation((_orgId: unknown, _t: unknown, _c: unknown, options?: unknown) => {
-      const opts = options as { surface?: string } | undefined;
-      expect(opts?.surface).toBeUndefined();
+      const opts = options as { origin?: string } | undefined;
+      expect(opts?.origin).toBeUndefined();
       return Effect.succeed({ required: false, matchedRules: [] });
     });
 
@@ -395,11 +395,11 @@ describe("F-54/F-55 executeSQL approval gate", () => {
     expect(result.success).toBe(true);
   });
 
-  it("#2072: stamps approvalSurface on the createApprovalRequest payload when a rule matches", async () => {
+  it("#2072: stamps agentOrigin on the createApprovalRequest payload when a rule matches", async () => {
     requestContextValue = {
       requestId: "test-approval",
       user: { id: "user-1", activeOrganizationId: "org-1", label: "user-1@example.com" },
-      approvalSurface: "slack",
+      agentOrigin: "slack",
     };
     mockCheckApprovalRequired.mockImplementation(() =>
       Effect.succeed({
@@ -408,8 +408,8 @@ describe("F-54/F-55 executeSQL approval gate", () => {
       }),
     );
     mockCreateApprovalRequest.mockImplementation((opts: unknown) => {
-      const p = opts as { surface?: string | null };
-      expect(p.surface).toBe("slack");
+      const p = opts as { origin?: string | null };
+      expect(p.origin).toBe("slack");
       return Effect.succeed({ id: "req-test", status: "pending" });
     });
 
@@ -422,7 +422,7 @@ describe("F-54/F-55 executeSQL approval gate", () => {
     expect(mockCreateApprovalRequest).toHaveBeenCalled();
   });
 
-  it("#2072: stamps null surface on the createApprovalRequest payload when caller didn't stamp one", async () => {
+  it("#2072: stamps null origin on the createApprovalRequest payload when caller didn't stamp one", async () => {
     // Legacy / unstamped path — the queue row records null which renders
     // as "unknown_origin" in admin-action metadata. Pinning this keeps
     // the audit-dimension contract intact for callers that haven't been
@@ -438,8 +438,8 @@ describe("F-54/F-55 executeSQL approval gate", () => {
       }),
     );
     mockCreateApprovalRequest.mockImplementation((opts: unknown) => {
-      const p = opts as { surface?: string | null };
-      expect(p.surface).toBeNull();
+      const p = opts as { origin?: string | null };
+      expect(p.origin).toBeNull();
       return Effect.succeed({ id: "req-test", status: "pending" });
     });
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1487,12 +1487,12 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
             const checkReqCtx = getRequestContext();
             const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
             const checkUserId = checkReqCtx?.user?.id;
-            const checkSurface = checkReqCtx?.approvalSurface;
+            const checkOrigin = checkReqCtx?.agentOrigin;
             approvalMatch = await Effect.runPromise(approvalGate.checkApprovalRequired(
               checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
               {
                 ...(checkUserId ? { requesterId: checkUserId } : {}),
-                ...(checkSurface ? { surface: checkSurface } : {}),
+                ...(checkOrigin ? { origin: checkOrigin } : {}),
               },
             ));
           } catch (err) {
@@ -1537,7 +1537,7 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
                 connectionId: connId,
                 tablesAccessed: classification.tablesAccessed,
                 columnsAccessed: classification.columnsAccessed,
-                surface: reqCtxForApproval?.approvalSurface ?? null,
+                origin: reqCtxForApproval?.agentOrigin ?? null,
               }));
               logQueryAudit({
                 sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
@@ -1811,14 +1811,14 @@ async function executeSqlForConnection({
               const checkReqCtx = getRequestContext();
               const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
               const checkUserId = checkReqCtx?.user?.id;
-              // #2072 — propagate the request's origin surface so
-              // surface-scoped rules only fire on the matching transport.
+              // #2072 — propagate the request's agent origin so
+              // origin-scoped rules only fire on the matching transport.
               // Routes stamp this on `withRequestContext`; an unstamped
               // route (or a legacy caller) reaches checkApprovalRequired
-              // with `surface: undefined` and only triggers `'any'`
+              // with `origin: undefined` and only triggers `'any'`
               // rules — scope isolation rather than governance bypass,
               // since the `'any'` migration default still fires.
-              const checkSurface = checkReqCtx?.approvalSurface;
+              const checkOrigin = checkReqCtx?.agentOrigin;
               // Pass requesterId so the defensive identity-missing check
               // distinguishes "scheduler/Slack/MCP forgot to bind anything"
               // (fail-closed) from "demo / single-user mode bound a user
@@ -1827,7 +1827,7 @@ async function executeSqlForConnection({
                 checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
                 {
                   ...(checkUserId ? { requesterId: checkUserId } : {}),
-                  ...(checkSurface ? { surface: checkSurface } : {}),
+                  ...(checkOrigin ? { origin: checkOrigin } : {}),
                 },
               ));
             } catch (err) {
@@ -1875,10 +1875,10 @@ async function executeSqlForConnection({
                   connectionId: connId,
                   tablesAccessed: classification.tablesAccessed,
                   columnsAccessed: classification.columnsAccessed,
-                  // #2072 — stamp the origin surface on the queue row
+                  // #2072 — stamp the agent origin on the queue row
                   // for the audit dimension (queryable via direct SQL
-                  // until a surface filter ships in /admin/audit).
-                  surface: reqCtxForApproval?.approvalSurface ?? null,
+                  // until an origin filter ships in /admin/audit).
+                  origin: reqCtxForApproval?.agentOrigin ?? null,
                 }));
                 logQueryAudit({
                   sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -1445,11 +1445,11 @@ export function createHostedMcpRouter(): Hono {
 
     try {
       return await withRequestContext(
-        // #2072 — outermost MCP transport frame stamps the surface so
+        // #2072 — outermost MCP transport frame stamps the origin so
         // that any code that reads RequestContext before the per-tool
         // frame is entered (e.g. session bootstrap auditing) sees the
         // correct origin.
-        { requestId, user: factoryCtx.user, atlasMode: "published", approvalSurface: "mcp" },
+        { requestId, user: factoryCtx.user, atlasMode: "published", agentOrigin: "mcp" },
         async () => {
           if (sessionId) {
             return dispatchExistingSession(c.req.raw, sessionId, requestId);

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -173,7 +173,7 @@ export function registerSemanticTools(
         { toolName: "listEntities", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-listEntities");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("listEntities"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("listEntities"), agentOrigin: "mcp" }, async () => {
             try {
               // Rate-limit gate (#2071) lives INSIDE the try so any
               // limiter throw lands in the same catch as a tool throw
@@ -230,7 +230,7 @@ export function registerSemanticTools(
         { toolName: "describeEntity", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-describeEntity");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("describeEntity"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("describeEntity"), agentOrigin: "mcp" }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,
@@ -288,7 +288,7 @@ export function registerSemanticTools(
         { toolName: "searchGlossary", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-searchGlossary");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("searchGlossary"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("searchGlossary"), agentOrigin: "mcp" }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,
@@ -402,7 +402,7 @@ export function registerSemanticTools(
         },
         () => {
           const requestId = dispatchId("mcp-runMetric");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("runMetric"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("runMetric"), agentOrigin: "mcp" }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -157,7 +157,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "explore", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-explore");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("explore"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("explore"), agentOrigin: "mcp" }, async () => {
             try {
               // Rate-limit gate (#2071) lives INSIDE the try so any throw
               // from the limiter (loader rejection, audit-emission
@@ -233,7 +233,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "executeSQL", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-executeSQL");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("executeSQL"), approvalSurface: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("executeSQL"), agentOrigin: "mcp" }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,

--- a/packages/schemas/src/__tests__/approval.test.ts
+++ b/packages/schemas/src/__tests__/approval.test.ts
@@ -10,9 +10,9 @@ const validTableRule = {
   threshold: null,
   enabled: true,
   // #2072 — 'any' is the migration default and preserves pre-2072
-  // fires-everywhere semantics. Surface-scoped variants are exercised
+  // fires-everywhere semantics. Origin-scoped variants are exercised
   // in the dedicated describe block below.
-  surface: "any" as const,
+  origin: "any" as const,
   createdAt: "2026-04-19T12:00:00.000Z",
   updatedAt: "2026-04-19T12:00:00.000Z",
 };
@@ -48,9 +48,9 @@ const pendingRequest = {
   connectionGroupId: "g_prod",
   tablesAccessed: ["users"],
   columnsAccessed: ["users.email"],
-  // #2072 — null is the legacy / unstamped default. A specific surface
-  // ("chat" / "mcp" / etc.) is asserted in the new surface block below.
-  surface: null,
+  // #2072 — null is the legacy / unstamped default. A specific origin
+  // ("chat" / "mcp" / etc.) is asserted in the new origin block below.
+  origin: null,
   status: "pending" as const,
   reviewerId: null,
   reviewerEmail: null,
@@ -204,41 +204,41 @@ describe("enum strict rejection", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Surface enum (#2072) — admin can pin a rule to a single transport, and
+// Origin enum (#2072) — admin can pin a rule to a single transport, and
 // the request row records its origin. The schemas reject typos before
 // they reach the rule evaluator (which would silently mismatch every
 // request and leave the operator wondering why the rule didn't fire).
 // ---------------------------------------------------------------------------
 
-describe("surface enum (#2072)", () => {
-  test("ApprovalRuleSchema parses every documented rule surface", () => {
-    for (const surface of ["any", "chat", "mcp", "scheduler", "slack", "teams", "webhook"] as const) {
-      const rule = { ...validTableRule, surface };
-      expect(ApprovalRuleSchema.parse(rule).surface).toBe(surface);
+describe("origin enum (#2072)", () => {
+  test("ApprovalRuleSchema parses every documented rule origin", () => {
+    for (const origin of ["any", "chat", "mcp", "scheduler", "slack", "teams", "webhook"] as const) {
+      const rule = { ...validTableRule, origin };
+      expect(ApprovalRuleSchema.parse(rule).origin).toBe(origin);
     }
   });
 
-  test("ApprovalRuleSchema rejects unknown rule surface", () => {
-    const drifted = { ...validTableRule, surface: "msc" };
+  test("ApprovalRuleSchema rejects unknown rule origin", () => {
+    const drifted = { ...validTableRule, origin: "msc" };
     expect(ApprovalRuleSchema.safeParse(drifted).success).toBe(false);
   });
 
-  test("ApprovalRuleSchema rejects null rule surface (rules must always pin a value)", () => {
-    const drifted = { ...validTableRule, surface: null };
+  test("ApprovalRuleSchema rejects null rule origin (rules must always pin a value)", () => {
+    const drifted = { ...validTableRule, origin: null };
     expect(ApprovalRuleSchema.safeParse(drifted).success).toBe(false);
   });
 
-  test("ApprovalRequestSchema parses every documented request surface plus null", () => {
-    for (const surface of ["chat", "mcp", "scheduler", "slack", "teams", "webhook", null] as const) {
-      const req = { ...pendingRequest, surface };
-      expect(ApprovalRequestSchema.parse(req).surface).toBe(surface);
+  test("ApprovalRequestSchema parses every documented request origin plus null", () => {
+    for (const origin of ["chat", "mcp", "scheduler", "slack", "teams", "webhook", null] as const) {
+      const req = { ...pendingRequest, origin };
+      expect(ApprovalRequestSchema.parse(req).origin).toBe(origin);
     }
   });
 
   test("ApprovalRequestSchema rejects 'any' on a request row (rule-only value)", () => {
     // 'any' is the rule-side wildcard. A REQUEST always originated from
-    // a single surface — emitting 'any' here would be a writer bug.
-    const drifted = { ...pendingRequest, surface: "any" };
+    // a single origin — emitting 'any' here would be a writer bug.
+    const drifted = { ...pendingRequest, origin: "any" };
     expect(ApprovalRequestSchema.safeParse(drifted).success).toBe(false);
   });
 });

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -27,16 +27,16 @@ import { z } from "zod";
 import {
   APPROVAL_RULE_TYPES,
   APPROVAL_STATUSES,
-  APPROVAL_RULE_SURFACES,
-  APPROVAL_REQUEST_SURFACES,
+  APPROVAL_RULE_ORIGINS,
+  APPROVAL_REQUEST_ORIGINS,
   type ApprovalRule,
   type ApprovalRequest,
 } from "@useatlas/types";
 
 const RuleTypeEnum = z.enum(APPROVAL_RULE_TYPES);
 const StatusEnum = z.enum(APPROVAL_STATUSES);
-const RuleSurfaceEnum = z.enum(APPROVAL_RULE_SURFACES);
-const RequestSurfaceEnum = z.enum(APPROVAL_REQUEST_SURFACES);
+const RuleOriginEnum = z.enum(APPROVAL_RULE_ORIGINS);
+const RequestOriginEnum = z.enum(APPROVAL_REQUEST_ORIGINS);
 
 // ---------------------------------------------------------------------------
 // ApprovalRule — discriminated on `ruleType`
@@ -47,7 +47,7 @@ const ApprovalRuleBaseShape = {
   orgId: z.string(),
   name: z.string(),
   enabled: z.boolean(),
-  surface: RuleSurfaceEnum,
+  origin: RuleOriginEnum,
   createdAt: z.string(),
   updatedAt: z.string(),
 };
@@ -101,7 +101,7 @@ const ApprovalRequestBaseShape = {
   connectionGroupId: z.string().nullable(),
   tablesAccessed: z.array(z.string()),
   columnsAccessed: z.array(z.string()),
-  surface: RequestSurfaceEnum.nullable(),
+  origin: RequestOriginEnum.nullable(),
   createdAt: z.string(),
   expiresAt: z.string(),
 };
@@ -149,4 +149,4 @@ export const ApprovalRequestSchema = z.discriminatedUnion("status", [
   ExpiredRequestSchema,
 ]) satisfies z.ZodType<ApprovalRequest>;
 
-export { StatusEnum, RuleSurfaceEnum, RequestSurfaceEnum };
+export { StatusEnum, RuleOriginEnum, RequestOriginEnum };

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/approval.ts
+++ b/packages/types/src/approval.ts
@@ -22,24 +22,25 @@ export const APPROVAL_STATUSES = ["pending", "approved", "denied", "expired"] as
 export type ApprovalStatus = (typeof APPROVAL_STATUSES)[number];
 
 /**
- * Surface scope for approval rules (#2072). `'any'` preserves pre-2072
- * fires-for-every-request semantics; the others pin to a transport.
+ * Agent origin scope for approval rules (#2072; renamed from "surface" in
+ * ADR-0015). `'any'` preserves pre-2072 fires-for-every-request semantics;
+ * the others pin to a transport.
  *
  * Two derived enums share a single source of truth:
- *   - `APPROVAL_RULE_SURFACES` — values an admin can pin a rule to,
+ *   - `APPROVAL_RULE_ORIGINS` — values an admin can pin a rule to,
  *     including the `'any'` wildcard.
- *   - `APPROVAL_REQUEST_SURFACES` — values stamped on a created approval
+ *   - `APPROVAL_REQUEST_ORIGINS` — values stamped on a created approval
  *     request to record where it originated. Derived from the rule
  *     enum by filtering out `'any'` because a real request always has
  *     a single concrete origin (or NULL when the caller didn't stamp).
  *
  * Both the runtime tuple (`.filter(...)`) and the type (`Exclude<>`)
- * are derived so a new transport added to `APPROVAL_RULE_SURFACES`
+ * are derived so a new transport added to `APPROVAL_RULE_ORIGINS`
  * automatically propagates to the request-side enum, the SQL CHECK,
  * and every consumer. PR #2191 review surfaced an earlier shape where
  * the two were independently declared and could drift silently.
  */
-export const APPROVAL_RULE_SURFACES = [
+export const APPROVAL_RULE_ORIGINS = [
   "any",
   "chat",
   "mcp",
@@ -60,11 +61,11 @@ export const APPROVAL_RULE_SURFACES = [
   "gchat",
   "webhook",
 ] as const;
-export type ApprovalRuleSurface = (typeof APPROVAL_RULE_SURFACES)[number];
+export type ApprovalRuleOrigin = (typeof APPROVAL_RULE_ORIGINS)[number];
 
-export type ApprovalRequestSurface = Exclude<ApprovalRuleSurface, "any">;
-export const APPROVAL_REQUEST_SURFACES = APPROVAL_RULE_SURFACES.filter(
-  (s): s is ApprovalRequestSurface => s !== "any",
+export type ApprovalRequestOrigin = Exclude<ApprovalRuleOrigin, "any">;
+export const APPROVAL_REQUEST_ORIGINS = APPROVAL_RULE_ORIGINS.filter(
+  (s): s is ApprovalRequestOrigin => s !== "any",
 );
 
 // ── Approval rule ───────────────────────────────────────────────────
@@ -78,8 +79,8 @@ interface ApprovalRuleBase {
   orgId: string;
   name: string;
   enabled: boolean;
-  /** #2072 — origin surface this rule applies to. `'any'` (default) fires for every request. */
-  surface: ApprovalRuleSurface;
+  /** #2072 — agent origin this rule applies to. `'any'` (default) fires for every request. */
+  origin: ApprovalRuleOrigin;
   createdAt: string;
   updatedAt: string;
 }
@@ -130,11 +131,11 @@ interface ApprovalRequestBase {
   tablesAccessed: string[];
   columnsAccessed: string[];
   /**
-   * #2072 — origin surface of the request that produced this row. `null`
-   * for legacy rows or callers that didn't stamp surface on the
+   * #2072 — agent origin of the request that produced this row. `null`
+   * for legacy rows or callers that didn't stamp an origin on the
    * RequestContext.
    */
-  surface: ApprovalRequestSurface | null;
+  origin: ApprovalRequestOrigin | null;
   createdAt: string;
   expiresAt: string;
 }
@@ -184,16 +185,16 @@ export type ApprovalRequest = ApprovalRequestBase & (
  * runtime validation alone.
  */
 export type CreateApprovalRuleRequest =
-  | { ruleType: "cost"; threshold: number; name: string; pattern?: ""; enabled?: boolean; surface?: ApprovalRuleSurface }
-  | { ruleType: "table"; pattern: string; name: string; threshold?: null; enabled?: boolean; surface?: ApprovalRuleSurface }
-  | { ruleType: "column"; pattern: string; name: string; threshold?: null; enabled?: boolean; surface?: ApprovalRuleSurface };
+  | { ruleType: "cost"; threshold: number; name: string; pattern?: ""; enabled?: boolean; origin?: ApprovalRuleOrigin }
+  | { ruleType: "table"; pattern: string; name: string; threshold?: null; enabled?: boolean; origin?: ApprovalRuleOrigin }
+  | { ruleType: "column"; pattern: string; name: string; threshold?: null; enabled?: boolean; origin?: ApprovalRuleOrigin };
 
 export interface UpdateApprovalRuleRequest {
   name?: string;
   pattern?: string;
   threshold?: number | null;
   enabled?: boolean;
-  surface?: ApprovalRuleSurface;
+  origin?: ApprovalRuleOrigin;
 }
 
 export interface ReviewApprovalRequest {

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -56,10 +56,10 @@ import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 import { ApprovalRuleSchema } from "@/ui/lib/admin-schemas";
 import {
-  APPROVAL_RULE_SURFACES,
+  APPROVAL_RULE_ORIGINS,
   type ApprovalRequest,
   type ApprovalRule,
-  type ApprovalRuleSurface,
+  type ApprovalRuleOrigin,
   type ApprovalRuleType,
   type ApprovalStatus,
 } from "@/ui/lib/types";
@@ -106,11 +106,11 @@ const RULE_TYPES: { value: ApprovalRuleType; label: string; description: string 
   { value: "cost", label: "Cost", description: "Match queries exceeding a cost threshold" },
 ];
 
-// #2072 — surface dropdown copy. The first row is the rule-side default
+// #2072 — origin dropdown copy. The first row is the rule-side default
 // ('any') so admins authoring a rule that should fire everywhere don't
-// have to think about scoping; surface-specific choices follow.
-const SURFACE_OPTIONS: { value: ApprovalRuleSurface; label: string; description: string }[] = [
-  { value: "any", label: "Any surface", description: "Fires for every request, regardless of origin" },
+// have to think about scoping; origin-specific choices follow.
+const ORIGIN_OPTIONS: { value: ApprovalRuleOrigin; label: string; description: string }[] = [
+  { value: "any", label: "Any origin", description: "Fires for every request, regardless of origin" },
   { value: "chat", label: "Chat only", description: "Chat UI / /api/v1/query / demo" },
   { value: "mcp", label: "MCP only", description: "Hosted Model Context Protocol clients (e.g. Claude Desktop)" },
   { value: "scheduler", label: "Scheduler only", description: "Scheduled task runs" },
@@ -125,9 +125,9 @@ const createRuleSchema = z
     ruleType: z.enum(["table", "column", "cost"]),
     pattern: z.string(),
     threshold: z.string(),
-    // #2072 — admin can pin a new rule to a single surface or leave it
+    // #2072 — admin can pin a new rule to a single origin or leave it
     // at 'any' (the migration default) for fires-everywhere semantics.
-    surface: z.enum(APPROVAL_RULE_SURFACES),
+    origin: z.enum(APPROVAL_RULE_ORIGINS),
   })
   .refine(
     (data) => data.ruleType === "cost" || data.pattern.trim().length > 0,
@@ -209,7 +209,7 @@ function RulesSection() {
     // #2072 — 'any' default keeps the form's behavior identical to the
     // pre-2072 UX: an admin who doesn't touch the dropdown gets a rule
     // that fires for every transport.
-    defaultValues: { name: "", ruleType: "table", pattern: "", threshold: "", surface: "any" },
+    defaultValues: { name: "", ruleType: "table", pattern: "", threshold: "", origin: "any" },
   });
 
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/admin/approval/rules", {
@@ -240,10 +240,10 @@ function RulesSection() {
         pattern: values.pattern,
         threshold: values.ruleType === "cost" ? Number(values.threshold) : null,
         enabled: true,
-        // #2072 — surface flows on the wire. The route layer's zod parser
+        // #2072 — origin flows on the wire. The route layer's zod parser
         // re-validates against the same enum and a typo here surfaces as
         // a 400 with a clear message instead of a 500.
-        surface: values.surface,
+        origin: values.origin,
       },
     });
     if (result.ok) {
@@ -340,26 +340,26 @@ function RulesSection() {
                   />
                 </div>
                 {/*
-                  #2072 — Surface dropdown. Full-width below the type/name
+                  #2072 — Origin dropdown. Full-width below the type/name
                   pair so the rule editor reads top-to-bottom: identity,
-                  type, then where it applies. 'Any surface' is the
+                  type, then where it applies. 'Any origin' is the
                   default and preserves pre-2072 fires-everywhere
                   semantics.
                 */}
                 <FormField
                   control={ruleForm.control}
-                  name="surface"
+                  name="origin"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Surface</FormLabel>
+                      <FormLabel>Origin</FormLabel>
                       <Select value={field.value} onValueChange={field.onChange}>
                         <FormControl>
-                          <SelectTrigger aria-label="Approval rule surface">
+                          <SelectTrigger aria-label="Approval rule origin">
                             <SelectValue />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {SURFACE_OPTIONS.map((s) => (
+                          {ORIGIN_OPTIONS.map((s) => (
                             <SelectItem key={s.value} value={s.value}>
                               {s.label} — {s.description}
                             </SelectItem>
@@ -432,7 +432,7 @@ function RulesSection() {
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead>Type</TableHead>
-                  <TableHead>Surface</TableHead>
+                  <TableHead>Origin</TableHead>
                   <TableHead>Pattern / Threshold</TableHead>
                   <TableHead>Enabled</TableHead>
                   <TableHead className="w-[80px]" />
@@ -448,12 +448,12 @@ function RulesSection() {
                     <TableCell>
                       {/*
                         #2072 — outline variant for 'any' (the default,
-                        which fires everywhere — visually subdued so a
-                        surface-pinned row stands out) and a filled
+                        which fires everywhere — visually subdued so an
+                        origin-pinned row stands out) and a filled
                         secondary badge for the scoped values.
                       */}
-                      <Badge variant={rule.surface === "any" ? "outline" : "secondary"}>
-                        {rule.surface}
+                      <Badge variant={rule.origin === "any" ? "outline" : "secondary"}>
+                        {rule.origin}
                       </Badge>
                     </TableCell>
                     <TableCell className="font-mono text-xs">

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -82,12 +82,12 @@ export type {
 export type {
   ApprovalRule,
   ApprovalRuleType,
-  ApprovalRuleSurface,
+  ApprovalRuleOrigin,
   ApprovalRequest,
-  ApprovalRequestSurface,
+  ApprovalRequestOrigin,
   ApprovalStatus,
 } from "@useatlas/types";
-export { APPROVAL_RULE_SURFACES, APPROVAL_REQUEST_SURFACES } from "@useatlas/types";
+export { APPROVAL_RULE_ORIGINS, APPROVAL_REQUEST_ORIGINS } from "@useatlas/types";
 export type {
   PIICategory,
   PIIConfidence,


### PR DESCRIPTION
## Summary

Clean-break rename of the agent-invocation-channel concept from **"approval surface"** to **agent origin**, per [ADR-0015](docs/adr/0015-agent-origin-not-surface.md). This frees the bare word "surface" for the pillar admin-page concept. Foundational slice of milestone #65 (blocks #3507 / #3508).

**Enum values are unchanged** (`chat` / `mcp` / `scheduler` / `slack` / `teams` / `telegram` / `discord` / `whatsapp` / `gchat` / `webhook` / `any`).

- **DB** — migration `0133_approval_origin_rename.sql` renames the `surface` column → `origin` on `approval_rules` + `approval_queue` (column, CHECK constraints `chk_approval_rule_origin` / `chk_approval_request_origin`, index `idx_approval_rules_org_origin`, comments). One-shot in-place `RENAME COLUMN` (pre-customer — no expand/contract). Mirrored in `db/schema.ts`; both migrate-test applied-lists + the total-count assertion updated.
- **Code** — `approvalSurface` → `agentOrigin` (RequestContext + every stamp site: chat/query/demo/scheduler/proactive/chat-plugin/MCP); wire field `surface` → `origin`; types `ApprovalRule[Request]Surface` → `*Origin`; constants `APPROVAL_RULE/REQUEST_SURFACES` → `*_ORIGINS`; `surfaceMatchesRule` → `originMatchesRule`; `selectMatchingRulesBySurface` → `*ByOrigin`; audit-log metadata key `surface` → `origin` (attribution intact); admin approval UI column + dropdown.
- **Clean cut** — no deprecated aliases (pre-customer clean-break window).

## ⚠️ Publish-first ordering (required for green CI)

This renames a **published `@useatlas/types` value export** (`APPROVAL_RULE_SURFACES` → `APPROVAL_RULE_ORIGINS`) consumed by scaffold-bound source. `@useatlas/types` is bumped **0.1.19 → 0.2.0** and the `create-atlas/templates/*` refs → `^0.2.0`.

**`@useatlas/types@0.2.0` must be published before this PR's `Deploy Validation` (scaffold-smoke) + `published-symbols` gates can go green:**
1. Publish `@useatlas/types@0.2.0` (tag `types-v0.2.0`) — from this branch HEAD, or however you prefer to sequence it first.
2. Once on npm, this PR's scaffold-smoke / published-symbols resolve `^0.2.0` → green.
3. Merge.

(Local gates green: lint, type, schema-drift, OpenAPI drift regenerated, 322 affected `@atlas/api` test files + ee/schemas/mcp approval suites.)

## Test plan
- [x] `surface` column → `origin` on both tables + schema.ts mirror — `bash scripts/check-schema-drift.sh` passes
- [x] every `approvalSurface` → `agentOrigin`; enum values unchanged
- [x] audit-log origin attribution intact; all tests updated and green (local)
- [x] type / lint / schema-drift / OpenAPI-drift (regenerated `apps/docs/openapi.json`)
- [ ] CI green **after** `@useatlas/types@0.2.0` is published

Closes #3491