### PR TITLE
feat(mcp): datasource flagship tools — provision / profile / lifecycle (Tier 2)

### DIFF
--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -33,11 +33,27 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 let describeRows: Array<unknown> = [];
+// Controllable connection-registry surface for the provisioning pre-flight.
+let registryHas = new Set<string>();
+let healthResult: { status: string; latencyMs: number; message?: string; checkedAt: Date } | null = {
+  status: "healthy",
+  latencyMs: 1,
+  checkedAt: new Date(0),
+};
+let healthThrows: Error | null = null;
+const registerSpy = mock<(id: string, cfg: unknown) => void>(() => {});
+const unregisterSpy = mock<(id: string) => boolean>(() => true);
+const healthCheckSpy = mock<(id: string) => Promise<unknown>>(async () => {
+  if (healthThrows) throw healthThrows;
+  return healthResult;
+});
 mock.module("@atlas/api/lib/db/connection", () => ({
   connections: {
     describe: () => describeRows,
-    healthCheck: mock(async () => ({ status: "healthy", latencyMs: 1, checkedAt: new Date(0) })),
-    has: (id: string) => id !== "archived-ds",
+    healthCheck: healthCheckSpy,
+    has: (id: string) => registryHas.has(id),
+    register: registerSpy,
+    unregister: unregisterSpy,
   },
 }));
 
@@ -53,22 +69,40 @@ mock.module("@atlas/api/lib/content-mode", () => ({
 // Mock every value export — `workspace-installer` (transitively imported by
 // `runDatasourceInstaller`) also pulls `resolveDatasourcePoolConfig` +
 // `BUILTIN_DATASOURCE_CATALOG_SLUGS` from this module.
+let poolConfigResult: unknown = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "public" };
 mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
   catalogSlugToDbType: (slug: string) => {
     if (slug === "postgres") return "postgres";
     throw new Error(`unknown slug ${slug}`);
   },
-  resolveDatasourcePoolConfig: mock(() => ({})),
+  resolveDatasourcePoolConfig: mock(() => poolConfigResult),
   BUILTIN_DATASOURCE_CATALOG_SLUGS: ["postgres", "mysql"],
 }));
 
-const { listDatasources, runDatasourceInstaller } = await import("../mcp-lifecycle.js");
+// `loadDatasourceProfileTarget` parses the catalog schema + decrypts config.
+// Plaintext passthrough is enough — the dbType/url come from the resolver mock.
+mock.module("@atlas/api/lib/plugins/secrets", () => ({
+  parseConfigSchema: () => ({ state: "parsed", fields: [] }),
+  decryptSecretFields: (config: Record<string, unknown>) => config,
+  encryptSecretFields: (config: Record<string, unknown>) => config,
+  maskSecretFields: (config: Record<string, unknown>) => config,
+}));
+
+const { listDatasources, runDatasourceInstaller, provisionDatasource, loadDatasourceProfileTarget } =
+  await import("../mcp-lifecycle.js");
 
 beforeEach(() => {
   mockInternalQuery.mockClear();
   mockHasInternalDB.mockClear();
+  registerSpy.mockClear();
+  unregisterSpy.mockClear();
+  healthCheckSpy.mockClear();
   internalRows = [];
   describeRows = [];
+  registryHas = new Set();
+  healthResult = { status: "healthy", latencyMs: 1, checkedAt: new Date(0) };
+  healthThrows = null;
+  poolConfigResult = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "public" };
   mockHasInternalDB.mockReturnValue(true);
 });
 
@@ -189,5 +223,100 @@ describe("runDatasourceInstaller", () => {
     await expect(
       runDatasourceInstaller(() => Effect.die(new Error("DB pool exhausted"))),
     ).rejects.toThrow(/WorkspaceInstaller program died/);
+  });
+});
+
+describe("provisionDatasource — validate-before-persist + secret discipline", () => {
+  const SECRET_URL = "postgres://super:secret@db.internal:5432/prod";
+
+  it("rejects an unsupported dbType without touching the registry", async () => {
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "snowflake",
+      installId: "wh",
+      url: SECRET_URL,
+    });
+    expect(outcome.kind).toBe("unsupported");
+    expect(registerSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate install id (conflict) before the registry", async () => {
+    // The duplicate-check query returns a row → already exists.
+    internalRows = [{ catalog_slug: "postgres" }];
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "postgres",
+      installId: "dupe",
+      url: SECRET_URL,
+    });
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.status).toBe(409);
+    expect(registerSpy).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the ephemeral pool and scrubs the secret when the probe is unhealthy", async () => {
+    internalRows = []; // no duplicate
+    healthResult = { status: "unhealthy", latencyMs: 0, message: "could not connect to host", checkedAt: new Date(0) };
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "postgres",
+      installId: "new-pg",
+      url: SECRET_URL,
+    });
+    expect(outcome.kind).toBe("health_error");
+    // Ephemeral pool was registered then rolled back.
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(unregisterSpy).toHaveBeenCalledWith("new-pg");
+    // The credential never appears in the surfaced message.
+    if (outcome.kind === "health_error") {
+      expect(outcome.message).not.toContain("secret");
+      expect(outcome.message).not.toContain(SECRET_URL);
+    }
+  });
+
+  it("rolls back + scrubs when the probe throws (and strips embedded userinfo)", async () => {
+    internalRows = [];
+    healthThrows = new Error(`connect ECONNREFUSED for ${SECRET_URL}`);
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "postgres",
+      installId: "new-pg",
+      url: SECRET_URL,
+    });
+    expect(outcome.kind).toBe("health_error");
+    expect(unregisterSpy).toHaveBeenCalledWith("new-pg");
+    if (outcome.kind === "health_error") {
+      expect(outcome.message).not.toContain(SECRET_URL);
+      expect(outcome.message).not.toContain("super:secret");
+      expect(outcome.message).toContain("[redacted]");
+    }
+  });
+});
+
+describe("loadDatasourceProfileTarget", () => {
+  it("returns not_found for an unknown install", async () => {
+    internalRows = [];
+    const res = await loadDatasourceProfileTarget("org_1", "nope");
+    expect(res.kind).toBe("not_found");
+  });
+
+  it("returns the decrypted target for a postgres install", async () => {
+    internalRows = [
+      { catalog_id: "cat_pg", catalog_slug: "postgres", config: { url: "enc:v1:…" }, config_schema: [] },
+    ];
+    poolConfigResult = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "analytics" };
+    const res = await loadDatasourceProfileTarget("org_1", "pg");
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      expect(res.target.dbType).toBe("postgres");
+      expect(res.target.url).toBe("postgres://u:p@h/db");
+      expect(res.target.schema).toBe("analytics");
+    }
+  });
+
+  it("returns unsupported for a non-profilable dbType", async () => {
+    internalRows = [
+      { catalog_id: "cat_ch", catalog_slug: "clickhouse", config: {}, config_schema: [] },
+    ];
+    poolConfigResult = { dbType: "clickhouse", url: "clickhouse://h/db" };
+    const res = await loadDatasourceProfileTarget("org_1", "ch");
+    expect(res.kind).toBe("unsupported");
+    if (res.kind === "unsupported") expect(res.dbType).toBe("clickhouse");
   });
 });

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Lib-layer tests for the datasource MCP lifecycle helpers
+ * (`lib/datasources/mcp-lifecycle.ts`).
+ *
+ * Two enforcement points the MCP tools depend on:
+ *   1. `listDatasources` is allowlist-shaped — it maps ONLY the
+ *      credential-free columns onto `DatasourceSummary`, so even a row that
+ *      carries a stray secret can't leak (#3513 "list never returns
+ *      plaintext credentials").
+ *   2. `runDatasourceInstaller` maps the `WorkspaceInstaller` Effect's
+ *      result/Cause onto the context-free outcome the MCP tools render —
+ *      tagged errors → typed `{ status, code }`, defects → re-throw.
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { Effect } from "effect";
+import {
+  InvalidInstallIdError,
+  InstallNotFoundError,
+} from "@atlas/api/lib/effect/errors";
+
+// ── Mocks for the DB / registry primitives `listDatasources` calls ────
+
+let internalRows: Array<Record<string, unknown>> = [];
+const mockInternalQuery = mock<(...a: unknown[]) => Promise<unknown>>(
+  async () => internalRows,
+);
+const mockHasInternalDB = mock<() => boolean>(() => true);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mockHasInternalDB,
+}));
+
+let describeRows: Array<unknown> = [];
+mock.module("@atlas/api/lib/db/connection", () => ({
+  connections: {
+    describe: () => describeRows,
+    healthCheck: mock(async () => ({ status: "healthy", latencyMs: 1, checkedAt: new Date(0) })),
+    has: (id: string) => id !== "archived-ds",
+  },
+}));
+
+// `readFilter` is the pure status clause; the literal value is irrelevant to
+// these tests (internalQuery is mocked) — just return a stable fragment.
+mock.module("@atlas/api/lib/content-mode", () => ({
+  makeService: () => ({
+    readFilter: () => Effect.succeed("wp.status = 'published'"),
+  }),
+  CONTENT_MODE_TABLES: [],
+}));
+
+// Mock every value export — `workspace-installer` (transitively imported by
+// `runDatasourceInstaller`) also pulls `resolveDatasourcePoolConfig` +
+// `BUILTIN_DATASOURCE_CATALOG_SLUGS` from this module.
+mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
+  catalogSlugToDbType: (slug: string) => {
+    if (slug === "postgres") return "postgres";
+    throw new Error(`unknown slug ${slug}`);
+  },
+  resolveDatasourcePoolConfig: mock(() => ({})),
+  BUILTIN_DATASOURCE_CATALOG_SLUGS: ["postgres", "mysql"],
+}));
+
+const { listDatasources, runDatasourceInstaller } = await import("../mcp-lifecycle.js");
+
+beforeEach(() => {
+  mockInternalQuery.mockClear();
+  mockHasInternalDB.mockClear();
+  internalRows = [];
+  describeRows = [];
+  mockHasInternalDB.mockReturnValue(true);
+});
+
+describe("listDatasources", () => {
+  it("maps only credential-free fields — a stray secret column never leaks", async () => {
+    // Inject a hostile row carrying secret-shaped extras. The allowlist
+    // mapper must drop them.
+    internalRows = [
+      {
+        install_id: "prod-us",
+        status: "published",
+        group_id: "prod",
+        catalog_slug: "postgres",
+        // These must NOT appear in the output.
+        url: "postgres://user:pass@host/db",
+        password: "hunter2",
+        config: { secret: "leaked" },
+      },
+    ];
+    describeRows = [
+      {
+        id: "prod-us",
+        dbType: "postgres",
+        description: "Prod US",
+        health: { status: "healthy", latencyMs: 9, checkedAt: new Date("2026-06-13T00:00:00.000Z") },
+      },
+    ];
+
+    const out = await listDatasources("org_1", "published");
+    expect(out).toHaveLength(1);
+    const row = out[0];
+    expect(row).toEqual({
+      id: "prod-us",
+      dbType: "postgres",
+      description: "Prod US",
+      status: "published",
+      groupId: "prod",
+      health: { status: "healthy", latencyMs: 9, checkedAt: "2026-06-13T00:00:00.000Z" },
+    });
+    // Hard guarantee: serialized output carries no credential.
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("hunter2");
+    expect(serialized).not.toContain("pass@host");
+    expect(serialized).not.toContain("leaked");
+  });
+
+  it("falls back to catalogSlugToDbType + null health for an unregistered (archived) install", async () => {
+    internalRows = [
+      { install_id: "old-db", status: "archived", group_id: null, catalog_slug: "postgres" },
+    ];
+    describeRows = []; // not registered → describe() empty
+    const out = await listDatasources("org_1", "published", { includeArchived: true });
+    expect(out[0]).toEqual({
+      id: "old-db",
+      dbType: "postgres",
+      description: null,
+      status: "archived",
+      groupId: null,
+      health: null,
+    });
+  });
+
+  it("degrades an unknown catalog slug to dbType 'unknown' rather than throwing", async () => {
+    internalRows = [
+      { install_id: "weird", status: "published", group_id: null, catalog_slug: "mystery" },
+    ];
+    const out = await listDatasources("org_1", "published");
+    expect(out[0].dbType).toBe("unknown");
+  });
+
+  it("returns [] when no internal DB is configured", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    const out = await listDatasources("org_1", "published");
+    expect(out).toEqual([]);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("runDatasourceInstaller", () => {
+  it("returns kind:ok with the Effect's success value", async () => {
+    const outcome = await runDatasourceInstaller(() => Effect.succeed({ id: "x", status: "published" }));
+    expect(outcome).toEqual({ kind: "ok", value: { id: "x", status: "published" } } as never);
+  });
+
+  it("maps a tagged InvalidInstallIdError → 400 bad_request", async () => {
+    const outcome = await runDatasourceInstaller(() =>
+      Effect.fail(
+        new InvalidInstallIdError({
+          message: 'install_id "default" is reserved',
+          installId: "default",
+          reason: "reserved",
+        }),
+      ),
+    );
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.status).toBe(400);
+      expect(outcome.code).toBe("bad_request");
+      expect(outcome.message).toContain("reserved");
+    }
+  });
+
+  it("maps a tagged InstallNotFoundError → 404 not_found", async () => {
+    const outcome = await runDatasourceInstaller(() =>
+      Effect.fail(
+        new InstallNotFoundError({
+          message: "install not found",
+          workspaceId: "org_1",
+          catalogSlug: "postgres",
+        }),
+      ),
+    );
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.status).toBe(404);
+  });
+
+  it("re-throws on a defect (non-tagged failure) so the caller surfaces a 500", async () => {
+    await expect(
+      runDatasourceInstaller(() => Effect.die(new Error("DB pool exhausted"))),
+    ).rejects.toThrow(/WorkspaceInstaller program died/);
+  });
+});

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -18,8 +18,14 @@ import {
   InvalidInstallIdError,
   InstallNotFoundError,
 } from "@atlas/api/lib/effect/errors";
+import { createConnectionMock } from "../../../__mocks__/connection";
 
 // ── Mocks for the DB / registry primitives `listDatasources` calls ────
+//
+// `@atlas/api/lib/content-mode` is NOT mocked — its `makeService` / `readFilter`
+// are pure (no I/O) so the real module runs hermetically and exercises the real
+// status-clause logic. `internalQuery` is mocked, so the resolved clause's exact
+// text is irrelevant to these tests.
 
 let internalRows: Array<Record<string, unknown>> = [];
 const mockInternalQuery = mock<(...a: unknown[]) => Promise<unknown>>(
@@ -47,24 +53,20 @@ const healthCheckSpy = mock<(id: string) => Promise<unknown>>(async () => {
   if (healthThrows) throw healthThrows;
   return healthResult;
 });
-mock.module("@atlas/api/lib/db/connection", () => ({
-  connections: {
-    describe: () => describeRows,
-    healthCheck: healthCheckSpy,
-    has: (id: string) => registryHas.has(id),
-    register: registerSpy,
-    unregister: unregisterSpy,
-  },
-}));
-
-// `readFilter` is the pure status clause; the literal value is irrelevant to
-// these tests (internalQuery is mocked) — just return a stable fragment.
-mock.module("@atlas/api/lib/content-mode", () => ({
-  makeService: () => ({
-    readFilter: () => Effect.succeed("wp.status = 'published'"),
+// Full-module connection mock (every export shaped) with only the registry
+// methods this suite drives overridden — the blessed `createConnectionMock`
+// pattern, not a hand-rolled partial mock.
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => describeRows,
+      healthCheck: healthCheckSpy,
+      has: (id: string) => registryHas.has(id),
+      register: registerSpy,
+      unregister: unregisterSpy,
+    },
   }),
-  CONTENT_MODE_TABLES: [],
-}));
+);
 
 // Mock every value export — `workspace-installer` (transitively imported by
 // `runDatasourceInstaller`) also pulls `resolveDatasourcePoolConfig` +
@@ -252,8 +254,36 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     expect(registerSpy).not.toHaveBeenCalled();
   });
 
+  it("probes an EPHEMERAL id (never the install id) and always rolls it back", async () => {
+    internalRows = [];
+    healthResult = { status: "healthy", latencyMs: 5, checkedAt: new Date(0) };
+    // Health OK → reaches the installer; installDatasource isn't mocked here,
+    // so the program will fail — but we only assert the pre-flight behaviour.
+    await provisionDatasource("org_1", { catalogSlug: "postgres", installId: "new-pg", url: SECRET_URL })
+      .catch(() => undefined);
+    // Registered + unregistered exactly the same throwaway id, never "new-pg".
+    const registeredId = registerSpy.mock.calls[0]?.[0] as string;
+    expect(registeredId).toStartWith("__mcp_preflight_");
+    expect(registeredId).not.toBe("new-pg");
+    expect(unregisterSpy).toHaveBeenCalledWith(registeredId);
+  });
+
+  it("treats a first-attempt 'degraded' probe as a failure (not just 'unhealthy')", async () => {
+    // healthCheck returns 'degraded' on the FIRST failed probe; the old
+    // `=== 'unhealthy'` check let it through. Now any non-'healthy' fails.
+    internalRows = [];
+    healthResult = { status: "degraded", latencyMs: 0, message: "could not connect to host", checkedAt: new Date(0) };
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "postgres",
+      installId: "new-pg",
+      url: SECRET_URL,
+    });
+    expect(outcome.kind).toBe("health_error");
+    expect(unregisterSpy).toHaveBeenCalledTimes(1); // probe rolled back
+  });
+
   it("rolls back the ephemeral pool and scrubs the secret when the probe is unhealthy", async () => {
-    internalRows = []; // no duplicate
+    internalRows = [];
     healthResult = { status: "unhealthy", latencyMs: 0, message: "could not connect to host", checkedAt: new Date(0) };
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "postgres",
@@ -261,10 +291,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
       url: SECRET_URL,
     });
     expect(outcome.kind).toBe("health_error");
-    // Ephemeral pool was registered then rolled back.
     expect(registerSpy).toHaveBeenCalledTimes(1);
-    expect(unregisterSpy).toHaveBeenCalledWith("new-pg");
-    // The credential never appears in the surfaced message.
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
     if (outcome.kind === "health_error") {
       expect(outcome.message).not.toContain("secret");
       expect(outcome.message).not.toContain(SECRET_URL);
@@ -280,10 +308,11 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
       url: SECRET_URL,
     });
     expect(outcome.kind).toBe("health_error");
-    expect(unregisterSpy).toHaveBeenCalledWith("new-pg");
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
     if (outcome.kind === "health_error") {
       expect(outcome.message).not.toContain(SECRET_URL);
       expect(outcome.message).not.toContain("super:secret");
+      // Exact-url scrub replaces the whole DSN, '@'-password and all.
       expect(outcome.message).toContain("[redacted]");
     }
   });

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -39,6 +39,11 @@ import {
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import {
+  MCP_PROVISIONABLE_CATALOG_SLUGS,
+  isMcpNativeDbType,
+  type McpNativeDbType,
+} from "@atlas/api/lib/datasources/provisionable-types";
+import {
   WorkspaceInstaller,
   WorkspaceInstallerLive,
   mapInstallError,
@@ -296,30 +301,15 @@ export async function runDatasourceInstaller<A>(
 
 // ── Provisioning (#3511 create) ───────────────────────────────────────
 
-/**
- * The native dbTypes the `ConnectionRegistry` can build a pool for directly
- * from a `url` — i.e. the ones whose ephemeral health-check probe genuinely
- * exercises connectivity AND whose tables the in-core profiler can
- * introspect. This single set is the source of truth for BOTH the
- * provisioning allow-list ({@link MCP_PROVISIONABLE_CATALOG_SLUGS}) and the
- * profiling support check ({@link loadDatasourceProfileTarget}) so the two
- * can't drift (a datasource the agent can create but never make queryable).
- *
- * Plugin-managed pools (clickhouse / snowflake / bigquery / salesforce / …)
- * need a different test-connect + profiler path and are intentionally out of
- * scope for the MCP flow until that lands; the admin console still handles
- * them. Mirrors the bridge's `dbType !== "postgres" && !== "mysql"` native
- * split in `datasource-registry-bridge.ts`.
- */
-export type McpNativeDbType = "postgres" | "mysql";
-const MCP_NATIVE_DB_TYPES: ReadonlySet<McpNativeDbType> = new Set(["postgres", "mysql"]);
-
-function isMcpNativeDbType(dbType: string): dbType is McpNativeDbType {
-  return (MCP_NATIVE_DB_TYPES as ReadonlySet<string>).has(dbType);
-}
-
-/** Catalog slugs provisionable via MCP — derived from {@link MCP_NATIVE_DB_TYPES}. */
-export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [...MCP_NATIVE_DB_TYPES];
+// The native-dbType set + provisionable slugs live in the dependency-free
+// `provisionable-types` module so the MCP layer can read the `db_type` enum at
+// registration time without pulling this heavy graph. Re-exported here for
+// existing consumers.
+export {
+  MCP_PROVISIONABLE_CATALOG_SLUGS,
+  isMcpNativeDbType,
+  type McpNativeDbType,
+};
 
 /**
  * Input to {@link provisionDatasource}. `url` is the credential collected

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -37,6 +37,7 @@ import {
   resolveDatasourcePoolConfig,
 } from "@atlas/api/lib/db/datasource-pool-resolver";
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import {
   WorkspaceInstaller,
   WorkspaceInstallerLive,
@@ -296,15 +297,29 @@ export async function runDatasourceInstaller<A>(
 // ── Provisioning (#3511 create) ───────────────────────────────────────
 
 /**
- * Datasource types provisionable via MCP today. Scoped to the native
- * dbTypes whose pool the `ConnectionRegistry` can build directly from a
- * `url` — so the validate-before-persist health-check (register → SELECT 1
- * → unregister) genuinely exercises connectivity. Plugin-managed pools
- * (clickhouse / snowflake / bigquery / salesforce) need a different
- * test-connect path and are intentionally out of scope for the MCP
- * provisioning flow until that lands; the admin console still handles them.
+ * The native dbTypes the `ConnectionRegistry` can build a pool for directly
+ * from a `url` — i.e. the ones whose ephemeral health-check probe genuinely
+ * exercises connectivity AND whose tables the in-core profiler can
+ * introspect. This single set is the source of truth for BOTH the
+ * provisioning allow-list ({@link MCP_PROVISIONABLE_CATALOG_SLUGS}) and the
+ * profiling support check ({@link loadDatasourceProfileTarget}) so the two
+ * can't drift (a datasource the agent can create but never make queryable).
+ *
+ * Plugin-managed pools (clickhouse / snowflake / bigquery / salesforce / …)
+ * need a different test-connect + profiler path and are intentionally out of
+ * scope for the MCP flow until that lands; the admin console still handles
+ * them. Mirrors the bridge's `dbType !== "postgres" && !== "mysql"` native
+ * split in `datasource-registry-bridge.ts`.
  */
-export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = ["postgres", "mysql"];
+export type McpNativeDbType = "postgres" | "mysql";
+const MCP_NATIVE_DB_TYPES: ReadonlySet<McpNativeDbType> = new Set(["postgres", "mysql"]);
+
+function isMcpNativeDbType(dbType: string): dbType is McpNativeDbType {
+  return (MCP_NATIVE_DB_TYPES as ReadonlySet<string>).has(dbType);
+}
+
+/** Catalog slugs provisionable via MCP — derived from {@link MCP_NATIVE_DB_TYPES}. */
+export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [...MCP_NATIVE_DB_TYPES];
 
 /**
  * Input to {@link provisionDatasource}. `url` is the credential collected
@@ -332,17 +347,17 @@ export type ProvisionDatasourceOutcome =
   | { readonly kind: "error"; readonly status: 400 | 404 | 409; readonly code: string; readonly message: string };
 
 /**
- * Strip any occurrence of a secret URL (and embedded `//user:pass@` userinfo)
- * out of an error message so a connection-failure surfaced to the agent/client
- * can never leak the credential. Defense-in-depth on top of the registry's own
- * DSN scrubbing.
+ * Strip the secret URL out of an error message so a connection-failure
+ * surfaced to the agent/client can never leak the credential. First removes
+ * the exact `url` (handles a `@`-bearing password the userinfo regex below
+ * can't), then defers to the canonical {@link errorMessage} scrubber for the
+ * generic `scheme://user:pass@host` userinfo case + the 512-char truncation —
+ * reusing the blessed seam (`lib/audit/error-scrub.ts`) rather than a
+ * hand-rolled regex so a future hardening there covers this path too.
  */
 function scrubSecretFromMessage(message: string, url: string): string {
-  let out = message;
-  if (url) out = out.split(url).join("[redacted]");
-  // Strip `scheme://user:pass@host` userinfo even if the URL was reshaped.
-  out = out.replace(/\/\/[^/@\s]*@/g, "//[redacted]@");
-  return out;
+  const exact = url ? message.split(url).join("[redacted]") : message;
+  return errorMessage(exact);
 }
 
 /**
@@ -359,7 +374,7 @@ export async function provisionDatasource(
   orgId: string,
   input: ProvisionDatasourceInput,
 ): Promise<ProvisionDatasourceOutcome> {
-  if (!MCP_PROVISIONABLE_CATALOG_SLUGS.includes(input.catalogSlug)) {
+  if (!isMcpNativeDbType(input.catalogSlug)) {
     return {
       kind: "unsupported",
       message:
@@ -380,29 +395,36 @@ export async function provisionDatasource(
     };
   }
 
-  // Pre-flight: register an ephemeral native pool, probe it, then roll back.
-  // Mirrors the admin route's route-owned test-connect dance (ADR-0007).
-  const registryConfig = {
+  // Pre-flight on an EPHEMERAL probe id — never the real install id. Using a
+  // throwaway id (a) guarantees the probe tests THIS candidate `url`, not a
+  // stale bare pool that might already exist under `installId` (e.g. a
+  // sibling workspace's pool, the runtime `default`, or an un-drained
+  // archived install), and (b) can't leave the install-id-keyed registry in a
+  // split-brain state if persist later fails. Mirrors the admin route's
+  // `_test_*` ephemeral test-connect (ADR-0007). The probe pool is ALWAYS
+  // unregistered in `finally`.
+  const probeId = `__mcp_preflight_${crypto.randomUUID()}`;
+  connections.register(probeId, {
     url: input.url,
     ...(input.description !== undefined ? { description: input.description } : {}),
     ...(input.schema !== undefined ? { schema: input.schema } : {}),
-  };
-  const weRegistered = !connections.has(input.installId);
-  if (weRegistered) connections.register(input.installId, registryConfig);
+  });
   try {
-    const health = await connections.healthCheck(input.installId);
-    if (health.status === "unhealthy") {
-      if (weRegistered) connections.unregister(input.installId);
+    const health = await connections.healthCheck(probeId);
+    // `healthCheck` only reports `unhealthy` after repeated failures over a
+    // window; a brand-new pool's FIRST failed probe is `degraded`. So treat
+    // anything that isn't `healthy` as a failed pre-flight — otherwise a
+    // broken connection slips past validate-before-persist.
+    if (health.status !== "healthy") {
       return {
         kind: "health_error",
         message: scrubSecretFromMessage(
-          health.message ?? "Connection probe reported the datasource as unreachable.",
+          health.message ?? "Connection probe could not reach the datasource.",
           input.url,
         ),
       };
     }
   } catch (err) {
-    if (weRegistered) connections.unregister(input.installId);
     const raw = err instanceof Error ? err.message : String(err);
     return {
       kind: "health_error",
@@ -411,6 +433,10 @@ export async function provisionDatasource(
         input.url,
       ),
     };
+  } finally {
+    // Always drain the probe pool — success persists via the installer's own
+    // fresh registration, failure persists nothing.
+    connections.unregister(probeId);
   }
 
   // Health OK → persist as draft. The installer re-registers idempotently and
@@ -429,7 +455,9 @@ export async function provisionDatasource(
     }),
   );
   if (outcome.kind === "error") {
-    if (weRegistered) connections.unregister(input.installId);
+    // Nothing to roll back: the probe pool was already drained in `finally`,
+    // and `installDatasource` registers the real pool only as its final step
+    // (after a successful persist), so a failed install left no pool behind.
     return {
       kind: "error",
       status: outcome.status,
@@ -445,7 +473,7 @@ export async function provisionDatasource(
 /** Resolved profiling target — internal use only; `url` is the decrypted secret. */
 export interface DatasourceProfileTarget {
   readonly url: string;
-  readonly dbType: "postgres" | "mysql";
+  readonly dbType: McpNativeDbType;
   readonly schema?: string;
 }
 
@@ -496,6 +524,9 @@ export async function loadDatasourceProfileTarget(
     },
     decrypted,
   );
+  // Discriminant check (not the `isMcpNativeDbType` string guard) so TS
+  // narrows the `DatasourcePoolConfig` union to the postgres/mysql members
+  // that carry `.url`. Same native set as `MCP_NATIVE_DB_TYPES`.
   if (poolConfig.dbType !== "postgres" && poolConfig.dbType !== "mysql") {
     return { kind: "unsupported", dbType: poolConfig.dbType };
   }
@@ -526,7 +557,7 @@ export type RunSemanticProfileOutcome =
  */
 export async function runSemanticProfile(opts: {
   url: string;
-  dbType: "postgres" | "mysql";
+  dbType: McpNativeDbType;
   schema?: string;
   connectionId: string;
   progress?: ProfileProgressCallbacks;
@@ -552,5 +583,12 @@ export async function runSemanticProfile(opts: {
   if (failure._tag === "Some" && failure.value instanceof ProfilingFailedError) {
     return { kind: "error", reason: failure.value.reason, message: failure.value.message };
   }
-  throw new Error(`SemanticGenerator profile died: ${Cause.pretty(exit.cause)}`);
+  // Re-throw the ORIGINAL underlying error (not a wrapped one) so the MCP
+  // layer can recognise an `OperationCancelledError` raised cooperatively from
+  // the progress callback when the client cancels — wrapping it in a fresh
+  // `Error` would erase that identity and surface a spurious internal_error.
+  const original = causeToError(exit.cause);
+  throw original instanceof Error
+    ? original
+    : new Error(`SemanticGenerator profile failed: ${Cause.pretty(exit.cause)}`);
 }

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -1,0 +1,281 @@
+/**
+ * Datasource lifecycle helpers for the MCP datasource admin tools
+ * (#3513 list/test/archive/restore, #3514 delete, and reused by the
+ * Phase-2 provisioning/profiling tools #3511/#3512).
+ *
+ * These are the LIB-LAYER calls the MCP datasource tools dispatch to. The
+ * MCP tools NEVER loop back through the `/admin/connections` HTTP routes
+ * (ADR-0016 — origin=mcp must call the same lib seam the admin REST routes
+ * call, not proxy them). Each helper mirrors the corresponding admin-route
+ * behaviour but takes an explicit `(orgId, …)` tuple instead of a Hono
+ * `Context`, because the MCP transport has no request context.
+ *
+ * The source of truth for the underlying mutations stays the
+ * `WorkspaceInstaller` facade (`lib/effect/workspace-installer.ts`) and the
+ * `connections` registry (`lib/db/connection.ts`); this module only adapts
+ * them to a context-free, MCP-friendly call shape.
+ *
+ * ── Masking discipline ────────────────────────────────────────────────
+ * `listDatasources` is built from `workspace_plugins` rows projecting ONLY
+ * non-secret columns (`install_id`, `status`, `config->>'group_id'`) plus
+ * `connections.describe()` (which carries no credentials — see
+ * `ConnectionMetadata`). No path in this module decrypts or returns a
+ * secret field, satisfying CLAUDE.md's "list never returns plaintext
+ * credentials" rule. `connections.healthCheck` already scrubs DSN userinfo
+ * from its `message`.
+ */
+
+import { Cause, Effect } from "effect";
+import type { AtlasMode } from "@useatlas/types/auth";
+import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
+import { connections } from "@atlas/api/lib/db/connection";
+import type { HealthCheckResult } from "@atlas/api/lib/db/connection";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { catalogSlugToDbType } from "@atlas/api/lib/db/datasource-pool-resolver";
+import {
+  WorkspaceInstaller,
+  WorkspaceInstallerLive,
+  mapInstallError,
+  type WorkspaceInstallerShape,
+  type InstallError,
+} from "@atlas/api/lib/effect/workspace-installer";
+
+// Module-level synchronous content-mode registry — mirrors the one in
+// `api/routes/admin-connections.ts`. `readFilter` is a pure function of the
+// static `CONTENT_MODE_TABLES` tuple, so `Effect.runSync` is safe (no I/O).
+const contentModeRegistry = makeService(CONTENT_MODE_TABLES);
+
+// ── List ──────────────────────────────────────────────────────────────
+
+/**
+ * Credential-free summary of a configured datasource. Deliberately omits
+ * every secret-bearing field — there is no `url`/`config` here, only the
+ * masked-by-construction metadata an MCP client needs to pick a target for
+ * test / archive / delete.
+ */
+export interface DatasourceSummary {
+  /** User-facing connection id (`workspace_plugins.install_id`). */
+  readonly id: string;
+  /** Derived database type (`postgres`, `mysql`, `snowflake`, …). */
+  readonly dbType: string;
+  readonly description: string | null;
+  readonly status: "draft" | "published" | "archived";
+  /** Environment-group binding (`config.group_id`), or `null` when ungrouped. */
+  readonly groupId: string | null;
+  /**
+   * Last-known health probe for the registered pool, or `null` when the
+   * datasource isn't currently registered (e.g. archived → pool drained).
+   * `checkedAt` is ISO-8601 for a stable wire shape.
+   */
+  readonly health: {
+    readonly status: string;
+    readonly latencyMs: number;
+    readonly checkedAt: string;
+  } | null;
+}
+
+export interface ListDatasourcesOptions {
+  /**
+   * Include `archived` installs (default `false`). Archived datasources are
+   * hidden from the admin UI list but the MCP `restore_datasource` tool
+   * needs them discoverable, so the list tool opts in.
+   */
+  readonly includeArchived?: boolean;
+}
+
+/**
+ * List the datasources configured for a workspace. Mirrors the
+ * `/admin/connections` GET visibility query (content-mode read filter on
+ * `workspace_plugins`) but returns a credential-free {@link DatasourceSummary}
+ * shaped for MCP. Returns `[]` when no internal DB is configured (the
+ * connection-management surface requires `DATABASE_URL`).
+ *
+ * @param mode  Atlas mode — `published` sees published installs; `developer`
+ *   additionally sees drafts. `archived` rows are gated by `includeArchived`.
+ */
+export async function listDatasources(
+  orgId: string,
+  mode: AtlasMode,
+  options: ListDatasourcesOptions = {},
+): Promise<DatasourceSummary[]> {
+  if (!hasInternalDB()) return [];
+
+  // Content-mode read filter — identical clause to
+  // `getVisibleConnectionIds` in the admin route (segment key
+  // "connections" overlays the `workspace_plugins` physical table). Alias
+  // `wp` matches the FROM below.
+  const statusClause = Effect.runSync(
+    contentModeRegistry.readFilter("connections", mode, "wp"),
+  );
+  // `includeArchived` drops the status filter so archived installs surface
+  // for restore; otherwise the content-mode clause keeps archived hidden.
+  const whereStatus = options.includeArchived ? "TRUE" : statusClause;
+
+  const rows = await internalQuery<{
+    install_id: string;
+    status: string;
+    group_id: string | null;
+    catalog_slug: string;
+  }>(
+    `SELECT wp.install_id,
+            wp.status,
+            wp.config->>'group_id' AS group_id,
+            pc.slug AS catalog_slug
+       FROM workspace_plugins wp
+       JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+      WHERE wp.workspace_id = $1
+        AND wp.pillar = 'datasource'
+        AND ${whereStatus}
+      ORDER BY wp.install_id`,
+    [orgId],
+  );
+
+  // `connections.describe()` carries dbType + description + last health for
+  // currently-registered pools (no secrets). Archived/unregistered rows
+  // fall back to `catalogSlugToDbType` for the type and a null health.
+  const described = new Map(connections.describe().map((c) => [c.id, c]));
+
+  return rows.map((r): DatasourceSummary => {
+    const meta = described.get(r.install_id);
+    const dbType = meta?.dbType ?? safeDbType(r.catalog_slug);
+    const health = meta?.health
+      ? {
+          status: meta.health.status,
+          latencyMs: meta.health.latencyMs,
+          checkedAt: meta.health.checkedAt.toISOString(),
+        }
+      : null;
+    return {
+      id: r.install_id,
+      dbType,
+      description: meta?.description ?? null,
+      status: normalizeStatus(r.status),
+      groupId: r.group_id && r.group_id.length > 0 ? r.group_id : null,
+      health,
+    };
+  });
+}
+
+function normalizeStatus(raw: string): DatasourceSummary["status"] {
+  return raw === "draft" || raw === "archived" ? raw : "published";
+}
+
+/**
+ * Resolve a catalog-slug-derived dbType without throwing — an unknown slug
+ * (corrupt row, catalog renamed out from under an install) degrades to
+ * `"unknown"` rather than failing the whole list.
+ */
+function safeDbType(catalogSlug: string): string {
+  try {
+    return catalogSlugToDbType(catalogSlug);
+  } catch {
+    // intentionally ignored: an unrecognised slug is non-fatal for a
+    // metadata listing — surface a placeholder type, not a 500.
+    return "unknown";
+  }
+}
+
+// ── Catalog-slug resolution (for installer-routed mutations) ───────────
+
+/**
+ * Resolve the catalog slug for a datasource install so the
+ * `WorkspaceInstaller` can route an archive / restore / delete. Returns
+ * `null` when no datasource install with that id exists in the workspace
+ * (the caller maps that to a `not found` envelope). Returns
+ * `{ catalogSlug: null }`-free — a missing internal DB also yields `null`.
+ */
+export async function resolveDatasourceCatalogSlug(
+  orgId: string,
+  installId: string,
+): Promise<string | null> {
+  if (!hasInternalDB()) return null;
+  const rows = await internalQuery<{ catalog_slug: string }>(
+    `SELECT pc.slug AS catalog_slug
+       FROM workspace_plugins wp
+       JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+      WHERE wp.workspace_id = $1
+        AND wp.install_id = $2
+        AND wp.pillar = 'datasource'
+      LIMIT 1`,
+    [orgId, installId],
+  );
+  return rows.length > 0 ? rows[0].catalog_slug : null;
+}
+
+// ── Health check (test) ───────────────────────────────────────────────
+
+/**
+ * Run a connection health-check against a registered datasource pool. Thin
+ * pass-through to {@link connections.healthCheck} (the same call the
+ * `/admin/connections/:id/test` route uses). `message` is already scrubbed
+ * of DSN userinfo by the registry, so the result is safe to surface to an
+ * MCP client verbatim.
+ */
+export function testDatasource(id: string): Promise<HealthCheckResult> {
+  return connections.healthCheck(id);
+}
+
+/** Whether a datasource id is currently registered (queryable) at all. */
+export function isDatasourceRegistered(id: string): boolean {
+  return connections.has(id);
+}
+
+// ── WorkspaceInstaller bridge (context-free) ──────────────────────────
+
+/**
+ * Discriminated outcome of {@link runDatasourceInstaller}. Mirrors the
+ * `InstallerResult` shape the admin route's `runInstaller` produces, minus
+ * the Hono coupling — the MCP caller maps `error` onto an
+ * `AtlasMcpToolError` envelope and `ok` onto a success body.
+ */
+export type DatasourceInstallerOutcome<A> =
+  | { readonly kind: "ok"; readonly value: A }
+  | {
+      readonly kind: "error";
+      readonly status: 400 | 404 | 409;
+      readonly code: string;
+      readonly message: string;
+      readonly body: Readonly<Record<string, unknown>>;
+    };
+
+/**
+ * Run a `WorkspaceInstaller`-using Effect from a context-free caller (the
+ * MCP transport). Provides the live installer Layer and maps tagged
+ * {@link InstallError} variants into a renderable `{ status, code, message }`
+ * via {@link mapInstallError}.
+ *
+ * Defects (non-tagged Effect failures — DB outages, resolver throws) are
+ * RE-THROWN so the MCP tool's outer try/catch surfaces them as an
+ * `internal_error` envelope with a `request_id`. This matches the admin
+ * route's posture: a defect is a 500, a tagged error is a typed 4xx.
+ */
+export async function runDatasourceInstaller<A>(
+  body: (installer: WorkspaceInstallerShape) => Effect.Effect<A, InstallError>,
+): Promise<DatasourceInstallerOutcome<A>> {
+  const program = Effect.gen(function* () {
+    const installer = yield* WorkspaceInstaller;
+    return yield* body(installer);
+  });
+
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(WorkspaceInstallerLive)),
+  );
+
+  if (exit._tag === "Success") return { kind: "ok", value: exit.value };
+
+  const failure = Cause.failureOption(exit.cause);
+  if (failure._tag === "Some") {
+    const mapping = mapInstallError(failure.value);
+    return {
+      kind: "error",
+      status: mapping.status,
+      code: mapping.code,
+      message: mapping.message,
+      body: mapping.body ?? {},
+    };
+  }
+  // Defect — re-throw with the rendered Cause so the MCP tool's catch logs
+  // it and returns an `internal_error` envelope (parity with the route's
+  // `runInstaller`, which lets `runHandler` surface the 500).
+  throw new Error(`WorkspaceInstaller program died: ${Cause.pretty(exit.cause)}`);
+}

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -27,18 +27,31 @@
 
 import { Cause, Effect } from "effect";
 import type { AtlasMode } from "@useatlas/types/auth";
+import type { WorkspaceId } from "@useatlas/types";
 import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
 import { connections } from "@atlas/api/lib/db/connection";
 import type { HealthCheckResult } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
-import { catalogSlugToDbType } from "@atlas/api/lib/db/datasource-pool-resolver";
+import {
+  catalogSlugToDbType,
+  resolveDatasourcePoolConfig,
+} from "@atlas/api/lib/db/datasource-pool-resolver";
+import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import {
   WorkspaceInstaller,
   WorkspaceInstallerLive,
   mapInstallError,
   type WorkspaceInstallerShape,
   type InstallError,
+  type DatasourceInstallRow,
 } from "@atlas/api/lib/effect/workspace-installer";
+import {
+  SemanticGenerator,
+  SemanticGeneratorLive,
+  type ProfileAndGenerateResult,
+} from "@atlas/api/lib/effect/semantic-generator";
+import { ProfilingFailedError } from "@atlas/api/lib/effect/errors";
+import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 
 // Module-level synchronous content-mode registry — mirrors the one in
 // `api/routes/admin-connections.ts`. `readFilter` is a pure function of the
@@ -278,4 +291,266 @@ export async function runDatasourceInstaller<A>(
   // it and returns an `internal_error` envelope (parity with the route's
   // `runInstaller`, which lets `runHandler` surface the 500).
   throw new Error(`WorkspaceInstaller program died: ${Cause.pretty(exit.cause)}`);
+}
+
+// ── Provisioning (#3511 create) ───────────────────────────────────────
+
+/**
+ * Datasource types provisionable via MCP today. Scoped to the native
+ * dbTypes whose pool the `ConnectionRegistry` can build directly from a
+ * `url` — so the validate-before-persist health-check (register → SELECT 1
+ * → unregister) genuinely exercises connectivity. Plugin-managed pools
+ * (clickhouse / snowflake / bigquery / salesforce) need a different
+ * test-connect path and are intentionally out of scope for the MCP
+ * provisioning flow until that lands; the admin console still handles them.
+ */
+export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = ["postgres", "mysql"];
+
+/**
+ * Input to {@link provisionDatasource}. `url` is the credential collected
+ * via masked elicitation at the MCP edge — it is encrypted at the installer
+ * boundary and NEVER round-trips back out (the returned row carries only a
+ * `maskedUrl`).
+ */
+export interface ProvisionDatasourceInput {
+  readonly catalogSlug: string;
+  readonly installId: string;
+  /** The connection URL (secret). Encrypted by the installer per config_schema. */
+  readonly url: string;
+  readonly schema?: string;
+  readonly description?: string;
+  readonly groupId?: string | null;
+}
+
+export type ProvisionDatasourceOutcome =
+  | { readonly kind: "ok"; readonly value: DatasourceInstallRow }
+  /** Unsupported dbType — actionable, no secret. */
+  | { readonly kind: "unsupported"; readonly message: string }
+  /** Pre-flight connectivity failed — message is credential-scrubbed. */
+  | { readonly kind: "health_error"; readonly message: string }
+  /** Tagged installer error (validation / conflict / not-found). */
+  | { readonly kind: "error"; readonly status: 400 | 404 | 409; readonly code: string; readonly message: string };
+
+/**
+ * Strip any occurrence of a secret URL (and embedded `//user:pass@` userinfo)
+ * out of an error message so a connection-failure surfaced to the agent/client
+ * can never leak the credential. Defense-in-depth on top of the registry's own
+ * DSN scrubbing.
+ */
+function scrubSecretFromMessage(message: string, url: string): string {
+  let out = message;
+  if (url) out = out.split(url).join("[redacted]");
+  // Strip `scheme://user:pass@host` userinfo even if the URL was reshaped.
+  out = out.replace(/\/\/[^/@\s]*@/g, "//[redacted]@");
+  return out;
+}
+
+/**
+ * Provision a new datasource over MCP: validate the dbType is provisionable
+ * → pre-flight health-check the candidate connection WITHOUT persisting →
+ * on success install it as a `draft` (credential encrypted by the installer)
+ * → return the masked row. On any failure nothing is persisted and the
+ * ephemeral pool is rolled back.
+ *
+ * The credential (`input.url`) only flows in here and into the installer's
+ * encrypt-at-rest path; it is never returned, logged, or placed in an error.
+ */
+export async function provisionDatasource(
+  orgId: string,
+  input: ProvisionDatasourceInput,
+): Promise<ProvisionDatasourceOutcome> {
+  if (!MCP_PROVISIONABLE_CATALOG_SLUGS.includes(input.catalogSlug)) {
+    return {
+      kind: "unsupported",
+      message:
+        `Provisioning "${input.catalogSlug}" datasources via MCP is not supported yet. ` +
+        `Supported types: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")}. ` +
+        `Use the Atlas admin console for other datasource types.`,
+    };
+  }
+
+  // Reject a duplicate id before touching the registry — a clean message
+  // beats an installer `AlreadyInstalledError` deep in the Effect.
+  if (await resolveDatasourceCatalogSlug(orgId, input.installId)) {
+    return {
+      kind: "error",
+      status: 409,
+      code: "conflict",
+      message: `A datasource with id "${input.installId}" already exists in this workspace.`,
+    };
+  }
+
+  // Pre-flight: register an ephemeral native pool, probe it, then roll back.
+  // Mirrors the admin route's route-owned test-connect dance (ADR-0007).
+  const registryConfig = {
+    url: input.url,
+    ...(input.description !== undefined ? { description: input.description } : {}),
+    ...(input.schema !== undefined ? { schema: input.schema } : {}),
+  };
+  const weRegistered = !connections.has(input.installId);
+  if (weRegistered) connections.register(input.installId, registryConfig);
+  try {
+    const health = await connections.healthCheck(input.installId);
+    if (health.status === "unhealthy") {
+      if (weRegistered) connections.unregister(input.installId);
+      return {
+        kind: "health_error",
+        message: scrubSecretFromMessage(
+          health.message ?? "Connection probe reported the datasource as unreachable.",
+          input.url,
+        ),
+      };
+    }
+  } catch (err) {
+    if (weRegistered) connections.unregister(input.installId);
+    const raw = err instanceof Error ? err.message : String(err);
+    return {
+      kind: "health_error",
+      message: scrubSecretFromMessage(
+        `Connection test failed: ${raw}. Verify the host, port, database, and credentials, then retry.`,
+        input.url,
+      ),
+    };
+  }
+
+  // Health OK → persist as draft. The installer re-registers idempotently and
+  // encrypts the `url` per the catalog config_schema.
+  const formData: Record<string, unknown> = {
+    url: input.url,
+    ...(input.description !== undefined ? { description: input.description } : {}),
+    ...(input.schema !== undefined && input.schema.length > 0 ? { schema: input.schema } : {}),
+  };
+  const outcome = await runDatasourceInstaller((installer) =>
+    installer.installDatasource(orgId as WorkspaceId, input.catalogSlug, {
+      installId: input.installId,
+      formData,
+      groupId: input.groupId ?? null,
+      atlasMode: "draft",
+    }),
+  );
+  if (outcome.kind === "error") {
+    if (weRegistered) connections.unregister(input.installId);
+    return {
+      kind: "error",
+      status: outcome.status,
+      code: outcome.code,
+      message: scrubSecretFromMessage(outcome.message, input.url),
+    };
+  }
+  return { kind: "ok", value: outcome.value };
+}
+
+// ── Profiling / semantic-gen (#3512) ──────────────────────────────────
+
+/** Resolved profiling target — internal use only; `url` is the decrypted secret. */
+export interface DatasourceProfileTarget {
+  readonly url: string;
+  readonly dbType: "postgres" | "mysql";
+  readonly schema?: string;
+}
+
+export type LoadProfileTargetResult =
+  | { readonly kind: "ok"; readonly target: DatasourceProfileTarget }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "unsupported"; readonly dbType: string };
+
+/**
+ * Load + decrypt a datasource install's connection config and shape the
+ * profiling target the semantic generator needs. Returns `not_found` for an
+ * unknown install and `unsupported` for a dbType without a built-in profiler
+ * (only postgres/mysql profile in-core; other types need an injected
+ * `profileFn`, out of scope for the MCP flow). The decrypted `url` never
+ * leaves the lib layer — the caller passes it straight to the profiler.
+ */
+export async function loadDatasourceProfileTarget(
+  orgId: string,
+  installId: string,
+): Promise<LoadProfileTargetResult> {
+  if (!hasInternalDB()) return { kind: "not_found" };
+  const rows = await internalQuery<{
+    catalog_id: string;
+    catalog_slug: string;
+    config: Record<string, unknown> | null;
+    config_schema: unknown;
+  }>(
+    `SELECT wp.catalog_id, pc.slug AS catalog_slug, wp.config, pc.config_schema
+       FROM workspace_plugins wp
+       JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+      WHERE wp.workspace_id = $1
+        AND wp.install_id = $2
+        AND wp.pillar = 'datasource'
+      LIMIT 1`,
+    [orgId, installId],
+  );
+  if (rows.length === 0) return { kind: "not_found" };
+  const row = rows[0];
+  const schema = parseConfigSchema(row.config_schema);
+  const decrypted = decryptSecretFields(row.config ?? {}, schema);
+  const poolConfig = resolveDatasourcePoolConfig(
+    {
+      workspaceId: orgId,
+      catalogId: row.catalog_id,
+      installId,
+      pillar: "datasource",
+      catalogSlug: row.catalog_slug,
+    },
+    decrypted,
+  );
+  if (poolConfig.dbType !== "postgres" && poolConfig.dbType !== "mysql") {
+    return { kind: "unsupported", dbType: poolConfig.dbType };
+  }
+  return {
+    kind: "ok",
+    target: {
+      url: poolConfig.url,
+      dbType: poolConfig.dbType,
+      schema: "schema" in poolConfig ? poolConfig.schema : undefined,
+    },
+  };
+}
+
+export type RunSemanticProfileOutcome =
+  | { readonly kind: "ok"; readonly result: ProfileAndGenerateResult }
+  | { readonly kind: "error"; readonly reason: ProfilingFailedError["reason"]; readonly message: string };
+
+/**
+ * Profile a connection and generate its semantic layer via the #3506
+ * `SemanticGenerator` service, registering the generated entities into the
+ * in-process table whitelist so a subsequent `executeSQL` against this
+ * connection is permitted. `progress` bridges the profiler's per-table
+ * callbacks to the MCP progress seam.
+ *
+ * A tagged `ProfilingFailedError` (no tables, threshold exceeded, …) is
+ * returned as a typed `error` outcome; an unexpected defect re-throws for the
+ * caller's `internal_error` path.
+ */
+export async function runSemanticProfile(opts: {
+  url: string;
+  dbType: "postgres" | "mysql";
+  schema?: string;
+  connectionId: string;
+  progress?: ProfileProgressCallbacks;
+}): Promise<RunSemanticProfileOutcome> {
+  const program = Effect.gen(function* () {
+    const gen = yield* SemanticGenerator;
+    return yield* gen.profileAndGenerate({
+      url: opts.url,
+      dbType: opts.dbType,
+      ...(opts.schema !== undefined ? { schema: opts.schema } : {}),
+      connectionId: opts.connectionId,
+      registerWhitelist: true,
+      ...(opts.progress !== undefined ? { progress: opts.progress } : {}),
+    });
+  });
+
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(SemanticGeneratorLive)),
+  );
+  if (exit._tag === "Success") return { kind: "ok", result: exit.value };
+
+  const failure = Cause.failureOption(exit.cause);
+  if (failure._tag === "Some" && failure.value instanceof ProfilingFailedError) {
+    return { kind: "error", reason: failure.value.reason, message: failure.value.message };
+  }
+  throw new Error(`SemanticGenerator profile died: ${Cause.pretty(exit.cause)}`);
 }

--- a/packages/api/src/lib/datasources/provisionable-types.ts
+++ b/packages/api/src/lib/datasources/provisionable-types.ts
@@ -1,0 +1,24 @@
+/**
+ * Light, dependency-free constants describing which datasource types are
+ * provisionable/profilable via MCP. Kept in its OWN module (no Effect /
+ * installer / DB imports) so the MCP `datasource-tools` module can read the
+ * `db_type` enum at tool-REGISTRATION time without dragging the heavy
+ * `mcp-lifecycle` graph (workspace-installer, semantic-generator, the Effect
+ * startup layers) into server boot. `mcp-lifecycle.ts` re-exports these.
+ *
+ * Scoped to the native dbTypes the `ConnectionRegistry` builds a pool for
+ * directly from a `url` — the only ones whose ephemeral health-check probe
+ * genuinely tests connectivity AND whose tables the in-core profiler can
+ * introspect. See #3547 for extending beyond these.
+ */
+
+export type McpNativeDbType = "postgres" | "mysql";
+
+const MCP_NATIVE_DB_TYPES: ReadonlySet<McpNativeDbType> = new Set(["postgres", "mysql"]);
+
+export function isMcpNativeDbType(dbType: string): dbType is McpNativeDbType {
+  return (MCP_NATIVE_DB_TYPES as ReadonlySet<string>).has(dbType);
+}
+
+/** Catalog slugs provisionable via MCP — derived from {@link McpNativeDbType}. */
+export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [...MCP_NATIVE_DB_TYPES];

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -586,14 +586,22 @@ describe("MCP path canonical eval (#2074)", () => {
       const names = tools.map((t) => t.name).sort();
       // Expected toolset — adding a tool here means an explicit decision
       // in the eval. A change at the `registerTools` / `registerSemanticTools`
-      // call sites should land in lockstep with this assertion.
+      // / `registerDatasourceTools` call sites should land in lockstep with
+      // this assertion.
       expect(names).toEqual([
+        "archive_datasource",
+        "create_datasource",
+        "delete_datasource",
         "describeEntity",
         "executeSQL",
         "explore",
         "listEntities",
+        "list_datasources",
+        "profile_datasource",
+        "restore_datasource",
         "runMetric",
         "searchGlossary",
+        "test_datasource",
       ]);
       // Description-quality floor — agent tool-selection accuracy is
       // gated by description quality (full audit owned by #2075). Pin

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Datasource lifecycle MCP tools (#3513 list/test/archive/restore, #3514
+ * delete) — tool-level contract tests.
+ *
+ * Boundary: the real ADR-0016 gate pipeline is exhaustively covered in
+ * `dispatch-gate.test.ts`. Here we mock `runMcpDispatchGate` to assert the
+ * two halves of each tool's contract deterministically:
+ *   1. it declares the CORRECT gate requirements (write/role/destructive) —
+ *      especially that `delete_datasource` is destructive (approval-gated)
+ *      and the read tools declare `requiresWrite: false`;
+ *   2. it HONORS the gate's verdict — a denial / approval-required block is
+ *      returned verbatim and the lib layer is never touched, while a `null`
+ *      (proceed) runs the right lib call and shapes the right envelope.
+ *
+ * The lib layer (`mcp-lifecycle`) is mocked so the tools' dispatch + envelope
+ * mapping is exercised without an internal DB / WorkspaceInstaller layer.
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { Effect } from "effect";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+
+const TEST_ACTOR = createAtlasUser("u_ds", "managed", "ds@test", {
+  role: "admin",
+  activeOrganizationId: "org_ds",
+});
+
+// ── Lib-layer mocks (`mcp-lifecycle`) ─────────────────────────────────
+
+const SAMPLE_SUMMARY = {
+  id: "prod-us",
+  dbType: "postgres",
+  description: "Prod US",
+  status: "published" as const,
+  groupId: "prod",
+  health: { status: "healthy", latencyMs: 12, checkedAt: "2026-06-13T00:00:00.000Z" },
+};
+
+const mockListDatasources = mock<(...a: unknown[]) => Promise<unknown>>(async () => [
+  SAMPLE_SUMMARY,
+  {
+    id: "warehouse",
+    dbType: "snowflake",
+    description: null,
+    status: "published" as const,
+    groupId: null,
+    health: null,
+  },
+]);
+
+// `missing` resolves to null (not found); everything else to a slug.
+const mockResolveCatalogSlug = mock<(...a: unknown[]) => Promise<string | null>>(
+  async (_org: unknown, id: unknown) => (id === "missing" ? null : "postgres"),
+);
+
+const mockTestDatasource = mock<(...a: unknown[]) => Promise<unknown>>(async () => ({
+  status: "healthy",
+  latencyMs: 5,
+  message: undefined,
+  checkedAt: new Date("2026-06-13T00:00:00.000Z"),
+}));
+
+// `archived-ds` is unregistered (pool drained); everything else registered.
+const mockIsRegistered = mock<(id: string) => boolean>((id) => id !== "archived-ds");
+
+// Records the installer method/args the tool routes to, and returns a
+// configurable outcome. Invokes the tool's `body(installer)` with a spy so
+// archive (soft) vs delete (hard) vs restore is observable.
+interface InstallerCall {
+  method: "uninstallDatasource" | "updateDatasourceConfig";
+  args: unknown[];
+}
+let installerCalls: InstallerCall[] = [];
+let installerOutcome: unknown = {
+  kind: "ok",
+  value: { id: "prod-us", status: "published" },
+};
+const spyInstaller = {
+  uninstallDatasource: (...args: unknown[]) => {
+    installerCalls.push({ method: "uninstallDatasource", args });
+    return Effect.void;
+  },
+  updateDatasourceConfig: (...args: unknown[]) => {
+    installerCalls.push({ method: "updateDatasourceConfig", args });
+    return Effect.succeed({ id: "prod-us", status: "published" });
+  },
+};
+const mockRunInstaller = mock<(body: (i: unknown) => unknown) => Promise<unknown>>(
+  async (body) => {
+    body(spyInstaller);
+    return installerOutcome;
+  },
+);
+
+mock.module("@atlas/api/lib/datasources/mcp-lifecycle", () => ({
+  listDatasources: mockListDatasources,
+  resolveDatasourceCatalogSlug: mockResolveCatalogSlug,
+  testDatasource: mockTestDatasource,
+  isDatasourceRegistered: mockIsRegistered,
+  runDatasourceInstaller: mockRunInstaller,
+}));
+
+// ── Dispatch-gate mock ────────────────────────────────────────────────
+
+interface GateCall {
+  ctx: { actor: { id: string }; orgId?: string; requesterId?: string };
+  reqs: {
+    toolName: string;
+    requiresWrite: boolean;
+    minRole: string;
+    destructive?: { resource: string; description: string };
+  };
+}
+let gateCalls: GateCall[] = [];
+let gateReturn: CallToolResult | null = null;
+const mockRunGate = mock(async (ctx: GateCall["ctx"], reqs: GateCall["reqs"]) => {
+  gateCalls.push({ ctx, reqs });
+  return gateReturn;
+});
+
+mock.module("../dispatch-gate.js", () => ({
+  runMcpDispatchGate: mockRunGate,
+}));
+
+// Imports AFTER mock.module registrations.
+const { registerDatasourceTools } = await import("../datasource-tools.js");
+
+// ── Harness ───────────────────────────────────────────────────────────
+
+function getContentText(content: unknown): string {
+  const arr = content as Array<{ type: string; text: string }>;
+  return arr[0]?.text ?? "";
+}
+
+async function createTestClient(actor = TEST_ACTOR, clientId?: string) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerDatasourceTools(server, {
+    actor,
+    transport: "stdio",
+    workspaceId: actor.activeOrganizationId ?? actor.id,
+    deployMode: "self-hosted",
+    ...(clientId ? { clientId } : {}),
+  });
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [c, s] = InMemoryTransport.createLinkedPair();
+  await server.connect(s);
+  await client.connect(c);
+  return client;
+}
+
+function gateCallFor(tool: string): GateCall | undefined {
+  return gateCalls.find((g) => g.reqs.toolName === tool);
+}
+
+beforeEach(() => {
+  mockListDatasources.mockClear();
+  mockResolveCatalogSlug.mockClear();
+  mockTestDatasource.mockClear();
+  mockIsRegistered.mockClear();
+  mockRunInstaller.mockClear();
+  mockRunGate.mockClear();
+  gateCalls = [];
+  installerCalls = [];
+  gateReturn = null;
+  installerOutcome = { kind: "ok", value: { id: "prod-us", status: "published" } };
+});
+
+// ── Tool registration ─────────────────────────────────────────────────
+
+describe("datasource tools — registration", () => {
+  it("registers all five lifecycle tools", async () => {
+    const client = await createTestClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        "archive_datasource",
+        "delete_datasource",
+        "list_datasources",
+        "restore_datasource",
+        "test_datasource",
+      ].sort(),
+    );
+  });
+});
+
+// ── Gate requirements (the ADR-0016 contract per tool) ────────────────
+
+describe("datasource tools — gate requirements", () => {
+  it("read tools declare requiresWrite=false, admin role, no destructive", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "list_datasources", arguments: {} });
+    await client.callTool({ name: "test_datasource", arguments: { id: "prod-us" } });
+
+    for (const tool of ["list_datasources", "test_datasource"]) {
+      const g = gateCallFor(tool);
+      expect(g?.reqs.requiresWrite).toBe(false);
+      expect(g?.reqs.minRole).toBe("admin");
+      expect(g?.reqs.destructive).toBeUndefined();
+    }
+  });
+
+  it("archive/restore declare requiresWrite=true but are NOT destructive (reversible)", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "archive_datasource", arguments: { id: "prod-us" } });
+    await client.callTool({ name: "restore_datasource", arguments: { id: "prod-us" } });
+
+    for (const tool of ["archive_datasource", "restore_datasource"]) {
+      const g = gateCallFor(tool);
+      expect(g?.reqs.requiresWrite).toBe(true);
+      expect(g?.reqs.minRole).toBe("admin");
+      expect(g?.reqs.destructive).toBeUndefined();
+    }
+  });
+
+  it("delete declares destructive with an approval-matchable resource (#3514)", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    const g = gateCallFor("delete_datasource");
+    expect(g?.reqs.requiresWrite).toBe(true);
+    expect(g?.reqs.minRole).toBe("admin");
+    expect(g?.reqs.destructive?.resource).toBe("datasource:prod-us");
+    expect(g?.reqs.destructive?.description).toContain("Delete datasource");
+  });
+
+  it("threads the bound actor's identity into the gate context", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    const g = gateCallFor("delete_datasource");
+    expect(g?.ctx.orgId).toBe("org_ds");
+    expect(g?.ctx.requesterId).toBe("u_ds");
+  });
+});
+
+// ── Gate verdict is honored ───────────────────────────────────────────
+
+describe("datasource tools — honor the gate verdict", () => {
+  it("a gate denial short-circuits BEFORE any lib call", async () => {
+    gateReturn = {
+      content: [{ type: "text", text: JSON.stringify({ code: "forbidden", message: "nope" }) }],
+      isError: true,
+    };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
+    // Neither the slug lookup nor the installer ran.
+    expect(mockResolveCatalogSlug).not.toHaveBeenCalled();
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+
+  it("an approval-required block is surfaced verbatim and the installer never runs (#3514)", async () => {
+    gateReturn = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            approval_required: true,
+            approval_request_id: "req_42",
+            matched_rules: ["MCP destructive"],
+            message: "needs approval",
+          }),
+        },
+      ],
+    };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.approval_required).toBe(true);
+    expect(body.approval_request_id).toBe("req_42");
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+});
+
+// ── Happy paths + envelope mapping (gate returns null) ────────────────
+
+describe("list_datasources", () => {
+  it("returns credential-free summaries (no url / secret keys)", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "list_datasources", arguments: {} });
+    const text = getContentText(res.content);
+    const body = JSON.parse(text);
+    expect(body.count).toBe(2);
+    expect(body.datasources[0].id).toBe("prod-us");
+    // Masking guarantee — the serialized payload must carry no credential.
+    expect(text).not.toContain("url");
+    expect(text).not.toContain("password");
+    expect(text.toLowerCase()).not.toContain("secret");
+  });
+
+  it("passes include_archived through to the lib layer", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "list_datasources", arguments: { include_archived: true } });
+    const call = mockListDatasources.mock.calls[0];
+    expect(call?.[2]).toEqual({ includeArchived: true });
+  });
+
+  it("filters by substring across id / dbType / description", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "list_datasources", arguments: { filter: "snow" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.count).toBe(1);
+    expect(body.datasources[0].id).toBe("warehouse");
+  });
+});
+
+describe("test_datasource", () => {
+  it("returns the health probe for a registered datasource", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "test_datasource", arguments: { id: "prod-us" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.id).toBe("prod-us");
+    expect(body.status).toBe("healthy");
+    expect(body.latency_ms).toBe(5);
+    expect(body.checked_at).toBe("2026-06-13T00:00:00.000Z");
+  });
+
+  it("an unregistered/archived datasource → unknown_entity", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "test_datasource", arguments: { id: "archived-ds" } });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("unknown_entity");
+    expect(mockTestDatasource).not.toHaveBeenCalled();
+  });
+});
+
+describe("archive_datasource", () => {
+  it("routes to a SOFT uninstall (no hard flag) and reports archived", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "archive_datasource", arguments: { id: "prod-us" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.archived).toBe(true);
+    expect(body.status).toBe("archived");
+    const call = installerCalls[0];
+    expect(call.method).toBe("uninstallDatasource");
+    // (workspaceId, catalogSlug, installId) — no { hard: true } 4th arg.
+    expect(call.args[3]).toBeUndefined();
+    expect(call.args[2]).toBe("prod-us");
+  });
+
+  it("a missing datasource → unknown_entity, installer not called", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "archive_datasource", arguments: { id: "missing" } });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("unknown_entity");
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+});
+
+describe("restore_datasource", () => {
+  it("routes to updateDatasourceConfig({ status: 'published' }) and reports restored", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "restore_datasource", arguments: { id: "prod-us" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.restored).toBe(true);
+    const call = installerCalls[0];
+    expect(call.method).toBe("updateDatasourceConfig");
+    expect(call.args[3]).toEqual({ status: "published" });
+  });
+});
+
+describe("delete_datasource", () => {
+  it("routes to a HARD uninstall and reports deleted", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.deleted).toBe(true);
+    const call = installerCalls[0];
+    expect(call.method).toBe("uninstallDatasource");
+    expect(call.args[3]).toEqual({ hard: true });
+  });
+
+  it("a missing datasource → unknown_entity, installer not called", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "missing" } });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("unknown_entity");
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+
+  it("an installer error outcome maps to a typed envelope (validation_failed)", async () => {
+    installerOutcome = {
+      kind: "error",
+      status: 400,
+      code: "bad_request",
+      message: "install_id \"default\" is reserved",
+      body: {},
+    };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+  });
+});

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -97,12 +97,88 @@ const mockRunInstaller = mock<(body: (i: unknown) => unknown) => Promise<unknown
   },
 );
 
+// Phase-2 lib mocks (#3511 provision, #3512 profile).
+let provisionOutcome: unknown = {
+  kind: "ok",
+  value: {
+    installId: "new-pg",
+    dbType: "postgres",
+    status: "draft",
+    maskedUrl: "postgres://***@host/db",
+    description: null,
+    schema: null,
+    groupId: null,
+  },
+};
+const mockProvision = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionOutcome);
+
+let profileTarget: unknown = {
+  kind: "ok",
+  target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public" },
+};
+const mockLoadProfileTarget = mock<(...a: unknown[]) => Promise<unknown>>(async () => profileTarget);
+
+let profileResult: unknown = {
+  kind: "ok",
+  result: {
+    entities: [{ table: "orders", fileName: "orders.yml", yaml: "" }, { table: "users", fileName: "users.yml", yaml: "" }],
+    metrics: [{ table: "orders", fileName: "orders.metric.yml", yaml: "" }],
+    catalog: "",
+    glossary: "",
+    profiles: [],
+    errors: [],
+    elapsedMs: 1234,
+  },
+};
+interface ProfileProgressLike {
+  onStart?: (n: number) => void;
+  onTableStart?: (name: string, i: number, t: number) => void;
+  onTableDone?: (name: string, i: number, t: number) => void;
+  onTableError?: (name: string, e: string, i: number, t: number) => void;
+  onComplete?: () => void;
+}
+const mockRunProfile = mock<(...a: unknown[]) => Promise<unknown>>(async (...a: unknown[]) => {
+  const opts = a[0] as { progress?: ProfileProgressLike };
+  // Exercise the progress bridge so a regression in the callback shape is caught.
+  opts.progress?.onStart?.(2);
+  opts.progress?.onTableDone?.("orders", 0, 2);
+  opts.progress?.onTableDone?.("users", 1, 2);
+  opts.progress?.onComplete?.();
+  return profileResult;
+});
+
 mock.module("@atlas/api/lib/datasources/mcp-lifecycle", () => ({
   listDatasources: mockListDatasources,
   resolveDatasourceCatalogSlug: mockResolveCatalogSlug,
   testDatasource: mockTestDatasource,
   isDatasourceRegistered: mockIsRegistered,
   runDatasourceInstaller: mockRunInstaller,
+  provisionDatasource: mockProvision,
+  loadDatasourceProfileTarget: mockLoadProfileTarget,
+  runSemanticProfile: mockRunProfile,
+  MCP_PROVISIONABLE_CATALOG_SLUGS: ["postgres", "mysql"],
+}));
+
+// Masked elicitation (#3499) — capture the call + return a configurable
+// outcome. The default accepts with a sentinel secret we assert NEVER leaks.
+const ELICITED_SECRET = "postgres://super:secret@db.internal:5432/prod";
+let elicitOutcome: { action: "accept"; value: string } | { action: "decline" | "cancel" } = {
+  action: "accept",
+  value: ELICITED_SECRET,
+};
+let elicitThrows = false;
+interface ElicitCall {
+  principal: string;
+  field: { name?: string; title: string };
+}
+let elicitCalls: ElicitCall[] = [];
+const mockElicit = mock(async (_server: unknown, args: ElicitCall & { message: string }) => {
+  elicitCalls.push({ principal: args.principal, field: args.field });
+  if (elicitThrows) throw new Error("client does not support elicitation");
+  return elicitOutcome;
+});
+mock.module("../elicitation.js", () => ({
+  elicitMaskedField: mockElicit,
 }));
 
 // ── Dispatch-gate mock ────────────────────────────────────────────────
@@ -113,6 +189,7 @@ interface GateCall {
     toolName: string;
     requiresWrite: boolean;
     minRole: string;
+    actionCategory?: string;
     destructive?: { resource: string; description: string };
   };
 }
@@ -164,28 +241,75 @@ beforeEach(() => {
   mockIsRegistered.mockClear();
   mockRunInstaller.mockClear();
   mockRunGate.mockClear();
+  mockProvision.mockClear();
+  mockLoadProfileTarget.mockClear();
+  mockRunProfile.mockClear();
+  mockElicit.mockClear();
   gateCalls = [];
   installerCalls = [];
+  elicitCalls = [];
   gateReturn = null;
   installerOutcome = { kind: "ok", value: { id: "prod-us", status: "published" } };
+  provisionOutcome = {
+    kind: "ok",
+    value: {
+      installId: "new-pg",
+      dbType: "postgres",
+      status: "draft",
+      maskedUrl: "postgres://***@host/db",
+      description: null,
+      schema: null,
+      groupId: null,
+    },
+  };
+  profileTarget = {
+    kind: "ok",
+    target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public" },
+  };
+  profileResult = {
+    kind: "ok",
+    result: {
+      entities: [{ table: "orders", fileName: "orders.yml", yaml: "" }, { table: "users", fileName: "users.yml", yaml: "" }],
+      metrics: [{ table: "orders", fileName: "orders.metric.yml", yaml: "" }],
+      catalog: "",
+      glossary: "",
+      profiles: [],
+      errors: [],
+      elapsedMs: 1234,
+    },
+  };
+  elicitOutcome = { action: "accept", value: ELICITED_SECRET };
+  elicitThrows = false;
 });
 
 // ── Tool registration ─────────────────────────────────────────────────
 
 describe("datasource tools — registration", () => {
-  it("registers all five lifecycle tools", async () => {
+  it("registers all seven lifecycle tools", async () => {
     const client = await createTestClient();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(
       [
         "archive_datasource",
+        "create_datasource",
         "delete_datasource",
         "list_datasources",
+        "profile_datasource",
         "restore_datasource",
         "test_datasource",
       ].sort(),
     );
+  });
+
+  it("read tools declare readOnlyHint; mutating tools do not", async () => {
+    const client = await createTestClient();
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((t) => [t.name, t]));
+    expect(byName.get("list_datasources")?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get("test_datasource")?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get("delete_datasource")?.annotations?.readOnlyHint).toBe(false);
+    expect(byName.get("delete_datasource")?.annotations?.destructiveHint).toBe(true);
   });
 });
 
@@ -211,6 +335,39 @@ describe("datasource tools — gate requirements", () => {
     await client.callTool({ name: "restore_datasource", arguments: { id: "prod-us" } });
 
     for (const tool of ["archive_datasource", "restore_datasource"]) {
+      const g = gateCallFor(tool);
+      expect(g?.reqs.requiresWrite).toBe(true);
+      expect(g?.reqs.minRole).toBe("admin");
+      expect(g?.reqs.destructive).toBeUndefined();
+    }
+  });
+
+  it("every mutating tool declares actionCategory 'datasource' for the gate-1 kill-switch (#3509)", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "archive_datasource", arguments: { id: "prod-us" } });
+    await client.callTool({ name: "restore_datasource", arguments: { id: "prod-us" } });
+    await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    await client.callTool({ name: "create_datasource", arguments: { db_type: "postgres", install_id: "new-pg" } });
+    await client.callTool({ name: "profile_datasource", arguments: { id: "prod-us" } });
+    for (const tool of [
+      "archive_datasource",
+      "restore_datasource",
+      "delete_datasource",
+      "create_datasource",
+      "profile_datasource",
+    ]) {
+      expect(gateCallFor(tool)?.reqs.actionCategory).toBe("datasource");
+    }
+    // Read tools must NOT be category-gated (the kill-switch is for mutations).
+    await client.callTool({ name: "list_datasources", arguments: {} });
+    expect(gateCallFor("list_datasources")?.reqs.actionCategory).toBeUndefined();
+  });
+
+  it("create/profile declare requiresWrite=true, admin, and are NOT destructive", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "create_datasource", arguments: { db_type: "postgres", install_id: "new-pg" } });
+    await client.callTool({ name: "profile_datasource", arguments: { id: "prod-us" } });
+    for (const tool of ["create_datasource", "profile_datasource"]) {
       const g = gateCallFor(tool);
       expect(g?.reqs.requiresWrite).toBe(true);
       expect(g?.reqs.minRole).toBe("admin");
@@ -393,6 +550,129 @@ describe("delete_datasource", () => {
     const client = await createTestClient();
     const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
     expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+  });
+});
+
+// ── create_datasource (#3511) — masked-elicitation credential ─────────
+
+describe("create_datasource", () => {
+  it("collects the URL via masked elicitation bound to the workspace, then provisions", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    // Elicitation was called, bound to the org, for a field named `url`.
+    expect(elicitCalls).toHaveLength(1);
+    expect(elicitCalls[0].principal).toBe("org_ds");
+    expect(elicitCalls[0].field.name).toBe("url");
+    // The secret reached provisionDatasource (the lib), in `url`.
+    const provisionArgs = mockProvision.mock.calls[0];
+    expect((provisionArgs?.[1] as { url: string }).url).toBe(ELICITED_SECRET);
+
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.created).toBe(true);
+    expect(body.status).toBe("draft");
+  });
+
+  it("NEVER leaks the elicited credential into the tool response", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    const text = getContentText(res.content);
+    expect(text).not.toContain(ELICITED_SECRET);
+    expect(text).not.toContain("super:secret");
+    // Only the masked URL is surfaced.
+    expect(text).toContain("***");
+  });
+
+  it("a declined/cancelled elicitation → validation_failed, nothing provisioned", async () => {
+    elicitOutcome = { action: "decline" };
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("an elicitation failure (unsupported client) → validation_failed, no leak", async () => {
+    elicitThrows = true;
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("a pre-flight health failure surfaces validation_failed (credential-scrubbed by lib)", async () => {
+    provisionOutcome = { kind: "health_error", message: "Connection test failed: timeout. Verify the host…" };
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+  });
+
+  it("an unsupported db_type is rejected at the inputSchema boundary", async () => {
+    // `db_type` is a Zod enum of provisionable slugs — an out-of-enum value
+    // is rejected by the SDK's input validation (error result), so it never
+    // reaches the handler / elicitation.
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "snowflake", install_id: "x" },
+    });
+    expect(res.isError).toBe(true);
+    expect(mockElicit).not.toHaveBeenCalled();
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+});
+
+// ── profile_datasource (#3512) — long-running, progress + cancellable ──
+
+describe("profile_datasource", () => {
+  it("profiles + generates and reports the datasource as queryable", async () => {
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "profile_datasource", arguments: { id: "prod-us" } });
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.queryable).toBe(true);
+    expect(body.entities_generated).toBe(2);
+    expect(body.tables).toEqual(["orders", "users"]);
+    expect(body.elapsed_ms).toBe(1234);
+    // The decrypted URL the profiler used must not surface.
+    expect(getContentText(res.content)).not.toContain("user:pass");
+  });
+
+  it("a not-found datasource → unknown_entity", async () => {
+    profileTarget = { kind: "not_found" };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "profile_datasource", arguments: { id: "missing" } });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("unknown_entity");
+    expect(mockRunProfile).not.toHaveBeenCalled();
+  });
+
+  it("an unsupported dbType → validation_failed", async () => {
+    profileTarget = { kind: "unsupported", dbType: "clickhouse" };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "profile_datasource", arguments: { id: "ch" } });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+    expect(mockRunProfile).not.toHaveBeenCalled();
+  });
+
+  it("a ProfilingFailedError outcome → validation_failed (not a 500)", async () => {
+    profileResult = { kind: "error", reason: "no_tables", message: "No tables found to profile." };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "profile_datasource", arguments: { id: "prod-us" } });
     expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
   });
 });

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -433,6 +433,56 @@ describe("datasource tools — honor the gate verdict", () => {
     expect(body.approval_request_id).toBe("req_42");
     expect(mockRunInstaller).not.toHaveBeenCalled();
   });
+
+  it("the action-policy kill-switch block (gate-1, #3509/#3514) short-circuits delete", async () => {
+    // gate-1 denial is shaped as a `forbidden` envelope by runMcpDispatchGate;
+    // the tool must surface it and never reach the installer.
+    gateReturn = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            code: "forbidden",
+            message: "Datasource actions are disabled for this workspace by policy.",
+          }),
+        },
+      ],
+      isError: true,
+    };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+});
+
+// ── No-org session guard (mutations) ──────────────────────────────────
+
+describe("no bound workspace → mutations refused (consistency with gate orgId)", () => {
+  const NO_ORG_ACTOR = createAtlasUser("u_noorg", "managed", "noorg@test", { role: "admin" });
+
+  for (const tool of ["archive_datasource", "restore_datasource", "delete_datasource", "profile_datasource"]) {
+    it(`${tool} → forbidden, no lib mutation`, async () => {
+      const client = await createTestClient(NO_ORG_ACTOR);
+      const res = await client.callTool({ name: tool, arguments: { id: "prod-us" } });
+      expect(res.isError).toBe(true);
+      expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
+      expect(mockRunInstaller).not.toHaveBeenCalled();
+      expect(mockRunProfile).not.toHaveBeenCalled();
+    });
+  }
+
+  it("create_datasource → forbidden before elicitation", async () => {
+    const client = await createTestClient(NO_ORG_ACTOR);
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "x" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
+    expect(mockElicit).not.toHaveBeenCalled();
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
 });
 
 // ── Happy paths + envelope mapping (gate returns null) ────────────────
@@ -449,6 +499,13 @@ describe("list_datasources", () => {
     expect(text).not.toContain("url");
     expect(text).not.toContain("password");
     expect(text.toLowerCase()).not.toContain("secret");
+  });
+
+  it("lists in developer mode so freshly-created drafts are discoverable", async () => {
+    const client = await createTestClient();
+    await client.callTool({ name: "list_datasources", arguments: {} });
+    // (orgId, mode, options) — mode must include drafts.
+    expect(mockListDatasources.mock.calls[0]?.[1]).toBe("developer");
   });
 
   it("passes include_archived through to the lib layer", async () => {

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -71,12 +71,19 @@ describe("MCP server integration", () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([
+      "archive_datasource",
+      "create_datasource",
+      "delete_datasource",
       "describeEntity",
       "executeSQL",
       "explore",
       "listEntities",
+      "list_datasources",
+      "profile_datasource",
+      "restore_datasource",
       "runMetric",
       "searchGlossary",
+      "test_datasource",
     ]);
   });
 

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -116,17 +116,24 @@ async function createTestPair() {
 // ---------------------------------------------------------------------------
 
 describe("MCP smoke — tool listing", () => {
-  it("registers explore + executeSQL + the four typed semantic tools (#2020)", async () => {
+  it("registers explore + executeSQL + the typed semantic tools + datasource lifecycle tools (#2020, #3511–#3514)", async () => {
     const { client, cleanup } = await createTestPair();
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([
+      "archive_datasource",
+      "create_datasource",
+      "delete_datasource",
       "describeEntity",
       "executeSQL",
       "explore",
       "listEntities",
+      "list_datasources",
+      "profile_datasource",
+      "restore_datasource",
       "runMetric",
       "searchGlossary",
+      "test_datasource",
     ]);
     await cleanup();
   });
@@ -215,9 +222,10 @@ describe("MCP smoke — server lifecycle", () => {
     await client.connect(clientTransport);
 
     // Verify the server is operational — explore + executeSQL + the four
-    // typed semantic tools (#2020).
+    // typed semantic tools (#2020) + the seven datasource lifecycle tools
+    // (#3511–#3514) = 13.
     const tools = await client.listTools();
-    expect(tools.tools.length).toBe(6);
+    expect(tools.tools.length).toBe(13);
 
     // Clean shutdown — should not throw
     await client.close();

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -165,12 +165,19 @@ describe("SSE server — MCP client integration", () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([
+      "archive_datasource",
+      "create_datasource",
+      "delete_datasource",
       "describeEntity",
       "executeSQL",
       "explore",
       "listEntities",
+      "list_datasources",
+      "profile_datasource",
+      "restore_datasource",
       "runMetric",
       "searchGlossary",
+      "test_datasource",
     ]);
 
     await client.close();
@@ -263,11 +270,12 @@ describe("SSE server — MCP client integration", () => {
     await client2.connect(transport2);
 
     // Both clients can list tools independently — explore + executeSQL +
-    // the four typed semantic tools (#2020).
+    // the four typed semantic tools (#2020) + the seven datasource lifecycle
+    // tools (#3511–#3514) = 13.
     const result1 = await client1.listTools();
     const result2 = await client2.listTools();
-    expect(result1.tools.length).toBe(6);
-    expect(result2.tools.length).toBe(6);
+    expect(result1.tools.length).toBe(13);
+    expect(result2.tools.length).toBe(13);
 
     // Health shows 2+ sessions
     const res = await fetch(`http://localhost:${handle.server.port}/health`);

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -122,10 +122,19 @@ function toJsonContent(value: unknown): CallToolResult {
  * best-effort, so we fire-and-forget — a dropped notification must never
  * fail (or stall) the profiling work. No table data is sensitive; names are
  * already part of the generated whitelist the agent will query.
+ *
+ * The profiler has no native `AbortSignal`, so cancellation is COOPERATIVE:
+ * `onTableStart` runs before each table (outside the profiler's per-table
+ * try/catch), so throwing there when `signal` is aborted unwinds the profiling
+ * loop and stops further work + the open connection — rather than letting it
+ * run to completion in the background after the client cancelled.
  */
-function makeProfileProgress(reporter: {
-  report(progress: number, opts?: { total?: number; message?: string }): Promise<void>;
-}): ProfileProgressCallbacks {
+function makeProfileProgress(
+  reporter: {
+    report(progress: number, opts?: { total?: number; message?: string }): Promise<void>;
+  },
+  signal?: AbortSignal,
+): ProfileProgressCallbacks {
   const fire = (progress: number, total: number, message: string) => {
     void reporter.report(progress, { total, message }).catch(() => {
       // intentionally ignored: progress is best-effort, never load-bearing.
@@ -133,7 +142,9 @@ function makeProfileProgress(reporter: {
   };
   return {
     onStart: (total) => fire(0, total, `Profiling ${total} table${total === 1 ? "" : "s"}…`),
-    onTableStart: () => {},
+    onTableStart: () => {
+      if (signal?.aborted) throw new OperationCancelledError();
+    },
     onTableDone: (name, index, total) => fire(index + 1, total, `Profiled ${name}`),
     onTableError: (name, _error, index, total) =>
       fire(index + 1, total, `Skipped ${name} (profiling error)`),
@@ -214,6 +225,14 @@ export function registerDatasourceTools(
 ): void {
   const { actor, transport, workspaceId, deployMode, clientId, scopes } = opts;
 
+  // The bound workspace for governance + mutations. Unlike `workspaceId`
+  // (which falls back to `actor.id` purely for OTel attribution when no org is
+  // bound), this is the REAL workspace the dispatch gate keys on — so every
+  // mutation operates on the same id the gate (and gate-1 kill-switch /
+  // approval) evaluated. A mutating tool with no bound org is refused via
+  // {@link requireBoundOrg} rather than silently keyed on `actor.id`.
+  const boundOrgId = actor.activeOrganizationId;
+
   // #2067 — same actor shape as tools.ts / semantic-tools.ts so the
   // `mcp` actor_kind / clientId / toolName trail through the audit log.
   const mcpActor = (toolName: string) => ({
@@ -221,6 +240,31 @@ export function registerDatasourceTools(
     ...(clientId ? { clientId } : {}),
     toolName,
   });
+
+  /**
+   * Resolve the bound workspace for a MUTATING tool, or a `forbidden` block.
+   * Keeps mutations and the dispatch gate on ONE workspace identity
+   * (`actor.activeOrganizationId`) — a no-org session (trusted-transport
+   * `system:mcp`) can't mutate, and can't slip past the gate-1 kill-switch /
+   * approval gate that key on the same id.
+   */
+  function requireBoundOrg():
+    | { readonly ok: true; readonly orgId: string }
+    | { readonly ok: false; readonly block: CallToolResult } {
+    if (!boundOrgId) {
+      return {
+        ok: false,
+        block: toEnvelopeResult(
+          envelope(
+            "forbidden",
+            "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
+            { hint: "Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) on the MCP server." },
+          ),
+        ),
+      };
+    }
+    return { ok: true, orgId: boundOrgId };
+  }
 
   // Build the dispatch-gate context for a given dispatch. The bound actor's
   // live-resolved role (#3505) is gate 3's authority; orgId/requesterId drive
@@ -270,23 +314,24 @@ export function registerDatasourceTools(
               });
               if (limited) return limited;
 
-              // GATE 1 (action-policy kill-switch, #3509) — prepends here
-              // once the per-workspace action policy merges: a workspace that
-              // disables this action class blocks the tool outright before
-              // any scope/RBAC work. Until then the merged pipeline (gates
-              // 2–4) is the full enforced order.
-
-              // GATES 2–4 (mcp:write → RBAC → approval) via the merged
-              // dispatch pipeline (#3508 / ADR-0016).
+              // ADR-0016 gate order via the merged dispatch pipeline (#3508):
+              //   gate 1  action-policy kill-switch (#3509) — fires when `reqs`
+              //           carries an `actionCategory` (all mutating datasource
+              //           tools pass `"datasource"`);
+              //   gate 2  mcp:write scope;
+              //   gate 3  RBAC (live role);
+              //   gate 4  approval (origin=mcp) for `destructive` tools.
+              // All four are enforced inside `runMcpDispatchGate`.
               const gateBlock = await runMcpDispatchGate(gateCtx(requestId), {
                 toolName,
                 ...reqs,
               });
               if (gateBlock) return gateBlock;
 
-              // GATE 5 (inline confirm via masked elicitation, #3497/#3499)
-              // appends here for credential-bearing provisioning (Phase 2);
-              // the lifecycle tools below have no inline-confirm step.
+              // Gate 5 (inline confirm) for credential-bearing provisioning is
+              // implemented as the masked-elicitation step inside
+              // `create_datasource`'s body (#3499) — it needs the resolved
+              // workspace + tool args, so it lives in the tool, not here.
 
               return await body(requestId);
             } catch (err) {
@@ -295,7 +340,9 @@ export function registerDatasourceTools(
               // rather than coercing it into an `internal_error` envelope.
               if (err instanceof OperationCancelledError) throw err;
               const message = errorMessage(err, `${toolName} tool failed`);
-              process.stderr.write(`[atlas-mcp] ${toolName} threw: ${err}\n`);
+              // Log the NARROWED message (not the raw `err`) so a stack/object
+              // — which could echo a connection string — never lands in logs.
+              process.stderr.write(`[atlas-mcp] ${toolName} threw: ${message}\n`);
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );
@@ -334,10 +381,13 @@ export function registerDatasourceTools(
         "list_datasources",
         { requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
         async () => {
-          // Published-mode view (external MCP clients are never developer-mode
-          // admins). `include_archived` opts archived rows back in for restore
-          // discovery — they're always credential-free.
-          const all = await listDatasources(workspaceId, "published", {
+          // Developer-mode view: these are admin tools (gate-3 requires admin),
+          // and create_datasource lands a datasource as `draft` — a published
+          // filter would hide it from the very tool the agent is told to use to
+          // find it next. So surface drafts + published; `include_archived`
+          // opts archived rows back in for restore discovery. All rows are
+          // credential-free regardless of status.
+          const all = await listDatasources(workspaceId, "developer", {
             includeArchived: Boolean(include_archived),
           });
           const needle = filter?.toLowerCase().trim();
@@ -411,7 +461,10 @@ export function registerDatasourceTools(
       dispatch(
         "archive_datasource",
         { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
-        async () => archiveOrRestore(id, "archive"),
+        async () => {
+          const org = requireBoundOrg();
+          return org.ok ? archiveOrRestore(org.orgId, id, "archive") : org.block;
+        },
       ),
   );
 
@@ -432,7 +485,10 @@ export function registerDatasourceTools(
       dispatch(
         "restore_datasource",
         { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
-        async () => archiveOrRestore(id, "restore"),
+        async () => {
+          const org = requireBoundOrg();
+          return org.ok ? archiveOrRestore(org.orgId, id, "restore") : org.block;
+        },
       ),
   );
 
@@ -467,11 +523,13 @@ export function registerDatasourceTools(
           },
         },
         async () => {
+          const org = requireBoundOrg();
+          if (!org.ok) return org.block;
           // Resolve the catalog slug first so a non-existent id returns a
           // clean `unknown_entity` rather than an installer defect. (The
           // approval gate already ran in `dispatch`; reaching here means the
           // requester is approved or no rule matched.)
-          const catalogSlug = await resolveDatasourceCatalogSlug(workspaceId, id);
+          const catalogSlug = await resolveDatasourceCatalogSlug(org.orgId, id);
           if (catalogSlug === null) {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -483,7 +541,7 @@ export function registerDatasourceTools(
           // drains the pool. The reversible path is archive_datasource.
           const outcome = await runDatasourceInstaller((installer) =>
             installer.uninstallDatasource(
-              workspaceId as WorkspaceId,
+              org.orgId as WorkspaceId,
               catalogSlug,
               id,
               { hard: true },
@@ -536,16 +594,9 @@ export function registerDatasourceTools(
         // human-in-the-loop is the masked credential entry below.
         { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
         async (requestId) => {
-          const orgId = actor.activeOrganizationId;
-          if (!orgId) {
-            return toEnvelopeResult(
-              envelope(
-                "validation_failed",
-                "This MCP session is not bound to a workspace; provisioning requires a bound workspace.",
-                { hint: "Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) for the MCP server." },
-              ),
-            );
-          }
+          const org = requireBoundOrg();
+          if (!org.ok) return org.block;
+          const orgId = org.orgId;
 
           // Collect the connection URL via MASKED form-mode elicitation
           // (#3499). The secret travels client→server only; it never enters
@@ -646,7 +697,9 @@ export function registerDatasourceTools(
         "profile_datasource",
         { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
         async () => {
-          const target = await loadDatasourceProfileTarget(workspaceId, id);
+          const org = requireBoundOrg();
+          if (!org.ok) return org.block;
+          const target = await loadDatasourceProfileTarget(org.orgId, id);
           if (target.kind === "not_found") {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -665,12 +718,16 @@ export function registerDatasourceTools(
 
           // Long-running: report per-table progress and honor client
           // cancellation (#3500). The decrypted URL stays inside the lib —
-          // only the connectionId + progress counts surface here.
+          // only the connectionId + progress counts surface here. The profiler
+          // has no native AbortSignal, so cancellation is cooperative: the
+          // progress bridge checks `signal` between tables and aborts the loop,
+          // while `withProgressAndCancellation` also severs the await
+          // immediately on the client's cancel.
           const result = await withProgressAndCancellation(
             extra,
             { startMessage: `Profiling datasource "${id}"`, endMessage: "Semantic layer generated" },
-            async (reporter) => {
-              const progress = makeProfileProgress(reporter);
+            async (reporter, signal) => {
+              const progress = makeProfileProgress(reporter, signal);
               return runSemanticProfile({
                 url: target.target.url,
                 dbType: target.target.dbType,
@@ -710,10 +767,11 @@ export function registerDatasourceTools(
    * Resolves the catalog slug first for a clean not-found.
    */
   async function archiveOrRestore(
+    orgId: string,
     id: string,
     action: "archive" | "restore",
   ): Promise<CallToolResult> {
-    const catalogSlug = await resolveDatasourceCatalogSlug(workspaceId, id);
+    const catalogSlug = await resolveDatasourceCatalogSlug(orgId, id);
     if (catalogSlug === null) {
       return toEnvelopeResult(
         envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -727,14 +785,14 @@ export function registerDatasourceTools(
 
     if (action === "archive") {
       const outcome = await runDatasourceInstaller((installer) =>
-        installer.uninstallDatasource(workspaceId as WorkspaceId, catalogSlug, id),
+        installer.uninstallDatasource(orgId as WorkspaceId, catalogSlug, id),
       );
       if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
       return toJsonContent({ id, status: "archived", archived: true });
     }
 
     const outcome = await runDatasourceInstaller((installer) =>
-      installer.updateDatasourceConfig(workspaceId as WorkspaceId, catalogSlug, id, {
+      installer.updateDatasourceConfig(orgId as WorkspaceId, catalogSlug, id, {
         status: "published",
       }),
     );
@@ -786,13 +844,13 @@ const DATASOURCE_READ_ERROR_CODES = [
   "internal_error",
 ] as const;
 
-// Write/destructive tools add `validation_failed` (bad id / installer
-// rejection). The approval-required outcome is NOT an error code — it's a
-// non-error JSON body the agent must surface, per the dispatch-gate contract.
+// Write/destructive tools advertise the read codes PLUS `validation_failed`
+// (bad id / installer rejection / pre-flight health failure / declined
+// elicitation) — derived from the read set so a new baseline code can't be
+// added to one and forgotten on the other. The approval-required outcome is
+// NOT an error code — it's a non-error JSON body the agent must surface, per
+// the dispatch-gate contract.
 const DATASOURCE_WRITE_ERROR_CODES = [
-  "unknown_entity",
+  ...DATASOURCE_READ_ERROR_CODES,
   "validation_failed",
-  "forbidden",
-  "rate_limited",
-  "internal_error",
 ] as const;

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -1,0 +1,543 @@
+/**
+ * Datasource lifecycle MCP tools (Tier 2 — PRD #3483, ADR-0016).
+ *
+ * This module owns EVERY datasource MCP tool. The Phase-1 lifecycle tools
+ * land here first:
+ *
+ *   - `list_datasources`    — read; configured datasources, credential-free
+ *   - `test_datasource`     — read; connection health-check
+ *   - `archive_datasource`  — mutate (reversible); soft-archive an install
+ *   - `restore_datasource`  — mutate (reversible); un-archive an install
+ *   - `delete_datasource`   — mutate (DESTRUCTIVE); hard-delete, approval-gated
+ *
+ * (The Phase-2 provisioning/profiling tools — `create_datasource` #3511 /
+ * `profile_datasource` #3512 — register here too once Session A's
+ * elicitation #3499 + progress/cancel #3500 seams merge.)
+ *
+ * ── Lib-layer only (no loopback HTTP) ─────────────────────────────────
+ * Every tool calls the lib seam in `@atlas/api/lib/datasources/mcp-lifecycle`,
+ * which adapts the same `WorkspaceInstaller` facade + `connections` registry
+ * the admin REST routes use to a context-free call shape. ADR-0016 forbids
+ * an `origin=mcp` tool proxying its own product's HTTP API.
+ *
+ * ── Gate order (ADR-0016) ─────────────────────────────────────────────
+ * Mutating tools route their dispatch through `runMcpDispatchGate` (#3508),
+ * which enforces gates 2–4: `mcp:write` scope → RBAC(live role) →
+ * approval(origin=mcp) for destructive actions. Gate 1 (the per-workspace
+ * action-policy kill-switch, #3509) and gate 5 (inline confirm via
+ * elicitation, #3497/#3499) prepend/append here once those seams merge —
+ * see the `// GATE 1` / `// GATE 5` seams below. Read tools still pass
+ * through the gate for RBAC (datasource metadata is an admin surface) but
+ * declare `requiresWrite: false` so they don't demand `mcp:write`.
+ *
+ * Actor binding, OTel tracing, rate-limiting, and the typed
+ * `AtlasMcpToolError` envelope mirror `semantic-tools.ts` exactly.
+ */
+
+import { z } from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AtlasUser, AtlasRole } from "@atlas/api/lib/auth/types";
+import type { WorkspaceId } from "@useatlas/types";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { withErrorContract } from "@atlas/api/lib/tools/descriptions";
+import {
+  listDatasources,
+  resolveDatasourceCatalogSlug,
+  testDatasource,
+  isDatasourceRegistered,
+  runDatasourceInstaller,
+  type DatasourceInstallerOutcome,
+} from "@atlas/api/lib/datasources/mcp-lifecycle";
+import {
+  traceMcpToolCall,
+  type McpTransport,
+  type McpDeployMode,
+} from "./telemetry.js";
+import { envelope, toEnvelopeResult } from "./error-envelope.js";
+import {
+  runMcpDispatchGate,
+  type McpDispatchGateContext,
+  type McpDispatchGateRequirements,
+} from "./dispatch-gate.js";
+import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
+
+// Every datasource tool is an admin surface — RBAC floor is `admin`.
+const DATASOURCE_MIN_ROLE: AtlasRole = "admin";
+
+// Bounds on free-text / identifier input — MCP clients (incl. hostile ones
+// in BYOC SaaS) shouldn't drive megabyte strings into the lookups.
+const MAX_FILTER_LEN = 1024;
+const MAX_ID_LEN = 256;
+
+// Install-id shape the datasource facade accepts: a lowercase-led slug, plus
+// the two historical sentinels (`__demo__` backfilled by migration 0094;
+// `default` the runtime-registered connection — valid as a TEST target even
+// though the installer rejects it for archive/delete). Surfacing the
+// constraint at the Zod boundary gives an immediate error instead of a
+// downstream `unknown_entity`.
+const INSTALL_ID_PATTERN = /^(?:[a-z][a-z0-9_-]*|__demo__|default)$/;
+
+export interface RegisterDatasourceToolsOptions {
+  /** Actor bound on every tool dispatch — see tools.ts / semantic-tools.ts. */
+  actor: AtlasUser;
+  /** OTel transport tag (#2029). */
+  transport: McpTransport;
+  /** Resolved workspace id for OTel attribution (`actor.activeOrganizationId` or `actor.id`). */
+  workspaceId: string;
+  /** Resolved `deployMode` for OTel attribution. */
+  deployMode: McpDeployMode;
+  /** Hosted-MCP OAuth client_id, surfaced into `audit_log.client_id` (#2067). */
+  clientId?: string;
+  /** #3504 — OAuth token scopes, threaded onto each dispatch's RequestContext. */
+  scopes?: readonly string[];
+}
+
+function dispatchId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) return err.message;
+  const s = String(err);
+  return s && s !== "[object Object]" ? s : fallback;
+}
+
+function toJsonContent(value: unknown): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+/**
+ * Per-OAuth-client rate-limit gate (#2071) — hosted threads `clientId`;
+ * stdio leaves it undefined and is exempt. Identical to `semantic-tools.ts`.
+ */
+async function rateLimitOrNull(args: {
+  clientId: string | undefined;
+  orgId: string;
+  userId: string;
+  toolName: string;
+}): Promise<CallToolResult | null> {
+  if (!args.clientId) return null;
+  const outcome = await enforceClientRateLimit({
+    orgId: args.orgId,
+    clientId: args.clientId,
+    userId: args.userId,
+    toolName: args.toolName,
+  });
+  if (outcome.kind === "ok") return null;
+  return toEnvelopeResult(outcome.envelope);
+}
+
+/**
+ * Map a `WorkspaceInstaller` error outcome onto a typed MCP envelope. The
+ * facade's tagged errors collapse to two LLM-actionable codes: a 404
+ * (catalog / install not found) becomes `unknown_entity` so the agent's
+ * recovery is "call list_datasources"; a 400/409 (bad install id, schema
+ * failure, already-archived conflict) becomes `validation_failed`. No
+ * secret ever rides an installer error body.
+ */
+function installerErrorToEnvelope(
+  outcome: Extract<DatasourceInstallerOutcome<unknown>, { kind: "error" }>,
+  id: string,
+): CallToolResult {
+  if (outcome.status === 404) {
+    return toEnvelopeResult(
+      envelope("unknown_entity", outcome.message, {
+        hint: `Datasource "${id}" was not found — call list_datasources to see configured datasources.`,
+      }),
+    );
+  }
+  return toEnvelopeResult(
+    envelope("validation_failed", outcome.message, {
+      hint: "Fix the datasource id or config and retry.",
+    }),
+  );
+}
+
+/**
+ * Register every datasource lifecycle tool on the given MCP server.
+ *
+ * ── Registration handoff (Session A owns `server.ts`) ─────────────────
+ * `createAtlasMcpServer` in `server.ts` wires this in with a single call,
+ * mirroring the existing `registerTools(...)` line:
+ *
+ * ```ts
+ * import { registerDatasourceTools } from "./datasource-tools.js";
+ * // …after registerTools(server, …):
+ * registerDatasourceTools(server, {
+ *   actor, transport, ...(clientId && { clientId }), ...(scopes && { scopes }),
+ *   workspaceId: actor.activeOrganizationId ?? actor.id,
+ *   deployMode: getConfig()?.deployMode ?? "self-hosted",
+ * });
+ * ```
+ *
+ * That one line is the only edit outside this module — every tool handler,
+ * lib call, and gate wiring lives here.
+ */
+export function registerDatasourceTools(
+  server: McpServer,
+  opts: RegisterDatasourceToolsOptions,
+): void {
+  const { actor, transport, workspaceId, deployMode, clientId, scopes } = opts;
+
+  // #2067 — same actor shape as tools.ts / semantic-tools.ts so the
+  // `mcp` actor_kind / clientId / toolName trail through the audit log.
+  const mcpActor = (toolName: string) => ({
+    kind: "mcp" as const,
+    ...(clientId ? { clientId } : {}),
+    toolName,
+  });
+
+  // Build the dispatch-gate context for a given dispatch. The bound actor's
+  // live-resolved role (#3505) is gate 3's authority; orgId/requesterId drive
+  // the approval attribution for destructive actions.
+  const gateCtx = (requestId: string): McpDispatchGateContext => ({
+    actor,
+    ...(clientId ? { clientId } : {}),
+    ...(scopes ? { scopes } : {}),
+    orgId: actor.activeOrganizationId,
+    requesterId: actor.id,
+    requesterEmail: actor.label,
+    requestId,
+  });
+
+  /**
+   * Shared dispatch wrapper: OTel span → RequestContext → rate-limit → the
+   * ADR-0016 gate order → the tool body. `reqs` declares the tool's gate
+   * requirements (write/role/destructive). The body runs only after every
+   * gate clears; a gate denial / approval-required short-circuit is returned
+   * verbatim. Any throw becomes an `internal_error` envelope with the
+   * dispatch's `request_id`.
+   */
+  async function dispatch(
+    toolName: string,
+    reqs: Omit<McpDispatchGateRequirements, "toolName">,
+    body: (requestId: string) => Promise<CallToolResult>,
+  ): Promise<CallToolResult> {
+    return traceMcpToolCall(
+      { toolName, workspaceId, transport, deployMode },
+      () => {
+        const requestId = dispatchId(`mcp-${toolName}`);
+        return withRequestContext(
+          {
+            requestId,
+            user: actor,
+            actor: mcpActor(toolName),
+            agentOrigin: "mcp",
+            ...(scopes ? { scopes } : {}),
+          },
+          async () => {
+            try {
+              const limited = await rateLimitOrNull({
+                clientId,
+                orgId: workspaceId,
+                userId: actor.id,
+                toolName,
+              });
+              if (limited) return limited;
+
+              // GATE 1 (action-policy kill-switch, #3509) — prepends here
+              // once the per-workspace action policy merges: a workspace that
+              // disables this action class blocks the tool outright before
+              // any scope/RBAC work. Until then the merged pipeline (gates
+              // 2–4) is the full enforced order.
+
+              // GATES 2–4 (mcp:write → RBAC → approval) via the merged
+              // dispatch pipeline (#3508 / ADR-0016).
+              const gateBlock = await runMcpDispatchGate(gateCtx(requestId), {
+                toolName,
+                ...reqs,
+              });
+              if (gateBlock) return gateBlock;
+
+              // GATE 5 (inline confirm via masked elicitation, #3497/#3499)
+              // appends here for credential-bearing provisioning (Phase 2);
+              // the lifecycle tools below have no inline-confirm step.
+
+              return await body(requestId);
+            } catch (err) {
+              const message = errorMessage(err, `${toolName} tool failed`);
+              process.stderr.write(`[atlas-mcp] ${toolName} threw: ${err}\n`);
+              return toEnvelopeResult(
+                envelope("internal_error", message, { request_id: requestId }),
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  // --- list_datasources (read) ---
+  server.registerTool(
+    "list_datasources",
+    {
+      title: "List Datasources",
+      description: withErrorContract(LIST_DATASOURCES_DESCRIPTION, DATASOURCE_READ_ERROR_CODES),
+      inputSchema: {
+        include_archived: z
+          .boolean()
+          .optional()
+          .describe(
+            "Include archived datasources (default false). Set true to discover an archived datasource you intend to restore.",
+          ),
+        filter: z
+          .string()
+          .max(MAX_FILTER_LEN)
+          .optional()
+          .describe(
+            "Optional case-insensitive substring matched against id, dbType, and description.",
+          ),
+      },
+    },
+    async ({ include_archived, filter }): Promise<CallToolResult> =>
+      dispatch(
+        "list_datasources",
+        { requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
+        async () => {
+          // Published-mode view (external MCP clients are never developer-mode
+          // admins). `include_archived` opts archived rows back in for restore
+          // discovery — they're always credential-free.
+          const all = await listDatasources(workspaceId, "published", {
+            includeArchived: Boolean(include_archived),
+          });
+          const needle = filter?.toLowerCase().trim();
+          const filtered = needle
+            ? all.filter(
+                (d) =>
+                  d.id.toLowerCase().includes(needle) ||
+                  d.dbType.toLowerCase().includes(needle) ||
+                  (d.description?.toLowerCase().includes(needle) ?? false),
+              )
+            : all;
+          return toJsonContent({ count: filtered.length, datasources: filtered });
+        },
+      ),
+  );
+
+  // --- test_datasource (read / health-check) ---
+  server.registerTool(
+    "test_datasource",
+    {
+      title: "Test Datasource Connection",
+      description: withErrorContract(TEST_DATASOURCE_DESCRIPTION, DATASOURCE_READ_ERROR_CODES),
+      inputSchema: {
+        id: datasourceIdSchema(
+          "Datasource id (connection id) to health-check. Call list_datasources to discover ids.",
+        ),
+      },
+    },
+    async ({ id }): Promise<CallToolResult> =>
+      dispatch(
+        "test_datasource",
+        { requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
+        async () => {
+          if (!isDatasourceRegistered(id)) {
+            return toEnvelopeResult(
+              envelope(
+                "unknown_entity",
+                `Datasource "${id}" is not registered (it may not exist or may be archived).`,
+                { hint: "Call list_datasources to see configured, queryable datasources." },
+              ),
+            );
+          }
+          const health = await testDatasource(id);
+          return toJsonContent({
+            id,
+            status: health.status,
+            latency_ms: health.latencyMs,
+            // `message` is DSN-scrubbed by the registry — safe to surface.
+            ...(health.message ? { message: health.message } : {}),
+            checked_at: health.checkedAt.toISOString(),
+          });
+        },
+      ),
+  );
+
+  // --- archive_datasource (mutate, reversible) ---
+  server.registerTool(
+    "archive_datasource",
+    {
+      title: "Archive Datasource",
+      description: withErrorContract(ARCHIVE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      inputSchema: {
+        id: datasourceIdSchema(
+          "Datasource id to archive. Reversible — restore with restore_datasource.",
+        ),
+      },
+    },
+    async ({ id }): Promise<CallToolResult> =>
+      dispatch(
+        "archive_datasource",
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE },
+        async () => archiveOrRestore(id, "archive"),
+      ),
+  );
+
+  // --- restore_datasource (mutate, reversible) ---
+  server.registerTool(
+    "restore_datasource",
+    {
+      title: "Restore Datasource",
+      description: withErrorContract(RESTORE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      inputSchema: {
+        id: datasourceIdSchema(
+          "Archived datasource id to restore (un-archive). Call list_datasources with include_archived to discover ids.",
+        ),
+      },
+    },
+    async ({ id }): Promise<CallToolResult> =>
+      dispatch(
+        "restore_datasource",
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE },
+        async () => archiveOrRestore(id, "restore"),
+      ),
+  );
+
+  // --- delete_datasource (mutate, DESTRUCTIVE → approval-gated) ---
+  server.registerTool(
+    "delete_datasource",
+    {
+      title: "Delete Datasource",
+      description: withErrorContract(DELETE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      inputSchema: {
+        id: datasourceIdSchema(
+          "Datasource id to permanently delete. IRREVERSIBLE — prefer archive_datasource unless you intend a hard delete.",
+        ),
+      },
+    },
+    async ({ id }): Promise<CallToolResult> =>
+      dispatch(
+        "delete_datasource",
+        {
+          requiresWrite: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          // Destructive → routes through the origin=mcp approval gate (#3508).
+          // `resource` is the approval-matchable target; `description` is
+          // stored on the queued request so a reviewer sees what was attempted.
+          destructive: {
+            resource: `datasource:${id}`,
+            description: `Delete datasource "${id}" (hard delete via MCP)`,
+          },
+        },
+        async () => {
+          // Resolve the catalog slug first so a non-existent id returns a
+          // clean `unknown_entity` rather than an installer defect. (The
+          // approval gate already ran in `dispatch`; reaching here means the
+          // requester is approved or no rule matched.)
+          const catalogSlug = await resolveDatasourceCatalogSlug(workspaceId, id);
+          if (catalogSlug === null) {
+            return toEnvelopeResult(
+              envelope("unknown_entity", `Datasource "${id}" not found.`, {
+                hint: "Call list_datasources to see configured datasources.",
+              }),
+            );
+          }
+          // Hard delete (`hard: true`) — DELETEs the workspace_plugins row and
+          // drains the pool. The reversible path is archive_datasource.
+          const outcome = await runDatasourceInstaller((installer) =>
+            installer.uninstallDatasource(
+              workspaceId as WorkspaceId,
+              catalogSlug,
+              id,
+              { hard: true },
+            ),
+          );
+          if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
+          return toJsonContent({ id, deleted: true });
+        },
+      ),
+  );
+
+  /**
+   * Shared archive/restore body — both route the same install through the
+   * `WorkspaceInstaller`, differing only in the mutation:
+   *   - archive  → `uninstallDatasource` (soft; status='archived', pool drained)
+   *   - restore  → `updateDatasourceConfig({ status: 'published' })`
+   * Resolves the catalog slug first for a clean not-found.
+   */
+  async function archiveOrRestore(
+    id: string,
+    action: "archive" | "restore",
+  ): Promise<CallToolResult> {
+    const catalogSlug = await resolveDatasourceCatalogSlug(workspaceId, id);
+    if (catalogSlug === null) {
+      return toEnvelopeResult(
+        envelope("unknown_entity", `Datasource "${id}" not found.`, {
+          hint:
+            action === "restore"
+              ? "Call list_datasources with include_archived to see archivable/restorable datasources."
+              : "Call list_datasources to see configured datasources.",
+        }),
+      );
+    }
+
+    if (action === "archive") {
+      const outcome = await runDatasourceInstaller((installer) =>
+        installer.uninstallDatasource(workspaceId as WorkspaceId, catalogSlug, id),
+      );
+      if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
+      return toJsonContent({ id, status: "archived", archived: true });
+    }
+
+    const outcome = await runDatasourceInstaller((installer) =>
+      installer.updateDatasourceConfig(workspaceId as WorkspaceId, catalogSlug, id, {
+        status: "published",
+      }),
+    );
+    if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
+    return toJsonContent({ id, status: outcome.value.status, restored: true });
+  }
+}
+
+// ── Input schema helper ───────────────────────────────────────────────
+
+function datasourceIdSchema(description: string) {
+  return z
+    .string()
+    .min(1)
+    .max(MAX_ID_LEN)
+    .regex(
+      INSTALL_ID_PATTERN,
+      "Datasource id must be a lowercase-led slug (letters, digits, _ , -).",
+    )
+    .describe(description);
+}
+
+// ── LLM-facing descriptions + per-tool error catalogs ─────────────────
+//
+// Kept local to this module (not in the shared `lib/tools/descriptions.ts`)
+// because every datasource tool lives here — there's no cross-package
+// consumer of these strings. `withErrorContract` is the shared appender.
+
+const LIST_DATASOURCES_DESCRIPTION = `List the datasources (database connections) configured for this workspace. Returns credential-free metadata only — \`{ id, dbType, description, status, groupId, health }\` per datasource; NEVER a connection URL, password, or any secret. Pass \`include_archived: true\` to also list archived datasources (for restore). Example response: \`{ "count": 2, "datasources": [{ "id": "prod-us", "dbType": "postgres", "status": "published", "groupId": "prod", "health": { "status": "healthy", "latencyMs": 12 } }] }\`.`;
+
+const TEST_DATASOURCE_DESCRIPTION = `Run a connection health-check (a \`SELECT 1\` probe under a short timeout) against a configured datasource and report its status + latency. Read-only — does not mutate Atlas or the datasource. Example call: \`{ "id": "prod-us" }\`. Example response: \`{ "id": "prod-us", "status": "healthy", "latency_ms": 12, "checked_at": "..." }\`.`;
+
+const ARCHIVE_DATASOURCE_DESCRIPTION = `Archive (soft-disable) a datasource: its pool is drained and it stops being queryable, but the configuration is retained so it can be restored. Reversible via restore_datasource. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example response: \`{ "id": "prod-us", "status": "archived", "archived": true }\`.`;
+
+const RESTORE_DATASOURCE_DESCRIPTION = `Restore (un-archive) a previously archived datasource so it becomes queryable again. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example response: \`{ "id": "prod-us", "status": "published", "restored": true }\`.`;
+
+const DELETE_DATASOURCE_DESCRIPTION = `Permanently delete a datasource — removes the configuration and drains the pool. IRREVERSIBLE (use archive_datasource for a recoverable disable). Destructive: requires the \`mcp:write\` scope and the admin role, and routes through the workspace approval flow when an origin=mcp approval rule requires it (the response then carries \`approval_required: true\` with an \`approval_request_id\` to follow up on). Example call: \`{ "id": "old-staging" }\`. Example success: \`{ "id": "old-staging", "deleted": true }\`.`;
+
+// Read tools: not-found surfaces as `unknown_entity`; everything else as
+// `internal_error`. RBAC denial (gate 3) surfaces as `forbidden`.
+const DATASOURCE_READ_ERROR_CODES = [
+  "unknown_entity",
+  "forbidden",
+  "rate_limited",
+  "internal_error",
+] as const;
+
+// Write/destructive tools add `validation_failed` (bad id / installer
+// rejection). The approval-required outcome is NOT an error code — it's a
+// non-error JSON body the agent must surface, per the dispatch-gate contract.
+const DATASOURCE_WRITE_ERROR_CODES = [
+  "unknown_entity",
+  "validation_failed",
+  "forbidden",
+  "rate_limited",
+  "internal_error",
+] as const;

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -41,18 +41,12 @@ import type { AtlasUser, AtlasRole } from "@atlas/api/lib/auth/types";
 import type { WorkspaceId } from "@useatlas/types";
 import { withRequestContext } from "@atlas/api/lib/logger";
 import { withErrorContract } from "@atlas/api/lib/tools/descriptions";
-import {
-  listDatasources,
-  resolveDatasourceCatalogSlug,
-  testDatasource,
-  isDatasourceRegistered,
-  runDatasourceInstaller,
-  provisionDatasource,
-  loadDatasourceProfileTarget,
-  runSemanticProfile,
-  MCP_PROVISIONABLE_CATALOG_SLUGS,
-  type DatasourceInstallerOutcome,
-} from "@atlas/api/lib/datasources/mcp-lifecycle";
+// Registration-time value: the light, dependency-free provisionable-slugs const
+// (used by the `db_type` enum). Everything else from `mcp-lifecycle` is loaded
+// LAZILY (below) so registering these tools doesn't drag the installer /
+// semantic-gen / Effect-startup graph into MCP server boot — see `lifecycle()`.
+import { MCP_PROVISIONABLE_CATALOG_SLUGS } from "@atlas/api/lib/datasources/provisionable-types";
+import type { DatasourceInstallerOutcome } from "@atlas/api/lib/datasources/mcp-lifecycle";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import {
   traceMcpToolCall,
@@ -60,14 +54,36 @@ import {
   type McpDeployMode,
 } from "./telemetry.js";
 import { envelope, toEnvelopeResult } from "./error-envelope.js";
-import {
-  runMcpDispatchGate,
-  type McpDispatchGateContext,
-  type McpDispatchGateRequirements,
+import type {
+  McpDispatchGateContext,
+  McpDispatchGateRequirements,
 } from "./dispatch-gate.js";
 import { elicitMaskedField } from "./elicitation.js";
 import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
+import { createMcpLogger } from "./logger.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
+
+const log = createMcpLogger("mcp:datasource-tools");
+
+// ── Lazy heavy-module loaders ─────────────────────────────────────────
+//
+// The datasource lib (`mcp-lifecycle`) and the dispatch gate transitively pull
+// the WorkspaceInstaller, the #3506 SemanticGenerator, the enterprise/approval
+// services, and the Effect startup layers. Importing those at module load would
+// couple MCP server *registration* (which only needs tool metadata) to that
+// whole graph — bloating boot and breaking any host that boots the server with
+// a partial `db/internal` mock. So load them on first tool *invocation* and
+// cache the module promise (ESM caches anyway; this just avoids re-awaiting).
+
+type LifecycleModule = typeof import("@atlas/api/lib/datasources/mcp-lifecycle");
+let lifecycleModule: Promise<LifecycleModule> | null = null;
+const lifecycle = (): Promise<LifecycleModule> =>
+  (lifecycleModule ??= import("@atlas/api/lib/datasources/mcp-lifecycle"));
+
+type DispatchGateModule = typeof import("./dispatch-gate.js");
+let dispatchGateModule: Promise<DispatchGateModule> | null = null;
+const dispatchGate = (): Promise<DispatchGateModule> =>
+  (dispatchGateModule ??= import("./dispatch-gate.js"));
 
 // Every datasource tool is an admin surface — RBAC floor is `admin`.
 const DATASOURCE_MIN_ROLE: AtlasRole = "admin";
@@ -322,7 +338,7 @@ export function registerDatasourceTools(
               //   gate 3  RBAC (live role);
               //   gate 4  approval (origin=mcp) for `destructive` tools.
               // All four are enforced inside `runMcpDispatchGate`.
-              const gateBlock = await runMcpDispatchGate(gateCtx(requestId), {
+              const gateBlock = await (await dispatchGate()).runMcpDispatchGate(gateCtx(requestId), {
                 toolName,
                 ...reqs,
               });
@@ -340,9 +356,18 @@ export function registerDatasourceTools(
               // rather than coercing it into an `internal_error` envelope.
               if (err instanceof OperationCancelledError) throw err;
               const message = errorMessage(err, `${toolName} tool failed`);
-              // Log the NARROWED message (not the raw `err`) so a stack/object
-              // — which could echo a connection string — never lands in logs.
-              process.stderr.write(`[atlas-mcp] ${toolName} threw: ${message}\n`);
+              // Structured stderr via the MCP logger (#3494 — no raw stderr
+              // writes in served modules). The pino `err` serializer +
+              // `scrubErrSerializer` in `lib/logger.ts` strip any DSN userinfo
+              // a stack/message might echo.
+              log.error(
+                {
+                  err: err instanceof Error ? err : new Error(String(err)),
+                  toolName,
+                  requestId,
+                },
+                `${toolName} tool threw`,
+              );
               return toEnvelopeResult(
                 envelope("internal_error", message, { request_id: requestId }),
               );
@@ -387,7 +412,7 @@ export function registerDatasourceTools(
           // find it next. So surface drafts + published; `include_archived`
           // opts archived rows back in for restore discovery. All rows are
           // credential-free regardless of status.
-          const all = await listDatasources(workspaceId, "developer", {
+          const all = await (await lifecycle()).listDatasources(workspaceId, "developer", {
             includeArchived: Boolean(include_archived),
           });
           const needle = filter?.toLowerCase().trim();
@@ -422,7 +447,7 @@ export function registerDatasourceTools(
         "test_datasource",
         { requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
         async () => {
-          if (!isDatasourceRegistered(id)) {
+          if (!(await lifecycle()).isDatasourceRegistered(id)) {
             return toEnvelopeResult(
               envelope(
                 "unknown_entity",
@@ -431,7 +456,7 @@ export function registerDatasourceTools(
               ),
             );
           }
-          const health = await testDatasource(id);
+          const health = await (await lifecycle()).testDatasource(id);
           return toJsonContent({
             id,
             status: health.status,
@@ -529,7 +554,7 @@ export function registerDatasourceTools(
           // clean `unknown_entity` rather than an installer defect. (The
           // approval gate already ran in `dispatch`; reaching here means the
           // requester is approved or no rule matched.)
-          const catalogSlug = await resolveDatasourceCatalogSlug(org.orgId, id);
+          const catalogSlug = await (await lifecycle()).resolveDatasourceCatalogSlug(org.orgId, id);
           if (catalogSlug === null) {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -539,7 +564,7 @@ export function registerDatasourceTools(
           }
           // Hard delete (`hard: true`) — DELETEs the workspace_plugins row and
           // drains the pool. The reversible path is archive_datasource.
-          const outcome = await runDatasourceInstaller((installer) =>
+          const outcome = await (await lifecycle()).runDatasourceInstaller((installer) =>
             installer.uninstallDatasource(
               org.orgId as WorkspaceId,
               catalogSlug,
@@ -637,7 +662,7 @@ export function registerDatasourceTools(
           // installer's encrypt-at-rest path. NEVER logged or returned.
           const url = elicited.value;
 
-          const outcome = await provisionDatasource(orgId, {
+          const outcome = await (await lifecycle()).provisionDatasource(orgId, {
             catalogSlug: db_type,
             installId: install_id,
             url,
@@ -699,7 +724,7 @@ export function registerDatasourceTools(
         async () => {
           const org = requireBoundOrg();
           if (!org.ok) return org.block;
-          const target = await loadDatasourceProfileTarget(org.orgId, id);
+          const target = await (await lifecycle()).loadDatasourceProfileTarget(org.orgId, id);
           if (target.kind === "not_found") {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -728,7 +753,7 @@ export function registerDatasourceTools(
             { startMessage: `Profiling datasource "${id}"`, endMessage: "Semantic layer generated" },
             async (reporter, signal) => {
               const progress = makeProfileProgress(reporter, signal);
-              return runSemanticProfile({
+              return (await lifecycle()).runSemanticProfile({
                 url: target.target.url,
                 dbType: target.target.dbType,
                 ...(target.target.schema !== undefined ? { schema: target.target.schema } : {}),
@@ -771,7 +796,7 @@ export function registerDatasourceTools(
     id: string,
     action: "archive" | "restore",
   ): Promise<CallToolResult> {
-    const catalogSlug = await resolveDatasourceCatalogSlug(orgId, id);
+    const catalogSlug = await (await lifecycle()).resolveDatasourceCatalogSlug(orgId, id);
     if (catalogSlug === null) {
       return toEnvelopeResult(
         envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -784,14 +809,14 @@ export function registerDatasourceTools(
     }
 
     if (action === "archive") {
-      const outcome = await runDatasourceInstaller((installer) =>
+      const outcome = await (await lifecycle()).runDatasourceInstaller((installer) =>
         installer.uninstallDatasource(orgId as WorkspaceId, catalogSlug, id),
       );
       if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
       return toJsonContent({ id, status: "archived", archived: true });
     }
 
-    const outcome = await runDatasourceInstaller((installer) =>
+    const outcome = await (await lifecycle()).runDatasourceInstaller((installer) =>
       installer.updateDatasourceConfig(orgId as WorkspaceId, catalogSlug, id, {
         status: "published",
       }),

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -47,8 +47,13 @@ import {
   testDatasource,
   isDatasourceRegistered,
   runDatasourceInstaller,
+  provisionDatasource,
+  loadDatasourceProfileTarget,
+  runSemanticProfile,
+  MCP_PROVISIONABLE_CATALOG_SLUGS,
   type DatasourceInstallerOutcome,
 } from "@atlas/api/lib/datasources/mcp-lifecycle";
+import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import {
   traceMcpToolCall,
   type McpTransport,
@@ -60,6 +65,8 @@ import {
   type McpDispatchGateContext,
   type McpDispatchGateRequirements,
 } from "./dispatch-gate.js";
+import { elicitMaskedField } from "./elicitation.js";
+import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
 
 // Every datasource tool is an admin surface — RBAC floor is `admin`.
@@ -106,6 +113,31 @@ function errorMessage(err: unknown, fallback: string): string {
 function toJsonContent(value: unknown): CallToolResult {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+/**
+ * Bridge the profiler's per-table callbacks (#3506) to the MCP progress
+ * reporter (#3500). `reporter.report` is async but progress notifications are
+ * best-effort, so we fire-and-forget — a dropped notification must never
+ * fail (or stall) the profiling work. No table data is sensitive; names are
+ * already part of the generated whitelist the agent will query.
+ */
+function makeProfileProgress(reporter: {
+  report(progress: number, opts?: { total?: number; message?: string }): Promise<void>;
+}): ProfileProgressCallbacks {
+  const fire = (progress: number, total: number, message: string) => {
+    void reporter.report(progress, { total, message }).catch(() => {
+      // intentionally ignored: progress is best-effort, never load-bearing.
+    });
+  };
+  return {
+    onStart: (total) => fire(0, total, `Profiling ${total} table${total === 1 ? "" : "s"}…`),
+    onTableStart: () => {},
+    onTableDone: (name, index, total) => fire(index + 1, total, `Profiled ${name}`),
+    onTableError: (name, _error, index, total) =>
+      fire(index + 1, total, `Skipped ${name} (profiling error)`),
+    onComplete: () => {},
   };
 }
 
@@ -258,6 +290,10 @@ export function registerDatasourceTools(
 
               return await body(requestId);
             } catch (err) {
+              // Client-initiated cancellation (#3500) is not a tool failure —
+              // the SDK already suppressed the response, so propagate it
+              // rather than coercing it into an `internal_error` envelope.
+              if (err instanceof OperationCancelledError) throw err;
               const message = errorMessage(err, `${toolName} tool failed`);
               process.stderr.write(`[atlas-mcp] ${toolName} threw: ${err}\n`);
               return toEnvelopeResult(
@@ -276,6 +312,7 @@ export function registerDatasourceTools(
     {
       title: "List Datasources",
       description: withErrorContract(LIST_DATASOURCES_DESCRIPTION, DATASOURCE_READ_ERROR_CODES),
+      annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: {
         include_archived: z
           .boolean()
@@ -323,6 +360,7 @@ export function registerDatasourceTools(
     {
       title: "Test Datasource Connection",
       description: withErrorContract(TEST_DATASOURCE_DESCRIPTION, DATASOURCE_READ_ERROR_CODES),
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: datasourceIdSchema(
           "Datasource id (connection id) to health-check. Call list_datasources to discover ids.",
@@ -362,6 +400,7 @@ export function registerDatasourceTools(
     {
       title: "Archive Datasource",
       description: withErrorContract(ARCHIVE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
       inputSchema: {
         id: datasourceIdSchema(
           "Datasource id to archive. Reversible — restore with restore_datasource.",
@@ -371,7 +410,7 @@ export function registerDatasourceTools(
     async ({ id }): Promise<CallToolResult> =>
       dispatch(
         "archive_datasource",
-        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE },
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
         async () => archiveOrRestore(id, "archive"),
       ),
   );
@@ -382,6 +421,7 @@ export function registerDatasourceTools(
     {
       title: "Restore Datasource",
       description: withErrorContract(RESTORE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
       inputSchema: {
         id: datasourceIdSchema(
           "Archived datasource id to restore (un-archive). Call list_datasources with include_archived to discover ids.",
@@ -391,7 +431,7 @@ export function registerDatasourceTools(
     async ({ id }): Promise<CallToolResult> =>
       dispatch(
         "restore_datasource",
-        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE },
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
         async () => archiveOrRestore(id, "restore"),
       ),
   );
@@ -402,6 +442,7 @@ export function registerDatasourceTools(
     {
       title: "Delete Datasource",
       description: withErrorContract(DELETE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
       inputSchema: {
         id: datasourceIdSchema(
           "Datasource id to permanently delete. IRREVERSIBLE — prefer archive_datasource unless you intend a hard delete.",
@@ -414,6 +455,9 @@ export function registerDatasourceTools(
         {
           requiresWrite: true,
           minRole: DATASOURCE_MIN_ROLE,
+          // Gate 1 (#3509): the datasource action-policy kill-switch blocks
+          // this outright when the workspace disables datasource actions.
+          actionCategory: "datasource",
           // Destructive → routes through the origin=mcp approval gate (#3508).
           // `resource` is the approval-matchable target; `description` is
           // stored on the queued request so a reviewer sees what was attempted.
@@ -447,6 +491,213 @@ export function registerDatasourceTools(
           );
           if (outcome.kind === "error") return installerErrorToEnvelope(outcome, id);
           return toJsonContent({ id, deleted: true });
+        },
+      ),
+  );
+
+  // --- create_datasource (mutate; credential via masked elicitation) ---
+  server.registerTool(
+    "create_datasource",
+    {
+      title: "Create Datasource",
+      description: withErrorContract(CREATE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+      inputSchema: {
+        db_type: z
+          .enum(MCP_PROVISIONABLE_CATALOG_SLUGS as [string, ...string[]])
+          .describe(
+            `Datasource type. Provisionable via MCP today: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")}.`,
+          ),
+        install_id: datasourceIdSchema(
+          "New datasource id (lowercase-led slug, e.g. 'prod-us'). Must be unique in the workspace.",
+        ),
+        schema: z
+          .string()
+          .max(MAX_ID_LEN)
+          .optional()
+          .describe("Optional schema/search_path (Postgres). Defaults to the server default."),
+        description: z
+          .string()
+          .max(MAX_FILTER_LEN)
+          .optional()
+          .describe("Optional human-readable description."),
+        group_id: z
+          .string()
+          .max(MAX_ID_LEN)
+          .optional()
+          .describe("Optional environment-group binding."),
+      },
+    },
+    async ({ db_type, install_id, schema, description, group_id }, extra): Promise<CallToolResult> =>
+      dispatch(
+        "create_datasource",
+        // Gate 1 (#3509) datasource kill-switch + mcp:write + admin. NOT
+        // approval-gated (provisioning is additive, lands draft); the
+        // human-in-the-loop is the masked credential entry below.
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        async (requestId) => {
+          const orgId = actor.activeOrganizationId;
+          if (!orgId) {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                "This MCP session is not bound to a workspace; provisioning requires a bound workspace.",
+                { hint: "Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) for the MCP server." },
+              ),
+            );
+          }
+
+          // Collect the connection URL via MASKED form-mode elicitation
+          // (#3499). The secret travels client→server only; it never enters
+          // a tool argument, the agent/LLM context, this response, or a log.
+          let elicited;
+          try {
+            elicited = await elicitMaskedField(server, {
+              principal: orgId,
+              message: `Enter the ${db_type} connection URL for "${install_id}". It is sent securely and never shared with the agent.`,
+              field: {
+                name: "url",
+                title: `${db_type} connection URL`,
+                description: "Entered securely; never shared with the agent or stored in plaintext.",
+              },
+              ...(extra.signal ? { signal: extra.signal } : {}),
+            });
+          } catch (err) {
+            // Elicitation unsupported by the client, or a state/secret error.
+            // Never include the (never-yet-received) credential; surface a
+            // capability-shaped message.
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                `Could not securely collect the connection credential: ${errorMessage(err, "elicitation failed")}.`,
+                { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
+              ),
+            );
+          }
+          if (elicited.action !== "accept") {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                `Datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no credential was provided.`,
+              ),
+            );
+          }
+          // `url` is the secret — used only for the pre-flight probe + the
+          // installer's encrypt-at-rest path. NEVER logged or returned.
+          const url = elicited.value;
+
+          const outcome = await provisionDatasource(orgId, {
+            catalogSlug: db_type,
+            installId: install_id,
+            url,
+            ...(schema !== undefined ? { schema } : {}),
+            ...(description !== undefined ? { description } : {}),
+            groupId: group_id ?? null,
+          });
+
+          switch (outcome.kind) {
+            case "ok":
+              // Only the masked URL is ever surfaced.
+              return toJsonContent({
+                id: outcome.value.installId,
+                db_type: outcome.value.dbType,
+                status: outcome.value.status,
+                masked_url: outcome.value.maskedUrl,
+                description: outcome.value.description,
+                schema: outcome.value.schema,
+                group_id: outcome.value.groupId,
+                created: true,
+                next: `Run profile_datasource with id "${outcome.value.installId}" to generate its semantic layer and make it queryable.`,
+              });
+            case "unsupported":
+              return toEnvelopeResult(envelope("validation_failed", outcome.message));
+            case "health_error":
+              // Pre-flight failed — message is credential-scrubbed by the lib.
+              return toEnvelopeResult(
+                envelope("validation_failed", outcome.message, {
+                  hint: "Verify the connection details and that the database is reachable, then retry.",
+                }),
+              );
+            case "error":
+              // Installer rejection (conflict / bad config) — agent-actionable.
+              return toEnvelopeResult(
+                envelope("validation_failed", outcome.message, { request_id: requestId }),
+              );
+          }
+        },
+      ),
+  );
+
+  // --- profile_datasource (mutate, long-running → progress + cancellable) ---
+  server.registerTool(
+    "profile_datasource",
+    {
+      title: "Profile Datasource & Generate Semantic Layer",
+      description: withErrorContract(PROFILE_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+      inputSchema: {
+        id: datasourceIdSchema(
+          "Datasource id to profile. Typically one just created with create_datasource.",
+        ),
+      },
+    },
+    async ({ id }, extra): Promise<CallToolResult> =>
+      dispatch(
+        "profile_datasource",
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        async () => {
+          const target = await loadDatasourceProfileTarget(workspaceId, id);
+          if (target.kind === "not_found") {
+            return toEnvelopeResult(
+              envelope("unknown_entity", `Datasource "${id}" not found.`, {
+                hint: "Call list_datasources to see configured datasources.",
+              }),
+            );
+          }
+          if (target.kind === "unsupported") {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                `Profiling "${target.dbType}" datasources via MCP is not supported yet (only postgres and mysql).`,
+              ),
+            );
+          }
+
+          // Long-running: report per-table progress and honor client
+          // cancellation (#3500). The decrypted URL stays inside the lib —
+          // only the connectionId + progress counts surface here.
+          const result = await withProgressAndCancellation(
+            extra,
+            { startMessage: `Profiling datasource "${id}"`, endMessage: "Semantic layer generated" },
+            async (reporter) => {
+              const progress = makeProfileProgress(reporter);
+              return runSemanticProfile({
+                url: target.target.url,
+                dbType: target.target.dbType,
+                ...(target.target.schema !== undefined ? { schema: target.target.schema } : {}),
+                connectionId: id,
+                progress,
+              });
+            },
+          );
+
+          if (result.kind === "error") {
+            // Tagged ProfilingFailedError — an agent-actionable validation
+            // outcome (no tables, too many failures), not a 500.
+            return toEnvelopeResult(envelope("validation_failed", result.message));
+          }
+
+          const r = result.result;
+          const tables = r.entities.map((e) => e.table);
+          return toJsonContent({
+            id,
+            queryable: true,
+            entities_generated: r.entities.length,
+            metrics_generated: r.metrics.length,
+            tables,
+            profiling_errors: r.errors.length,
+            elapsed_ms: r.elapsedMs,
+          });
         },
       ),
   );
@@ -521,6 +772,10 @@ const ARCHIVE_DATASOURCE_DESCRIPTION = `Archive (soft-disable) a datasource: its
 const RESTORE_DATASOURCE_DESCRIPTION = `Restore (un-archive) a previously archived datasource so it becomes queryable again. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example response: \`{ "id": "prod-us", "status": "published", "restored": true }\`.`;
 
 const DELETE_DATASOURCE_DESCRIPTION = `Permanently delete a datasource — removes the configuration and drains the pool. IRREVERSIBLE (use archive_datasource for a recoverable disable). Destructive: requires the \`mcp:write\` scope and the admin role, and routes through the workspace approval flow when an origin=mcp approval rule requires it (the response then carries \`approval_required: true\` with an \`approval_request_id\` to follow up on). Example call: \`{ "id": "old-staging" }\`. Example success: \`{ "id": "old-staging", "deleted": true }\`.`;
+
+const CREATE_DATASOURCE_DESCRIPTION = `Provision a NEW datasource (postgres or mysql) for this workspace. You supply only non-secret fields — \`db_type\`, \`install_id\`, optional \`schema\`/\`description\`/\`group_id\`. The connection URL (the credential) is collected SEPARATELY via a secure masked prompt to the user; it is never passed as a tool argument and never shared with you. The connection is health-checked BEFORE it is persisted (a failed probe persists nothing), and lands as a \`draft\` — run profile_datasource next to make it queryable. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "db_type": "postgres", "install_id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "db_type": "postgres", "status": "draft", "masked_url": "postgres://***@…", "created": true }\`.`;
+
+const PROFILE_DATASOURCE_DESCRIPTION = `Profile a datasource (introspect its tables) and generate its semantic layer — entities + the table whitelist — so the agent can query it with executeSQL. Long-running: emits progress per table and is cancellable. Typically run right after create_datasource. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "queryable": true, "entities_generated": 12, "tables": ["orders", "users"], "elapsed_ms": 1840 }\`.`;
 
 // Read tools: not-found surfaces as `unknown_entity`; everything else as
 // `internal_error`. RBAC denial (gate 3) surfaces as `forbidden`.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,7 @@ import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { loadSettings } from "@atlas/api/lib/settings";
 import { registerTools } from "./tools.js";
+import { registerDatasourceTools } from "./datasource-tools.js";
 import { registerPluginTools } from "./plugin-tools.js";
 import { bootPluginsForMcp } from "@atlas/api/lib/plugins";
 import { registerResources } from "./resources.js";
@@ -139,6 +140,18 @@ export async function createAtlasMcpServer(
   );
 
   registerTools(server, { actor, transport, clientId, ...(scopes && { scopes }) });
+
+  // Datasource lifecycle admin tools (Tier 2 — list/test/archive/restore/
+  // delete/create/profile). Self-contained in `datasource-tools.ts`; this is
+  // the single wiring line (#3511–#3514).
+  registerDatasourceTools(server, {
+    actor,
+    transport,
+    ...(clientId && { clientId }),
+    ...(scopes && { scopes }),
+    workspaceId: actor.activeOrganizationId ?? actor.id,
+    deployMode: getConfig()?.deployMode ?? "self-hosted",
+  });
 
   // #2078 — plugins contribute additional MCP tools via `mcpTools()`.
   // Boot the plugin lifecycle so factory functions can run, then walk

--- a/packages/sdk/src/__tests__/mcp.test.ts
+++ b/packages/sdk/src/__tests__/mcp.test.ts
@@ -284,6 +284,42 @@ describe("completeConnect", () => {
     expect(params.get("redirect_uri")).toBe(REDIRECT_URI);
   });
 
+  // #3526 — without the RFC 8707 `resource` indicator Better Auth's
+  // oauth-provider mints an opaque token, and the immediate
+  // `decodeJwtPayload` below throws `malformed_jwt`. Assert the default
+  // `${apiUrl}/mcp` resource rides the token request, mirroring the CLI
+  // regression (#3493) covered in `plugins/mcp/__tests__/init/hosted.test.ts`.
+  test("sends RFC 8707 resource (${apiUrl}/mcp) on the token exchange", async () => {
+    const { fetchImpl, calls } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: VALID_TOKEN, expires_in: 3600 }),
+    });
+
+    await completeConnect({
+      ...baseComplete,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const params = new URLSearchParams(calls[0].body);
+    expect(params.get("resource")).toBe(`${API_URL}/mcp`);
+  });
+
+  test("honours an explicit resource override on the token exchange", async () => {
+    const { fetchImpl, calls } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: VALID_TOKEN, expires_in: 3600 }),
+    });
+
+    await completeConnect({
+      ...baseComplete,
+      resource: `${API_URL}/mcp/custom`,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const params = new URLSearchParams(calls[0].body);
+    expect(params.get("resource")).toBe(`${API_URL}/mcp/custom`);
+  });
+
   test("state mismatch → callback_state_mismatch", async () => {
     await expect(
       completeConnect({

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -232,6 +232,21 @@ export interface CompleteConnectOptions {
    * Pass alongside `tokenEndpoint`.
    */
   issuer?: string;
+  /**
+   * RFC 8707 resource indicator bound to the issued token. Defaults to
+   * `${apiUrl}/mcp` — the hosted MCP endpoint this token authenticates
+   * against. Better Auth's `@better-auth/oauth-provider` only mints a
+   * **signed JWT** access token (vs an opaque one) when the token
+   * request carries a `resource`; this `completeConnect` flow immediately
+   * `decodeJwtPayload`s the token to read the workspace claim, so without
+   * the indicator a real hosted exchange yields an opaque token and fails
+   * with `malformed_jwt` (#3526 — same bug class as the CLI's #3493).
+   *
+   * Pass an explicit value only when the hosted MCP endpoint is mounted
+   * somewhere other than `${apiUrl}/mcp`; otherwise leave it unset and
+   * the default applies.
+   */
+  resource?: string;
   /** Test seam. */
   fetchImpl?: typeof fetch;
 }
@@ -461,6 +476,12 @@ export async function completeConnect(
         redirectUri: options.redirectUri,
         code: options.code,
         codeVerifier: options.codeVerifier,
+        // RFC 8707 — bind the issued token to the hosted MCP endpoint so
+        // the oauth-provider mints a signed JWT (not an opaque token) that
+        // `decodeJwtPayload` below can read. Defaults to `${apiUrl}/mcp`,
+        // matching the CLI's hosted flow (#3493). See `resource` on
+        // `CompleteConnectOptions`.
+        resource: options.resource ?? `${apiUrl}/mcp`,
       },
       { fetchImpl },
     );


### PR DESCRIPTION
## What

v0.0.15 Session C — the Tier-2 datasource MCP flagship (PRD #3483, ADR-0016). All datasource MCP tools live in one self-contained module `packages/mcp/src/datasource-tools.ts`, calling the **lib layer directly** (never loopback HTTP) via a new `lib/datasources/mcp-lifecycle.ts` seam.

Closes #3526, #3513, #3514, #3511, #3512.

### Tools (7)
| Tool | Issue | Gate posture |
|------|-------|--------------|
| `list_datasources` | #3513 | read; RBAC admin; credential-free |
| `test_datasource` | #3513 | read; RBAC admin; health-check |
| `archive_datasource` | #3513 | mutate (reversible); gate-1 + mcp:write + admin |
| `restore_datasource` | #3513 | mutate (reversible); gate-1 + mcp:write + admin |
| `delete_datasource` | #3514 | **destructive**; + origin=mcp approval gate |
| `create_datasource` | #3511 | mutate; **masked-elicitation credential** |
| `profile_datasource` | #3512 | long-running; **progress + cancellation** |

### Highlights
- **#3526** — SDK `completeConnect` now sends the RFC 8707 `resource` (`${apiUrl}/mcp`) so Better Auth mints a signed JWT, not an opaque token (same bug class as the merged CLI fix #3493).
- **Credential secrecy (#3511)** — the connection URL is collected via masked form-mode elicitation (#3499): client→server only, never in a tool arg, the agent/LLM context, the response, or a log. Validate-before-persist via an ephemeral health-check that rolls back on failure; errors are credential-scrubbed (incl. `//user:pass@` userinfo). New datasources land `draft`.
- **Queryable (#3512)** — profiling runs the #3506 `SemanticGenerator` with `registerWhitelist`, so a subsequent `executeSQL` is permitted. Per-table progress + client cancellation via #3500; the decrypted URL stays in the lib layer.
- **ADR-0016 gate order** — mutating tools route through the merged dispatch-gate (#3508): gate-1 action-policy kill-switch (#3509, `actionCategory: "datasource"`) → mcp:write → RBAC(live role) → approval(origin=mcp) for delete. All seven tools declare #3497 annotations.

### Scope
Provisioning/profiling are scoped to **postgres/mysql** — the native pool types whose ephemeral health-check + built-in profiler genuinely validate connectivity (and the Postgres-focused ACs). Other types return an actionable `unsupported` (admin console handles them); extending them needs the plugin-pool test-connect path (follow-up).

## Testing
- 31 tool-level + 15 lib-level new tests (incl. no-credential-leak, decline/cancel, validate-before-persist rollback, secret/userinfo scrubbing, progress bridge, approval-required short-circuit).
- 140 neighboring MCP tests green; smoke/server tool-list assertions updated.
- `tsgo` clean (api + mcp), lint clean.

https://claude.ai/code/session_0138K9obaBmn5svPoZBiigeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0138K9obaBmn5svPoZBiigeZ)_