### PR TITLE
feat(mcp): cursor pagination on list operations (#3501)

### DIFF
--- a/packages/mcp/src/__tests__/pagination.test.ts
+++ b/packages/mcp/src/__tests__/pagination.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for cursor pagination on MCP list operations (#3501).
+ *
+ * Unit: the opaque cursor codec + `paginate` slicing. End-to-end: a real
+ * Client pages through tools / resources / prompts over the in-memory
+ * transport with a tiny page size, asserting every item is reached across
+ * pages, cursors are opaque, and the final page omits `nextCursor`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  encodeCursor,
+  decodeCursor,
+  paginate,
+  installListPagination,
+} from "../pagination.js";
+
+describe("cursor codec", () => {
+  it("round-trips an offset", () => {
+    expect(decodeCursor(encodeCursor(42))).toBe(42);
+  });
+
+  it("treats an absent cursor as offset 0", () => {
+    expect(decodeCursor(undefined)).toBe(0);
+  });
+
+  it("rejects a malformed cursor with InvalidParams", () => {
+    expect(() => decodeCursor("not-a-cursor")).toThrow(McpError);
+    // A base64 payload that doesn't match the internal shape is still rejected.
+    expect(() => decodeCursor(Buffer.from("garbage").toString("base64url"))).toThrow(McpError);
+  });
+
+  it("does not expose the offset as a plain number (opaque)", () => {
+    expect(encodeCursor(5)).not.toBe("5");
+    expect(encodeCursor(5)).not.toContain("o:");
+  });
+});
+
+describe("paginate", () => {
+  it("returns one page + nextCursor when more remain", () => {
+    const { page, nextCursor } = paginate([1, 2, 3, 4, 5], undefined, 2);
+    expect(page).toEqual([1, 2]);
+    expect(nextCursor).toBeDefined();
+    expect(decodeCursor(nextCursor)).toBe(2);
+  });
+
+  it("omits nextCursor on the final page", () => {
+    const { page, nextCursor } = paginate([1, 2, 3], encodeCursor(2), 2);
+    expect(page).toEqual([3]);
+    expect(nextCursor).toBeUndefined();
+  });
+});
+
+/** Drain a paginated list, returning every item name across pages + the page count. */
+async function drainTools(client: Client) {
+  const names: string[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+  do {
+    const r = await client.listTools(cursor ? { cursor } : {});
+    names.push(...r.tools.map((t) => t.name));
+    cursor = r.nextCursor;
+    pages++;
+  } while (cursor && pages < 50);
+  return { names, pages };
+}
+
+describe("installListPagination end-to-end", () => {
+  async function wire(pageSize: number) {
+    const server = new McpServer(
+      { name: "test", version: "0.0.1" },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } },
+    );
+    for (const n of ["t1", "t2", "t3", "t4", "t5"]) {
+      server.registerTool(n, { description: n, inputSchema: {} }, async () => ({
+        content: [{ type: "text", text: n }],
+      }));
+    }
+    for (const n of ["r1", "r2", "r3"]) {
+      server.registerResource(
+        n,
+        `atlas://test/${n}`,
+        { description: n },
+        async (uri) => ({ contents: [{ uri: uri.href, text: n }] }),
+      );
+    }
+    for (const n of ["p1", "p2", "p3", "p4"]) {
+      server.registerPrompt(n, { description: n }, () => ({
+        messages: [{ role: "user", content: { type: "text", text: n } }],
+      }));
+    }
+
+    installListPagination(server, { pageSize });
+
+    const client = new Client({ name: "c", version: "0.0.1" });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    await client.connect(ct);
+    return client;
+  }
+
+  it("pages tools end to end", async () => {
+    const client = await wire(2);
+    const { names, pages } = await drainTools(client);
+    expect(names.sort()).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(pages).toBe(3); // 2 + 2 + 1
+  });
+
+  it("pages resources and omits nextCursor on the last page", async () => {
+    const client = await wire(2);
+    const first = await client.listResources();
+    expect(first.resources).toHaveLength(2);
+    expect(first.nextCursor).toBeDefined();
+    const second = await client.listResources({ cursor: first.nextCursor });
+    expect(second.resources).toHaveLength(1);
+    expect(second.nextCursor).toBeUndefined();
+  });
+
+  it("pages prompts end to end", async () => {
+    const client = await wire(3);
+    const first = await client.listPrompts();
+    expect(first.prompts).toHaveLength(3);
+    expect(first.nextCursor).toBeDefined();
+    const second = await client.listPrompts({ cursor: first.nextCursor });
+    expect(second.prompts).toHaveLength(1);
+    expect(second.nextCursor).toBeUndefined();
+  });
+
+  it("returns the whole list in one page when it fits", async () => {
+    const client = await wire(100);
+    const { names, pages } = await drainTools(client);
+    expect(names).toHaveLength(5);
+    expect(pages).toBe(1);
+  });
+});

--- a/packages/mcp/src/pagination.ts
+++ b/packages/mcp/src/pagination.ts
@@ -1,0 +1,142 @@
+/**
+ * Cursor pagination for MCP list operations (#3501, spec 2025-11-25).
+ *
+ * `tools/list`, `resources/list`, `resources/templates/list`, and
+ * `prompts/list` listings shouldn't balloon as config tools + entities grow.
+ * The high-level `McpServer` list handlers return the full set and ignore
+ * `params.cursor`, so this wraps each registered handler: it calls the inner
+ * handler for the full list, then returns one page + an opaque `nextCursor`
+ * when more remain.
+ *
+ * Wrapping (rather than reimplementing) keeps the SDK as the single source of
+ * the item shapes — tool input/output JSON schemas, resource templates,
+ * prompt arguments — so pagination can't drift from registration. It also
+ * means the custom `prompts/list` handler in `prompts/registry.ts` is paged
+ * the same way without that file knowing about pagination.
+ *
+ * Cursors are opaque to clients (base64url of an internal offset). They are
+ * NOT a stable contract — a client must only ever echo back the `nextCursor`
+ * it received, never construct or interpret one.
+ *
+ * Forward-compat: the 2026-07-28 draft keeps cursor pagination, so this needs
+ * no migration seam beyond the cursor codec living in one place.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ErrorCode,
+  McpError,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListPromptsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Default page size. Deliberately generous — pagination exists to bound
+ * worst-case growth, not to chunk today's small lists. No env knob: the
+ * value is an internal detail, and cursors are opaque so it can change
+ * without breaking clients.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
+const CURSOR_PREFIX = "o:";
+
+/** Encode an internal offset as an opaque cursor. */
+export function encodeCursor(offset: number): string {
+  return Buffer.from(`${CURSOR_PREFIX}${offset}`, "utf8").toString("base64url");
+}
+
+/**
+ * Decode an opaque cursor to its offset. `undefined` (first page) → 0. A
+ * malformed cursor is a client error → `McpError(InvalidParams)`, matching
+ * how the spec treats an invalid cursor.
+ */
+export function decodeCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, "base64url").toString("utf8");
+  } catch {
+    throw new McpError(ErrorCode.InvalidParams, "Invalid pagination cursor");
+  }
+  if (!decoded.startsWith(CURSOR_PREFIX)) {
+    throw new McpError(ErrorCode.InvalidParams, "Invalid pagination cursor");
+  }
+  const offset = Number(decoded.slice(CURSOR_PREFIX.length));
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new McpError(ErrorCode.InvalidParams, "Invalid pagination cursor");
+  }
+  return offset;
+}
+
+/** Slice `items` to the page at `cursor`, returning a `nextCursor` if more remain. */
+export function paginate<T>(
+  items: readonly T[],
+  cursor: string | undefined,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): { page: T[]; nextCursor?: string } {
+  const offset = decodeCursor(cursor);
+  const page = items.slice(offset, offset + pageSize);
+  const next = offset + pageSize;
+  return { page, ...(next < items.length ? { nextCursor: encodeCursor(next) } : {}) };
+}
+
+/** A request handler as stored in the SDK's internal handler map. */
+type RawListHandler = (
+  request: { params?: { cursor?: string } },
+  extra: unknown,
+) => Promise<Record<string, unknown>>;
+
+/**
+ * Read the handler the high-level server registered for `method`. Reaches
+ * into the SDK's `_requestHandlers` map (no public accessor) via a narrowly
+ * typed `unknown` cast — the {@link installListPagination} guard test asserts
+ * each handler is found so an SDK upgrade that renames the map fails CI
+ * loudly rather than silently dropping pagination.
+ */
+function captureHandler(server: McpServer, method: string): RawListHandler {
+  const map = (
+    server.server as unknown as {
+      _requestHandlers: Map<string, RawListHandler>;
+    }
+  )._requestHandlers;
+  const handler = map.get(method);
+  if (!handler) {
+    throw new Error(
+      `installListPagination: no registered handler for "${method}" to wrap — register tools/resources/prompts first`,
+    );
+  }
+  return handler;
+}
+
+const LIST_METHODS = [
+  { schema: ListToolsRequestSchema, method: "tools/list", itemsKey: "tools" },
+  { schema: ListResourcesRequestSchema, method: "resources/list", itemsKey: "resources" },
+  {
+    schema: ListResourceTemplatesRequestSchema,
+    method: "resources/templates/list",
+    itemsKey: "resourceTemplates",
+  },
+  { schema: ListPromptsRequestSchema, method: "prompts/list", itemsKey: "prompts" },
+] as const;
+
+/**
+ * Wrap every registered list handler with cursor pagination. Call once after
+ * all tools/resources/prompts are registered (so the handlers exist).
+ */
+export function installListPagination(
+  server: McpServer,
+  opts?: { pageSize?: number },
+): void {
+  const pageSize = opts?.pageSize ?? DEFAULT_PAGE_SIZE;
+  for (const { schema, method, itemsKey } of LIST_METHODS) {
+    const inner = captureHandler(server, method);
+    server.server.setRequestHandler(schema, async (request, extra) => {
+      const full = await inner(request, extra);
+      const items = Array.isArray(full[itemsKey]) ? (full[itemsKey] as unknown[]) : [];
+      const { page, nextCursor } = paginate(items, request.params?.cursor, pageSize);
+      return { ...full, [itemsKey]: page, ...(nextCursor ? { nextCursor } : {}) };
+    });
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -23,6 +23,7 @@ import { registerPrompts } from "./prompts/registry.js";
 import { resolveMcpActor } from "./actor.js";
 import type { McpTransport } from "./telemetry.js";
 import { createMcpLogger } from "./logger.js";
+import { installListPagination } from "./pagination.js";
 
 // Boot diagnostics go to stderr (JSON), not the api logger's stdout — stdout
 // carries the JSON-RPC stream on the stdio transport (#3494).
@@ -191,6 +192,11 @@ export async function createAtlasMcpServer(
     deployMode: getConfig()?.deployMode ?? "self-hosted",
     authMode: actor.mode,
   });
+
+  // #3501 — wrap every list handler (tools/resources/templates/prompts) with
+  // cursor pagination. Must run AFTER all registration so the handlers it
+  // wraps exist (including the custom prompts/list handler).
+  installListPagination(server);
 
   return server;
 }


### PR DESCRIPTION
Closes #3501. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, spec 2025-11-25).

## What

`tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` now return an opaque `nextCursor` when more results remain, so listings don't balloon as config tools + entities grow.

## Approach

The high-level `McpServer` list handlers return the full set and ignore `params.cursor`, so `installListPagination` (called once after registration in `server.ts`) **wraps** each registered handler: it calls the inner handler for the full list, then returns one page + `nextCursor`. Wrapping rather than reimplementing keeps the SDK as the single source of the item shapes — tool input/output JSON schemas, resource templates, prompt arguments — so pagination can't drift from registration, and the custom `prompts/list` handler is paged the same way without `prompts/registry.ts` knowing about pagination. (Net result: pagination lives entirely in `pagination.ts` + a one-line call in `server.ts`.)

Cursors are opaque (base64url of an internal offset); a malformed cursor is an `InvalidParams` error. The handler capture reaches into the SDK's `_requestHandlers` map (no public accessor) via a narrowly typed `unknown` cast, **guarded by the end-to-end test** so an SDK upgrade that renames it fails CI loudly.

## Acceptance criteria (#3501)

- [x] list handlers return `nextCursor` when more results exist; cursors are opaque
- [x] a client can page through a large list
- [x] test paginates a list end to end

## Tests

- cursor codec + `paginate` units (round-trip, absent → offset 0, malformed → `McpError`, opacity).
- end-to-end over the in-memory Client/Server with a tiny page size: tools paged across 3 pages (all reached), resources/prompts last page omits `nextCursor`, and a fits-in-one-page list returns no cursor.

Local: full MCP suite (25 files) + monorepo type + lint all green.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_