### PR TITLE
refactor(wizard): route /generate entity YAML through generateSemanticLayer (#3529)

### DIFF
--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -233,6 +233,11 @@ import {
   FATAL_ERROR_PATTERN as _fatalPatternReal,
 } from "@atlas/api/lib/profiler";
 
+// The shared assembly engine (#3506) — imported unmocked so the wire-shape
+// tests can assert the wizard's `/generate` YAML is byte-identical to what the
+// shared core emits (the consolidation contract, #3529).
+import { generateSemanticLayer } from "@atlas/api/lib/semantic/generate";
+
 const mockUserProfile = {
   table_name: "users",
   object_type: "table" as const,
@@ -606,6 +611,54 @@ describe("POST /api/v1/wizard/generate", () => {
     // (neither the canonical `group:` nor the deprecated `connection:` alias).
     expect(entities[0].yaml).not.toContain("group:");
     expect(entities[0].yaml).not.toContain("connection:");
+  });
+
+  it("pins the /generate wire response shape (consolidation must not reshape it, #3529)", async () => {
+    // The entity YAML is now produced by the shared `generateSemanticLayer`
+    // (#3529), but the wizard's preview-metadata wrapper stays wizard-local.
+    // Pin the exact response shape so the delegation can't silently drop or
+    // rename a field the frontend reads.
+    const res = await postJson("/api/v1/wizard/generate", {
+      connectionId: "default",
+      tables: ["users"],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(Object.keys(data).toSorted()).toEqual(
+      ["connectionId", "dbType", "entities", "errors", "schema"].toSorted(),
+    );
+    const entities = data.entities as Array<Record<string, unknown>>;
+    expect(entities).toHaveLength(1);
+    expect(Object.keys(entities[0]).toSorted()).toEqual(
+      ["columnCount", "objectType", "profile", "rowCount", "tableName", "yaml"].toSorted(),
+    );
+    const profile = entities[0].profile as Record<string, unknown>;
+    expect(Object.keys(profile).toSorted()).toEqual(
+      ["columns", "flags", "foreignKeys", "inferredForeignKeys", "notes", "primaryKeys"].toSorted(),
+    );
+    expect(typeof entities[0].yaml).toBe("string");
+    expect(entities[0].tableName).toBe("users");
+    expect(entities[0].objectType).toBe("table");
+    expect(entities[0].rowCount).toBe(1000);
+    expect(entities[0].columnCount).toBe(2);
+  });
+
+  it("routes /generate entity YAML through the shared core, byte-identical (#3529)", async () => {
+    // The wizard preview YAML must match exactly what the shared engine emits
+    // for the same analyzed profiles — that byte-equality is the whole point of
+    // the consolidation (one engine, no per-caller drift). Default connection →
+    // NULL default group → no sourceId, matching the wizard's resolution.
+    const res = await postJson("/api/v1/wizard/generate", {
+      connectionId: "default",
+      tables: ["users"],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    const entities = data.entities as { tableName: string; yaml: string }[];
+
+    const analyzed = _analyzeReal([mockUserProfile]);
+    const expected = generateSemanticLayer(analyzed, { dbType: "postgres", schema: "public" });
+    expect(entities[0].yaml).toBe(expected.entities[0].yaml);
   });
 
   it("scopes generated YAML by the connection's group (non-default connection)", async () => {
@@ -1305,6 +1358,43 @@ describe("POST /api/v1/wizard/save", () => {
     expect(files).toContain("entities/users.yml");
     expect(files).toContain("catalog.yml");
     expect(files).toContain("glossary.yml");
+  });
+
+  it("sanitizes path-bearing metric table names via path.basename before writing (#3529 filename safety)", async () => {
+    // The wizard delegates catalog/glossary/metric assembly to the shared core
+    // but PRESERVES its own filename-safety guard: a path-bearing profile table
+    // name (which the SAFE_TABLE_NAME entity guard never sees, since profiles
+    // arrive separately) must be reduced to its basename via
+    // `safeSemanticRowName` so the metric file can never escape metricsDir.
+    mockWriteFileSync.mockClear();
+    const unsafeMetricProfile = { ...mockOrdersProfile, table_name: "../../../etc/passwd" };
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      // Entities carry a safe name (they pass the SAFE_TABLE_NAME guard); the
+      // path-bearing name lives only in the raw profile.
+      entities: [{ tableName: "passwd", yaml: "table: passwd\n" }],
+      schema: "public",
+      profiles: [unsafeMetricProfile],
+    });
+
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    const files = data.files as string[];
+    // basename("../../../etc/passwd") === "passwd": the metric lands under the
+    // sanitized name, never the traversing path.
+    expect(files).toContain("metrics/passwd.yml");
+
+    // Defense-in-depth: no write path escapes via the raw traversing name.
+    const writePaths = mockWriteFileSync.mock.calls.map(([p]) => String(p));
+    expect(writePaths.every((p) => !p.includes("etc/passwd"))).toBe(true);
+    expect(writePaths.every((p) => !p.includes(".."))).toBe(true);
+
+    // The persisted metric row is keyed by the same sanitized basename.
+    const allRows = mockBulkUpsertEntities.mock.calls.flatMap(([, rows]) => rows);
+    const metricRows = allRows.filter((r) => r.entityType === "metric");
+    expect(metricRows.length).toBeGreaterThan(0);
+    expect(metricRows[0].name).toBe("passwd");
   });
 
   it("returns 422 when profiles contain invalid objects", async () => {

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -643,22 +643,39 @@ describe("POST /api/v1/wizard/generate", () => {
     expect(entities[0].columnCount).toBe(2);
   });
 
-  it("routes /generate entity YAML through the shared core, byte-identical (#3529)", async () => {
+  it("routes /generate entity YAML through the shared core, byte-identical and correctly paired (#3529)", async () => {
     // The wizard preview YAML must match exactly what the shared engine emits
     // for the same analyzed profiles — that byte-equality is the whole point of
     // the consolidation (one engine, no per-caller drift). Default connection →
     // NULL default group → no sourceId, matching the wizard's resolution.
+    //
+    // Two profiles (not one) so the test also pins per-table PAIRING: each
+    // preview row must carry ITS OWN table's YAML. A regression that mis-pairs
+    // YAML with the wrong metadata row would pass a single-table check but fail
+    // here (users' YAML names "users", orders' YAML names "orders").
+    mockProfilePostgres.mockImplementation(async () => ({
+      profiles: [mockUserProfile, mockOrdersProfile],
+      errors: [],
+    }));
+
     const res = await postJson("/api/v1/wizard/generate", {
       connectionId: "default",
-      tables: ["users"],
+      tables: ["users", "orders"],
     });
     expect(res.status).toBe(200);
     const data = await json(res);
     const entities = data.entities as { tableName: string; yaml: string }[];
 
-    const analyzed = _analyzeReal([mockUserProfile]);
+    const analyzed = _analyzeReal([mockUserProfile, mockOrdersProfile]);
     const expected = generateSemanticLayer(analyzed, { dbType: "postgres", schema: "public" });
-    expect(entities[0].yaml).toBe(expected.entities[0].yaml);
+
+    expect(entities).toHaveLength(2);
+    // Compare the whole tableName → YAML mapping: each preview row must carry
+    // its OWN table's byte-identical shared-core YAML. A mis-paired row (users'
+    // metadata + orders' YAML) would diverge from the expected mapping and fail.
+    const actualByTable = Object.fromEntries(entities.map((e) => [e.tableName, e.yaml]));
+    const expectedByTable = Object.fromEntries(expected.entities.map((e) => [e.table, e.yaml]));
+    expect(actualByTable).toEqual(expectedByTable);
   });
 
   it("scopes generated YAML by the connection's group (non-default connection)", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -47,12 +47,12 @@ import {
   outputDirForGroup,
 } from "@atlas/api/lib/profiler";
 // Mechanical generation runs through the shared semantic engine (issue #3233)
-// so the wizard and the CLI emit identical YAML. The catalog/glossary/metric
-// assembly delegates to `generateSemanticLayer` — the same shared core the CLI
-// and the `SemanticGenerator` service use (#3506) — so the three can't drift.
+// so the wizard and the CLI emit identical YAML. Both the `/generate` entity
+// YAML and the `/save` catalog/glossary/metric assembly delegate to
+// `generateSemanticLayer` (#3529) — the same shared core the CLI and the
+// `SemanticGenerator` service use (#3506) — so the three can't drift.
 import {
   analyzeTableProfiles,
-  generateEntityYAML,
   generateSemanticLayer,
 } from "@atlas/api/lib/semantic/generate";
 import { SAFE_TABLE_NAME, safeSemanticRowName } from "@atlas/api/lib/semantic/shapes";
@@ -679,12 +679,23 @@ wizard.openapi(generateRoute, async (c) => {
           }
         }
         const sourceId = connectionGroupId ?? undefined;
-        const entities = analyzedProfiles.map((profile) => ({
+
+        // Entity YAML goes through the shared engine (#3529) so the wizard
+        // preview, the CLI, and the SemanticGenerator service emit identical
+        // YAML — only the preview-metadata wrapper below stays wizard-local.
+        // `generateSemanticLayer` returns `entities` in profile order (one per
+        // input profile), so the index aligns 1:1 with `analyzedProfiles`.
+        const generated = generateSemanticLayer(analyzedProfiles, {
+          dbType,
+          schema,
+          sourceId,
+        });
+        const entities = analyzedProfiles.map((profile, index) => ({
           tableName: profile.table_name,
           objectType: profile.object_type,
           rowCount: profile.row_count,
           columnCount: profile.columns.length,
-          yaml: generateEntityYAML(profile, analyzedProfiles, dbType, schema, sourceId),
+          yaml: generated.entities[index].yaml,
           profile: {
             columns: profile.columns.map((col) => ({
               name: col.name,

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -683,52 +683,67 @@ wizard.openapi(generateRoute, async (c) => {
         // Entity YAML goes through the shared engine (#3529) so the wizard
         // preview, the CLI, and the SemanticGenerator service emit identical
         // YAML — only the preview-metadata wrapper below stays wizard-local.
-        // `generateSemanticLayer` returns `entities` in profile order (one per
-        // input profile), so the index aligns 1:1 with `analyzedProfiles`.
+        // Pair the returned artifact to its profile by table name rather than by
+        // position: `generateSemanticLayer` emits one entity per profile today,
+        // but keying on `table` keeps the wrapper correct even if the engine
+        // ever reorders or filters artifacts (as it already does for metrics),
+        // instead of silently mis-pairing YAML with the wrong metadata.
         const generated = generateSemanticLayer(analyzedProfiles, {
           dbType,
           schema,
           sourceId,
         });
-        const entities = analyzedProfiles.map((profile, index) => ({
-          tableName: profile.table_name,
-          objectType: profile.object_type,
-          rowCount: profile.row_count,
-          columnCount: profile.columns.length,
-          yaml: generated.entities[index].yaml,
-          profile: {
-            columns: profile.columns.map((col) => ({
-              name: col.name,
-              type: col.type,
-              mappedType: col.is_enum_like ? "enum" : undefined,
-              nullable: col.nullable,
-              isPrimaryKey: col.is_primary_key,
-              isForeignKey: col.is_foreign_key,
-              isEnumLike: col.is_enum_like,
-              semanticType: col.semantic_type,
-              sampleValues: col.sample_values.slice(0, 5),
-              uniqueCount: col.unique_count,
-              nullCount: col.null_count,
-            })),
-            primaryKeys: profile.primary_key_columns,
-            foreignKeys: profile.foreign_keys.map((fk) => ({
-              fromColumn: fk.from_column,
-              toTable: fk.to_table,
-              toColumn: fk.to_column,
-              source: fk.source,
-            })),
-            inferredForeignKeys: profile.inferred_foreign_keys.map((fk) => ({
-              fromColumn: fk.from_column,
-              toTable: fk.to_table,
-              toColumn: fk.to_column,
-            })),
-            flags: {
-              possiblyAbandoned: profile.table_flags.possibly_abandoned,
-              possiblyDenormalized: profile.table_flags.possibly_denormalized,
+        const entityYamlByTable = new Map(generated.entities.map((e) => [e.table, e.yaml]));
+        const entities = analyzedProfiles.map((profile) => {
+          const entityYaml = entityYamlByTable.get(profile.table_name);
+          if (entityYaml === undefined) {
+            // The shared core guarantees an entity per profile; a miss means its
+            // contract changed under us. Fail loud (→ 500 generate_failed with a
+            // requestId) rather than emit a preview row with empty/wrong YAML.
+            throw new Error(
+              `Shared semantic engine produced no entity YAML for table "${profile.table_name}"`,
+            );
+          }
+          return {
+            tableName: profile.table_name,
+            objectType: profile.object_type,
+            rowCount: profile.row_count,
+            columnCount: profile.columns.length,
+            yaml: entityYaml,
+            profile: {
+              columns: profile.columns.map((col) => ({
+                name: col.name,
+                type: col.type,
+                mappedType: col.is_enum_like ? "enum" : undefined,
+                nullable: col.nullable,
+                isPrimaryKey: col.is_primary_key,
+                isForeignKey: col.is_foreign_key,
+                isEnumLike: col.is_enum_like,
+                semanticType: col.semantic_type,
+                sampleValues: col.sample_values.slice(0, 5),
+                uniqueCount: col.unique_count,
+                nullCount: col.null_count,
+              })),
+              primaryKeys: profile.primary_key_columns,
+              foreignKeys: profile.foreign_keys.map((fk) => ({
+                fromColumn: fk.from_column,
+                toTable: fk.to_table,
+                toColumn: fk.to_column,
+                source: fk.source,
+              })),
+              inferredForeignKeys: profile.inferred_foreign_keys.map((fk) => ({
+                fromColumn: fk.from_column,
+                toTable: fk.to_table,
+                toColumn: fk.to_column,
+              })),
+              flags: {
+                possiblyAbandoned: profile.table_flags.possibly_abandoned,
+                possiblyDenormalized: profile.table_flags.possibly_denormalized,
+              },
+              notes: profile.profiler_notes,
             },
-            notes: profile.profiler_notes,
-          },
-        }));
+          };
+        });
 
         return { ok: true as const, analyzedProfiles, entities, errors: result.errors };
       },


### PR DESCRIPTION
## What

Consolidates the web wizard's last hand-inlined generation path onto the shared `generateSemanticLayer` engine.

The `/generate` handler (`packages/api/src/api/routes/wizard.ts`) hand-inlined the per-profile `generateEntityYAML` call — a third copy of the entity/catalog/glossary/metric loop alongside the CLI (`atlas init`) and the `SemanticGenerator` service. That's the exact drift the shared core (#3506) exists to prevent. (`/save`'s catalog/glossary/metric assembly was already routed through the shared core in #3506/#3550, so this PR finishes the job.)

## How

- `/generate` now calls `generateSemanticLayer(analyzedProfiles, { dbType, schema, sourceId })` and reads each entity's YAML from the returned artifacts. The shared core returns `entities` in profile order, so the index aligns 1:1 with `analyzedProfiles`.
- The wizard-local preview-metadata wrapper (`tableName`/`objectType`/`rowCount`/`columnCount`/`profile`) stays in the route — only the `yaml` field moves to the shared core.
- Removed the now-unused `generateEntityYAML` import.

**No change to the wizard's wire response shape.**

## Tests

- Pin the full `/generate` wire response shape (top-level + per-entity + nested `profile` keys) so the delegation can't silently drop or rename a field the frontend reads.
- Assert `/generate` YAML is byte-identical to `generateSemanticLayer` output — the byte-equality that is the whole point of the consolidation.
- Cover the `/save` filename-safety guard: a path-bearing metric table name (which arrives via the separate `profiles` array, bypassing the entity `SAFE_TABLE_NAME` guard) is reduced to its basename via `safeSemanticRowName` and never escapes `metricsDir`.

## Acceptance criteria (#3529)

- [x] wizard `/save` catalog/glossary/metric generation delegates to `generateSemanticLayer` (already shipped in #3506/#3550; filename-safety guard now pinned by test)
- [x] wizard `/generate` entity YAML goes through the shared core (preview metadata wrapper stays wizard-local)
- [x] no change to the wizard's wire response shape

## CI

Local gates all green: lint, type, full `bun run test`, syncpack, template/security-headers/railway-watch/schema/openapi/oauth-helper/test-discipline/twenty-resolver/settings-readers/published-symbols drift checks.

Closes #3529.

https://claude.ai/code/session_01XN6QgBzp78Tz9kTPXK5UxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN6QgBzp78Tz9kTPXK5UxE)_