### PR TITLE
feat(mcp): elicitation adapter — masked form-mode behind a thin seam (#3499)

### DIFF
--- a/packages/mcp/src/__tests__/elicitation.test.ts
+++ b/packages/mcp/src/__tests__/elicitation.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the elicitation adapter seam (#3499).
+ *
+ * Two halves:
+ *   1. The server-held `requestState` security primitive — HMAC tamper-
+ *      evidence, principal binding, TTL, and single-use anti-replay.
+ *   2. A masked-field elicitation round-trip over the in-memory Client/Server
+ *      transport, asserting the entered value reaches the server WITHOUT
+ *      entering the agent/LLM context (it never appears in the tool result).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  signRequestState,
+  verifyRequestState,
+  elicitMaskedField,
+  NonceStore,
+  ElicitationError,
+  DEFAULT_REQUEST_STATE_TTL_MS,
+} from "../elicitation.js";
+
+const SECRET = "test-elicitation-secret";
+const PRINCIPAL = "org_test";
+
+describe("requestState", () => {
+  it("round-trips a freshly signed state", () => {
+    const token = signRequestState({ principal: PRINCIPAL, purpose: "elicit:apiKey" }, SECRET);
+    const result = verifyRequestState(token, { principal: PRINCIPAL, secret: SECRET });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.principal).toBe(PRINCIPAL);
+      expect(result.payload.purpose).toBe("elicit:apiKey");
+    }
+  });
+
+  it("rejects a tampered body (bad signature)", () => {
+    const token = signRequestState({ principal: PRINCIPAL, purpose: "p" }, SECRET);
+    const [v, , sig] = token.split(".");
+    const forgedBody = Buffer.from(
+      JSON.stringify({ v: 1, principal: "attacker", purpose: "p", nonce: "x", iat: 0, exp: 9e15 }),
+    ).toString("base64url");
+    const forged = `${v}.${forgedBody}.${sig}`;
+    expect(verifyRequestState(forged, { principal: "attacker", secret: SECRET })).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+
+  it("rejects a state minted for a different principal", () => {
+    const token = signRequestState({ principal: "org_a", purpose: "p" }, SECRET);
+    expect(verifyRequestState(token, { principal: "org_b", secret: SECRET })).toEqual({
+      ok: false,
+      reason: "principal_mismatch",
+    });
+  });
+
+  it("rejects an expired state", () => {
+    const token = signRequestState(
+      { principal: PRINCIPAL, purpose: "p", now: 1_000, ttlMs: 100 },
+      SECRET,
+    );
+    expect(
+      verifyRequestState(token, { principal: PRINCIPAL, secret: SECRET, now: 2_000 }),
+    ).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a wrong-secret signature", () => {
+    const token = signRequestState({ principal: PRINCIPAL, purpose: "p" }, SECRET);
+    expect(
+      verifyRequestState(token, { principal: PRINCIPAL, secret: "other-secret" }),
+    ).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a malformed token", () => {
+    expect(verifyRequestState("not-a-token", { principal: PRINCIPAL, secret: SECRET })).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("enforces single-use (anti-replay) against a NonceStore", () => {
+    const store = new NonceStore();
+    const token = signRequestState({ principal: PRINCIPAL, purpose: "p" }, SECRET);
+    const first = verifyRequestState(token, { principal: PRINCIPAL, secret: SECRET, nonceStore: store });
+    const second = verifyRequestState(token, { principal: PRINCIPAL, secret: SECRET, nonceStore: store });
+    expect(first.ok).toBe(true);
+    expect(second).toEqual({ ok: false, reason: "replayed" });
+  });
+
+  it("uses the documented default TTL", () => {
+    const token = signRequestState({ principal: PRINCIPAL, purpose: "p", now: 0 }, SECRET);
+    const result = verifyRequestState(token, { principal: PRINCIPAL, secret: SECRET, now: 0 });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.payload.exp).toBe(DEFAULT_REQUEST_STATE_TTL_MS);
+  });
+});
+
+/**
+ * Wire an in-memory client whose elicitation handler returns `reply`, plus a
+ * server exposing one test tool that elicits a masked field and stashes the
+ * value server-side. Returns the client + the server-side capture closure.
+ */
+async function wireElicitation(reply: {
+  action: "accept" | "decline" | "cancel";
+  content?: Record<string, string>;
+}) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  const captured: { value?: string; outcome?: string; error?: string } = {};
+
+  server.registerTool(
+    "needsSecret",
+    { description: "Elicits a masked secret", inputSchema: {} },
+    async (): Promise<CallToolResult> => {
+      try {
+        const outcome = await elicitMaskedField(server, {
+          principal: PRINCIPAL,
+          message: "Enter your API key",
+          field: { name: "apiKey", title: "API key", description: "never shared with the agent" },
+          secret: SECRET,
+          nonceStore: new NonceStore(),
+        });
+        captured.outcome = outcome.action;
+        if (outcome.action === "accept") captured.value = outcome.value;
+        // Deliberately DO NOT put the secret in the result — it must never
+        // re-enter the agent/LLM context.
+        return { content: [{ type: "text", text: `done:${outcome.action}` }] };
+      } catch (err) {
+        captured.error = err instanceof ElicitationError ? err.code : String(err);
+        return { content: [{ type: "text", text: "error" }], isError: true };
+      }
+    },
+  );
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.1" },
+    { capabilities: { elicitation: {} } },
+  );
+  client.setRequestHandler(ElicitRequestSchema, async () => reply);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, captured };
+}
+
+describe("elicitMaskedField round-trip", () => {
+  it("delivers the entered value to the server without it entering the tool result", async () => {
+    const { client, captured } = await wireElicitation({
+      action: "accept",
+      content: { apiKey: "sk-super-secret" },
+    });
+
+    const result = await client.callTool({ name: "needsSecret", arguments: {} });
+
+    // Server received the value out of band.
+    expect(captured.outcome).toBe("accept");
+    expect(captured.value).toBe("sk-super-secret");
+
+    // The secret NEVER appears in the agent-visible tool result.
+    expect(JSON.stringify(result.content)).not.toContain("sk-super-secret");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("surfaces a decline without a value", async () => {
+    const { client, captured } = await wireElicitation({ action: "decline" });
+    await client.callTool({ name: "needsSecret", arguments: {} });
+    expect(captured.outcome).toBe("decline");
+    expect(captured.value).toBeUndefined();
+  });
+
+  it("treats an accept with an empty field as an empty_value error", async () => {
+    const { client, captured } = await wireElicitation({
+      action: "accept",
+      content: { apiKey: "" },
+    });
+    await client.callTool({ name: "needsSecret", arguments: {} });
+    expect(captured.error).toBe("empty_value");
+  });
+});

--- a/packages/mcp/src/elicitation.ts
+++ b/packages/mcp/src/elicitation.ts
@@ -1,0 +1,338 @@
+/**
+ * Elicitation adapter — masked form-mode behind a thin seam (#3499 /
+ * ADR-0016, spec 2025-11-25).
+ *
+ * A tool can ask the client for a single field mid-call via
+ * `elicitMaskedField`. The entered value travels client→server out of band
+ * and NEVER enters the agent/LLM context — which is the real security goal
+ * for credentials. The adapter returns the value to the *server-side*
+ * caller; it is the caller's contract never to echo it into a tool result.
+ * (The 2025-11-25 form schema has no "password" primitive, so visual masking
+ * is the client's rendering responsibility; the out-of-band delivery is the
+ * structural guarantee.)
+ *
+ * ## Why a seam
+ *
+ * The 2026-07-28 draft replaces in-session elicitation delivery with the
+ * stateless MRTR model, where server-held state is round-tripped through the
+ * (attacker-controlled) client. Isolating every `elicitInput` call here
+ * makes that migration a one-file edit. To be aligned with the draft's
+ * attacker-controlled-state model **from day one**, the `requestState` this
+ * adapter mints is:
+ *
+ *   - **HMAC-signed** (tamper-evident) with a key derived from
+ *     `BETTER_AUTH_SECRET` — no new env knob;
+ *   - **principal-bound** — a state minted for principal A can't authorize a
+ *     value consumed under principal B;
+ *   - **TTL-bounded** — expires so a captured state is useless after a window;
+ *   - **single-use (anti-replay)** — a {@link NonceStore} consumes the nonce
+ *     on verify, so the same state can't be replayed.
+ *
+ * Today the SDK correlates request/response by JSON-RPC id, so the state is
+ * purely server-held: minted locally before the call, verified locally when
+ * the value is consumed. In the MRTR model the state will instead be carried
+ * by the client — the verify path here is already the single place that
+ * change lands.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const REQUEST_STATE_VERSION = "v1";
+
+/** Default validity window for a minted requestState. */
+export const DEFAULT_REQUEST_STATE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Default property key for the single elicited field. */
+const DEFAULT_FIELD_NAME = "value";
+
+// --- Errors -----------------------------------------------------------------
+
+/** Why a requestState failed verification, or why elicitation couldn't run. */
+export type ElicitationFailureCode =
+  | "malformed"
+  | "bad_signature"
+  | "expired"
+  | "principal_mismatch"
+  | "replayed"
+  | "missing_secret"
+  | "empty_value";
+
+/**
+ * Raised when a requestState fails verification or the masked field comes
+ * back empty. Carries a discriminating `code` so a caller maps it to an
+ * envelope without string-matching the message.
+ */
+export class ElicitationError extends Error {
+  override readonly name = "ElicitationError";
+  readonly code: ElicitationFailureCode;
+  constructor(code: ElicitationFailureCode, message?: string) {
+    super(message ?? `elicitation failed: ${code}`);
+    this.code = code;
+  }
+}
+
+// --- requestState: HMAC-signed, principal-bound, TTL'd, single-use ----------
+
+/** Decoded requestState body. `nonce` is the anti-replay token. */
+export interface RequestStatePayload {
+  readonly v: 1;
+  /** Principal (e.g. workspace/actor id) the state is bound to. */
+  readonly principal: string;
+  /** What the state authorizes (e.g. `elicit:apiKey`) — namespacing only. */
+  readonly purpose: string;
+  /** Single-use anti-replay nonce. */
+  readonly nonce: string;
+  /** Issued-at (epoch ms). */
+  readonly iat: number;
+  /** Expiry (epoch ms). */
+  readonly exp: number;
+}
+
+function b64url(input: string): string {
+  return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function hmac(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
+/**
+ * Derive a dedicated elicitation signing key from `BETTER_AUTH_SECRET` so the
+ * raw auth secret is never used directly. Throws {@link ElicitationError}
+ * (`missing_secret`) when the deployment has no auth secret configured —
+ * elicitation is only reachable on hosted/governed deployments, which always
+ * set it.
+ */
+export function resolveElicitationSecret(): string {
+  const base = process.env.BETTER_AUTH_SECRET;
+  if (!base) throw new ElicitationError("missing_secret");
+  return createHmac("sha256", base)
+    .update("atlas:mcp:elicitation:requestState")
+    .digest("hex");
+}
+
+/**
+ * Mint a signed requestState. Token shape: `v1.<payloadB64url>.<sigB64url>`.
+ * `nonce` / `now` are injectable for tests; production leaves them unset.
+ */
+export function signRequestState(
+  input: {
+    principal: string;
+    purpose: string;
+    ttlMs?: number;
+    now?: number;
+    nonce?: string;
+  },
+  secret: string,
+): string {
+  const iat = input.now ?? Date.now();
+  const payload: RequestStatePayload = {
+    v: 1,
+    principal: input.principal,
+    purpose: input.purpose,
+    nonce: input.nonce ?? randomBytes(16).toString("hex"),
+    iat,
+    exp: iat + (input.ttlMs ?? DEFAULT_REQUEST_STATE_TTL_MS),
+  };
+  const body = b64url(JSON.stringify(payload));
+  return `${REQUEST_STATE_VERSION}.${body}.${hmac(body, secret)}`;
+}
+
+export type VerifyRequestStateResult =
+  | { readonly ok: true; readonly payload: RequestStatePayload }
+  | { readonly ok: false; readonly reason: ElicitationFailureCode };
+
+/**
+ * Verify a requestState: signature (constant-time), principal binding, TTL,
+ * and — when a {@link NonceStore} is supplied — single-use (anti-replay).
+ * The nonce is consumed on the first successful verify, so a second verify of
+ * the same token against the same store fails with `replayed`.
+ */
+export function verifyRequestState(
+  token: string,
+  opts: {
+    principal: string;
+    secret: string;
+    now?: number;
+    nonceStore?: NonceStore;
+  },
+): VerifyRequestStateResult {
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== REQUEST_STATE_VERSION) {
+    return { ok: false, reason: "malformed" };
+  }
+  const [, body, sig] = parts;
+
+  const expectedSig = hmac(body, opts.secret);
+  const a = Buffer.from(sig, "utf8");
+  const b = Buffer.from(expectedSig, "utf8");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  let payload: RequestStatePayload;
+  try {
+    payload = JSON.parse(
+      Buffer.from(body, "base64url").toString("utf8"),
+    ) as RequestStatePayload;
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (payload.v !== 1 || typeof payload.nonce !== "string") {
+    return { ok: false, reason: "malformed" };
+  }
+
+  if (payload.principal !== opts.principal) {
+    return { ok: false, reason: "principal_mismatch" };
+  }
+
+  const now = opts.now ?? Date.now();
+  if (now >= payload.exp) {
+    return { ok: false, reason: "expired" };
+  }
+
+  // Anti-replay last: only burn the nonce once everything else checks out, so
+  // a tampered/expired token can be retried with a fresh state.
+  if (opts.nonceStore && !opts.nonceStore.consume(payload.nonce, payload.exp, now)) {
+    return { ok: false, reason: "replayed" };
+  }
+
+  return { ok: true, payload };
+}
+
+/**
+ * In-memory single-use nonce ledger for requestState anti-replay. Process-
+ * local — sufficient for the in-session model where a session is pinned to
+ * one process. The MRTR migration will swap this for a shared store; the
+ * `consume` contract is the seam.
+ */
+export class NonceStore {
+  private readonly seen = new Map<string, number>();
+
+  /**
+   * Record `nonce`, returning `true` if it was unseen (proceed) or `false`
+   * if it's a replay. Expired entries are pruned opportunistically so the
+   * map can't grow without bound.
+   */
+  consume(nonce: string, exp: number, now: number = Date.now()): boolean {
+    this.prune(now);
+    if (this.seen.has(nonce)) return false;
+    this.seen.set(nonce, exp);
+    return true;
+  }
+
+  private prune(now: number): void {
+    for (const [nonce, exp] of this.seen) {
+      if (exp <= now) this.seen.delete(nonce);
+    }
+  }
+
+  /** Test-only: drop all recorded nonces. */
+  clear(): void {
+    this.seen.clear();
+  }
+}
+
+/** Process-wide default nonce ledger used when a caller doesn't inject one. */
+const defaultNonceStore = new NonceStore();
+
+// --- The masked-field elicitation call --------------------------------------
+
+export interface MaskedFieldSpec {
+  /** Property key on the returned form object. Defaults to `"value"`. */
+  readonly name?: string;
+  /** Human-facing field label shown by the client. */
+  readonly title: string;
+  /** Optional field help text (e.g. "entered securely; never shared with the agent"). */
+  readonly description?: string;
+}
+
+export type ElicitMaskedOutcome =
+  | { readonly action: "accept"; readonly value: string }
+  | { readonly action: "decline" | "cancel" };
+
+export interface ElicitMaskedArgs {
+  /** Principal the elicitation is bound to (workspace/actor id). */
+  readonly principal: string;
+  /** Prompt shown to the user. */
+  readonly message: string;
+  /** The single field to collect. */
+  readonly field: MaskedFieldSpec;
+  /** Validity window for the minted requestState. */
+  readonly ttlMs?: number;
+  /** Signing secret. Defaults to {@link resolveElicitationSecret}. Injectable for tests. */
+  readonly secret?: string;
+  /** Anti-replay ledger. Defaults to the process-wide store. Injectable for tests. */
+  readonly nonceStore?: NonceStore;
+  /** Abort signal so a long-pending elicitation can be cancelled. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Ask the client for a single masked field mid-call.
+ *
+ * Flow: mint a server-held requestState (principal-bound, TTL'd) → send a
+ * form-mode `elicitInput` for one string field → on `accept`, verify+consume
+ * the requestState (binding the value-consumption to the principal, the
+ * window, and a single use) → return the entered value to the caller.
+ *
+ * The returned value is NEVER logged or placed in a tool result by this
+ * adapter — keeping it out of the agent/LLM context is the whole point.
+ */
+export async function elicitMaskedField(
+  server: McpServer,
+  args: ElicitMaskedArgs,
+): Promise<ElicitMaskedOutcome> {
+  const secret = args.secret ?? resolveElicitationSecret();
+  const nonceStore = args.nonceStore ?? defaultNonceStore;
+  const fieldName = args.field.name ?? DEFAULT_FIELD_NAME;
+
+  const requestState = signRequestState(
+    {
+      principal: args.principal,
+      purpose: `elicit:${fieldName}`,
+      ...(args.ttlMs != null ? { ttlMs: args.ttlMs } : {}),
+    },
+    secret,
+  );
+
+  const result = await server.server.elicitInput(
+    {
+      mode: "form",
+      message: args.message,
+      requestedSchema: {
+        type: "object",
+        properties: {
+          [fieldName]: {
+            type: "string",
+            title: args.field.title,
+            ...(args.field.description ? { description: args.field.description } : {}),
+          },
+        },
+        required: [fieldName],
+      },
+    },
+    args.signal ? { signal: args.signal } : undefined,
+  );
+
+  if (result.action !== "accept") {
+    return { action: result.action };
+  }
+
+  // Bind value-consumption to the issued state: principal + TTL + single use.
+  const verified = verifyRequestState(requestState, {
+    principal: args.principal,
+    secret,
+    nonceStore,
+  });
+  if (!verified.ok) {
+    throw new ElicitationError(verified.reason);
+  }
+
+  const raw = result.content?.[fieldName];
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ElicitationError("empty_value");
+  }
+  return { action: "accept", value: raw };
+}


### PR DESCRIPTION
Closes #3499. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, ADR-0016, spec 2025-11-25). One of the seams Session C's datasource credential entry builds on.

## What

A thin elicitation adapter (`elicitation.ts`). A tool can ask the client for a single field mid-call via `elicitMaskedField`; the entered value travels client→server **out of band** and never enters the agent/LLM context — the real security goal for credentials. The adapter returns the value to the *server-side* caller, whose contract is never to echo it into a tool result. (The 2025-11-25 form schema has no `password` primitive, so visual masking is the client's rendering concern; the out-of-band delivery is the structural guarantee.)

## Forward-compat seam + server-held state hardening

Every `elicitInput` call is isolated here so the 2026-07-28 MRTR delivery change is a one-file edit. To already match the draft's attacker-controlled-state model, the server-held `requestState` is — **from day one**:

- **HMAC-signed** — key derived from `BETTER_AUTH_SECRET` (no new env knob);
- **principal-bound** — a state minted for A can't authorize a value consumed under B;
- **TTL-bounded** — default 5 min;
- **single-use (anti-replay)** — a `NonceStore` consumes the nonce on verify.

Today the SDK correlates request/response by JSON-RPC id, so the state is minted + verified locally; `verifyRequestState` is the single place the future MRTR client round-trip lands.

## Acceptance criteria (#3499)

- [x] a tool can elicit a masked field mid-call
- [x] the entered value reaches the server without entering the agent/LLM context
- [x] the adapter is the single swap-point for the future MRTR migration
- [x] test covers a masked elicitation round-trip

## Tests

- requestState primitive: round-trip, tamper → `bad_signature`, wrong principal → `principal_mismatch`, expiry → `expired`, wrong secret, malformed, and replay → `replayed`.
- masked elicitation round-trip over the in-memory Client/Server: the value reaches the server (`captured.value`) but never appears in the agent-visible tool result; decline and empty-value paths covered.

Local: full MCP suite (24 files) + monorepo type + lint all green. `elicitation.ts` is a standalone seam (not yet wired to a tool — datasource credential entry consumes it in Session C's tier).

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_