### PR TITLE
feat(mcp): structured logging for the standalone MCP process (#3494)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -301,6 +301,7 @@
         "effect": "^3.21.2",
         "hono": "^4.12.23",
         "js-yaml": "^4.2.0",
+        "pino": "^10.3.1",
       },
       "devDependencies": {
         "@better-auth/oauth-provider": "^1.6.16",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,7 +31,8 @@
     "better-auth": "^1.6.16",
     "effect": "^3.21.2",
     "hono": "^4.12.23",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "@better-auth/oauth-provider": "^1.6.16",

--- a/packages/mcp/src/__tests__/logger.test.ts
+++ b/packages/mcp/src/__tests__/logger.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Wire-shape tests for the MCP structured logger (#3494).
+ *
+ * Asserts the external behavior an operator's log aggregator sees: a line
+ * emitted inside an MCP dispatch is structured JSON carrying the dispatch's
+ * `requestId`, `toolName`, and (hosted) `clientId`, credential-bearing
+ * fields are redacted, and lines emitted outside any request context omit
+ * the correlation keys. We pipe a logger built from the *same*
+ * `mcpLoggerOptions` to an in-memory stream rather than intercepting fd 2 —
+ * the fd binding is a trivial one-liner; the mixin + redaction are the
+ * contract worth testing.
+ */
+
+import { describe, test, expect } from "bun:test";
+import pino from "pino";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { mcpLoggerOptions } from "../logger";
+
+/** Build a logger over an in-memory stream that collects parsed JSON records. */
+function captureLogger() {
+  const records: Record<string, unknown>[] = [];
+  const stream = {
+    write(chunk: string) {
+      records.push(JSON.parse(chunk) as Record<string, unknown>);
+    },
+  };
+  const logger = pino(mcpLoggerOptions, stream).child({ component: "mcp:test" });
+  return { logger, records };
+}
+
+describe("mcp logger", () => {
+  test("emits structured JSON with the component tag", () => {
+    const { logger, records } = captureLogger();
+    logger.warn("boom");
+    expect(records).toHaveLength(1);
+    expect(records[0].component).toBe("mcp:test");
+    expect(records[0].msg).toBe("boom");
+    // Structured, not a raw `[atlas-mcp] ...` string line.
+    expect(typeof records[0].level).toBe("number");
+  });
+
+  test("carries requestId + toolName + clientId from an MCP dispatch context", () => {
+    const { logger, records } = captureLogger();
+    withRequestContext(
+      {
+        requestId: "mcp-executeSQL-123",
+        actor: { kind: "mcp", toolName: "executeSQL", clientId: "claude-desktop" },
+      },
+      () => {
+        logger.error("executeSQL tool threw");
+      },
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].requestId).toBe("mcp-executeSQL-123");
+    expect(records[0].toolName).toBe("executeSQL");
+    expect(records[0].clientId).toBe("claude-desktop");
+  });
+
+  test("omits clientId for a stdio (unbound) MCP dispatch", () => {
+    const { logger, records } = captureLogger();
+    withRequestContext(
+      { requestId: "mcp-explore-9", actor: { kind: "mcp", toolName: "explore" } },
+      () => {
+        logger.info("explore done");
+      },
+    );
+    expect(records[0].requestId).toBe("mcp-explore-9");
+    expect(records[0].toolName).toBe("explore");
+    expect(records[0]).not.toHaveProperty("clientId");
+  });
+
+  test("omits correlation keys when emitted outside a request context", () => {
+    const { logger, records } = captureLogger();
+    logger.info("boot");
+    expect(records[0]).not.toHaveProperty("requestId");
+    expect(records[0]).not.toHaveProperty("toolName");
+  });
+
+  test("redacts credential-bearing fields so secrets never reach the log sink", () => {
+    const { logger, records } = captureLogger();
+    logger.warn({ password: "hunter2", token: "sk-secret", safe: "ok" }, "blocked");
+    expect(records[0].password).toBe("[Redacted]");
+    expect(records[0].token).toBe("[Redacted]");
+    expect(records[0].safe).toBe("ok");
+  });
+
+  test("scrubs a connection-string URI echoed through the err serializer", () => {
+    const { logger, records } = captureLogger();
+    logger.error(
+      { err: new Error("connect failed: postgres://user:s3cret@db.internal/app") },
+      "dispatch failed",
+    );
+    const serialized = JSON.stringify(records[0]);
+    expect(serialized).not.toContain("s3cret");
+  });
+});

--- a/packages/mcp/src/__tests__/no-raw-stderr.test.ts
+++ b/packages/mcp/src/__tests__/no-raw-stderr.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Structural guard (#3494): no production MCP module writes raw diagnostic
+ * strings to `process.stderr` — every diagnostic site goes through the
+ * structured `createMcpLogger` (stderr, JSON, requestId-correlated) instead.
+ *
+ * Mirrors the surface-stamper guard the PRD (#3483) references: it encodes
+ * the acceptance criterion as a test so the class of regression ("someone
+ * adds a `process.stderr.write` back") can't slip past CI.
+ *
+ * Excluded:
+ * - `__tests__/` — test scaffolding may capture/emit freely.
+ * - `eval/` — the offline eval harness, not a served diagnostic path.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { Glob } from "bun";
+import { readFileSync } from "node:fs";
+import { resolve, relative } from "node:path";
+
+const SRC = resolve(import.meta.dir, "..");
+
+describe("no raw stderr diagnostics in production MCP modules", () => {
+  test("process.stderr.write appears in no served module", async () => {
+    const glob = new Glob("**/*.ts");
+    const offenders: string[] = [];
+    for await (const path of glob.scan({ cwd: SRC, absolute: true })) {
+      const rel = relative(SRC, path);
+      if (rel.startsWith("__tests__/") || rel.startsWith("eval/")) continue;
+      const source = readFileSync(path, "utf8");
+      if (source.includes("process.stderr.write")) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/mcp/src/__tests__/prompts/registry.test.ts
+++ b/packages/mcp/src/__tests__/prompts/registry.test.ts
@@ -51,8 +51,11 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingAuto: (key: string, _orgId?: string) => mockSettings[key],
 }));
 
-mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({
+// The prompts chain (registry → gating / listing / canonical) logs via the
+// MCP stderr logger (#3494). Stub it so the suite stays quiet and never
+// pulls the real pino-to-fd-2 sink into the test process.
+mock.module("../../logger", () => ({
+  createMcpLogger: () => ({
     info: () => {},
     warn: () => {},
     error: () => {},

--- a/packages/mcp/src/billing-gate.ts
+++ b/packages/mcp/src/billing-gate.ts
@@ -30,6 +30,9 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
 import { envelope, toEnvelopeResult } from "./error-envelope.js";
+import { createMcpLogger } from "./logger.js";
+
+const log = createMcpLogger("mcp:billing-gate");
 
 const BILLING_BLOCKED_HINT =
   "Retrying will not help. The workspace owner must resolve the workspace's billing or suspension status in Atlas before queries can run.";
@@ -52,8 +55,16 @@ export async function billingGateOrNull(args: {
   const gate = await checkAgentBillingGate(args.orgId);
   if (gate.allowed) return null;
 
-  process.stderr.write(
-    `[atlas-mcp] dispatch blocked by billing enforcement [${gate.errorCode}] (request ${args.requestId})\n`,
+  // Carry orgId / requestId / errorCode explicitly so a billing-block line
+  // is self-describing in the aggregator even though the mixin would also
+  // stamp requestId from the dispatch context (#3494).
+  log.warn(
+    {
+      orgId: args.orgId,
+      requestId: args.requestId,
+      errorCode: gate.errorCode,
+    },
+    "dispatch blocked by billing enforcement",
   );
 
   if (gate.errorCode === "workspace_throttled") {

--- a/packages/mcp/src/logger.ts
+++ b/packages/mcp/src/logger.ts
@@ -1,0 +1,76 @@
+/**
+ * Structured logging for the standalone MCP process (#3494).
+ *
+ * The shared `@atlas/api` logger (`createLogger`) writes to **stdout**,
+ * which on the MCP stdio transport carries the JSON-RPC stream — a stray log
+ * line there corrupts the protocol. This module reuses that logger's
+ * redaction paths, error scrubber, and URL-credential formatter but pins the
+ * destination to **fd 2 (stderr)**, the transport-safe diagnostic channel
+ * for both the stdio and SSE transports. Output is structured JSON (no
+ * pino-pretty worker) so an operator's log aggregator can parse it and a
+ * pretty transport can never accidentally reclaim stdout.
+ *
+ * `requestId` / actor correlation is automatic: every MCP tool dispatch
+ * wraps its handler in `withRequestContext({ requestId, actor, ... })` (see
+ * `tools.ts` / `semantic-tools.ts`), so a log line emitted inside a dispatch
+ * carries that dispatch's `requestId`, `toolName`, and (hosted) OAuth
+ * `clientId` via the mixin below — the caller never threads them by hand.
+ *
+ * We deliberately keep pino/OTel rather than adopting the MCP `logging`
+ * capability (deprecated in the 2026-07-28 draft). See PRD #3483.
+ */
+
+import pino from "pino";
+import {
+  redactPaths,
+  scrubErrSerializer,
+  scrubLogFormatter,
+  getRequestContext,
+} from "@atlas/api/lib/logger";
+
+/**
+ * Pino options shared by the production stderr logger and test loggers.
+ *
+ * Exported so a test can pipe an identical logger to an in-memory capture
+ * stream and assert the wire shape (mixin fields + redaction) without
+ * intercepting fd 2 — the fd binding itself is a one-liner below and not
+ * worth a fixture.
+ */
+export const mcpLoggerOptions: pino.LoggerOptions = {
+  level: process.env.ATLAS_LOG_LEVEL ?? "info",
+  redact: redactPaths,
+  serializers: { err: scrubErrSerializer },
+  formatters: { log: scrubLogFormatter },
+  mixin() {
+    const ctx = getRequestContext();
+    if (!ctx) return {};
+    const base: Record<string, unknown> = { requestId: ctx.requestId };
+    // The MCP dispatch actor carries the tool name (and, hosted, the OAuth
+    // client id). Threading them onto every line is what makes a tool
+    // failure traceable to a specific client + tool in a log aggregator.
+    const actor = ctx.actor;
+    if (actor?.kind === "mcp") {
+      base.toolName = actor.toolName;
+      if (actor.clientId) base.clientId = actor.clientId;
+    }
+    return base;
+  },
+};
+
+// `sync: true` — diagnostics are low-volume and a short-lived stdio process
+// may exit (or crash) before an async buffer flushes; synchronous writes
+// guarantee the line reaches the operator's terminal / aggregator, matching
+// the reliability the raw stderr writes / `console.error` calls had.
+const rootLogger = pino(
+  mcpLoggerOptions,
+  pino.destination({ dest: 2, sync: true }),
+);
+
+/**
+ * Create a named child logger for an MCP component. `requestId` / actor
+ * context is injected at log-emission time via the mixin — safe to call at
+ * module scope.
+ */
+export function createMcpLogger(component: string): pino.Logger {
+  return rootLogger.child({ component });
+}

--- a/packages/mcp/src/prompts/canonical.ts
+++ b/packages/mcp/src/prompts/canonical.ts
@@ -34,6 +34,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
+import { createMcpLogger } from "../logger.js";
+
+const log = createMcpLogger("mcp:prompts:canonical");
 
 export const CANONICAL_PROMPT_PREFIX = "canonical-";
 
@@ -149,8 +152,9 @@ export function loadCanonicalPrompts(
   const filePath = opts?.path ?? getCanonicalQuestionsPath();
 
   if (!fs.existsSync(filePath)) {
-    process.stderr.write(
-      `[atlas-mcp] canonical questions file not found at ${filePath} — skipping canonical prompts\n`,
+    log.warn(
+      { filePath },
+      "canonical questions file not found — skipping canonical prompts",
     );
     return [];
   }
@@ -159,8 +163,9 @@ export function loadCanonicalPrompts(
   try {
     content = fs.readFileSync(filePath, "utf8");
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] Failed to read canonical questions: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), filePath },
+      "Failed to read canonical questions",
     );
     return [];
   }
@@ -169,22 +174,25 @@ export function loadCanonicalPrompts(
   try {
     parsed = yaml.load(content);
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] Failed to parse canonical questions YAML: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), filePath },
+      "Failed to parse canonical questions YAML",
     );
     return [];
   }
 
   if (!parsed || typeof parsed !== "object") {
-    process.stderr.write(
-      `[atlas-mcp] canonical questions YAML did not parse to an object at ${filePath} — skipping\n`,
+    log.warn(
+      { filePath },
+      "canonical questions YAML did not parse to an object — skipping",
     );
     return [];
   }
   const root = parsed as QuestionsRoot;
   if (!Array.isArray(root.questions)) {
-    process.stderr.write(
-      `[atlas-mcp] canonical questions YAML at ${filePath} has no top-level "questions:" array — skipping\n`,
+    log.warn(
+      { filePath },
+      'canonical questions YAML has no top-level "questions:" array — skipping',
     );
     return [];
   }

--- a/packages/mcp/src/prompts/gating.ts
+++ b/packages/mcp/src/prompts/gating.ts
@@ -28,6 +28,9 @@ import type { CanonicalToggle } from "@useatlas/types/mcp";
 import type { CanonicalGateReason } from "@useatlas/schemas/mcp-prompts";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createMcpLogger } from "../logger.js";
+
+const log = createMcpLogger("mcp:prompts:gating");
 
 export const EXPOSE_CANONICAL_SETTING = "ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS";
 
@@ -116,8 +119,9 @@ async function probeDemoConnection(
     );
     return rows[0]?.active === true ? "active" : "inactive";
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] canonical gating: workspace_plugins query failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), workspaceId },
+      "canonical gating: workspace_plugins query failed",
     );
     return "error";
   }

--- a/packages/mcp/src/prompts/listing.ts
+++ b/packages/mcp/src/prompts/listing.ts
@@ -34,6 +34,9 @@ import {
   evaluateCanonicalGate,
   type CanonicalGateResult,
 } from "./gating.js";
+import { createMcpLogger } from "../logger.js";
+
+const log = createMcpLogger("mcp:prompts:listing");
 // Wire-shape types come from `@useatlas/schemas/mcp-prompts` so the
 // listing pipeline, the route layer, and the web client all derive
 // from one Zod source. See the schemas module header for the
@@ -166,8 +169,9 @@ export function loadSemanticPrompts(): SemanticPrompt[] {
   try {
     root = getSemanticRoot();
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] Semantic root not available, skipping semantic prompts: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Semantic root not available, skipping semantic prompts",
     );
     return prompts;
   }
@@ -176,8 +180,9 @@ export function loadSemanticPrompts(): SemanticPrompt[] {
   try {
     ({ entities } = scanEntities(root));
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] Failed to scan entities for prompts: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Failed to scan entities for prompts",
     );
     return prompts;
   }
@@ -246,8 +251,9 @@ export async function loadLibraryPrompts(): Promise<LibraryPrompt[]> {
       question: row.question,
     }));
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] Failed to load prompt library: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Failed to load prompt library",
     );
     return [];
   }

--- a/packages/mcp/src/prompts/registry.ts
+++ b/packages/mcp/src/prompts/registry.ts
@@ -100,6 +100,9 @@ function substituteArgs(
 
 import type { PromptSource } from "./listing.js";
 export type { PromptSource };
+import { createMcpLogger } from "../logger.js";
+
+const log = createMcpLogger("mcp:prompts:registry");
 
 /**
  * Synthetic source label used by `prompts/list` telemetry — the dispatch
@@ -197,8 +200,9 @@ function recordPromptCounter(
       "deploy.mode": ctx.deployMode,
     });
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] prompt counter failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), method, prompt: name },
+      "prompt counter failed",
     );
   }
 }
@@ -245,8 +249,9 @@ function writePromptAudit(
       ],
     );
   } catch (err) {
-    process.stderr.write(
-      `[atlas-mcp] prompt audit insert failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), method, prompt: name },
+      "prompt audit insert failed",
     );
   }
 }

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -18,6 +18,9 @@ import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
+import { createMcpLogger } from "./logger.js";
+
+const log = createMcpLogger("mcp:resources");
 
 const SEMANTIC_ROOT = getSemanticRoot();
 
@@ -45,7 +48,10 @@ function listYamlFiles(subdir: string): string[] {
       .sort();
   } catch (err) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return [];
-    process.stderr.write(`[atlas-mcp] Failed to list YAML files in "${subdir}": ${err instanceof Error ? err.message : String(err)}\n`);
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)), subdir },
+      "Failed to list YAML files in semantic subdirectory",
+    );
     throw err;
   }
 }
@@ -58,7 +64,10 @@ function readSemanticFile(relativePath: string): string | null {
     return fs.readFileSync(filePath, "utf-8");
   } catch (err) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return null;
-    process.stderr.write(`[atlas-mcp] Failed to read "${relativePath}": ${err instanceof Error ? err.message : String(err)}\n`);
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)), relativePath },
+      "Failed to read semantic file",
+    );
     throw err;
   }
 }

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -60,6 +60,9 @@ import {
 } from "./error-envelope.js";
 import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
+import { createMcpLogger } from "./logger.js";
+
+const log = createMcpLogger("mcp:semantic-tools");
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
 // SaaS) shouldn't be able to drive megabyte strings into the catalog
@@ -200,7 +203,10 @@ export function registerSemanticTools(
               return toJsonContent({ count: entities.length, entities });
             } catch (err) {
               const message = errorMessage(err, "listEntities tool failed");
-              process.stderr.write(`[atlas-mcp] listEntities threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "listEntities tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );
@@ -259,7 +265,10 @@ export function registerSemanticTools(
               return toJsonContent({ found: true, entity });
             } catch (err) {
               const message = errorMessage(err, "describeEntity tool failed");
-              process.stderr.write(`[atlas-mcp] describeEntity threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "describeEntity tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );
@@ -342,7 +351,10 @@ export function registerSemanticTools(
               });
             } catch (err) {
               const message = errorMessage(err, "searchGlossary tool failed");
-              process.stderr.write(`[atlas-mcp] searchGlossary threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "searchGlossary tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );
@@ -573,7 +585,10 @@ export function registerSemanticTools(
               });
             } catch (err) {
               const message = errorMessage(err, "runMetric tool failed");
-              process.stderr.write(`[atlas-mcp] runMetric threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "runMetric tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -12,7 +12,6 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { initializeConfig, getConfig } from "@atlas/api/lib/config";
-import { createLogger } from "@atlas/api/lib/logger";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { loadSettings } from "@atlas/api/lib/settings";
@@ -23,8 +22,11 @@ import { registerResources } from "./resources.js";
 import { registerPrompts } from "./prompts/registry.js";
 import { resolveMcpActor } from "./actor.js";
 import type { McpTransport } from "./telemetry.js";
+import { createMcpLogger } from "./logger.js";
 
-const log = createLogger("mcp:boot");
+// Boot diagnostics go to stderr (JSON), not the api logger's stdout — stdout
+// carries the JSON-RPC stream on the stdio transport (#3494).
+const log = createMcpLogger("mcp:boot");
 // `serverInfo.version` is what MCP clients (Claude Desktop, Cursor) show
 // in their server picker. Reading from package.json keeps the value in
 // sync without a hand-edit on every bump.

--- a/packages/mcp/src/telemetry-bootstrap.ts
+++ b/packages/mcp/src/telemetry-bootstrap.ts
@@ -42,12 +42,16 @@ export async function startMcpTelemetry(): Promise<
     return await initTelemetry({ serviceName: MCP_OTEL_SERVICE_NAME });
   } catch (err) {
     // Telemetry is best-effort — a failed exporter import or SDK start must
-    // not stop the MCP server from serving. Log to stderr (the MCP package's
-    // logging convention — stdout carries JSON-RPC on the stdio transport).
-    process.stderr.write(
-      `[atlas-mcp] Failed to initialize OpenTelemetry: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
+    // not stop the MCP server from serving. The logger import is dynamic so
+    // this module's STATIC graph stays minimal: `bin/serve.ts` imports it
+    // before `startMcpTelemetry()` runs, and the #3199 ordering contract
+    // requires no `atlas.mcp.*` instrument module load onto the static path.
+    // `createMcpLogger` (→ `@atlas/api/lib/logger`) creates no OTel
+    // instruments, and on this branch the SDK failed to start anyway.
+    const { createMcpLogger } = await import("./logger.js");
+    createMcpLogger("mcp:telemetry-bootstrap").error(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Failed to initialize OpenTelemetry",
     );
     return null;
   }

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -32,6 +32,9 @@ import {
   mcpActivations,
 } from "@atlas/api/lib/metrics";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { createMcpLogger } from "./logger.js";
+
+const log = createMcpLogger("mcp:telemetry");
 
 export type McpTransport = "stdio" | "sse";
 
@@ -90,8 +93,9 @@ function emitActivationOnce(
     });
   } catch (err) {
     seenWorkspaces.delete(workspaceId);
-    process.stderr.write(
-      `[atlas-mcp] activation counter failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    log.warn(
+      { err: err instanceof Error ? err : new Error(String(err)), workspaceId },
+      "activation counter failed",
     );
   }
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -49,6 +49,9 @@ import {
 } from "./error-envelope.js";
 import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
+import { createMcpLogger } from "./logger.js";
+
+const log = createMcpLogger("mcp:tools");
 
 export interface RegisterToolsOptions {
   /**
@@ -238,7 +241,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               };
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
-              process.stderr.write(`[atlas-mcp] explore tool threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "explore tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message || "explore tool failed", {
                   request_id: requestId,
@@ -370,7 +376,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               };
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
-              process.stderr.write(`[atlas-mcp] executeSQL tool threw: ${err}\n`);
+              log.error(
+                { err: err instanceof Error ? err : new Error(String(err)) },
+                "executeSQL tool threw",
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message || "executeSQL tool failed", {
                   request_id: requestId,


### PR DESCRIPTION
Closes #3494. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 0).

## What

Replaces the raw `process.stderr.write` diagnostic sites across the served MCP modules with a structured pino logger (`createMcpLogger`) carrying `requestId` / actor correlation. We deliberately keep pino/OTel rather than adopting the MCP `logging` capability (deprecated in the 2026-07-28 draft).

## Why a dedicated MCP logger

The shared `@atlas/api` `createLogger` writes to **stdout**, which on the MCP stdio transport carries the JSON-RPC stream — a stray log line there corrupts the protocol (the original reason every site used `process.stderr.write`). `src/logger.ts` reuses the api logger's redaction paths, error scrubber, and URL-credential formatter but pins the destination to **fd 2 (stderr)** and emits structured JSON (no pino-pretty worker that could reclaim stdout). `requestId` / `toolName` / `clientId` are injected from each dispatch's `withRequestContext` via a pino mixin — no manual threading.

## Changes

- Tool/dispatch diagnostics (`tools`, `semantic-tools`, `resources`, `prompts/*`, `telemetry`) now log structured JSON with `requestId`.
- Billing-block logs carry `orgId` / `requestId` / `errorCode`.
- Server boot logs move off the api stdout logger onto stderr.
- `telemetry-bootstrap` imports the logger **lazily** (dynamic import in the catch) so its static import graph stays minimal — preserving the #3199 OTel-meter binding order.
- Added `pino` as an explicit `@atlas/mcp` dependency (matches the api `^10.3.1` pin; syncpack-clean).

## Acceptance criteria (#3494)

- [x] no raw stderr string writes for diagnostics remain — enforced by a new structural guard test (`no-raw-stderr.test.ts`, mirrors the surface-stamper guard; `eval/` + `__tests__/` excluded)
- [x] tool/dispatch logs are structured and carry `requestId`
- [x] billing-block logs carry `orgId` / `requestId` / `errorCode`

## Tests

- `logger.test.ts` — wire-shape assertions: a line emitted inside an MCP dispatch context carries `requestId` / `toolName` / `clientId`, credential fields are redacted, connection-string URIs are scrubbed, and correlation keys are absent outside a request context.
- `no-raw-stderr.test.ts` — structural guard against regressions.

## CI

Local gates all green: lint, type (full monorepo), full `bun run test`, syncpack, template-drift, railway-watch, schema-drift, openapi-drift, oauth-helper-drift, test-discipline, settings-readers, security-headers, twenty-resolver, published-symbols.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_