### PR TITLE
Add batch entity description support to describeEntity tool

### DIFF
--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -39,11 +39,13 @@ Use this when you do not yet know which entity holds the data the user is asking
 
 Don't use this to read a single entity's columns or query patterns — call \`describeEntity\` once you know the name. Avoid the \`explore\` shell for catalog reads; the typed result is structured and faster.`;
 
-export const DESCRIBE_ENTITY_TOOL_DESCRIPTION = `Return the parsed entity definition — dimensions (with types and \`sample_values\`), measures, joins, \`query_patterns\`, grain, and the \`connection\` it lives on — for one entity, looked up by either its \`name\` field or \`table\` name. Example call: \`{ "name": "orders" }\`. Example response: \`{ "found": true, "entity": { "name": "orders", "dimensions": [...], "measures": [...], "query_patterns": [...] } }\`.
+export const DESCRIBE_ENTITY_TOOL_DESCRIPTION = `Return the parsed entity definition — dimensions (types, \`sample_values\`), measures, joins, \`query_patterns\`, grain, and \`connection\` — looked up by \`name\` field or \`table\` name. Pass \`name\` for one entity or \`names\` for a batch (exactly one). Single: \`{"name":"orders"}\` → \`{"found":true,"entity":{...}}\`. Batch: \`{"names":["orders","order_items"]}\` → \`{"count":2,"entities":[...],"notFound":[]}\`.
 
-Use this when you are about to write SQL against an unfamiliar table, when you need exact column names, when you need a pre-validated query pattern (preferred over hand-written SQL), or when you need the \`connection\` field to route an \`executeSQL\` call to the right datasource.
+Prefer the \`names\` batch when a query spans multiple entities (a join): one round-trip instead of one call per table. In batch mode an unrecognized name is not an error — matches return in \`entities\`, misses in \`notFound\`.
 
-Don't use this to enumerate the catalog — call \`listEntities\` first when the entity name is unknown. Avoid \`explore\` for entity reads; the typed result is normalized and survives YAML format changes.`;
+Use this when you are about to write SQL against an unfamiliar table, need exact column names, want a pre-validated query pattern (preferred over hand-written SQL), or need the \`connection\` to route an \`executeSQL\` call.
+
+Don't use this to enumerate the catalog — call \`listEntities\` first when names are unknown. Avoid \`explore\` for entity reads; the typed result survives YAML format changes.`;
 
 export const SEARCH_GLOSSARY_TOOL_DESCRIPTION = `Search the business glossary for a term, phrase, or column name. Returns matching entries with \`{ term, status, definition, note, possible_mappings, source }\` — substring match across term, definition, note, and \`possible_mappings\`, so \`orders.status\` will surface a parent term that lists it. Example call: \`{ "term": "churn" }\`. Example response: \`{ "count": 1, "matches": [{ "term": "churn", "status": "defined", "definition": "...", "possible_mappings": ["users.churned_at"] }] }\`.
 
@@ -93,6 +95,10 @@ export const LIST_ENTITIES_ERROR_CODES = [
   "internal_error",
 ] as const satisfies readonly AtlasMcpToolErrorCode[];
 export const DESCRIBE_ENTITY_ERROR_CODES = [
+  // `validation_failed` (#mcp-token-reduction): the raw-shape inputSchema
+  // can't express "exactly one of `name` / `names`", so the handler enforces
+  // it and returns this code when both or neither are supplied.
+  "validation_failed",
   "unknown_entity",
   "rate_limited",
   "internal_error",

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -470,6 +470,58 @@ describe("MCP semantic tools", () => {
     expect(envelope!.code).toBe("validation_failed");
   });
 
+  it("describeEntity batch with every name unknown returns count 0 and a hint", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: ["ghost", "phantom"] },
+    });
+    // The all-miss case is where the agent most needs the recovery hint —
+    // confirm it's present even when nothing resolved.
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(0);
+    expect(parsed.entities).toEqual([]);
+    expect(parsed.notFound).toEqual(["ghost", "phantom"]);
+    expect(parsed.hint).toContain("listEntities");
+  });
+
+  it("describeEntity rejects a batch larger than the cap (schema bound)", async () => {
+    const { client } = await createTestClient();
+    // 51 distinct, well-formed names — exceeds MAX_DESCRIBE_BATCH (50). The
+    // Zod `.max()` rejects before the handler runs, capping the payload a
+    // hostile client can force into one round-trip. The SDK surfaces a
+    // schema rejection as `isError`, not as our `validation_failed` envelope.
+    const tooMany = Array.from({ length: 51 }, (_, i) => `entity_${i}`);
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: tooMany },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("describeEntity rejects an empty `names` batch (schema bound)", async () => {
+    const { client } = await createTestClient();
+    // Empty array is distinct from "neither supplied" ({}): `names` is
+    // present, so the mutual-exclusion check passes, but `.min(1)` rejects it.
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: [] },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("describeEntity rejects path-traversal characters in a batch name (schema bound)", async () => {
+    const { client } = await createTestClient();
+    // The per-element regex is the same path-traversal guard the single-name
+    // path enforces — a `/` must be rejected before reaching the resolver.
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: ["users", "../etc/passwd"] },
+    });
+    expect(result.isError).toBe(true);
+  });
+
   // --- searchGlossary ---
 
   it("searchGlossary returns an ambiguous_term envelope when any match has status: ambiguous", async () => {

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -20,10 +20,13 @@ const mockListEntities = mock<(...args: unknown[]) => unknown>(async () => [
   { name: "orders", table: "orders", description: "Orders", source: "default" },
 ]);
 const mockGetEntityByName = mock<(...args: unknown[]) => unknown>(
-  (name: unknown) =>
-    name === "users"
-      ? { name: "User", table: "users", dimensions: [{ name: "id" }] }
-      : null,
+  (name: unknown) => {
+    if (name === "users")
+      return { name: "User", table: "users", dimensions: [{ name: "id" }] };
+    if (name === "orders")
+      return { name: "orders", table: "orders", dimensions: [{ name: "id" }] };
+    return null;
+  },
 );
 const mockSearchGlossary = mock<(...args: unknown[]) => unknown>(
   (term: unknown) =>
@@ -391,6 +394,80 @@ describe("MCP semantic tools", () => {
     expect(envelope!.code).toBe("unknown_entity");
     expect(envelope!.message).toContain("ghost");
     expect(envelope!.hint).toContain("listEntities");
+  });
+
+  it("describeEntity batches multiple entities in one call via `names`", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: ["users", "orders"] },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(2);
+    expect(parsed.entities.map((e: { table: string }) => e.table)).toEqual([
+      "users",
+      "orders",
+    ]);
+    expect(parsed.notFound).toEqual([]);
+    expect(parsed.hint).toBeUndefined();
+  });
+
+  it("describeEntity batch reports misses in `notFound` without failing the call", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: ["users", "ghost"] },
+    });
+    // A bad name in a batch is not a tool failure — the resolved entity still
+    // comes back, and the miss is machine-readable in `notFound`.
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(1);
+    expect(parsed.entities).toHaveLength(1);
+    expect(parsed.entities[0].table).toBe("users");
+    expect(parsed.notFound).toEqual(["ghost"]);
+    expect(parsed.hint).toContain("listEntities");
+  });
+
+  it("describeEntity batch dedupes names, preserving first-seen order", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { names: ["orders", "users", "orders"] },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(2);
+    expect(parsed.entities.map((e: { table: string }) => e.table)).toEqual([
+      "orders",
+      "users",
+    ]);
+  });
+
+  it("describeEntity rejects supplying both `name` and `names`", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "users", names: ["orders"] },
+    });
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("validation_failed");
+    expect(envelope!.message).toContain("exactly one");
+  });
+
+  it("describeEntity rejects supplying neither `name` nor `names`", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("validation_failed");
   });
 
   // --- searchGlossary ---

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -65,6 +65,12 @@ import { withProgressAndCancellation } from "./progress.js";
 const MAX_IDENTIFIER_LEN = 256;
 const MAX_FREE_TEXT_LEN = 1024;
 
+// Upper bound on a single batched `describeEntity` call. Generous enough to
+// cover any realistic multi-entity join (the whole catalog is typically a few
+// dozen entities) while capping the payload a hostile client can force into
+// one round-trip.
+const MAX_DESCRIBE_BATCH = 50;
+
 // Mirrors the entity-name shape `isValidEntityName` accepts in
 // `lib/semantic/files.ts` (no `/`, `\`, `..`, `\0`). Surfacing the
 // constraint at the Zod boundary gives the MCP client an immediate
@@ -186,8 +192,19 @@ export function registerSemanticTools(
           .min(1)
           .max(MAX_IDENTIFIER_LEN)
           .regex(ENTITY_NAME_PATTERN)
+          .optional()
           .describe(
-            "Entity name (`name` field) or table name. Alphanumerics, `_`, `-`, `.` only — no path separators.",
+            "Single entity name (`name` field) or table name. Alphanumerics, `_`, `-`, `.` only — no path separators. Mutually exclusive with `names`.",
+          ),
+        names: z
+          .array(
+            z.string().min(1).max(MAX_IDENTIFIER_LEN).regex(ENTITY_NAME_PATTERN),
+          )
+          .min(1)
+          .max(MAX_DESCRIBE_BATCH)
+          .optional()
+          .describe(
+            `Batch of entity/table names to describe in a single call (up to ${MAX_DESCRIBE_BATCH}). Prefer this over repeated single calls when a query spans multiple entities. Mutually exclusive with \`name\`.`,
           ),
       },
       // Read-only over the local semantic catalog (closed world).
@@ -196,27 +213,79 @@ export function registerSemanticTools(
         openWorldHint: false,
       },
     },
-    async ({ name }): Promise<CallToolResult> =>
+    async ({ name, names }): Promise<CallToolResult> =>
       dispatch(
         "describeEntity",
         { requiresWrite: false, minRole: "member" },
         async () => {
-          const entity = getEntityByName(name);
-          if (!entity) {
-            // Unknown-entity isn't really a "tool failed" condition for the
-            // agent — the agent's recovery is "call listEntities and pick a
-            // known one." Emit it as a typed envelope so the recovery is
-            // machine-readable, with a hint pointing the agent at the right
-            // next call.
+          // The MCP raw-shape inputSchema can't express a cross-field
+          // "exactly one of" refinement, so enforce it here. Both-or-neither
+          // is a client mistake, not a catalog miss — return `validation_failed`
+          // with a hint rather than guessing which arg was intended.
+          if ((name !== undefined) === (names !== undefined)) {
             return toEnvelopeResult(
               envelope(
-                "unknown_entity",
-                `Entity "${name}" not found in the semantic layer.`,
-                { hint: "Call listEntities to discover available entities." },
+                "validation_failed",
+                "Provide exactly one of `name` (single entity) or `names` (batch).",
+                {
+                  hint: "Pass `name` to describe one entity, or `names` to describe several in one call.",
+                },
               ),
             );
           }
-          return toJsonContent({ found: true, entity });
+
+          // Single-name path — wire shape unchanged for existing clients.
+          if (name !== undefined) {
+            const entity = getEntityByName(name);
+            if (!entity) {
+              // Unknown-entity isn't really a "tool failed" condition for the
+              // agent — the agent's recovery is "call listEntities and pick a
+              // known one." Emit it as a typed envelope so the recovery is
+              // machine-readable, with a hint pointing the agent at the right
+              // next call.
+              return toEnvelopeResult(
+                envelope(
+                  "unknown_entity",
+                  `Entity "${name}" not found in the semantic layer.`,
+                  { hint: "Call listEntities to discover available entities." },
+                ),
+              );
+            }
+            return toJsonContent({ found: true, entity });
+          }
+
+          // Batch path — dedupe (preserving first-seen order) and resolve each.
+          // A miss is not a tool failure here: resolved entities come back in
+          // `entities`, misses in `notFound`, so the agent recovers per-name
+          // instead of losing the whole batch to one bad name.
+          const requested = names ?? [];
+          const seen = new Set<string>();
+          const ordered: string[] = [];
+          for (const n of requested) {
+            if (!seen.has(n)) {
+              seen.add(n);
+              ordered.push(n);
+            }
+          }
+
+          const entities: unknown[] = [];
+          const notFound: string[] = [];
+          for (const n of ordered) {
+            const entity = getEntityByName(n);
+            if (entity) entities.push(entity);
+            else notFound.push(n);
+          }
+
+          return toJsonContent({
+            count: entities.length,
+            entities,
+            notFound,
+            ...(notFound.length > 0
+              ? {
+                  hint: "Unrecognized names are listed in `notFound`; call listEntities to discover valid names.",
+                }
+              : {}),
+          });
         },
       ),
   );

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -204,7 +204,7 @@ export function registerSemanticTools(
           .max(MAX_DESCRIBE_BATCH)
           .optional()
           .describe(
-            `Batch of entity/table names to describe in a single call (up to ${MAX_DESCRIBE_BATCH}). Prefer this over repeated single calls when a query spans multiple entities. Mutually exclusive with \`name\`.`,
+            `Batch of entity/table names to describe in a single call (up to ${MAX_DESCRIBE_BATCH}). Prefer this over repeated single calls when a query spans multiple entities. Duplicate names are de-duplicated, so \`count\` may be smaller than the number of names sent. Mutually exclusive with \`name\`.`,
           ),
       },
       // Read-only over the local semantic catalog (closed world).
@@ -268,7 +268,7 @@ export function registerSemanticTools(
             }
           }
 
-          const entities: unknown[] = [];
+          const entities: NonNullable<ReturnType<typeof getEntityByName>>[] = [];
           const notFound: string[] = [];
           for (const n of ordered) {
             const entity = getEntityByName(n);


### PR DESCRIPTION
## Summary

Extends the `describeEntity` MCP tool to support batching multiple entity lookups in a single call via a new `names` parameter, while maintaining backward compatibility with the existing `name` parameter.

**Key changes:**
- Added `names` parameter (array of 1–50 entity names) as an alternative to `name`
- Enforces mutual exclusivity: exactly one of `name` or `names` must be provided
- Batch mode returns `{ count, entities, notFound, hint? }` instead of `{ found, entity }`
- Single-name mode preserves existing response shape for backward compatibility
- Batch deduplicates input names while preserving first-seen order
- Unrecognized names in batch mode are reported in `notFound` without failing the call
- Added `MAX_DESCRIBE_BATCH = 50` constant to cap payload size from hostile clients
- Updated tool description to document both modes and recommend batch for multi-entity queries (joins)

**Motivation:**
Agents querying across multiple entities (e.g., joins) can now fetch all entity definitions in one round-trip instead of N sequential calls, improving performance and reducing latency.

## Test Plan

- Added 5 new unit tests covering:
  - Batch lookup of multiple entities
  - Partial batch failures (some entities found, some not)
  - Deduplication with order preservation
  - Validation: rejecting both `name` and `names` supplied
  - Validation: rejecting neither `name` nor `names` supplied
- Updated mock `getEntityByName` to return both "users" and "orders" entities for test coverage
- Existing single-entity test continues to pass, confirming backward compatibility

## Checklist

- [x] Types pass
- [x] Tests pass (9 new tests: 5 batch behaviors + 4 schema-boundary guards)
- [x] Lint passes
- [x] Changelog — n/a; this repo banks per-tag entries in `apps/docs/src/components/changelog-data.ts` at `/release`, not per-PR (CLAUDE.md release process)

https://claude.ai/code/session_018dE597zdZPJAFxzkv6aepe
