### PR TITLE
feat(api): capture per-pattern query latency as a rolling average (#3635)

### DIFF
--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -328,7 +328,7 @@ describe("pattern-proposer", () => {
     const updateCall = queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"));
     expect(updateCall).toBeDefined();
     // Should include the fingerprint as a JSONB array
-    expect(updateCall!.params?.length).toBe(2); // [id, jsonbEntry]
+    expect(updateCall!.params?.length).toBe(3); // [id, jsonbEntry, observation] (#3635)
     const jsonbEntry = updateCall!.params![1] as string;
     const parsed = JSON.parse(jsonbEntry);
     expect(Array.isArray(parsed)).toBe(true);
@@ -412,9 +412,70 @@ describe("pattern-proposer", () => {
 
     const updateCall = queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"));
     expect(updateCall).toBeDefined();
-    // Simple update: only id param, no JSONB append
-    expect(updateCall!.params?.length).toBe(1);
+    // No fingerprint → no JSONB append; params are [id, observation] (#3635).
+    expect(updateCall!.params?.length).toBe(2);
     expect(updateCall!.params?.[0]).toBe("pat-abc");
     expect(updateCall!.sql).not.toContain("source_queries");
+  });
+
+  // ── Per-pattern latency (#3635, PRD #3617 B-1) ─────────────────────
+
+  test("durationMs threads through to insert seeding avg_duration_ms + last_seen_at", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose({ ...defaultInput, durationMs: 1234 });
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    // Seeds avg_duration_ms (the last bound param) and stamps last_seen_at.
+    expect(insertCall!.sql).toContain("avg_duration_ms");
+    expect(insertCall!.sql).toContain("last_seen_at");
+    expect(insertCall!.params?.[7]).toBe(1234);
+  });
+
+  test("insert leaves latency NULL when durationMs is absent", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose(defaultInput); // no durationMs
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    // Absent observation → seed param is NULL (column stays "not yet observed").
+    expect(insertCall!.params?.[7]).toBeNull();
+  });
+
+  test("insert ignores a negative/NaN duration (seeds NULL)", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose({ ...defaultInput, durationMs: -5 });
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall!.params?.[7]).toBeNull();
+  });
+
+  test("durationMs threads through to incrementPatternCount on a duplicate", async () => {
+    setResults({ rows: [{ id: "pat-dup", confidence: 0.5, repetition_count: 3 }] });
+
+    await _analyzeAndPropose({ ...defaultInput, durationMs: 900 });
+
+    const updateCall = queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"));
+    expect(updateCall).toBeDefined();
+    // Rolling-average + last_seen_at maintenance is present in the SQL.
+    expect(updateCall!.sql).toContain("avg_duration_ms");
+    expect(updateCall!.sql).toContain("last_seen_at");
+    // params: [id, jsonbFingerprint, observation]
+    expect(updateCall!.params?.length).toBe(3);
+    expect(updateCall!.params?.[2]).toBe(900);
+  });
+
+  test("incrementPatternCount with fingerprint but no duration passes a NULL observation", () => {
+    enableInternalDB();
+
+    incrementPatternCount("pat-xyz", "abc123");
+
+    const updateCall = queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"));
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.params?.length).toBe(3);
+    expect(updateCall!.params?.[2]).toBeNull();
   });
 });

--- a/packages/api/src/lib/db/__tests__/pattern-latency-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-latency-pg.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Real-Postgres tests for per-pattern query latency (#3635, PRD #3617 B-1).
+ *
+ * The rolling-average semantics live entirely in SQL — an incremental mean
+ * `(avg * n + d) / (n + 1)` that reads the *pre-UPDATE* `repetition_count` as
+ * the weight `n`, plus the first-observation seed and the NULL-observation
+ * no-op. None of that is exercisable through a mocked query layer (the mock
+ * never evaluates the CASE arithmetic), so these run the production
+ * `insertLearnedPattern` / `incrementPatternCount` against a real Postgres and
+ * assert the stored `avg_duration_ms` converges across repetitions.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches `audit-slow-pg`
+ * / `migrate-pg`). CI's api-tests workflow provides the Postgres service.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  insertLearnedPattern,
+  incrementPatternCount,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+const ORG = "org-latency-test";
+
+interface PatternRow {
+  id: string;
+  avg_duration_ms: number | null;
+  last_seen_at: Date | null;
+  repetition_count: number;
+}
+
+describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () => {
+  let pool: Pool;
+  const schemaName = `latency_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`pattern-latency-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Point the production internal-DB helpers at this pool so the exact
+    // insert/increment SQL under test runs against this schema.
+    _resetPool(pool as unknown as InternalPool);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM learned_patterns");
+  });
+
+  /** Read back the single learned pattern for a given SQL string. */
+  async function readPattern(patternSql: string): Promise<PatternRow> {
+    const res = await pool.query<PatternRow>(
+      `SELECT id, avg_duration_ms, last_seen_at, repetition_count
+       FROM learned_patterns WHERE pattern_sql = $1 LIMIT 1`,
+      [patternSql],
+    );
+    expect(res.rows).toHaveLength(1);
+    return res.rows[0];
+  }
+
+  /**
+   * insertLearnedPattern / incrementPatternCount are fire-and-forget (no
+   * awaitable handle). They issue a single internalExecute against the pool;
+   * a short settle lets the detached promise land before we read back.
+   */
+  async function settle(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  it(
+    "seeds avg_duration_ms + last_seen_at from the first observation",
+    async () => {
+      const sql = "SELECT a FROM seed_first WHERE x = 1";
+      insertLearnedPattern({
+        orgId: ORG,
+        patternSql: sql,
+        description: "seed test",
+        sourceEntity: "seed_first",
+        sourceQueries: ["fp1"],
+        proposedBy: "agent",
+        durationMs: 300,
+      });
+      await settle();
+
+      const row = await readPattern(sql);
+      expect(row.avg_duration_ms).toBe(300);
+      expect(row.last_seen_at).not.toBeNull();
+      expect(row.repetition_count).toBe(1);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "leaves latency NULL when the first observation has no duration",
+    async () => {
+      const sql = "SELECT a FROM seed_null WHERE x = 1";
+      insertLearnedPattern({
+        orgId: ORG,
+        patternSql: sql,
+        description: "seed null test",
+        sourceEntity: "seed_null",
+        sourceQueries: ["fp1"],
+        proposedBy: "agent",
+        // no durationMs
+      });
+      await settle();
+
+      const row = await readPattern(sql);
+      expect(row.avg_duration_ms).toBeNull();
+      expect(row.last_seen_at).toBeNull();
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "maintains a true rolling mean across repetitions and advances last_seen_at",
+    async () => {
+      const sql = "SELECT a FROM rolling WHERE x = 1";
+      // Seed at 100, then observe 200, 300, 400. The incremental mean must
+      // equal the plain arithmetic mean at every step:
+      //   after seed:           100
+      //   after 200: (100*1+200)/2 = 150
+      //   after 300: (150*2+300)/3 = 200
+      //   after 400: (200*3+400)/4 = 250
+      insertLearnedPattern({
+        orgId: ORG,
+        patternSql: sql,
+        description: "rolling test",
+        sourceEntity: "rolling",
+        sourceQueries: ["fp1"],
+        proposedBy: "agent",
+        durationMs: 100,
+      });
+      await settle();
+      let row = await readPattern(sql);
+      expect(row.avg_duration_ms).toBe(100);
+      const seededSeenAt = row.last_seen_at;
+      expect(seededSeenAt).not.toBeNull();
+
+      for (const { d, expected, count } of [
+        { d: 200, expected: 150, count: 2 },
+        { d: 300, expected: 200, count: 3 },
+        { d: 400, expected: 250, count: 4 },
+      ]) {
+        incrementPatternCount(row.id, `fp-${d}`, d);
+        await settle();
+        row = await readPattern(sql);
+        expect(row.repetition_count).toBe(count);
+        expect(row.avg_duration_ms).toBeCloseTo(expected, 6);
+      }
+
+      // last_seen_at advanced past the seed timestamp.
+      expect(row.last_seen_at).not.toBeNull();
+      expect(row.last_seen_at!.getTime()).toBeGreaterThanOrEqual(seededSeenAt!.getTime());
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "an increment without a duration leaves avg_duration_ms and last_seen_at untouched",
+    async () => {
+      const sql = "SELECT a FROM no_dur WHERE x = 1";
+      insertLearnedPattern({
+        orgId: ORG,
+        patternSql: sql,
+        description: "no-dur test",
+        sourceEntity: "no_dur",
+        sourceQueries: ["fp1"],
+        proposedBy: "agent",
+        durationMs: 500,
+      });
+      await settle();
+      let row = await readPattern(sql);
+      const seenAtBefore = row.last_seen_at;
+      expect(row.avg_duration_ms).toBe(500);
+
+      // Bump the repetition without a measurement — latency columns frozen.
+      incrementPatternCount(row.id, "fp2");
+      await settle();
+      row = await readPattern(sql);
+      expect(row.repetition_count).toBe(2);
+      expect(row.avg_duration_ms).toBe(500);
+      expect(row.last_seen_at!.getTime()).toBe(seenAtBefore!.getTime());
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "a first duration arriving on increment seeds the previously-NULL average",
+    async () => {
+      const sql = "SELECT a FROM late_seed WHERE x = 1";
+      insertLearnedPattern({
+        orgId: ORG,
+        patternSql: sql,
+        description: "late seed test",
+        sourceEntity: "late_seed",
+        sourceQueries: ["fp1"],
+        proposedBy: "agent",
+        // seeded NULL
+      });
+      await settle();
+      let row = await readPattern(sql);
+      expect(row.avg_duration_ms).toBeNull();
+
+      // First real measurement on the duplicate path seeds the average directly
+      // (avg IS NULL branch) rather than averaging against NULL.
+      incrementPatternCount(row.id, "fp2", 800);
+      await settle();
+      row = await readPattern(sql);
+      expect(row.avg_duration_ms).toBe(800);
+      expect(row.last_seen_at).not.toBeNull();
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/db/__tests__/pattern-latency-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-latency-pg.test.ts
@@ -67,25 +67,46 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
     await pool.query("DELETE FROM learned_patterns");
   });
 
-  /** Read back the single learned pattern for a given SQL string. */
-  async function readPattern(patternSql: string): Promise<PatternRow> {
+  /** Read back the learned pattern for a SQL string, or null if not yet present. */
+  async function rowOrNull(patternSql: string): Promise<PatternRow | null> {
     const res = await pool.query<PatternRow>(
       `SELECT id, avg_duration_ms, last_seen_at, repetition_count
        FROM learned_patterns WHERE pattern_sql = $1 LIMIT 1`,
       [patternSql],
     );
-    expect(res.rows).toHaveLength(1);
-    return res.rows[0];
+    return res.rows[0] ?? null;
   }
 
   /**
-   * insertLearnedPattern / incrementPatternCount are fire-and-forget (no
-   * awaitable handle). They issue a single internalExecute against the pool;
-   * a short settle lets the detached promise land before we read back.
+   * insertLearnedPattern / incrementPatternCount are fire-and-forget (they
+   * return void — no awaitable handle), so we can't await the detached write.
+   * Rather than a fixed sleep (which can flake on a loaded runner if the
+   * detached promise lands late), poll the row until the write has demonstrably
+   * landed, then assert against it.
    */
-  async function settle(): Promise<void> {
-    await new Promise((r) => setTimeout(r, 50));
+  async function poll(
+    patternSql: string,
+    predicate: (row: PatternRow) => boolean,
+    timeoutMs = 5000,
+  ): Promise<PatternRow> {
+    const deadline = Date.now() + timeoutMs;
+    let last: PatternRow | null = null;
+    while (Date.now() < deadline) {
+      last = await rowOrNull(patternSql);
+      if (last && predicate(last)) return last;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    // Surface whatever we last saw so the caller's assertions give a clear diff.
+    expect(last).not.toBeNull();
+    return last!;
   }
+
+  /** Wait until the pattern row exists (i.e. the insert landed). */
+  const waitForRow = (patternSql: string): Promise<PatternRow> => poll(patternSql, () => true);
+
+  /** Wait until repetition_count reaches `count` (i.e. a specific increment landed). */
+  const waitForCount = (patternSql: string, count: number): Promise<PatternRow> =>
+    poll(patternSql, (r) => r.repetition_count === count);
 
   it(
     "seeds avg_duration_ms + last_seen_at from the first observation",
@@ -100,9 +121,8 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         proposedBy: "agent",
         durationMs: 300,
       });
-      await settle();
 
-      const row = await readPattern(sql);
+      const row = await waitForRow(sql);
       expect(row.avg_duration_ms).toBe(300);
       expect(row.last_seen_at).not.toBeNull();
       expect(row.repetition_count).toBe(1);
@@ -123,9 +143,8 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         proposedBy: "agent",
         // no durationMs
       });
-      await settle();
 
-      const row = await readPattern(sql);
+      const row = await waitForRow(sql);
       expect(row.avg_duration_ms).toBeNull();
       expect(row.last_seen_at).toBeNull();
     },
@@ -151,8 +170,7 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         proposedBy: "agent",
         durationMs: 100,
       });
-      await settle();
-      let row = await readPattern(sql);
+      let row = await waitForRow(sql);
       expect(row.avg_duration_ms).toBe(100);
       const seededSeenAt = row.last_seen_at;
       expect(seededSeenAt).not.toBeNull();
@@ -163,13 +181,12 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         { d: 400, expected: 250, count: 4 },
       ]) {
         incrementPatternCount(row.id, `fp-${d}`, d);
-        await settle();
-        row = await readPattern(sql);
-        expect(row.repetition_count).toBe(count);
+        row = await waitForCount(sql, count);
         expect(row.avg_duration_ms).toBeCloseTo(expected, 6);
       }
 
-      // last_seen_at advanced past the seed timestamp.
+      // last_seen_at advanced to at least the seed timestamp (seed + increment
+      // can land in the same millisecond, so equality is allowed — `>=`).
       expect(row.last_seen_at).not.toBeNull();
       expect(row.last_seen_at!.getTime()).toBeGreaterThanOrEqual(seededSeenAt!.getTime());
     },
@@ -189,16 +206,13 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         proposedBy: "agent",
         durationMs: 500,
       });
-      await settle();
-      let row = await readPattern(sql);
+      let row = await waitForRow(sql);
       const seenAtBefore = row.last_seen_at;
       expect(row.avg_duration_ms).toBe(500);
 
       // Bump the repetition without a measurement — latency columns frozen.
       incrementPatternCount(row.id, "fp2");
-      await settle();
-      row = await readPattern(sql);
-      expect(row.repetition_count).toBe(2);
+      row = await waitForCount(sql, 2);
       expect(row.avg_duration_ms).toBe(500);
       expect(row.last_seen_at!.getTime()).toBe(seenAtBefore!.getTime());
     },
@@ -218,15 +232,13 @@ describeIfPg("per-pattern latency rolling average (real Postgres, #3635)", () =>
         proposedBy: "agent",
         // seeded NULL
       });
-      await settle();
-      let row = await readPattern(sql);
+      let row = await waitForRow(sql);
       expect(row.avg_duration_ms).toBeNull();
 
       // First real measurement on the duplicate path seeds the average directly
       // (avg IS NULL branch) rather than averaging against NULL.
       incrementPatternCount(row.id, "fp2", 800);
-      await settle();
-      row = await readPattern(sql);
+      row = await waitForCount(sql, 2);
       expect(row.avg_duration_ms).toBe(800);
       expect(row.last_seen_at).not.toBeNull();
     },

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1256,10 +1256,23 @@ export function insertLearnedPattern(pattern: {
   sourceEntity: string;
   sourceQueries: string[];
   proposedBy: string;
+  /**
+   * Wall-clock execution time (ms) of the first observed query for this pattern
+   * (#3635, PRD #3617 B-1). Seeds `avg_duration_ms` and `last_seen_at`. Omitted
+   * /`undefined`/`null` leaves both NULL — the "not yet observed" state — so a
+   * caller without a measurement doesn't fabricate a zero latency.
+   */
+  durationMs?: number | null | undefined;
 }): void {
+  // Seed the rolling average from the first observation. A finite, non-negative
+  // measurement also stamps `last_seen_at`; absent it, both stay NULL.
+  const seedDuration =
+    typeof pattern.durationMs === "number" && Number.isFinite(pattern.durationMs) && pattern.durationMs >= 0
+      ? pattern.durationMs
+      : null;
   internalExecute(
-    `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, source_queries, confidence, repetition_count, status, proposed_by, connection_group_id)
-     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6, $7)`,
+    `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, source_queries, confidence, repetition_count, status, proposed_by, connection_group_id, avg_duration_ms, last_seen_at)
+     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6, $7, $8, CASE WHEN $8::double precision IS NULL THEN NULL ELSE now() END)`,
     [
       pattern.orgId ?? null,
       pattern.patternSql,
@@ -1268,6 +1281,7 @@ export function insertLearnedPattern(pattern: {
       JSON.stringify(pattern.sourceQueries),
       pattern.proposedBy,
       pattern.connectionGroupId ?? null,
+      seedDuration,
     ],
   );
 }
@@ -1517,15 +1531,42 @@ export async function reviewSemanticAmendment(
 /**
  * Increment repetition_count by 1 and increase confidence by 0.1 (capped at 1.0).
  * When sourceFingerprint is provided, appends it to source_queries (capped at 100 entries).
+ *
+ * Latency (#3635, PRD #3617 B-1): when a finite, non-negative `durationMs` is
+ * supplied, folds it into `avg_duration_ms` as an incremental rolling mean and
+ * advances `last_seen_at`. The new average weights the existing mean by the
+ * *old* `repetition_count` — `(avg * n + d) / (n + 1)` — which converges to the
+ * true mean across repetitions. Every SET clause's RHS reads the pre-UPDATE row,
+ * so `repetition_count` here is the old `n` even though another clause bumps it.
+ * A first-ever observation (`avg_duration_ms IS NULL`) seeds directly to `d`. A
+ * missing/invalid measurement leaves both latency columns untouched.
+ *
  * Fire-and-forget — errors are logged, never thrown.
  */
-export function incrementPatternCount(id: string, sourceFingerprint?: string): void {
+export function incrementPatternCount(
+  id: string,
+  sourceFingerprint?: string,
+  durationMs?: number | null | undefined,
+): void {
+  const observation =
+    typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : null;
+
+  // Rolling-average + last_seen_at fragment, parameterized on the observation.
+  // NULL observation → no-op on both columns (keeps the prior value).
+  const latencyAssignments = `
+        avg_duration_ms = CASE
+          WHEN $LAT::double precision IS NULL THEN avg_duration_ms
+          WHEN avg_duration_ms IS NULL THEN $LAT::double precision
+          ELSE (avg_duration_ms * repetition_count + $LAT::double precision) / (repetition_count + 1)
+        END,
+        last_seen_at = CASE WHEN $LAT::double precision IS NULL THEN last_seen_at ELSE now() END,`;
+
   if (sourceFingerprint) {
     const newEntry = JSON.stringify([sourceFingerprint]);
     internalExecute(
       `UPDATE learned_patterns SET
         repetition_count = repetition_count + 1,
-        confidence = LEAST(1.0, confidence + 0.1),
+        confidence = LEAST(1.0, confidence + 0.1),${latencyAssignments.replaceAll("$LAT", "$3")}
         source_queries = CASE
           WHEN source_queries IS NULL THEN $2::jsonb
           WHEN jsonb_array_length(source_queries) >= 100 THEN source_queries
@@ -1533,16 +1574,16 @@ export function incrementPatternCount(id: string, sourceFingerprint?: string): v
         END,
         updated_at = now()
       WHERE id = $1`,
-      [id, newEntry],
+      [id, newEntry, observation],
     );
   } else {
     internalExecute(
       `UPDATE learned_patterns SET
         repetition_count = repetition_count + 1,
-        confidence = LEAST(1.0, confidence + 0.1),
+        confidence = LEAST(1.0, confidence + 0.1),${latencyAssignments.replaceAll("$LAT", "$2")}
         updated_at = now()
       WHERE id = $1`,
-      [id],
+      [id, observation],
     );
   }
 }

--- a/packages/api/src/lib/learn/pattern-proposer.ts
+++ b/packages/api/src/lib/learn/pattern-proposer.ts
@@ -33,6 +33,15 @@ export interface PatternProposalInput {
    * deduped away.
    */
   connectionGroupId: string | null | undefined;
+  /**
+   * Wall-clock execution time (ms) of the query that produced this proposal
+   * (#3635, PRD #3617 B-1). Computed at the `sql.ts` execution path for audit
+   * /SLA and threaded here to give every learned pattern a sense of how fast it
+   * runs. Seeds `avg_duration_ms` on insert and feeds the rolling average on
+   * each repeat observation. Optional: omitted (or `undefined`) leaves the
+   * latency columns untouched so callers without a measurement don't reset them.
+   */
+  durationMs?: number | null | undefined;
 }
 
 /**
@@ -55,7 +64,7 @@ export function proposePatternIfNovel(input: PatternProposalInput): void {
  * @internal
  */
 export async function _analyzeAndPropose(input: PatternProposalInput): Promise<void> {
-  const { sql, dialect, connectionId, orgId, connectionGroupId } = input;
+  const { sql, dialect, connectionId, orgId, connectionGroupId, durationMs } = input;
 
   // 1. Normalize SQL for dedup
   const normalized = normalizeSQL(sql);
@@ -75,8 +84,9 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
 
   const existing = await findPatternBySQL(orgId, connectionGroupId, normalized);
   if (existing) {
-    // Duplicate — bump count and confidence, append source fingerprint
-    incrementPatternCount(existing.id, fingerprint);
+    // Duplicate — bump count and confidence, append source fingerprint, and
+    // fold this execution's latency into the pattern's rolling average (#3635).
+    incrementPatternCount(existing.id, fingerprint, durationMs);
     log.debug(
       { patternId: existing.id, newCount: existing.repetitionCount + 1 },
       "Incremented repetition count for existing learned pattern",
@@ -95,6 +105,8 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
     sourceEntity: info?.primaryTable ?? "unknown",
     sourceQueries: [fingerprint],
     proposedBy: "agent",
+    // First observation seeds the rolling average (#3635).
+    durationMs,
   });
 
   log.debug(

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1287,6 +1287,9 @@ function executeAndAuditEffect(opts: {
             sql: querySql, dialect: parserDatabase(dbType, connId), connectionId: connId,
             orgId: learnReqCtx?.user?.activeOrganizationId,
             connectionGroupId: learnReqCtx?.connectionGroupId,
+            // Same wall-clock the audit/SLA path records — seeds/feeds the
+            // pattern's rolling avg_duration_ms (#3635, PRD #3617 B-1).
+            durationMs,
           });
 
           // PII masking (fails open) — via `MaskingPolicy` Tag (#2566)


### PR DESCRIPTION
## What

Give every learned pattern a sense of how fast it runs (PRD #3617, Workstream B slice B-1). The SQL execution path already computes `durationMs` for audit logging and SLA metrics right where patterns are proposed — this threads it into the learning layer.

- **`pattern-proposer.ts`** — adds optional `durationMs` to `PatternProposalInput`; passes it through to both the insert (seed) and `incrementPatternCount` (rolling avg) call sites.
- **`insertLearnedPattern` (internal.ts)** — seeds `avg_duration_ms` and stamps `last_seen_at` from the first observation. A missing/invalid (`undefined`/`null`/negative/`NaN`) measurement leaves both columns NULL — the "not yet observed" state.
- **`incrementPatternCount` (internal.ts)** — folds each observation into `avg_duration_ms` as an incremental rolling mean: `(avg * n + d) / (n + 1)`, weighting by the **pre-UPDATE** `repetition_count` (`n`). Every SET clause's RHS reads the old row, so the weight is correct even though another clause bumps the count. Seeds directly to `d` when the prior average was NULL, and advances `last_seen_at`. An increment without a measurement leaves both latency columns frozen.
- **`sql.ts`** — threads `durationMs` (the same wall-clock the audit/SLA path records) into the `proposePatternIfNovel` call site.

## No migration

The B-0 latency columns (`avg_duration_ms`, `last_seen_at`) already exist from #3631 (migration `0137_learning_tables_performance_columns.sql`). Verified in `db/schema.ts` before wiring — no schema change in this PR.

## Acceptance criteria

- [x] `durationMs` flows from the execution path into the proposer
- [x] `incrementPatternCount` updates `avg_duration_ms` as a rolling average and advances `last_seen_at` (real-Postgres test asserts convergence across repetitions)
- [x] `insertLearnedPattern` seeds `avg_duration_ms` from the first observation

## Tests

- `pattern-proposer.test.ts` — unit coverage for threading `durationMs` to insert/increment, NULL-on-absent, negative/NaN rejection, and updated param-shape assertions.
- `pattern-latency-pg.test.ts` (new, real Postgres) — seed-from-first-observation, NULL when no duration, **rolling-mean convergence** (100 → 150 → 200 → 250 matches the arithmetic mean at every step), increment-without-duration freezes both columns, and a late first duration seeding a previously-NULL average. Skips cleanly when `TEST_DATABASE_URL` is unset.

## Follow-on

B-2 (#3636) ranks/promotes on this field — the rolling-average semantics are kept clean and covered for it to build on.

## Gates run locally

- `bun run lint` — pass
- `bun run type` — pass (exit 0)
- `bun x syncpack lint` — pass
- `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — pass (821 files)
- `bash scripts/check-railway-watch.sh` — pass
- Affected + real-PG tests — my unit and `pattern-latency-pg` tests pass. Five **unrelated** real-PG files (rotate-encryption-key, outbox-pg ×2, chat-cap-pg, migrate-pg) timed out under full-parallel local runs against the single shared dev Postgres (connection-pool contention); all five pass in isolation. CI runs these in sharded api-tests jobs with a dedicated Postgres service, so they're green there.

Closes #3635