### PR TITLE
refactor(semantic): converge wizard /save metrics onto the DB persist path (#3550)

### DIFF
--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -475,6 +475,11 @@ beforeEach(() => {
 
   mockMkdirSync.mockReset();
   mockWriteFileSync.mockReset();
+  // Reset the bulk-upsert impl every test so a failure-injection impl
+  // (mockImplementation, e.g. the partial-metric-persist test) can't leak into
+  // a later test. Default mirrors the module-level stub: every row "lands".
+  mockBulkUpsertEntities.mockReset();
+  mockBulkUpsertEntities.mockImplementation(async (_orgId, entities) => entities.length);
   mockResetWhitelists.mockReset();
   mockSyncEntityToDisk.mockReset();
   mockSyncEntityToDisk.mockImplementation(async () => {});
@@ -1385,9 +1390,80 @@ describe("POST /api/v1/wizard/save", () => {
     expect(res.status).toBe(500);
     const data = await json(res);
     expect(data.error).toBe("db_partial_persist");
+    expect(data.requestId).toBeDefined();
+    // beforeEach resets the impl, so no manual restore is needed here.
+  });
 
-    // Restore the default impl so later tests aren't affected by the leaked mock.
-    mockBulkUpsertEntities.mockImplementation(async (_orgId, rows) => rows.length);
+  it("returns 500 db_persist_failed when the metric upsert throws (#3550)", async () => {
+    // Distinct from the partial-count branch: a *thrown* metric upsert (DB
+    // unreachable) must fail loud, not 201 a workspace whose metrics never
+    // landed. Mirrors the entity `db_persist_failed` test.
+    mockBulkUpsertEntities.mockReset();
+    // First call (entities) succeeds; second call (metrics) rejects.
+    mockBulkUpsertEntities.mockImplementationOnce(async (_orgId, rows) => rows.length);
+    mockBulkUpsertEntities.mockImplementationOnce(() =>
+      Promise.reject(new Error("internal DB unreachable")),
+    );
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      schema: "public",
+      profiles: [mockOrdersProfile],
+    });
+
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("db_persist_failed");
+    expect(data.requestId).toBeDefined();
+  });
+
+  it("falls through to disk-only metrics when there is no internal DB (#3550)", async () => {
+    // Self-hosted without an internal DB: the DB persist is gated on
+    // hasInternalDB(), so metrics must still be written to disk and the save
+    // must 201 without ever calling bulkUpsertEntities for a metric row.
+    mockHasInternalDB.mockReset();
+    mockHasInternalDB.mockImplementation(() => false);
+    mockBulkUpsertEntities.mockClear();
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      schema: "public",
+      profiles: [mockOrdersProfile],
+    });
+
+    expect(res.status).toBe(201);
+    // No DB → no upsert at all (entities or metrics).
+    expect(mockBulkUpsertEntities).not.toHaveBeenCalled();
+    // Metric YAML still lands on disk (the only durable copy in this mode).
+    const data = await json(res);
+    expect(data.files as string[]).toContain("metrics/orders.yml");
+  });
+
+  it("scopes persisted metric rows by the resolved connection group, not the raw connectionId (#3550)", async () => {
+    // The metric row carries connectionGroupId — the same group-keying the
+    // entity rows use (#3234). A non-default connection resolves to its group
+    // (group-of-one here), so the metric must NOT be scoped to the NULL default
+    // group. Pins the field the convergence comment calls shared-keying-critical.
+    mockBulkUpsertEntities.mockClear();
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "warehouse",
+      entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      schema: "public",
+      profiles: [mockOrdersProfile],
+    });
+
+    expect(res.status).toBe(201);
+    const allRows = mockBulkUpsertEntities.mock.calls.flatMap(([, rows]) => rows);
+    const metricRows = allRows.filter((r) => r.entityType === "metric");
+    expect(metricRows.length).toBeGreaterThan(0);
+    expect(metricRows[0]).toMatchObject({
+      entityType: "metric",
+      name: "orders",
+      connectionGroupId: "warehouse",
+    });
   });
 });
 

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -274,6 +274,51 @@ const mockUserProfile = {
   table_flags: { possibly_abandoned: false, possibly_denormalized: false },
 };
 
+// A profile with a numeric (non-PK, non-FK, non-`_id`) measure column, so
+// `generateMetricYAML` yields a metric artifact (#3550). `mockUserProfile`
+// has only a PK + text column and produces NO metric, which is why the
+// metric-persistence tests need their own profile.
+const mockOrdersProfile = {
+  table_name: "orders",
+  object_type: "table" as const,
+  row_count: 5000,
+  columns: [
+    {
+      name: "id",
+      type: "integer",
+      nullable: false,
+      unique_count: 5000,
+      null_count: 0,
+      sample_values: [],
+      is_primary_key: true,
+      is_foreign_key: false,
+      fk_target_table: null,
+      fk_target_column: null,
+      is_enum_like: false,
+      profiler_notes: [],
+    },
+    {
+      name: "amount",
+      type: "numeric",
+      nullable: false,
+      unique_count: 4200,
+      null_count: 0,
+      sample_values: ["19.99", "42.50"],
+      is_primary_key: false,
+      is_foreign_key: false,
+      fk_target_table: null,
+      fk_target_column: null,
+      is_enum_like: false,
+      profiler_notes: [],
+    },
+  ],
+  primary_key_columns: ["id"],
+  foreign_keys: [],
+  inferred_foreign_keys: [],
+  profiler_notes: [],
+  table_flags: { possibly_abandoned: false, possibly_denormalized: false },
+};
+
 // Controllable mocks for DB-calling profiler functions
 const mockListPostgresObjects: Mock<() => Promise<{ name: string; type: string }[]>> = mock(
   async () => [
@@ -1276,6 +1321,73 @@ describe("POST /api/v1/wizard/save", () => {
     });
     // Unknown fields are silently stripped — request still succeeds
     expect(res.status).toBe(201);
+  });
+
+  // --- Metric persistence: wizard /save converges with SemanticGenerator.persist (#3550) ---
+
+  it("persists generated metrics to semantic_entities as draft metric rows, not disk-only (#3550)", async () => {
+    // Pre-#3550 the wizard wrote metrics to disk only — they never landed in
+    // `semantic_entities`, so a wizard-onboarded workspace had a different
+    // metric durability guarantee than an MCP-profiled one. Both paths now
+    // persist metrics to the DB via bulkUpsertEntities.
+    mockBulkUpsertEntities.mockClear();
+    mockInvalidateOrgWhitelist.mockClear();
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      schema: "public",
+      profiles: [mockOrdersProfile],
+    });
+    expect(res.status).toBe(201);
+
+    // Some bulkUpsertEntities call carries a `metric` row keyed identically to
+    // the MCP path (path.basename(table) → "orders"), scoped by the resolved
+    // connection group (default connection → NULL default group).
+    const allRows = mockBulkUpsertEntities.mock.calls.flatMap(([, rows]) => rows);
+    const metricRows = allRows.filter((r) => r.entityType === "metric");
+    expect(metricRows.length).toBeGreaterThan(0);
+    expect(metricRows[0]).toMatchObject({
+      entityType: "metric",
+      name: "orders",
+      connectionGroupId: null,
+    });
+    expect(typeof metricRows[0].yamlContent).toBe("string");
+    expect((metricRows[0].yamlContent as string).length).toBeGreaterThan(0);
+
+    // Disk write is RETAINED but additive — the metric YAML is still on disk
+    // for legibility (DB is the source of truth for queryability).
+    const data = await json(res);
+    const files = data.files as string[];
+    expect(files).toContain("metrics/orders.yml");
+  });
+
+  it("fails loud (db_partial_persist) on a partial metric upsert — contract pin against drift back to disk-only (#3550)", async () => {
+    // Pins the chosen contract: metrics go through bulkUpsertEntities and a
+    // short count fails the whole save, exactly like entities. A future
+    // regression that writes metrics to disk only (no DB call) would never
+    // produce a `metric` upsert, so this short-count path could not fire — the
+    // test would fail, flagging the drift.
+    mockBulkUpsertEntities.mockClear();
+    mockWriteFileSync.mockClear();
+    // Entities upsert fully; the metric upsert lands one row short.
+    mockBulkUpsertEntities.mockImplementation(async (_orgId, rows) =>
+      rows.some((r) => r.entityType === "metric") ? Math.max(0, rows.length - 1) : rows.length,
+    );
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "orders", yaml: "table: orders\n" }],
+      schema: "public",
+      profiles: [mockOrdersProfile],
+    });
+
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("db_partial_persist");
+
+    // Restore the default impl so later tests aren't affected by the leaked mock.
+    mockBulkUpsertEntities.mockImplementation(async (_orgId, rows) => rows.length);
   });
 });
 

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -1104,8 +1104,11 @@ wizard.openapi(saveRoute, async (c) => {
         // durability guarantees. Both paths now persist metrics as drafts
         // (promoted via the atomic `/api/v1/admin/publish` endpoint) and key
         // rows through the shared `safeSemanticRowName`, so the two can't drift
-        // again. The disk write below is RETAINED but purely additive (YAML
-        // legibility on disk) — do not treat it as the source of truth.
+        // again. The disk write below is RETAINED as a derived legibility
+        // artifact (it is also re-read by boot reconciliation / disk sync), but
+        // the DB is the source of truth for queryability — so a disk-write
+        // failure is surfaced as a non-fatal warning rather than 500ing an
+        // already-committed persist, mirroring the entity disk-sync path.
         //
         // Untrusted HTTP profiles still pass the path-traversal guard:
         // `safeSemanticRowName` strips path segments and rejects unsafe names
@@ -1177,8 +1180,21 @@ wizard.openapi(saveRoute, async (c) => {
 
         for (const metric of metricArtifacts) {
           const filePath = path.join(metricsDir, `${metric.name}.yml`);
-          fs.writeFileSync(filePath, metric.yaml, "utf-8");
-          savedFiles.push(`metrics/${metric.name}.yml`);
+          try {
+            fs.writeFileSync(filePath, metric.yaml, "utf-8");
+            savedFiles.push(`metrics/${metric.name}.yml`);
+          } catch (err) {
+            // DB persist above is authoritative and already committed; the disk
+            // copy is derived. Don't escalate a disk failure to a 500 that would
+            // misreport a successful persist as a save failure — surface it as a
+            // warning, the same contract `syncEntityToDisk` uses for entities.
+            const reason = err instanceof Error ? err.message : String(err);
+            log.warn(
+              { requestId, orgId, table: metric.name, reason },
+              "Wizard save: metric disk write failed (DB persist already succeeded)",
+            );
+            warnings.push({ kind: "disk_sync_failed", tableName: metric.name, reason });
+          }
         }
       }
 

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -55,7 +55,7 @@ import {
   generateEntityYAML,
   generateSemanticLayer,
 } from "@atlas/api/lib/semantic/generate";
-import { SAFE_TABLE_NAME } from "@atlas/api/lib/semantic/shapes";
+import { SAFE_TABLE_NAME, safeSemanticRowName } from "@atlas/api/lib/semantic/shapes";
 // Phase-2 enrichment is the same shared engine (issue #3236, § D); the in-memory
 // variant lets the wizard enrich a YAML string per table without touching disk.
 import { enrichEntityYaml } from "@atlas/api/lib/semantic/enrich";
@@ -1082,9 +1082,7 @@ wizard.openapi(saveRoute, async (c) => {
         // Assemble through the shared engine (#3506) so the wizard, the CLI,
         // and the SemanticGenerator service can't drift. Entities are supplied
         // by the frontend, so only the catalog/glossary/metric artifacts are
-        // consumed here. The metric write keeps the wizard's path-traversal
-        // guard for untrusted HTTP profiles: unsafe table names are skipped and
-        // the filename is re-sanitized with `path.basename`.
+        // consumed here.
         const generated = generateSemanticLayer(profiles, {
           dbType: resolvedDbType,
           schema: resolvedSchema,
@@ -1098,12 +1096,89 @@ wizard.openapi(saveRoute, async (c) => {
         fs.writeFileSync(glossaryPath, generated.glossary, "utf-8");
         savedFiles.push("glossary.yml");
 
-        for (const metric of generated.metrics) {
-          if (!metric.table || !SAFE_TABLE_NAME.test(metric.table)) continue;
-          const safeMetricName = path.basename(metric.table);
-          const filePath = path.join(metricsDir, `${safeMetricName}.yml`);
+        // DECISION (#3550): metrics land in `semantic_entities` (DB), which is
+        // the source of truth for queryability — converging with
+        // `SemanticGenerator.persist` (the MCP path), which already persists
+        // entities AND metrics to the DB. Pre-#3550 the wizard wrote metrics to
+        // disk only, so wizard- vs MCP-onboarded workspaces had different metric
+        // durability guarantees. Both paths now persist metrics as drafts
+        // (promoted via the atomic `/api/v1/admin/publish` endpoint) and key
+        // rows through the shared `safeSemanticRowName`, so the two can't drift
+        // again. The disk write below is RETAINED but purely additive (YAML
+        // legibility on disk) — do not treat it as the source of truth.
+        //
+        // Untrusted HTTP profiles still pass the path-traversal guard:
+        // `safeSemanticRowName` strips path segments and rejects unsafe names
+        // (skipped + logged, never silently swallowed), and the same name keys
+        // both the DB row and the disk filename so the two can't disagree on
+        // which metrics landed.
+        const metricArtifacts = generated.metrics
+          .map((metric) => {
+            const name = safeSemanticRowName(metric.table);
+            if (name === null) {
+              log.warn(
+                { requestId, orgId, table: metric.table },
+                "Wizard save: skipping generated metric — table name is not path-safe",
+              );
+              return null;
+            }
+            return { name, yaml: metric.yaml };
+          })
+          .filter((m): m is { name: string; yaml: string } => m !== null);
+
+        // DB-first (mirrors the entity write above): persist metrics, fail loud
+        // on a short count, THEN write to disk so a partial DB persist never
+        // 201s a half-queryable state (#2142 class, now for metrics too). Same
+        // `db_persist_failed` / `db_partial_persist` contract as entities.
+        if (hasInternalDB() && metricArtifacts.length > 0) {
+          const metricRows = metricArtifacts.map((m) => ({
+            entityType: "metric" as const,
+            name: m.name,
+            yamlContent: m.yaml,
+            connectionGroupId,
+          }));
+          const upsertedMetrics = yield* Effect.tryPromise({
+            try: () => bulkUpsertEntities(orgId, metricRows),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(Effect.catchAll((err) => {
+            log.error(
+              { err: err.message, requestId, orgId, connectionId },
+              "Wizard save: bulkUpsertEntities threw persisting metrics — no metric rows persisted",
+            );
+            return Effect.succeed(null as number | null);
+          }));
+          if (upsertedMetrics === null) {
+            return c.json({
+              error: "db_persist_failed",
+              message:
+                "Failed to register metrics for queries. SQL execution will reject these metrics until this is resolved. Retry the wizard.",
+              requestId,
+            }, 500);
+          }
+          if (upsertedMetrics < metricRows.length) {
+            // bulkUpsertEntities swallows per-row errors and returns the count
+            // that succeeded — returning 201 would silently drop the rows that
+            // didn't land, exactly the #2142 failure mode for metrics.
+            log.error(
+              { requestId, orgId, attempted: metricRows.length, upserted: upsertedMetrics },
+              "Wizard save: partial metric upsert — failing loud rather than 201ing a half-persisted state",
+            );
+            invalidateOrgWhitelist(orgId);
+            return c.json({
+              error: "db_partial_persist",
+              message: `Registered ${upsertedMetrics} of ${metricRows.length} metrics. Retry the wizard.`,
+              requestId,
+              attempted: metricRows.length,
+              succeeded: upsertedMetrics,
+            }, 500);
+          }
+          invalidateOrgWhitelist(orgId);
+        }
+
+        for (const metric of metricArtifacts) {
+          const filePath = path.join(metricsDir, `${metric.name}.yml`);
           fs.writeFileSync(filePath, metric.yaml, "utf-8");
-          savedFiles.push(`metrics/${safeMetricName}.yml`);
+          savedFiles.push(`metrics/${metric.name}.yml`);
         }
       }
 

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -27,7 +27,6 @@
  * instead of the caller.
  */
 
-import * as path from "path";
 import { Context, Effect, Layer } from "effect";
 import type {
   DatabaseObject,
@@ -55,7 +54,7 @@ import {
   bulkUpsertEntities,
   type SemanticEntityType,
 } from "@atlas/api/lib/semantic/entities";
-import { SAFE_TABLE_NAME } from "@atlas/api/lib/semantic/shapes";
+import { safeSemanticRowName } from "@atlas/api/lib/semantic/shapes";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ProfilingFailedError } from "./errors";
@@ -412,16 +411,19 @@ function registerWhitelistImpl(
  * `[a-zA-Z0-9_.-]` that would never survive DB validation anyway. Returns `null`
  * for names that fail the check; callers must filter those artifacts out (logged,
  * never silently swallowed).
+ *
+ * The basename + `SAFE_TABLE_NAME` derivation itself lives in the shared
+ * {@link safeSemanticRowName} so the wizard `/save` path keys metric/entity rows
+ * identically (#3550); this wrapper adds the persist-path's skip logging.
  */
 function artifactRowName(artifact: GeneratedArtifact): string | null {
-  const name = path.basename(artifact.table);
-  if (!SAFE_TABLE_NAME.test(name)) {
+  const name = safeSemanticRowName(artifact.table);
+  if (name === null) {
     log.warn(
-      { table: artifact.table, basename: name },
-      "artifactRowName: skipping artifact — basename does not match SAFE_TABLE_NAME; " +
+      { table: artifact.table },
+      "artifactRowName: skipping artifact — name does not match SAFE_TABLE_NAME; " +
         "the generated name contains characters not permitted in a semantic-store row key",
     );
-    return null;
   }
   return name;
 }
@@ -440,13 +442,16 @@ function persistImpl(
       })
       .filter((r): r is NonNullable<typeof r> => r !== null);
 
-    // NOTE: intentional divergence from the wizard `/save` write path.
-    // The wizard persists entities to `semantic_entities` (DB) but writes metrics
-    // to disk only (`semantic/metrics/*.yml`). This MCP path persists BOTH entities
-    // AND metrics to `semantic_entities` so that a durable MCP-profiled connection
-    // is fully queryable across process restarts and visible to the web `/chat`
-    // process (which can't read disk artifacts written by a stdio MCP server).
-    // Tracked for reconciliation in #3551.
+    // CONTRACT (#3550): both durable write paths persist metrics to
+    // `semantic_entities` (DB) as the source of truth for queryability. This
+    // MCP path persists entities AND metrics to the DB; the wizard `/save`
+    // handler (`api/routes/wizard.ts`) does the same, keying its metric rows
+    // through the shared `safeSemanticRowName` used by `artifactRowName` here.
+    // Both then promote via the atomic `/api/v1/admin/publish` endpoint. The DB
+    // is what makes a profiled connection queryable across process restarts and
+    // visible to the web `/chat` process (which can't read disk artifacts
+    // written by a stdio MCP server). Don't reintroduce a disk-only metric path
+    // for either caller without updating the other.
     const metricRows = (opts.metrics ?? [])
       .map((m) => {
         const name = artifactRowName(m);

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -395,26 +395,17 @@ function registerWhitelistImpl(
 }
 
 /**
- * Map a generated artifact to its semantic-store row `name`. Mirrors the wizard
- * `/save` path (`path.basename(e.tableName)`) so the two write paths key rows
- * identically. `path.basename` strips any path-traversal segment (a `/`-bearing
- * name), leaving a path-safe identifier; a schema-qualified dotted name like
- * `public.orders` is preserved verbatim (no slash to strip), which keeps two
- * same-named tables in different schemas distinct. The row `name` is only the
- * upsert key — queryability keys on the entity YAML's `table:` field (set by
- * the generator), not this name. Entity + metric rows for the same table share
- * the name but differ by `entity_type`, so the 0063 partial unique index keeps
- * them distinct.
+ * Map a generated artifact to its semantic-store row `name`, or `null` when the
+ * name can't be made safe. The derivation (basename + `SAFE_TABLE_NAME`) lives
+ * in the shared {@link safeSemanticRowName} — the SAME function the wizard
+ * `/save` path uses — so the two durable write paths key rows identically and
+ * can't drift (#3550). This wrapper only adds the persist-path's skip logging.
  *
- * Defense-in-depth: after basename-stripping, the name must pass `SAFE_TABLE_NAME`
- * (same guard the wizard `/save` applies) — rejects names with characters outside
- * `[a-zA-Z0-9_.-]` that would never survive DB validation anyway. Returns `null`
- * for names that fail the check; callers must filter those artifacts out (logged,
- * never silently swallowed).
- *
- * The basename + `SAFE_TABLE_NAME` derivation itself lives in the shared
- * {@link safeSemanticRowName} so the wizard `/save` path keys metric/entity rows
- * identically (#3550); this wrapper adds the persist-path's skip logging.
+ * The row `name` is only the upsert key — queryability keys on the entity YAML's
+ * `table:` field (set by the generator), not this name. Entity + metric rows for
+ * the same table share the name but differ by `entity_type`, so the 0063 partial
+ * unique index keeps them distinct. Callers must filter out the `null` results
+ * (logged here, never silently swallowed).
  */
 function artifactRowName(artifact: GeneratedArtifact): string | null {
   const name = safeSemanticRowName(artifact.table);

--- a/packages/api/src/lib/semantic/shapes.ts
+++ b/packages/api/src/lib/semantic/shapes.ts
@@ -8,6 +8,7 @@
  * surface to the agent" — exactly the #2142 class.
  */
 
+import * as path from "path";
 import { z } from "zod";
 
 /**
@@ -23,6 +24,29 @@ import { z } from "zod";
  * and avoids independent regex drift.
  */
 export const SAFE_TABLE_NAME = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/;
+
+/**
+ * Derive the `semantic_entities.name` upsert key for a generated artifact's
+ * logical table name, or `null` when the name can't be made safe.
+ *
+ * `path.basename` strips any path-traversal segment (a `/`-bearing name),
+ * leaving a path-safe identifier; a schema-qualified dotted name like
+ * `public.orders` is preserved verbatim (no slash to strip), which keeps two
+ * same-named tables in different schemas distinct. The result must then pass
+ * {@link SAFE_TABLE_NAME} — defense-in-depth against characters that would
+ * never survive DB validation anyway. Returns `null` for names that fail the
+ * check; callers MUST filter those artifacts out and log the skip (never
+ * silently swallow).
+ *
+ * This is the single source of truth for how a generated table name becomes a
+ * semantic-store row key, shared by BOTH durable write paths —
+ * `SemanticGenerator.persist` (MCP, via `artifactRowName`) and the wizard
+ * `/save` handler — so the two can't drift on the upsert key (#3550).
+ */
+export function safeSemanticRowName(table: string): string | null {
+  const name = path.basename(table);
+  return SAFE_TABLE_NAME.test(name) ? name : null;
+}
 
 /**
  * Core entity shape — validates the table name and the Connection-group

--- a/packages/api/src/lib/semantic/shapes.ts
+++ b/packages/api/src/lib/semantic/shapes.ts
@@ -32,11 +32,14 @@ export const SAFE_TABLE_NAME = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/;
  * `path.basename` strips any path-traversal segment (a `/`-bearing name),
  * leaving a path-safe identifier; a schema-qualified dotted name like
  * `public.orders` is preserved verbatim (no slash to strip), which keeps two
- * same-named tables in different schemas distinct. The result must then pass
- * {@link SAFE_TABLE_NAME} — defense-in-depth against characters that would
- * never survive DB validation anyway. Returns `null` for names that fail the
- * check; callers MUST filter those artifacts out and log the skip (never
- * silently swallow).
+ * same-named tables in different schemas distinct. Two inputs that share a
+ * basename across differing path prefixes (`a/orders`, `b/orders`) are
+ * intentionally coalesced to the same row key — generated table names are flat
+ * identifiers, not paths, so this only bites pathological inputs that the
+ * generator does not produce. The result must then pass {@link SAFE_TABLE_NAME}
+ * — defense-in-depth against characters that would never survive DB validation
+ * anyway. Returns `null` for names that fail the check; callers MUST filter
+ * those artifacts out and log the skip (never silently swallow).
  *
  * This is the single source of truth for how a generated table name becomes a
  * semantic-store row key, shared by BOTH durable write paths —


### PR DESCRIPTION
Closes #3550.

## Problem

Two code paths write a generated semantic layer durably and diverged on metrics:

| Path | Entities | Metrics |
|------|----------|---------|
| `SemanticGenerator.persist` (MCP — `effect/semantic-generator.ts`) | `semantic_entities` DB | `semantic_entities` DB |
| Wizard `/save` (`api/routes/wizard.ts`) | `semantic_entities` DB | **disk only** (`semantic/<group>/metrics/*.yml`) |

The asymmetry was silent — no comment, test, or doc flagged it — so a wizard-onboarded workspace and an MCP-profiled one had different metric durability/queryability guarantees. Disk-only metrics never reach the org-whitelist DB-backed load path that the API process behind web `/chat` reads.

## Resolution (issue Option 1 — converge)

Wizard `/save` now persists generated metrics to `semantic_entities` as **drafts**, mirroring `SemanticGenerator.persist`:

- **DB is the source of truth for queryability.** Metrics persist via `bulkUpsertEntities` (`entity_type = 'metric'`), promoted through the same atomic `/api/v1/admin/publish` endpoint as entities — never stamped published outside it.
- **Same fail-loud contract as entities.** DB-first, then the disk write; a thrown upsert → `db_persist_failed` (500), a short count → `db_partial_persist` (500). `bulkUpsertEntities` swallows per-row errors and returns a count, so a partial persist can't silently 201 a half-queryable state (#2142 class, now for metrics).
- **Disk write retained but additive.** The metric YAML still lands on disk for legibility; a code comment states this decision so future readers don't re-diff the two paths (AC2).
- **Shared row-name seam so the paths can't drift again.** The `path.basename` + `SAFE_TABLE_NAME` derivation moved into `safeSemanticRowName` (`semantic/shapes.ts`), now used by **both** `artifactRowName` (MCP) and the wizard. The same name keys the DB row and the disk filename, so disk/DB can't disagree on which metrics landed. The stale `#3551 reconciliation` divergence note in `semantic-generator.ts` is replaced with the resolved contract.

Path-traversal protection on the disk write is preserved (`safeSemanticRowName` strips path segments and rejects unsafe names — skipped + logged, never silently swallowed).

## Scope notes

- Only the server-side **raw-`profiles` submission branch** of `/save` generates metrics. The wizard UI sends pre-generated entities (no profiles) and never produced metrics, so the user-facing wizard flow is unchanged — no docs update needed. The `semantic-layer-wizard.mdx` guide ("the wizard generates entity YAML files only") stays accurate.
- No route response shape changed (`attempted`/`succeeded` fields already returned by the entity partial-persist path), so no OpenAPI regeneration.
- Kept compatible with #3529 (consolidate wizard generation onto `generateSemanticLayer`) — did not widen into it.

## Acceptance criteria

- [x] Both write paths agree on where metrics land (**DB**, enforced via shared `safeSemanticRowName` + fail-loud upsert)
- [x] A comment **and** tests document the chosen contract so future readers don't have to diff the two paths

## Tests (TDD)

- `persists generated metrics to semantic_entities as draft metric rows, not disk-only (#3550)` — asserts a `metric` row reaches `bulkUpsertEntities` keyed `orders`, scoped to the resolved group, and that the disk file is still written (additive).
- `fails loud (db_partial_persist) on a partial metric upsert — contract pin against drift back to disk-only (#3550)` — pins the contract; a regression to a disk-only metric write would never produce a `metric` upsert and this test would fail.

Local: full `wizard.test.ts` (65), both `semantic-generator` suites, all 15 `lib/semantic/__tests__`, `lib/semantic.test.ts`, `api/semantic.test.ts`, `admin-wizard-save-audit.test.ts` pass; `tsgo --noEmit` clean; eslint clean on changed files. Full CI is the arbiter.