### PR TITLE
refactor(api): extract shared profiling/semantic-gen service (#3506)

### DIFF
--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -47,13 +47,13 @@ import {
   outputDirForGroup,
 } from "@atlas/api/lib/profiler";
 // Mechanical generation runs through the shared semantic engine (issue #3233)
-// so the wizard and the CLI emit identical YAML.
+// so the wizard and the CLI emit identical YAML. The catalog/glossary/metric
+// assembly delegates to `generateSemanticLayer` — the same shared core the CLI
+// and the `SemanticGenerator` service use (#3506) — so the three can't drift.
 import {
   analyzeTableProfiles,
   generateEntityYAML,
-  generateCatalogYAML,
-  generateGlossaryYAML,
-  generateMetricYAML,
+  generateSemanticLayer,
 } from "@atlas/api/lib/semantic/generate";
 // Phase-2 enrichment is the same shared engine (issue #3236, § D); the in-memory
 // variant lets the wizard enrich a YAML string per table without touching disk.
@@ -1079,25 +1079,31 @@ wizard.openapi(saveRoute, async (c) => {
         // pass dbType explicitly.
         const resolvedDbType = bodyDbType ?? "postgres";
 
-        const catalogYaml = generateCatalogYAML(profiles);
+        // Assemble through the shared engine (#3506) so the wizard, the CLI,
+        // and the SemanticGenerator service can't drift. Entities are supplied
+        // by the frontend, so only the catalog/glossary/metric artifacts are
+        // consumed here. The metric write keeps the wizard's path-traversal
+        // guard for untrusted HTTP profiles: unsafe table names are skipped and
+        // the filename is re-sanitized with `path.basename`.
+        const generated = generateSemanticLayer(profiles, {
+          dbType: resolvedDbType,
+          schema: resolvedSchema,
+        });
+
         const catalogPath = path.join(outputBase, "catalog.yml");
-        fs.writeFileSync(catalogPath, catalogYaml, "utf-8");
+        fs.writeFileSync(catalogPath, generated.catalog, "utf-8");
         savedFiles.push("catalog.yml");
 
-        const glossaryYaml = generateGlossaryYAML(profiles);
         const glossaryPath = path.join(outputBase, "glossary.yml");
-        fs.writeFileSync(glossaryPath, glossaryYaml, "utf-8");
+        fs.writeFileSync(glossaryPath, generated.glossary, "utf-8");
         savedFiles.push("glossary.yml");
 
-        for (const profile of profiles) {
-          if (!profile.table_name || !SAFE_TABLE_NAME.test(profile.table_name)) continue;
-          const metricYaml = generateMetricYAML(profile, resolvedSchema, resolvedDbType);
-          if (metricYaml) {
-            const safeMetricName = path.basename(profile.table_name);
-            const filePath = path.join(metricsDir, `${safeMetricName}.yml`);
-            fs.writeFileSync(filePath, metricYaml, "utf-8");
-            savedFiles.push(`metrics/${safeMetricName}.yml`);
-          }
+        for (const metric of generated.metrics) {
+          if (!metric.table || !SAFE_TABLE_NAME.test(metric.table)) continue;
+          const safeMetricName = path.basename(metric.table);
+          const filePath = path.join(metricsDir, `${safeMetricName}.yml`);
+          fs.writeFileSync(filePath, metric.yaml, "utf-8");
+          savedFiles.push(`metrics/${safeMetricName}.yml`);
         }
       }
 

--- a/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
+++ b/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
@@ -1,0 +1,341 @@
+/**
+ * `SemanticGenerator` service (#3506 — MCP V2 Blocker #1).
+ *
+ * Proves the shared profiling/semantic-generation seam end to end, independent
+ * of the CLI:
+ *
+ *  - `profile` runs the (injected) dialect profiler, applies analysis
+ *    heuristics, and surfaces `ProfilingFailedError` for the no-tables /
+ *    threshold / unsupported-dbType cases;
+ *  - `generate` assembles artifacts (delegates to the shared core);
+ *  - `profileAndGenerate` ties them together and **populates the table
+ *    whitelist**, so a freshly-profiled connection becomes queryable — the
+ *    exact gap that made an MCP-created datasource connected-but-unqueryable.
+ *
+ * Profiler behavior is injected per-call via `opts.profileFn` (no `mock.module`,
+ * no live DB), and the assertions read through the real `whitelist` module so
+ * the queryability claim is exercised against production code.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { Effect } from "effect";
+import type {
+  ColumnProfile,
+  ProfilingResult,
+  TableProfile,
+} from "@useatlas/types";
+import {
+  SemanticGenerator,
+  SemanticGeneratorLive,
+  createSemanticGeneratorTestLayer,
+  type DatasourceProfiler,
+} from "../semantic-generator";
+import {
+  getWhitelistedTables,
+  _resetWhitelists,
+  _resetPluginEntities,
+} from "@atlas/api/lib/semantic/whitelist";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+function col(
+  over: Partial<ColumnProfile> & Pick<ColumnProfile, "name" | "type">,
+): ColumnProfile {
+  return {
+    name: over.name,
+    type: over.type,
+    nullable: over.nullable ?? false,
+    unique_count: over.unique_count ?? null,
+    null_count: over.null_count ?? null,
+    sample_values: over.sample_values ?? [],
+    is_primary_key: over.is_primary_key ?? false,
+    is_foreign_key: over.is_foreign_key ?? false,
+    fk_target_table: over.fk_target_table ?? null,
+    fk_target_column: over.fk_target_column ?? null,
+    is_enum_like: over.is_enum_like ?? false,
+    profiler_notes: over.profiler_notes ?? [],
+  };
+}
+
+function profile(
+  over: Partial<TableProfile> & Pick<TableProfile, "table_name">,
+): TableProfile {
+  return {
+    table_name: over.table_name,
+    object_type: over.object_type ?? "table",
+    row_count: over.row_count ?? 100,
+    columns: over.columns ?? [
+      col({ name: "id", type: "integer", is_primary_key: true }),
+      col({ name: "total", type: "numeric" }),
+    ],
+    primary_key_columns: over.primary_key_columns ?? ["id"],
+    foreign_keys: over.foreign_keys ?? [],
+    inferred_foreign_keys: over.inferred_foreign_keys ?? [],
+    profiler_notes: over.profiler_notes ?? [],
+    table_flags: over.table_flags ?? {
+      possibly_abandoned: false,
+      possibly_denormalized: false,
+    },
+  };
+}
+
+/** A profiler that returns a fixed result and records that it was called. */
+function fakeProfiler(result: ProfilingResult): DatasourceProfiler & { calls: number } {
+  const fn = Object.assign(
+    () => {
+      fn.calls += 1;
+      return Promise.resolve(result);
+    },
+    { calls: 0 },
+  );
+  return fn;
+}
+
+function run<A, E>(effect: Effect.Effect<A, E, SemanticGenerator>): Promise<A> {
+  return Effect.runPromise(effect.pipe(Effect.provide(SemanticGeneratorLive)));
+}
+
+function runExit<A, E>(effect: Effect.Effect<A, E, SemanticGenerator>) {
+  return Effect.runPromiseExit(effect.pipe(Effect.provide(SemanticGeneratorLive)));
+}
+
+afterEach(() => {
+  _resetPluginEntities();
+  _resetWhitelists();
+});
+
+// ── generate (pure) ──────────────────────────────────────────────────
+
+describe("SemanticGenerator.generate", () => {
+  it("assembles entity/catalog/glossary/metric artifacts from analyzed profiles", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return svc.generate([profile({ table_name: "orders" })], { dbType: "postgres" });
+      }),
+    );
+    expect(result.entities.map((e) => e.table)).toEqual(["orders"]);
+    expect(result.catalog.length).toBeGreaterThan(0);
+    expect(result.glossary.length).toBeGreaterThan(0);
+    expect(result.metrics.map((m) => m.table)).toEqual(["orders"]);
+  });
+});
+
+// ── profile ──────────────────────────────────────────────────────────
+
+describe("SemanticGenerator.profile", () => {
+  it("runs the injected profiler and returns analyzed profiles", async () => {
+    const fp = fakeProfiler({
+      profiles: [profile({ table_name: "orders" }), profile({ table_name: "customers" })],
+      errors: [],
+    });
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({
+          url: "clickhouse://example",
+          dbType: "clickhouse",
+          profileFn: fp,
+        });
+      }),
+    );
+    expect(fp.calls).toBe(1);
+    expect(result.profiles.map((p) => p.table_name)).toEqual(["orders", "customers"]);
+    expect(result.errors).toEqual([]);
+    expect(typeof result.elapsedMs).toBe("number");
+  });
+
+  it("fails with ProfilingFailedError(no_tables) when nothing profiles", async () => {
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({
+          url: "postgres://x",
+          dbType: "postgres",
+          profileFn: fakeProfiler({ profiles: [], errors: [] }),
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = exit.cause;
+      expect(JSON.stringify(err)).toContain("no_tables");
+    }
+  });
+
+  it("aborts on threshold breach but continues with force", async () => {
+    // 1 success, 3 errors → 75% failure rate (over the 50% threshold).
+    const result: ProfilingResult = {
+      profiles: [profile({ table_name: "orders" })],
+      errors: [
+        { table: "a", error: "boom" },
+        { table: "b", error: "boom" },
+        { table: "c", error: "boom" },
+      ],
+    };
+
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({
+          url: "postgres://x",
+          dbType: "postgres",
+          profileFn: fakeProfiler(result),
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("threshold_exceeded");
+    }
+
+    const forced = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({
+          url: "postgres://x",
+          dbType: "postgres",
+          force: true,
+          profileFn: fakeProfiler(result),
+        });
+      }),
+    );
+    expect(forced.profiles.map((p) => p.table_name)).toEqual(["orders"]);
+  });
+
+  it("fails with unsupported_db_type when no profiler is available for a non-core dbType", async () => {
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({ url: "clickhouse://x", dbType: "clickhouse" });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("unsupported_db_type");
+    }
+  });
+
+  it("normalizes a thrown profiler error into ProfilingFailedError(profiler_error)", async () => {
+    const throwing: DatasourceProfiler = () =>
+      Promise.reject(new Error("connection refused"));
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profile({
+          url: "postgres://x",
+          dbType: "postgres",
+          profileFn: throwing,
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("profiler_error");
+      expect(json).toContain("connection refused");
+    }
+  });
+});
+
+// ── profileAndGenerate (the Blocker #1 entry point) ──────────────────
+
+describe("SemanticGenerator.profileAndGenerate", () => {
+  it("profiles, generates, and populates the table whitelist (connection becomes queryable)", async () => {
+    const connectionId = "mcp_conn_a";
+    const fp = fakeProfiler({
+      profiles: [profile({ table_name: "orders" }), profile({ table_name: "customers" })],
+      errors: [],
+    });
+
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profileAndGenerate({
+          url: "postgres://x",
+          dbType: "postgres",
+          connectionId,
+          profileFn: fp,
+        });
+      }),
+    );
+
+    expect(result.entities.map((e) => e.table)).toEqual(["orders", "customers"]);
+    expect(result.profiles).toHaveLength(2);
+
+    // The blocker: before this, the whitelist was empty → every query rejected.
+    const whitelist = getWhitelistedTables(connectionId);
+    expect(whitelist.has("orders")).toBe(true);
+    expect(whitelist.has("customers")).toBe(true);
+  });
+
+  it("does not touch the whitelist when registerWhitelist is false", async () => {
+    const connectionId = "mcp_conn_b";
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profileAndGenerate({
+          url: "postgres://x",
+          dbType: "postgres",
+          connectionId,
+          registerWhitelist: false,
+          profileFn: fakeProfiler({
+            profiles: [profile({ table_name: "orders" })],
+            errors: [],
+          }),
+        });
+      }),
+    );
+    expect(getWhitelistedTables(connectionId).has("orders")).toBe(false);
+  });
+
+  it("propagates the profiling failure (no artifacts, no whitelist mutation)", async () => {
+    const connectionId = "mcp_conn_c";
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.profileAndGenerate({
+          url: "postgres://x",
+          dbType: "postgres",
+          connectionId,
+          profileFn: fakeProfiler({ profiles: [], errors: [] }),
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    expect(getWhitelistedTables(connectionId).size).toBe(0);
+  });
+});
+
+// ── registerWhitelist (direct) ───────────────────────────────────────
+
+describe("SemanticGenerator.registerWhitelist", () => {
+  it("registers generated entity tables under the connection id", async () => {
+    const connectionId = "mcp_conn_d";
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        const generated = svc.generate([profile({ table_name: "orders" })], {
+          dbType: "postgres",
+        });
+        svc.registerWhitelist(connectionId, generated.entities);
+      }),
+    );
+    expect(getWhitelistedTables(connectionId).has("orders")).toBe(true);
+  });
+});
+
+// ── Test layer factory ───────────────────────────────────────────────
+
+describe("createSemanticGeneratorTestLayer", () => {
+  it("provides a working SemanticGenerator", async () => {
+    const layer = createSemanticGeneratorTestLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return svc.generate([profile({ table_name: "orders" })], { dbType: "postgres" });
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(result.entities.map((e) => e.table)).toEqual(["orders"]);
+  });
+});

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -884,6 +884,26 @@ export class DeliveryError extends Data.TaggedError("DeliveryError")<{
   readonly permanent: boolean;
 }> {}
 
+// ── Profiling / semantic generation ─────────────────────────────────
+
+/**
+ * Profiling a datasource (or generating its semantic layer) failed.
+ *
+ * Raised by the `SemanticGenerator` service (Blocker #1 of the MCP V2
+ * datasource flagship, #3506) when a connection cannot be profiled into a
+ * queryable semantic layer: the connection yielded no tables, too many tables
+ * failed to profile (over the failure threshold, no `force`), or no profiler is
+ * registered for the requested `dbType`. `reason` is the machine-readable
+ * cause; `failedCount`/`totalCount` are forensic context for the
+ * threshold-breach case.
+ */
+export class ProfilingFailedError extends Data.TaggedError("ProfilingFailedError")<{
+  readonly message: string;
+  readonly reason: "no_tables" | "threshold_exceeded" | "unsupported_db_type" | "profiler_error";
+  readonly failedCount?: number;
+  readonly totalCount?: number;
+}> {}
+
 // ── Union type ──────────────────────────────────────────────────────
 
 /** Union of all known Atlas error types for exhaustive matching. */
@@ -939,6 +959,7 @@ export type AtlasError =
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
+  | ProfilingFailedError
   | PublishPhaseError
   | UnknownTableError
   | ExoticReadFilterUnavailableError
@@ -1017,6 +1038,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",
+  "ProfilingFailedError",
   "PublishPhaseError",
   "UnknownTableError",
   "ExoticReadFilterUnavailableError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -481,6 +481,16 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         code: "upstream_error",
         message: `Unknown content-mode table "${error.table}"`,
       };
+    // #3506 — a datasource could not be profiled into a queryable semantic
+    // layer (no tables, threshold breach, or unsupported dbType). The caller
+    // (CLI today, an MCP datasource tool in the flagship) supplied a
+    // connection that can't be made queryable, so 422 is the right surface.
+    case "ProfilingFailedError":
+      return {
+        status: 422,
+        code: "unprocessable_entity",
+        message: error.message,
+      };
     case "ExoticReadFilterUnavailableError":
       return {
         status: 500,

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -178,6 +178,20 @@ export {
   type AtlasToolkitShape,
 } from "./toolkit";
 
+// ── SemanticGenerator Service (#3506 — MCP V2 Blocker #1) ───────────
+
+export {
+  SemanticGenerator,
+  SemanticGeneratorLive,
+  createSemanticGeneratorTestLayer,
+  type SemanticGeneratorShape,
+  type DatasourceProfiler,
+  type ProfileConnectionOptions,
+  type ProfileConnectionResult,
+  type ProfileAndGenerateOptions,
+  type ProfileAndGenerateResult,
+} from "./semantic-generator";
+
 // ── SQL Client Service (native @effect/sql) ─────────────────────────
 
 export {

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -1,0 +1,341 @@
+/**
+ * SemanticGenerator — profile a datasource and generate its semantic layer.
+ *
+ * This is **Blocker #1** of the MCP V2 datasource flagship (#3506 / PRD #3483):
+ * the shared, API-callable seam that turns a live connection into a *queryable*
+ * semantic layer. Without it an MCP-created datasource is connected-but-
+ * unqueryable — empty table whitelist, no entities. Both the CLI (`atlas init`,
+ * via the pure {@link generateSemanticLayer} core) and a future long-running MCP
+ * datasource tool drive the same generation logic, so the two can never drift.
+ *
+ * The service composes three responsibilities:
+ *   1. **profile** — run the dialect profiler, enforce the failure threshold,
+ *      and apply the analysis heuristics, yielding analyzed `TableProfile`s.
+ *   2. **generate** — assemble entity/catalog/glossary/metric YAML (pure;
+ *      delegates to {@link generateSemanticLayer}).
+ *   3. **registerWhitelist** — make the generated tables queryable by populating
+ *      the in-memory table whitelist for a connection.
+ *
+ * `profileAndGenerate` ties all three together for a programmatic caller.
+ *
+ * **Profiler resolution (registry seam — ADR-0013 sibling).** Core profiles
+ * Postgres and MySQL directly (the two engines `@atlas/api` owns). Other
+ * dbTypes live in plugin packages that core must not import (ADR-0013), so the
+ * caller injects a {@link DatasourceProfiler} via `opts.profileFn`. This keeps
+ * THIS extraction scoped while pointing at the eventual registry-resolved
+ * profiler seam (PRD #3303) — when that lands, the registry supplies `profileFn`
+ * instead of the caller.
+ */
+
+import { Context, Effect, Layer } from "effect";
+import type {
+  DatabaseObject,
+  ProfileError,
+  ProfilingResult,
+  TableProfile,
+} from "@useatlas/types";
+import type { DBType } from "@atlas/api/lib/db/connection";
+import {
+  profilePostgres,
+  profileMySQL,
+  checkFailureThreshold,
+  type ProfileLogger,
+  type ProfileProgressCallbacks,
+} from "@atlas/api/lib/profiler";
+import {
+  analyzeTableProfiles,
+  generateSemanticLayer,
+  type GeneratedSemanticLayer,
+  type GenerateSemanticLayerOptions,
+} from "@atlas/api/lib/semantic/generate";
+import { registerPluginEntities } from "@atlas/api/lib/semantic/whitelist";
+import { createLogger } from "@atlas/api/lib/logger";
+import { ProfilingFailedError } from "./errors";
+
+const log = createLogger("effect:semantic-generator");
+
+// ── Profiler seam ────────────────────────────────────────────────────
+
+/**
+ * A function that profiles a single datasource into a {@link ProfilingResult}.
+ *
+ * Core resolves this for Postgres/MySQL; callers inject it for plugin dbTypes
+ * (ClickHouse, Snowflake, DuckDB, Salesforce, …) whose adapters core must not
+ * import (ADR-0013). The shape mirrors the core `profilePostgres`/`profileMySQL`
+ * signatures, normalized to a single options object.
+ */
+export type DatasourceProfiler = (args: {
+  url: string;
+  schema: string;
+  selectedTables?: string[];
+  prefetchedObjects?: DatabaseObject[];
+  progress?: ProfileProgressCallbacks;
+  logger?: ProfileLogger;
+}) => Promise<ProfilingResult>;
+
+// ── Option / result shapes ───────────────────────────────────────────
+
+/** Inputs for profiling one connection into analyzed profiles. */
+export interface ProfileConnectionOptions {
+  /** Connection string / URL for the datasource. */
+  url: string;
+  /** Datasource dialect. */
+  dbType: DBType;
+  /** Schema to profile (Postgres). Defaults to `"public"`. */
+  schema?: string;
+  /** Restrict profiling to these tables/views. Omit to profile all. */
+  selectedTables?: string[];
+  /** Pre-listed database objects (avoids a second catalog round-trip). */
+  prefetchedObjects?: DatabaseObject[];
+  /** Progress callbacks (e.g. a CLI progress bar). */
+  progress?: ProfileProgressCallbacks;
+  /** Structured logger for profiler diagnostics. */
+  logger?: ProfileLogger;
+  /** Continue past the failure-rate threshold instead of aborting. */
+  force?: boolean;
+  /**
+   * Profiler override for non-core dbTypes. Required for any dbType other than
+   * `postgres`/`mysql`; ignored (but honored if present) for those two.
+   */
+  profileFn?: DatasourceProfiler;
+}
+
+/** Outcome of {@link SemanticGeneratorShape.profile}. */
+export interface ProfileConnectionResult {
+  /** Profiles with analysis heuristics applied, ready for generation. */
+  profiles: TableProfile[];
+  /** Per-table profiling errors (below the abort threshold). */
+  errors: ProfileError[];
+  /** Wall-clock profiling duration in milliseconds. */
+  elapsedMs: number;
+}
+
+/** Inputs for the end-to-end profile → generate (→ register) flow. */
+export interface ProfileAndGenerateOptions extends ProfileConnectionOptions {
+  /**
+   * Connection-group identifier. Drives the entity `connection:` field and the
+   * whitelist key. Omit (or `"default"`) for the default group.
+   */
+  connectionId?: string;
+  /**
+   * Register the generated entity tables into the in-memory whitelist so the
+   * connection is immediately queryable. Defaults to `true`.
+   */
+  registerWhitelist?: boolean;
+}
+
+/** Outcome of {@link SemanticGeneratorShape.profileAndGenerate}. */
+export interface ProfileAndGenerateResult extends GeneratedSemanticLayer {
+  /** Analyzed profiles that produced the artifacts. */
+  profiles: TableProfile[];
+  /** Per-table profiling errors (below the abort threshold). */
+  errors: ProfileError[];
+  /** Wall-clock profiling duration in milliseconds. */
+  elapsedMs: number;
+}
+
+// ── Service interface ────────────────────────────────────────────────
+
+export interface SemanticGeneratorShape {
+  /**
+   * Profile a connection into analyzed `TableProfile`s. Fails with
+   * {@link ProfilingFailedError} when the connection yields no tables, breaches
+   * the failure threshold (without `force`), or has no profiler for its dbType.
+   */
+  readonly profile: (
+    opts: ProfileConnectionOptions,
+  ) => Effect.Effect<ProfileConnectionResult, ProfilingFailedError>;
+
+  /**
+   * Assemble semantic-layer artifacts from analyzed profiles. Pure — no I/O.
+   * (Same engine the CLI uses; see {@link generateSemanticLayer}.)
+   */
+  readonly generate: (
+    profiles: TableProfile[],
+    opts: GenerateSemanticLayerOptions,
+  ) => GeneratedSemanticLayer;
+
+  /**
+   * Register generated entity tables into the in-memory whitelist for a
+   * connection, making them queryable by `executeSQL`. No files are written.
+   */
+  readonly registerWhitelist: (
+    connectionId: string,
+    entities: ReadonlyArray<{ table: string; yaml: string }>,
+  ) => void;
+
+  /**
+   * Profile a connection, generate its semantic layer, and (by default)
+   * register the tables into the whitelist — the one-call programmatic entry
+   * point for an MCP datasource tool.
+   */
+  readonly profileAndGenerate: (
+    opts: ProfileAndGenerateOptions,
+  ) => Effect.Effect<ProfileAndGenerateResult, ProfilingFailedError>;
+}
+
+export class SemanticGenerator extends Context.Tag("SemanticGenerator")<
+  SemanticGenerator,
+  SemanticGeneratorShape
+>() {}
+
+// ── Implementation ───────────────────────────────────────────────────
+
+/** Resolve the profiler for a dbType: core for pg/mysql, injected otherwise. */
+function resolveProfiler(
+  dbType: DBType,
+  profileFn: DatasourceProfiler | undefined,
+): DatasourceProfiler | ProfilingFailedError {
+  if (profileFn) return profileFn;
+  if (dbType === "postgres") {
+    return ({ url, schema, selectedTables, prefetchedObjects, progress, logger }) =>
+      profilePostgres(url, selectedTables, prefetchedObjects, schema, progress, logger);
+  }
+  if (dbType === "mysql") {
+    return ({ url, selectedTables, prefetchedObjects, progress, logger }) =>
+      profileMySQL(url, selectedTables, prefetchedObjects, progress, logger);
+  }
+  return new ProfilingFailedError({
+    message:
+      `No profiler available for dbType "${dbType}". Core profiles postgres/mysql; ` +
+      `pass opts.profileFn to profile a plugin datasource.`,
+    reason: "unsupported_db_type",
+  });
+}
+
+function profileImpl(
+  opts: ProfileConnectionOptions,
+): Effect.Effect<ProfileConnectionResult, ProfilingFailedError> {
+  return Effect.gen(function* () {
+    const schema = opts.schema ?? "public";
+    const profiler = resolveProfiler(opts.dbType, opts.profileFn);
+    if (profiler instanceof ProfilingFailedError) {
+      return yield* Effect.fail(profiler);
+    }
+
+    const start = Date.now();
+    const result: ProfilingResult = yield* Effect.tryPromise({
+      try: () =>
+        profiler({
+          url: opts.url,
+          schema,
+          selectedTables: opts.selectedTables,
+          prefetchedObjects: opts.prefetchedObjects,
+          progress: opts.progress,
+          logger: opts.logger,
+        }),
+      catch: (err) =>
+        new ProfilingFailedError({
+          message: `Profiling failed: ${err instanceof Error ? err.message : String(err)}`,
+          reason: "profiler_error",
+        }),
+    });
+    const elapsedMs = Date.now() - start;
+
+    if (result.profiles.length === 0) {
+      return yield* Effect.fail(
+        new ProfilingFailedError({
+          message:
+            "No tables or views were successfully profiled. Check database " +
+            "permissions and that the schema is non-empty.",
+          reason: "no_tables",
+        }),
+      );
+    }
+
+    const { shouldAbort } = checkFailureThreshold(result, opts.force ?? false);
+    if (shouldAbort) {
+      const totalCount = result.profiles.length + result.errors.length;
+      return yield* Effect.fail(
+        new ProfilingFailedError({
+          message:
+            `Profiling failed for ${result.errors.length}/${totalCount} tables ` +
+            `(${Math.round((result.errors.length / totalCount) * 100)}%). ` +
+            `Pass force to continue anyway.`,
+          reason: "threshold_exceeded",
+          failedCount: result.errors.length,
+          totalCount,
+        }),
+      );
+    }
+
+    return {
+      profiles: analyzeTableProfiles(result.profiles),
+      errors: result.errors,
+      elapsedMs,
+    } satisfies ProfileConnectionResult;
+  });
+}
+
+function generateImpl(
+  profiles: TableProfile[],
+  opts: GenerateSemanticLayerOptions,
+): GeneratedSemanticLayer {
+  return generateSemanticLayer(profiles, opts);
+}
+
+function registerWhitelistImpl(
+  connectionId: string,
+  entities: ReadonlyArray<{ table: string; yaml: string }>,
+): void {
+  // The in-memory whitelist registration path keys tables by connection id and
+  // parses each entity's YAML with the same `EntityShape` validation as disk-
+  // and DB-backed entities. No files are written — the registration is the
+  // mechanism that makes a freshly-profiled connection queryable in-process.
+  registerPluginEntities(
+    connectionId,
+    entities.map((e) => ({ name: e.table, yaml: e.yaml })),
+  );
+}
+
+function profileAndGenerateImpl(
+  opts: ProfileAndGenerateOptions,
+): Effect.Effect<ProfileAndGenerateResult, ProfilingFailedError> {
+  return Effect.gen(function* () {
+    const { profiles, errors, elapsedMs } = yield* profileImpl(opts);
+
+    const connectionId = opts.connectionId ?? "default";
+    const sourceId = connectionId === "default" ? undefined : connectionId;
+    const generated = generateImpl(profiles, {
+      dbType: opts.dbType,
+      schema: opts.schema,
+      sourceId,
+    });
+
+    if (opts.registerWhitelist !== false) {
+      registerWhitelistImpl(connectionId, generated.entities);
+      log.info(
+        { connectionId, entityCount: generated.entities.length },
+        "Registered generated entities into the table whitelist",
+      );
+    }
+
+    return { ...generated, profiles, errors, elapsedMs } satisfies ProfileAndGenerateResult;
+  });
+}
+
+const service: SemanticGeneratorShape = {
+  profile: profileImpl,
+  generate: generateImpl,
+  registerWhitelist: registerWhitelistImpl,
+  profileAndGenerate: profileAndGenerateImpl,
+} satisfies SemanticGeneratorShape;
+
+// ── Layers ───────────────────────────────────────────────────────────
+
+/**
+ * Live layer for {@link SemanticGenerator}. The service holds no resources and
+ * opens its own short-lived pools through the dialect profilers, so a plain
+ * `Layer.succeed` suffices — no scope, no dependencies.
+ */
+export const SemanticGeneratorLive: Layer.Layer<SemanticGenerator> =
+  Layer.succeed(SemanticGenerator, service);
+
+/**
+ * Test layer for {@link SemanticGenerator}. Identical to the live layer (the
+ * service is deterministic and dependency-free); profiler behavior is injected
+ * per-call via `opts.profileFn`, so no `mock.module()` is needed.
+ */
+export function createSemanticGeneratorTestLayer(): Layer.Layer<SemanticGenerator> {
+  return Layer.succeed(SemanticGenerator, service);
+}

--- a/packages/api/src/lib/semantic/__tests__/generate-layer.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/generate-layer.test.ts
@@ -102,6 +102,27 @@ describe("generateSemanticLayer", () => {
     expect(() => yaml.load(result.glossary)).not.toThrow();
   });
 
+  it("derives traversal-safe filenames (basename) for entity and metric artifacts", () => {
+    // A profiler that yields a path-laden table name must not let the artifact
+    // filename escape the output directory when a caller path.joins it.
+    const evil = profile({
+      table_name: "../../etc/orders",
+      primary_key_columns: ["id"],
+      columns: [
+        col({ name: "id", type: "integer", is_primary_key: true }),
+        col({ name: "total", type: "numeric" }),
+      ],
+    });
+    const result = generateSemanticLayer([evil], { dbType: "postgres" });
+
+    // table: keeps the logical name; fileName: is sanitized to a bare basename.
+    expect(result.entities[0].table).toBe("../../etc/orders");
+    expect(result.entities[0].fileName).toBe("orders.yml");
+    expect(result.entities[0].fileName).not.toContain("/");
+    expect(result.metrics[0].fileName).toBe("orders.yml");
+    expect(result.metrics[0].fileName).not.toContain("/");
+  });
+
   it("emits a metric only for measure-bearing tables (views/measureless omitted)", () => {
     // `orders` has a numeric non-key column → measure; `customers` has none;
     // a view yields no metric.

--- a/packages/api/src/lib/semantic/__tests__/generate-layer.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/generate-layer.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `generateSemanticLayer` — the shared semantic-layer assembly (#3506).
+ *
+ * The per-function YAML correctness lives in the profiler/generate suites; this
+ * file proves the *assembly* contract the CLI and the `SemanticGenerator`
+ * service both depend on: one entity per profile (in order), catalog + glossary
+ * present, one metric per measure-bearing profile (views/measureless omitted),
+ * filenames derived from the table name, and dialect/schema/sourceId threaded
+ * through to the underlying generators.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { TableProfile, ColumnProfile } from "@useatlas/types";
+import * as yaml from "js-yaml";
+import { analyzeTableProfiles } from "../generate";
+import { generateSemanticLayer } from "../generate/layer";
+import { generateEntityYAML } from "../generate/yaml";
+
+function col(
+  over: Partial<ColumnProfile> & Pick<ColumnProfile, "name" | "type">,
+): ColumnProfile {
+  return {
+    name: over.name,
+    type: over.type,
+    nullable: over.nullable ?? false,
+    unique_count: over.unique_count ?? null,
+    null_count: over.null_count ?? null,
+    sample_values: over.sample_values ?? [],
+    is_primary_key: over.is_primary_key ?? false,
+    is_foreign_key: over.is_foreign_key ?? false,
+    fk_target_table: over.fk_target_table ?? null,
+    fk_target_column: over.fk_target_column ?? null,
+    is_enum_like: over.is_enum_like ?? false,
+    profiler_notes: over.profiler_notes ?? [],
+    ...(over.semantic_type ? { semantic_type: over.semantic_type } : {}),
+  };
+}
+
+function profile(
+  over: Partial<TableProfile> & Pick<TableProfile, "table_name">,
+): TableProfile {
+  return {
+    table_name: over.table_name,
+    object_type: over.object_type ?? "table",
+    row_count: over.row_count ?? 100,
+    columns: over.columns ?? [],
+    primary_key_columns: over.primary_key_columns ?? [],
+    foreign_keys: over.foreign_keys ?? [],
+    inferred_foreign_keys: over.inferred_foreign_keys ?? [],
+    profiler_notes: over.profiler_notes ?? [],
+    table_flags: over.table_flags ?? {
+      possibly_abandoned: false,
+      possibly_denormalized: false,
+    },
+  };
+}
+
+const orders = profile({
+  table_name: "orders",
+  primary_key_columns: ["id"],
+  columns: [
+    col({ name: "id", type: "integer", is_primary_key: true }),
+    col({ name: "total", type: "numeric" }),
+    col({ name: "status", type: "text", is_enum_like: true, sample_values: ["paid", "pending"] }),
+  ],
+});
+
+const customers = profile({
+  table_name: "customers",
+  primary_key_columns: ["id"],
+  columns: [
+    col({ name: "id", type: "integer", is_primary_key: true }),
+    col({ name: "email", type: "text" }),
+  ],
+});
+
+const ordersView = profile({
+  table_name: "orders_summary",
+  object_type: "view",
+  columns: [col({ name: "id", type: "integer" }), col({ name: "total", type: "numeric" })],
+});
+
+describe("generateSemanticLayer", () => {
+  it("emits one entity per profile, preserving order", () => {
+    const result = generateSemanticLayer([orders, customers], { dbType: "postgres" });
+
+    expect(result.entities.map((e) => e.table)).toEqual(["orders", "customers"]);
+    expect(result.entities.map((e) => e.fileName)).toEqual(["orders.yml", "customers.yml"]);
+    for (const entity of result.entities) {
+      expect(entity.yaml.length).toBeGreaterThan(0);
+      // Round-trips as valid YAML with the expected table.
+      const parsed = yaml.load(entity.yaml) as { table?: string };
+      expect(parsed.table).toBe(entity.table);
+    }
+  });
+
+  it("includes catalog and glossary", () => {
+    const result = generateSemanticLayer([orders, customers], { dbType: "postgres" });
+    expect(result.catalog.length).toBeGreaterThan(0);
+    expect(result.glossary.length).toBeGreaterThan(0);
+    expect(() => yaml.load(result.catalog)).not.toThrow();
+    expect(() => yaml.load(result.glossary)).not.toThrow();
+  });
+
+  it("emits a metric only for measure-bearing tables (views/measureless omitted)", () => {
+    // `orders` has a numeric non-key column → measure; `customers` has none;
+    // a view yields no metric.
+    const result = generateSemanticLayer([orders, customers, ordersView], {
+      dbType: "postgres",
+    });
+    expect(result.metrics.map((m) => m.table)).toEqual(["orders"]);
+    expect(result.metrics[0].fileName).toBe("orders.yml");
+  });
+
+  it("threads dbType, schema, and sourceId through to the entity generator", () => {
+    const withSource = generateSemanticLayer([orders], {
+      dbType: "postgres",
+      schema: "analytics",
+      sourceId: "warehouse",
+    });
+    const direct = generateEntityYAML(orders, [orders], "postgres", "analytics", "warehouse");
+    expect(withSource.entities[0].yaml).toBe(direct);
+
+    const parsed = yaml.load(withSource.entities[0].yaml) as {
+      group?: string;
+      table?: string;
+    };
+    expect(parsed.group).toBe("warehouse");
+    // schema qualification appears in the entity's `table:` for postgres.
+    expect(parsed.table).toContain("analytics");
+  });
+
+  it("defaults schema to public and omits the group field for the default group", () => {
+    const result = generateSemanticLayer([orders], { dbType: "postgres" });
+    const parsed = yaml.load(result.entities[0].yaml) as {
+      group?: string;
+      table?: string;
+    };
+    expect(parsed.group).toBeUndefined();
+  });
+
+  it("matches the legacy inlined loop byte-for-byte (golden reference)", () => {
+    // The CLI previously inlined this exact loop; the shared core must produce
+    // identical bytes so `atlas init` output never drifts.
+    const analyzed = analyzeTableProfiles([orders, customers]);
+    const result = generateSemanticLayer(analyzed, { dbType: "postgres", schema: "public" });
+    for (const entity of result.entities) {
+      const expected = generateEntityYAML(
+        analyzed.find((p) => p.table_name === entity.table)!,
+        analyzed,
+        "postgres",
+        "public",
+        undefined,
+      );
+      expect(entity.yaml).toBe(expected);
+    }
+  });
+});

--- a/packages/api/src/lib/semantic/generate/index.ts
+++ b/packages/api/src/lib/semantic/generate/index.ts
@@ -28,3 +28,10 @@ export {
   generateMetricYAML,
   generateGlossaryYAML,
 } from "./yaml";
+
+export {
+  generateSemanticLayer,
+  type GeneratedArtifact,
+  type GeneratedSemanticLayer,
+  type GenerateSemanticLayerOptions,
+} from "./layer";

--- a/packages/api/src/lib/semantic/generate/layer.ts
+++ b/packages/api/src/lib/semantic/generate/layer.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared semantic-layer assembly — one engine, every caller.
+ *
+ * `generateSemanticLayer` turns an array of **already-analyzed** `TableProfile`s
+ * into the full set of in-memory semantic-layer artifacts (entity YAMLs, the
+ * catalog, the glossary, and per-table metric YAMLs) without touching the
+ * filesystem. Callers decide where the bytes land:
+ *
+ *  - the CLI (`atlas init`) writes them to `semantic/.../` on disk;
+ *  - the `SemanticGenerator` Effect service (Blocker #1, #3506) returns them to
+ *    a programmatic / MCP caller and registers their tables into the whitelist.
+ *
+ * Before this module the entity/catalog/glossary/metric loop was hand-inlined
+ * in three places (CLI SQL path, CLI CSV/Parquet path, the web wizard), so the
+ * filename + ordering conventions could silently drift. Centralizing the
+ * assembly keeps "what each caller produces" identical by construction.
+ *
+ * Pure + deterministic: it composes the existing `generate*` functions
+ * (`./yaml`) and performs no I/O, no LLM, no DB access. It expects profiles to
+ * have already passed through {@link analyzeTableProfiles} (the heuristics that
+ * populate inferred FKs, table flags, enum detection) — generation does not
+ * re-run them.
+ */
+
+import type { TableProfile } from "@useatlas/types";
+import type { DBType } from "@atlas/api/lib/db/connection";
+import {
+  generateEntityYAML,
+  generateCatalogYAML,
+  generateGlossaryYAML,
+  generateMetricYAML,
+} from "./yaml";
+
+/** A single generated YAML artifact and the filename callers should write it to. */
+export interface GeneratedArtifact {
+  /** Logical table name the artifact describes (e.g. `orders`, `public.orders`). */
+  table: string;
+  /** Suggested filename, e.g. `orders.yml`. */
+  fileName: string;
+  /** Rendered YAML content. */
+  yaml: string;
+}
+
+/** The complete set of semantic-layer artifacts for one datasource. */
+export interface GeneratedSemanticLayer {
+  /** One entity YAML per profile, in profile order. */
+  entities: GeneratedArtifact[];
+  /** `catalog.yml` content. */
+  catalog: string;
+  /** `glossary.yml` content. */
+  glossary: string;
+  /**
+   * One metric YAML per profile that yields measures, in profile order.
+   * Profiles for which {@link generateMetricYAML} returns `null` (views,
+   * no numeric columns) are omitted — mirroring the CLI's existing behavior.
+   */
+  metrics: GeneratedArtifact[];
+}
+
+/** Options controlling how the semantic layer is rendered. */
+export interface GenerateSemanticLayerOptions {
+  /** Datasource dialect — drives type mapping and `FROM` qualification. */
+  dbType: DBType;
+  /** Schema used to qualify table names. Defaults to `"public"`. */
+  schema?: string;
+  /**
+   * Connection-group identifier emitted as the entity `connection:` field.
+   * Omit (or pass `undefined`) for the default group, which emits no field.
+   */
+  sourceId?: string;
+}
+
+/**
+ * Assemble the full semantic layer for a set of analyzed profiles.
+ *
+ * @param profiles - Analyzed `TableProfile`s (post-{@link analyzeTableProfiles}).
+ * @param opts - Dialect, schema, and connection-group context.
+ * @returns In-memory entity/catalog/glossary/metric artifacts. No I/O.
+ */
+export function generateSemanticLayer(
+  profiles: TableProfile[],
+  opts: GenerateSemanticLayerOptions,
+): GeneratedSemanticLayer {
+  const schema = opts.schema ?? "public";
+
+  const entities: GeneratedArtifact[] = profiles.map((profile) => ({
+    table: profile.table_name,
+    fileName: `${profile.table_name}.yml`,
+    yaml: generateEntityYAML(profile, profiles, opts.dbType, schema, opts.sourceId),
+  }));
+
+  const catalog = generateCatalogYAML(profiles);
+  const glossary = generateGlossaryYAML(profiles);
+
+  const metrics: GeneratedArtifact[] = [];
+  for (const profile of profiles) {
+    const metricYaml = generateMetricYAML(profile, schema, opts.dbType);
+    if (metricYaml) {
+      metrics.push({
+        table: profile.table_name,
+        fileName: `${profile.table_name}.yml`,
+        yaml: metricYaml,
+      });
+    }
+  }
+
+  return { entities, catalog, glossary, metrics };
+}

--- a/packages/api/src/lib/semantic/generate/layer.ts
+++ b/packages/api/src/lib/semantic/generate/layer.ts
@@ -22,6 +22,7 @@
  * re-run them.
  */
 
+import path from "node:path";
 import type { TableProfile } from "@useatlas/types";
 import type { DBType } from "@atlas/api/lib/db/connection";
 import {
@@ -31,11 +32,28 @@ import {
   generateMetricYAML,
 } from "./yaml";
 
+/**
+ * Derive the on-disk filename for a table's artifact, stripping any path
+ * components a table name might smuggle in. Callers write `fileName` straight
+ * into `path.join(dir, fileName)`, so sanitizing here makes the field
+ * traversal-safe by construction for *every* caller (the CLI profiles a trusted
+ * local DB; a future MCP datasource tool profiles caller-supplied connections).
+ * `path.basename` leaves ordinary identifiers — including dotted ones like
+ * `public.orders` — untouched.
+ */
+function artifactFileName(tableName: string): string {
+  return `${path.basename(tableName)}.yml`;
+}
+
 /** A single generated YAML artifact and the filename callers should write it to. */
 export interface GeneratedArtifact {
   /** Logical table name the artifact describes (e.g. `orders`, `public.orders`). */
   table: string;
-  /** Suggested filename, e.g. `orders.yml`. */
+  /**
+   * Filename to write the artifact to, e.g. `orders.yml`. Path-component-safe
+   * by construction (`path.basename`), so callers can `path.join` it directly
+   * without re-sanitizing.
+   */
   fileName: string;
   /** Rendered YAML content. */
   yaml: string;
@@ -85,7 +103,7 @@ export function generateSemanticLayer(
 
   const entities: GeneratedArtifact[] = profiles.map((profile) => ({
     table: profile.table_name,
-    fileName: `${profile.table_name}.yml`,
+    fileName: artifactFileName(profile.table_name),
     yaml: generateEntityYAML(profile, profiles, opts.dbType, schema, opts.sourceId),
   }));
 
@@ -98,7 +116,7 @@ export function generateSemanticLayer(
     if (metricYaml) {
       metrics.push({
         table: profile.table_name,
-        fileName: `${profile.table_name}.yml`,
+        fileName: artifactFileName(profile.table_name),
         yaml: metricYaml,
       });
     }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -27,13 +27,13 @@ import {
   listMySQLObjects,
 } from "@atlas/api/lib/profiler";
 // Mechanical generation runs through the shared semantic engine (issue #3233)
-// so the CLI and the web wizard emit identical YAML.
+// so the CLI and the web wizard emit identical YAML. The full entity / catalog /
+// glossary / metric assembly is delegated to `generateSemanticLayer` — the same
+// shared core the `SemanticGenerator` service uses (Blocker #1, #3506) — so the
+// CLI and a future MCP datasource tool can never drift.
 import {
   analyzeTableProfiles,
-  generateEntityYAML,
-  generateCatalogYAML,
-  generateMetricYAML,
-  generateGlossaryYAML,
+  generateSemanticLayer,
 } from "@atlas/api/lib/semantic/generate";
 import {
   createProgressTracker,
@@ -746,48 +746,39 @@ async function profileDatasource(
     }
   }
 
-  // Generate entity YAMLs
+  // Generate the full semantic layer through the shared engine, then write
+  // the in-memory artifacts to disk. The CLI owns the file I/O and console UX;
+  // `generateSemanticLayer` owns the YAML assembly (same engine as the
+  // SemanticGenerator service — #3506).
   console.log(`\nGenerating semantic layer...\n`);
 
-  for (const profile of profiles) {
-    const filePath = path.join(
-      entitiesOutDir,
-      `${profile.table_name}.yml`,
-    );
-    fs.writeFileSync(
-      filePath,
-      generateEntityYAML(
-        profile,
-        profiles,
-        dbType,
-        schemaArg,
-        sourceId,
-      ),
-    );
+  const generated = generateSemanticLayer(profiles, {
+    dbType,
+    schema: schemaArg,
+    sourceId,
+  });
+
+  for (const entity of generated.entities) {
+    const filePath = path.join(entitiesOutDir, entity.fileName);
+    fs.writeFileSync(filePath, entity.yaml);
     console.log(`  wrote ${filePath}`);
   }
 
   // Generate catalog
   const catalogPath = path.join(outputBase, "catalog.yml");
-  fs.writeFileSync(catalogPath, generateCatalogYAML(profiles));
+  fs.writeFileSync(catalogPath, generated.catalog);
   console.log(`  wrote ${catalogPath}`);
 
   // Generate glossary
   const glossaryPath = path.join(outputBase, "glossary.yml");
-  fs.writeFileSync(glossaryPath, generateGlossaryYAML(profiles));
+  fs.writeFileSync(glossaryPath, generated.glossary);
   console.log(`  wrote ${glossaryPath}`);
 
   // Generate metric files per table
-  for (const profile of profiles) {
-    const metricYaml = generateMetricYAML(profile, schemaArg, dbType);
-    if (metricYaml) {
-      const filePath = path.join(
-        metricsOutDir,
-        `${profile.table_name}.yml`,
-      );
-      fs.writeFileSync(filePath, metricYaml);
-      console.log(`  wrote ${filePath}`);
-    }
+  for (const metric of generated.metrics) {
+    const filePath = path.join(metricsOutDir, metric.fileName);
+    fs.writeFileSync(filePath, metric.yaml);
+    console.log(`  wrote ${filePath}`);
   }
 
   // Overlay hand-crafted semantic files with richer descriptions for the demo dataset
@@ -1060,42 +1051,30 @@ export async function handleInit(args: string[]): Promise<void> {
 
     // DuckDB uses PostgreSQL-compatible SQL — "public" schema is not meaningful
     const duckSchema = "main";
-    for (const profile of profiles) {
-      const filePath = path.join(
-        entitiesOutDir,
-        `${profile.table_name}.yml`,
-      );
-      fs.writeFileSync(
-        filePath,
-        generateEntityYAML(
-          profile,
-          profiles,
-          "duckdb" as DBType,
-          duckSchema,
-          sourceArg,
-        ),
-      );
+    const generated = generateSemanticLayer(profiles, {
+      dbType: "duckdb" as DBType,
+      schema: duckSchema,
+      sourceId: sourceArg,
+    });
+
+    for (const entity of generated.entities) {
+      const filePath = path.join(entitiesOutDir, entity.fileName);
+      fs.writeFileSync(filePath, entity.yaml);
       console.log(`  wrote ${filePath}`);
     }
 
     const catalogPath = path.join(outputBase, "catalog.yml");
-    fs.writeFileSync(catalogPath, generateCatalogYAML(profiles));
+    fs.writeFileSync(catalogPath, generated.catalog);
     console.log(`  wrote ${catalogPath}`);
 
     const glossaryPath = path.join(outputBase, "glossary.yml");
-    fs.writeFileSync(glossaryPath, generateGlossaryYAML(profiles));
+    fs.writeFileSync(glossaryPath, generated.glossary);
     console.log(`  wrote ${glossaryPath}`);
 
-    for (const profile of profiles) {
-      const metricYaml = generateMetricYAML(profile, duckSchema, "duckdb" as DBType);
-      if (metricYaml) {
-        const filePath = path.join(
-          metricsOutDir,
-          `${profile.table_name}.yml`,
-        );
-        fs.writeFileSync(filePath, metricYaml);
-        console.log(`  wrote ${filePath}`);
-      }
+    for (const metric of generated.metrics) {
+      const filePath = path.join(metricsOutDir, metric.fileName);
+      fs.writeFileSync(filePath, metric.yaml);
+      console.log(`  wrote ${filePath}`);
     }
 
     const duckDbUrl = `duckdb://${dbPath}`;


### PR DESCRIPTION
## What &amp; why

Extracts the DB-profiling + semantic-layer-generation logic from the CLI `atlas init` path into a shared, API-callable seam so **both** the CLI and a future MCP datasource tool can profile a connection and generate a *queryable* semantic layer.

This is **Blocker #1** of the MCP V2 datasource flagship (PRD #3483 / Phase 3.1, #3506): without it an MCP-created datasource is connected-but-unqueryable — empty table whitelist, no entities. **No behavior change to the CLI.**

Closes #3506. Unblocks #3511–#3514.

## How

Two layers, one engine:

- **Pure core — `generateSemanticLayer`** (`lib/semantic/generate/layer.ts`). Turns analyzed `TableProfile[]` into the full set of in-memory artifacts (entity / catalog / glossary / metric YAML) with no I/O. The CLI's SQL and CSV/Parquet paths now delegate to it instead of hand-inlining the entity/catalog/glossary/metric loop. Output is **byte-identical** — same filenames, same order, same content, same `wrote …` logs.

- **Effect service — `SemanticGenerator`** (`lib/effect/semantic-generator.ts`). Wraps profiling (failure-threshold + analysis heuristics) + generation + whitelist population:
  - `profile` — run the dialect profiler → analyzed profiles (or `ProfilingFailedError`).
  - `generate` — pure assembly (delegates to the shared core).
  - `registerWhitelist` — make the generated tables queryable in-process.
  - `profileAndGenerate` — the one-call programmatic entry point an MCP datasource tool will drive: profile → generate → register whitelist.

### Profiler resolution = registry seam (ADR-0013 sibling)

Core profiles **postgres/mysql** directly (the two engines `@atlas/api` owns). Other dbTypes live in plugin packages core must not import (ADR-0013), so the caller injects a `DatasourceProfiler` via `opts.profileFn`. This keeps the extraction scoped while pointing at the eventual registry-resolved profiler seam (PRD #3303) — when that lands, the registry supplies `profileFn` instead of the caller. No multi-datasource profiler registry is pulled in here.

### Error surface

New `ProfilingFailedError` tagged error wired into the exhaustive `mapTaggedError` switch + `ATLAS_ERROR_TAG_LIST` → **422 unprocessable_entity** (the caller supplied a connection that can't be made queryable). No route consumes it yet; the mapping is in place for the MCP tool phase.

### Web wizard consolidated onto the same seam

The web wizard's `/save` route (`api/routes/wizard.ts`) previously hand-inlined the same catalog/glossary/metric loop. It now delegates to `generateSemanticLayer`, so the CLI, the wizard, and the `SemanticGenerator` service share one assembly engine and can't drift. Entities remain frontend-supplied (only catalog/glossary/metric artifacts are consumed here), and the metric write **keeps the wizard's path-traversal guard for untrusted HTTP profiles** — unsafe table names are skipped (`SAFE_TABLE_NAME`) and the filename is re-sanitized with `path.basename`. Byte-identical to the prior loop; covered by the existing `wizard.test.ts` + `admin-wizard-save-audit.test.ts` suites.

## Tests (independent of the CLI)

- `lib/semantic/__tests__/generate-layer.test.ts` — pure-core assembly contract + a golden-reference check that the shared core matches the legacy inlined loop byte-for-byte.
- `lib/effect/__tests__/semantic-generator.test.ts` — service end-to-end via injected `profileFn` (no `mock.module`, no live DB): profile/threshold/unsupported-dbType/profiler-error failure modes, and the integration assertion that **`profileAndGenerate` populates the real table whitelist** so a freshly-profiled connection becomes queryable (read through the production `whitelist` module).

## CI

`/ci` — lint, type, full test suite, syncpack, template / schema / openapi / security-headers / railway-watch / oauth-helper drift, test-discipline, settings-readers, twenty-resolver, published-symbols — **all green**.

https://claude.ai/code/session_01VSymS6PRgYmwPECgzoXPp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSymS6PRgYmwPECgzoXPp6)_