### PR TITLE
docs: accuracy audit fixes for v0.0.13–v0.0.16 release surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,7 +107,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_AUTH_ISSUER=                       # BYOT mode — expected JWT issuer
 # ATLAS_AUTH_AUDIENCE=                     # BYOT mode — expected JWT audience (optional)
 # ATLAS_AUTH_ROLE_CLAIM=role              # JWT claim path for BYOT role extraction (supports nested: app_metadata.role)
-# ATLAS_API_KEY_ROLE=analyst              # Role for simple-key auth (viewer/analyst/admin)
+# ATLAS_API_KEY_ROLE=admin                # Role for simple-key auth (member/admin/owner). Default: admin; invalid values fall back to admin
 # ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0/empty = disabled). Default: from
 #                                         # ATLAS_DEPLOY_ENV profile (prod/dev: disabled, staging: 300). A platform-level
 #                                         # DB override and this env var both win over the profile default.

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -29,13 +29,13 @@ On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View 
 | **Max seats** | 10 | 25 | Unlimited | Unlimited |
 | **Datasource connections** | 1 | 3 | Unlimited | Unlimited |
 | **Extra connections** | Upgrade plan | Upgrade plan | Included | N/A |
-| **Default model** | claude-haiku-4-5 | claude-sonnet-4-6 | claude-sonnet-4-6 | BYOK |
+| **Default model** | claude-haiku-4.5 | claude-sonnet-4.6 | claude-sonnet-4.6 | BYOK |
 | **Custom domain** | — | ✓ | ✓ | N/A |
 | **SSO / SCIM** | — | — | ✓ | N/A |
 | **Data residency** | — | — | ✓ | N/A |
 | **SLA** | — | — | 99.9% | N/A |
 
-Annual billing is available for Starter and Pro (pay for 10 months, get 12).
+Annual billing is available for Starter, Pro, and Business (pay for 10 months, get 12).
 
 - **Trial** — Auto-assigned to the first workspace a user creates on SaaS. One trial per user: further workspaces you create start **locked** (blocked until subscribed) rather than receiving a fresh trial. Same limits as Starter (10 seats, 1 connection, ~100 queries/seat). Expires after 14 days, then queries are blocked until the workspace upgrades.
 - **Starter** — Entry paid tier. Per-seat billing via Stripe.

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -470,13 +470,13 @@ The `filters` parameter is reserved for future pre-aggregation filter pass-throu
 
 ## Datasource lifecycle tools
 
-Beyond the read-only semantic tools above, the server exposes a set of **admin, write-scoped** tools for managing datasources from an agent: `list_datasources`, `test_datasource`, `create_datasource`, `profile_datasource`, `archive_datasource`, `restore_datasource`, and `delete_datasource`. They require the `admin` role and (for the mutating tools) the `mcp:write` scope, and route through the same RBAC + approval gates as the rest of the admin surface. None of them ever return a connection URL or any secret — `create_datasource` collects the credential via a separate masked prompt that is never shared with the agent.
+Beyond the read-only semantic tools above, the server exposes a set of **admin, write-scoped** tools for managing datasources from an agent: `list_datasources`, `test_datasource`, `create_datasource`, `create_rest_datasource`, `profile_datasource`, `archive_datasource`, `restore_datasource`, and `delete_datasource`. They require the `admin` role and (for the mutating tools) the `mcp:write` scope, and route through RBAC plus the per-workspace MCP action policy; the `destructive` `delete_datasource` additionally routes through the approval gate. None of them ever return a connection URL or any secret — `create_datasource` collects the credential via a separate masked prompt that is never shared with the agent.
 
 The two-step path to make a new datasource queryable is **create → profile**:
 
 ### create_datasource
 
-Provision a new datasource of any type whose plugin can open a live connection — Postgres and MySQL natively, plus plugin-managed datasources such as BigQuery, Snowflake, ClickHouse, DuckDB, Elasticsearch/OpenSearch, and Salesforce. You pass only non-secret fields (`db_type`, `install_id`, optional `schema` / `description` / `group_id`); the connection URL or credential is collected via a masked prompt, health-checked **before** anything is persisted, and the datasource lands as a `draft`. It is not yet queryable — run `profile_datasource` next.
+Provision a new config-installable datasource — Postgres and MySQL natively, plus the plugin-managed types BigQuery, Snowflake, ClickHouse, and Elasticsearch/OpenSearch. (DuckDB is file-based and Salesforce is OAuth-managed, so neither is provisioned through `create_datasource`; a profiled Salesforce datasource is created through its OAuth install flow. REST/OpenAPI sources use `create_rest_datasource`.) You pass only non-secret fields (`db_type`, `install_id`, optional `schema` / `description` / `group_id`); the connection URL or credential is collected via a masked prompt, health-checked **before** anything is persisted, and the datasource lands as a `draft`. It is not yet queryable — run `profile_datasource` next.
 
 ### profile_datasource
 
@@ -505,6 +505,19 @@ Profiling does two things with the generated layer:
 Because the persisted rows land as **drafts**, they follow the standard [content-mode](/security/sql-validation) status discipline: queryable immediately in **developer mode** (the draft overlay), but **not** on the published `/chat` surface until an admin promotes them through the atomic publish endpoint (`/api/v1/admin/publish`). This keeps machine-generated, unreviewed entities out of the published whitelist until a human signs off. Profiling fails loud (a `validation_failed` envelope) rather than report success if any generated table cannot be persisted — a partially-persisted layer would silently leave some tables unqueryable.
 
 If profiling persists fewer rows than it generated, or the workspace has no internal database configured (a self-hosted stdio server with no `DATABASE_URL`), `persisted` is `false` and only the in-process whitelist is populated for the current session.
+
+---
+
+## MCP action policy
+
+Each workspace has a **per-workspace MCP action policy** — a customer-admin kill-switch that governs which categories of MCP action are allowed from MCP clients. Admins manage it from **Admin → MCP Action Policy** in the web app; it is also exposed over the API at `GET` / `PUT /api/v1/admin/mcp/action-policy` (admin role required).
+
+- **Default posture is `allowed`** — every action category is permitted until an admin explicitly sets it to `blocked`.
+- A `blocked` category **short-circuits** matching MCP tool dispatches *before* scope, RBAC, and approval checks run.
+- **Governance is raise-only** (ADR-0016): the policy can only ever *tighten* what MCP clients may do. It never lowers the non-configurable origin ceiling — MCP can restrict, but never broaden, the workspace's configured permissions.
+- Policy changes and gated dispatches carry audit-trail attribution.
+
+This is the kill-switch to reach for when you want to keep, say, datasource mutation or destructive actions off the MCP surface for a workspace while leaving the read-only analyst tools available.
 
 ---
 

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -304,7 +304,7 @@ describe("my-datasource plugin", () => {
   test("creates plugin with valid config", () => {
     const plugin = myPlugin({ url: "postgresql://localhost/test" });
     expect(plugin.id).toBe("my-datasource");
-    expect(plugin.type).toBe("datasource");
+    expect(plugin.types).toContain("datasource");
   });
 
   test("health check reports status", async () => {
@@ -318,7 +318,7 @@ describe("my-datasource plugin", () => {
 Key testing patterns:
 
 - **Config validation** — Verify that invalid configs throw at factory call time, not at runtime
-- **Plugin shape** — Check `id`, `type`, `version`, and variant-specific properties (`connection`, `contextProvider`, `actions`, etc.)
+- **Plugin shape** — Check `id`, `types` (a readonly array), `version`, and variant-specific properties (`connection`, `contextProvider`, `actions`, etc.)
 - **Health checks** — Ensure `healthCheck()` returns `{ healthy: boolean }` and never throws (even when the service is unreachable)
 - **Connection factory** — For datasource plugins, test that `connection.create()` returns a valid `PluginDBConnection`
 
@@ -580,13 +580,13 @@ import type { $InferServerPlugin } from "@useatlas/plugin-sdk";
 import type { clickhousePlugin } from "@useatlas/clickhouse";
 
 type CH = $InferServerPlugin<typeof clickhousePlugin>;
-// CH["Config"] → { url: string; database?: string }
-// CH["Type"]   → "datasource"
+// CH["Config"] → { url?: string; database?: string }
+// CH["Types"]  → readonly ["datasource"]
 // CH["Id"]     → string
 // CH["DbType"] → "clickhouse"
 ```
 
-Available inference keys: `Config`, `Type`, `Id`, `Name`, `Version`, `DbType` (datasource only), `Actions` (action only), `Security` (sandbox only).
+Available inference keys: `Config`, `Types`, `Id`, `Name`, `Version`, `DbType` (datasource only), `Actions` (action only), `Security` (sandbox only).
 
 ## Plugin Status Lifecycle
 
@@ -724,14 +724,16 @@ export default definePlugin({
 
 | Hook | Context | Mutable | Description |
 |------|---------|---------|-------------|
-| `beforeQuery` | `{ sql, connectionId? }` | Yes -- return `{ sql }` to rewrite, throw to reject | Fires before each SQL query is executed |
-| `afterQuery` | `{ sql, connectionId?, result, durationMs }` | No | Fires after each SQL query with results |
+| `beforeQuery` | `{ sql, connectionId?, metadata? }` | Yes -- return `{ sql }` to rewrite, throw to reject | Fires before each SQL query is executed |
+| `afterQuery` | `{ sql, connectionId?, metadata?, result, durationMs }` | No | Fires after each SQL query with results |
+| `beforeToolCall` | `{ toolName, args, context }` | Yes -- return `{ args }` to rewrite, throw to reject | Fires before each tool call |
+| `afterToolCall` | `{ toolName, args, context, result, durationMs }` | No | Fires after each tool call with its return value |
 | `beforeExplore` | `{ command }` | Yes -- return `{ command }` to rewrite, throw to reject | Fires before each explore command |
 | `afterExplore` | `{ command, output }` | No | Fires after each explore command with output |
 | `onRequest` | `{ path, method, headers }` | No | HTTP-level: fires before routing a request |
 | `onResponse` | `{ path, method, status }` | No | HTTP-level: fires after sending a response |
 
-`beforeQuery` and `beforeExplore` are mutable hooks -- handlers can return a mutation object (`{ sql }` or `{ command }`) to rewrite the operation, or throw an error to reject it entirely. All other hooks are observation-only (void return).
+`beforeQuery`, `beforeToolCall`, and `beforeExplore` are mutable hooks -- handlers can return a mutation object (`{ sql }`, `{ args }`, or `{ command }`) to rewrite the operation, or throw an error to reject it entirely. All other hooks are observation-only (void return).
 
 ## Schema Migrations
 
@@ -961,15 +963,15 @@ async initialize(ctx) {
 
 ## Reference Plugins
 
-The Atlas monorepo includes 21 reference plugin implementations in the `plugins/` directory. These serve as working examples for every plugin type:
+The Atlas monorepo includes 25 reference plugin implementations in the `plugins/` directory. These serve as working examples for every plugin type:
 
-**Datasource:** `bigquery`, `clickhouse`, `duckdb`, `mysql`, `salesforce`, `snowflake`
+**Datasource:** `bigquery`, `clickhouse`, `duckdb`, `elasticsearch`, `mysql`, `salesforce`, `snowflake`
 
 **Context:** `yaml-context`
 
-**Interaction:** `chat`, `email-digest`, `mcp`, `obsidian`, `slack`, `teams`, `webhook`
+**Interaction:** `chat`, `email-digest`, `mcp`, `obsidian`, `teams`, `webhook`
 
-**Action:** `email`, `jira`
+**Action:** `email`, `jira`, `obsidian-reader`, `twenty`, `webhook-action`
 
 **Sandbox:** `daytona`, `e2b`, `nsjail`, `railway-sandbox`, `sidecar`, `vercel-sandbox`
 

--- a/apps/docs/content/docs/plugins/datasources/bigquery.mdx
+++ b/apps/docs/content/docs/plugins/datasources/bigquery.mdx
@@ -128,6 +128,16 @@ When a query proceeds (in `"auto"` mode or under threshold in `"threshold"` mode
 
 The agent uses this metadata to inform the user about query costs.
 
+## Profiling & semantic layer
+
+BigQuery profiles into a semantic layer (entities, metrics, glossary) the same way Postgres and MySQL do. Since v0.0.16 profiling rides connection resolution — if Atlas can connect to the datasource, it can profile it — and BigQuery uses the shared plugin profiler contract (`listObjects` / `profile`), including over MCP. Three entry points share one profiler:
+
+- **In-product wizard** — add and profile the connection from **Admin → Connections** (no terminal needed).
+- **CLI** — `bun run atlas -- init` (and `diff`) against a named BigQuery datasource from `atlas.config.ts` (`--connection <name>`).
+- **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
+
+See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+
 ## Validation
 
 In addition to the standard SQL validation pipeline (regex guard + AST parse + table whitelist), the plugin blocks BigQuery-specific statements: `MERGE`, `EXPORT DATA`, `DECLARE`, `SET`, `BEGIN`, `ASSERT`, and `RAISE`. The AST parser uses BigQuery mode natively (supported by `node-sql-parser`).

--- a/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
+++ b/apps/docs/content/docs/plugins/datasources/clickhouse.mdx
@@ -60,6 +60,16 @@ The following hints are injected into the agent's system prompt so it writes val
 - Do not add `FORMAT` clauses -- the adapter handles output format automatically
 - ClickHouse is column-oriented -- avoid `SELECT *` on wide tables
 
+## Profiling & semantic layer
+
+ClickHouse profiles into a semantic layer (entities, metrics, glossary) the same way Postgres and MySQL do. Since v0.0.16 profiling rides connection resolution — if Atlas can connect to the datasource, it can profile it — and ClickHouse uses the shared plugin profiler contract (`listObjects` / `profile`). Three entry points share one profiler:
+
+- **In-product wizard** — add and profile the connection from **Admin → Connections** (no terminal needed).
+- **CLI** — `bun run atlas -- init` (and `diff`) against a named ClickHouse datasource from `atlas.config.ts` (`--connection <name>`) or a `clickhouse://` `ATLAS_DATASOURCE_URL`.
+- **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
+
+See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+
 ## Validation
 
 In addition to the standard SQL validation pipeline (regex guard + AST parse + table whitelist), the plugin blocks ClickHouse-specific admin commands: `SYSTEM`, `KILL`, `ATTACH`, `DETACH`, `RENAME`, `EXCHANGE`, `SHOW`, `DESCRIBE`, `EXPLAIN`, and `USE`. The AST parser uses PostgreSQL mode (the closest available match in `node-sql-parser`).

--- a/apps/docs/content/docs/plugins/datasources/duckdb.mdx
+++ b/apps/docs/content/docs/plugins/datasources/duckdb.mdx
@@ -66,6 +66,15 @@ duckdb:///absolute/path.duckdb
 - Supports window functions, CTEs, and lateral joins
 - In-process engine -- no connection pooling needed
 
+## Profiling & semantic layer
+
+DuckDB profiles into a semantic layer (entities, metrics, glossary) the same way Postgres and MySQL do. Since v0.0.16 profiling rides connection resolution — if Atlas can connect to the datasource, it can profile it — and DuckDB uses the shared plugin profiler contract (`listObjects` / `profile`). DuckDB is a self-hosted datasource (not SaaS-eligible), so profiling runs locally:
+
+- **CLI** — `bun run atlas -- init` (and `diff`) against a DuckDB file, or load flat files directly with `--csv <files>` / `--parquet <files>` (no DB server needed; requires `@duckdb/node-api`).
+- **In-product wizard / MCP** — on a self-hosted deployment, the same connection can be profiled from the install wizard or the `profile_datasource` MCP tool.
+
+See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+
 ## Validation
 
 The plugin blocks DuckDB-specific statements beyond the standard SQL pipeline: `PRAGMA`, `ATTACH`, `DETACH`, `INSTALL`, `EXPORT`, `IMPORT`, `CHECKPOINT`, `SET`, `DESCRIBE`, `EXPLAIN`, and `SHOW`. File-reading table functions (`read_csv_auto`, `read_csv`, `read_parquet`, `read_json`, `read_json_auto`, `read_text`, `parquet_scan`, `csv_scan`, `json_scan`) are blocked to prevent host filesystem access. The AST parser uses PostgreSQL mode.

--- a/apps/docs/content/docs/plugins/datasources/salesforce.mdx
+++ b/apps/docs/content/docs/plugins/datasources/salesforce.mdx
@@ -105,6 +105,16 @@ SOQL is not SQL. The agent receives these hints to write valid SOQL:
 - Date literals: `YESTERDAY`, `TODAY`, `LAST_WEEK`, `THIS_MONTH`, `LAST_N_DAYS:n`, etc.
 - No wildcards in field lists -- always list specific fields (no `SELECT *`)
 
+## Profiling & semantic layer
+
+Salesforce profiles into a semantic layer (entities mapped to SObjects, plus metrics and glossary) the same way SQL datasources do. Since v0.0.16 profiling rides connection resolution — if Atlas can connect to the datasource, it can profile it — and Salesforce uses the shared plugin profiler contract (`listObjects` / `profile`), including over MCP. Entry points:
+
+- **In-product wizard** — connect via OAuth and profile from **Admin → Connections**. Because Salesforce is OAuth-managed, it is created through its OAuth install flow (not the MCP `create_datasource` tool).
+- **CLI** — `bun run atlas -- init` (and `diff`) against a configured Salesforce datasource.
+- **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
+
+See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+
 ## Validation
 
 Salesforce uses a custom SOQL validation pipeline instead of the standard `node-sql-parser`-based SQL validation:

--- a/apps/docs/content/docs/plugins/datasources/snowflake.mdx
+++ b/apps/docs/content/docs/plugins/datasources/snowflake.mdx
@@ -68,6 +68,16 @@ snowflake://user:password@account/database/schema?warehouse=WAREHOUSE&role=ROLE
 - Identifiers are case-insensitive and stored uppercase by default
 - `VARIANT` type supports semi-structured data -- use `:key` or `['key']` notation to access fields
 
+## Profiling & semantic layer
+
+Snowflake profiles into a semantic layer (entities, metrics, glossary) the same way Postgres and MySQL do. Since v0.0.16 profiling rides connection resolution — if Atlas can connect to the datasource, it can profile it — and Snowflake uses the shared plugin profiler contract (`listObjects` / `profile`). Three entry points share one profiler:
+
+- **In-product wizard** — add and profile the connection from **Admin → Connections** (no terminal needed).
+- **CLI** — `bun run atlas -- init` (and `diff`) against a named Snowflake datasource from `atlas.config.ts` (`--connection <name>`) or a `snowflake://` `ATLAS_DATASOURCE_URL`.
+- **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
+
+See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+
 ## Validation
 
 The plugin blocks Snowflake-specific statements beyond the standard SQL pipeline: `PUT`, `GET`, `LIST`, `REMOVE`, `RM`, `MERGE`, `SHOW`, `DESCRIBE`, `DESC`, `EXPLAIN`, and `USE`. The AST parser uses `Snowflake` mode (native support in `node-sql-parser`).

--- a/apps/docs/content/docs/plugins/sdk/mcp-tools.mdx
+++ b/apps/docs/content/docs/plugins/sdk/mcp-tools.mdx
@@ -35,6 +35,10 @@ interface McpToolContext {
   readonly clientId?: string;
   readonly requestId: string;
   readonly pluginId: string;
+  /** Conversation execution target (or per-turn override). Absent for non-chat-routed dispatches. Pass through to connection-keyed tools. (#2345) */
+  readonly connectionId?: string;
+  /** Content scope — the connection group whose entities/dashboards/approvals resolve for this turn. Decoupled from `connectionId`. (#2345) */
+  readonly connectionGroupId?: string;
   readonly logger: PluginLogger;
   audit(entry: McpToolAuditEntry): void;
 }

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -38,7 +38,7 @@ bun run atlas -- init [options]
 | `--enrich` | Add LLM-enriched descriptions and query patterns (requires API key) |
 | `--no-enrich` | Explicitly skip LLM enrichment |
 | `--force` | Continue even if more than 20% of tables fail to profile |
-| `--demo` | Load the canonical demo dataset (NovaMart e-commerce, 13 entities, 52 tables, ~480K rows) then profile. Boolean — Atlas ships a single canonical seed (#2021) |
+| `--demo` | Load the canonical demo dataset (NovaMart e-commerce, 13 entities, 52 tables, ~480K rows) then profile. Boolean — Atlas ships a single canonical seed (#2021). **PostgreSQL-only**: the demo SQL uses Postgres-specific syntax, so `--demo` against a non-Postgres datasource exits with an error |
 | `--org <orgId>` | Write to `semantic/.orgs/{orgId}/` and auto-import to DB (org-scoped mode). Requires managed auth (`DATABASE_URL` + `BETTER_AUTH_SECRET`) |
 | `--no-import` | Skip auto-import to DB in org-scoped mode (write disk only). Only meaningful with `--org` |
 

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -868,7 +868,7 @@ export default defineConfig({
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `label` | `string` | Yes | — | Human-readable region name for the admin console |
-| `databaseUrl` | `string` | Yes | — | Connection string for the region's internal database |
+| `databaseUrl` | `string` | Conditional | — | Connection string for the region's internal database. Optional in the schema, but the URL for the region **this service serves** must resolve at boot (hard-validated by the region guard); URLs for other regions may be left empty |
 | `datasourceUrl` | `string` | No | — | Analytics datasource override for the region. When unset, uses the default datasource |
 | `apiUrl` | `string` | No | — | Public API endpoint for this region (e.g. `https://api-eu.useatlas.dev`). Used in `421 Misdirected Request` responses to redirect clients to the correct region |
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -253,7 +253,7 @@ ATLAS_API_KEY_ROLE=member
 | `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN` | `false` | Opt-in fallback: when `ATLAS_ADMIN_EMAIL` is unset and no admin user exists, the first signup is promoted to `platform_admin`. Accepts `true`/`1`/`yes`/`on` (case-insensitive). **Do not enable in production** — any unauthenticated visitor could race the operator and claim admin with a single signup |
 | `ATLAS_REQUIRE_EMAIL_VERIFICATION` | profile default — `true` in `production`, `false` in `staging`/`development` | Require email verification on signup. When unset, the default comes from the [`ATLAS_DEPLOY_ENV`](#runtime) profile; setting it explicitly overrides the profile. Setting `false` re-enables Better Auth's `USER_ALREADY_EXISTS` signup error (an email-enumeration oracle) and is only acceptable for self-hosted single-tenant deployments without an email provider |
 | `ATLAS_MFA_ISSUER` | `Atlas` | Issuer label shown in TOTP authenticator apps (Google Authenticator, 1Password, etc.) when users enroll an MFA device |
-| `ATLAS_RPID` | `app.useatlas.dev` | WebAuthn relying-party ID used during passkey enrollment and assertion. Set explicitly to the production hostname when self-hosting under a custom domain — mismatched RP IDs reject every authenticator response |
+| `ATLAS_RPID` | derived from web origin | WebAuthn relying-party ID used during passkey enrollment and assertion. Resolution precedence: explicit `ATLAS_RPID` → the host of the configured web origin (`ATLAS_CORS_ORIGIN` / `BETTER_AUTH_TRUSTED_ORIGINS`) → the legacy default `app.useatlas.dev` when no origin is configured. Set explicitly to the production hostname when self-hosting under a custom domain — a mismatched RP ID (not equal to, or a parent of, the origin host) fails boot loudly, and IP-literal hosts disable passkeys |
 | `ATLAS_RPNAME` | `Atlas` | Human-readable relying-party name shown to users in passkey enrollment prompts |
 
 <Callout type="warn">
@@ -406,7 +406,7 @@ Actor binding for the [MCP server](/guides/mcp). The transport runs in one of tw
 | `ATLAS_MCP_USER_ID` | — | MCP actor binding (#1858) — Atlas user ID the MCP transport should act as. Set **both** `ATLAS_MCP_USER_ID` and `ATLAS_MCP_ORG_ID` for governed transport (approval rules + audit apply to MCP queries). Leaving both unset selects trusted transport with a synthetic `system:mcp` actor — only safe when no approval rules exist |
 | `ATLAS_MCP_ORG_ID` | — | MCP actor binding — org ID the bound user acts under. The MCP server fails to boot when approval rules exist and the binding is missing, or when only one of the two vars is set |
 | `ATLAS_MCP_MAX_SESSIONS` | `100` | Max concurrent hosted-MCP sessions per API instance. Counts both registered sessions and in-flight initializations. Hitting the cap returns `503 too_many_sessions`. Sessions are in-process; Railway does not support sticky session routing, so each api region runs `numReplicas: 1` (see [#2069](https://github.com/AtlasDevHQ/atlas/issues/2069) for the rationale and [#2109](https://github.com/AtlasDevHQ/atlas/issues/2109) for the durable-session-store path that lifts the cap). The [hosted MCP performance profile](/architecture/mcp-performance) documents the bottleneck order (session cap → datasource pool → API CPU → OAuth verify → SQL validation), tuning recipes for raising the cap, and reproducible k6 scripts at [`eval/load-tests/mcp/`](https://github.com/AtlasDevHQ/atlas/tree/main/eval/load-tests/mcp) for measuring against your own deployment |
-| `ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS` | `auto` | Tri-state gate (`auto` / `always` / `never`) for exposing the 20 NovaMart canonical eval questions ([#2076](https://github.com/AtlasDevHQ/atlas/issues/2076)) as `canonical-{slug}` `prompts/list` entries on the hosted MCP endpoint. `auto` exposes them only on the `__demo__` workspace (default — discoverable in the demo, hidden in customer prompt lists). `always` forces exposure for every workspace. `never` fails closed. The Settings → AI Agents → MCP Prompts preview block reflects this gate live |
+| `ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS` | `auto` | Tri-state gate (`auto` / `always` / `never`) for exposing the 20 NovaMart canonical eval questions ([#2076](https://github.com/AtlasDevHQ/atlas/issues/2076)) as `canonical-{slug}` `prompts/list` entries on the hosted MCP endpoint. `auto` (default) exposes them when the workspace has a published `__demo__` connection **or** `ATLAS_DEMO_INDUSTRY` is set — discoverable in the demo, hidden in customer prompt lists. `always` forces exposure for every workspace regardless of dataset. `never` fails closed. The Settings → AI Agents → MCP Prompts preview block reflects this gate live |
 | `ATLAS_MCP_RATE_LIMIT_FAIL_CLOSED` | `false` | Fail-closed gate for MCP rate-limit infrastructure errors. When `true`, a rate-limit-store outage (Redis down, internal DB unreachable) causes MCP requests to be rejected rather than allowed through. SaaS regions opt in; self-hosted defaults to fail-open so a transient infra blip doesn't block agent access |
 | `ATLAS_MCP_RATE_LIMIT_MAX_KEYS` | (oauth-client clamp default) | Maximum cardinality of distinct rate-limit keys retained per workspace before LRU eviction. Bounds memory usage on workspaces with many short-lived OAuth clients. Clamped to a minimum at startup |
 | `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS` | `1800000` (30m) | Idle timeout for hosted-MCP sessions. The sweep evicts sessions whose `lastSeenAt` is older than this. Floored at `60000` (1m) — values below the floor log a warning and fall back to the default. Test-only overrides set this below the floor in-process. Source: `packages/mcp/src/hosted.ts` |
@@ -607,6 +607,7 @@ Scheduled task execution. Can also be configured via [`atlas.config.ts`](/refere
 | `ATLAS_SCHEDULER_MAX_CONCURRENT` | `5` | Max concurrent task executions per tick |
 | `ATLAS_SCHEDULER_TIMEOUT` | `60000` | Per-task timeout in milliseconds |
 | `ATLAS_SCHEDULER_TICK_INTERVAL` | `60` | Tick interval in seconds |
+| `ATLAS_DELIVERY_MAX_ROWS` | `50` | Max rows per dataset embedded in a scheduled-delivery report (distinct from `ATLAS_ROW_LIMIT`, the SQL execution cap). Clamped to the range `1–10000`; invalid values fall back to the default. Overridable per-workspace via Settings. Source: `packages/api/src/lib/scheduler/shape-result.ts` |
 | `ATLAS_BYOT_DORMANCY_DAYS` | `30` | Workspace-inactivity window (whole days) before the BYOT model-catalog refresh cycle skips a dormant workspace. Only an explicit `0` disables the dormancy gate (falls back to the TTL-only query); any other invalid value falls back to `30`. Source: `packages/api/src/lib/scheduler/byot-catalog-refresh.ts` |
 | `ATLAS_ORPHAN_TASK_RECONCILE` | `false` | Set `=true` to enable the **destructive** orphan-task sweep — auto-deletes plugin `scheduled_tasks` left behind by a failed uninstall. Default is measure-only: the orphan count is always observed (span + `log.warn`); only the deletion is gated. Source: `packages/api/src/lib/scheduler/orphan-task-reconcile.ts` |
 
@@ -844,6 +845,23 @@ The generic [OpenAPI (REST) datasource](/plugins/datasources/openapi-generic) is
 
 ---
 
+## Elasticsearch / OpenSearch Datasource
+
+Credentials for the Elasticsearch / OpenSearch datasource when profiling from the CLI (`atlas init` / `diff`) on a self-hosted deployment. On the hosted platform these are entered through **Admin → Connections** and encrypted at rest instead. The endpoint comes from the `elasticsearch://` / `opensearch://` `ATLAS_DATASOURCE_URL` (or `ATLAS_ES_CLOUD_ID`); credentials are **never** carried in the URL. Pick one auth mode — precedence is **SigV4 → HTTP Basic → API key**. See the [Elasticsearch datasource guide](/plugins/datasources/elasticsearch).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_ES_CLOUD_ID` | — | Elastic Cloud ID (`<name>:<base64>`) — an endpoint alternative to the `elasticsearch://` URL |
+| `ATLAS_ES_API_KEY` | — | Base64 API key (API-key auth mode) |
+| `ATLAS_ES_USERNAME` | — | HTTP Basic username (requires `ATLAS_ES_PASSWORD`) |
+| `ATLAS_ES_PASSWORD` | — | HTTP Basic password (requires `ATLAS_ES_USERNAME`) |
+| `ATLAS_ES_AWS_REGION` | — | Selects AWS SigV4 auth (Amazon OpenSearch Service); signing keys come from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`) |
+| `ATLAS_ES_AWS_SERVICE` | `es` | SigV4 service code; set `aoss` for OpenSearch Serverless |
+| `ATLAS_ES_ENGINE` | from URL scheme | Explicit engine override: `elasticsearch` or `opensearch`. Wins over the URL scheme |
+| `ATLAS_ES_TERMINATE_AFTER` | `100000` | Per-shard document cap for query/aggregation requests. Set `0` to disable. Source: `plugins/elasticsearch/src/dsl.ts` |
+
+---
+
 ## Stripe Billing
 
 Stripe billing integration for SaaS deployments. Self-hosted deployments do not need these — the self-hosted experience has no billing or usage limits.
@@ -980,6 +998,11 @@ Destructive operator-CLI subcommands gated by explicit env confirmation. None of
 | `PORT` | `3001` | HTTP port for the standalone Hono API server. Most platforms (Railway, Vercel) set this automatically |
 | `ATLAS_DEPLOY_ENV` | `production` | Deployment-shape discriminator for the env-profile module (`packages/api/src/lib/env-profile.ts`). One of `production`, `staging`, `development`. Unset or unrecognized → `production`. Selects a typed table of non-secret runtime defaults so a deploy shape can be switched with one var instead of many. Currently drives the defaults for `ATLAS_REQUIRE_EMAIL_VERIFICATION` and `ATLAS_ONBOARDING_EMAILS_ENABLED` (both `true` under `production`, `false` under `staging`/`development`) — each individual env var still overrides the profile default when set explicitly |
 | `ATLAS_MIGRATION_RETRIES` | `5` | Number of retry attempts for internal database migrations at startup. Retries use exponential backoff. Set `0` to disable retries (useful in tests) |
+| `ATLAS_COOKIE_PREFIX` | `ATLAS_DEPLOY_ENV` profile | Session-cookie name prefix (`advanced.cookiePrefix`). A non-empty value wins over the `ATLAS_DEPLOY_ENV` profile default. Distinct prefixes keep prod and staging sessions isolated when multiple Atlas environments share one parent domain. **Must equal** the web service's `NEXT_PUBLIC_ATLAS_COOKIE_PREFIX` |
+| `NEXT_PUBLIC_ATLAS_COOKIE_PREFIX` | `atlas` | Session-cookie name prefix the **web** proxy reads. Must match the API's `ATLAS_COOKIE_PREFIX`. Set per env when several Atlas envs share a parent domain (e.g. `atlas-staging`); use `atlas-dev` for local dev |
+| `ATLAS_PUBLIC_WEB_URL` | — | Public base URL of the web app, used to build the "link your Atlas account" CTA in proactive chat DMs. Set to the user-facing origin (e.g. `https://app.useatlas.dev`) |
+| `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS` | `15000` (15s) | TTL for the plugin health-check cache. Bounds how often the registry re-runs plugin health probes. Invalid values fall back to the default. Source: `packages/api/src/lib/plugins/registry.ts` |
+| `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS` | `60000` (60s) | Overall render timeout for headless dashboard screenshot/export. Clamped to the range `5000–180000`; non-numeric values fall back to the default. Source: `packages/api/src/lib/dashboard-screenshot.ts` |
 
 ---
 
@@ -1020,6 +1043,8 @@ The sub-processor publisher fetches Atlas's authoritative sub-processor list (th
 |----------|---------|-------------|
 | `ATLAS_LOG_LEVEL` | `info` | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry collector endpoint (e.g. `http://localhost:4318`). When set, the API server (`atlas-api`) and web frontend (`atlas`) emit distributed trace spans for HTTP requests, agent steps, SQL queries, and explore commands |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | Auth/header(s) your collector requires, in W3C Baggage format (percent-encode spaces, e.g. `authorization=Bearer%20<token>`). Most hosted collectors are non-functional without this. Set per-service in production |
+| `OTEL_SERVICE_NAME` | `atlas-api` | Overrides the `service.name` resource attribute reported on emitted spans |
 
 See [Observability](/platform-ops/observability) for the full setup guide.
 

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -58,6 +58,7 @@ These codes are returned by billing enforcement and workspace status middleware.
 | Code | HTTP Status | Description | Common Cause | Fix |
 |------|-------------|-------------|--------------|-----|
 | `trial_expired` | 403 | Trial has expired | 14-day SaaS trial ended | Upgrade to a paid plan |
+| `subscription_required` | 403 | Subscription required | The workspace subscription has ended (past-due/canceled) | Resubscribe from the billing page to continue using Atlas |
 | `billing_check_failed` | 503 | Billing check failed | Failed to fetch plan data from internal DB | Retry — transient infrastructure issue |
 | `workspace_check_failed` | 503 | Workspace check failed | Failed to verify workspace status | Retry — transient infrastructure issue |
 | `workspace_throttled` | 429 | Workspace throttled | Workspace triggered abuse detection thresholds | Wait for the throttle delay to pass and retry. See [Abuse Prevention](/platform-ops/abuse-prevention) |

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -21,7 +21,7 @@ The hooks require these peer dependencies:
 bun add react react-dom ai @ai-sdk/react
 ```
 
-The pre-built `AtlasChat` component additionally uses `lucide-react`, `react-syntax-highlighter`, `recharts`, `tailwindcss`, and `xlsx` (all optional peer deps).
+The pre-built `AtlasChat` component additionally uses `lucide-react`, `react-syntax-highlighter`, `recharts`, `tailwindcss`, and `exceljs` (all optional peer deps).
 
 ## Imports
 
@@ -1050,6 +1050,7 @@ type ChatErrorCode =
   | "org_not_found"
   | "plan_limit_exceeded"
   | "trial_expired"
+  | "subscription_required"
   | "billing_check_failed"
   | "workspace_check_failed"
   | "workspace_throttled"

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -757,6 +757,7 @@ try {
 | `provider_error` | 502 | Yes | LLM provider error |
 | `plan_limit_exceeded` | 429 | No | Workspace exceeded plan query/token limit |
 | `trial_expired` | 403 | No | Trial has expired — upgrade to a paid plan |
+| `subscription_required` | 403 | No | Subscription ended (past-due/canceled) — resubscribe from the billing page |
 | `billing_check_failed` | 503 | Yes | Billing check failed — transient infrastructure issue |
 | `workspace_check_failed` | 503 | Yes | Workspace check failed — transient infrastructure issue |
 | `workspace_throttled` | 429 | Yes | Workspace throttled by abuse detection — retry after delay |

--- a/apps/docs/content/docs/semantic-layer/index.mdx
+++ b/apps/docs/content/docs/semantic-layer/index.mdx
@@ -71,5 +71,5 @@ These five questions — drawn from the [NovaMart demo dataset](/getting-started
 </Cards>
 
 <Callout type="info" title="Generating the YAML">
-  Run `bun run atlas -- init` against any PostgreSQL or MySQL database to auto-generate entity files, glossary, metrics, and catalog from the schema. The profiler picks up types, samples real values, infers joins from foreign keys, and flags data-quality issues. See the [CLI reference](/reference/cli#init) for all flags.
+  Run `bun run atlas -- init` against any datasource Atlas can connect to — PostgreSQL and MySQL natively, plus plugin-managed types like BigQuery, Snowflake, ClickHouse, DuckDB, Elasticsearch/OpenSearch, and Salesforce — to auto-generate entity files, glossary, metrics, and catalog from the schema. The profiler picks up types, samples real values, infers joins from foreign keys, and flags data-quality issues. See the [CLI reference](/reference/cli#init) for all flags.
 </Callout>


### PR DESCRIPTION
## What

A four-domain docs accuracy audit (env/config, CLI/API, plugin/SDK/errors, guides/discovery) cross-referenced `apps/docs/content/docs/` against source, biased toward the last week's releases (v0.0.13–v0.0.16). Every finding below was **verified against code** before fixing; audit false positives were dropped (see *Left as findings*).

Docs-only change. `tsgo --noEmit -p apps/docs/tsconfig.json` passes. No API-reference/OpenAPI files touched, so no `generate:api` needed.

## Fixed

**Reference**
- **environment-variables.mdx** — added 9 undocumented vars read by code: `ATLAS_ES_*` (Elasticsearch/OpenSearch, v0.0.13), `ATLAS_DELIVERY_MAX_ROWS`, `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`, `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_HEADERS`, `ATLAS_PUBLIC_WEB_URL`, `ATLAS_COOKIE_PREFIX`, `NEXT_PUBLIC_ATLAS_COOKIE_PREFIX`. Fixed `ATLAS_RPID` default (derived from the web-origin host, not a hard `app.useatlas.dev`) and the `ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS` `auto` description (also triggers on `ATLAS_DEMO_INDUSTRY`).
- **config.mdx** — `residency.databaseUrl` is `.optional()` in the schema (Conditional), not `Required: Yes`.
- **cli.mdx** — `--demo` is PostgreSQL-only.
- **error-codes.mdx / sdk.mdx / react.mdx** — added `subscription_required` (403, non-retryable), present in `CHAT_ERROR_CODES` but undocumented everywhere.
- **react.mdx** — `AtlasChat` optional peer dep is `exceljs`, not `xlsx`.
- **.env.example** — `ATLAS_API_KEY_ROLE` valid values are `member/admin/owner` (was `viewer/analyst/admin`); code accepts the former.

**Plugins & datasources**
- **authoring-guide.mdx** — `plugin.types` (readonly array), not `plugin.type`; `$InferServerPlugin` key is `Types` → `readonly ["datasource"]`, not `Type`; added `beforeToolCall`/`afterToolCall` hooks and `metadata?` on query hook contexts; corrected the reference-plugin list/count (25, was a stale 21 that listed phantom `slack` and omitted `elasticsearch`/`twenty`/`webhook-action`/`obsidian-reader`).
- **plugins/sdk/mcp-tools.mdx** — `McpToolContext` carries `connectionId?`/`connectionGroupId?`.
- **datasource pages** (snowflake, bigquery, clickhouse, duckdb, salesforce) — documented universal profiling (wizard / `atlas init` / MCP `profile_datasource`), the v0.0.16 headline; none claimed pg/mysql-only, but all five were silent about it.

**Guides**
- **mcp.mdx** — `create_datasource` provisionable set excludes DuckDB (file-based) and Salesforce (OAuth-managed); added `create_rest_datasource` to the lifecycle tool list (8, not 7); documented the per-workspace **MCP action policy** kill-switch (v0.0.15).
- **billing-and-plans.mdx** — gateway-canonical model versions (`claude-haiku-4.5`/`claude-sonnet-4.6`); annual billing also covers Business.
- **semantic-layer/index.mdx** — `atlas init` profiles any connectable datasource, not just PostgreSQL/MySQL.

## Left as findings (not fixed)

- **`openapi.json` freshness** — the API/CLI audit recommends running `extract-openapi.ts` to confirm sync; spot-checks of all v0.0.13–16 routes were already in sync, and regenerating modifies a tracked artifact outside this docs pass.
- **`config.mdx` `overrideImplementationStatus`** — reportedly wired but inert until a UI consumer ships (#2747); left rather than guessing the exact status copy.
- **A few vague env-var defaults** (`ATLAS_MCP_RATE_LIMIT_MAX_KEYS`, `ATLAS_ORG_WHITELIST_TTL_MS`, `ATLAS_BYOT_CATALOG_TTL_MS`) — descriptions say "(… default)" where `.env.example` has explicit numbers; not wrong, just imprecise. LOW.

## Verified false positives (dropped)

- `ATLAS_EMAIL_FROM` — docs already correct (`noreply@ship.useatlas.dev`).
- `ATLAS_EMAIL_PROVIDER` — "primarily Admin, falls back to env" is the correct settings semantics.
- `ATLAS_API_KEY_ROLE` **in docs** — docs were right; `.env.example` was the stale side (fixed there).
- sdk.mdx `forbidden`/`not_found` — genuinely in `CHAT_ERROR_CODES`, not mislabeled.
- authoring-guide `^0.0.2` plugin-sdk pin — matches the canonical `create-atlas-plugin` scaffold.
- signup wizard "pg/mysql only" — accurate; the URL-paste step does only accept those schemes.

https://claude.ai/code/session_01QeXUWDsBkRiX3rgyHin5rD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeXUWDsBkRiX3rgyHin5rD)_