### PR TITLE
chore: sync bun.lock plugin-sdk version to 0.0.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -315,7 +315,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@useatlas/plugin-sdk",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "devDependencies": {
         "ai": "^6.0.193",
         "hono": "^4.12.23",


### PR DESCRIPTION
The committed `bun.lock` still recorded `@useatlas/plugin-sdk` at `0.0.13`, but `packages/plugin-sdk/package.json` (and the `plugin-sdk-v0.0.14` tag) are at `0.0.14`. `bun install` corrects the drift.

Cosmetic — bun resolves workspace packages from the on-disk `package.json`, not this lockfile version field (which is why main CI is green despite the drift). The value is removing a recurring papercut: every fresh `bun install` / `/reset` re-dirties `bun.lock` until main records `0.0.14`.

One-line change, provably correct against the published tag.

https://claude.ai/code/session_01MKeShsJmvgLm3i7mP73jpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKeShsJmvgLm3i7mP73jpo)_