### PR TITLE
fix(api): TTL on YAML pattern dedup cache (#3614)

### DIFF
--- a/packages/api/src/lib/learn/__tests__/pattern-analyzer-cache.test.ts
+++ b/packages/api/src/lib/learn/__tests__/pattern-analyzer-cache.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the YAML pattern dedup cache TTL + invalidation (#3614).
+ *
+ * `getYamlPatterns()` caches the normalized `query_patterns` SQL from entity
+ * YAMLs so `proposePatternIfNovel` can suppress re-proposing patterns that are
+ * already authored in the semantic layer. The cache used to live for the
+ * process lifetime, so an admin adding a `query_patterns` entry kept getting
+ * duplicate `learned_patterns` rows until the API restarted. The cache now has
+ * a 5-minute TTL AND is actively dropped when the semantic index is
+ * invalidated.
+ */
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  getYamlPatterns,
+  invalidateYamlPatternCache,
+  _resetYamlPatternCache,
+  normalizeSQL,
+} from "../pattern-analyzer";
+import { invalidateSemanticIndex } from "@atlas/api/lib/semantic/search";
+import { _analyzeAndPropose, type PatternProposalInput } from "../pattern-proposer";
+import { _resetPool, type InternalPool } from "../../db/internal";
+
+const PATTERN_A_SQL = "SELECT plan, SUM(monthly_value) AS total_mrr FROM accounts GROUP BY plan";
+const PATTERN_B_SQL = "SELECT region, COUNT(*) AS account_count FROM accounts GROUP BY region";
+
+let tmpRoot: string;
+const origSemanticRoot = process.env.ATLAS_SEMANTIC_ROOT;
+
+/** Build an entity YAML with the given `query_patterns` SQL list. */
+function entityYaml(patternSqls: string[]): string {
+  if (patternSqls.length === 0) return "table: accounts\n";
+  const patterns = patternSqls
+    .map((sql, i) => `  - name: p${i}\n    sql: "${sql}"`)
+    .join("\n");
+  return `table: accounts\nquery_patterns:\n${patterns}\n`;
+}
+
+/** Write the entity YAML into the temp semantic root's `entities/` dir. */
+function writeAccountsEntity(patternSqls: string[]): void {
+  const entitiesDir = path.join(tmpRoot, "entities");
+  fs.mkdirSync(entitiesDir, { recursive: true });
+  fs.writeFileSync(path.join(entitiesDir, "accounts.yml"), entityYaml(patternSqls), "utf-8");
+}
+
+describe("YAML pattern cache TTL + invalidation (#3614)", () => {
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "yaml-pattern-cache-"));
+    process.env.ATLAS_SEMANTIC_ROOT = tmpRoot;
+    _resetYamlPatternCache();
+  });
+
+  afterEach(() => {
+    _resetYamlPatternCache();
+    if (origSemanticRoot === undefined) {
+      delete process.env.ATLAS_SEMANTIC_ROOT;
+    } else {
+      process.env.ATLAS_SEMANTIC_ROOT = origSemanticRoot;
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("caches within the TTL window — a YAML edit is not seen until reload", () => {
+    writeAccountsEntity([PATTERN_A_SQL]);
+
+    const first = getYamlPatterns();
+    expect(first.has(normalizeSQL(PATTERN_A_SQL))).toBe(true);
+    expect(first.has(normalizeSQL(PATTERN_B_SQL))).toBe(false);
+
+    // Admin appends a new query pattern to the entity YAML.
+    writeAccountsEntity([PATTERN_A_SQL, PATTERN_B_SQL]);
+
+    // Still served from cache — the new pattern is not visible yet. This is the
+    // bug surface: without invalidation/TTL the cache would stay stale forever.
+    expect(getYamlPatterns().has(normalizeSQL(PATTERN_B_SQL))).toBe(false);
+  });
+
+  test("invalidateSemanticIndex drops the cache so new patterns are reflected", () => {
+    writeAccountsEntity([PATTERN_A_SQL]);
+    getYamlPatterns(); // populate cache
+
+    writeAccountsEntity([PATTERN_A_SQL, PATTERN_B_SQL]);
+
+    // Mutating the in-memory semantic layer fires invalidateSemanticIndex,
+    // which must also drop the derived YAML pattern cache.
+    invalidateSemanticIndex();
+
+    const after = getYamlPatterns();
+    expect(after.has(normalizeSQL(PATTERN_A_SQL))).toBe(true);
+    expect(after.has(normalizeSQL(PATTERN_B_SQL))).toBe(true);
+  });
+
+  test("invalidateYamlPatternCache forces a re-read on the next call", () => {
+    writeAccountsEntity([PATTERN_A_SQL]);
+    getYamlPatterns(); // populate cache
+
+    writeAccountsEntity([PATTERN_A_SQL, PATTERN_B_SQL]);
+    invalidateYamlPatternCache();
+
+    expect(getYamlPatterns().has(normalizeSQL(PATTERN_B_SQL))).toBe(true);
+  });
+
+  test("TTL backstop: cache expires after the window without explicit invalidation", () => {
+    let now = 1_000_000;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      writeAccountsEntity([PATTERN_A_SQL]);
+      getYamlPatterns(); // cached at t=1_000_000, expires at +5min
+
+      writeAccountsEntity([PATTERN_A_SQL, PATTERN_B_SQL]);
+
+      // Within the 5-minute window → still stale.
+      now += 4 * 60 * 1000;
+      expect(getYamlPatterns().has(normalizeSQL(PATTERN_B_SQL))).toBe(false);
+
+      // Past the TTL → re-reads from disk even though nothing called invalidate.
+      now += 2 * 60 * 1000;
+      expect(getYamlPatterns().has(normalizeSQL(PATTERN_B_SQL))).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("empty results are not cached so a not-yet-synced root retries", () => {
+    // No entities/ dir yet → empty result, must not be pinned.
+    expect(getYamlPatterns().size).toBe(0);
+
+    writeAccountsEntity([PATTERN_A_SQL]);
+    expect(getYamlPatterns().has(normalizeSQL(PATTERN_A_SQL))).toBe(true);
+  });
+
+  test("proposePatternIfNovel suppresses a pattern added after invalidation — no duplicate row (#3614)", async () => {
+    const origDbUrl = process.env.DATABASE_URL;
+    const queryCalls: Array<{ sql: string }> = [];
+    const mockPool: InternalPool = {
+      query: async (sql: string) => {
+        queryCalls.push({ sql });
+        return { rows: [] };
+      },
+      async connect() {
+        return { query: async () => ({ rows: [] }), release() {} };
+      },
+      end: async () => {},
+      on: () => {},
+    };
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+
+    const input: PatternProposalInput = {
+      sql: PATTERN_A_SQL,
+      dialect: "PostgresQL",
+      connectionId: "default",
+      orgId: undefined,
+      connectionGroupId: undefined,
+    };
+
+    try {
+      // Entity has no query_patterns yet → the query is novel and gets proposed,
+      // which touches the DB (SELECT + INSERT).
+      writeAccountsEntity([]);
+      await _analyzeAndPropose(input);
+      expect(queryCalls.length).toBeGreaterThan(0);
+
+      // Admin authors the pattern into the YAML; the semantic layer reloads.
+      queryCalls.length = 0;
+      writeAccountsEntity([PATTERN_A_SQL]);
+      invalidateSemanticIndex();
+
+      // Now the query matches a YAML pattern → suppressed before any DB write,
+      // so no duplicate learned_patterns row is inserted.
+      await _analyzeAndPropose(input);
+      expect(queryCalls.length).toBe(0);
+    } finally {
+      if (origDbUrl === undefined) {
+        delete process.env.DATABASE_URL;
+      } else {
+        process.env.DATABASE_URL = origDbUrl;
+      }
+      _resetPool(null);
+    }
+  });
+});

--- a/packages/api/src/lib/learn/__tests__/pattern-analyzer-cache.test.ts
+++ b/packages/api/src/lib/learn/__tests__/pattern-analyzer-cache.test.ts
@@ -20,6 +20,7 @@ import {
   normalizeSQL,
 } from "../pattern-analyzer";
 import { invalidateSemanticIndex } from "@atlas/api/lib/semantic/search";
+import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { _analyzeAndPropose, type PatternProposalInput } from "../pattern-proposer";
 import { _resetPool, type InternalPool } from "../../db/internal";
 
@@ -90,6 +91,21 @@ describe("YAML pattern cache TTL + invalidation (#3614)", () => {
     const after = getYamlPatterns();
     expect(after.has(normalizeSQL(PATTERN_A_SQL))).toBe(true);
     expect(after.has(normalizeSQL(PATTERN_B_SQL))).toBe(true);
+  });
+
+  test("the real semantic-layer reset path (_resetWhitelists) cascades to the YAML cache", () => {
+    writeAccountsEntity([PATTERN_A_SQL]);
+    getYamlPatterns(); // populate cache
+
+    writeAccountsEntity([PATTERN_A_SQL, PATTERN_B_SQL]);
+
+    // _resetWhitelists() is the broad "semantic layer changed" reset fanned out
+    // from admin entity-edit routes; it calls invalidateSemanticIndex(), which
+    // must in turn drop the derived YAML pattern cache. Exercising it here
+    // proves the whole wiring, not just the invalidateSemanticIndex leaf.
+    _resetWhitelists();
+
+    expect(getYamlPatterns().has(normalizeSQL(PATTERN_B_SQL))).toBe(true);
   });
 
   test("invalidateYamlPatternCache forces a re-read on the next call", () => {

--- a/packages/api/src/lib/learn/pattern-analyzer.ts
+++ b/packages/api/src/lib/learn/pattern-analyzer.ts
@@ -196,15 +196,15 @@ function loadPatternsFromDir(dir: string, out: Set<string>): void {
 // ── YAML pattern cache ─────────────────────────────────────────────
 
 /**
- * TTL for the YAML pattern cache. Bounded by the semantic-layer reload
- * interval so an admin edit to an entity's `query_patterns` can never go
- * unseen for longer than the rest of the semantic layer (#3614). Matches the
- * approved-pattern cache TTL in `pattern-cache.ts`.
+ * TTL for the YAML pattern cache (#3614). Matches the approved-pattern cache
+ * TTL in `pattern-cache.ts`.
  *
- * This is a backstop: the cache is also actively invalidated when the semantic
- * index is rebuilt (see `invalidateYamlPatternCache` wired into
- * `invalidateSemanticIndex`), so edits are usually reflected immediately. The
- * TTL guarantees an upper bound even on paths that don't fire that hook.
+ * Primary invalidation is event-driven: the cache is dropped whenever the
+ * semantic index is invalidated (see `invalidateYamlPatternCache` wired into
+ * `invalidateSemanticIndex`), so an admin edit to an entity's `query_patterns`
+ * is reflected immediately. The TTL is a backstop that bounds how long a stale
+ * cache can live on any path that doesn't fire that hook — without it the cache
+ * lived for the whole process and kept re-proposing already-authored patterns.
  */
 const YAML_PATTERN_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 

--- a/packages/api/src/lib/learn/pattern-analyzer.ts
+++ b/packages/api/src/lib/learn/pattern-analyzer.ts
@@ -195,22 +195,55 @@ function loadPatternsFromDir(dir: string, out: Set<string>): void {
 
 // ── YAML pattern cache ─────────────────────────────────────────────
 
-let _yamlPatternCache: Set<string> | null = null;
+/**
+ * TTL for the YAML pattern cache. Bounded by the semantic-layer reload
+ * interval so an admin edit to an entity's `query_patterns` can never go
+ * unseen for longer than the rest of the semantic layer (#3614). Matches the
+ * approved-pattern cache TTL in `pattern-cache.ts`.
+ *
+ * This is a backstop: the cache is also actively invalidated when the semantic
+ * index is rebuilt (see `invalidateYamlPatternCache` wired into
+ * `invalidateSemanticIndex`), so edits are usually reflected immediately. The
+ * TTL guarantees an upper bound even on paths that don't fire that hook.
+ */
+const YAML_PATTERN_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface YamlPatternCacheEntry {
+  patterns: Set<string>;
+  expiresAt: number;
+}
+
+let _yamlPatternCache: YamlPatternCacheEntry | null = null;
 
 /** Get YAML patterns. When semanticRoot is provided, reads directly from disk
  * (bypasses cache). Otherwise, lazily loads from the default semantic directory
- * and caches for subsequent calls. Empty results are not cached so subsequent
- * calls retry the load. */
+ * and caches for subsequent calls until the TTL expires or the cache is
+ * invalidated. Empty results are not cached so subsequent calls retry the
+ * load. */
 export function getYamlPatterns(semanticRoot?: string): Set<string> {
   if (semanticRoot) return loadYamlQueryPatterns(semanticRoot);
-  if (!_yamlPatternCache) {
-    const loaded = loadYamlQueryPatterns();
-    if (loaded.size > 0) {
-      _yamlPatternCache = loaded;
-    }
-    return loaded;
+  if (_yamlPatternCache && Date.now() < _yamlPatternCache.expiresAt) {
+    return _yamlPatternCache.patterns;
   }
-  return _yamlPatternCache;
+  const loaded = loadYamlQueryPatterns();
+  if (loaded.size > 0) {
+    _yamlPatternCache = { patterns: loaded, expiresAt: Date.now() + YAML_PATTERN_CACHE_TTL_MS };
+  } else {
+    // Don't cache empty results — a transient read failure or not-yet-synced
+    // semantic root shouldn't pin an empty set for the whole TTL window.
+    _yamlPatternCache = null;
+  }
+  return loaded;
+}
+
+/**
+ * Invalidate the YAML pattern cache so the next `getYamlPatterns()` re-reads
+ * from disk. Wired into `invalidateSemanticIndex()` so an admin edit to an
+ * entity's `query_patterns` is reflected immediately rather than waiting out
+ * the TTL (#3614).
+ */
+export function invalidateYamlPatternCache(): void {
+  _yamlPatternCache = null;
 }
 
 /** Clear the YAML pattern cache. For testing. */
@@ -220,5 +253,5 @@ export function _resetYamlPatternCache(): void {
 
 /** Pre-populate the YAML pattern cache. For testing. */
 export function _setYamlPatternCache(patterns: Set<string>): void {
-  _yamlPatternCache = patterns;
+  _yamlPatternCache = { patterns, expiresAt: Date.now() + YAML_PATTERN_CACHE_TTL_MS };
 }

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -16,6 +16,7 @@ import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSemanticRoot as getDefaultSemanticRoot } from "./files";
 import { scanEntities, resolveEntityGroup, readGroupField, getGroupDirs } from "./scanner";
+import { invalidateYamlPatternCache } from "@atlas/api/lib/learn/pattern-analyzer";
 
 const log = createLogger("semantic-index");
 
@@ -154,10 +155,14 @@ export function getIndexedEntityCount(): number {
   return _cachedEntityCount;
 }
 
-/** Clear the cached index (called on semantic layer changes). */
+/** Clear the cached index (called on semantic layer changes). Also drops the
+ *  learned-pattern dedup cache, which is derived from the same entity YAMLs'
+ *  `query_patterns` — otherwise a freshly-added pattern would keep being
+ *  proposed as "novel" until that cache's TTL expires (#3614). */
 export function invalidateSemanticIndex(): void {
   _cachedIndex = null;
   _cachedEntityCount = 0;
+  invalidateYamlPatternCache();
 }
 
 export interface SemanticIndexStats {


### PR DESCRIPTION
Closes #3614

## What

`getYamlPatterns()` in `pattern-analyzer.ts` cached the normalized `query_patterns` SQL from entity YAMLs in a module-level `_yamlPatternCache` with no TTL and no invalidation hook, so it lived for the whole process lifetime. After an admin added a `query_patterns` entry to an entity YAML, the running API kept proposing those patterns as "novel" and inserting duplicate `learned_patterns` rows until restart.

## Why / fix

The cache is derived from the same entity YAMLs the rest of the semantic layer reads, so it should not outlive a semantic-layer reload. Two complementary mechanisms:

- **Active invalidation** — `invalidateSemanticIndex()` (the canonical "semantic layer changed" hook, fanned out from `_resetWhitelists()`) now also calls the new `invalidateYamlPatternCache()`, so an entity edit is reflected immediately.
- **TTL backstop** — the cache now carries a 5-minute TTL (matching the approved-pattern cache in `pattern-cache.ts:19`), guaranteeing an upper bound even on paths that don't fire the invalidation hook. Empty results stay uncached so a not-yet-synced root retries.

`search.ts → pattern-analyzer.ts` is acyclic (`pattern-analyzer` imports only `semantic/files`, a leaf), so no import cycle is introduced.

## Tests

New `packages/api/src/lib/learn/__tests__/pattern-analyzer-cache.test.ts`:
- caches within the TTL window (a YAML edit is not seen until reload — proves it actually caches)
- `invalidateSemanticIndex()` drops the cache so new `query_patterns` are reflected (mutating the in-memory semantic layer triggers invalidation)
- `invalidateYamlPatternCache()` forces a re-read
- TTL backstop expires the cache after 5 min without explicit invalidation (clock spied)
- empty results are not cached
- `proposePatternIfNovel` suppresses a pattern authored after invalidation — no duplicate `learned_patterns` row

All `/ci` gates pass locally: lint, type, full test suite, syncpack, and every drift check.

https://claude.ai/code/session_01YATfBTPVRpjcWmdndEFwSW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YATfBTPVRpjcWmdndEFwSW)_