### PR TITLE
feat(db): add latency/staleness columns to learning tables (B-0)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -381,6 +381,7 @@ describe("migrateAuthTables", () => {
             { name: "0134_mcp_action_policy.sql" },
             { name: "0135_approval_rule_type_datasource.sql" },
             { name: "0136_mcp_action_policy_default_allowed.sql" },
+            { name: "0137_learning_tables_performance_columns.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -156,7 +156,9 @@ describe("runMigrations", () => {
     //   Plus 0134 (mcp_action_policy per-workspace kill-switch, #3509) = 135.
     //   Plus 0135 (approval_rules chk_approval_rule_type + 'datasource', #3573) = 136.
     //   Plus 0136 (mcp_action_policy.status DEFAULT 'blocked'→'allowed', #3578) = 137.
-    expect(count).toBe(137);
+    //   Plus 0137 (learned_patterns + query_suggestions latency/staleness
+    //   columns, PRD #3617 B-0, #3631) = 138.
+    expect(count).toBe(138);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -322,6 +324,7 @@ describe("runMigrations", () => {
         "0134_mcp_action_policy.sql",
         "0135_approval_rule_type_datasource.sql",
         "0136_mcp_action_policy_default_allowed.sql",
+        "0137_learning_tables_performance_columns.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0137_learning_tables_performance_columns.sql
+++ b/packages/api/src/lib/db/migrations/0137_learning_tables_performance_columns.sql
@@ -1,0 +1,46 @@
+-- 0137 — latency/staleness columns on the learning tables (PRD #3617 B-0, #3631).
+--
+-- Workstream B (Performance-aware Atlas) needs a place to persist query
+-- performance on the learning tables so later B slices can rank, decay, and
+-- surface patterns by how fast/reliable they actually run:
+--
+--   learned_patterns:
+--     avg_duration_ms  — rolling mean wall-clock of the pattern's executions
+--     last_seen_at     — last time the pattern was observed running (staleness)
+--     error_count      — how many times executing it errored
+--   query_suggestions:
+--     avg_duration_ms  — rolling mean wall-clock of the suggestion's runs
+--
+-- (query_suggestions already carries `last_seen_at`, added with the table, so
+-- it only needs the duration column here.)
+--
+-- Additive-only: nullable columns plus one NOT NULL DEFAULT 0 counter — no
+-- constraint changes, no rewrites of existing semantics. Under the
+-- two-phase-drop discipline only DROP COLUMN / DROP TABLE need the N / N+1
+-- split, so this ships safely in a single release. The Drizzle mirror in
+-- `db/schema.ts` (`learnedPatterns` / `querySuggestions`) lands in the SAME PR
+-- so `check-schema-drift` stays green and the next `drizzle-kit generate`
+-- doesn't revert these columns.
+--
+-- Neither table is Better-Auth-managed, so this file does NOT join
+-- MANAGED_AUTH_MIGRATIONS (db/internal.ts).
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE learned_patterns
+  ADD COLUMN IF NOT EXISTS avg_duration_ms DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS error_count INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN learned_patterns.avg_duration_ms IS
+  'Rolling mean wall-clock (ms) of the pattern''s executions. NULL until first observed. PRD #3617 B-0.';
+COMMENT ON COLUMN learned_patterns.last_seen_at IS
+  'Last time the pattern was observed running (staleness signal). NULL until first observed. PRD #3617 B-0.';
+COMMENT ON COLUMN learned_patterns.error_count IS
+  'Count of executions of this pattern that errored. PRD #3617 B-0.';
+
+ALTER TABLE query_suggestions
+  ADD COLUMN IF NOT EXISTS avg_duration_ms DOUBLE PRECISION;
+
+COMMENT ON COLUMN query_suggestions.avg_duration_ms IS
+  'Rolling mean wall-clock (ms) of the suggestion''s runs. NULL until first observed. PRD #3617 B-0.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -542,6 +542,13 @@ export const learnedPatterns = pgTable(
     // NULL = default (flat entities/) group. Lets the admin approve path
     // rebuild the correct group scope from a persisted amendment row.
     connectionGroupId: text("connection_group_id"),
+    // Performance-aware Atlas (PRD #3617 B-0, #3631). Rolling mean wall-clock
+    // (ms), last-observed timestamp (staleness), and error counter for the
+    // pattern's executions. avg_duration_ms / last_seen_at are NULL until the
+    // pattern is first observed; error_count starts at 0.
+    avgDurationMs: doublePrecision("avg_duration_ms"),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+    errorCount: integer("error_count").notNull().default(0),
   },
   (t) => [
     index("idx_learned_patterns_org_status").on(t.orgId, t.status),
@@ -679,6 +686,9 @@ export const querySuggestions = pgTable(
     approvedAt: timestamp("approved_at", { withTimezone: true }),
     distinctUserClicks: integer("distinct_user_clicks").notNull().default(0),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+    // Performance-aware Atlas (PRD #3617 B-0, #3631). Rolling mean wall-clock
+    // (ms) of the suggestion's runs. NULL until first observed.
+    avgDurationMs: doublePrecision("avg_duration_ms"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },


### PR DESCRIPTION
## What

Workstream **B-0** of PRD #3617 (Performance-aware Atlas) — the additive foundation every other B slice builds on. Gives the learning tables a place to persist query performance.

Migration `0137_learning_tables_performance_columns.sql`:

- `learned_patterns`
  - `avg_duration_ms` — `DOUBLE PRECISION`, nullable (rolling mean wall-clock)
  - `last_seen_at` — `TIMESTAMPTZ`, nullable (staleness signal)
  - `error_count` — `INTEGER NOT NULL DEFAULT 0`
- `query_suggestions`
  - `avg_duration_ms` — `DOUBLE PRECISION`, nullable (`last_seen_at` already exists on this table)

All additive (nullable columns + one `NOT NULL DEFAULT 0` counter) — no two-phase-drop concern.

## Drizzle mirror (same PR — CLAUDE.md drift rule)

`schema.ts` mirrors all four columns in the same commit. `check-schema-drift.sh` only verifies table *existence*, not columns, so an unmirrored `ADD COLUMN` passes CI green and a later `drizzle-kit generate` would revert it. The mirror types/defaults match the migration exactly (`doublePrecision(...)`, `timestamp(..., { withTimezone: true })`, `integer(...).notNull().default(0)`).

Neither table is Better-Auth-managed, so `0137` does not join `MANAGED_AUTH_MIGRATIONS`.

## Verification

- ✅ `scripts/check-schema-drift.sh`
- ✅ `bun run type`
- ✅ `bun run lint`
- ✅ real-Postgres migration smoke (`migrate-pg.test.ts`) — 74 pass, `0137` applies cleanly
- ✅ affected isolated tests — 9 pass

Closes #3631

https://claude.ai/code/session_014BB4pz8opF4QwYf4Rt6gDy

---
_Generated by [Claude Code](https://claude.ai/code/session_014BB4pz8opF4QwYf4Rt6gDy)_