### PR TITLE
refactor(openapi): converge REST datasources onto the semantic-layer surface (#3628)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2629,3 +2629,20 @@ The implementation survey narrowed the candidate's "16 pages" to the surfaces th
 - Fail-closed is the invariant, and the review cycle is itself the documentation of why: the first cut left `checkApprovalRequired`/`hasApprovedRequest` outside the try/catch, where the EE layer's `Effect.promise` turns a DB rejection into a defect that escapes uncaught — two independent reviewers caught it, and the fix put all four gate calls behind one boundary that denies on any throw, mirroring executeSQL's single-tryPromise shape.
 
 **Category:** New cross-cutting infrastructure collapsed to a single reusable seam — the gate order has one home and one RBAC primitive, so the datasource flagship tools inherit governance for free instead of each re-deriving (and risking drift on) the security model.
+
+## 94. REST datasources converge onto the `/admin/semantic` surface + a shared entity-YAML vocabulary contract — two renderers stay separate, can't drift (#3628)
+
+**Date:** 2026-06-14
+**Issue:** #3628
+**PR:** #3639
+
+**Problem:** REST/OpenAPI datasources were queryable-but-invisible. The agent rendered their entities live from the cached `openapi_snapshot` at prompt-build time, but `/admin/semantic` knew nothing about them — a REST-only workspace saw a misleading "no semantic layer / run `atlas init`" empty state. Separately, the two entity-YAML renderers (REST's `renderEntityYaml` and the DB profiler's `generateEntityYAML`) shared a field vocabulary (`dimensions` / `joins`+`target_entity` / `query_patterns` / type tags) only by coincidence of duplicated string literals — free to drift silently, which would break the human-facing surface for one source only.
+
+**Solution:** Convergence, not consolidation. (1) A new read-only `lib/openapi/admin-rest-entities.ts` derives entities on read from the cached snapshot via the **same pure `generateSemanticModel`** the agent uses — never persisted to `semantic_entities`, never publish-gated — wired into the admin list/detail/raw routes + overview count behind a namespaced storage key. (2) The shared key vocabulary is lifted into one contract in `@useatlas/schemas/semantic-entity-yaml.ts` (`ENTITY_YAML_KEYS` etc. + `SharedEntityYamlSchema`); both renderers consume the constants as computed keys, and a drift test validates both outputs — a field-name drift is now a compile/test failure, not a silent break. (3) ADR-0017 records why the spec-derived (ephemeral, pure) and profiled (persisted, I/O + publish-gated) generators intentionally do NOT share a generator seam — a unifying super-seam would be accidental complexity.
+
+**Impact:**
+- A REST-only workspace finally sees its semantic layer in `/admin/semantic` (read-only), and Overview/Semantic agree on the entity count.
+- The two YAML dialects can no longer drift: shared key names have one home, asserted by a cross-renderer contract test.
+- Zero agent-token cost and zero prompt-representation change — the bake-off's `operation-graph` (Path A) default is untouched (the `twenty-acceptance` test passes unchanged); renderer golden output is byte-identical.
+
+**Category:** A visibility gap closed with one read-only derive-on-read module reusing the existing pure generator, plus a duplicated-vocabulary smell collapsed into a single shared contract — convergence on surface + vocabulary while the two generators stay deliberately, documentedly separate (ADR-0017).

--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -138,6 +138,12 @@ The alert is **dismissible**: click **Acknowledge** on the card to clear it. It 
 Breaking-vs-additive is a heuristic over the structured diff, bounded by the same field-walk depth the diff uses — treat the alert as "worth a look", not a proof. Always confirm against the upstream API's own changelog.
 </Callout>
 
+## Seeing the entities (Admin → Semantic)
+
+A REST datasource's entities show up in **Admin → Semantic** alongside any SQL entities — one entity per REST resource, with its dimensions (columns), joins, and operations. This is the same entity-relational model the agent can reason over, derived live from the cached spec snapshot, so a REST-only workspace no longer sees an empty "run `atlas init`" state.
+
+These entries are **read-only**. Unlike SQL entities (which are profiled into editable, publish-gated YAML), REST entities are deterministic from the spec — there's nothing to author or promote. To change what's surfaced, change the upstream spec and **Rediscover schema**; there is no edit, delete, or version history for them. (The agent prompt itself stays on the compact operation-graph representation by default — this admin view is for humans and adds no agent-token cost.)
+
 ## Configuration fields
 
 Install-form fields (Admin → Connections):

--- a/docs/adr/0017-two-semantic-generators-stay-separate.md
+++ b/docs/adr/0017-two-semantic-generators-stay-separate.md
@@ -1,0 +1,92 @@
+# ADR-0017: The two semantic generators stay separate (spec-derived vs profiled)
+
+**Status:** Accepted
+**Date:** 2026-06-14
+**Context milestone:** v0.0.16 — In-Product Datasource Onboarding (Profiler Seam)
+**Depends on:** [ADR-0010](./0010-rest-datasource-environment-scoping.md), [ADR-0013](./0013-db-stored-plugin-datasource-connections.md)
+**Closes:** [#3628](https://github.com/AtlasDevHQ/atlas/issues/3628) (the REST exclusion left open by the [#3303](https://github.com/AtlasDevHQ/atlas/issues/3303) profiler-seam PRD)
+
+## Context
+
+Atlas has **two** code paths that turn a datasource into a semantic-layer entity model, and they look superficially mergeable — both emit "entities" with columns/dimensions, joins, and query patterns. The #3303 profiler-seam epic deliberately *excluded* REST/OpenAPI datasources, and that exclusion invited a recurring question: should the two generators be unified behind one `SemanticGenerator` seam? This ADR records why the answer is **no** — they converge on a shared *surface* and a shared *vocabulary*, but never on a shared *generator*.
+
+The two paths sit at opposite ends of the persistence spectrum:
+
+1. **Spec-derived (ephemeral)** — `lib/openapi/semantic-generator.ts`
+   (`generateSemanticModel` → `renderEntityYaml`). Pure functions over the
+   normalized OpenAPI `OperationGraph`. **No I/O.** Entities are deterministic
+   from the spec, generated lazily at prompt-build time (and, as of #3628, at
+   admin read time), and **never written to `semantic_entities`**. The cached
+   `workspace_plugins.config.openapi_snapshot` is the only durable artifact; the
+   refresh model is "rediscover" (re-probe → diff → swap snapshot), not
+   "regenerate + persist".
+
+2. **Profiled (persisted)** — `lib/effect/semantic-generator.ts` +
+   `lib/semantic/generate/yaml.ts` (`generateEntityYAML`). Profiles a **live
+   connection** (row sampling, heuristics), generates editable YAML, and writes
+   it as **draft rows** in `semantic_entities` — publish-gated through the atomic
+   `/api/v1/admin/publish` endpoint and registered into the SQL whitelist. The
+   YAML is a human-editable authoring artifact.
+
+## Decision
+
+**Keep the two generators separate. Converge them on a shared display surface
+and a shared field vocabulary — not on a shared generator abstraction.**
+
+Concretely (all shipped in #3628):
+
+- **Shared surface.** REST-derived entities are now visible (read-only) in
+  `/admin/semantic`, sourced live from the cached snapshot via
+  `generateSemanticModel` — so both onboarding paths converge on one place to
+  *see* the semantic layer. REST entities are **not** routed through
+  `semantic_entities` / draft-publish; a read-only view is enough, and
+  persisting a rediscover-refreshed, spec-derived model would re-introduce the
+  staleness/sync problem the snapshot model exists to avoid.
+
+- **Shared vocabulary.** Where both renderers emit entity YAML, the shared key
+  names (`type`, `dimensions`, `joins` / `target_entity` / `relationship`,
+  `query_patterns`, `primary_key`) are lifted into a contract in
+  `@useatlas/schemas/semantic-entity-yaml` (`ENTITY_YAML_KEYS` etc. +
+  `SharedEntityYamlSchema`). Both renderers consume the constants and a drift
+  test validates both outputs, so the two YAML dialects can't silently diverge.
+
+- **No shared generator.** The generators themselves stay distinct. A unifying
+  `SemanticGenerator` super-seam would be accidental complexity: the two share
+  only vocabulary, while differing on every load-bearing axis — input (spec
+  graph vs live connection), purity (pure vs I/O + heuristics), output lifetime
+  (ephemeral vs durable draft), and lifecycle (rediscover vs profile + publish).
+
+## Consequences
+
+- **REST onboarding is unchanged.** No profiling/"generate" step is added to
+  REST install — there's no row-sampling to do; the install-time probe is the
+  right model. Install remains the whole onboarding step.
+
+- **The agent prompt is untouched.** The REST agent prompt keeps the compact
+  `operation-graph` representation (Path A) as its default — the #2931 bake-off
+  measured it as materially cheaper than entity-YAML (Path B). The shared-surface
+  work renders entity YAML for the **human** admin view only; it adds no
+  agent-token cost and must never push the prompt toward Path B. See
+  [the bake-off](../architecture/openapi-representation-bakeoff.md).
+
+- **One place to look, two places to change.** Operators see all entities in
+  `/admin/semantic`; SQL entities are edited there, REST entities change only by
+  editing the upstream spec + rediscovering. The read-only affordance on REST
+  rows encodes that difference in the UI.
+
+## Alternatives considered
+
+- **(A) Merge into one `SemanticGenerator`.** Rejected — the only real overlap
+  is vocabulary, now captured by the schema contract. A shared seam would couple
+  a pure, no-I/O spec walk to a connection-profiling, DB-writing, publish-gated
+  pipeline.
+
+- **(B) Persist REST entities into `semantic_entities` for parity.** Rejected —
+  a rediscover-refreshed spec model would constantly drift from its persisted
+  copy, recreating the exact sync problem the snapshot model avoids. Read-only,
+  derive-on-read is correct for a deterministic-from-spec model.
+
+- **(C) Leave REST invisible in `/admin/semantic`.** Rejected — a REST-only
+  workspace saw a misleading "no semantic layer / run `atlas init`" empty state
+  while the agent was already querying REST entities. The visibility gap was the
+  coherence bug #3628 set out to close.

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -68,6 +68,13 @@ import {
   AdminEntityYamlShapeError,
   type AdminEntityYamlError,
 } from "@atlas/api/lib/semantic/admin-source";
+// REST/OpenAPI datasources converge onto the `/admin/semantic` surface
+// read-only (#3628) — derived live from the cached snapshot, never persisted.
+import {
+  listRestAdminEntities,
+  getRestAdminEntityDetail,
+  parseRestEntityKey,
+} from "@atlas/api/lib/openapi/admin-rest-entities";
 // Shared, layout-aware traversal (ADR-0012): the single source of truth so
 // metric/glossary discovery recognizes the canonical groups/<group>/ namespace
 // alongside flat-root + legacy <source>/ layouts (#3240).
@@ -1609,8 +1616,11 @@ admin.openapi(overviewRoute, async (c) => {
       orgId: orgId ?? undefined,
       mode,
     });
-    entityCount = entityList.entities.length;
-    entityWarnings = [...entityList.warnings];
+    // Include REST-derived entities (#3628) so Overview and the Semantic page
+    // agree on the count — the page lists both SQL and REST entities.
+    const restList = orgId ? await listRestAdminEntities(orgId) : { entities: [], warnings: [] };
+    entityCount = entityList.entities.length + restList.entities.length;
+    entityWarnings = [...entityList.warnings, ...restList.warnings];
   } catch (err) {
     const requestId = reqId(c);
     log.error(
@@ -1700,14 +1710,24 @@ admin.openapi(listEntitiesRoute, async (c) => {
   try {
     const result = await listAdminEntities({ orgId, mode });
 
+    // REST/OpenAPI datasources converge onto this surface read-only (#3628):
+    // derived live from the cached snapshot, never persisted to
+    // `semantic_entities`. They carry no DB↔YAML drift (they're spec-derived,
+    // not profiled), so they always get `drift: null` in the drift branches.
+    const restList = orgId
+      ? await listRestAdminEntities(orgId)
+      : { entities: [], warnings: [] };
+    const restWarnings = restList.warnings;
+
     // Backwards-compat path: no `?connection=` → return the existing shape.
     // Drift attachment is opt-in so legacy callers (the entity tab on the
     // /admin/semantic page before slice 1, the SDK, integration tests) keep
     // working unchanged.
     if (!connectionId) {
+      const warnings = [...result.warnings, ...restWarnings];
       return c.json({
-        entities: result.entities,
-        ...(result.warnings.length > 0 && { warnings: result.warnings }),
+        entities: [...result.entities, ...restList.entities],
+        ...(warnings.length > 0 && { warnings }),
       }, 200);
     }
 
@@ -1718,11 +1738,15 @@ admin.openapi(listEntitiesRoute, async (c) => {
     // break the existing list rendering, which is worse than a quiet drift
     // signal.
     if (!connections.has(connectionId)) {
+      const warnings = [...result.warnings, ...restWarnings];
       return c.json({
-        entities: result.entities.map((e) => ({ ...e, drift: null })),
+        entities: [
+          ...result.entities.map((e) => ({ ...e, drift: null })),
+          ...restList.entities.map((e) => ({ ...e, drift: null })),
+        ],
         noIntrospectedTables: true,
         requestId,
-        ...(result.warnings.length > 0 && { warnings: result.warnings }),
+        ...(warnings.length > 0 && { warnings }),
       }, 200);
     }
 
@@ -1730,9 +1754,12 @@ admin.openapi(listEntitiesRoute, async (c) => {
       const driftDiff = await runDriftDiff(connectionId, { orgId, atlasMode });
       const noIntrospectedTables = driftDiff.introspectedTableCount === 0;
       const envelope = attachDrift(result.entities, driftDiff.diff, { noIntrospectedTables });
-      const mergedWarnings = [...result.warnings, ...driftDiff.warnings];
+      const mergedWarnings = [...result.warnings, ...driftDiff.warnings, ...restWarnings];
       return c.json({
-        entities: envelope.entities,
+        entities: [
+          ...envelope.entities,
+          ...restList.entities.map((e) => ({ ...e, drift: null })),
+        ],
         noIntrospectedTables: envelope.noIntrospectedTables,
         requestId,
         ...(mergedWarnings.length > 0 && { warnings: mergedWarnings }),
@@ -1757,10 +1784,14 @@ admin.openapi(listEntitiesRoute, async (c) => {
         "Drift diff failed — returning entities without drift attachment",
       );
       return c.json({
-        entities: result.entities.map((e) => ({ ...e, drift: null })),
+        entities: [
+          ...result.entities.map((e) => ({ ...e, drift: null })),
+          ...restList.entities.map((e) => ({ ...e, drift: null })),
+        ],
         requestId,
         warnings: [
           ...result.warnings,
+          ...restWarnings,
           `Drift check failed (requestId: ${requestId}). See server logs.`,
         ],
       }, 200);
@@ -1823,6 +1854,23 @@ admin.openapi(getEntityRoute, async (c) => {
   }
 
   if (!result) {
+    // #3628: a REST-derived entity has a namespaced storage key and lives only
+    // in the cached snapshot — not in DB/disk — so it falls through to here.
+    // Resolve it read-only from the snapshot before declaring 404.
+    if (orgId && parseRestEntityKey(name)) {
+      try {
+        const restDetail = await getRestAdminEntityDetail(orgId, name);
+        if (restDetail) {
+          return c.json({ entity: restDetail.entity }, 200);
+        }
+      } catch (err) {
+        log.error(
+          { err: err instanceof Error ? err : new Error(String(err)), entityName: name, orgId, requestId },
+          "Failed to resolve REST admin entity",
+        );
+        return c.json({ error: "internal_error", message: `Failed to load entity "${name}".`, requestId }, 500);
+      }
+    }
     return c.json({ error: "not_found", message: `Entity "${name}" not found.`, requestId }, 404);
   }
   return c.json({ entity: result.entity }, 200);
@@ -1893,6 +1941,36 @@ admin.openapi(getRawYamlDirFileRoute, async (c) => {
   const { dir, file } = c.req.valid("param");
   const { authResult, requestId } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
+
+  // #3628: a REST-derived entity's YAML is rendered live from the cached
+  // snapshot — there's no DB row or disk file, and its namespaced key (`::`)
+  // would trip `serveRawYaml`'s allowlist regex. Intercept and render it here.
+  if (orgId && dir === "entities" && file.endsWith(".yml")) {
+    const stem = file.slice(0, -".yml".length);
+    if (parseRestEntityKey(stem)) {
+      try {
+        const restDetail = await getRestAdminEntityDetail(orgId, stem);
+        if (restDetail) {
+          throw new HTTPException(200, {
+            res: new Response(restDetail.yaml, {
+              status: 200,
+              headers: { "Content-Type": "text/plain; charset=utf-8" },
+            }),
+          });
+        }
+      } catch (err) {
+        if (err instanceof HTTPException) throw err;
+        log.error(
+          { err: err instanceof Error ? err : new Error(String(err)), file: stem, orgId, requestId },
+          "Failed to render REST entity YAML",
+        );
+        throw new HTTPException(500, {
+          res: Response.json({ error: "internal_error", message: "Failed to load YAML.", requestId }, { status: 500 }),
+        });
+      }
+    }
+  }
+
   // Empty `?connectionGroupId=` maps to null (legacy / `__global__` row).
   // Missing param falls through to getEntity's unique-or-409 default (#2412).
   const rawGroup = c.req.query("connectionGroupId");

--- a/packages/api/src/lib/openapi/__tests__/admin-rest-entities.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/admin-rest-entities.test.ts
@@ -1,0 +1,100 @@
+/**
+ * REST-derived admin entity helpers (#3628) — pure mapping + key round-trip.
+ *
+ * The resolver-backed `listRestAdminEntities` / `getRestAdminEntityDetail`
+ * orchestrators are covered by the route-level suites; here we pin the pure,
+ * routing-critical logic: the namespaced storage key (so detail/raw can resolve
+ * the exact datasource) and the GeneratedEntity → admin shapes.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  makeRestEntityKey,
+  parseRestEntityKey,
+  summarizeEntity,
+  toDetailEntity,
+  REST_ENTITY_KEY_DELIMITER,
+} from "../admin-rest-entities";
+import type { GeneratedEntity } from "../semantic-generator";
+import type { RestDatasource } from "../datasource";
+import { REST_ENTITY_TYPE_TAG } from "@useatlas/schemas/semantic-entity-yaml";
+
+const entity: GeneratedEntity = {
+  name: "Person",
+  resource: "people",
+  recordSchema: "Person",
+  description: "A person",
+  operations: [],
+  columns: [
+    { name: "id", type: "string", primaryKey: true, description: "id" },
+    { name: "name", type: "string" },
+  ],
+  joins: [{ via: "company", targetEntity: "Company", relationship: "many_to_one", description: "owner" }],
+  queryPatterns: [{ name: "search", description: "search" }],
+};
+
+const ds = {
+  id: "install-123",
+  displayName: "Twenty",
+  groupId: undefined,
+  graph: {} as RestDatasource["graph"],
+  baseUrl: "https://example.com",
+  auth: { kind: "none" } as RestDatasource["auth"],
+  representationMode: "operation-graph",
+  writeAllowlist: new Set<string>(),
+  sideEffectingOperations: new Set<string>(),
+} as RestDatasource;
+
+describe("REST admin entity key", () => {
+  it("round-trips install id + entity name", () => {
+    const key = makeRestEntityKey("install-123", "Person");
+    expect(key).toBe(`install-123${REST_ENTITY_KEY_DELIMITER}Person`);
+    expect(parseRestEntityKey(key)).toEqual({ installId: "install-123", entityName: "Person" });
+  });
+
+  it("returns null for a non-REST (delimiter-less) key", () => {
+    expect(parseRestEntityKey("orders")).toBeNull();
+    expect(parseRestEntityKey("public.orders")).toBeNull();
+  });
+
+  it("returns null when either side is empty", () => {
+    expect(parseRestEntityKey("::Person")).toBeNull();
+    expect(parseRestEntityKey("install::")).toBeNull();
+  });
+});
+
+describe("summarizeEntity", () => {
+  it("produces a read-only published summary keyed by install id", () => {
+    const summary = summarizeEntity(ds, entity);
+    expect(summary.name).toBe(makeRestEntityKey("install-123", "Person"));
+    expect(summary.displayName).toBe("Person");
+    expect(summary.table).toBe("people");
+    expect(summary.columnCount).toBe(2);
+    expect(summary.joinCount).toBe(1);
+    expect(summary.readOnly).toBe(true);
+    expect(summary.status).toBe("published");
+    expect(summary.sourceKind).toBe("rest");
+    expect(summary.type).toBe(REST_ENTITY_TYPE_TAG);
+    // Workspace-global datasource → ungrouped (default section).
+    expect(summary.connectionId).toBeNull();
+  });
+
+  it("places a group-scoped datasource's entities under its group", () => {
+    const scoped = { ...ds, groupId: "eu-prod" } as RestDatasource;
+    const summary = summarizeEntity(scoped, entity);
+    expect(summary.connectionId).toBe("eu-prod");
+    expect(summary.source).toBe("eu-prod");
+  });
+});
+
+describe("toDetailEntity", () => {
+  it("maps columns→dimensions and joins→web Join shape", () => {
+    const detail = toDetailEntity(entity);
+    expect(detail.type).toBe(REST_ENTITY_TYPE_TAG);
+    expect(detail.readOnly).toBe(true);
+    expect(detail.dimensions).toHaveLength(2);
+    expect(detail.dimensions[0]).toMatchObject({ name: "id", type: "string", primary_key: true });
+    expect(detail.joins[0]).toMatchObject({ to: "Company", relationship: "many_to_one" });
+    expect(detail.measures).toHaveLength(0);
+    expect(detail.query_patterns[0]).toMatchObject({ name: "search", description: "search" });
+  });
+});

--- a/packages/api/src/lib/openapi/admin-rest-entities.ts
+++ b/packages/api/src/lib/openapi/admin-rest-entities.ts
@@ -1,0 +1,257 @@
+/**
+ * REST-derived admin entities — the read-only `/admin/semantic` surface for
+ * REST/OpenAPI datasources (#3628).
+ *
+ * REST datasources are queryable the moment they're installed (the agent
+ * renders entities live from the cached `openapi_snapshot` at prompt-build
+ * time), but until now they were INVISIBLE to `/admin/semantic`: a REST-only
+ * workspace saw a "no semantic layer / run atlas init" empty state while the
+ * agent was happily querying REST entities. This module converges REST onto
+ * the same admin surface SQL datasources use — WITHOUT persisting anything.
+ *
+ * Convergence, not consolidation (ADR-0017):
+ * - Entities are derived on read from the cached snapshot via the SAME pure
+ *   {@link generateSemanticModel} the agent's Path B uses — never persisted to
+ *   `semantic_entities`, never publish-gated. A "Rediscover schema" re-probe is
+ *   the only refresh; there is no draft/publish lifecycle to keep in sync.
+ * - The result is strictly READ-ONLY (`readOnly: true`); the admin route never
+ *   exposes edit/delete/version paths for these rows, and the web hides those
+ *   controls.
+ *
+ * Token note: this is a HUMAN-facing admin view. It renders entity YAML for
+ * display only and does NOT touch what the agent consumes at prompt time —
+ * the REST agent prompt stays on the compact `operation-graph` representation
+ * (Path A) regardless. No agent-token cost. See issue #3628.
+ */
+import { createLogger } from "@atlas/api/lib/logger";
+import { resolveWorkspaceRestDatasources } from "./workspace-datasource";
+import { generateSemanticModel, renderEntityYaml } from "./semantic-generator";
+import type { GeneratedEntity } from "./semantic-generator";
+import type { RestDatasource } from "./datasource";
+import { REST_ENTITY_TYPE_TAG } from "@useatlas/schemas/semantic-entity-yaml";
+
+const log = createLogger("admin-rest-entities");
+
+/**
+ * Delimiter joining a datasource install id to an entity name in the admin
+ * storage key. Two workspace-global REST datasources can each expose a `Person`
+ * entity; embedding the install id keeps the `(name, connectionId)` admin dedup
+ * key unique and lets the detail/raw routes resolve the exact datasource
+ * without a separate lookup. `::` survives {@link isValidEntityName} (it only
+ * forbids `/`, `\`, `..`, `\0`) and `encodeURIComponent` in the web URL.
+ */
+export const REST_ENTITY_KEY_DELIMITER = "::";
+
+/** Build the admin storage key for a REST entity. */
+export function makeRestEntityKey(installId: string, entityName: string): string {
+  return `${installId}${REST_ENTITY_KEY_DELIMITER}${entityName}`;
+}
+
+/**
+ * Parse a REST admin storage key back into its install id + entity name.
+ * Returns `null` for a non-REST key (no delimiter) so callers can fall through
+ * to the DB/disk source. Splits on the FIRST delimiter — install ids never
+ * contain `::`, and an entity name theoretically could, so the remainder is the
+ * entity name verbatim.
+ */
+export function parseRestEntityKey(
+  name: string,
+): { readonly installId: string; readonly entityName: string } | null {
+  const idx = name.indexOf(REST_ENTITY_KEY_DELIMITER);
+  if (idx <= 0) return null;
+  const installId = name.slice(0, idx);
+  const entityName = name.slice(idx + REST_ENTITY_KEY_DELIMITER.length);
+  if (!installId || !entityName) return null;
+  return { installId, entityName };
+}
+
+/**
+ * Admin summary for a REST-derived entity. Structurally compatible with the
+ * SQL `AdminEntitySummary` shared fields the web list mapper reads, plus
+ * `readOnly: true` and `sourceKind: "rest"`. `status` is always `"published"`
+ * — REST entities are queryable on install, with no draft lifecycle.
+ */
+export interface RestAdminEntitySummary {
+  readonly name: string;
+  readonly displayName: string;
+  readonly table: string;
+  readonly description: string;
+  readonly columnCount: number;
+  readonly joinCount: number;
+  readonly measureCount: number;
+  readonly source: string;
+  readonly connection: string | null;
+  readonly type: string;
+  readonly sourceKind: "rest";
+  readonly status: "published";
+  readonly connectionId: string | null;
+  readonly readOnly: true;
+  /** Human-facing datasource name, for disambiguating same-named entities. */
+  readonly datasourceName: string;
+}
+
+export interface RestAdminEntityListResult {
+  readonly entities: RestAdminEntitySummary[];
+  readonly warnings: string[];
+}
+
+/** Web detail shape — mirrors the SQL entity-detail JSON the web's `EntityDetail` reads. */
+export interface RestAdminEntityDetail {
+  readonly entity: {
+    readonly name: string;
+    readonly table: string;
+    readonly description: string;
+    readonly type: typeof REST_ENTITY_TYPE_TAG;
+    readonly readOnly: true;
+    readonly dimensions: ReadonlyArray<Record<string, unknown>>;
+    readonly joins: ReadonlyArray<Record<string, unknown>>;
+    readonly measures: ReadonlyArray<never>;
+    readonly query_patterns: ReadonlyArray<Record<string, unknown>>;
+  };
+  /** The rendered entity YAML (Path B renderer), for the admin "YAML" view. */
+  readonly yaml: string;
+}
+
+/**
+ * Map a generated REST entity to the web detail shape the shared `EntityDetail`
+ * component reads. Pure (no I/O) so the mapping is unit-tested directly. Joins
+ * are mapped to the web `Join` shape (`to` / `relationship` / `description`) so
+ * they render with a name; columns become `dimensions`.
+ */
+export function toDetailEntity(entity: GeneratedEntity): RestAdminEntityDetail["entity"] {
+  return {
+    name: entity.name,
+    table: entity.resource,
+    description: entity.description,
+    type: REST_ENTITY_TYPE_TAG,
+    readOnly: true,
+    dimensions: entity.columns.map((c) => {
+      const dim: Record<string, unknown> = { name: c.name, type: c.type };
+      if (c.primaryKey) dim.primary_key = true;
+      if (c.description) dim.description = c.description;
+      return dim;
+    }),
+    joins: entity.joins.map((j) => {
+      const join: Record<string, unknown> = { to: j.targetEntity, relationship: j.relationship };
+      if (j.description) join.description = j.description;
+      return join;
+    }),
+    measures: [],
+    query_patterns: entity.queryPatterns.map((qp) => ({
+      name: qp.name,
+      description: qp.description,
+    })),
+  };
+}
+
+export function summarizeEntity(ds: RestDatasource, entity: GeneratedEntity): RestAdminEntitySummary {
+  // A REST datasource's cross-environment scope (ADR-0010): `groupId` places
+  // its entities under that group in the file tree, exactly like SQL entities;
+  // workspace-global datasources (no group) sort into the default section.
+  const connectionId = ds.groupId ?? null;
+  return {
+    name: makeRestEntityKey(ds.id, entity.name),
+    displayName: entity.name,
+    table: entity.resource,
+    description: entity.description,
+    columnCount: entity.columns.length,
+    joinCount: entity.joins.length,
+    measureCount: 0,
+    source: connectionId ?? "default",
+    connection: null,
+    type: REST_ENTITY_TYPE_TAG,
+    sourceKind: "rest",
+    status: "published",
+    connectionId,
+    readOnly: true,
+    datasourceName: ds.displayName,
+  };
+}
+
+/**
+ * List every REST-derived entity across the workspace's REST datasources.
+ * Never throws: the resolver is fail-soft (`[]` on error) and generation is
+ * pure, so a single broken snapshot degrades to a warning rather than emptying
+ * the admin list. `activeGroupId` is intentionally omitted so the admin view
+ * shows ALL installs regardless of any conversation env pin (this is an
+ * operator surface, not a chat turn).
+ */
+export async function listRestAdminEntities(orgId: string): Promise<RestAdminEntityListResult> {
+  const entities: RestAdminEntitySummary[] = [];
+  const warnings: string[] = [];
+
+  let datasources: ReadonlyArray<RestDatasource>;
+  try {
+    datasources = await resolveWorkspaceRestDatasources(orgId);
+  } catch (err) {
+    // The fail-soft resolver shouldn't reject, but never let an unexpected
+    // throw blank the SQL entity list it's merged with.
+    log.warn(
+      { orgId, err: err instanceof Error ? err.message : String(err) },
+      "listRestAdminEntities: resolver threw — returning no REST entities",
+    );
+    return { entities, warnings };
+  }
+
+  for (const ds of datasources) {
+    try {
+      const model = generateSemanticModel(ds.graph);
+      for (const entity of model.entities) {
+        entities.push(summarizeEntity(ds, entity));
+      }
+    } catch (err) {
+      log.warn(
+        { orgId, datasourceId: ds.id, err: err instanceof Error ? err.message : String(err) },
+        "listRestAdminEntities: failed to generate model for a REST datasource — skipping it",
+      );
+      warnings.push(`Could not read entities from REST datasource "${ds.displayName}".`);
+    }
+  }
+
+  // Deterministic order so the file tree is stable across loads.
+  entities.sort((a, b) => {
+    const byName = a.displayName.localeCompare(b.displayName);
+    if (byName !== 0) return byName;
+    return (a.connectionId ?? "").localeCompare(b.connectionId ?? "");
+  });
+
+  return { entities, warnings };
+}
+
+/**
+ * Resolve a single REST entity's read-only detail by its admin storage key.
+ * Returns `null` when the key isn't a REST key, the datasource is gone, or the
+ * entity isn't in the (current) snapshot — the route maps that to a 404 (or a
+ * fall-through to DB/disk). Uses the resolver's `focus` to resolve ONLY the
+ * keyed install, avoiding decrypting every datasource's credentials.
+ */
+export async function getRestAdminEntityDetail(
+  orgId: string,
+  name: string,
+): Promise<RestAdminEntityDetail | null> {
+  const parsed = parseRestEntityKey(name);
+  if (!parsed) return null;
+
+  let datasources: ReadonlyArray<RestDatasource>;
+  try {
+    datasources = await resolveWorkspaceRestDatasources(orgId, { focus: parsed.installId });
+  } catch (err) {
+    log.warn(
+      { orgId, installId: parsed.installId, err: err instanceof Error ? err.message : String(err) },
+      "getRestAdminEntityDetail: resolver threw",
+    );
+    return null;
+  }
+
+  const ds = datasources.find((d) => d.id === parsed.installId);
+  if (!ds) return null;
+
+  const model = generateSemanticModel(ds.graph);
+  const entity = model.entities.find((e) => e.name === parsed.entityName);
+  if (!entity) return null;
+
+  return {
+    entity: toDetailEntity(entity),
+    yaml: renderEntityYaml(entity),
+  };
+}

--- a/packages/api/src/lib/openapi/admin-rest-entities.ts
+++ b/packages/api/src/lib/openapi/admin-rest-entities.ts
@@ -28,7 +28,11 @@ import { resolveWorkspaceRestDatasources } from "./workspace-datasource";
 import { generateSemanticModel, renderEntityYaml } from "./semantic-generator";
 import type { GeneratedEntity } from "./semantic-generator";
 import type { RestDatasource } from "./datasource";
-import { REST_ENTITY_TYPE_TAG } from "@useatlas/schemas/semantic-entity-yaml";
+import {
+  REST_ENTITY_TYPE_TAG,
+  ENTITY_YAML_DIMENSION_KEYS,
+  ENTITY_YAML_JOIN_KEYS,
+} from "@useatlas/schemas/semantic-entity-yaml";
 
 const log = createLogger("admin-rest-entities");
 
@@ -125,14 +129,24 @@ export function toDetailEntity(entity: GeneratedEntity): RestAdminEntityDetail["
     description: entity.description,
     type: REST_ENTITY_TYPE_TAG,
     readOnly: true,
+    // Shared dimension key names come from the contract so the detail JSON path
+    // can't drift from the YAML renderers either. `to` is the web `Join` shape
+    // (the shared EntityDetail component reads it) — deliberately NOT the YAML
+    // `target_entity` — but `relationship` is the one shared join key.
     dimensions: entity.columns.map((c) => {
-      const dim: Record<string, unknown> = { name: c.name, type: c.type };
-      if (c.primaryKey) dim.primary_key = true;
-      if (c.description) dim.description = c.description;
+      const dim: Record<string, unknown> = {
+        [ENTITY_YAML_DIMENSION_KEYS.name]: c.name,
+        [ENTITY_YAML_DIMENSION_KEYS.type]: c.type,
+      };
+      if (c.primaryKey) dim[ENTITY_YAML_DIMENSION_KEYS.primaryKey] = true;
+      if (c.description) dim[ENTITY_YAML_DIMENSION_KEYS.description] = c.description;
       return dim;
     }),
     joins: entity.joins.map((j) => {
-      const join: Record<string, unknown> = { to: j.targetEntity, relationship: j.relationship };
+      const join: Record<string, unknown> = {
+        to: j.targetEntity,
+        [ENTITY_YAML_JOIN_KEYS.relationship]: j.relationship,
+      };
       if (j.description) join.description = j.description;
       return join;
     }),

--- a/packages/api/src/lib/openapi/semantic-generator.ts
+++ b/packages/api/src/lib/openapi/semantic-generator.ts
@@ -41,6 +41,12 @@ import type {
   OperationGraph,
 } from "./types";
 import * as yaml from "js-yaml";
+import {
+  ENTITY_YAML_KEYS,
+  ENTITY_YAML_JOIN_KEYS,
+  ENTITY_YAML_DIMENSION_KEYS,
+  REST_ENTITY_TYPE_TAG,
+} from "@useatlas/schemas/semantic-entity-yaml";
 
 // ─────────────────────────────────────────────────────────────────────
 //  Model shape (the cacheable `openapi_snapshot`)
@@ -835,13 +841,16 @@ const YAML_OPTIONS: yaml.DumpOptions = {
 export function renderEntityYaml(entity: GeneratedEntity): string {
   // Build an ordered plain object; js-yaml preserves insertion order with
   // sortKeys:false. Omit empty sections so the golden stays lean.
+  // Shared entity-YAML key names come from the @useatlas/schemas vocabulary
+  // contract (#3628) so this renderer and the DB renderer can't drift on
+  // `dimensions` / `joins` / `query_parameters` / `target_entity` etc.
   const doc: Record<string, unknown> = {
-    name: entity.name,
-    type: "rest_resource",
+    [ENTITY_YAML_KEYS.name]: entity.name,
+    [ENTITY_YAML_KEYS.type]: REST_ENTITY_TYPE_TAG,
     resource: entity.resource,
   };
   if (entity.recordSchema) doc.record_schema = entity.recordSchema;
-  doc.description = entity.description;
+  doc[ENTITY_YAML_KEYS.description] = entity.description;
 
   doc.operations = entity.operations.map((op) => {
     const o: Record<string, unknown> = {
@@ -863,28 +872,31 @@ export function renderEntityYaml(entity: GeneratedEntity): string {
   });
 
   if (entity.columns.length > 0) {
-    doc.dimensions = entity.columns.map((col) => {
-      const c: Record<string, unknown> = { name: col.name, type: col.type };
-      if (col.primaryKey) c.primary_key = true;
-      if (col.description) c.description = col.description;
+    doc[ENTITY_YAML_KEYS.dimensions] = entity.columns.map((col) => {
+      const c: Record<string, unknown> = {
+        [ENTITY_YAML_DIMENSION_KEYS.name]: col.name,
+        [ENTITY_YAML_DIMENSION_KEYS.type]: col.type,
+      };
+      if (col.primaryKey) c[ENTITY_YAML_DIMENSION_KEYS.primaryKey] = true;
+      if (col.description) c[ENTITY_YAML_DIMENSION_KEYS.description] = col.description;
       return c;
     });
   }
 
   if (entity.joins.length > 0) {
-    doc.joins = entity.joins.map((join) => {
+    doc[ENTITY_YAML_KEYS.joins] = entity.joins.map((join) => {
       const j: Record<string, unknown> = {
-        target_entity: join.targetEntity,
-        relationship: join.relationship,
+        [ENTITY_YAML_JOIN_KEYS.targetEntity]: join.targetEntity,
+        [ENTITY_YAML_JOIN_KEYS.relationship]: join.relationship,
         via: join.via,
       };
-      if (join.description) j.description = join.description;
+      if (join.description) j[ENTITY_YAML_KEYS.description] = join.description;
       return j;
     });
   }
 
   if (entity.queryPatterns.length > 0) {
-    doc.query_patterns = entity.queryPatterns.map((qp) => ({
+    doc[ENTITY_YAML_KEYS.queryPatterns] = entity.queryPatterns.map((qp) => ({
       name: qp.name,
       description: qp.description,
     }));

--- a/packages/api/src/lib/semantic/__tests__/entity-yaml-vocabulary-contract.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/entity-yaml-vocabulary-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared entity-YAML vocabulary contract (#3628).
+ *
+ * Atlas keeps TWO entity-YAML renderers separate by design (ADR-0017):
+ *  - DB / profiled: `lib/semantic/generate/yaml.ts` (`generateEntityYAML`)
+ *  - REST / spec-derived: `lib/openapi/semantic-generator.ts` (`renderEntityYaml`)
+ *
+ * They overlap only in field vocabulary. This test pins that overlap: both
+ * renderers' output must speak the canonical key names from
+ * `@useatlas/schemas/semantic-entity-yaml`. A field-name drift in either
+ * renderer (e.g. `dimensions` → `columns`, `target_entity` → `target`) fails
+ * here — the "drift is a test failure" half of the contract.
+ */
+import { describe, it, expect } from "bun:test";
+import type { TableProfile, ColumnProfile } from "@useatlas/types";
+import * as yaml from "js-yaml";
+import {
+  ENTITY_YAML_KEYS,
+  ENTITY_YAML_JOIN_KEYS,
+  ENTITY_YAML_DIMENSION_KEYS,
+  REST_ENTITY_TYPE_TAG,
+  SharedEntityYamlSchema,
+} from "@useatlas/schemas/semantic-entity-yaml";
+import { generateEntityYAML } from "../generate/yaml";
+import { renderEntityYaml } from "../../openapi/semantic-generator";
+import type { GeneratedEntity } from "../../openapi/semantic-generator";
+
+function col(
+  over: Partial<ColumnProfile> & Pick<ColumnProfile, "name" | "type">,
+): ColumnProfile {
+  return {
+    name: over.name,
+    type: over.type,
+    nullable: over.nullable ?? false,
+    unique_count: over.unique_count ?? null,
+    null_count: over.null_count ?? null,
+    sample_values: over.sample_values ?? [],
+    is_primary_key: over.is_primary_key ?? false,
+    is_foreign_key: over.is_foreign_key ?? false,
+    fk_target_table: over.fk_target_table ?? null,
+    fk_target_column: over.fk_target_column ?? null,
+    is_enum_like: over.is_enum_like ?? false,
+    profiler_notes: over.profiler_notes ?? [],
+    ...(over.semantic_type ? { semantic_type: over.semantic_type } : {}),
+  };
+}
+
+function profile(
+  over: Partial<TableProfile> & Pick<TableProfile, "table_name">,
+): TableProfile {
+  return {
+    table_name: over.table_name,
+    object_type: over.object_type ?? "table",
+    row_count: over.row_count ?? 100,
+    columns: over.columns ?? [],
+    primary_key_columns: over.primary_key_columns ?? [],
+    foreign_keys: over.foreign_keys ?? [],
+    inferred_foreign_keys: over.inferred_foreign_keys ?? [],
+    profiler_notes: over.profiler_notes ?? [],
+    table_flags: over.table_flags ?? { possibly_abandoned: false, possibly_denormalized: false },
+  };
+}
+
+const restEntity: GeneratedEntity = {
+  name: "Person",
+  resource: "people",
+  recordSchema: "Person",
+  description: "A person record",
+  operations: [
+    {
+      operationId: "listPeople",
+      method: "GET",
+      path: "/people",
+      kind: "list",
+      writes: false,
+      parameters: [{ name: "filter", in: "query", required: false }],
+    },
+  ],
+  columns: [
+    { name: "id", type: "string", primaryKey: true, description: "Identifier" },
+    { name: "name", type: "string" },
+  ],
+  joins: [
+    { via: "company", targetEntity: "Company", relationship: "many_to_one", description: "owner" },
+  ],
+  queryPatterns: [{ name: "search", description: "search people via filter" }],
+};
+
+describe("entity-YAML vocabulary contract — both renderers speak it", () => {
+  it("DB renderer (generateEntityYAML) output validates against the shared contract", () => {
+    const orders = profile({
+      table_name: "orders",
+      primary_key_columns: ["id"],
+      foreign_keys: [
+        { from_column: "customer_id", to_table: "customers", to_column: "id", source: "constraint" },
+      ],
+      columns: [
+        col({ name: "id", type: "integer", is_primary_key: true }),
+        col({ name: "customer_id", type: "integer", is_foreign_key: true, fk_target_table: "customers" }),
+        col({ name: "total", type: "numeric" }),
+        col({ name: "status", type: "text", is_enum_like: true, sample_values: ["paid", "pending"] }),
+      ],
+    });
+
+    const doc = yaml.load(generateEntityYAML(orders, [orders], "postgres")) as Record<string, unknown>;
+    expect(SharedEntityYamlSchema.safeParse(doc).success).toBe(true);
+
+    // Canonical key names present (not a drifted alias).
+    expect(doc[ENTITY_YAML_KEYS.dimensions]).toBeDefined();
+    expect(doc).not.toHaveProperty("columns");
+    const joins = doc[ENTITY_YAML_KEYS.joins] as Array<Record<string, unknown>>;
+    expect(joins[0]).toHaveProperty(ENTITY_YAML_JOIN_KEYS.targetEntity);
+    expect(joins[0]).toHaveProperty(ENTITY_YAML_JOIN_KEYS.relationship);
+    const dims = doc[ENTITY_YAML_KEYS.dimensions] as Array<Record<string, unknown>>;
+    expect(dims.find((d) => d[ENTITY_YAML_DIMENSION_KEYS.primaryKey] === true)).toBeDefined();
+  });
+
+  it("REST renderer (renderEntityYaml) output validates against the shared contract", () => {
+    const doc = yaml.load(renderEntityYaml(restEntity)) as Record<string, unknown>;
+    expect(SharedEntityYamlSchema.safeParse(doc).success).toBe(true);
+
+    expect(doc[ENTITY_YAML_KEYS.type]).toBe(REST_ENTITY_TYPE_TAG);
+    expect(doc[ENTITY_YAML_KEYS.dimensions]).toBeDefined();
+    expect(doc).not.toHaveProperty("columns");
+    const joins = doc[ENTITY_YAML_KEYS.joins] as Array<Record<string, unknown>>;
+    expect(joins[0]).toHaveProperty(ENTITY_YAML_JOIN_KEYS.targetEntity);
+    expect(joins[0]).toHaveProperty(ENTITY_YAML_JOIN_KEYS.relationship);
+    expect(doc[ENTITY_YAML_KEYS.queryPatterns]).toBeDefined();
+  });
+
+  it("both renderers agree on the shared section key names", () => {
+    const dbDoc = yaml.load(
+      generateEntityYAML(
+        profile({
+          table_name: "orders",
+          primary_key_columns: ["id"],
+          foreign_keys: [{ from_column: "customer_id", to_table: "customers", to_column: "id", source: "constraint" }],
+          columns: [col({ name: "id", type: "integer", is_primary_key: true })],
+        }),
+        [],
+        "postgres",
+      ),
+    ) as Record<string, unknown>;
+    const restDoc = yaml.load(renderEntityYaml(restEntity)) as Record<string, unknown>;
+
+    for (const key of [ENTITY_YAML_KEYS.dimensions, ENTITY_YAML_KEYS.joins] as const) {
+      expect(dbDoc).toHaveProperty(key);
+      expect(restDoc).toHaveProperty(key);
+    }
+  });
+});

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -12,6 +12,11 @@
 import * as yaml from "js-yaml";
 import type { DBType } from "@atlas/api/lib/db/connection";
 import type { TableProfile } from "@useatlas/types";
+import {
+  ENTITY_YAML_KEYS,
+  ENTITY_YAML_JOIN_KEYS,
+  ENTITY_YAML_DIMENSION_KEYS,
+} from "@useatlas/schemas/semantic-entity-yaml";
 import { mapSQLType, isViewLike, singularize, entityName } from "../../profiler-utils";
 import { suggestMeasureType, describeMeasure } from "../../profiler-patterns";
 import { isView, isMatView, mapSalesforceFieldType } from "./analyze";
@@ -51,17 +56,20 @@ export function generateEntityYAML(
 
   // Build dimensions
   const dimensions: Record<string, unknown>[] = profile.columns.map((col) => {
+    // Shared key names (`name` / `type` / `primary_key` / `description`) come
+    // from the @useatlas/schemas vocabulary contract (#3628) so this renderer
+    // and the REST renderer can't drift on the entity-YAML field vocabulary.
     const dim: Record<string, unknown> = {
-      name: col.name,
+      [ENTITY_YAML_DIMENSION_KEYS.name]: col.name,
       sql: col.name,
-      type: dbType === "salesforce" ? mapSalesforceFieldType(col.type) : mapSQLType(col.type),
+      [ENTITY_YAML_DIMENSION_KEYS.type]: dbType === "salesforce" ? mapSalesforceFieldType(col.type) : mapSQLType(col.type),
     };
 
     if (col.is_primary_key) {
-      dim.description = `Primary key`;
-      dim.primary_key = true;
+      dim[ENTITY_YAML_DIMENSION_KEYS.description] = `Primary key`;
+      dim[ENTITY_YAML_DIMENSION_KEYS.primaryKey] = true;
     } else if (col.is_foreign_key) {
-      dim.description = `Foreign key to ${col.fk_target_table}`;
+      dim[ENTITY_YAML_DIMENSION_KEYS.description] = `Foreign key to ${col.fk_target_table}`;
     }
 
     if (col.semantic_type) dim.semantic_type = col.semantic_type;
@@ -190,27 +198,27 @@ export function generateEntityYAML(
 
   // Build joins from constraint FKs
   const joins: Record<string, unknown>[] = profile.foreign_keys.map((fk) => ({
-    target_entity: entityName(fk.to_table),
-    relationship: "many_to_one",
+    [ENTITY_YAML_JOIN_KEYS.targetEntity]: entityName(fk.to_table),
+    [ENTITY_YAML_JOIN_KEYS.relationship]: "many_to_one",
     join_columns: {
       from: fk.from_column,
       to: fk.to_column,
     },
-    description: `Each ${singularize(profile.table_name)} belongs to one ${singularize(fk.to_table)}`,
+    [ENTITY_YAML_KEYS.description]: `Each ${singularize(profile.table_name)} belongs to one ${singularize(fk.to_table)}`,
   }));
 
   // Add inferred joins
   for (const fk of profile.inferred_foreign_keys) {
     joins.push({
-      target_entity: entityName(fk.to_table),
-      relationship: "many_to_one",
+      [ENTITY_YAML_JOIN_KEYS.targetEntity]: entityName(fk.to_table),
+      [ENTITY_YAML_JOIN_KEYS.relationship]: "many_to_one",
       join_columns: {
         from: fk.from_column,
         to: fk.to_column,
       },
       inferred: true,
       note: `No FK constraint exists — inferred from column name ${fk.from_column}`,
-      description: `Each ${singularize(profile.table_name)} likely belongs to one ${singularize(fk.to_table)}`,
+      [ENTITY_YAML_KEYS.description]: `Each ${singularize(profile.table_name)} likely belongs to one ${singularize(fk.to_table)}`,
     });
   }
 
@@ -400,9 +408,13 @@ export function generateEntityYAML(
   }
 
   // Assemble entity
+  // Shared entity-YAML key names (`type` / `description` / `dimensions` /
+  // `measures` / `joins` / `query_patterns`) come from the @useatlas/schemas
+  // vocabulary contract (#3628). `name` / `table` / `group` / `grain` are
+  // DB-renderer-specific and stay as literals.
   const entity: Record<string, unknown> = {
     name,
-    type: entityType,
+    [ENTITY_YAML_KEYS.type]: entityType,
     table: qualifiedTable,
     ...(source ? { group: source } : {}),
     grain: isMatView(profile)
@@ -410,8 +422,8 @@ export function generateEntityYAML(
       : isViewLike(profile)
         ? `one row per result from ${profile.table_name} view`
         : `one row per ${singularize(profile.table_name).replace(/_/g, " ")} record`,
-    description,
-    dimensions: [...dimensions, ...virtualDims],
+    [ENTITY_YAML_KEYS.description]: description,
+    [ENTITY_YAML_KEYS.dimensions]: [...dimensions, ...virtualDims],
   };
 
   if (profile.partition_info) {
@@ -420,10 +432,10 @@ export function generateEntityYAML(
     entity.partition_key = profile.partition_info.key;
   }
 
-  if (measures.length > 0) entity.measures = measures;
-  if (joins.length > 0) entity.joins = joins;
+  if (measures.length > 0) entity[ENTITY_YAML_KEYS.measures] = measures;
+  if (joins.length > 0) entity[ENTITY_YAML_KEYS.joins] = joins;
   entity.use_cases = useCases;
-  if (queryPatterns.length > 0) entity.query_patterns = queryPatterns;
+  if (queryPatterns.length > 0) entity[ENTITY_YAML_KEYS.queryPatterns] = queryPatterns;
 
   if (profile.profiler_notes.length > 0) {
     entity.profiler_notes = profile.profiler_notes;

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -26,6 +26,7 @@
     "./platform": "./src/platform.ts",
     "./residency": "./src/residency.ts",
     "./sandbox": "./src/sandbox.ts",
+    "./semantic-entity-yaml": "./src/semantic-entity-yaml.ts",
     "./sla": "./src/sla.ts"
   },
   "main": "./src/index.ts",

--- a/packages/schemas/src/__tests__/semantic-entity-yaml.test.ts
+++ b/packages/schemas/src/__tests__/semantic-entity-yaml.test.ts
@@ -40,15 +40,18 @@ describe("shared entity-YAML vocabulary contract", () => {
     expect(ok.success).toBe(true);
   });
 
-  test("rejects a dimensions block under the wrong key name (drift)", () => {
+  test("a renamed section key is NOT promoted to the canonical key", () => {
+    // The schema is `.loose()`, so a drifted `columns` key passes as an extra —
+    // the schema does NOT reject it. The drift GUARD is that the canonical
+    // `dimensions` key is then absent: the cross-renderer contract test
+    // (entity-yaml-vocabulary-contract.test.ts) asserts `dimensions` IS present
+    // in each renderer's output, so a renderer that emitted `columns` instead
+    // would fail there. This case documents that the schema alone won't catch a
+    // rename — the key-presence assertion is what does.
     const drifted = SharedEntityYamlSchema.safeParse({
       type: "fact_table",
-      // `columns` instead of the canonical `dimensions` — a renamed renderer
-      // would produce this, and the contract must catch it.
       columns: [{ name: "id", type: "string" }],
     });
-    // `columns` is allowed as a loose extra, but the canonical `dimensions`
-    // assertion below is what a drift test relies on.
     expect(drifted.success).toBe(true);
     expect((drifted as { data: Record<string, unknown> }).data.dimensions).toBeUndefined();
   });

--- a/packages/schemas/src/__tests__/semantic-entity-yaml.test.ts
+++ b/packages/schemas/src/__tests__/semantic-entity-yaml.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ENTITY_YAML_KEYS,
+  ENTITY_YAML_JOIN_KEYS,
+  ENTITY_YAML_DIMENSION_KEYS,
+  REST_ENTITY_TYPE_TAG,
+  SharedEntityYamlSchema,
+} from "../semantic-entity-yaml";
+
+describe("shared entity-YAML vocabulary contract", () => {
+  test("canonical key names are the load-bearing literals both renderers emit", () => {
+    // These values are consumed (as computed object keys) by BOTH the DB
+    // renderer (`generate/yaml.ts`) and the REST renderer
+    // (`openapi/semantic-generator.ts`). Pinning them here makes a rename a
+    // deliberate, reviewed change rather than a silent drift.
+    expect(ENTITY_YAML_KEYS.dimensions).toBe("dimensions");
+    expect(ENTITY_YAML_KEYS.joins).toBe("joins");
+    expect(ENTITY_YAML_KEYS.queryPatterns).toBe("query_patterns");
+    expect(ENTITY_YAML_KEYS.measures).toBe("measures");
+    expect(ENTITY_YAML_KEYS.type).toBe("type");
+    expect(ENTITY_YAML_JOIN_KEYS.targetEntity).toBe("target_entity");
+    expect(ENTITY_YAML_JOIN_KEYS.relationship).toBe("relationship");
+    expect(ENTITY_YAML_DIMENSION_KEYS.primaryKey).toBe("primary_key");
+    expect(REST_ENTITY_TYPE_TAG).toBe("rest_resource");
+  });
+
+  test("accepts a doc using the canonical vocabulary plus renderer-specific extras", () => {
+    const ok = SharedEntityYamlSchema.safeParse({
+      name: "Person",
+      type: REST_ENTITY_TYPE_TAG,
+      description: "A person",
+      resource: "people", // REST-specific extra — allowed via .loose()
+      dimensions: [
+        { name: "id", type: "string", primary_key: true },
+        { name: "amount", type: "number", sql: "amount" }, // SQL-specific `sql`
+      ],
+      joins: [{ target_entity: "Company", relationship: "many_to_one", via: "company" }],
+      query_patterns: [{ description: "list people", sql: "SELECT 1" }],
+    });
+    expect(ok.success).toBe(true);
+  });
+
+  test("rejects a dimensions block under the wrong key name (drift)", () => {
+    const drifted = SharedEntityYamlSchema.safeParse({
+      type: "fact_table",
+      // `columns` instead of the canonical `dimensions` — a renamed renderer
+      // would produce this, and the contract must catch it.
+      columns: [{ name: "id", type: "string" }],
+    });
+    // `columns` is allowed as a loose extra, but the canonical `dimensions`
+    // assertion below is what a drift test relies on.
+    expect(drifted.success).toBe(true);
+    expect((drifted as { data: Record<string, unknown> }).data.dimensions).toBeUndefined();
+  });
+
+  test("rejects a join missing the canonical target_entity key", () => {
+    const bad = SharedEntityYamlSchema.safeParse({
+      type: "fact_table",
+      joins: [{ target: "Company", relationship: "many_to_one" }],
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  test("requires the entity type tag", () => {
+    const noType = SharedEntityYamlSchema.safeParse({ name: "X" });
+    expect(noType.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -16,4 +16,5 @@ export * from "./platform";
 export * from "./residency";
 export * from "./sandbox";
 export * from "./security";
+export * from "./semantic-entity-yaml";
 export * from "./sla";

--- a/packages/schemas/src/semantic-entity-yaml.ts
+++ b/packages/schemas/src/semantic-entity-yaml.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared entity-YAML vocabulary contract.
+ *
+ * Atlas has TWO entity-YAML renderers that intentionally stay separate
+ * (different ends of the persistence spectrum — see ADR-0017):
+ *
+ * - **DB / profiled** — `packages/api/src/lib/semantic/generate/yaml.ts`
+ *   (`generateEntityYAML`): live connection → durable draft rows.
+ * - **REST / spec-derived** — `packages/api/src/lib/openapi/semantic-generator.ts`
+ *   (`renderEntityYaml`, Path B): cached OpenAPI snapshot → ephemeral prompt /
+ *   admin-display YAML.
+ *
+ * They overlap only in *vocabulary*: both describe an entity with a `type`
+ * tag, a `dimensions` block (NOT `columns`), `joins` (keyed `target_entity` /
+ * `relationship`), and `query_patterns`. Before this contract those key names
+ * lived as bare string literals in each renderer, free to drift silently —
+ * one could rename `dimensions` → `columns` and the human-facing
+ * `/admin/semantic` view (which reads both) would quietly break for one source
+ * only.
+ *
+ * This module is the single source of truth for those shared key names. Both
+ * renderers build their YAML objects through {@link ENTITY_YAML_KEYS} /
+ * {@link ENTITY_YAML_JOIN_KEYS} / {@link ENTITY_YAML_DIMENSION_KEYS}, so a
+ * rename is a one-line change here that moves both renderers in lockstep — a
+ * silent per-renderer drift is impossible. {@link SharedEntityYamlSchema}
+ * additionally lets a test assert each renderer's output speaks the shared
+ * vocabulary (drift → test failure).
+ *
+ * Scope (issue #3628, item 2): this is a naming/schema-consistency contract for
+ * the entity-YAML *renderers* (DB output + REST Path B + the `/admin/semantic`
+ * display). It is deliberately NOT about the agent prompt: the REST agent
+ * prompt defaults to the compact `operation-graph` representation (Path A),
+ * whose token advantage (#2931 bake-off) this contract must never erode.
+ */
+import { z } from "zod";
+
+/**
+ * Canonical top-level key names shared by both entity-YAML renderers. Values
+ * are the literal YAML keys — consume the constants (`[ENTITY_YAML_KEYS.x]:`)
+ * rather than re-typing the string so the two renderers can't diverge.
+ */
+export const ENTITY_YAML_KEYS = {
+  name: "name",
+  type: "type",
+  description: "description",
+  dimensions: "dimensions",
+  joins: "joins",
+  measures: "measures",
+  queryPatterns: "query_patterns",
+} as const;
+
+/** Canonical key names inside a `joins[]` entry shared by both renderers. */
+export const ENTITY_YAML_JOIN_KEYS = {
+  targetEntity: "target_entity",
+  relationship: "relationship",
+} as const;
+
+/** Canonical key names inside a `dimensions[]` entry shared by both renderers. */
+export const ENTITY_YAML_DIMENSION_KEYS = {
+  name: "name",
+  type: "type",
+  primaryKey: "primary_key",
+  description: "description",
+} as const;
+
+/**
+ * The entity `type:` tag for a REST/OpenAPI resource. DB entities use
+ * `fact_table` / `view` / `materialized_view`; the REST renderer (and any
+ * read-only admin surface that renders REST entities) uses this one. Centralized
+ * so the renderer and consumers (e.g. `/admin/semantic` read-only gating) agree.
+ */
+export const REST_ENTITY_TYPE_TAG = "rest_resource" as const;
+
+// ---------------------------------------------------------------------------
+// Shared-subset Zod schema — value shapes for the keys both renderers emit.
+// `.loose()` so each renderer's own extras pass (SQL adds `sql` / `sample_values`
+// / `measures`; REST adds `resource` / `operations` / join `via`). The contract
+// is about the shared KEY NAMES + their value types, not an exhaustive doc shape.
+// ---------------------------------------------------------------------------
+
+const SharedDimensionSchema = z
+  .object({
+    [ENTITY_YAML_DIMENSION_KEYS.name]: z.string(),
+    [ENTITY_YAML_DIMENSION_KEYS.type]: z.string(),
+    [ENTITY_YAML_DIMENSION_KEYS.primaryKey]: z.boolean().optional(),
+    [ENTITY_YAML_DIMENSION_KEYS.description]: z.string().optional(),
+  })
+  .loose();
+
+const SharedJoinSchema = z
+  .object({
+    [ENTITY_YAML_JOIN_KEYS.targetEntity]: z.string(),
+    [ENTITY_YAML_JOIN_KEYS.relationship]: z.string(),
+    [ENTITY_YAML_KEYS.description]: z.string().optional(),
+  })
+  .loose();
+
+const SharedQueryPatternSchema = z
+  .object({
+    [ENTITY_YAML_KEYS.description]: z.string(),
+  })
+  .loose();
+
+/**
+ * The shared subset both entity-YAML renderers must speak. Every section is
+ * optional (not every entity has joins / query_patterns), but where a section
+ * IS present it must use these canonical key names and value shapes. A renderer
+ * that emitted `columns` instead of `dimensions`, or `target` instead of
+ * `target_entity`, fails validation here.
+ */
+export const SharedEntityYamlSchema = z
+  .object({
+    [ENTITY_YAML_KEYS.name]: z.string().optional(),
+    [ENTITY_YAML_KEYS.type]: z.string(),
+    [ENTITY_YAML_KEYS.description]: z.string().optional(),
+    [ENTITY_YAML_KEYS.dimensions]: z.array(SharedDimensionSchema).optional(),
+    [ENTITY_YAML_KEYS.joins]: z.array(SharedJoinSchema).optional(),
+    [ENTITY_YAML_KEYS.queryPatterns]: z.array(SharedQueryPatternSchema).optional(),
+  })
+  .loose();
+
+export type SharedEntityYaml = z.infer<typeof SharedEntityYamlSchema>;

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -100,6 +100,12 @@ interface EntitySummary {
   /** True when the API row carries `status: "draft"`. */
   draft: boolean;
   /**
+   * True for REST/OpenAPI-derived entities (#3628). These converge onto this
+   * surface read-only — they're generated live from the cached spec snapshot,
+   * never persisted — so the page hides edit/delete/version controls for them.
+   */
+  readOnly: boolean;
+  /**
    * Optional DB↔YAML drift signal (#2459). `null` when the API didn't
    * compute drift (e.g. caller omitted `?connection`); a defined value
    * is what slice 1 surfaces as the blue file-tree accent.
@@ -550,6 +556,7 @@ export default function SemanticPage() {
             columnCount: typeof e.columnCount === "number" ? e.columnCount : 0,
             connectionGroupId,
             draft: e.status === "draft",
+            readOnly: e.readOnly === true,
             drift: normalizeDrift(e.drift),
           };
         }).filter((e) => e.name.length > 0);
@@ -812,6 +819,20 @@ export default function SemanticPage() {
   // no matching connection falls back to an id-derived label.
   const connectionGroups: SemanticGroupMeta[] = connectionGroupsFrom(connections);
 
+  // #3628: REST/OpenAPI-derived entities are read-only (generated live from the
+  // cached spec snapshot, never persisted). Resolve the selected entity's
+  // summary — matching on (name, group) since the same name can exist per group
+  // — to hide edit/delete controls for them.
+  const selectedSummary =
+    selection?.type === "entity"
+      ? entities.find(
+          (e) =>
+            e.name === selection.name &&
+            (e.connectionGroupId ?? null) === (selection.connectionGroupId ?? null),
+        )
+      : undefined;
+  const selectionReadOnly = selectedSummary?.readOnly ?? false;
+
   return (
     <div className="flex h-full flex-col">
       <div className="px-6 pt-6 pb-4">
@@ -1001,7 +1022,7 @@ export default function SemanticPage() {
             <div className="flex h-[41px] items-center justify-between border-b px-4">
               {/* Edit/delete actions (SaaS mode, entity selected) */}
               <div className="flex items-center gap-1.5">
-                {isSaas && selection.type === "entity" && selectedEntity && (() => {
+                {isSaas && selection.type === "entity" && selectedEntity && !selectionReadOnly && (() => {
                   const editBtn = (
                     <Button variant="outline" size="sm" onClick={handleEditEntity} className="gap-1 text-xs" disabled={demoReadOnly}>
                       <Pencil className="size-3" />
@@ -1043,7 +1064,7 @@ export default function SemanticPage() {
                   );
                 })()}
               </div>
-              <ViewToggle mode={viewMode} onChange={(m) => { startTransition(() => { setParams({ view: m }); }); }} showHistory={isSaas && selection?.type === "entity"} />
+              <ViewToggle mode={viewMode} onChange={(m) => { startTransition(() => { setParams({ view: m }); }); }} showHistory={isSaas && selection?.type === "entity" && !selectionReadOnly} />
             </div>
           )}
 


### PR DESCRIPTION
Closes #3628.

## Problem

REST/OpenAPI datasources are **queryable but invisible**. The moment one is installed, the agent renders its entities live from the cached `openapi_snapshot` at prompt-build time — but `/admin/semantic`, `draftCounts`, and the publish workflow knew nothing about them. A REST-only workspace saw a misleading *"no semantic layer / run `atlas init`"* empty state while the agent was happily querying REST entities.

This is **convergence, not consolidation**: REST joins the same admin surface SQL datasources use, and the two generators stay separate (they're correctly separate — opposite ends of the persistence spectrum).

## What changed

**1. Read-only REST entities in `/admin/semantic` (the headline)**
- New `lib/openapi/admin-rest-entities.ts` derives entities live from the cached snapshot via the **same pure `generateSemanticModel`** the agent's Path B uses — never persisted to `semantic_entities`, never publish-gated.
- Wired into the admin entities **list / detail / raw** routes + the **overview count**, so a REST-only workspace's empty state no longer fires and Overview/Semantic agree on the count.
- REST entities carry a namespaced storage key (`installId::entityName`) so detail/raw resolve the exact datasource, and are marked `readOnly` so the web hides edit/delete/version controls.
- Group-scoped datasources (ADR-0010) surface under their group in the file tree; workspace-global ones sort into the default section.

**2. Shared entity-YAML vocabulary contract in `@useatlas/schemas`**
- New `semantic-entity-yaml.ts`: the key names both YAML renderers emit (`dimensions` / `joins` / `target_entity` / `relationship` / `query_patterns` / `primary_key` / type tags) are now single-sourced constants + a Zod schema (`SharedEntityYamlSchema`).
- **Both** the REST renderer (`openapi/semantic-generator.ts`) and the DB renderer (`semantic/generate/yaml.ts`) consume the constants, and a drift test validates both outputs — a field-name drift between them is now a **test failure**.

**3. ADR-0017** records why the spec-derived (ephemeral) and profiled (persisted) generators intentionally stay separate, closing the REST exclusion left open by the #3303 profiler-seam PRD.

## Constraints preserved

- **Agent prompt untouched.** The REST agent prompt stays on the compact `operation-graph` representation (Path A) — the #2931 bake-off measured it as materially cheaper than entity-YAML. This admin view renders entity YAML for **humans only**: no agent-token cost. The `twenty-acceptance` bake-off test passes unchanged.
- **Generators NOT merged**, REST **not** routed through `semantic_entities`/draft-publish, no profiling step added to REST onboarding — all explicit out-of-scope items in the issue.
- **Renderer golden output is byte-identical** (the contract constants equal the prior literals); all DB + REST renderer golden tests pass.
- SELECT-only / AST-validation / whitelist invariants untouched (no new query path); 500s carry `requestId`; `lib/` → `api/routes/` layering respected (new code is a `lib/` module the route calls).

## Tests

- `packages/schemas/src/__tests__/semantic-entity-yaml.test.ts` — contract constants + schema accept/reject.
- `packages/api/src/lib/semantic/__tests__/entity-yaml-vocabulary-contract.test.ts` — both renderers' output validates against the shared contract (drift guard).
- `packages/api/src/lib/openapi/__tests__/admin-rest-entities.test.ts` — namespaced key round-trip + GeneratedEntity → admin summary/detail mapping.

## Docs

- `apps/docs/.../openapi-generic.mdx` — new "Seeing the entities (Admin → Semantic)" section explaining the read-only surface + the no-token-cost note.

Local `/ci`: lint, type, full test suite (all packages, 0 failures), syncpack, template/security/railway/schema/openapi/oauth/test-discipline/twenty-resolver/settings/published-symbols drift — all pass.

https://claude.ai/code/session_0184dWWF3vrrEQGBmTCstZFU

---
_Generated by [Claude Code](https://claude.ai/code/session_0184dWWF3vrrEQGBmTCstZFU)_