### PR TITLE
fix(learned-patterns): invalidate pattern cache on approve/reject and bulk approve

### DIFF
--- a/packages/api/src/api/__tests__/admin-learned-patterns-cache-invalidation.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-cache-invalidation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression tests for learned-pattern cache invalidation (#3612).
+ *
+ * The in-memory approved-pattern cache (5-min TTL, `lib/learn/pattern-cache.ts`)
+ * was only invalidated by the DELETE handler. The PATCH single approve/reject
+ * handler and the POST /bulk approve handler changed `status` to
+ * approved/rejected without invalidating, so the agent served stale patterns
+ * for up to 5 minutes — approvals looked broken.
+ *
+ * These tests assert the route handlers call `invalidatePatternCache(orgId)`
+ * after the DB write for approve AND reject (PATCH) and for bulk approve.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+// Override the pattern-cache mock with a spy on invalidatePatternCache so we
+// can assert the route wiring. Registered before importing the app so the
+// route picks up the spy (later mock.module wins). All named exports mocked.
+const invalidatePatternCache = mock((_orgId: string | null) => {});
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  buildRetrievalQuery: () => "",
+  getRetrievalTurns: () => 3,
+  getConfidenceThreshold: () => 0.7,
+  invalidatePatternCache,
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+  DEFAULT_RETRIEVAL_TURNS: 3,
+}));
+
+// --- Import the app AFTER mocks ---
+
+const { app } = await import("../index");
+
+// --- Helpers ---
+
+function req(method: string, urlPath: string, body?: unknown) {
+  const url = `http://localhost/api/v1/admin/learned-patterns${urlPath}`;
+  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  return app.fetch(new Request(url, init));
+}
+
+function mockRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "pat-1",
+    org_id: "org-1",
+    pattern_sql: "SELECT COUNT(*) FROM orders",
+    description: "Order count",
+    source_entity: "orders",
+    source_queries: ["audit-1"],
+    confidence: 0.8,
+    repetition_count: 5,
+    status: "pending",
+    proposed_by: "agent",
+    reviewed_by: null,
+    created_at: "2026-03-18T00:00:00Z",
+    updated_at: "2026-03-18T00:00:00Z",
+    reviewed_at: null,
+    type: "query_pattern",
+    amendment_payload: null,
+    connection_group_id: null,
+    ...overrides,
+  };
+}
+
+// --- Cleanup ---
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+// --- Reset mocks between tests ---
+
+beforeEach(() => {
+  mocks.mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+  invalidatePatternCache.mockClear();
+});
+
+describe("learned-pattern cache invalidation (#3612)", () => {
+  it("PATCH approve invalidates the org cache after the DB write", async () => {
+    let callCount = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([mockRow()]); // existence SELECT
+      return Promise.resolve([mockRow({ status: "approved", reviewed_by: "admin-1", reviewed_at: "2026-03-18T00:00:00Z" })]);
+    });
+
+    const res = await req("PATCH", "/pat-1", { status: "approved" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).toHaveBeenCalledTimes(1);
+    expect(invalidatePatternCache).toHaveBeenCalledWith("org-1");
+  });
+
+  it("PATCH reject also invalidates the org cache (rejected pattern evicted from approved set)", async () => {
+    let callCount = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([mockRow({ status: "approved" })]);
+      return Promise.resolve([mockRow({ status: "rejected", reviewed_by: "admin-1", reviewed_at: "2026-03-18T00:00:00Z" })]);
+    });
+
+    const res = await req("PATCH", "/pat-1", { status: "rejected" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).toHaveBeenCalledTimes(1);
+    expect(invalidatePatternCache).toHaveBeenCalledWith("org-1");
+  });
+
+  it("PATCH description-only update does NOT invalidate (no approved-set change)", async () => {
+    let callCount = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([mockRow()]);
+      return Promise.resolve([mockRow({ description: "Updated" })]);
+    });
+
+    const res = await req("PATCH", "/pat-1", { description: "Updated" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).not.toHaveBeenCalled();
+  });
+
+  it("bulk approve invalidates the org cache after the DB write", async () => {
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT")) return Promise.resolve([{ id: "pat-1", type: "query_pattern" }]);
+      return Promise.resolve([mockRow({ status: "approved" })]);
+    });
+
+    const res = await req("POST", "/bulk", { ids: ["pat-1", "pat-2"], status: "approved" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).toHaveBeenCalledWith("org-1");
+  });
+
+  it("bulk does NOT invalidate when no rows were updated", async () => {
+    // Every SELECT returns empty → all ids not found, nothing updated.
+    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+
+    const res = await req("POST", "/bulk", { ids: ["missing-1", "missing-2"], status: "approved" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/api/__tests__/admin-learned-patterns-cache-invalidation.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-cache-invalidation.test.ts
@@ -8,7 +8,9 @@
  * for up to 5 minutes — approvals looked broken.
  *
  * These tests assert the route handlers call `invalidatePatternCache(orgId)`
- * after the DB write for approve AND reject (PATCH) and for bulk approve.
+ * after the DB write for any PATCH status flip (approve, reject, or un-approve
+ * back to pending — each changes the `status = 'approved'` set) and for bulk
+ * approve, while description-only PATCH and no-op bulk do not.
  */
 
 import {
@@ -135,6 +137,20 @@ describe("learned-pattern cache invalidation (#3612)", () => {
     });
 
     const res = await req("PATCH", "/pat-1", { status: "rejected" });
+    expect(res.status).toBe(200);
+    expect(invalidatePatternCache).toHaveBeenCalledTimes(1);
+    expect(invalidatePatternCache).toHaveBeenCalledWith("org-1");
+  });
+
+  it("PATCH un-approve (approved → pending) also invalidates (pattern leaves approved set)", async () => {
+    let callCount = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([mockRow({ status: "approved" })]);
+      return Promise.resolve([mockRow({ status: "pending", reviewed_by: "admin-1", reviewed_at: "2026-03-18T00:00:00Z" })]);
+    });
+
+    const res = await req("PATCH", "/pat-1", { status: "pending" });
     expect(res.status).toBe(200);
     expect(invalidatePatternCache).toHaveBeenCalledTimes(1);
     expect(invalidatePatternCache).toHaveBeenCalledWith("org-1");

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -512,6 +512,14 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${updateOrg.clause} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Pattern was deleted before update completed." }, 404);
 
+    // A status flip changes which patterns the agent sees — approve adds to the
+    // approved set, reject removes from it. Evict the org's cached patterns so
+    // the next agent turn reads fresh data instead of the stale 5-min TTL copy
+    // (#3612). Description-only edits don't touch the approved set, so skip.
+    if (status === "approved" || status === "rejected") {
+      invalidatePatternCache(orgId ?? null);
+    }
+
     if (status === "approved") {
       logAdminAction({
         actionType: ADMIN_ACTIONS.pattern.approve,
@@ -615,6 +623,13 @@ adminLearnedPatterns.openapi(bulkStatusRoute, async (c) => {
       } else {
         updated.push(id);
       }
+    }
+
+    // Bulk approve/reject flips the approved set for this org. Evict once after
+    // the loop (the handler is org-scoped) so the agent stops serving the stale
+    // 5-min TTL cache — only when at least one row actually changed (#3612).
+    if (updated.length > 0) {
+      invalidatePatternCache(orgId ?? null);
     }
 
     return c.json({ updated, notFound, ...(errors.length > 0 ? { errors } : {}) }, 200);

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -512,11 +512,13 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${updateOrg.clause} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Pattern was deleted before update completed." }, 404);
 
-    // A status flip changes which patterns the agent sees — approve adds to the
-    // approved set, reject removes from it. Evict the org's cached patterns so
-    // the next agent turn reads fresh data instead of the stale 5-min TTL copy
-    // (#3612). Description-only edits don't touch the approved set, so skip.
-    if (status === "approved" || status === "rejected") {
+    // Any status flip changes which patterns the agent sees: the approved set
+    // is `status = 'approved'` (db/internal.ts getApprovedPatterns), so approve
+    // adds to it and reject OR un-approve (back to pending) removes from it.
+    // Evict the org's cached patterns so the next agent turn reads fresh data
+    // instead of the stale 5-min TTL copy (#3612). Description-only edits leave
+    // `status` undefined and don't touch the approved set, so skip those.
+    if (status !== undefined) {
       invalidatePatternCache(orgId ?? null);
     }
 

--- a/packages/api/src/lib/__tests__/pattern-cache.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-cache.test.ts
@@ -91,6 +91,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 const {
   getRelevantPatterns,
+  invalidatePatternCache,
   _resetPatternCache,
 } = await import("@atlas/api/lib/learn/pattern-cache");
 
@@ -151,5 +152,71 @@ describe("pattern cache LRU eviction", () => {
     const countBefore2 = getApprovedPatternsCallCount;
     await getRelevantPatterns("org:1", "revenue");
     expect(getApprovedPatternsCallCount).toBe(countBefore2 + 1);
+  });
+});
+
+describe("pattern cache invalidation (#3612)", () => {
+  beforeEach(() => {
+    _resetPatternCache();
+    mockApprovedPatterns = [{
+      id: "1",
+      org_id: "org-1",
+      pattern_sql: "SELECT SUM(revenue) FROM companies",
+      description: "Total revenue",
+      source_entity: "companies",
+      confidence: 0.9,
+    }];
+    mockConfigLearn = { confidenceThreshold: 0.7 };
+    getApprovedPatternsCallCount = 0;
+  });
+
+  // The bug behind #3612: an admin approve flips the row to `approved`, but
+  // until the org cache is invalidated the next agent turn keeps serving the
+  // stale 5-min TTL copy. This proves invalidation forces a fresh DB read.
+  test("invalidatePatternCache forces the next read to fetch fresh patterns", async () => {
+    // First read populates the cache (one DB fetch).
+    await getRelevantPatterns("org-1", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(1);
+
+    // Second read is served from cache — no new fetch.
+    await getRelevantPatterns("org-1", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(1);
+
+    // An approve/reject would call this. After it, the cached copy is stale and
+    // must be re-fetched on the next read.
+    invalidatePatternCache("org-1");
+
+    // A newly approved pattern is now visible to the DB layer.
+    mockApprovedPatterns = [
+      ...mockApprovedPatterns,
+      {
+        id: "2",
+        org_id: "org-1",
+        pattern_sql: "SELECT AVG(revenue) FROM companies",
+        description: "Average revenue",
+        source_entity: "companies",
+        confidence: 0.95,
+      },
+    ];
+
+    const fresh = await getRelevantPatterns("org-1", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(2);
+    expect(fresh).toHaveLength(2);
+  });
+
+  test("invalidating one org does not evict another org's cache", async () => {
+    await getRelevantPatterns("org-1", "revenue");
+    await getRelevantPatterns("org-2", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(2);
+
+    invalidatePatternCache("org-1");
+
+    // org-2 is untouched — still served from cache.
+    await getRelevantPatterns("org-2", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(2);
+
+    // org-1 was evicted — re-fetches.
+    await getRelevantPatterns("org-1", "revenue");
+    expect(getApprovedPatternsCallCount).toBe(3);
   });
 });


### PR DESCRIPTION
Fixes #3612.

## Problem

`invalidatePatternCache()` was only called by the DELETE handler. The PATCH single approve/reject handler and the POST `/bulk` approve handler in `admin-learned-patterns.ts` both flipped `status` to `approved`/`rejected` without invalidating the in-memory approved-pattern cache (5-min TTL, `lib/learn/pattern-cache.ts:19`). So an admin approval didn't reach the agent for up to 5 minutes — the approval workflow appeared broken.

## Fix

- **PATCH** (`admin-learned-patterns.ts`): call `invalidatePatternCache(orgId)` after the DB write when `status` flips to `approved` **or** `rejected` (a rejected pattern must be evicted from the approved set too). Description-only edits skip invalidation — they don't change the approved set.
- **Bulk** (`POST /bulk`): invalidate once after the loop, only when at least one row actually changed (the handler is org-scoped).

The cache module's `invalidatePatternCache` already clears every connection-group-scoped entry for the org (#3611), so a single org-level call is correct.

## Tests

- `admin-learned-patterns-cache-invalidation.test.ts` (new) — asserts the route wiring: PATCH approve, PATCH reject, and bulk approve each call `invalidatePatternCache("org-1")`; description-only PATCH and a no-op bulk (no rows matched) do **not**.
- `pattern-cache.test.ts` — proves the acceptance-criterion behaviour end-to-end at the cache layer: after `invalidatePatternCache(org)`, the next read triggers a fresh `getApprovedPatterns()` fetch (newly approved pattern now visible) rather than returning the stale cached copy; and invalidating one org leaves another org's cache intact.

## Acceptance criteria

- [x] PATCH approve immediately invalidates the org cache
- [x] Bulk approve immediately invalidates the org cache
- [x] PATCH reject also invalidates
- [x] A test confirms the next `getApprovedPatterns()` fetches fresh data after invalidation rather than a cached stale result

## Gates

Local `/ci` green: lint, type, full `@atlas/api` test suite (635 files), syncpack, template drift, railway-watch, schema drift, OpenAPI drift, test discipline.

https://claude.ai/code/session_01XyUFzkRn32Vq8oUG1xH7r2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyUFzkRn32Vq8oUG1xH7r2)_