### PR TITLE
feat(agent): teach sargable SQL in system prompt; fix MySQL date-filter guidance

### DIFF
--- a/packages/api/src/lib/__tests__/agent-sargability.test.ts
+++ b/packages/api/src/lib/__tests__/agent-sargability.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import type { ConnectionMetadata } from "../db/connection";
+import type { DialectHint } from "../plugins/wiring";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// --- Mutable state for tests ---
+let mockDialectHints: readonly DialectHint[] = [];
+
+const mockEntries: ConnectionMetadata[] = [];
+
+function resetMockEntries() {
+  mockEntries.length = 0;
+  mockEntries.push({ id: "default", dbType: "postgres" });
+}
+
+resetMockEntries();
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      list: () => mockEntries.map((e) => e.id),
+      describe: () =>
+        mockEntries.map((e) => ({
+          id: e.id,
+          dbType: e.dbType,
+          description: e.description,
+        })),
+      _reset: () => { mockEntries.length = 0; },
+    },
+  }),
+);
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => mockDialectHints,
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+const { buildSystemParam } = await import("@atlas/api/lib/agent");
+
+function assembledPrompt(): string {
+  const result = buildSystemParam("openai");
+  return typeof result === "string" ? result : result.content;
+}
+
+describe("sargability guidance (shared suffix — covers PostgreSQL)", () => {
+  beforeEach(() => {
+    resetMockEntries();
+    mockDialectHints = [];
+  });
+
+  test("assembled prompt contains an explicit Sargability section", () => {
+    const content = assembledPrompt();
+    expect(content).toContain("Sargability");
+  });
+
+  test("teaches preferring indexed columns and not wrapping them in functions in filters", () => {
+    const content = assembledPrompt();
+    expect(content).toContain("indexed column");
+    // The anti-pattern it warns against
+    expect(content).toContain("YEAR(created_at) = 2024");
+    // The sargable rewrite it prescribes
+    expect(content).toContain("created_at >= '2024-01-01' AND created_at < '2025-01-01'");
+  });
+
+  test("scopes the concern to filter/join predicates, allowing functions for projection/grouping", () => {
+    const content = assembledPrompt();
+    expect(content).toMatch(/projection and grouping/i);
+  });
+
+  test("sargability guidance ships on a PostgreSQL workspace (no inline dialect guide)", () => {
+    // default mock entry is postgres; there is no MySQL guide for it
+    const content = assembledPrompt();
+    expect(content).not.toContain("SQL Dialect: MySQL");
+    expect(content).toContain("Sargability");
+  });
+});
+
+describe("MySQL dialect guide — date functions no longer 'preferred' for filtering", () => {
+  beforeEach(() => {
+    mockEntries.length = 0;
+    mockEntries.push({ id: "default", dbType: "mysql" });
+    mockDialectHints = [];
+  });
+
+  test("MySQL guide is present", () => {
+    expect(assembledPrompt()).toContain("SQL Dialect: MySQL");
+  });
+
+  test("does not label YEAR()/DATE_FORMAT() as '(preferred)'", () => {
+    const content = assembledPrompt();
+    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
+    expect(mysqlSection).not.toContain("(preferred)");
+  });
+
+  test("teaches the half-open range rewrite for filtering indexed date columns", () => {
+    const content = assembledPrompt();
+    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
+    expect(mysqlSection).toContain("col >= '2024-01-01' AND col < '2025-01-01'");
+  });
+
+  test("retains YEAR()/DATE_FORMAT() for projection/grouping", () => {
+    const content = assembledPrompt();
+    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
+    expect(mysqlSection).toContain("DATE_FORMAT");
+    expect(mysqlSection).toMatch(/projecting or grouping/i);
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-sargability.test.ts
+++ b/packages/api/src/lib/__tests__/agent-sargability.test.ts
@@ -87,6 +87,14 @@ describe("sargability guidance (shared suffix — covers PostgreSQL)", () => {
     expect(content).toContain("created_at >= '2024-01-01' AND created_at < '2025-01-01'");
   });
 
+  test("warns against the spec's explicitly-named anti-patterns (LOWER on a plain index, date_trunc on an indexed timestamp)", () => {
+    const content = assembledPrompt();
+    // Spec #3629 body: "avoid `LOWER(col) = …` on a plain index"
+    expect(content).toContain("LOWER(email) = 'x@y.com'");
+    // Spec #3629 criterion: "prefer date ranges over `YEAR()`/`date_trunc` on indexed timestamps"
+    expect(content).toContain("date_trunc");
+  });
+
   test("scopes the concern to filter/join predicates, allowing functions for projection/grouping", () => {
     const content = assembledPrompt();
     expect(content).toMatch(/projection and grouping/i);

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -106,6 +106,16 @@ const SYSTEM_PROMPT_SUFFIX = `## Rules
 - If you cannot answer a question with the available data, say so clearly
 - Be concise but thorough in your interpretations
 
+## Writing Performant SQL (Sargability)
+Write filters that let the database use its indexes. A predicate is "sargable" when the optimizer can use an index for it; wrapping a column in a function or arithmetic usually disables the index and forces a full scan.
+- **Prefer filtering and joining on indexed columns.** Keep the indexed column bare on one side of the comparison — compare it against a literal or parameter, not against an expression of the same column.
+- **Never wrap an indexed column in a function inside a \`WHERE\` (or \`JOIN\`) predicate.** For example, do NOT write \`WHERE YEAR(created_at) = 2024\`, \`WHERE date_trunc('year', created_at) = '2024-01-01'\`, or \`WHERE LOWER(email) = 'x@y.com'\` against a plainly-indexed column — each forces a full scan.
+- **Rewrite date filters as half-open ranges** on the bare column instead of extracting parts of it:
+  - Instead of \`WHERE YEAR(created_at) = 2024\`, write \`WHERE created_at >= '2024-01-01' AND created_at < '2025-01-01'\`.
+  - Instead of \`WHERE MONTH(created_at) = 3 AND YEAR(created_at) = 2024\`, write \`WHERE created_at >= '2024-03-01' AND created_at < '2024-04-01'\`.
+  - Use \`< next-period-start\` (a half-open upper bound) rather than \`<= last-day\` so the range is correct for both dates and timestamps.
+- Function-wrapped expressions are fine for **projection and grouping** (e.g. \`SELECT date_trunc('month', created_at) AS month ... GROUP BY 1\`) — the sargability concern is specifically about **filter and join predicates** on indexed columns.
+
 ## Follow-up Questions
 When the user asks a follow-up question:
 - Reference previous query results — don't re-explore the semantic layer if you already know the schema
@@ -145,8 +155,8 @@ const MYSQL_DIALECT_GUIDE = `
 
 ## SQL Dialect: MySQL
 This database uses MySQL. Key differences from PostgreSQL:
-- Use \`YEAR(col)\` and \`MONTH(col)\` (preferred) or \`EXTRACT(YEAR FROM col)\` — both work
-- Use \`DATE_FORMAT(col, '%Y-%m')\` instead of \`TO_CHAR(col, 'YYYY-MM')\`
+- For **projecting or grouping** by a date part, use \`YEAR(col)\` / \`MONTH(col)\` (or \`EXTRACT(YEAR FROM col)\`) and \`DATE_FORMAT(col, '%Y-%m')\` (instead of \`TO_CHAR(col, 'YYYY-MM')\`) — e.g. \`SELECT DATE_FORMAT(created_at, '%Y-%m') AS month ... GROUP BY 1\`
+- For **filtering** an indexed date column, do NOT wrap it: \`WHERE YEAR(col) = 2024\` or \`WHERE DATE_FORMAT(col, '%Y-%m') = '2024-03'\` forces a full table scan. Use a half-open range on the bare column instead — \`WHERE col >= '2024-01-01' AND col < '2025-01-01'\` (year) or \`WHERE col >= '2024-03-01' AND col < '2024-04-01'\` (month). See the Sargability rules above
 - Use \`IFNULL(col, default)\` or \`COALESCE(col, default)\` — both work
 - Use backtick quoting for identifiers: \`\\\`column\\\`\` instead of \`"column"\`
 - Use \`CONCAT(a, b)\` for string concatenation — \`||\` is logical OR in MySQL


### PR DESCRIPTION
## What

Workstream A-0 of PRD #3617 (Performance-aware Atlas) — the highest-ROI quick win, pure prompt text. Closes #3629.

1. **Sargability rule in the shared system-prompt suffix** (`SYSTEM_PROMPT_SUFFIX`, covers PostgreSQL which has no inline dialect guide):
   - Prefer filtering/joining on indexed columns; keep the indexed column bare on one side.
   - Never wrap an indexed column in a function inside a `WHERE`/`JOIN` predicate (e.g. `YEAR(created_at) = 2024`, `date_trunc(...)`, `LOWER(email) = …`).
   - Rewrite date filters as half-open ranges — `created_at >= '2024-01-01' AND created_at < '2025-01-01'` — and use `< next-period-start` rather than `<= last-day`.
   - Clarifies the concern is **filter/join predicates only**; function-wrapped expressions remain fine for **projection and grouping**.

2. **Rewrote the MySQL dialect guide**, which previously labeled `YEAR(col)` / `DATE_FORMAT(col, …)` as **"(preferred)"** — directly teaching the full-scan anti-pattern. They are now presented for projection/grouping only; for filtering indexed date columns the guide teaches the range rewrite.

## Test

`packages/api/src/lib/__tests__/agent-sargability.test.ts` asserts the guidance at the `buildSystemParam` assembly seam (pure string assertions, no DB):
- Assembled prompt contains the Sargability section, the warned anti-pattern, and the prescribed range rewrite — and ships on a PostgreSQL workspace.
- MySQL guide no longer contains `(preferred)`, teaches the half-open range rewrite, and retains `DATE_FORMAT` for projection/grouping.

Existing `agent-dialect.test.ts` still passes. Lint + type-check green locally.

## Acceptance criteria
- [x] Assembled system prompt contains an explicit sargability rule (prefer indexed columns; don't wrap indexed columns in functions in filters; prefer date ranges over `YEAR()`/`date_trunc` on indexed timestamps)
- [x] MySQL dialect guide no longer presents `YEAR()`/`DATE_FORMAT()` as "(preferred)" for filtering; shows the range rewrite and retains them for projection/grouping
- [x] Test asserts the guidance via the system-prompt assembly seam (pure string assertion, no DB)
- [x] Existing agent prompt tests still pass

https://claude.ai/code/session_019HJ5xknTCzvMSL2Kycpkan

---
_Generated by [Claude Code](https://claude.ai/code/session_019HJ5xknTCzvMSL2Kycpkan)_