### PR TITLE
feat(mcp): progress notifications + cancellation on long ops (#3500)

### DIFF
--- a/packages/mcp/src/__tests__/progress.test.ts
+++ b/packages/mcp/src/__tests__/progress.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the progress + cancellation seam (#3500).
+ *
+ * Exercises the shared wrapper directly with a minimal fake `extra` so the
+ * progress-token gating and the cancellation race are covered independently
+ * of any tool. The end-to-end progress/cancel paths over a real
+ * Client/Server are asserted in tools.test.ts / semantic-tools.test.ts.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  withProgressAndCancellation,
+  OperationCancelledError,
+  type McpRequestExtra,
+} from "../progress.js";
+
+interface ProgressParams {
+  progressToken: string | number;
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+/** Minimal `extra` double capturing emitted progress notifications. */
+function fakeExtra(opts: {
+  progressToken?: string | number;
+  signal?: AbortSignal;
+}): { extra: McpRequestExtra; progress: ProgressParams[] } {
+  const progress: ProgressParams[] = [];
+  const sendNotification = mock(async (n: { method: string; params?: ProgressParams }) => {
+    if (n.method === "notifications/progress" && n.params) progress.push(n.params);
+  });
+  const extra = {
+    signal: opts.signal ?? new AbortController().signal,
+    requestId: 1,
+    sendNotification,
+    sendRequest: mock(async () => ({})),
+    ...(opts.progressToken != null ? { _meta: { progressToken: opts.progressToken } } : {}),
+  } as unknown as McpRequestExtra;
+  return { extra, progress };
+}
+
+describe("withProgressAndCancellation", () => {
+  it("emits a start (0) and final progress when a token is supplied", async () => {
+    const { extra, progress } = fakeExtra({ progressToken: "tok" });
+    const result = await withProgressAndCancellation(extra, { total: 3 }, async (reporter) => {
+      await reporter.report(2, { message: "halfway" });
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(progress.map((p) => p.progress)).toEqual([0, 2, 3]);
+    expect(progress.every((p) => p.progressToken === "tok")).toBe(true);
+    expect(progress.at(-1)?.total).toBe(3);
+  });
+
+  it("is a no-op (no notifications) without a progressToken", async () => {
+    const { extra, progress } = fakeExtra({});
+    const result = await withProgressAndCancellation(extra, {}, async (reporter) => {
+      await reporter.report(1);
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(progress).toEqual([]);
+  });
+
+  it("throws OperationCancelledError when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const { extra } = fakeExtra({ signal: ac.signal });
+    await expect(
+      withProgressAndCancellation(extra, {}, async () => "never"),
+    ).rejects.toBeInstanceOf(OperationCancelledError);
+  });
+
+  it("rejects with OperationCancelledError when aborted mid-flight", async () => {
+    const ac = new AbortController();
+    const { extra } = fakeExtra({ signal: ac.signal });
+    const pending = withProgressAndCancellation(
+      extra,
+      {},
+      // Work that never resolves on its own — only the abort ends it.
+      () => new Promise<never>(() => {}),
+    );
+    setTimeout(() => ac.abort(), 10);
+    await expect(pending).rejects.toBeInstanceOf(OperationCancelledError);
+  });
+});

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -536,6 +536,19 @@ describe("MCP semantic tools", () => {
     expect(tools.find((t) => t.name === "runMetric")?.outputSchema).toBeDefined();
   });
 
+  it("runMetric emits progress notifications when a progressToken is supplied (#3500)", async () => {
+    const { client } = await createTestClient();
+    const progresses: number[] = [];
+    await client.callTool(
+      { name: "runMetric", arguments: { id: "orders_count" } },
+      undefined,
+      { onprogress: (p) => progresses.push(p.progress) },
+    );
+    expect(progresses.length).toBeGreaterThanOrEqual(2);
+    expect(progresses[0]).toBe(0);
+    expect(progresses.at(-1)!).toBeGreaterThan(progresses[0]);
+  });
+
   // Scalar coercion edge cases — `0`, `false`, and `null` are the most
   // likely metric values to silently break under a defensive `?? rows`.
   it.each([

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -267,6 +267,38 @@ describe("MCP tools", () => {
     expect(tools.find((t) => t.name === "executeSQL")?.outputSchema).toBeDefined();
   });
 
+  it("emits progress notifications when a progressToken is supplied (#3500)", async () => {
+    const { client } = await createTestClient();
+    const progresses: number[] = [];
+    await client.callTool(
+      { name: "executeSQL", arguments: { sql: "SELECT 1", explanation: "x" } },
+      undefined,
+      { onprogress: (p) => progresses.push(p.progress) },
+    );
+    // Start (0) + completion (>0), monotonically increasing.
+    expect(progresses.length).toBeGreaterThanOrEqual(2);
+    expect(progresses[0]).toBe(0);
+    expect(progresses.at(-1)!).toBeGreaterThan(progresses[0]);
+  });
+
+  it("aborts the dispatch when the client cancels (#3500)", async () => {
+    const { client } = await createTestClient();
+    // A query that never resolves on its own — only cancellation ends it.
+    mockExecuteSQLExecute.mockImplementationOnce(() => new Promise<never>(() => {}));
+
+    const ac = new AbortController();
+    const pending = client.callTool(
+      { name: "executeSQL", arguments: { sql: "SELECT pg_sleep(60)", explanation: "slow" } },
+      undefined,
+      { signal: ac.signal },
+    );
+    // Let the request reach the server, then cancel.
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort();
+
+    await expect(pending).rejects.toThrow();
+  });
+
   // Each test below uses the LITERAL upstream message string emitted by the
   // upstream constructor (sql.ts / rls.ts / source-rate-limit.ts /
   // connection.ts) — NOT a synthetic stand-in. If the upstream rewords its

--- a/packages/mcp/src/progress.ts
+++ b/packages/mcp/src/progress.ts
@@ -1,0 +1,113 @@
+/**
+ * Progress notifications + cancellation for long-running MCP dispatches
+ * (#3500, spec 2025-11-25).
+ *
+ * The shared wrapper threads the client's `progressToken` (from the
+ * `tools/call` `_meta`) into `notifications/progress`, and races the work
+ * against `extra.signal` — aborted when the client sends
+ * `notifications/cancelled` — so a cancelled dispatch stops awaiting
+ * immediately and frees the MCP layer. `executeSQL` / `runMetric` are the
+ * first consumers; the long-running profiling / semantic-gen tool (a later
+ * tier) is the reason this is a shared seam rather than per-tool code.
+ *
+ * Cancellation scope: `work` also receives the `AbortSignal`, so an op that
+ * natively honors it (profiling) aborts end to end. `executeSQL` does not yet
+ * thread the signal into the driver, so a cancelled query is cut loose at the
+ * MCP boundary and capped datasource-side by the existing statement timeout
+ * (`ATLAS_QUERY_TIMEOUT`).
+ */
+
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+
+/** The `extra` arg every MCP request handler receives from the SDK. */
+export type McpRequestExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+/**
+ * Thrown when the client cancels an in-flight dispatch
+ * (`notifications/cancelled`). The SDK suppresses the response for a
+ * cancelled request, so this propagates only to stop the dispatch and is not
+ * surfaced to the (already-gone) caller.
+ */
+export class OperationCancelledError extends Error {
+  override readonly name = "OperationCancelledError";
+  constructor() {
+    super("operation cancelled by client");
+  }
+}
+
+export interface ProgressReporter {
+  /**
+   * Emit an interim progress update. No-op when the client supplied no
+   * `progressToken`. `progress` must increase monotonically across a call.
+   */
+  report(progress: number, opts?: { total?: number; message?: string }): Promise<void>;
+}
+
+export interface ProgressOptions {
+  /** Known total units of work, if any (a determinate progress bar). */
+  readonly total?: number;
+  /** Message on the initial (0) progress notification. */
+  readonly startMessage?: string;
+  /** Message on the final progress notification. */
+  readonly endMessage?: string;
+}
+
+/**
+ * Run `work` with progress reporting + cancellation.
+ *
+ * - When the `tools/call` carried a `progressToken`, an initial progress (0)
+ *   is emitted, `reporter.report` forwards interim updates, and a final
+ *   progress (`total`, or `1`) is emitted on success. Without a token every
+ *   emit is a no-op (zero overhead for clients that don't ask).
+ * - `extra.signal` races the work; on cancellation the wrapper rejects with
+ *   {@link OperationCancelledError} so the dispatch stops awaiting at once.
+ */
+export async function withProgressAndCancellation<T>(
+  extra: McpRequestExtra,
+  opts: ProgressOptions,
+  work: (reporter: ProgressReporter, signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const progressToken = extra._meta?.progressToken;
+
+  const emit = (progress: number, message?: string, total?: number): Promise<void> => {
+    if (progressToken == null) return Promise.resolve();
+    const effectiveTotal = total ?? opts.total;
+    // Best-effort: a failed progress emit must never fail the underlying op.
+    return extra
+      .sendNotification({
+        method: "notifications/progress",
+        params: {
+          progressToken,
+          progress,
+          ...(effectiveTotal != null ? { total: effectiveTotal } : {}),
+          ...(message ? { message } : {}),
+        },
+      })
+      .catch(() => {});
+  };
+
+  const reporter: ProgressReporter = {
+    report: (progress, o) => emit(progress, o?.message, o?.total),
+  };
+
+  if (extra.signal.aborted) throw new OperationCancelledError();
+  await emit(0, opts.startMessage);
+
+  let onAbort: (() => void) | undefined;
+  const cancellation = new Promise<never>((_, reject) => {
+    onAbort = () => reject(new OperationCancelledError());
+    extra.signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    const result = await Promise.race([work(reporter, extra.signal), cancellation]);
+    await emit(opts.total ?? 1, opts.endMessage);
+    return result;
+  } finally {
+    if (onAbort) extra.signal.removeEventListener("abort", onAbort);
+  }
+}

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -62,6 +62,7 @@ import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
 import { createMcpLogger } from "./logger.js";
 import { runMetricOutputShape } from "./structured-output.js";
+import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
 
 const log = createMcpLogger("mcp:semantic-tools");
 
@@ -446,7 +447,7 @@ export function registerSemanticTools(
       // re-parsing the text block (which is retained below).
       outputSchema: runMetricOutputShape,
     },
-    async ({ id, filters, connectionId }): Promise<CallToolResult> =>
+    async ({ id, filters, connectionId }, extra): Promise<CallToolResult> =>
       traceMcpToolCall(
         {
           toolName: "runMetric",
@@ -558,9 +559,15 @@ export function registerSemanticTools(
                 ? `MCP runMetric ${metric.id}: ${metric.description}`
                 : `MCP runMetric ${metric.id}`;
 
-              const result = (await executeSQL.execute!(
-                { sql: metric.sql, explanation, connectionId: targetConnectionId },
-                { toolCallId: "mcp-runMetric", messages: [] },
+              // #3500 — progress + cancellation around the metric query.
+              const result = (await withProgressAndCancellation(
+                extra,
+                { startMessage: "Running metric", endMessage: "Metric complete" },
+                async (_reporter, signal) =>
+                  executeSQL.execute!(
+                    { sql: metric.sql, explanation, connectionId: targetConnectionId },
+                    { toolCallId: "mcp-runMetric", messages: [], abortSignal: signal },
+                  ),
               )) as Record<string, unknown>;
 
               if (result.success === false) {
@@ -625,6 +632,9 @@ export function registerSemanticTools(
                 executed_at: new Date().toISOString(),
               });
             } catch (err) {
+              // Client cancellation (#3500): re-throw so the SDK suppresses
+              // the response; not an error worth logging.
+              if (err instanceof OperationCancelledError) throw err;
               const message = errorMessage(err, "runMetric tool failed");
               log.error(
                 { err: err instanceof Error ? err : new Error(String(err)) },

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -51,6 +51,7 @@ import { billingGateOrNull } from "./billing-gate.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
 import { createMcpLogger } from "./logger.js";
 import { executeSqlOutputShape } from "./structured-output.js";
+import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
 
 const log = createMcpLogger("mcp:tools");
 
@@ -293,7 +294,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
       // re-parsing the text block (which is retained below).
       outputSchema: executeSqlOutputShape,
     },
-    async ({ sql, explanation, connectionId }): Promise<CallToolResult> =>
+    async ({ sql, explanation, connectionId }, extra): Promise<CallToolResult> =>
       traceMcpToolCall(
         { toolName: "executeSQL", workspaceId, transport, deployMode },
         () => {
@@ -319,9 +320,19 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                 requestId,
               });
               if (blocked) return blocked;
-              const result = await executeSQL.execute!(
-                { sql, explanation, connectionId },
-                { toolCallId: "mcp-executeSQL", messages: [] },
+              // #3500 — progress + cancellation around the query work. The
+              // signal is threaded into the execute ctx so a future
+              // signal-honoring path aborts end to end; today a cancel cuts
+              // the dispatch loose at the MCP boundary (statement timeout
+              // caps the datasource side).
+              const result = await withProgressAndCancellation(
+                extra,
+                { startMessage: "Running query", endMessage: "Query complete" },
+                async (_reporter, signal) =>
+                  executeSQL.execute!(
+                    { sql, explanation, connectionId },
+                    { toolCallId: "mcp-executeSQL", messages: [], abortSignal: signal },
+                  ),
               );
 
               // executeSQL collapses every PipelineError (8 tagged variants
@@ -388,6 +399,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                 structuredContent: structured,
               };
             } catch (err) {
+              // Client cancellation (#3500): the SDK suppresses the response,
+              // so re-throw without logging an error — it's expected, not a
+              // failure.
+              if (err instanceof OperationCancelledError) throw err;
               const message = err instanceof Error ? err.message : String(err);
               log.error(
                 { err: err instanceof Error ? err : new Error(String(err)) },


### PR DESCRIPTION
Closes #3500. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, spec 2025-11-25). The seam the long-running profiling/semantic-gen tool (Session C) builds on.

## What

A shared wrapper (`progress.ts`, `withProgressAndCancellation`) that:

- threads the client's `progressToken` (from the `tools/call` `_meta`) into `notifications/progress` — an initial `0` and a final progress are emitted when a token is supplied, and `reporter.report` forwards interim updates; **no token → every emit is a no-op** (zero overhead);
- races the dispatch against `extra.signal` (aborted by `notifications/cancelled`), so a cancelled dispatch stops awaiting at once and rejects with `OperationCancelledError` (the SDK suppresses the response for a cancelled request).

`executeSQL` and `runMetric` are the first consumers; the signal is also threaded into the `execute` ctx so a future signal-honoring path aborts end to end.

## Cancellation scope (honest note)

`executeSQL` doesn't yet thread the abort signal into the pg driver (that lives in `sql.ts`, outside this slice), so a cancelled query is cut loose at the MCP boundary and capped datasource-side by the existing statement timeout (`ATLAS_QUERY_TIMEOUT`, default 30s). The cancellable profiling tool will honor the signal natively through the same wrapper.

## Acceptance criteria (#3500)

- [x] long ops emit progress when a `progressToken` is supplied
- [x] a cancellation notification aborts a running dispatch and frees the MCP layer
- [x] test covers progress + cancel

## Tests

- `progress.test.ts` — unit: token gating (no token → no notifications), start/interim/final emission, already-aborted and mid-flight cancellation both reject with `OperationCancelledError`.
- `tools.test.ts` / `semantic-tools.test.ts` — end-to-end over the in-memory Client/Server: `onprogress` receives `[0, …]`, and a `callTool` with an aborted signal rejects (a never-resolving query is ended only by the cancel).

Local: full MCP suite (24 files) + monorepo type + lint all green.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_