### PR TITLE
feat(mcp): enforce mcp:write on mutating plugin-contributed MCP tools (#3520)

### DIFF
--- a/packages/api/src/__tests__/plugin-mcp-tools.test.ts
+++ b/packages/api/src/__tests__/plugin-mcp-tools.test.ts
@@ -41,6 +41,7 @@ import {
   PluginMcpToolRegistry,
   wireMcpToolPlugins,
   registerPluginMcpTools,
+  pluginToolMutates,
   type AtlasMcpToolLike,
   type McpServerLike,
   type McpCallToolResult,
@@ -703,5 +704,132 @@ describe("registerPluginMcpTools (MCP server registration)", () => {
       ]);
       expect(JSON.parse(result.content[0].text)).toEqual({ ok: true });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3520 — mcp:write gate for mutating plugin-contributed MCP tools.
+// ---------------------------------------------------------------------------
+
+describe("pluginToolMutates (annotation → mutation signal)", () => {
+  it("is read-only (false) with no annotations — opt-in gate", () => {
+    expect(pluginToolMutates(undefined)).toBe(false);
+    expect(pluginToolMutates({})).toBe(false);
+  });
+  it("readOnlyHint:true wins even alongside destructiveHint:true", () => {
+    expect(pluginToolMutates({ readOnlyHint: true, destructiveHint: true })).toBe(false);
+  });
+  it("mutates when readOnlyHint:false or destructiveHint:true", () => {
+    expect(pluginToolMutates({ readOnlyHint: false })).toBe(true);
+    expect(pluginToolMutates({ destructiveHint: true })).toBe(true);
+  });
+});
+
+describe("registerPluginMcpTools — mcp:write gate for mutating plugin tools (#3520)", () => {
+  let registry: PluginMcpToolRegistry;
+  let server: FakeMcpServer;
+
+  beforeEach(() => {
+    registry = new PluginMcpToolRegistry();
+    server = new FakeMcpServer();
+    rateLimitState.outcome = { kind: "ok" };
+    rateLimitState.calls = [];
+  });
+
+  function actor() {
+    return { id: "user-1", label: "user-1", mode: "simple-key" as const, activeOrganizationId: "org-1" };
+  }
+
+  /** A mutating tool (explicitly not read-only). */
+  function mutatingTool(over: Partial<AtlasMcpToolLike> = {}): AtlasMcpToolLike {
+    return makeTool({ name: "createThing", annotations: { readOnlyHint: false }, ...over });
+  }
+
+  function hostedOpts(scopes: readonly string[]) {
+    return {
+      registry,
+      actor: actor(),
+      transport: "sse" as const,
+      workspaceId: "org-1",
+      deployMode: "saas" as const,
+      clientId: "claude-desktop",
+      scopes,
+    };
+  }
+
+  it("registry carries the annotation through to the registered tool", () => {
+    const entry = registry.register("infra", mutatingTool());
+    expect(entry.annotations).toEqual({ readOnlyHint: false });
+  });
+
+  it("denies a mutating tool when a hosted mcp:read-only token lacks mcp:write", async () => {
+    registry.register("infra", mutatingTool());
+    registerPluginMcpTools(server, hostedOpts(["mcp:read"]));
+    const handler = server.registered.get("infra.createThing")!.handler;
+    const res = await handler({ value: "x" });
+    expect(res.isError).toBe(true);
+    const env = JSON.parse(res.content[0].text);
+    expect(env.code).toBe("forbidden");
+    expect(env.message).toContain("mcp:write");
+    // The gate runs BEFORE the rate-limit gate — a forbidden call must not
+    // consume the client's rate budget.
+    expect(rateLimitState.calls).toHaveLength(0);
+  });
+
+  it("allows a mutating tool when the hosted token carries mcp:write", async () => {
+    let called = false;
+    registry.register(
+      "infra",
+      mutatingTool({ handler: async () => { called = true; return { ok: true }; } }),
+    );
+    registerPluginMcpTools(server, hostedOpts(["mcp:read", "mcp:write"]));
+    const handler = server.registered.get("infra.createThing")!.handler;
+    const res = await handler({ value: "x" });
+    expect(res.isError).toBeFalsy();
+    expect(called).toBe(true);
+  });
+
+  it("leaves a read-only plugin tool unaffected for a mcp:read-only client", async () => {
+    registry.register("infra", makeTool({ name: "listThings", annotations: { readOnlyHint: true } }));
+    registerPluginMcpTools(server, hostedOpts(["mcp:read"]));
+    const handler = server.registered.get("infra.listThings")!.handler;
+    const res = await handler({ value: "x" });
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("leaves an un-annotated plugin tool unaffected (opt-in gate)", async () => {
+    registry.register("infra", makeTool({ name: "legacy" }));
+    registerPluginMcpTools(server, hostedOpts(["mcp:read"]));
+    const handler = server.registered.get("infra.legacy")!.handler;
+    const res = await handler({ value: "x" });
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("treats destructiveHint:true as mutating (denied without mcp:write)", async () => {
+    registry.register("infra", makeTool({ name: "deleteThing", annotations: { destructiveHint: true } }));
+    registerPluginMcpTools(server, hostedOpts(["mcp:read"]));
+    const handler = server.registered.get("infra.deleteThing")!.handler;
+    const res = await handler({ value: "x" });
+    expect(JSON.parse(res.content[0].text).code).toBe("forbidden");
+  });
+
+  it("exempts stdio (no clientId) even for a mutating tool", async () => {
+    let called = false;
+    registry.register(
+      "infra",
+      mutatingTool({ handler: async () => { called = true; return { ok: true }; } }),
+    );
+    registerPluginMcpTools(server, {
+      registry,
+      actor: actor(),
+      transport: "stdio",
+      workspaceId: "org-1",
+      deployMode: "self-hosted",
+      // no clientId, no scopes — stdio
+    });
+    const handler = server.registered.get("infra.createThing")!.handler;
+    const res = await handler({ value: "x" });
+    expect(res.isError).toBeFalsy();
+    expect(called).toBe(true);
   });
 });

--- a/packages/api/src/lib/plugins/mcp-tools.ts
+++ b/packages/api/src/lib/plugins/mcp-tools.ts
@@ -92,12 +92,52 @@ export interface McpToolContextShape {
   audit(entry: McpToolAuditEntry): void;
 }
 
+/**
+ * Structural mirror of MCP's standard `ToolAnnotations` (spec 2025-11-25).
+ * Only the read/write hints are load-bearing for the host today — the
+ * `mcp:write` dispatch gate (#3520) keys on them. `idempotentHint` /
+ * `openWorldHint` / `title` are accepted and carried for forward-compat with
+ * the annotation-surfacing work (#3497) but unused by enforcement.
+ *
+ * Why annotations, not a bespoke `mutates` flag (#3520): MCP already defines
+ * `readOnlyHint` / `destructiveHint`, so a plugin author declares mutation in
+ * the protocol's own vocabulary and a future MCP client reads the same hint.
+ */
+export interface McpToolAnnotationsShape {
+  readonly title?: string;
+  /** `true` ⇒ the tool does not mutate its environment (read-only). */
+  readonly readOnlyHint?: boolean;
+  /** `true` ⇒ the tool may perform destructive (mutating) updates. */
+  readonly destructiveHint?: boolean;
+  readonly idempotentHint?: boolean;
+  readonly openWorldHint?: boolean;
+}
+
+/**
+ * Does this plugin tool MUTATE (and therefore require `mcp:write` on a hosted
+ * dispatch)? Opt-in by design (#3520): a tool with no annotations is treated
+ * as read-only, so existing read-only plugin tools are unaffected for
+ * `mcp:read` clients. A tool opts into the gate by declaring `readOnlyHint:
+ * false` or `destructiveHint: true`. `readOnlyHint: true` always wins (a tool
+ * can't be both read-only and destructive).
+ */
+export function pluginToolMutates(annotations?: McpToolAnnotationsShape): boolean {
+  if (!annotations) return false;
+  if (annotations.readOnlyHint === true) return false;
+  return annotations.destructiveHint === true || annotations.readOnlyHint === false;
+}
+
 export interface AtlasMcpToolLike<TInput = unknown, TOutput = unknown> {
   readonly name: string;
   readonly description: string;
   readonly errorCodes?: ReadonlyArray<string>;
   readonly inputSchema: ZodSchemaLike;
   readonly outputSchema?: ZodSchemaLike;
+  /**
+   * MCP tool annotations (#3520 keys on `readOnlyHint`/`destructiveHint` for
+   * the `mcp:write` gate). Optional — absence means "read-only" for gating.
+   */
+  readonly annotations?: McpToolAnnotationsShape;
   handler(args: TInput, ctx: McpToolContextShape): Promise<TOutput>;
 }
 
@@ -120,6 +160,8 @@ export interface RegisteredPluginMcpTool {
   readonly errorCodes?: ReadonlyArray<string>;
   readonly inputSchema: ZodSchemaLike;
   readonly outputSchema?: ZodSchemaLike;
+  /** MCP annotations carried from the authored tool — see {@link pluginToolMutates}. */
+  readonly annotations?: McpToolAnnotationsShape;
   handler(args: unknown, ctx: McpToolContextShape): Promise<unknown>;
 }
 
@@ -195,6 +237,9 @@ export class PluginMcpToolRegistry {
       errorCodes: tool.errorCodes,
       inputSchema: tool.inputSchema,
       outputSchema: tool.outputSchema,
+      // #3520 — carry the read/write annotation through so the dispatch
+      // wrapper can decide whether a hosted call needs `mcp:write`.
+      ...(tool.annotations && { annotations: tool.annotations }),
       handler: tool.handler as RegisteredPluginMcpTool["handler"],
     };
     this.tools.set(qualifiedName, entry);
@@ -489,16 +534,35 @@ export function registerPluginMcpTools(
         // #3507 — stamp `mcp` as the agent origin so origin-scoped approval
         // rules (ADR-0016) match plugin-tool dispatches, parity with the
         // built-in MCP tools in packages/mcp/src/{tools,semantic-tools}.ts.
-        // #3504 — `scopes` is threaded onto the context here so a future
-        // write-gated plugin tool can read it, BUT no `mcp:write` gate runs
-        // on this path yet: unlike built-in tools (which call
-        // `writeScopeOrNull` per-tool), plugin tools carry no read/write
-        // signal until tool annotations land (#3497), so the host can't tell
-        // which plugin tools mutate. Generic enforcement here is deferred to
-        // the gate-order pipeline (#3508). Until then, a mutating plugin MCP
-        // tool is NOT scope-gated — tracked in #3520.
+        // #3504 — `scopes` is threaded onto the context here; #3520 enforces
+        // the `mcp:write` gate (gate 2 of the ADR-0016 order) on it for
+        // *mutating* plugin tools, keyed on the MCP `readOnlyHint` /
+        // `destructiveHint` annotation (see {@link pluginToolMutates}).
         { requestId, user: actor, agentOrigin: "mcp", actor: mcpActor, ...(scopes ? { scopes } : {}) },
         async () => {
+          // ── mcp:write gate (#3520, ADR-0016 gate 2) ──
+          // A mutating plugin tool requires the `mcp:write` scope on a HOSTED
+          // dispatch (clientId set). stdio MCP carries no third-party client,
+          // so no scope term applies (exempt) — parity with the built-in
+          // `writeScopeOrNull` gate, which `dispatch-gate.ts` can't be reused
+          // here because packages/mcp depends on packages/api, not the
+          // reverse. Read-only / un-annotated tools are unaffected. Runs
+          // BEFORE the rate-limit gate so a forbidden call doesn't consume
+          // the client's rate budget.
+          if (clientId && pluginToolMutates(tool.annotations) && !scopes?.includes("mcp:write")) {
+            log.warn(
+              { qualifiedName: tool.qualifiedName, clientId, requestId },
+              "Mutating plugin MCP tool denied — token lacks mcp:write",
+            );
+            return envelopeResult(
+              "forbidden",
+              "This tool mutates data and requires the 'mcp:write' OAuth scope, which this token does not carry.",
+              {
+                hint: "Re-authorize the MCP client with the mcp:write scope (the workspace admin controls which scopes a client may request).",
+              },
+            );
+          }
+
           // Per-OAuth-client rate-limit gate (#2071). Hosted MCP threads
           // `clientId`; stdio MCP leaves it undefined and is intentionally
           // exempt — the limiter scopes hosted-tenant abuse, not local

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -50,6 +50,7 @@ export type {
   AtlasPlugin,
   $InferServerPlugin,
   AtlasMcpTool,
+  McpToolAnnotations,
   McpToolContext,
   McpToolAuditEntry,
   PluginZodSchema,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -598,6 +598,30 @@ export interface McpToolAuditEntry {
  * envelope carrying the dispatch's `request_id` so an LLM agent can
  * correlate the failure with server logs.
  */
+/**
+ * MCP tool annotations (spec 2025-11-25 `ToolAnnotations`). Declare a tool's
+ * read/write nature so the host can gate it and clients can render the right
+ * confirmation affordance.
+ *
+ * The read/write hints are load-bearing for governance: a tool that mutates
+ * data MUST set `readOnlyHint: false` (or `destructiveHint: true`) so the host
+ * enforces the `mcp:write` scope on hosted dispatches (#3520). A tool with no
+ * annotations is treated as read-only and is NOT write-gated — annotate any
+ * mutating tool explicitly.
+ */
+export interface McpToolAnnotations {
+  /** Human-readable tool title for display. */
+  readonly title?: string;
+  /** `true` ⇒ the tool does not mutate its environment (read-only). */
+  readonly readOnlyHint?: boolean;
+  /** `true` ⇒ the tool may perform destructive (mutating) updates. */
+  readonly destructiveHint?: boolean;
+  /** `true` ⇒ repeated calls with the same args have no additional effect. */
+  readonly idempotentHint?: boolean;
+  /** `true` ⇒ the tool interacts with an open/external world (e.g. the web). */
+  readonly openWorldHint?: boolean;
+}
+
 export interface AtlasMcpTool<
   TInput = unknown,
   TOutput = unknown,
@@ -617,6 +641,12 @@ export interface AtlasMcpTool<
   readonly inputSchema: PluginZodSchema<TInput>;
   /** Optional Zod schema describing the structured response shape. */
   readonly outputSchema?: PluginZodSchema<TOutput>;
+  /**
+   * MCP annotations. A mutating tool MUST declare `readOnlyHint: false` (or
+   * `destructiveHint: true`) so the host enforces `mcp:write` on hosted
+   * dispatches (#3520). Omit (or set `readOnlyHint: true`) for read-only tools.
+   */
+  readonly annotations?: McpToolAnnotations;
   /** Tool handler. Receives the parsed args and a per-dispatch context. */
   handler(args: TInput, context: McpToolContext): Promise<TOutput>;
 }


### PR DESCRIPTION
Closes #3520 · Parent PRD #3483 · ADR-0016 · follow-up from #3504

#3504 threaded the OAuth `scopes` onto the plugin MCP dispatch context as groundwork but ran **no** `mcp:write` gate there: plugin-contributed tools carried no read/write signal, so the host couldn't tell which ones mutate. Result — a hosted `mcp:read`-only client could invoke a mutating plugin tool with no `mcp:write` check. (Not exploitable today: no mutating plugin MCP tools ship yet; the gate is opt-in.)

## What's here
- **Annotation signal (the read/write hint #3520 needs).** Since #3497 hasn't landed, this introduces the MCP-standard `readOnlyHint`/`destructiveHint` annotation on the plugin tool contract — `McpToolAnnotations` in `@useatlas/plugin-sdk` (type-only) + the host-side mirror in `lib/plugins/mcp-tools.ts`. The registry carries it through to the dispatch wrapper. (No `tools/list` surfacing — that's #3497; this is enforcement-only.)
- **`pluginToolMutates()`** derives the mutation signal — **opt-in by design**: a tool with no annotations is treated as read-only, so existing read-only plugin tools are unaffected for `mcp:read` clients. A tool opts into the gate via `readOnlyHint:false` / `destructiveHint:true`.
- **Gate 2 (`mcp:write`)** enforced in the plugin dispatch wrapper for mutating tools on a **hosted** dispatch (`clientId` set); **stdio is exempt** (no third-party client). Runs **before** the rate-limit gate so a forbidden call doesn't spend rate budget. The check is inlined — `packages/mcp`'s `writeScopeOrNull` can't be imported here (mcp depends on api, not the reverse).

## Acceptance criteria
- [x] A mutating plugin MCP tool dispatched by a hosted `mcp:read`-only client is denied with the `forbidden` envelope
- [x] A read-only (and un-annotated) plugin tool is unaffected for `mcp:read` clients
- [x] stdio plugin dispatches remain exempt
- [x] test covers allow / deny / stdio on the real plugin dispatch path

## Tests
`pluginToolMutates` truth table + allow/deny/stdio-exempt/read-only-unaffected/un-annotated/`destructiveHint` on the real `registerPluginMcpTools` dispatch path. Local type/lint/affected-api suite green.

https://claude.ai/code/session_01TCsGzUfn8gaTSwopCeVRhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCsGzUfn8gaTSwopCeVRhA)_