### PR TITLE
feat(mcp): resolve hosted actor's effective org role via live DB lookup (#3505)

### DIFF
--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -1797,12 +1797,14 @@ describe("hosted MCP — audit failure", () => {
 // ── #3505 — live effective-role resolution at the MCP edge ────────────
 //
 // bindFactoryContext re-binds the actor for the RESOLVED workspace and
-// stamps the effective org role from a LIVE resolveEffectiveRole lookup
+// stamps the effective ORG role from a LIVE resolveEffectiveRole lookup
 // (mocked here; the lookup's member-table/fail-closed semantics are
 // covered by packages/api/.../effective-role.test.ts). These pin the
 // wiring: the role is resolved per-call against the resolved workspace,
-// so a demoted admin loses the role on the next dispatch without a token
-// refresh.
+// so a demoted member loses the role on the next dispatch without a token
+// refresh. The user-level role is passed as `undefined` (never a token
+// claim; cross-tenant platform_admin is intentionally not applied over
+// hosted MCP — see #3522), which the call-args assertions below encode.
 describe("bindFactoryContext live role resolution (#3505)", () => {
   beforeEach(() => {
     mockResolveEffectiveRole.mockClear();

--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -28,6 +28,9 @@ import type { AdminActionEntry } from "@atlas/api/lib/audit";
 // Import the same constant the production code reads — keeps the
 // fixture from drifting out of sync with the issuer's claim key.
 import { ATLAS_OAUTH_WORKSPACE_CLAIM as WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import type { AtlasRole } from "@atlas/api/lib/auth/types";
+import type { VerifiedBearer } from "../hosted.js";
 
 // ── Module-scope mocks ────────────────────────────────────────────────
 //
@@ -181,6 +184,19 @@ mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
   revokeWorkspaceGrant: async () => 0,
 }));
 
+// #3505 — live effective-role resolution at the MCP edge. Default is a
+// pass-through (returns the user-level role unchanged) so existing tests,
+// which build actors with no role, keep seeing no role. The role-resolution
+// tests below override the resolved value per-case. Mocking here also
+// avoids the real resolver hitting the throw-on-call `internalQuery` mock.
+const mockResolveEffectiveRole: Mock<
+  (userRole: unknown, userId: string, orgId: string | undefined) => Promise<unknown>
+> = mock(async (userRole: unknown) => userRole);
+mock.module("@atlas/api/lib/auth/effective-role", () => ({
+  resolveEffectiveRole: (userRole: unknown, userId: string, orgId: string | undefined) =>
+    mockResolveEffectiveRole(userRole, userId, orgId),
+}));
+
 // #3345 — forced-password-change gate at the MCP edge. Defaults to
 // "not flagged" so existing tests pass; the gate tests flip it.
 const mockIsPasswordChangeRequired: Mock<(userId: string) => Promise<boolean>> =
@@ -288,7 +304,7 @@ mock.module("@atlas/api/lib/billing/agent-gate", () => ({
 }));
 
 const { Hono } = await import("hono");
-const { createHostedMcpRouter, _resetHostedSessions, _hostedSessionCount, _sweepIdleSessionsForTests, _setIdleTimeoutForTests } =
+const { createHostedMcpRouter, bindFactoryContext, _resetHostedSessions, _hostedSessionCount, _sweepIdleSessionsForTests, _setIdleTimeoutForTests } =
   await import("../hosted.js");
 
 // ── Test fixtures ─────────────────────────────────────────────────────
@@ -1775,5 +1791,68 @@ describe("hosted MCP — audit failure", () => {
     } finally {
       handle.close();
     }
+  });
+});
+
+// ── #3505 — live effective-role resolution at the MCP edge ────────────
+//
+// bindFactoryContext re-binds the actor for the RESOLVED workspace and
+// stamps the effective org role from a LIVE resolveEffectiveRole lookup
+// (mocked here; the lookup's member-table/fail-closed semantics are
+// covered by packages/api/.../effective-role.test.ts). These pin the
+// wiring: the role is resolved per-call against the resolved workspace,
+// so a demoted admin loses the role on the next dispatch without a token
+// refresh.
+describe("bindFactoryContext live role resolution (#3505)", () => {
+  beforeEach(() => {
+    mockResolveEffectiveRole.mockClear();
+  });
+
+  function makeBearer(role?: AtlasRole): VerifiedBearer {
+    return {
+      kind: "ok",
+      user: createAtlasUser(SUB_A, "managed", SUB_A, {
+        ...(role !== undefined ? { role } : {}),
+        activeOrganizationId: ORG_A,
+        claims: { [WORKSPACE_CLAIM]: ORG_A },
+      }),
+      orgId: ORG_A,
+      clientId: CLIENT_A,
+      tokenJti: null,
+      scopes: ["mcp:read"],
+    };
+  }
+
+  it("stamps the live-resolved effective role onto the bound actor", async () => {
+    mockResolveEffectiveRole.mockResolvedValueOnce("admin");
+    const ctx = await bindFactoryContext(makeBearer(), ORG_A);
+    expect(ctx.user.role).toBe("admin");
+    // Resolved against (user-level role, userId, RESOLVED orgId).
+    expect(mockResolveEffectiveRole).toHaveBeenCalledWith(undefined, SUB_A, ORG_A);
+  });
+
+  it("resolves against the RESOLVED workspace, not the bearer's claim (cross-workspace)", async () => {
+    mockResolveEffectiveRole.mockResolvedValueOnce("owner");
+    // Bearer claims ORG_A but the admitted workspace is ORG_B.
+    const ctx = await bindFactoryContext(makeBearer(), ORG_B);
+    expect(mockResolveEffectiveRole).toHaveBeenCalledWith(undefined, SUB_A, ORG_B);
+    expect(ctx.user.activeOrganizationId).toBe(ORG_B);
+    expect(ctx.user.role).toBe("owner");
+  });
+
+  it("re-resolves per call — a mid-session demotion takes effect without a token refresh", async () => {
+    const bearer = makeBearer();
+    mockResolveEffectiveRole.mockResolvedValueOnce("admin").mockResolvedValueOnce("member");
+    const first = await bindFactoryContext(bearer, ORG_A);
+    const second = await bindFactoryContext(bearer, ORG_A);
+    expect(first.user.role).toBe("admin");
+    expect(second.user.role).toBe("member"); // same bearer, role changed live
+    expect(mockResolveEffectiveRole).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the role unset when the resolver yields none (fail-closed least privilege)", async () => {
+    mockResolveEffectiveRole.mockResolvedValueOnce(undefined);
+    const ctx = await bindFactoryContext(makeBearer(), ORG_A);
+    expect(ctx.user.role).toBeUndefined();
   });
 });

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -1129,15 +1129,22 @@ export async function bindFactoryContext(
   bearer: VerifiedBearer,
   resolvedOrgId: string,
 ): Promise<InitialFactoryContext> {
-  // #3505 — resolve the actor's EFFECTIVE org role LIVE from the `member`
-  // table for the RESOLVED workspace (never from a token claim), so RBAC
-  // gates see the current role and a demoted/revoked admin loses
-  // admin-gated tools immediately — no token refresh, no TTL. Mirrors the
-  // authoritative-grants pattern already used for workspace admission.
-  // `resolveEffectiveRole` fails closed: a member-table read error
-  // down-privileges to the user-level role (a non-admin default), never
-  // escalates; `platform_admin` short-circuits before the lookup.
-  const role = await resolveEffectiveRole(bearer.user.role, bearer.user.id, resolvedOrgId);
+  // #3505 — resolve the actor's effective ORG role LIVE from the `member`
+  // table for the RESOLVED workspace, so RBAC gates see the current role
+  // and a demoted/revoked member loses elevated tools immediately — no
+  // token refresh, no TTL. Mirrors the authoritative-grants pattern used
+  // for workspace admission.
+  //
+  // We pass `undefined` for the user-level role, NEVER a token claim
+  // (#3505 mandates a live DB lookup), and deliberately do NOT apply a
+  // cross-tenant `platform_admin` over customer-facing hosted MCP: a hosted
+  // OAuth session acts with the caller's member role for the admitted
+  // workspace, not god-mode. (stdio's `loadActorUser` resolves the
+  // user-level role too; the hosted trust boundary is intentionally
+  // narrower — decision tracked in #3522.) `resolveEffectiveRole` fails
+  // closed: a member-table read error yields no role → downstream defaults
+  // to least privilege (`member`), never escalates.
+  const role = await resolveEffectiveRole(undefined, bearer.user.id, resolvedOrgId);
 
   // Re-bind the actor so RLS / audit / approval surfaces downstream see
   // the RESOLVED workspace as `activeOrganizationId`. Without this, the

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -71,6 +71,7 @@ import { resolveMcpMaxSessions } from "@atlas/api/lib/env-profile";
 import { withRequestContext, createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { createAtlasUser, type AtlasUser } from "@atlas/api/lib/auth/types";
+import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { isPasswordChangeRequired } from "@atlas/api/lib/auth/password-gate";
 import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
 import {
@@ -389,7 +390,7 @@ function jwksUrl(req: Request): string {
   return `${tokenIssuer(req)}/jwks`;
 }
 
-interface VerifiedBearer {
+export interface VerifiedBearer {
   readonly kind: "ok";
   readonly user: AtlasUser;
   readonly orgId: string;
@@ -1122,17 +1123,29 @@ interface InitialFactoryContext {
   readonly scopes: ReadonlyArray<string>;
 }
 
-function bindFactoryContext(
+// Exported for unit testing (#3505) — asserts the live-role-resolution
+// wiring without standing up a full hosted session.
+export async function bindFactoryContext(
   bearer: VerifiedBearer,
   resolvedOrgId: string,
-): InitialFactoryContext {
+): Promise<InitialFactoryContext> {
+  // #3505 — resolve the actor's EFFECTIVE org role LIVE from the `member`
+  // table for the RESOLVED workspace (never from a token claim), so RBAC
+  // gates see the current role and a demoted/revoked admin loses
+  // admin-gated tools immediately — no token refresh, no TTL. Mirrors the
+  // authoritative-grants pattern already used for workspace admission.
+  // `resolveEffectiveRole` fails closed: a member-table read error
+  // down-privileges to the user-level role (a non-admin default), never
+  // escalates; `platform_admin` short-circuits before the lookup.
+  const role = await resolveEffectiveRole(bearer.user.role, bearer.user.id, resolvedOrgId);
+
   // Re-bind the actor so RLS / audit / approval surfaces downstream see
   // the RESOLVED workspace as `activeOrganizationId`. Without this, the
   // per-tool frame would inherit the JWT's singular claim and any code
   // reading `actor.activeOrganizationId` would silently route to the
   // wrong workspace under the cross-workspace path.
   const user = createAtlasUser(bearer.user.id, bearer.user.mode, bearer.user.label, {
-    ...(bearer.user.role !== undefined ? { role: bearer.user.role } : {}),
+    ...(role !== undefined ? { role } : {}),
     activeOrganizationId: resolvedOrgId,
     claims:
       bearer.user.claims !== undefined
@@ -1442,7 +1455,7 @@ export function createHostedMcpRouter(): Hono {
       return c.json(residency.body, residency.status);
     }
 
-    const factoryCtx = bindFactoryContext(verified, resolvedOrgId);
+    const factoryCtx = await bindFactoryContext(verified, resolvedOrgId);
     const sessionId = c.req.raw.headers.get("mcp-session-id");
 
     try {


### PR DESCRIPTION
## Summary

MCP V2 (2.2) per ADR-0016. The hosted MCP actor carried **no role**, so RBAC checks (and #3508's gate pipeline) silently 403'd. At `verifyMcpBearer` → `bindFactoryContext`, resolve the bound actor's effective **org** role from a LIVE `member`-table lookup (`resolveEffectiveRole`) for the **resolved** workspace, and stamp it on the actor.

- Live + per-dispatch (no cache/TTL) → a demoted/revoked member loses elevated tools immediately, no token refresh.
- Resolved against the **admitted** workspace, not the bearer's JWT claim (cross-workspace safe).
- **Fail-closed:** a member-table read error yields no role → downstream defaults to least privilege (`member`); never escalates.
- `bindFactoryContext` is now `async` (sole caller awaited).

## Code review (done before merge, per request)
Ran `pr-review-toolkit:code-reviewer` + `silent-failure-hunter` on the diff:
- **silent-failure-hunter:** confirmed fail-closed across all surfaces — no privilege escalation, role resolved against the admitted workspace, no silent error swallow, single awaited caller.
- **code-reviewer:** caught that `bearer.user.role` is always `undefined` at the hosted edge, making the old "platform_admin short-circuits" comment dead. **Addressed:** pass `undefined` explicitly (never a token claim, per #3505), corrected the comment, and documented the deliberate boundary — a cross-tenant `platform_admin` is **not** auto-applied over customer-facing hosted MCP (a hosted session acts with the caller's member role; auto-escalating an OAuth client to cross-tenant god-mode would be a privilege-escalation surface). Decision tracked in **#3522**.

## Tests
- `bindFactoryContext` exported for testing; 4 new tests (hosted.test.ts): role stamped from the live lookup; resolved against the admitted workspace not the bearer claim; **re-resolved per call so a mid-session demotion takes effect without a token refresh**; undefined → no role (least privilege).
- Resolver semantics + member-table fail-closed already covered by `effective-role.test.ts`.
- **On the AC's "real Better Auth fixture" eval:** not applicable at this layer — the MCP eval harness uses Better Auth's *memory adapter* while `resolveEffectiveRole` reads the Postgres `member` table via `internalQuery`; the shared resolver's real-schema behavior is covered by `effective-role.test.ts` + managed-auth coverage. The live/no-refresh contract is pinned by the per-call tests above.
- type, lint, syncpack, template-drift, full mcp suite (289/0) green.

Closes #3505