### PR TITLE
fix(health): gate per-source fleet breakdown behind operator signal

### DIFF
--- a/apps/docs/content/docs/deployment/multi-datasource.mdx
+++ b/apps/docs/content/docs/deployment/multi-datasource.mdx
@@ -322,10 +322,16 @@ curl -X POST https://your-atlas.com/api/chat \
 
 ### Health endpoint
 
-The `/api/health` endpoint reports the status of each registered datasource:
+The `/api/health` endpoint reports the status of each registered datasource. The
+full per-source breakdown — every datasource id and its latency — is only
+returned to **operators**: an authenticated admin/owner/platform_admin session
+(the same signal the admin health dashboard uses), a request carrying the
+`ATLAS_API_KEY` bearer token, or local-dev/self-hosted no-auth mode.
 
 ```bash
-curl http://localhost:3001/api/health
+# Operator request (admin session cookie or API key) — full breakdown:
+curl http://localhost:3001/api/health \
+  -H "Authorization: Bearer $ATLAS_API_KEY"
 ```
 
 ```json
@@ -341,6 +347,33 @@ curl http://localhost:3001/api/health
   }
 }
 ```
+
+Anonymous callers (e.g. uptime monitors) get the aggregate `status` and only the
+region's own datasource (`default`) — never the rest of the fleet's ids or
+latencies. This keeps the response a stable monitoring target without exposing
+cross-region topology:
+
+```bash
+# Anonymous request — aggregate status + own datasource only:
+curl http://localhost:3001/api/health
+```
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "datasource": { "status": "ok" }
+  },
+  "sources": {
+    "default": { "dbType": "postgres", "status": "healthy" }
+  }
+}
+```
+
+The aggregate `status` (and the 503-on-unhealthy contract) always reflects
+**every** registered source regardless of who is asking — a degraded or
+unhealthy non-`default` source still degrades or fails the overall status for
+anonymous callers; it just isn't enumerated in their `sources` breakdown.
 
 ---
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -17,6 +17,23 @@ import {
 } from "bun:test";
 import type { ConnectionMetadata, HealthCheckResult } from "@atlas/api/lib/db/connection";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { AuthResult } from "@atlas/api/lib/auth/types";
+
+/**
+ * Build an authenticated managed/simple-key AuthResult for the gating tests.
+ * Constructed inline (not via createAtlasUser) so the test doesn't pull the
+ * `@useatlas/types/auth` value export into the test module graph.
+ */
+function authedAs(
+  mode: "managed" | "simple-key",
+  role: "admin" | "owner" | "platform_admin" | "member",
+): AuthResult {
+  return {
+    authenticated: true,
+    mode,
+    user: { id: `user-${role}`, mode, label: `${role}@example.com`, role },
+  };
+}
 
 // --- Mocks ---
 
@@ -140,14 +157,26 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
+// #3685 — the health route reads an operator signal via authenticateRequest to
+// gate the full per-source fleet breakdown. Default to local-dev no-auth
+// (mode "none" = implicit operator) so the existing source/plugin tests keep
+// seeing the full breakdown; the gating tests below flip this per-scenario.
+const OPERATOR_NONE_AUTH: AuthResult = {
+  authenticated: true,
+  mode: "none",
+  user: undefined,
+};
+const ANON_AUTH: AuthResult = {
+  authenticated: false,
+  mode: "managed",
+  status: 401,
+  error: "Not signed in",
+};
+let authenticateRequestImpl: () => Promise<AuthResult> = () =>
+  Promise.resolve(OPERATOR_NONE_AUTH);
+
 mock.module("@atlas/api/lib/auth/middleware", () => ({
-  authenticateRequest: mock(() =>
-    Promise.resolve({
-      authenticated: true as const,
-      mode: "none" as const,
-      user: undefined,
-    }),
-  ),
+  authenticateRequest: mock(() => authenticateRequestImpl()),
   checkRateLimit: mock(() => ({ allowed: true })),
   getClientIP: mock(() => null),
 }));
@@ -720,5 +749,178 @@ describe("GET /api/health — plugin component", () => {
     expect(message ?? "").not.toContain("postgres://");
     // A generic operator-facing string is the contract.
     expect(message).toBeDefined();
+  });
+});
+
+// #3685 — the US region's /api/health enumerated the entire multi-region fleet
+// (us-prod, eu-prod, apac-prod, __demo__, default) with per-DB latencies to
+// anonymous callers; EU/APAC exposed only `default`. The full per-source
+// breakdown is recon surface, so it's now gated behind an operator signal
+// (admin session / API key / local-dev no-auth). Anonymous callers see only the
+// aggregate `status` + the region's own datasource (`default`). The overall
+// status-promotion aggregation (and the 503-on-unhealthy contract) is unchanged
+// — it still considers every source regardless of who's asking.
+describe("GET /api/health — per-source fleet visibility gating (#3685)", () => {
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+  const origDatabaseUrl = process.env.DATABASE_URL;
+
+  // Mirrors the multi-region US registry that triggered #3685: the region's own
+  // datasource ("default") plus the full cross-region fleet.
+  function fleet(
+    overrides: Record<string, HealthCheckResult> = {},
+  ): ConnectionMetadata[] {
+    const checkedAt = new Date("2026-01-15T12:00:00Z");
+    const mk = (
+      status: HealthCheckResult["status"],
+      latencyMs: number,
+    ): HealthCheckResult => ({ status, latencyMs, checkedAt });
+    const ids: Record<string, HealthCheckResult> = {
+      default: mk("healthy", 3),
+      "us-prod": mk("healthy", 4),
+      "eu-prod": mk("healthy", 80),
+      "apac-prod": mk("healthy", 120),
+      __demo__: mk("healthy", 2),
+      ...overrides,
+    };
+    return Object.entries(ids).map(([id, health]) => ({
+      id,
+      dbType: "postgres",
+      health,
+    }));
+  }
+
+  beforeEach(() => {
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.DATABASE_URL;
+    connMetadata = [];
+    mockValidateEnvironment.mockReset();
+    mockValidateEnvironment.mockResolvedValue([]);
+    mockGetStartupWarnings.mockReset();
+    mockGetStartupWarnings.mockReturnValue([]);
+    authenticateRequestImpl = () => Promise.resolve(OPERATOR_NONE_AUTH);
+  });
+
+  afterEach(() => {
+    if (origDatasource !== undefined) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
+    authenticateRequestImpl = () => Promise.resolve(OPERATOR_NONE_AUTH);
+  });
+
+  it("anonymous callers see only the region's own datasource (default), not the fleet", async () => {
+    connMetadata = fleet();
+    authenticateRequestImpl = () => Promise.resolve(ANON_AUTH);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+
+    // Only the region's own datasource — no cross-region ids/latencies.
+    expect(Object.keys(sources)).toEqual(["default"]);
+    expect(sources["us-prod"]).toBeUndefined();
+    expect(sources["eu-prod"]).toBeUndefined();
+    expect(sources["apac-prod"]).toBeUndefined();
+    expect(sources["__demo__"]).toBeUndefined();
+    // No other region's id (and therefore latency) appears anywhere in the section.
+    const serialized = JSON.stringify(sources);
+    expect(serialized).not.toContain("us-prod");
+    expect(serialized).not.toContain("eu-prod");
+    expect(serialized).not.toContain("apac-prod");
+    expect(serialized).not.toContain("__demo__");
+  });
+
+  it("operator (admin session) sees the full fleet breakdown", async () => {
+    connMetadata = fleet();
+    authenticateRequestImpl = () => Promise.resolve(authedAs("managed", "admin"));
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+
+    expect(Object.keys(sources).sort()).toEqual([
+      "__demo__",
+      "apac-prod",
+      "default",
+      "eu-prod",
+      "us-prod",
+    ]);
+  });
+
+  it("operator via simple-key (admin role) sees the full fleet breakdown", async () => {
+    connMetadata = fleet();
+    authenticateRequestImpl = () => Promise.resolve(authedAs("simple-key", "admin"));
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+    expect(Object.keys(sources)).toContain("eu-prod");
+  });
+
+  it("authenticated non-admin (member) is treated as anonymous for the breakdown", async () => {
+    connMetadata = fleet();
+    authenticateRequestImpl = () => Promise.resolve(authedAs("managed", "member"));
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+    expect(Object.keys(sources)).toEqual(["default"]);
+  });
+
+  it("overall status promotion stays intact for anonymous callers — a degraded non-default source still degrades the aggregate without being enumerated", async () => {
+    connMetadata = fleet({
+      "eu-prod": {
+        status: "degraded",
+        latencyMs: 5000,
+        message: "High latency",
+        checkedAt: new Date(),
+      },
+    });
+    authenticateRequestImpl = () => Promise.resolve(ANON_AUTH);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    // Aggregate reflects the fleet (eu-prod degraded) ...
+    expect(body.status).toBe("degraded");
+    // ... but the breakdown does not enumerate the degraded region.
+    const sources = body.sources as Record<string, unknown>;
+    expect(Object.keys(sources)).toEqual(["default"]);
+  });
+
+  it("503-on-unhealthy-source contract holds for anonymous callers without enumerating the fleet", async () => {
+    connMetadata = fleet({
+      "eu-prod": {
+        status: "unhealthy",
+        latencyMs: 5000,
+        message: "timeout",
+        checkedAt: new Date(),
+      },
+    });
+    authenticateRequestImpl = () => Promise.resolve(ANON_AUTH);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+    const sources = body.sources as Record<string, unknown>;
+    expect(Object.keys(sources)).toEqual(["default"]);
+  });
+
+  it("anonymous callers with no default source get no sources section even when the fleet is non-empty", async () => {
+    // A region whose registry has only cross-region entries (no own "default").
+    connMetadata = [
+      {
+        id: "eu-prod",
+        dbType: "postgres",
+        health: { status: "healthy", latencyMs: 80, checkedAt: new Date() },
+      },
+    ];
+    authenticateRequestImpl = () => Promise.resolve(ANON_AUTH);
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.sources).toBeUndefined();
   });
 });

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -23,6 +23,7 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 import { getConfig } from "@atlas/api/lib/config";
+import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import type { PluginStatus } from "@atlas/api/lib/plugins/registry";
 
 // Canonical plugin lifecycle states for the /health wire format. The
@@ -157,6 +158,55 @@ function findDiagnostic(
   ...codes: DiagnosticError["code"][]
 ): DiagnosticError | undefined {
   return diagnostics.find((d) => codes.includes(d.code));
+}
+
+// Roles that may see the full per-source fleet breakdown. Mirrors adminAuth's
+// role gate in api/routes/middleware.ts (#3685).
+const OPERATOR_ROLES = new Set<string>(["admin", "owner", "platform_admin"]);
+
+/**
+ * Whether the request carries an operator signal authorizing the full
+ * per-source fleet breakdown on /health (#3685).
+ *
+ * Reuses the existing auth dispatcher — the SAME signal the admin health
+ * dashboard sends (session cookie, managed mode) and self-hosted operators send
+ * (`ATLAS_API_KEY` bearer, simple-key) — rather than inventing a new one:
+ *   - mode "none" (local-dev / self-hosted no-auth) is an implicit operator,
+ *     matching adminAuth's treatment.
+ *   - an authenticated admin/owner/platform_admin (managed or simple-key) is an
+ *     operator.
+ * Anyone else (no credentials, expired session, non-admin member) is anonymous.
+ *
+ * `authenticateRequest` normalizes validator failures to an unauthenticated
+ * result rather than throwing, but we still wrap defensively and fail CLOSED to
+ * anonymous: a public health probe must never leak the fleet because the auth
+ * layer errored.
+ */
+async function isOperatorHealthRequest(req: Request): Promise<boolean> {
+  try {
+    const auth = await authenticateRequest(req);
+    if (!auth.authenticated) return false;
+    if (auth.mode === "none") return true;
+    return !!auth.user.role && OPERATOR_ROLES.has(auth.user.role);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Operator-signal check failed on /health — treating caller as anonymous",
+    );
+    return false;
+  }
+}
+
+/**
+ * The region's own datasource view of a per-source health map — the single
+ * `default` entry, or `undefined` when this region has no `default` registered.
+ * Strips the cross-region fleet from the anonymous /health response (#3685)
+ * while leaving the operator view untouched.
+ */
+function ownRegionSources<T>(
+  all: Record<string, T>,
+): Record<string, T> | undefined {
+  return "default" in all ? { default: all.default } : undefined;
 }
 
 const HealthErrorSchema = z.object({
@@ -485,6 +535,22 @@ health.openapi(healthRoute, async (c) => {
       plugins: pluginsComponent,
     };
 
+    // #3685 — gate the per-source fleet breakdown. `sourcesSection` above
+    // enumerates EVERY registered datasource (in the US region that's the whole
+    // multi-region fleet — us-prod, eu-prod, apac-prod, __demo__, default) with
+    // per-DB latencies. That breakdown is reconnaissance surface for an
+    // unauthenticated caller, so only operators receive it. Anonymous callers
+    // get the aggregate `status` plus the region's own datasource (`default`) —
+    // the shape EU/APAC already return. The status-promotion aggregation above
+    // (lines computing sourceStatuses) still considers every source regardless
+    // of who's asking, so the 503-on-unhealthy-source contract is unchanged.
+    const isOperator = await isOperatorHealthRequest(c.req.raw);
+    const visibleSources = sourcesSection
+      ? isOperator
+        ? sourcesSection
+        : ownRegionSources(sourcesSection)
+      : undefined;
+
     // Brand color for frontend theming (public, no auth required)
     const brandColor = getSetting("ATLAS_BRAND_COLOR");
 
@@ -555,7 +621,7 @@ health.openapi(healthRoute, async (c) => {
               : ("single-workspace" as const),
         },
       },
-      ...(sourcesSection ? { sources: sourcesSection } : {}),
+      ...(visibleSources ? { sources: visibleSources } : {}),
     };
 
     // Health response is built dynamically with many conditional fields — TypeScript


### PR DESCRIPTION
## Summary

Fixes #3685. The US region's `/api/health` `sources` object enumerated the **entire multi-region fleet** (`us-prod`, `eu-prod`, `apac-prod`, `__demo__`, `default`) with per-DB latencies to anonymous callers; EU/APAC exposed only `default`. No customer data leaked, but it revealed cross-region topology, the demo DB's existence, and relative DB health/latency — reconnaissance surface and a cross-region inconsistency.

## What changed

- **`packages/api/src/api/routes/health.ts`** — the full per-source breakdown is now gated behind an operator signal. Anonymous callers get the aggregate `status` plus only the region's own datasource (`default`), matching the EU/APAC shape.
  - The operator signal reuses the existing auth dispatcher (`authenticateRequest`) — **no new signal invented**. It's the same signal the admin health dashboard sends (session cookie, managed mode) and self-hosted operators send (`ATLAS_API_KEY` bearer, simple-key). `mode: "none"` (local-dev / self-hosted no-auth) is an implicit operator; an authenticated `admin`/`owner`/`platform_admin` is an operator. The check **fails closed to anonymous** on any auth-layer error.
  - The `sourceStatuses` aggregation that promotes overall status is **untouched** — it still considers every source, so the overall `status` and the 503-on-unhealthy-source / SaaS-internal-DB-down contracts are unchanged. Uptime monitors keep working.
- **`apps/docs/content/docs/deployment/multi-datasource.mdx`** — documents the anon-gated `sources` shape (operator vs anonymous example responses).

## Acceptance criteria

- [x] Anonymous `/api/health` does **not** enumerate other regions' source ids/latencies
- [x] Overall `status` (and 503-on-internal-DB-down for SaaS) behavior unchanged — uptime monitors keep working
- [x] Full per-source breakdown still available to the admin health dashboard / operator
- [x] Tests cover anonymous vs operator response shape

## Tests

Added a `per-source fleet visibility gating (#3685)` describe block covering: anonymous sees only `default`; operator (admin session) sees the full fleet; operator via simple-key sees the full fleet; authenticated non-admin member is treated as anonymous; status promotion (degraded + 503) still fires for anonymous callers without enumerating the offending region; no-`default` region returns no `sources` to anonymous callers.

All `/ci` gates pass locally: lint, type, full test suite (api 629 / web 211 / all packages, 0 failures), syncpack, OpenAPI drift, schema drift, template drift, and the remaining drift/discipline checks.

https://claude.ai/code/session_01CQevbnKUZZ4XsyjSYks8Gd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQevbnKUZZ4XsyjSYks8Gd)_