### PR TITLE
fix(learn): scope learned patterns to org + connection group (#3610, #3611)

### DIFF
--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -2357,10 +2357,16 @@ authed.openapi(suggestCardsRoute, async (c) => {
       return Effect.succeed("");
     }));
 
-    // Optionally load learned patterns for extra context
+    // Optionally load learned patterns for extra context. Scope to the
+    // dashboard's connection group (#3611) — dashboards are group-scoped
+    // (migration 0066) and cards share a group, so use the first card's group.
+    // Without this the suggestion path would only ever see default-scope
+    // (connection_group_id IS NULL) patterns once getApprovedPatterns filters
+    // by group.
+    const dashboardGroupId = dash.data.cards[0]?.connectionGroupId ?? null;
     const { buildLearnedPatternsSection } = yield* Effect.promise(() => import("@atlas/api/lib/learn/pattern-cache"));
     const patternsSection = yield* Effect.tryPromise({
-      try: () => buildLearnedPatternsSection(orgId ?? null, "dashboard suggestions"),
+      try: () => buildLearnedPatternsSection(orgId ?? null, "dashboard suggestions", dashboardGroupId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
     }).pipe(Effect.catchAll((err) => {
       log.warn({ err: err.message, orgId, dashboardId: id }, "Failed to load learned patterns for suggestions — proceeding without patterns");

--- a/packages/api/src/lib/__tests__/pattern-injection.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-injection.test.ts
@@ -17,6 +17,12 @@ let mockConfigLearn: { confidenceThreshold: number } | undefined = {
 
 let mockGetApprovedPatternsError: Error | null = null;
 
+// #3611 — record retrieval calls + allow per-group result sets so tests can
+// assert that each connection group sees only its own patterns and that the
+// active group is threaded all the way to the DB layer.
+let getApprovedPatternsCalls: Array<{ orgId: string | null; connectionGroupId: string | null | undefined }> = [];
+let mockPatternsByGroup: Map<string | null, typeof mockApprovedPatterns> | null = null;
+
 // --- Mocks (all named exports) ---
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -34,8 +40,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   encryptSecret: (v: string) => v,
   decryptSecret: (v: string) => v,
   isPlaintextUrl: () => true,
-  getApprovedPatterns: async () => {
+  getApprovedPatterns: async (orgId: string | null, connectionGroupId?: string | null) => {
+    getApprovedPatternsCalls.push({ orgId, connectionGroupId });
     if (mockGetApprovedPatternsError) throw mockGetApprovedPatternsError;
+    if (mockPatternsByGroup) return mockPatternsByGroup.get(connectionGroupId ?? null) ?? [];
     return mockApprovedPatterns;
   },
   upsertSuggestion: mock(() => Promise.resolve("created")),
@@ -198,7 +206,7 @@ describe("getRelevantPatterns", () => {
       confidence: 0.9,
     }));
 
-    const results = await getRelevantPatterns(null, "Show me revenue", 5);
+    const results = await getRelevantPatterns(null, "Show me revenue", null, 5);
     expect(results.length).toBe(5);
   });
 
@@ -418,6 +426,98 @@ describe("pattern cache invalidation", () => {
     // Next call should succeed — failure was NOT cached
     const afterFix = await getRelevantPatterns(null, "What is the revenue?");
     expect(afterFix.length).toBe(1);
+  });
+});
+
+describe("connection-group scoping (#3611)", () => {
+  beforeEach(() => {
+    _resetPatternCache();
+    mockApprovedPatterns = [];
+    mockPatternsByGroup = null;
+    getApprovedPatternsCalls = [];
+    mockConfigLearn = { confidenceThreshold: 0.7 };
+    mockGetApprovedPatternsError = null;
+  });
+
+  test("threads the active connection group through to the DB layer", async () => {
+    await getRelevantPatterns("org-1", "What is the revenue?", "us-prod");
+
+    expect(getApprovedPatternsCalls).toHaveLength(1);
+    expect(getApprovedPatternsCalls[0]).toEqual({ orgId: "org-1", connectionGroupId: "us-prod" });
+  });
+
+  test("each agent session sees only its own group's patterns", async () => {
+    // Same org, two groups, disjoint pattern libraries.
+    mockPatternsByGroup = new Map([
+      [
+        "us-prod",
+        [
+          {
+            id: "us-1",
+            org_id: "org-1",
+            pattern_sql: "SELECT SUM(revenue) FROM us_companies",
+            description: "US revenue",
+            source_entity: "us_companies",
+            confidence: 0.9,
+          },
+        ],
+      ],
+      [
+        "eu-prod",
+        [
+          {
+            id: "eu-1",
+            org_id: "org-1",
+            pattern_sql: "SELECT SUM(revenue) FROM eu_companies",
+            description: "EU revenue",
+            source_entity: "eu_companies",
+            confidence: 0.9,
+          },
+        ],
+      ],
+    ]);
+
+    const us = await getRelevantPatterns("org-1", "What is the revenue?", "us-prod");
+    const eu = await getRelevantPatterns("org-1", "What is the revenue?", "eu-prod");
+
+    expect(us.map((p) => p.patternSql)).toEqual(["SELECT SUM(revenue) FROM us_companies"]);
+    expect(eu.map((p) => p.patternSql)).toEqual(["SELECT SUM(revenue) FROM eu_companies"]);
+    // No cross-group bleed: the us-prod session never sees the eu pattern.
+    expect(us.some((p) => p.patternSql.includes("eu_companies"))).toBe(false);
+  });
+
+  test("cache is partitioned per group — distinct groups each hit the DB", async () => {
+    mockPatternsByGroup = new Map([
+      ["us-prod", []],
+      ["eu-prod", []],
+    ]);
+
+    await getRelevantPatterns("org-1", "revenue", "us-prod");
+    await getRelevantPatterns("org-1", "revenue", "us-prod"); // cached — no new DB call
+    await getRelevantPatterns("org-1", "revenue", "eu-prod"); // different group — DB call
+
+    const groupsFetched = getApprovedPatternsCalls.map((c) => c.connectionGroupId);
+    expect(groupsFetched).toEqual(["us-prod", "eu-prod"]);
+  });
+
+  test("org-scoped invalidation clears every group entry for that org", async () => {
+    mockPatternsByGroup = new Map([
+      ["us-prod", [{ id: "u", org_id: "org-1", pattern_sql: "SELECT revenue FROM t", description: "d", source_entity: "t", confidence: 0.9 }]],
+      ["eu-prod", [{ id: "e", org_id: "org-1", pattern_sql: "SELECT revenue FROM t", description: "d", source_entity: "t", confidence: 0.9 }]],
+    ]);
+
+    // Warm both group caches for org-1.
+    await getRelevantPatterns("org-1", "revenue", "us-prod");
+    await getRelevantPatterns("org-1", "revenue", "eu-prod");
+    const callsAfterWarm = getApprovedPatternsCalls.length;
+
+    // Admin approve/reject invalidates at org granularity (no group known).
+    invalidatePatternCache("org-1");
+
+    // Both groups must re-fetch — neither served a stale cache entry.
+    await getRelevantPatterns("org-1", "revenue", "us-prod");
+    await getRelevantPatterns("org-1", "revenue", "eu-prod");
+    expect(getApprovedPatternsCalls.length).toBe(callsAfterWarm + 2);
   });
 });
 

--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -50,6 +50,8 @@ const defaultInput: PatternProposalInput = {
   sql: "SELECT name, email FROM users WHERE status = 'active' ORDER BY created_at DESC",
   dialect: "PostgresQL",
   connectionId: "default",
+  orgId: undefined,
+  connectionGroupId: undefined,
 };
 
 // ---------------------------------------------------------------------------
@@ -126,16 +128,12 @@ describe("pattern-proposer", () => {
 
   // ── Org-scoping ────────────────────────────────────────────────────
 
-  test("uses orgId from request context when available", async () => {
+  test("uses orgId from the explicit input param, not ALS (#3610)", async () => {
     setResults({ rows: [] });
 
-    const user = createAtlasUser("user-1", "simple-key", "Test User", {
-      activeOrganizationId: "org-456",
-    });
-
-    await withRequestContext({ requestId: "test-req", user }, async () => {
-      await _analyzeAndPropose(defaultInput);
-    });
+    // orgId is threaded explicitly — captured synchronously at the sql.ts call
+    // site. _analyzeAndPropose must NOT read ALS.
+    await _analyzeAndPropose({ ...defaultInput, orgId: "org-456" });
 
     // findPatternBySQL should use org_id = $2
     const selectCall = queryCalls[0];
@@ -148,14 +146,86 @@ describe("pattern-proposer", () => {
     expect(insertCall!.params?.[0]).toBe("org-456");
   });
 
-  test("uses org_id IS NULL when no org context", async () => {
+  test("ignores ALS request context entirely — only the input orgId is used (#3610)", async () => {
     setResults({ rows: [] });
 
-    // No withRequestContext → getRequestContext() returns undefined
-    await _analyzeAndPropose(defaultInput);
+    // A live request context with a DIFFERENT org must NOT influence the
+    // proposal: the detached path is decoupled from ALS. The input orgId wins.
+    const user = createAtlasUser("user-1", "simple-key", "Test User", {
+      activeOrganizationId: "als-org-should-be-ignored",
+    });
+
+    await withRequestContext({ requestId: "test-req", user }, async () => {
+      await _analyzeAndPropose({ ...defaultInput, orgId: "org-from-input" });
+    });
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.params?.[0]).toBe("org-from-input");
+  });
+
+  test("uses org_id IS NULL when input orgId is undefined", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose({ ...defaultInput, orgId: undefined });
 
     const selectCall = queryCalls[0];
     expect(selectCall.sql).toContain("org_id IS NULL");
+  });
+
+  // ── Connection-group scoping (#3611) ───────────────────────────────
+
+  test("scopes lookup + insert to the connection group", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose({
+      ...defaultInput,
+      orgId: "org-1",
+      connectionGroupId: "us-prod",
+    });
+
+    // findPatternBySQL uniqueness is (org_id, connection_group_id, sql)
+    const selectCall = queryCalls[0];
+    expect(selectCall.sql).toContain("org_id = $2");
+    expect(selectCall.sql).toContain("connection_group_id = $3");
+    expect(selectCall.params).toContain("us-prod");
+
+    // INSERT stores connection_group_id (last positional param)
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.sql).toContain("connection_group_id");
+    expect(insertCall!.params?.[6]).toBe("us-prod");
+  });
+
+  test("connection_group_id IS NULL when group is undefined (default scope)", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose({ ...defaultInput, orgId: "org-1", connectionGroupId: undefined });
+
+    const selectCall = queryCalls[0];
+    expect(selectCall.sql).toContain("connection_group_id IS NULL");
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall!.params?.[6]).toBeNull();
+  });
+
+  test("two groups with identical SQL produce two independent rows (#3611)", async () => {
+    // Each group's findPatternBySQL is scoped to its own group, so neither
+    // finds the other → both insert. Four pool.query calls: SELECT_A, INSERT_A,
+    // SELECT_B, INSERT_B (internalExecute also goes through the mock pool).
+    setResults({ rows: [] }, { rows: [] }, { rows: [] }, { rows: [] });
+
+    const sameSql = { ...defaultInput, orgId: "org-1" };
+    await _analyzeAndPropose({ ...sameSql, connectionGroupId: "group-a" });
+    await _analyzeAndPropose({ ...sameSql, connectionGroupId: "group-b" });
+
+    const inserts = queryCalls.filter((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].params?.[6]).toBe("group-a");
+    expect(inserts[1].params?.[6]).toBe("group-b");
+    // Both rows belong to the same org but are distinct per group.
+    expect(inserts[0].params?.[0]).toBe("org-1");
+    expect(inserts[1].params?.[0]).toBe("org-1");
   });
 
   // ── Fire-and-forget safety ─────────────────────────────────────────
@@ -175,6 +245,8 @@ describe("pattern-proposer", () => {
       sql: "SELECT 1",
       dialect: "PostgresQL",
       connectionId: "default",
+      orgId: undefined,
+      connectionGroupId: undefined,
     };
 
     await _analyzeAndPropose(shortInput);
@@ -192,6 +264,8 @@ describe("pattern-proposer", () => {
       sql: "SELECT status, COUNT(*) FROM orders GROUP BY status",
       dialect: "PostgresQL",
       connectionId: "warehouse",
+      orgId: undefined,
+      connectionGroupId: undefined,
     };
 
     await _analyzeAndPropose(input);
@@ -246,6 +320,26 @@ describe("pattern-proposer", () => {
     expect(queryCalls.length).toBe(0);
   });
 
+  test("fire-and-forget insert carries the captured org_id with no ALS context (#3610)", async () => {
+    setResults({ rows: [] });
+
+    // Simulate the real call path: org captured synchronously at the call site,
+    // then the proposal runs detached with NO live request context (ALS already
+    // unwound). The pre-fix code read ALS inside the detached promise → NULL.
+    proposePatternIfNovel({ ...defaultInput, orgId: "org-tenant-a", connectionGroupId: "us-prod" });
+
+    // Let the detached fire-and-forget promise settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    // org_id is the captured tenant, NOT null — no cross-org leak.
+    expect(insertCall!.params?.[0]).toBe("org-tenant-a");
+    expect(insertCall!.params?.[0]).not.toBeNull();
+    // connection_group_id is preserved through the detached path too.
+    expect(insertCall!.params?.[6]).toBe("us-prod");
+  });
+
   test("proposePatternIfNovel swallows errors without throwing", async () => {
     queryThrow = new Error("DB connection exploded");
 
@@ -273,6 +367,8 @@ describe("pattern-proposer", () => {
       sql: "SELECT plan, SUM(monthly_value) AS total_mrr, COUNT(*) AS account_count FROM accounts WHERE status = 'Premium' GROUP BY plan ORDER BY total_mrr DESC",
       dialect: "PostgresQL",
       connectionId: "default",
+      orgId: undefined,
+      connectionGroupId: undefined,
     };
 
     await _analyzeAndPropose(input);

--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { _resetPool, type InternalPool } from "../db/internal";
-import { withRequestContext } from "../logger";
+import { withRequestContext, getRequestContext } from "../logger";
 import { createAtlasUser } from "../auth/types";
 import { _resetYamlPatternCache, _setYamlPatternCache, normalizeSQL } from "../learn/pattern-analyzer";
 import { _analyzeAndPropose, proposePatternIfNovel, type PatternProposalInput } from "../learn/pattern-proposer";
@@ -144,6 +144,32 @@ describe("pattern-proposer", () => {
     const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
     expect(insertCall).toBeDefined();
     expect(insertCall!.params?.[0]).toBe("org-456");
+  });
+
+  test("captured org survives after the ALS context has unwound (#3610)", async () => {
+    setResults({ rows: [] });
+
+    // Reproduce the real timing: the sql.ts call site captures orgId
+    // synchronously WHILE the request context is live, then the detached
+    // proposal runs AFTER that context has exited. The pre-fix code read ALS
+    // inside the detached promise → undefined → org_id = NULL.
+    let capturedOrgId: string | undefined;
+    const user = createAtlasUser("user-1", "simple-key", "Test User", {
+      activeOrganizationId: "org-live-then-gone",
+    });
+    await withRequestContext({ requestId: "req-1", user }, async () => {
+      capturedOrgId = getRequestContext()?.user?.activeOrganizationId;
+    });
+
+    // Context is now unwound — assert it really is gone before proceeding.
+    expect(getRequestContext()).toBeFalsy();
+
+    await _analyzeAndPropose({ ...defaultInput, orgId: capturedOrgId });
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.params?.[0]).toBe("org-live-then-gone");
+    expect(insertCall!.params?.[0]).not.toBeNull();
   });
 
   test("ignores ALS request context entirely — only the input orgId is used (#3610)", async () => {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -949,7 +949,13 @@ export async function runAgent({
                 .map((p) => p.text)
                 .join(" ") ?? "";
               if (!question) return undefined;
-              const section = await buildLearnedPatternsSection(orgId ?? null, question);
+              // #3611 — scope retrieval to the active connection group so a
+              // `us-prod` session is never primed with `eu-prod`'s patterns.
+              const section = await buildLearnedPatternsSection(
+                orgId ?? null,
+                question,
+                connectionGroupId ?? null,
+              );
               return section || undefined;
             },
             catch: normalizeError,

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1193,11 +1193,13 @@ function isPgError(err: unknown): err is Error & { code: string } {
  * Find a learned pattern by exact normalized SQL match, scoped to the given
  * org AND connection group.
  *
- * Uniqueness is `(org_id, connection_group_id, normalised_sql)` (#3611): the
- * SAME normalised SQL learned against a different connection group (e.g.
- * `us-prod` vs `eu-prod`) is a DISTINCT pattern — different schema, different
- * tables, potentially different dialect — so it must not collide. A NULL group
- * (the default flat `entities/` scope) is matched with `IS NULL`, not `=`.
+ * The dedup key is `(org_id, connection_group_id, normalised_sql)` (#3611) —
+ * enforced application-side here (read-then-insert in `_analyzeAndPropose`),
+ * NOT by a DB unique constraint. The SAME normalised SQL learned against a
+ * different connection group (e.g. `us-prod` vs `eu-prod`) is a DISTINCT pattern
+ * — different schema, different tables, potentially different dialect — so it
+ * must not collide. A NULL group (the default flat `entities/` scope) is matched
+ * with `IS NULL`, not `=`.
  *
  * Returns the pattern's id, confidence, and repetition count, or null if not found.
  */

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1190,24 +1190,41 @@ function isPgError(err: unknown): err is Error & { code: string } {
 // ── Learned pattern helpers ─────────────────────────────────────────
 
 /**
- * Find a learned pattern by exact normalized SQL match for the given org.
+ * Find a learned pattern by exact normalized SQL match, scoped to the given
+ * org AND connection group.
+ *
+ * Uniqueness is `(org_id, connection_group_id, normalised_sql)` (#3611): the
+ * SAME normalised SQL learned against a different connection group (e.g.
+ * `us-prod` vs `eu-prod`) is a DISTINCT pattern — different schema, different
+ * tables, potentially different dialect — so it must not collide. A NULL group
+ * (the default flat `entities/` scope) is matched with `IS NULL`, not `=`.
+ *
  * Returns the pattern's id, confidence, and repetition count, or null if not found.
  */
 export async function findPatternBySQL(
   orgId: string | null | undefined,
+  connectionGroupId: string | null | undefined,
   patternSql: string,
 ): Promise<{ id: string; confidence: number; repetitionCount: number } | null> {
   const params: unknown[] = [patternSql];
   let orgClause: string;
   if (orgId) {
     params.push(orgId);
-    orgClause = `org_id = $2`;
+    orgClause = `org_id = $${params.length}`;
   } else {
     orgClause = `org_id IS NULL`;
   }
 
+  let groupClause: string;
+  if (connectionGroupId) {
+    params.push(connectionGroupId);
+    groupClause = `connection_group_id = $${params.length}`;
+  } else {
+    groupClause = `connection_group_id IS NULL`;
+  }
+
   const rows = await internalQuery<{ id: string; confidence: number; repetition_count: number }>(
-    `SELECT id, confidence, repetition_count FROM learned_patterns WHERE pattern_sql = $1 AND ${orgClause} LIMIT 1`,
+    `SELECT id, confidence, repetition_count FROM learned_patterns WHERE pattern_sql = $1 AND ${orgClause} AND ${groupClause} LIMIT 1`,
     params,
   );
 
@@ -1225,6 +1242,13 @@ export async function findPatternBySQL(
  */
 export function insertLearnedPattern(pattern: {
   orgId: string | null | undefined;
+  /**
+   * Connection group the pattern was learned against (#3611). NULL/omitted =
+   * the default (flat `entities/`) scope. Stored on every row so retrieval
+   * (`getApprovedPatterns`) and dedup (`findPatternBySQL`) can keep one group's
+   * patterns from leaking into another group's agent context.
+   */
+  connectionGroupId?: string | null | undefined;
   patternSql: string;
   description: string;
   sourceEntity: string;
@@ -1232,8 +1256,8 @@ export function insertLearnedPattern(pattern: {
   proposedBy: string;
 }): void {
   internalExecute(
-    `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, source_queries, confidence, repetition_count, status, proposed_by)
-     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6)`,
+    `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, source_queries, confidence, repetition_count, status, proposed_by, connection_group_id)
+     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6, $7)`,
     [
       pattern.orgId ?? null,
       pattern.patternSql,
@@ -1241,6 +1265,7 @@ export function insertLearnedPattern(pattern: {
       pattern.sourceEntity,
       JSON.stringify(pattern.sourceQueries),
       pattern.proposedBy,
+      pattern.connectionGroupId ?? null,
     ],
   );
 }
@@ -1524,6 +1549,9 @@ export function incrementPatternCount(id: string, sourceFingerprint?: string): v
 export interface ApprovedPatternRow {
   id: string;
   org_id: string | null;
+  /** Connection group the pattern was learned against (#3611). NULL = the
+   *  default (flat `entities/`) scope. */
+  connection_group_id: string | null;
   pattern_sql: string;
   description: string | null;
   source_entity: string | null;
@@ -1556,25 +1584,48 @@ export interface QuerySuggestionRow {
 }
 
 /**
- * Fetch approved learned patterns, scoped to an org (or global when orgId is null).
- * Ordered by confidence DESC, capped at 100 rows.
+ * Fetch approved learned patterns, scoped to an org (or global when orgId is
+ * null) AND a connection group (#3611).
+ *
+ * Group scoping mirrors the org rule: a pattern is in scope when its
+ * `connection_group_id` matches the active group OR is NULL (the default flat
+ * `entities/` scope, shared across groups the same way `org_id IS NULL` is
+ * shared across orgs). When `connectionGroupId` is null/omitted the active
+ * scope IS the default group, so only `connection_group_id IS NULL` rows match
+ * — this keeps `us-prod` patterns out of a `eu-prod` agent session and
+ * vice-versa. Ordered by confidence DESC, capped at 100 rows.
  */
-export async function getApprovedPatterns(orgId: string | null): Promise<ApprovedPatternRow[]> {
+export async function getApprovedPatterns(
+  orgId: string | null,
+  connectionGroupId?: string | null,
+): Promise<ApprovedPatternRow[]> {
   if (!hasInternalDB()) return [];
 
+  const params: unknown[] = [];
+
+  let orgClause: string;
+  if (orgId) {
+    params.push(orgId);
+    orgClause = `(org_id = $${params.length} OR org_id IS NULL)`;
+  } else {
+    orgClause = `org_id IS NULL`;
+  }
+
+  let groupClause: string;
+  if (connectionGroupId) {
+    params.push(connectionGroupId);
+    groupClause = `(connection_group_id = $${params.length} OR connection_group_id IS NULL)`;
+  } else {
+    groupClause = `connection_group_id IS NULL`;
+  }
+
   return internalQuery<ApprovedPatternRow>(
-    orgId
-      ? `SELECT id, org_id, pattern_sql, description, source_entity, confidence
-         FROM learned_patterns
-         WHERE status = 'approved' AND (org_id = $1 OR org_id IS NULL)
-         ORDER BY confidence DESC
-         LIMIT 100`
-      : `SELECT id, org_id, pattern_sql, description, source_entity, confidence
-         FROM learned_patterns
-         WHERE status = 'approved' AND org_id IS NULL
-         ORDER BY confidence DESC
-         LIMIT 100`,
-    orgId ? [orgId] : [],
+    `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence
+     FROM learned_patterns
+     WHERE status = 'approved' AND ${orgClause} AND ${groupClause}
+     ORDER BY confidence DESC
+     LIMIT 100`,
+    params,
   );
 }
 

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -27,15 +27,27 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
-/** Canonical cache key — `"__global__"` for null orgId, prefixed to avoid collision. */
-function cacheKey(orgId: string | null): string {
+/** Org segment of a cache key — `"__global__"` for null orgId, prefixed to
+ *  avoid collision. */
+function orgKeyPart(orgId: string | null): string {
   return orgId === null ? "__global__" : `org:${orgId}`;
 }
 
-/** Get approved patterns for an org, hitting cache first.
+/** Canonical cache key — scoped by org AND connection group (#3611) so a
+ *  `us-prod` agent session never serves a `eu-prod` group's cached patterns.
+ *  `"__nogroup__"` represents the default (flat `entities/`) scope. */
+function cacheKey(orgId: string | null, connectionGroupId: string | null): string {
+  const groupPart = connectionGroupId === null ? "__nogroup__" : `group:${connectionGroupId}`;
+  return `${orgKeyPart(orgId)}::${groupPart}`;
+}
+
+/** Get approved patterns for an org + connection group, hitting cache first.
  *  DB failures are logged and return [] without being cached. */
-async function getCachedPatterns(orgId: string | null): Promise<ApprovedPatternRow[]> {
-  const key = cacheKey(orgId);
+async function getCachedPatterns(
+  orgId: string | null,
+  connectionGroupId: string | null,
+): Promise<ApprovedPatternRow[]> {
+  const key = cacheKey(orgId, connectionGroupId);
   const entry = cache.get(key);
 
   if (entry && Date.now() < entry.expiresAt) {
@@ -44,7 +56,7 @@ async function getCachedPatterns(orgId: string | null): Promise<ApprovedPatternR
   }
 
   try {
-    const patterns = await getApprovedPatterns(orgId);
+    const patterns = await getApprovedPatterns(orgId, connectionGroupId);
 
     // Evict oldest entry if cache is at capacity
     if (cache.size >= MAX_ENTRIES) {
@@ -71,9 +83,17 @@ async function getCachedPatterns(orgId: string | null): Promise<ApprovedPatternR
   }
 }
 
-/** Invalidate the pattern cache for a specific org. */
+/**
+ * Invalidate the pattern cache for a specific org, across ALL of its connection
+ * groups. The admin approve/reject path (`admin-learned-patterns.ts`) operates
+ * at org granularity and doesn't know which group a reviewed pattern belongs
+ * to, so a single call must clear every group-scoped entry for the org (#3611).
+ */
 export function invalidatePatternCache(orgId: string | null): void {
-  cache.delete(cacheKey(orgId));
+  const prefix = `${orgKeyPart(orgId)}::`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
 }
 
 /** Reset entire cache. For testing only. */
@@ -155,15 +175,19 @@ export interface RelevantPattern {
  *
  * @param orgId - Organization ID (null for global).
  * @param question - The user's question to match against.
+ * @param connectionGroupId - Active connection group (null for the default
+ *   flat scope). Scopes retrieval so one group's patterns never leak into
+ *   another group's agent session (#3611).
  * @param maxPatterns - Maximum patterns to return (default 10).
  */
 export async function getRelevantPatterns(
   orgId: string | null,
   question: string,
+  connectionGroupId: string | null = null,
   maxPatterns: number = DEFAULT_MAX_PATTERNS,
 ): Promise<RelevantPattern[]> {
   const threshold = getConfig()?.learn?.confidenceThreshold ?? 0.7;
-  const allPatterns = await getCachedPatterns(orgId);
+  const allPatterns = await getCachedPatterns(orgId, connectionGroupId);
 
   // Filter by confidence threshold
   const aboveThreshold = allPatterns.filter((p) => p.confidence >= threshold);
@@ -200,10 +224,11 @@ function sanitizeForPrompt(text: string, maxLen: number): string {
 export async function buildLearnedPatternsSection(
   orgId: string | null,
   question: string,
+  connectionGroupId: string | null = null,
   maxPatterns?: number,
 ): Promise<string> {
   try {
-    const patterns = await getRelevantPatterns(orgId, question, maxPatterns);
+    const patterns = await getRelevantPatterns(orgId, question, connectionGroupId, maxPatterns);
     if (patterns.length === 0) return "";
 
     const lines = patterns.map((p) => {

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -76,7 +76,7 @@ async function getCachedPatterns(
     return patterns;
   } catch (err) {
     log.warn(
-      { orgId, err: err instanceof Error ? err.message : String(err) },
+      { orgId, connectionGroupId, err: err instanceof Error ? err.message : String(err) },
       "Failed to load approved patterns (table may not exist yet) — not caching",
     );
     return [];

--- a/packages/api/src/lib/learn/pattern-proposer.ts
+++ b/packages/api/src/lib/learn/pattern-proposer.ts
@@ -6,7 +6,7 @@
  * learned_patterns rows.
  */
 
-import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, findPatternBySQL, insertLearnedPattern, incrementPatternCount } from "@atlas/api/lib/db/internal";
 import { normalizeSQL, fingerprintSQL, extractPatternInfo, getYamlPatterns } from "@atlas/api/lib/learn/pattern-analyzer";
 
@@ -17,6 +17,22 @@ export interface PatternProposalInput {
   dialect: string;
   /** Used for debug logging only; not stored in the learned pattern record. */
   connectionId: string;
+  /**
+   * Owning org for the learned pattern. MUST be captured synchronously at the
+   * `sql.ts` call site while the request's AsyncLocalStorage context is still
+   * live (#3610). This proposal runs fire-and-forget AFTER the originating
+   * request has unwound, so reading `orgId` from ALS in here would resolve to
+   * `undefined` and write `org_id = NULL` — the global-scope sentinel — leaking
+   * one org's SQL patterns into every org's agent context.
+   */
+  orgId: string | null | undefined;
+  /**
+   * Connection group the query ran against (#3611). Captured synchronously
+   * alongside `orgId`. Scopes the pattern so `us-prod` patterns don't leak into
+   * a `eu-prod` agent session and identical SQL from a different group is not
+   * deduped away.
+   */
+  connectionGroupId: string | null | undefined;
 }
 
 /**
@@ -39,7 +55,7 @@ export function proposePatternIfNovel(input: PatternProposalInput): void {
  * @internal
  */
 export async function _analyzeAndPropose(input: PatternProposalInput): Promise<void> {
-  const { sql, dialect, connectionId } = input;
+  const { sql, dialect, connectionId, orgId, connectionGroupId } = input;
 
   // 1. Normalize SQL for dedup
   const normalized = normalizeSQL(sql);
@@ -52,12 +68,12 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
     return;
   }
 
-  // 3. Check against learned_patterns table
-  const reqCtx = getRequestContext();
-  const orgId = reqCtx?.user?.activeOrganizationId;
+  // 3. Check against learned_patterns table. `orgId`/`connectionGroupId` were
+  // captured synchronously at the call site (#3610/#3611) — never read from ALS
+  // here, the request context has already unwound by the time this runs.
   const fingerprint = fingerprintSQL(normalized);
 
-  const existing = await findPatternBySQL(orgId, normalized);
+  const existing = await findPatternBySQL(orgId, connectionGroupId, normalized);
   if (existing) {
     // Duplicate — bump count and confidence, append source fingerprint
     incrementPatternCount(existing.id, fingerprint);
@@ -73,6 +89,7 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
 
   insertLearnedPattern({
     orgId,
+    connectionGroupId,
     patternSql: normalized,
     description: info?.description ?? "Query pattern",
     sourceEntity: info?.primaryTable ?? "unknown",
@@ -81,7 +98,7 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
   });
 
   log.debug(
-    { primaryTable: info?.primaryTable, fingerprint, connectionId },
+    { primaryTable: info?.primaryTable, fingerprint, connectionId, connectionGroupId },
     "Proposed novel learned pattern",
   );
 }

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1269,9 +1269,21 @@ function executeAndAuditEffect(opts: {
             );
           }
 
-          // Pattern learning (fire-and-forget)
+          // Pattern learning (fire-and-forget). Capture org + connection group
+          // SYNCHRONOUSLY here (#3610/#3611): `proposePatternIfNovel` spawns a
+          // detached promise that runs AFTER this request's ALS context has
+          // unwound. Reading the context inside that promise would resolve the
+          // org to `undefined` → `org_id = NULL` (the global-scope sentinel),
+          // leaking one org's patterns into every org, and would drop the
+          // connection group so identical SQL from a different group collides.
+          // We use the auth org (`activeOrganizationId`), NOT the pooling-gated
+          // `orgId`, which is `undefined` when org-pooling is off. The masking
+          // block below reads the same live context the same way.
+          const learnReqCtx = getRequestContext();
           proposePatternIfNovel({
             sql: querySql, dialect: parserDatabase(dbType, connId), connectionId: connId,
+            orgId: learnReqCtx?.user?.activeOrganizationId,
+            connectionGroupId: learnReqCtx?.connectionGroupId,
           });
 
           // PII masking (fails open) — via `MaskingPolicy` Tag (#2566)


### PR DESCRIPTION
Fixes #3610
Fixes #3611

Two cross-tenant isolation leaks in the learned-patterns path, fixed together since they share the same `propose → retrieve → dedup` chain and touch the same files.

## #3610 — cross-org leak (org_id nulled by fire-and-forget timing)

`_analyzeAndPropose` read `orgId` from the request's AsyncLocalStorage context, but it runs in a **detached fire-and-forget promise** that executes *after* the originating request has unwound. By then ALS resolved to `undefined`, so rows were written with `org_id = NULL` — the global-scope sentinel the agent-injection query treats as "visible to every org". One org's SQL patterns leaked into every org's agent context on the next cache miss.

**Fix:** capture the auth org (`activeOrganizationId`) **synchronously at the `sql.ts` call site** — where the request context is still live (the masking block right below reads it the same way) — and thread it explicitly through `PatternProposalInput`. `_analyzeAndPropose` no longer touches ALS. We capture the *auth* org, not the pooling-gated `orgId` (which is `undefined` when org-pooling is off), matching the pre-bug intent.

## #3611 — cross-schema leak (connection_group_id ignored)

Migration 0122 added `connection_group_id` to `learned_patterns`, but retrieval and dedup never honoured it. `getApprovedPatterns` / `findPatternBySQL` ignored the column and the agent injection passed only `orgId`, so a `us-prod` session was primed with `eu-prod`'s patterns (different schema, tables, possibly dialect), and identical normalised SQL from group A blocked group B from ever building its own library.

**Fix:** thread `connectionGroupId` through the whole chain:
- `getApprovedPatterns(orgId, connectionGroupId)` — filters by group, mirroring the org rule (exact group **OR** the shared `NULL` default scope), and selects the column.
- `findPatternBySQL(orgId, connectionGroupId, sql)` — uniqueness is now `(org_id, connection_group_id, normalised_sql)` (NULL matched with `IS NULL`).
- `agent.ts` injection passes the active connection group (`reqCtx.connectionGroupId`).
- `pattern-cache` key is partitioned per group; org-scoped invalidation (admin approve/reject, which doesn't know the group) clears every group entry for the org.
- `insertLearnedPattern` stores `connection_group_id` on every new row.

## On the `org_id` NOT NULL constraint

`org_id` stays **nullable by design** — `NULL` is a legitimate value (global / self-hosted scope used by the agent-injection query and by `getApprovedPatterns`). The unintended NULLs came from the fire-and-forget timing bug, now closed at the application layer. A DB-level `NOT NULL` constraint would break global patterns, so none is added; no follow-up migration is needed.

## Tests

- **Unit (#3610):** fire-and-forget insert carries the captured `org_id` even with **no live ALS context**; a live ALS context with a *different* org is ignored (only the input param wins).
- **Unit (#3611):** lookup + insert scope to the connection group; `(org_id, connection_group_id, sql)` uniqueness; two groups with identical SQL produce two independent rows.
- **Integration (#3611):** active group threaded to the DB layer; each agent session sees only its own group's patterns (no cross-group bleed); cache partitioned per group; org-scoped invalidation clears all group entries.

## CI

Local gates all green: lint, type, full test suite, syncpack, template drift, schema drift, security-headers, railway-watch, oauth-helper, test-discipline, twenty-resolver, settings-readers, published-symbols, openapi drift.

https://claude.ai/code/session_017Pdivf1y3YMxdjmc5kJJGX

---
_Generated by [Claude Code](https://claude.ai/code/session_017Pdivf1y3YMxdjmc5kJJGX)_