### PR TITLE
docs(mcp): document ATLAS_MCP_* knobs + fix stale setup-guide spots (#3495)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,20 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_MCP_RATE_LIMIT_MAX_KEYS=10000       # Max distinct MCP rate-limit keys retained per workspace before LRU
 #                                           # eviction (bounds memory on many short-lived OAuth clients). Default
 #                                           # 10000; clamped to a minimum of 100.
+# ATLAS_MCP_MAX_SESSIONS=100                # Hosted (SSE / Streamable HTTP) concurrent-session cap. A positive
+#                                           # integer overrides the deploy-env profile default (100); it bounds the
+#                                           # in-memory session map, and connections past the cap get 503 until an
+#                                           # idle session is swept. Non-positive / malformed → profile default.
+# ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS=1800000 # Hosted idle-session reap threshold (ms). A session whose last activity
+#                                           # is older than this is closed under cap-pressure so vanished clients
+#                                           # (closed laptop, killed app) don't permanently exhaust the pool.
+#                                           # Default 1800000 (30m); floor 60000 (1m) — below floor / missing /
+#                                           # malformed falls back to the default.
+# ATLAS_CANONICAL_QUESTIONS_PATH=           # Override path to the canonical-questions YAML backing the canonical
+#                                           # MCP prompts (eval harness #2025). Defaults to
+#                                           # eval/canonical-questions/questions.yml resolved from the repo root.
+#                                           # Setting it to an empty string is rejected (refuses rather than
+#                                           # silently masking an env-template error).
 
 # === OAuth Provider (MCP / DCR) ===
 # Atlas issues OAuth 2.1 tokens via @better-auth/oauth-provider so MCP clients

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -108,8 +108,8 @@ Claude Desktop also supports DCR natively — point it at the URL alone and it w
 The CLI ships an `mcp add` subcommand that writes to the right scope automatically:
 
 ```bash
-claude mcp add atlas --scope user \
-  --url https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse \
+claude mcp add atlas --scope user --transport sse \
+  https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse \
   --header "Authorization: Bearer <jwt>"
 ```
 
@@ -222,10 +222,10 @@ The CLI knows how to launch a stdio server by command + args:
 
 ```bash
 claude mcp add atlas --scope user \
-  -- bun run mcp \
   --env ATLAS_DATASOURCE_URL=postgresql://user:pass@host:5432/db \
   --env ATLAS_PROVIDER=anthropic \
-  --env ANTHROPIC_API_KEY=sk-ant-...
+  --env ANTHROPIC_API_KEY=sk-ant-... \
+  -- bun run mcp
 ```
 
 Run from inside your Atlas project root so the implicit `cwd` resolves the `mcp` script. `--scope user` makes Atlas available across every project; `--scope project` scopes to the current repo.
@@ -573,7 +573,7 @@ Canonical prompts are **gated by workspace** so real-data deployments don't see 
 | `always` | Always expose, regardless of dataset |
 | `never` | Always hide |
 
-Flip the toggle from **Admin → Settings → MCP**. Same-instance writes propagate immediately (the in-process settings cache updates synchronously on save); cross-replica SaaS propagation is bounded by the periodic settings refresh (`ATLAS_SETTINGS_REFRESH_INTERVAL`, default 30s). No MCP process restart required either way.
+Flip the toggle from **Admin → Settings**, in the `ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS` row (the legacy `/admin/settings/mcp` path now redirects to that anchor on the consolidated settings page). Same-instance writes propagate immediately (the in-process settings cache updates synchronously on save); cross-replica SaaS propagation is bounded by the periodic settings refresh (`ATLAS_SETTINGS_REFRESH_INTERVAL`, default 30s). No MCP process restart required either way.
 
 ### Semantic layer patterns
 


### PR DESCRIPTION
Closes #3495. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 0).

Closes the documentation gaps the V1 review found.

## `.env.example`

Adds the runtime-read but undocumented MCP env vars to the **MCP transport** section, with defaults/floors read from the resolvers:

| Var | Default | Notes |
|-----|---------|-------|
| `ATLAS_MCP_MAX_SESSIONS` | `100` | Hosted concurrent-session cap (overrides the deploy-env profile); past the cap → 503 until an idle session is swept |
| `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS` | `1800000` (30m) | Idle-session reap threshold; floor `60000` (1m); below floor/missing/malformed → default |
| `ATLAS_CANONICAL_QUESTIONS_PATH` | `eval/canonical-questions/questions.yml` | Canonical-prompts YAML override; empty string is rejected |

Verified every read `ATLAS_MCP_*` / `ATLAS_CANONICAL_*` var (`USER_ID`, `ORG_ID`, `RATE_LIMIT_FAIL_CLOSED`, `RATE_LIMIT_MAX_KEYS`, `MAX_SESSIONS`, `SESSION_IDLE_TIMEOUT_MS`, `QUESTIONS_PATH`) is now documented.

## `apps/docs/content/docs/guides/mcp.mdx`

- **`claude mcp add` syntax** (verified against the official Claude Code docs):
  - Remote: `--transport sse` with the URL as a **positional** arg (not `--url`), `--header` after it.
  - Local stdio: `--env` flags go **before** the `--` command separator — after `--` they were silently passed to `bun run mcp` instead of being read by `claude`.
- **Canonical-prompts toggle note**: the toggle lives on the consolidated **Admin → Settings** page; the legacy `/admin/settings/mcp` path now redirects to the `ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS` anchor there.

## Acceptance criteria (#3495)

- [x] every read `ATLAS_MCP_*` var is documented in `.env.example`
- [x] the `claude mcp add` example uses correct syntax
- [x] the settings-redirect note is accurate

Docs/comment-only change. Local lint passes; remote CI runs the docs build.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_