### PR TITLE
feat(mcp): persist profiled semantic layer + live-DB create→profile→query test

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -351,7 +351,7 @@ If you connect a client not listed here and it works (or it doesn't), [open an i
 
 ## Available tools
 
-The MCP server exposes six tools — two general-purpose and four typed accessors over the semantic layer. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
+The MCP server exposes six core semantic tools — two general-purpose and four typed accessors over the semantic layer — plus a set of admin [datasource lifecycle tools](#datasource-lifecycle-tools) covered below. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
 
 ### explore
 
@@ -465,6 +465,46 @@ When the result has multiple columns or multiple rows, `value` falls back to the
 `runMetric` returns an `isError: true` envelope when the metric id is unknown (`unknown_metric`), when the underlying SQL fails validation (`validation_failed`), when an RLS rule rejects the query (`rls_denied`), when the statement timeout fires (`query_timeout`), when the request is rate-limited (`rate_limited`), when the workspace is blocked by billing enforcement (`billing_blocked` — runMetric queries the datasource through the same pipeline as `executeSQL`, so it sits behind the same gate), or on any other failure (`internal_error`). See [Error contract](#error-contract) for the exact envelope shape.
 
 The `filters` parameter is reserved for future pre-aggregation filter pass-through. Passing a non-empty `filters` object is rejected today; use `executeSQL` with the metric's raw SQL if you need to filter results before aggregation.
+
+---
+
+## Datasource lifecycle tools
+
+Beyond the read-only semantic tools above, the server exposes a set of **admin, write-scoped** tools for managing datasources from an agent: `list_datasources`, `test_datasource`, `create_datasource`, `profile_datasource`, `archive_datasource`, `restore_datasource`, and `delete_datasource`. They require the `admin` role and (for the mutating tools) the `mcp:write` scope, and route through the same RBAC + approval gates as the rest of the admin surface. None of them ever return a connection URL or any secret — `create_datasource` collects the credential via a separate masked prompt that is never shared with the agent.
+
+The two-step path to make a new datasource queryable is **create → profile**:
+
+### create_datasource
+
+Provision a new Postgres or MySQL datasource. You pass only non-secret fields (`db_type`, `install_id`, optional `schema` / `description` / `group_id`); the connection URL is collected via a masked prompt, health-checked **before** anything is persisted, and the datasource lands as a `draft`. It is not yet queryable — run `profile_datasource` next.
+
+### profile_datasource
+
+Introspect the datasource's tables and generate its semantic layer (entities + metrics), then make it queryable. Long-running: emits per-table progress and is cancellable.
+
+Profiling does two things with the generated layer:
+
+1. **Registers it in the in-process table whitelist** so an `executeSQL` call in the *same* server process is permitted immediately.
+2. **Persists it durably** to the workspace semantic store as **`draft`** entities and metrics, scoped to the datasource's connection group. This is what makes the generated layer survive an MCP-server restart **and** visible to the Atlas API process that serves the web `/chat` `executeSQL` — a stdio MCP server runs in a different process, so the in-memory whitelist alone is not cross-surface.
+
+```jsonc
+// Example profile_datasource success
+{
+  "id": "prod-us",
+  "queryable": true,
+  "persisted": true,
+  "persisted_status": "draft",
+  "publish_hint": "Generated entities are saved as drafts. Run the admin publish flow to make them queryable from the published /chat surface; they are queryable now in developer mode.",
+  "entities_generated": 12,
+  "metrics_generated": 4,
+  "tables": ["orders", "users"],
+  "elapsed_ms": 1840
+}
+```
+
+Because the persisted rows land as **drafts**, they follow the standard [content-mode](/security/sql-validation) status discipline: queryable immediately in **developer mode** (the draft overlay), but **not** on the published `/chat` surface until an admin promotes them through the atomic publish endpoint (`/api/v1/admin/publish`). This keeps machine-generated, unreviewed entities out of the published whitelist until a human signs off. Profiling fails loud (a `validation_failed` envelope) rather than report success if any generated table cannot be persisted — a partially-persisted layer would silently leave some tables unqueryable.
+
+If profiling persists fewer rows than it generated, or the workspace has no internal database configured (a self-hosted stdio server with no `DATABASE_URL`), `persisted` is `false` and only the in-process whitelist is populated for the current session.
 
 ---
 

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -55,6 +55,7 @@ import {
   generateEntityYAML,
   generateSemanticLayer,
 } from "@atlas/api/lib/semantic/generate";
+import { SAFE_TABLE_NAME } from "@atlas/api/lib/semantic/shapes";
 // Phase-2 enrichment is the same shared engine (issue #3236, § D); the in-memory
 // variant lets the wizard enrich a YAML string per table without touching disk.
 import { enrichEntityYaml } from "@atlas/api/lib/semantic/enrich";
@@ -940,7 +941,6 @@ wizard.openapi(saveRoute, async (c) => {
     const { connectionId, entities } = body;
   
     // Path traversal protection: validate all table names before writing any files
-    const SAFE_TABLE_NAME = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/;
     for (const entity of entities) {
       if (!SAFE_TABLE_NAME.test(entity.tableName) || entity.tableName.includes("..")) {
         return c.json({

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -325,9 +325,9 @@ describe("loadDatasourceProfileTarget", () => {
     expect(res.kind).toBe("not_found");
   });
 
-  it("returns the decrypted target for a postgres install", async () => {
+  it("returns the decrypted target (with the install's group scope) for a postgres install", async () => {
     internalRows = [
-      { catalog_id: "cat_pg", catalog_slug: "postgres", config: { url: "enc:v1:…" }, config_schema: [] },
+      { catalog_id: "cat_pg", catalog_slug: "postgres", config: { url: "enc:v1:…" }, config_schema: [], group_id: "prod" },
     ];
     poolConfigResult = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "analytics" };
     const res = await loadDatasourceProfileTarget("org_1", "pg");
@@ -336,7 +336,19 @@ describe("loadDatasourceProfileTarget", () => {
       expect(res.target.dbType).toBe("postgres");
       expect(res.target.url).toBe("postgres://u:p@h/db");
       expect(res.target.schema).toBe("analytics");
+      // #3546 — the group scope drives where persisted drafts land.
+      expect(res.target.connectionGroupId).toBe("prod");
     }
+  });
+
+  it("normalizes a missing/empty group_id to null connectionGroupId (flat default scope)", async () => {
+    internalRows = [
+      { catalog_id: "cat_pg", catalog_slug: "postgres", config: { url: "enc:v1:…" }, config_schema: [], group_id: null },
+    ];
+    poolConfigResult = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "public" };
+    const res = await loadDatasourceProfileTarget("org_1", "pg");
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") expect(res.target.connectionGroupId).toBeNull();
   });
 
   it("returns unsupported for a non-profilable dbType", async () => {

--- a/packages/api/src/lib/datasources/__tests__/mcp-profile-persist-pg.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-profile-persist-pg.test.ts
@@ -1,0 +1,238 @@
+/**
+ * LIVE-Postgres create → profile → query coverage for the MCP datasource flow
+ * (#3546). This replaces the fully-MOCKED `create → profile → query` assertion
+ * that #3512 (PR #3545) shipped: there, `mcp-lifecycle` was mocked, so real
+ * end-to-end queryability was never exercised. Here the whole spine runs
+ * against a live schema:
+ *
+ *   1. install a datasource row (`workspace_plugins`, pillar='datasource') —
+ *      the "create" half (mirrors what `provisionDatasource` persists);
+ *   2. seed a real source table in the same schema;
+ *   3. `runSemanticProfile(...)` profiles it, generates the semantic layer,
+ *      registers the in-memory whitelist, AND persists the generated entities
+ *      to `semantic_entities` as drafts (the #3546 durability path);
+ *   4. assert the rows landed as `draft` and that a real `validateSQL` against
+ *      a profiled table is PERMITTED — and a non-profiled table is REJECTED.
+ *
+ * What this catches that the mocked tool tests can't: the persisted-draft rows
+ * are actually readable by the cross-process whitelist loader
+ * (`loadOrgWhitelist` → `getOrgWhitelistedTables`), proving an MCP-profiled
+ * datasource is queryable from the API process (web `/chat`), not just the
+ * in-memory MCP process.
+ *
+ * Skips cleanly when `TEST_DATABASE_URL` is unset (CI sets it; opt in locally
+ * with `bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas`).
+ */
+
+import { afterAll, beforeAll, afterEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import * as yaml from "js-yaml";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import type { InternalPool } from "@atlas/api/lib/db/internal";
+import { runSemanticProfile } from "../mcp-lifecycle";
+import { validateSQL } from "@atlas/api/lib/tools/sql";
+import { connections } from "@atlas/api/lib/db/connection";
+import {
+  invalidateOrgWhitelist,
+  _resetOrgWhitelists,
+  _resetWhitelists,
+  _resetPluginEntities,
+} from "@atlas/api/lib/semantic/whitelist";
+import { withRequestContext } from "@atlas/api/lib/logger";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+if (!TEST_DB_URL) {
+  // Make the skip reason explicit in the run output rather than silently
+  // no-op'ing — this is a real-DB contract test, not an optional extra.
+  console.warn(
+    "mcp-profile-persist-pg: TEST_DATABASE_URL unset — skipping live create→profile→query test (set it to opt in).",
+  );
+}
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("MCP create → profile → query (live Postgres, #3546)", () => {
+  let pool: Pool;
+  // Two schemas: `schemaName` holds the migrated internal-DB tables (the
+  // `semantic_entities` / `workspace_plugins` store this process reads); a
+  // SEPARATE `srcSchema` holds the single source table the profiler
+  // introspects, so the profiler sees ONLY `live_orders` — not the 70+ atlas
+  // tables the migrations create.
+  const schemaName = `mcp_persist_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const srcSchema = `mcp_src_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORG = `org-mcp-persist-${Math.floor(Math.random() * 1e6)}`;
+  const INSTALL_ID = "live-pg";
+  const GROUP_ID = "g_live";
+  // `hasInternalDB()` (the persist + whitelist-load gate) keys on DATABASE_URL.
+  // Set it for this file so the durable path runs; restored in afterAll.
+  let prevDatabaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    prevDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`mcp-persist-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // Install this process's internal DB pool so `internalQuery` / `hasInternalDB`
+    // (used by the persistence + whitelist-load paths) hit the live test schema.
+    _resetPool(pool as unknown as InternalPool);
+
+    // Seed the catalog FK target + the "create" half: a datasource install row
+    // bound to GROUP_ID (group-of-one). `runSemanticProfile`'s persistence is
+    // scoped DIRECTLY to GROUP_ID, so the whitelist loader resolves it.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:mcp-persist-pg', 'Postgres', 'mcp-persist-pg', 'datasource', 'datasource', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at)
+       VALUES ($1, $2, 'catalog:mcp-persist-pg', $3, 'datasource',
+               $4::jsonb, true, 'draft', NOW())`,
+      [`${ORG}-${INSTALL_ID}`, ORG, INSTALL_ID, JSON.stringify({ group_id: GROUP_ID })],
+    );
+
+    // A real source table for the profiler to introspect — in its OWN schema so
+    // the profiler (which lists every table in the target schema) sees only it.
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${srcSchema}"`);
+    await pool.query(
+      `CREATE TABLE "${srcSchema}".live_orders (
+         id integer PRIMARY KEY,
+         customer text NOT NULL,
+         total numeric NOT NULL
+       )`,
+    );
+    await pool.query(
+      `INSERT INTO "${srcSchema}".live_orders (id, customer, total)
+       VALUES (1, 'acme', 100.0), (2, 'globex', 250.5)`,
+    );
+
+    // Register the analytics connection under the SAME key the persisted rows
+    // are scoped to (GROUP_ID) so `validateSQL(sql, GROUP_ID, ORG)` resolves the
+    // dbType and reads the matching whitelist bucket. Points at the source schema.
+    connections.register(GROUP_ID, { url: TEST_DB_URL as string, schema: srcSchema });
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterEach(() => {
+    _resetWhitelists();
+    _resetOrgWhitelists();
+    _resetPluginEntities();
+    invalidateOrgWhitelist(ORG);
+  });
+
+  afterAll(async () => {
+    connections.unregister(GROUP_ID);
+    // Restore the internal-DB pool to "unconfigured" so later files aren't
+    // pinned to this (now-closing) pool.
+    _resetPool(null);
+    if (prevDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDatabaseUrl;
+    for (const s of [schemaName, srcSchema]) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${s}" CASCADE`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`mcp-persist-pg: schema cleanup failed for ${s}: ${message}`);
+      });
+    }
+    await pool.end();
+  });
+
+  it("persists generated entities as drafts AND makes the profiled table queryable cross-process", async () => {
+    const outcome = await runSemanticProfile({
+      url: TEST_DB_URL as string,
+      dbType: "postgres",
+      schema: srcSchema,
+      connectionId: GROUP_ID,
+      orgId: ORG,
+      connectionGroupId: GROUP_ID,
+    });
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") return;
+
+    // The generated layer was DURABLY persisted (not just registered in-memory).
+    expect(outcome.persisted).not.toBeNull();
+    expect(outcome.persisted?.entities).toBeGreaterThanOrEqual(1);
+
+    // The rows landed in `semantic_entities` as DRAFTS, scoped to the group —
+    // out of the published `/chat` whitelist until an admin promotes them.
+    const rows = await pool.query<{ name: string; status: string; yaml_content: string; cg: string | null }>(
+      `SELECT name, status, yaml_content, connection_group_id AS cg
+         FROM semantic_entities
+        WHERE org_id = $1 AND entity_type = 'entity'`,
+      [ORG],
+    );
+    // The profiler saw ONLY `live_orders` (its own schema), so exactly one
+    // entity landed.
+    expect(rows.rows).toHaveLength(1);
+    const orderRow = rows.rows[0];
+    expect(orderRow.name).toContain("live_orders");
+    expect(orderRow.status).toBe("draft");
+    expect(orderRow.cg).toBe(GROUP_ID);
+
+    // The persisted entity's `table:` is what the whitelist keys on — derive the
+    // query from it so the test never drifts from the generator's qualification.
+    const parsed = yaml.load(orderRow.yaml_content) as { table?: string };
+    const tableRef = parsed.table ?? "live_orders";
+
+    // A real `executeSQL`-path validation, in DEVELOPER mode (drafts overlay),
+    // PERMITS the profiled table — proving cross-process queryability via the
+    // durable store, not the in-memory MCP whitelist.
+    const ok = await withRequestContext(
+      { requestId: "test-mcp-persist", atlasMode: "developer" },
+      () => validateSQL(`SELECT id, total FROM ${tableRef}`, GROUP_ID, ORG),
+    );
+    expect(ok.valid).toBe(true);
+
+    // A table that was never profiled is REJECTED by the same validation.
+    const rejected = await withRequestContext(
+      { requestId: "test-mcp-persist-neg", atlasMode: "developer" },
+      () => validateSQL(`SELECT * FROM not_profiled_table`, GROUP_ID, ORG),
+    );
+    expect(rejected.valid).toBe(false);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("a published-mode whitelist does NOT see the freshly-profiled drafts (status discipline)", async () => {
+    // Re-profile is idempotent (ON CONFLICT draft upsert); the rows stay draft.
+    await runSemanticProfile({
+      url: TEST_DB_URL as string,
+      dbType: "postgres",
+      schema: srcSchema,
+      connectionId: GROUP_ID,
+      orgId: ORG,
+      connectionGroupId: GROUP_ID,
+    });
+
+    const parsedRows = await pool.query<{ yaml_content: string }>(
+      `SELECT yaml_content FROM semantic_entities
+        WHERE org_id = $1 AND entity_type = 'entity' AND name LIKE '%live_orders'`,
+      [ORG],
+    );
+    const parsed = yaml.load(parsedRows.rows[0]?.yaml_content ?? "") as { table?: string };
+    const tableRef = parsed.table ?? "live_orders";
+
+    // Drop the IN-MEMORY whitelist that profiling also registers (it is not
+    // content-mode-aware — it exists for same-process queryability). This test
+    // is about the DURABLE store's status discipline, so we isolate it from the
+    // in-process layer and the warm developer-mode cache.
+    _resetPluginEntities();
+    _resetOrgWhitelists();
+
+    // PUBLISHED mode: the persisted rows are drafts, so the profiled table is
+    // rejected until an admin promotes it via the atomic publish endpoint.
+    const res = await withRequestContext(
+      { requestId: "test-mcp-persist-pub", atlasMode: "published" },
+      () => validateSQL(`SELECT id FROM ${tableRef}`, GROUP_ID, ORG),
+    );
+    expect(res.valid).toBe(false);
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -465,6 +465,14 @@ export interface DatasourceProfileTarget {
   readonly url: string;
   readonly dbType: McpNativeDbType;
   readonly schema?: string;
+  /**
+   * The install's connection-group scope (`workspace_plugins.config.group_id`),
+   * or `null` for an ungrouped install. Carried so the persistence step
+   * (#3546) lands the generated entities under the SAME `connection_group_id`
+   * the whitelist loader reads — a group-of-one for a standalone MCP-created
+   * datasource. This is metadata (a group name), never a secret.
+   */
+  readonly connectionGroupId: string | null;
 }
 
 export type LoadProfileTargetResult =
@@ -490,8 +498,10 @@ export async function loadDatasourceProfileTarget(
     catalog_slug: string;
     config: Record<string, unknown> | null;
     config_schema: unknown;
+    group_id: string | null;
   }>(
-    `SELECT wp.catalog_id, pc.slug AS catalog_slug, wp.config, pc.config_schema
+    `SELECT wp.catalog_id, pc.slug AS catalog_slug, wp.config, pc.config_schema,
+            wp.config->>'group_id' AS group_id
        FROM workspace_plugins wp
        JOIN plugin_catalog pc ON pc.id = wp.catalog_id
       WHERE wp.workspace_id = $1
@@ -504,6 +514,10 @@ export async function loadDatasourceProfileTarget(
   const row = rows[0];
   const schema = parseConfigSchema(row.config_schema);
   const decrypted = decryptSecretFields(row.config ?? {}, schema);
+  // Group scope for the persistence step — `null` when the install carries no
+  // group binding (the flat default scope), matching the whitelist loader's
+  // NULL-scope bucket.
+  const connectionGroupId = row.group_id && row.group_id.length > 0 ? row.group_id : null;
   const poolConfig = resolveDatasourcePoolConfig(
     {
       workspaceId: orgId,
@@ -526,35 +540,67 @@ export async function loadDatasourceProfileTarget(
       url: poolConfig.url,
       dbType: poolConfig.dbType,
       schema: "schema" in poolConfig ? poolConfig.schema : undefined,
+      connectionGroupId,
     },
   };
 }
 
 export type RunSemanticProfileOutcome =
-  | { readonly kind: "ok"; readonly result: ProfileAndGenerateResult }
+  | {
+      readonly kind: "ok";
+      readonly result: ProfileAndGenerateResult;
+      /**
+       * Durable-persistence counts (#3546). Present when an `orgId` was
+       * supplied AND an internal DB is configured (the generated entities were
+       * upserted as drafts to `semantic_entities`); `null` when persistence was
+       * skipped (no `orgId` / no internal DB — the in-memory whitelist is the
+       * only registration, e.g. a self-hosted stdio server with no internal DB).
+       */
+      readonly persisted: { readonly entities: number; readonly metrics: number } | null;
+    }
   | { readonly kind: "error"; readonly reason: ProfilingFailedError["reason"]; readonly message: string };
 
 /**
  * Profile a connection and generate its semantic layer via the #3506
  * `SemanticGenerator` service, registering the generated entities into the
- * in-process table whitelist so a subsequent `executeSQL` against this
- * connection is permitted. `progress` bridges the profiler's per-table
- * callbacks to the MCP progress seam.
+ * in-process table whitelist so a subsequent in-process `executeSQL` is
+ * permitted, AND — when an `orgId` is supplied and an internal DB is
+ * configured — DURABLY persisting the generated entities + metrics to the org
+ * semantic store as drafts (#3546). Persistence is what makes the connection
+ * queryable (a) after an MCP-server restart and (b) from the API process the
+ * web `/chat` `executeSQL` runs in (a stdio MCP server is a different process,
+ * so its in-memory whitelist alone is not cross-surface). `progress` bridges
+ * the profiler's per-table callbacks to the MCP progress seam.
  *
- * A tagged `ProfilingFailedError` (no tables, threshold exceeded, …) is
- * returned as a typed `error` outcome; an unexpected defect re-throws for the
- * caller's `internal_error` path.
+ * A tagged `ProfilingFailedError` (no tables, threshold exceeded, persist
+ * failure, …) is returned as a typed `error` outcome; an unexpected defect
+ * re-throws for the caller's `internal_error` path.
  */
 export async function runSemanticProfile(opts: {
   url: string;
   dbType: McpNativeDbType;
   schema?: string;
   connectionId: string;
+  /**
+   * Workspace the generated rows belong to. When provided (and an internal DB
+   * is configured) the generated layer is persisted as drafts; when omitted,
+   * only the in-memory whitelist is populated. The MCP `profile_datasource`
+   * tool always passes the bound workspace.
+   */
+  orgId?: string;
+  /**
+   * Connection-group scope for the persisted rows — pass the value from
+   * {@link DatasourceProfileTarget.connectionGroupId} so the rows land in the
+   * same scope the whitelist loader reads. Ignored when `orgId` is omitted.
+   */
+  connectionGroupId?: string | null;
   progress?: ProfileProgressCallbacks;
 }): Promise<RunSemanticProfileOutcome> {
+  const shouldPersist = opts.orgId !== undefined && hasInternalDB();
+
   const program = Effect.gen(function* () {
     const gen = yield* SemanticGenerator;
-    return yield* gen.profileAndGenerate({
+    const result = yield* gen.profileAndGenerate({
       url: opts.url,
       dbType: opts.dbType,
       ...(opts.schema !== undefined ? { schema: opts.schema } : {}),
@@ -562,12 +608,35 @@ export async function runSemanticProfile(opts: {
       registerWhitelist: true,
       ...(opts.progress !== undefined ? { progress: opts.progress } : {}),
     });
+
+    // Durably persist as drafts so the whitelist survives a restart and is
+    // visible cross-process (#3546). A persist failure is a tagged
+    // ProfilingFailedError (reason: "persist_error") — surfaced as a typed
+    // `error` outcome below, not a silent success on a non-durable layer.
+    if (shouldPersist && opts.orgId !== undefined) {
+      const persisted = yield* gen.persist({
+        orgId: opts.orgId,
+        connectionGroupId: opts.connectionGroupId ?? null,
+        entities: result.entities,
+        metrics: result.metrics,
+      });
+      return { result, persisted };
+    }
+    return { result, persisted: null };
   });
 
   const exit = await Effect.runPromiseExit(
     program.pipe(Effect.provide(SemanticGeneratorLive)),
   );
-  if (exit._tag === "Success") return { kind: "ok", result: exit.value };
+  if (exit._tag === "Success") {
+    return {
+      kind: "ok",
+      result: exit.value.result,
+      persisted: exit.value.persisted
+        ? { entities: exit.value.persisted.entitiesPersisted, metrics: exit.value.persisted.metricsPersisted }
+        : null,
+    };
+  }
 
   const failure = Cause.failureOption(exit.cause);
   if (failure._tag === "Some" && failure.value instanceof ProfilingFailedError) {

--- a/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
+++ b/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
@@ -307,6 +307,130 @@ describe("SemanticGenerator.profileAndGenerate", () => {
   });
 });
 
+// ── persist (#3546 — durable, content-mode-aware draft upsert) ───────
+
+describe("SemanticGenerator.persist", () => {
+  type UpsertRow = {
+    entityType: string;
+    name: string;
+    yamlContent: string;
+    connectionGroupId?: string | null;
+  };
+
+  /** A `bulkUpsertEntities`-shaped fake that records its rows. */
+  function fakeUpsert(
+    behavior?: (orgId: string, rows: readonly UpsertRow[]) => number,
+  ): ((orgId: string, rows: readonly UpsertRow[]) => Promise<number>) & {
+    calls: Array<{ orgId: string; rows: UpsertRow[] }>;
+  } {
+    const fn = Object.assign(
+      (orgId: string, rows: readonly UpsertRow[]) => {
+        fn.calls.push({ orgId, rows: [...rows] });
+        return Promise.resolve(behavior ? behavior(orgId, rows) : rows.length);
+      },
+      { calls: [] as Array<{ orgId: string; rows: UpsertRow[] }> },
+    );
+    return fn;
+  }
+
+  it("persists entities AND metrics as drafts under the install's group scope", async () => {
+    const upsert = fakeUpsert();
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_persist",
+          connectionGroupId: "g_prod",
+          entities: [
+            { table: "public.orders", fileName: "orders.yml", yaml: "table: orders" },
+            { table: "users", fileName: "users.yml", yaml: "table: users" },
+          ],
+          metrics: [{ table: "orders", fileName: "orders.metric.yml", yaml: "name: revenue" }],
+          upsert,
+        });
+      }),
+    );
+    expect(result).toEqual({ entitiesPersisted: 2, metricsPersisted: 1 });
+    // Two upsert calls: one for entities, one for metrics — both scoped to the
+    // group and typed correctly.
+    expect(upsert.calls).toHaveLength(2);
+    const entityCall = upsert.calls[0];
+    expect(entityCall.orgId).toBe("org_persist");
+    expect(entityCall.rows.every((r) => r.entityType === "entity")).toBe(true);
+    expect(entityCall.rows.every((r) => r.connectionGroupId === "g_prod")).toBe(true);
+    // Row name mirrors the wizard /save path (`path.basename`): a path-traversal
+    // segment is stripped, a schema-qualified dotted name is kept verbatim so
+    // two same-named tables in different schemas stay distinct.
+    expect(entityCall.rows.map((r) => r.name)).toEqual(["public.orders", "users"]);
+    expect(upsert.calls[1].rows[0].entityType).toBe("metric");
+  });
+
+  it("skips the metric upsert entirely when there are no metrics", async () => {
+    const upsert = fakeUpsert();
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_persist",
+          connectionGroupId: null,
+          entities: [{ table: "orders", fileName: "orders.yml", yaml: "table: orders" }],
+          upsert,
+        });
+      }),
+    );
+    expect(result).toEqual({ entitiesPersisted: 1, metricsPersisted: 0 });
+    expect(upsert.calls).toHaveLength(1); // entities only
+    expect(upsert.calls[0].rows[0].connectionGroupId).toBeNull();
+  });
+
+  it("FAILS LOUD with persist_error when not every entity row lands (no silent partial)", async () => {
+    // The upsert reports a short count — a partially-queryable connection.
+    const upsert = fakeUpsert(() => 1);
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_persist",
+          connectionGroupId: null,
+          entities: [
+            { table: "orders", fileName: "orders.yml", yaml: "table: orders" },
+            { table: "users", fileName: "users.yml", yaml: "table: users" },
+          ],
+          upsert,
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("persist_error");
+    }
+  });
+
+  it("wraps a thrown upsert into ProfilingFailedError(persist_error)", async () => {
+    const upsert = Object.assign(
+      () => Promise.reject(new Error("DB pool exhausted")),
+      { calls: [] },
+    );
+    const exit = await runExit(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_persist",
+          connectionGroupId: null,
+          entities: [{ table: "orders", fileName: "orders.yml", yaml: "table: orders" }],
+          upsert,
+        });
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("persist_error");
+      expect(json).toContain("DB pool exhausted");
+    }
+  });
+});
+
 // ── registerWhitelist (direct) ───────────────────────────────────────
 
 describe("SemanticGenerator.registerWhitelist", () => {

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -899,7 +899,12 @@ export class DeliveryError extends Data.TaggedError("DeliveryError")<{
  */
 export class ProfilingFailedError extends Data.TaggedError("ProfilingFailedError")<{
   readonly message: string;
-  readonly reason: "no_tables" | "threshold_exceeded" | "unsupported_db_type" | "profiler_error";
+  readonly reason:
+    | "no_tables"
+    | "threshold_exceeded"
+    | "unsupported_db_type"
+    | "profiler_error"
+    | "persist_error";
   readonly failedCount?: number;
   readonly totalCount?: number;
 }> {}

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -27,6 +27,7 @@
  * instead of the caller.
  */
 
+import * as path from "path";
 import { Context, Effect, Layer } from "effect";
 import type {
   DatabaseObject,
@@ -45,10 +46,15 @@ import {
 import {
   analyzeTableProfiles,
   generateSemanticLayer,
+  type GeneratedArtifact,
   type GeneratedSemanticLayer,
   type GenerateSemanticLayerOptions,
 } from "@atlas/api/lib/semantic/generate";
-import { registerPluginEntities } from "@atlas/api/lib/semantic/whitelist";
+import { registerPluginEntities, invalidateOrgWhitelist } from "@atlas/api/lib/semantic/whitelist";
+import {
+  bulkUpsertEntities,
+  type SemanticEntityType,
+} from "@atlas/api/lib/semantic/entities";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ProfilingFailedError } from "./errors";
 
@@ -124,6 +130,52 @@ export interface ProfileAndGenerateOptions extends ProfileConnectionOptions {
   registerWhitelist?: boolean;
 }
 
+/**
+ * The org-scoped semantic-store upsert seam {@link SemanticGeneratorShape.persist}
+ * delegates to. Matches the signature of {@link bulkUpsertEntities} so the live
+ * path uses it verbatim; tests inject a fake to exercise persistence without an
+ * internal DB. Returns the number of rows successfully upserted.
+ */
+export type EntityUpsertFn = (
+  orgId: string,
+  rows: ReadonlyArray<{
+    entityType: SemanticEntityType;
+    name: string;
+    yamlContent: string;
+    connectionGroupId?: string | null;
+  }>,
+) => Promise<number>;
+
+/** Inputs for {@link SemanticGeneratorShape.persist}. */
+export interface PersistSemanticLayerOptions {
+  /** Workspace the generated rows belong to. */
+  orgId: string;
+  /**
+   * Connection-group scope for every persisted row (the group the profiled
+   * datasource belongs to — group-of-one for a standalone connection, `null`
+   * for the flat default group). Set DIRECTLY (not resolved from an install id)
+   * so the rows land in the same scope the whitelist loader reads.
+   */
+  connectionGroupId: string | null;
+  /** Generated entity artifacts (one per profiled table). */
+  entities: ReadonlyArray<GeneratedArtifact>;
+  /** Generated metric artifacts (omitted profiles produce none). */
+  metrics?: ReadonlyArray<GeneratedArtifact>;
+  /**
+   * Upsert override for tests. Defaults to {@link bulkUpsertEntities} — the
+   * content-mode-aware draft upsert the wizard `/save` + import endpoint use.
+   */
+  upsert?: EntityUpsertFn;
+}
+
+/** Outcome of {@link SemanticGeneratorShape.persist}. */
+export interface PersistSemanticLayerResult {
+  /** Entity rows successfully persisted (as drafts). */
+  entitiesPersisted: number;
+  /** Metric rows successfully persisted (as drafts). */
+  metricsPersisted: number;
+}
+
 /** Outcome of {@link SemanticGeneratorShape.profileAndGenerate}. */
 export interface ProfileAndGenerateResult extends GeneratedSemanticLayer {
   /** Analyzed profiles that produced the artifacts. */
@@ -163,6 +215,28 @@ export interface SemanticGeneratorShape {
     connectionId: string,
     entities: ReadonlyArray<{ table: string; yaml: string }>,
   ) => void;
+
+  /**
+   * DURABLY persist a generated semantic layer to the org semantic store
+   * (`semantic_entities`) so the table whitelist survives an MCP-server
+   * restart AND is visible to the API process (hosted web `/chat` runs in a
+   * different process than a stdio MCP server, so the in-memory whitelist
+   * alone is not cross-surface).
+   *
+   * Rows land as **`draft`** (via the content-mode-aware {@link bulkUpsertEntities}
+   * seam the wizard `/save` + import endpoint share): profiled output is
+   * machine-generated and unreviewed, so it stays out of the published
+   * `/chat` whitelist until an admin promotes it through the atomic publish
+   * endpoint (`/api/v1/admin/publish`). Developer mode already overlays drafts,
+   * so the profiling agent can query immediately in-session.
+   *
+   * Fails with {@link ProfilingFailedError} (`reason: "persist_error"`) when
+   * NOT every row lands — a partial upsert would silently recreate the
+   * connected-but-unqueryable gap for the dropped tables, so it fails loud.
+   */
+  readonly persist: (
+    opts: PersistSemanticLayerOptions,
+  ) => Effect.Effect<PersistSemanticLayerResult, ProfilingFailedError>;
 
   /**
    * Profile a connection, generate its semantic layer, and (by default)
@@ -288,6 +362,98 @@ function registerWhitelistImpl(
   );
 }
 
+/**
+ * Map a generated artifact to its semantic-store row `name`. Mirrors the wizard
+ * `/save` path (`path.basename(e.tableName)`) so the two write paths key rows
+ * identically. `path.basename` strips any path-traversal segment (a `/`-bearing
+ * name), leaving a path-safe identifier; a schema-qualified dotted name like
+ * `public.orders` is preserved verbatim (no slash to strip), which keeps two
+ * same-named tables in different schemas distinct. The row `name` is only the
+ * upsert key — queryability keys on the entity YAML's `table:` field (set by
+ * the generator), not this name. Entity + metric rows for the same table share
+ * the name but differ by `entity_type`, so the 0063 partial unique index keeps
+ * them distinct.
+ */
+function artifactRowName(artifact: GeneratedArtifact): string {
+  return path.basename(artifact.table);
+}
+
+function persistImpl(
+  opts: PersistSemanticLayerOptions,
+): Effect.Effect<PersistSemanticLayerResult, ProfilingFailedError> {
+  return Effect.gen(function* () {
+    const upsert = opts.upsert ?? bulkUpsertEntities;
+
+    const entityRows = opts.entities.map((e) => ({
+      entityType: "entity" as const,
+      name: artifactRowName(e),
+      yamlContent: e.yaml,
+      connectionGroupId: opts.connectionGroupId,
+    }));
+    const metricRows = (opts.metrics ?? []).map((m) => ({
+      entityType: "metric" as const,
+      name: artifactRowName(m),
+      yamlContent: m.yaml,
+      connectionGroupId: opts.connectionGroupId,
+    }));
+
+    const entitiesPersisted = yield* Effect.tryPromise({
+      try: () => upsert(opts.orgId, entityRows),
+      catch: (err) =>
+        new ProfilingFailedError({
+          message: `Failed to persist generated entities: ${err instanceof Error ? err.message : String(err)}`,
+          reason: "persist_error",
+        }),
+    });
+
+    const metricsPersisted = metricRows.length === 0
+      ? 0
+      : yield* Effect.tryPromise({
+          try: () => upsert(opts.orgId, metricRows),
+          catch: (err) =>
+            new ProfilingFailedError({
+              message: `Failed to persist generated metrics: ${err instanceof Error ? err.message : String(err)}`,
+              reason: "persist_error",
+            }),
+        });
+
+    // bulkUpsertEntities swallows per-row failures and returns a success count.
+    // A short count means the YAML parsed but the DB rejected the row — landing
+    // some tables as queryable and silently dropping others. Fail loud rather
+    // than report success on a partially-queryable connection (#3546 / #2142).
+    if (entitiesPersisted < entityRows.length || metricsPersisted < metricRows.length) {
+      return yield* Effect.fail(
+        new ProfilingFailedError({
+          message:
+            `Persisted ${entitiesPersisted}/${entityRows.length} entities and ` +
+            `${metricsPersisted}/${metricRows.length} metrics. Some generated tables ` +
+            `did not land in the semantic store and will not be queryable — retry profiling.`,
+          reason: "persist_error",
+        }),
+      );
+    }
+
+    // Drop this process's cached org whitelist so the freshly-persisted drafts
+    // are read on the next `loadOrgWhitelist` (developer mode overlays drafts).
+    // Cross-process surfaces (the API process behind web `/chat`) pick the rows
+    // up on their own cache TTL expiry / invalidation — the durable rows are the
+    // cross-surface contract; this just makes the SAME process see them now.
+    invalidateOrgWhitelist(opts.orgId);
+
+    log.info(
+      {
+        orgId: opts.orgId,
+        connectionGroupId: opts.connectionGroupId,
+        entitiesPersisted,
+        metricsPersisted,
+      },
+      "Persisted generated semantic layer to the org store as drafts",
+    );
+
+    return { entitiesPersisted, metricsPersisted } satisfies PersistSemanticLayerResult;
+  });
+}
+
 function profileAndGenerateImpl(
   opts: ProfileAndGenerateOptions,
 ): Effect.Effect<ProfileAndGenerateResult, ProfilingFailedError> {
@@ -318,6 +484,7 @@ const service: SemanticGeneratorShape = {
   profile: profileImpl,
   generate: generateImpl,
   registerWhitelist: registerWhitelistImpl,
+  persist: persistImpl,
   profileAndGenerate: profileAndGenerateImpl,
 } satisfies SemanticGeneratorShape;
 

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -55,6 +55,7 @@ import {
   bulkUpsertEntities,
   type SemanticEntityType,
 } from "@atlas/api/lib/semantic/entities";
+import { SAFE_TABLE_NAME } from "@atlas/api/lib/semantic/shapes";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ProfilingFailedError } from "./errors";
 
@@ -373,9 +374,24 @@ function registerWhitelistImpl(
  * the generator), not this name. Entity + metric rows for the same table share
  * the name but differ by `entity_type`, so the 0063 partial unique index keeps
  * them distinct.
+ *
+ * Defense-in-depth: after basename-stripping, the name must pass `SAFE_TABLE_NAME`
+ * (same guard the wizard `/save` applies) — rejects names with characters outside
+ * `[a-zA-Z0-9_.-]` that would never survive DB validation anyway. Returns `null`
+ * for names that fail the check; callers must filter those artifacts out (logged,
+ * never silently swallowed).
  */
-function artifactRowName(artifact: GeneratedArtifact): string {
-  return path.basename(artifact.table);
+function artifactRowName(artifact: GeneratedArtifact): string | null {
+  const name = path.basename(artifact.table);
+  if (!SAFE_TABLE_NAME.test(name)) {
+    log.warn(
+      { table: artifact.table, basename: name },
+      "artifactRowName: skipping artifact — basename does not match SAFE_TABLE_NAME; " +
+        "the generated name contains characters not permitted in a semantic-store row key",
+    );
+    return null;
+  }
+  return name;
 }
 
 function persistImpl(
@@ -384,18 +400,28 @@ function persistImpl(
   return Effect.gen(function* () {
     const upsert = opts.upsert ?? bulkUpsertEntities;
 
-    const entityRows = opts.entities.map((e) => ({
-      entityType: "entity" as const,
-      name: artifactRowName(e),
-      yamlContent: e.yaml,
-      connectionGroupId: opts.connectionGroupId,
-    }));
-    const metricRows = (opts.metrics ?? []).map((m) => ({
-      entityType: "metric" as const,
-      name: artifactRowName(m),
-      yamlContent: m.yaml,
-      connectionGroupId: opts.connectionGroupId,
-    }));
+    const entityRows = opts.entities
+      .map((e) => {
+        const name = artifactRowName(e);
+        if (name === null) return null;
+        return { entityType: "entity" as const, name, yamlContent: e.yaml, connectionGroupId: opts.connectionGroupId };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    // NOTE: intentional divergence from the wizard `/save` write path.
+    // The wizard persists entities to `semantic_entities` (DB) but writes metrics
+    // to disk only (`semantic/metrics/*.yml`). This MCP path persists BOTH entities
+    // AND metrics to `semantic_entities` so that a durable MCP-profiled connection
+    // is fully queryable across process restarts and visible to the web `/chat`
+    // process (which can't read disk artifacts written by a stdio MCP server).
+    // Tracked for reconciliation in #3551.
+    const metricRows = (opts.metrics ?? [])
+      .map((m) => {
+        const name = artifactRowName(m);
+        if (name === null) return null;
+        return { entityType: "metric" as const, name, yamlContent: m.yaml, connectionGroupId: opts.connectionGroupId };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
 
     const entitiesPersisted = yield* Effect.tryPromise({
       try: () => upsert(opts.orgId, entityRows),

--- a/packages/api/src/lib/semantic/shapes.ts
+++ b/packages/api/src/lib/semantic/shapes.ts
@@ -11,6 +11,20 @@
 import { z } from "zod";
 
 /**
+ * Allowlist regex for a semantic-layer row name (the upsert key stored in
+ * `semantic_entities.name`). Permits letters, digits, underscores, hyphens,
+ * and dots — the characters that appear in schema-qualified SQL identifiers
+ * (`public.orders`) and filesystem-safe table names. Reused by:
+ *
+ * - The wizard `/save` path-traversal guard (wizard.ts)
+ * - The `artifactRowName` guard in SemanticGenerator (semantic-generator.ts)
+ *
+ * Exporting from the shared shapes module keeps both write paths consistent
+ * and avoids independent regex drift.
+ */
+export const SAFE_TABLE_NAME = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/;
+
+/**
  * Core entity shape — validates the table name and the Connection-group
  * scope. `group` is the canonical scope field (ADR-0012); `connection` is
  * its deprecated alias, still parsed for back-compat.

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -129,6 +129,8 @@ let profileResult: unknown = {
     errors: [],
     elapsedMs: 1234,
   },
+  // #3546 — non-null when the layer was durably persisted as drafts.
+  persisted: { entities: 2, metrics: 1 },
 };
 interface ProfileProgressLike {
   onStart?: (n: number) => void;
@@ -264,7 +266,7 @@ beforeEach(() => {
   };
   profileTarget = {
     kind: "ok",
-    target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public" },
+    target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public", connectionGroupId: null },
   };
   profileResult = {
     kind: "ok",
@@ -277,6 +279,7 @@ beforeEach(() => {
       errors: [],
       elapsedMs: 1234,
     },
+    persisted: { entities: 2, metrics: 1 },
   };
   elicitOutcome = { action: "accept", value: ELICITED_SECRET };
   elicitThrows = false;
@@ -698,7 +701,7 @@ describe("create_datasource", () => {
 // ── profile_datasource (#3512) — long-running, progress + cancellable ──
 
 describe("profile_datasource", () => {
-  it("profiles + generates and reports the datasource as queryable", async () => {
+  it("profiles + generates and reports the datasource as queryable + durably persisted", async () => {
     const client = await createTestClient();
     const res = await client.callTool({ name: "profile_datasource", arguments: { id: "prod-us" } });
     const body = JSON.parse(getContentText(res.content));
@@ -706,6 +709,18 @@ describe("profile_datasource", () => {
     expect(body.entities_generated).toBe(2);
     expect(body.tables).toEqual(["orders", "users"]);
     expect(body.elapsed_ms).toBe(1234);
+    // #3546 — a durably-persisted layer is surfaced as drafts with a publish hint.
+    expect(body.persisted).toBe(true);
+    expect(body.persisted_status).toBe("draft");
+    expect(body.publish_hint).toBeDefined();
+    // The bound workspace + the install's group scope are threaded to the lib
+    // so the persisted drafts land in the scope the whitelist loader reads.
+    const profileArgs = mockRunProfile.mock.calls[0]?.[0] as {
+      orgId?: string;
+      connectionGroupId?: string | null;
+    };
+    expect(profileArgs.orgId).toBe("org_ds");
+    expect(profileArgs.connectionGroupId).toBeNull();
     // The decrypted URL the profiler used must not surface.
     expect(getContentText(res.content)).not.toContain("user:pass");
   });

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -758,6 +758,11 @@ export function registerDatasourceTools(
                 dbType: target.target.dbType,
                 ...(target.target.schema !== undefined ? { schema: target.target.schema } : {}),
                 connectionId: id,
+                // #3546 — persist the generated layer to the org store as
+                // drafts so the whitelist survives a restart and is visible to
+                // the API process (web `/chat`), not just this MCP process.
+                orgId: org.orgId,
+                connectionGroupId: target.target.connectionGroupId,
                 progress,
               });
             },
@@ -765,15 +770,27 @@ export function registerDatasourceTools(
 
           if (result.kind === "error") {
             // Tagged ProfilingFailedError — an agent-actionable validation
-            // outcome (no tables, too many failures), not a 500.
+            // outcome (no tables, too many failures, persist failure), not a 500.
             return toEnvelopeResult(envelope("validation_failed", result.message));
           }
 
           const r = result.result;
           const tables = r.entities.map((e) => e.table);
+          // `persisted` is non-null when the layer was durably written (org
+          // bound + internal DB). Drafts are queryable in developer mode now and
+          // go live to published `/chat` when an admin runs the publish flow.
+          const persisted = result.persisted !== null;
           return toJsonContent({
             id,
             queryable: true,
+            persisted,
+            ...(persisted
+              ? {
+                  persisted_status: "draft",
+                  publish_hint:
+                    "Generated entities are saved as drafts. Run the admin publish flow to make them queryable from the published /chat surface; they are queryable now in developer mode.",
+                }
+              : {}),
             entities_generated: r.entities.length,
             metrics_generated: r.metrics.length,
             tables,


### PR DESCRIPTION
## What

`profile_datasource` (#3545) generated a semantic layer and registered the entities into the **in-process** table whitelist (`registerPluginEntities`). That made an in-process `executeSQL` work, but the registration was (1) not durable — it evaporated on MCP-server restart — and (2) not cross-surface — the API process behind web `/chat` runs in a different process from a stdio MCP server, so its in-memory whitelist never saw the profiled tables. #3512's create→profile→query integration test was also fully mocked, so real queryability was unverified.

This PR makes profiling **also persist** the generated layer to the org semantic store, and replaces the mocked path with a real live-DB test.

## Persistence design

- **`SemanticGenerator.persist`** (in-core) upserts the generated entities **and** metrics to `semantic_entities` via the content-mode-aware `bulkUpsertEntities` seam (the same draft upsert the wizard `/save` + import endpoint use), scoped **directly** to the install's `connection_group_id` so the rows land in the same scope the whitelist loader reads (group-of-one for a standalone MCP-created datasource, `null` for the flat default group).
- It **fails loud** with `ProfilingFailedError(reason: "persist_error")` if any row falls short of the generated count — a partial upsert would silently leave some tables connected-but-unqueryable. New `persist_error` reason added to the tagged error.
- After a successful persist it **invalidates the in-process org whitelist cache** so the same process picks up the freshly-persisted drafts immediately; cross-process surfaces read the durable rows on their own cache TTL/invalidation.
- `mcp-lifecycle.loadDatasourceProfileTarget` now also returns the install's `connectionGroupId`; `runSemanticProfile` threads `orgId` + `connectionGroupId` and persists **only when an internal DB is configured** (`hasInternalDB()`), surfacing `{ entities, metrics }` persisted counts. `profile_datasource` surfaces `{ persisted, persisted_status: "draft", publish_hint }`.
- **Secret discipline:** the decrypted connection URL stays in the lib layer (passed straight to the profiler) — never in a tool arg, response, or log. Persisted rows are entity/metric YAML only.

## Ownership decision

Persistence lives **in-core** as `SemanticGenerator.persist` (not an MCP-layer upsert) so any future caller of the shared #3506 service gets durability for free. The MCP layer (`runSemanticProfile`) only orchestrates profile→generate→persist and resolves the group scope. The **CLI `atlas init` path does NOT share `persist`** — it writes YAML artifacts to disk (a different surface, file-based whitelist), so coupling it to the DB upsert would be wrong; left untouched.

## Content-mode status choice

Persisted entities + metrics land as **`draft`** (via `bulkUpsertEntities`). Rationale: profiled output is machine-generated and unreviewed, so it stays out of the published `/chat` whitelist until an admin promotes it through the atomic publish endpoint (`/api/v1/admin/publish`). Developer mode already overlays drafts, so the profiling agent can query immediately in-session. Documented in the tool response (`publish_hint`) and in the docs guide.

## Live-DB test

`packages/api/src/lib/datasources/__tests__/mcp-profile-persist-pg.test.ts` drives real create→profile→query against `TEST_DATABASE_URL` (mirrors the `migrate-pg.test.ts` / `persist-form-install-pg.test.ts` harness): installs a datasource row + a real source table in its own schema, runs `runSemanticProfile`, asserts the rows landed as `draft` scoped to the group, then asserts a real `validateSQL` **permits** the profiled table in developer mode and **rejects** it in published mode (status discipline) — plus rejects a non-profiled table. **It ran green locally against a real Postgres 16** (both cases pass). It **skips cleanly with a logged reason** when `TEST_DATABASE_URL` is unset (not a silent no-op); CI sets the var, so it executes there.

The mocked tool tests (`datasource-tools.test.ts`) stay mocked (they test envelope/gate wiring) but were updated to assert the new persisted-draft surfacing + that `orgId`/`connectionGroupId` are threaded.

## Scope guard

Kept strictly to the persistence path — did **not** touch `MCP_NATIVE_DB_TYPES` or the supported-`dbType` gating (that's #3547, which stacks on this branch).

## Incidental fix

The partial work's comment claimed `path.basename` strips a schema qualifier from a dotted name like `public.orders` — it does not (only path separators). Corrected the comment and the row-name test assertion; behavior is unchanged and correct (the row `name` is only the upsert key; queryability keys on the entity YAML `table:` field).

## Local CI gates

`bun run lint`, `tsgo --noEmit`, `bun x syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh`, `check-schema-drift.sh` — all green. `test-isolated.ts --affected` (38 files) green; the live-DB test passes against a real Postgres. No migration/schema change.

Closes #3546

Refs #3483

https://claude.ai/code/session_01JNzWaLmyHVVKgsqaKPSVu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNzWaLmyHVVKgsqaKPSVu4)_