### PR TITLE
feat(mcp): tool annotations + explicit capabilities object (#3497)

### DIFF
--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -80,6 +80,23 @@ describe("MCP server integration", () => {
     ]);
   });
 
+  it("advertises tools/resources/prompts capabilities and not logging (#3497)", async () => {
+    const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
+    const client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.tools).toBeDefined();
+    expect(caps?.resources).toBeDefined();
+    expect(caps?.prompts).toBeDefined();
+    // `logging`/`sampling`/`roots` are intentionally not adopted (deprecated
+    // in the 2026-07-28 draft) — PRD #3483.
+    expect(caps?.logging).toBeUndefined();
+  });
+
   it("creates a server and lists resources", async () => {
     const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
     const client = new Client({ name: "test-client", version: "0.0.1" });

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -119,6 +119,44 @@ describe("MCP tools", () => {
     ]);
   });
 
+  it("declares read-only annotations on every native tool (#3497)", async () => {
+    const { client } = await createTestClient();
+    const { tools } = await client.listTools();
+    const annotationsByName = new Map(
+      tools.map((t) => [t.name, t.annotations]),
+    );
+
+    // All six native tools are read-only: explore + the semantic-layer
+    // tools read YAML, executeSQL / runMetric are SELECT-only (validated).
+    // A client must NOT prompt for confirmation on any of them.
+    for (const name of [
+      "explore",
+      "executeSQL",
+      "listEntities",
+      "describeEntity",
+      "searchGlossary",
+      "runMetric",
+    ]) {
+      expect(annotationsByName.get(name)?.readOnlyHint).toBe(true);
+    }
+
+    // Semantic-layer tools operate on a closed, local domain (the semantic
+    // directory) → openWorldHint false.
+    for (const name of [
+      "explore",
+      "listEntities",
+      "describeEntity",
+      "searchGlossary",
+    ]) {
+      expect(annotationsByName.get(name)?.openWorldHint).toBe(false);
+    }
+
+    // Datasource-query tools reach an external database → openWorldHint true.
+    for (const name of ["executeSQL", "runMetric"]) {
+      expect(annotationsByName.get(name)?.openWorldHint).toBe(true);
+    }
+  });
+
   it("tool descriptions document the error contract (#2030)", async () => {
     const { client } = await createTestClient();
     const result = await client.listTools();

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -172,6 +172,11 @@ export function registerSemanticTools(
             "Optional case-insensitive substring matched against name, table, and description.",
           ),
       },
+      // Read-only over the local semantic catalog (closed world).
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ filter }): Promise<CallToolResult> =>
       traceMcpToolCall(
@@ -231,6 +236,11 @@ export function registerSemanticTools(
           .describe(
             "Entity name (`name` field) or table name. Alphanumerics, `_`, `-`, `.` only — no path separators.",
           ),
+      },
+      // Read-only over the local semantic catalog (closed world).
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
       },
     },
     async ({ name }): Promise<CallToolResult> =>
@@ -292,6 +302,11 @@ export function registerSemanticTools(
           .describe(
             "Term, phrase, or substring to search across glossary entries.",
           ),
+      },
+      // Read-only over the local business glossary (closed world).
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
       },
     },
     async ({ term }): Promise<CallToolResult> =>
@@ -403,6 +418,13 @@ export function registerSemanticTools(
           .describe(
             "Target connection id. Omit to run the metric against its own group — a metric defined under `groups/<group>/` runs against `<group>`, an ungrouped metric against the default connection. Passing a connection id that does not match the metric's group is rejected.",
           ),
+      },
+      // Runs the metric's authoritative SELECT through the same validated
+      // executeSQL path — read-only, but against an external database
+      // (openWorldHint true), like executeSQL.
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
       },
     },
     async ({ id, filters, connectionId }): Promise<CallToolResult> =>

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -116,10 +116,26 @@ export async function createAtlasMcpServer(
   const clientId = opts?.clientId;
   const scopes = opts?.scopes;
 
-  const server = new McpServer({
-    name: "atlas",
-    version: VERSION,
-  });
+  // Declare the capabilities Atlas actually serves today (#3497, spec
+  // 2025-11-25). The high-level `McpServer` also auto-registers these as
+  // tools/resources/prompts are added, but stating them explicitly makes
+  // the supported surface the source of truth and is where later protocol
+  // work (resource `subscribe`, `completions`) hangs its flags. We
+  // deliberately omit `logging`, `sampling`, and `roots` — deprecated in
+  // the 2026-07-28 draft (PRD #3483).
+  const server = new McpServer(
+    {
+      name: "atlas",
+      version: VERSION,
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+    },
+  );
 
   registerTools(server, { actor, transport, clientId, ...(scopes && { scopes }) });
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -195,6 +195,13 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
             'A bash command to run against the semantic layer, e.g. \'cat catalog.yml\', \'grep -r revenue entities/\'',
           ),
       },
+      // Read-only over a closed, local domain: explore only ever runs
+      // read commands (ls/cat/grep/find) against the semantic directory —
+      // no datasource, no mutations. A client must not prompt for a confirm.
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ command }): Promise<CallToolResult> =>
       traceMcpToolCall(
@@ -273,6 +280,13 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           .describe(
             "Target connection ID. Omit for the default connection.",
           ),
+      },
+      // SELECT-only (DML/DDL is rejected by the 4-layer SQL validator), so
+      // the query never modifies the datasource — read-only. It does reach
+      // an external database, so the world is open (openWorldHint true).
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
       },
     },
     async ({ sql, explanation, connectionId }): Promise<CallToolResult> =>


### PR DESCRIPTION
Closes #3497. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, spec 2025-11-25).

## What

Declares MCP tool annotations on every native tool so clients render the right confirmation affordances, and establishes the server `capabilities` pattern (the `McpServer` was previously created with none).

## Annotations

| Tool | `readOnlyHint` | `openWorldHint` | Rationale |
|------|----------------|-----------------|-----------|
| `explore` | `true` | `false` | read commands over the local semantic dir |
| `listEntities` / `describeEntity` / `searchGlossary` | `true` | `false` | read the local catalog/glossary |
| `executeSQL` | `true` | `true` | SELECT-only (validated), but hits an external DB |
| `runMetric` | `true` | `true` | runs the metric's SELECT via the same validated path |

All six are `readOnlyHint: true` — none mutate the datasource or semantic layer — so a client must not prompt for confirmation on a read. `openWorldHint` separates the closed-domain semantic tools from the external-DB query tools.

## Capabilities

`server.ts` now constructs the `McpServer` with an explicit `capabilities` object (`tools` / `resources` / `prompts`). `logging` / `sampling` / `roots` are deliberately omitted (deprecated in the 2026-07-28 draft). This is the anchor where later protocol work (resource `subscribe` in #3502, `completions` in #3503) hangs its flags.

## Tests

External wire-behavior assertions (per the PRD testing philosophy):
- `tools.test.ts` — `listTools()` exposes the correct `readOnlyHint` / `openWorldHint` per tool.
- `server.test.ts` — the negotiated capabilities advertise `tools`/`resources`/`prompts` and **not** `logging`.

Local: full MCP suite (23 files) + monorepo type + lint all green.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_