### PR TITLE
docs(publish): warn that pushing >3 tags at once fires no publish runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,12 @@
 name: Publish Atlas npm packages
 
+# ⚠️ GOTCHA: GitHub does NOT fire `push` events for tags when you push MORE THAN
+# THREE tags in a single `git push`. Batch-pushing 4+ release tags at once
+# silently triggers NONE of these publish runs (the tags land on the remote, but
+# nothing publishes). Push release tags in groups of ≤3, or one at a time, when
+# you need the publish to run. See https://docs.github.com/actions/reference/events-that-trigger-workflows#push
+# (caught 2026-06-15 backfilling 6 missing tags — all 6 pushes published nothing).
+
 on:
   push:
     tags:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,9 @@ For `0.0.x` semver, `^0.0.2` pins EXACTLY to `0.0.2`. When bumping a published p
 2. **After merge** — tag the release (`git tag types-v0.0.4 && git push origin types-v0.0.4`); wait for the publish workflow
 3. **Then** push a follow-up bumping refs in `packages/sdk`, `packages/react`, `create-atlas/templates/*/package.json`
 
-`scripts/check-published-symbols.ts` (in `/ci`) catches "added a new export and used it before publishing" locally — it diffs braced **value** imports from `@useatlas/*` in scaffold-bound source against the symbols exported by the pinned published version. Type-only imports are skipped.
+⚠️ **Never push more than 3 release tags in one `git push`** — GitHub silently fires NO `push` event for tags when >3 land in a single push, so `publish.yml` runs for none of them (the tags land on the remote, nothing publishes). Push release tags in groups of ≤3, or one at a time. (Caught 2026-06-15 backfilling 6 tags — published nothing.)
+
+Two guards keep this honest: `scripts/check-published-symbols.ts` catches "added a new export and used it before publishing" (diffs braced **value** imports from `@useatlas/*` in scaffold-bound source against the pinned published version; type-only imports skipped). `scripts/check-unpublished-versions.ts` (in the `drift` CI job) fails when a publishable package's version is on `main` but not on npm and the current change didn't introduce the bump — i.e. a merged version bump whose post-merge publish was forgotten (npm is the oracle; the bumping PR is exempt so it stays green). `publish.yml` publishes via `scripts/npm-publish-if-new.sh`, which skips when `name@version` is already on npm, so re-tagging an already-published version is a green no-op rather than a 403.
 
 ## Environment Variables
 


### PR DESCRIPTION
Documents the GitHub gotcha that suppresses tag `push` events when more than 3 tags land in a single `git push` (so `publish.yml` runs for none of them — caught 2026-06-15 backfilling 6 release tags). Adds the ≤3-per-push rule to `publish.yml`'s header comment and CLAUDE.md's Publishing section, alongside notes on the new `check-unpublished-versions.ts` drift guard and `npm-publish-if-new.sh` idempotent publish.

Docs/workflow-comment only — no code change.

_Generated by Claude Code_