### PR TITLE
feat(api): surface column cardinality to the agent (#3630)

### DIFF
--- a/packages/api/src/lib/semantic/__tests__/format-entity-cardinality.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/format-entity-cardinality.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "bun:test";
+import { formatEntity, type ParsedEntity } from "../search";
+
+// Pure-function tests for the column-cardinality markers (#3630). They feed
+// in-memory entity objects carrying the profiler's `unique_count` / `null_count`
+// fields and assert the prompt text `formatEntity` emits in both modes — no YAML
+// loader, no disk.
+
+describe("formatEntity — cardinality markers", () => {
+  const entity: ParsedEntity = {
+    name: "orders",
+    table: "orders",
+    type: "fact_table",
+    dimensions: [
+      { name: "id", type: "uuid", primary_key: true, unique_count: 1000, null_count: 0 },
+      { name: "status", type: "text", unique_count: 6, null_count: 0, description: "order status" },
+      { name: "region", type: "text", unique_count: 50, null_count: 12 },
+      // No profiled stats — must render exactly as before.
+      { name: "notes", type: "text" },
+    ],
+  };
+
+  describe("full mode", () => {
+    const out = formatEntity(entity, true, null);
+
+    it("emits distinct + null-free marker inside the type parenthetical", () => {
+      expect(out).toContain("- status (text, ~6 distinct, no nulls) — order status");
+    });
+
+    it("reports a non-zero null count as an absolute count", () => {
+      expect(out).toContain("- region (text, ~50 distinct, 12 null)");
+    });
+
+    it("keeps the PK marker alongside the cardinality fragments", () => {
+      expect(out).toContain("- id (uuid PK, ~1000 distinct, no nulls)");
+    });
+
+    it("leaves columns without profiled stats untouched", () => {
+      expect(out).toContain("- notes (text)");
+      expect(out).not.toContain("notes (text,");
+    });
+  });
+
+  describe("summary mode", () => {
+    const out = formatEntity(entity, false, null);
+
+    it("emits a compact distinct-count form for profiled real columns", () => {
+      expect(out).toContain("cardinality: id(~1000), status(~6), region(~50)");
+    });
+
+    it("does not list unprofiled columns in the compact form", () => {
+      expect(out).not.toContain("notes(~");
+    });
+  });
+
+  it("omits the cardinality marker entirely when no dimension is profiled", () => {
+    const bare: ParsedEntity = {
+      table: "plain",
+      dimensions: [{ name: "a", type: "text" }, { name: "b", type: "int" }],
+    };
+    expect(formatEntity(bare, true, null)).toContain("- a (text)");
+    expect(formatEntity(bare, false, null)).not.toContain("cardinality:");
+  });
+
+  it("caps the compact summary form and reports the overflow count", () => {
+    const wide: ParsedEntity = {
+      table: "wide",
+      dimensions: Array.from({ length: 10 }, (_, i) => ({
+        name: `c${i}`,
+        type: "text",
+        unique_count: i,
+      })),
+    };
+    const out = formatEntity(wide, false, null);
+    expect(out).toContain("c0(~0)");
+    expect(out).toContain("c7(~7)");
+    // 10 profiled columns, cap of 8 → 2 hidden.
+    expect(out).toContain("+2 more");
+    expect(out).not.toContain("c8(~8)");
+  });
+});

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -35,6 +35,16 @@ interface EntityDimension {
   sample_values?: unknown[];
   primary_key?: boolean;
   virtual?: boolean;
+  /**
+   * Profiler cardinality stats, mirrored from the entity YAML the profiler
+   * emits (`generate/yaml.ts`). Surfaced to the agent by {@link formatEntity}
+   * so it can pick high-selectivity filter columns and judge when
+   * `COUNT(DISTINCT …)` is cheap (#3630). Both are spread untyped from
+   * `yaml.load`, so consumers type-narrow with `typeof … === "number"` before
+   * formatting rather than trusting the static type.
+   */
+  unique_count?: number;
+  null_count?: number;
 }
 
 interface EntityMeasure {
@@ -58,7 +68,7 @@ interface EntityQueryPattern {
   sql?: string;
 }
 
-interface ParsedEntity {
+export interface ParsedEntity {
   name?: string;
   table: string;
   type?: string;
@@ -287,7 +297,36 @@ export function buildSemanticIndex(semanticRoot: string): string {
 
 // --- Formatters ---
 
-function formatEntity(
+/**
+ * Build the per-dimension cardinality fragments the agent uses to pick
+ * high-selectivity filters and judge `COUNT(DISTINCT …)` cost (#3630).
+ *
+ * Returns an ordered fragment list (never a joined string) so callers control
+ * spacing per mode, and so slice A-2 (#3634) can append an index marker
+ * (e.g. `"indexed"`) without reshaping the formatters. Empty when the
+ * dimension carries no profiled stats.
+ *
+ * `unique_count` / `null_count` are spread untyped from `yaml.load`, so each is
+ * narrowed with `typeof … === "number"` here rather than trusting the static
+ * type. `null_count` is omitted entirely by the profiler when zero, so an
+ * explicit `0` (or a finite count) is the only thing worth surfacing; we report
+ * the absolute count rather than a percentage because the per-dimension stats
+ * carry no row total to divide by.
+ */
+function cardinalityFragments(dim: EntityDimension): string[] {
+  const fragments: string[] = [];
+  if (typeof dim.unique_count === "number" && dim.unique_count >= 0) {
+    fragments.push(`~${dim.unique_count} distinct`);
+  }
+  if (typeof dim.null_count === "number" && dim.null_count >= 0) {
+    fragments.push(dim.null_count === 0 ? "no nulls" : `${dim.null_count} null`);
+  }
+  return fragments;
+}
+
+// Exported for unit testing the cardinality markers (#3630) as a pure
+// function over in-memory entity objects, without touching the YAML loader.
+export function formatEntity(
   entity: ParsedEntity,
   full: boolean,
   catalog: ParsedCatalog | null,
@@ -338,7 +377,9 @@ function formatEntity(
           const type = dim.type ?? "unknown";
           const pk = dim.primary_key ? " PK" : "";
           const desc = dim.description ? ` — ${dim.description}` : "";
-          lines.push(`  - ${name} (${type}${pk})${desc}`);
+          const card = cardinalityFragments(dim);
+          const cardSuffix = card.length > 0 ? `, ${card.join(", ")}` : "";
+          lines.push(`  - ${name} (${type}${pk}${cardSuffix})${desc}`);
         }
       }
 
@@ -395,6 +436,22 @@ function formatEntity(
     const parts: string[] = [`${colCount} columns`];
     if (pks.length > 0)
       parts.push(`PK: ${pks.map((p) => p.name ?? p.sql).join(", ")}`);
+
+    // Compact cardinality form: distinct counts for profiled real columns, so
+    // the agent can still spot high-selectivity filters in large layers without
+    // the full per-column listing (#3630). Capped so a wide table can't blow up
+    // the summary line.
+    const cardCols = dims
+      .filter((d) => !d.virtual && typeof d.unique_count === "number")
+      .map((d) => `${d.name ?? d.sql ?? "?"}(~${d.unique_count})`);
+    if (cardCols.length > 0) {
+      const CARD_CAP = 8;
+      const shown = cardCols.slice(0, CARD_CAP).join(", ");
+      const overflow =
+        cardCols.length > CARD_CAP ? `, +${cardCols.length - CARD_CAP} more` : "";
+      parts.push(`cardinality: ${shown}${overflow}`);
+    }
+
     if (measureCount > 0) parts.push(`${measureCount} measures`);
     if (joinCount > 0)
       parts.push(

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -442,7 +442,12 @@ export function formatEntity(
     // the full per-column listing (#3630). Capped so a wide table can't blow up
     // the summary line.
     const cardCols = dims
-      .filter((d) => !d.virtual && typeof d.unique_count === "number")
+      .filter(
+        (d) =>
+          !d.virtual &&
+          typeof d.unique_count === "number" &&
+          d.unique_count >= 0,
+      )
       .map((d) => `${d.name ?? d.sql ?? "?"}(~${d.unique_count})`);
     if (cardCols.length > 0) {
       const CARD_CAP = 8;


### PR DESCRIPTION
Closes #3630 — v0.0.17 "Performance-aware Atlas" slice A-1.

## What
The profiler already computes `unique_count` / `null_count` per column and writes them into entity YAML, but the `EntityDimension` type in the semantic-index builder (`search.ts`) never declared them, so `formatEntity` couldn't read them — they were dropped before reaching the agent.

- **`EntityDimension`** now declares `unique_count` / `null_count`. The loader already passes `raw.dimensions` through wholesale, so the runtime data now flows through type-safely (no per-dimension remap needed).
- **`formatEntity` full mode** emits a per-dimension cardinality marker inside the type parenthetical: `status (text, ~6 distinct, no nulls)` / `region (text, ~50 distinct, 12 null)`.
- **`formatEntity` summary mode** emits a compact, capped form: `cardinality: status(~6), region(~50)` (capped at 8 columns with a `+N more` overflow so a wide table can't blow up the summary line).
- The marker is built from an **ordered fragment list** (`cardinalityFragments`) so slice A-2 (#3634) can append index markers (`"indexed"`) without reshaping the formatters.
- `formatEntity` + `ParsedEntity` are exported for testing.

## Why
Lets the agent pick high-selectivity filter columns and judge when `COUNT(DISTINCT …)` is cheap, straight from the pre-indexed semantic summary — no extra `explore` round-trips.

## Design note
Null counts are reported as **absolute values, not percentages**: the per-dimension stats carry no row total to divide by, so a percentage would be fabricated. The profiler omits `null_count` when zero, so an explicit `0` renders as `no nulls`.

## Tests
New pure-function test `__tests__/format-entity-cardinality.test.ts` feeds in-memory entity objects carrying the cardinality fields and asserts the emitted prompt text in both modes (distinct + null markers, PK coexistence, unprofiled-column passthrough, summary cap/overflow). No whitelist or entity-validation change.

Local `/ci`: lint, type, full test suite, syncpack, all drift checks — green.

https://claude.ai/code/session_01KihG9QKMKoKzBDL1cU4k3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01KihG9QKMKoKzBDL1cU4k3D)_