### PR TITLE
feat(api): feed favorites + approved suggestions into agent org-knowledge block (#3633)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -597,6 +597,14 @@ export function createApiTestMocks(
     _resetPatternCache: () => {},
   }));
 
+  // #3633 — agent.ts assembles the org-knowledge block (learned patterns +
+  // favorites + approved suggestions) via this module. Stubbed here too so
+  // shared-harness runAgent tests don't execute the real orchestrator's
+  // resolvers; the dedicated org-knowledge-section.test.ts covers it directly.
+  mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+    resolveOrgKnowledgeSection: async () => "",
+  }));
+
   // ── Plugins ───────────────────────────────────────────────────
 
   mock.module("@atlas/api/lib/plugins/registry", () => ({

--- a/packages/api/src/lib/__tests__/agent-cache.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cache.test.ts
@@ -64,6 +64,11 @@ mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   _resetPatternCache: () => {},
 }));
 
+// #3633 — agent.ts assembles the org-knowledge block via this module.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
 const { applyCacheControl, buildSystemParam } = await import("@atlas/api/lib/agent");
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
+++ b/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
@@ -85,9 +85,17 @@ mock.module("@atlas/api/lib/semantic", () => ({
 mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   buildRetrievalQuery: () => "revenue by region",
   getRetrievalTurns: () => 3,
-  buildLearnedPatternsSection: async () => {
+  buildLearnedPatternsSection: async () => "",
+}));
+
+// #3633 — agent.ts assembles the org-knowledge block (learned patterns +
+// favorites + approved suggestions) via this module. Toggleable so the
+// per-branch tests can pin the "org-knowledge loader fails alone" case that
+// surfaces the `learned_patterns_unavailable` structured warning.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => {
     if (semanticState.patternsThrows) {
-      throw new Error("simulated pool exhaustion (learned patterns)");
+      throw new Error("simulated pool exhaustion (org knowledge)");
     }
     return "";
   },

--- a/packages/api/src/lib/__tests__/agent-dialect.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect.test.ts
@@ -62,6 +62,11 @@ mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   _resetPatternCache: () => {},
 }));
 
+// #3633 — agent.ts assembles the org-knowledge block via this module.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
 const { buildSystemParam } = await import("@atlas/api/lib/agent");
 
 describe("appendDialectHints", () => {

--- a/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
@@ -74,6 +74,11 @@ mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   _resetPatternCache: () => {},
 }));
 
+// #3633 — agent.ts assembles the org-knowledge block via this module.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
 const { buildSystemParam } = await import("@atlas/api/lib/agent");
 
 describe("#2505 agent system prompt — default connection visibility by deployMode", () => {

--- a/packages/api/src/lib/__tests__/agent-sargability.test.ts
+++ b/packages/api/src/lib/__tests__/agent-sargability.test.ts
@@ -62,6 +62,11 @@ mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   _resetPatternCache: () => {},
 }));
 
+// #3633 — agent.ts assembles the org-knowledge block via this module.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
 const { buildSystemParam } = await import("@atlas/api/lib/agent");
 
 function assembledPrompt(): string {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -961,6 +961,10 @@ export async function runAgent({
               // follow-up ("now break that down by region") still matches
               // patterns via the keywords of earlier turns.
               const question = buildRetrievalQuery(messages, getRetrievalTurns(orgId ?? null));
+              // No early return on an empty `question` (#3633): only pattern
+              // retrieval is keyword-scored, and `getRelevantPatterns` already
+              // yields [] when there are no keywords. Favorites/suggestions are
+              // question-independent, so we always resolve the block.
               // #3611 — scope retrieval to the active connection group so a
               // `us-prod` session is never primed with `eu-prod`'s patterns.
               // Favorites/suggestions are scoped by org (and user) inside their

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -42,7 +42,8 @@ import { getSetting } from "./settings";
 import { hasInternalDB, internalExecute } from "./db/internal";
 import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
-import { buildLearnedPatternsSection, buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
+import { buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
+import { resolveOrgKnowledgeSection } from "./learn/org-knowledge-section";
 import { dispatchMutableHook } from "./plugins/hooks";
 import { plugins } from "./plugins/registry";
 import {
@@ -949,7 +950,9 @@ export async function runAgent({
             }),
           )
         : Effect.succeed(undefined),
-      // Learned patterns
+      // Organizational knowledge — learned patterns + user favorites +
+      // approved popular suggestions (#3633). All three are intent signals;
+      // before #3633 only learned patterns reached the agent.
       hasInternalDB()
         ? Effect.tryPromise({
             try: async () => {
@@ -958,14 +961,18 @@ export async function runAgent({
               // follow-up ("now break that down by region") still matches
               // patterns via the keywords of earlier turns.
               const question = buildRetrievalQuery(messages, getRetrievalTurns(orgId ?? null));
-              if (!question) return undefined;
               // #3611 — scope retrieval to the active connection group so a
               // `us-prod` session is never primed with `eu-prod`'s patterns.
-              const section = await buildLearnedPatternsSection(
-                orgId ?? null,
+              // Favorites/suggestions are scoped by org (and user) inside their
+              // resolvers, so cross-tenant leakage is structurally impossible.
+              const section = await resolveOrgKnowledgeSection({
+                orgId: orgId ?? null,
+                userId,
+                connectionGroupId: connectionGroupId ?? null,
+                mode: atlasMode,
                 question,
-                connectionGroupId ?? null,
-              );
+                requestId: reqCtx?.requestId,
+              });
               return section || undefined;
             },
             catch: normalizeError,

--- a/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
+++ b/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
@@ -39,20 +39,43 @@ let patternRows: PatRow[] = [];
 
 // --- Mocks (all named exports) ---
 
-// internalQuery is routed by SQL text so the real `listFavorites` resolver
-// runs against an in-memory table that honors the (user_id, org_id) WHERE
-// predicate exactly like Postgres would — the scoping under test.
+// internalQuery is the single Postgres-emulation chokepoint, routed by SQL
+// text. Both the real `listFavorites` resolver (separate, unmocked module) and
+// the `getPopularSuggestions` stub route through it, so the WHERE predicates
+// under test — favorites' (user_id, org_id) and suggestions' org + approval +
+// mode-driven status clause — are honored exactly like Postgres would.
+async function mockInternalQuery(sql: string, paramsArg?: unknown[]) {
+  const params = paramsArg ?? [];
+  if (sql.includes("user_favorite_prompts")) {
+    const [userId, orgId] = params as [string, string];
+    return favoriteRows.filter((r) => r.user_id === userId && r.org_id === orgId);
+  }
+  if (sql.includes("query_suggestions")) {
+    // Interpret the real resolver's SQL: org scope (or IS NULL), the approval
+    // gate, and the mode-driven status clause — `published` only unless the
+    // SQL opted developer-mode drafts in.
+    const orgIsNull = sql.includes("org_id IS NULL");
+    const allowDraft = sql.includes("'draft'");
+    const limit = Number(params[params.length - 1] ?? 10);
+    return suggestionRows
+      .filter((s) => {
+        if (orgIsNull ? s.org_id !== null : s.org_id !== params[0]) return false;
+        if (sql.includes("approval_status = 'approved'") && s.approval_status !== "approved") {
+          return false;
+        }
+        return allowDraft
+          ? s.status === "published" || s.status === "draft"
+          : s.status === "published";
+      })
+      .slice(0, limit);
+  }
+  return [];
+}
+
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: async (sql: string, paramsArg?: unknown[]) => {
-    const params = paramsArg ?? [];
-    if (sql.includes("user_favorite_prompts")) {
-      const [userId, orgId] = params as [string, string];
-      return favoriteRows.filter((r) => r.user_id === userId && r.org_id === orgId);
-    }
-    return [];
-  },
+  internalQuery: mockInternalQuery,
   internalExecute: () => {},
   _resetPool: () => {},
   _resetCircuitBreaker: () => {},
@@ -71,16 +94,27 @@ mock.module("@atlas/api/lib/db/internal", () => ({
         (p.org_id === orgId || p.org_id === null) &&
         (p.connection_group_id === (connectionGroupId ?? null) || p.connection_group_id === null),
     ),
-  // Popular-suggestion resolver — scoped by org, approved + published only.
-  getPopularSuggestions: async (orgId: string | null, limit = 10) =>
-    suggestionRows
-      .filter(
-        (s) =>
-          s.org_id === orgId &&
-          s.approval_status === "approved" &&
-          s.status === "published",
-      )
-      .slice(0, limit),
+  // Popular-suggestion resolver — mirrors the real impl: builds the same SQL
+  // (org scope + approval gate + mode-driven status clause) and routes through
+  // `internalQuery`, so the predicate lives in the chokepoint above rather than
+  // being reimplemented here. Honors `mode` so a developer-mode caller would
+  // see drafts exactly as Postgres would.
+  getPopularSuggestions: async (
+    orgId: string | null,
+    limit = 10,
+    mode: "published" | "developer" = "published",
+  ) => {
+    const orgClause = orgId != null ? "org_id = $1" : "org_id IS NULL";
+    const statusClause =
+      mode === "developer"
+        ? "query_suggestions.status IN ('published', 'draft')"
+        : "query_suggestions.status = 'published'";
+    const params = orgId != null ? [orgId, limit] : [limit];
+    return mockInternalQuery(
+      `SELECT * FROM query_suggestions WHERE ${orgClause} AND approval_status = 'approved' AND ${statusClause} ORDER BY score DESC LIMIT $${params.length}`,
+      params,
+    );
+  },
   upsertSuggestion: async () => "created",
   getSuggestionsByTables: async () => [],
   incrementSuggestionClick: () => {},
@@ -321,6 +355,33 @@ describe("resolveOrgKnowledgeSection (scoping)", () => {
 
     expect(section).toContain("Approved question");
     expect(section).not.toContain("Pending question");
+  });
+
+  test("developer mode surfaces approved drafts that published mode hides", async () => {
+    suggestionRows = [
+      { id: "s-draft", org_id: "org-a", description: "Queued approved draft", approval_status: "approved", status: "draft" },
+      { id: "s-published", org_id: "org-a", description: "Live published question", approval_status: "approved", status: "published" },
+    ];
+
+    const published = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+    expect(published).toContain("Live published question");
+    expect(published).not.toContain("Queued approved draft");
+
+    const developer = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "developer",
+      question: "show me revenue",
+    });
+    expect(developer).toContain("Live published question");
+    expect(developer).toContain("Queued approved draft");
   });
 
   test("returns empty string when the org has no signals", async () => {

--- a/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
+++ b/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
@@ -1,0 +1,336 @@
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import type { RelevantPattern } from "@atlas/api/lib/learn/pattern-cache";
+
+// ---------------------------------------------------------------------------
+// Fixtures — two orgs with disjoint favorites / suggestions / patterns so the
+// scoping tests can prove org-A never sees org-B's rows.
+// ---------------------------------------------------------------------------
+
+interface FavRow {
+  id: string;
+  user_id: string;
+  org_id: string;
+  text: string;
+  position: number;
+  created_at: string;
+}
+
+let favoriteRows: FavRow[] = [];
+
+interface SuggRow {
+  id: string;
+  org_id: string | null;
+  description: string;
+  approval_status: string;
+  status: string;
+}
+let suggestionRows: SuggRow[] = [];
+
+interface PatRow {
+  id: string;
+  org_id: string | null;
+  connection_group_id: string | null;
+  pattern_sql: string;
+  description: string | null;
+  source_entity: string | null;
+  confidence: number;
+}
+let patternRows: PatRow[] = [];
+
+// --- Mocks (all named exports) ---
+
+// internalQuery is routed by SQL text so the real `listFavorites` resolver
+// runs against an in-memory table that honors the (user_id, org_id) WHERE
+// predicate exactly like Postgres would — the scoping under test.
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
+  internalQuery: async (sql: string, paramsArg?: unknown[]) => {
+    const params = paramsArg ?? [];
+    if (sql.includes("user_favorite_prompts")) {
+      const [userId, orgId] = params as [string, string];
+      return favoriteRows.filter((r) => r.user_id === userId && r.org_id === orgId);
+    }
+    return [];
+  },
+  internalExecute: () => {},
+  _resetPool: () => {},
+  _resetCircuitBreaker: () => {},
+  migrateInternalDB: async () => {},
+  closeInternalDB: async () => {},
+  loadSavedConnections: async () => 0,
+  getEncryptionKey: () => null,
+  _resetEncryptionKeyCache: () => {},
+  encryptSecret: (v: string) => v,
+  decryptSecret: (v: string) => v,
+  isPlaintextUrl: () => true,
+  // Approved-pattern resolver — scoped by org + connection group.
+  getApprovedPatterns: async (orgId: string | null, connectionGroupId?: string | null) =>
+    patternRows.filter(
+      (p) =>
+        (p.org_id === orgId || p.org_id === null) &&
+        (p.connection_group_id === (connectionGroupId ?? null) || p.connection_group_id === null),
+    ),
+  // Popular-suggestion resolver — scoped by org, approved + published only.
+  getPopularSuggestions: async (orgId: string | null, limit = 10) =>
+    suggestionRows
+      .filter(
+        (s) =>
+          s.org_id === orgId &&
+          s.approval_status === "approved" &&
+          s.status === "published",
+      )
+      .slice(0, limit),
+  upsertSuggestion: async () => "created",
+  getSuggestionsByTables: async () => [],
+  incrementSuggestionClick: () => {},
+  deleteSuggestion: async () => false,
+  getAuditLogQueries: async () => [],
+}));
+
+mock.module("@atlas/api/lib/settings", () => {
+  const settingValue = (key: string): string | undefined => {
+    if (key === "ATLAS_LEARN_CONFIDENCE_THRESHOLD") return "0.7";
+    if (key === "ATLAS_LEARN_RETRIEVAL_TURNS") return undefined;
+    return undefined;
+  };
+  return {
+    getSetting: (key: string) => settingValue(key),
+    getSettingAuto: (key: string) => settingValue(key),
+    getSettingLive: async (key: string) => settingValue(key),
+  };
+});
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+const {
+  buildOrgKnowledgeSection,
+  resolveOrgKnowledgeSection,
+} = await import("@atlas/api/lib/learn/org-knowledge-section");
+const { _resetPatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
+
+function pattern(over: Partial<RelevantPattern> = {}): RelevantPattern {
+  return {
+    sourceEntity: "companies",
+    description: "Total company revenue",
+    patternSql: "SELECT SUM(revenue) FROM companies",
+    ...over,
+  };
+}
+
+// ===========================================================================
+// Pure builder
+// ===========================================================================
+
+describe("buildOrgKnowledgeSection (pure)", () => {
+  test("returns empty string when every signal list is empty", () => {
+    expect(
+      buildOrgKnowledgeSection({ patterns: [], favorites: [], suggestions: [] }),
+    ).toBe("");
+  });
+
+  test("renders the learned-patterns subsection", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [pattern()],
+      favorites: [],
+      suggestions: [],
+    });
+    expect(section).toContain("## Organizational knowledge");
+    expect(section).toContain("semantic layer definitions above always take precedence");
+    expect(section).toContain("### Previously successful query patterns");
+    expect(section).toContain("[companies]: Total company revenue");
+    expect(section).toContain("SQL: SELECT SUM(revenue) FROM companies");
+  });
+
+  test("renders favorites and suggestions alongside patterns", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [pattern()],
+      favorites: [{ text: "Show MRR by month" }],
+      suggestions: [{ description: "Top 10 customers by revenue" }],
+    });
+    expect(section).toContain("### Prompts your team has pinned");
+    expect(section).toContain("- Show MRR by month");
+    expect(section).toContain("### Popular questions in this workspace");
+    expect(section).toContain("- Top 10 customers by revenue");
+  });
+
+  test("renders favorites/suggestions even when there are no patterns", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [],
+      favorites: [{ text: "Churn this quarter" }],
+      suggestions: [{ description: "Active users today" }],
+    });
+    expect(section).toContain("## Organizational knowledge");
+    expect(section).not.toContain("### Previously successful query patterns");
+    expect(section).toContain("- Churn this quarter");
+    expect(section).toContain("- Active users today");
+  });
+
+  test("uses [general] when source_entity is null and falls back to a default description", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [pattern({ sourceEntity: null, description: null })],
+      favorites: [],
+      suggestions: [],
+    });
+    expect(section).toContain("[general]: Query pattern");
+  });
+
+  test("caps favorites and suggestions and skips blank text", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [],
+      favorites: [
+        { text: "f1" },
+        { text: "   " },
+        { text: "f2" },
+        { text: "f3" },
+        { text: "f4" },
+        { text: "f5" },
+        { text: "f6" },
+      ],
+      suggestions: [],
+      maxFavorites: 3,
+    });
+    expect(section).toContain("- f1");
+    expect(section).toContain("- f2");
+    expect(section).toContain("- f3");
+    // Blank dropped, and beyond the cap of 3 nothing else renders.
+    expect(section).not.toContain("- f4");
+    expect(section).not.toContain("-    ");
+  });
+
+  test("sanitizes injected text — strips headings, collapses newlines, truncates", () => {
+    const long = "x".repeat(400);
+    const section = buildOrgKnowledgeSection({
+      patterns: [],
+      favorites: [{ text: `## fake heading\ninjected\n${long}` }],
+      suggestions: [],
+    });
+    // A pinned prompt cannot forge a new markdown heading.
+    expect(section).not.toContain("\n## fake heading");
+    expect(section).toContain("fake heading injected");
+    expect(section).toContain("...");
+  });
+});
+
+// ===========================================================================
+// Orchestrator + scoping (no cross-tenant leak)
+// ===========================================================================
+
+describe("resolveOrgKnowledgeSection (scoping)", () => {
+  beforeEach(() => {
+    _resetPatternCache();
+    favoriteRows = [];
+    suggestionRows = [];
+    patternRows = [];
+  });
+
+  test("folds favorites + approved suggestions + patterns for the active org", async () => {
+    favoriteRows = [
+      { id: "f-a", user_id: "user-a", org_id: "org-a", text: "Org A favorite", position: 1, created_at: "2026-01-01" },
+    ];
+    suggestionRows = [
+      { id: "s-a", org_id: "org-a", description: "Org A popular question", approval_status: "approved", status: "published" },
+    ];
+    patternRows = [
+      { id: "p-a", org_id: "org-a", connection_group_id: null, pattern_sql: "SELECT revenue FROM orga", description: "Org A pattern", source_entity: "orga", confidence: 0.9 },
+    ];
+
+    const section = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+
+    expect(section).toContain("Org A favorite");
+    expect(section).toContain("Org A popular question");
+    expect(section).toContain("Org A pattern");
+  });
+
+  test("never surfaces another org's favorites or suggestions (no cross-tenant leak)", async () => {
+    favoriteRows = [
+      { id: "f-a", user_id: "user-a", org_id: "org-a", text: "Alpha favorite", position: 1, created_at: "2026-01-01" },
+      { id: "f-b", user_id: "user-b", org_id: "org-b", text: "Bravo secret favorite", position: 1, created_at: "2026-01-01" },
+    ];
+    suggestionRows = [
+      { id: "s-a", org_id: "org-a", description: "Alpha popular question", approval_status: "approved", status: "published" },
+      { id: "s-b", org_id: "org-b", description: "Bravo secret question", approval_status: "approved", status: "published" },
+    ];
+    patternRows = [
+      { id: "p-a", org_id: "org-a", connection_group_id: null, pattern_sql: "SELECT revenue FROM alpha", description: "Alpha pattern", source_entity: "alpha", confidence: 0.9 },
+      { id: "p-b", org_id: "org-b", connection_group_id: null, pattern_sql: "SELECT revenue FROM bravo", description: "Bravo pattern", source_entity: "bravo", confidence: 0.9 },
+    ];
+
+    const section = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+
+    expect(section).toContain("Alpha favorite");
+    expect(section).toContain("Alpha popular question");
+    // The other tenant's signals must never appear.
+    expect(section).not.toContain("Bravo secret favorite");
+    expect(section).not.toContain("Bravo secret question");
+    expect(section).not.toContain("bravo");
+  });
+
+  test("a user only sees their own pins within the org", async () => {
+    favoriteRows = [
+      { id: "f-a", user_id: "user-a", org_id: "org-a", text: "Mine", position: 1, created_at: "2026-01-01" },
+      { id: "f-c", user_id: "user-c", org_id: "org-a", text: "Someone else pin", position: 1, created_at: "2026-01-01" },
+    ];
+
+    const section = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+
+    expect(section).toContain("Mine");
+    expect(section).not.toContain("Someone else pin");
+  });
+
+  test("excludes pending / unpublished suggestions", async () => {
+    suggestionRows = [
+      { id: "s-pending", org_id: "org-a", description: "Pending question", approval_status: "pending", status: "draft" },
+      { id: "s-approved", org_id: "org-a", description: "Approved question", approval_status: "approved", status: "published" },
+    ];
+
+    const section = await resolveOrgKnowledgeSection({
+      orgId: "org-a",
+      userId: "user-a",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+
+    expect(section).toContain("Approved question");
+    expect(section).not.toContain("Pending question");
+  });
+
+  test("returns empty string when the org has no signals", async () => {
+    const section = await resolveOrgKnowledgeSection({
+      orgId: "org-empty",
+      userId: "user-x",
+      connectionGroupId: null,
+      mode: "published",
+      question: "show me revenue",
+    });
+    expect(section).toBe("");
+  });
+});

--- a/packages/api/src/lib/learn/org-knowledge-section.ts
+++ b/packages/api/src/lib/learn/org-knowledge-section.ts
@@ -1,0 +1,245 @@
+/**
+ * Organizational-knowledge prompt block (#3633).
+ *
+ * Today only `learned_patterns` reaches the agent. But a workspace's
+ * `user_favorite_prompts` (per-user pins) and its admin-approved, high-click
+ * `query_suggestions` are equally strong intent signals — they're just used
+ * only for the empty-chat starter grid. This module folds all three into a
+ * single "Organizational knowledge" block fed to the agent's system prompt.
+ *
+ * The build is split into two halves:
+ *
+ *   - {@link buildOrgKnowledgeSection} — a PURE function that takes the three
+ *     already-resolved (and already-scoped) signal lists and renders the block.
+ *     No DB, no I/O — trivially testable for inclusion and formatting.
+ *
+ *   - {@link resolveOrgKnowledgeSection} — the async orchestrator that fetches
+ *     each signal via the EXISTING scoped resolvers (`getRelevantPatterns`,
+ *     `listFavorites`, `getPopularSuggestions`) and hands them to the pure
+ *     builder. Scoping (org / connection-group / user) lives in those
+ *     resolvers' SQL, so cross-tenant leakage is structurally impossible —
+ *     this layer only ever sees rows the DB already scoped.
+ */
+import type { AtlasMode } from "@useatlas/types/auth";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getPopularSuggestions } from "@atlas/api/lib/db/internal";
+import { listFavorites } from "@atlas/api/lib/starter-prompts/favorite-store";
+import { getRelevantPatterns, type RelevantPattern } from "./pattern-cache";
+
+const log = createLogger("org-knowledge-section");
+
+// ---------------------------------------------------------------------------
+// Pure section builder
+// ---------------------------------------------------------------------------
+
+/** A user-pinned prompt — the minimal shape the builder needs from
+ *  `user_favorite_prompts`. */
+export interface OrgKnowledgeFavorite {
+  readonly text: string;
+}
+
+/** An admin-approved popular suggestion — the minimal shape the builder needs
+ *  from `query_suggestions`. */
+export interface OrgKnowledgeSuggestion {
+  readonly description: string;
+}
+
+/** Inputs to {@link buildOrgKnowledgeSection}. All three lists are assumed
+ *  already org/group/user-scoped by the caller's resolvers. */
+export interface OrgKnowledgeInput {
+  readonly patterns: readonly RelevantPattern[];
+  readonly favorites: readonly OrgKnowledgeFavorite[];
+  readonly suggestions: readonly OrgKnowledgeSuggestion[];
+  /** Cap on rendered favorites (default 5). */
+  readonly maxFavorites?: number;
+  /** Cap on rendered suggestions (default 5). */
+  readonly maxSuggestions?: number;
+}
+
+const DEFAULT_MAX_FAVORITES = 5;
+const DEFAULT_MAX_SUGGESTIONS = 5;
+
+/** Sanitize free text for safe prompt injection — collapse newlines, strip
+ *  markdown headings (so injected text can't forge a new section), truncate.
+ *  Kept local so the pure module pulls in no DB/settings deps. */
+function sanitize(text: string, maxLen: number): string {
+  let safe = text.replace(/^#{1,6}\s/gm, "").replace(/\s*\n+\s*/g, " ").trim();
+  if (safe.length > maxLen) safe = safe.slice(0, maxLen - 3) + "...";
+  return safe;
+}
+
+/** Non-empty, sanitized one-liners from a list of text-bearing rows. */
+function bulletLines(texts: readonly string[], maxItems: number, maxLen: number): string[] {
+  return texts
+    .map((t) => sanitize(t, maxLen))
+    .filter((t) => t.length > 0)
+    .slice(0, maxItems);
+}
+
+/**
+ * Render the organizational-knowledge block from already-resolved signals.
+ *
+ * PURE: depends only on its inputs. Emits only the subsections that have
+ * content and returns `""` when every signal list is empty — so the caller
+ * can append it unconditionally without injecting an empty heading.
+ */
+export function buildOrgKnowledgeSection(input: OrgKnowledgeInput): string {
+  const maxFavorites = input.maxFavorites ?? DEFAULT_MAX_FAVORITES;
+  const maxSuggestions = input.maxSuggestions ?? DEFAULT_MAX_SUGGESTIONS;
+
+  const subsections: string[] = [];
+
+  if (input.patterns.length > 0) {
+    const lines = input.patterns.map((p) => {
+      const entity = p.sourceEntity ? `[${p.sourceEntity}]` : "[general]";
+      const desc = sanitize(p.description ?? "Query pattern", 200);
+      const sql = sanitize(p.patternSql, 500);
+      return `- ${entity}: ${desc}\n  SQL: ${sql}`;
+    });
+    subsections.push(
+      [
+        "### Previously successful query patterns",
+        "These patterns have been validated by your organization.",
+        ...lines,
+      ].join("\n"),
+    );
+  }
+
+  const favoriteLines = bulletLines(
+    input.favorites.map((f) => f.text),
+    maxFavorites,
+    200,
+  );
+  if (favoriteLines.length > 0) {
+    subsections.push(
+      [
+        "### Prompts your team has pinned",
+        "Questions users in your workspace pin for quick access — strong signals of what they care about.",
+        ...favoriteLines.map((t) => `- ${t}`),
+      ].join("\n"),
+    );
+  }
+
+  const suggestionLines = bulletLines(
+    input.suggestions.map((s) => s.description),
+    maxSuggestions,
+    200,
+  );
+  if (suggestionLines.length > 0) {
+    subsections.push(
+      [
+        "### Popular questions in this workspace",
+        "Frequently-clicked questions your admins have approved.",
+        ...suggestionLines.map((t) => `- ${t}`),
+      ].join("\n"),
+    );
+  }
+
+  if (subsections.length === 0) return "";
+
+  return [
+    "## Organizational knowledge",
+    "The signals below capture how your organization works with this data. Use them to anticipate common questions and reuse validated query shapes, but the semantic layer definitions above always take precedence.",
+    "",
+    subsections.join("\n\n"),
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Async orchestrator
+// ---------------------------------------------------------------------------
+
+/** Default number of approved popular suggestions to fold into the block. */
+const DEFAULT_SUGGESTION_FETCH = 5;
+
+export interface ResolveOrgKnowledgeParams {
+  readonly orgId: string | null;
+  readonly userId: string | null;
+  /** Active connection group (null = default flat scope). Threaded to the
+   *  pattern resolver so one group's patterns never prime another's session. */
+  readonly connectionGroupId: string | null;
+  /** Mode-system filter for the suggestions tier (admins in developer mode
+   *  preview drafts; non-admins are downgraded to `published` upstream). */
+  readonly mode: AtlasMode;
+  /** Retrieval query (assembled from recent user turns). */
+  readonly question: string;
+  /** Correlation id for log lines. */
+  readonly requestId?: string;
+  readonly maxPatterns?: number;
+  readonly maxFavorites?: number;
+  readonly maxSuggestions?: number;
+}
+
+/**
+ * Resolve and render the organizational-knowledge block for one agent turn.
+ *
+ * Each signal is fetched via its EXISTING scoped resolver — no ad-hoc queries:
+ *   - learned patterns → `getRelevantPatterns` (org + connection-group scoped)
+ *   - favorites        → `listFavorites` (user + org scoped)
+ *   - suggestions      → `getPopularSuggestions` (org scoped, approved-only)
+ *
+ * Favorites and suggestions are optimizations: a transient read failure on
+ * either is logged and falls through to an empty tier rather than blacking out
+ * the whole block (mirrors the starter-prompt resolver). The patterns fetch is
+ * allowed to propagate so the caller's `learned_patterns_unavailable` warning
+ * path stays intact.
+ */
+export async function resolveOrgKnowledgeSection(
+  params: ResolveOrgKnowledgeParams,
+): Promise<string> {
+  const patterns = await getRelevantPatterns(
+    params.orgId,
+    params.question,
+    params.connectionGroupId,
+    params.maxPatterns,
+  );
+
+  // Favorites — best-effort, only with a user+org context.
+  let favorites: OrgKnowledgeFavorite[] = [];
+  if (params.userId && params.orgId) {
+    try {
+      const rows = await listFavorites(params.userId, params.orgId);
+      favorites = rows.map((r) => ({ text: r.text }));
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          userId: params.userId,
+          orgId: params.orgId,
+          requestId: params.requestId,
+        },
+        "Failed to load favorites for org-knowledge block — continuing without favorites",
+      );
+    }
+  }
+
+  // Popular approved suggestions — best-effort, only with an org context.
+  let suggestions: OrgKnowledgeSuggestion[] = [];
+  if (params.orgId) {
+    try {
+      const rows = await getPopularSuggestions(
+        params.orgId,
+        params.maxSuggestions ?? DEFAULT_SUGGESTION_FETCH,
+        params.mode,
+      );
+      suggestions = rows.map((r) => ({ description: r.description }));
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          orgId: params.orgId,
+          requestId: params.requestId,
+        },
+        "Failed to load popular suggestions for org-knowledge block — continuing without suggestions",
+      );
+    }
+  }
+
+  return buildOrgKnowledgeSection({
+    patterns,
+    favorites,
+    suggestions,
+    maxFavorites: params.maxFavorites,
+    maxSuggestions: params.maxSuggestions,
+  });
+}

--- a/packages/api/src/lib/learn/org-knowledge-section.ts
+++ b/packages/api/src/lib/learn/org-knowledge-section.ts
@@ -187,6 +187,10 @@ export interface ResolveOrgKnowledgeParams {
 export async function resolveOrgKnowledgeSection(
   params: ResolveOrgKnowledgeParams,
 ): Promise<string> {
+  // Patterns first and on its own: its throw must propagate so the caller's
+  // `learned_patterns_unavailable` warning path stays intact. The two
+  // best-effort tiers below are independent of it and of each other, so they
+  // run concurrently rather than as a waterfall.
   const patterns = await getRelevantPatterns(
     params.orgId,
     params.question,
@@ -194,46 +198,10 @@ export async function resolveOrgKnowledgeSection(
     params.maxPatterns,
   );
 
-  // Favorites — best-effort, only with a user+org context.
-  let favorites: OrgKnowledgeFavorite[] = [];
-  if (params.userId && params.orgId) {
-    try {
-      const rows = await listFavorites(params.userId, params.orgId);
-      favorites = rows.map((r) => ({ text: r.text }));
-    } catch (err) {
-      log.warn(
-        {
-          err: err instanceof Error ? err.message : String(err),
-          userId: params.userId,
-          orgId: params.orgId,
-          requestId: params.requestId,
-        },
-        "Failed to load favorites for org-knowledge block — continuing without favorites",
-      );
-    }
-  }
-
-  // Popular approved suggestions — best-effort, only with an org context.
-  let suggestions: OrgKnowledgeSuggestion[] = [];
-  if (params.orgId) {
-    try {
-      const rows = await getPopularSuggestions(
-        params.orgId,
-        params.maxSuggestions ?? DEFAULT_SUGGESTION_FETCH,
-        params.mode,
-      );
-      suggestions = rows.map((r) => ({ description: r.description }));
-    } catch (err) {
-      log.warn(
-        {
-          err: err instanceof Error ? err.message : String(err),
-          orgId: params.orgId,
-          requestId: params.requestId,
-        },
-        "Failed to load popular suggestions for org-knowledge block — continuing without suggestions",
-      );
-    }
-  }
+  const [favorites, suggestions] = await Promise.all([
+    loadFavorites(params),
+    loadSuggestions(params),
+  ]);
 
   return buildOrgKnowledgeSection({
     patterns,
@@ -242,4 +210,53 @@ export async function resolveOrgKnowledgeSection(
     maxFavorites: params.maxFavorites,
     maxSuggestions: params.maxSuggestions,
   });
+}
+
+/** Best-effort favorites tier — scoped `(user_id, org_id)`. A read failure is
+ *  logged and degrades to an empty tier rather than failing the whole block. */
+async function loadFavorites(
+  params: ResolveOrgKnowledgeParams,
+): Promise<OrgKnowledgeFavorite[]> {
+  if (!params.userId || !params.orgId) return [];
+  try {
+    const rows = await listFavorites(params.userId, params.orgId);
+    return rows.map((r) => ({ text: r.text }));
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        userId: params.userId,
+        orgId: params.orgId,
+        requestId: params.requestId,
+      },
+      "Failed to load favorites for org-knowledge block — continuing without favorites",
+    );
+    return [];
+  }
+}
+
+/** Best-effort suggestions tier — scoped by org, approved + published only. A
+ *  read failure is logged and degrades to an empty tier. */
+async function loadSuggestions(
+  params: ResolveOrgKnowledgeParams,
+): Promise<OrgKnowledgeSuggestion[]> {
+  if (!params.orgId) return [];
+  try {
+    const rows = await getPopularSuggestions(
+      params.orgId,
+      params.maxSuggestions ?? DEFAULT_SUGGESTION_FETCH,
+      params.mode,
+    );
+    return rows.map((r) => ({ description: r.description }));
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        orgId: params.orgId,
+        requestId: params.requestId,
+      },
+      "Failed to load popular suggestions for org-knowledge block — continuing without suggestions",
+    );
+    return [];
+  }
 }


### PR DESCRIPTION
## What & why

Closes #3633 (v0.0.17 slice B-4).

Before this, only `learned_patterns` reached the agent. `user_favorite_prompts` (per-user pins) and the workspace's admin-approved, high-click `query_suggestions` are equally strong intent signals — but they were used only for the empty-chat starter grid. This folds all three into a single **Organizational knowledge** block in the agent's system prompt.

## How

New `packages/api/src/lib/learn/org-knowledge-section.ts`, split into two halves:

- **`buildOrgKnowledgeSection(input)` — PURE function.** Takes the three already-resolved signal lists and renders the block: a learned-patterns subsection, a "Prompts your team has pinned" subsection, and a "Popular questions in this workspace" subsection. Emits only non-empty subsections and returns `""` when all are empty. Sanitizes injected text (strips markdown headings, collapses newlines, truncates) and caps favorites/suggestions. No DB, no I/O — tested in isolation.
- **`resolveOrgKnowledgeSection(params)` — async orchestrator.** Reuses the *existing* scoped resolvers — `getRelevantPatterns` (org + connection-group scoped), `listFavorites` (user + org scoped), `getPopularSuggestions` (org scoped, approved + published only) — so no ad-hoc queries and **scoping lives entirely in SQL**. Favorites/suggestions are best-effort tiers (logged + fall through on read failure, mirroring the starter-prompt resolver); the patterns fetch still drives the `learned_patterns_unavailable` warning path.

`agent.ts` swaps `buildLearnedPatternsSection` for `resolveOrgKnowledgeSection`, threading `userId` + `atlasMode` + `connectionGroupId`. `buildLearnedPatternsSection` is unchanged (still used by the dashboard-suggestions path).

## Scoping / no cross-tenant leak

Neither `user_favorite_prompts` nor `query_suggestions` has a `connection_group_id` column — connection-group scoping flows through learned patterns (org + group), favorites are scoped `(user_id, org_id)`, suggestions by `org_id`. Because the orchestrator only ever sees rows the resolvers' `WHERE` clauses already scoped, cross-tenant leakage is structurally impossible.

## Acceptance criteria

- [x] Favorites and approved suggestions render into the org-knowledge block fed to the agent
- [x] Section-builder pure function tested for inclusion and formatting
- [x] Org and connection-group scoping respected — includes a test asserting another org's favorites/suggestions never appear, plus a per-user-pin-isolation test and a pending-suggestion-exclusion test

## Testing

- New `learn/__tests__/org-knowledge-section.test.ts` (12 tests): pure builder (inclusion / formatting / caps / sanitization / empty-handling) + orchestrator scoping (cross-tenant leak, per-user pins, approval gating).
- Updated 5 agent tests that mock `pattern-cache` to also mock the new module (the `agent-context-warnings` failure-path test now drives `resolveOrgKnowledgeSection`).
- `/ci`: lint, type, full test suite, syncpack, all drift checks (template / security-headers / railway-watch / schema / openapi / oauth-helper), test-discipline, settings-readers, published-symbols — all green.

https://claude.ai/code/session_01PEGpsPLVhwb21hKhW9NmYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEGpsPLVhwb21hKhW9NmYu)_