### PR TITLE
ci: guard against merged-but-unpublished package versions + idempotent publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Check template drift
         run: bash scripts/check-template-drift.sh
 
+      - name: Check no publishable package version is merged-but-unpublished
+        run: bun scripts/check-unpublished-versions.ts
+
       - name: Check security-headers drift
         run: bash scripts/check-security-headers-drift.sh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,140 +71,140 @@ jobs:
 
       - name: Build and publish @useatlas/types
         if: startsWith(github.ref, 'refs/tags/types-v')
-        run: cd packages/types && bun run build && npm publish --access public --provenance
+        run: cd packages/types && bun run build && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish create-atlas-agent
         if: startsWith(github.ref, 'refs/tags/atlas-agent-v')
-        run: cd create-atlas && npm publish --access public --provenance
+        run: cd create-atlas && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish create-atlas-plugin
         if: startsWith(github.ref, 'refs/tags/atlas-plugin-v')
-        run: cd create-atlas-plugin && npm publish --access public --provenance
+        run: cd create-atlas-plugin && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Build, test, and publish @useatlas/sdk
         if: startsWith(github.ref, 'refs/tags/sdk-v')
-        run: cd packages/sdk && bun run build && bun run test && npm publish --access public --provenance
+        run: cd packages/sdk && bun run build && bun run test && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Build, test, and publish @useatlas/plugin-sdk
         if: startsWith(github.ref, 'refs/tags/plugin-sdk-v')
-        run: cd packages/plugin-sdk && bun run build && bun run test && npm publish --access public --provenance
+        run: cd packages/plugin-sdk && bun run build && bun run test && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Build, test, and publish @useatlas/webhook-publisher
         if: startsWith(github.ref, 'refs/tags/webhook-publisher-v')
-        run: cd packages/webhook-publisher && bun run build && bun run test && npm publish --access public --provenance
+        run: cd packages/webhook-publisher && bun run build && bun run test && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Build and publish @useatlas/react
         if: startsWith(github.ref, 'refs/tags/react-v')
         run: |
           cd packages/sdk && bun run build
-          cd ../react && bun run build && npm publish --access public --provenance
+          cd ../react && bun run build && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Plugins — ship raw TypeScript, no build step needed
       # Tests are already run by CI on every push to main; tags are always cut from main
       # Datasource
       - name: Publish @useatlas/bigquery
         if: startsWith(github.ref, 'refs/tags/bigquery-v')
-        run: cd plugins/bigquery && npm publish --access public --provenance
+        run: cd plugins/bigquery && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/clickhouse
         if: startsWith(github.ref, 'refs/tags/clickhouse-v')
-        run: cd plugins/clickhouse && npm publish --access public --provenance
+        run: cd plugins/clickhouse && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/snowflake
         if: startsWith(github.ref, 'refs/tags/snowflake-v')
-        run: cd plugins/snowflake && npm publish --access public --provenance
+        run: cd plugins/snowflake && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/duckdb
         if: startsWith(github.ref, 'refs/tags/duckdb-v')
-        run: cd plugins/duckdb && npm publish --access public --provenance
+        run: cd plugins/duckdb && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/mysql
         if: startsWith(github.ref, 'refs/tags/mysql-v')
-        run: cd plugins/mysql && npm publish --access public --provenance
+        run: cd plugins/mysql && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/salesforce
         if: startsWith(github.ref, 'refs/tags/salesforce-v')
         # Ordering guard: fails if a bumped @useatlas/* peer range isn't published yet
-        run: bun scripts/check-publishable-peers.ts plugins/salesforce && cd plugins/salesforce && npm publish --access public --provenance
+        run: bun scripts/check-publishable-peers.ts plugins/salesforce && cd plugins/salesforce && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/elasticsearch
         if: startsWith(github.ref, 'refs/tags/elasticsearch-v')
         # Ordering guard: fails if a bumped @useatlas/* peer range isn't published yet
-        run: bun scripts/check-publishable-peers.ts plugins/elasticsearch && cd plugins/elasticsearch && npm publish --access public --provenance
+        run: bun scripts/check-publishable-peers.ts plugins/elasticsearch && cd plugins/elasticsearch && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Sandbox
       - name: Publish @useatlas/e2b
         if: startsWith(github.ref, 'refs/tags/e2b-v')
-        run: cd plugins/e2b && npm publish --access public --provenance
+        run: cd plugins/e2b && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/daytona
         if: startsWith(github.ref, 'refs/tags/daytona-v')
-        run: cd plugins/daytona && npm publish --access public --provenance
+        run: cd plugins/daytona && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/nsjail
         if: startsWith(github.ref, 'refs/tags/nsjail-v')
-        run: cd plugins/nsjail && npm publish --access public --provenance
+        run: cd plugins/nsjail && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/sidecar
         if: startsWith(github.ref, 'refs/tags/sidecar-v')
-        run: cd plugins/sidecar && npm publish --access public --provenance
+        run: cd plugins/sidecar && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/vercel-sandbox
         if: startsWith(github.ref, 'refs/tags/vercel-sandbox-v')
-        run: cd plugins/vercel-sandbox && npm publish --access public --provenance
+        run: cd plugins/vercel-sandbox && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/railway-sandbox
         if: startsWith(github.ref, 'refs/tags/railway-sandbox-v')
-        run: cd plugins/railway-sandbox && npm publish --access public --provenance
+        run: cd plugins/railway-sandbox && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Interaction
       - name: Publish @useatlas/chat
         if: startsWith(github.ref, 'refs/tags/chat-v')
-        run: cd plugins/chat && npm publish --access public --provenance
+        run: cd plugins/chat && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/webhook
         if: startsWith(github.ref, 'refs/tags/webhook-v')
-        run: cd plugins/webhook && npm publish --access public --provenance
+        run: cd plugins/webhook && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/teams
         if: startsWith(github.ref, 'refs/tags/teams-v')
-        run: cd plugins/teams && npm publish --access public --provenance
+        run: cd plugins/teams && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/email-digest
         if: startsWith(github.ref, 'refs/tags/email-digest-v')
-        run: cd plugins/email-digest && npm publish --access public --provenance
+        run: cd plugins/email-digest && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/mcp
         if: startsWith(github.ref, 'refs/tags/mcp-v')
-        run: cd plugins/mcp && npm publish --access public --provenance
+        run: cd plugins/mcp && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Action
       - name: Publish @useatlas/email
         if: startsWith(github.ref, 'refs/tags/email-v')
-        run: cd plugins/email && npm publish --access public --provenance
+        run: cd plugins/email && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/jira
         if: startsWith(github.ref, 'refs/tags/jira-v')
-        run: cd plugins/jira && npm publish --access public --provenance
+        run: cd plugins/jira && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/twenty
         if: startsWith(github.ref, 'refs/tags/twenty-v')
-        run: cd plugins/twenty && npm publish --access public --provenance
+        run: cd plugins/twenty && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/webhook-action
         if: startsWith(github.ref, 'refs/tags/webhook-action-v')
-        run: cd plugins/webhook-action && npm publish --access public --provenance
+        run: cd plugins/webhook-action && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Context
       - name: Publish @useatlas/yaml-context
         if: startsWith(github.ref, 'refs/tags/yaml-context-v')
-        run: cd plugins/yaml-context && npm publish --access public --provenance
+        run: cd plugins/yaml-context && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       - name: Publish @useatlas/obsidian-reader
         if: startsWith(github.ref, 'refs/tags/obsidian-reader-v')
-        run: cd plugins/obsidian-reader && npm publish --access public --provenance
+        run: cd plugins/obsidian-reader && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
 
       # Community
       - name: Publish obsidian-atlas
         if: startsWith(github.ref, 'refs/tags/obsidian-v')
-        run: cd plugins/obsidian && npm publish --access public --provenance
+        run: cd plugins/obsidian && bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"

--- a/scripts/check-unpublished-versions.ts
+++ b/scripts/check-unpublished-versions.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env bun
+// Recurrence guard for the "version bumped on main but never published" drift.
+//
+// Why: every `@useatlas/*` (and the `create-atlas*`) package publishes
+// independently via a tag-triggered step in .github/workflows/publish.yml. The
+// flow is publish-AFTER-merge: a PR bumps `version` in package.json, and only
+// after it lands does someone push the `<prefix>-v<version>` tag that triggers
+// the publish. That manual post-merge step gets forgotten — e.g. @useatlas/plugin-sdk
+// drifted to 0.0.13 on main while npm sat at 0.0.9 (#3638/#3667 bumps were never
+// tagged), and @useatlas/bigquery@0.0.6 shipped to main untagged. Consumers on a
+// `>=` range silently miss the change.
+//
+// This turns that into a CI failure — but WITHOUT blocking the legitimate
+// post-merge window. A bump INTRODUCED by the current change is exempt (it's
+// about to be published); the guard only fails when a version that is already on
+// the base (a PRIOR merge) is still missing from npm. So the bumping PR is green,
+// and if the publish is then forgotten, the NEXT PR/push goes red until the tag
+// is pushed.
+//
+// npm is the oracle, not git tags: some packages were first-published before the
+// tag convention (or had tags pruned), so they're live on npm with no matching
+// tag — a tag-based check would false-positive on them. "Published" == "the
+// version resolves on the registry".
+//
+// Network/registry hiccups are non-fatal (warn + skip that package) so a blip
+// can't block merges; a definite "unpublished + not introduced here" is fatal.
+//
+// Usage: bun scripts/check-unpublished-versions.ts
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = join(import.meta.dir, "..");
+
+// SSOT for publishable packages: tag prefix (the part before `-v`) -> package
+// dir, mirroring .github/workflows/publish.yml. `null` = a reserved tag prefix
+// with no package yet. The publish.yml-sync guard below asserts this map covers
+// every prefix publish.yml declares, so a newly publishable package can't be
+// wired into publish.yml without being covered here.
+const PREFIX_TO_DIR: Record<string, string | null> = {
+  types: "packages/types",
+  "atlas-agent": "create-atlas",
+  "atlas-plugin": "create-atlas-plugin",
+  sdk: "packages/sdk",
+  "plugin-sdk": "packages/plugin-sdk",
+  "webhook-publisher": "packages/webhook-publisher",
+  react: "packages/react",
+  bigquery: "plugins/bigquery",
+  clickhouse: "plugins/clickhouse",
+  snowflake: "plugins/snowflake",
+  duckdb: "plugins/duckdb",
+  mysql: "plugins/mysql",
+  salesforce: "plugins/salesforce",
+  elasticsearch: "plugins/elasticsearch",
+  e2b: "plugins/e2b",
+  daytona: "plugins/daytona",
+  nsjail: "plugins/nsjail",
+  sidecar: "plugins/sidecar",
+  "vercel-sandbox": "plugins/vercel-sandbox",
+  "railway-sandbox": "plugins/railway-sandbox",
+  chat: "plugins/chat",
+  slack: null, // reserved prefix, no package dir yet
+  webhook: "plugins/webhook",
+  teams: "plugins/teams",
+  "email-digest": "plugins/email-digest",
+  mcp: "plugins/mcp",
+  email: "plugins/email",
+  jira: "plugins/jira",
+  twenty: "plugins/twenty",
+  "webhook-action": "plugins/webhook-action",
+  "yaml-context": "plugins/yaml-context",
+  "obsidian-reader": "plugins/obsidian-reader",
+  obsidian: "plugins/obsidian",
+};
+
+interface Pkg {
+  name?: string;
+  version?: string;
+  private?: boolean;
+}
+
+function readPkg(text: string): Pkg {
+  return JSON.parse(text) as Pkg;
+}
+
+/** Tag prefixes declared in publish.yml's `on.push.tags` (without the `-v*`). */
+function declaredPrefixes(): string[] {
+  const yml = readFileSync(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
+  const out = new Set<string>();
+  for (const m of yml.matchAll(/^\s*-\s*'([a-z0-9-]+)-v\*'/gm)) out.add(m[1]);
+  return [...out];
+}
+
+function refExists(ref: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The ref to read each package's "already on the base" version from. PRs compare
+ * to the base branch tip; a push (or local run) compares to the previous commit,
+ * so a freshly-merged bump is treated as "introduced here" (exempt) exactly
+ * once, then enforced on the next change. Returns null when no base can be
+ * resolved (shallow clone with no history) — the caller then degrades to lenient.
+ */
+function resolveBaseRef(): string | null {
+  const prBase = process.env.GITHUB_BASE_REF;
+  if (prBase) {
+    try {
+      execFileSync(
+        "git",
+        ["fetch", "--quiet", "--depth=1", "origin", `+refs/heads/${prBase}:refs/remotes/origin/${prBase}`],
+        { cwd: repoRoot, stdio: "ignore" },
+      );
+    } catch {
+      // best-effort: the ref may already be present
+    }
+    if (refExists(`origin/${prBase}`)) return `origin/${prBase}`;
+  }
+  try {
+    execFileSync("git", ["fetch", "--quiet", "--deepen=1"], { cwd: repoRoot, stdio: "ignore" });
+  } catch {
+    // not a shallow clone (or offline) — HEAD~1 may already be reachable
+  }
+  if (refExists("HEAD~1")) return "HEAD~1";
+  if (refExists("origin/main")) return "origin/main";
+  return null;
+}
+
+/** Version of `<dir>/package.json` at `ref`, or null if absent there (new package). */
+function versionAtRef(ref: string, dir: string): string | null {
+  try {
+    const text = execFileSync("git", ["show", `${ref}:${dir}/package.json`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return readPkg(text).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Published versions on npm, or null if the registry read failed (treated leniently). */
+async function publishedVersions(name: string): Promise<string[] | null> {
+  try {
+    const { stdout } = await execFileAsync("npm", ["view", name, "versions", "--json"], {
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(stdout) as string[] | string;
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // A 404 (never-published package) is a definite empty set, not a blip.
+    if (/E404|not found|is not in this registry/i.test(msg)) return [];
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  // ── publish.yml-sync guard ────────────────────────────────────────────
+  const declared = declaredPrefixes();
+  const unmapped = declared.filter((p) => !(p in PREFIX_TO_DIR));
+  if (unmapped.length > 0) {
+    for (const p of unmapped) {
+      console.error(
+        `::error::publish.yml declares tag prefix "${p}-v*" but scripts/check-unpublished-versions.ts has no PREFIX_TO_DIR entry. Add it (point it at the package dir, or null if reserved).`,
+      );
+    }
+    process.exit(1);
+  }
+
+  const baseRef = resolveBaseRef();
+  if (!baseRef) {
+    console.warn(
+      "⚠ could not resolve a base ref (shallow clone, no history) — skipping the unpublished-version guard.",
+    );
+    return;
+  }
+
+  const targets = Object.entries(PREFIX_TO_DIR).filter(
+    (e): e is [string, string] => e[1] !== null,
+  );
+
+  const results = await Promise.all(
+    targets.map(async ([prefix, dir]) => {
+      let pkg: Pkg;
+      try {
+        pkg = readPkg(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+      } catch {
+        return { prefix, dir, kind: "skip" as const, msg: `no package.json at ${dir}` };
+      }
+      if (pkg.private) return { prefix, dir, kind: "skip" as const, msg: `${pkg.name} is private` };
+      const name = pkg.name;
+      const version = pkg.version;
+      if (!name || !version) {
+        return { prefix, dir, kind: "skip" as const, msg: `${dir} has no name/version` };
+      }
+
+      const published = await publishedVersions(name);
+      if (published === null) {
+        return { prefix, dir, kind: "warn" as const, msg: `${name}: registry read failed — skipped` };
+      }
+      if (published.includes(version)) {
+        return { prefix, dir, kind: "ok" as const, msg: `${name}@${version} published` };
+      }
+
+      // Not on npm — exempt if THIS change introduced the bump (pending publish).
+      const baseVersion = versionAtRef(baseRef, dir);
+      if (baseVersion === null || baseVersion !== version) {
+        return {
+          prefix,
+          dir,
+          kind: "pending" as const,
+          msg: `${name}@${version} not yet on npm (latest: ${published.at(-1) ?? "none"}) — bump introduced by this change; tag it after merge.`,
+        };
+      }
+
+      return {
+        prefix,
+        dir,
+        kind: "fail" as const,
+        msg:
+          `${name}@${version} is on the base branch but NOT published to npm (latest: ${published.at(-1) ?? "none"}), ` +
+          `and this change didn't introduce the bump — a prior merged bump was never published. ` +
+          `Publish it: git tag -a ${prefix}-v${version} <main-sha> -m "Release ${name} ${version}" && git push origin ${prefix}-v${version}`,
+      };
+    }),
+  );
+
+  let failed = false;
+  for (const r of results.sort((a, b) => a.prefix.localeCompare(b.prefix))) {
+    if (r.kind === "fail") {
+      console.error(`::error::${r.msg}`);
+      failed = true;
+    } else if (r.kind === "warn") {
+      console.warn(`⚠ ${r.msg}`);
+    } else if (r.kind === "pending") {
+      console.log(`⏳ ${r.msg}`);
+    } else if (r.kind === "ok") {
+      console.log(`✓ ${r.msg}`);
+    }
+  }
+
+  if (failed) {
+    console.error(
+      "\nAt least one publishable package has a merged-but-unpublished version. Push the missing tag(s) above to publish.",
+    );
+    process.exit(1);
+  }
+  console.log("\nAll publishable packages are published or have a pending (this-change) bump.");
+}
+
+main().catch((err) => {
+  console.error(`check-unpublished-versions: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(2);
+});

--- a/scripts/npm-publish-if-new.sh
+++ b/scripts/npm-publish-if-new.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Idempotent npm publish: publish the package in the current directory (or $1)
+# ONLY if its exact name@version is not already on the registry.
+#
+# Why: publish.yml's steps are tag-triggered with no `needs:` ordering, and a tag
+# can legitimately point at a commit whose package.json version is already live —
+# notably when BACKFILLING a missing release tag for an already-published version
+# (see scripts/check-unpublished-versions.ts). A plain `npm publish` 403s with
+# EPUBLISHCONFLICT in that case and turns the run red for no real problem. This
+# makes "already published" a green no-op while still publishing genuinely new
+# versions. Preserves --provenance (needs the workflow's id-token permission).
+#
+# Usage (from a publish step, after `cd <pkgdir>`): bash "$GITHUB_WORKSPACE/scripts/npm-publish-if-new.sh"
+#    or with an explicit dir:                       bash scripts/npm-publish-if-new.sh plugins/clickhouse
+set -euo pipefail
+
+dir="${1:-.}"
+cd "$dir"
+
+name=$(node -p "require('./package.json').name")
+version=$(node -p "require('./package.json').version")
+
+if npm view "${name}@${version}" version >/dev/null 2>&1; then
+  echo "::notice::${name}@${version} is already published — skipping publish (idempotent)."
+  exit 0
+fi
+
+echo "Publishing ${name}@${version}..."
+npm publish --access public --provenance


### PR DESCRIPTION
## Goal

Stop the publish-after-merge flow from silently dropping publishes. Recently `@useatlas/plugin-sdk` drifted to 0.0.13 on main while npm sat at 0.0.9 (the #3638/#3667 bumps were never tagged), and `@useatlas/bigquery@0.0.6` shipped untagged. Both are now reconciled (published 0.0.14 / 0.0.6 manually); this PR prevents recurrence and lets us safely backfill the missing historical tags.

## What changed

1. **`scripts/check-unpublished-versions.ts`** — new `drift`-job CI check. For every publishable package (SSOT mirrored from `publish.yml`, with a sync guard that fails if `publish.yml` declares a tag prefix not mapped here), it **fails when the package's version is on the base branch but not on npm**.
   - **npm is the oracle, not git tags** — 6 packages were first-published before the tag convention, so they're live on npm with no matching tag; a tag-based check would false-positive on them.
   - A bump **introduced by the current change is exempt** (pending publish), so the bumping PR stays green; the guard only fires if the follow-up publish is then forgotten (caught on the next PR/push).
   - Registry-read failures are **non-fatal** (warn + skip) so a blip can't block merges.

2. **`scripts/npm-publish-if-new.sh`** — idempotent publish: skip when `name@version` is already on npm instead of 403ing. All 32 `publish.yml` steps route through it (`--provenance` preserved). This lets us **backfill missing release tags for already-published versions** without red runs.

## Validation

- New check: green on current main (all published); fail-path, pending-exemption, and publish.yml-sync guard all verified locally.
- Idempotent script: verified it skips an already-published version and would publish a new one.

## Follow-up (after merge)

Backfill the 6 missing release tags at the merged commit (they'll run green via the idempotent guard): `atlas-agent-v0.3.3`, `atlas-plugin-v0.1.1`, `chat-v0.0.1`, `email-digest-v0.0.6`, `obsidian-v0.1.0`, `webhook-action-v0.0.2`.

_Generated by Claude Code_