### PR TITLE
feat(duckdb): move the DuckDB profiler onto the plugin profiler contract (#3623)

### DIFF
--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -213,12 +213,12 @@ export async function handleDiff(args: string[]): Promise<void> {
           break;
         }
         case "duckdb": {
-          const { parseDuckDBUrl } = await import(
-            "../../../../plugins/duckdb/src/connection"
+          // DuckDB profiling consumes the plugin's `profile` export directly
+          // (ADR-0017, #3623) — CLI → plugin, no @atlas/api.
+          const { profileDuckDB } = await import(
+            "../../../../plugins/duckdb/src/profiler"
           );
-          const { profileDuckDB } = await import("../../lib/profilers/duckdb");
-          const duckConfig = parseDuckDBUrl(connStr);
-          result = await profileDuckDB(duckConfig.path, filterTables);
+          result = await profileDuckDB({ url: connStr, selectedTables: filterTables });
           break;
         }
         case "salesforce": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -58,9 +58,12 @@ import {
   listSalesforceObjects,
   profileSalesforce,
   ingestIntoDuckDB,
-  listDuckDBObjects,
-  profileDuckDB,
 } from "../../lib/profilers";
+// DuckDB profiling moved onto the plugin profiler contract (ADR-0017, #3623):
+// the CLI consumes the plugin's `listObjects`/`profile` exports directly (CLI →
+// plugin, no @atlas/api). Relative-path import matches the existing CLI ↔ duckdb
+// plugin convention (e.g. the duckdb connection import in test-connection.ts).
+import { listDuckDBObjects, profileDuckDB } from "../../../../plugins/duckdb/src/profiler";
 import { profileMySQL, profilePostgres } from "@atlas/api/lib/profiler";
 import {
   profileElasticsearch,
@@ -467,11 +470,7 @@ async function profileDatasource(
           allObjects = await listSnowflakeObjects(connStr);
           break;
         case "duckdb": {
-          const { parseDuckDBUrl } = await import(
-            "../../../../plugins/duckdb/src/connection"
-          );
-          const duckConfig = parseDuckDBUrl(connStr);
-          allObjects = await listDuckDBObjects(duckConfig.path);
+          allObjects = await listDuckDBObjects({ url: connStr });
           break;
         }
         case "salesforce":
@@ -573,16 +572,12 @@ async function profileDatasource(
       );
       break;
     case "duckdb": {
-      const { parseDuckDBUrl } = await import(
-        "../../../../plugins/duckdb/src/connection"
-      );
-      const duckConfig = parseDuckDBUrl(connStr);
-      result = await profileDuckDB(
-        duckConfig.path,
+      result = await profileDuckDB({
+        url: connStr,
         selectedTables,
         prefetchedObjects,
         progress,
-      );
+      });
       break;
     }
     case "salesforce":
@@ -984,12 +979,13 @@ export async function handleInit(args: string[]): Promise<void> {
     const duckFilterTables = filterTables ?? tableNames;
     const duckProgress = createProgressTracker();
     const duckStart = Date.now();
-    const duckResult = await profileDuckDB(
-      dbPath,
-      duckFilterTables,
-      undefined,
-      duckProgress,
-    );
+    // The plugin profiler takes a duckdb:// URL; `parseDuckDBUrl` treats
+    // everything after the scheme as the path verbatim, round-tripping dbPath.
+    const duckResult = await profileDuckDB({
+      url: `duckdb://${dbPath}`,
+      selectedTables: duckFilterTables,
+      progress: duckProgress,
+    });
     let { profiles } = duckResult;
     duckProgress.onComplete(profiles.length, Date.now() - duckStart);
 

--- a/plugins/duckdb/__tests__/profiler.test.ts
+++ b/plugins/duckdb/__tests__/profiler.test.ts
@@ -1,0 +1,197 @@
+/**
+ * DuckDB introspection (ADR-0017) — `listObjects` / `profile` against a mocked
+ * @duckdb/node-api. Asserts external behavior through the contract: the right
+ * objects/profiles come back, profiling stays read-only (`access_mode:
+ * "READ_ONLY"` on every file-database connection), an empty schema yields no
+ * profiles, a per-table failure is recorded (not thrown), and a fatal
+ * connection error aborts.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+/**
+ * A canned reader for `runAndReadAll`: `getRowObjects()` returns the rows the
+ * profiler reads by property name.
+ */
+function reader(rows: Record<string, unknown>[]) {
+  return Promise.resolve({
+    columnNames: () => (rows[0] ? Object.keys(rows[0]) : []),
+    getRowObjects: () => rows,
+  });
+}
+
+// Record every create() option so the read-only posture can be asserted.
+const seenCreateOpts: Array<Record<string, string> | undefined> = [];
+let fatalNextQuery: string | null = null;
+
+// Route each profiler query to a canned response by matching the SQL text.
+function runQuery(sql: string) {
+  if (fatalNextQuery && sql.includes(fatalNextQuery)) {
+    return Promise.reject(new Error("getaddrinfo ENOTFOUND duck.host"));
+  }
+  if (sql.includes("information_schema.tables")) {
+    return reader([
+      { name: "events", type: "table" },
+      { name: "daily_report", type: "view" },
+    ]);
+  }
+  if (sql.includes("information_schema.columns")) {
+    return reader([
+      { column_name: "id", data_type: "BIGINT", is_nullable: "NO" },
+      { column_name: "status", data_type: "VARCHAR", is_nullable: "YES" },
+    ]);
+  }
+  // unique/null stats: COUNT(DISTINCT ...) as u, ... as n
+  if (sql.includes("COUNT(DISTINCT")) {
+    // status: low cardinality → enum-like; id: leave it non-enum by high unique.
+    if (sql.includes('"status"')) return reader([{ u: 2, n: 0 }]);
+    return reader([{ u: 100, n: 0 }]);
+  }
+  if (sql.includes("DISTINCT CAST")) {
+    if (sql.includes('"status"')) return reader([{ v: "active" }, { v: "churned" }]);
+    return reader([{ v: "1" }, { v: "2" }]);
+  }
+  if (sql.includes("COUNT(*)")) {
+    return reader([{ c: 100 }]);
+  }
+  return reader([]);
+}
+
+const mockRunAndReadAll = mock((sql: string) => runQuery(sql));
+const mockDisconnectSync = mock(() => {});
+const mockCloseSync = mock(() => {});
+const mockConnect = mock(() =>
+  Promise.resolve({ runAndReadAll: mockRunAndReadAll, disconnectSync: mockDisconnectSync }),
+);
+const mockCreate = mock((_path: string, opts?: Record<string, string>) => {
+  seenCreateOpts.push(opts);
+  return Promise.resolve({ connect: mockConnect, closeSync: mockCloseSync });
+});
+
+mock.module("@duckdb/node-api", () => ({ DuckDBInstance: { create: mockCreate } }));
+
+import { listDuckDBObjects, profileDuckDB } from "../src/profiler";
+
+const URL = "duckdb:///data/analytics.duckdb";
+
+beforeEach(() => {
+  mockRunAndReadAll.mockClear();
+  mockDisconnectSync.mockClear();
+  mockCloseSync.mockClear();
+  mockConnect.mockClear();
+  mockCreate.mockClear();
+  seenCreateOpts.length = 0;
+  fatalNextQuery = null;
+
+  mockRunAndReadAll.mockImplementation((sql: string) => runQuery(sql));
+  mockConnect.mockImplementation(() =>
+    Promise.resolve({ runAndReadAll: mockRunAndReadAll, disconnectSync: mockDisconnectSync }),
+  );
+  mockCreate.mockImplementation((_path: string, opts?: Record<string, string>) => {
+    seenCreateOpts.push(opts);
+    return Promise.resolve({ connect: mockConnect, closeSync: mockCloseSync });
+  });
+});
+
+describe("listDuckDBObjects", () => {
+  test("enumerates tables and views, mapping table_type → object type", async () => {
+    const objects = await listDuckDBObjects({ url: URL });
+    expect(objects).toEqual([
+      { name: "events", type: "table" },
+      { name: "daily_report", type: "view" },
+    ]);
+    expect(mockDisconnectSync).toHaveBeenCalledTimes(1);
+    expect(mockCloseSync).toHaveBeenCalledTimes(1);
+  });
+
+  test("opens a file database read-only", async () => {
+    await listDuckDBObjects({ url: URL });
+    expect(seenCreateOpts.length).toBeGreaterThan(0);
+    expect(seenCreateOpts.every((o) => o?.access_mode === "READ_ONLY")).toBe(true);
+  });
+});
+
+describe("profileDuckDB", () => {
+  test("profiles columns, types, enum-like sample values; no PK/FK", async () => {
+    const result = await profileDuckDB({ url: URL, selectedTables: ["events"] });
+    expect(result.errors).toEqual([]);
+    expect(result.profiles).toHaveLength(1);
+
+    const events = result.profiles[0];
+    expect(events.table_name).toBe("events");
+    expect(events.object_type).toBe("table");
+    expect(events.row_count).toBe(100);
+    // DuckDB enforces neither PKs nor FKs on loaded data.
+    expect(events.primary_key_columns).toEqual([]);
+    expect(events.foreign_keys).toEqual([]);
+
+    const idCol = events.columns.find((c) => c.name === "id");
+    expect(idCol?.type).toBe("BIGINT");
+    expect(idCol?.nullable).toBe(false);
+    expect(idCol?.is_primary_key).toBe(false);
+    expect(idCol?.is_enum_like).toBe(false);
+
+    const statusCol = events.columns.find((c) => c.name === "status");
+    expect(statusCol?.nullable).toBe(true);
+    expect(statusCol?.is_enum_like).toBe(true);
+    expect(statusCol?.sample_values).toEqual(["active", "churned"]);
+    expect(events.columns.every((c) => c.is_foreign_key === false)).toBe(true);
+  });
+
+  test("every connection is opened read-only (access_mode: READ_ONLY)", async () => {
+    await profileDuckDB({ url: URL, selectedTables: ["events"] });
+    expect(seenCreateOpts.length).toBeGreaterThan(0);
+    expect(seenCreateOpts.every((o) => o?.access_mode === "READ_ONLY")).toBe(true);
+  });
+
+  test("honors prefetchedObjects (no second catalog round-trip)", async () => {
+    const result = await profileDuckDB({
+      url: URL,
+      prefetchedObjects: [{ name: "events", type: "table" }],
+    });
+    expect(result.profiles).toHaveLength(1);
+    expect(
+      mockRunAndReadAll.mock.calls.some((c) => c[0].includes("information_schema.tables")),
+    ).toBe(false);
+  });
+
+  test("empty schema yields no profiles and no errors", async () => {
+    mockRunAndReadAll.mockImplementation((sql: string) => {
+      if (sql.includes("information_schema.tables")) return reader([]);
+      return runQuery(sql);
+    });
+    const result = await profileDuckDB({ url: URL });
+    expect(result.profiles).toEqual([]);
+    expect(result.errors).toEqual([]);
+    // Connection still closed on the empty path.
+    expect(mockDisconnectSync).toHaveBeenCalled();
+    expect(mockCloseSync).toHaveBeenCalled();
+  });
+
+  test("records a per-table error instead of throwing on a non-fatal failure", async () => {
+    mockRunAndReadAll.mockImplementation((sql: string) => {
+      if (sql.includes("COUNT(*)")) {
+        return Promise.reject(new Error("Catalog Error: Table does not exist"));
+      }
+      return runQuery(sql);
+    });
+    const result = await profileDuckDB({
+      url: URL,
+      prefetchedObjects: [{ name: "events", type: "table" }],
+    });
+    expect(result.profiles).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].table).toBe("events");
+    expect(result.errors[0].error).toContain("Table does not exist");
+  });
+
+  test("aborts on a fatal connection error", async () => {
+    fatalNextQuery = "COUNT(*)";
+    await expect(
+      profileDuckDB({ url: URL, prefetchedObjects: [{ name: "events", type: "table" }] }),
+    ).rejects.toThrow(/Fatal database error/);
+    // Connection is still closed on the abort path.
+    expect(mockDisconnectSync).toHaveBeenCalled();
+    expect(mockCloseSync).toHaveBeenCalled();
+  });
+});

--- a/plugins/duckdb/src/index.ts
+++ b/plugins/duckdb/src/index.ts
@@ -35,6 +35,7 @@ import { createPlugin } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult } from "@useatlas/plugin-sdk";
 import { createDuckDBConnection, parseDuckDBUrl } from "./connection";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
+import { listDuckDBObjects, profileDuckDB } from "./profiler";
 import { DUCKDB_FORBIDDEN_PATTERNS } from "./validation";
 
 /**
@@ -124,6 +125,12 @@ export function buildDuckDBPlugin(
     dbType: "duckdb",
     parserDialect: "PostgresQL",
     forbiddenPatterns: DUCKDB_FORBIDDEN_PATTERNS,
+    // Introspection half of the datasource contract (ADR-0017). The host resolves
+    // `profile` off the registry (same predicate as `createFromConfig`) and feeds
+    // it into SemanticGenerator's profiler seam; the CLI consumes these exports
+    // directly. Both run read-only via the connection's READ_ONLY access mode.
+    listObjects: listDuckDBObjects,
+    profile: profileDuckDB,
   };
 
   if (hasStaticConfig) {
@@ -232,4 +239,5 @@ export const duckdbPlugin = createPlugin({
 });
 
 export { createDuckDBConnection, parseDuckDBUrl } from "./connection";
+export { listDuckDBObjects, profileDuckDB } from "./profiler";
 export { DUCKDB_FORBIDDEN_PATTERNS } from "./validation";

--- a/plugins/duckdb/src/profiler.ts
+++ b/plugins/duckdb/src/profiler.ts
@@ -1,0 +1,264 @@
+/**
+ * DuckDB profiler — the introspection half of the datasource contract
+ * (ADR-0017). Enumerates objects (`listDuckDBObjects`) and profiles columns
+ * + sample values (`profileDuckDB`) into the SDK's structural `ProfilingResult`
+ * mirror, which the host's registry-resolved profiler seam feeds into
+ * `SemanticGenerator` without importing this package.
+ *
+ * Logic relocated from the CLI's `packages/cli/lib/profilers/duckdb.ts` — this
+ * plugin package becomes the home the registry resolves and the CLI consumes
+ * directly. CSV/Parquet ingestion (`ingestIntoDuckDB`) is a write path and stays
+ * in the CLI; only the read-only introspection moves here. The CLI profiler lib
+ * is intentionally NOT deleted in this slice; that consolidation is the deferred
+ * umbrella follow-up (#3627), so the two coexist for now.
+ *
+ * It runs every query through {@link createDuckDBConnection}, which opens file
+ * databases with `access_mode: "READ_ONLY"` — so profiling honors the same
+ * read-only posture as the query path and never mutates the database. Errors are
+ * type-narrowed and never echo the connection string / file path beyond the
+ * table name being profiled.
+ */
+
+import type {
+  PluginDatabaseObject,
+  PluginColumnProfile,
+  PluginTableProfile,
+  PluginProfileError,
+  PluginProfilingResult,
+  PluginListObjectsOptions,
+  PluginProfileOptions,
+  PluginDBConnection,
+} from "@useatlas/plugin-sdk";
+import { createDuckDBConnection, parseDuckDBUrl } from "./connection";
+
+/** Connection-level errors that will fail every remaining table — abort fast. */
+const FATAL_ERROR_PATTERN =
+  /\bECONNRESET\b|\bECONNREFUSED\b|\bEHOSTUNREACH\b|\bENOTFOUND\b|\bEPIPE\b|\bETIMEDOUT\b/i;
+
+/**
+ * Detect a connection-level (vs. per-table) failure. A fatal error means the
+ * whole profile should abort rather than recording N identical per-table errors.
+ * Mirrors the host's `isFatalConnectionError` (kept local to avoid importing
+ * `@atlas/api` into the plugin package — ADR-0013).
+ */
+function isFatalConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return FATAL_ERROR_PATTERN.test(String(err));
+  if (FATAL_ERROR_PATTERN.test(err.message)) return true;
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code && FATAL_ERROR_PATTERN.test(code)) return true;
+  if (err.cause) return isFatalConnectionError(err.cause);
+  return false;
+}
+
+/** Single-quote escape for a DuckDB string literal. */
+function ddLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/** Escape a DuckDB identifier with double quotes (doubles any embedded quotes). */
+function ddIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+const LIST_OBJECTS_SQL = `SELECT table_name as name,
+        CASE WHEN table_type = 'VIEW' THEN 'view' ELSE 'table' END as type
+ FROM information_schema.tables
+ WHERE table_schema = 'main'
+ ORDER BY table_name`;
+
+function rowToObject(r: { name: string; type: string }): PluginDatabaseObject {
+  return { name: r.name, type: r.type === "view" ? "view" : "table" };
+}
+
+/**
+ * Open a read-only DuckDB connection for the given url. File databases are
+ * opened with `access_mode: "READ_ONLY"`; `:memory:` cannot be read-only.
+ */
+function openConnection(url: string): PluginDBConnection {
+  const parsed = parseDuckDBUrl(url);
+  return createDuckDBConnection({ path: parsed.path, readOnly: parsed.readOnly });
+}
+
+/** Map DuckDB types to the common type system for enum-like heuristics. */
+function mapDuckDBType(duckType: string): string {
+  const t = duckType.toLowerCase();
+  if (
+    t.includes("int") ||
+    t.includes("float") ||
+    t.includes("double") ||
+    t.includes("decimal") ||
+    t.includes("numeric") ||
+    t.includes("real") ||
+    t === "hugeint" ||
+    t === "uhugeint"
+  ) {
+    return "number";
+  }
+  if (t.startsWith("bool")) return "boolean";
+  if (t.includes("date") || t.includes("time") || t.includes("timestamp")) {
+    return "date";
+  }
+  return "string";
+}
+
+/**
+ * Enumerate the queryable tables/views in the DuckDB `main` schema.
+ */
+export async function listDuckDBObjects(
+  options: PluginListObjectsOptions,
+): Promise<PluginDatabaseObject[]> {
+  const conn = openConnection(options.url);
+  try {
+    const { rows } = await conn.query(LIST_OBJECTS_SQL);
+    return (rows as { name: string; type: string }[]).map(rowToObject);
+  } finally {
+    await conn.close();
+  }
+}
+
+/**
+ * Profile the DuckDB database into a {@link PluginProfilingResult}. For each
+ * object: row count, column types/nullability, per-column null/unique counts,
+ * and enum-like sample values. DuckDB does not enforce primary or foreign keys
+ * on loaded data, so PK/FK fields are always empty.
+ */
+export async function profileDuckDB(
+  options: PluginProfileOptions,
+): Promise<PluginProfilingResult> {
+  const { url, selectedTables, prefetchedObjects, progress } = options;
+  const conn = openConnection(url);
+
+  const profiles: PluginTableProfile[] = [];
+  const errors: PluginProfileError[] = [];
+
+  try {
+    const allObjects: PluginDatabaseObject[] = prefetchedObjects
+      ? prefetchedObjects
+      : ((await conn.query(LIST_OBJECTS_SQL)).rows as { name: string; type: string }[]).map(
+          rowToObject,
+        );
+
+    const objectsToProfile = selectedTables
+      ? allObjects.filter((o) => selectedTables.includes(o.name))
+      : allObjects;
+
+    progress?.onStart(objectsToProfile.length);
+
+    for (const [i, obj] of objectsToProfile.entries()) {
+      const tableName = obj.name;
+      const objectType = obj.type;
+      const objectLabel = objectType === "view" ? " [view]" : "";
+      progress?.onTableStart(tableName + objectLabel, i, objectsToProfile.length);
+
+      try {
+        const countRows = (
+          await conn.query(`SELECT COUNT(*) as c FROM ${ddIdentifier(tableName)}`)
+        ).rows as { c: number | bigint }[];
+        const rowCount = Number(countRows[0]?.c ?? 0);
+
+        const colRows = (
+          await conn.query(
+            `SELECT column_name, data_type, is_nullable
+             FROM information_schema.columns
+             WHERE table_name = '${ddLiteral(tableName)}' AND table_schema = 'main'
+             ORDER BY ordinal_position`,
+          )
+        ).rows as { column_name: string; data_type: string; is_nullable: string }[];
+
+        const columns: PluginColumnProfile[] = [];
+        for (const col of colRows) {
+          let uniqueCount: number | null = null;
+          let nullCount: number | null = null;
+          let sampleValues: string[] = [];
+          let isEnumLike = false;
+
+          try {
+            const stats = (
+              await conn.query(
+                `SELECT COUNT(DISTINCT ${ddIdentifier(col.column_name)}) as u, COUNT(*) - COUNT(${ddIdentifier(col.column_name)}) as n FROM ${ddIdentifier(tableName)}`,
+              )
+            ).rows as { u: number | bigint; n: number | bigint }[];
+            uniqueCount = Number(stats[0]?.u ?? 0);
+            nullCount = Number(stats[0]?.n ?? 0);
+
+            // Enum-like detection: text columns with <=20 unique values and
+            // either <5% cardinality or <=10 distinct values.
+            const mappedType = mapDuckDBType(col.data_type);
+            if (
+              mappedType === "string" &&
+              uniqueCount > 0 &&
+              uniqueCount <= 20 &&
+              rowCount > 0
+            ) {
+              const cardinality = uniqueCount / rowCount;
+              if (cardinality < 0.05 || uniqueCount <= 10) {
+                isEnumLike = true;
+                const enumRows = (
+                  await conn.query(
+                    `SELECT DISTINCT CAST(${ddIdentifier(col.column_name)} AS VARCHAR) as v FROM ${ddIdentifier(tableName)} WHERE ${ddIdentifier(col.column_name)} IS NOT NULL ORDER BY v LIMIT 20`,
+                  )
+                ).rows as { v: unknown }[];
+                sampleValues = enumRows.map((r) => String(r.v));
+              }
+            }
+
+            // Sample values for non-enum columns.
+            if (!isEnumLike) {
+              const sampleRows = (
+                await conn.query(
+                  `SELECT DISTINCT CAST(${ddIdentifier(col.column_name)} AS VARCHAR) as v FROM ${ddIdentifier(tableName)} WHERE ${ddIdentifier(col.column_name)} IS NOT NULL LIMIT 5`,
+                )
+              ).rows as { v: unknown }[];
+              sampleValues = sampleRows.map((r) => String(r.v));
+            }
+          } catch (colErr) {
+            if (isFatalConnectionError(colErr)) throw colErr;
+            // Non-fatal: emit the column with the metadata we have.
+          }
+
+          columns.push({
+            name: col.column_name,
+            type: col.data_type,
+            nullable: col.is_nullable === "YES",
+            unique_count: uniqueCount,
+            null_count: nullCount,
+            sample_values: sampleValues,
+            is_primary_key: false, // DuckDB doesn't enforce PKs on loaded data.
+            is_foreign_key: false,
+            fk_target_table: null,
+            fk_target_column: null,
+            is_enum_like: isEnumLike,
+            profiler_notes: [],
+          });
+        }
+
+        profiles.push({
+          table_name: tableName,
+          object_type: objectType,
+          row_count: rowCount,
+          columns,
+          primary_key_columns: [],
+          foreign_keys: [],
+          inferred_foreign_keys: [],
+          profiler_notes: [],
+          table_flags: { possibly_abandoned: false, possibly_denormalized: false },
+        });
+        progress?.onTableDone(tableName, i, objectsToProfile.length);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (isFatalConnectionError(err)) {
+          // Connection-level — every remaining table will fail the same way.
+          throw new Error(`Fatal database error while profiling ${tableName}: ${msg}`, {
+            cause: err,
+          });
+        }
+        progress?.onTableError(tableName, msg, i, objectsToProfile.length);
+        errors.push({ table: tableName, error: msg });
+      }
+    }
+  } finally {
+    await conn.close();
+  }
+
+  return { profiles, errors };
+}


### PR DESCRIPTION
## What shipped

Moves DuckDB onto the datasource profiler seam (ADR-0017), following the ClickHouse tracer pattern.

- **`plugins/duckdb/src/profiler.ts`** — `listDuckDBObjects` / `profileDuckDB` implemented against the SDK contract (`PluginListObjectsOptions` / `PluginProfileOptions` → `PluginProfilingResult`). Logic relocated from the CLI's `lib/profilers/duckdb.ts`. Per-table failures are recorded (not thrown); fatal connection errors abort. A local `isFatalConnectionError` mirror keeps `@atlas/api` out of the plugin.
- **`plugins/duckdb/src/index.ts`** — exposes `listObjects` / `profile` on the plugin's `connection` (mirroring ClickHouse) and re-exports them, so the API resolves `profile` structurally off the registry and the CLI consumes the export directly.
- **CLI rewire (DuckDB case only)** — `init.ts` and `diff.ts` now call the plugin's `profileDuckDB` / `listDuckDBObjects` with a `duckdb://` URL via the existing relative-path CLI ↔ plugin convention. The shared dispatch is otherwise untouched.
- **Read-only** — every query runs through `createDuckDBConnection`, which opens file databases with `access_mode: "READ_ONLY"`. Caught errors are type-narrowed and never echo the connection string.
- The CLI `lib/profilers/duckdb.ts` (and `ingestIntoDuckDB`, a write path) are intentionally **left intact and coexisting** — the umbrella `lib/profilers` consolidation is the deferred follow-up (#3627), matching the ClickHouse precedent.

## Tests

`plugins/duckdb/__tests__/profiler.test.ts` mocks `@duckdb/node-api` and covers `listObjects`, `profile` (column types, nullability, enum-like sample values, no PK/FK), an empty schema, per-table error recording without throwing, fatal-error abort, and the read-only posture.

## Acceptance criteria

- [x] DuckDB `listObjects`/`profile` live in the DuckDB plugin package, exposed on `connection`, conforming to the seam contract
- [x] DuckDB is profilable through the shared engine (API via registry, CLI via direct export); no `@atlas/api` → plugin import
- [x] Profiling is read-only and never surfaces credentials in errors
- [x] Tests: DuckDB `listObjects`/`profile` against a mocked backend

## Local checks

- `bun run lint` — clean
- `bun run type` — clean
- `plugins/duckdb` tests — 86 pass; new `profiler.test.ts` — 8 pass
- CLI DuckDB tests (`duckdb-ingest`, `fatal-error-propagation`) — pass

Closes #3623

https://claude.ai/code/session_01NwuR96WWvtVqQrzZ8bL9Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwuR96WWvtVqQrzZ8bL9Nz)_