### PR TITLE
fix(api): populate audit_log.actor_kind on web + scheduler paths (#3615)

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -1344,6 +1344,10 @@ chat.openapi(chatRoute, async (c) => {
               user: authResult.user,
               atlasMode,
               agentOrigin: "chat",
+              // #3615 — web-app chat is human-initiated; stamp the audit
+              // discriminator so audit_log.actor_kind = 'human' for every
+              // SQL the agent runs on this turn.
+              actor: { kind: "human" },
               ...(effectiveConnectionId !== undefined && {
                 connectionId: effectiveConnectionId,
               }),

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -527,9 +527,11 @@ demo.openapi(demoChatRoute, async (c) => {
 
   // Bind request context (no org for demo users).
   // #2072 — demo runs the same flow as chat from the user's POV.
+  // #3615 — and is human-initiated like the web chat route, so stamp the
+  // same 'human' audit discriminator rather than letting it default to 'agent'.
   const demoUser = createAtlasUser(userId, "simple-key", `demo:${email}`);
   return withRequestContext(
-    { requestId, user: demoUser, agentOrigin: "chat" },
+    { requestId, user: demoUser, agentOrigin: "chat", actor: { kind: "human" } },
     async () => {
       // Startup diagnostics
       const diagnostics = await validateEnvironment();

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -214,8 +214,11 @@ query.openapi(
       // Bind user identity into AsyncLocalStorage for downstream logging/audit.
       // #2072 — `/api/v1/query` is the API form of chat; origin-scoped
       // approval rules treat it identically to the chat UI.
+      // #3615 — same reasoning for the audit discriminator: stamp `human`.
+      // `executeAgentQuery` re-enters `withRequestContext` and propagates this
+      // inherited actor, so executeSQL audit rows record actor_kind='human'.
       return withRequestContext(
-        { requestId, user: authResult.user, agentOrigin: "chat" },
+        { requestId, user: authResult.user, agentOrigin: "chat", actor: { kind: "human" } },
         async () => {
 
         // #3419/#3420 — workspace status, abuse, and plan-limit

--- a/packages/api/src/lib/__tests__/agent-query.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query.test.ts
@@ -16,7 +16,9 @@
 
 import { describe, it, expect, mock } from "bun:test";
 
-const observedContexts: { requestId?: string; user?: { id: string; activeOrganizationId?: string } | undefined }[] = [];
+import type { RequestActor } from "@atlas/api/lib/logger";
+
+const observedContexts: { requestId?: string; user?: { id: string; activeOrganizationId?: string } | undefined; actor?: RequestActor | undefined }[] = [];
 
 mock.module("@atlas/api/lib/agent", () => ({
   runAgent: mock(async () => {
@@ -25,6 +27,7 @@ mock.module("@atlas/api/lib/agent", () => ({
     observedContexts.push({
       ...(ctx?.requestId !== undefined ? { requestId: ctx.requestId } : {}),
       ...(ctx?.user !== undefined ? { user: { id: ctx.user.id, ...(ctx.user.activeOrganizationId !== undefined ? { activeOrganizationId: ctx.user.activeOrganizationId } : {}) } } : {}),
+      ...(ctx?.actor !== undefined ? { actor: ctx.actor } : {}),
     });
     return {
       text: Promise.resolve("done"),
@@ -78,6 +81,35 @@ describe("executeAgentQuery actor binding", () => {
     expect(observedContexts).toHaveLength(1);
     expect(observedContexts[0].user?.id).toBe("user-parent");
     expect(observedContexts[0].user?.activeOrganizationId).toBe("org-parent");
+  });
+
+  it("#3615: stamps the explicit actorKind (scheduler) onto RequestContext for the agent run", async () => {
+    observedContexts.length = 0;
+    const actor = createAtlasUser("owner-1", "managed", "owner-1@example.com", {
+      activeOrganizationId: "org-sched",
+    });
+    await executeAgentQuery("nightly report", "req-sched", { actor, actorKind: "scheduler" });
+    expect(observedContexts).toHaveLength(1);
+    expect(observedContexts[0].actor).toEqual({ kind: "scheduler" });
+  });
+
+  it("#3615: propagates an inherited actor (human) when no actorKind is passed", async () => {
+    observedContexts.length = 0;
+    await withRequestContext(
+      { requestId: "outer", actor: { kind: "human" } },
+      async () => {
+        await executeAgentQuery("API form of chat", "inner-req");
+      },
+    );
+    expect(observedContexts).toHaveLength(1);
+    expect(observedContexts[0].actor).toEqual({ kind: "human" });
+  });
+
+  it("#3615: leaves actor unset when neither option nor parent context provides one (audit defaults to 'agent')", async () => {
+    observedContexts.length = 0;
+    await executeAgentQuery("bare agent run", "req-bare");
+    expect(observedContexts).toHaveLength(1);
+    expect(observedContexts[0].actor).toBeUndefined();
   });
 
   it("F-54/F-55: surfaces pendingApproval from tool results so callers can fail-loud", async () => {

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -8,6 +8,7 @@
 
 import { runAgent } from "@atlas/api/lib/agent";
 import { createLogger, getRequestContext, withRequestContext } from "@atlas/api/lib/logger";
+import type { ActorKind, RequestActor } from "@atlas/api/lib/logger";
 import { checkAgentBillingGate, BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
 import type { PlanLimitWarning } from "@atlas/api/lib/billing/enforcement";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
@@ -79,6 +80,17 @@ export interface ExecuteAgentQueryOptions {
    */
   actor?: AtlasUser;
   /**
+   * #3615 — audit_log discriminator for this agent run. System callers
+   * that run outside a route-level `withRequestContext` (the scheduler)
+   * MUST pass this so executeSQL audit rows record the right actor_kind
+   * (e.g. `scheduler`). When omitted, the actor is propagated from the
+   * parent RequestContext (e.g. the `/query` route stamps `human`); when
+   * neither is present, `logQueryAudit` defaults the row to `agent`.
+   * Excludes `mcp` because the MCP dispatchers set their own actor (with
+   * `clientId` / `toolName`) and never route through `executeAgentQuery`.
+   */
+  actorKind?: Exclude<ActorKind, "mcp">;
+  /**
    * #2072 — agent origin for origin-scoped approval rules. System
    * callers (scheduler, chat-platform receivers) MUST pass this so an
    * "MCP-only" or "scheduler-only" rule fires for the correct transport.
@@ -136,6 +148,13 @@ export async function executeAgentQuery(
   const origin = options?.agentOrigin ?? inheritedCtx?.agentOrigin;
   const connectionId = options?.connectionId ?? inheritedCtx?.connectionId;
   const connectionGroupId = options?.connectionGroupId ?? inheritedCtx?.connectionGroupId;
+  // #3615 — explicit `actorKind` wins (the scheduler passes "scheduler");
+  // otherwise propagate the parent context's actor (the `/query` route stamps
+  // "human") so the re-entered context below doesn't drop it. When neither is
+  // present, leave it unset — `logQueryAudit` defaults the audit row to "agent".
+  const actor: RequestActor | undefined = options?.actorKind
+    ? { kind: options.actorKind }
+    : inheritedCtx?.actor;
 
   if (!boundUser) {
     log.warn(
@@ -151,6 +170,7 @@ export async function executeAgentQuery(
       ...(boundUser ? { user: boundUser } : {}),
       ...(inheritedMode ? { atlasMode: inheritedMode } : {}),
       ...(origin ? { agentOrigin: origin } : {}),
+      ...(actor ? { actor } : {}),
       ...(connectionId ? { connectionId } : {}),
       ...(connectionGroupId ? { connectionGroupId } : {}),
     },

--- a/packages/api/src/lib/auth/__tests__/audit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/audit.test.ts
@@ -81,7 +81,7 @@ describe("logQueryAudit()", () => {
       null, // tables_accessed
       null, // columns_accessed
       null, // org_id
-      null, // actor_kind (#2067)
+      "agent", // actor_kind — #3615: agent-loop SQL with no specific actor defaults to "agent"
       null, // client_id (#2067)
       null, // tool_name (#2067)
       null, // parent_audit_id (#2519)
@@ -134,6 +134,24 @@ describe("logQueryAudit()", () => {
     expect(params[15]).toBe("claude-desktop"); // client_id
     expect(params[16]).toBe("executeSQL");     // tool_name
   });
+
+  it.each([
+    ["human", "human"],
+    ["scheduler", "scheduler"],
+  ] as const)(
+    "persists actor_kind=%s from the request context (#3615)",
+    (kind, expected) => {
+      enableInternalDB();
+      withRequestContext({ requestId: "req-x", actor: { kind } }, () => {
+        logQueryAudit({ sql: "SELECT 1", durationMs: 1, rowCount: 1, success: true });
+      });
+      expect(queryCalls).toHaveLength(1);
+      const params = queryCalls[0].params!;
+      expect(params[14]).toBe(expected); // actor_kind
+      expect(params[15]).toBeNull();     // client_id — only mcp carries it
+      expect(params[16]).toBeNull();     // tool_name — only mcp carries it
+    },
+  );
 
   it("does not insert when internal DB is not available", () => {
     delete process.env.DATABASE_URL;

--- a/packages/api/src/lib/auth/audit.ts
+++ b/packages/api/src/lib/auth/audit.ts
@@ -68,7 +68,15 @@ export function logQueryAudit(entry: AuditEntry): void {
   const userLabel = ctx?.user?.label ?? null;
   const authMode = ctx?.user?.mode ?? "none";
   const actor = ctx?.actor;
-  const actorKind = actor?.kind ?? null;
+  // #3615 — `logQueryAudit` is reached only from the `executeSQL` tool, which
+  // only ever runs inside an agent loop (web chat, scheduler, MCP, chat
+  // platforms, proactive). So an audit row with no more-specific actor IS an
+  // agent-loop SQL execution — default it to "agent" rather than NULL so the
+  // admin audit filter never has invisible rows. The specific entry paths
+  // override this: web chat / `/query` stamp "human", the scheduler stamps
+  // "scheduler", and both MCP dispatchers stamp "mcp" before executeSQL runs,
+  // so this fallback never relabels those.
+  const actorKind = actor?.kind ?? "agent";
   // The mcp branch is the only one carrying clientId / toolName — the
   // discriminated union in `lib/logger.ts` makes this guard a type
   // narrow rather than an ad-hoc truthy check.

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -60,8 +60,11 @@ export const auditLog = pgTable(
     orgId: text("org_id"),
     // Soft-delete (retention purge)
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
-    // #2067 — MCP filter discriminators. NULL for non-MCP rows; today
-    // only the MCP transport populates these. See migration 0049.
+    // #2067 / #3615 — actor discriminators. `actor_kind` is populated on
+    // every new row (web chat / `/query` → 'human', scheduler → 'scheduler',
+    // MCP → 'mcp', any other agent-loop SQL → 'agent'); only pre-#3615
+    // historical rows are NULL. `client_id` / `tool_name` stay MCP-only. See
+    // migrations 0049 (columns) + the writer wiring in lib/auth/audit.ts.
     actorKind: text("actor_kind"),
     clientId: text("client_id"),
     toolName: text("tool_name"),

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -17,10 +17,11 @@ import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 
 /**
  * Discriminator on who initiated the request, threaded through audit_log
- * via #2067. Only `mcp` is wired today; `human` / `agent` / `scheduler`
- * are reserved for future writer paths to opt into without a schema
- * change. Rows that never set `actor` write NULL and stay invisible to
- * actor-scoped filters.
+ * via #2067. All four kinds are wired (#3615): web chat / `/api/v1/query`
+ * stamp `human`, the scheduler stamps `scheduler`, the MCP dispatchers stamp
+ * `mcp`, and `logQueryAudit` defaults any agent-loop SQL with no more-specific
+ * actor to `agent` (the only `executeSQL` writer is the agent loop). Rows are
+ * therefore never NULL for actor-scoped filters.
  *
  * Modeled as a discriminated union so `clientId` / `toolName` are only
  * reachable on the `mcp` branch — the type system enforces the

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -191,6 +191,10 @@ export async function executeScheduledTask(
     // scheduler from a broad rule, narrow that rule's origin.)
     agentQueryEffect(task.question, requestId, taskId, timeoutMs, {
       actor,
+      // #3615 — scheduled runs execute outside any route-level
+      // `withRequestContext`, so stamp the audit discriminator explicitly;
+      // executeSQL audit rows then record actor_kind='scheduler'.
+      actorKind: "scheduler",
       agentOrigin: "scheduler",
       ...(resolvedConnectionId ? { connectionId: resolvedConnectionId } : {}),
       ...(task.connectionGroupId ? { connectionGroupId: task.connectionGroupId } : {}),

--- a/packages/api/src/lib/tools/__tests__/sql-audit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-audit.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it, beforeEach, afterEach, mock, type Mock } from "bun:test";
 import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { withRequestContext, type RequestActor } from "@atlas/api/lib/logger";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyResult = any;
@@ -109,6 +110,10 @@ function extractAuditParams(params: unknown[]) {
     targetHost: params[10] as string | null,
     tablesAccessed: params[11] as string | null,
     columnsAccessed: params[12] as string | null,
+    orgId: params[13] as string | null,
+    actorKind: params[14] as string | null,
+    clientId: params[15] as string | null,
+    toolName: params[16] as string | null,
   };
 }
 
@@ -282,5 +287,59 @@ describe("executeSQL audit logging", () => {
     // Validation failures don't have classification data
     expect(audit.tablesAccessed).toBeNull();
     expect(audit.columnsAccessed).toBeNull();
+  });
+
+  // #3615 — actor_kind must reflect the entry path that initiated the SQL.
+  // Each entry path establishes a `RequestContext.actor` before the agent
+  // loop runs executeSQL; this exercises the audit write site under the
+  // context each path produces and asserts the recorded actor_kind.
+  describe("actor_kind by entry path (#3615)", () => {
+    const execWithActor = (sql: string, actor: RequestActor | undefined) =>
+      withRequestContext(
+        { requestId: "audit-test", ...(actor ? { actor } : {}) },
+        () => exec(sql),
+      );
+
+    it("defaults to 'agent' for an agent-loop query with no specific actor", async () => {
+      // The bare agent loop (chat platforms, proactive, admin tooling) does
+      // not stamp a more-specific actor — executeSQL is only ever reached
+      // from an agent loop, so the row is an agent run.
+      await execWithActor("SELECT id FROM companies", undefined);
+
+      const inserts = getAuditInserts();
+      expect(inserts).toHaveLength(1);
+      expect(extractAuditParams(inserts[0].params!).actorKind).toBe("agent");
+    });
+
+    it("records 'human' for web-app / API human-initiated queries", async () => {
+      await execWithActor("SELECT id FROM companies", { kind: "human" });
+
+      const inserts = getAuditInserts();
+      expect(inserts).toHaveLength(1);
+      expect(extractAuditParams(inserts[0].params!).actorKind).toBe("human");
+    });
+
+    it("records 'scheduler' for scheduled-task queries", async () => {
+      await execWithActor("SELECT id FROM companies", { kind: "scheduler" });
+
+      const inserts = getAuditInserts();
+      expect(inserts).toHaveLength(1);
+      expect(extractAuditParams(inserts[0].params!).actorKind).toBe("scheduler");
+    });
+
+    it("records 'mcp' (no regression) and threads client_id / tool_name", async () => {
+      await execWithActor("SELECT id FROM companies", {
+        kind: "mcp",
+        clientId: "claude-desktop",
+        toolName: "executeSQL",
+      });
+
+      const inserts = getAuditInserts();
+      expect(inserts).toHaveLength(1);
+      const audit = extractAuditParams(inserts[0].params!);
+      expect(audit.actorKind).toBe("mcp");
+      expect(audit.clientId).toBe("claude-desktop");
+      expect(audit.toolName).toBe("executeSQL");
+    });
   });
 });

--- a/packages/web/src/ui/components/admin/audit/filter-bar.tsx
+++ b/packages/web/src/ui/components/admin/audit/filter-bar.tsx
@@ -26,10 +26,10 @@ import {
 } from "@/components/ui/select";
 
 /**
- * Canonical actor-kind values surfaced in the dropdown. Only `"mcp"`
- * is currently populated by a writer (see `audit_log.actor_kind`);
- * the others are reserved for future writer paths (chat, scheduler)
- * to opt into without a UI change.
+ * Canonical actor-kind values surfaced in the dropdown. All four are now
+ * populated by writers (#3615, see `audit_log.actor_kind`): web chat /
+ * `/api/v1/query` write `human`, the scheduler writes `scheduler`, the MCP
+ * dispatchers write `mcp`, and any other agent-loop SQL defaults to `agent`.
  */
 export const ACTOR_KIND_OPTIONS = [
   { value: "human", label: "Human" },


### PR DESCRIPTION
Closes #3615

## What

Migration 0049 added `actor_kind` (`human`|`agent`|`mcp`|`scheduler`) to `audit_log`, but only the MCP dispatchers stamped it. The web-app chat and scheduler query paths wrote `NULL`, so the admin audit UI filter by `human`/`scheduler` returned zero rows and looked broken.

This wires `actor_kind` at every entry path:

- **`human`** — web chat (`chat.ts`) and `/api/v1/query` (`query.ts`) stamp `actor: { kind: "human" }`.
- **`scheduler`** — the scheduler executor passes a new `actorKind: "scheduler"` option.
- **`agent`** — `logQueryAudit` defaults an unset actor to `"agent"`. `logQueryAudit` is reached **only** from the `executeSQL` tool, which only ever runs inside an agent loop, so any row with no more-specific actor *is* an agent-loop SQL execution (chat platforms, proactive, admin tooling).
- **`mcp`** — unchanged. Both the plugin (`mcp-tools.ts`) and native (`mcp-dispatch.ts`) MCP dispatchers already stamp `actor: { kind: "mcp", … }` before `executeSQL` runs, so the `agent` default never relabels MCP rows.

`executeAgentQuery` re-enters `withRequestContext` for the agent run, so it now propagates the parent context's `actor` (keeps the `/query` `human` stamp) and accepts the explicit `actorKind` option (lets the scheduler set its own kind from a background job with no parent context).

## Why

`audit.ts` read `actor?.kind ?? null` and neither the web nor scheduler caller populated `actor.kind` — so those rows were invisible to the actor-scoped admin filter. The filter dropdown and the backend WHERE clause (`audit/query.ts`, validated against the canonical `ACTOR_KINDS`) already supported all four values; only the writers were missing.

## Tests

- `lib/tools/__tests__/sql-audit.test.ts` — end-to-end at the audit write site: `executeSQL` under each request-context actor records `agent` (default), `human`, `scheduler`, `mcp` (with `client_id`/`tool_name` threaded — no regression).
- `lib/auth/__tests__/audit.test.ts` — `logQueryAudit` persists `human`/`scheduler` from context; the no-actor default is now `agent` (was `null`); the existing MCP assertion is unchanged.
- `lib/__tests__/agent-query.test.ts` — `executeAgentQuery` stamps the explicit `actorKind` (scheduler), propagates an inherited actor (human), and leaves it unset (→ audit `agent`) when neither is provided.

All `/ci` gates pass locally: lint, type, full test suite, syncpack, and every drift/parity check.

https://claude.ai/code/session_01PPVUzoa8t4YwkH1MaFfHqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPVUzoa8t4YwkH1MaFfHqB)_