### PR TITLE
fix: v0.0.16 profiler-seam review batch (#3662, #3664) + cleanup (#3663, #3665)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2645,7 +2645,7 @@ The implementation survey narrowed the candidate's "16 pages" to the surfaces th
 - The two YAML dialects can no longer drift: shared key names have one home, asserted by a cross-renderer contract test.
 - Zero agent-token cost and zero prompt-representation change — the bake-off's `operation-graph` (Path A) default is untouched (the `twenty-acceptance` test passes unchanged); renderer golden output is byte-identical.
 
-**Category:** A visibility gap closed with one read-only derive-on-read module reusing the existing pure generator, plus a duplicated-vocabulary smell collapsed into a single shared contract — convergence on surface + vocabulary while the two generators stay deliberately, documentedly separate (ADR-0017).
+**Category:** A visibility gap closed with one read-only derive-on-read module reusing the existing pure generator, plus a duplicated-vocabulary smell collapsed into a single shared contract — convergence on surface + vocabulary while the two generators stay deliberately, documentedly separate (ADR-0019).
 
 ---
 

--- a/docs/adr/0017-datasource-profiler-seam.md
+++ b/docs/adr/0017-datasource-profiler-seam.md
@@ -113,3 +113,24 @@ The original spine made the seam **url-only**: `profile(options)` took `{ url, s
 
 - A separate-field-credential plugin onboarded via the in-product wizard enumerates AND profiles with the tenant's own credentials — closing the wizard's operator-env-fallback hole for both seam halves. Native pg/mysql and url-embedded plugins (ClickHouse/Snowflake) are unchanged (they ignore `config`).
 - **Mirror-drift cost now also applies to `PluginListObjectsOptions.config`** — the SDK type and the host bridge shape (`DatasourceConnectionShape.listObjects`) are hand-maintained mirrors and must stay in lockstep.
+
+## Amendment (#3664): BigQuery profiles over MCP from its multi-field config
+
+**Status:** Accepted (#3664). Lifts the BigQuery fail-closed scope decision in *Decision* above.
+
+### Context
+
+The original scope (above) left `bigquery` **fail-closed** behind `loadDatasourceProfileTarget`'s URL-shape gate, because BigQuery is multi-field / non-url-shaped: its credentials live in a SEPARATE `service_account_json` config field, never in a connection string. But the milestone goal (#3664, #3552 AC #1) is that **every provisioning-supported type profiles over MCP** — and BigQuery is in `MCP_PROVISIONABLE_CATALOG_SLUGS`. The #3552/#3621 `config` amendment already carries the decrypted config through the seam; BigQuery just needed to pass the url-shape gate and consume it.
+
+### Decision
+
+**Synthesize a url for non-url-shaped config-credential types and have the profiler authenticate from the carried `config` — the same pattern ES uses.**
+
+- `loadDatasourceProfileTarget` resolves the seam url via `resolveProfileUrl(poolConfig)`: url-bearing pool configs return their url; BigQuery synthesizes `bigquery://<project>` from its `projectId`. The synthetic url is an identifier/routing hint only — it carries NO credentials. Types still without a path (duckdb file, salesforce OAuth) return `undefined` and stay fail-closed in their own slices.
+- The BigQuery profiler's `resolveConfig` builds the connection from `options.config` when present (the tenant's decrypted `service_account_json` → `credentials`, `project_id` → `projectId`, the generic `schema` routing hint → `dataset`), mirroring ES's `configForOptions`. It falls back to `parseBigQueryUrl(options.url)` for the CLI / static-config path (operator shell). No SDK contract change — `config` already exists on `PluginProfileOptions`/`PluginListObjectsOptions`.
+- `BigQueryPoolConfig` gains an optional `schema` (the dataset routing hint) so a dataset set at `create_datasource` time flows through to the profiler. The credentials never leave the lib layer (the existing `config` SECURITY discipline).
+
+### Consequences
+
+- BigQuery onboards end-to-end over MCP (add datasource → `profile_datasource` → semantic layer), with the tenant's own service-account creds, closing the add-but-can't-onboard dead-end for BigQuery.
+- The `resolveProfileUrl` seam is the extension point for the remaining non-url types: DuckDB (#3627) and Salesforce OAuth (#3663) plug in there rather than re-opening the gate.

--- a/docs/adr/0019-two-semantic-generators-stay-separate.md
+++ b/docs/adr/0019-two-semantic-generators-stay-separate.md
@@ -1,4 +1,4 @@
-# ADR-0017: The two semantic generators stay separate (spec-derived vs profiled)
+# ADR-0019: The two semantic generators stay separate (spec-derived vs profiled)
 
 **Status:** Accepted
 **Date:** 2026-06-14

--- a/packages/api/src/lib/datasources/__tests__/mcp-profile-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-profile-plugin.test.ts
@@ -198,6 +198,44 @@ describe("loadDatasourceProfileTarget — plugin types (#3552)", () => {
     expect(res.target.config).toEqual({ url: "elasticsearch://es.tenant:9200", apiKey: "tenant-es-key" });
   });
 
+  it("bigquery (non-url-shaped) resolves to ok — synthetic url + decrypted config carried (#3664)", async () => {
+    // BigQuery's pool config has NO url (service-account multi-field). The seam
+    // synthesizes a `bigquery://<project>` identifier so it is profilable over
+    // MCP, and carries the decrypted config so the profiler authenticates with
+    // the tenant's own service-account creds.
+    poolConfigResult = {
+      dbType: "bigquery",
+      serviceAccountJson: '{"type":"service_account","project_id":"my-project"}',
+      projectId: "my-project",
+      schema: "analytics",
+    };
+    const profile = chProfiler();
+    pluginConn = { dbType: "bigquery", createFromConfig: () => ({}), profile };
+    internalRows = [
+      {
+        catalog_id: "cat_bq",
+        catalog_slug: "bigquery",
+        config: {
+          service_account_json: '{"type":"service_account","project_id":"my-project"}',
+          project_id: "my-project",
+          schema: "analytics",
+        },
+        config_schema: [],
+        group_id: null,
+      },
+    ];
+    const res = await loadDatasourceProfileTarget("org_1", "bq");
+    expect(res.kind).toBe("ok");
+    if (res.kind !== "ok") return;
+    expect(res.target.dbType).toBe("bigquery");
+    // Synthetic url derived from the project — NOT empty (it would fail the gate).
+    expect(res.target.url).toBe("bigquery://my-project");
+    // The dataset routing hint flows as the target schema.
+    expect(res.target.schema).toBe("analytics");
+    // The decrypted service-account config rides on the target (tenant creds).
+    expect(res.target.config).toMatchObject({ project_id: "my-project" });
+  });
+
   it("native pg/mysql resolves WITHOUT a profileFn (SemanticGenerator profiles in-core)", async () => {
     poolConfigResult = { dbType: "postgres", url: "postgres://u:p@h/db", schema: "public" };
     internalRows = [

--- a/packages/api/src/lib/datasources/__tests__/mcp-profile-plugin.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-profile-plugin.test.ts
@@ -335,3 +335,45 @@ describe("runSemanticProfile — plugin profileFn (#3552: entities + whitelist +
     expect([...tables].some((t) => t.includes("events"))).toBe(true);
   });
 });
+
+// =====================================================================
+// #3662 — the MCP seam must NOT coerce a missing schema to "public" for a
+// plugin dbType. This mirrors the #3621 wizard `effectiveSchema` fix: "public"
+// is Postgres's canonical default search-path, but it's meaningless for a
+// plugin dbType (ClickHouse's default database is `default`, not `public`).
+// Leaking "public" overrides the URL-embedded database and profiles zero
+// objects against a nonexistent database — the exact bug class #3621 fixed,
+// surviving on the sibling MCP seam.
+// =====================================================================
+describe("runSemanticProfile — schema default does not leak to plugin dbTypes (#3662)", () => {
+  it("clickhouse with NO configured schema → the plugin profiler receives undefined, NOT \"public\"", async () => {
+    const profile = chProfiler();
+    const outcome = await runSemanticProfile({
+      url: "clickhouse://h:8443/analytics",
+      dbType: "clickhouse",
+      profileFn: profile,
+      connectionId: "wh",
+      // no `schema` — relying on the URL-embedded database.
+    });
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") return;
+    expect(profile.calls).toHaveLength(1);
+    // The bug: this would be "public", overriding the URL's `analytics` database.
+    expect(profile.calls[0].schema).toBeUndefined();
+  });
+
+  it("clickhouse with an explicit schema → passed through verbatim", async () => {
+    const profile = chProfiler();
+    const outcome = await runSemanticProfile({
+      url: "clickhouse://h:8443/analytics",
+      dbType: "clickhouse",
+      profileFn: profile,
+      schema: "analytics",
+      connectionId: "wh",
+    });
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") return;
+    expect(profile.calls).toHaveLength(1);
+    expect(profile.calls[0].schema).toBe("analytics");
+  });
+});

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -35,6 +35,7 @@ import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import {
   catalogSlugToDbType,
   resolveDatasourcePoolConfig,
+  type DatasourcePoolConfig,
 } from "@atlas/api/lib/db/datasource-pool-resolver";
 import {
   findDatasourcePluginConnection,
@@ -871,6 +872,31 @@ export type LoadProfileTargetResult =
   | { readonly kind: "unsupported"; readonly dbType: string; readonly message: string };
 
 /**
+ * Resolve the `url` the profiler seam passes to the resolved `profileFn`.
+ *
+ * - URL-shaped pool configs (native pg/mysql, clickhouse/snowflake/elasticsearch)
+ *   return their `url` directly.
+ * - BigQuery is multi-field / non-url-shaped: its credentials live in SEPARATE
+ *   config fields (`service_account_json`), never a connection string. The host
+ *   carries the decrypted `config` (the ADR-0017 amendment), and the BigQuery
+ *   profiler authenticates from it — but the seam contract is still
+ *   `url: string`, so synthesize a `bigquery://<project>` identifier from the
+ *   pool config. The synthetic url is a routing/identifier hint only; the
+ *   profiler reads credentials from `config`, never from this url (#3664).
+ * - Everything else with no url (duckdb file path, salesforce OAuth) returns
+ *   `undefined` and stays fail-closed in its own slice.
+ */
+function resolveProfileUrl(poolConfig: DatasourcePoolConfig): string | undefined {
+  if ("url" in poolConfig && typeof poolConfig.url === "string" && poolConfig.url.length > 0) {
+    return poolConfig.url;
+  }
+  if (poolConfig.dbType === "bigquery" && poolConfig.projectId.length > 0) {
+    return `bigquery://${encodeURIComponent(poolConfig.projectId)}`;
+  }
+  return undefined;
+}
+
+/**
  * Load + decrypt a datasource install's connection config and shape the
  * profiling target the semantic generator needs.
  *
@@ -936,14 +962,17 @@ export async function loadDatasourceProfileTarget(
     },
     decrypted,
   );
-  // The profiler seam is url-based (ADR-0017 spine): the resolved `profileFn`
-  // (and the in-core pg/mysql profiler) takes a `url`. Native pg/mysql and the
-  // url-bearing plugin pool configs (clickhouse / snowflake / elasticsearch)
-  // carry one; a multi-field-credential type (bigquery / duckdb) or an
-  // OAuth-managed one (salesforce) does not and is handled in its own per-dbType
-  // slice — fail closed here with an actionable message rather than profiling
-  // against an empty url.
-  const url = "url" in poolConfig ? poolConfig.url : undefined;
+  // The profiler seam passes a `url: string` to the resolved `profileFn` (and to
+  // the in-core pg/mysql profiler). Native pg/mysql and the url-bearing plugin
+  // pool configs (clickhouse / snowflake / elasticsearch) carry one directly. A
+  // multi-field-credential type (bigquery) carries its connection in SEPARATE
+  // config fields, not a url — the host carries the decrypted `config` (the
+  // ADR-0017 amendment that already lets ES authenticate from tenant config) and
+  // the plugin profiler builds the connection from it; we synthesize a url so
+  // the seam's `url: string` contract holds and logs/identifiers stay meaningful
+  // (#3664). Types with neither a url nor a config-credential profiler path
+  // (duckdb file path, salesforce OAuth) stay fail-closed in their own slices.
+  const url = resolveProfileUrl(poolConfig);
   if (typeof url !== "string" || url.length === 0) {
     return {
       kind: "unsupported",

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -1088,9 +1088,9 @@ export async function runSemanticProfile(opts: {
       // types is a no-op; a plugin type requires it.
       ...(opts.profileFn !== undefined ? { profileFn: opts.profileFn } : {}),
       // Forward the decrypted tenant config (ADR-0017 amendment) so a
-      // separate-field-credential plugin profiler (ES) authenticates with the
-      // tenant's own creds, not operator env. Native + url-embedded profilers
-      // ignore it. Never logged.
+      // separate-field-credential / non-url-shaped plugin profiler (ES,
+      // BigQuery — #3664) authenticates with the tenant's own creds, not
+      // operator env. Native + url-embedded profilers ignore it. Never logged.
       ...(opts.config !== undefined ? { config: opts.config } : {}),
       connectionId: opts.connectionId,
       registerWhitelist: !shouldPersist,

--- a/packages/api/src/lib/db/datasource-pool-resolver.ts
+++ b/packages/api/src/lib/db/datasource-pool-resolver.ts
@@ -169,6 +169,12 @@ export interface BigQueryPoolConfig {
   readonly dbType: "bigquery";
   readonly serviceAccountJson: string;
   readonly projectId: string;
+  /**
+   * Optional default dataset / routing hint (the generic `schema` field). Not a
+   * pool-routing key (BigQuery has no schema namespace in the pg sense), but
+   * carried so the profiler seam (#3664) can scope introspection to a dataset.
+   */
+  readonly schema?: string;
   readonly description?: string;
 }
 
@@ -387,6 +393,7 @@ function resolveBigQuery(c: Readonly<Record<string, unknown>>): BigQueryPoolConf
     dbType: "bigquery",
     serviceAccountJson,
     projectId,
+    ...(asString(c.schema) !== undefined ? { schema: asString(c.schema)! } : {}),
     ...(asString(c.description) !== undefined
       ? { description: asString(c.description)! }
       : {}),

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -315,7 +315,15 @@ function profileImpl(
   opts: ProfileConnectionOptions,
 ): Effect.Effect<ProfileConnectionResult, ProfilingFailedError> {
   return Effect.gen(function* () {
-    const schema = opts.schema ?? "public";
+    // #3662 — mirror the wizard's `effectiveSchema` (#3621) on the MCP seam:
+    // default a missing schema to `"public"` ONLY for native Postgres (its
+    // canonical search-path). A plugin dbType — where `"public"` is meaningless
+    // (ClickHouse database, Elasticsearch index) — passes the user-provided
+    // schema through, or `undefined` so the plugin profiler uses its OWN default
+    // (e.g. ClickHouse's `default`, or the URL-embedded database) instead of
+    // overriding it with a literal `"public"` and profiling zero objects. MySQL
+    // ignores schema either way.
+    const schema = opts.dbType === "postgres" ? opts.schema ?? "public" : opts.schema;
     const profiler = resolveProfiler(opts.dbType, opts.profileFn);
     if (profiler instanceof ProfilingFailedError) {
       return yield* Effect.fail(profiler);

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -355,9 +355,12 @@ function profileImpl(
           prefetchedObjects: opts.prefetchedObjects,
           progress: opts.progress,
           logger: opts.logger,
-          // Decrypted tenant config for separate-field-credential plugins
-          // (ES). The in-core pg/mysql profilers and url-embedded plugin
-          // profilers ignore it. Never logged (ADR-0017 amendment).
+          // Decrypted tenant config for separate-field-credential / non-url-shaped
+          // plugins (Elasticsearch's apiKey, BigQuery's service_account_json +
+          // project — #3664). The in-core pg/mysql profilers and url-embedded
+          // plugin profilers (ClickHouse/Snowflake) ignore it. Never logged
+          // (ADR-0017 amendment). NOTE: BigQuery depends on this forwarding —
+          // without it, its profiler falls back to ADC/operator env.
           ...(opts.config !== undefined ? { config: opts.config } : {}),
         }),
       catch: (err) => err,

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/schemas",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Shared Zod schemas for Atlas wire format — single source of truth for API route validation and web response parsing",
   "type": "module",
   "private": true,

--- a/plugins/bigquery/__tests__/profiler.test.ts
+++ b/plugins/bigquery/__tests__/profiler.test.ts
@@ -349,6 +349,35 @@ describe("config-based credential resolution (#3664)", () => {
     ).rejects.toThrow(/service_account_json is not valid JSON/);
   });
 
+  test("throws (no silent ADC fallback) when service_account_json parses to a non-object", async () => {
+    // `JSON.parse("null")` succeeds → null. Without a shape check, credentials
+    // would be a falsy non-object, createBigQueryConnection would omit it, and
+    // BigQuery would fall back to operator/ADC creds — a per-tenant-creds
+    // isolation violation. Fail loud instead.
+    for (const bad of ["null", "42", '"a-string"', "[1,2,3]"]) {
+      await expect(
+        profileBigQuery({
+          url: "bigquery://my-project",
+          config: { service_account_json: bad, project_id: "my-project", schema: "analytics" },
+        }),
+      ).rejects.toThrow(/must be a JSON object/);
+    }
+  });
+
+  test("an empty / label-only config does NOT suppress URL parsing (falls back to the bigquery:// url)", async () => {
+    // A truthy-but-empty config must not discard a perfectly valid url.
+    const result = await profileBigQuery({ url: "bigquery://US@my-project/analytics", config: {} });
+    expect(result.errors).toEqual([]);
+    expect(result.profiles).toHaveLength(2);
+    // No tenant creds in the config → the client resolved from the url path.
+    const clientOpts = (mockBigQuery.mock.calls.at(-1) as unknown[] | undefined)?.[0] as {
+      projectId?: string;
+      credentials?: unknown;
+    };
+    expect(clientOpts.projectId).toBe("my-project");
+    expect(clientOpts.credentials).toBeUndefined();
+  });
+
   test("listBigQueryObjects also authenticates from options.config", async () => {
     const objects = await listBigQueryObjects({
       url: "bigquery://my-project",

--- a/plugins/bigquery/__tests__/profiler.test.ts
+++ b/plugins/bigquery/__tests__/profiler.test.ts
@@ -278,3 +278,86 @@ describe("profileBigQuery", () => {
     expect(msg).not.toContain("/secrets/key.json");
   });
 });
+
+// The registry/MCP seam (#3664): BigQuery is non-url-shaped, so the host carries
+// the datasource's DECRYPTED config (service_account_json + project_id + the
+// generic `schema` routing hint) and the profiler authenticates from it — the
+// tenant's own service-account creds, never operator env (the per-tenant-creds
+// rule), mirroring the Elasticsearch amendment. The url is a synthetic
+// identifier only; credentials NEVER ride on it.
+describe("config-based credential resolution (#3664)", () => {
+  const SERVICE_ACCOUNT = JSON.stringify({
+    type: "service_account",
+    project_id: "my-project",
+    private_key: "-----BEGIN PRIVATE KEY-----\\nXXX\\n-----END PRIVATE KEY-----\\n",
+    client_email: "sa@my-project.iam.gserviceaccount.com",
+  });
+
+  test("builds the BigQuery client from options.config (parsed service account creds + project)", async () => {
+    const result = await profileBigQuery({
+      url: "bigquery://my-project", // synthetic identifier — carries no creds
+      config: {
+        service_account_json: SERVICE_ACCOUNT,
+        project_id: "my-project",
+        schema: "analytics",
+      },
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.profiles).toHaveLength(2);
+
+    // The client was constructed with the tenant's parsed service-account
+    // credentials and project — not from the url.
+    const clientOpts = (mockBigQuery.mock.calls.at(-1) as unknown[] | undefined)?.[0] as {
+      projectId?: string;
+      credentials?: Record<string, unknown>;
+    };
+    expect(clientOpts.projectId).toBe("my-project");
+    expect(clientOpts.credentials).toMatchObject({
+      type: "service_account",
+      client_email: "sa@my-project.iam.gserviceaccount.com",
+    });
+  });
+
+  test("resolves the dataset from the config `schema` routing hint when no schema option is passed", async () => {
+    await profileBigQuery({
+      url: "bigquery://my-project",
+      config: { service_account_json: SERVICE_ACCOUNT, project_id: "my-project", schema: "analytics" },
+    });
+    // INFORMATION_SCHEMA queries are scoped to the `analytics` dataset.
+    expect(seenQueries.some((q) => q.includes("analytics") && q.includes("INFORMATION_SCHEMA"))).toBe(
+      true,
+    );
+  });
+
+  test("the schema OPTION still wins over the config dataset", async () => {
+    await profileBigQuery({
+      url: "bigquery://my-project",
+      schema: "override_ds",
+      config: { service_account_json: SERVICE_ACCOUNT, project_id: "my-project", schema: "analytics" },
+    });
+    expect(seenQueries.some((q) => q.includes("override_ds") && q.includes("INFORMATION_SCHEMA"))).toBe(
+      true,
+    );
+  });
+
+  test("throws an actionable error when service_account_json is not valid JSON", async () => {
+    await expect(
+      profileBigQuery({
+        url: "bigquery://my-project",
+        config: { service_account_json: "{not json", project_id: "my-project", schema: "analytics" },
+      }),
+    ).rejects.toThrow(/service_account_json is not valid JSON/);
+  });
+
+  test("listBigQueryObjects also authenticates from options.config", async () => {
+    const objects = await listBigQueryObjects({
+      url: "bigquery://my-project",
+      config: { service_account_json: SERVICE_ACCOUNT, project_id: "my-project", schema: "analytics" },
+    });
+    expect(objects.map((o) => o.name)).toEqual(["events", "daily_report"]);
+    const clientOpts = (mockBigQuery.mock.calls.at(-1) as unknown[] | undefined)?.[0] as {
+      credentials?: unknown;
+    };
+    expect(clientOpts.credentials).toBeDefined();
+  });
+});

--- a/plugins/bigquery/src/connection.ts
+++ b/plugins/bigquery/src/connection.ts
@@ -86,6 +86,69 @@ export function parseBigQueryUrl(url: string): BigQueryConnectionConfig {
 }
 
 /**
+ * Coerce a service-account JSON string into a credentials object, with an
+ * actionable error for malformed input. Shared by the connection factory's
+ * config normalization ({@link normalizeBigQueryConfigFields}) and the
+ * registry/MCP profiler so the two credential paths can't drift (#3664).
+ *
+ * @throws {Error} when the string is not valid JSON, OR parses to something
+ *   other than a JSON object (a non-null, non-array object). The shape check
+ *   matters: `JSON.parse("null")` / a parsed array/number/string would
+ *   otherwise be handed on as a falsy-or-malformed `credentials`, and the
+ *   BigQuery client would silently fall back to Application Default Credentials
+ *   (operator/ambient env) — a per-tenant-credential-isolation violation. Fail
+ *   loud instead.
+ */
+export function parseServiceAccountJson(serviceAccountJson: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serviceAccountJson);
+  } catch (err) {
+    throw new Error(
+      `BigQuery service_account_json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "BigQuery service_account_json must be a JSON object (the service account key contents).",
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Normalize a DB-stored / tenant BigQuery config (the Admin → Connections
+ * catalog form shape: snake_case `service_account_json` + `project_id`) onto the
+ * connection factory's field shape (camelCase `credentials` + `projectId`),
+ * WITHOUT clobbering explicit camelCase values a programmatic caller passed.
+ * Shared by `createFromConfig` (index.ts) and the registry/MCP profiler
+ * (profiler.ts `bigQueryConfigFromTenantConfig`) so the connection path and the
+ * profiling path resolve credentials identically and can't drift (#3664). An
+ * explicit `keyFilename` takes precedence over `service_account_json` (the key
+ * file wins), matching the connection factory's historical behavior.
+ *
+ * @throws {Error} when `service_account_json` is present but not a valid JSON object.
+ */
+export function normalizeBigQueryConfigFields(
+  raw: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw };
+  if (out.projectId === undefined && typeof out.project_id === "string") {
+    out.projectId = out.project_id;
+  }
+  if (
+    out.credentials === undefined &&
+    out.keyFilename === undefined &&
+    typeof out.service_account_json === "string" &&
+    out.service_account_json.trim().length > 0
+  ) {
+    out.credentials = parseServiceAccountJson(out.service_account_json);
+  }
+  return out;
+}
+
+/**
  * Create a PluginDBConnection backed by @google-cloud/bigquery.
  * BigQuery is stateless REST — no pool to manage.
  *

--- a/plugins/bigquery/src/index.ts
+++ b/plugins/bigquery/src/index.ts
@@ -41,6 +41,7 @@ import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult, Plu
 import {
   createBigQueryConnection,
   extractProjectId,
+  normalizeBigQueryConfigFields,
 } from "./connection";
 import { listBigQueryObjects, profileBigQuery } from "./profiler";
 import { BIGQUERY_FORBIDDEN_PATTERNS } from "./validation";
@@ -83,43 +84,6 @@ const BigQueryConfigSchema = z.object({
 const BigQueryRuntimeConfigSchema = BigQueryConfigSchema.extend({
   projectId: z.string().min(1, "BigQuery projectId must not be empty"),
 });
-
-/**
- * Normalize a DB-stored BigQuery datasource config into the connection factory's
- * field shape. The Admin → Connections catalog form
- * (`seed-builtin-datasource-catalog.ts`) collects `service_account_json` (the raw
- * key JSON, as a string) + `project_id` (snake_case); the connection factory and
- * {@link BigQueryRuntimeConfigSchema} use `credentials` (object) + `projectId`
- * (camelCase). Map the form shape onto the factory shape WITHOUT clobbering
- * explicit camelCase values (so a programmatic `createFromConfig` caller passing
- * `projectId`/`credentials` directly still works). Without this, every
- * admin-installed BigQuery datasource would be rejected by the runtime schema
- * (missing `projectId`) and never register as a live connection.
- */
-function normalizeBigQueryRuntimeConfig(
-  raw: Readonly<Record<string, unknown>>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = { ...raw };
-  if (out.projectId === undefined && typeof out.project_id === "string") {
-    out.projectId = out.project_id;
-  }
-  if (
-    out.credentials === undefined &&
-    out.keyFilename === undefined &&
-    typeof out.service_account_json === "string" &&
-    out.service_account_json.trim().length > 0
-  ) {
-    try {
-      out.credentials = JSON.parse(out.service_account_json);
-    } catch (err) {
-      throw new Error(
-        `BigQuery service_account_json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
-    }
-  }
-  return out;
-}
 
 /**
  * BigQuery config type. Uses `z.input` so both the `bigqueryPlugin()` factory
@@ -199,7 +163,7 @@ export function buildBigQueryPlugin(
       // Normalize the catalog form's snake_case / service_account_json shape onto
       // the factory's camelCase / credentials shape before validating.
       const parsed = BigQueryRuntimeConfigSchema.parse(
-        normalizeBigQueryRuntimeConfig(runtimeConfig),
+        normalizeBigQueryConfigFields(runtimeConfig),
       );
       return createBigQueryConnection({
         projectId: parsed.projectId,

--- a/plugins/bigquery/src/profiler.ts
+++ b/plugins/bigquery/src/profiler.ts
@@ -83,29 +83,93 @@ function bqLiteral(value: string): string {
 }
 
 /**
- * Resolve the dataset to introspect. `schema` (the SDK option) wins over the
- * dataset embedded in the URL, mirroring how the CLI passes `--schema`.
- * @throws {Error} when neither the URL nor the option names a dataset.
+ * Build the base connection config from the host-carried tenant config
+ * (#3664 — the ADR-0017 amendment that lets a multi-field-credential profiler
+ * authenticate with the TENANT's own creds over the registry/MCP seam, mirroring
+ * Elasticsearch's `configForOptions`).
+ *
+ * BigQuery is non-url-shaped: its credentials (`service_account_json`) live in a
+ * SEPARATE config field, NEVER in the connection string. The Admin → Connections
+ * catalog form collects `service_account_json` (raw key JSON string) + `project_id`
+ * (snake_case) + the generic `schema` routing hint; map them onto the connection
+ * factory's `credentials` (object) + `projectId` + `dataset` shape. A
+ * programmatic caller passing camelCase `projectId`/`credentials`/`dataset`
+ * directly still works.
+ *
+ * @throws {Error} when `service_account_json` is present but not valid JSON.
+ */
+function bigQueryConfigFromTenantConfig(
+  raw: Readonly<Record<string, unknown>>,
+): BigQueryConnectionConfig {
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" && v.length > 0 ? v : undefined;
+  const projectId = str(raw.projectId) ?? str(raw.project_id);
+  const dataset = str(raw.dataset) ?? str(raw.schema);
+  const location = str(raw.location);
+  const keyFilename = str(raw.keyFilename);
+
+  let credentials: Record<string, unknown> | undefined;
+  const serviceAccountJson = str(raw.service_account_json);
+  if (serviceAccountJson) {
+    try {
+      credentials = JSON.parse(serviceAccountJson) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `BigQuery service_account_json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  } else if (raw.credentials && typeof raw.credentials === "object") {
+    credentials = raw.credentials as Record<string, unknown>;
+  }
+
+  return {
+    ...(projectId !== undefined ? { projectId } : {}),
+    ...(dataset !== undefined ? { dataset } : {}),
+    ...(location !== undefined ? { location } : {}),
+    ...(keyFilename !== undefined ? { keyFilename } : {}),
+    ...(credentials !== undefined ? { credentials } : {}),
+  };
+}
+
+/**
+ * Resolve the dataset to introspect and the base connection config.
+ *
+ * Two credential sources, chosen by whether the host seam supplied the tenant's
+ * config (registry/MCP path) or only a url (CLI / static-config path):
+ *   - `options.config` present → the host carried the datasource's DECRYPTED
+ *     config; build from the tenant's own service-account creds (#3664).
+ *   - `options.config` absent → parse the `bigquery://` url (operator shell).
+ *
+ * `options.schema` (the SDK routing hint) wins over the dataset embedded in
+ * either source, mirroring how the CLI passes `--schema`.
+ *
+ * @throws {Error} when no dataset or no project can be resolved.
  */
 function resolveConfig(
-  url: string,
-  schema: string | undefined,
+  options: PluginListObjectsOptions,
 ): { config: BigQueryConnectionConfig; projectId: string; dataset: string } {
-  const config = parseBigQueryUrl(url);
-  const dataset = schema ?? config.dataset;
+  const base = options.config
+    ? bigQueryConfigFromTenantConfig(options.config)
+    : parseBigQueryUrl(options.url);
+  const dataset = options.schema ?? base.dataset;
   if (!dataset) {
     throw new Error(
       "BigQuery profiling requires a dataset. Pass it in the URL " +
-        "(bigquery://project/dataset) or via the schema option.",
+        "(bigquery://project/dataset), via the schema option, or as a `schema` " +
+        "field on the datasource config.",
     );
   }
-  const projectId = config.projectId;
+  const projectId = base.projectId;
   if (!projectId) {
-    throw new Error("BigQuery profiling requires a project in the bigquery:// URL.");
+    throw new Error(
+      "BigQuery profiling requires a project (the bigquery:// URL host or a " +
+        "`project_id` datasource config field).",
+    );
   }
   // Scope the connection to the resolved dataset so unqualified references
   // (e.g. INFORMATION_SCHEMA) resolve against it.
-  return { config: { ...config, dataset }, projectId, dataset };
+  return { config: { ...base, dataset }, projectId, dataset };
 }
 
 /** A row from INFORMATION_SCHEMA.TABLES. */
@@ -142,7 +206,7 @@ function listObjectsSql(dataset: string): string {
 export async function listBigQueryObjects(
   options: PluginListObjectsOptions,
 ): Promise<PluginDatabaseObject[]> {
-  const { config, dataset } = resolveConfig(options.url, options.schema);
+  const { config, dataset } = resolveConfig(options);
   const conn = createBigQueryConnection(config);
   try {
     const { rows } = await conn.query(listObjectsSql(dataset));
@@ -203,8 +267,8 @@ function isTextType(dataType: string): boolean {
 export async function profileBigQuery(
   options: PluginProfileOptions,
 ): Promise<PluginProfilingResult> {
-  const { url, schema, selectedTables, prefetchedObjects, progress } = options;
-  const { config, dataset } = resolveConfig(url, schema);
+  const { selectedTables, prefetchedObjects, progress } = options;
+  const { config, dataset } = resolveConfig(options);
   const conn = createBigQueryConnection(config);
 
   const profiles: PluginTableProfile[] = [];

--- a/plugins/bigquery/src/profiler.ts
+++ b/plugins/bigquery/src/profiler.ts
@@ -50,6 +50,7 @@ import type {
 import {
   createBigQueryConnection,
   parseBigQueryUrl,
+  normalizeBigQueryConfigFields,
   type BigQueryConnectionConfig,
 } from "./connection";
 
@@ -101,33 +102,30 @@ function bqLiteral(value: string): string {
 function bigQueryConfigFromTenantConfig(
   raw: Readonly<Record<string, unknown>>,
 ): BigQueryConnectionConfig {
+  // Shared with the connection factory's `createFromConfig` (index.ts) so the
+  // profiling path and the query path resolve project + credentials identically:
+  // snake_case `project_id` → `projectId`, `service_account_json` →
+  // `credentials` (validated as a JSON object, never a silent ADC fallback),
+  // keyFilename-wins precedence.
+  const normalized = normalizeBigQueryConfigFields(raw);
   const str = (v: unknown): string | undefined =>
     typeof v === "string" && v.length > 0 ? v : undefined;
-  const projectId = str(raw.projectId) ?? str(raw.project_id);
-  const dataset = str(raw.dataset) ?? str(raw.schema);
-  const location = str(raw.location);
-  const keyFilename = str(raw.keyFilename);
-
-  let credentials: Record<string, unknown> | undefined;
-  const serviceAccountJson = str(raw.service_account_json);
-  if (serviceAccountJson) {
-    try {
-      credentials = JSON.parse(serviceAccountJson) as Record<string, unknown>;
-    } catch (err) {
-      throw new Error(
-        `BigQuery service_account_json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
-    }
-  } else if (raw.credentials && typeof raw.credentials === "object") {
-    credentials = raw.credentials as Record<string, unknown>;
-  }
+  // BigQuery's dataset rides on the generic `schema` routing hint over the seam
+  // (the catalog form has no dedicated dataset field); an explicit `dataset`
+  // still wins for a programmatic caller.
+  const dataset = str(normalized.dataset) ?? str(normalized.schema);
+  const credentials =
+    normalized.credentials &&
+    typeof normalized.credentials === "object" &&
+    !Array.isArray(normalized.credentials)
+      ? (normalized.credentials as Record<string, unknown>)
+      : undefined;
 
   return {
-    ...(projectId !== undefined ? { projectId } : {}),
+    ...(str(normalized.projectId) !== undefined ? { projectId: str(normalized.projectId)! } : {}),
     ...(dataset !== undefined ? { dataset } : {}),
-    ...(location !== undefined ? { location } : {}),
-    ...(keyFilename !== undefined ? { keyFilename } : {}),
+    ...(str(normalized.location) !== undefined ? { location: str(normalized.location)! } : {}),
+    ...(str(normalized.keyFilename) !== undefined ? { keyFilename: str(normalized.keyFilename)! } : {}),
     ...(credentials !== undefined ? { credentials } : {}),
   };
 }
@@ -149,9 +147,16 @@ function bigQueryConfigFromTenantConfig(
 function resolveConfig(
   options: PluginListObjectsOptions,
 ): { config: BigQueryConnectionConfig; projectId: string; dataset: string } {
-  const base = options.config
-    ? bigQueryConfigFromTenantConfig(options.config)
-    : parseBigQueryUrl(options.url);
+  // Prefer the tenant config (registry/MCP path) ONLY when it actually carries
+  // connection fields (project / credentials / key file). An empty or
+  // label-only `config` (e.g. `{}` or `{ description }`) must NOT suppress URL
+  // parsing — fall back to the `bigquery://` url (CLI / static path) so a valid
+  // url isn't discarded just because a truthy-but-empty config was passed (#3664 review).
+  const fromConfig = options.config ? bigQueryConfigFromTenantConfig(options.config) : undefined;
+  const base =
+    fromConfig && (fromConfig.projectId || fromConfig.credentials || fromConfig.keyFilename)
+      ? fromConfig
+      : parseBigQueryUrl(options.url);
   const dataset = options.schema ?? base.dataset;
   if (!dataset) {
     throw new Error(

--- a/plugins/salesforce/src/profiler.ts
+++ b/plugins/salesforce/src/profiler.ts
@@ -13,10 +13,16 @@
  * profiler is therefore **read-only** — describe + a single aggregate SELECT
  * per object, no DML.
  *
- * Salesforce stays on OAuth (ADR-0014): the `url` here is the same
- * `salesforce://` value `createFromConfig` resolves, which the connection
- * factory turns into the OAuth/jsforce session. No SQL `url` assumption — the
- * connection is built the same way the query path builds it.
+ * Auth: this profiler takes a credentialed `salesforce://` url and authenticates
+ * via jsforce's SOAP username/password login (`parseSalesforceURL` extracts the
+ * username, password, and optional security token; `conn.login()` performs the
+ * SOAP login) — it is NOT the OAuth-token path. Production OAuth Salesforce
+ * connections are built from tokens in `integration_credentials` via the
+ * `LazyPluginLoader`, not from this url. The registry consequently keeps
+ * Salesforce fail-closed for over-the-registry (MCP) profiling — see
+ * `datasource-registry-bridge.ts` (HANDLER_MANAGED_DATASOURCE_DBTYPES); only the
+ * CLI-with-credentialed-url path reaches this profiler today. OAuth-token-resolved
+ * registry profiling is tracked as a follow-up (ADR-0014, ADR-0017; #3663).
  *
  * Logic adapted from the CLI's `packages/cli/lib/profilers/salesforce.ts` —
  * this plugin package becomes the home the registry resolves and the CLI


### PR DESCRIPTION
Addresses the v0.0.16 "Profiler Seam" review findings under #3661. Tiered: unambiguous fixes shipped here; the two scope-decision findings were surfaced for a call (BigQuery → implement; Salesforce → dedicated designed PR).

## Tier 1 — fixes
- **#3662** — MCP profiling no longer hardcodes `schema "public"` for plugin dbTypes. `profileImpl` defaults to `"public"` only for native Postgres (mirroring the wizard's `effectiveSchema` #3621); plugin dbTypes get the user schema or `undefined`. A ClickHouse profile over MCP no longer overrides its URL-embedded database. +2 regression tests on the MCP seam.
- **#3663 (comment)** — Corrected the Salesforce profiler header comment to describe the actual SOAP username/password auth (was misleadingly claiming "OAuth/jsforce session"). Comment-only; no auth change.
- **#3665 (ADR dup)** — Renumbered the duplicate `0017-two-semantic-generators` → **ADR-0019**; kept profiler-seam as 0017 (what CLAUDE.md / plugin comments reference); fixed the inbound reference.

## Tier 2 — decisions
- **#3664 (BigQuery) — implemented.** BigQuery now profiles end-to-end over MCP from its multi-field config (ES decrypted-config template):
  - `resolveProfileUrl()` synthesizes `bigquery://<project>` for non-URL-shaped config-credential types so the seam's `url: string` contract holds (credentials never ride on the url).
  - The BigQuery profiler builds its connection from the decrypted tenant `config` (service-account creds + project + dataset routing hint), falling back to URL parsing for the CLI path.
  - `BigQueryPoolConfig` carries the optional `schema`/dataset hint. ADR-0017 amended. +5 profiler tests, +1 MCP-seam test.
- **#3663 (Salesforce, deeper) — carved to #3667.** Investigation found this crosses the integration↔datasource pillar boundary (the SF datasource plugin is dormant; real SF lives in the integration pillar via OAuth/`lazy-builder`), touching ADR-0014 — scoped as its own designed PR (#3667) rather than landing a cross-pillar, security-sensitive change in a review-fixes branch.

## Tier 3 — housekeeping
- **#3665 (schemas)** — `@useatlas/schemas` `0.0.6 → 0.0.7` for the new `semantic-entity-yaml` export. All consumers are `workspace:*` → no scaffold ref bump.
- **#3665 (duckdb)** — Confirmed the DuckDB CLI copy remains tracked under open umbrella #3627. No action.
- **#3665 (wizard placeholder)** — Left as-is (harmless display nit).

## Issue admin
- Split the 3 architecture nits out of #3665 → **#3666** (under #3656); trimmed #3665 to the lean audit cleanup.
- Filed **#3667** (Salesforce OAuth cross-pillar profiling) under #3663, both on the v0.0.16 milestone.

## CI (touched scope)
lint ✓ · type ✓ · 17 affected API test files ✓ · 255 plugin tests ✓ · 365 schemas tests ✓ · syncpack ✓. No migrations/templates touched.

Closes #3662, #3664. Addresses #3663 (comment half; deeper work → #3667) and #3665.

https://claude.ai/code/session_01FFrFzmJRdKGegLTQYyJEfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFrFzmJRdKGegLTQYyJEfP)_