### PR TITLE
feat(mcp): capability-derived datasource provisioning + plugin-aware test-connect (#3547)

### DIFF
--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
@@ -49,10 +49,11 @@ mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
   catalogSlugToDbType: (slug: string) => {
     if (slug === "clickhouse") return "clickhouse";
     if (slug === "snowflake") return "snowflake";
+    if (slug === "bigquery") return "bigquery";
     throw new Error(`unknown slug ${slug}`);
   },
   resolveDatasourcePoolConfig: mock(() => ({ dbType: "clickhouse", url: "x" })),
-  BUILTIN_DATASOURCE_CATALOG_SLUGS: ["postgres", "mysql", "clickhouse", "snowflake"],
+  BUILTIN_DATASOURCE_CATALOG_SLUGS: ["postgres", "mysql", "clickhouse", "snowflake", "bigquery"],
 }));
 
 // The plugin test-connect seam — fully controllable per test.
@@ -211,5 +212,94 @@ describe("provisionDatasource — plugin path", () => {
     expect(outcome.kind).toBe("unsupported");
     expect(probeSpy).not.toHaveBeenCalled();
     expect(installDatasourceSpy).not.toHaveBeenCalled();
+  });
+});
+
+// #3547 AC4 — provision success + probe-failure rollback + credential scrub for
+// EACH added plugin type. ClickHouse is covered above; Snowflake (url-shaped)
+// and BigQuery (multi-field: service_account_json + project_id) below, so the
+// per-type matrix is literal, not just generic.
+describe("provisionDatasource — Snowflake (url-shaped)", () => {
+  const SF_SECRET_URL = "snowflake://user:topsecret@acct.snowflakecomputing.com/db";
+
+  beforeEach(() => {
+    pluginConn = { dbType: "snowflake", createFromConfig: () => ({}) };
+  });
+
+  it("probes via createFromConfig and persists a draft on success", async () => {
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "snowflake",
+      installId: "sf",
+      config: { url: SF_SECRET_URL },
+      secretKeys: ["url"],
+    });
+    expect(probeSpy).toHaveBeenCalledTimes(1);
+    expect(probeSpy.mock.calls[0][0]).toBe("snowflake");
+    expect(probeSpy.mock.calls[0][1]).toEqual({ url: SF_SECRET_URL });
+    expect(registerSpy).not.toHaveBeenCalled();
+    expect(installDatasourceSpy).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("ok");
+  });
+
+  it("a failed probe persists NOTHING and scrubs the secret URL", async () => {
+    probeOutcome = { ok: false, reason: "connect_failed", message: `auth failed for ${SF_SECRET_URL}` };
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "snowflake",
+      installId: "sf",
+      config: { url: SF_SECRET_URL },
+      secretKeys: ["url"],
+    });
+    expect(outcome.kind).toBe("health_error");
+    expect(installDatasourceSpy).not.toHaveBeenCalled();
+    if (outcome.kind === "health_error") {
+      expect(outcome.message).not.toContain(SF_SECRET_URL);
+      expect(outcome.message).not.toContain("topsecret");
+      expect(outcome.message).toContain("[redacted]");
+    }
+  });
+});
+
+describe("provisionDatasource — BigQuery (multi-field credential)", () => {
+  const SA_JSON = '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----SUPERSECRETKEYMATERIAL-----END PRIVATE KEY-----"}';
+  const BQ_CONFIG = { service_account_json: SA_JSON, project_id: "my-gcp-project" };
+
+  beforeEach(() => {
+    pluginConn = { dbType: "bigquery", createFromConfig: () => ({}) };
+  });
+
+  it("probes with the FULL multi-field config and persists a draft on success", async () => {
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "bigquery",
+      installId: "bq",
+      config: { ...BQ_CONFIG },
+      secretKeys: ["service_account_json"],
+    });
+    expect(probeSpy).toHaveBeenCalledTimes(1);
+    expect(probeSpy.mock.calls[0][0]).toBe("bigquery");
+    // Both the secret JSON and the non-secret project_id reach the probe.
+    expect(probeSpy.mock.calls[0][1]).toEqual(BQ_CONFIG);
+    expect(installDatasourceSpy).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("ok");
+  });
+
+  it("a failed probe persists NOTHING and scrubs the service_account_json key material", async () => {
+    probeOutcome = {
+      ok: false,
+      reason: "connect_failed",
+      message: `invalid credentials: ${SA_JSON}`,
+    };
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "bigquery",
+      installId: "bq",
+      config: { ...BQ_CONFIG },
+      secretKeys: ["service_account_json"],
+    });
+    expect(outcome.kind).toBe("health_error");
+    expect(installDatasourceSpy).not.toHaveBeenCalled();
+    if (outcome.kind === "health_error") {
+      expect(outcome.message).not.toContain(SA_JSON);
+      expect(outcome.message).not.toContain("SUPERSECRETKEYMATERIAL");
+      expect(outcome.message).toContain("[redacted]");
+    }
   });
 });

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Lib-layer tests for the PLUGIN-managed half of MCP datasource provisioning
+ * (#3547): the capability-derived gate (`resolveProvisionCapability`) and the
+ * plugin-aware validate-before-persist pre-flight in `provisionDatasource`.
+ *
+ * The native pg/mysql path (ephemeral `connections.register` → `healthCheck`
+ * probe) is covered by `mcp-lifecycle.test.ts`. Here the candidate is a
+ * plugin-managed SQL type (ClickHouse / Snowflake), whose pre-flight goes
+ * through `probePluginDatasourceConnection` (`createFromConfig` → `SELECT 1` →
+ * close) instead — and which is gated by whether a plugin implementing
+ * `createFromConfig` is registered for the dbType.
+ *
+ * Two invariants the MCP `create_datasource` tool relies on:
+ *   1. A type with no registered plugin resolves to `unsupported` — never a
+ *      throw, never a persist.
+ *   2. A failed plugin probe persists NOTHING and returns a credential-scrubbed
+ *      `health_error` (the secret URL never rides the message).
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { Context, Effect, Layer } from "effect";
+import { createConnectionMock } from "../../../__mocks__/connection";
+
+// ── internal DB (duplicate-id check) ──────────────────────────────────
+// Spread the real module so EVERY export (InternalDB Tag, etc.) stays present —
+// the mocked workspace-installer reshapes the import graph such that a real
+// module named-imports `InternalDB`, so a partial mock would break linking.
+// Only the two I/O entry points this suite drives are overridden.
+const realInternal = await import("@atlas/api/lib/db/internal");
+let internalRows: Array<Record<string, unknown>> = [];
+const mockInternalQuery = mock<(...a: unknown[]) => Promise<unknown>>(async () => internalRows);
+const mockHasInternalDB = mock<() => boolean>(() => true);
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mockHasInternalDB,
+}));
+
+// `provisionDatasource`'s plugin path never touches the ConnectionRegistry, but
+// `mcp-lifecycle` imports it at module load — mock it so no real pg pool spins.
+const registerSpy = mock<(id: string, cfg: unknown) => void>(() => {});
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({ connections: { register: registerSpy } }),
+);
+
+// catalogSlug → dbType: clickhouse maps 1:1; an unknown slug throws (the real
+// resolver's contract), which `resolveProvisionCapability` turns into `unsupported`.
+mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
+  catalogSlugToDbType: (slug: string) => {
+    if (slug === "clickhouse") return "clickhouse";
+    if (slug === "snowflake") return "snowflake";
+    throw new Error(`unknown slug ${slug}`);
+  },
+  resolveDatasourcePoolConfig: mock(() => ({ dbType: "clickhouse", url: "x" })),
+  BUILTIN_DATASOURCE_CATALOG_SLUGS: ["postgres", "mysql", "clickhouse", "snowflake"],
+}));
+
+// The plugin test-connect seam — fully controllable per test.
+let pluginConn: { dbType: string; createFromConfig?: unknown } | undefined;
+let probeOutcome:
+  | { ok: true }
+  | { ok: false; reason: "no_plugin" | "connect_failed"; message: string } = { ok: true };
+const probeSpy = mock<(dbType: string, cfg: Record<string, unknown>) => Promise<unknown>>(
+  async () => probeOutcome,
+);
+mock.module("@atlas/api/lib/db/datasource-registry-bridge", () => ({
+  findDatasourcePluginConnection: mock(async () => pluginConn),
+  probePluginDatasourceConnection: probeSpy,
+  registerDatasourceInstall: mock(async () => true),
+  unregisterDatasourceInstall: mock(() => true),
+}));
+
+// Secrets passthrough (loadDatasourceProfileTarget imports these too).
+mock.module("@atlas/api/lib/plugins/secrets", () => ({
+  parseConfigSchema: () => ({ state: "parsed", fields: [] }),
+  decryptSecretFields: (c: Record<string, unknown>) => c,
+  encryptSecretFields: (c: Record<string, unknown>) => c,
+  maskSecretFields: (c: Record<string, unknown>) => c,
+}));
+
+// Installer seam — a fake `WorkspaceInstaller` Layer so the happy path persists
+// without a real DB. `installDatasource` returns a masked install row.
+const installDatasourceSpy = mock((_org: unknown, _slug: string, _opts: unknown) =>
+  Effect.succeed({
+    installId: "wh",
+    dbType: "clickhouse",
+    status: "draft" as const,
+    maskedUrl: "clickhouse://***@h:8443/db",
+    description: undefined,
+    schema: undefined,
+    groupId: null,
+  }),
+);
+const InstallerTag = Context.GenericTag<{ installDatasource: typeof installDatasourceSpy }>(
+  "WorkspaceInstaller",
+);
+mock.module("@atlas/api/lib/effect/workspace-installer", () => ({
+  WorkspaceInstaller: InstallerTag,
+  WorkspaceInstallerLive: Layer.succeed(InstallerTag, { installDatasource: installDatasourceSpy }),
+  mapInstallError: (e: { message?: string }) => ({
+    status: 400 as const,
+    code: "bad_request",
+    message: e?.message ?? "install error",
+    body: {},
+  }),
+}));
+
+const { resolveProvisionCapability, provisionDatasource } = await import("../mcp-lifecycle.js");
+
+const CH_SECRET_URL = "clickhouse://admin:topsecret@warehouse.internal:8443/analytics";
+
+beforeEach(() => {
+  internalRows = [];
+  mockHasInternalDB.mockReturnValue(true);
+  registerSpy.mockClear();
+  probeSpy.mockClear();
+  installDatasourceSpy.mockClear();
+  probeOutcome = { ok: true };
+  pluginConn = { dbType: "clickhouse", createFromConfig: () => ({}) };
+});
+
+describe("resolveProvisionCapability", () => {
+  it("native pg/mysql → kind:native", async () => {
+    expect(await resolveProvisionCapability("postgres")).toEqual({ kind: "native", dbType: "postgres" });
+    expect(await resolveProvisionCapability("mysql")).toEqual({ kind: "native", dbType: "mysql" });
+  });
+
+  it("a plugin type with a registered createFromConfig → kind:plugin", async () => {
+    const cap = await resolveProvisionCapability("clickhouse");
+    expect(cap).toEqual({ kind: "plugin", dbType: "clickhouse" });
+  });
+
+  it("a plugin type with NO registered plugin → unsupported (not a throw)", async () => {
+    pluginConn = undefined;
+    const cap = await resolveProvisionCapability("clickhouse");
+    expect(cap.kind).toBe("unsupported");
+  });
+
+  it("an unknown catalog slug → unsupported (the resolver throw is swallowed)", async () => {
+    const cap = await resolveProvisionCapability("mystery-db");
+    expect(cap.kind).toBe("unsupported");
+  });
+});
+
+describe("provisionDatasource — plugin path", () => {
+  it("probes via createFromConfig (not the native registry) and persists a draft on success", async () => {
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "clickhouse",
+      installId: "wh",
+      url: CH_SECRET_URL,
+    });
+    // Plugin probe ran with the exact config the installer will persist.
+    expect(probeSpy).toHaveBeenCalledTimes(1);
+    expect(probeSpy.mock.calls[0][0]).toBe("clickhouse");
+    expect(probeSpy.mock.calls[0][1]).toEqual({ url: CH_SECRET_URL });
+    // Native pre-flight registry probe was NOT used.
+    expect(registerSpy).not.toHaveBeenCalled();
+    // Persisted as a draft via the installer.
+    expect(installDatasourceSpy).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") expect(outcome.value.installId).toBe("wh");
+  });
+
+  it("a failed plugin probe persists NOTHING and scrubs the secret URL", async () => {
+    probeOutcome = {
+      ok: false,
+      reason: "connect_failed",
+      message: `getaddrinfo ENOTFOUND for ${CH_SECRET_URL}`,
+    };
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "clickhouse",
+      installId: "wh",
+      url: CH_SECRET_URL,
+    });
+    expect(outcome.kind).toBe("health_error");
+    expect(installDatasourceSpy).not.toHaveBeenCalled();
+    if (outcome.kind === "health_error") {
+      expect(outcome.message).not.toContain(CH_SECRET_URL);
+      expect(outcome.message).not.toContain("topsecret");
+      expect(outcome.message).toContain("[redacted]");
+    }
+  });
+
+  it("rejects a duplicate install id (conflict) before probing", async () => {
+    internalRows = [{ catalog_slug: "clickhouse" }];
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "clickhouse",
+      installId: "wh",
+      url: CH_SECRET_URL,
+    });
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.status).toBe(409);
+    expect(probeSpy).not.toHaveBeenCalled();
+  });
+
+  it("an unsupported (no-plugin) type returns unsupported without probing", async () => {
+    pluginConn = undefined;
+    const outcome = await provisionDatasource("org_1", {
+      catalogSlug: "clickhouse",
+      installId: "wh",
+      url: CH_SECRET_URL,
+    });
+    expect(outcome.kind).toBe("unsupported");
+    expect(probeSpy).not.toHaveBeenCalled();
+    expect(installDatasourceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
@@ -70,8 +70,12 @@ mock.module("@atlas/api/lib/db/datasource-registry-bridge", () => ({
   unregisterDatasourceInstall: mock(() => true),
 }));
 
-// Secrets passthrough (loadDatasourceProfileTarget imports these too).
+// Secrets passthrough (loadDatasourceProfileTarget imports these too). Spread the
+// real module so the form-install handler graph (pulled transitively via the
+// REST install seam) keeps every named export it imports.
+const realSecrets = await import("@atlas/api/lib/plugins/secrets");
 mock.module("@atlas/api/lib/plugins/secrets", () => ({
+  ...realSecrets,
   parseConfigSchema: () => ({ state: "parsed", fields: [] }),
   decryptSecretFields: (c: Record<string, unknown>) => c,
   encryptSecretFields: (c: Record<string, unknown>) => c,

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-plugin.test.ts
@@ -147,7 +147,8 @@ describe("provisionDatasource — plugin path", () => {
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "clickhouse",
       installId: "wh",
-      url: CH_SECRET_URL,
+      config: { url: CH_SECRET_URL },
+      secretKeys: ["url"],
     });
     // Plugin probe ran with the exact config the installer will persist.
     expect(probeSpy).toHaveBeenCalledTimes(1);
@@ -170,7 +171,8 @@ describe("provisionDatasource — plugin path", () => {
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "clickhouse",
       installId: "wh",
-      url: CH_SECRET_URL,
+      config: { url: CH_SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("health_error");
     expect(installDatasourceSpy).not.toHaveBeenCalled();
@@ -186,7 +188,8 @@ describe("provisionDatasource — plugin path", () => {
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "clickhouse",
       installId: "wh",
-      url: CH_SECRET_URL,
+      config: { url: CH_SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("error");
     if (outcome.kind === "error") expect(outcome.status).toBe(409);
@@ -198,7 +201,8 @@ describe("provisionDatasource — plugin path", () => {
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "clickhouse",
       installId: "wh",
-      url: CH_SECRET_URL,
+      config: { url: CH_SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("unsupported");
     expect(probeSpy).not.toHaveBeenCalled();

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-rest.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-rest.test.ts
@@ -92,4 +92,23 @@ describe("provisionRestDatasource", () => {
       provisionRestDatasource("org_1", { openapi_url: SPEC_URL }, []),
     ).rejects.toThrow(/DB pool exhausted/);
   });
+
+  it("scrubs the credential from a re-thrown non-validation error", async () => {
+    validateConfigImpl = async () => {
+      throw new Error(`probe blew up with Authorization: Bearer ${AUTH_SECRET}`);
+    };
+    await expect(
+      provisionRestDatasource(
+        "org_1",
+        { openapi_url: SPEC_URL, auth_value: AUTH_SECRET },
+        ["auth_value"],
+      ),
+    ).rejects.toThrow(/\[redacted\]/);
+    // And the secret itself never rides the thrown message.
+    await provisionRestDatasource("org_1", { openapi_url: SPEC_URL, auth_value: AUTH_SECRET }, ["auth_value"]).catch(
+      (e: unknown) => {
+        expect(e instanceof Error ? e.message : String(e)).not.toContain(AUTH_SECRET);
+      },
+    );
+  });
 });

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-rest.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle-provision-rest.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Lib-layer tests for REST/OpenAPI provisioning over MCP (#3547):
+ * `provisionRestDatasource`, which routes the elicited form config through the
+ * `openapi-generic` form-install handler (probe-on-install) rather than the
+ * native/plugin `createFromConfig` path.
+ *
+ * Two invariants the `create_rest_datasource` tool relies on:
+ *   1. A `FormInstallValidationError` (bad spec URL / auth / failed probe)
+ *      becomes a typed `validation` outcome — never a throw, nothing installed.
+ *   2. The credential (`auth_value`) is scrubbed from that validation message.
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { createConnectionMock } from "../../../__mocks__/connection";
+import { FormInstallValidationError } from "@atlas/api/lib/integrations/install/persist-form-install";
+
+// Heavy graph: keep the real modules, mock only the I/O boundaries.
+const realInternal = await import("@atlas/api/lib/db/internal");
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: mock(async () => []),
+  hasInternalDB: mock(() => true),
+}));
+mock.module("@atlas/api/lib/db/connection", () => createConnectionMock({}));
+
+// The openapi-generic form-install handler — fully controllable per test.
+let validateConfigImpl: (orgId: string, formData: Record<string, unknown>) => Promise<unknown> = async () => ({
+  installRecord: { id: "rest-xyz", workspaceId: "org_1", catalogId: "openapi-generic" },
+});
+const validateConfigSpy = mock((orgId: string, formData: Record<string, unknown>) => validateConfigImpl(orgId, formData));
+const realDispatch = await import("@atlas/api/lib/integrations/install/dispatch");
+mock.module("@atlas/api/lib/integrations/install/dispatch", () => ({
+  ...realDispatch,
+  getInstallHandler: mock(() => ({ kind: "form", validateConfig: validateConfigSpy })),
+}));
+const realRegister = await import("@atlas/api/lib/integrations/install/register");
+mock.module("@atlas/api/lib/integrations/install/register", () => ({
+  ...realRegister,
+  registerBuiltinInstallHandlers: mock(() => {}),
+}));
+
+const { provisionRestDatasource } = await import("../mcp-lifecycle.js");
+
+const SPEC_URL = "https://api.example.com/openapi.json";
+const AUTH_SECRET = "sk-super-secret-token";
+
+beforeEach(() => {
+  validateConfigSpy.mockClear();
+  validateConfigImpl = async () => ({
+    installRecord: { id: "rest-xyz", workspaceId: "org_1", catalogId: "openapi-generic" },
+  });
+});
+
+describe("provisionRestDatasource", () => {
+  it("installs via the openapi-generic handler and returns the minted install id", async () => {
+    const outcome = await provisionRestDatasource(
+      "org_1",
+      { openapi_url: SPEC_URL, auth_kind: "bearer", auth_value: AUTH_SECRET },
+      ["auth_value"],
+    );
+    expect(outcome).toEqual({ kind: "ok", installId: "rest-xyz" });
+    // The handler received the full formData (credential included).
+    expect((validateConfigSpy.mock.calls[0][1] as Record<string, unknown>).auth_value).toBe(AUTH_SECRET);
+  });
+
+  it("maps a FormInstallValidationError to a `validation` outcome, scrubbing the credential", async () => {
+    validateConfigImpl = async () => {
+      throw new FormInstallValidationError({
+        fieldErrors: { openapi_url: [`spec fetch failed for ${SPEC_URL} with token ${AUTH_SECRET}`] },
+        formErrors: [],
+      });
+    };
+    const outcome = await provisionRestDatasource(
+      "org_1",
+      { openapi_url: SPEC_URL, auth_kind: "bearer", auth_value: AUTH_SECRET },
+      ["auth_value"],
+    );
+    expect(outcome.kind).toBe("validation");
+    if (outcome.kind === "validation") {
+      expect(outcome.message).toContain("openapi_url:");
+      // The secret credential never rides the surfaced message.
+      expect(outcome.message).not.toContain(AUTH_SECRET);
+      expect(outcome.message).toContain("[redacted]");
+    }
+  });
+
+  it("re-throws a non-validation error for the caller's internal_error path", async () => {
+    validateConfigImpl = async () => {
+      throw new Error("internal DB pool exhausted");
+    };
+    await expect(
+      provisionRestDatasource("org_1", { openapi_url: SPEC_URL }, []),
+    ).rejects.toThrow(/DB pool exhausted/);
+  });
+});

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -84,14 +84,22 @@ mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
 // `loadDatasourceProfileTarget` parses the catalog schema + decrypts config.
 // Plaintext passthrough is enough — the dbType/url come from the resolver mock.
 mock.module("@atlas/api/lib/plugins/secrets", () => ({
-  parseConfigSchema: () => ({ state: "parsed", fields: [] }),
+  // Echo a config_schema array verbatim as parsed fields so
+  // `loadProvisionConfigFields` can be exercised; non-array → empty (matches
+  // the prior `config_schema: []` profile-target cases).
+  parseConfigSchema: (s: unknown) => ({ state: "parsed", fields: Array.isArray(s) ? s : [] }),
   decryptSecretFields: (config: Record<string, unknown>) => config,
   encryptSecretFields: (config: Record<string, unknown>) => config,
   maskSecretFields: (config: Record<string, unknown>) => config,
 }));
 
-const { listDatasources, runDatasourceInstaller, provisionDatasource, loadDatasourceProfileTarget } =
-  await import("../mcp-lifecycle.js");
+const {
+  listDatasources,
+  runDatasourceInstaller,
+  provisionDatasource,
+  loadDatasourceProfileTarget,
+  loadProvisionConfigFields,
+} = await import("../mcp-lifecycle.js");
 
 beforeEach(() => {
   mockInternalQuery.mockClear();
@@ -235,7 +243,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "snowflake",
       installId: "wh",
-      url: SECRET_URL,
+      config: { url: SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("unsupported");
     expect(registerSpy).not.toHaveBeenCalled();
@@ -247,7 +256,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "postgres",
       installId: "dupe",
-      url: SECRET_URL,
+      config: { url: SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("error");
     if (outcome.kind === "error") expect(outcome.status).toBe(409);
@@ -259,7 +269,7 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     healthResult = { status: "healthy", latencyMs: 5, checkedAt: new Date(0) };
     // Health OK → reaches the installer; installDatasource isn't mocked here,
     // so the program will fail — but we only assert the pre-flight behaviour.
-    await provisionDatasource("org_1", { catalogSlug: "postgres", installId: "new-pg", url: SECRET_URL })
+    await provisionDatasource("org_1", { catalogSlug: "postgres", installId: "new-pg", config: { url: SECRET_URL }, secretKeys: ["url"] })
       .catch(() => undefined);
     // Registered + unregistered exactly the same throwaway id, never "new-pg".
     const registeredId = registerSpy.mock.calls[0]?.[0] as string;
@@ -276,7 +286,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "postgres",
       installId: "new-pg",
-      url: SECRET_URL,
+      config: { url: SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("health_error");
     expect(unregisterSpy).toHaveBeenCalledTimes(1); // probe rolled back
@@ -288,7 +299,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "postgres",
       installId: "new-pg",
-      url: SECRET_URL,
+      config: { url: SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("health_error");
     expect(registerSpy).toHaveBeenCalledTimes(1);
@@ -305,7 +317,8 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
     const outcome = await provisionDatasource("org_1", {
       catalogSlug: "postgres",
       installId: "new-pg",
-      url: SECRET_URL,
+      config: { url: SECRET_URL },
+      secretKeys: ["url"],
     });
     expect(outcome.kind).toBe("health_error");
     expect(unregisterSpy).toHaveBeenCalledTimes(1);
@@ -315,6 +328,36 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
       // Exact-url scrub replaces the whole DSN, '@'-password and all.
       expect(outcome.message).toContain("[redacted]");
     }
+  });
+});
+
+describe("loadProvisionConfigFields", () => {
+  it("maps the catalog config_schema to elicitation fields + secretKeys, excluding description", async () => {
+    // Mirrors the elasticsearch catalog row: non-secret url + secret apiKey,
+    // plus a description field that must NOT be elicited (it's a tool arg).
+    internalRows = [
+      {
+        config_schema: [
+          { key: "url", type: "string", label: "Connection URL", required: true, description: "es://…" },
+          { key: "apiKey", type: "string", label: "API Key", secret: true },
+          { key: "description", type: "string", label: "Description" },
+        ],
+      },
+    ];
+    const res = await loadProvisionConfigFields("elasticsearch");
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      expect(res.fields.map((f) => f.key)).toEqual(["url", "apiKey"]); // description excluded
+      expect(res.fields[0]).toEqual({ key: "url", label: "Connection URL", description: "es://…", required: true, secret: false });
+      expect(res.fields[1].secret).toBe(true);
+      expect(res.secretKeys).toEqual(["apiKey"]);
+    }
+  });
+
+  it("returns not_found when the catalog row is missing", async () => {
+    internalRows = [];
+    const res = await loadProvisionConfigFields("nope");
+    expect(res.kind).toBe("not_found");
   });
 });
 

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -83,7 +83,12 @@ mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
 
 // `loadDatasourceProfileTarget` parses the catalog schema + decrypts config.
 // Plaintext passthrough is enough — the dbType/url come from the resolver mock.
+// Spread the real module so every export (restoreMaskedSecrets, …) the form-
+// install handler graph named-imports stays present; override only the few this
+// suite drives.
+const realSecrets = await import("@atlas/api/lib/plugins/secrets");
 mock.module("@atlas/api/lib/plugins/secrets", () => ({
+  ...realSecrets,
   // Echo a config_schema array verbatim as parsed fields so
   // `loadProvisionConfigFields` can be exercised; non-array → empty (matches
   // the prior `config_schema: []` profile-target cases).

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -337,14 +337,16 @@ describe("provisionDatasource — validate-before-persist + secret discipline", 
 });
 
 describe("loadProvisionConfigFields", () => {
-  it("maps the catalog config_schema to elicitation fields + secretKeys, excluding description", async () => {
-    // Mirrors the elasticsearch catalog row: non-secret url + secret apiKey,
-    // plus a description field that must NOT be elicited (it's a tool arg).
+  it("maps the catalog config_schema to elicitation fields + secretKeys, excluding description + schema", async () => {
+    // Mirrors a SQL catalog row: non-secret url + secret apiKey, plus a
+    // description (tool-arg label) and a schema (search_path) field that must
+    // NOT be elicited into the secure prompt — both are non-secret agent args.
     internalRows = [
       {
         config_schema: [
           { key: "url", type: "string", label: "Connection URL", required: true, description: "es://…" },
           { key: "apiKey", type: "string", label: "API Key", secret: true },
+          { key: "schema", type: "string", label: "Schema" },
           { key: "description", type: "string", label: "Description" },
         ],
       },
@@ -352,7 +354,7 @@ describe("loadProvisionConfigFields", () => {
     const res = await loadProvisionConfigFields("elasticsearch");
     expect(res.kind).toBe("ok");
     if (res.kind === "ok") {
-      expect(res.fields.map((f) => f.key)).toEqual(["url", "apiKey"]); // description excluded
+      expect(res.fields.map((f) => f.key)).toEqual(["url", "apiKey"]); // description + schema excluded
       expect(res.fields[0]).toEqual({ key: "url", label: "Connection URL", description: "es://…", required: true, secret: false });
       expect(res.fields[1].secret).toBe(true);
       expect(res.secretKeys).toEqual(["apiKey"]);

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -393,6 +393,31 @@ describe("loadProvisionConfigFields", () => {
     }
   });
 
+  it("propagates a select field's options + default so the masked form renders a dropdown", async () => {
+    // Mirrors the openapi-generic auth_kind: a required select with a default —
+    // its enum + default must reach the elicitation field, not collapse to text.
+    internalRows = [
+      {
+        config_schema: [
+          { key: "openapi_url", type: "string", label: "OpenAPI spec URL", required: true },
+          { key: "auth_kind", type: "select", label: "Authentication", required: true, options: ["bearer", "basic", "apikey"], default: "bearer" },
+          { key: "auth_value", type: "string", label: "Credential", secret: true },
+        ],
+      },
+    ];
+    const res = await loadProvisionConfigFields("openapi-generic");
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      const authKind = res.fields.find((f) => f.key === "auth_kind");
+      expect(authKind?.options).toEqual(["bearer", "basic", "apikey"]);
+      expect(authKind?.default).toBe("bearer");
+      // A plain string field carries neither.
+      const url = res.fields.find((f) => f.key === "openapi_url");
+      expect(url?.options).toBeUndefined();
+      expect(url?.default).toBeUndefined();
+    }
+  });
+
   it("returns not_found when the catalog row is missing", async () => {
     internalRows = [];
     const res = await loadProvisionConfigFields("nope");

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -359,6 +359,38 @@ describe("loadProvisionConfigFields", () => {
     }
   });
 
+  it("excludes non-credential fields (display_name + write-governance) from the masked form", async () => {
+    // Mirrors the openapi-generic catalog row: connection/auth fields are
+    // elicited; display_name + write_allowlist + side_effecting_operations are
+    // NOT (label / write-governance, not credentials).
+    internalRows = [
+      {
+        config_schema: [
+          { key: "openapi_url", type: "string", label: "OpenAPI spec URL", required: true },
+          { key: "auth_kind", type: "select", label: "Authentication", required: true },
+          { key: "auth_value", type: "string", label: "Credential", secret: true },
+          { key: "auth_header_name", type: "string", label: "API key header name" },
+          { key: "write_allowlist", type: "string", label: "Write allowlist (JSON)" },
+          { key: "side_effecting_operations", type: "string", label: "Side-effecting GET operations (JSON)" },
+          { key: "display_name", type: "string", label: "Display name" },
+        ],
+      },
+    ];
+    const res = await loadProvisionConfigFields("openapi-generic");
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      // auth_header_name (a connection/auth field) is kept; the label + the two
+      // write-governance JSON fields are dropped.
+      expect(res.fields.map((f) => f.key)).toEqual([
+        "openapi_url",
+        "auth_kind",
+        "auth_value",
+        "auth_header_name",
+      ]);
+      expect(res.secretKeys).toEqual(["auth_value"]);
+    }
+  });
+
   it("returns not_found when the catalog row is missing", async () => {
     internalRows = [];
     const res = await loadProvisionConfigFields("nope");

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -371,18 +371,85 @@ export async function resolveProvisionCapability(
 }
 
 /**
- * Input to {@link provisionDatasource}. `url` is the credential collected
- * via masked elicitation at the MCP edge — it is encrypted at the installer
- * boundary and NEVER round-trips back out (the returned row carries only a
- * `maskedUrl`).
+ * A `config_schema` field surfaced to the MCP edge so `create_datasource` can
+ * drive its masked elicitation form (#3547 AC #4). Carries only the metadata the
+ * form needs — never a value. `description` (a UI label, not a connection
+ * credential) is excluded: the tool collects it as a plain tool argument so the
+ * agent can set it. The remaining connection fields — secret AND non-secret
+ * (e.g. ES `url`) — are elicited so the agent never sees connection details.
+ */
+export interface ProvisionConfigField {
+  readonly key: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly required: boolean;
+  readonly secret: boolean;
+}
+
+export type LoadProvisionConfigFieldsResult =
+  | { readonly kind: "ok"; readonly fields: ProvisionConfigField[]; readonly secretKeys: string[] }
+  /** No catalog row for the slug (shouldn't happen after a capability check passes). */
+  | { readonly kind: "not_found" }
+  /** The catalog `config_schema` is absent/corrupt — an operator misconfig, fail closed. */
+  | { readonly kind: "schema_error" };
+
+/**
+ * Load the `config_schema` for a provisionable datasource and shape its fields
+ * for the MCP masked-elicitation form. Reads the SAME catalog row the installer
+ * validates + encrypts against, so the elicited field set and the secret-field
+ * set stay schema-driven (a new auth field propagates with zero MCP changes).
+ */
+export async function loadProvisionConfigFields(
+  catalogSlug: string,
+): Promise<LoadProvisionConfigFieldsResult> {
+  if (!hasInternalDB()) return { kind: "not_found" };
+  const rows = await internalQuery<{ config_schema: unknown }>(
+    `SELECT config_schema FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+    [catalogSlug],
+  );
+  if (rows.length === 0) return { kind: "not_found" };
+  const schema = parseConfigSchema(rows[0].config_schema);
+  if (schema.state !== "parsed") return { kind: "schema_error" };
+
+  const fields: ProvisionConfigField[] = [];
+  const secretKeys: string[] = [];
+  for (const f of schema.fields) {
+    if (f.key === "description") continue; // collected as a tool arg, not elicited
+    const secret = f.secret === true;
+    if (secret) secretKeys.push(f.key);
+    fields.push({
+      key: f.key,
+      label: f.label ?? f.key,
+      ...(f.description !== undefined ? { description: f.description } : {}),
+      required: f.required === true,
+      secret,
+    });
+  }
+  return { kind: "ok", fields, secretKeys };
+}
+
+/**
+ * Input to {@link provisionDatasource}. `config` carries the full set of
+ * `config_schema` field values collected via masked elicitation at the MCP edge
+ * (the secret fields among them are listed in `secretKeys`). Secret fields are
+ * encrypted at the installer boundary and NEVER round-trip back out (the
+ * returned row carries only a `maskedUrl` / masked fields). The shape is
+ * credential-agnostic so url-shaped (pg/mysql/clickhouse/snowflake), apiKey-
+ * shaped (Elasticsearch), and multi-field (BigQuery) datasources all flow
+ * through one path (#3547).
  */
 export interface ProvisionDatasourceInput {
   readonly catalogSlug: string;
   readonly installId: string;
-  /** The connection URL (secret). Encrypted by the installer per config_schema. */
-  readonly url: string;
-  readonly schema?: string;
-  readonly description?: string;
+  /**
+   * All `config_schema` field values (secret + non-secret) keyed by field key —
+   * e.g. `{ url }`, `{ url, apiKey }`, `{ service_account_json, project_id }`.
+   * Passed verbatim to the installer (which encrypts the `secret: true` fields)
+   * and to the pre-flight probe.
+   */
+  readonly config: Readonly<Record<string, unknown>>;
+  /** Keys of `config` that are `secret: true` — scrubbed from any surfaced error. */
+  readonly secretKeys: readonly string[];
   readonly groupId?: string | null;
 }
 
@@ -404,26 +471,30 @@ export type ProvisionDatasourceOutcome =
  * reusing the blessed seam (`lib/audit/error-scrub.ts`) rather than a
  * hand-rolled regex so a future hardening there covers this path too.
  */
-function scrubSecretFromMessage(message: string, url: string): string {
-  const exact = url ? message.split(url).join("[redacted]") : message;
-  return errorMessage(exact);
+function scrubSecretsFromMessage(message: string, secrets: readonly string[]): string {
+  let scrubbed = message;
+  for (const secret of secrets) {
+    if (secret) scrubbed = scrubbed.split(secret).join("[redacted]");
+  }
+  return errorMessage(scrubbed);
+}
+
+/** The plaintext secret values in `input.config` (the `secretKeys` subset), for scrubbing. */
+function secretValues(input: ProvisionDatasourceInput): string[] {
+  return input.secretKeys
+    .map((k) => input.config[k])
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
 /** Result of a validate-before-persist pre-flight; `message` is already scrubbed. */
 type PreflightResult = { readonly ok: true } | { readonly ok: false; readonly message: string };
 
 /**
- * The credential-bearing config the probe + installer both consume. For the
- * url-shaped provisionable types (native pg/mysql, plugin clickhouse/snowflake)
- * the secret is `url`; `schema`/`description` are non-secret metadata. Built in
- * one place so the pre-flight probe tests EXACTLY what the installer persists.
+ * The config the probe + installer both consume — `input.config` verbatim. Built
+ * in one place so the pre-flight probe tests EXACTLY what the installer persists.
  */
 function buildProvisionFormData(input: ProvisionDatasourceInput): Record<string, unknown> {
-  return {
-    url: input.url,
-    ...(input.description !== undefined ? { description: input.description } : {}),
-    ...(input.schema !== undefined && input.schema.length > 0 ? { schema: input.schema } : {}),
-  };
+  return { ...input.config };
 }
 
 /**
@@ -435,11 +506,15 @@ function buildProvisionFormData(input: ProvisionDatasourceInput): Record<string,
  * probe pool is ALWAYS unregistered in `finally`.
  */
 async function preflightNativeConnection(input: ProvisionDatasourceInput): Promise<PreflightResult> {
+  const secrets = secretValues(input);
+  const url = typeof input.config.url === "string" ? input.config.url : "";
+  const schema = typeof input.config.schema === "string" ? input.config.schema : undefined;
+  const description = typeof input.config.description === "string" ? input.config.description : undefined;
   const probeId = `__mcp_preflight_${crypto.randomUUID()}`;
   connections.register(probeId, {
-    url: input.url,
-    ...(input.description !== undefined ? { description: input.description } : {}),
-    ...(input.schema !== undefined ? { schema: input.schema } : {}),
+    url,
+    ...(description !== undefined ? { description } : {}),
+    ...(schema !== undefined ? { schema } : {}),
   });
   try {
     const health = await connections.healthCheck(probeId);
@@ -450,9 +525,9 @@ async function preflightNativeConnection(input: ProvisionDatasourceInput): Promi
     if (health.status !== "healthy") {
       return {
         ok: false,
-        message: scrubSecretFromMessage(
+        message: scrubSecretsFromMessage(
           health.message ?? "Connection probe could not reach the datasource.",
-          input.url,
+          secrets,
         ),
       };
     }
@@ -461,9 +536,9 @@ async function preflightNativeConnection(input: ProvisionDatasourceInput): Promi
     const raw = err instanceof Error ? err.message : String(err);
     return {
       ok: false,
-      message: scrubSecretFromMessage(
+      message: scrubSecretsFromMessage(
         `Connection test failed: ${raw}. Verify the host, port, database, and credentials, then retry.`,
-        input.url,
+        secrets,
       ),
     };
   } finally {
@@ -481,7 +556,7 @@ async function preflightNativeConnection(input: ProvisionDatasourceInput): Promi
  * installer will persist (`buildProvisionFormData`). A missing plugin
  * (`no_plugin`) shouldn't normally reach here — `resolveProvisionCapability`
  * already gated it — but is handled defensively. The raw driver error is
- * scrubbed of the credential before it returns.
+ * scrubbed of every secret field value before it returns.
  */
 async function preflightPluginConnection(
   dbType: string,
@@ -493,7 +568,7 @@ async function preflightPluginConnection(
     outcome.reason === "no_plugin"
       ? outcome.message
       : `Connection test failed: ${outcome.message}. Verify the connection details and credentials, then retry.`;
-  return { ok: false, message: scrubSecretFromMessage(friendly, input.url) };
+  return { ok: false, message: scrubSecretsFromMessage(friendly, secretValues(input)) };
 }
 
 /**
@@ -503,8 +578,9 @@ async function preflightPluginConnection(
  * → return the masked row. On any failure nothing is persisted and the
  * ephemeral pool is rolled back.
  *
- * The credential (`input.url`) only flows in here and into the installer's
- * encrypt-at-rest path; it is never returned, logged, or placed in an error.
+ * The secret fields in `input.config` only flow in here and into the
+ * installer's encrypt-at-rest path; they are never returned, logged, or placed
+ * in an error (every secret value is scrubbed from any surfaced message).
  */
 export async function provisionDatasource(
   orgId: string,
@@ -561,7 +637,7 @@ export async function provisionDatasource(
       kind: "error",
       status: outcome.status,
       code: outcome.code,
-      message: scrubSecretFromMessage(outcome.message, input.url),
+      message: scrubSecretsFromMessage(outcome.message, secretValues(input)),
     };
   }
   return { kind: "ok", value: outcome.value };

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -42,6 +42,10 @@ import {
 } from "@atlas/api/lib/db/datasource-registry-bridge";
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
+import { getInstallHandler } from "@atlas/api/lib/integrations/install/dispatch";
+import { FormInstallValidationError } from "@atlas/api/lib/integrations/install/persist-form-install";
+import { registerBuiltinInstallHandlers } from "@atlas/api/lib/integrations/install/register";
+import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import {
   MCP_PROVISIONABLE_CATALOG_SLUGS,
   isMcpNativeDbType,
@@ -641,6 +645,66 @@ export async function provisionDatasource(
     };
   }
   return { kind: "ok", value: outcome.value };
+}
+
+// ── REST / OpenAPI provisioning (#3547) ───────────────────────────────
+//
+// REST datasources do NOT flow through the native/plugin `createFromConfig`
+// path — they're the `openapi-generic` form-install handler, which PROBES the
+// OpenAPI spec on install and caches a normalized snapshot (no separate
+// pre-flight: a probe failure surfaces as a field validation error and persists
+// nothing). So MCP REST provisioning calls the SAME form handler the admin
+// `/install-form` route calls (ADR-0016 — the lib seam, not the route),
+// `getInstallHandler(openapi-generic).validateConfig`, rather than
+// `provisionDatasource`.
+
+export type ProvisionRestOutcome =
+  | { readonly kind: "ok"; readonly installId: string }
+  /** Spec-probe / field validation failed — nothing persisted. `message` is secret-scrubbed. */
+  | { readonly kind: "validation"; readonly message: string };
+
+/**
+ * Provision a generic OpenAPI/REST datasource over MCP. Routes the elicited
+ * `formData` (openapi_url + auth fields, the credential among them) through the
+ * `openapi-generic` form-install handler, which validates + probes the spec and
+ * persists the snapshot as a new multi-instance install. A
+ * {@link FormInstallValidationError} (bad URL, auth, or a failed probe) becomes
+ * a typed `validation` outcome with the secret values scrubbed; any other throw
+ * re-throws for the caller's `internal_error` path.
+ */
+export async function provisionRestDatasource(
+  orgId: string,
+  formData: Readonly<Record<string, unknown>>,
+  secretKeys: readonly string[],
+): Promise<ProvisionRestOutcome> {
+  // Idempotent (latch-guarded) — ensures the openapi-generic form handler is
+  // registered even in a process that didn't run the full app-boot wiring.
+  registerBuiltinInstallHandlers();
+  const handler = getInstallHandler({ slug: OPENAPI_GENERIC_SLUG, install_model: "form" });
+  if (handler.kind !== "form") {
+    // Registration drift — a non-form handler under a form slug. Re-throw so the
+    // MCP caller surfaces an internal_error (parity with the admin route's 501).
+    throw new Error(`openapi-generic install handler is misregistered (kind=${handler.kind}).`);
+  }
+
+  const secrets = secretKeys
+    .map((k) => formData[k])
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+
+  try {
+    const { installRecord } = await handler.validateConfig(orgId as WorkspaceId, formData);
+    return { kind: "ok", installId: installRecord.id };
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) {
+      const parts = [
+        ...err.formErrors,
+        ...Object.entries(err.fieldErrors).map(([k, v]) => `${k}: ${v.join(", ")}`),
+      ];
+      const message = parts.length > 0 ? parts.join("; ") : "Invalid REST datasource configuration.";
+      return { kind: "validation", message: scrubSecretsFromMessage(message, secrets) };
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
 }
 
 // ── Profiling / semantic-gen (#3512) ──────────────────────────────────

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -483,10 +483,18 @@ function scrubSecretsFromMessage(message: string, secrets: readonly string[]): s
   return errorMessage(scrubbed);
 }
 
-/** The plaintext secret values in `input.config` (the `secretKeys` subset), for scrubbing. */
-function secretValues(input: ProvisionDatasourceInput): string[] {
-  return input.secretKeys
-    .map((k) => input.config[k])
+/**
+ * The plaintext secret values in a config (the `secretKeys` subset), for
+ * scrubbing. Takes `(config, secretKeys)` so both the SQL provision path
+ * ({@link ProvisionDatasourceInput}) and the REST path (a bare `formData`) reuse
+ * it — there is exactly one definition of "which values must be redacted".
+ */
+function secretValues(
+  config: Readonly<Record<string, unknown>>,
+  secretKeys: readonly string[],
+): string[] {
+  return secretKeys
+    .map((k) => config[k])
     .filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
@@ -510,7 +518,7 @@ function buildProvisionFormData(input: ProvisionDatasourceInput): Record<string,
  * probe pool is ALWAYS unregistered in `finally`.
  */
 async function preflightNativeConnection(input: ProvisionDatasourceInput): Promise<PreflightResult> {
-  const secrets = secretValues(input);
+  const secrets = secretValues(input.config, input.secretKeys);
   const url = typeof input.config.url === "string" ? input.config.url : "";
   const schema = typeof input.config.schema === "string" ? input.config.schema : undefined;
   const description = typeof input.config.description === "string" ? input.config.description : undefined;
@@ -572,7 +580,7 @@ async function preflightPluginConnection(
     outcome.reason === "no_plugin"
       ? outcome.message
       : `Connection test failed: ${outcome.message}. Verify the connection details and credentials, then retry.`;
-  return { ok: false, message: scrubSecretsFromMessage(friendly, secretValues(input)) };
+  return { ok: false, message: scrubSecretsFromMessage(friendly, secretValues(input.config, input.secretKeys)) };
 }
 
 /**
@@ -641,7 +649,7 @@ export async function provisionDatasource(
       kind: "error",
       status: outcome.status,
       code: outcome.code,
-      message: scrubSecretsFromMessage(outcome.message, secretValues(input)),
+      message: scrubSecretsFromMessage(outcome.message, secretValues(input.config, input.secretKeys)),
     };
   }
   return { kind: "ok", value: outcome.value };
@@ -687,9 +695,7 @@ export async function provisionRestDatasource(
     throw new Error(`openapi-generic install handler is misregistered (kind=${handler.kind}).`);
   }
 
-  const secrets = secretKeys
-    .map((k) => formData[k])
-    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const secrets = secretValues(formData, secretKeys);
 
   try {
     const { installRecord } = await handler.validateConfig(orgId as WorkspaceId, formData);
@@ -703,7 +709,15 @@ export async function provisionRestDatasource(
       const message = parts.length > 0 ? parts.join("; ") : "Invalid REST datasource configuration.";
       return { kind: "validation", message: scrubSecretsFromMessage(message, secrets) };
     }
-    throw err instanceof Error ? err : new Error(String(err));
+    // Re-throw for the caller's internal_error path, but SCRUB the secret values
+    // (auth_value, etc.) first — an unexpected handler error can echo the elicited
+    // credential in its message, which the MCP dispatch logs + surfaces verbatim.
+    // Deliberately do NOT attach `{ cause: err }`: the original error carries the
+    // UNSCRUBBED message, and a cause chain is serialized by loggers — re-attaching
+    // it would re-introduce the exact credential this scrub removes.
+    const raw = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line preserve-caught-error -- attaching the raw cause would leak the scrubbed credential (see above)
+    throw new Error(scrubSecretsFromMessage(raw, secrets));
   }
 }
 

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -392,6 +392,10 @@ export interface ProvisionConfigField {
   readonly description?: string;
   readonly required: boolean;
   readonly secret: boolean;
+  /** A closed value set (catalog `select`) — drives an enum/dropdown in the form. */
+  readonly options?: readonly string[];
+  /** The catalog default, surfaced + injected when the client returns empty. */
+  readonly default?: string;
 }
 
 /**
@@ -451,6 +455,10 @@ export async function loadProvisionConfigFields(
       ...(f.description !== undefined ? { description: f.description } : {}),
       required: f.required === true,
       secret,
+      // Carry select options + default so the masked form renders a dropdown
+      // (with its default) rather than collapsing every field to free text.
+      ...(Array.isArray(f.options) && f.options.length > 0 ? { options: f.options } : {}),
+      ...(typeof f.default === "string" ? { default: f.default } : {}),
     });
   }
   return { kind: "ok", fields, secretKeys };

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -377,10 +377,14 @@ export async function resolveProvisionCapability(
 /**
  * A `config_schema` field surfaced to the MCP edge so `create_datasource` can
  * drive its masked elicitation form (#3547 AC #4). Carries only the metadata the
- * form needs — never a value. `description` (a UI label, not a connection
- * credential) is excluded: the tool collects it as a plain tool argument so the
- * agent can set it. The remaining connection fields — secret AND non-secret
- * (e.g. ES `url`) — are elicited so the agent never sees connection details.
+ * form needs — never a value. {@link NON_CREDENTIAL_CONFIG_KEYS} (UI label +
+ * write-governance fields) are excluded: they are NOT connection credentials, so
+ * a secure "enter your credentials" prompt is the wrong place for them. A label
+ * (`description`/`display_name`) is collected as a plain tool argument instead so
+ * the agent can set it; write-governance fields default to read-only and are
+ * configured via the admin console. The remaining connection/auth fields —
+ * secret AND non-secret (e.g. ES `url`, the apikey-header name) — are elicited so
+ * the agent never sees connection details.
  */
 export interface ProvisionConfigField {
   readonly key: string;
@@ -389,6 +393,22 @@ export interface ProvisionConfigField {
   readonly required: boolean;
   readonly secret: boolean;
 }
+
+/**
+ * Catalog `config_schema` keys that must NEVER appear in the masked credential
+ * elicitation form, because they are not connection credentials:
+ *   - `description` / `display_name` — a human label (collected as a tool arg);
+ *   - `write_allowlist` / `side_effecting_operations` — REST write-governance
+ *     (JSON allowlists); provisioning lands read-only by default and these are
+ *     configured via the admin console, not typed into a "secure credential" box.
+ * Everything else in a schema is treated as connection/auth and elicited.
+ */
+const NON_CREDENTIAL_CONFIG_KEYS: ReadonlySet<string> = new Set([
+  "description",
+  "display_name",
+  "write_allowlist",
+  "side_effecting_operations",
+]);
 
 export type LoadProvisionConfigFieldsResult =
   | { readonly kind: "ok"; readonly fields: ProvisionConfigField[]; readonly secretKeys: string[] }
@@ -418,7 +438,7 @@ export async function loadProvisionConfigFields(
   const fields: ProvisionConfigField[] = [];
   const secretKeys: string[] = [];
   for (const f of schema.fields) {
-    if (f.key === "description") continue; // collected as a tool arg, not elicited
+    if (NON_CREDENTIAL_CONFIG_KEYS.has(f.key)) continue; // label / governance, not a credential
     const secret = f.secret === true;
     if (secret) secretKeys.push(f.key);
     fields.push({

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -36,6 +36,10 @@ import {
   catalogSlugToDbType,
   resolveDatasourcePoolConfig,
 } from "@atlas/api/lib/db/datasource-pool-resolver";
+import {
+  findDatasourcePluginConnection,
+  probePluginDatasourceConnection,
+} from "@atlas/api/lib/db/datasource-registry-bridge";
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import {
@@ -312,6 +316,61 @@ export {
 };
 
 /**
+ * Capability resolution for a candidate provisioning target — the single
+ * predicate that decides whether (and how) a catalog slug can be provisioned
+ * over MCP (#3547 AC #1). Replaces the hardcoded `MCP_NATIVE_DB_TYPES` gate so
+ * provisioning and (future #3552) profiling stay in lockstep as types are
+ * added: a type is provisionable iff it is native pg/mysql OR a datasource
+ * plugin implementing `createFromConfig` is registered for its dbType.
+ *
+ *   - `native`      — pg/mysql: pre-flight via the `connections.register` →
+ *                     `healthCheck` ephemeral probe.
+ *   - `plugin`      — clickhouse/snowflake/…: pre-flight via the plugin-aware
+ *                     `createFromConfig` → `SELECT 1` → close probe.
+ *   - `unsupported` — no native handler and no registered plugin (or an unknown
+ *                     slug). `message` is actionable, carries no secret.
+ */
+export type ProvisionCapability =
+  | { readonly kind: "native"; readonly dbType: McpNativeDbType }
+  | { readonly kind: "plugin"; readonly dbType: string }
+  | { readonly kind: "unsupported"; readonly dbType: string; readonly message: string };
+
+function unsupportedProvisionMessage(catalogSlug: string): string {
+  return (
+    `Provisioning "${catalogSlug}" datasources via MCP is not supported in this deployment. ` +
+    `Supported types: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")} (plugin types require the ` +
+    `corresponding datasource plugin to be installed). Use the Atlas admin console for other types.`
+  );
+}
+
+export async function resolveProvisionCapability(
+  catalogSlug: string,
+): Promise<ProvisionCapability> {
+  // Native fast path — the catalog slug IS the dbType for pg/mysql (the
+  // `demo-postgres` slug maps to postgres but is NOT MCP-provisionable, and
+  // falls through to the plugin lookup below, which finds no plugin → unsupported).
+  if (isMcpNativeDbType(catalogSlug)) {
+    return { kind: "native", dbType: catalogSlug };
+  }
+  // Map slug → dbType; an unknown slug is `unsupported`, never a throw.
+  let dbType: string;
+  try {
+    dbType = catalogSlugToDbType(catalogSlug);
+  } catch {
+    // intentionally ignored: an unrecognised slug is a normal "unsupported"
+    // provisioning outcome, surfaced as an actionable envelope — not a 500.
+    return { kind: "unsupported", dbType: catalogSlug, message: unsupportedProvisionMessage(catalogSlug) };
+  }
+  // Plugin-managed: provisionable iff a plugin implementing `createFromConfig`
+  // is registered for this dbType (the same lookup the install/probe paths use).
+  const conn = await findDatasourcePluginConnection(dbType);
+  if (conn && typeof conn.createFromConfig === "function") {
+    return { kind: "plugin", dbType };
+  }
+  return { kind: "unsupported", dbType, message: unsupportedProvisionMessage(catalogSlug) };
+}
+
+/**
  * Input to {@link provisionDatasource}. `url` is the credential collected
  * via masked elicitation at the MCP edge — it is encrypted at the installer
  * boundary and NEVER round-trips back out (the returned row carries only a
@@ -350,49 +409,32 @@ function scrubSecretFromMessage(message: string, url: string): string {
   return errorMessage(exact);
 }
 
+/** Result of a validate-before-persist pre-flight; `message` is already scrubbed. */
+type PreflightResult = { readonly ok: true } | { readonly ok: false; readonly message: string };
+
 /**
- * Provision a new datasource over MCP: validate the dbType is provisionable
- * → pre-flight health-check the candidate connection WITHOUT persisting →
- * on success install it as a `draft` (credential encrypted by the installer)
- * → return the masked row. On any failure nothing is persisted and the
- * ephemeral pool is rolled back.
- *
- * The credential (`input.url`) only flows in here and into the installer's
- * encrypt-at-rest path; it is never returned, logged, or placed in an error.
+ * The credential-bearing config the probe + installer both consume. For the
+ * url-shaped provisionable types (native pg/mysql, plugin clickhouse/snowflake)
+ * the secret is `url`; `schema`/`description` are non-secret metadata. Built in
+ * one place so the pre-flight probe tests EXACTLY what the installer persists.
  */
-export async function provisionDatasource(
-  orgId: string,
-  input: ProvisionDatasourceInput,
-): Promise<ProvisionDatasourceOutcome> {
-  if (!isMcpNativeDbType(input.catalogSlug)) {
-    return {
-      kind: "unsupported",
-      message:
-        `Provisioning "${input.catalogSlug}" datasources via MCP is not supported yet. ` +
-        `Supported types: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")}. ` +
-        `Use the Atlas admin console for other datasource types.`,
-    };
-  }
+function buildProvisionFormData(input: ProvisionDatasourceInput): Record<string, unknown> {
+  return {
+    url: input.url,
+    ...(input.description !== undefined ? { description: input.description } : {}),
+    ...(input.schema !== undefined && input.schema.length > 0 ? { schema: input.schema } : {}),
+  };
+}
 
-  // Reject a duplicate id before touching the registry — a clean message
-  // beats an installer `AlreadyInstalledError` deep in the Effect.
-  if (await resolveDatasourceCatalogSlug(orgId, input.installId)) {
-    return {
-      kind: "error",
-      status: 409,
-      code: "conflict",
-      message: `A datasource with id "${input.installId}" already exists in this workspace.`,
-    };
-  }
-
-  // Pre-flight on an EPHEMERAL probe id — never the real install id. Using a
-  // throwaway id (a) guarantees the probe tests THIS candidate `url`, not a
-  // stale bare pool that might already exist under `installId` (e.g. a
-  // sibling workspace's pool, the runtime `default`, or an un-drained
-  // archived install), and (b) can't leave the install-id-keyed registry in a
-  // split-brain state if persist later fails. Mirrors the admin route's
-  // `_test_*` ephemeral test-connect (ADR-0007). The probe pool is ALWAYS
-  // unregistered in `finally`.
+/**
+ * Native pg/mysql pre-flight on an EPHEMERAL probe id — never the real install
+ * id. A throwaway id (a) guarantees the probe tests THIS candidate `url`, not a
+ * stale bare pool that might already exist under `installId`, and (b) can't
+ * leave the install-id-keyed registry split-brained if persist later fails.
+ * Mirrors the admin route's `_test_*` ephemeral test-connect (ADR-0007). The
+ * probe pool is ALWAYS unregistered in `finally`.
+ */
+async function preflightNativeConnection(input: ProvisionDatasourceInput): Promise<PreflightResult> {
   const probeId = `__mcp_preflight_${crypto.randomUUID()}`;
   connections.register(probeId, {
     url: input.url,
@@ -407,17 +449,18 @@ export async function provisionDatasource(
     // broken connection slips past validate-before-persist.
     if (health.status !== "healthy") {
       return {
-        kind: "health_error",
+        ok: false,
         message: scrubSecretFromMessage(
           health.message ?? "Connection probe could not reach the datasource.",
           input.url,
         ),
       };
     }
+    return { ok: true };
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
     return {
-      kind: "health_error",
+      ok: false,
       message: scrubSecretFromMessage(
         `Connection test failed: ${raw}. Verify the host, port, database, and credentials, then retry.`,
         input.url,
@@ -428,14 +471,80 @@ export async function provisionDatasource(
     // fresh registration, failure persists nothing.
     connections.unregister(probeId);
   }
+}
 
-  // Health OK → persist as draft. The installer re-registers idempotently and
-  // encrypts the `url` per the catalog config_schema.
-  const formData: Record<string, unknown> = {
-    url: input.url,
-    ...(input.description !== undefined ? { description: input.description } : {}),
-    ...(input.schema !== undefined && input.schema.length > 0 ? { schema: input.schema } : {}),
-  };
+/**
+ * Plugin-managed pre-flight (#3547) — builds a throwaway connection via the
+ * registered plugin's `createFromConfig` and runs a `SELECT 1` probe through
+ * the shared {@link probePluginDatasourceConnection} seam, which closes the
+ * probe connection regardless of outcome. Tests exactly the config the
+ * installer will persist (`buildProvisionFormData`). A missing plugin
+ * (`no_plugin`) shouldn't normally reach here — `resolveProvisionCapability`
+ * already gated it — but is handled defensively. The raw driver error is
+ * scrubbed of the credential before it returns.
+ */
+async function preflightPluginConnection(
+  dbType: string,
+  input: ProvisionDatasourceInput,
+): Promise<PreflightResult> {
+  const outcome = await probePluginDatasourceConnection(dbType, buildProvisionFormData(input));
+  if (outcome.ok) return { ok: true };
+  const friendly =
+    outcome.reason === "no_plugin"
+      ? outcome.message
+      : `Connection test failed: ${outcome.message}. Verify the connection details and credentials, then retry.`;
+  return { ok: false, message: scrubSecretFromMessage(friendly, input.url) };
+}
+
+/**
+ * Provision a new datasource over MCP: validate the dbType is provisionable
+ * → pre-flight health-check the candidate connection WITHOUT persisting →
+ * on success install it as a `draft` (credential encrypted by the installer)
+ * → return the masked row. On any failure nothing is persisted and the
+ * ephemeral pool is rolled back.
+ *
+ * The credential (`input.url`) only flows in here and into the installer's
+ * encrypt-at-rest path; it is never returned, logged, or placed in an error.
+ */
+export async function provisionDatasource(
+  orgId: string,
+  input: ProvisionDatasourceInput,
+): Promise<ProvisionDatasourceOutcome> {
+  // Capability-derived gate (#3547 AC #1) — native pg/mysql OR a plugin-managed
+  // type with a registered `createFromConfig`. Anything else is an actionable
+  // `unsupported` envelope (no secret).
+  const capability = await resolveProvisionCapability(input.catalogSlug);
+  if (capability.kind === "unsupported") {
+    return { kind: "unsupported", message: capability.message };
+  }
+
+  // Reject a duplicate id before touching the registry — a clean message
+  // beats an installer `AlreadyInstalledError` deep in the Effect.
+  if (await resolveDatasourceCatalogSlug(orgId, input.installId)) {
+    return {
+      kind: "error",
+      status: 409,
+      code: "conflict",
+      message: `A datasource with id "${input.installId}" already exists in this workspace.`,
+    };
+  }
+
+  // Validate-before-persist pre-flight: native via the ephemeral
+  // ConnectionRegistry probe, plugin via the plugin-aware
+  // `createFromConfig → SELECT 1 → close` probe. Either way nothing is
+  // persisted and no pool survives a failure (the credential never leaks — the
+  // message is scrubbed before it returns).
+  const preflight =
+    capability.kind === "native"
+      ? await preflightNativeConnection(input)
+      : await preflightPluginConnection(capability.dbType, input);
+  if (!preflight.ok) {
+    return { kind: "health_error", message: preflight.message };
+  }
+
+  // Pre-flight OK → persist as draft. The installer re-registers idempotently
+  // and encrypts the secret fields per the catalog config_schema.
+  const formData = buildProvisionFormData(input);
   const outcome = await runDatasourceInstaller((installer) =>
     installer.installDatasource(orgId as WorkspaceId, input.catalogSlug, {
       installId: input.installId,

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -398,6 +398,9 @@ export interface ProvisionConfigField {
  * Catalog `config_schema` keys that must NEVER appear in the masked credential
  * elicitation form, because they are not connection credentials:
  *   - `description` / `display_name` — a human label (collected as a tool arg);
+ *   - `schema` — the optional Postgres/MySQL/ClickHouse search_path; a
+ *     non-secret routing hint, set by the agent as a tool arg, not typed into a
+ *     "secure credential" box;
  *   - `write_allowlist` / `side_effecting_operations` — REST write-governance
  *     (JSON allowlists); provisioning lands read-only by default and these are
  *     configured via the admin console, not typed into a "secure credential" box.
@@ -406,6 +409,7 @@ export interface ProvisionConfigField {
 const NON_CREDENTIAL_CONFIG_KEYS: ReadonlySet<string> = new Set([
   "description",
   "display_name",
+  "schema",
   "write_allowlist",
   "side_effecting_operations",
 ]);

--- a/packages/api/src/lib/datasources/provisionable-types.ts
+++ b/packages/api/src/lib/datasources/provisionable-types.ts
@@ -6,10 +6,13 @@
  * `mcp-lifecycle` graph (workspace-installer, semantic-generator, the Effect
  * startup layers) into server boot. `mcp-lifecycle.ts` re-exports these.
  *
- * Scoped to the native dbTypes the `ConnectionRegistry` builds a pool for
- * directly from a `url` — the only ones whose ephemeral health-check probe
- * genuinely tests connectivity AND whose tables the in-core profiler can
- * introspect. See #3547 for extending beyond these.
+ * `McpNativeDbType` is the set the `ConnectionRegistry` builds a pool for
+ * directly from a `url` — the only ones whose ephemeral health-check probe runs
+ * through `connections.register` → `healthCheck`. Plugin-managed SQL types
+ * (ClickHouse, Snowflake) are also provisionable via MCP (#3547), but through a
+ * different, plugin-aware pre-flight (`createFromConfig` → `SELECT 1` → close),
+ * gated by a RUNTIME capability check (`mcp-lifecycle.resolveProvisionCapability`)
+ * rather than this static set.
  */
 
 export type McpNativeDbType = "postgres" | "mysql";
@@ -20,5 +23,20 @@ export function isMcpNativeDbType(dbType: string): dbType is McpNativeDbType {
   return (MCP_NATIVE_DB_TYPES as ReadonlySet<string>).has(dbType);
 }
 
-/** Catalog slugs provisionable via MCP — derived from {@link McpNativeDbType}. */
-export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [...MCP_NATIVE_DB_TYPES];
+/**
+ * Catalog slugs offered by the MCP `create_datasource` `db_type` enum — the
+ * static "menu". Native pg/mysql are always provisionable. The plugin-managed
+ * SQL types (clickhouse / snowflake) are provisionable ONLY when a datasource
+ * plugin implementing `createFromConfig` is registered for that dbType — a
+ * RUNTIME capability check in `mcp-lifecycle.resolveProvisionCapability` gates
+ * that and returns an actionable `unsupported` envelope when the plugin is
+ * absent. Kept dependency-free (no registry / installer import) so the enum
+ * builds at tool-REGISTRATION time without dragging the heavy graph into MCP
+ * server boot. ES/OpenSearch + BigQuery (non-`url` credential shapes) join once
+ * their per-type masked elicitation lands; REST is tracked separately.
+ */
+export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [
+  ...MCP_NATIVE_DB_TYPES,
+  "clickhouse",
+  "snowflake",
+];

--- a/packages/api/src/lib/datasources/provisionable-types.ts
+++ b/packages/api/src/lib/datasources/provisionable-types.ts
@@ -32,11 +32,14 @@ export function isMcpNativeDbType(dbType: string): dbType is McpNativeDbType {
  * that and returns an actionable `unsupported` envelope when the plugin is
  * absent. Kept dependency-free (no registry / installer import) so the enum
  * builds at tool-REGISTRATION time without dragging the heavy graph into MCP
- * server boot. ES/OpenSearch + BigQuery (non-`url` credential shapes) join once
- * their per-type masked elicitation lands; REST is tracked separately.
+ * server boot. `elasticsearch` covers both Elasticsearch and OpenSearch (one
+ * catalog slug, engine selected via a config field). REST/OpenAPI provisioning
+ * is a separate install path (not `createFromConfig`) handled by its own tool.
  */
 export const MCP_PROVISIONABLE_CATALOG_SLUGS: readonly string[] = [
   ...MCP_NATIVE_DB_TYPES,
   "clickhouse",
   "snowflake",
+  "bigquery",
+  "elasticsearch",
 ];

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -418,3 +418,59 @@ describe("unregisterDatasourceInstall", () => {
     expect(unregisterCalls).toHaveLength(0);
   });
 });
+
+describe("probePluginDatasourceConnection (#3547)", () => {
+  it("returns no_plugin when no datasource plugin is registered for the dbType", async () => {
+    fakeDatasourcePlugins = [];
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://h/db" });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toBe("no_plugin");
+  });
+
+  it("probes a SQL-only adapter (no ping) via SELECT 1, then closes it", async () => {
+    const sqlCalls: string[] = [];
+    let closed = false;
+    const conn = {
+      query: async (sql: string) => { sqlCalls.push(sql); return { columns: [], rows: [] }; },
+      close: async () => { closed = true; },
+    };
+    fakeDatasourcePlugins = [{ types: ["datasource"], connection: { dbType: "clickhouse", createFromConfig: () => conn } }];
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://h/db" });
+    expect(out.ok).toBe(true);
+    expect(sqlCalls).toEqual(["SELECT 1"]);
+    expect(closed).toBe(true);
+  });
+
+  it("prefers the connection's ping() over SELECT 1 (ES/OpenSearch) and never runs SQL", async () => {
+    let pinged = false;
+    let queried = false;
+    let closed = false;
+    const conn = {
+      query: async () => { queried = true; return { columns: [], rows: [] }; },
+      ping: async () => { pinged = true; return { cluster_name: "es" }; },
+      close: async () => { closed = true; },
+    };
+    fakeDatasourcePlugins = [{ types: ["datasource"], connection: { dbType: "elasticsearch", createFromConfig: () => conn } }];
+    const out = await bridge.probePluginDatasourceConnection("elasticsearch", { url: "elasticsearch://h:9200", apiKey: "k" });
+    expect(out.ok).toBe(true);
+    expect(pinged).toBe(true);
+    expect(queried).toBe(false); // SQL surface (optional on OpenSearch) is NOT probed
+    expect(closed).toBe(true);
+  });
+
+  it("surfaces a failed probe as connect_failed (raw message; caller scrubs) and still closes", async () => {
+    let closed = false;
+    const conn = {
+      query: async () => { throw new Error("getaddrinfo ENOTFOUND warehouse"); },
+      close: async () => { closed = true; },
+    };
+    fakeDatasourcePlugins = [{ types: ["datasource"], connection: { dbType: "clickhouse", createFromConfig: () => conn } }];
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://h/db" });
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.reason).toBe("connect_failed");
+      expect(out.message).toContain("ENOTFOUND");
+    }
+    expect(closed).toBe(true);
+  });
+});

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -473,4 +473,53 @@ describe("probePluginDatasourceConnection (#3547)", () => {
     }
     expect(closed).toBe(true);
   });
+
+  it("bounds a hung createFromConfig under the deadline (createFromConfig has no timeout of its own)", async () => {
+    // An adapter whose createFromConfig eagerly opens a TCP connection to an
+    // unreachable host (no RST) would otherwise hang the MCP create call; the
+    // overall deadline must reject it as connect_failed, not stall.
+    fakeDatasourcePlugins = [
+      {
+        types: ["datasource"],
+        connection: {
+          dbType: "clickhouse",
+          // Never resolves — simulates a build that blocks on a dead host.
+          createFromConfig: () => new Promise(() => {}),
+        },
+      },
+    ];
+    const start = Date.now();
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://dead/db" }, 50);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.reason).toBe("connect_failed");
+      expect(out.message).toContain("exceeded");
+    }
+    // Returned promptly on the deadline rather than hanging.
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it("salvage-closes a connection whose build resolves AFTER the deadline (no pool leak)", async () => {
+    let closed = false;
+    // Build resolves late (after the deadline) — the probe must still close the
+    // orphaned connection rather than leaking it.
+    const conn = {
+      query: async () => ({ columns: [], rows: [] }),
+      close: async () => { closed = true; },
+    };
+    fakeDatasourcePlugins = [
+      {
+        types: ["datasource"],
+        connection: {
+          dbType: "clickhouse",
+          createFromConfig: () => new Promise((resolve) => setTimeout(() => resolve(conn), 60)),
+        },
+      },
+    ];
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://slow/db" }, 20);
+    expect(out.ok).toBe(false);
+    // Give the late build time to resolve + the salvage-close to run.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(closed).toBe(true);
+  });
 });

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -102,19 +102,34 @@ export type PluginProbeOutcome =
 const PLUGIN_PROBE_SQL = "SELECT 1";
 const PLUGIN_PROBE_TIMEOUT_MS = 10_000;
 
+/** A built plugin connection, plus the OPTIONAL liveness surface some adapters expose. */
+type ProbeableConnection = {
+  query(sql: string, timeoutMs?: number): Promise<unknown>;
+  close(): Promise<void>;
+  /**
+   * A non-SQL liveness round-trip (e.g. Elasticsearch/OpenSearch `ping()` → cluster
+   * info). Preferred over `SELECT 1` when present: the ES connection's `query()`
+   * routes to the cluster SQL API (`/_sql`, optional on OpenSearch), so probing it
+   * with `SELECT 1` would test the wrong surface — `ping()` is what the plugin's own
+   * health check uses.
+   */
+  ping?(timeoutMs?: number): Promise<unknown>;
+};
+
 /**
  * Plugin-aware ephemeral test-connect for a CANDIDATE plugin-managed datasource
  * (#3547). Builds a throwaway connection via the registered plugin's
- * `createFromConfig(decryptedConfig)`, runs a `SELECT 1` probe under a short
- * timeout, and ALWAYS closes it — registering nothing in the
- * `ConnectionRegistry` and persisting nothing. This is the plugin counterpart
- * to the native `connections.register(probeId) → healthCheck` pre-flight, so
- * the MCP `create_datasource` validate-before-persist path is uniform across
- * native and plugin dbTypes.
+ * `createFromConfig(decryptedConfig)`, runs a liveness probe under a short
+ * timeout — the connection's own `ping()` when it exposes one (ES/OpenSearch),
+ * else a `SELECT 1` (ClickHouse/Snowflake/BigQuery) — and ALWAYS closes it,
+ * registering nothing in the `ConnectionRegistry` and persisting nothing. The
+ * plugin counterpart to the native `connections.register(probeId) → healthCheck`
+ * pre-flight, so the MCP `create_datasource` validate-before-persist path is
+ * uniform across native and plugin dbTypes.
  *
  * `message` carries the RAW driver error (which may echo the credential) — the
  * caller (`mcp-lifecycle.provisionDatasource`) runs it through
- * `scrubSecretFromMessage` before it ever reaches a client/agent/log. Returning
+ * `scrubSecretsFromMessage` before it ever reaches a client/agent/log. Returning
  * the raw string keeps the secret-scrub seam in one place.
  */
 export async function probePluginDatasourceConnection(
@@ -132,10 +147,16 @@ export async function probePluginDatasourceConnection(
     };
   }
 
-  let built: { query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> } | undefined;
+  let built: ProbeableConnection | undefined;
   try {
-    built = await conn.createFromConfig(decryptedConfig);
-    await built.query(PLUGIN_PROBE_SQL, PLUGIN_PROBE_TIMEOUT_MS);
+    built = (await conn.createFromConfig(decryptedConfig)) as ProbeableConnection;
+    // Prefer the connection's native liveness check (ES/OpenSearch `ping`); fall
+    // back to `SELECT 1` for SQL-only adapters that expose no `ping`.
+    if (typeof built.ping === "function") {
+      await built.ping(PLUGIN_PROBE_TIMEOUT_MS);
+    } else {
+      await built.query(PLUGIN_PROBE_SQL, PLUGIN_PROBE_TIMEOUT_MS);
+    }
     return { ok: true };
   } catch (err) {
     return {

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -70,6 +70,93 @@ function getDatasourceConnection(plugin: unknown): DatasourceConnectionShape | u
 }
 
 /**
+ * Find the registered datasource plugin `connection` for a `dbType`, or
+ * `undefined` when none is registered. The single home for the
+ * `PluginRegistry.getAll()` → structural-shape → `dbType` match that both the
+ * boot/install registration ({@link registerPluginDatasourceInstall}) and the
+ * pre-flight probe ({@link probePluginDatasourceConnection}) consult — so
+ * "which plugin builds this type" lives in exactly one place (#3547).
+ *
+ * Uses `getAll()` (not `getByType`, which filters to `status==="healthy"`): the
+ * plugin is consulted purely as an ADAPTER via `createFromConfig`, independent
+ * of whether a static config-defined connection of its dbType is healthy. Lazy-
+ * imports the registry to keep it out of this module's static graph (several
+ * tests partial-mock this bridge's imports).
+ */
+export async function findDatasourcePluginConnection(
+  dbType: string,
+): Promise<DatasourceConnectionShape | undefined> {
+  const { plugins } = await import("@atlas/api/lib/plugins/registry");
+  return plugins
+    .getAll()
+    .map(getDatasourceConnection)
+    .find((c): c is DatasourceConnectionShape => c != null && c.dbType === dbType);
+}
+
+/** Outcome of {@link probePluginDatasourceConnection} — `message` is NOT scrubbed; the caller scrubs. */
+export type PluginProbeOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: "no_plugin" | "connect_failed"; readonly message: string };
+
+/** Probe query + timeout — a trivial connectivity check that every SQL-shaped plugin pool answers. */
+const PLUGIN_PROBE_SQL = "SELECT 1";
+const PLUGIN_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Plugin-aware ephemeral test-connect for a CANDIDATE plugin-managed datasource
+ * (#3547). Builds a throwaway connection via the registered plugin's
+ * `createFromConfig(decryptedConfig)`, runs a `SELECT 1` probe under a short
+ * timeout, and ALWAYS closes it — registering nothing in the
+ * `ConnectionRegistry` and persisting nothing. This is the plugin counterpart
+ * to the native `connections.register(probeId) → healthCheck` pre-flight, so
+ * the MCP `create_datasource` validate-before-persist path is uniform across
+ * native and plugin dbTypes.
+ *
+ * `message` carries the RAW driver error (which may echo the credential) — the
+ * caller (`mcp-lifecycle.provisionDatasource`) runs it through
+ * `scrubSecretFromMessage` before it ever reaches a client/agent/log. Returning
+ * the raw string keeps the secret-scrub seam in one place.
+ */
+export async function probePluginDatasourceConnection(
+  dbType: string,
+  decryptedConfig: Readonly<Record<string, unknown>>,
+): Promise<PluginProbeOutcome> {
+  const conn = await findDatasourcePluginConnection(dbType);
+  if (!conn || typeof conn.createFromConfig !== "function") {
+    return {
+      ok: false,
+      reason: "no_plugin",
+      message:
+        `No datasource plugin registered for type "${dbType}". Add the corresponding ` +
+        `plugin (e.g. clickhousePlugin()) to the plugins array in atlas.config.ts.`,
+    };
+  }
+
+  let built: { query(sql: string, timeoutMs?: number): Promise<unknown>; close(): Promise<void> } | undefined;
+  try {
+    built = await conn.createFromConfig(decryptedConfig);
+    await built.query(PLUGIN_PROBE_SQL, PLUGIN_PROBE_TIMEOUT_MS);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "connect_failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (built) {
+      try {
+        await built.close();
+      } catch {
+        // intentionally ignored: best-effort teardown of a throwaway probe
+        // connection — a close failure must not mask the probe result, and this
+        // module stays logger-free (callers own breadcrumbs).
+      }
+    }
+  }
+}
+
+/**
  * Datasource dbTypes whose per-workspace connections are NOT built by this
  * bridge from `workspace_plugins.config`. Salesforce is the sole member:
  *
@@ -129,16 +216,9 @@ async function registerPluginDatasourceInstall(
   poolConfig: DatasourcePoolConfig,
   decryptedConfig: Readonly<Record<string, unknown>>,
 ): Promise<boolean> {
-  // Lazy import keeps the plugin registry out of this module's static import
-  // graph — several tests partial-mock this bridge's imports.
-  const { plugins } = await import("@atlas/api/lib/plugins/registry");
-  // Use getAll() (not getByType, which filters to status==="healthy"): the
-  // plugin is consulted purely as an ADAPTER via createFromConfig, independent
-  // of whether a static config-defined connection of its dbType is healthy.
-  const conn = plugins
-    .getAll()
-    .map(getDatasourceConnection)
-    .find((c): c is DatasourceConnectionShape => c != null && c.dbType === poolConfig.dbType);
+  // Shared registry lookup — the same seam the pre-flight probe consults so
+  // "which plugin builds this type" lives in one place (#3547).
+  const conn = await findDatasourcePluginConnection(poolConfig.dbType);
 
   if (!conn || typeof conn.createFromConfig !== "function") {
     throw new Error(

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -135,6 +135,7 @@ type ProbeableConnection = {
 export async function probePluginDatasourceConnection(
   dbType: string,
   decryptedConfig: Readonly<Record<string, unknown>>,
+  timeoutMs: number = PLUGIN_PROBE_TIMEOUT_MS,
 ): Promise<PluginProbeOutcome> {
   const conn = await findDatasourcePluginConnection(dbType);
   if (!conn || typeof conn.createFromConfig !== "function") {
@@ -147,25 +148,50 @@ export async function probePluginDatasourceConnection(
     };
   }
 
+  // Capture the narrowed factory before the nested closure below — TS resets the
+  // `typeof conn.createFromConfig === "function"` narrowing inside the async IIFE.
+  const createFromConfig = conn.createFromConfig;
   let built: ProbeableConnection | undefined;
-  try {
-    built = (await conn.createFromConfig(decryptedConfig)) as ProbeableConnection;
+  let timedOut = false;
+  // The WHOLE build+probe runs under one deadline. `createFromConfig` has no
+  // timeout of its own, and the `query`/`ping` timeoutMs is only honored if the
+  // adapter chooses to — so an adapter that eagerly connects on build, or
+  // ignores its own probe timeout, must not hang the MCP `create_datasource`
+  // call against an unreachable host. On a deadline breach we salvage-close any
+  // connection the build later yields (below) so a slow-but-eventual resolve
+  // can't leak a pool.
+  const probeRun = (async () => {
+    built = (await createFromConfig(decryptedConfig)) as ProbeableConnection;
     // Prefer the connection's native liveness check (ES/OpenSearch `ping`); fall
     // back to `SELECT 1` for SQL-only adapters that expose no `ping`.
     if (typeof built.ping === "function") {
-      await built.ping(PLUGIN_PROBE_TIMEOUT_MS);
+      await built.ping(timeoutMs);
     } else {
-      await built.query(PLUGIN_PROBE_SQL, PLUGIN_PROBE_TIMEOUT_MS);
+      await built.query(PLUGIN_PROBE_SQL, timeoutMs);
     }
+  })();
+  void probeRun.catch(() => {}).finally(() => {
+    if (timedOut && built) void built.close().catch(() => {});
+  });
+  try {
+    await withProbeTimeout(probeRun, timeoutMs, () => {
+      timedOut = true;
+    });
     return { ok: true };
   } catch (err) {
     return {
       ok: false,
       reason: "connect_failed",
-      message: err instanceof Error ? err.message : String(err),
+      message: timedOut
+        ? `Connection probe exceeded ${timeoutMs}ms — the datasource may be unreachable.`
+        : err instanceof Error
+          ? err.message
+          : String(err),
     };
   } finally {
-    if (built) {
+    // The timed-out path's salvage-close (above) owns teardown of a late build;
+    // here we close only the connection we actually awaited in-deadline.
+    if (!timedOut && built) {
       try {
         await built.close();
       } catch {
@@ -175,6 +201,30 @@ export async function probePluginDatasourceConnection(
       }
     }
   }
+}
+
+/**
+ * Reject `p` if it has not settled within `ms`, invoking `onTimeout` so the
+ * caller can flag the breach + salvage-close a late-resolving connection. Clears
+ * its timer on settle so a resolved probe never keeps the event loop alive.
+ */
+function withProbeTimeout(p: Promise<void>, ms: number, onTimeout: () => void): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      onTimeout();
+      reject(new Error(`probe timed out after ${ms}ms`));
+    }, ms);
+    p.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
 }
 
 /**

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -698,6 +698,19 @@ describe("create_datasource", () => {
     expect(input.secretKeys).toEqual(["apiKey"]);
   });
 
+  it("merges the optional non-secret schema (search_path) tool arg into config — not into the masked prompt", async () => {
+    const client = await createTestClient();
+    await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg", schema: "analytics" },
+    });
+    // `schema` is an agent-set arg, NOT an elicited credential field.
+    expect(elicitCalls[0].fields.map((f) => f.name)).toEqual(["url"]);
+    const input = mockProvision.mock.calls[0]?.[1] as { config: Record<string, string> };
+    expect(input.config.schema).toBe("analytics");
+    expect(input.config.url).toBe(ELICITED_SECRET);
+  });
+
   it("an unsupported (no-plugin) type is rejected BEFORE elicitation", async () => {
     provisionCapability = { kind: "unsupported", dbType: "clickhouse", message: "no clickhouse plugin installed" };
     const client = await createTestClient();

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -735,6 +735,22 @@ describe("create_datasource", () => {
     expect(mockProvision).not.toHaveBeenCalled();
   });
 
+  it("a non-compliant client that accepts with a required field blank → validation_failed, nothing provisioned", async () => {
+    // elicitMaskedForm drops empty values, so a blank required `url` arrives as
+    // an accept with no `url` key — the tool must reject before pre-flight.
+    elicitOutcome = { action: "accept", values: {} };
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+    expect(res.isError).toBe(true);
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    expect(err?.code).toBe("validation_failed");
+    expect(err?.message).toContain("Connection URL"); // the required field's label
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
   it("an elicitation failure (unsupported client) → validation_failed, no leak", async () => {
     elicitThrows = true;
     const client = await createTestClient();

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -829,6 +829,22 @@ describe("create_rest_datasource", () => {
     expect(getContentText(res.content)).not.toContain("sk-secret");
   });
 
+  it("merges the optional display_name tool arg (non-secret) into the install config", async () => {
+    provisionConfigFields = REST_FIELDS;
+    elicitOutcome = {
+      action: "accept",
+      values: { openapi_url: "https://api.example.com/openapi.json", auth_kind: "none" },
+    };
+    const client = await createTestClient();
+    await client.callTool({
+      name: "create_rest_datasource",
+      arguments: { display_name: "My CRM API" },
+    });
+    const formData = mockProvisionRest.mock.calls[0]?.[1] as Record<string, string>;
+    expect(formData.display_name).toBe("My CRM API");
+    expect(formData.openapi_url).toBe("https://api.example.com/openapi.json");
+  });
+
   it("a spec-probe / validation failure → validation_failed, nothing installed (scrubbed by lib)", async () => {
     provisionConfigFields = REST_FIELDS;
     provisionRestOutcome = { kind: "validation", message: "openapi_url: spec could not be fetched" };

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -125,6 +125,10 @@ let provisionConfigFields: unknown = {
 };
 const mockLoadConfigFields = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionConfigFields);
 
+// REST/OpenAPI provisioning (#3547) — the openapi-generic form-install seam.
+let provisionRestOutcome: unknown = { kind: "ok", installId: "rest-abc123" };
+const mockProvisionRest = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionRestOutcome);
+
 let profileTarget: unknown = {
   kind: "ok",
   target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public" },
@@ -169,6 +173,7 @@ mock.module("@atlas/api/lib/datasources/mcp-lifecycle", () => ({
   isDatasourceRegistered: mockIsRegistered,
   runDatasourceInstaller: mockRunInstaller,
   provisionDatasource: mockProvision,
+  provisionRestDatasource: mockProvisionRest,
   resolveProvisionCapability: mockResolveCapability,
   loadProvisionConfigFields: mockLoadConfigFields,
   loadDatasourceProfileTarget: mockLoadProfileTarget,
@@ -260,6 +265,7 @@ beforeEach(() => {
   mockRunInstaller.mockClear();
   mockRunGate.mockClear();
   mockProvision.mockClear();
+  mockProvisionRest.mockClear();
   mockResolveCapability.mockClear();
   mockLoadConfigFields.mockClear();
   mockLoadProfileTarget.mockClear();
@@ -309,12 +315,13 @@ beforeEach(() => {
     ],
     secretKeys: ["url"],
   };
+  provisionRestOutcome = { kind: "ok", installId: "rest-abc123" };
 });
 
 // ── Tool registration ─────────────────────────────────────────────────
 
 describe("datasource tools — registration", () => {
-  it("registers all seven lifecycle tools", async () => {
+  it("registers all eight lifecycle tools", async () => {
     const client = await createTestClient();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
@@ -322,6 +329,7 @@ describe("datasource tools — registration", () => {
       [
         "archive_datasource",
         "create_datasource",
+        "create_rest_datasource",
         "delete_datasource",
         "list_datasources",
         "profile_datasource",
@@ -762,6 +770,65 @@ describe("create_datasource", () => {
     expect(res.isError).toBe(true);
     expect(mockElicit).not.toHaveBeenCalled();
     expect(mockProvision).not.toHaveBeenCalled();
+  });
+});
+
+// ── create_rest_datasource (#3547) — OpenAPI spec + auth via masked form ──
+
+describe("create_rest_datasource", () => {
+  // The openapi-generic config_schema: spec URL + auth_kind + secret auth_value.
+  const REST_FIELDS = {
+    kind: "ok",
+    fields: [
+      { key: "openapi_url", label: "OpenAPI spec URL", required: true, secret: false },
+      { key: "auth_kind", label: "Authentication", required: true, secret: false },
+      { key: "auth_value", label: "Credential", required: false, secret: true },
+    ],
+    secretKeys: ["auth_value"],
+  };
+
+  it("collects the spec URL + auth as a masked form, then installs via the openapi seam", async () => {
+    provisionConfigFields = REST_FIELDS;
+    elicitOutcome = {
+      action: "accept",
+      values: { openapi_url: "https://api.example.com/openapi.json", auth_kind: "bearer", auth_value: "sk-secret" },
+    };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "create_rest_datasource", arguments: {} });
+
+    // Masked form carried the schema's fields, with auth_value marked secret.
+    expect(elicitCalls).toHaveLength(1);
+    expect(elicitCalls[0].fields.map((f) => f.name)).toEqual(["openapi_url", "auth_kind", "auth_value"]);
+    expect(elicitCalls[0].fields[2].secret).toBe(true);
+    // The lib seam received the formData + secretKeys.
+    const args = mockProvisionRest.mock.calls[0];
+    expect(args?.[1]).toEqual({ openapi_url: "https://api.example.com/openapi.json", auth_kind: "bearer", auth_value: "sk-secret" });
+    expect(args?.[2]).toEqual(["auth_value"]);
+
+    const body = JSON.parse(getContentText(res.content));
+    expect(body.created).toBe(true);
+    expect(body.kind).toBe("rest");
+    expect(body.id).toBe("rest-abc123");
+    // The credential never appears in the response.
+    expect(getContentText(res.content)).not.toContain("sk-secret");
+  });
+
+  it("a spec-probe / validation failure → validation_failed, nothing installed (scrubbed by lib)", async () => {
+    provisionConfigFields = REST_FIELDS;
+    provisionRestOutcome = { kind: "validation", message: "openapi_url: spec could not be fetched" };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "create_rest_datasource", arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+  });
+
+  it("a declined elicitation → validation_failed, nothing installed", async () => {
+    provisionConfigFields = REST_FIELDS;
+    elicitOutcome = { action: "decline" };
+    const client = await createTestClient();
+    const res = await client.callTool({ name: "create_rest_datasource", arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(mockProvisionRest).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -112,6 +112,19 @@ let provisionOutcome: unknown = {
 };
 const mockProvision = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionOutcome);
 
+// Capability + config-field resolution (#3547). Defaults: provisionable native
+// postgres with a single secret `url` field — the existing happy path.
+let provisionCapability: unknown = { kind: "native", dbType: "postgres" };
+const mockResolveCapability = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionCapability);
+let provisionConfigFields: unknown = {
+  kind: "ok",
+  fields: [
+    { key: "url", label: "Connection URL", description: "postgres://…", required: true, secret: true },
+  ],
+  secretKeys: ["url"],
+};
+const mockLoadConfigFields = mock<(...a: unknown[]) => Promise<unknown>>(async () => provisionConfigFields);
+
 let profileTarget: unknown = {
   kind: "ok",
   target: { url: "postgres://user:pass@host/db", dbType: "postgres", schema: "public" },
@@ -156,31 +169,34 @@ mock.module("@atlas/api/lib/datasources/mcp-lifecycle", () => ({
   isDatasourceRegistered: mockIsRegistered,
   runDatasourceInstaller: mockRunInstaller,
   provisionDatasource: mockProvision,
+  resolveProvisionCapability: mockResolveCapability,
+  loadProvisionConfigFields: mockLoadConfigFields,
   loadDatasourceProfileTarget: mockLoadProfileTarget,
   runSemanticProfile: mockRunProfile,
   MCP_PROVISIONABLE_CATALOG_SLUGS: ["postgres", "mysql"],
 }));
 
-// Masked elicitation (#3499) — capture the call + return a configurable
-// outcome. The default accepts with a sentinel secret we assert NEVER leaks.
+// Masked multi-field elicitation (#3499 / #3547) — capture the call + return a
+// configurable outcome. The default accepts with a sentinel secret we assert
+// NEVER leaks, keyed by the `url` field the default config-field set declares.
 const ELICITED_SECRET = "postgres://super:secret@db.internal:5432/prod";
-let elicitOutcome: { action: "accept"; value: string } | { action: "decline" | "cancel" } = {
+let elicitOutcome: { action: "accept"; values: Record<string, string> } | { action: "decline" | "cancel" } = {
   action: "accept",
-  value: ELICITED_SECRET,
+  values: { url: ELICITED_SECRET },
 };
 let elicitThrows = false;
-interface ElicitCall {
+interface ElicitFormCall {
   principal: string;
-  field: { name?: string; title: string };
+  fields: Array<{ name: string; title: string; required?: boolean; secret?: boolean }>;
 }
-let elicitCalls: ElicitCall[] = [];
-const mockElicit = mock(async (_server: unknown, args: ElicitCall & { message: string }) => {
-  elicitCalls.push({ principal: args.principal, field: args.field });
+let elicitCalls: ElicitFormCall[] = [];
+const mockElicit = mock(async (_server: unknown, args: ElicitFormCall & { message: string }) => {
+  elicitCalls.push({ principal: args.principal, fields: args.fields });
   if (elicitThrows) throw new Error("client does not support elicitation");
   return elicitOutcome;
 });
 mock.module("../elicitation.js", () => ({
-  elicitMaskedField: mockElicit,
+  elicitMaskedForm: mockElicit,
 }));
 
 // ── Dispatch-gate mock ────────────────────────────────────────────────
@@ -244,6 +260,8 @@ beforeEach(() => {
   mockRunInstaller.mockClear();
   mockRunGate.mockClear();
   mockProvision.mockClear();
+  mockResolveCapability.mockClear();
+  mockLoadConfigFields.mockClear();
   mockLoadProfileTarget.mockClear();
   mockRunProfile.mockClear();
   mockElicit.mockClear();
@@ -281,8 +299,16 @@ beforeEach(() => {
     },
     persisted: { entities: 2, metrics: 1 },
   };
-  elicitOutcome = { action: "accept", value: ELICITED_SECRET };
+  elicitOutcome = { action: "accept", values: { url: ELICITED_SECRET } };
   elicitThrows = false;
+  provisionCapability = { kind: "native", dbType: "postgres" };
+  provisionConfigFields = {
+    kind: "ok",
+    fields: [
+      { key: "url", label: "Connection URL", description: "postgres://…", required: true, secret: true },
+    ],
+    secretKeys: ["url"],
+  };
 });
 
 // ── Tool registration ─────────────────────────────────────────────────
@@ -617,23 +643,63 @@ describe("delete_datasource", () => {
 // ── create_datasource (#3511) — masked-elicitation credential ─────────
 
 describe("create_datasource", () => {
-  it("collects the URL via masked elicitation bound to the workspace, then provisions", async () => {
+  it("collects config via the schema-driven masked form, then provisions", async () => {
     const client = await createTestClient();
     const res = await client.callTool({
       name: "create_datasource",
       arguments: { db_type: "postgres", install_id: "new-pg" },
     });
-    // Elicitation was called, bound to the org, for a field named `url`.
+    // Elicitation was a masked FORM bound to the org, carrying the catalog's
+    // `url` field (marked required + secret).
     expect(elicitCalls).toHaveLength(1);
     expect(elicitCalls[0].principal).toBe("org_ds");
-    expect(elicitCalls[0].field.name).toBe("url");
-    // The secret reached provisionDatasource (the lib), in `url`.
+    expect(elicitCalls[0].fields.map((f) => f.name)).toEqual(["url"]);
+    expect(elicitCalls[0].fields[0].secret).toBe(true);
+    // The secret reached provisionDatasource (the lib) inside `config`, with
+    // `secretKeys` driving the scrub.
     const provisionArgs = mockProvision.mock.calls[0];
-    expect((provisionArgs?.[1] as { url: string }).url).toBe(ELICITED_SECRET);
+    const input = provisionArgs?.[1] as { config: Record<string, string>; secretKeys: string[] };
+    expect(input.config.url).toBe(ELICITED_SECRET);
+    expect(input.secretKeys).toEqual(["url"]);
 
     const body = JSON.parse(getContentText(res.content));
     expect(body.created).toBe(true);
     expect(body.status).toBe("draft");
+  });
+
+  it("collects multi-field credentials (e.g. Elasticsearch apiKey) as one masked form", async () => {
+    // ES: non-secret url + secret apiKey — the config_schema drives the form.
+    provisionConfigFields = {
+      kind: "ok",
+      fields: [
+        { key: "url", label: "Connection URL", required: true, secret: false },
+        { key: "apiKey", label: "API Key", required: false, secret: true },
+      ],
+      secretKeys: ["apiKey"],
+    };
+    provisionCapability = { kind: "plugin", dbType: "elasticsearch" };
+    elicitOutcome = { action: "accept", values: { url: "elasticsearch://h:9200", apiKey: "BASE64KEY==" } };
+    const client = await createTestClient();
+    await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "elasticsearch", install_id: "logs" },
+    });
+    expect(elicitCalls[0].fields.map((f) => f.name)).toEqual(["url", "apiKey"]);
+    const input = mockProvision.mock.calls[0]?.[1] as { config: Record<string, string>; secretKeys: string[] };
+    expect(input.config).toEqual({ url: "elasticsearch://h:9200", apiKey: "BASE64KEY==" });
+    expect(input.secretKeys).toEqual(["apiKey"]);
+  });
+
+  it("an unsupported (no-plugin) type is rejected BEFORE elicitation", async () => {
+    provisionCapability = { kind: "unsupported", dbType: "clickhouse", message: "no clickhouse plugin installed" };
+    const client = await createTestClient();
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "x" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
+    expect(mockElicit).not.toHaveBeenCalled();
+    expect(mockProvision).not.toHaveBeenCalled();
   });
 
   it("NEVER leaks the elicited credential into the tool response", async () => {
@@ -683,14 +749,15 @@ describe("create_datasource", () => {
     expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("validation_failed");
   });
 
-  it("an unsupported db_type is rejected at the inputSchema boundary", async () => {
-    // `db_type` is a Zod enum of provisionable slugs — an out-of-enum value
-    // is rejected by the SDK's input validation (error result), so it never
-    // reaches the handler / elicitation.
+  it("a non-provisionable db_type is rejected at the inputSchema boundary", async () => {
+    // `db_type` is a Zod enum of provisionable slugs (the real
+    // MCP_PROVISIONABLE_CATALOG_SLUGS the tool imports directly). `duckdb` is a
+    // real datasource slug but NOT MCP-provisionable, so it's an out-of-enum
+    // value rejected by the SDK's input validation — never reaching the handler.
     const client = await createTestClient();
     const res = await client.callTool({
       name: "create_datasource",
-      arguments: { db_type: "snowflake", install_id: "x" },
+      arguments: { db_type: "duckdb", install_id: "x" },
     });
     expect(res.isError).toBe(true);
     expect(mockElicit).not.toHaveBeenCalled();

--- a/packages/mcp/src/__tests__/elicitation.test.ts
+++ b/packages/mcp/src/__tests__/elicitation.test.ts
@@ -19,6 +19,7 @@ import {
   signRequestState,
   verifyRequestState,
   elicitMaskedField,
+  elicitMaskedForm,
   NonceStore,
   ElicitationError,
   DEFAULT_REQUEST_STATE_TTL_MS,
@@ -180,5 +181,76 @@ describe("elicitMaskedField round-trip", () => {
     });
     await client.callTool({ name: "needsSecret", arguments: {} });
     expect(captured.error).toBe("empty_value");
+  });
+});
+
+async function wireFormElicitation(reply: {
+  action: "accept" | "decline" | "cancel";
+  content?: Record<string, string>;
+}) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  const captured: { values?: Record<string, string>; outcome?: string } = {};
+
+  server.registerTool(
+    "needsForm",
+    { description: "Elicits a multi-field credential form", inputSchema: {} },
+    async (): Promise<CallToolResult> => {
+      const outcome = await elicitMaskedForm(server, {
+        principal: PRINCIPAL,
+        message: "Enter the connection details",
+        fields: [
+          { name: "url", title: "URL", required: true },
+          { name: "apiKey", title: "API key", required: false, secret: true },
+        ],
+        secret: SECRET,
+        nonceStore: new NonceStore(),
+      });
+      captured.outcome = outcome.action;
+      if (outcome.action === "accept") captured.values = outcome.values;
+      // The values must NEVER re-enter the agent/LLM context.
+      return { content: [{ type: "text", text: `done:${outcome.action}` }] };
+    },
+  );
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.1" },
+    { capabilities: { elicitation: {} } },
+  );
+  client.setRequestHandler(ElicitRequestSchema, async () => reply);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, captured };
+}
+
+describe("elicitMaskedForm round-trip", () => {
+  it("delivers every entered field to the server without any entering the tool result", async () => {
+    const { client, captured } = await wireFormElicitation({
+      action: "accept",
+      content: { url: "elasticsearch://h:9200", apiKey: "BASE64KEY==" },
+    });
+    const result = await client.callTool({ name: "needsForm", arguments: {} });
+    expect(captured.outcome).toBe("accept");
+    expect(captured.values).toEqual({ url: "elasticsearch://h:9200", apiKey: "BASE64KEY==" });
+    // No secret in the agent-visible result.
+    expect(JSON.stringify(result.content)).not.toContain("BASE64KEY");
+  });
+
+  it("omits empty/unprovided optional fields rather than persisting an empty value", async () => {
+    const { captured, client } = await wireFormElicitation({
+      action: "accept",
+      content: { url: "elasticsearch://h:9200", apiKey: "" },
+    });
+    await client.callTool({ name: "needsForm", arguments: {} });
+    expect(captured.values).toEqual({ url: "elasticsearch://h:9200" });
+    expect(captured.values).not.toHaveProperty("apiKey");
+  });
+
+  it("surfaces a decline with no values", async () => {
+    const { captured, client } = await wireFormElicitation({ action: "decline" });
+    await client.callTool({ name: "needsForm", arguments: {} });
+    expect(captured.outcome).toBe("decline");
+    expect(captured.values).toBeUndefined();
   });
 });

--- a/packages/mcp/src/__tests__/elicitation.test.ts
+++ b/packages/mcp/src/__tests__/elicitation.test.ts
@@ -247,6 +247,28 @@ describe("elicitMaskedForm round-trip", () => {
     expect(captured.values).not.toHaveProperty("apiKey");
   });
 
+  it("drops a whitespace-only field rather than persisting it as a present-but-blank value", async () => {
+    // A non-compliant client could `accept` with a required field set to only
+    // whitespace; that must be dropped (so the caller's presence check rejects
+    // it) instead of flowing into the config as a blank credential.
+    const { captured, client } = await wireFormElicitation({
+      action: "accept",
+      content: { url: "   ", apiKey: "BASE64KEY==" },
+    });
+    await client.callTool({ name: "needsForm", arguments: {} });
+    expect(captured.values).toEqual({ apiKey: "BASE64KEY==" });
+    expect(captured.values).not.toHaveProperty("url");
+  });
+
+  it("preserves a value with significant internal whitespace (only the emptiness test trims)", async () => {
+    const { captured, client } = await wireFormElicitation({
+      action: "accept",
+      content: { url: "elasticsearch://h:9200", apiKey: "key with spaces" },
+    });
+    await client.callTool({ name: "needsForm", arguments: {} });
+    expect(captured.values).toEqual({ url: "elasticsearch://h:9200", apiKey: "key with spaces" });
+  });
+
   it("surfaces a decline with no values", async () => {
     const { captured, client } = await wireFormElicitation({ action: "decline" });
     await client.callTool({ name: "needsForm", arguments: {} });

--- a/packages/mcp/src/__tests__/elicitation.test.ts
+++ b/packages/mcp/src/__tests__/elicitation.test.ts
@@ -276,3 +276,75 @@ describe("elicitMaskedForm round-trip", () => {
     expect(captured.values).toBeUndefined();
   });
 });
+
+// A select field (e.g. openapi `auth_kind`) must render as an enum with its
+// default, and a defaulted field returned empty must fall back to the default.
+async function wireSelectForm(reply: {
+  action: "accept" | "decline" | "cancel";
+  content?: Record<string, string>;
+}) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  const captured: { values?: Record<string, string>; requestedSchema?: unknown } = {};
+
+  server.registerTool(
+    "needsSelect",
+    { description: "Elicits a form with a select field", inputSchema: {} },
+    async (): Promise<CallToolResult> => {
+      const outcome = await elicitMaskedForm(server, {
+        principal: PRINCIPAL,
+        message: "Enter the connection details",
+        fields: [
+          { name: "auth_kind", title: "Authentication", required: true, options: ["bearer", "basic", "apikey"], default: "bearer" },
+          { name: "engine", title: "Engine", required: false, options: ["elasticsearch", "opensearch"], default: "elasticsearch" },
+          { name: "auth_value", title: "Credential", required: true, secret: true },
+        ],
+        secret: SECRET,
+        nonceStore: new NonceStore(),
+      });
+      if (outcome.action === "accept") captured.values = outcome.values;
+      return { content: [{ type: "text", text: `done:${outcome.action}` }] };
+    },
+  );
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.1" },
+    { capabilities: { elicitation: {} } },
+  );
+  client.setRequestHandler(ElicitRequestSchema, async (req) => {
+    captured.requestedSchema = (req.params as { requestedSchema?: unknown }).requestedSchema;
+    return reply;
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, captured };
+}
+
+describe("elicitMaskedForm select fields", () => {
+  it("renders a select field as an enum with its default in the requested schema", async () => {
+    const { client, captured } = await wireSelectForm({
+      action: "accept",
+      content: { auth_kind: "bearer", engine: "elasticsearch", auth_value: "tok" },
+    });
+    await client.callTool({ name: "needsSelect", arguments: {} });
+    const schema = captured.requestedSchema as {
+      properties: Record<string, { type: string; enum?: string[]; default?: string }>;
+    };
+    expect(schema.properties.auth_kind.enum).toEqual(["bearer", "basic", "apikey"]);
+    expect(schema.properties.auth_kind.default).toBe("bearer");
+    // A plain secret field carries no enum/default.
+    expect(schema.properties.auth_value.enum).toBeUndefined();
+  });
+
+  it("injects the catalog default when the client omits an optional defaulted field", async () => {
+    const { client, captured } = await wireSelectForm({
+      action: "accept",
+      // The client collected auth but left the optional `engine` unset.
+      content: { auth_kind: "bearer", auth_value: "tok" },
+    });
+    await client.callTool({ name: "needsSelect", arguments: {} });
+    // `engine` was omitted but its catalog default lands → zero-effort.
+    expect(captured.values).toEqual({ auth_kind: "bearer", engine: "elasticsearch", auth_value: "tok" });
+  });
+});

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -73,6 +73,7 @@ describe("MCP server integration", () => {
     expect(names).toEqual([
       "archive_datasource",
       "create_datasource",
+      "create_rest_datasource",
       "delete_datasource",
       "describeEntity",
       "executeSQL",

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -123,6 +123,7 @@ describe("MCP smoke — tool listing", () => {
     expect(names).toEqual([
       "archive_datasource",
       "create_datasource",
+      "create_rest_datasource",
       "delete_datasource",
       "describeEntity",
       "executeSQL",
@@ -222,10 +223,10 @@ describe("MCP smoke — server lifecycle", () => {
     await client.connect(clientTransport);
 
     // Verify the server is operational — explore + executeSQL + the four
-    // typed semantic tools (#2020) + the seven datasource lifecycle tools
-    // (#3511–#3514) = 13.
+    // typed semantic tools (#2020) + the eight datasource lifecycle tools
+    // (#3511–#3514, #3547) = 14.
     const tools = await client.listTools();
-    expect(tools.tools.length).toBe(13);
+    expect(tools.tools.length).toBe(14);
 
     // Clean shutdown — should not throw
     await client.close();

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -167,6 +167,7 @@ describe("SSE server — MCP client integration", () => {
     expect(names).toEqual([
       "archive_datasource",
       "create_datasource",
+      "create_rest_datasource",
       "delete_datasource",
       "describeEntity",
       "executeSQL",
@@ -270,12 +271,12 @@ describe("SSE server — MCP client integration", () => {
     await client2.connect(transport2);
 
     // Both clients can list tools independently — explore + executeSQL +
-    // the four typed semantic tools (#2020) + the seven datasource lifecycle
-    // tools (#3511–#3514) = 13.
+    // the four typed semantic tools (#2020) + the eight datasource lifecycle
+    // tools (#3511–#3514, #3547) = 14.
     const result1 = await client1.listTools();
     const result2 = await client2.listTools();
-    expect(result1.tools.length).toBe(13);
-    expect(result2.tools.length).toBe(13);
+    expect(result1.tools.length).toBe(14);
+    expect(result2.tools.length).toBe(14);
 
     // Health shows 2+ sessions
     const res = await fetch(`http://localhost:${handle.server.port}/health`);

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -681,6 +681,13 @@ export function registerDatasourceTools(
           .max(MAX_FILTER_LEN)
           .optional()
           .describe("Optional human-readable description (shown in the agent system prompt)."),
+        schema: z
+          .string()
+          .max(MAX_ID_LEN)
+          .optional()
+          .describe(
+            "Optional schema / search_path for SQL datasources (postgres/mysql/clickhouse). Non-secret routing hint — set here, not in the secure prompt.",
+          ),
         group_id: z
           .string()
           .max(MAX_ID_LEN)
@@ -688,7 +695,7 @@ export function registerDatasourceTools(
           .describe("Optional environment-group binding."),
       },
     },
-    async ({ db_type, install_id, description, group_id }, extra): Promise<CallToolResult> =>
+    async ({ db_type, install_id, description, schema, group_id }, extra): Promise<CallToolResult> =>
       dispatch(
         "create_datasource",
         // Gate 1 (#3509) datasource kill-switch + mcp:write + admin. NOT
@@ -738,11 +745,14 @@ export function registerDatasourceTools(
 
           // `config` holds the secret + non-secret connection fields — used only
           // for the pre-flight probe + the installer's encrypt-at-rest path,
-          // NEVER logged or returned. `description` is an agent-set label, merged
-          // in here. `secretKeys` drives the lib's error-scrub.
+          // NEVER logged or returned. `description` (label) and `schema`
+          // (search_path) are non-secret agent-set fields — they're tool args,
+          // NOT elicited in the secure prompt — merged in here. `secretKeys`
+          // drives the lib's error-scrub.
           const config: Record<string, unknown> = {
             ...collected.values,
             ...(description !== undefined ? { description } : {}),
+            ...(schema !== undefined ? { schema } : {}),
           };
 
           const outcome = await lib.provisionDatasource(orgId, {

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -793,9 +793,15 @@ export function registerDatasourceTools(
       title: "Create REST (OpenAPI) Datasource",
       description: withErrorContract(CREATE_REST_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-      inputSchema: {},
+      inputSchema: {
+        display_name: z
+          .string()
+          .max(MAX_FILTER_LEN)
+          .optional()
+          .describe("Optional friendly name shown in the connections UI (non-secret; set by you, not collected in the secure prompt)."),
+      },
     },
-    async (_args, extra): Promise<CallToolResult> =>
+    async ({ display_name }, extra): Promise<CallToolResult> =>
       dispatch(
         "create_rest_datasource",
         // Gate 1 kill-switch + mcp:write + admin. NOT approval-gated — additive,
@@ -808,7 +814,9 @@ export function registerDatasourceTools(
           const lib = await lifecycle();
 
           // The openapi-generic config_schema (spec URL + auth_kind + auth_value
-          // + …) drives the masked form, exactly like the SQL types.
+          // + …) drives the masked form, exactly like the SQL types. Non-credential
+          // fields (display_name, write_allowlist, …) are excluded from the secure
+          // prompt by loadProvisionConfigFields; display_name comes from the arg.
           const fieldsResult = await lib.loadProvisionConfigFields(REST_CATALOG_SLUG);
           if (fieldsResult.kind !== "ok") {
             return toEnvelopeResult(
@@ -833,10 +841,11 @@ export function registerDatasourceTools(
 
           // The handler probes the spec on install (no separate pre-flight): a
           // bad URL / auth / unreachable spec comes back as `validation`,
-          // secret-scrubbed, with nothing persisted.
+          // secret-scrubbed, with nothing persisted. `display_name` is the
+          // agent-set label (non-secret), merged in alongside the elicited config.
           const outcome = await lib.provisionRestDatasource(
             orgId,
-            { ...collected.values },
+            { ...collected.values, ...(display_name !== undefined ? { display_name } : {}) },
             fieldsResult.secretKeys,
           );
           if (outcome.kind === "validation") {
@@ -1028,7 +1037,7 @@ const DELETE_DATASOURCE_DESCRIPTION = `Permanently delete a datasource — remov
 
 const CREATE_DATASOURCE_DESCRIPTION = `Provision a NEW datasource for this workspace. Supported types: postgres, mysql, clickhouse, snowflake, bigquery, elasticsearch/opensearch (plugin types require the corresponding datasource plugin to be installed). You supply only non-secret fields — \`db_type\`, \`install_id\`, optional \`description\`/\`group_id\`. ALL connection details (URL, API key, service-account JSON, etc.) are collected SEPARATELY via a secure masked prompt to the user; they are never passed as tool arguments and never shared with you. The connection is tested BEFORE it is persisted (a failed probe persists nothing), and lands as a \`draft\` — run profile_datasource next to make it queryable. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "db_type": "clickhouse", "install_id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "db_type": "clickhouse", "status": "draft", "masked_url": "clickhouse://***@…", "created": true }\`.`;
 
-const CREATE_REST_DATASOURCE_DESCRIPTION = `Provision a NEW generic REST datasource from an OpenAPI 3.x spec for this workspace. Takes NO tool arguments — the spec URL, authentication type, and credential are ALL collected via a secure masked prompt to the user; they are never passed as tool arguments and never shared with you. The spec is fetched + validated BEFORE anything is persisted (a failed probe persists nothing). On success the API's operations become available to the agent; it is read-only by default (any write allowlist is configured via the admin console). Use this instead of create_datasource for HTTP/REST APIs (Stripe, GitHub, an internal service); use create_datasource for SQL databases. Requires the \`mcp:write\` scope and the admin role. Example success: \`{ "id": "<install-id>", "created": true, "kind": "rest" }\`.`;
+const CREATE_REST_DATASOURCE_DESCRIPTION = `Provision a NEW generic REST datasource from an OpenAPI 3.x spec for this workspace. You may pass an optional non-secret \`display_name\`; the spec URL, authentication type, and credential are ALL collected via a secure masked prompt to the user — they are never passed as tool arguments and never shared with you. The spec is fetched + validated BEFORE anything is persisted (a failed probe persists nothing). On success the API's operations become available to the agent; it is read-only by default (any write allowlist is configured via the admin console). Use this instead of create_datasource for HTTP/REST APIs (Stripe, GitHub, an internal service); use create_datasource for SQL databases. Requires the \`mcp:write\` scope and the admin role. Example success: \`{ "id": "<install-id>", "created": true, "kind": "rest" }\`.`;
 
 const PROFILE_DATASOURCE_DESCRIPTION = `Profile a datasource (introspect its tables) and generate its semantic layer — entities + the table whitelist — so the agent can query it with executeSQL. Long-running: emits progress per table and is cancellable. Typically run right after create_datasource. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "queryable": true, "entities_generated": 12, "tables": ["orders", "users"], "elapsed_ms": 1840 }\`.`;
 

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -391,7 +391,15 @@ export function registerDatasourceTools(
    * context, a response, or a log. Returns the collected values or a renderable
    * block; the caller assembles the provision config from `values`.
    */
-  type ProvisionFormField = { key: string; label: string; description?: string; required: boolean; secret: boolean };
+  type ProvisionFormField = {
+    key: string;
+    label: string;
+    description?: string;
+    required: boolean;
+    secret: boolean;
+    options?: readonly string[];
+    default?: string;
+  };
   async function collectMaskedConfig(
     orgId: string,
     fields: readonly ProvisionFormField[],
@@ -409,6 +417,8 @@ export function registerDatasourceTools(
           ...(f.description ? { description: f.description } : {}),
           required: f.required,
           secret: f.secret,
+          ...(f.options ? { options: f.options } : {}),
+          ...(f.default !== undefined ? { default: f.default } : {}),
         })),
         ...(signal ? { signal } : {}),
       });

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -58,7 +58,7 @@ import type {
   McpDispatchGateContext,
   McpDispatchGateRequirements,
 } from "./dispatch-gate.js";
-import { elicitMaskedField } from "./elicitation.js";
+import { elicitMaskedForm } from "./elicitation.js";
 import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
 import { createMcpLogger } from "./logger.js";
 import { enforceClientRateLimit } from "@atlas/api/lib/rate-limit/middleware";
@@ -589,21 +589,17 @@ export function registerDatasourceTools(
         db_type: z
           .enum(MCP_PROVISIONABLE_CATALOG_SLUGS as [string, ...string[]])
           .describe(
-            `Datasource type. Provisionable via MCP today: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")}.`,
+            `Datasource type. Provisionable via MCP: ${MCP_PROVISIONABLE_CATALOG_SLUGS.join(", ")}. ` +
+              `Connection details (URL / API key / service-account JSON, etc.) are collected separately via a secure masked prompt — never as tool arguments.`,
           ),
         install_id: datasourceIdSchema(
           "New datasource id (lowercase-led slug, e.g. 'prod-us'). Must be unique in the workspace.",
         ),
-        schema: z
-          .string()
-          .max(MAX_ID_LEN)
-          .optional()
-          .describe("Optional schema/search_path (Postgres). Defaults to the server default."),
         description: z
           .string()
           .max(MAX_FILTER_LEN)
           .optional()
-          .describe("Optional human-readable description."),
+          .describe("Optional human-readable description (shown in the agent system prompt)."),
         group_id: z
           .string()
           .max(MAX_ID_LEN)
@@ -611,7 +607,7 @@ export function registerDatasourceTools(
           .describe("Optional environment-group binding."),
       },
     },
-    async ({ db_type, install_id, schema, description, group_id }, extra): Promise<CallToolResult> =>
+    async ({ db_type, install_id, description, group_id }, extra): Promise<CallToolResult> =>
       dispatch(
         "create_datasource",
         // Gate 1 (#3509) datasource kill-switch + mcp:write + admin. NOT
@@ -622,30 +618,58 @@ export function registerDatasourceTools(
           const org = requireBoundOrg();
           if (!org.ok) return org.block;
           const orgId = org.orgId;
+          const lib = await lifecycle();
 
-          // Collect the connection URL via MASKED form-mode elicitation
-          // (#3499). The secret travels client→server only; it never enters
-          // a tool argument, the agent/LLM context, this response, or a log.
+          // Capability check BEFORE prompting for credentials — don't ask the
+          // user for a connection we can't provision (unknown type, or a plugin
+          // type with no plugin installed).
+          const capability = await lib.resolveProvisionCapability(db_type);
+          if (capability.kind === "unsupported") {
+            return toEnvelopeResult(envelope("validation_failed", capability.message));
+          }
+
+          // Resolve the per-type credential field set from the catalog
+          // config_schema (#3547 AC #4) so the masked form is schema-driven —
+          // url-shaped (pg/mysql/clickhouse/snowflake), apiKey-shaped (ES), and
+          // multi-field (BigQuery) all collect the right fields with zero
+          // per-type code here.
+          const fieldsResult = await lib.loadProvisionConfigFields(db_type);
+          if (fieldsResult.kind !== "ok") {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                fieldsResult.kind === "not_found"
+                  ? `Datasource type "${db_type}" is not configured in this workspace's catalog.`
+                  : `The "${db_type}" datasource catalog is misconfigured; provisioning is unavailable. Use the admin console.`,
+              ),
+            );
+          }
+
+          // Collect every config field via MASKED form-mode elicitation (#3499).
+          // The entered values travel client→server only; they never enter a
+          // tool argument, the agent/LLM context, this response, or a log.
           let elicited;
           try {
-            elicited = await elicitMaskedField(server, {
+            elicited = await elicitMaskedForm(server, {
               principal: orgId,
-              message: `Enter the ${db_type} connection URL for "${install_id}". It is sent securely and never shared with the agent.`,
-              field: {
-                name: "url",
-                title: `${db_type} connection URL`,
-                description: "Entered securely; never shared with the agent or stored in plaintext.",
-              },
+              message: `Enter the connection details for the ${db_type} datasource "${install_id}". They are sent securely and never shared with the agent.`,
+              fields: fieldsResult.fields.map((f) => ({
+                name: f.key,
+                title: f.label,
+                ...(f.description ? { description: f.description } : {}),
+                required: f.required,
+                secret: f.secret,
+              })),
               ...(extra.signal ? { signal: extra.signal } : {}),
             });
           } catch (err) {
             // Elicitation unsupported by the client, or a state/secret error.
-            // Never include the (never-yet-received) credential; surface a
+            // Never include any (never-yet-received) credential; surface a
             // capability-shaped message.
             return toEnvelopeResult(
               envelope(
                 "validation_failed",
-                `Could not securely collect the connection credential: ${errorMessage(err, "elicitation failed")}.`,
+                `Could not securely collect the connection credentials: ${errorMessage(err, "elicitation failed")}.`,
                 { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
               ),
             );
@@ -654,31 +678,36 @@ export function registerDatasourceTools(
             return toEnvelopeResult(
               envelope(
                 "validation_failed",
-                `Datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no credential was provided.`,
+                `Datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no credentials were provided.`,
               ),
             );
           }
-          // `url` is the secret — used only for the pre-flight probe + the
-          // installer's encrypt-at-rest path. NEVER logged or returned.
-          const url = elicited.value;
 
-          const outcome = await (await lifecycle()).provisionDatasource(orgId, {
+          // `config` holds the secret + non-secret connection fields — used only
+          // for the pre-flight probe + the installer's encrypt-at-rest path,
+          // NEVER logged or returned. `description` is an agent-set label, merged
+          // in here. `secretKeys` drives the lib's error-scrub.
+          const config: Record<string, unknown> = {
+            ...elicited.values,
+            ...(description !== undefined ? { description } : {}),
+          };
+
+          const outcome = await lib.provisionDatasource(orgId, {
             catalogSlug: db_type,
             installId: install_id,
-            url,
-            ...(schema !== undefined ? { schema } : {}),
-            ...(description !== undefined ? { description } : {}),
+            config,
+            secretKeys: fieldsResult.secretKeys,
             groupId: group_id ?? null,
           });
 
           switch (outcome.kind) {
             case "ok":
-              // Only the masked URL is ever surfaced.
+              // Only masked (never plaintext) credential material is surfaced.
               return toJsonContent({
                 id: outcome.value.installId,
                 db_type: outcome.value.dbType,
                 status: outcome.value.status,
-                masked_url: outcome.value.maskedUrl,
+                ...(outcome.value.maskedUrl ? { masked_url: outcome.value.maskedUrl } : {}),
                 description: outcome.value.description,
                 schema: outcome.value.schema,
                 group_id: outcome.value.groupId,
@@ -691,7 +720,7 @@ export function registerDatasourceTools(
               // Pre-flight failed — message is credential-scrubbed by the lib.
               return toEnvelopeResult(
                 envelope("validation_failed", outcome.message, {
-                  hint: "Verify the connection details and that the database is reachable, then retry.",
+                  hint: "Verify the connection details and that the datasource is reachable, then retry.",
                 }),
               );
             case "error":
@@ -873,7 +902,7 @@ const RESTORE_DATASOURCE_DESCRIPTION = `Restore (un-archive) a previously archiv
 
 const DELETE_DATASOURCE_DESCRIPTION = `Permanently delete a datasource — removes the configuration and drains the pool. IRREVERSIBLE (use archive_datasource for a recoverable disable). Destructive: requires the \`mcp:write\` scope and the admin role, and routes through the workspace approval flow when an origin=mcp approval rule requires it (the response then carries \`approval_required: true\` with an \`approval_request_id\` to follow up on). Example call: \`{ "id": "old-staging" }\`. Example success: \`{ "id": "old-staging", "deleted": true }\`.`;
 
-const CREATE_DATASOURCE_DESCRIPTION = `Provision a NEW datasource (postgres or mysql) for this workspace. You supply only non-secret fields — \`db_type\`, \`install_id\`, optional \`schema\`/\`description\`/\`group_id\`. The connection URL (the credential) is collected SEPARATELY via a secure masked prompt to the user; it is never passed as a tool argument and never shared with you. The connection is health-checked BEFORE it is persisted (a failed probe persists nothing), and lands as a \`draft\` — run profile_datasource next to make it queryable. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "db_type": "postgres", "install_id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "db_type": "postgres", "status": "draft", "masked_url": "postgres://***@…", "created": true }\`.`;
+const CREATE_DATASOURCE_DESCRIPTION = `Provision a NEW datasource for this workspace. Supported types: postgres, mysql, clickhouse, snowflake, bigquery, elasticsearch/opensearch (plugin types require the corresponding datasource plugin to be installed). You supply only non-secret fields — \`db_type\`, \`install_id\`, optional \`description\`/\`group_id\`. ALL connection details (URL, API key, service-account JSON, etc.) are collected SEPARATELY via a secure masked prompt to the user; they are never passed as tool arguments and never shared with you. The connection is tested BEFORE it is persisted (a failed probe persists nothing), and lands as a \`draft\` — run profile_datasource next to make it queryable. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "db_type": "clickhouse", "install_id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "db_type": "clickhouse", "status": "draft", "masked_url": "clickhouse://***@…", "created": true }\`.`;
 
 const PROFILE_DATASOURCE_DESCRIPTION = `Profile a datasource (introspect its tables) and generate its semantic layer — entities + the table whitelist — so the agent can query it with executeSQL. Long-running: emits progress per table and is cancellable. Typically run right after create_datasource. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "queryable": true, "entities_generated": 12, "tables": ["orders", "users"], "elapsed_ms": 1840 }\`.`;
 

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -88,6 +88,11 @@ const dispatchGate = (): Promise<DispatchGateModule> =>
 // Every datasource tool is an admin surface — RBAC floor is `admin`.
 const DATASOURCE_MIN_ROLE: AtlasRole = "admin";
 
+// Catalog slug for the generic OpenAPI/REST datasource. A string literal (not an
+// import from `@atlas/api/lib/openapi/catalog`) so registering these tools stays
+// off the heavy openapi graph — the lib seam resolves it at invocation time.
+const REST_CATALOG_SLUG = "openapi-generic";
+
 // Bounds on free-text / identifier input — MCP clients (incl. hostile ones
 // in BYOC SaaS) shouldn't drive megabyte strings into the lookups.
 const MAX_FILTER_LEN = 1024;
@@ -733,6 +738,101 @@ export function registerDatasourceTools(
       ),
   );
 
+  // --- create_rest_datasource (mutate; OpenAPI spec + auth via masked form) ---
+  server.registerTool(
+    "create_rest_datasource",
+    {
+      title: "Create REST (OpenAPI) Datasource",
+      description: withErrorContract(CREATE_REST_DATASOURCE_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+      inputSchema: {},
+    },
+    async (_args, extra): Promise<CallToolResult> =>
+      dispatch(
+        "create_rest_datasource",
+        // Gate 1 kill-switch + mcp:write + admin. NOT approval-gated — additive,
+        // the human-in-the-loop is the masked spec-URL/credential entry below.
+        { requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        async (requestId) => {
+          const org = requireBoundOrg();
+          if (!org.ok) return org.block;
+          const orgId = org.orgId;
+          const lib = await lifecycle();
+
+          // The openapi-generic config_schema (spec URL + auth_kind + auth_value
+          // + …) drives the masked form, exactly like the SQL types.
+          const fieldsResult = await lib.loadProvisionConfigFields(REST_CATALOG_SLUG);
+          if (fieldsResult.kind !== "ok") {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                fieldsResult.kind === "not_found"
+                  ? "The generic REST (OpenAPI) datasource is not available in this workspace's catalog."
+                  : "The REST datasource catalog is misconfigured; provisioning is unavailable. Use the admin console.",
+              ),
+            );
+          }
+
+          // Collect spec URL + auth (the credential among them) via the masked
+          // form — values travel client→server only, never into agent context.
+          let elicited;
+          try {
+            elicited = await elicitMaskedForm(server, {
+              principal: orgId,
+              message: `Enter the OpenAPI spec URL and authentication for the new REST datasource. Sent securely and never shared with the agent.`,
+              fields: fieldsResult.fields.map((f) => ({
+                name: f.key,
+                title: f.label,
+                ...(f.description ? { description: f.description } : {}),
+                required: f.required,
+                secret: f.secret,
+              })),
+              ...(extra.signal ? { signal: extra.signal } : {}),
+            });
+          } catch (err) {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                `Could not securely collect the REST datasource configuration: ${errorMessage(err, "elicitation failed")}.`,
+                { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
+              ),
+            );
+          }
+          if (elicited.action !== "accept") {
+            return toEnvelopeResult(
+              envelope(
+                "validation_failed",
+                `REST datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no configuration was provided.`,
+              ),
+            );
+          }
+
+          // The handler probes the spec on install (no separate pre-flight): a
+          // bad URL / auth / unreachable spec comes back as `validation`,
+          // secret-scrubbed, with nothing persisted.
+          const outcome = await lib.provisionRestDatasource(
+            orgId,
+            { ...elicited.values },
+            fieldsResult.secretKeys,
+          );
+          if (outcome.kind === "validation") {
+            return toEnvelopeResult(
+              envelope("validation_failed", outcome.message, {
+                hint: "Check the OpenAPI spec URL, the auth type/credential, and that the spec is reachable, then retry.",
+                request_id: requestId,
+              }),
+            );
+          }
+          return toJsonContent({
+            id: outcome.installId,
+            created: true,
+            kind: "rest",
+            next: "The REST datasource is installed and its operations are available to the agent. It is read-only by default; configure any write allowlist via the admin console.",
+          });
+        },
+      ),
+  );
+
   // --- profile_datasource (mutate, long-running → progress + cancellable) ---
   server.registerTool(
     "profile_datasource",
@@ -903,6 +1003,8 @@ const RESTORE_DATASOURCE_DESCRIPTION = `Restore (un-archive) a previously archiv
 const DELETE_DATASOURCE_DESCRIPTION = `Permanently delete a datasource — removes the configuration and drains the pool. IRREVERSIBLE (use archive_datasource for a recoverable disable). Destructive: requires the \`mcp:write\` scope and the admin role, and routes through the workspace approval flow when an origin=mcp approval rule requires it (the response then carries \`approval_required: true\` with an \`approval_request_id\` to follow up on). Example call: \`{ "id": "old-staging" }\`. Example success: \`{ "id": "old-staging", "deleted": true }\`.`;
 
 const CREATE_DATASOURCE_DESCRIPTION = `Provision a NEW datasource for this workspace. Supported types: postgres, mysql, clickhouse, snowflake, bigquery, elasticsearch/opensearch (plugin types require the corresponding datasource plugin to be installed). You supply only non-secret fields — \`db_type\`, \`install_id\`, optional \`description\`/\`group_id\`. ALL connection details (URL, API key, service-account JSON, etc.) are collected SEPARATELY via a secure masked prompt to the user; they are never passed as tool arguments and never shared with you. The connection is tested BEFORE it is persisted (a failed probe persists nothing), and lands as a \`draft\` — run profile_datasource next to make it queryable. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "db_type": "clickhouse", "install_id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "db_type": "clickhouse", "status": "draft", "masked_url": "clickhouse://***@…", "created": true }\`.`;
+
+const CREATE_REST_DATASOURCE_DESCRIPTION = `Provision a NEW generic REST datasource from an OpenAPI 3.x spec for this workspace. Takes NO tool arguments — the spec URL, authentication type, and credential are ALL collected via a secure masked prompt to the user; they are never passed as tool arguments and never shared with you. The spec is fetched + validated BEFORE anything is persisted (a failed probe persists nothing). On success the API's operations become available to the agent; it is read-only by default (any write allowlist is configured via the admin console). Use this instead of create_datasource for HTTP/REST APIs (Stripe, GitHub, an internal service); use create_datasource for SQL databases. Requires the \`mcp:write\` scope and the admin role. Example success: \`{ "id": "<install-id>", "created": true, "kind": "rest" }\`.`;
 
 const PROFILE_DATASOURCE_DESCRIPTION = `Profile a datasource (introspect its tables) and generate its semantic layer — entities + the table whitelist — so the agent can query it with executeSQL. Long-running: emits progress per table and is cancellable. Typically run right after create_datasource. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "queryable": true, "entities_generated": 12, "tables": ["orders", "users"], "elapsed_ms": 1840 }\`.`;
 

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -383,6 +383,82 @@ export function registerDatasourceTools(
     );
   }
 
+  /**
+   * Shared masked-credential collection for the two create tools (#3547): run a
+   * schema-driven masked form, map a client failure / decline to a typed block,
+   * and defensively enforce required-field presence. The entered values travel
+   * client→server only — they never enter a tool argument, the agent/LLM
+   * context, a response, or a log. Returns the collected values or a renderable
+   * block; the caller assembles the provision config from `values`.
+   */
+  type ProvisionFormField = { key: string; label: string; description?: string; required: boolean; secret: boolean };
+  async function collectMaskedConfig(
+    orgId: string,
+    fields: readonly ProvisionFormField[],
+    message: string,
+    signal: AbortSignal | undefined,
+  ): Promise<{ ok: true; values: Record<string, string> } | { ok: false; block: CallToolResult }> {
+    let elicited;
+    try {
+      elicited = await elicitMaskedForm(server, {
+        principal: orgId,
+        message,
+        fields: fields.map((f) => ({
+          name: f.key,
+          title: f.label,
+          ...(f.description ? { description: f.description } : {}),
+          required: f.required,
+          secret: f.secret,
+        })),
+        ...(signal ? { signal } : {}),
+      });
+    } catch (err) {
+      // Elicitation unsupported by the client, or a state/secret error. Never
+      // include any (never-yet-received) credential; surface a capability-shaped
+      // message.
+      return {
+        ok: false,
+        block: toEnvelopeResult(
+          envelope(
+            "validation_failed",
+            `Could not securely collect the connection credentials: ${errorMessage(err, "elicitation failed")}.`,
+            { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
+          ),
+        ),
+      };
+    }
+    if (elicited.action !== "accept") {
+      return {
+        ok: false,
+        block: toEnvelopeResult(
+          envelope(
+            "validation_failed",
+            `Datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no configuration was provided.`,
+          ),
+        ),
+      };
+    }
+    // Defense-in-depth: a non-spec-compliant client could `accept` with a
+    // required field left blank (elicitMaskedForm drops empty values), which
+    // would otherwise surface as a confusing pre-flight "could not reach"
+    // error. Reject with an actionable, field-named message instead.
+    const values = elicited.values;
+    const missing = fields.filter((f) => f.required && !(f.key in values)).map((f) => f.label);
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        block: toEnvelopeResult(
+          envelope(
+            "validation_failed",
+            `Missing required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}.`,
+            { hint: "Provide every required field in the secure prompt, then retry." },
+          ),
+        ),
+      };
+    }
+    return { ok: true, values };
+  }
+
   // --- list_datasources (read) ---
   server.registerTool(
     "list_datasources",
@@ -650,50 +726,22 @@ export function registerDatasourceTools(
             );
           }
 
-          // Collect every config field via MASKED form-mode elicitation (#3499).
-          // The entered values travel client→server only; they never enter a
-          // tool argument, the agent/LLM context, this response, or a log.
-          let elicited;
-          try {
-            elicited = await elicitMaskedForm(server, {
-              principal: orgId,
-              message: `Enter the connection details for the ${db_type} datasource "${install_id}". They are sent securely and never shared with the agent.`,
-              fields: fieldsResult.fields.map((f) => ({
-                name: f.key,
-                title: f.label,
-                ...(f.description ? { description: f.description } : {}),
-                required: f.required,
-                secret: f.secret,
-              })),
-              ...(extra.signal ? { signal: extra.signal } : {}),
-            });
-          } catch (err) {
-            // Elicitation unsupported by the client, or a state/secret error.
-            // Never include any (never-yet-received) credential; surface a
-            // capability-shaped message.
-            return toEnvelopeResult(
-              envelope(
-                "validation_failed",
-                `Could not securely collect the connection credentials: ${errorMessage(err, "elicitation failed")}.`,
-                { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
-              ),
-            );
-          }
-          if (elicited.action !== "accept") {
-            return toEnvelopeResult(
-              envelope(
-                "validation_failed",
-                `Datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no credentials were provided.`,
-              ),
-            );
-          }
+          // Collect every config field via MASKED form-mode elicitation (#3499),
+          // schema-driven + required-field-checked by the shared helper.
+          const collected = await collectMaskedConfig(
+            orgId,
+            fieldsResult.fields,
+            `Enter the connection details for the ${db_type} datasource "${install_id}". They are sent securely and never shared with the agent.`,
+            extra.signal,
+          );
+          if (!collected.ok) return collected.block;
 
           // `config` holds the secret + non-secret connection fields — used only
           // for the pre-flight probe + the installer's encrypt-at-rest path,
           // NEVER logged or returned. `description` is an agent-set label, merged
           // in here. `secretKeys` drives the lib's error-scrub.
           const config: Record<string, unknown> = {
-            ...elicited.values,
+            ...collected.values,
             ...(description !== undefined ? { description } : {}),
           };
 
@@ -775,44 +823,20 @@ export function registerDatasourceTools(
 
           // Collect spec URL + auth (the credential among them) via the masked
           // form — values travel client→server only, never into agent context.
-          let elicited;
-          try {
-            elicited = await elicitMaskedForm(server, {
-              principal: orgId,
-              message: `Enter the OpenAPI spec URL and authentication for the new REST datasource. Sent securely and never shared with the agent.`,
-              fields: fieldsResult.fields.map((f) => ({
-                name: f.key,
-                title: f.label,
-                ...(f.description ? { description: f.description } : {}),
-                required: f.required,
-                secret: f.secret,
-              })),
-              ...(extra.signal ? { signal: extra.signal } : {}),
-            });
-          } catch (err) {
-            return toEnvelopeResult(
-              envelope(
-                "validation_failed",
-                `Could not securely collect the REST datasource configuration: ${errorMessage(err, "elicitation failed")}.`,
-                { hint: "Use an MCP client that supports masked form elicitation, or provision via the admin console." },
-              ),
-            );
-          }
-          if (elicited.action !== "accept") {
-            return toEnvelopeResult(
-              envelope(
-                "validation_failed",
-                `REST datasource creation was ${elicited.action === "decline" ? "declined" : "cancelled"} — no configuration was provided.`,
-              ),
-            );
-          }
+          const collected = await collectMaskedConfig(
+            orgId,
+            fieldsResult.fields,
+            `Enter the OpenAPI spec URL and authentication for the new REST datasource. Sent securely and never shared with the agent.`,
+            extra.signal,
+          );
+          if (!collected.ok) return collected.block;
 
           // The handler probes the spec on install (no separate pre-flight): a
           // bad URL / auth / unreachable spec comes back as `validation`,
           // secret-scrubbed, with nothing persisted.
           const outcome = await lib.provisionRestDatasource(
             orgId,
-            { ...elicited.values },
+            { ...collected.values },
             fieldsResult.secretKeys,
           );
           if (outcome.kind === "validation") {

--- a/packages/mcp/src/elicitation.ts
+++ b/packages/mcp/src/elicitation.ts
@@ -339,6 +339,19 @@ export interface MaskedFormField {
    * field. Recorded so a caller can know which returned values are secrets.
    */
   readonly secret?: boolean;
+  /**
+   * A closed set of allowed values (a catalog `select` field). Rendered as an
+   * enum in the requested schema so the client shows a dropdown instead of free
+   * text — restores client-side validation for fields like `auth_kind`.
+   */
+  readonly options?: readonly string[];
+  /**
+   * The catalog default for the field. Surfaced in the schema AND injected
+   * server-side when the client returns the field empty, so a defaulted field
+   * (e.g. `auth_kind: "bearer"`) stays zero-effort rather than failing the
+   * required-field check.
+   */
+  readonly default?: string;
 }
 
 export type ElicitMaskedFormOutcome =
@@ -385,13 +398,19 @@ export async function elicitMaskedForm(
     secret,
   );
 
-  const properties: Record<string, { type: "string"; title: string; description?: string }> = {};
+  const properties: Record<
+    string,
+    { type: "string"; title: string; description?: string; enum?: string[]; default?: string }
+  > = {};
   const required: string[] = [];
   for (const field of args.fields) {
     properties[field.name] = {
       type: "string",
       title: field.title,
       ...(field.description ? { description: field.description } : {}),
+      // A `select` field renders as a dropdown (enum), with its catalog default.
+      ...(field.options && field.options.length > 0 ? { enum: [...field.options] } : {}),
+      ...(field.default !== undefined ? { default: field.default } : {}),
     };
     if (field.required) required.push(field.name);
   }
@@ -428,7 +447,13 @@ export async function elicitMaskedForm(
   const values: Record<string, string> = {};
   for (const field of args.fields) {
     const raw = result.content?.[field.name];
-    if (typeof raw === "string" && raw.trim().length > 0) values[field.name] = raw;
+    if (typeof raw === "string" && raw.trim().length > 0) {
+      values[field.name] = raw;
+    } else if (field.default !== undefined && field.default.trim().length > 0) {
+      // The client returned the field empty but the catalog declares a default
+      // (e.g. `auth_kind: "bearer"`) — apply it so the field stays zero-effort.
+      values[field.name] = field.default;
+    }
   }
   return { action: "accept", values };
 }

--- a/packages/mcp/src/elicitation.ts
+++ b/packages/mcp/src/elicitation.ts
@@ -284,57 +284,40 @@ export async function elicitMaskedField(
   server: McpServer,
   args: ElicitMaskedArgs,
 ): Promise<ElicitMaskedOutcome> {
-  const secret = args.secret ?? resolveElicitationSecret();
-  const nonceStore = args.nonceStore ?? defaultNonceStore;
+  // Thin wrapper over the multi-field {@link elicitMaskedForm} (a single
+  // required field) — the mint → elicit → verify → single-use-consume sequence
+  // lives in ONE place, so the MRTR-migration hardening this seam exists for
+  // can't drift between a single- and multi-field copy.
   const fieldName = args.field.name ?? DEFAULT_FIELD_NAME;
-
-  const requestState = signRequestState(
-    {
-      principal: args.principal,
-      purpose: `elicit:${fieldName}`,
-      ...(args.ttlMs != null ? { ttlMs: args.ttlMs } : {}),
-    },
-    secret,
-  );
-
-  const result = await server.server.elicitInput(
-    {
-      mode: "form",
-      message: args.message,
-      requestedSchema: {
-        type: "object",
-        properties: {
-          [fieldName]: {
-            type: "string",
-            title: args.field.title,
-            ...(args.field.description ? { description: args.field.description } : {}),
-          },
-        },
-        required: [fieldName],
-      },
-    },
-    args.signal ? { signal: args.signal } : undefined,
-  );
-
-  if (result.action !== "accept") {
-    return { action: result.action };
-  }
-
-  // Bind value-consumption to the issued state: principal + TTL + single use.
-  const verified = verifyRequestState(requestState, {
+  const outcome = await elicitMaskedForm(server, {
     principal: args.principal,
-    secret,
-    nonceStore,
+    message: args.message,
+    fields: [
+      {
+        name: fieldName,
+        title: args.field.title,
+        ...(args.field.description ? { description: args.field.description } : {}),
+        required: true,
+        secret: true,
+      },
+    ],
+    ...(args.ttlMs != null ? { ttlMs: args.ttlMs } : {}),
+    ...(args.secret ? { secret: args.secret } : {}),
+    ...(args.nonceStore ? { nonceStore: args.nonceStore } : {}),
+    ...(args.signal ? { signal: args.signal } : {}),
   });
-  if (!verified.ok) {
-    throw new ElicitationError(verified.reason);
-  }
 
-  const raw = result.content?.[fieldName];
-  if (typeof raw !== "string" || raw.length === 0) {
+  if (outcome.action !== "accept") {
+    return { action: outcome.action };
+  }
+  // elicitMaskedForm drops empty values, so a missing key means the client
+  // returned an empty value for this required field — preserve the original
+  // single-field contract of failing closed on empty.
+  const value = outcome.values[fieldName];
+  if (typeof value !== "string" || value.length === 0) {
     throw new ElicitationError("empty_value");
   }
-  return { action: "accept", value: raw };
+  return { action: "accept", value };
 }
 
 // --- Multi-field masked form elicitation ------------------------------------

--- a/packages/mcp/src/elicitation.ts
+++ b/packages/mcp/src/elicitation.ts
@@ -419,13 +419,16 @@ export async function elicitMaskedForm(
     throw new ElicitationError(verified.reason);
   }
 
-  // Collect every non-empty string value. Empty/omitted optionals are dropped so
-  // a blank field never persists as an empty credential; the caller enforces
-  // required-field presence against the catalog schema.
+  // Collect every non-blank string value. Empty/omitted/whitespace-only optionals
+  // are dropped so a blank field never persists as an empty credential (and the
+  // caller's required-field check, which tests key presence, then catches a
+  // blank required field instead of probing it as a present-but-empty value).
+  // The original (untrimmed) value is preserved when non-blank — a credential may
+  // legitimately carry internal whitespace; only the emptiness test trims.
   const values: Record<string, string> = {};
   for (const field of args.fields) {
     const raw = result.content?.[field.name];
-    if (typeof raw === "string" && raw.length > 0) values[field.name] = raw;
+    if (typeof raw === "string" && raw.trim().length > 0) values[field.name] = raw;
   }
   return { action: "accept", values };
 }

--- a/packages/mcp/src/elicitation.ts
+++ b/packages/mcp/src/elicitation.ts
@@ -336,3 +336,113 @@ export async function elicitMaskedField(
   }
   return { action: "accept", value: raw };
 }
+
+// --- Multi-field masked form elicitation ------------------------------------
+
+/** One field in a masked elicitation form. */
+export interface MaskedFormField {
+  /** Property key on the returned form object + in the built schema. */
+  readonly name: string;
+  /** Human-facing label shown by the client. */
+  readonly title: string;
+  /** Optional help text. */
+  readonly description?: string;
+  /** Whether the client must collect this field (drives the schema `required` list). */
+  readonly required?: boolean;
+  /**
+   * Marks the field as a credential. The 2025-11-25 form schema has no
+   * "password" primitive, so this is a hint the client SHOULD render masked;
+   * the structural guarantee is the out-of-band delivery, identical for every
+   * field. Recorded so a caller can know which returned values are secrets.
+   */
+  readonly secret?: boolean;
+}
+
+export type ElicitMaskedFormOutcome =
+  | { readonly action: "accept"; readonly values: Record<string, string> }
+  | { readonly action: "decline" | "cancel" };
+
+export interface ElicitMaskedFormArgs {
+  readonly principal: string;
+  readonly message: string;
+  /** The fields to collect in one form. At least one required field is expected. */
+  readonly fields: readonly MaskedFormField[];
+  readonly ttlMs?: number;
+  readonly secret?: string;
+  readonly nonceStore?: NonceStore;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Ask the client for SEVERAL fields in one masked form mid-call — the
+ * multi-field sibling of {@link elicitMaskedField}, for credentials whose shape
+ * isn't a single `url` (e.g. Elasticsearch `apiKey` + `url`, BigQuery
+ * `service_account_json` + `project_id`).
+ *
+ * Same security contract as the single-field call: the entered values travel
+ * client→server out of band and NEVER enter the agent/LLM context, and a single
+ * principal-bound, TTL'd, single-use requestState authorizes consuming the whole
+ * form. The returned values are the caller's to use for connect/persist only —
+ * never to echo into a tool result. Empty optional fields are omitted; the
+ * caller validates required-field presence against its own schema.
+ */
+export async function elicitMaskedForm(
+  server: McpServer,
+  args: ElicitMaskedFormArgs,
+): Promise<ElicitMaskedFormOutcome> {
+  const secret = args.secret ?? resolveElicitationSecret();
+  const nonceStore = args.nonceStore ?? defaultNonceStore;
+
+  const requestState = signRequestState(
+    {
+      principal: args.principal,
+      purpose: "elicit:form",
+      ...(args.ttlMs != null ? { ttlMs: args.ttlMs } : {}),
+    },
+    secret,
+  );
+
+  const properties: Record<string, { type: "string"; title: string; description?: string }> = {};
+  const required: string[] = [];
+  for (const field of args.fields) {
+    properties[field.name] = {
+      type: "string",
+      title: field.title,
+      ...(field.description ? { description: field.description } : {}),
+    };
+    if (field.required) required.push(field.name);
+  }
+
+  const result = await server.server.elicitInput(
+    {
+      mode: "form",
+      message: args.message,
+      requestedSchema: { type: "object", properties, required },
+    },
+    args.signal ? { signal: args.signal } : undefined,
+  );
+
+  if (result.action !== "accept") {
+    return { action: result.action };
+  }
+
+  // Bind value-consumption to the issued state: principal + TTL + single use.
+  const verified = verifyRequestState(requestState, {
+    principal: args.principal,
+    secret,
+    nonceStore,
+  });
+  if (!verified.ok) {
+    throw new ElicitationError(verified.reason);
+  }
+
+  // Collect every non-empty string value. Empty/omitted optionals are dropped so
+  // a blank field never persists as an empty credential; the caller enforces
+  // required-field presence against the catalog schema.
+  const values: Record<string, string> = {};
+  for (const field of args.fields) {
+    const raw = result.content?.[field.name];
+    if (typeof raw === "string" && raw.length > 0) values[field.name] = raw;
+  }
+  return { action: "accept", values };
+}


### PR DESCRIPTION
## What & why

Implements the **provisioning** half of **#3547** — extends MCP datasource provisioning beyond native postgres/mysql to **every provisionable datasource type**. The profiling half is split to **#3552** (child of PRD #3303, blocked on the reusable plugin-profiler seam).

Three commits, by mechanism:

### 1. Capability seam + plugin-aware test-connect (SQL types via `createFromConfig`)
- **AC #1** — `resolveProvisionCapability` replaces the hardcoded `MCP_NATIVE_DB_TYPES` gate: provisionable iff native pg/mysql **OR** a datasource plugin with a registered `createFromConfig`. Provisioning and future profiling read the same predicate, so support stays in lockstep.
- **AC #2** — extracted `findDatasourcePluginConnection` + added `probePluginDatasourceConnection` (`createFromConfig → SELECT 1 → close`, always closing the probe) to `datasource-registry-bridge` — one seam shared by install and pre-flight. `provisionDatasource` validate-before-persists plugin connections, scrubbing credentials and persisting nothing on failure. Lands **ClickHouse + Snowflake**.

### 2. Schema-driven multi-field masked elicitation (non-`url` credential shapes)
- **AC #4** — `create_datasource` now collects credentials via a **config_schema-driven masked form** (`elicitMaskedForm`, the multi-field sibling of `elicitMaskedField`): one principal-bound, TTL'd, single-use requestState authorizes the whole form; values travel out-of-band, never into agent/LLM context. `ProvisionDatasourceInput` generalized from a single `url` to `{ config, secretKeys }`; the error-scrub redacts **every** secret field value. Adds **Elasticsearch / OpenSearch** (`apiKey` / basic / SigV4, one catalog slug) + **BigQuery** (`service_account_json` + `project_id`).

### 3. REST / OpenAPI provisioning
- Adds `create_rest_datasource` — REST uses a different install path (the `openapi-generic` form handler, which probes the spec on install). Routes through the **same lib seam the admin `/install-form` route calls** (`getInstallHandler().validateConfig`, ADR-0016), maps a failed probe / bad auth to a typed validation outcome with the credential scrubbed, read-only by default.

## Result
`create_datasource` (postgres · mysql · clickhouse · snowflake · bigquery · elasticsearch/opensearch) + `create_rest_datasource` (OpenAPI) — the full #3547 provisioning set, all with masked, schema-driven, out-of-band credential collection and validate-before-persist.

## Out of scope (tracked)
- **AC #3 — profiling** these types → **#3552** (depends on #3303's plugin-profiler seam; CLI profilers must not be imported into `@atlas/api`).

## Testing
- New lib tests: capability resolution, plugin probe (success / failure-rolls-back-nothing / scrub), `loadProvisionConfigFields` mapping, REST install / validation-scrub / rethrow.
- New MCP tool tests: schema-driven single + multi-field (ES) elicitation, capability-unsupported-before-elicitation, REST form install / validation / decline; `elicitMaskedForm` round-trip (multi-field, empty-drop, decline).
- Existing provision tests migrated to the `{ config, secretKeys }` shape; server/smoke/sse tool-list + count assertions updated (13 → 14 tools).
- Green locally: lint, `tsgo` (api + mcp, 0 errors), full MCP suite (27/27), api affected, syncpack, template-drift, railway-watch.

Closes the provisioning scope of #3547; profiling tracked in #3552.

https://claude.ai/code/session_01PXSoKuosXCuocF4LcbEeSM