### PR TITLE
fix(prod-audit): observability + boot-guard + fail-closed hardening (v0.0.13–v0.0.16)

### DIFF
--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -991,6 +991,7 @@ Destructive operator-CLI subcommands gated by explicit env confirmation. None of
 | `ATLAS_DASHBOARD_DRAFTS_ENABLED` | `true` | Per-user dashboard drafts. When enabled, admin mutations to a bound dashboard write to the caller's draft and the **Publish** flow promotes them via an atomic three-way merge against the persisted baseline. Set to the literal string `false` to fall back to the direct-write model — draft fetch returns `503` and the chat-bound editor degrades to a read-only viewer. See [Dashboards → Chat as editor](/guides/dashboards#chat-as-editor) |
 | `ATLAS_INTERNAL_SCREENSHOT_COOKIE` | — | Service cookie value used by the `screenshotDashboard` vision tool (#2367). The headless Chromium worker calls back into `/admin/dashboards/:id/screenshot` and must authenticate as the requesting user; without this cookie the screenshot request is rejected and the agent falls back to its last-good description. Set this on **both** the API and web services when running behind a reverse proxy. See [Dashboards → Chat as editor](/guides/dashboards#chat-as-editor) |
 | `ATLAS_WEB_BASE_URL` | `http://localhost:3000` | Base URL of the Next.js web app used by `screenshotDashboard` to construct the screenshot target URL (`${ATLAS_WEB_BASE_URL}/dashboards/:id`). Set to the production web origin when self-hosting (e.g. `https://atlas.acme.com`) so the headless Chromium worker hits the right host |
+| `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS` | `60000` | Overall render timeout (ms) for the headless dashboard export/screenshot worker. Clamped to the range `5000`–`180000`; out-of-range or unparseable values fall back to the default. Raise it for dashboards with many heavy panels that exceed 60s to render |
 
 ---
 
@@ -1020,6 +1021,7 @@ The sub-processor publisher fetches Atlas's authoritative sub-processor list (th
 |----------|---------|-------------|
 | `ATLAS_LOG_LEVEL` | `info` | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry collector endpoint (e.g. `http://localhost:4318`). When set, the API server (`atlas-api`) and web frontend (`atlas`) emit distributed trace spans for HTTP requests, agent steps, SQL queries, and explore commands |
+| `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS` | `15000` | TTL (ms) for the cached plugin-liveness results that feed the `plugins` component of `/api/health`. Clamped to `0`–`300000`; out-of-range or unparseable values fall back to the default with a warning. `0` disables caching so every health hit re-probes each plugin upstream |
 
 See [Observability](/platform-ops/observability) for the full setup guide.
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -859,8 +859,10 @@ onboarding.openapi(
 
       // Skip re-registration if the in-memory pool already has this id —
       // concurrent onboarders would otherwise needlessly drain and recreate
-      // the pool. The DB-level race (different URLs racing to commit) is
-      // resolved by ON CONFLICT DO NOTHING above.
+      // the pool. The DB-level race (two onboarders racing to commit) is
+      // resolved by the `(workspace_id, catalog_id, install_id)` unique index
+      // backing the `ON CONFLICT DO UPDATE` above — last write wins on the same
+      // demo config, so no duplicate rows result.
       try {
         if (!connections.has(id)) {
           connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });

--- a/packages/api/src/lib/auth/__tests__/effective-role.test.ts
+++ b/packages/api/src/lib/auth/__tests__/effective-role.test.ts
@@ -92,13 +92,18 @@ describe("resolveEffectiveRole()", () => {
     expect(r).toBe("member");
   });
 
-  it("fails open to userRole on a DB error", async () => {
+  it("fails closed to undefined on a DB error (intrinsic, caller-independent)", async () => {
     // Non-platform role so resolution actually reaches the member-table
-    // lookup (platform_admin short-circuits before the try/catch).
+    // lookup (platform_admin short-circuits before the try/catch). The lookup
+    // was attempted and threw, so we don't know the tenant role → least
+    // privilege (`undefined`), regardless of the passed `userRole`.
     mockHasInternalDB = true;
     mockInternalQuery = () => { queryCalls++; return Promise.reject(new Error("connection lost")); };
-    const r = await resolveEffectiveRole("member", "usr_1", "org_1");
-    expect(r).toBe("member");
+    expect(await resolveEffectiveRole("member", "usr_1", "org_1")).toBeUndefined();
+    // Even a privileged userRole is NOT retained through a brownout — the
+    // fail-closed direction no longer depends on the caller passing a non-admin
+    // default.
+    expect(await resolveEffectiveRole("admin", "usr_1", "org_1")).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/auth/effective-role.ts
+++ b/packages/api/src/lib/auth/effective-role.ts
@@ -22,12 +22,13 @@
  *   2. `customSession` plugin — populates `session.user.effectiveRole` so
  *      the client (`useUserRole`) can hide/show admin chrome consistently.
  *
- * Returns the resolved role on success, `undefined` only when neither side
- * yields one. On a member-table lookup error it falls back to `userRole` —
- * the SAFE (fail-closed) direction: post-#2890 a non-platform user's
- * `userRole` is a non-admin default, so a transient DB blip down-privileges an
- * org admin (bounces them from the console) rather than over-granting.
- * Platform admins are unaffected — they short-circuit before the lookup.
+ * Returns the resolved role on success, `undefined` when neither side yields
+ * one. On a member-table lookup ERROR it returns `undefined` (least privilege)
+ * — the intrinsic fail-closed direction: a transient DB blip down-privileges an
+ * org admin (bounces them from the console) rather than over-granting, and does
+ * so regardless of what `userRole` the caller passed (no longer relying on it
+ * being a non-admin default). Platform admins are unaffected — they
+ * short-circuit before the lookup.
  */
 
 import type { AtlasRole } from "@atlas/api/lib/auth/types";
@@ -62,8 +63,16 @@ export async function resolveEffectiveRole(
     // is a real production signal, and it down-privileges an org admin.
     log.error(
       { err: err instanceof Error ? err.message : String(err), userId, orgId: activeOrganizationId },
-      "Failed to look up org member role — falling back to user-level role (org admins fail closed)",
+      "Failed to look up org member role — failing closed to least privilege (org admins down-privileged)",
     );
-    return userRole;
+    // Intrinsic fail-closed: the member lookup was ATTEMPTED (we have an active
+    // org) and threw, so we genuinely don't know the tenant role. Return
+    // `undefined` — least privilege downstream — rather than `userRole`. The
+    // old `return userRole` was only safe because every current caller passes a
+    // non-admin `userRole` here (platform_admin short-circuits at the top, the
+    // hosted MCP path forces `undefined`); making it `undefined` removes that
+    // caller-dependent invariant so a future caller passing a privileged
+    // `userRole` can't accidentally retain it through a DB brownout.
+    return undefined;
   }
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2182,6 +2182,16 @@ export function buildStripePluginOptions(deps: {
         }
 
         await recordStripeEvent(ledgerEvent, appliedTier);
+
+        // Observability: the skip path logged, but a SUCCESSFULLY-processed
+        // event (tier write applied + ledger recorded) was silent — so a
+        // tier-write storm or slow processing left no positive audit trail of
+        // which subscription events were actually applied. Log the applied
+        // disposition (no PII — ids + tier only).
+        billingLog.info(
+          { eventId: event.id, eventType: event.type, appliedTier: appliedTier ?? null },
+          "Processed Stripe webhook event",
+        );
       });
     },
   };

--- a/packages/api/src/lib/billing/agent-gate.ts
+++ b/packages/api/src/lib/billing/agent-gate.ts
@@ -43,6 +43,7 @@ import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
 import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import { checkPlanLimits, type PlanLimitWarning } from "./enforcement";
 import { createLogger } from "@atlas/api/lib/logger";
+import { withSpan } from "@atlas/api/lib/tracing";
 
 const log = createLogger("billing:agent-gate");
 
@@ -105,6 +106,23 @@ export class BillingBlockedError extends Error {
  * optional plan-limit warning (80–109% band) passed through.
  */
 export async function checkAgentBillingGate(
+  orgId: string | undefined,
+): Promise<AgentBillingGateResult> {
+  // Span the composed enforcement seam so its three DB-touching checks are
+  // attributable on the hot path (a slow checkWorkspaceStatus / checkPlanLimits
+  // lookup was previously invisible in traces). Zero overhead when OTel is off.
+  return withSpan(
+    "billing.agent_gate",
+    { "atlas.org_id": orgId ?? "none" },
+    () => runAgentBillingGate(orgId),
+    (result) => ({
+      "atlas.billing.allowed": result.allowed,
+      ...(result.allowed ? {} : { "atlas.billing.error_code": result.errorCode }),
+    }),
+  );
+}
+
+async function runAgentBillingGate(
   orgId: string | undefined,
 ): Promise<AgentBillingGateResult> {
   // 1. Workspace status — suspended / deleted / lookup failure.

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -212,6 +212,11 @@ export async function checkPlanLimits(
   // entitlements even with its own keys configured — resubscribing is the
   // only way back in.
   if (tier === "locked") {
+    // Defense-in-depth breadcrumb: every current caller logs the block at the
+    // seam, but logging the decision here too means a future caller can't
+    // accidentally make a billing-block invisible (parity with the token
+    // hard-limit log in evaluateUsage).
+    log.warn({ orgId, tier, reason: "subscription_required" }, "Plan enforcement blocked request — workspace locked (subscription ended)");
     return {
       allowed: false,
       errorCode: "subscription_required",
@@ -230,6 +235,7 @@ export async function checkPlanLimits(
   if (tier === "trial") {
     const trialExpired = isTrialExpired(workspace);
     if (trialExpired) {
+      log.warn({ orgId, tier, reason: "trial_expired" }, "Plan enforcement blocked request — trial expired");
       return {
         allowed: false,
         errorCode: "trial_expired",

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -56,6 +56,7 @@ import {
 import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
 import type { DatabaseObject, ProfilingResult } from "@useatlas/types";
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import { getInstallHandler } from "@atlas/api/lib/integrations/install/dispatch";
 import { FormInstallValidationError } from "@atlas/api/lib/integrations/install/persist-form-install";
@@ -81,6 +82,8 @@ import {
 } from "@atlas/api/lib/effect/semantic-generator";
 import { ProfilingFailedError, IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
+
+const log = createLogger("datasources:mcp-lifecycle");
 
 // Module-level synchronous content-mode registry — mirrors the one in
 // `api/routes/admin-connections.ts`. `readFilter` is a pure function of the
@@ -951,6 +954,18 @@ export async function resolveLiveConnection(
   const row = rows[0];
 
   const schema = parseConfigSchema(row.config_schema);
+  if (schema.state === "corrupt") {
+    // Breadcrumb only — `decryptSecretFields` fails closed on a corrupt schema
+    // (it attempts to decrypt every string value), so profiling can still
+    // proceed, but a malformed `config_schema` (DB drift / SDK skew / manual
+    // ops edit) is the kind of silent root cause that makes a profile-over-MCP
+    // outage undiagnosable. Mirror the breadcrumb `loadProvisionConfigFields`
+    // emits on the write path. No credential material is logged.
+    log.error(
+      { orgId, installId, catalogSlug: row.catalog_slug, reason: schema.reason },
+      "resolveLiveConnection: catalog config_schema is corrupt — credential field mapping is degraded",
+    );
+  }
   const decrypted = decryptSecretFields(row.config ?? {}, schema);
   const connectionGroupId = row.group_id && row.group_id.length > 0 ? row.group_id : null;
   const poolConfig = resolveDatasourcePoolConfig(

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -1542,6 +1542,7 @@ describe("ChatAdapterEnvGuardLive", () => {
 // `withCleanEnv` doesn't manage them. Save/clear/restore them here.
 const BILLING_ENV_KEYS = [
   "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
   "STRIPE_STARTER_PRICE_ID",
   "STRIPE_PRO_PRICE_ID",
   "STRIPE_BUSINESS_PRICE_ID",
@@ -1625,6 +1626,26 @@ describe("BillingConfigGuardLive", () => {
     );
   });
 
+  test("fails boot in SaaS when STRIPE_WEBHOOK_SECRET is missing", async () => {
+    // Secret key + all prices valid, but no webhook secret. Without this the
+    // @better-auth/stripe plugin silently declines to mount (auth/server.ts
+    // logs + continues), so the region boots green with billing dead.
+    await withBillingEnv(
+      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      async () => {
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(BillingConfigInvalidError);
+        const e = failure as TBillingConfigInvalidError;
+        expect(e.message).toContain("STRIPE_WEBHOOK_SECRET");
+        // The price/key checks pass — only the webhook-secret gap fires.
+        expect(e.missingPriceIdEnvVars).toEqual([]);
+        expect(e.keyMode).toBe("test");
+      },
+    );
+  });
+
   test("fails boot in SaaS on a non-standard secret-key mode", async () => {
     await withBillingEnv(
       { STRIPE_SECRET_KEY: "rk_live_restricted", ...ALL_PRICES },
@@ -1655,7 +1676,7 @@ describe("BillingConfigGuardLive", () => {
 
   test("boots (warn-only) when all prices resolve consistently with the key mode", async () => {
     await withBillingEnv(
-      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      { STRIPE_SECRET_KEY: "sk_test_abc", STRIPE_WEBHOOK_SECRET: "whsec_test", ...ALL_PRICES },
       async () => {
         // All three prices are test-mode (livemode false) — consistent with sk_test_.
         mockStripePrices = {
@@ -1671,7 +1692,7 @@ describe("BillingConfigGuardLive", () => {
 
   test("does NOT fail boot when a configured price can't be resolved (warn, not crash)", async () => {
     await withBillingEnv(
-      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      { STRIPE_SECRET_KEY: "sk_test_abc", STRIPE_WEBHOOK_SECRET: "whsec_test", ...ALL_PRICES },
       async () => {
         // price_pro absent from the mock → "No such price" → unresolved warn path.
         mockStripePrices = {
@@ -1686,7 +1707,7 @@ describe("BillingConfigGuardLive", () => {
 
   test("does NOT fail boot on a livemode↔key-mode mismatch (warn, not crash)", async () => {
     await withBillingEnv(
-      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      { STRIPE_SECRET_KEY: "sk_test_abc", STRIPE_WEBHOOK_SECRET: "whsec_test", ...ALL_PRICES },
       async () => {
         // A live-mode price configured under a test key — the classic mixup.
         mockStripePrices = {
@@ -1702,7 +1723,7 @@ describe("BillingConfigGuardLive", () => {
 
   test("does NOT fail boot when getStripeClient() returns null", async () => {
     await withBillingEnv(
-      { STRIPE_SECRET_KEY: "sk_test_abc", ...ALL_PRICES },
+      { STRIPE_SECRET_KEY: "sk_test_abc", STRIPE_WEBHOOK_SECRET: "whsec_test", ...ALL_PRICES },
       async () => {
         mockStripeClientNull = true;
         const exit = await runBillingGuard("saas");

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -1161,6 +1161,15 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
     const secretKey = process.env.STRIPE_SECRET_KEY;
     if (!secretKey) return;
 
+    // Once Stripe IS configured (secret key present), the webhook secret is
+    // mandatory: `auth/server.ts` only LOGS and then silently declines to mount
+    // the @better-auth/stripe plugin when STRIPE_WEBHOOK_SECRET is absent, so a
+    // region boots green with checkout + plan-sync dead. This is the exact
+    // silent-billing-outage class this guard exists to convert into a boot
+    // failure — keep it in the pure fail-fast block below.
+    const webhookSecretMissing =
+      !process.env.STRIPE_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET.length === 0;
+
     const {
       findMissingMonthlyPriceIdEnvVars,
       detectStripeKeyMode,
@@ -1179,12 +1188,19 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
     // ── Pure check 2: secret-key mode shape (fail-fast) ──────────────────
     // Collected with the price-ID result so a region missing both gets one
     // boot-failure log naming both, rather than fixing one then re-failing.
-    if (missingPriceIdEnvVars.length > 0 || keyMode === "unknown") {
+    if (missingPriceIdEnvVars.length > 0 || keyMode === "unknown" || webhookSecretMissing) {
       const parts: string[] = [];
       if (missingPriceIdEnvVars.length > 0) {
         parts.push(
           `missing required monthly price ID env var(s): [${missingPriceIdEnvVars.join(", ")}] — ` +
             `getStripePlans() silently omits each absent tier from checkout`,
+        );
+      }
+      if (webhookSecretMissing) {
+        parts.push(
+          `STRIPE_WEBHOOK_SECRET is unset — the @better-auth/stripe plugin declines to mount ` +
+            `(auth/server.ts logs and continues), so checkout, the billing portal, and webhook ` +
+            `plan-sync are all dead while the region boots green`,
         );
       }
       if (keyMode === "unknown") {

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -495,6 +495,7 @@ export async function profilePostgres({
         let null_count: number | null = null;
         let sample_values: string[] = [];
         let isEnumLike = false;
+        const colNotes: string[] = [];
 
         const isPK = primaryKeyColumns.includes(col.column_name);
         const fkInfo = fkLookup.get(col.column_name);
@@ -532,6 +533,10 @@ export async function profilePostgres({
           } catch (colErr) {
             if (isFatalConnectionError(colErr)) throw colErr;
             log.warn({ err: colErr instanceof Error ? colErr.message : String(colErr), table: table_name, column: col.column_name }, "Could not profile column");
+            // Mark the degraded column so a missing stats/samples set reads as
+            // "introspection failed" rather than a genuinely empty column —
+            // matches the plugin-profiler discipline restored in #3676.
+            colNotes.push("Column statistics unavailable (introspection query failed).");
           }
         }
 
@@ -547,7 +552,7 @@ export async function profilePostgres({
           fk_target_table: fkInfo?.to_table ?? null,
           fk_target_column: fkInfo?.to_column ?? null,
           is_enum_like: isEnumLike,
-          profiler_notes: [],
+          profiler_notes: colNotes,
         });
       }
 
@@ -781,6 +786,7 @@ export async function profileMySQL({
           let null_count: number | null = null;
           let sample_values: string[] = [];
           let isEnumLike = false;
+          const colNotes: string[] = [];
 
           const isPK = primaryKeyColumns.includes(col.COLUMN_NAME);
           const fkInfo = fkLookup.get(col.COLUMN_NAME);
@@ -822,6 +828,10 @@ export async function profileMySQL({
           } catch (colErr) {
             if (isFatalConnectionError(colErr)) throw colErr;
             log.warn({ err: colErr instanceof Error ? colErr.message : String(colErr), table: table_name, column: col.COLUMN_NAME }, "Could not profile column");
+            // Mark the degraded column so a missing stats/samples set reads as
+            // "introspection failed" rather than a genuinely empty column —
+            // matches the plugin-profiler discipline restored in #3676.
+            colNotes.push("Column statistics unavailable (introspection query failed).");
           }
 
           columns.push({
@@ -836,7 +846,7 @@ export async function profileMySQL({
             fk_target_table: fkInfo?.to_table ?? null,
             fk_target_column: fkInfo?.to_column ?? null,
             is_enum_like: isEnumLike,
-            profiler_notes: [],
+            profiler_notes: colNotes,
           });
         }
 

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -488,6 +488,17 @@ async function checkConfigFile(errors: DiagnosticError[]): Promise<void> {
     if (typeof configMod.loadConfig === "function" && !configMod.getConfig()) {
       await configMod.loadConfig();
     }
+    // #3184 follow-up: a config-file `deployMode: "saas"` that silently
+    // downgraded to self-hosted (enterprise off) previously surfaced ONLY as a
+    // CRITICAL log + a `/health` flag — not in the diagnostics warnings array
+    // that the startup surface aggregates. Mirror the other startup warnings so
+    // an operator paging on `getStartupWarnings()` sees the downgrade reason
+    // alongside the rest. (The env-var path fails boot via EnterpriseGuardLive.)
+    const downgrade = configMod.getConfig()?.deployModeDowngraded;
+    if (downgrade) {
+      const msg = `Deploy-mode downgrade: ${downgrade.reason}`;
+      if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
+    }
   } catch (err) {
     const detail = errorMessage(err);
     log.error({ err: detail }, "Config validation failed");

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -886,6 +886,12 @@ export function registerDatasourceTools(
             metrics_generated: r.metrics.length,
             tables,
             profiling_errors: r.errors.length,
+            // Honest partial-success signal: some tables failed introspection
+            // but stayed under the fatal threshold, so the layer persisted with
+            // those tables ABSENT. `profiling_errors` alone reads as a side
+            // note next to an unconditional success; `incomplete` makes the
+            // degraded layer unmissable to the MCP client before it publishes.
+            incomplete: r.errors.length > 0,
             elapsed_ms: r.elapsedMs,
           });
         },

--- a/packages/mcp/src/dispatch-gate.ts
+++ b/packages/mcp/src/dispatch-gate.ts
@@ -169,7 +169,20 @@ export async function runMcpDispatchGate(
   // ── Gate 2: mcp:write scope (hosted only; stdio exempt via clientId) ──
   if (reqs.requiresWrite) {
     const scopeBlock = writeScopeOrNull({ clientId: ctx.clientId, scopes: ctx.scopes });
-    if (scopeBlock) return scopeBlock;
+    if (scopeBlock) {
+      // Observability parity with gates 1/3/4: a write-scope denial is a
+      // security decision on the v0.0.15 spine and must leave a server-side
+      // breadcrumb (probing / mis-scoped client), not a silent fail-closed.
+      log.warn(
+        {
+          toolName: reqs.toolName,
+          ...(ctx.clientId ? { clientId: ctx.clientId } : {}),
+          ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
+        },
+        "MCP tool denied at gate 2 — missing mcp:write scope",
+      );
+      return scopeBlock;
+    }
   }
 
   // ── Gate 3: RBAC role on the bound actor (live-resolved, #3505/#3569) ──


### PR DESCRIPTION
## Summary

Production-readiness audit of the last week's releases (**v0.0.13 Billing Webhooks + BYOC**, **v0.0.14 Enforcement Perimeter**, **v0.0.15 MCP V2 security spine**, **v0.0.16 Profiler Seam**), with the actionable code findings fixed here. Six parallel audit agents swept observability, graceful degradation, config/boot guards, and migration/live-surface.

**No CRITICAL findings.** Every security gate (MCP spine, billing enforcement, auth-on-internal-DB-outage, health 503, sandbox/BYOC) verified **fail-closed**; zero missing-`requestId`-on-500 and zero empty `catch` blocks; the billing/MCP migration batch (0126–0136) is additive-only and fully schema-mirrored. The gaps were observability blind spots, the profiler fail-open seam, and a silent billing-config boot hole.

## Fixed in this PR

**Boot guards (config hygiene)**
- `BillingConfigGuardLive` now **fails boot** when `STRIPE_SECRET_KEY` is set but `STRIPE_WEBHOOK_SECRET` is missing — `auth/server.ts` only logged and then silently declined to mount the `@better-auth/stripe` plugin, so a SaaS region booted green with checkout + plan-sync dead (`saas-guards.ts`).
- Config-file `deployMode:"saas"` → self-hosted downgrade now surfaces in `getStartupWarnings()`, not just a CRITICAL log + `/health` flag (`startup.ts`).

**Fail-closed / corrupt-state**
- `effective-role`: a member-lookup DB error now returns `undefined` (least privilege) **intrinsically**, instead of depending on the caller passing a non-admin `userRole` — removes a latent privilege-retention footgun during a DB brownout.
- `resolveLiveConnection` logs a credential-free breadcrumb when a catalog `config_schema` is corrupt, making a profile-over-MCP outage diagnosable (the decrypt path already fails closed).

**Structured logs / spans (security + billing decisions)**
- MCP dispatch **gate 2 (`mcp:write`) denial now logs**, matching gates 1/3/4 (was the one silent gate).
- `enforcement` `locked`/`trial` blocks log in-file (defense-in-depth breadcrumb).
- Stripe webhook `onEvent` logs a positive "processed" line (success path was silent).
- The v0.0.14 enforcement seam (`checkAgentBillingGate`) is now wrapped in an OTel span.

**Profiler honesty (completes #3676's intent for the core engine)**
- Core pg/mysql profiler per-column stat failures push a credential-free `"Column statistics unavailable"` `profiler_note` instead of a silent `[]`. #3676 only patched the 6 *plugin* profilers — `packages/api/src/lib/profiler.ts` still hardcoded `profiler_notes: []`.
- MCP `profile_datasource` success now carries `incomplete: true` when tables failed introspection.

**Docs**
- Documented `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS` and `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`; corrected a stale `ON CONFLICT` comment in `/use-demo`.

## Filed as follow-up issues (larger refactor / migration / infra — not auto-changed)

| Issue | Finding | Why deferred |
|---|---|---|
| #3679 | Stripe teardown strands a live subscription on a deleted/purged workspace | Needs a new `stripe_teardown_pending` table + reconciliation sweep (migration) |
| #3680 | Dunning emails bypass the durable `email_outbox` | Dedup-timing refactor |
| #3681 | Plugin catalog/marketplace/datasource uninstall orphans state | Teardown refactor across 3 entry points |
| #3682 | Profiler sub-20% partial profile persists as complete | Durable partial-marker through persistence (product decision) |
| #3683 | `/use-demo` non-atomic + concurrent deadlock | Transaction/advisory-lock change |
| #3684 | Missing OTel spans (profiler seam, Stripe webhook) | Observability follow-on |
| #3685 | US `/api/health` enumerates the full fleet to anonymous callers | Health-endpoint reshape (uptime-monitor risk) |
| #3686 | Migration 0133 single-phase rename must become expand-contract before v0.1.0 | Pre-customer clean-break; expires at launch |
| #3687 | Ops verifications (EU/APAC scheduler, MCP-spine boot guard, prod-floor warnings) | Operator decisions / live config |

## Test plan
- [x] `bun run lint` — 0 errors/warnings
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite, 33 packages, 0 failures
- [x] syncpack + all drift/discipline gates (template, security-headers, railway-watch, schema-drift, openapi-drift, oauth-helper, test-discipline, twenty-resolver, settings-readers, published-symbols) — pass
- [x] New test: `BillingConfigGuardLive` fails boot when `STRIPE_WEBHOOK_SECRET` is missing
- [x] Updated test: `effective-role` DB-error now intrinsically fails closed (caller-independent)

No `Closes #N` — this PR fixes the directly-actionable findings; #3679–#3687 are deferred follow-up work, not resolved here.

https://claude.ai/code/session_01Bo5NQDZvgegyZKJmNVbico

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo5NQDZvgegyZKJmNVbico)_