### PR TITLE
fix(mcp): plugin tools stamp origin=mcp for origin-scoped approval rules (#3507)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
+++ b/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
@@ -120,6 +120,9 @@ const KNOWN_ORIGIN_STAMPERS: OriginStamperSpec[] = [
   { file: "packages/mcp/src/tools.ts", originProof: /agentOrigin:\s*"mcp"/ },
   { file: "packages/mcp/src/semantic-tools.ts", originProof: /agentOrigin:\s*"mcp"/ },
   { file: "packages/mcp/src/hosted.ts", originProof: /agentOrigin:\s*"mcp"/ },
+  // #3507 — plugin-contributed MCP tools dispatch through this wrapper;
+  // it must stamp 'mcp' too or origin-scoped approval rules skip them.
+  { file: "packages/api/src/lib/plugins/mcp-tools.ts", originProof: /agentOrigin:\s*"mcp"/ },
 ];
 
 describe("F-54/F-55 agent-surface registry", () => {

--- a/packages/api/src/lib/plugins/__tests__/mcp-tools-binding.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/mcp-tools-binding.test.ts
@@ -34,10 +34,16 @@ describe("plugin MCP dispatch binding registry (#2078)", () => {
     // call must appear before the handler invocation lexically — a
     // refactor that lifted the limiter or input parse out of the
     // wrap would land here.
+    // #3507 — the wrap also stamps `agentOrigin: "mcp"` so origin-scoped
+    // approval rules match plugin-tool dispatches; pin that here too (a
+    // comment line may precede the object literal, hence the optional
+    // `//…` prefix matcher).
     expect(
       source,
-      "dispatch handler must call withRequestContext({ actor: { kind: 'mcp', ... } })",
-    ).toMatch(/withRequestContext\s*\(\s*\{\s*requestId\s*,\s*user:\s*actor\s*,\s*actor:\s*mcpActor/);
+      "dispatch handler must call withRequestContext({ requestId, user: actor, agentOrigin: 'mcp', actor: mcpActor })",
+    ).toMatch(
+      /withRequestContext\(\s*(?:\/\/[^\n]*\n\s*)*\{\s*requestId\s*,\s*user:\s*actor\s*,\s*agentOrigin:\s*"mcp"\s*,\s*actor:\s*mcpActor/,
+    );
   });
 
   it("rate-limit gate runs INSIDE the withRequestContext callback", async () => {

--- a/packages/api/src/lib/plugins/mcp-tools.ts
+++ b/packages/api/src/lib/plugins/mcp-tools.ts
@@ -428,11 +428,13 @@ function defaultLogger(pluginId: string, qualifiedName: string): McpToolContextS
  *
  * 1. Generates a per-call `request_id` (`mcp-plugin-<uuid>`).
  * 2. Wraps everything below in `withRequestContext({ user: actor,
- *    actor: { kind: "mcp", clientId, toolName: qualifiedName } })` so
- *    any nested `executeSQL` audit_log row inherits the plugin tool's
- *    `tool_name`, `client_id`, and `actor_kind` consistently with
- *    native tools. The wrap is the OUTERMOST step — every subsequent
- *    step runs inside the actor binding.
+ *    agentOrigin: "mcp", actor: { kind: "mcp", clientId, toolName:
+ *    qualifiedName } })` so any nested `executeSQL` audit_log row inherits
+ *    the plugin tool's `tool_name`, `client_id`, and `actor_kind`
+ *    consistently with native tools, AND so origin-scoped approval rules
+ *    (#3507 / ADR-0016) match plugin-tool calls — without the `mcp` origin
+ *    stamp, an `origin='mcp'` rule would silently skip them. The wrap is
+ *    the OUTERMOST step — every subsequent step runs inside the binding.
  * 3. Per-OAuth-client rate-limit gate (#2071). Hosted MCP threads
  *    `clientId`; stdio MCP leaves it undefined and is exempt.
  *    A denied bucket short-circuits with the limiter's `rate_limited`
@@ -477,7 +479,10 @@ export function registerPluginMcpTools(
       };
 
       return withRequestContext(
-        { requestId, user: actor, actor: mcpActor },
+        // #3507 — stamp `mcp` as the agent origin so origin-scoped approval
+        // rules (ADR-0016) match plugin-tool dispatches, parity with the
+        // built-in MCP tools in packages/mcp/src/{tools,semantic-tools}.ts.
+        { requestId, user: actor, agentOrigin: "mcp", actor: mcpActor },
         async () => {
           // Per-OAuth-client rate-limit gate (#2071). Hosted MCP threads
           // `clientId`; stdio MCP leaves it undefined and is intentionally


### PR DESCRIPTION
## Summary

Plugin-contributed MCP tools dispatched through `registerPluginMcpTools`'s `withRequestContext` wrapper **without** an agent origin, so origin-scoped approval rules (#2072 / ADR-0016) silently skipped plugin tool calls — a governance bypass. This stamps `agentOrigin: "mcp"` on the dispatch context, bringing plugin tools to parity with the built-in MCP tools (`packages/mcp/src/{tools,semantic-tools}.ts`).

- `packages/api/src/lib/plugins/mcp-tools.ts` — add `agentOrigin: "mcp"` to the dispatch `withRequestContext({ requestId, user: actor, ... })`.
- `packages/api/src/lib/__tests__/agent-surface-registry.test.ts` — add `mcp-tools.ts` to `KNOWN_ORIGIN_STAMPERS` so the CI origin-stamper guard fails if the stamp regresses.
- `packages/api/src/lib/plugins/__tests__/mcp-tools-binding.test.ts` — update the #2078 binding meta-test to pin the new context shape (now including the `mcp` origin stamp).

## Test plan
- [x] plugin-tool dispatches carry `agentOrigin="mcp"` and are matched by `origin=mcp` approval rules
- [x] CI origin-stamper guard fails if any MCP dispatcher omits the stamp (`agent-surface-registry.test.ts`, 3 pass)
- [x] #2078 binding meta-test green (`mcp-tools-binding.test.ts`)
- [x] full plugin suite (314 pass), type, lint

Closes #3507