### PR TITLE
fix(mcp): send RFC 8707 resource in hosted-CLI token exchange

### DIFF
--- a/packages/mcp/src/eval/auth.ts
+++ b/packages/mcp/src/eval/auth.ts
@@ -33,19 +33,17 @@
  *   schema reasons unrelated to OAuth; the eval pares the plugin set down
  *   to the OAuth surface.
  *
- * ── Resource-indicator workaround ────────────────────────────────────
+ * ── Resource-indicator (RFC 8707) ────────────────────────────────────
  *
  * `@better-auth/oauth-provider` only issues JWT-formatted access tokens
- * when the token request carries a `resource` parameter (RFC 8707). The
- * upstream `runHostedAuthFlow` in `@useatlas/mcp/init` does not include
- * `resource` today — #2124 is closed (Gap 2 fixed in commit 70e262c1)
- * but Gap 1 (the resource-indicator parameter on `runHostedAuthFlow`)
- * is still open at the time of writing; verify by grepping
- * `plugins/mcp/src/init/hosted.ts` for `resource`. For the eval we
- * wrap the test seam's `fetchImpl` to inject `resource=${apiUrl}/mcp`
- * into the token-exchange POST body so the issued token is JWT-formatted
- * and carries the `aud` claim the MCP route's verifier requires. When
- * Gap 1 lands the `fetchImpl` body-patch can be removed.
+ * when the token request carries a `resource` parameter (RFC 8707), and
+ * the MCP route's verifier requires that JWT shape with the matching
+ * `aud` claim. `runHostedAuthFlow` now threads `resource=${apiUrl}/mcp`
+ * into the token exchange itself (#3493), so the eval exercises the same
+ * wire request production sends — no `fetchImpl` body-patch needed. This
+ * is what makes the eval a valid regression test for the production path:
+ * if the real flow stopped sending `resource`, the issued token would be
+ * opaque and this eval would fail at bearer verification.
  */
 
 import { betterAuth } from "better-auth";
@@ -494,9 +492,9 @@ interface RunFlowInput {
  * The seams:
  *
  *   - `fetchImpl` — dispatches discovery, DCR, and the token exchange
- *     directly through `app.fetch`. We also inject `resource=${apiUrl}/mcp`
- *     into the token-exchange body so Better Auth issues a JWT (RFC 8707
- *     workaround for #2124).
+ *     directly through `app.fetch`. The token request already carries
+ *     `resource=${apiUrl}/mcp` because `runHostedAuthFlow` sends it (#3493),
+ *     so Better Auth issues a JWT without any body-patch here.
  *   - `serveImpl` — captures the loopback handler. The "browser" calls it
  *     directly with the redirect params; no real port is bound.
  *   - `openBrowserImpl` — drives the authorize endpoint with the session
@@ -505,8 +503,6 @@ interface RunFlowInput {
  *     `code` + `state` from the redirect URL.
  */
 async function runEvalAuthFlow(input: RunFlowInput): Promise<HostedFlowResult> {
-  const resourceIndicator = `${input.apiUrl.replace(/\/+$/, "")}/mcp`;
-
   // ── fetchImpl ────────────────────────────────────────────────────
   const fetchImpl: typeof fetch = (async (
     rawInput: string | URL | Request,
@@ -523,25 +519,16 @@ async function runEvalAuthFlow(input: RunFlowInput): Promise<HostedFlowResult> {
     // CLI loopback flow does not currently thread cookies, but the
     // eval needs to so the issued token actually exercises the
     // workspace-claim path the MCP edge verifies.
+    //
+    // The token request's `resource=${apiUrl}/mcp` (RFC 8707) is sent by
+    // `runHostedAuthFlow` itself (#3493) — no body-patch here — so this
+    // eval exercises the exact wire request production sends. If the real
+    // flow regressed and dropped `resource`, Better Auth would mint an
+    // opaque token and the MCP route's verifier would reject it, failing
+    // this eval.
     const headersWithCookie = new Headers(req.headers);
     if (!headersWithCookie.has("Cookie")) {
       headersWithCookie.set("Cookie", input.sessionCookie);
-    }
-    if (req.method === "POST" && req.url.includes("/oauth2/token")) {
-      // Patch the body to include `resource=${resourceIndicator}`.
-      // Without this Better Auth issues an opaque token and the MCP
-      // route's verifier (which expects JWT) rejects with
-      // invalid_bearer. See the module docstring's resource-indicator
-      // workaround note (#2124 Gap 1, still open).
-      const body = await req.text();
-      const params = new URLSearchParams(body);
-      if (!params.has("resource")) params.set("resource", resourceIndicator);
-      const patched = new Request(req.url, {
-        method: req.method,
-        headers: headersWithCookie,
-        body: params.toString(),
-      });
-      return input.app.fetch(patched);
     }
     const withCookie = new Request(req.url, {
       method: req.method,

--- a/packages/oauth-helper/__tests__/exchange.test.ts
+++ b/packages/oauth-helper/__tests__/exchange.test.ts
@@ -50,6 +50,38 @@ describe("exchangeCode", () => {
     expect(params.get("redirect_uri")).toBe(BASE_PARAMS.redirectUri);
     expect(params.get("client_id")).toBe(BASE_PARAMS.clientId);
     expect(params.get("code_verifier")).toBe(BASE_PARAMS.codeVerifier);
+    // No resource indicator supplied → none sent on the wire.
+    expect(params.has("resource")).toBe(false);
+  });
+
+  test("threads the RFC 8707 resource indicator onto the token request (#3493)", async () => {
+    const { fetchImpl, calls } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: "at-jwt", expires_in: 3600 }),
+    });
+
+    await exchangeCode(
+      { ...BASE_PARAMS, resource: "https://api.useatlas.dev/mcp" },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    const params = new URLSearchParams(calls[0].body);
+    expect(params.get("resource")).toBe("https://api.useatlas.dev/mcp");
+  });
+
+  test("omits an empty resource indicator", async () => {
+    const { fetchImpl, calls } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: "at-3", expires_in: 3600 }),
+    });
+
+    await exchangeCode(
+      { ...BASE_PARAMS, resource: "" },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    const params = new URLSearchParams(calls[0].body);
+    expect(params.has("resource")).toBe(false);
   });
 
   test("rejects http:// (non-loopback) tokenEndpoint with invalid_token_endpoint (#2198)", async () => {

--- a/packages/oauth-helper/src/exchange.ts
+++ b/packages/oauth-helper/src/exchange.ts
@@ -9,6 +9,17 @@ export interface ExchangeCodeParams {
   redirectUri: string;
   code: string;
   codeVerifier: string;
+  /**
+   * RFC 8707 resource indicator — the protected resource the issued token
+   * is bound to (e.g. `${apiUrl}/mcp`). When present it's sent as the
+   * `resource` form field on the token request. Better Auth's
+   * `@better-auth/oauth-provider` only mints a JWT-formatted access token
+   * (vs an opaque one) when the token request carries a `resource`; the
+   * MCP route's `verifyMcpBearer` requires the JWT shape. Omit it for
+   * consumers that don't bind to a specific resource — the field is simply
+   * not sent and the server falls back to its default token format.
+   */
+  resource?: string;
 }
 
 export interface ExchangeCodeOptions {
@@ -55,6 +66,12 @@ export async function exchangeCode(
     client_id: params.clientId,
     code_verifier: params.codeVerifier,
   });
+  // RFC 8707 — bind the issued token to the requested resource. Appended
+  // only when the caller supplies it so consumers that don't need
+  // resource-scoped tokens keep the original request shape.
+  if (params.resource !== undefined && params.resource.length > 0) {
+    body.set("resource", params.resource);
+  }
   let res: Response;
   try {
     res = await fetchImpl(params.tokenEndpoint, {

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -316,6 +316,11 @@ describe("runHostedAuthFlow — wire format (pins acceptance criteria from #2024
     expect(tokenForm!.get("redirect_uri")).toBe(expectedRedirect);
     expect(tokenForm!.get("client_id")).toBe("test-client-id");
     expect(tokenForm!.get("code_verifier")).toBe(EXPECTED_VERIFIER);
+    // RFC 8707 resource indicator (#3493) — bound to `${apiUrl}/mcp` so
+    // Better Auth mints a JWT (not an opaque token) that `verifyMcpBearer`
+    // accepts. Without this the real hosted install fails bearer
+    // verification; the eval used to body-patch it in, masking the gap.
+    expect(tokenForm!.get("resource")).toBe(`${FAKE_API}/mcp`);
   });
 });
 

--- a/plugins/mcp/src/init/hosted.ts
+++ b/plugins/mcp/src/init/hosted.ts
@@ -357,6 +357,14 @@ export async function runHostedAuthFlow(
     // response advertising `token_endpoint: "http://evil/token"` cannot
     // smuggle the auth code over plaintext — the guard lives in the
     // helper, so both consumers (SDK + CLI) are covered identically.
+    //
+    // `resource` (RFC 8707) binds the issued token to the MCP endpoint
+    // (`${apiUrl}/mcp`). Better Auth's oauth-provider only mints a
+    // JWT-formatted access token when the token request carries it; the
+    // hosted MCP route's `verifyMcpBearer` requires that JWT shape, so
+    // without `resource` real hosted installs receive an opaque token and
+    // fail bearer verification. This is the production counterpart to the
+    // resource-indicator the eval previously body-patched in (#3493).
     const tokenResponse = await liftHelper(() =>
       exchangeCode(
         {
@@ -365,6 +373,7 @@ export async function runHostedAuthFlow(
           redirectUri,
           code,
           codeVerifier,
+          resource: `${apiUrl}/mcp`,
         },
         { fetchImpl },
       ),


### PR DESCRIPTION
## Summary
- Thread an optional RFC 8707 `resource` indicator through `exchangeCode` (`@atlas/oauth-helper`) — sent on the token request only when supplied.
- Pass `resource: ${apiUrl}/mcp` on the real hosted-CLI flow (`plugins/mcp/src/init/hosted.ts`) so Better Auth's oauth-provider issues a **JWT** (not an opaque token) that `verifyMcpBearer` accepts. Without it, real hosted installs receive an opaque token and fail bearer verification.
- Remove the `fetchImpl` body-patch workaround in the eval (`packages/mcp/src/eval/auth.ts`). The real path now sends `resource`, so the eval exercises the exact wire request production sends — making it a genuine regression test (it would fail at bearer verification if the real flow dropped `resource`).

## Why
Today the production `@useatlas/mcp init --hosted` flow may omit `resource`. The eval suite patched it in via `fetchImpl`, masking the gap so real hosted installs could fail bearer verification.

## Test plan
- [x] `packages/oauth-helper/__tests__/exchange.test.ts` — asserts `resource` threads onto the wire when supplied, and is absent when omitted/empty.
- [x] `plugins/mcp/__tests__/init/hosted.test.ts` — wire-format test asserts the production flow sends `resource=${apiUrl}/mcp`.
- [x] `packages/mcp/src/__tests__/canonical-mcp-auth.test.ts` — end-to-end real OAuth round-trip passes with the workaround removed (issued JWT verifies against in-process JWKS).
- [x] Full `/ci` green: lint, type, test, syncpack, all drift checks (incl. oauth-helper-drift), published-symbols, test-discipline, settings-readers.

Closes #3493

---
_Generated by [Claude Code](https://claude.ai/code/session_01SV9ZVLUPCjXxtr9A6D5kBb)_