### PR TITLE
fix(mcp): backport session hardening to standalone SSE transport (#3492)

### DIFF
--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -406,6 +406,39 @@ function bindTokensAB(): void {
   });
 }
 
+/**
+ * Initialize a hosted MCP session via a raw POST (no SDK client), returning
+ * the Response. Unlike an SDK client — which holds its standalone GET
+ * notification stream open for the life of the connection — this keeps no
+ * stream open, so the resulting session has `activeStreams === 0` and can age
+ * out of the idle window: the shape of a genuinely-abandoned session (a client
+ * that vanished without sending DELETE).
+ */
+async function rawHostedInit(
+  handle: { url: string },
+  org: string,
+  token: string,
+): Promise<Response> {
+  return fetch(`${handle.url}/mcp/${org}/sse`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "raw", version: "0.0.1" },
+      },
+      id: 1,
+    }),
+  });
+}
+
 // ── Bearer / authorization ────────────────────────────────────────────
 
 describe("hosted MCP — bearer enforcement", () => {
@@ -1631,13 +1664,12 @@ describe("hosted MCP — capacity", () => {
     process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS = "60000"; // 1 min — at the floor
     const handle = await startServer();
     try {
-      // Open one session — fills the cap.
-      const first = new Client({ name: "client-stale", version: "0.0.1" });
-      const firstTransport = new StreamableHTTPClientTransport(
-        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
-        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
-      );
-      await first.connect(firstTransport);
+      // Fill the cap with a genuinely-abandoned session: a raw init that
+      // holds no notification stream, so `activeStreams` stays 0 and it can
+      // be swept. (An SDK client would keep its GET stream open and correctly
+      // resist eviction — see the live-stream test below.)
+      const leaked = await rawHostedInit(handle, ORG_A, TOKEN_A);
+      await leaked.body?.cancel().catch(() => {});
       expect(_hostedSessionCount()).toBe(1);
 
       // Without the sweep this would 503. The sweep with a clock far
@@ -1649,10 +1681,9 @@ describe("hosted MCP — capacity", () => {
       expect(evicted).toBe(1);
       expect(_hostedSessionCount()).toBe(0);
 
-      // The originally-leaked client object is now orphaned; the
-      // server-side transport+server were closed by the sweep. A new
-      // connection can land cleanly because the cap is no longer
-      // saturated.
+      // The abandoned session's server-side transport+server were closed by
+      // the sweep. A new connection can land cleanly because the cap is no
+      // longer saturated.
       const second = new Client({ name: "client-fresh", version: "0.0.1" });
       const secondTransport = new StreamableHTTPClientTransport(
         new URL(`${handle.url}/mcp/${ORG_A}/sse`),
@@ -1728,20 +1759,17 @@ describe("hosted MCP — capacity", () => {
     _setIdleTimeoutForTests(50); // 50 ms
     const handle = await startServer();
     try {
-      // Step 1 — open the session that occupies the cap.
-      const leaker = new Client({ name: "client-leaker", version: "0.0.1" });
-      const leakerTransport = new StreamableHTTPClientTransport(
-        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
-        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
-      );
-      await leaker.connect(leakerTransport);
+      // Step 1 — occupy the cap with an abandoned (no-stream) session via a
+      // raw init, so it can age out and be swept.
+      const leaked = await rawHostedInit(handle, ORG_A, TOKEN_A);
+      await leaked.body?.cancel().catch(() => {});
       expect(_hostedSessionCount()).toBe(1);
 
-      // Step 2 — wait past the idle window so the leaker is sweepable.
+      // Step 2 — wait past the idle window so it is sweepable.
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       // Step 3 — a fresh init should now succeed because the route's
-      // cap-check sweep evicts the stale leaker.
+      // cap-check sweep evicts the stale abandoned session.
       const fresh = new Client({ name: "client-fresh", version: "0.0.1" });
       const freshTransport = new StreamableHTTPClientTransport(
         new URL(`${handle.url}/mcp/${ORG_A}/sse`),
@@ -1749,12 +1777,55 @@ describe("hosted MCP — capacity", () => {
       );
       await fresh.connect(freshTransport);
 
-      // Final state: only the fresh session remains; the leaker was
-      // swept. The assertion is on count so a future bug that
-      // double-counts during the eviction transition would fail it.
+      // Final state: only the fresh session remains; the abandoned one was
+      // swept. The assertion is on count so a future bug that double-counts
+      // during the eviction transition would fail it.
       expect(_hostedSessionCount()).toBe(1);
 
       await fresh.close();
+    } finally {
+      _setIdleTimeoutForTests(null);
+      handle.close();
+    }
+  });
+
+  it("does not sweep a session whose client still holds a live notification stream", async () => {
+    // The mirror of the abandoned-session test: an SDK client keeps its
+    // standalone GET notification stream open, so `activeStreams > 0` and the
+    // cap-pressure sweep must NOT reclaim it even though `lastSeenAt` has aged
+    // out — otherwise a busy region would evict live listeners.
+    bindToken(TOKEN_A, {
+      sub: SUB_A,
+      azp: CLIENT_A,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG_A,
+    });
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    _setIdleTimeoutForTests(50); // 50 ms — age lastSeenAt out aggressively
+    const handle = await startServer();
+    try {
+      const connected = new Client({ name: "client-connected", version: "0.0.1" });
+      const connectedTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await connected.connect(connectedTransport);
+      expect(_hostedSessionCount()).toBe(1);
+
+      // Let lastSeenAt age well past the 50ms window while the client listens.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // A second connection hits the cap. The live-stream session must not be
+      // swept, so the new init is rejected rather than stealing its slot.
+      const blocked = new Client({ name: "client-blocked", version: "0.0.1" });
+      const blockedTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await expect(blocked.connect(blockedTransport)).rejects.toThrow();
+      expect(_hostedSessionCount()).toBe(1);
+
+      await connected.close();
     } finally {
       _setIdleTimeoutForTests(null);
       handle.close();

--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -1831,6 +1831,54 @@ describe("hosted MCP — capacity", () => {
       handle.close();
     }
   });
+
+  it("sweeps multiple idle sessions in one pass while preserving a live-stream session", async () => {
+    // The sweep loop must be SELECTIVE within a mixed population, not
+    // all-or-nothing: evict every aged no-stream session while skipping any
+    // with `activeStreams > 0`. Prior tests only ever drove a lone session.
+    bindToken(TOKEN_A, {
+      sub: SUB_A,
+      azp: CLIENT_A,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG_A,
+    });
+    process.env.ATLAS_MCP_MAX_SESSIONS = "5";
+    const handle = await startServer();
+    try {
+      // Two abandoned sessions (raw init, body drained → no live stream).
+      const a = await rawHostedInit(handle, ORG_A, TOKEN_A);
+      await a.body?.cancel().catch(() => {});
+      const b = await rawHostedInit(handle, ORG_A, TOKEN_A);
+      await b.body?.cancel().catch(() => {});
+
+      // One connected session holding a live GET notification stream.
+      const connected = new Client({ name: "client-live", version: "0.0.1" });
+      const connectedTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await connected.connect(connectedTransport);
+
+      expect(_hostedSessionCount()).toBe(3);
+
+      // The SDK client's standalone GET notification stream opens asynchronously
+      // after connect() resolves; give it a beat to establish so `activeStreams`
+      // is > 0 before the sweep (mirrors the lone live-stream test above).
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // A far-future sweep ages every session past the idle window. Both
+      // abandoned sessions must be evicted in the SAME pass while the
+      // live-stream one is skipped.
+      const farFuture = Date.now() + 24 * 60 * 60 * 1000; // +1 day
+      const evicted = _sweepIdleSessionsForTests(farFuture, 60_000);
+      expect(evicted).toBe(2);
+      expect(_hostedSessionCount()).toBe(1);
+
+      await connected.close();
+    } finally {
+      handle.close();
+    }
+  });
 });
 
 describe("hosted MCP — audit failure", () => {

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -59,7 +59,7 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 
 // Import after mocks
 const { createAtlasMcpServer } = await import("../server.js");
-const { startSseServer } = await import("../sse.js");
+const { startSseServer, _setIdleTimeoutForTests } = await import("../sse.js");
 
 type SseHandle = Awaited<ReturnType<typeof startSseServer>>;
 let handle: SseHandle | null = null;
@@ -69,6 +69,11 @@ afterEach(async () => {
     await handle.close();
     handle = null;
   }
+  // Reset session-hardening knobs so one test's env/override can't bleed
+  // into the next (the in-process Bun runner shares module state).
+  delete process.env.ATLAS_MCP_MAX_SESSIONS;
+  delete process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+  _setIdleTimeoutForTests(null);
 });
 
 describe("SSE server — lifecycle", () => {
@@ -317,5 +322,188 @@ describe("SSE server — MCP client integration", () => {
     // Server is still healthy after the bad request
     const health = await fetch(`http://localhost:${handle.server.port}/health`);
     expect(health.status).toBe(200);
+  });
+});
+
+// ── Session hardening (#3492) — idle sweep + TOCTOU cap parity ───────
+//
+// Backport of the hosted.ts session lifecycle: an idle-session sweep, a
+// `pendingReservations` cap guard, and `ATLAS_MCP_MAX_SESSIONS` honored via
+// the env-profile. Without these, a self-hosted `--transport sse` deploy
+// permanently exhausts its session pool once enough clients vanish without
+// sending DELETE.
+
+function rawInitRequest(port: number): Promise<Response> {
+  return fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 1,
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "raw", version: "0.0.1" },
+      },
+    }),
+  });
+}
+
+describe("SSE server — session hardening (#3492)", () => {
+  it("evicts idle sessions on a far-future sweep", async () => {
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+      maxSessions: 1,
+    });
+
+    const client = new Client({ name: "client-stale", version: "0.0.1" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await client.connect(transport);
+    expect(handle._sessionCount()).toBe(1);
+
+    // Drive the sweep with a clock far enough in the future that the
+    // freshly-created session is past the idle window. The assertion is
+    // unambiguous: sweep evicts, count drops to zero. The leaked client is
+    // intentionally left un-closed — its server-side transport+server were
+    // already torn down by the sweep.
+    const farFuture = Date.now() + 24 * 60 * 60 * 1000; // +1 day
+    const evicted = handle._sweepIdleSessionsForTests(farFuture, 60_000);
+    expect(evicted).toBe(1);
+    expect(handle._sessionCount()).toBe(0);
+  });
+
+  it("preserves recently-active sessions across a sweep", async () => {
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+      maxSessions: 5,
+    });
+
+    const client = new Client({ name: "client-active", version: "0.0.1" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await client.connect(transport);
+    expect(handle._sessionCount()).toBe(1);
+
+    // Sweep with the current clock — the session was created moments ago,
+    // so lastSeenAt is fresh and eviction must be a no-op.
+    const evicted = handle._sweepIdleSessionsForTests(Date.now(), 60_000);
+    expect(evicted).toBe(0);
+    expect(handle._sessionCount()).toBe(1);
+
+    // The preserved session must still function — listTools is the cheapest
+    // dispatch that hits the existing-session path.
+    const tools = await client.listTools();
+    expect(tools.tools.length).toBeGreaterThan(0);
+
+    await client.close();
+  });
+
+  it("honors ATLAS_MCP_MAX_SESSIONS on the SSE path", async () => {
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    // No explicit `maxSessions` opt — the cap must resolve from the env via
+    // resolveMcpMaxSessions, proving the SSE path honors the override.
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+    });
+
+    const client = new Client({ name: "client-cap", version: "0.0.1" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await client.connect(transport);
+    expect(handle._sessionCount()).toBe(1);
+
+    const res = await rawInitRequest(handle.server.port);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("too_many_sessions");
+
+    await client.close();
+  });
+
+  it("rejects concurrent inits over the cap via the reservation counter", async () => {
+    // The TOCTOU the reservation counter closes: with cap=1 and two inits
+    // in flight, both pass a naïve `sessions.size >= cap` check before
+    // either registers. The factory parks inside `createServer` so the
+    // first init holds a reservation (pendingReservations=1, sessions.size=0)
+    // while the second arrives — the second must be rejected by the
+    // reservation guard, before any McpServer is even allocated.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered = 0;
+
+    handle = await startSseServer(
+      async () => {
+        entered++;
+        await gate;
+        return createAtlasMcpServer({ actor: SSE_ACTOR });
+      },
+      { port: 0, maxSessions: 1 },
+    );
+    const port = handle.server.port;
+
+    // Fire the first init and wait until it is parked inside the factory.
+    const p1 = rawInitRequest(port);
+    while (entered < 1) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    // Second concurrent init — must be rejected by the reservation guard.
+    const res2 = await rawInitRequest(port);
+    expect(res2.status).toBe(503);
+    const body2 = (await res2.json()) as { error: string };
+    expect(body2.error).toBe("too_many_sessions");
+    // The guard short-circuited before the factory ran a second time.
+    expect(entered).toBe(1);
+
+    // Release the first init so it registers its session cleanly.
+    release();
+    const res1 = await p1;
+    expect(res1.status).not.toBe(503);
+    expect(handle._sessionCount()).toBe(1);
+  });
+
+  it("auto-sweeps a leaked session on cap-pressure (regression for the pool-exhaustion bug)", async () => {
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    // Bypass the production 1-min idle floor so the age-out path can be
+    // driven with a sub-second sleep instead of a 60s wait.
+    _setIdleTimeoutForTests(50); // 50 ms
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+    });
+
+    // Open the session that occupies the cap, then let it go idle past the
+    // window so it becomes sweepable — simulating a client that vanished
+    // without sending DELETE.
+    const leaker = new Client({ name: "client-leaker", version: "0.0.1" });
+    const leakerTransport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await leaker.connect(leakerTransport);
+    expect(handle._sessionCount()).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // A fresh init should now succeed: the new-session path's cap-check
+    // sweep evicts the stale leaker first, freeing the slot. Without the
+    // sweep this would 503 forever until process restart.
+    const fresh = new Client({ name: "client-fresh", version: "0.0.1" });
+    const freshTransport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await fresh.connect(freshTransport);
+    // Only the fresh session remains; the leaker was swept.
+    expect(handle._sessionCount()).toBe(1);
+
+    await fresh.close();
   });
 });

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -540,4 +540,97 @@ describe("SSE server — session hardening (#3492)", () => {
 
     await connected.close();
   });
+
+  it("tears down an unregistered session (non-initialize first frame) without leaking a server", async () => {
+    // This guards the shared `!registered` teardown logic, which hosted.ts
+    // mirrors line-for-line. The close-spy assertion is only achievable here
+    // because startSseServer takes the server factory as a param; hosted.ts
+    // builds its per-session server internally, so this test stands in for
+    // both transports.
+    let created = 0;
+    let closed = 0;
+    handle = await startSseServer(
+      async () => {
+        created++;
+        const server = await createAtlasMcpServer({ actor: SSE_ACTOR });
+        const origClose = server.close.bind(server);
+        // Spy on close() so we can prove the orphaned server is torn down.
+        server.close = async () => {
+          closed++;
+          return origClose();
+        };
+        return server;
+      },
+      { port: 0, maxSessions: 1 },
+    );
+
+    // A well-formed but non-initialize first frame with no session id: the SDK
+    // allocates a transport + server, then rejects the frame without firing
+    // `onsessioninitialized`, so the session never registers. Without the
+    // `!registered` teardown this leaks one McpServer per request.
+    const res = await fetch(`http://localhost:${handle.server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    await res.body?.cancel().catch(() => {});
+
+    // Nothing registered, and the orphaned server was closed rather than leaked.
+    expect(handle._sessionCount()).toBe(0);
+    expect(created).toBe(1);
+    expect(closed).toBe(1);
+
+    // The cap slot was never consumed — a real init still succeeds under cap=1.
+    const client = new Client({ name: "client-after", version: "0.0.1" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await client.connect(transport);
+    expect(handle._sessionCount()).toBe(1);
+
+    await client.close();
+  });
+
+  it("sweeps multiple idle sessions in one pass while preserving a live-stream session", async () => {
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+      maxSessions: 5,
+    });
+    const port = handle.server.port;
+
+    // Two abandoned sessions (raw init, body drained → no live stream).
+    const a = await rawInitRequest(port);
+    await a.body?.cancel().catch(() => {});
+    const c = await rawInitRequest(port);
+    await c.body?.cancel().catch(() => {});
+
+    // One connected session holding a live GET notification stream.
+    const connected = new Client({ name: "client-live", version: "0.0.1" });
+    const connectedTransport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/mcp`),
+    );
+    await connected.connect(connectedTransport);
+
+    expect(handle._sessionCount()).toBe(3);
+
+    // The SDK client's standalone GET notification stream opens asynchronously
+    // after connect() resolves; give it a beat to establish so `activeStreams`
+    // is > 0 before the sweep (mirrors the lone live-stream test above).
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // A far-future sweep ages every session past the idle window. The loop must
+    // evict BOTH abandoned sessions (selective, not all-or-nothing) and skip the
+    // one with `activeStreams > 0` — proving the live-stream guard holds within a
+    // mixed population, not just for a lone session.
+    const farFuture = Date.now() + 24 * 60 * 60 * 1000; // +1 day
+    const evicted = handle._sweepIdleSessionsForTests(farFuture, 60_000);
+    expect(evicted).toBe(2);
+    expect(handle._sessionCount()).toBe(1);
+
+    await connected.close();
+  });
 });

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -472,7 +472,7 @@ describe("SSE server — session hardening (#3492)", () => {
     expect(handle._sessionCount()).toBe(1);
   });
 
-  it("auto-sweeps a leaked session on cap-pressure (regression for the pool-exhaustion bug)", async () => {
+  it("auto-sweeps an abandoned (no-stream) session on cap-pressure (regression for the pool-exhaustion bug)", async () => {
     process.env.ATLAS_MCP_MAX_SESSIONS = "1";
     // Bypass the production 1-min idle floor so the age-out path can be
     // driven with a sub-second sleep instead of a 60s wait.
@@ -481,29 +481,63 @@ describe("SSE server — session hardening (#3492)", () => {
       port: 0,
     });
 
-    // Open the session that occupies the cap, then let it go idle past the
-    // window so it becomes sweepable — simulating a client that vanished
-    // without sending DELETE.
-    const leaker = new Client({ name: "client-leaker", version: "0.0.1" });
-    const leakerTransport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${handle.server.port}/mcp`),
-    );
-    await leaker.connect(leakerTransport);
+    // A genuinely-abandoned session: initialized via a raw POST, then the
+    // response drained and nothing kept open — no live notification stream,
+    // so `activeStreams` stays 0 and it can age out of the idle window. (An
+    // SDK client would instead hold its GET notification stream open, which
+    // correctly keeps the session unsweepable — covered by the next test.)
+    const leaked = await rawInitRequest(handle.server.port);
+    await leaked.body?.cancel().catch(() => {});
     expect(handle._sessionCount()).toBe(1);
 
     await new Promise((resolve) => setTimeout(resolve, 200));
 
     // A fresh init should now succeed: the new-session path's cap-check
-    // sweep evicts the stale leaker first, freeing the slot. Without the
-    // sweep this would 503 forever until process restart.
+    // sweep evicts the aged-out abandoned session first, freeing the slot.
+    // Without the sweep this would 503 forever until process restart.
     const fresh = new Client({ name: "client-fresh", version: "0.0.1" });
     const freshTransport = new StreamableHTTPClientTransport(
       new URL(`http://localhost:${handle.server.port}/mcp`),
     );
     await fresh.connect(freshTransport);
-    // Only the fresh session remains; the leaker was swept.
+    // Only the fresh session remains; the abandoned one was swept.
     expect(handle._sessionCount()).toBe(1);
 
     await fresh.close();
+  });
+
+  it("does not sweep a session whose client still holds a live notification stream", async () => {
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    // Age lastSeenAt out aggressively — the live stream, not the timestamp,
+    // is what must keep the session alive here.
+    _setIdleTimeoutForTests(50); // 50 ms
+    handle = await startSseServer(() => createAtlasMcpServer({ actor: SSE_ACTOR }), {
+      port: 0,
+    });
+
+    // An SDK client holds its standalone GET notification stream open for the
+    // life of the connection, so `activeStreams > 0`.
+    const connected = new Client({ name: "client-connected", version: "0.0.1" });
+    const connectedTransport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await connected.connect(connectedTransport);
+    expect(handle._sessionCount()).toBe(1);
+
+    // Let lastSeenAt age well past the 50ms idle window while the client
+    // keeps listening.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // A second connection hits the cap. The cap-pressure sweep must NOT
+    // reclaim the first session — its client is still listening — so the new
+    // init is rejected rather than stealing a live client's slot.
+    const blocked = new Client({ name: "client-blocked", version: "0.0.1" });
+    const blockedTransport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${handle.server.port}/mcp`),
+    );
+    await expect(blocked.connect(blockedTransport)).rejects.toThrow();
+    expect(handle._sessionCount()).toBe(1);
+
+    await connected.close();
   });
 });

--- a/packages/mcp/src/__tests__/stream-liveness.test.ts
+++ b/packages/mcp/src/__tests__/stream-liveness.test.ts
@@ -53,6 +53,54 @@ describe("trackResponseStreamLifetime", () => {
     expect(closes).toBe(1);
   });
 
+  it("fires onError then onClose and propagates when the source errors mid-stream", async () => {
+    let closes = 0;
+    let onErrorArg: unknown = null;
+    const boom = new Error("source exploded");
+    const src = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // Error on the first pull so the wrapper's catch branch runs.
+        controller.error(boom);
+      },
+    });
+
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => {},
+      onClose: () => closes++,
+      onError: (err) => {
+        onErrorArg = err;
+      },
+    });
+
+    const reader = tracked.body!.getReader();
+    // The error must propagate to the consumer (not be swallowed)...
+    await expect(reader.read()).rejects.toThrow("source exploded");
+    // ...and the caller must be notified for server-side logging, exactly once,
+    // with the original error, alongside the single onClose.
+    expect(onErrorArg).toBe(boom);
+    expect(closes).toBe(1);
+  });
+
+  it("normalizes a non-Error rejection before propagating", async () => {
+    const errors: unknown[] = [];
+    const src = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error("plain string failure");
+      },
+    });
+
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => {},
+      onClose: () => {},
+      onError: (err) => errors.push(err),
+    });
+
+    const reader = tracked.body!.getReader();
+    await expect(reader.read()).rejects.toThrow("plain string failure");
+    // onError sees the raw value; the propagated error is wrapped in an Error.
+    expect(errors).toEqual(["plain string failure"]);
+  });
+
   it("passes a byte-for-byte copy of the source through", async () => {
     const payload = "event: message\ndata: {\"x\":1}\n\nevent: ping\ndata: {}\n\n";
     const src = new ReadableStream<Uint8Array>({

--- a/packages/mcp/src/__tests__/stream-liveness.test.ts
+++ b/packages/mcp/src/__tests__/stream-liveness.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "bun:test";
+import { trackResponseStreamLifetime } from "../stream-liveness.js";
+
+const enc = new TextEncoder();
+
+function sseResponse(body: ReadableStream<Uint8Array>): Response {
+  return new Response(body, { headers: { "content-type": "text/event-stream" } });
+}
+
+describe("trackResponseStreamLifetime", () => {
+  it("fires onOpen immediately and onClose exactly once when the source ends", async () => {
+    let opens = 0;
+    let closes = 0;
+    const src = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode("data: hi\n\n"));
+        controller.close();
+      },
+    });
+
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => opens++,
+      onClose: () => closes++,
+    });
+
+    // onOpen is synchronous; onClose waits for the stream to drain.
+    expect(opens).toBe(1);
+    expect(closes).toBe(0);
+
+    const text = await new Response(tracked.body).text();
+    expect(text).toContain("data: hi");
+    expect(closes).toBe(1);
+  });
+
+  it("fires onClose when the consumer cancels mid-stream", async () => {
+    let closes = 0;
+    const src = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Emit one chunk and stay open — mimics an idle notification stream.
+        controller.enqueue(enc.encode("data: hi\n\n"));
+      },
+    });
+
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => {},
+      onClose: () => closes++,
+    });
+
+    const reader = tracked.body!.getReader();
+    await reader.read(); // pull the first chunk
+    expect(closes).toBe(0);
+    await reader.cancel();
+    expect(closes).toBe(1);
+  });
+
+  it("passes a byte-for-byte copy of the source through", async () => {
+    const payload = "event: message\ndata: {\"x\":1}\n\nevent: ping\ndata: {}\n\n";
+    const src = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Split across chunks to exercise the pull loop.
+        controller.enqueue(enc.encode(payload.slice(0, 10)));
+        controller.enqueue(enc.encode(payload.slice(10)));
+        controller.close();
+      },
+    });
+
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => {},
+      onClose: () => {},
+    });
+
+    expect(await new Response(tracked.body).text()).toBe(payload);
+  });
+
+  it("returns non-SSE responses untouched without firing onOpen", () => {
+    let opens = 0;
+    const res = new Response("ok", {
+      headers: { "content-type": "application/json" },
+    });
+    const out = trackResponseStreamLifetime(res, {
+      onOpen: () => opens++,
+      onClose: () => {},
+    });
+    expect(out).toBe(res);
+    expect(opens).toBe(0);
+  });
+
+  it("returns body-less responses untouched", () => {
+    let opens = 0;
+    const res = new Response(null, {
+      status: 204,
+      headers: { "content-type": "text/event-stream" },
+    });
+    const out = trackResponseStreamLifetime(res, {
+      onOpen: () => opens++,
+      onClose: () => {},
+    });
+    expect(out).toBe(res);
+    expect(opens).toBe(0);
+  });
+});

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -1229,9 +1229,9 @@ async function dispatchExistingSession(
   // A GET opens the standalone SSE notification stream, which stays open
   // for the life of the connection. Track its liveness so the idle sweep
   // never evicts a session that still has a client listening — `lastSeenAt`
-  // alone would age out a connected-but-quiet client mid-stream. POST/DELETE
-  // responses are short-lived and tied to the just-refreshed `lastSeenAt`,
-  // so they need no tracking.
+  // alone would age out a connected-but-quiet client mid-stream. A POST/DELETE
+  // is actively producing and closes when done (and `lastSeenAt` was just
+  // refreshed), so it's never the eviction target and needs no tracking.
   if (req.method === "GET") {
     return trackResponseStreamLifetime(response, {
       onOpen: () => {
@@ -1242,6 +1242,13 @@ async function dispatchExistingSession(
         // Reset the idle clock from the moment the client actually
         // disconnected, not from when the stream opened.
         entry.lastSeenAt = Date.now();
+      },
+      onError: (err) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        log.debug(
+          { sessionId: entry.transport.sessionId, err: detail },
+          "SSE notification stream errored",
+        );
       },
     });
   }

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -80,6 +80,7 @@ import {
   userIsWorkspaceMember,
 } from "@atlas/api/lib/auth/oauth-workspace-grants";
 import { createAtlasMcpServer } from "./server.js";
+import { trackResponseStreamLifetime } from "./stream-liveness.js";
 
 const log = createLogger("mcp-hosted");
 
@@ -99,6 +100,13 @@ interface SessionEntry {
    * property of the on-hot-path activity refresh.
    */
   lastSeenAt: number;
+  /**
+   * Count of live GET SSE notification streams held open by this session.
+   * A session with `activeStreams > 0` has a client actively listening and
+   * is never idle, so the sweep skips it even when `lastSeenAt` has aged
+   * out — see {@link sweepIdleSessions} and `trackResponseStreamLifetime`.
+   */
+  activeStreams: number;
 }
 
 const sessions = new Map<string, SessionEntry>();
@@ -220,6 +228,9 @@ function sweepIdleSessions(now: number, idleTimeoutMs: number): number {
   let evicted = 0;
   const cutoff = now - idleTimeoutMs;
   for (const [id, entry] of sessions) {
+    // A session with a live notification stream has a client actively
+    // listening — never idle, regardless of how stale `lastSeenAt` looks.
+    if (entry.activeStreams > 0) continue;
     if (entry.lastSeenAt > cutoff) continue;
     sessions.delete(id);
     // intentionally ignored: best-effort teardown of an already-
@@ -1214,7 +1225,27 @@ async function dispatchExistingSession(
   // a long-running tool call (executeSQL on a large query) doesn't
   // race with a concurrent sweep observing a stale `lastSeenAt`.
   entry.lastSeenAt = Date.now();
-  return entry.transport.handleRequest(req);
+  const response = await entry.transport.handleRequest(req);
+  // A GET opens the standalone SSE notification stream, which stays open
+  // for the life of the connection. Track its liveness so the idle sweep
+  // never evicts a session that still has a client listening — `lastSeenAt`
+  // alone would age out a connected-but-quiet client mid-stream. POST/DELETE
+  // responses are short-lived and tied to the just-refreshed `lastSeenAt`,
+  // so they need no tracking.
+  if (req.method === "GET") {
+    return trackResponseStreamLifetime(response, {
+      onOpen: () => {
+        entry.activeStreams++;
+      },
+      onClose: () => {
+        entry.activeStreams = Math.max(0, entry.activeStreams - 1);
+        // Reset the idle clock from the moment the client actually
+        // disconnected, not from when the stream opened.
+        entry.lastSeenAt = Date.now();
+      },
+    });
+  }
+  return response;
 }
 
 async function dispatchNewSession(
@@ -1257,7 +1288,12 @@ async function dispatchNewSession(
         // Stamp `lastSeenAt: Date.now()` at registration so the sweep
         // doesn't immediately evict a freshly-created session that
         // hasn't yet received a follow-up frame.
-        sessions.set(id, { transport, server: mcpServer, lastSeenAt: Date.now() });
+        sessions.set(id, {
+          transport,
+          server: mcpServer,
+          lastSeenAt: Date.now(),
+          activeStreams: 0,
+        });
         registered = true;
         emitSessionStartAudit(
           {

--- a/packages/mcp/src/sse.ts
+++ b/packages/mcp/src/sse.ts
@@ -294,9 +294,9 @@ export async function startSseServer(
     // A GET opens the standalone SSE notification stream, which stays open
     // for the life of the connection. Track its liveness so the idle sweep
     // never evicts a session that still has a client listening — `lastSeenAt`
-    // alone would age out a connected-but-quiet client mid-stream. POST/DELETE
-    // responses are short-lived and tied to the just-refreshed `lastSeenAt`,
-    // so they need no tracking.
+    // alone would age out a connected-but-quiet client mid-stream. A POST/DELETE
+    // is actively producing and closes when done (and `lastSeenAt` was just
+    // refreshed), so it's never the eviction target and needs no tracking.
     if (req.method === "GET") {
       return trackResponseStreamLifetime(response, {
         onOpen: () => {
@@ -307,6 +307,13 @@ export async function startSseServer(
           // Reset the idle clock from the moment the client actually
           // disconnected, not from when the stream opened.
           entry.lastSeenAt = Date.now();
+        },
+        onError: (err) => {
+          const detail = err instanceof Error ? err.message : String(err);
+          log.debug(
+            { sessionId: entry.transport.sessionId, err: detail },
+            "SSE notification stream errored",
+          );
         },
       });
     }

--- a/packages/mcp/src/sse.ts
+++ b/packages/mcp/src/sse.ts
@@ -44,6 +44,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { resolveMcpMaxSessions } from "@atlas/api/lib/env-profile";
 import { createLogger } from "@atlas/api/lib/logger";
+import { trackResponseStreamLifetime } from "./stream-liveness.js";
 
 const log = createLogger("mcp-sse");
 
@@ -102,6 +103,13 @@ interface SessionEntry {
    * every dispatch, defeating the cheap on-hot-path activity refresh.
    */
   lastSeenAt: number;
+  /**
+   * Count of live GET SSE notification streams held open by this session.
+   * A session with `activeStreams > 0` has a client actively listening and
+   * is never idle, so the sweep skips it even when `lastSeenAt` has aged
+   * out — see {@link sweepIdleSessions} and `trackResponseStreamLifetime`.
+   */
+  activeStreams: number;
 }
 type SessionMap = Map<string, SessionEntry>;
 
@@ -206,6 +214,9 @@ function sweepIdleSessions(
   let evicted = 0;
   const cutoff = now - idleTimeoutMs;
   for (const [id, entry] of sessions) {
+    // A session with a live notification stream has a client actively
+    // listening — never idle, regardless of how stale `lastSeenAt` looks.
+    if (entry.activeStreams > 0) continue;
     if (entry.lastSeenAt > cutoff) continue;
     sessions.delete(id);
     // intentionally ignored: best-effort teardown of an already-orphaned
@@ -279,7 +290,27 @@ export async function startSseServer(
     // long-running tool call (executeSQL on a large query) doesn't race
     // with a concurrent sweep observing a stale `lastSeenAt`.
     entry.lastSeenAt = Date.now();
-    return entry.transport.handleRequest(req);
+    const response = await entry.transport.handleRequest(req);
+    // A GET opens the standalone SSE notification stream, which stays open
+    // for the life of the connection. Track its liveness so the idle sweep
+    // never evicts a session that still has a client listening — `lastSeenAt`
+    // alone would age out a connected-but-quiet client mid-stream. POST/DELETE
+    // responses are short-lived and tied to the just-refreshed `lastSeenAt`,
+    // so they need no tracking.
+    if (req.method === "GET") {
+      return trackResponseStreamLifetime(response, {
+        onOpen: () => {
+          entry.activeStreams++;
+        },
+        onClose: () => {
+          entry.activeStreams = Math.max(0, entry.activeStreams - 1);
+          // Reset the idle clock from the moment the client actually
+          // disconnected, not from when the stream opened.
+          entry.lastSeenAt = Date.now();
+        },
+      });
+    }
+    return response;
   }
 
   async function dispatchNewSession(req: Request): Promise<Response> {
@@ -316,7 +347,12 @@ export async function startSseServer(
           // Stamp `lastSeenAt: Date.now()` at registration so the sweep
           // doesn't immediately evict a freshly-created session that hasn't
           // yet received a follow-up frame.
-          sessions.set(id, { transport, server: mcpServer, lastSeenAt: Date.now() });
+          sessions.set(id, {
+            transport,
+            server: mcpServer,
+            lastSeenAt: Date.now(),
+            activeStreams: 0,
+          });
           registered = true;
           log.info({ sessionId: id }, "Session created");
         },

--- a/packages/mcp/src/sse.ts
+++ b/packages/mcp/src/sse.ts
@@ -11,6 +11,23 @@
  * - /mcp     — All MCP traffic (POST, GET, DELETE) delegated to the SDK transport
  * - /health  — Health check
  *
+ * ── Session hardening (#3492) ──────────────────────────────────────
+ *
+ * This standalone transport mirrors the session-lifecycle hardening that
+ * `hosted.ts` carries: an idle-session sweep, a `pendingReservations`
+ * TOCTOU cap guard, and `ATLAS_MCP_MAX_SESSIONS` honored via
+ * `resolveMcpMaxSessions`. Without these, a self-hosted `--transport sse`
+ * deployment permanently exhausts its session pool once enough clients
+ * vanish without sending the explicit `DELETE` (Streamable HTTP has no
+ * transport-level disconnect event). Patterns/naming are kept in lockstep
+ * with `hosted.ts` so the two transports stay legible side-by-side. The
+ * one intentional shape difference: `sse.ts` is a multi-instance factory
+ * (each `startSseServer` call owns its own session store), so the session
+ * map and the `pendingReservations` counter live in the closure rather
+ * than at module scope, and the per-instance test seams hang off the
+ * returned handle (`_sessionCount`, `_sweepIdleSessionsForTests`) instead
+ * of being module exports.
+ *
  * @example
  * ```typescript
  * import { createAtlasMcpServer } from "./server.js";
@@ -25,12 +42,12 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { resolveMcpMaxSessions } from "@atlas/api/lib/env-profile";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("mcp-sse");
 
 const DEFAULT_PORT = 8080;
-const DEFAULT_MAX_SESSIONS = 100;
 
 interface SseServerOptions {
   /** Port to listen on. 0 for OS-assigned ephemeral port. Default: 8080. */
@@ -39,7 +56,13 @@ interface SseServerOptions {
   hostname?: string;
   /** CORS allowed origin. Default: "*". */
   corsOrigin?: string;
-  /** Maximum concurrent sessions. Default: 100. */
+  /**
+   * Maximum concurrent sessions. When omitted, the cap resolves through
+   * the env-profile via `resolveMcpMaxSessions` (the `ATLAS_MCP_MAX_SESSIONS`
+   * override wins when a positive integer, otherwise the deploy-env profile
+   * default — 100). An explicit value here always wins over the env so a
+   * caller can pin the cap regardless of the ambient environment.
+   */
   maxSessions?: number;
 }
 
@@ -52,13 +75,156 @@ interface SseServerHandle {
   };
   /** Gracefully stop the server, close all transports and per-session MCP servers. */
   close(): Promise<void>;
+  /**
+   * @internal — test-only. Current live session count for this instance.
+   * Mirrors `hosted.ts:_hostedSessionCount`, but bound to this server's
+   * closure-scoped store rather than the module store.
+   */
+  _sessionCount(): number;
+  /**
+   * @internal — test-only. Drive the idle sweep deterministically with a
+   * pinned clock against this instance's store. Mirrors
+   * `hosted.ts:_sweepIdleSessionsForTests`; returns the number evicted.
+   */
+  _sweepIdleSessionsForTests(now?: number, idleTimeoutMs?: number): number;
 }
 
-type SessionEntry = {
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: McpServer;
-};
+interface SessionEntry {
+  readonly transport: WebStandardStreamableHTTPServerTransport;
+  readonly server: McpServer;
+  /**
+   * Wall-clock ms of the most recent successful frame against this
+   * session. Updated on every dispatch (init AND every subsequent
+   * request). The lazy sweep at session-creation reads this to evict
+   * idle entries when the cap-check trips — see {@link sweepIdleSessions}.
+   *
+   * Mutable by design: a `Map` of frozen objects would force a re-set on
+   * every dispatch, defeating the cheap on-hot-path activity refresh.
+   */
+  lastSeenAt: number;
+}
 type SessionMap = Map<string, SessionEntry>;
+
+// ── Concurrent-session cap ──────────────────────────────────────────
+//
+// The cap resolves through the env-profile (`resolveMcpMaxSessions`): the
+// `ATLAS_MCP_MAX_SESSIONS` override wins when a positive integer, otherwise
+// the deploy-env profile default (100) applies. An explicit `opts.maxSessions`
+// passed by the caller always wins over the env. The resolver is pure and
+// cannot log, so the malformed-override warn lives here at the call site
+// where a logger is available. Mirrors `hosted.ts:maxSessions`.
+
+function resolveMaxSessions(explicit: number | undefined): number {
+  if (explicit !== undefined) return explicit;
+  // Mirror resolveMcpMaxSessions's `.trim()` so a whitespace-only value is
+  // treated as unset (no spurious warn) — the warn fires only for a genuinely
+  // malformed non-empty override, matching what the resolver actually rejects.
+  const raw = process.env.ATLAS_MCP_MAX_SESSIONS?.trim();
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      log.warn(
+        { raw },
+        "ATLAS_MCP_MAX_SESSIONS is not a positive integer — falling back to the deploy-env profile default",
+      );
+    }
+  }
+  return resolveMcpMaxSessions();
+}
+
+// ── Idle-session sweep ─────────────────────────────────────────────
+//
+// Streamable HTTP is request-response, not a long-lived socket — there is
+// no transport-level disconnect event for a client that closes without
+// sending the explicit `DELETE`. Real-world MCP clients (Claude Desktop,
+// Cursor) routinely vanish (laptop lid closed, app killed, OS update)
+// without a clean handshake. The pre-sweep implementation kept those
+// orphaned sessions in the in-memory map forever — eventually saturating
+// the cap and 503-ing every new connection until process restart.
+//
+// The sweep evicts any session whose `lastSeenAt` is older than the idle
+// timeout, and runs lazily, only on cap-pressure (inside the new-session
+// path when `sessions.size + pendingReservations >= cap`). A quiet server
+// with no traffic doesn't burn CPU on a periodic sweep; the newly-arriving
+// caller pays the O(n) sweep cost, which is the right shape — the work is
+// amortized against the request that benefits from it. Mirrors the lazy
+// sweep in `hosted.ts`; a `setInterval` background sweep is deliberately
+// not used (extra fiber to reason about, spends CPU on idle servers).
+
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const MIN_SESSION_IDLE_TIMEOUT_MS = 60 * 1000; // 1 minute floor
+
+/**
+ * Test-only override. Bypasses the production floor so the cap-pressure
+ * sweep can be driven end-to-end with sub-second timeouts. Production must
+ * keep the 1-minute floor so a misconfigured env var can't degenerate the
+ * sweep into a close-everything-on-every-request loop. Production code paths
+ * never set this. Module-scoped (mirrors `hosted.ts`) because it tunes the
+ * env-driven timeout resolution, not any one server instance's store.
+ */
+let _idleTimeoutOverrideMs: number | null = null;
+
+/** @internal — test-only. Pin idle timeout below the prod floor. */
+export function _setIdleTimeoutForTests(ms: number | null): void {
+  _idleTimeoutOverrideMs = ms;
+}
+
+function sessionIdleTimeoutMs(): number {
+  if (_idleTimeoutOverrideMs !== null) return _idleTimeoutOverrideMs;
+  const raw = process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < MIN_SESSION_IDLE_TIMEOUT_MS) {
+    log.warn(
+      { raw, floor: MIN_SESSION_IDLE_TIMEOUT_MS },
+      "ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS missing/below floor — falling back to default",
+    );
+    return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+/**
+ * Evict sessions whose `lastSeenAt` is older than the configured idle
+ * timeout. Returns the count evicted so the caller can decide whether the
+ * cap-check should be retried (a successful sweep means a slot opened up).
+ *
+ * Eviction calls `transport.close()` + `server.close()` so the underlying
+ * resources are released, not just the map entry. Both close paths swallow
+ * their own errors via `.catch(() => {})` to match the existing teardown
+ * pattern in `close()` and `transport.onclose` — a hanging close on a
+ * leaked session must not block the new caller's init from proceeding.
+ *
+ * Takes the session map as a parameter (rather than reading a module store
+ * like `hosted.ts`) because `startSseServer` is a multi-instance factory.
+ */
+function sweepIdleSessions(
+  sessions: SessionMap,
+  now: number,
+  idleTimeoutMs: number,
+): number {
+  let evicted = 0;
+  const cutoff = now - idleTimeoutMs;
+  for (const [id, entry] of sessions) {
+    if (entry.lastSeenAt > cutoff) continue;
+    sessions.delete(id);
+    // intentionally ignored: best-effort teardown of an already-orphaned
+    // session — the client that owned this entry is gone by definition (no
+    // frames in `idleTimeoutMs`), so a close failure has nowhere to surface.
+    // The sweep counter is the signal that matters; missing one out of N
+    // closes does not affect cap accounting.
+    void entry.transport.close().catch(() => {});
+    void entry.server.close().catch(() => {});
+    evicted++;
+  }
+  if (evicted > 0) {
+    log.info(
+      { evicted, remaining: sessions.size, idleTimeoutMs },
+      "Swept idle MCP sessions",
+    );
+  }
+  return evicted;
+}
 
 function corsHeaders(origin: string): Record<string, string> {
   return {
@@ -87,7 +253,7 @@ export async function startSseServer(
   const port = opts?.port ?? DEFAULT_PORT;
   const hostname = opts?.hostname ?? "0.0.0.0";
   const origin = opts?.corsOrigin ?? "*";
-  const maxSessions = opts?.maxSessions ?? DEFAULT_MAX_SESSIONS;
+  const explicitMaxSessions = opts?.maxSessions;
 
   if (port !== 0 && (isNaN(port) || port < 1 || port > 65535)) {
     throw new Error(`Invalid port: ${port}. Must be 0 (ephemeral) or 1-65535.`);
@@ -96,67 +262,130 @@ export async function startSseServer(
   const sessions: SessionMap = new Map();
   const cors = corsHeaders(origin);
 
+  // Reservation counter prevents the TOCTOU between the cap check and the
+  // async `createServer` call. `sessions.size` only reflects post-
+  // `onsessioninitialized` state; with N concurrent inits, all N would pass
+  // a naïve `sessions.size >= max` check before any registers. We bump this
+  // at the gate and decrement on failure or after the session registers.
+  // Per-instance (closure-scoped) because each server owns its own store.
+  let pendingReservations = 0;
+
+  async function dispatchExistingSession(
+    req: Request,
+    entry: SessionEntry,
+  ): Promise<Response> {
+    // Refresh the activity timestamp so the lazy sweep at the cap-check
+    // doesn't evict an actively-used session. Updated PRE-dispatch so a
+    // long-running tool call (executeSQL on a large query) doesn't race
+    // with a concurrent sweep observing a stale `lastSeenAt`.
+    entry.lastSeenAt = Date.now();
+    return entry.transport.handleRequest(req);
+  }
+
+  async function dispatchNewSession(req: Request): Promise<Response> {
+    const cap = resolveMaxSessions(explicitMaxSessions);
+
+    // Lazy sweep: when the cap appears full, evict idle sessions FIRST and
+    // re-check. Without this, a server that has accumulated leaked sessions
+    // (Streamable HTTP has no transport disconnect event for a client that
+    // vanishes without sending DELETE) will permanently 503 every new
+    // connection until process restart. The sweep cost is paid only on
+    // cap-pressure, so quiet servers don't burn CPU evicting nothing.
+    if (sessions.size + pendingReservations >= cap) {
+      sweepIdleSessions(sessions, Date.now(), sessionIdleTimeoutMs());
+      if (sessions.size + pendingReservations >= cap) {
+        return new Response(
+          JSON.stringify({
+            error: "too_many_sessions",
+            message: "Too many active MCP sessions. Try again later.",
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        );
+      }
+    }
+
+    pendingReservations++;
+    let registered = false;
+
+    try {
+      const mcpServer = await createServer();
+
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+        onsessioninitialized: (id) => {
+          // Stamp `lastSeenAt: Date.now()` at registration so the sweep
+          // doesn't immediately evict a freshly-created session that hasn't
+          // yet received a follow-up frame.
+          sessions.set(id, { transport, server: mcpServer, lastSeenAt: Date.now() });
+          registered = true;
+          log.info({ sessionId: id }, "Session created");
+        },
+        onsessionclosed: (id) => {
+          const entry = sessions.get(id);
+          if (entry) {
+            sessions.delete(id);
+            entry.server.close().catch((err) => {
+              const detail = err instanceof Error ? err.message : String(err);
+              log.warn({ sessionId: id, err: detail }, "Failed to close server");
+            });
+          }
+          log.info({ sessionId: id }, "Session closed");
+        },
+      });
+
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid && sessions.has(sid)) {
+          const entry = sessions.get(sid)!;
+          sessions.delete(sid);
+          // intentionally ignored: best-effort cleanup on transport close
+          entry.server.close().catch(() => {});
+        }
+      };
+
+      try {
+        await mcpServer.connect(transport);
+      } catch (err) {
+        // intentionally ignored: best-effort cleanup before re-throwing connect error
+        await transport.close().catch(() => {});
+        await mcpServer.close().catch(() => {});
+        throw err;
+      }
+
+      const response = await transport.handleRequest(req);
+
+      // The leak path: a non-initialize first frame (no `mcp-session-id`
+      // header) is rejected by the SDK without firing `onsessioninitialized`.
+      // The server + transport stay live but unregistered, so nothing ever
+      // cleans them up. Detect via the `registered` flag set inside the init
+      // callback and tear down here. Without this, every malformed first
+      // frame leaks one McpServer per request. Mirrors `hosted.ts`.
+      if (!registered) {
+        // intentionally ignored: best-effort teardown of an unregistered
+        // session — we already lost the request, no point surfacing close
+        // errors that nothing can act on.
+        await transport.close().catch(() => {});
+        await mcpServer.close().catch(() => {});
+      }
+
+      return response;
+    } finally {
+      pendingReservations--;
+    }
+  }
+
   async function handleMcpRequest(req: Request): Promise<Response> {
     const sessionId = req.headers.get("mcp-session-id");
 
-    if (sessionId && sessions.has(sessionId)) {
-      const entry = sessions.get(sessionId)!;
-      return entry.transport.handleRequest(req);
-    }
-
     if (sessionId) {
+      const entry = sessions.get(sessionId);
+      if (entry) {
+        return dispatchExistingSession(req, entry);
+      }
       return new Response("Session not found", { status: 404 });
     }
 
-    if (sessions.size >= maxSessions) {
-      return new Response(
-        JSON.stringify({ error: "Too many active sessions. Try again later." }),
-        { status: 503, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
-    // New session — create a per-session MCP server and transport
-    const mcpServer = await createServer();
-
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: () => crypto.randomUUID(),
-      onsessioninitialized: (id) => {
-        sessions.set(id, { transport, server: mcpServer });
-        log.info({ sessionId: id }, "Session created");
-      },
-      onsessionclosed: (id) => {
-        const entry = sessions.get(id);
-        if (entry) {
-          sessions.delete(id);
-          entry.server.close().catch((err) => {
-            const detail = err instanceof Error ? err.message : String(err);
-            log.warn({ sessionId: id, err: detail }, "Failed to close server");
-          });
-        }
-        log.info({ sessionId: id }, "Session closed");
-      },
-    });
-
-    transport.onclose = () => {
-      const sid = transport.sessionId;
-      if (sid && sessions.has(sid)) {
-        const entry = sessions.get(sid)!;
-        sessions.delete(sid);
-        // intentionally ignored: best-effort cleanup on transport close
-        entry.server.close().catch(() => {});
-      }
-    };
-
-    try {
-      await mcpServer.connect(transport);
-    } catch (err) {
-      // intentionally ignored: best-effort cleanup before re-throwing connect error
-      await transport.close().catch(() => {});
-      await mcpServer.close().catch(() => {});
-      throw err;
-    }
-
-    return transport.handleRequest(req);
+    return dispatchNewSession(req);
   }
 
   const bunServer = Bun.serve({
@@ -225,6 +454,7 @@ export async function startSseServer(
       // callback-triggered double-cleanup
       const entries = [...sessions.entries()];
       sessions.clear();
+      pendingReservations = 0;
 
       for (const [sessionId, entry] of entries) {
         await entry.transport.close().catch((err) => {
@@ -238,6 +468,16 @@ export async function startSseServer(
       }
 
       bunServer.stop(true);
+    },
+    _sessionCount() {
+      return sessions.size;
+    },
+    _sweepIdleSessionsForTests(now?: number, idleTimeoutMs?: number): number {
+      return sweepIdleSessions(
+        sessions,
+        now ?? Date.now(),
+        idleTimeoutMs ?? sessionIdleTimeoutMs(),
+      );
     },
   };
 }

--- a/packages/mcp/src/stream-liveness.ts
+++ b/packages/mcp/src/stream-liveness.ts
@@ -1,0 +1,93 @@
+/**
+ * SSE stream-liveness tracking shared by the MCP transports (sse.ts +
+ * hosted.ts).
+ *
+ * ── Why this exists (#3492 review follow-up) ───────────────────────
+ *
+ * The idle-session sweep evicts sessions whose `lastSeenAt` is older than
+ * the idle timeout. But `lastSeenAt` is refreshed per *dispatch*, and the
+ * standalone GET SSE notification stream is a single dispatch that then
+ * stays open for the whole life of the connection. A client that opens the
+ * notification channel and then sits quiet (no POST frames) would age out
+ * of `lastSeenAt` and could be swept mid-stream under cap-pressure —
+ * dropping a still-connected listener.
+ *
+ * The MCP SDK's `WebStandardStreamableHTTPServerTransport` exposes no
+ * public "stream closed" event (its stream bookkeeping is private), so the
+ * transport-agnostic way to learn when the notification stream actually
+ * ends is to wrap the streamed Response body and observe its close / cancel
+ * / error. While the stream is open the owning session is marked active and
+ * the sweep skips it; when it closes we release the mark and reset the idle
+ * clock from the moment the client actually disconnected.
+ *
+ * Only the GET notification stream is wrapped — POST tool-call responses are
+ * short-lived and tied to a just-refreshed `lastSeenAt`, so wrapping them
+ * would add per-chunk overhead on the hot path for no idle-eviction benefit.
+ */
+
+export interface StreamLifetimeHooks {
+  /** Fires synchronously when a long-lived SSE stream is handed to the client. */
+  readonly onOpen: () => void;
+  /** Fires once when that stream ends — client disconnect, server end, or error. */
+  readonly onClose: () => void;
+}
+
+/**
+ * If `res` is an SSE (`text/event-stream`) streaming response, wrap its body
+ * so `hooks.onOpen` fires now and `hooks.onClose` fires exactly once when the
+ * stream completes, is cancelled by the client, or errors. Non-SSE or
+ * body-less responses are returned untouched (nothing to track).
+ *
+ * The wrapper is a pull-driven byte-for-byte pass-through: it preserves SSE
+ * ordering and backpressure (an idle stream parks in `reader.read()` rather
+ * than spinning), so the client sees an identical stream.
+ */
+export function trackResponseStreamLifetime(
+  res: Response,
+  hooks: StreamLifetimeHooks,
+): Response {
+  const body = res.body;
+  const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+  if (!body || !contentType.includes("text/event-stream")) {
+    return res;
+  }
+
+  hooks.onOpen();
+  let finished = false;
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    hooks.onClose();
+  };
+
+  const reader = body.getReader();
+  const tracked = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          finish();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        // The source stream errored — propagate to the client and release
+        // the liveness mark. Normalize per the repo's caught-error rule.
+        finish();
+        controller.error(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+    cancel(reason) {
+      // Client disconnected (Bun cancels the response body on socket close).
+      finish();
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(tracked, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  });
+}

--- a/packages/mcp/src/stream-liveness.ts
+++ b/packages/mcp/src/stream-liveness.ts
@@ -20,9 +20,13 @@
  * the sweep skips it; when it closes we release the mark and reset the idle
  * clock from the moment the client actually disconnected.
  *
- * Only the GET notification stream is wrapped — POST tool-call responses are
- * short-lived and tied to a just-refreshed `lastSeenAt`, so wrapping them
- * would add per-chunk overhead on the hot path for no idle-eviction benefit.
+ * Only the GET notification stream is wrapped: it's the one stream that can
+ * stay open while *quiet*, so it's the only one a `lastSeenAt`-based sweep can
+ * wrongly age out. A POST response can also be `text/event-stream` (a
+ * long-running tool call streams its result), but it's actively producing and
+ * closes once the result is sent — and `lastSeenAt` was just refreshed at
+ * dispatch — so it's never the eviction target. Wrapping POSTs would add
+ * per-chunk overhead on the hot path for no idle-eviction benefit.
  */
 
 export interface StreamLifetimeHooks {
@@ -30,6 +34,15 @@ export interface StreamLifetimeHooks {
   readonly onOpen: () => void;
   /** Fires once when that stream ends — client disconnect, server end, or error. */
   readonly onClose: () => void;
+  /**
+   * Fires if the underlying source stream throws mid-flight, just before the
+   * error is propagated to the client via `controller.error`. The wrapper is
+   * transport-agnostic and has no logger of its own, so this is the seam a
+   * caller uses to log the failure server-side — `controller.error` only ever
+   * reaches the client, which on a disconnecting SSE socket is often already
+   * gone, so without this the fault would be operator-invisible.
+   */
+  readonly onError?: (err: unknown) => void;
 }
 
 /**
@@ -72,8 +85,11 @@ export function trackResponseStreamLifetime(
         }
         controller.enqueue(value);
       } catch (err) {
-        // The source stream errored — propagate to the client and release
-        // the liveness mark. Normalize per the repo's caught-error rule.
+        // The source stream errored. Surface it to the caller for server-side
+        // logging (controller.error only reaches the client), release the
+        // liveness mark, then propagate. Normalize per the repo's caught-error
+        // rule.
+        hooks.onError?.(err);
         finish();
         controller.error(err instanceof Error ? err : new Error(String(err)));
       }


### PR DESCRIPTION
## Summary

Backports the session-lifecycle hardening from `hosted.ts` into the standalone `sse.ts` transport, fixing a real availability bug: self-hosted `--transport sse` deployments permanently exhaust their session pool once enough clients vanish without sending `DELETE` (Streamable HTTP has no transport-level disconnect event — laptop lid closed, app killed, OS update).

- **Idle-session sweep** (`sweepIdleSessions`) — lazy eviction on cap-pressure, gated by `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS` with a 1-minute production floor. Eviction closes the transport + per-session server so resources actually free.
- **TOCTOU cap guard** (`pendingReservations`) — a per-instance reservation counter closes the race between the cap check and the async server factory, so N concurrent inits can't all slip past a naïve `sessions.size >= cap` check before any registers.
- **`ATLAS_MCP_MAX_SESSIONS` honored on the SSE path** via `resolveMcpMaxSessions` (env-profile). An explicit `opts.maxSessions` still wins for callers that pin a cap.
- **Unregistered-session teardown** — a malformed non-initialize first frame no longer leaks one `McpServer` per request.

### Review follow-up: stream-aware sweep (both transports)

A `/code-review` + `/review` pass surfaced that the sweep keyed only on `lastSeenAt`, which is refreshed per *dispatch* — but the standalone GET SSE **notification stream** is a single dispatch that then stays open for the whole connection. A connected-but-quiet client (no POST frames) could age out and be swept mid-stream under cap-pressure, dropping a live listener.

Fixed in **both** `sse.ts` and `hosted.ts` (the user asked to keep them in lockstep) via a shared `stream-liveness.ts` helper: the MCP SDK exposes no public stream-closed event, so we wrap the GET notification stream's response body (a pull-driven, byte-for-byte SSE pass-through) and observe its close/cancel/error. While a session holds a live stream (`activeStreams > 0`) the sweep skips it; on stream close we release the mark and reset the idle clock from the actual disconnect moment. Only the GET stream is wrapped — POST tool-call responses are short-lived and tied to a just-refreshed `lastSeenAt`, so the hot path is untouched.

### Notes
- Patterns/naming kept in lockstep with `hosted.ts`. The one intentional shape difference: `sse.ts` is a multi-instance factory (each `startSseServer` owns its own session store), so the session map + reservation counter live in the closure and the per-instance test seams hang off the returned handle (`_sessionCount`, `_sweepIdleSessionsForTests`).
- `ATLAS_MCP_MAX_SESSIONS` / `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS` are intentionally operator/region-level, not per-customer config: they guard a *shared, process-wide* session pool, and `sse.ts` is the self-hosted standalone path. The cap already flows through the env-profile resolver (the SaaS-aware layer). A per-workspace MCP session quota, if wanted, is a separate `hosted.ts`/`ee` feature.

## Test plan

- [x] sse: far-future sweep evicts; recently-active preserved; `ATLAS_MCP_MAX_SESSIONS` honored; concurrent-init cap race rejected by the reservation counter; abandoned (no-stream) session auto-swept on cap-pressure; **live-stream session resists cap-pressure eviction**
- [x] hosted: existing eviction tests updated (SDK-client "leakers" — which hold a real stream and are now correctly protected — switched to raw-init abandoned sessions); **new live-stream protection test**
- [x] `stream-liveness.ts` unit tests: onOpen-once / onClose-once on end + on cancel, byte-for-byte pass-through, non-SSE & body-less pass-through untouched
- [x] Local gates: lint, type, full test (api 613/613 + all workspaces, mcp 21/21 files, `@useatlas/mcp` 140), syncpack, all drift checks, test-discipline, railway-watch, published-symbols

Closes #3492