### PR TITLE
fix(api): bulk-approve applies semantic_amendment YAML rewrite (#3613)

### DIFF
--- a/packages/api/src/api/__tests__/admin-learned-patterns-amendment.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-amendment.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the semantic_amendment YAML side-effect on the learned-patterns
+ * approve paths (#3613).
+ *
+ * Approving a `type='semantic_amendment'` row — via the single PATCH route OR
+ * the bulk-approve route — must rewrite the entity YAML through
+ * `applyAmendmentToEntity` BEFORE the row's status flips to `approved`. The bug:
+ * the bulk handler stamped `approved` with a raw UPDATE, so semantic amendments
+ * went live in the DB while their YAML on disk + the in-memory layer stayed
+ * stale until restart.
+ *
+ * These tests assert:
+ *   1. bulk-approving a mix of query_pattern + semantic_amendment dispatches the
+ *      YAML rewrite for ONLY the semantic row, with the inner `amendment` object
+ *      (not the stored envelope);
+ *   2. a failed YAML apply aborts the status update — the row never reaches
+ *      `approved`;
+ *   3. the single PATCH approve path applies the YAML side-effect too.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+// Capture every applyAmendmentToEntity invocation so each test can assert what
+// AnalysisResult the approve path dispatched. Default: resolve (apply succeeds);
+// tests that exercise the failure path override the implementation.
+const applyAmendmentToEntity = mock(
+  async (_orgId: string | null, _result: unknown, _requestId: string): Promise<void> => {},
+);
+
+mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendmentToEntity,
+  // Pure helper also exported by the real module — keep it present so a
+  // transitive `import { applyAmendment }` never SyntaxErrors at load time.
+  applyAmendment: mock((entity: Record<string, unknown>) => entity),
+}));
+
+// --- Import the app AFTER mocks ---
+
+const { app } = await import("../index");
+
+// --- Helpers ---
+
+function req(method: string, urlPath: string, body?: unknown) {
+  const url = `http://localhost/api/v1/admin/learned-patterns${urlPath}`;
+  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  return app.fetch(new Request(url, init));
+}
+
+/** Inner amendment object — the dimension that should land in the YAML. */
+const INNER_AMENDMENT = { name: "region", sql: "region", type: "string", description: "Customer region" };
+
+/** Full stored envelope, as written by proposeAmendment / the scheduler. */
+const AMENDMENT_PAYLOAD = {
+  entityName: "orders",
+  amendmentType: "add_dimension",
+  amendment: INNER_AMENDMENT,
+  rationale: "Add a region dimension for geo breakdowns",
+  category: "coverage_gaps",
+  confidence: 0.9,
+};
+
+function semanticRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "pat-sem",
+    org_id: "org-1",
+    type: "semantic_amendment",
+    source_entity: "orders",
+    connection_group_id: null,
+    amendment_payload: AMENDMENT_PAYLOAD,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function queryRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "pat-query",
+    org_id: "org-1",
+    type: "query_pattern",
+    pattern_sql: "SELECT COUNT(*) FROM orders",
+    source_entity: "orders",
+    amendment_payload: null,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+// --- Cleanup ---
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+  applyAmendmentToEntity.mockReset();
+  applyAmendmentToEntity.mockImplementation(async () => {});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("learned-patterns semantic_amendment YAML side-effect (#3613)", () => {
+  describe("POST /bulk", () => {
+    it("applies the YAML rewrite for semantic_amendment rows and not query_pattern rows", async () => {
+      // Per-id SELECT returns the matching row; UPDATE returns []. The handler
+      // SELECTs `id, type, source_entity, amendment_payload, connection_group_id`.
+      mocks.mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT")) {
+          const id = (params?.[0] as string) ?? "";
+          if (id === "pat-sem") return Promise.resolve([semanticRow()]);
+          if (id === "pat-query") return Promise.resolve([queryRow()]);
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]); // UPDATE
+      });
+
+      const res = await req("POST", "/bulk", { ids: ["pat-query", "pat-sem"], status: "approved" });
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.updated).toContain("pat-query");
+      expect(body.updated).toContain("pat-sem");
+      expect(body.errors).toBeUndefined();
+
+      // The YAML rewrite ran exactly once — for the semantic row only.
+      expect(applyAmendmentToEntity).toHaveBeenCalledTimes(1);
+      const [orgId, result, requestId] = applyAmendmentToEntity.mock.calls[0];
+      expect(orgId).toBe("org-1");
+      expect(typeof requestId).toBe("string");
+      // The inner amendment object feeds the YAML mutation — NOT the envelope.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const ar = result as any;
+      expect(ar.entityName).toBe("orders");
+      expect(ar.amendmentType).toBe("add_dimension");
+      expect(ar.group).toBe("default"); // NULL connection_group_id → explicit default scope
+      expect(ar.amendment).toEqual(INNER_AMENDMENT);
+    });
+
+    it("does NOT stamp approved when the YAML apply fails", async () => {
+      applyAmendmentToEntity.mockImplementation(async () => {
+        throw new Error("entity not found");
+      });
+
+      const updateCalls: string[] = [];
+      mocks.mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT")) {
+          const id = (params?.[0] as string) ?? "";
+          if (id === "pat-sem") return Promise.resolve([semanticRow()]);
+          return Promise.resolve([]);
+        }
+        updateCalls.push(sql);
+        return Promise.resolve([]);
+      });
+
+      const res = await req("POST", "/bulk", { ids: ["pat-sem"], status: "approved" });
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      // The failed apply is reported per-id; the row is NOT marked updated.
+      expect(body.updated).not.toContain("pat-sem");
+      expect(body.errors).toBeArray();
+      expect(body.errors[0].id).toBe("pat-sem");
+      // Critically: no UPDATE ran, so the row never reached status='approved'.
+      expect(updateCalls.length).toBe(0);
+    });
+
+    it("does not invoke the YAML apply when bulk-rejecting a semantic_amendment", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT")) {
+          const id = (params?.[0] as string) ?? "";
+          if (id === "pat-sem") return Promise.resolve([semanticRow()]);
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await req("POST", "/bulk", { ids: ["pat-sem"], status: "rejected" });
+      expect(res.status).toBe(200);
+      expect(applyAmendmentToEntity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PATCH /:id", () => {
+    it("applies the YAML rewrite before updating status to approved", async () => {
+      let sawUpdate = false;
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.startsWith("SELECT") || sql.includes("SELECT *")) {
+          return Promise.resolve([semanticRow()]);
+        }
+        // UPDATE … RETURNING *
+        sawUpdate = true;
+        return Promise.resolve([semanticRow({ status: "approved", reviewed_by: "admin-1" })]);
+      });
+
+      const res = await req("PATCH", "/pat-sem", { status: "approved" });
+      expect(res.status).toBe(200);
+      expect(applyAmendmentToEntity).toHaveBeenCalledTimes(1);
+      expect(sawUpdate).toBe(true);
+      const [, result] = applyAmendmentToEntity.mock.calls[0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      expect((result as any).amendment).toEqual(INNER_AMENDMENT);
+    });
+
+    it("returns 500 and does NOT update status when the YAML apply fails", async () => {
+      applyAmendmentToEntity.mockImplementation(async () => {
+        throw new Error("entity not found");
+      });
+
+      const updateCalls: string[] = [];
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("UPDATE")) {
+          updateCalls.push(sql);
+          return Promise.resolve([semanticRow({ status: "approved" })]);
+        }
+        return Promise.resolve([semanticRow()]);
+      });
+
+      const res = await req("PATCH", "/pat-sem", { status: "approved" });
+      expect(res.status).toBe(500);
+      expect(updateCalls.length).toBe(0);
+    });
+  });
+});

--- a/packages/api/src/api/__tests__/admin-learned-patterns-amendment.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-amendment.test.ts
@@ -33,17 +33,28 @@ const mocks = createApiTestMocks({
   },
 });
 
-// Capture every applyAmendmentToEntity invocation so each test can assert what
-// AnalysisResult the approve path dispatched. Default: resolve (apply succeeds);
-// tests that exercise the failure path override the implementation.
-const applyAmendmentToEntity = mock(
-  async (_orgId: string | null, _result: unknown, _requestId: string): Promise<void> => {},
+// The approve paths delegate to the shared `applyAmendmentFromPayload` helper.
+// Capture every invocation so each test can assert what the route dispatched
+// (entity, group, raw payload). The helper's own envelope→AnalysisResult
+// mapping — including pulling the INNER `amendment` object — is unit-tested in
+// lib/semantic/expert/__tests__/apply-from-payload.test.ts. Default: resolve
+// (apply succeeds); failure-path tests override the implementation.
+const applyAmendmentFromPayload = mock(
+  async (_params: {
+    orgId: string | null;
+    sourceEntity: string;
+    connectionGroupId: string | null;
+    rawPayload: unknown;
+    requestId: string;
+    label?: string;
+  }): Promise<void> => {},
 );
 
 mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
-  applyAmendmentToEntity,
-  // Pure helper also exported by the real module — keep it present so a
-  // transitive `import { applyAmendment }` never SyntaxErrors at load time.
+  applyAmendmentFromPayload,
+  // Other exports of the real module — keep them present so a transitive
+  // `import { … }` never SyntaxErrors at load time.
+  applyAmendmentToEntity: mock(async () => undefined),
   applyAmendment: mock((entity: Record<string, unknown>) => entity),
 }));
 
@@ -113,8 +124,8 @@ beforeEach(() => {
   mocks.mockInternalQuery.mockReset();
   mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
-  applyAmendmentToEntity.mockReset();
-  applyAmendmentToEntity.mockImplementation(async () => {});
+  applyAmendmentFromPayload.mockReset();
+  applyAmendmentFromPayload.mockImplementation(async () => {});
 });
 
 // ---------------------------------------------------------------------------
@@ -144,22 +155,20 @@ describe("learned-patterns semantic_amendment YAML side-effect (#3613)", () => {
       expect(body.updated).toContain("pat-sem");
       expect(body.errors).toBeUndefined();
 
-      // The YAML rewrite ran exactly once — for the semantic row only.
-      expect(applyAmendmentToEntity).toHaveBeenCalledTimes(1);
-      const [orgId, result, requestId] = applyAmendmentToEntity.mock.calls[0];
-      expect(orgId).toBe("org-1");
-      expect(typeof requestId).toBe("string");
-      // The inner amendment object feeds the YAML mutation — NOT the envelope.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const ar = result as any;
-      expect(ar.entityName).toBe("orders");
-      expect(ar.amendmentType).toBe("add_dimension");
-      expect(ar.group).toBe("default"); // NULL connection_group_id → explicit default scope
-      expect(ar.amendment).toEqual(INNER_AMENDMENT);
+      // The YAML rewrite was dispatched exactly once — for the semantic row only
+      // — with the row's authoritative entity, group, and the raw payload (the
+      // helper extracts the inner amendment; see apply-from-payload.test.ts).
+      expect(applyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+      const [params] = applyAmendmentFromPayload.mock.calls[0];
+      expect(params.orgId).toBe("org-1");
+      expect(params.sourceEntity).toBe("orders");
+      expect(params.connectionGroupId).toBeNull();
+      expect(params.rawPayload).toEqual(AMENDMENT_PAYLOAD);
+      expect(typeof params.requestId).toBe("string");
     });
 
     it("does NOT stamp approved when the YAML apply fails", async () => {
-      applyAmendmentToEntity.mockImplementation(async () => {
+      applyAmendmentFromPayload.mockImplementation(async () => {
         throw new Error("entity not found");
       });
 
@@ -198,7 +207,7 @@ describe("learned-patterns semantic_amendment YAML side-effect (#3613)", () => {
 
       const res = await req("POST", "/bulk", { ids: ["pat-sem"], status: "rejected" });
       expect(res.status).toBe(200);
-      expect(applyAmendmentToEntity).not.toHaveBeenCalled();
+      expect(applyAmendmentFromPayload).not.toHaveBeenCalled();
     });
   });
 
@@ -216,15 +225,15 @@ describe("learned-patterns semantic_amendment YAML side-effect (#3613)", () => {
 
       const res = await req("PATCH", "/pat-sem", { status: "approved" });
       expect(res.status).toBe(200);
-      expect(applyAmendmentToEntity).toHaveBeenCalledTimes(1);
+      expect(applyAmendmentFromPayload).toHaveBeenCalledTimes(1);
       expect(sawUpdate).toBe(true);
-      const [, result] = applyAmendmentToEntity.mock.calls[0];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      expect((result as any).amendment).toEqual(INNER_AMENDMENT);
+      const [params] = applyAmendmentFromPayload.mock.calls[0];
+      expect(params.sourceEntity).toBe("orders");
+      expect(params.rawPayload).toEqual(AMENDMENT_PAYLOAD);
     });
 
     it("returns 500 and does NOT update status when the YAML apply fails", async () => {
-      applyAmendmentToEntity.mockImplementation(async () => {
+      applyAmendmentFromPayload.mockImplementation(async () => {
         throw new Error("entity not found");
       });
 

--- a/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
@@ -75,6 +75,7 @@ mock.module("@atlas/api/lib/audit", async () => {
 // Stub YAML apply so the approved branch does not touch the filesystem.
 mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
   applyAmendmentToEntity: mock(async () => undefined),
+  applyAmendmentFromPayload: mock(async () => undefined),
 }));
 
 // Seed `createSession` to return one proposal so /proposals/0/(approve|reject)

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -81,6 +81,96 @@ function orgFilter(
 
 const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
 
+/**
+ * Apply a `semantic_amendment` learned-pattern row's YAML side-effect.
+ *
+ * Approving a `semantic_amendment` row must rewrite the entity YAML on disk and
+ * the entity row — the same path the dedicated review endpoint
+ * (`/admin/semantic/improve/amendments/:id/review`) runs. Both the single-PATCH
+ * and bulk-approve handlers call this BEFORE persisting `status='approved'`, so
+ * a failed apply never leaves an approved-but-unapplied row whose YAML stays
+ * stale until restart (#3613).
+ *
+ * The stored `amendment_payload` is the full envelope
+ * (`{ entityName, amendmentType, amendment, rationale, category, … }`); the YAML
+ * mutation consumes the inner `amendment` object, not the envelope — so the
+ * reconstructed {@link AnalysisResult} carries `payload.amendment`, never
+ * `payload` itself.
+ *
+ * @throws when the payload is missing/malformed or the YAML apply fails. An
+ *   `AmbiguousEntityError` (a name shared across Connection groups) propagates
+ *   so the route layer maps it to 409 with the conflicting groups.
+ */
+async function applyAmendmentRow(
+  row: Record<string, unknown>,
+  orgId: string | null,
+  requestId: string,
+): Promise<void> {
+  const rawPayload = row.amendment_payload;
+  let payload: Record<string, unknown> | null = null;
+  if (typeof rawPayload === "string") {
+    try {
+      const parsed: unknown = JSON.parse(rawPayload);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch (err) {
+      throw new Error(
+        `Corrupt amendment_payload JSON for semantic amendment ${String(row.id)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  } else if (rawPayload && typeof rawPayload === "object" && !Array.isArray(rawPayload)) {
+    payload = rawPayload as Record<string, unknown>;
+  }
+
+  if (!payload) {
+    throw new Error(
+      `Semantic amendment ${String(row.id)} has no amendment_payload — cannot apply its YAML change.`,
+    );
+  }
+
+  const innerAmendment = payload.amendment;
+  if (!innerAmendment || typeof innerAmendment !== "object" || Array.isArray(innerAmendment)) {
+    throw new Error(
+      `Semantic amendment ${String(row.id)} payload is missing a valid \`amendment\` object — cannot apply its YAML change.`,
+    );
+  }
+
+  const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
+  const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
+  const { AMENDMENT_TYPES } = await import("@useatlas/types");
+
+  const rawCategory = String(payload.category ?? "coverage_gaps");
+  const rawAmendmentType = String(payload.amendmentType ?? "update_description");
+
+  await applyAmendmentToEntity(
+    orgId,
+    {
+      entityName: String(row.source_entity),
+      // Recover the Connection group the amendment was analyzed against so the
+      // apply targets that group's row, not the default scope or a 409 (#3284).
+      // A NULL column means the default (flat) group — map it to the explicit
+      // `"default"` label so the lookup is scoped to NULL rather than running
+      // the unscoped ambiguity check.
+      group: (row.connection_group_id as string | null) ?? "default",
+      category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
+        ? (rawCategory as (typeof ANALYSIS_CATEGORIES)[number])
+        : "coverage_gaps",
+      amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
+        ? (rawAmendmentType as (typeof AMENDMENT_TYPES)[number])
+        : "update_description",
+      amendment: innerAmendment as Record<string, unknown>,
+      rationale: typeof payload.rationale === "string" ? payload.rationale : "",
+      confidence: 0,
+      impact: 0,
+      score: 0,
+      staleness: 0,
+    },
+    requestId,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
@@ -445,6 +535,7 @@ adminLearnedPatterns.openapi(getPatternRoute, async (c) => {
 
 adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
+    const { requestId } = yield* RequestContext;
     const { orgId, user } = yield* AuthContext;
 
     const { id } = c.req.valid("param");
@@ -455,6 +546,17 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const org = orgFilter(orgId, checkParams, checkParams.length + 1);
     const existing = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams);
     if (existing.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+
+    // Approving a semantic_amendment must rewrite the entity YAML BEFORE the
+    // status flips to approved — apply first so a failed apply (incl. an
+    // AmbiguousEntityError → 409) aborts the request and never leaves an
+    // approved-but-unapplied row (#3613).
+    if (status === "approved" && existing[0].type === "semantic_amendment") {
+      yield* Effect.tryPromise({
+        try: () => applyAmendmentRow(existing[0], orgId ?? null, requestId),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
+    }
 
     const setClauses: string[] = ["updated_at = now()"];
     const updateParams: unknown[] = [];
@@ -544,8 +646,17 @@ adminLearnedPatterns.openapi(bulkStatusRoute, async (c) => {
         try: async () => {
           const checkParams: unknown[] = [id];
           const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-          const existing = await internalQuery<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams);
+          const existing = await internalQuery<Record<string, unknown>>(`SELECT id, type, source_entity, amendment_payload, connection_group_id FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams);
           if (existing.length === 0) return "not_found" as const;
+
+          // Approving a semantic_amendment must rewrite the entity YAML BEFORE
+          // the status flips to approved — otherwise the row reads "approved"
+          // while the on-disk YAML + in-memory layer stay stale until restart
+          // (#3613). Apply first; a failed apply throws, is recorded per-id in
+          // `errors`, and the status update never runs.
+          if (status === "approved" && existing[0].type === "semantic_amendment") {
+            await applyAmendmentRow(existing[0], orgId ?? null, requestId);
+          }
 
           const updateParams: unknown[] = [status, user?.id ?? null, id];
           const updateOrg = orgFilter(orgId, updateParams, updateParams.length + 1);

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -91,84 +91,25 @@ const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
  * a failed apply never leaves an approved-but-unapplied row whose YAML stays
  * stale until restart (#3613).
  *
- * The stored `amendment_payload` is the full envelope
- * (`{ entityName, amendmentType, amendment, rationale, category, … }`); the YAML
- * mutation consumes the inner `amendment` object, not the envelope — so the
- * reconstructed {@link AnalysisResult} carries `payload.amendment`, never
- * `payload` itself.
- *
- * @throws when the payload is missing/malformed or the YAML apply fails. An
- *   `AmbiguousEntityError` (a name shared across Connection groups) propagates
- *   so the route layer maps it to 409 with the conflicting groups.
+ * Adapts a `learned_patterns` row to the shared `applyAmendmentFromPayload`
+ * helper, which owns the envelope→`AnalysisResult` mapping (incl. extracting the
+ * inner `amendment` object and recovering the Connection group). Throws on a
+ * missing/malformed payload or a failed apply.
  */
 async function applyAmendmentRow(
   row: Record<string, unknown>,
   orgId: string | null,
   requestId: string,
 ): Promise<void> {
-  const rawPayload = row.amendment_payload;
-  let payload: Record<string, unknown> | null = null;
-  if (typeof rawPayload === "string") {
-    try {
-      const parsed: unknown = JSON.parse(rawPayload);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        payload = parsed as Record<string, unknown>;
-      }
-    } catch (err) {
-      throw new Error(
-        `Corrupt amendment_payload JSON for semantic amendment ${String(row.id)}: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
-    }
-  } else if (rawPayload && typeof rawPayload === "object" && !Array.isArray(rawPayload)) {
-    payload = rawPayload as Record<string, unknown>;
-  }
-
-  if (!payload) {
-    throw new Error(
-      `Semantic amendment ${String(row.id)} has no amendment_payload — cannot apply its YAML change.`,
-    );
-  }
-
-  const innerAmendment = payload.amendment;
-  if (!innerAmendment || typeof innerAmendment !== "object" || Array.isArray(innerAmendment)) {
-    throw new Error(
-      `Semantic amendment ${String(row.id)} payload is missing a valid \`amendment\` object — cannot apply its YAML change.`,
-    );
-  }
-
-  const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
-  const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
-  const { AMENDMENT_TYPES } = await import("@useatlas/types");
-
-  const rawCategory = String(payload.category ?? "coverage_gaps");
-  const rawAmendmentType = String(payload.amendmentType ?? "update_description");
-
-  await applyAmendmentToEntity(
+  const { applyAmendmentFromPayload } = await import("@atlas/api/lib/semantic/expert/apply");
+  await applyAmendmentFromPayload({
     orgId,
-    {
-      entityName: String(row.source_entity),
-      // Recover the Connection group the amendment was analyzed against so the
-      // apply targets that group's row, not the default scope or a 409 (#3284).
-      // A NULL column means the default (flat) group — map it to the explicit
-      // `"default"` label so the lookup is scoped to NULL rather than running
-      // the unscoped ambiguity check.
-      group: (row.connection_group_id as string | null) ?? "default",
-      category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
-        ? (rawCategory as (typeof ANALYSIS_CATEGORIES)[number])
-        : "coverage_gaps",
-      amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
-        ? (rawAmendmentType as (typeof AMENDMENT_TYPES)[number])
-        : "update_description",
-      amendment: innerAmendment as Record<string, unknown>,
-      rationale: typeof payload.rationale === "string" ? payload.rationale : "",
-      confidence: 0,
-      impact: 0,
-      score: 0,
-      staleness: 0,
-    },
+    sourceEntity: String(row.source_entity),
+    connectionGroupId: (row.connection_group_id as string | null) ?? null,
+    rawPayload: row.amendment_payload,
     requestId,
-  );
+    label: String(row.id),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -902,35 +902,20 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
 
       const payload = target.amendment_payload;
       if (payload) {
-        const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
-        const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
-        const { AMENDMENT_TYPES } = await import("@useatlas/types");
-
-        const rawCategory = String(payload.category ?? "coverage_gaps");
-        const rawAmendmentType = String(payload.amendmentType ?? "update_description");
-
-        // This throws on failure — runHandler maps it to 500
-        await applyAmendmentToEntity(orgId, {
-          entityName: target.source_entity,
-          // Recover the Connection group the amendment was analyzed against so
-          // the apply targets that group's row, not the default scope or a 409
-          // (#3284). A NULL column means the default (flat) group — map it to
-          // the explicit `"default"` label so the lookup is scoped to NULL
-          // rather than running the unscoped ambiguity check.
-          group: target.connection_group_id ?? "default",
-          category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
-            ? rawCategory as typeof ANALYSIS_CATEGORIES[number]
-            : "coverage_gaps",
-          amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
-            ? rawAmendmentType as typeof AMENDMENT_TYPES[number]
-            : "update_description",
-          amendment: payload,
-          rationale: typeof payload.rationale === "string" ? payload.rationale : "",
-          confidence: 0,
-          impact: 0,
-          score: 0,
-          staleness: 0,
-        }, requestId);
+        const { applyAmendmentFromPayload } = await import("@atlas/api/lib/semantic/expert/apply");
+        // This throws on failure — runHandler maps it to 500 (or 409 for an
+        // AmbiguousEntityError). The shared helper owns the envelope→
+        // AnalysisResult mapping, including extracting the INNER `amendment`
+        // object (the YAML mutation reads `payload.amendment`, not the whole
+        // envelope) and recovering the Connection group (#3284).
+        await applyAmendmentFromPayload({
+          orgId,
+          sourceEntity: target.source_entity,
+          connectionGroupId: target.connection_group_id ?? null,
+          rawPayload: payload,
+          requestId,
+          label: target.id,
+        });
       }
     }
 

--- a/packages/api/src/lib/semantic/expert/__tests__/apply-from-payload.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/apply-from-payload.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for `applyAmendmentFromPayload` (#3613).
+ *
+ * Proves the shared envelope→`AnalysisResult` reconstruction that every admin
+ * approve path delegates to:
+ *
+ *   1. it feeds the YAML mutation the INNER `amendment` object — the dimension
+ *      lands in the entity, NOT the surrounding envelope (`entityName`,
+ *      `amendmentType`, `rationale`, …). This is the regression guard for the
+ *      pre-#3613 bug where the whole payload was passed as `amendment`;
+ *   2. it accepts the raw payload as either a JSON string or a parsed object;
+ *   3. it recovers the Connection group (NULL → explicit `"default"` scope);
+ *   4. malformed payloads throw rather than silently corrupt the entity.
+ *
+ * Mocks the DB/disk layer so we assert the reconstruction, not persistence.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import * as yaml from "js-yaml";
+
+class AmbiguousEntityError extends Error {
+  readonly groups: (string | null)[];
+  constructor(opts: { message: string; groups: (string | null)[] }) {
+    super(opts.message);
+    this.name = "AmbiguousEntityError";
+    this.groups = opts.groups;
+  }
+}
+
+type Row = { id: string; connection_group_id: string | null; yaml_content: string };
+
+const getEntity = mock(
+  async (_org: string, _type: string, _name: string, group?: string | null): Promise<Row | null> => ({
+    id: "orders-row",
+    connection_group_id: group === undefined ? null : group,
+    yaml_content: "table: orders\ndescription: Orders\n",
+  }),
+);
+const upsertEntityForGroup = mock(
+  async (_org: string, _type: string, _name: string, _yaml: string, _group?: string | null): Promise<void> => {},
+);
+const createVersion = mock(
+  async (
+    _id: string, _org: string, _type: string, _name: string, _yaml: string,
+    _summary: string | null, _authorId: string | null, _authorLabel: string | null,
+  ): Promise<string> => "version-1",
+);
+const generateChangeSummary = mock(async (_before: string, _after: string): Promise<string> => "summary");
+const invalidateOrgWhitelist = mock((_org: string): void => {});
+const syncEntityToDisk = mock(
+  async (_org: string, _name: string, _type: string, _yaml: string, _group?: string | null): Promise<void> => {},
+);
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  getEntity,
+  upsertEntityForGroup,
+  createVersion,
+  generateChangeSummary,
+  AmbiguousEntityError,
+}));
+mock.module("@atlas/api/lib/semantic", () => ({ invalidateOrgWhitelist }));
+mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { applyAmendmentFromPayload } = await import(`../apply.ts?t=${Date.now()}`);
+
+const INNER_AMENDMENT = { name: "region", sql: "region", type: "string", description: "Customer region" };
+
+const ENVELOPE = {
+  entityName: "orders",
+  amendmentType: "add_dimension",
+  amendment: INNER_AMENDMENT,
+  rationale: "Add a region dimension",
+  category: "coverage_gaps",
+  confidence: 0.9,
+};
+
+/** The YAML object written back by the last upsert. */
+function writtenYaml(): Record<string, unknown> {
+  const lastCall = upsertEntityForGroup.mock.calls.at(-1);
+  if (!lastCall) throw new Error("upsertEntityForGroup was not called");
+  return yaml.load(lastCall[3] as string) as Record<string, unknown>;
+}
+
+describe("applyAmendmentFromPayload (#3613)", () => {
+  beforeEach(() => {
+    getEntity.mockClear();
+    upsertEntityForGroup.mockClear();
+    createVersion.mockClear();
+    syncEntityToDisk.mockClear();
+  });
+
+  it("writes the INNER amendment object into the entity, not the envelope", async () => {
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      rawPayload: ENVELOPE,
+      requestId: "req-1",
+      label: "pat-1",
+    });
+
+    const doc = writtenYaml();
+    const dims = doc.dimensions as Record<string, unknown>[];
+    expect(dims).toHaveLength(1);
+    // The dimension is the inner spec — NOT the envelope.
+    expect(dims[0]).toEqual(INNER_AMENDMENT);
+    expect(dims[0]).not.toHaveProperty("entityName");
+    expect(dims[0]).not.toHaveProperty("amendmentType");
+    expect(dims[0]).not.toHaveProperty("rationale");
+  });
+
+  it("accepts a raw payload supplied as a JSON string", async () => {
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      rawPayload: JSON.stringify(ENVELOPE),
+      requestId: "req-2",
+    });
+
+    const dims = writtenYaml().dimensions as Record<string, unknown>[];
+    expect(dims[0]).toEqual(INNER_AMENDMENT);
+  });
+
+  it("recovers a NULL connection group as the explicit default scope", async () => {
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      rawPayload: ENVELOPE,
+      requestId: "req-3",
+    });
+    // group "default" → null lookup scope (apply.ts groupToLookupScope).
+    expect(getEntity.mock.calls[0][3]).toBeNull();
+  });
+
+  it("scopes the lookup to a named connection group", async () => {
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: "orders",
+      connectionGroupId: "eu_prod",
+      rawPayload: ENVELOPE,
+      requestId: "req-4",
+    });
+    expect(getEntity.mock.calls[0][3]).toBe("eu_prod");
+  });
+
+  it("throws on a payload missing its inner amendment object", async () => {
+    await expect(
+      applyAmendmentFromPayload({
+        orgId: "org-1",
+        sourceEntity: "orders",
+        connectionGroupId: null,
+        rawPayload: { amendmentType: "add_dimension", rationale: "no amendment key" },
+        requestId: "req-5",
+        label: "pat-bad",
+      }),
+    ).rejects.toThrow(/missing a valid `amendment` object/);
+    expect(upsertEntityForGroup).not.toHaveBeenCalled();
+  });
+
+  it("throws on a corrupt JSON string payload", async () => {
+    await expect(
+      applyAmendmentFromPayload({
+        orgId: "org-1",
+        sourceEntity: "orders",
+        connectionGroupId: null,
+        rawPayload: "{not json",
+        requestId: "req-6",
+        label: "pat-corrupt",
+      }),
+    ).rejects.toThrow(/Corrupt amendment_payload JSON/);
+    expect(upsertEntityForGroup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -6,7 +6,8 @@
  */
 
 import * as yaml from "js-yaml";
-import type { AnalysisResult } from "./types";
+import { ANALYSIS_CATEGORIES, type AnalysisResult, type AnalysisCategory } from "./types";
+import { AMENDMENT_TYPES, type AmendmentType } from "@useatlas/types";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("semantic-expert-apply");
@@ -136,6 +137,97 @@ export async function applyAmendmentToEntity(
   log.info(
     { requestId, orgId, entity: result.entityName, amendmentType: result.amendmentType, group: targetGroupId },
     "Semantic amendment applied via expert agent",
+  );
+}
+
+/**
+ * Reconstruct an {@link AnalysisResult} from a stored `amendment_payload`
+ * envelope and apply it to the org's semantic entity. Shared by every admin
+ * approve path — the learned-patterns single-PATCH + bulk handlers and the
+ * dedicated amendment-review endpoint — so the envelope→`AnalysisResult`
+ * mapping lives once, beside {@link applyAmendmentToEntity} that consumes it.
+ *
+ * The stored payload is the full envelope
+ * (`{ entityName, amendmentType, amendment, rationale, category, … }`); the YAML
+ * mutation in {@link applyAmendment} reads the INNER `amendment` object, so the
+ * reconstructed result carries `payload.amendment`, never the envelope itself.
+ *
+ * @throws when the payload is missing/malformed, or the YAML apply fails. An
+ *   `AmbiguousEntityError` (a name shared across Connection groups) propagates
+ *   to the caller (the route layer maps it to 409).
+ */
+export async function applyAmendmentFromPayload(params: {
+  orgId: string | null;
+  /** Entity the amendment targets — the row's authoritative `source_entity`. */
+  sourceEntity: string;
+  /** The amendment's Connection group; NULL = the default (flat) scope. */
+  connectionGroupId: string | null;
+  /** Raw `amendment_payload` column value — a JSON string or a parsed object. */
+  rawPayload: unknown;
+  requestId: string;
+  /** Identifier surfaced in error messages (pattern / amendment id). */
+  label?: string;
+}): Promise<void> {
+  const { orgId, sourceEntity, connectionGroupId, rawPayload, requestId } = params;
+  const label = params.label ?? sourceEntity;
+
+  let payload: Record<string, unknown> | null = null;
+  if (typeof rawPayload === "string") {
+    try {
+      const parsed: unknown = JSON.parse(rawPayload);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch (err) {
+      throw new Error(
+        `Corrupt amendment_payload JSON for amendment ${label}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  } else if (rawPayload && typeof rawPayload === "object" && !Array.isArray(rawPayload)) {
+    payload = rawPayload as Record<string, unknown>;
+  }
+
+  if (!payload) {
+    throw new Error(
+      `Amendment ${label} has no amendment_payload — cannot apply its YAML change.`,
+    );
+  }
+
+  const innerAmendment = payload.amendment;
+  if (!innerAmendment || typeof innerAmendment !== "object" || Array.isArray(innerAmendment)) {
+    throw new Error(
+      `Amendment ${label} payload is missing a valid \`amendment\` object — cannot apply its YAML change.`,
+    );
+  }
+
+  const rawCategory = String(payload.category ?? "coverage_gaps");
+  const rawAmendmentType = String(payload.amendmentType ?? "update_description");
+
+  await applyAmendmentToEntity(
+    orgId,
+    {
+      entityName: sourceEntity,
+      // Recover the Connection group the amendment was analyzed against so the
+      // apply targets that group's row, not the default scope or a 409 (#3284).
+      // A NULL group means the default (flat) group — map it to the explicit
+      // `"default"` label so the lookup is scoped to NULL rather than running
+      // the unscoped ambiguity check.
+      group: connectionGroupId ?? "default",
+      category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
+        ? (rawCategory as AnalysisCategory)
+        : "coverage_gaps",
+      amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
+        ? (rawAmendmentType as AmendmentType)
+        : "update_description",
+      amendment: innerAmendment as Record<string, unknown>,
+      rationale: typeof payload.rationale === "string" ? payload.rationale : "",
+      confidence: 0,
+      impact: 0,
+      score: 0,
+      staleness: 0,
+    },
+    requestId,
   );
 }
 


### PR DESCRIPTION
Closes #3613

## What
Approving a `type='semantic_amendment'` learned-pattern row must rewrite the entity YAML on disk + the entity row via `applyAmendmentToEntity`. The **bulk-approve** handler did a raw `UPDATE learned_patterns SET status='approved'` without branching on `type`, so semantic-amendment rows were stamped approved while their YAML on disk and the in-memory semantic layer stayed **stale until restart**. (The single PATCH handler turned out to have the same gap, despite the issue assuming it already applied — fixed too.)

## Why
Silent data inconsistency: the admin UI showed the amendment as approved, but the agent kept operating on the stale entity definition. The dedicated review endpoint (`/admin/semantic/improve/amendments/:id/review`) already applies-then-stamps; the generic learned-patterns CRUD surface didn't.

## How
- New shared `applyAmendmentRow(row, orgId, requestId)` helper reconstructs an `AnalysisResult` from the stored `amendment_payload` envelope and calls `applyAmendmentToEntity`. It passes the **inner** `payload.amendment` object (what the YAML mutation consumes) — not the envelope — and recovers the Connection group (`connection_group_id` → `"default"` for NULL) so the apply targets the correct group scope (#3284).
- Both the single PATCH and bulk-approve handlers now apply the YAML side-effect **before** persisting `status='approved'`. A failed apply (including `AmbiguousEntityError` → 409) aborts: in bulk it's recorded per-id in `errors` and the status update never runs; in PATCH it surfaces as 500/409. **No `semantic_amendment` row can reach `approved` without its YAML side-effect applied.**
- Bulk SELECT now fetches `type, source_entity, amendment_payload, connection_group_id` (was `id` only).

## Tests
New `admin-learned-patterns-amendment.test.ts`:
- bulk-approve of a `query_pattern` + `semantic_amendment` mix dispatches the rewrite for **only** the semantic row, with the inner amendment object (deep-equal guard against the envelope-vs-inner bug);
- a failed apply leaves the row **un-stamped** (no UPDATE issued);
- bulk-**reject** of a semantic amendment skips the apply;
- single PATCH approve applies before updating status, and returns 500 + no UPDATE when the apply fails.

`/ci`: lint, type, full test (`@atlas/api` 631 files / 0 fail), syncpack, template/schema/openapi/oauth-helper/security-header drift, railway-watch, test-discipline, settings-readers, published-symbols — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWUHo7kFMc28REzwhXosRX)_