### PR TITLE
feat(mcp): resource subscriptions + lazy SEMANTIC_ROOT (#3502)

### DIFF
--- a/packages/mcp/src/__tests__/resources.test.ts
+++ b/packages/mcp/src/__tests__/resources.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { registerResources } from "../resources.js";
+import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { registerResources, semanticFileToResourceUri } from "../resources.js";
 
 // We test against the actual semantic/ directory in the repo root.
 // The test assumes cwd is the repo root (which bun test uses by default).
@@ -18,7 +20,7 @@ function getText(contents: Array<Record<string, unknown>>): string {
 
 async function createTestClient() {
   const server = new McpServer({ name: "test", version: "0.0.1" });
-  registerResources(server);
+  const handle = registerResources(server);
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -26,7 +28,7 @@ async function createTestClient() {
   await server.connect(serverTransport);
   await client.connect(clientTransport);
 
-  return { client, server };
+  return { client, server, handle };
 }
 
 describe("MCP resources", () => {
@@ -123,5 +125,94 @@ describe("MCP resources", () => {
     });
     const text = getText(result.contents as Array<Record<string, unknown>>);
     expect(text).toMatch(/Invalid metric name|not found/);
+  });
+});
+
+describe("semanticFileToResourceUri (#3502)", () => {
+  it("maps semantic files to their resource URIs", () => {
+    expect(semanticFileToResourceUri("catalog.yml")).toBe("atlas://semantic/catalog");
+    expect(semanticFileToResourceUri("glossary.yml")).toBe("atlas://semantic/glossary");
+    expect(semanticFileToResourceUri("entities/orders.yml")).toBe(
+      "atlas://semantic/entities/orders",
+    );
+    expect(semanticFileToResourceUri("metrics/revenue.yml")).toBe(
+      "atlas://semantic/metrics/revenue",
+    );
+  });
+
+  it("returns null for non-resource files", () => {
+    expect(semanticFileToResourceUri("README.md")).toBeNull();
+    expect(semanticFileToResourceUri("entities/nested/deep.yml")).toBeNull();
+    expect(semanticFileToResourceUri("metrics/foo.txt")).toBeNull();
+  });
+});
+
+describe("resource subscriptions (#3502)", () => {
+  /** Resolve once the client receives an `updated` for `uri` (or reject on timeout). */
+  function waitForUpdate(client: Client, uri: string, timeoutMs = 1000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timed out waiting for update")), timeoutMs);
+      client.setNotificationHandler(ResourceUpdatedNotificationSchema, (n) => {
+        if (n.params.uri === uri) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+  }
+
+  it("advertises the resources.subscribe capability", async () => {
+    const { client } = await createTestClient();
+    expect(client.getServerCapabilities()?.resources?.subscribe).toBe(true);
+  });
+
+  it("delivers notifications/resources/updated to a subscriber", async () => {
+    const { client, handle } = await createTestClient();
+    const uri = "atlas://semantic/entities/orders";
+    const updated = waitForUpdate(client, uri);
+    await client.subscribeResource({ uri });
+    expect(handle.subscriptionCount()).toBe(1);
+
+    // Simulate a semantic-layer change through the seam (what a regeneration
+    // / the fs watcher calls).
+    await handle.notifyResourceUpdated(uri);
+    await updated; // resolves only if the notification arrived
+  });
+
+  it("stops delivering after unsubscribe", async () => {
+    const { client, handle } = await createTestClient();
+    const uri = "atlas://semantic/entities/orders";
+    await client.subscribeResource({ uri });
+    await client.unsubscribeResource({ uri });
+    expect(handle.subscriptionCount()).toBe(0);
+
+    let received = false;
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, () => {
+      received = true;
+    });
+    await handle.notifyResourceUpdated(uri); // no-op: not subscribed
+    await new Promise((r) => setTimeout(r, 50));
+    expect(received).toBe(false);
+  });
+});
+
+describe("lazy semantic root (#3502)", () => {
+  it("resolves the semantic root per read, honoring ATLAS_SEMANTIC_ROOT set after import", async () => {
+    const original = process.env.ATLAS_SEMANTIC_ROOT;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-sem-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "catalog.yml"), "lazy-root-marker: true\n");
+      process.env.ATLAS_SEMANTIC_ROOT = tmp;
+      const { client } = await createTestClient();
+      const result = await client.readResource({ uri: "atlas://semantic/catalog" });
+      const text = getText(result.contents as Array<Record<string, unknown>>);
+      // Proves the root was read at request time (from the env set above),
+      // not captured at module-load time.
+      expect(text).toContain("lazy-root-marker");
+    } finally {
+      if (original === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+      else process.env.ATLAS_SEMANTIC_ROOT = original;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -16,21 +16,36 @@ import * as fs from "fs";
 import * as path from "path";
 import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  type ReadResourceResult,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
 import { createMcpLogger } from "./logger.js";
 
 const log = createMcpLogger("mcp:resources");
 
-const SEMANTIC_ROOT = getSemanticRoot();
+/**
+ * Resolve the semantic root lazily, per read (#3502). The previous
+ * module-load `const SEMANTIC_ROOT = getSemanticRoot()` captured the value
+ * before `initializeConfig()` could set `ATLAS_SEMANTIC_ROOT`, so a non-
+ * default root (or a root configured after import) was silently ignored.
+ * Resolving on each call closes that ordering hole and lets the resource
+ * watcher track the live root.
+ */
+function semanticRoot(): string {
+  return getSemanticRoot();
+}
 
 /**
  * Resolve a path within the semantic directory, rejecting path traversal.
- * Returns null if the resolved path escapes SEMANTIC_ROOT.
+ * Returns null if the resolved path escapes the semantic root.
  */
 function safePath(relativePath: string): string | null {
-  const resolved = path.resolve(SEMANTIC_ROOT, relativePath);
-  if (!resolved.startsWith(SEMANTIC_ROOT + path.sep) && resolved !== SEMANTIC_ROOT) {
+  const root = semanticRoot();
+  const resolved = path.resolve(root, relativePath);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
     return null;
   }
   return resolved;
@@ -72,7 +87,40 @@ function readSemanticFile(relativePath: string): string | null {
   }
 }
 
-export function registerResources(server: McpServer): void {
+/**
+ * Map a semantic file path (relative to the semantic root, POSIX-style) to
+ * the `atlas://semantic/...` resource URI it backs, or `null` if the file
+ * isn't an exposed resource. Used by the change watcher to fan a file change
+ * out to the subscribed resource URI. Exported for testing.
+ */
+export function semanticFileToResourceUri(relPath: string): string | null {
+  const normalized = relPath.split(path.sep).join("/");
+  if (normalized === "catalog.yml") return "atlas://semantic/catalog";
+  if (normalized === "glossary.yml") return "atlas://semantic/glossary";
+  const entity = /^entities\/([^/]+)\.yml$/.exec(normalized);
+  if (entity) return `atlas://semantic/entities/${entity[1]}`;
+  const metric = /^metrics\/([^/]+)\.yml$/.exec(normalized);
+  if (metric) return `atlas://semantic/metrics/${metric[1]}`;
+  return null;
+}
+
+/**
+ * Handle returned by {@link registerResources} for the resource-subscription
+ * seam (#3502). `notifyResourceUpdated` is the single place a
+ * `notifications/resources/updated` is emitted — the change hook a
+ * semantic-layer regeneration (the datasource/profiling tool) calls, and the
+ * file watcher's sink. Keeping it behind this seam means the 2026-07-28
+ * `subscriptions/listen` delivery change is a contained edit. `close` stops
+ * the watcher (call on server shutdown).
+ */
+export interface ResourceSubscriptionHandle {
+  notifyResourceUpdated(uri: string): Promise<void>;
+  /** Test-only/operational: current subscription set size. */
+  readonly subscriptionCount: () => number;
+  close(): void;
+}
+
+export function registerResources(server: McpServer): ResourceSubscriptionHandle {
   // --- Static: catalog.yml ---
   server.registerResource(
     "catalog",
@@ -227,4 +275,83 @@ export function registerResources(server: McpServer): void {
       };
     },
   );
+
+  // --- Resource subscriptions (#3502) ---------------------------------------
+  // Declare the capability alongside the listChanged the SDK already set when
+  // resources were registered, then handle subscribe/unsubscribe. A semantic
+  // resource changes when the layer is regenerated (the datasource/profiling
+  // tool calls `notifyResourceUpdated`) or when a file on disk changes (the
+  // lazy fs watcher below) — both funnel through the one seam.
+  server.server.registerCapabilities({ resources: { subscribe: true } });
+
+  const subscriptions = new Set<string>();
+  let watcher: fs.FSWatcher | undefined;
+
+  const notifyResourceUpdated = async (uri: string): Promise<void> => {
+    if (!subscriptions.has(uri)) return;
+    // Best-effort: a failed notify must not crash the watcher / caller.
+    await server.server.sendResourceUpdated({ uri }).catch((err: unknown) => {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)), uri },
+        "failed to send resources/updated notification",
+      );
+    });
+  };
+
+  const stopWatching = (): void => {
+    if (watcher) {
+      watcher.close();
+      watcher = undefined;
+    }
+  };
+
+  // Start watching lazily on the first subscription, and only watch while at
+  // least one subscription is live — so an idle server holds no FS watcher.
+  const ensureWatching = (): void => {
+    if (watcher) return;
+    const root = semanticRoot();
+    if (!fs.existsSync(root)) return;
+    try {
+      watcher = fs.watch(root, { recursive: true }, (_event, filename) => {
+        if (!filename) return;
+        const uri = semanticFileToResourceUri(filename.toString());
+        if (uri) void notifyResourceUpdated(uri);
+      });
+      // A watcher must never take down the process — log and degrade to the
+      // explicit-notify path (regeneration still emits updates).
+      watcher.on("error", (err) => {
+        log.warn(
+          { err: err instanceof Error ? err : new Error(String(err)) },
+          "semantic resource watcher errored — file-change notifications disabled",
+        );
+        stopWatching();
+      });
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)) },
+        "could not start semantic resource watcher — file-change notifications disabled",
+      );
+    }
+  };
+
+  server.server.setRequestHandler(SubscribeRequestSchema, async ({ params }) => {
+    subscriptions.add(params.uri);
+    ensureWatching();
+    return {};
+  });
+
+  server.server.setRequestHandler(UnsubscribeRequestSchema, async ({ params }) => {
+    subscriptions.delete(params.uri);
+    if (subscriptions.size === 0) stopWatching();
+    return {};
+  });
+
+  return {
+    notifyResourceUpdated,
+    subscriptionCount: () => subscriptions.size,
+    close: () => {
+      stopWatching();
+      subscriptions.clear();
+    },
+  };
 }


### PR DESCRIPTION
Closes #3502. Part of the v0.0.15 MCP V2 protocol uplift (PRD #3483, Tier 1, spec 2025-11-25).

## What

- Declares the `resources.subscribe` capability and handles `resources/subscribe` + `resources/unsubscribe`, emitting `notifications/resources/updated` so clients refresh when an entity definition changes.
- Fixes the latent ordering bug: the semantic root is now resolved **lazily per read** (`semanticRoot()`), not captured at module load — a non-default `ATLAS_SEMANTIC_ROOT` set after import was previously silently ignored.

## Design (the seam)

- `notifyResourceUpdated(uri)` is the **single** change-emission point — the hook a semantic-layer regeneration (the datasource/profiling tool, Session C) calls, and the sink of the lazy `fs.watch` (started on the first subscription, stopped when the last drops, errors degrade gracefully). Keeping it behind this seam makes the 2026-07-28 `subscriptions/listen` delivery change a contained edit.
- The capability is declared via `registerCapabilities` inside `registerResources`, so **server.ts is untouched** (no overlap with the pagination wiring).
- `semanticFileToResourceUri` maps a changed file to its `atlas://` URI.

## Acceptance criteria (#3502)

- [x] a client can subscribe to a semantic resource and receives `updated` on change
- [x] `SEMANTIC_ROOT` is resolved lazily, not at module-load time
- [x] test covers a subscribe → update round-trip

## Tests

- the file→URI mapper, capability advertisement, a subscribe → `updated` round-trip through the seam, unsubscribe stops delivery, and a lazy-root test proving the root is read at request time (`ATLAS_SEMANTIC_ROOT` set after import is honored).

Local: full MCP suite (25 files) + monorepo type + lint + test-discipline all green.

https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xvx4aY8vfXjDwxnoPdoTn)_