### PR TITLE
fix(www): marketing + legal accuracy audit — chat count, trial copy, sub-processor, MCP, datasource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Atlas turns a directory of YAML files into a complete semantic layer for analyti
 
 Every YAML field exists because an LLM needs it to write correct SQL: `sample_values` ground the agent in real data, `glossary.status: ambiguous` forces clarifying questions, `metrics.objective` picks `MAX` vs `MIN`, `query_patterns` teach the canonical join shapes for your domain.
 
-Built with Hono, Vercel AI SDK, and bun. Supports Anthropic, OpenAI, Bedrock, Ollama, and Vercel AI Gateway. Works with PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, and Salesforce.
+Built with Hono, Vercel AI SDK, and bun. Supports Anthropic, OpenAI, Bedrock, Ollama, and Vercel AI Gateway. Works with PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, and Salesforce.
 
 ## Try the demo locally
 
@@ -135,7 +135,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 | **Deploy anywhere** | Docker, Railway, Vercel, or your own infra | Vendor-hosted | Vendor-hosted |
 | **Plugin ecosystem** | 21 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
-| **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce | Usually one | Usually one |
+| **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, Salesforce | Usually one | Usually one |
 | **REST APIs as datasources** | Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated; generic OpenAPI installs auto-refresh | None | None |
 
 ## Deploy

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -19,7 +19,7 @@ Atlas works across four onboarding shapes. Pick the one that matches what you wa
   <Card
     title="Just try Atlas (no install)"
     href="https://app.useatlas.dev/demo"
-    description="Open the hosted demo at demo.useatlas.dev and ask any of the canonical NovaMart questions — GMV, top categories, return reasons. No signup, no install."
+    description="Open the hosted demo at app.useatlas.dev/demo and ask any of the canonical NovaMart questions — GMV, top categories, return reasons. No signup, no install."
   />
   <Card
     title="Use Atlas in my AI agent"

--- a/apps/www/content/social/linkedin-launch.md
+++ b/apps/www/content/social/linkedin-launch.md
@@ -11,4 +11,4 @@ Today we're open-sourcing Atlas, a text-to-SQL agent that solves this differentl
 
 Atlas ships with 7 database adapters (PostgreSQL, MySQL, BigQuery, ClickHouse, DuckDB, Snowflake, Salesforce), 20+ plugins (Slack, Teams, Discord, MCP server, webhooks), an embeddable React widget, TypeScript SDK, admin console, and enterprise features like SSO/SCIM, custom roles, and audit log export. It's built in TypeScript end-to-end (Hono + Next.js + Effect.ts + bun) and deploys with Docker, Railway, or Vercel. The core is AGPL-3.0 licensed — self-host the full product for free, every feature, no artificial limits. Atlas Cloud (app.useatlas.dev) is the managed option for teams that don't want to run infrastructure.
 
-Try the live demo at demo.useatlas.dev — no signup, no installation. It's connected to a cybersecurity SaaS dataset with 60 tables and 200K rows of realistic data. Source code and quick start: github.com/AtlasDevHQ/atlas
+Try the live demo at app.useatlas.dev/demo — no signup, no installation. It's connected to a cybersecurity SaaS dataset with 60 tables and 200K rows of realistic data. Source code and quick start: github.com/AtlasDevHQ/atlas

--- a/apps/www/content/social/twitter-launch.md
+++ b/apps/www/content/social/twitter-launch.md
@@ -76,7 +76,7 @@ Self-hosted is free, every feature, no limits. Cloud is for teams that want mana
 
 Try it now — no signup needed:
 
-demo.useatlas.dev
+app.useatlas.dev/demo
 
 60 tables, 200K rows of realistic cybersecurity SaaS data. Ask it anything.
 

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -123,7 +123,7 @@ const TIERS: Tier[] = [
       "Unlimited seats & connections",
       "Default model: Sonnet 4.6",
       "BYOK for unlimited queries",
-      "All 8 chat integrations",
+      "All 8 integrations (6 chat + Linear + GitHub)",
       "SSO, SCIM & custom roles",
       "IP allowlist & approval workflows",
       "PII masking & audit retention",
@@ -151,7 +151,7 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
       { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 4.6", business: "Sonnet 4.6" },
       { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
       { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
-      { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 8" },
+      { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6" },
       { feature: "When you hit the budget", selfHosted: "No limit (BYOK)", starter: "Warn → 10% grace → pause", pro: "Warn → 10% grace → pause", business: "Warn → 10% grace → pause" },
     ],
   },
@@ -208,7 +208,7 @@ const FAQS: FAQ[] = [
   {
     question: "Is there a free option?",
     answer:
-      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required.",
+      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required. Every trial runs at Starter-tier usage limits (2M tokens/seat, up to 10 seats, 1 connection) for 14 days, regardless of the plan you start from.",
   },
   {
     question: "Do you offer annual billing?",

--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -116,13 +116,13 @@ const SECTIONS: LegalSectionData[] = [
     id: "share",
     title: "Who we share with",
     legal: [
-      "Sub-processors: a small set of vendors that help us run the Service (cloud infrastructure, error monitoring, payment processing). The current list is published at useatlas.dev/dpa and customers receive 30 days’ notice of additions.",
+      "Sub-processors: a small set of vendors that help us run the Service (cloud infrastructure, uptime monitoring, payment processing). The current list is published at useatlas.dev/dpa and customers receive 30 days’ notice of additions.",
       "Model providers: when Customer uses Atlas’s hosted models, prompts are routed through Vercel AI Gateway, which forwards them to the upstream model provider configured for that Customer (e.g. Anthropic, OpenAI). Vercel acts as a sub-processor for routing, observability, and fallback. Where Customer uses BYO model keys, traffic is sent directly to the provider Customer specifies and does not transit Vercel.",
       "Legal: we may disclose information when required by law, court order, or to protect our rights, with notice to Customer where legally permitted.",
       "Successors: in a merger or sale of substantially all assets, the acquirer takes on the same obligations under this Policy.",
     ],
     plain:
-      "A short list of operational vendors (cloud infra, error monitoring, payments), the model provider you select, and disclosures required by valid legal process.",
+      "A short list of operational vendors (cloud infra, uptime monitoring, payments), the model provider you select, and disclosures required by valid legal process.",
   },
   {
     id: "rights",

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -19,13 +19,13 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Agent-native",
     atlas:
-      "MCP server first — Claude Desktop, Cursor, Continue with bunx @useatlas/mcp init",
+      "MCP server first — Claude Desktop, Cursor, Continue with bunx @useatlas/mcp init; read tools open, datasource writes gated by OAuth scope + RBAC",
     bi: "Bolted-on AI feature",
     textToSql: "Standalone chat UI",
   },
   {
     feature: "Embeddable",
-    atlas: "Script tag, React component, headless API, MCP, 8 chat platforms",
+    atlas: "Script tag, React component, headless API, MCP, 6 chat platforms",
     bi: "Standalone app",
     textToSql: "Standalone app",
   },


### PR DESCRIPTION
## What

Ran a full **www marketing + legal accuracy audit** (`/www-audit`) across pricing/billing code, vendor reality, deployed regions, security.txt, sub-processors, and the v0.0.13–v0.0.16 release surface. Every finding was triaged against code as source of truth; the safe + sign-off-approved fixes are applied here.

## Fixed in this PR

All verified against `packages/api/src/lib/billing/plans.ts` + MCP scopes:

1. **Chat-platform count** — `plans.ts` documents **6** chat-pillar platforms (Slack, Teams, Discord, Google Chat, Telegram, WhatsApp) and explicitly notes the marketed "All 8" wrongly counts Linear + GitHub (`pillar='action'`).
   - Landing `comparison.tsx`: "8 chat platforms" → "6 chat platforms"
   - Pricing Business card: "All 8 chat integrations" → "All 8 integrations (6 chat + Linear + GitHub)"
   - Pricing comparison row: business "All 8" → "All 6"
2. **Trial-tier copy** — every 14-day trial runs at **Starter-tier limits** (2M tokens/seat, 10 seats, 1 connection) regardless of the plan selected (`plans.ts` trial tier = Starter limits). Clarified in the pricing FAQ.
3. **Privacy sub-processor category** — "error monitoring" → "uptime monitoring" (no error-monitoring vendor is contracted; OpenStatus is uptime). *(legal copy, sign-off given)*
4. **MCP V2 framing** — comparison copy now notes the surface is read-tools-open with datasource writes gated by OAuth scope + RBAC.
5. **Demo URL** — docs + social referenced the unbacked `demo.useatlas.dev` in prose; pointed to the backed `app.useatlas.dev/demo`.
6. **README datasource list** — added Elasticsearch (landing + docs already listed it; plugin registered in `deploy/api/atlas.config.ts`).

## Verified accurate — no change needed

- **Pricing numbers** ($29/$59/$99, 14-day trial, 10% grace / hard-cap-with-grace, caps, SSO+SCIM Business-only, self-hosted free) all match billing code exactly.
- **security.txt** RFC 9116-compliant; PGP fingerprint matches.
- **Sub-processors** (Railway, Stripe, Vercel, Anthropic, OpenAI, Resend, OpenStatus) all real; retention (365d/30d), TOTP MFA, effective dates current; SOC 2 / ISO 27001 correctly framed as not-yet-held.
- **3 regions** backed by residency config; all links resolve.

## Not changed — flagged for awareness (ops, out of code scope)

- **OpenStatus free-tier coverage** (1 monitor) — tracked by #1936 (paid-tier decision).
- **`NEXT_PUBLIC_STATUS_URL`** — code already handles set/unset correctly (external redirect vs built-in checks by design); only a Railway dashboard confirmation, no code change appropriate.
- **"~queries" approximations** left as-is — already hedged with "~" and explained in the token-budget FAQ.

## Verification

- `tsgo --noEmit -p apps/www/tsconfig.json` → clean
- `eslint` on changed `.tsx` → clean

https://claude.ai/code/session_01EfYo7K3JqRxshewjF9B1cu