### PR TITLE
feat(web): audit-UI MCP attribution column + rows path on useAdminFetch (#3496)

### DIFF
--- a/packages/web/src/app/admin/audit/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/audit/__tests__/columns.test.ts
@@ -12,6 +12,7 @@ describe("getAuditColumns", () => {
     expect(ids).toEqual([
       "timestamp",
       "user",
+      "source",
       "sql",
       "tables_accessed",
       "duration_ms",

--- a/packages/web/src/app/admin/audit/columns.tsx
+++ b/packages/web/src/app/admin/audit/columns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
-import { Clock, User, Code, Timer, Rows3, CheckCircle, Table2 } from "lucide-react";
+import { Clock, User, Code, Timer, Rows3, CheckCircle, Table2, Bot } from "lucide-react";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -21,6 +21,11 @@ export interface AuditRow {
   source_id?: string | null;
   tables_accessed: string[] | null;
   columns_accessed: string[] | null;
+  // MCP attribution (migration 0049). NULL for non-MCP rows; populated by the
+  // MCP transport with the actor kind, OAuth client id, and dispatched tool.
+  actor_kind?: string | null;
+  client_id?: string | null;
+  tool_name?: string | null;
 }
 
 // ── Columns ───────────────────────────────────────────────────────
@@ -64,6 +69,43 @@ export function getAuditColumns(): ColumnDef<AuditRow>[] {
       enableColumnFilter: true,
       enableSorting: false,
       size: 128,
+    },
+    {
+      id: "source",
+      accessorFn: (row) => row.actor_kind ?? "",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Source" />
+      ),
+      // Surfaces the MCP attribution the row already carries (actor kind /
+      // OAuth client / dispatched tool) so an admin can tell an agent/MCP
+      // query from a human one — and which tool produced it — without raw SQL.
+      cell: ({ row }) => {
+        const { actor_kind, client_id, tool_name } = row.original;
+        if (!actor_kind) return <span className="text-xs text-muted-foreground">—</span>;
+        return (
+          <div className="flex flex-col gap-0.5 max-w-[160px]">
+            <Badge variant="secondary" className="w-fit text-[10px] px-1.5 py-0 capitalize">
+              {actor_kind}
+            </Badge>
+            {client_id && (
+              <span className="truncate text-[10px] text-muted-foreground" title={client_id}>
+                {client_id}
+              </span>
+            )}
+            {tool_name && (
+              <span className="truncate font-mono text-[10px] text-muted-foreground" title={tool_name}>
+                {tool_name}
+              </span>
+            )}
+          </div>
+        );
+      },
+      meta: {
+        label: "Source",
+        icon: Bot,
+      },
+      enableSorting: false,
+      size: 160,
     },
     {
       id: "sql",

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useQueryStates } from "nuqs";
+import { useEffect, useMemo, useState } from "react";
+import { useQueryStates, useQueryState, parseAsInteger } from "nuqs";
+import { getSortingStateParser } from "@/lib/parsers";
 import { auditSearchParams } from "./search-params";
 import { AnalyticsPanel } from "./analytics-panel";
 import { getAuditColumns, type AuditRow } from "./columns";
@@ -29,11 +30,12 @@ import { AdminActionsTab } from "../action-log/tab";
 import { RetentionPanel } from "./retention-panel";
 import { AdminActionRetentionPanel } from "./admin-action-retention-panel";
 import { Separator } from "@/components/ui/separator";
-import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import {
   AuditStatsSchema,
   AuditFacetsSchema,
+  AuditRowsResponseSchema,
   ConnectionsResponseSchema,
   AuditOAuthClientsSchema,
 } from "@/ui/lib/admin-schemas";
@@ -89,10 +91,6 @@ export default function AuditPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
-  const [rows, setRows] = useState<AuditRow[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<FetchError | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
 
@@ -156,9 +154,47 @@ export default function AuditPage() {
 
   // Column definitions
   const columns = getAuditColumns();
+  const columnIds = useMemo(
+    () => new Set(columns.map((c) => c.id).filter(Boolean) as string[]),
+    [columns],
+  );
+
+  // `useDataTable` writes pagination to `?page=` (1-indexed) + `?perPage=` and
+  // sorting to `?sort=`. Read them here so `useAdminFetch` can key the rows
+  // path off the same URL state WITHOUT a circular dependency on the table
+  // instance (mirrors the sessions/users admin pages). The sort parser is the
+  // exact one `useDataTable` uses, so page and table share one source of truth.
+  const [page] = useQueryState("page", parseAsInteger.withDefault(1));
+  const [perPage] = useQueryState("perPage", parseAsInteger.withDefault(LIMIT));
+  const [sorting] = useQueryState(
+    "sort",
+    getSortingStateParser<AuditRow>(columnIds).withDefault([{ id: "timestamp", desc: true }]),
+  );
+  const offset = (page - 1) * perPage;
+  const sortId = sorting[0]?.id;
+  const sortDesc = sorting[0]?.desc;
+
+  const queryParams: AuditQueryParams = {
+    pageSize: perPage, offset, search, connection, tableFilter, columnFilter, status, from, to, actorKind, clientId, tool, sortId, sortDesc,
+  };
+
+  // Rows — paginated, Zod-validated, off `useAdminFetch` so wire drift is a TS
+  // error (#3496). Disabled on the analytics tab (no rows needed there).
+  const rowsPath = `/api/v1/admin/audit?${buildQueryString(queryParams).toString()}`;
+  const {
+    data: rowsData,
+    loading,
+    error,
+    refetch: refetchRows,
+  } = useAdminFetch(rowsPath, {
+    schema: AuditRowsResponseSchema,
+    enabled: tab !== "analytics",
+  });
+  const rows = (rowsData?.rows ?? []) as AuditRow[];
+  const total = rowsData?.total ?? 0;
 
   // Data table with nuqs-managed pagination, sorting, column visibility
-  const pageCount = Math.max(1, Math.ceil(total / LIMIT));
+  const pageCount = Math.max(1, Math.ceil(total / perPage));
   const { table } = useDataTable({
     data: rows,
     columns,
@@ -176,59 +212,11 @@ export default function AuditPage() {
     { schema: AuditStatsSchema },
   );
 
-  // Clear stale errors when switching tabs
+  // Clear the export error when switching tabs (the rows error is owned by
+  // useAdminFetch and resets itself on refetch).
   useEffect(() => {
-    setError(null);
     setExportError(null);
   }, [tab]);
-
-  // Read pagination from table state for fetching
-  const { pageIndex, pageSize } = table.getState().pagination;
-  const offset = pageIndex * pageSize;
-
-  // Read sorting from table state
-  const sorting = table.getState().sorting;
-  const sortId = sorting[0]?.id;
-  const sortDesc = sorting[0]?.desc;
-
-  const queryParams: AuditQueryParams = {
-    pageSize, offset, search, connection, tableFilter, columnFilter, status, from, to, actorKind, clientId, tool, sortId, sortDesc,
-  };
-
-  // Fetch rows on mount and when table state changes (only for log tab)
-  useEffect(() => {
-    if (tab === "analytics") return;
-    let cancelled = false;
-    async function fetchRows() {
-      setLoading(true);
-      setError(null);
-      try {
-        const qs = buildQueryString(queryParams);
-        const res = await fetch(`${apiUrl}/api/v1/admin/audit?${qs}`, { credentials });
-        if (!res.ok) {
-          if (!cancelled) {
-            setError(await extractFetchError(res));
-          }
-          return;
-        }
-        const data = await res.json();
-        if (!cancelled) {
-          setRows(data.rows ?? []);
-          setTotal(data.total ?? 0);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError({
-            message: err instanceof Error ? err.message : "Failed to load audit log",
-          });
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    fetchRows();
-    return () => { cancelled = true; };
-  }, [apiUrl, offset, pageSize, search, connection, tableFilter, columnFilter, status, from, to, actorKind, clientId, tool, sortId, sortDesc, tab, credentials]);
 
   async function handleExport() {
     setExporting(true);
@@ -536,7 +524,7 @@ export default function AuditPage() {
             loading={loading}
             error={error}
             feature="Audit Log"
-            onRetry={() => { table.setPageIndex(0); }}
+            onRetry={() => { refetchRows(); }}
             loadingMessage="Loading audit log..."
             emptyIcon={ScrollText}
             emptyTitle="No query activity recorded yet"

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -152,6 +152,38 @@ export const AuditFacetsSchema = z.object({
   columns: z.array(z.string()),
 });
 
+/**
+ * One audit-log row as returned by `GET /api/v1/admin/audit` (the route
+ * selects `a.*`, so every audit_log column is present). Validating here turns
+ * a wire-shape drift into a TS/runtime error instead of a silent `undefined`.
+ * `.passthrough()` keeps forward-compat columns the table doesn't render yet.
+ */
+export const AuditRowSchema = z
+  .object({
+    id: z.string(),
+    user_id: z.string().nullable(),
+    sql: z.string(),
+    success: z.boolean(),
+    duration_ms: z.number(),
+    row_count: z.number().nullable(),
+    timestamp: z.string(),
+    user_email: z.string().nullable().optional(),
+    error: z.string().nullable().optional(),
+    source_id: z.string().nullable().optional(),
+    tables_accessed: z.array(z.string()).nullable(),
+    columns_accessed: z.array(z.string()).nullable(),
+    // MCP attribution (migration 0049) — NULL for non-MCP rows.
+    actor_kind: z.string().nullable().optional(),
+    client_id: z.string().nullable().optional(),
+    tool_name: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const AuditRowsResponseSchema = z.object({
+  rows: z.array(AuditRowSchema),
+  total: z.number(),
+});
+
 // `AuditConnectionMetaSchema` removed in #2444 — the audit page now reuses
 // the canonical `ConnectionsResponseSchema` so every consumer of
 // `/api/v1/admin/connections` shares the same TanStack Query cache shape


### PR DESCRIPTION
Closes #3496 · Parent PRD #3483

Surface the MCP attribution the audit rows already carry (`actor_kind` / `client_id` / `tool_name`, added by migration 0049 — the route `SELECT a.*` already returns them) and move the paginated rows fetch off raw `fetch` onto `useAdminFetch` with a typed schema so wire drift is a TS error. **Web-only** — no API change.

## What's here
- **`columns.tsx`** — extend `AuditRow` with `actor_kind`/`client_id`/`tool_name` + add a **"Source"** column (origin badge + client id + tool name; `—` for non-MCP rows). Filtering by `origin=mcp` now shows the attribution inline without reading raw SQL.
- **`admin-schemas.ts`** — `AuditRowSchema` + `AuditRowsResponseSchema` (`{ rows, total }`), `.passthrough()` for forward-compat columns.
- **`page.tsx`** — replace the raw `fetch` + `useState(rows/total/loading/error)` + `useEffect` with `useAdminFetch(rowsPath, { schema, enabled })`. Pagination/sort are read from nuqs (the same `page`/`perPage`/`sort` keys `useDataTable` writes) so the rows path keys on the same URL state with **no circular dependency** on the table instance — the established sessions/users-page pattern. The sort parser is the exact one `useDataTable` uses, so page and table share one source of truth.
- **`columns.test.ts`** — pin the new `source` column id.

## Acceptance criteria
- [x] audit table shows origin/client/tool (a "Source" column); filtering by `origin=mcp` shows attribution inline without raw SQL
- [x] paginated rows path uses `useAdminFetch` + Zod-validated response

Local web `type` + eslint + the columns test green.

https://claude.ai/code/session_01TCsGzUfn8gaTSwopCeVRhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCsGzUfn8gaTSwopCeVRhA)_