### PR TITLE
fix(profiler): de-silence non-fatal failures + scrub per-table errors[] (v0.0.16 whole-cycle review)

### DIFF
--- a/packages/api/src/lib/datasources/__tests__/universal-profiling-enforcement.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/universal-profiling-enforcement.test.ts
@@ -28,20 +28,28 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
 import type { ProfilingResult, DatabaseObject } from "@useatlas/types";
 import { createConnectionMock } from "../../../__mocks__/connection";
-import { MCP_PROVISIONABLE_CATALOG_SLUGS } from "../provisionable-types";
 
 // ── The enumerated universe of connectable datasource types ───────────
 //
-// The MCP provisionable catalog slugs already cover native pg/mysql + the
-// url/config plugin types (clickhouse / snowflake / bigquery / elasticsearch).
-// Salesforce is connectable via the OAuth pillar (NOT in the provisionable
-// slug list — it installs via OAuth, ADR-0014), so we add it explicitly. The
-// guarantee under test spans ALL of them.
+// Derived from the PRODUCTION SSOT (`BUILTIN_DATASOURCE_CATALOG_SLUGS`),
+// captured here before that module is mocked below. Deriving from the SSOT —
+// rather than the narrower `MCP_PROVISIONABLE_CATALOG_SLUGS` subset this test
+// used originally — is what keeps the guard fail-CLOSED: a new built-in
+// datasource type lands in this enumeration automatically instead of being
+// silently omitted. DuckDB was the live blind spot — connectable + profilable
+// via `createFromConfig`, yet absent from the old subset, so a DuckDB profiler
+// regression would not have turned this test red. `demo-postgres` is a demo
+// alias that resolves to native postgres (`catalogSlugToDbType` → postgres) and
+// is covered by the postgres case, so it's excluded from the iteration.
+// Salesforce is in the SSOT and routes via the OAuth pillar (ADR-0014);
+// `OAUTH_DATASOURCE_DBTYPES` drives that routing.
+const { BUILTIN_DATASOURCE_CATALOG_SLUGS: REAL_BUILTIN_SLUGS } = await import(
+  "@atlas/api/lib/db/datasource-pool-resolver"
+);
 const OAUTH_DATASOURCE_DBTYPES = ["salesforce"] as const;
-const CONNECTABLE_DATASOURCE_DBTYPES: readonly string[] = [
-  ...MCP_PROVISIONABLE_CATALOG_SLUGS,
-  ...OAUTH_DATASOURCE_DBTYPES,
-];
+const CONNECTABLE_DATASOURCE_DBTYPES: readonly string[] = REAL_BUILTIN_SLUGS.filter(
+  (s: string) => s !== "demo-postgres",
+);
 
 // ── A one-table profiling result + one discovered object ──────────────
 function oneTableResult(): ProfilingResult {
@@ -127,7 +135,7 @@ mock.module("@atlas/api/lib/db/connection", () =>
 mock.module("@atlas/api/lib/db/datasource-pool-resolver", () => ({
   catalogSlugToDbType: (slug: string) => slug,
   resolveDatasourcePoolConfig: mock(() => poolConfigResult),
-  BUILTIN_DATASOURCE_CATALOG_SLUGS: [...CONNECTABLE_DATASOURCE_DBTYPES],
+  BUILTIN_DATASOURCE_CATALOG_SLUGS: REAL_BUILTIN_SLUGS,
 }));
 
 // secrets — passthrough decrypt (the resolver decrypts the row config).
@@ -235,10 +243,23 @@ beforeEach(() => {
 
 describe("universal datasource profiling — profilable iff connectable (#3667 AC #1)", () => {
   it("enumerates the full connectable universe (guards against a forgotten type)", () => {
-    // Sanity: the SSOT enumeration must cover every type the milestone names.
-    for (const t of ["postgres", "mysql", "clickhouse", "snowflake", "elasticsearch", "bigquery", "salesforce"]) {
+    // Derived from the production SSOT, so any new built-in datasource appears
+    // here automatically. Assert the milestone's named types are present —
+    // including duckdb, the type the old MCP_PROVISIONABLE subset silently dropped.
+    for (const t of [
+      "postgres",
+      "mysql",
+      "clickhouse",
+      "snowflake",
+      "elasticsearch",
+      "bigquery",
+      "duckdb",
+      "salesforce",
+    ]) {
       expect(CONNECTABLE_DATASOURCE_DBTYPES).toContain(t);
     }
+    // And nothing connectable was excluded except the documented demo alias.
+    expect(CONNECTABLE_DATASOURCE_DBTYPES).not.toContain("demo-postgres");
   });
 
   for (const dbType of CONNECTABLE_DATASOURCE_DBTYPES) {

--- a/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
+++ b/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
@@ -494,6 +494,37 @@ describe("SemanticGenerator.profile — DSN scrub (#3579)", () => {
       expect(json).toContain("postgres://***@");
     }
   });
+
+  it("strips scheme://user:pass@host from per-table errors[] surfaced to the client", async () => {
+    // Plugin profilers push raw driver `err.message` into the per-table
+    // `errors[]` array (e.g. ClickHouse's `Fatal database error: ${msg}`). A
+    // driver connection error can echo the full DSN; on the wizard route the
+    // whole `errors[]` array is returned to the client. The host scrubs each
+    // entry at this boundary so no plugin (current or future) leaks credentials.
+    const DSN = "clickhouse://admin:hunter2@ch.prod:8123/analytics";
+    const result: ProfilingResult = {
+      profiles: [profile({ table_name: "a" })],
+      errors: [{ table: "events", error: `Fatal database error: connect ${DSN}` }],
+    };
+    const res = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        // `force` bypasses the failure-threshold abort so the errors[] flows
+        // back to the caller (the path the wizard route returns to the client).
+        return yield* svc.profile({
+          url: DSN,
+          dbType: "clickhouse",
+          force: true,
+          profileFn: fakeProfiler(result),
+        });
+      }),
+    );
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].table).toBe("events");
+    expect(res.errors[0].error).not.toContain("hunter2");
+    expect(res.errors[0].error).not.toContain("admin:hunter2");
+    expect(res.errors[0].error).toContain("clickhouse://***@");
+  });
 });
 
 // ── #3581 — OperationCancelledError propagates as a defect ──────────

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -456,7 +456,19 @@ function profileImpl(
 
     return {
       profiles: analyzeTableProfiles(result.profiles),
-      errors: result.errors,
+      // Scrub DSN userinfo from per-table profiler errors before they reach
+      // the client. Plugin profilers push raw driver `err.message` into
+      // `errors[]` (a `count()`/describe failure can echo
+      // `scheme://user:pass@host`); the top-level catch above already scrubs
+      // whole-profile failures via `errorMessage`, but this per-table array
+      // flowed through verbatim. Scrubbing here — the one host boundary that
+      // surfaces plugin errors to the wizard/MCP client — closes the leak for
+      // every plugin (current and future) without a per-plugin scrubber, which
+      // dependency-free plugin packages cannot share anyway (#3579 follow-up).
+      errors: result.errors.map((e) => ({
+        table: e.table,
+        error: errorMessage(e.error),
+      })),
       elapsedMs,
     } satisfies ProfileConnectionResult;
   });

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -895,6 +895,8 @@ export interface PluginProfileOptions extends PluginListObjectsOptions {
 export interface PluginConnectionListObjectsOptions {
   /** Schema / database to enumerate. Dialect-specific; omit for the connection's default. */
   schema?: string;
+  /** Structured logger for diagnostics — mirrors core `LiveConnectionListOptions.logger`. */
+  logger?: PluginProfileLogger;
 }
 
 /**

--- a/plugins/bigquery/src/profiler.ts
+++ b/plugins/bigquery/src/profiler.ts
@@ -272,7 +272,7 @@ function isTextType(dataType: string): boolean {
 export async function profileBigQuery(
   options: PluginProfileOptions,
 ): Promise<PluginProfilingResult> {
-  const { selectedTables, prefetchedObjects, progress } = options;
+  const { selectedTables, prefetchedObjects, progress, logger } = options;
   const { config, dataset } = resolveConfig(options);
   const conn = createBigQueryConnection(config);
 
@@ -295,6 +295,11 @@ export async function profileBigQuery(
     // Row counts for the whole dataset come from one metadata read of
     // INFORMATION_SCHEMA.TABLE_STORAGE (total_rows) — no per-table COUNT(*).
     const rowCounts = new Map<string, number>();
+    // When this single read fails, EVERY base table falls back to row_count 0 at
+    // once — a permissions/region error would otherwise look like a dataset-wide
+    // "empty" answer. Track the failure so each affected base table carries a
+    // credential-free note explaining the 0 (views legitimately report 0).
+    let storageReadFailed = false;
     if (objectsToProfile.length > 0) {
       try {
         const storageRows = (
@@ -310,7 +315,15 @@ export async function profileBigQuery(
         if (isFatalConnectionError(storageErr)) throw storageErr;
         // Non-fatal: TABLE_STORAGE may be unavailable (e.g. for some view-only
         // datasets or restricted permissions). Fall back to a 0 row count per
-        // table rather than failing the whole profile — views report 0 anyway.
+        // table rather than failing the whole profile — views report 0 anyway —
+        // but record the cause once (server log) and mark each base table below
+        // so its 0 isn't mistaken for a genuinely empty table.
+        storageReadFailed = true;
+        const msg = storageErr instanceof Error ? storageErr.message : String(storageErr);
+        logger?.warn(
+          { err: msg },
+          "BigQuery: could not read row counts from TABLE_STORAGE for dataset",
+        );
       }
     }
 
@@ -320,8 +333,16 @@ export async function profileBigQuery(
       const objectLabel = objectType === "view" ? " [view]" : "";
       progress?.onTableStart(tableName + objectLabel, i, objectsToProfile.length);
 
+      const tableNotes: string[] = [];
       try {
         const rowCount = rowCounts.get(tableName) ?? 0;
+        // A base table sitting at 0 only because the dataset-wide storage read
+        // failed gets a credential-free marker, so an empty answer isn't read as
+        // a genuinely empty table. Views legitimately report 0 storage rows, so
+        // they're exempt.
+        if (storageReadFailed && objectType === "table" && rowCount === 0) {
+          tableNotes.push("Row count unavailable (storage metadata read failed).");
+        }
 
         const colRows = (
           await conn.query(
@@ -337,6 +358,7 @@ export async function profileBigQuery(
         // sampled storage blocks (a bare LIMIT would still bill the whole
         // table); views fall back to LIMIT. See sampleSql / the file header.
         let sampleRows: Record<string, unknown>[] = [];
+        let sampleReadFailed = false;
         try {
           sampleRows = (
             await conn.query(sampleSql(dataset, tableName, objectType))
@@ -344,7 +366,15 @@ export async function profileBigQuery(
         } catch (sampleErr) {
           if (isFatalConnectionError(sampleErr)) throw sampleErr;
           // Non-fatal: emit columns with metadata but no sample values rather
-          // than failing the table (e.g. a view that errors on read).
+          // than failing the table (e.g. a view that errors on read). Record the
+          // cause (server log) and mark each column below so missing samples
+          // aren't mistaken for a genuinely value-less column.
+          sampleReadFailed = true;
+          const msg = sampleErr instanceof Error ? sampleErr.message : String(sampleErr);
+          logger?.warn(
+            { table: tableName, err: msg },
+            "BigQuery: could not read sample rows",
+          );
         }
 
         const columns: PluginColumnProfile[] = colRows.map((col) => {
@@ -384,8 +414,9 @@ export async function profileBigQuery(
             fk_target_table: null,
             fk_target_column: null,
             is_enum_like: isEnumLike,
-            profiler_notes:
-              sampleRows.length > 0
+            profiler_notes: sampleReadFailed
+              ? ["Column samples unavailable (sample read failed)."]
+              : sampleRows.length > 0
                 ? [
                     `Sampled ${sampleRows.length} row(s) (${
                       objectType === "table" ? "TABLESAMPLE-bounded" : "LIMIT-bounded"
@@ -403,7 +434,7 @@ export async function profileBigQuery(
           primary_key_columns: [],
           foreign_keys: [],
           inferred_foreign_keys: [],
-          profiler_notes: [],
+          profiler_notes: tableNotes,
           table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         });
         progress?.onTableDone(tableName, i, objectsToProfile.length);

--- a/plugins/clickhouse/src/profiler.ts
+++ b/plugins/clickhouse/src/profiler.ts
@@ -5,11 +5,9 @@
  * mirror, which the host's registry-resolved profiler seam feeds into
  * `SemanticGenerator` without importing this package.
  *
- * Logic adapted from the CLI's `packages/cli/lib/profilers/clickhouse.ts` —
- * this plugin package becomes the home the registry resolves and the CLI will
- * consume directly. The CLI profiler lib is intentionally NOT deleted in this
- * slice; that consolidation (and thinning the CLI lib to a re-export) is a
- * deferred follow-up per ADR-0017, so the two coexist for now.
+ * Logic relocated from the CLI's former `packages/cli/lib/profilers/clickhouse.ts`
+ * (now deleted, #3672) — this plugin package is the one home the registry
+ * resolves and the CLI consumes directly via re-export.
  *
  * It runs every query through {@link createClickHouseConnection}, whose `query()`
  * enforces `readonly: 1` and a per-statement timeout — so profiling honors the
@@ -91,7 +89,7 @@ export async function listClickHouseObjects(
 export async function profileClickHouse(
   options: PluginProfileOptions,
 ): Promise<PluginProfilingResult> {
-  const { url, schema, selectedTables, prefetchedObjects, progress } = options;
+  const { url, schema, selectedTables, prefetchedObjects, progress, logger } = options;
   const conn = createClickHouseConnection({ url, database: schema });
 
   const profiles: PluginTableProfile[] = [];
@@ -116,6 +114,7 @@ export async function profileClickHouse(
       const objectLabel = objectType === "view" ? " [view]" : "";
       progress?.onTableStart(tableName + objectLabel, i, objectsToProfile.length);
 
+      const tableNotes: string[] = [];
       try {
         const countRows = (await conn.query(
           `SELECT count() AS c FROM ${chIdentifier(tableName)}`,
@@ -137,7 +136,16 @@ export async function profileClickHouse(
             primaryKeyColumns = pkRows.map((r) => r.name);
           } catch (pkErr) {
             if (isFatalConnectionError(pkErr)) throw pkErr;
-            // Non-fatal: continue with no PK hints rather than failing the table.
+            // Non-fatal: continue with no PK hints rather than failing the table,
+            // but signal the gap (server log carries the cause; the note is a
+            // credential-free client-facing marker so empty PKs aren't mistaken
+            // for a genuinely keyless table).
+            const msg = pkErr instanceof Error ? pkErr.message : String(pkErr);
+            logger?.warn(
+              { table: tableName, err: msg },
+              "ClickHouse: could not read primary-key columns",
+            );
+            tableNotes.push("Primary-key hints unavailable (introspection query failed).");
           }
         }
 
@@ -154,6 +162,7 @@ export async function profileClickHouse(
           let sampleValues: string[] = [];
           let isEnumLike = false;
           const isPK = primaryKeyColumns.includes(col.name);
+          const colNotes: string[] = col.comment ? [`Column comment: ${col.comment}`] : [];
 
           try {
             const uqRows = (await conn.query(
@@ -188,7 +197,14 @@ export async function profileClickHouse(
             sampleValues = svRows.map((r) => String(r.v));
           } catch (colErr) {
             if (isFatalConnectionError(colErr)) throw colErr;
-            // Non-fatal: emit the column with the metadata we have.
+            // Non-fatal: emit the column with the metadata we have, but signal
+            // that its stats/samples are missing rather than dropping silently.
+            const msg = colErr instanceof Error ? colErr.message : String(colErr);
+            logger?.warn(
+              { table: tableName, column: col.name, err: msg },
+              "ClickHouse: could not compute column statistics",
+            );
+            colNotes.push("Column statistics unavailable (introspection query failed).");
           }
 
           columns.push({
@@ -203,7 +219,7 @@ export async function profileClickHouse(
             fk_target_table: null,
             fk_target_column: null,
             is_enum_like: isEnumLike,
-            profiler_notes: col.comment ? [`Column comment: ${col.comment}`] : [],
+            profiler_notes: colNotes,
           });
         }
 
@@ -215,7 +231,7 @@ export async function profileClickHouse(
           primary_key_columns: primaryKeyColumns,
           foreign_keys: [],
           inferred_foreign_keys: [],
-          profiler_notes: [],
+          profiler_notes: tableNotes,
           table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         });
         progress?.onTableDone(tableName, i, objectsToProfile.length);

--- a/plugins/duckdb/src/profiler.ts
+++ b/plugins/duckdb/src/profiler.ts
@@ -5,12 +5,11 @@
  * mirror, which the host's registry-resolved profiler seam feeds into
  * `SemanticGenerator` without importing this package.
  *
- * Logic relocated from the CLI's `packages/cli/lib/profilers/duckdb.ts` — this
- * plugin package becomes the home the registry resolves and the CLI consumes
- * directly. CSV/Parquet ingestion (`ingestIntoDuckDB`) is a write path and stays
- * in the CLI; only the read-only introspection moves here. The CLI profiler lib
- * is intentionally NOT deleted in this slice; that consolidation is the deferred
- * umbrella follow-up (#3627), so the two coexist for now.
+ * Logic relocated from the CLI's former `packages/cli/lib/profilers/duckdb.ts`
+ * (now deleted, #3672) — this plugin package is the one home the registry
+ * resolves and the CLI consumes directly. CSV/Parquet ingestion
+ * (`ingestIntoDuckDB`) is a write path and stays in the CLI
+ * (`packages/cli/lib/duckdb-ingest.ts`); only the read-only introspection lives here.
  *
  * It runs every query through {@link createDuckDBConnection}, which opens file
  * databases with `access_mode: "READ_ONLY"` — so profiling honors the same
@@ -125,7 +124,7 @@ export async function listDuckDBObjects(
 export async function profileDuckDB(
   options: PluginProfileOptions,
 ): Promise<PluginProfilingResult> {
-  const { url, selectedTables, prefetchedObjects, progress } = options;
+  const { url, selectedTables, prefetchedObjects, progress, logger } = options;
   const conn = openConnection(url);
 
   const profiles: PluginTableProfile[] = [];
@@ -171,6 +170,7 @@ export async function profileDuckDB(
           let nullCount: number | null = null;
           let sampleValues: string[] = [];
           let isEnumLike = false;
+          const colNotes: string[] = [];
 
           try {
             const stats = (
@@ -213,7 +213,14 @@ export async function profileDuckDB(
             }
           } catch (colErr) {
             if (isFatalConnectionError(colErr)) throw colErr;
-            // Non-fatal: emit the column with the metadata we have.
+            // Non-fatal: emit the column with the metadata we have, but signal
+            // that its stats/samples are missing rather than dropping silently.
+            const msg = colErr instanceof Error ? colErr.message : String(colErr);
+            logger?.warn(
+              { table: tableName, column: col.column_name, err: msg },
+              "DuckDB: could not compute column statistics",
+            );
+            colNotes.push("Column statistics unavailable (introspection query failed).");
           }
 
           columns.push({
@@ -228,7 +235,7 @@ export async function profileDuckDB(
             fk_target_table: null,
             fk_target_column: null,
             is_enum_like: isEnumLike,
-            profiler_notes: [],
+            profiler_notes: colNotes,
           });
         }
 

--- a/plugins/elasticsearch/src/profiler.ts
+++ b/plugins/elasticsearch/src/profiler.ts
@@ -34,6 +34,7 @@ import type {
   PluginTableProfile,
   PluginListObjectsOptions,
   PluginProfileOptions,
+  PluginProfileLogger,
 } from "@useatlas/plugin-sdk";
 import {
   createElasticsearchClient,
@@ -176,6 +177,14 @@ export interface ProfileElasticsearchOptions {
    * per-tenant-creds rule). The tenant's own SigV4 keys must be in its config.
    */
   allowAmbientAwsCreds?: boolean;
+  /**
+   * Structured logger for best-effort enrichment failures (alias / data-stream /
+   * per-stream mapping fetches). The seam path threads the host's injected
+   * {@link PluginProfileLogger} here so these warnings reach the pino logger /
+   * request-id correlation instead of `console.warn`. Raw driver/error text goes
+   * ONLY here (server-side) — never into client-facing `profiler_notes`.
+   */
+  logger?: PluginProfileLogger;
 }
 
 /** The collapsed cluster shape both profiling paths consume. */
@@ -184,6 +193,14 @@ interface DiscoveredCluster {
   entities: EsEntityDoc[];
   /** Maps every concrete/backing index name to the `table` of its owning entity. */
   coverage: Map<string, string>;
+  /**
+   * Best-effort discovery failures that silently omit a logical object from the
+   * collapse (currently a per-data-stream `_mapping` fetch that failed → the
+   * stream vanishes). Surfaced so the caller can fold them into its
+   * `PluginProfilingResult.errors[]` rather than the omission going unnoticed.
+   * Messages are generic + credential-free (the raw cause is logged server-side).
+   */
+  discoveryErrors: PluginProfileError[];
 }
 
 /**
@@ -213,6 +230,10 @@ async function discoverCluster(
   );
 
   const includeSystem = options.includeSystem ?? false;
+  const logger = options.logger;
+  // Per-data-stream mapping failures collapse a stream out of the output — collect
+  // them so the omission is surfaced in the caller's `errors[]` rather than silent.
+  const discoveryErrors: PluginProfileError[] = [];
 
   try {
     // Mapping is required; aliases + data streams are best-effort enrichment —
@@ -220,14 +241,16 @@ async function discoverCluster(
     // must not abort the whole profile. The mapping rejection still propagates.
     const mappingP = client.getMapping();
     const aliasesP = client.getAliases().catch((err) => {
-      console.warn(
-        `  Warning: could not fetch aliases (${err instanceof Error ? err.message : String(err)}) — continuing without alias entities.`,
+      logger?.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Elasticsearch: could not fetch aliases — continuing without alias entities.",
       );
       return {};
     });
     const dataStreamsP = client.getDataStreams().catch((err) => {
-      console.warn(
-        `  Warning: could not fetch data streams (${err instanceof Error ? err.message : String(err)}) — continuing without data-stream entities.`,
+      logger?.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Elasticsearch: could not fetch data streams — continuing without data-stream entities.",
       );
       return {};
     });
@@ -242,9 +265,17 @@ async function discoverCluster(
       const dsMaps = await Promise.all(
         names.map((name) =>
           client.getMapping(name).catch((err) => {
-            console.warn(
-              `  Warning: could not fetch mapping for data stream "${name}" (${err instanceof Error ? err.message : String(err)}).`,
+            // A failed per-stream mapping fetch would silently drop this data
+            // stream from the collapse. Log the raw cause server-side and surface
+            // a generic, credential-free entry so the omission isn't invisible.
+            logger?.warn(
+              { dataStream: name, err: err instanceof Error ? err.message : String(err) },
+              "Elasticsearch: could not fetch mapping for data stream",
             );
+            discoveryErrors.push({
+              table: name,
+              error: "Data stream omitted (mapping fetch failed).",
+            });
             return {} as EsMappingResponse;
           }),
         ),
@@ -267,7 +298,7 @@ async function discoverCluster(
       },
     );
 
-    return { client, cluster: { entities, coverage } };
+    return { client, cluster: { entities, coverage, discoveryErrors } };
   } catch (err) {
     client.close();
     // `getMapping` already scrubs its errors, and `resolveElasticsearchConfig`
@@ -341,7 +372,9 @@ export async function profileElasticsearch(
   const secrets = collectConfigSecrets(config);
   const { client, cluster } = await discoverCluster(config, options ?? {}, secrets);
   try {
-    const errors: PluginProfileError[] = [];
+    // Seed with any best-effort discovery failures (e.g. a data stream whose
+    // mapping fetch failed and was collapsed out) so the omission is reported.
+    const errors: PluginProfileError[] = [...cluster.discoveryErrors];
     const entities = applyEntityFilter(cluster, filterIndices, errors);
     // One `_mapping` round-trip covers every index, so there is no per-index
     // progress to report — the caller logs the index list from `entities`.
@@ -444,6 +477,7 @@ async function sampleFields(
   client: ElasticsearchClient,
   objectName: string,
   fieldPaths: string[],
+  logger?: PluginProfileLogger,
 ): Promise<Map<string, FieldSamples>> {
   const out = new Map<string, FieldSamples>();
   for (const path of fieldPaths) {
@@ -462,8 +496,9 @@ async function sampleFields(
   } catch (err) {
     // Non-fatal: a sample-fetch failure leaves the columns with mapping-only
     // metadata. Logged, never silent (CLAUDE.md: no swallowed errors).
-    console.warn(
-      `  Warning: could not sample documents for "${objectName}" (${err instanceof Error ? err.message : String(err)}) — emitting fields without sample values.`,
+    logger?.warn(
+      { index: objectName, err: err instanceof Error ? err.message : String(err) },
+      "Elasticsearch: could not sample documents — emitting fields without sample values.",
     );
     return out;
   }
@@ -497,19 +532,40 @@ async function sampleFields(
   return out;
 }
 
-/** Best-effort document count for a logical object via `_count`. Never throws. */
-async function countDocs(client: ElasticsearchClient, objectName: string): Promise<number> {
+/** Outcome of a best-effort `_count`: the count, plus whether the query failed. */
+interface CountDocsResult {
+  /** Document count — `0` both when the index is genuinely empty AND on failure. */
+  count: number;
+  /** True when the `_count` query failed (so `count: 0` is "unknown", not "empty"). */
+  failed: boolean;
+}
+
+/**
+ * Best-effort document count for a logical object via `_count`. Never throws. A
+ * `_count` permission/timeout failure folds into `count: 0`, indistinguishable
+ * from a genuinely empty index — so the result also carries `failed` so the
+ * caller can mark the row count as unavailable rather than reporting a real
+ * index as empty. The raw cause is logged server-side, never echoed to the client.
+ */
+async function countDocs(
+  client: ElasticsearchClient,
+  objectName: string,
+  logger?: PluginProfileLogger,
+): Promise<CountDocsResult> {
   try {
     const response = await client.dslQuery({ index: objectName, endpoint: "_count", body: {} });
     if (isPlainObject(response) && typeof response.count === "number") {
-      return response.count;
+      return { count: response.count, failed: false };
     }
   } catch (err) {
-    console.warn(
-      `  Warning: could not count documents for "${objectName}" (${err instanceof Error ? err.message : String(err)}).`,
+    logger?.warn(
+      { index: objectName, err: err instanceof Error ? err.message : String(err) },
+      "Elasticsearch: could not count documents",
     );
+    return { count: 0, failed: true };
   }
-  return 0;
+  // A well-formed response without a numeric `count` is also a degraded result.
+  return { count: 0, failed: true };
 }
 
 /**
@@ -617,7 +673,7 @@ export async function profileElasticsearchObjects(
 ): Promise<PluginProfilingResult> {
   const { config, fromTenantConfig } = configForOptions(options);
   const secrets = collectConfigSecrets(config);
-  const { selectedTables, prefetchedObjects, progress } = options;
+  const { selectedTables, prefetchedObjects, progress, logger } = options;
 
   // When the host seam supplied the tenant's DB-stored config, SigV4 must NOT
   // read the operator's ambient AWS env (per-tenant-creds rule); the tenant's
@@ -625,11 +681,13 @@ export async function profileElasticsearchObjects(
   // shell's ambient creds (CLI `atlas init`).
   const { client, cluster } = await discoverCluster(
     config,
-    { allowAmbientAwsCreds: !fromTenantConfig },
+    { allowAmbientAwsCreds: !fromTenantConfig, ...(logger ? { logger } : {}) },
     secrets,
   );
   const profiles: PluginTableProfile[] = [];
-  const errors: PluginProfileError[] = [];
+  // Seed with any best-effort discovery failures (e.g. a data stream whose
+  // mapping fetch failed and was collapsed out) so the omission is surfaced.
+  const errors: PluginProfileError[] = [...cluster.discoveryErrors];
 
   try {
     // Honor a prefetched object list (from a prior listObjects) by name; else use
@@ -639,7 +697,11 @@ export async function profileElasticsearchObjects(
       const wanted = new Set(prefetchedObjects.map((o) => o.name));
       entities = entities.filter((e) => wanted.has(e.table));
     }
-    entities = applyEntityFilter({ entities, coverage: cluster.coverage }, selectedTables, errors);
+    entities = applyEntityFilter(
+      { entities, coverage: cluster.coverage, discoveryErrors: [] },
+      selectedTables,
+      errors,
+    );
 
     progress?.onStart(entities.length);
 
@@ -649,20 +711,28 @@ export async function profileElasticsearchObjects(
       try {
         const fieldPaths = entity.dimensions.map((d) => d.name);
         // Count + sample run independently — no waterfall.
-        const [rowCount, samples] = await Promise.all([
-          countDocs(client, objectName),
-          sampleFields(client, objectName, fieldPaths),
+        const [count, samples] = await Promise.all([
+          countDocs(client, objectName, logger),
+          sampleFields(client, objectName, fieldPaths, logger),
         ]);
+
+        // A `_count` failure folds into `row_count: 0`, indistinguishable from a
+        // genuinely empty index — flag it with a generic, credential-free note so
+        // a populated index isn't reported as empty. Keep `row_count` as 0 (the
+        // SDK mirror types it as a number, not nullable).
+        const tableNotes: string[] = count.failed
+          ? ["Row count unavailable (document count query failed)."]
+          : [];
 
         profiles.push({
           table_name: objectName,
           object_type: "table",
-          row_count: rowCount,
+          row_count: count.count,
           columns: columnsForEntity(entity, samples),
           primary_key_columns: [],
           foreign_keys: [],
           inferred_foreign_keys: [],
-          profiler_notes: [],
+          profiler_notes: tableNotes,
           table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         });
         progress?.onTableDone(objectName, i, entities.length);

--- a/plugins/salesforce/src/connection.ts
+++ b/plugins/salesforce/src/connection.ts
@@ -201,8 +201,23 @@ export function createSalesforceConnection(
         await ensureLoggedIn();
 
         let timeoutId: ReturnType<typeof setTimeout>;
+        // jsforce exposes no abort handle for an in-flight query, so on a
+        // timeout the underlying HTTP request keeps running and settles after
+        // the race already rejected. Hold a ref to that promise and attach a
+        // catch so a late rejection can never surface as an unhandledRejection.
+        const queryPromise = conn.query(soql) as Promise<{
+          records?: Record<string, unknown>[];
+        }>;
+        queryPromise.catch((lateErr: unknown) => {
+          // intentionally ignored: the race already settled (timeout won); this
+          // is the dropped loser's late rejection — log at debug, never rethrow.
+          logger?.debug(
+            { err: lateErr instanceof Error ? lateErr.message : String(lateErr) },
+            "Salesforce query settled after timeout (ignored)",
+          );
+        });
         const result = await Promise.race([
-          conn.query(soql),
+          queryPromise,
           new Promise<never>((_, reject) => {
             timeoutId = setTimeout(
               () => reject(new Error("Salesforce query timed out")),

--- a/plugins/salesforce/src/profiler.ts
+++ b/plugins/salesforce/src/profiler.ts
@@ -145,6 +145,8 @@ export async function profileSalesforce(
       try {
         const desc = await source.describe(objectName);
 
+        const tableNotes: string[] = [];
+
         // Row count via a bounded aggregate SOQL query. Non-fatal failures
         // (e.g. objects that disallow COUNT) leave the count at 0.
         let rowCount = 0;
@@ -157,8 +159,24 @@ export async function profileSalesforce(
             // Salesforce COUNT(Id) returns { expr0: N } (or { count: N }).
             const countVal =
               firstRow.expr0 ?? firstRow.count ?? Object.values(firstRow)[0];
-            rowCount = parseInt(String(countVal ?? "0"), 10);
-            if (Number.isNaN(rowCount)) rowCount = 0;
+            const parsed = parseInt(String(countVal ?? "0"), 10);
+            if (countVal == null || Number.isNaN(parsed)) {
+              // Successful query but an unexpected result shape — distinct from
+              // the catch below (which handles a failed query). Signal the gap
+              // so a populated SObject isn't silently reported as 0 rows. The
+              // server log carries the raw cause; the note is a credential-free
+              // client-facing marker.
+              rowCount = 0;
+              logger?.warn(
+                { object: objectName, keys: Object.keys(firstRow) },
+                "Could not parse row count from COUNT() result (unexpected shape)",
+              );
+              tableNotes.push(
+                "Row count unavailable (unexpected COUNT() result shape).",
+              );
+            } else {
+              rowCount = parsed;
+            }
           }
         } catch (countErr) {
           if (isFatalConnectionError(countErr)) throw countErr;
@@ -222,7 +240,7 @@ export async function profileSalesforce(
           primary_key_columns: primaryKeyColumns,
           foreign_keys: foreignKeys,
           inferred_foreign_keys: [],
-          profiler_notes: [],
+          profiler_notes: tableNotes,
           table_flags: {
             possibly_abandoned: false,
             possibly_denormalized: false,

--- a/plugins/snowflake/src/profiler.ts
+++ b/plugins/snowflake/src/profiler.ts
@@ -66,6 +66,11 @@ function isFatalConnectionError(err: unknown): boolean {
   return false;
 }
 
+/** Type-narrow a caught error to a message string (never echoes secrets). */
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /** Escape a Snowflake identifier for use inside double quotes (doubles any embedded quotes). */
 function escId(name: string): string {
   return name.replace(/"/g, '""');
@@ -198,7 +203,7 @@ async function querySnowflakeForeignKeys(
 export async function profileSnowflake(
   options: PluginProfileOptions,
 ): Promise<PluginProfilingResult> {
-  const { url, selectedTables, prefetchedObjects, progress } = options;
+  const { url, selectedTables, prefetchedObjects, progress, logger } = options;
   const conn = createSnowflakeConnection({ url, maxConnections: 3 });
   // Resolve the schema/database context for SHOW … IN TABLE qualification, parsed
   // from the URL (never logged) — same source the connection factory uses.
@@ -224,6 +229,7 @@ export async function profileSnowflake(
       const objectLabel = objectType === "view" ? " [view]" : "";
       progress?.onTableStart(tableName + objectLabel, i, objectsToProfile.length);
 
+      const tableNotes: string[] = [];
       try {
         let primaryKeyColumns: string[] = [];
         let foreignKeys: PluginForeignKey[] = [];
@@ -237,7 +243,15 @@ export async function profileSnowflake(
             );
           } catch (pkErr) {
             if (isFatalConnectionError(pkErr)) throw pkErr;
-            // Non-fatal: continue with no PK hints rather than failing the table.
+            // Non-fatal: continue with no PK hints rather than failing the table,
+            // but signal the gap (server log carries the cause; the note is a
+            // credential-free client-facing marker so empty PKs aren't mistaken
+            // for a genuinely keyless table).
+            logger?.warn(
+              { table: tableName, err: errMessage(pkErr) },
+              "Snowflake: could not read primary-key columns",
+            );
+            tableNotes.push("Primary-key metadata unavailable (introspection query failed).");
           }
           try {
             foreignKeys = await querySnowflakeForeignKeys(
@@ -248,7 +262,13 @@ export async function profileSnowflake(
             );
           } catch (fkErr) {
             if (isFatalConnectionError(fkErr)) throw fkErr;
-            // Non-fatal: continue with no FK metadata.
+            // Non-fatal: continue with no FK metadata, but signal the gap so empty
+            // FKs aren't mistaken for a table with no referential constraints.
+            logger?.warn(
+              { table: tableName, err: errMessage(fkErr) },
+              "Snowflake: could not read foreign-key constraints",
+            );
+            tableNotes.push("Foreign-key metadata unavailable (introspection query failed).");
           }
         }
 
@@ -284,7 +304,14 @@ export async function profileSnowflake(
             }
           } catch (bulkErr) {
             if (isFatalConnectionError(bulkErr)) throw bulkErr;
-            // Non-fatal: fall back to a bare row count.
+            // Non-fatal: per-column stats are lost; signal the gap so the null
+            // unique/null counts aren't mistaken for real values, then fall back
+            // to a bare row count.
+            logger?.warn(
+              { table: tableName, err: errMessage(bulkErr) },
+              "Snowflake: could not compute column statistics",
+            );
+            tableNotes.push("Column statistics unavailable (introspection query failed).");
             try {
               const countResult = await conn.query(
                 `SELECT COUNT(*) as "RC" FROM "${escId(tableName)}"`,
@@ -292,7 +319,13 @@ export async function profileSnowflake(
               rowCount = parseInt(String(countResult.rows[0]?.RC ?? "0"), 10);
             } catch (countErr) {
               if (isFatalConnectionError(countErr)) throw countErr;
-              // Non-fatal: leave rowCount at 0.
+              // Non-fatal: leave rowCount at 0, but flag it so a real-zero count
+              // can't be confused with a failed count query.
+              logger?.warn(
+                { table: tableName, err: errMessage(countErr) },
+                "Snowflake: could not read row count",
+              );
+              tableNotes.push("Row count unavailable (count query failed).");
             }
           }
         } else {
@@ -303,7 +336,13 @@ export async function profileSnowflake(
             rowCount = parseInt(String(countResult.rows[0]?.RC ?? "0"), 10);
           } catch (countErr) {
             if (isFatalConnectionError(countErr)) throw countErr;
-            // Non-fatal: leave rowCount at 0.
+            // Non-fatal: leave rowCount at 0, but flag it so a real-zero count
+            // can't be confused with a failed count query.
+            logger?.warn(
+              { table: tableName, err: errMessage(countErr) },
+              "Snowflake: could not read row count",
+            );
+            tableNotes.push("Row count unavailable (count query failed).");
           }
         }
 
@@ -338,7 +377,14 @@ export async function profileSnowflake(
             }
           } catch (sampleErr) {
             if (isFatalConnectionError(sampleErr)) throw sampleErr;
-            // Non-fatal: emit columns without sample values.
+            // Non-fatal: the batched sample query covers every column, so its
+            // failure drops sample values table-wide; signal the gap rather than
+            // emitting empty sample arrays silently.
+            logger?.warn(
+              { table: tableName, err: errMessage(sampleErr) },
+              "Snowflake: could not read sample values",
+            );
+            tableNotes.push("Sample values unavailable (introspection query failed).");
           }
         }
 
@@ -371,7 +417,7 @@ export async function profileSnowflake(
           primary_key_columns: primaryKeyColumns,
           foreign_keys: foreignKeys,
           inferred_foreign_keys: [],
-          profiler_notes: [],
+          profiler_notes: tableNotes,
           table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         });
         progress?.onTableDone(tableName, i, objectsToProfile.length);


### PR DESCRIPTION
## Why

A whole-cycle review of the **v0.0.15→v0.0.16 profiler-seam milestone** (`v0.0.15..c3c78518`, 100 files, 19 PRs) — run *after* code-complete to catch cross-cutting issues the per-PR local-scope reviews missed. Five specialized review agents converged on one theme: **the six profilers, written in parallel, diverged in rigor**, and one host-boundary credential leak slipped through. This PR fixes the source defects + the one fail-open guardrail.

The orchestration spine (`resolveLiveConnection` / `profileLiveDatasource` / wizard routes) reviewed as exemplary and is unchanged.

## What changed

### 1. Credential scrub at the host boundary (the real leak)
`semantic-generator.ts` returned per-table profiler `errors[]` to the client **verbatim** — only the *top-level* catch was scrubbed (#3579). Plugin profilers push raw driver `err.message`, which can echo `scheme://user:pass@host`; the wizard route returns the full `errors[]` array. Now each entry is scrubbed through `errorMessage` at the one host boundary that surfaces plugin errors — covering all six plugins **and future ones** (plugin packages are dependency-free and can't share the host scrubber). Locked by a new host-level scrub test.

### 2. De-silence non-fatal failures across all 6 profilers
Every non-fatal swallow (`if (isFatalConnectionError) throw` then a bare `// Non-fatal`) degraded the profile — null column stats, empty PK/FK, `row_count: 0` — **with no signal**, so a permission/timeout failure was indistinguishable from a genuinely empty/keyless table (the agent then reasons wrongly about the data). Each site now emits:
- `logger?.warn({ …context, err }, "message")` — server-side, carries the cause (two-arg pino shape, matching the existing Salesforce/Snowflake convention);
- a **generic, credential-free** `profiler_notes` / `errors[]` marker — client-facing, so the gap is visible.

`row_count` stays `number` (no wire-contract change); a count/storage failure now carries a *"Row count unavailable"* note instead of a silent `0`. This matches the in-core pg/mysql profiler's long-standing discipline.

Per-profiler highlights:
- **BigQuery** `TABLE_STORAGE` failure no longer silently zeroes row_count for *every* base table.
- **Elasticsearch** routed all `console.warn` → injected structured logger; a failed per-data-stream mapping fetch now records an `errors[]` entry instead of vanishing from the layer.
- **Salesforce** `COUNT()` result-shape fallback now signals; the query-timeout race no longer drops the losing jsforce promise (no unhandled rejection).

### 3. SDK type mirror + stale comments
- Added `logger?: PluginProfileLogger` to `PluginConnectionListObjectsOptions` — restores parity with core `LiveConnectionListOptions` (mirror drift the rejected diff-guard can't catch).
- Fixed ClickHouse/DuckDB profiler headers claiming the CLI profiler *"is intentionally NOT deleted … coexist for now"* — it was deleted in #3672.

### 4. Enforcement test was fail-OPEN (guardrail hole)
`universal-profiling-enforcement.test.ts` enumerated the `MCP_PROVISIONABLE_CATALOG_SLUGS` subset and **silently omitted `duckdb`** (connectable + profilable via `createFromConfig`) — a DuckDB profiler regression would have shipped green. Now derives the connectable universe from the production SSOT (`BUILTIN_DATASOURCE_CATALOG_SLUGS`), so a new built-in type can't escape the guard by construction. DuckDB now has a case (**9 pass, was 8**).

## Validation
- `bun run type` → 0 errors · `bun run lint` (changed files) → clean
- `bun run scripts/test-isolated.ts --affected` → **190/190 files pass**
- All 6 plugin profiler suites + enforcement + new host-scrub test pass in isolation
- No behavior change to profiling *output* for any dbType — this is signal + scrub + test hardening

## Deliberate follow-ups (coverage of already-correct behavior, not bugs)
Tracked for a later pass — the connection-close (leak-guard) invariant is already covered on the success + mid-profile-error paths, and the MCP SDK suppresses the response on cancel (making the pure cancellation variant brittle to assert e2e):
- `profile_datasource` cancellation e2e (connection-close on abort)
- Salesforce #2850 no-`config`-fallback contract test; ES read-only HTTP-verb assertion
- `resolveLiveConnection` resolution-time OAuth `reconnect_required` / generic-defect→`internal_error` / archived→`not_found`
- The plugin-level BigQuery/Salesforce scrub tests are trivially-passing (false confidence); the authoritative scrub coverage now lives at the host boundary (added here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)