### PR TITLE
feat(mcp): dispatch gate-order pipeline + origin=mcp approval flow (#3508)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/permissions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/permissions.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { canApprove, getUserRole, parseRole } from "../permissions";
+import { canApprove, getUserRole, parseRole, meetsRoleRequirement } from "../permissions";
 import { createAtlasUser } from "../types";
 import type { AtlasRole } from "../types";
 import type { ActionApprovalMode } from "@atlas/api/lib/action-types";
@@ -220,4 +220,30 @@ describe("full permission matrix", () => {
       }
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// meetsRoleRequirement() — #3508 MCP dispatch RBAC gate primitive
+// ---------------------------------------------------------------------------
+
+describe("meetsRoleRequirement()", () => {
+  it("fails closed for an undefined user (no bound identity)", () => {
+    expect(meetsRoleRequirement(undefined, "member")).toBe(false);
+    expect(meetsRoleRequirement(undefined, "admin")).toBe(false);
+  });
+
+  it("allows at-or-above the threshold and denies below it (managed roles)", () => {
+    expect(meetsRoleRequirement(makeUser("managed", "member"), "admin")).toBe(false);
+    expect(meetsRoleRequirement(makeUser("managed", "admin"), "admin")).toBe(true);
+    expect(meetsRoleRequirement(makeUser("managed", "owner"), "admin")).toBe(true);
+    expect(meetsRoleRequirement(makeUser("managed", "platform_admin"), "admin")).toBe(true);
+    // owner threshold: admin is below, owner/platform_admin at-or-above.
+    expect(meetsRoleRequirement(makeUser("managed", "admin"), "owner")).toBe(false);
+    expect(meetsRoleRequirement(makeUser("managed", "owner"), "owner")).toBe(true);
+  });
+
+  it("uses the auth-mode default role when none is set (managed → member fails admin gate)", () => {
+    expect(meetsRoleRequirement(makeUser("managed"), "admin")).toBe(false);
+    expect(meetsRoleRequirement(makeUser("managed"), "member")).toBe(true);
+  });
 });

--- a/packages/api/src/lib/auth/__tests__/permissions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/permissions.test.ts
@@ -247,3 +247,19 @@ describe("meetsRoleRequirement()", () => {
     expect(meetsRoleRequirement(makeUser("managed"), "member")).toBe(true);
   });
 });
+
+describe("meetsRoleRequirement() — simple-key default-role documentation (#3508)", () => {
+  it("a ROLELESS simple-key user defaults to admin — so MCP safety MUST live in the actor model", () => {
+    // getUserRole defaults simple-key → admin. meetsRoleRequirement honors
+    // that, so a roleless simple-key actor would clear an admin gate. This is
+    // intentional for first-party API keys, but it means the MCP dispatch
+    // RBAC gate's safety relies on MCP actors NEVER being a roleless
+    // simple-key: hosted/stdio bound actors are `mode: "managed"`, and the
+    // only simple-key MCP actor (system:mcp) is explicitly pinned to
+    // `role: "member"`. If this assertion ever needs changing, re-audit MCP
+    // actor construction (packages/mcp/src/actor.ts, hosted.ts) first.
+    expect(meetsRoleRequirement(makeUser("simple-key"), "admin")).toBe(true);
+    // An explicit member role on a simple-key user is honored (not defaulted).
+    expect(meetsRoleRequirement(makeUser("simple-key", "member"), "admin")).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/permissions.ts
+++ b/packages/api/src/lib/auth/permissions.ts
@@ -200,3 +200,26 @@ export function canApprove(
 
   return allowed;
 }
+
+/**
+ * Does the user's effective role meet a minimum-role threshold?
+ *
+ * The role primitive behind the MCP dispatch RBAC gate (#3508 / ADR-0016
+ * gate 3): authority is the bound actor's role, live-resolved at the MCP
+ * edge (#3505), compared on the `member < admin < owner < platform_admin`
+ * hierarchy. Distinct from {@link canApprove}, which is the action-approval
+ * decision keyed on an approval *mode*; this is a plain "is this actor at
+ * least <role>" check for gating admin/config tools.
+ *
+ * Fail-closed: an absent user (no bound identity — e.g. the stdio
+ * `system:mcp` trusted actor) returns `false`, so admin tools always
+ * register but only a real bound identity at/above `minRole` clears the
+ * gate (ADR-0016: "RBAC is the only source of authority").
+ */
+export function meetsRoleRequirement(
+  user: AtlasUser | undefined,
+  minRole: AtlasRole,
+): boolean {
+  if (!user) return false;
+  return ROLE_LEVEL[getUserRole(user)] >= ROLE_LEVEL[minRole];
+}

--- a/packages/mcp/src/__tests__/dispatch-gate.test.ts
+++ b/packages/mcp/src/__tests__/dispatch-gate.test.ts
@@ -1,0 +1,253 @@
+/**
+ * #3508 — MCP dispatch gate-order pipeline (ADR-0016).
+ *
+ * Pins the gate order (scope → RBAC → approval) and each branch:
+ *   - gate 2 (mcp:write scope) denies a hosted mcp:read-only caller and is
+ *     checked BEFORE RBAC; stdio (no clientId) is exempt;
+ *   - gate 3 (RBAC) denies a non-admin actor with a `forbidden` envelope;
+ *   - gate 4 (approval) routes a destructive action through the approval
+ *     gate keyed on origin=mcp, returning the `approval_required` body when a
+ *     rule matches, proceeding when none matches / already approved, and
+ *     failing closed when the gate is unavailable.
+ *
+ * Gate 4 uses an injected stub `ApprovalGateShape` (no EE layer needed). A
+ * final end-to-end test drives a stub admin tool through a real MCP client
+ * to prove a tool wires the pipeline correctly.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import type { AtlasUser, AtlasRole } from "@atlas/api/lib/auth/types";
+import type { ApprovalGateShape } from "@atlas/api/lib/effect/services";
+import type { ApprovalRequest } from "@useatlas/types";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+import {
+  runMcpDispatchGate,
+  type McpDispatchGateContext,
+  type McpDispatchGateRequirements,
+} from "../dispatch-gate.js";
+
+const ORG = "org_test";
+
+function actor(role: AtlasRole | undefined): AtlasUser {
+  return createAtlasUser("user_1", "managed", "u@example.com", {
+    ...(role !== undefined ? { role } : {}),
+    activeOrganizationId: ORG,
+  });
+}
+
+function getContentText(content: unknown): string {
+  const arr = content as Array<{ type: string; text: string }>;
+  return arr[0]?.text ?? "";
+}
+
+/** A pending approval request fixture — only `id` is read by the pipeline. */
+function pendingRequest(id: string): ApprovalRequest {
+  return {
+    id,
+    orgId: ORG,
+    ruleId: "rule_1",
+    ruleName: "MCP destructive",
+    requesterId: "user_1",
+    requesterEmail: "u@example.com",
+    querySql: "delete datasource prod",
+    explanation: "delete datasource prod",
+    connectionGroupId: null,
+    tablesAccessed: ["datasource:prod"],
+    columnsAccessed: [],
+    origin: "mcp",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-02T00:00:00.000Z",
+    status: "pending",
+    reviewerId: null,
+    reviewerEmail: null,
+    reviewComment: null,
+    reviewedAt: null,
+  };
+}
+
+/**
+ * Build a stub `ApprovalGateShape`. The pipeline only calls
+ * checkApprovalRequired / hasApprovedRequest / createApprovalRequest; the
+ * rest die loudly if a refactor starts depending on them.
+ */
+function stubApprovalGate(opts: {
+  required: boolean;
+  alreadyApproved?: boolean;
+  matchedRules?: { id: string; name: string }[];
+  onCreate?: () => void;
+}): ApprovalGateShape {
+  const unused = () => Effect.die(new Error("approval gate method not used in this test"));
+  return {
+    available: true,
+    checkApprovalRequired: () =>
+      Effect.succeed({
+        required: opts.required,
+        matchedRules: (opts.matchedRules ?? [{ id: "rule_1", name: "MCP destructive" }]) as never,
+      }),
+    hasApprovedRequest: () => Effect.succeed(opts.alreadyApproved ?? false),
+    createApprovalRequest: () => {
+      opts.onCreate?.();
+      return Effect.succeed(pendingRequest("req_stub"));
+    },
+    listApprovalRules: unused,
+    createApprovalRule: unused,
+    updateApprovalRule: unused,
+    deleteApprovalRule: unused,
+    listApprovalRequests: unused,
+    getApprovalRequest: unused,
+    reviewApprovalRequest: unused,
+    expireStaleRequests: unused,
+    getPendingCount: unused,
+  };
+}
+
+const baseCtx = (over: Partial<McpDispatchGateContext> = {}): McpDispatchGateContext => ({
+  actor: actor("admin"),
+  clientId: "claude-desktop",
+  scopes: ["mcp:read", "mcp:write"],
+  orgId: ORG,
+  requesterId: "user_1",
+  requesterEmail: "u@example.com",
+  ...over,
+});
+
+const adminReqs: McpDispatchGateRequirements = {
+  toolName: "stub_admin",
+  requiresWrite: true,
+  minRole: "admin",
+};
+
+describe("runMcpDispatchGate — gate order + branches (#3508)", () => {
+  it("gate 2: denies a hosted mcp:read-only caller (forbidden)", async () => {
+    const res = await runMcpDispatchGate(baseCtx({ scopes: ["mcp:read"] }), adminReqs);
+    expect(res?.isError).toBe(true);
+    const env = parseAtlasMcpToolError(getContentText(res?.content));
+    expect(env?.code).toBe("forbidden");
+    expect(env?.message).toContain("mcp:write");
+  });
+
+  it("gate 3: denies a non-admin actor at RBAC (forbidden)", async () => {
+    const res = await runMcpDispatchGate(baseCtx({ actor: actor("member") }), adminReqs);
+    expect(res?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("forbidden");
+    expect(getContentText(res?.content)).toContain("admin");
+  });
+
+  it("order: scope is checked BEFORE RBAC (no-scope + non-admin → scope denial)", async () => {
+    // A non-admin with NO mcp:write must be denied at gate 2 (scope), whose
+    // message mentions mcp:write — proving scope runs before RBAC.
+    const res = await runMcpDispatchGate(
+      baseCtx({ actor: actor("member"), scopes: ["mcp:read"] }),
+      adminReqs,
+    );
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.message).toContain("mcp:write");
+  });
+
+  it("stdio (no clientId) is scope-exempt but still RBAC-gated", async () => {
+    // No clientId → gate 2 skipped; a member still fails gate 3.
+    const denied = await runMcpDispatchGate(
+      baseCtx({ clientId: undefined, scopes: undefined, actor: actor("member") }),
+      adminReqs,
+    );
+    expect(parseAtlasMcpToolError(getContentText(denied?.content))?.code).toBe("forbidden");
+    // An admin over stdio clears scope (exempt) + RBAC + non-destructive → proceeds.
+    const ok = await runMcpDispatchGate(
+      baseCtx({ clientId: undefined, scopes: undefined, actor: actor("admin") }),
+      adminReqs,
+    );
+    expect(ok).toBeNull();
+  });
+
+  it("non-destructive admin tool clears all gates → proceeds (null)", async () => {
+    const res = await runMcpDispatchGate(baseCtx(), adminReqs);
+    expect(res).toBeNull();
+  });
+
+  it("gate 4: destructive action routes through approval when an origin=mcp rule matches", async () => {
+    let created = false;
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: true, onCreate: () => { created = true; } }) },
+    );
+    expect(res?.isError).toBeFalsy();
+    const body = JSON.parse(getContentText(res?.content));
+    expect(body.approval_required).toBe(true);
+    expect(body.approval_request_id).toBe("req_stub");
+    expect(body.matched_rules).toContain("MCP destructive");
+    expect(created).toBe(true);
+  });
+
+  it("gate 4: destructive action proceeds when no origin=mcp rule matches", async () => {
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: false }) },
+    );
+    expect(res).toBeNull();
+  });
+
+  it("gate 4: proceeds (no new request) when the requester was already approved", async () => {
+    let created = false;
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: true, alreadyApproved: true, onCreate: () => { created = true; } }) },
+    );
+    expect(res).toBeNull();
+    expect(created).toBe(false);
+  });
+
+  it("gate 4: fails closed (internal_error) when the approval gate is unavailable", async () => {
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => { throw new Error("EE layer not bound"); } },
+    );
+    expect(res?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("internal_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: a stub admin tool wired through the pipeline + a real client.
+// ---------------------------------------------------------------------------
+
+async function clientForStubAdminTool(ctx: McpDispatchGateContext): Promise<Client> {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  server.registerTool(
+    "stub_admin",
+    { title: "Stub admin tool", description: "No-op admin tool gated by the dispatch pipeline.", inputSchema: {} },
+    async () => {
+      const denied = await runMcpDispatchGate(ctx, adminReqs);
+      if (denied) return denied;
+      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
+    },
+  );
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [c, s] = InMemoryTransport.createLinkedPair();
+  await server.connect(s);
+  await client.connect(c);
+  return client;
+}
+
+describe("stub admin tool through the pipeline (#3508 e2e)", () => {
+  it("denies a non-admin caller at RBAC", async () => {
+    const client = await clientForStubAdminTool(baseCtx({ actor: actor("member") }));
+    const res = await client.callTool({ name: "stub_admin", arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
+  });
+
+  it("allows an admin with mcp:write", async () => {
+    const client = await clientForStubAdminTool(baseCtx());
+    const res = await client.callTool({ name: "stub_admin", arguments: {} });
+    expect(res.isError).toBeFalsy();
+    expect(getContentText(res.content)).toContain('"ok":true');
+  });
+});

--- a/packages/mcp/src/__tests__/dispatch-gate.test.ts
+++ b/packages/mcp/src/__tests__/dispatch-gate.test.ts
@@ -80,16 +80,25 @@ function stubApprovalGate(opts: {
   alreadyApproved?: boolean;
   matchedRules?: { id: string; name: string }[];
   onCreate?: () => void;
+  /** Simulate a DB defect (Effect.promise rejection) during the check read. */
+  checkThrows?: boolean;
+  /** Simulate a DB defect during the already-approved read. */
+  hasApprovedThrows?: boolean;
 }): ApprovalGateShape {
   const unused = () => Effect.die(new Error("approval gate method not used in this test"));
   return {
     available: true,
     checkApprovalRequired: () =>
-      Effect.succeed({
-        required: opts.required,
-        matchedRules: (opts.matchedRules ?? [{ id: "rule_1", name: "MCP destructive" }]) as never,
-      }),
-    hasApprovedRequest: () => Effect.succeed(opts.alreadyApproved ?? false),
+      opts.checkThrows
+        ? Effect.die(new Error("member-table read failed"))
+        : Effect.succeed({
+            required: opts.required,
+            matchedRules: (opts.matchedRules ?? [{ id: "rule_1", name: "MCP destructive" }]) as never,
+          }),
+    hasApprovedRequest: () =>
+      opts.hasApprovedThrows
+        ? Effect.die(new Error("approval_queue read failed"))
+        : Effect.succeed(opts.alreadyApproved ?? false),
     createApprovalRequest: () => {
       opts.onCreate?.();
       return Effect.succeed(pendingRequest("req_stub"));
@@ -211,6 +220,38 @@ describe("runMcpDispatchGate — gate order + branches (#3508)", () => {
     );
     expect(res?.isError).toBe(true);
     expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("internal_error");
+  });
+
+  it("gate 4: fails closed when checkApprovalRequired throws (DB defect, not just gate-load)", async () => {
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: true, checkThrows: true }) },
+    );
+    expect(res?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("internal_error");
+  });
+
+  it("gate 4: fails closed when hasApprovedRequest throws (DB defect)", async () => {
+    const res = await runMcpDispatchGate(
+      baseCtx(),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: true, hasApprovedThrows: true }) },
+    );
+    expect(res?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("internal_error");
+  });
+
+  it("gate 4: denies a destructive action with no bound identity (guard runs before the approval check)", async () => {
+    let checked = false;
+    const res = await runMcpDispatchGate(
+      baseCtx({ orgId: undefined }),
+      { ...adminReqs, destructive: { resource: "datasource:prod", description: "delete datasource prod" } },
+      { loadApprovalGate: async () => stubApprovalGate({ required: false, onCreate: () => { checked = true; } }) },
+    );
+    expect(res?.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res?.content))?.code).toBe("forbidden");
+    expect(checked).toBe(false); // never reached the gate
   });
 });
 

--- a/packages/mcp/src/dispatch-gate.ts
+++ b/packages/mcp/src/dispatch-gate.ts
@@ -1,0 +1,273 @@
+/**
+ * MCP dispatch gate-order pipeline (#3508 / ADR-0016).
+ *
+ * Every MUTATING MCP tool routes its dispatch through this composer before
+ * doing any work. The gate order is fixed by ADR-0016; this module wires
+ * gates 2–4 (gate 1, the per-workspace MCP action policy, lands in #3509;
+ * gate 5, inline confirm via destructiveHint + elicitation, in #3497/#3499):
+ *
+ *   2. `mcp:write` scope  — hosted only; stdio is exempt (no third-party
+ *      client). Reuses {@link writeScopeOrNull} (#3504).
+ *   3. RBAC role          — authority is the bound MCP actor's role,
+ *      live-resolved at bearer-verify time (#3505), compared on the
+ *      member < admin < owner < platform_admin hierarchy via
+ *      {@link meetsRoleRequirement}. Called directly on the lib layer —
+ *      NEVER a loopback HTTP proxy (ADR-0016).
+ *   4. Approval flow      — destructive actions route through Atlas's
+ *      existing approval gate keyed on `origin=mcp`. If a matching rule
+ *      fires (and the requester hasn't already been approved), an approval
+ *      request is queued and the caller is told to wait.
+ *
+ * Every gate FAILS CLOSED: a missing scope, an insufficient/absent role, or
+ * an unavailable approval gate denies rather than proceeds. Read-only tools
+ * never call this; the origin ceiling (MCP can raise but never lower
+ * governance) is enforced structurally by which tools exist, not here.
+ *
+ * Returns `null` when all gates clear (the caller proceeds), or a
+ * `CallToolResult` to short-circuit: a `forbidden` envelope for a
+ * scope/RBAC denial, or a non-error `approval_required` JSON body for gate 4
+ * (mirroring the shape executeSQL already surfaces, so agents/SDK parse one
+ * contract).
+ */
+
+import { Effect } from "effect";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AtlasUser, AtlasRole } from "@atlas/api/lib/auth/types";
+import { meetsRoleRequirement, getUserRole } from "@atlas/api/lib/auth/permissions";
+import {
+  ApprovalGate,
+  type ApprovalGateShape,
+} from "@atlas/api/lib/effect/services";
+import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { createLogger } from "@atlas/api/lib/logger";
+import { writeScopeOrNull } from "./tools.js";
+import { envelope, toEnvelopeResult } from "./error-envelope.js";
+
+const log = createLogger("mcp:dispatch-gate");
+
+/**
+ * Resolve the `ApprovalGate` Tag fail-closed — mirrors `loadApprovalGate`
+ * in `lib/tools/sql.ts`. On SaaS (`ATLAS_ENTERPRISE_ENABLED=true`) a gate
+ * that didn't bind is a governance break, so we throw rather than treat it
+ * as "no rules". Self-hosted with `available: false` is the expected no-op.
+ */
+function loadApprovalGate(): Promise<ApprovalGateShape> {
+  return runEnterprise(
+    Effect.gen(function* () {
+      const gate = yield* ApprovalGate;
+      if (isEnterpriseEnabled() && !gate.available) {
+        return yield* Effect.fail(
+          new EnterpriseUnavailableError({
+            message:
+              "Approval gate unavailable — MCP action blocked to prevent governance bypass. Contact your administrator.",
+            tag: "ApprovalGate",
+          }),
+        );
+      }
+      return gate;
+    }),
+  );
+}
+
+export interface McpDispatchGateContext {
+  /** Bound MCP actor — its live-resolved role (#3505) is gate 3's authority. */
+  readonly actor: AtlasUser;
+  /** Hosted-MCP OAuth client_id; absent for stdio (which is scope-exempt). */
+  readonly clientId?: string;
+  /** OAuth token scopes (#3504), threaded onto RequestContext at dispatch. */
+  readonly scopes?: readonly string[];
+  /** Resolved workspace id (the admitted org). */
+  readonly orgId: string | undefined;
+  /** Requester id for approval attribution; falls back from the actor. */
+  readonly requesterId?: string;
+  /** Requester email stamped on the approval request, when known. */
+  readonly requesterEmail?: string | null;
+  /** Per-call request id for log correlation. */
+  readonly requestId?: string;
+}
+
+export interface McpDispatchGateRequirements {
+  /** Tool name for logs / envelopes. */
+  readonly toolName: string;
+  /** Gate 2: the tool mutates data → require the `mcp:write` scope (hosted). */
+  readonly requiresWrite: boolean;
+  /** Gate 3: minimum RBAC role on the bound actor (e.g. `"admin"`). */
+  readonly minRole: AtlasRole;
+  /**
+   * Gate 4: a destructive action that must route through the approval gate.
+   * Omit for non-destructive (e.g. read-back / list) admin tools. `resource`
+   * is the approval-matchable target (e.g. `"datasource:prod-db"`) matched
+   * against `origin=mcp` approval rules; `description` is stored on the
+   * queued request so a reviewer sees what was attempted.
+   */
+  readonly destructive?: {
+    readonly resource: string;
+    readonly description: string;
+  };
+}
+
+export interface McpDispatchGateDeps {
+  /**
+   * Override the approval-gate loader (tests inject a mock
+   * {@link ApprovalGateShape}). Defaults to the fail-closed EE loader.
+   */
+  readonly loadApprovalGate?: () => Promise<ApprovalGateShape>;
+}
+
+/**
+ * Run the MCP dispatch gate order (scope → RBAC → approval). Returns `null`
+ * when the caller may proceed, or a `CallToolResult` to short-circuit.
+ */
+export async function runMcpDispatchGate(
+  ctx: McpDispatchGateContext,
+  reqs: McpDispatchGateRequirements,
+  deps: McpDispatchGateDeps = {},
+): Promise<CallToolResult | null> {
+  // ── Gate 2: mcp:write scope (hosted only; stdio exempt via clientId) ──
+  if (reqs.requiresWrite) {
+    const scopeBlock = writeScopeOrNull({ clientId: ctx.clientId, scopes: ctx.scopes });
+    if (scopeBlock) return scopeBlock;
+  }
+
+  // ── Gate 3: RBAC role on the bound actor (live-resolved, #3505) ──
+  if (!meetsRoleRequirement(ctx.actor, reqs.minRole)) {
+    log.warn(
+      {
+        toolName: reqs.toolName,
+        actorRole: getUserRole(ctx.actor),
+        minRole: reqs.minRole,
+        ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
+      },
+      "MCP admin tool denied at RBAC — actor role below required minimum",
+    );
+    return toEnvelopeResult(
+      envelope(
+        "forbidden",
+        `This tool requires the '${reqs.minRole}' role (or higher); your role does not meet that.`,
+        {
+          hint: "Ask a workspace owner/admin to run this action, or have them grant you the role.",
+        },
+      ),
+    );
+  }
+
+  // ── Gate 4: approval flow for destructive actions (origin=mcp) ──
+  if (reqs.destructive) {
+    return runApprovalGate(ctx, reqs.destructive, deps);
+  }
+
+  return null;
+}
+
+async function runApprovalGate(
+  ctx: McpDispatchGateContext,
+  destructive: NonNullable<McpDispatchGateRequirements["destructive"]>,
+  deps: McpDispatchGateDeps,
+): Promise<CallToolResult | null> {
+  const load = deps.loadApprovalGate ?? loadApprovalGate;
+
+  let gate: ApprovalGateShape;
+  try {
+    gate = await load();
+  } catch (err) {
+    log.error(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
+      },
+      "Approval gate unavailable — blocking destructive MCP action (fail-closed)",
+    );
+    return toEnvelopeResult(
+      envelope(
+        "internal_error",
+        "Approval system unavailable — action blocked. Contact your administrator.",
+        ctx.requestId ? { request_id: ctx.requestId } : undefined,
+      ),
+    );
+  }
+
+  const tablesAccessed = [destructive.resource];
+  const match = await Effect.runPromise(
+    gate.checkApprovalRequired(ctx.orgId, tablesAccessed, [], {
+      ...(ctx.requesterId ? { requesterId: ctx.requesterId } : {}),
+      origin: "mcp",
+    }),
+  );
+  if (!match.required) return null;
+
+  // Identity is guaranteed by gate 3 (a bound admin), but guard anyway —
+  // a destructive action with no requester must not silently proceed.
+  if (!ctx.orgId || !ctx.requesterId) {
+    return toEnvelopeResult(
+      envelope(
+        "forbidden",
+        "This action requires approval but the requester identity could not be determined.",
+      ),
+    );
+  }
+
+  // Don't re-queue a request the requester has already had approved for the
+  // same action (parity with executeSQL — avoids duplicate approvals on retry).
+  const alreadyApproved = await Effect.runPromise(
+    gate.hasApprovedRequest(ctx.orgId, ctx.requesterId, destructive.description),
+  );
+  if (alreadyApproved) return null;
+
+  const firstRule = match.matchedRules[0];
+  let approvalRequestId: string;
+  try {
+    const req = await Effect.runPromise(
+      gate.createApprovalRequest({
+        orgId: ctx.orgId,
+        ruleId: firstRule.id,
+        ruleName: firstRule.name,
+        requesterId: ctx.requesterId,
+        requesterEmail: ctx.requesterEmail ?? null,
+        querySql: destructive.description,
+        explanation: destructive.description,
+        connectionId: null,
+        tablesAccessed,
+        columnsAccessed: [],
+        origin: "mcp",
+      }),
+    );
+    approvalRequestId = req.id;
+  } catch (err) {
+    log.error(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
+      },
+      "Failed to queue MCP approval request — blocking action (fail-closed)",
+    );
+    return toEnvelopeResult(
+      envelope(
+        "internal_error",
+        "Could not submit the approval request — action blocked. Contact your administrator.",
+        ctx.requestId ? { request_id: ctx.requestId } : undefined,
+      ),
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            approval_required: true,
+            approval_request_id: approvalRequestId,
+            matched_rules: match.matchedRules.map((r) => r.name),
+            message:
+              `This action requires approval before execution. Rule: "${firstRule.name}". ` +
+              `An approval request has been submitted (ID: ${approvalRequestId}).`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/packages/mcp/src/dispatch-gate.ts
+++ b/packages/mcp/src/dispatch-gate.ts
@@ -80,7 +80,7 @@ export interface McpDispatchGateContext {
   readonly scopes?: readonly string[];
   /** Resolved workspace id (the admitted org). */
   readonly orgId: string | undefined;
-  /** Requester id for approval attribution; falls back from the actor. */
+  /** Requester id for approval attribution (typically the bound actor's id). */
   readonly requesterId?: string;
   /** Requester email stamped on the approval request, when known. */
   readonly requesterEmail?: string | null;
@@ -166,39 +166,12 @@ async function runApprovalGate(
   destructive: NonNullable<McpDispatchGateRequirements["destructive"]>,
   deps: McpDispatchGateDeps,
 ): Promise<CallToolResult | null> {
-  const load = deps.loadApprovalGate ?? loadApprovalGate;
-
-  let gate: ApprovalGateShape;
-  try {
-    gate = await load();
-  } catch (err) {
-    log.error(
-      {
-        err: err instanceof Error ? err.message : String(err),
-        ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
-      },
-      "Approval gate unavailable — blocking destructive MCP action (fail-closed)",
-    );
-    return toEnvelopeResult(
-      envelope(
-        "internal_error",
-        "Approval system unavailable — action blocked. Contact your administrator.",
-        ctx.requestId ? { request_id: ctx.requestId } : undefined,
-      ),
-    );
-  }
-
-  const tablesAccessed = [destructive.resource];
-  const match = await Effect.runPromise(
-    gate.checkApprovalRequired(ctx.orgId, tablesAccessed, [], {
-      ...(ctx.requesterId ? { requesterId: ctx.requesterId } : {}),
-      origin: "mcp",
-    }),
-  );
-  if (!match.required) return null;
-
-  // Identity is guaranteed by gate 3 (a bound admin), but guard anyway —
-  // a destructive action with no requester must not silently proceed.
+  // Identity guard FIRST (before consulting the gate): a destructive action
+  // with no bound requester/workspace must deny, not fall through. Gate 3
+  // already requires a bound admin, but checking here keeps the guard
+  // load-bearing for any future caller that derives identity differently —
+  // and must precede `checkApprovalRequired`, which returns `required:false`
+  // for an undefined org (so an absent org would otherwise skip approval).
   if (!ctx.orgId || !ctx.requesterId) {
     return toEnvelopeResult(
       envelope(
@@ -207,23 +180,42 @@ async function runApprovalGate(
       ),
     );
   }
+  const orgId = ctx.orgId;
+  const requesterId = ctx.requesterId;
 
-  // Don't re-queue a request the requester has already had approved for the
-  // same action (parity with executeSQL — avoids duplicate approvals on retry).
-  const alreadyApproved = await Effect.runPromise(
-    gate.hasApprovedRequest(ctx.orgId, ctx.requesterId, destructive.description),
-  );
-  if (alreadyApproved) return null;
-
-  const firstRule = match.matchedRules[0];
-  let approvalRequestId: string;
+  // One fail-closed boundary around EVERY approval-gate interaction. The EE
+  // impl runs its reads via `Effect.promise` (DB rejection → defect →
+  // `runPromise` throws), so checkApprovalRequired / hasApprovedRequest can
+  // throw despite their `never` error channel — a DB blip during the *check*
+  // must block the destructive action, not escape as an unhandled rejection.
+  // Mirrors executeSQL's single tryPromise around the whole approval block.
   try {
+    const load = deps.loadApprovalGate ?? loadApprovalGate;
+    const gate = await load();
+
+    const tablesAccessed = [destructive.resource];
+    const match = await Effect.runPromise(
+      gate.checkApprovalRequired(orgId, tablesAccessed, [], {
+        requesterId,
+        origin: "mcp",
+      }),
+    );
+    if (!match.required) return null;
+
+    // Don't re-queue a request the requester has already had approved for the
+    // same action (parity with executeSQL — avoids duplicate approvals on retry).
+    const alreadyApproved = await Effect.runPromise(
+      gate.hasApprovedRequest(orgId, requesterId, destructive.description),
+    );
+    if (alreadyApproved) return null;
+
+    const firstRule = match.matchedRules[0];
     const req = await Effect.runPromise(
       gate.createApprovalRequest({
-        orgId: ctx.orgId,
+        orgId,
         ruleId: firstRule.id,
         ruleName: firstRule.name,
-        requesterId: ctx.requesterId,
+        requesterId,
         requesterEmail: ctx.requesterEmail ?? null,
         querySql: destructive.description,
         explanation: destructive.description,
@@ -233,41 +225,40 @@ async function runApprovalGate(
         origin: "mcp",
       }),
     );
-    approvalRequestId = req.id;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              approval_required: true,
+              approval_request_id: req.id,
+              matched_rules: match.matchedRules.map((r) => r.name),
+              message:
+                `This action requires approval before execution. Rule: "${firstRule.name}". ` +
+                `An approval request has been submitted (ID: ${req.id}).`,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   } catch (err) {
     log.error(
       {
         err: err instanceof Error ? err.message : String(err),
         ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
       },
-      "Failed to queue MCP approval request — blocking action (fail-closed)",
+      "Approval gate unavailable / errored — blocking destructive MCP action (fail-closed)",
     );
     return toEnvelopeResult(
       envelope(
         "internal_error",
-        "Could not submit the approval request — action blocked. Contact your administrator.",
+        "Approval system unavailable — action blocked. Contact your administrator.",
         ctx.requestId ? { request_id: ctx.requestId } : undefined,
       ),
     );
   }
-
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            approval_required: true,
-            approval_request_id: approvalRequestId,
-            matched_rules: match.matchedRules.map((r) => r.name),
-            message:
-              `This action requires approval before execution. Rule: "${firstRule.name}". ` +
-              `An approval request has been submitted (ID: ${approvalRequestId}).`,
-          },
-          null,
-          2,
-        ),
-      },
-    ],
-  };
 }


### PR DESCRIPTION
## Summary

MCP V2 (2.3) per ADR-0016 — the **keystone** of the security spine. A reusable `runMcpDispatchGate` composer that every mutating MCP tool routes through, wiring gates 2–4 in the ADR's fixed order:

1. **mcp:write scope** (gate 2) — `writeScopeOrNull` (#3504); hosted-only, stdio exempt.
2. **RBAC role** (gate 3) — new `meetsRoleRequirement(actor, minRole)` on the bound actor's **live-resolved** role (#3505), `member<admin<owner<platform_admin`. Authority is RBAC on the actor via the **lib layer directly — no loopback HTTP** (ADR-0016 hard requirement).
3. **Approval flow** (gate 4) — destructive actions route through the existing approval gate keyed on `origin=mcp`; a matching rule queues an approval request and returns the `approval_required` body (same contract executeSQL surfaces).

Every gate **fails closed**; read-only tools never call it. Gate 1 (action policy) is #3509; gate 5 (inline confirm) is #3497/#3499. Reusable as-is by the datasource tools (#3511–#3514).

- `packages/api/src/lib/auth/permissions.ts` — `meetsRoleRequirement` (undefined user → false; the stdio `system:mcp` trusted actor is admin-incapable).
- `packages/mcp/src/dispatch-gate.ts` — the composer + fail-closed approval-gate loader (mirrors `sql.ts`), injectable for tests.

## Code review (done before opening, per request — no blind merge)
Ran `pr-review-toolkit:code-reviewer` + `silent-failure-hunter`. Both independently caught one real **fail-closed gap** and a latent ordering issue — **both fixed**:
- `checkApprovalRequired`/`hasApprovedRequest` ran *outside* try/catch; the EE impl uses `Effect.promise` (DB rejection → defect → `runPromise` throws), so a DB blip during the approval *check* would escape uncaught instead of `internal_error`. Now **all** gate calls (load + check + hasApproved + create) are wrapped in one fail-closed boundary (mirrors executeSQL).
- The identity guard sat after the `!required` early-return (dead no-op); **hoisted** above the approval check so it's load-bearing.
- Reviewers confirmed the simple-key default-admin escalation vector is structurally unreachable (MCP actors are `managed`, or `system:mcp` pinned to `member`); added a documentation test pinning that the safety lives in the actor model.

## Test plan
- [x] gate order (scope before RBAC), each branch: scope-deny / RBAC-deny / approval-required / not-required / already-approved / gate-unavailable / **check-throws** / **hasApproved-throws** / **no-identity-on-destructive**
- [x] stdio scope-exemption (still RBAC-gated); e2e stub admin tool through a real MCP client
- [x] `meetsRoleRequirement` units incl. the simple-key documentation test
- [x] type, lint, full mcp suite (303/0), permissions (64/0)

Closes #3508