### PR TITLE
refactor(railway-sandbox): native sandbox.files upload, drop base64-over-exec (#3530)

### DIFF
--- a/plugins/railway-sandbox/README.md
+++ b/plugins/railway-sandbox/README.md
@@ -58,10 +58,10 @@ export default defineConfig({
   evicted (`close()` → `destroy()`); `idleTimeoutMinutes` is the billing
   backstop for leaked sandboxes. Health checks create + destroy a sandbox with
   a 1-minute backstop.
-- **File upload.** The Railway SDK has no bulk file API ("use exec or SSH"),
-  so the semantic tree is uploaded as base64 inside batched `exec` commands.
-  Symlinks escaping the semantic root are skipped, matching the other sandbox
-  backends.
+- **File upload.** The semantic tree is uploaded via the native, binary-safe
+  `sandbox.files` API (`write` + `mkdir`; streamed, no shell) — this requires
+  `railway >= 3.3.0`. Symlinks escaping the semantic root are skipped, matching
+  the other sandbox backends.
 - **Per-environment sandbox cap.** Railway caps sandboxes per environment —
   10 (Trial/Free), 50 (Hobby), 100 (Pro/Enterprise); only `CREATING`/`RUNNING`
   count. Atlas caches one explore backend per semantic root (per org), so more

--- a/plugins/railway-sandbox/__tests__/railway-sandbox.test.ts
+++ b/plugins/railway-sandbox/__tests__/railway-sandbox.test.ts
@@ -221,13 +221,30 @@ describe("sandbox.create", () => {
   test("uploads the semantic tree via files.mkdir + files.write (no shell)", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const plugin = railwaySandboxPlugin({} as any);
+    // Record the interleaving of mkdir/write so we can assert ordering, not
+    // just membership — the semantic root must be mkdir'd BEFORE any write so
+    // the explore cwd exists even if files.write's auto-parent behavior changes.
+    const order: string[] = [];
+    mockMkdir.mockImplementation((p?: string) => {
+      order.push(`mkdir:${p}`);
+      return Promise.resolve();
+    });
+    mockWrite.mockImplementation((p?: string) => {
+      order.push(`write:${p}`);
+      return Promise.resolve();
+    });
     await withSemanticDir(async (dir) => {
       await plugin.sandbox.create(dir);
     });
-    // The semantic root is mkdir'd up front so the explore cwd exists.
+    // The semantic root is mkdir'd up front, before the first file write.
     expect(mockMkdir).toHaveBeenCalledWith("/atlas/semantic");
-    // Each file is written to its absolute path with its raw Buffer content.
+    const mkdirIdx = order.indexOf("mkdir:/atlas/semantic");
+    const firstWriteIdx = order.findIndex((o) => o.startsWith("write:"));
+    expect(mkdirIdx).toBeGreaterThanOrEqual(0);
+    expect(firstWriteIdx).toBeGreaterThan(mkdirIdx);
+    // Every collected file is written — exactly the two-file fixture, no drops.
     const writePaths = mockWrite.mock.calls.map((c) => String(c[0]));
+    expect(writePaths.length).toBe(2);
     expect(writePaths).toContain("/atlas/semantic/glossary.yml");
     expect(writePaths).toContain("/atlas/semantic/entities/users.yml");
     const usersCall = mockWrite.mock.calls.find(
@@ -332,6 +349,45 @@ describe("sandbox.create", () => {
       await expect(plugin.sandbox.create(dir)).rejects.toThrow(
         /Failed to upload semantic files/,
       );
+    });
+    expect(mockDestroy).toHaveBeenCalled();
+  });
+
+  test("destroys the sandbox when mkdir (not write) fails", async () => {
+    // mkdir shares the upload guard with write — a mkdir rejection must take
+    // the same Failed-to-upload → destroy path, proving mkdir is inside the
+    // guarded block.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = railwaySandboxPlugin({} as any);
+    mockMkdir.mockImplementation(() =>
+      Promise.reject(new Error("permission denied")),
+    );
+    await withSemanticDir(async (dir) => {
+      await expect(plugin.sandbox.create(dir)).rejects.toThrow(
+        /Failed to upload semantic files/,
+      );
+    });
+    expect(mockDestroy).toHaveBeenCalled();
+  });
+
+  test("redacts sensitive detail from an upload-failure message", async () => {
+    // A files.write rejection whose message carries a credential must be
+    // scrubbed before it reaches the caller (CLAUDE.md: no secrets in responses).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = railwaySandboxPlugin({} as any);
+    mockWrite.mockImplementation(() =>
+      Promise.reject(new Error("upload rejected: token=rw_supersecret_abc123")),
+    );
+    await withSemanticDir(async (dir) => {
+      let err: Error | null = null;
+      try {
+        await plugin.sandbox.create(dir);
+      } catch (e) {
+        err = e instanceof Error ? e : new Error(String(e));
+      }
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("details in server logs");
+      expect(err!.message).not.toContain("rw_supersecret_abc123");
     });
     expect(mockDestroy).toHaveBeenCalled();
   });

--- a/plugins/railway-sandbox/__tests__/railway-sandbox.test.ts
+++ b/plugins/railway-sandbox/__tests__/railway-sandbox.test.ts
@@ -12,10 +12,17 @@ const mockExec = mock((_command?: string, _opts?: Record<string, unknown>) =>
   }),
 );
 const mockDestroy = mock(() => Promise.resolve());
+// Native sandbox.files API (railway >= 3.3.0) — the upload path writes each
+// semantic file binary-safe via files.write and mkdir's the semantic root.
+const mockWrite = mock((_path?: string, _content?: unknown) =>
+  Promise.resolve(),
+);
+const mockMkdir = mock((_path?: string) => Promise.resolve());
 
 const mockSandboxInstance = {
   exec: mockExec,
   destroy: mockDestroy,
+  files: { write: mockWrite, mkdir: mockMkdir },
 };
 
 const mockCreate = mock((_opts?: Record<string, unknown>) =>
@@ -31,18 +38,21 @@ import { definePlugin, isSandboxPlugin } from "@useatlas/plugin-sdk";
 import {
   railwaySandboxPlugin,
   buildRailwaySandboxPlugin,
-  buildUploadBatches,
 } from "../src/index";
 
 function resetMocks() {
   mockCreate.mockClear();
   mockExec.mockClear();
   mockDestroy.mockClear();
+  mockWrite.mockClear();
+  mockMkdir.mockClear();
   mockCreate.mockImplementation(() => Promise.resolve(mockSandboxInstance));
   mockExec.mockImplementation(() =>
     Promise.resolve({ stdout: "railway-ok\n", stderr: "", exitCode: 0 }),
   );
   mockDestroy.mockImplementation(() => Promise.resolve());
+  mockWrite.mockImplementation(() => Promise.resolve());
+  mockMkdir.mockImplementation(() => Promise.resolve());
 }
 
 async function withSemanticDir<T>(
@@ -208,21 +218,66 @@ describe("sandbox.create", () => {
     expect("environmentId" in opts).toBe(false);
   });
 
-  test("uploads the semantic tree via mkdir + base64 exec commands", async () => {
+  test("uploads the semantic tree via files.mkdir + files.write (no shell)", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const plugin = railwaySandboxPlugin({} as any);
     await withSemanticDir(async (dir) => {
       await plugin.sandbox.create(dir);
     });
-    const commands = mockExec.mock.calls.map((c) => String(c[0]));
-    expect(commands[0]).toContain("mkdir -p");
-    expect(commands[0]).toContain("'/atlas/semantic/entities'");
-    const uploadCmd = commands.find((c) => c.includes("base64 -d"));
-    expect(uploadCmd).toBeDefined();
-    expect(uploadCmd).toContain("set -e");
-    expect(uploadCmd).toContain("> '/atlas/semantic/entities/users.yml'");
-    // payload is base64 of the file content
-    expect(uploadCmd).toContain(Buffer.from("table: users\n").toString("base64"));
+    // The semantic root is mkdir'd up front so the explore cwd exists.
+    expect(mockMkdir).toHaveBeenCalledWith("/atlas/semantic");
+    // Each file is written to its absolute path with its raw Buffer content.
+    const writePaths = mockWrite.mock.calls.map((c) => String(c[0]));
+    expect(writePaths).toContain("/atlas/semantic/glossary.yml");
+    expect(writePaths).toContain("/atlas/semantic/entities/users.yml");
+    const usersCall = mockWrite.mock.calls.find(
+      (c) => c[0] === "/atlas/semantic/entities/users.yml",
+    );
+    expect(usersCall).toBeDefined();
+    expect(Buffer.isBuffer(usersCall![1])).toBe(true);
+    expect((usersCall![1] as Buffer).equals(Buffer.from("table: users\n"))).toBe(true);
+    // The upload no longer touches the shell — no base64-over-exec.
+    const execCmds = mockExec.mock.calls.map((c) => String(c[0]));
+    expect(execCmds.some((c) => c.includes("base64"))).toBe(false);
+  });
+
+  test("writes binary-safe content unchanged (no base64 round-trip)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = railwaySandboxPlugin({} as any);
+    const tmpDir = `/tmp/railway-sandbox-bin-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const { mkdirSync, writeFileSync, rmSync } = await import("fs");
+    mkdirSync(`${tmpDir}/entities`, { recursive: true });
+    // Bytes that are not valid UTF-8 — a base64-over-exec path could mangle these.
+    const binary = Buffer.from([0x00, 0xff, 0xfe, 0x10, 0x80, 0x0a]);
+    writeFileSync(`${tmpDir}/entities/blob.bin`, binary);
+    writeFileSync(`${tmpDir}/glossary.yml`, "terms: []\n");
+    try {
+      await plugin.sandbox.create(tmpDir);
+      const blobCall = mockWrite.mock.calls.find((c) =>
+        String(c[0]).endsWith("blob.bin"),
+      );
+      expect(blobCall).toBeDefined();
+      expect(Buffer.isBuffer(blobCall![1])).toBe(true);
+      expect((blobCall![1] as Buffer).equals(binary)).toBe(true);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("throws a clear error (and destroys the sandbox) when the files API is missing", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = railwaySandboxPlugin({} as any);
+    // Simulate an older SDK whose Sandbox instance has no `files` surface.
+    mockCreate.mockImplementation(() =>
+      Promise.resolve({
+        exec: mockExec,
+        destroy: mockDestroy,
+      } as unknown as typeof mockSandboxInstance),
+    );
+    await withSemanticDir(async (dir) => {
+      await expect(plugin.sandbox.create(dir)).rejects.toThrow(/railway >= 3\.3\.0/);
+    });
+    expect(mockDestroy).toHaveBeenCalled();
   });
 
   test("throws when no semantic files found — without creating a sandbox", async () => {
@@ -255,10 +310,13 @@ describe("sandbox.create", () => {
     symlinkSync(`${base}/semantic_evil/secret.yml`, `${base}/semantic/leak.yml`);
     try {
       await plugin.sandbox.create(`${base}/semantic`);
-      const uploads = mockExec.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(uploads).toContain("real.yml");
-      expect(uploads).not.toContain("leak.yml");
-      expect(uploads).not.toContain(Buffer.from("secret: yes\n").toString("base64"));
+      const writePaths = mockWrite.mock.calls.map((c) => String(c[0]));
+      const writeContents = mockWrite.mock.calls.map((c) =>
+        Buffer.isBuffer(c[1]) ? (c[1] as Buffer).toString() : String(c[1]),
+      );
+      expect(writePaths.some((p) => p.endsWith("real.yml"))).toBe(true);
+      expect(writePaths.some((p) => p.endsWith("leak.yml"))).toBe(false);
+      expect(writeContents.some((c) => c.includes("secret: yes"))).toBe(false);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -267,8 +325,8 @@ describe("sandbox.create", () => {
   test("destroys the sandbox when the upload fails", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const plugin = railwaySandboxPlugin({} as any);
-    mockExec.mockImplementation(() =>
-      Promise.resolve({ stdout: "", stderr: "disk full", exitCode: 1 }),
+    mockWrite.mockImplementation(() =>
+      Promise.reject(new Error("disk full")),
     );
     await withSemanticDir(async (dir) => {
       await expect(plugin.sandbox.create(dir)).rejects.toThrow(
@@ -392,61 +450,6 @@ describe("exec / close", () => {
       );
       await backend.close!(); // must not throw
     });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Upload batching
-// ---------------------------------------------------------------------------
-
-describe("buildUploadBatches", () => {
-  test("packs small files into one batch", () => {
-    const files = [
-      { path: "semantic/a.yml", content: Buffer.from("a") },
-      { path: "semantic/b.yml", content: Buffer.from("b") },
-    ];
-    const batches = buildUploadBatches(files);
-    expect(batches.length).toBe(1);
-    expect(batches[0]).toStartWith("set -e\n");
-    expect(batches[0]).toContain("'/atlas/semantic/a.yml'");
-    expect(batches[0]).toContain("'/atlas/semantic/b.yml'");
-  });
-
-  test("splits when the batch size cap is exceeded", () => {
-    // ~100KB raw → ~134KB base64 each (under the chunk cap); two files cannot
-    // share one 180KB batch, so they land in two batches
-    const big = Buffer.alloc(100_000, "x");
-    const files = [
-      { path: "semantic/a.yml", content: big },
-      { path: "semantic/b.yml", content: big },
-    ];
-    const batches = buildUploadBatches(files);
-    expect(batches.length).toBe(2);
-  });
-
-  test("chunks a single file whose base64 exceeds the cap across > and >> appends", () => {
-    // 150KB raw → 200KB base64 → must split into 160KB + 40KB chunks; no
-    // single command may exceed the batch cap
-    const big = Buffer.alloc(150_000, "x");
-    const batches = buildUploadBatches([{ path: "semantic/huge.yml", content: big }]);
-    const lines = batches.flatMap((b) => b.split("\n")).filter((l) => l.includes("base64 -d"));
-    expect(lines.length).toBe(2);
-    expect(lines[0]).toContain("base64 -d > '/atlas/semantic/huge.yml'");
-    expect(lines[1]).toContain("base64 -d >> '/atlas/semantic/huge.yml'");
-    for (const batch of batches) {
-      expect(batch.length).toBeLessThanOrEqual(180_000 + 100);
-    }
-    // The chunks reassemble to the original content
-    const b64 = lines
-      .map((l) => /printf '%s' '([A-Za-z0-9+/=]+)'/.exec(l)?.[1] ?? "")
-      .join("");
-    expect(Buffer.from(b64, "base64").equals(big)).toBe(true);
-  });
-
-  test("quotes paths containing single quotes", () => {
-    const files = [{ path: "semantic/it's.yml", content: Buffer.from("x") }];
-    const batches = buildUploadBatches(files);
-    expect(batches[0]).toContain(`'/atlas/semantic/it'\\''s.yml'`);
   });
 });
 

--- a/plugins/railway-sandbox/package.json
+++ b/plugins/railway-sandbox/package.json
@@ -37,7 +37,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "railway": ">=0.1.0",
+    "railway": ">=3.3.0",
     "@useatlas/plugin-sdk": ">=0.0.1"
   },
   "devDependencies": {

--- a/plugins/railway-sandbox/src/index.ts
+++ b/plugins/railway-sandbox/src/index.ts
@@ -5,7 +5,8 @@
  * Wraps the Railway Sandboxes SDK (`railway` package) to run explore
  * commands in an ephemeral Linux microVM on the same vendor Atlas's SaaS
  * deploys on. Semantic layer files are uploaded into the sandbox at
- * creation time (base64 over `exec` — the SDK has no bulk file API).
+ * creation time via the native, binary-safe `sandbox.files` API (write +
+ * mkdir; streamed, no shell — requires railway >= 3.3.0).
  *
  * **⚠ Security (read before adopting):** Railway Sandboxes offer only
  * `ISOLATED` (outbound internet via NAT) and `PRIVATE` (private network +
@@ -99,11 +100,22 @@ interface RailwayExecResult {
   timedOut?: boolean;
 }
 
+// Native binary-safe file surface (railway >= 3.3.0). We declare only the two
+// operations the upload path needs; `write` accepts a Buffer (a Uint8Array) and
+// auto-creates parent directories, `mkdir` is `mkdir -p`. Optional defensively:
+// an older SDK exposes no `files` getter, which the backend turns into a clear
+// install-hint error rather than a crash.
+interface RailwaySandboxFiles {
+  write(path: string, content: Buffer): Promise<void>;
+  mkdir(path: string): Promise<void>;
+}
+
 interface RailwaySandboxInstance {
   exec(
     command: string,
     opts?: { timeoutSec?: number },
   ): Promise<RailwayExecResult>;
+  files?: RailwaySandboxFiles;
   destroy(): Promise<void>;
 }
 
@@ -229,90 +241,43 @@ export function collectSemanticFiles(
 const SANDBOX_ROOT_DIR = "/atlas";
 const SANDBOX_SEMANTIC_DIR = "/atlas/semantic";
 
-// The SDK has no bulk file API ("use exec or SSH" per Railway docs), so files
-// travel as base64 inside exec commands. Keep each command comfortably under
-// API payload limits; base64 inflates content 4/3.
-const UPLOAD_BATCH_MAX_CHARS = 180_000;
-// Files whose base64 exceeds this are split across append (`>>`) chunks so no
-// single command can blow past the batch cap. Multiple of 4 so every chunk is
-// independently base64-decodable (only the final chunk may carry padding).
-const UPLOAD_CHUNK_MAX_CHARS = 160_000;
-// Uploads can carry the whole semantic tree — give them more headroom than
-// a single explore command gets.
-const UPLOAD_TIMEOUT_SEC = 120;
-
 /** POSIX single-quote a string for safe embedding in a shell command. */
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-/** Build the per-file upload lines, batched to stay under the command-size cap. */
-export function buildUploadBatches(
-  files: { path: string; content: Buffer }[],
-): string[] {
-  const batches: string[] = [];
-  let lines: string[] = [];
-  let size = 0;
-
-  const flush = () => {
-    if (lines.length > 0) {
-      batches.push(`set -e\n${lines.join("\n")}`);
-      lines = [];
-      size = 0;
-    }
-  };
-  const push = (line: string) => {
-    if (size + line.length > UPLOAD_BATCH_MAX_CHARS && lines.length > 0) flush();
-    lines.push(line);
-    size += line.length;
-  };
-
-  for (const f of files) {
-    const b64 = f.content.toString("base64");
-    const target = shellQuote(`${SANDBOX_ROOT_DIR}/${f.path}`);
-    if (b64.length <= UPLOAD_CHUNK_MAX_CHARS) {
-      push(`printf '%s' '${b64}' | base64 -d > ${target}`);
-      continue;
-    }
-    // Oversized file: first chunk truncates (`>`), the rest append (`>>`).
-    // Chunk order is preserved — lines within a batch and batches themselves
-    // both execute sequentially.
-    for (let i = 0; i < b64.length; i += UPLOAD_CHUNK_MAX_CHARS) {
-      const part = b64.slice(i, i + UPLOAD_CHUNK_MAX_CHARS);
-      const redirect = i === 0 ? ">" : ">>";
-      push(`printf '%s' '${part}' | base64 -d ${redirect} ${target}`);
-    }
-  }
-  flush();
-  return batches;
 }
 
 async function uploadSemanticFiles(
   sandbox: RailwaySandboxInstance,
   files: { path: string; content: Buffer }[],
 ): Promise<void> {
-  // mkdir -p every leaf directory first (creates parents).
-  const dirs = [
-    ...new Set(
-      files.map((f) => path.posix.dirname(`${SANDBOX_ROOT_DIR}/${f.path}`)),
-    ),
-  ].sort();
-  const commands = [
-    `mkdir -p ${dirs.map(shellQuote).join(" ")}`,
-    ...buildUploadBatches(files),
-  ];
+  // The native files API (railway >= 3.3.0) is binary-safe, streamed, and
+  // creates parent dirs on write — none of the old base64-over-exec machinery
+  // is needed. An older SDK exposes no `files` getter; surface a clear install
+  // hint rather than crashing on a missing property.
+  const sandboxFiles = sandbox.files;
+  if (!sandboxFiles) {
+    throw new Error(
+      "Railway sandbox file API unavailable: sandbox.files requires " +
+        "railway >= 3.3.0. Upgrade with: bun add railway@latest",
+    );
+  }
 
-  for (const command of commands) {
-    const res = await sandbox.exec(command, { timeoutSec: UPLOAD_TIMEOUT_SEC });
-    if (res.exitCode !== 0) {
-      const detail = res.stderr || res.stdout || `exit ${res.exitCode}`;
-      const safeDetail = SENSITIVE_PATTERNS.test(detail)
-        ? "sandbox error (details in server logs)"
-        : detail.slice(0, 500);
-      throw new Error(
-        `Failed to upload semantic files to Railway sandbox: ${safeDetail}`,
-      );
+  try {
+    // mkdir the semantic root up front so the explore cwd exists even before
+    // the first file lands; files.write auto-creates the per-file parent dirs.
+    await sandboxFiles.mkdir(SANDBOX_SEMANTIC_DIR);
+    for (const f of files) {
+      await sandboxFiles.write(`${SANDBOX_ROOT_DIR}/${f.path}`, f.content);
     }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const safeDetail = SENSITIVE_PATTERNS.test(detail)
+      ? "sandbox error (details in server logs)"
+      : detail.slice(0, 500);
+    throw new Error(
+      `Failed to upload semantic files to Railway sandbox: ${safeDetail}`,
+      { cause: err },
+    );
   }
 }
 


### PR DESCRIPTION
Closes #3530.

## What

Replaces the railway-sandbox semantic-layer upload (base64-encoded files embedded in shell `exec` commands) with the Railway SDK's native binary-safe `sandbox.files` API (`write` + `mkdir`; streamed, no shell).

## Changes

- **Deleted** `buildUploadBatches`, `UPLOAD_BATCH_MAX_CHARS` / `UPLOAD_CHUNK_MAX_CHARS` / `UPLOAD_TIMEOUT_SEC`, and the upload-path base64 + `shellQuote` machinery (~80 lines, including the `printf | base64 -d` chunking and `>`/`>>` append ordering — and the shell-injection surface on the upload path).
- `uploadSemanticFiles` now `files.mkdir`'s the semantic root and `files.write`'s each `collectSemanticFiles` `Buffer` directly. Binary-safe, parent dirs auto-created, never touches a shell.
- Extended the structural SDK interface with an optional `files` surface (`write`/`mkdir`) — the plugin still never imports real `railway` types. Degrades to a **clear install-hint error** (not a crash) when the SDK predates the file API.
- **`exec` path for running explore commands is unchanged** (still `cd <semantic> && sh -c <command>`).
- Bumped `railway` peer floor `>=0.1.0` → `>=3.3.0`.
- Updated the module docstring + README to drop the "no bulk file API" note.

## ⚠ Verification note (peer floor)

The changelog (and the issue) said the file API shipped in **v3.2.0**. That's wrong for the published npm package: I inspected `railway@3.2.0`'s `.d.ts` — it has **no** `sandbox.files`. The API actually landed in **3.3.0** (`SandboxFiles` class with `write`/`mkdir`/…, `get files()` on `Sandbox`). Floor pinned to the **verified** `>=3.3.0`, not the changelog's claim.

## Tests

`buildUploadBatches` tests replaced with `files.write`/`files.mkdir` call-shape assertions. Coverage: multi-file write, nested dirs, binary-safe (non-UTF-8) content passed through unchanged, upload-failure → sandbox destroyed (teardown contract preserved), and a clear error when the `files` surface is missing. 34/34 pass.

## Gates

- ✅ `bun test plugins/railway-sandbox` (34 pass)
- ✅ `bun run type` (clean)
- ✅ `bun run lint` (clean)
- ✅ `bun x syncpack lint` (no issues)

## Out of scope

No network-posture change (#3231 — Railway still has no deny-all egress; SaaS stays pinned to `vercel-sandbox`; `executePython` not enabled). Independent of #3373.