### PR TITLE
refactor(api): make learn tuning knobs SaaS-first runtime settings (#3632)

### DIFF
--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -362,23 +362,15 @@ The cache is automatically flushed on config reload. Manual flush is available v
 
 ## Dynamic Learning
 
-Configure how the offline learning loop (`atlas learn`) promotes discovered query patterns into the semantic layer.
+Tuning for how learned query patterns are retrieved and promoted into agent context.
 
-```typescript
-export default defineConfig({
-  learn: {
-    confidenceThreshold: 0.7,  // default: 0.7
-    retrievalTurns: 3,         // default: 3
-  },
-});
-```
+These are **runtime settings**, not `atlas.config.ts` fields: they resolve as `workspace override > platform override > env var > default`, so each workspace can tune them from **Admin → Settings** with no redeploy (hot-reloaded in SaaS). Set the env var for a self-host default.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `confidenceThreshold` | `number` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for auto-promotion. Lower values promote more aggressively; higher values require stronger evidence from the audit log |
-| `retrievalTurns` | `number` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
+| Setting | Env var | Default | Description |
+|---------|---------|---------|-------------|
+| Pattern Confidence Threshold | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval/auto-promotion. Lower values promote more aggressively; higher values require stronger evidence from the audit log |
+| Pattern Retrieval Turns | `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
 
-**Env var equivalent:**
 ```bash
 ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7
 ATLAS_LEARN_RETRIEVAL_TURNS=3
@@ -1039,11 +1031,8 @@ export default defineConfig({
     enabled: true,
   },
 
-  // Dynamic learning (offline audit log analysis)
-  learn: {
-    confidenceThreshold: 0.7,
-    retrievalTurns: 3,
-  },
+  // Dynamic learning knobs are runtime settings, not config fields — see the
+  // "Dynamic Learning" section above (Admin → Settings or ATLAS_LEARN_* env vars).
 
   // Enterprise features (commercial license, /ee directory)
   enterprise: {

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -621,10 +621,12 @@ Scheduled task execution. Can also be configured via [`atlas.config.ts`](/refere
 
 ## Dynamic Learning
 
+These are the self-host fallback tier for two **workspace-scoped runtime settings** — they also resolve from `workspace override > platform override > env var > default` and can be tuned per-workspace from **Admin → Settings** with no redeploy (see [Dynamic Learning config](/reference/config#dynamic-learning)).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for auto-promotion. Used by the `atlas learn` CLI command and the dynamic learning loop. Can also be set via [`atlas.config.ts`](/reference/config#dynamic-learning) |
-| `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns. Can also be set via [`atlas.config.ts`](/reference/config#dynamic-learning) |
+| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Used at retrieval time to filter which approved patterns are injected into the agent prompt |
+| `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
 
 ---
 

--- a/packages/api/src/lib/__tests__/pattern-cache.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-cache.test.ts
@@ -61,6 +61,19 @@ mock.module("@atlas/api/lib/config", () => ({
   _setConfigForTest: () => {},
 }));
 
+// pattern-cache reads the confidence threshold from the settings registry.
+mock.module("@atlas/api/lib/settings", () => {
+  const settingValue = (key: string): string | undefined =>
+    key === "ATLAS_LEARN_CONFIDENCE_THRESHOLD" && mockConfigLearn?.confidenceThreshold !== undefined
+      ? String(mockConfigLearn.confidenceThreshold)
+      : undefined;
+  return {
+    getSetting: (key: string) => settingValue(key),
+    getSettingAuto: (key: string) => settingValue(key),
+    getSettingLive: async (key: string) => settingValue(key),
+  };
+});
+
 mock.module("@atlas/api/lib/db/connection", () =>
   createConnectionMock(),
 );

--- a/packages/api/src/lib/__tests__/pattern-injection.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-injection.test.ts
@@ -72,6 +72,30 @@ mock.module("@atlas/api/lib/config", () => ({
   _setConfigForTest: () => {},
 }));
 
+// pattern-cache reads the learn knobs from the settings registry (workspace
+// override > platform override > env var > default). Drive them from the same
+// `mockConfigLearn` object the tests already mutate.
+mock.module("@atlas/api/lib/settings", () => {
+  const settingValue = (key: string): string | undefined => {
+    if (key === "ATLAS_LEARN_CONFIDENCE_THRESHOLD") {
+      return mockConfigLearn?.confidenceThreshold === undefined
+        ? undefined
+        : String(mockConfigLearn.confidenceThreshold);
+    }
+    if (key === "ATLAS_LEARN_RETRIEVAL_TURNS") {
+      return mockConfigLearn?.retrievalTurns === undefined
+        ? undefined
+        : String(mockConfigLearn.retrievalTurns);
+    }
+    return undefined;
+  };
+  return {
+    getSetting: (key: string) => settingValue(key),
+    getSettingAuto: (key: string) => settingValue(key),
+    getSettingLive: async (key: string) => settingValue(key),
+  };
+});
+
 mock.module("@atlas/api/lib/db/connection", () =>
   createConnectionMock(),
 );

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -957,7 +957,7 @@ export async function runAgent({
               // turns, not just the final message, so a keyword-less
               // follow-up ("now break that down by region") still matches
               // patterns via the keywords of earlier turns.
-              const question = buildRetrievalQuery(messages, getRetrievalTurns());
+              const question = buildRetrievalQuery(messages, getRetrievalTurns(orgId ?? null));
               if (!question) return undefined;
               // #3611 — scope retrieval to the active connection group so a
               // `us-prod` session is never primed with `eu-prod`'s patterns.

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -572,22 +572,6 @@ const AtlasConfigSchema = z.object({
   }).optional(),
 
   /**
-   * Dynamic learning configuration. Controls how learned query patterns
-   * are promoted and injected into agent context.
-   */
-  learn: z.object({
-    /** Minimum confidence score for a pattern to be eligible for auto-promotion. Default: 0.7. */
-    confidenceThreshold: z.number().min(0).max(1).default(0.7),
-    /**
-     * Number of trailing user turns assembled into the learned-pattern
-     * retrieval query (#3632). Widening the window lets a keyword-less
-     * follow-up ("now break that down by region") still match patterns via
-     * the keywords of earlier turns. Default: 3.
-     */
-    retrievalTurns: z.number().int().positive().default(3),
-  }).optional(),
-
-  /**
    * Adaptive starter prompt configuration. Controls the empty-chat grid
    * served by the resolver behind `GET /api/v1/starter-prompts`.
    */
@@ -726,8 +710,6 @@ export interface ResolvedConfig {
   pool?: { perOrg?: { maxConnections: number; idleTimeoutMs: number; maxOrgs: number; warmupProbes: number; drainThreshold: number } };
   /** Query result cache configuration. */
   cache?: { enabled: boolean; ttl: number; maxSize: number };
-  /** Dynamic learning configuration. */
-  learn?: { confidenceThreshold: number; retrievalTurns?: number };
   /** Adaptive starter prompt configuration. */
   starterPrompts?: { coldWindowDays: number; autoPromoteClicks: number; maxFavorites: number };
   /** Enterprise feature gating. */
@@ -948,17 +930,6 @@ export function configFromEnv(): ResolvedConfig {
           enabled,
           ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : 300_000,
           maxSize: Number.isFinite(maxSize) && maxSize > 0 ? maxSize : 1000,
-        },
-      };
-    })()),
-    // Learn config from env vars
-    ...((() => {
-      const threshold = parseFloat(process.env.ATLAS_LEARN_CONFIDENCE_THRESHOLD ?? "");
-      const turns = parseInt(process.env.ATLAS_LEARN_RETRIEVAL_TURNS ?? "", 10);
-      return {
-        learn: {
-          confidenceThreshold: Number.isFinite(threshold) && threshold >= 0 && threshold <= 1 ? threshold : 0.7,
-          retrievalTurns: Number.isInteger(turns) && turns > 0 ? turns : 3,
         },
       };
     })()),
@@ -1336,7 +1307,6 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
     ...(config.semanticIndex ? { semanticIndex: config.semanticIndex } : {}),
     ...(config.pool ? { pool: config.pool } : {}),
     ...(config.cache ? { cache: config.cache } : {}),
-    ...(config.learn ? { learn: config.learn } : {}),
     ...(config.starterPrompts ? { starterPrompts: config.starterPrompts } : {}),
     ...(config.enterprise ? { enterprise: config.enterprise } : {}),
     ...(config.residency ? { residency: config.residency } : {}),

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -7,7 +7,7 @@
  */
 
 import { getApprovedPatterns, type ApprovedPatternRow } from "@atlas/api/lib/db/internal";
-import { getConfig } from "@atlas/api/lib/config";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("pattern-cache");
@@ -194,12 +194,31 @@ export function buildRetrievalQuery(
   return collected.reverse().join(" ").trim();
 }
 
-/** Resolve the configured retrieval-turn count, falling back to the default. */
-export function getRetrievalTurns(): number {
-  const configured = getConfig()?.learn?.retrievalTurns;
-  return typeof configured === "number" && Number.isFinite(configured) && configured >= 1
-    ? Math.floor(configured)
-    : DEFAULT_RETRIEVAL_TURNS;
+/**
+ * Resolve the retrieval-turn count for an org, falling back to the default.
+ *
+ * Read from the settings registry (`getSettingAuto`) so the value is tunable
+ * per-workspace at runtime via Admin → Settings and hot-reloaded in SaaS —
+ * `workspace override > platform override > env var > default`. The env var is
+ * only the self-host fallback tier.
+ */
+export function getRetrievalTurns(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_RETRIEVAL_TURNS", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : DEFAULT_RETRIEVAL_TURNS;
+}
+
+/** Default minimum confidence for a learned pattern to be eligible. */
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+
+/**
+ * Resolve the pattern confidence threshold for an org, falling back to the
+ * default. Workspace-scoped settings-registry read (see {@link getRetrievalTurns}).
+ */
+export function getConfidenceThreshold(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_CONFIDENCE_THRESHOLD", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_CONFIDENCE_THRESHOLD;
 }
 
 /** Extract meaningful keywords from a text string. */
@@ -261,7 +280,7 @@ export async function getRelevantPatterns(
   connectionGroupId: string | null = null,
   maxPatterns: number = DEFAULT_MAX_PATTERNS,
 ): Promise<RelevantPattern[]> {
-  const threshold = getConfig()?.learn?.confidenceThreshold ?? 0.7;
+  const threshold = getConfidenceThreshold(orgId);
   const allPatterns = await getCachedPatterns(orgId, connectionGroupId);
 
   // Filter by confidence threshold

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -604,6 +604,33 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+
+  // Dynamic Learning — retrieval-time tuning for learned query patterns.
+  // Workspace-scoped + hot-reloaded (read per-request via getSettingAuto), so
+  // a tenant can tune them from Admin → Settings with no redeploy. The env var
+  // is just the self-host fallback tier.
+  {
+    key: "ATLAS_LEARN_CONFIDENCE_THRESHOLD",
+    section: "Dynamic Learning",
+    label: "Pattern Confidence Threshold",
+    description:
+      "Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval/auto-promotion. Lower promotes more aggressively; higher requires stronger evidence.",
+    type: "number",
+    default: "0.7",
+    envVar: "ATLAS_LEARN_CONFIDENCE_THRESHOLD",
+    scope: "workspace",
+  },
+  {
+    key: "ATLAS_LEARN_RETRIEVAL_TURNS",
+    section: "Dynamic Learning",
+    label: "Pattern Retrieval Turns",
+    description:
+      "Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up (\"now break that down by region\") still match patterns via the keywords of earlier turns.",
+    type: "number",
+    default: "3",
+    envVar: "ATLAS_LEARN_RETRIEVAL_TURNS",
+    scope: "workspace",
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #3698.

## Why
#3698 added `retrievalTurns` by mirroring the existing `confidenceThreshold` pattern — a field on the `learn` config in `atlas.config.ts` plus a hand-rolled env read. That's the **env-first** posture: operator-global, **redeploy to change**, no admin UI, **not per-tenant**. Atlas is SaaS-first, so a per-tenant tuning knob belongs in the **settings registry**, not config.ts.

## What
Move **both** learn knobs to the settings registry as **workspace-scoped** keys:

- **`settings.ts`** — register `ATLAS_LEARN_CONFIDENCE_THRESHOLD` and `ATLAS_LEARN_RETRIEVAL_TURNS` (`scope: "workspace"`, section "Dynamic Learning"). They now resolve `workspace override > platform override > env var > default`, are tunable per-workspace from **Admin → Settings** with no redeploy, and **hot-reload in SaaS**.
- **`pattern-cache.ts`** — read both via `getSettingAuto(key, orgId)` with parse + range validation. `getRetrievalTurns(orgId)` / new `getConfidenceThreshold(orgId)` take the org so the workspace tier applies.
- **`agent.ts`** — thread `orgId` into `getRetrievalTurns` (already in scope at the call site).
- **`config.ts`** — remove the legacy `learn` config field, its `ResolvedConfig` type, and the bespoke env builder. `AtlasConfigSchema` is non-strict (closes plain, not `.strict()`), so a stale `learn:` key in an existing `atlas.config.ts` is **silently stripped — no boot break**; the value now comes from the env var / setting.
- **docs** — `config.mdx` Dynamic Learning section reframed as a runtime setting (Admin UI / env var) rather than a config field.

The `ATLAS_LEARN_*` env vars remain valid as the **self-host fallback tier**.

## Behavior change
Self-host users who set `learn: { confidenceThreshold }` in `atlas.config.ts` must instead set the `ATLAS_LEARN_CONFIDENCE_THRESHOLD` env var or use Admin → Settings. Acceptable on the pre-launch `v0.0.x` train; called out here for the changelog.

## Tests
- `pattern-injection.test.ts` / `pattern-cache.test.ts` now drive the knobs through a mocked `getSettingAuto` (same `mockConfigLearn` object the tests already mutate) instead of `getConfig().learn`. The `getRetrievalTurns` / threshold suites are unchanged in intent.
- `check-settings-readers` passes — both keys have literal `getSettingAuto` readers (41 keys total).

## Gates
Local `/ci` green: lint, type, affected (139) + full api suite (630 files), syncpack, template/openapi drift, test-discipline, settings-readers, published-symbols.

https://claude.ai/code/session_01AANixYdqA49D6MgwM3eRVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AANixYdqA49D6MgwM3eRVP)_