### PR TITLE
feat(mcp): thread OAuth scopes into RequestContext + enforce mcp:write (#3504)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -413,7 +413,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "typescript": "^6.0.3",
       },

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -61,6 +61,14 @@ interface RequestContext {
    */
   agentOrigin?: import("@useatlas/types").ApprovalRequestOrigin;
   /**
+   * #3504 — OAuth token scopes (from the JWT `scope` claim) on hosted MCP
+   * requests, threaded by `verifyMcpBearer` through the dispatch frame.
+   * The dispatch seam gates write tools on `mcp:write` (see
+   * `writeScopeOrNull` in packages/mcp/src/tools.ts). Undefined for stdio
+   * MCP and non-MCP requests, which carry no OAuth bearer.
+   */
+  scopes?: readonly string[];
+  /**
    * #2345 — group-aware chat routing.
    *
    * `connectionId` is the *execution target* for SQL on this request —

--- a/packages/api/src/lib/plugins/mcp-tools.ts
+++ b/packages/api/src/lib/plugins/mcp-tools.ts
@@ -489,6 +489,14 @@ export function registerPluginMcpTools(
         // #3507 — stamp `mcp` as the agent origin so origin-scoped approval
         // rules (ADR-0016) match plugin-tool dispatches, parity with the
         // built-in MCP tools in packages/mcp/src/{tools,semantic-tools}.ts.
+        // #3504 — `scopes` is threaded onto the context here so a future
+        // write-gated plugin tool can read it, BUT no `mcp:write` gate runs
+        // on this path yet: unlike built-in tools (which call
+        // `writeScopeOrNull` per-tool), plugin tools carry no read/write
+        // signal until tool annotations land (#3497), so the host can't tell
+        // which plugin tools mutate. Generic enforcement here is deferred to
+        // the gate-order pipeline (#3508). Until then, a mutating plugin MCP
+        // tool is NOT scope-gated — tracked in #3520.
         { requestId, user: actor, agentOrigin: "mcp", actor: mcpActor, ...(scopes ? { scopes } : {}) },
         async () => {
           // Per-OAuth-client rate-limit gate (#2071). Hosted MCP threads

--- a/packages/api/src/lib/plugins/mcp-tools.ts
+++ b/packages/api/src/lib/plugins/mcp-tools.ts
@@ -358,6 +358,12 @@ export interface RegisterPluginMcpToolsOptions {
   workspaceId: string;
   deployMode: "self-hosted" | "saas";
   clientId?: string;
+  /**
+   * #3504 — OAuth token scopes, threaded onto the dispatch RequestContext
+   * so a write-gated plugin tool can enforce `mcp:write`. Undefined for
+   * stdio MCP (exempt).
+   */
+  scopes?: readonly string[];
   /** OTel wrapper. Default is passthrough. */
   traceWrap?: <T>(
     spanCtx: {
@@ -460,6 +466,7 @@ export function registerPluginMcpTools(
     workspaceId,
     deployMode,
     clientId,
+    scopes,
     traceWrap,
     loggerFor = defaultLogger,
   } = opts;
@@ -482,7 +489,7 @@ export function registerPluginMcpTools(
         // #3507 — stamp `mcp` as the agent origin so origin-scoped approval
         // rules (ADR-0016) match plugin-tool dispatches, parity with the
         // built-in MCP tools in packages/mcp/src/{tools,semantic-tools}.ts.
-        { requestId, user: actor, agentOrigin: "mcp", actor: mcpActor },
+        { requestId, user: actor, agentOrigin: "mcp", actor: mcpActor, ...(scopes ? { scopes } : {}) },
         async () => {
           // Per-OAuth-client rate-limit gate (#2071). Hosted MCP threads
           // `clientId`; stdio MCP leaves it undefined and is intentionally

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -76,9 +76,17 @@ function getContentText(content: unknown): string {
   return arr[0]?.text ?? "";
 }
 
-async function createTestClient(actor = TEST_ACTOR, clientId?: string) {
+async function createTestClient(
+  actor = TEST_ACTOR,
+  clientId?: string,
+  scopes?: readonly string[],
+) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
-  registerTools(server, { actor, ...(clientId ? { clientId } : {}) });
+  registerTools(server, {
+    actor,
+    ...(clientId ? { clientId } : {}),
+    ...(scopes ? { scopes } : {}),
+  });
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -600,6 +608,42 @@ describe("MCP tools", () => {
       clientId: "claude-desktop",
       toolName: "executeSQL",
     });
+  });
+
+  it("#3504: threads OAuth token scopes through registerTools into RequestContext.scopes", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "noop", row_count: 0, columns: [], rows: [] };
+    });
+
+    const { client } = await createTestClient(TEST_ACTOR, "claude-desktop", [
+      "mcp:read",
+      "mcp:write",
+    ]);
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "scope probe" },
+    });
+
+    expect(observed!.scopes).toEqual(["mcp:read", "mcp:write"]);
+  });
+
+  it("#3504: leaves RequestContext.scopes undefined for stdio dispatch (no bearer)", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "noop", row_count: 0, columns: [], rows: [] };
+    });
+
+    // stdio: createTestClient with no clientId / no scopes.
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "stdio probe" },
+    });
+
+    expect(observed!.scopes).toBeUndefined();
   });
 
   // #3437 — billing enforcement on the MCP datasource-query perimeter.

--- a/packages/mcp/src/__tests__/write-scope-gate.test.ts
+++ b/packages/mcp/src/__tests__/write-scope-gate.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #3504 — `mcp:write` enforcement gate.
+ *
+ * Two layers:
+ *   1. Unit tests of `writeScopeOrNull` — the pure gate decision (stdio
+ *      exempt, hosted requires `mcp:write`, fail-closed on missing scopes).
+ *   2. An end-to-end "stub write tool" registered on a real MCP server +
+ *      in-memory client, gated exactly how a future mutating tool will gate:
+ *      wrap dispatch in `withRequestContext({ scopes })`, read the scopes
+ *      back off the context, and call `writeScopeOrNull`. Proves the token's
+ *      scopes flow through the dispatch frame to the gate and that an
+ *      `mcp:read`-only client is denied while an `mcp:write` client passes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { getRequestContext, withRequestContext } from "@atlas/api/lib/logger";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+import { writeScopeOrNull } from "../tools.js";
+
+const ACTOR = createAtlasUser("u_test", "managed", "test@example.com", {
+  role: "admin",
+  activeOrganizationId: "org_test",
+});
+
+function getContentText(content: unknown): string {
+  const arr = content as Array<{ type: string; text: string }>;
+  return arr[0]?.text ?? "";
+}
+
+describe("writeScopeOrNull (#3504 mcp:write gate)", () => {
+  it("exempts stdio (no clientId) regardless of scopes", () => {
+    expect(writeScopeOrNull({ clientId: undefined, scopes: undefined })).toBeNull();
+    expect(writeScopeOrNull({ clientId: undefined, scopes: ["mcp:read"] })).toBeNull();
+  });
+
+  it("allows a hosted client carrying mcp:write", () => {
+    expect(
+      writeScopeOrNull({ clientId: "claude-desktop", scopes: ["mcp:read", "mcp:write"] }),
+    ).toBeNull();
+  });
+
+  it("denies a hosted client with only mcp:read (forbidden envelope)", () => {
+    const result = writeScopeOrNull({ clientId: "claude-desktop", scopes: ["mcp:read"] });
+    expect(result?.isError).toBe(true);
+    const env = parseAtlasMcpToolError(getContentText(result?.content));
+    expect(env?.code).toBe("forbidden");
+    expect(env?.message).toContain("mcp:write");
+  });
+
+  it("fails closed for a hosted client whose scopes weren't threaded", () => {
+    const result = writeScopeOrNull({ clientId: "claude-desktop", scopes: undefined });
+    expect(result?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(result?.content))?.code).toBe("forbidden");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: a stub write tool gated the way a real mutating tool will be.
+// ---------------------------------------------------------------------------
+
+async function clientForStubWriteTool(opts: {
+  clientId?: string;
+  scopes?: readonly string[];
+}): Promise<Client> {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  server.registerTool(
+    "stub_write",
+    { title: "Stub write tool", description: "Mutating stub for the mcp:write gate test.", inputSchema: {} },
+    async () => {
+      // Mirror the real dispatch frame: stamp the session scopes onto the
+      // RequestContext, then gate by reading them back off the context.
+      return withRequestContext(
+        {
+          requestId: "stub-write",
+          user: ACTOR,
+          agentOrigin: "mcp",
+          ...(opts.scopes ? { scopes: opts.scopes } : {}),
+        },
+        async () => {
+          const denied = writeScopeOrNull({
+            clientId: opts.clientId,
+            scopes: getRequestContext()?.scopes,
+          });
+          if (denied) return denied;
+          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
+        },
+      );
+    },
+  );
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("stub write tool through the dispatch seam (#3504)", () => {
+  it("denies a hosted mcp:read-only client", async () => {
+    const client = await clientForStubWriteTool({ clientId: "claude-desktop", scopes: ["mcp:read"] });
+    const result = await client.callTool({ name: "stub_write", arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(result.content))?.code).toBe("forbidden");
+  });
+
+  it("allows a hosted mcp:write client", async () => {
+    const client = await clientForStubWriteTool({
+      clientId: "claude-desktop",
+      scopes: ["mcp:read", "mcp:write"],
+    });
+    const result = await client.callTool({ name: "stub_write", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(getContentText(result.content)).toContain('"ok":true');
+  });
+
+  it("allows stdio (no clientId, no scopes)", async () => {
+    const client = await clientForStubWriteTool({});
+    const result = await client.callTool({ name: "stub_write", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(getContentText(result.content)).toContain('"ok":true');
+  });
+});

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -1158,6 +1158,8 @@ async function createBoundMcpServer(
     actor: ctx.user,
     transport: "sse",
     skipConfig: true,
+    // #3504 — thread the bearer's OAuth scopes so write tools enforce mcp:write.
+    scopes: ctx.scopes,
     // #2067 — surface the registered OAuth client_id into
     // `audit_log.client_id` so the admin filter can scope to "rows from
     // claude-desktop" without joining on token tables.

--- a/packages/mcp/src/plugin-tools.ts
+++ b/packages/mcp/src/plugin-tools.ts
@@ -43,6 +43,8 @@ export interface RegisterPluginToolsOptions {
   clientId?: string;
   workspaceId: string;
   deployMode: McpDeployMode;
+  /** #3504 — OAuth token scopes, threaded onto the dispatch RequestContext. */
+  scopes?: readonly string[];
   /** Override the registry (test seam). */
   registry?: PluginMcpToolRegistry;
 }
@@ -64,6 +66,7 @@ export function registerPluginTools(
       workspaceId: opts.workspaceId,
       deployMode: opts.deployMode,
       ...(opts.clientId && { clientId: opts.clientId }),
+      ...(opts.scopes && { scopes: opts.scopes }),
       // The api-side dispatch always resolves the wrapper with an
       // `McpCallToolResult` (structurally a `CallToolResult`). Cast
       // to/from `Promise<CallToolResult>` so `traceMcpToolCall` (which

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -92,6 +92,8 @@ export interface RegisterSemanticToolsOptions {
   deployMode: McpDeployMode;
   /** Hosted-MCP OAuth client_id, surfaced into `audit_log.client_id` (#2067). */
   clientId?: string;
+  /** #3504 — OAuth token scopes, threaded onto each dispatch's RequestContext. */
+  scopes?: readonly string[];
 }
 
 function dispatchId(prefix: string): string {
@@ -142,7 +144,7 @@ export function registerSemanticTools(
   server: McpServer,
   opts: RegisterSemanticToolsOptions,
 ): void {
-  const { actor, transport, workspaceId, deployMode, clientId } = opts;
+  const { actor, transport, workspaceId, deployMode, clientId, scopes } = opts;
   // #2067 — wrap each dispatch with the same actor shape as tools.ts. The
   // `mcp` actor_kind / clientId / toolName trail through `logQueryAudit`
   // so admins can scope `audit_log` rows to a specific MCP tool/client.
@@ -173,7 +175,7 @@ export function registerSemanticTools(
         { toolName: "listEntities", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-listEntities");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("listEntities"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("listEntities"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               // Rate-limit gate (#2071) lives INSIDE the try so any
               // limiter throw lands in the same catch as a tool throw
@@ -230,7 +232,7 @@ export function registerSemanticTools(
         { toolName: "describeEntity", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-describeEntity");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("describeEntity"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("describeEntity"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,
@@ -288,7 +290,7 @@ export function registerSemanticTools(
         { toolName: "searchGlossary", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-searchGlossary");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("searchGlossary"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("searchGlossary"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,
@@ -402,7 +404,7 @@ export function registerSemanticTools(
         },
         () => {
           const requestId = dispatchId("mcp-runMetric");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("runMetric"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("runMetric"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -52,6 +52,12 @@ interface CreateMcpServerOptions {
    * `RequestContext.actor.clientId` (#2067). Stdio MCP leaves this unset.
    */
   clientId?: string;
+  /**
+   * #3504 — OAuth token scopes for this hosted-MCP session, threaded from
+   * `verifyMcpBearer` onto every dispatch's `RequestContext` so write tools
+   * can enforce `mcp:write`. Stdio MCP leaves this unset (exempt).
+   */
+  scopes?: readonly string[];
 }
 
 /**
@@ -106,13 +112,14 @@ export async function createAtlasMcpServer(
   const actor = opts?.actor ?? (await resolveMcpActor());
   const transport: McpTransport = opts?.transport ?? "stdio";
   const clientId = opts?.clientId;
+  const scopes = opts?.scopes;
 
   const server = new McpServer({
     name: "atlas",
     version: VERSION,
   });
 
-  registerTools(server, { actor, transport, clientId });
+  registerTools(server, { actor, transport, clientId, ...(scopes && { scopes }) });
 
   // #2078 — plugins contribute additional MCP tools via `mcpTools()`.
   // Boot the plugin lifecycle so factory functions can run, then walk
@@ -138,6 +145,7 @@ export async function createAtlasMcpServer(
       actor,
       transport,
       ...(clientId && { clientId }),
+      ...(scopes && { scopes }),
       workspaceId: actor.activeOrganizationId ?? actor.id,
       deployMode: getConfig()?.deployMode ?? "self-hosted",
     });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -73,6 +73,14 @@ export interface RegisterToolsOptions {
    * by registered OAuth client (#2067). Stdio MCP leaves this undefined.
    */
   clientId?: string;
+  /**
+   * #3504 — OAuth token scopes for this hosted-MCP session (from the JWT
+   * `scope` claim, extracted by `verifyMcpBearer`). Threaded onto every
+   * dispatch's `RequestContext` so write-gated tools can enforce
+   * `mcp:write` via {@link writeScopeOrNull}. Undefined for stdio MCP,
+   * which is exempt (trusted local operator).
+   */
+  scopes?: readonly string[];
 }
 
 function dispatchId(prefix: string): string {
@@ -111,6 +119,39 @@ async function rateLimitOrNull(args: {
 }
 
 /**
+ * `mcp:write` enforcement gate (#3504 / ADR-0016). Mutating MCP tools call
+ * this at the top of their handler; read tools never do.
+ *
+ * - **stdio MCP** (`clientId` undefined) is exempt — it runs in-process in
+ *   the operator's own deployment, not behind OAuth. Mirrors the
+ *   `rateLimitOrNull` stdio carve-out so a single signal (`clientId`)
+ *   distinguishes hosted from local.
+ * - **hosted MCP** must present a bearer carrying the `mcp:write` scope.
+ *   Fails CLOSED: a hosted dispatch whose `scopes` weren't threaded (or
+ *   that lacks `mcp:write`) is denied with a `forbidden` envelope rather
+ *   than silently allowed.
+ *
+ * Returns `null` when the dispatch may proceed; a `forbidden` tool-result
+ * envelope when it must be blocked.
+ */
+export function writeScopeOrNull(args: {
+  clientId: string | undefined;
+  scopes: readonly string[] | undefined;
+}): CallToolResult | null {
+  if (!args.clientId) return null;
+  if (args.scopes?.includes("mcp:write")) return null;
+  return toEnvelopeResult(
+    envelope(
+      "forbidden",
+      "This tool mutates data and requires the 'mcp:write' OAuth scope, which this token does not carry.",
+      {
+        hint: "Re-authorize the MCP client with the mcp:write scope (the workspace admin controls which scopes a client may request).",
+      },
+    ),
+  );
+}
+
+/**
  * Resolve the workspace id for OTel span / counter attribution. In
  * trusted-transport mode the actor is `system:mcp` with no
  * `activeOrganizationId`; falling back to the actor id keeps the
@@ -126,7 +167,7 @@ function deployModeOf(): McpDeployMode {
 }
 
 export function registerTools(server: McpServer, opts: RegisterToolsOptions): void {
-  const { actor, transport = "stdio", clientId } = opts;
+  const { actor, transport = "stdio", clientId, scopes } = opts;
   const workspaceId = workspaceIdOf(actor);
   const deployMode = deployModeOf();
   // #2067 — every MCP tool dispatch wraps in the same `actor` shape so
@@ -157,7 +198,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "explore", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-explore");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("explore"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("explore"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               // Rate-limit gate (#2071) lives INSIDE the try so any throw
               // from the limiter (loader rejection, audit-emission
@@ -233,7 +274,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "executeSQL", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-executeSQL");
-          return withRequestContext({ requestId, user: actor, actor: mcpActor("executeSQL"), agentOrigin: "mcp" }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("executeSQL"), agentOrigin: "mcp", ...(scopes ? { scopes } : {}) }, async () => {
             try {
               const limited = await rateLimitOrNull({
                 clientId,
@@ -342,5 +383,5 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
   );
 
   // --- typed semantic-layer tools ---
-  registerSemanticTools(server, { actor, transport, workspaceId, deployMode, clientId });
+  registerSemanticTools(server, { actor, transport, workspaceId, deployMode, clientId, scopes });
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/__tests__/mcp.test.ts
+++ b/packages/types/src/__tests__/mcp.test.ts
@@ -10,10 +10,10 @@ import {
 describe("AtlasMcpToolErrorCode catalog", () => {
   test("union and runtime list stay in lockstep", () => {
     // satisfies + readonly array force the union to match the literal at
-    // compile time; the test pins the size at 9 so accidentally widening
+    // compile time; the test pins the size at 10 so accidentally widening
     // the union (e.g. adding "auth_failed" without updating consumers) is
     // caught here too.
-    expect(ATLAS_MCP_TOOL_ERROR_CODES).toHaveLength(9);
+    expect(ATLAS_MCP_TOOL_ERROR_CODES).toHaveLength(10);
     const set = new Set<AtlasMcpToolErrorCode>(ATLAS_MCP_TOOL_ERROR_CODES);
     expect(set.size).toBe(ATLAS_MCP_TOOL_ERROR_CODES.length);
   });

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -49,6 +49,11 @@
  *   directly from the typed billing-gate verdict in
  *   `packages/mcp/src/billing-gate.ts` — it never flows through the
  *   string classifiers in `error-envelope.ts`, so no regex branch exists.
+ * - `forbidden` — the bound MCP actor lacks the authority for this tool:
+ *   a missing OAuth scope (e.g. `mcp:write`, #3504), or insufficient RBAC
+ *   role (#3505/#3508). Retrying won't help; the workspace admin must
+ *   grant the scope/role. Distinct from `rls_denied` (row-level data
+ *   policy) and `billing_blocked` (account standing).
  * - `internal_error` — unexpected failure. Includes `request_id` so the
  *   user can quote it when filing a support ticket.
  *
@@ -75,6 +80,7 @@ export type AtlasMcpToolErrorCode =
   | "ambiguous_term"
   | "rate_limited"
   | "billing_blocked"
+  | "forbidden"
   | "internal_error";
 
 /**
@@ -105,6 +111,7 @@ export const ATLAS_MCP_TOOL_ERROR_CODES = [
   "ambiguous_term",
   "rate_limited",
   "billing_blocked",
+  "forbidden",
   "internal_error",
 ] as const satisfies readonly AtlasMcpToolErrorCode[];
 


### PR DESCRIPTION
## Summary

MCP V2 (2.1) per ADR-0016: extract the bearer's OAuth scopes and enforce `mcp:write` at the MCP dispatch seam. Unblocked by #3491; prerequisite for #3508.

- **`@useatlas/types`** — add `forbidden` to `AtlasMcpToolErrorCode` (authz denials: scope today, RBAC in #3505/#3508). Bumped `0.2.0 → 0.3.0` (additive/backward-compatible — see Publishing note).
- **`RequestContext.scopes`** (`logger.ts`) — threaded `verifyMcpBearer` → `InitialFactoryContext` → `createBoundMcpServer` → `createMcpServer` → `registerTools`/`registerSemanticTools`/`registerPluginTools` → **every per-tool `withRequestContext` frame**. `withRequestContext` replaces (not merges) the context, so each dispatch frame must carry `scopes` itself — all six built-in/semantic frames + the plugin frame do.
- **`writeScopeOrNull`** gate (`tools.ts`) — stdio exempt (no `clientId`, mirrors the rate-limiter signal), hosted requires `mcp:write`, **fail-closed** on missing/empty scopes → `forbidden` envelope. Read tools never call it; the first write tool will.

## Code review (done before merge, per request)
Ran `pr-review-toolkit:code-reviewer` + `silent-failure-hunter` on the diff:
- General reviewer: **no material issues, ship it**.
- Silent-failure-hunter: confirmed the gate is **genuinely fail-closed** (hosted bearers always carry a non-empty `clientId` — `verifyMcpBearer` 401s otherwise — so the stdio carve-out can't be spoofed; empty/undefined scopes deny). Its "CRITICAL merge-divergence" flag was a **false alarm from a stale `origin/main` ref** (diffed against pre-#3491 `daf0ae5a`); verified HEAD is a clean descendant of current `main` with `agentOrigin` present and the threading guarded by the `tools.test.ts` #3504 test.
- **Real follow-up filed as #3520:** mutating *plugin* MCP tools aren't `mcp:write`-gated yet (the host has no read/write signal for plugin tools until tool annotations #3497; generic enforcement is #3508's pipeline). Documented in-code + tracked; not exploitable today (no mutating plugin MCP tools ship).

## Test plan
- [x] `writeScopeOrNull` unit branches (allow / deny / stdio-exempt / fail-closed) — `write-scope-gate.test.ts`
- [x] stub write tool denied for `mcp:read`-only, allowed for `mcp:write`, exempt for stdio — end-to-end through a real MCP client
- [x] scopes reach `RequestContext` through the **real** `registerTools` dispatch; undefined for stdio — `tools.test.ts` #3504
- [x] `forbidden` code: union + runtime array + pinned-length test in lockstep
- [x] type, lint, published-symbols, schema-drift, OpenAPI-drift, full MCP + api-plugin suites green

## Publishing
`@useatlas/types@0.3.0` is additive (new error code only) and backward-compatible. Template refs stay `^0.2.0`; nothing scaffold-bound imports the new value, so CI is green without a pre-publish. Publish `types-v0.3.0` post-merge at leisure; bump refs when convenient.

Closes #3504