### PR TITLE
feat(mcp): structured output for executeSQL + runMetric (#3498)

### DIFF
--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -5,6 +5,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
 import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+import { runMetricOutputSchema } from "../structured-output.js";
 
 const TEST_ACTOR = createAtlasUser("u_sem", "managed", "sem@test", {
   role: "admin",
@@ -512,6 +513,27 @@ describe("MCP semantic tools", () => {
     // would silently break MCP clients that parse this as a Date. Pin
     // the format with a regex.
     expect(parsed.executed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("runMetric returns structuredContent conforming to the declared outputSchema (#3498)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    expect(result.structuredContent).toBeDefined();
+    const validated = runMetricOutputSchema.parse(result.structuredContent);
+    expect(validated.id).toBe("orders_count");
+    expect(validated.value).toBe(42);
+    expect(validated.row_count).toBe(1);
+
+    // Text block retained and mirrors the structured payload (#3498).
+    expect(JSON.parse(getContentText(result.content))).toEqual(result.structuredContent);
+
+    // The SDK advertises the outputSchema on the tool definition.
+    const { tools } = await client.listTools();
+    expect(tools.find((t) => t.name === "runMetric")?.outputSchema).toBeDefined();
   });
 
   // Scalar coercion edge cases — `0`, `false`, and `null` are the most

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -6,6 +6,7 @@ import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
 import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
 import { registerTools } from "../tools.js";
+import { executeSqlOutputSchema } from "../structured-output.js";
 
 const TEST_ACTOR = createAtlasUser("u_test", "managed", "test@example.com", {
   role: "admin",
@@ -241,6 +242,29 @@ describe("MCP tools", () => {
     expect(parsed.row_count).toBe(1);
     expect(parsed.rows).toEqual([{ count: 42 }]);
     expect(result.isError).toBeFalsy();
+  });
+
+  it("executeSQL returns structuredContent conforming to the declared outputSchema (#3498)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT count(*) FROM users", explanation: "Count users" },
+    });
+
+    // Structured output present and schema-valid.
+    expect(result.structuredContent).toBeDefined();
+    const validated = executeSqlOutputSchema.parse(result.structuredContent);
+    expect(validated.row_count).toBe(1);
+    expect(validated.columns).toEqual(["count"]);
+    expect(validated.rows).toEqual([{ count: 42 }]);
+
+    // The text block is retained and mirrors the structured payload (#3498
+    // requires backward-compat).
+    expect(JSON.parse(getContentText(result.content))).toEqual(result.structuredContent);
+
+    // The SDK advertises the outputSchema on the tool definition.
+    const { tools } = await client.listTools();
+    expect(tools.find((t) => t.name === "executeSQL")?.outputSchema).toBeDefined();
   });
 
   // Each test below uses the LITERAL upstream message string emitted by the

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -61,6 +61,7 @@ import {
 import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
 import { createMcpLogger } from "./logger.js";
+import { runMetricOutputShape } from "./structured-output.js";
 
 const log = createMcpLogger("mcp:semantic-tools");
 
@@ -130,6 +131,21 @@ async function rateLimitOrNull(args: {
 function toJsonContent(value: unknown): CallToolResult {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+/**
+ * Like {@link toJsonContent} but also attaches `structuredContent` (#3498).
+ * Used by tools that declare an `outputSchema` (runMetric): the MCP SDK
+ * requires `structuredContent` on every non-error result once an output
+ * schema is present. The text block is retained for clients that don't
+ * consume structured output; both are built from the same object so they
+ * can't drift.
+ */
+function toStructuredContent(value: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
   };
 }
 
@@ -426,6 +442,9 @@ export function registerSemanticTools(
         readOnlyHint: true,
         openWorldHint: true,
       },
+      // #3498 — typed result so agents parse value/columns/rows instead of
+      // re-parsing the text block (which is retained below).
+      outputSchema: runMetricOutputShape,
     },
     async ({ id, filters, connectionId }): Promise<CallToolResult> =>
       traceMcpToolCall(
@@ -550,7 +569,7 @@ export function registerSemanticTools(
                 // agent doesn't retry and silently duplicate the request.
                 // Mirrors the same branch in tools.ts:executeSQL.
                 if (result.approval_required === true) {
-                  return toJsonContent({
+                  return toStructuredContent({
                     id: metric.id,
                     approval_required: true,
                     approval_request_id: result.approval_request_id,
@@ -594,7 +613,7 @@ export function registerSemanticTools(
                   ? rows[0][columns[0]]
                   : rows;
 
-              return toJsonContent({
+              return toStructuredContent({
                 id: metric.id,
                 label: metric.label,
                 value,

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -1,0 +1,75 @@
+/**
+ * Structured-output schemas for the MCP datasource-query tools (#3498,
+ * spec 2025-11-25).
+ *
+ * `executeSQL` and `runMetric` declare an `outputSchema` and return
+ * `structuredContent` so downstream clients/agents parse a typed result
+ * instead of re-parsing the stringified text block (which is retained for
+ * backward compatibility).
+ *
+ * No wire shape for the `{ columns, rows, row_count, truncated }` result
+ * exists in `@useatlas/schemas` today, so these live in the MCP package as
+ * the single source of truth for the MCP tool-output shape. A future
+ * consolidation could lift them into `@useatlas/schemas` for reuse by the
+ * web/SDK clients.
+ *
+ * Why every field is optional: the MCP SDK requires `structuredContent` on
+ * *every* non-error result once a tool declares an `outputSchema`, and a
+ * tool has two disjoint non-error shapes — the data result and the
+ * `approval_required` governance signal (origin=mcp, never an error). An MCP
+ * `outputSchema` must be a single `type: object` schema, so the union of
+ * those two shapes is expressed as one object with optional members rather
+ * than a top-level `oneOf`. Tests validate a full data result against the
+ * schema to keep the success contract honest.
+ */
+
+import { z } from "zod/v4";
+
+/** A result row: a flat map of column name → cell value. */
+const rowsField = z.array(z.record(z.string(), z.unknown()));
+const columnsField = z.array(z.string());
+
+/** Fields shared by the `approval_required` governance branch of both tools. */
+const approvalFields = {
+  approval_required: z.boolean().optional(),
+  approval_request_id: z.string().optional(),
+  matched_rules: z.array(z.unknown()).optional(),
+  message: z.string().optional(),
+} as const;
+
+/**
+ * `executeSQL` output. Data branch: `explanation` + the
+ * `{ columns, rows, row_count, truncated }` result. Plus the approval
+ * governance branch.
+ */
+export const executeSqlOutputShape = {
+  explanation: z.string().optional(),
+  row_count: z.number().int().nonnegative().optional(),
+  columns: columnsField.optional(),
+  rows: rowsField.optional(),
+  truncated: z.boolean().optional(),
+  ...approvalFields,
+} as const;
+
+/**
+ * `runMetric` output. Data branch: the metric identity (`id`/`label`/`sql`),
+ * the coerced `value` (scalar for single-cell results, rows otherwise), the
+ * `{ columns, rows, row_count, truncated }` result, and `executed_at`. Plus
+ * the approval governance branch.
+ */
+export const runMetricOutputShape = {
+  id: z.string().optional(),
+  label: z.string().optional(),
+  value: z.unknown().optional(),
+  columns: columnsField.optional(),
+  rows: rowsField.optional(),
+  row_count: z.number().int().nonnegative().optional(),
+  truncated: z.boolean().optional(),
+  sql: z.string().optional(),
+  executed_at: z.string().optional(),
+  ...approvalFields,
+} as const;
+
+/** Zod objects for validating a result against the declared output schema. */
+export const executeSqlOutputSchema = z.object(executeSqlOutputShape);
+export const runMetricOutputSchema = z.object(runMetricOutputShape);

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -50,6 +50,7 @@ import {
 import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
 import { createMcpLogger } from "./logger.js";
+import { executeSqlOutputShape } from "./structured-output.js";
 
 const log = createMcpLogger("mcp:tools");
 
@@ -288,6 +289,9 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         readOnlyHint: true,
         openWorldHint: true,
       },
+      // #3498 — typed result so agents parse columns/rows instead of
+      // re-parsing the text block (which is retained below).
+      outputSchema: executeSqlOutputShape,
     },
     async ({ sql, explanation, connectionId }): Promise<CallToolResult> =>
       traceMcpToolCall(
@@ -334,22 +338,20 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                 // duplicate approval requests. Pass it through as a non-error
                 // JSON body so the agent + user see the full payload.
                 if (obj.approval_required === true) {
+                  // Non-error governance branch — still carries
+                  // structuredContent (#3498) since the declared outputSchema
+                  // makes the SDK require it on every non-error result.
+                  const approval: Record<string, unknown> = {
+                    approval_required: true,
+                    approval_request_id: obj.approval_request_id,
+                    matched_rules: obj.matched_rules,
+                    message: obj.message,
+                  };
                   return {
                     content: [
-                      {
-                        type: "text" as const,
-                        text: JSON.stringify(
-                          {
-                            approval_required: true,
-                            approval_request_id: obj.approval_request_id,
-                            matched_rules: obj.matched_rules,
-                            message: obj.message,
-                          },
-                          null,
-                          2,
-                        ),
-                      },
+                      { type: "text" as const, text: JSON.stringify(approval, null, 2) },
                     ],
+                    structuredContent: approval,
                   };
                 }
 
@@ -370,23 +372,20 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                 );
               }
 
+              // #3498 — typed result + retained text block. Both are built
+              // from the same object so they can never drift.
+              const structured: Record<string, unknown> = {
+                explanation: obj.explanation,
+                row_count: obj.row_count,
+                columns: obj.columns,
+                rows: obj.rows,
+                truncated: obj.truncated,
+              };
               return {
                 content: [
-                  {
-                    type: "text" as const,
-                    text: JSON.stringify(
-                      {
-                        explanation: obj.explanation,
-                        row_count: obj.row_count,
-                        columns: obj.columns,
-                        rows: obj.rows,
-                        truncated: obj.truncated,
-                      },
-                      null,
-                      2,
-                    ),
-                  },
+                  { type: "text" as const, text: JSON.stringify(structured, null, 2) },
                 ],
+                structuredContent: structured,
               };
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Closes #3498. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, spec 2025-11-25). One of the seams Session C's datasource tools build on.

## What

`executeSQL` and `runMetric` now declare an `outputSchema` and return `structuredContent`, so downstream clients/agents parse a typed `{ columns, rows, row_count, truncated, … }` result instead of re-parsing the stringified text block (which is **retained** for backward compatibility).

## Design notes

- **SSOT**: a new `structured-output.ts` holds the Zod output shapes, reused by both tools and the tests. No `{columns,rows,row_count,truncated}` wire shape exists in `@useatlas/schemas` today, so it lives in the MCP package; a future consolidation could lift it into `@useatlas/schemas` for the web/SDK.
- **Non-error branches**: the MCP SDK requires `structuredContent` on *every* non-error result once a tool declares an `outputSchema` (error envelopes are exempt — verified in `validateToolOutput`). Each tool has two disjoint non-error shapes — the data result and the non-error `approval_required` governance signal — so both now carry `structuredContent`. Because an MCP `outputSchema` must be a single `type: object`, the union is expressed as one object with optional members.
- **No drift**: the text block and `structuredContent` are built from the same object.

## Acceptance criteria (#3498)

- [x] `executeSQL` / `runMetric` declare `outputSchema`
- [x] responses include `structuredContent` conforming to it; text block retained
- [x] test validates output against the declared schema

## Tests

- `tools.test.ts` / `semantic-tools.test.ts` — a real success result is validated against the declared schema (`executeSqlOutputSchema` / `runMetricOutputSchema`), the text block is asserted to mirror `structuredContent`, and `listTools()` advertises the `outputSchema`.

Local: full MCP suite (23 files) + monorepo type + lint all green.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_