### PR TITLE
feat(api): index-aware semantic layer — harvest index metadata + composite-aware prompt hints (#3634)

### DIFF
--- a/apps/docs/content/docs/getting-started/semantic-layer.mdx
+++ b/apps/docs/content/docs/getting-started/semantic-layer.mdx
@@ -60,6 +60,8 @@ dimensions:
     type: string
     description: Current order status
     sample_values: [pending, shipped, delivered, cancelled]
+    indexed: true                       # auto-profiled — backed by an index
+    index_type: btree
 
   - name: order_month
     sql: "DATE_TRUNC('month', created_at)"
@@ -106,6 +108,11 @@ query_patterns:
       GROUP BY 1
       ORDER BY 1
 
+indexes:                              # auto-profiled composite / partial indexes
+  - name: orders_customer_status_idx
+    columns: [customer_id, status]
+    type: btree
+
 use_cases:
   - Revenue analysis and forecasting
   - Order fulfillment tracking
@@ -130,6 +137,11 @@ cross_source_joins:                   # Optional: joins to other datasources
 | `virtual` | boolean | No | Marks computed columns (not raw DB columns) |
 | `semantic_type` | string | No | Auto-detected pattern: `currency`, `percentage`, `email`, `url`, `phone`, `timestamp`. Guides measure inference and agent descriptions |
 | `sample_values` | array | No | Example values to guide the agent |
+| `indexed` | boolean | No | Auto-profiled: the column is backed by a database index. Surfaced to the agent so it prefers indexed columns for filters |
+| `index_type` | string | No | Auto-profiled access method of the column's index: `btree`, `gin`, `gist`, `brin`, `hash` |
+| `filter_hint` | string | No | Auto-profiled warning emitted when a column is indexed only as a *trailing* member of a composite B-tree — filtering on it alone is not sargable. Names the composite index and the leading column to constrain alongside it |
+
+> **Index awareness.** The profiler (`atlas init` / the wizard) harvests index metadata from the database catalog and stamps `indexed` / `index_type` / `filter_hint` onto dimensions, plus an entity-level [`indexes[]`](#index-fields) block for composite and partial indexes. These are hints — they never restrict which columns the agent may query.
 
 ### Measure Fields
 
@@ -149,6 +161,30 @@ cross_source_joins:                   # Optional: joins to other datasources
 | `join_columns.from` | string | Yes | Local foreign key column |
 | `join_columns.to` | string | Yes | Target primary key column |
 | `description` | string | No | Human-readable relationship description |
+
+### Index Fields
+
+Entity-level `indexes[]` is auto-profiled for **composite** (multi-column) and **partial** indexes — single-column indexes are conveyed by the per-dimension `indexed` flag instead. Column order is load-bearing: only the leading prefix of a composite B-tree is independently sargable.
+
+```yaml
+indexes:
+  - name: events_tenant_created_idx
+    columns: [tenant_id, created_at]   # leading column (tenant_id) is sargable; created_at needs tenant_id too
+    type: btree
+  - name: events_active_idx
+    columns: [status]
+    type: btree
+    unique: false
+    predicate: deleted_at IS NULL      # partial index — only covers matching rows
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Index name from the database catalog |
+| `columns` | array | Yes | Ordered index members. Composite order matters; expression-index members render as their definition text (e.g. `lower(email)`) |
+| `type` | string | Yes | Access method: `btree`, `gin`, `gist`, `brin`, `hash` |
+| `unique` | boolean | No | Present (`true`) for unique indexes |
+| `predicate` | string | No | Partial-index `WHERE` clause (PostgreSQL only) — the index only covers rows matching this predicate |
 
 ### Entity Types
 

--- a/apps/docs/content/docs/getting-started/semantic-layer.mdx
+++ b/apps/docs/content/docs/getting-started/semantic-layer.mdx
@@ -174,7 +174,6 @@ indexes:
   - name: events_active_idx
     columns: [status]
     type: btree
-    unique: false
     predicate: deleted_at IS NULL      # partial index — only covers matching rows
 ```
 

--- a/packages/api/src/lib/__tests__/profiler-index-harvest-mysql.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-index-harvest-mysql.test.ts
@@ -28,7 +28,7 @@ if (!TEST_MYSQL_URL) {
 }
 
 const MYSQL_TEST_TIMEOUT_MS = 30_000;
-const TABLE = `idx_events_${Date.now()}`;
+const TABLE = `idx_events_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
 
 describeIfMySQL("profileMySQL — index harvest (live MySQL, #3634)", () => {
   let profiles: TableProfile[];

--- a/packages/api/src/lib/__tests__/profiler-index-harvest-mysql.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-index-harvest-mysql.test.ts
@@ -1,0 +1,97 @@
+/**
+ * LIVE-MySQL index harvest coverage (#3634, slice A-2).
+ *
+ * Seeds a table with single-column, composite, and unique indexes, runs
+ * `profileMySQL`, and asserts the harvested `TableProfile.indexes` are grouped
+ * by index name and ordered by `SEQ_IN_INDEX` (composite order preserved).
+ * MySQL has no partial indexes, so every harvested index is `is_partial: false`
+ * with a null predicate.
+ *
+ * Skips cleanly when `TEST_MYSQL_URL` is unset. There is no MySQL container in
+ * the default dev stack or CI today, so this test is opt-in: point it at a
+ * throwaway MySQL with
+ *   export TEST_MYSQL_URL=mysql://user:pass@localhost:3306/atlas_test
+ * The grouping/ordering logic also has DB-free coverage in
+ * `semantic/generate/__tests__/index-awareness.test.ts` via fixture rows.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { profileMySQL } from "@atlas/api/lib/profiler";
+import type { IndexProfile, TableProfile } from "@useatlas/types";
+
+const TEST_MYSQL_URL = process.env.TEST_MYSQL_URL;
+const describeIfMySQL = TEST_MYSQL_URL ? describe : describe.skip;
+
+if (!TEST_MYSQL_URL) {
+  console.warn(
+    "profiler-index-harvest-mysql: TEST_MYSQL_URL unset — skipping live MySQL index harvest test (set it to opt in).",
+  );
+}
+
+const MYSQL_TEST_TIMEOUT_MS = 30_000;
+const TABLE = `idx_events_${Date.now()}`;
+
+describeIfMySQL("profileMySQL — index harvest (live MySQL, #3634)", () => {
+  let profiles: TableProfile[];
+
+  const events = (): TableProfile => profiles.find((p) => p.table_name === TABLE)!;
+  const indexNamed = (name: string): IndexProfile | undefined =>
+    (events().indexes ?? []).find((i) => i.name === name);
+
+  // Lazily import mysql2 only when the test actually runs.
+  let pool: { execute: (sql: string) => Promise<unknown>; end: () => Promise<void> };
+
+  beforeAll(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mysql = require("mysql2/promise");
+    pool = mysql.createPool({ uri: TEST_MYSQL_URL });
+    await pool.execute(`DROP TABLE IF EXISTS \`${TABLE}\``);
+    await pool.execute(`
+      CREATE TABLE \`${TABLE}\` (
+        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+        tenant_id BINARY(16) NOT NULL,
+        created_at DATETIME NOT NULL,
+        status VARCHAR(32),
+        email VARCHAR(255),
+        UNIQUE KEY events_email_uq (email),
+        KEY events_status_idx (status),
+        KEY events_tenant_created_idx (tenant_id, created_at)
+      )
+    `);
+
+    const result = await profileMySQL({ url: TEST_MYSQL_URL as string });
+    profiles = result.profiles;
+  }, MYSQL_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.execute(`DROP TABLE IF EXISTS \`${TABLE}\``).catch(() => {});
+      await pool.end().catch(() => {});
+    }
+  });
+
+  it("harvests the PRIMARY index as unique + primary", () => {
+    const pk = indexNamed("PRIMARY")!;
+    expect(pk.is_primary).toBe(true);
+    expect(pk.is_unique).toBe(true);
+    expect(pk.columns).toEqual(["id"]);
+  });
+
+  it("groups + orders a composite index by SEQ_IN_INDEX", () => {
+    const idx = indexNamed("events_tenant_created_idx")!;
+    expect(idx.columns).toEqual(["tenant_id", "created_at"]);
+    expect(idx.is_partial).toBe(false);
+    expect(idx.predicate).toBeNull();
+  });
+
+  it("harvests a unique secondary index", () => {
+    const idx = indexNamed("events_email_uq")!;
+    expect(idx.is_unique).toBe(true);
+    expect(idx.columns).toEqual(["email"]);
+  });
+
+  it("harvests a single-column non-unique index", () => {
+    const idx = indexNamed("events_status_idx")!;
+    expect(idx.is_unique).toBe(false);
+    expect(idx.columns).toEqual(["status"]);
+  });
+});

--- a/packages/api/src/lib/__tests__/profiler-index-harvest-pg.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-index-harvest-pg.test.ts
@@ -1,0 +1,121 @@
+/**
+ * LIVE-Postgres index harvest coverage (#3634, slice A-2).
+ *
+ * Seeds a dedicated source schema with single-column, composite, partial,
+ * unique, and expression indexes, runs `profilePostgres`, and asserts the
+ * harvested `TableProfile.indexes` carry ordered columns, the access method,
+ * `is_unique` / `is_primary` / `is_partial`, and the partial predicate — i.e.
+ * everything the YAML generator and prompt surfacing build on.
+ *
+ * Skips cleanly when `TEST_DATABASE_URL` is unset (CI sets it; opt in locally
+ * with `bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas`).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { profilePostgres } from "@atlas/api/lib/profiler";
+import type { IndexProfile, TableProfile } from "@useatlas/types";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+if (!TEST_DB_URL) {
+  console.warn(
+    "profiler-index-harvest-pg: TEST_DATABASE_URL unset — skipping live index harvest test (set it to opt in).",
+  );
+}
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("profilePostgres — index harvest (live Postgres, #3634)", () => {
+  const srcSchema = `idx_src_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let pool: Pool;
+  let profiles: TableProfile[];
+
+  const byTable = (name: string): TableProfile =>
+    profiles.find((p) => p.table_name === name)!;
+  const indexNamed = (t: TableProfile, name: string): IndexProfile | undefined =>
+    (t.indexes ?? []).find((i) => i.name === name);
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${srcSchema}"`);
+
+    // Single-column + unique + composite + partial + expression indexes.
+    await pool.query(`
+      CREATE TABLE "${srcSchema}".events (
+        id          bigserial PRIMARY KEY,
+        tenant_id   uuid NOT NULL,
+        created_at  timestamptz NOT NULL,
+        status      text,
+        email       text,
+        deleted_at  timestamptz
+      );
+      CREATE INDEX events_status_idx ON "${srcSchema}".events (status);
+      CREATE UNIQUE INDEX events_email_uq ON "${srcSchema}".events (email);
+      CREATE INDEX events_tenant_created_idx ON "${srcSchema}".events (tenant_id, created_at);
+      CREATE INDEX events_active_idx ON "${srcSchema}".events (status) WHERE deleted_at IS NULL;
+      CREATE INDEX events_lower_email_idx ON "${srcSchema}".events (lower(email));
+    `);
+
+    const result = await profilePostgres({ url: TEST_DB_URL as string, schema: srcSchema });
+    profiles = result.profiles;
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${srcSchema}" CASCADE`).catch(() => {});
+      await pool.end().catch(() => {});
+    }
+  });
+
+  it("harvests the primary-key index as unique + primary", () => {
+    const events = byTable("events");
+    const pk = (events.indexes ?? []).find((i) => i.is_primary);
+    expect(pk).toBeDefined();
+    expect(pk!.is_unique).toBe(true);
+    expect(pk!.columns).toEqual(["id"]);
+    expect(pk!.index_type).toBe("btree");
+  });
+
+  it("harvests a single-column btree index", () => {
+    const idx = indexNamed(byTable("events"), "events_status_idx")!;
+    expect(idx.columns).toEqual(["status"]);
+    expect(idx.index_type).toBe("btree");
+    expect(idx.is_unique).toBe(false);
+    expect(idx.is_partial).toBe(false);
+    expect(idx.predicate).toBeNull();
+  });
+
+  it("harvests a unique index", () => {
+    const idx = indexNamed(byTable("events"), "events_email_uq")!;
+    expect(idx.is_unique).toBe(true);
+    expect(idx.columns).toEqual(["email"]);
+  });
+
+  it("harvests a composite index preserving column order", () => {
+    const idx = indexNamed(byTable("events"), "events_tenant_created_idx")!;
+    expect(idx.columns).toEqual(["tenant_id", "created_at"]);
+  });
+
+  it("harvests a partial index with its predicate", () => {
+    const idx = indexNamed(byTable("events"), "events_active_idx")!;
+    expect(idx.is_partial).toBe(true);
+    expect(idx.predicate).toBeTruthy();
+    expect(idx.predicate!.toLowerCase()).toContain("deleted_at is null");
+    expect(idx.columns).toEqual(["status"]);
+  });
+
+  it("harvests an expression index rendering the expression text", () => {
+    const idx = indexNamed(byTable("events"), "events_lower_email_idx")!;
+    expect(idx.columns).toHaveLength(1);
+    expect(idx.columns[0].toLowerCase()).toContain("lower(email)");
+  });
+
+  it("fails soft — index harvest never blocks profiling", () => {
+    // The whole table profiled successfully (columns present) AND carried
+    // indexes; a soft failure would have left indexes empty but columns intact.
+    const events = byTable("events");
+    expect(events.columns.length).toBeGreaterThan(0);
+    expect((events.indexes ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -55,6 +55,8 @@ export interface ProfileLogger {
   info(obj: Record<string, unknown>, msg: string): void;
   warn(obj: Record<string, unknown>, msg: string): void;
   error(obj: Record<string, unknown>, msg: string): void;
+  /** Optional — pino has it; a minimal injected logger may not. Called via `?.`. */
+  debug?(obj: Record<string, unknown>, msg: string): void;
 }
 
 const defaultLog: ProfileLogger = createLogger("profiler");
@@ -385,12 +387,23 @@ function normalizeIndexType(amname: string | null | undefined): IndexType {
  *
  * Returns ONLY the catalog facts; the leading-vs-trailing sargability marker is
  * derived later in `analyzeTableProfiles`, not here.
+ *
+ * `serverVersionNum` (from `SHOW server_version_num`) selects the key-column
+ * count: `indnkeyatts` (PG 11+, excludes INCLUDE/covering columns so they aren't
+ * mistaken for sargable members) when available, else `indnatts` — older servers
+ * have no INCLUDE feature, so `indnatts` equals the key count there. A 0/unknown
+ * version falls back to the portable `indnatts`, so harvest never throws on the
+ * column reference (it would otherwise be lost to the fail-soft catch).
  */
 async function queryPostgresIndexes(
   pool: import("pg").Pool,
   tableName: string,
-  schema: string = "public"
+  schema: string = "public",
+  serverVersionNum: number = 0
 ): Promise<IndexProfile[]> {
+  // `indnkeyatts` only exists on PG 11+; reference it only when we know we're on
+  // 11+. The value is a controlled internal constant, never user input.
+  const keyCountCol = serverVersionNum >= 110000 ? "ix.indnkeyatts" : "ix.indnatts";
   const result = await pool.query(
     `
     SELECT
@@ -400,10 +413,10 @@ async function queryPostgresIndexes(
       ix.indisprimary AS is_primary,
       (ix.indpred IS NOT NULL) AS is_partial,
       pg_get_expr(ix.indpred, ix.indrelid) AS predicate,
-      ix.indnkeyatts AS key_count,
+      ${keyCountCol} AS key_count,
       ARRAY(
         SELECT pg_get_indexdef(ix.indexrelid, k + 1, true)
-        FROM generate_series(0, ix.indnkeyatts - 1) AS k
+        FROM generate_series(0, ${keyCountCol} - 1) AS k
       ) AS key_defs
     FROM pg_index ix
     JOIN pg_class ic ON ic.oid = ix.indexrelid
@@ -452,6 +465,22 @@ export async function profilePostgres({
   try {
   const profiles: TableProfile[] = [];
   const errors: ProfileError[] = [];
+
+  // Detect the server version once so the per-table index harvest can pick
+  // `indnkeyatts` (PG 11+) vs the portable `indnatts` (#3634). Fail-soft: an
+  // unknown version (0) falls back to `indnatts`, which exists on every server.
+  let pgServerVersionNum = 0;
+  try {
+    const verRes = await pool.query(`SHOW server_version_num`);
+    const verVal = (verRes.rows[0] as { server_version_num?: string } | undefined)?.server_version_num;
+    pgServerVersionNum = Number.parseInt(verVal ?? "0", 10) || 0;
+  } catch (verErr) {
+    if (isFatalConnectionError(verErr)) throw verErr;
+    log.warn(
+      { err: verErr instanceof Error ? verErr.message : String(verErr) },
+      "Could not read server_version_num — index harvest falls back to indnatts"
+    );
+  }
 
   let allObjects: DatabaseObject[];
   if (prefetchedObjects) {
@@ -548,7 +577,7 @@ export async function profilePostgres({
           log.warn({ err: fkErr instanceof Error ? fkErr.message : String(fkErr), table: table_name }, "Could not read FK constraints");
         }
         try {
-          indexes = await queryPostgresIndexes(pool, table_name, schema);
+          indexes = await queryPostgresIndexes(pool, table_name, schema, pgServerVersionNum);
         } catch (idxErr) {
           if (isFatalConnectionError(idxErr)) throw idxErr;
           // Fail soft: index metadata is an optimization hint, never required to
@@ -827,6 +856,7 @@ function mysqlIndexType(indexType: string | null | undefined): IndexType {
 async function queryMySQLIndexes(
   pool: { execute: (sql: string, params?: unknown[]) => Promise<[unknown[], unknown]> },
   tableName: string,
+  log: ProfileLogger = defaultLog,
 ): Promise<IndexProfile[]> {
   const [rows] = await pool.execute(
     `SELECT INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX, NON_UNIQUE, INDEX_TYPE
@@ -839,15 +869,21 @@ async function queryMySQLIndexes(
   // Group ordered rows into one IndexProfile per INDEX_NAME, preserving the
   // first-seen index order (rows already ordered by INDEX_NAME, SEQ_IN_INDEX).
   const grouped = new Map<string, IndexProfile>();
+  let skippedExpressionParts = 0;
   for (const r of rows as {
     INDEX_NAME: string;
     COLUMN_NAME: string | null;
     NON_UNIQUE: number;
     INDEX_TYPE: string | null;
   }[]) {
-    // Expression/functional index parts report a null COLUMN_NAME in older
-    // MySQL; skip them rather than emit an empty member.
-    if (r.COLUMN_NAME == null) continue;
+    // Expression/functional index parts report a null COLUMN_NAME (MySQL 8.0.13+
+    // functional key parts); skip them rather than emit an empty member. A wholly
+    // functional index thus drops out of indexes[] — trace the count so the
+    // omission is visible rather than silent.
+    if (r.COLUMN_NAME == null) {
+      skippedExpressionParts++;
+      continue;
+    }
     let idx = grouped.get(r.INDEX_NAME);
     if (!idx) {
       idx = {
@@ -862,6 +898,12 @@ async function queryMySQLIndexes(
       grouped.set(r.INDEX_NAME, idx);
     }
     idx.columns.push(r.COLUMN_NAME);
+  }
+  if (skippedExpressionParts > 0) {
+    log.debug?.(
+      { table: tableName, skippedExpressionParts },
+      "Skipped functional/expression index key parts (null COLUMN_NAME) during MySQL index harvest"
+    );
   }
   return [...grouped.values()];
 }
@@ -940,7 +982,7 @@ export async function profileMySQL({
             log.warn({ err: fkErr instanceof Error ? fkErr.message : String(fkErr), table: table_name }, "Could not read FK constraints");
           }
           try {
-            indexes = await queryMySQLIndexes(pool, table_name);
+            indexes = await queryMySQLIndexes(pool, table_name, log);
           } catch (idxErr) {
             if (isFatalConnectionError(idxErr)) throw idxErr;
             // Fail soft: index metadata is an optimization hint (#3634).

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -17,6 +17,8 @@ export {
   FK_SOURCES,
   PARTITION_STRATEGIES,
   SEMANTIC_TYPES,
+  INDEX_TYPES,
+  INDEX_POSITIONS,
 } from "@useatlas/types";
 export type {
   ObjectType,
@@ -31,6 +33,9 @@ export type {
   TableProfile,
   ProfileError,
   ProfilingResult,
+  IndexProfile,
+  IndexType,
+  IndexPosition,
 } from "@useatlas/types";
 
 // Also import locally for use within this module's function signatures.
@@ -41,6 +46,8 @@ import type {
   TableProfile,
   ProfileError,
   ProfilingResult,
+  IndexProfile,
+  IndexType,
 } from "@useatlas/types";
 
 /** Minimal structured logger interface — compatible with pino's (obj, msg) calling convention. */
@@ -347,6 +354,90 @@ async function queryForeignKeys(
   }));
 }
 
+/** Map a PostgreSQL `pg_am.amname` (or MySQL pseudo-type) to our index vocabulary. */
+function normalizeIndexType(amname: string | null | undefined): IndexType {
+  switch ((amname ?? "").toLowerCase()) {
+    case "btree":
+      return "btree";
+    case "gin":
+      return "gin";
+    case "gist":
+    case "spgist":
+      return "gist";
+    case "brin":
+      return "brin";
+    case "hash":
+      return "hash";
+    default:
+      return "other";
+  }
+}
+
+/**
+ * Harvest index metadata for one Postgres table (#3634).
+ *
+ * Keyed by `regclass` so it works for any schema-qualified table. Each index's
+ * member columns are rendered one-by-one via `pg_get_indexdef(indexrelid, n,
+ * true)` so composite ORDER survives and expression-index members (e.g.
+ * `lower(email)`) come back as their definition text rather than vanishing —
+ * `pg_index.indkey` would render expression members as `0`. Partial-index
+ * predicates come from `pg_get_expr(indpred, indrelid)`.
+ *
+ * Returns ONLY the catalog facts; the leading-vs-trailing sargability marker is
+ * derived later in `analyzeTableProfiles`, not here.
+ */
+async function queryPostgresIndexes(
+  pool: import("pg").Pool,
+  tableName: string,
+  schema: string = "public"
+): Promise<IndexProfile[]> {
+  const result = await pool.query(
+    `
+    SELECT
+      ic.relname AS index_name,
+      am.amname AS index_type,
+      ix.indisunique AS is_unique,
+      ix.indisprimary AS is_primary,
+      (ix.indpred IS NOT NULL) AS is_partial,
+      pg_get_expr(ix.indpred, ix.indrelid) AS predicate,
+      ix.indnkeyatts AS key_count,
+      ARRAY(
+        SELECT pg_get_indexdef(ix.indexrelid, k + 1, true)
+        FROM generate_series(0, ix.indnkeyatts - 1) AS k
+      ) AS key_defs
+    FROM pg_index ix
+    JOIN pg_class ic ON ic.oid = ix.indexrelid
+    JOIN pg_am am ON am.oid = ic.relam
+    WHERE ix.indrelid = $1::regclass
+      AND ix.indislive
+    ORDER BY ic.relname
+    `,
+    [pgTableRef(tableName, schema)]
+  );
+
+  return result.rows.map(
+    (r: {
+      index_name: string;
+      index_type: string | null;
+      is_unique: boolean;
+      is_primary: boolean;
+      is_partial: boolean;
+      predicate: string | null;
+      key_defs: string[];
+    }) => ({
+      name: r.index_name,
+      // key_defs is already ordered (generate_series 0..n-1); each entry is the
+      // rendered column or expression text for that index position.
+      columns: (r.key_defs ?? []).map((d) => d.trim()).filter((d) => d.length > 0),
+      index_type: normalizeIndexType(r.index_type),
+      is_unique: r.is_unique,
+      is_primary: r.is_primary,
+      is_partial: r.is_partial,
+      predicate: r.is_partial ? r.predicate : null,
+    })
+  );
+}
+
 export async function profilePostgres({
   url,
   schema = "public",
@@ -442,6 +533,7 @@ export async function profilePostgres({
 
       let primaryKeyColumns: string[] = [];
       let foreignKeys: ForeignKey[] = [];
+      let indexes: IndexProfile[] = [];
       if (objectType === "table") {
         try {
           primaryKeyColumns = await queryPrimaryKeys(pool, table_name, schema);
@@ -454,6 +546,14 @@ export async function profilePostgres({
         } catch (fkErr) {
           if (isFatalConnectionError(fkErr)) throw fkErr;
           log.warn({ err: fkErr instanceof Error ? fkErr.message : String(fkErr), table: table_name }, "Could not read FK constraints");
+        }
+        try {
+          indexes = await queryPostgresIndexes(pool, table_name, schema);
+        } catch (idxErr) {
+          if (isFatalConnectionError(idxErr)) throw idxErr;
+          // Fail soft: index metadata is an optimization hint, never required to
+          // profile the table — warn and continue (#3634).
+          log.warn({ err: idxErr instanceof Error ? idxErr.message : String(idxErr), table: table_name }, "Could not read index metadata");
         }
       }
 
@@ -564,6 +664,7 @@ export async function profilePostgres({
         primary_key_columns: primaryKeyColumns,
         foreign_keys: foreignKeys,
         inferred_foreign_keys: [],
+        indexes,
         profiler_notes: [],
         table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         ...(matview_populated !== undefined ? { matview_populated } : {}),
@@ -693,6 +794,78 @@ async function queryMySQLForeignKeys(
   }));
 }
 
+/**
+ * Map a MySQL `information_schema.STATISTICS.INDEX_TYPE` to our vocabulary
+ * (#3634). MySQL has no partial indexes, so harvested indexes never carry a
+ * predicate. FULLTEXT/SPATIAL map onto gin/gist so the agent sees a consistent
+ * "non-btree, position-independent" signal.
+ */
+function mysqlIndexType(indexType: string | null | undefined): IndexType {
+  switch ((indexType ?? "").toUpperCase()) {
+    case "BTREE":
+      return "btree";
+    case "HASH":
+      return "hash";
+    case "FULLTEXT":
+      return "gin";
+    case "SPATIAL":
+      return "gist";
+    default:
+      return "other";
+  }
+}
+
+/**
+ * Harvest index metadata for one MySQL table (#3634).
+ *
+ * `information_schema.STATISTICS` returns one row per (index, column); we group
+ * by `INDEX_NAME` and order members by `SEQ_IN_INDEX` so composite order
+ * survives. `NON_UNIQUE = 0` means unique; the implicit `PRIMARY` index is
+ * flagged `is_primary`. MySQL has no partial indexes (`is_partial: false`,
+ * `predicate: null`).
+ */
+async function queryMySQLIndexes(
+  pool: { execute: (sql: string, params?: unknown[]) => Promise<[unknown[], unknown]> },
+  tableName: string,
+): Promise<IndexProfile[]> {
+  const [rows] = await pool.execute(
+    `SELECT INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX, NON_UNIQUE, INDEX_TYPE
+     FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+     ORDER BY INDEX_NAME, SEQ_IN_INDEX`,
+    [tableName]
+  );
+
+  // Group ordered rows into one IndexProfile per INDEX_NAME, preserving the
+  // first-seen index order (rows already ordered by INDEX_NAME, SEQ_IN_INDEX).
+  const grouped = new Map<string, IndexProfile>();
+  for (const r of rows as {
+    INDEX_NAME: string;
+    COLUMN_NAME: string | null;
+    NON_UNIQUE: number;
+    INDEX_TYPE: string | null;
+  }[]) {
+    // Expression/functional index parts report a null COLUMN_NAME in older
+    // MySQL; skip them rather than emit an empty member.
+    if (r.COLUMN_NAME == null) continue;
+    let idx = grouped.get(r.INDEX_NAME);
+    if (!idx) {
+      idx = {
+        name: r.INDEX_NAME,
+        columns: [],
+        index_type: mysqlIndexType(r.INDEX_TYPE),
+        is_unique: Number(r.NON_UNIQUE) === 0,
+        is_primary: r.INDEX_NAME === "PRIMARY",
+        is_partial: false,
+        predicate: null,
+      };
+      grouped.set(r.INDEX_NAME, idx);
+    }
+    idx.columns.push(r.COLUMN_NAME);
+  }
+  return [...grouped.values()];
+}
+
 export async function profileMySQL({
   url,
   selectedTables: filterTables,
@@ -752,6 +925,7 @@ export async function profileMySQL({
 
         let primaryKeyColumns: string[] = [];
         let foreignKeys: ForeignKey[] = [];
+        let indexes: IndexProfile[] = [];
         if (objectType === "table") {
           try {
             primaryKeyColumns = await queryMySQLPrimaryKeys(pool, table_name);
@@ -764,6 +938,13 @@ export async function profileMySQL({
           } catch (fkErr) {
             if (isFatalConnectionError(fkErr)) throw fkErr;
             log.warn({ err: fkErr instanceof Error ? fkErr.message : String(fkErr), table: table_name }, "Could not read FK constraints");
+          }
+          try {
+            indexes = await queryMySQLIndexes(pool, table_name);
+          } catch (idxErr) {
+            if (isFatalConnectionError(idxErr)) throw idxErr;
+            // Fail soft: index metadata is an optimization hint (#3634).
+            log.warn({ err: idxErr instanceof Error ? idxErr.message : String(idxErr), table: table_name }, "Could not read index metadata");
           }
         }
 
@@ -858,6 +1039,7 @@ export async function profileMySQL({
           primary_key_columns: primaryKeyColumns,
           foreign_keys: foreignKeys,
           inferred_foreign_keys: [],
+          indexes,
           profiler_notes: [],
           table_flags: { possibly_abandoned: false, possibly_denormalized: false },
         });

--- a/packages/api/src/lib/semantic/__tests__/format-entity-indexes.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/format-entity-indexes.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test";
+import { formatEntity, type ParsedEntity } from "../search";
+
+// Pure-function tests for the composite-aware index markers (#3634, slice A-2),
+// building on the A-1 cardinality-fragment pipeline. They feed in-memory entity
+// objects carrying the profiler's per-dimension `indexed`/`index_type`/
+// `filter_hint` and entity-level `indexes[]` fields, asserting the prompt text
+// `formatEntity` emits in both modes — no YAML loader, no disk.
+
+describe("formatEntity — index markers", () => {
+  const entity: ParsedEntity = {
+    name: "events",
+    table: "events",
+    type: "fact_table",
+    dimensions: [
+      { name: "tenant_id", type: "uuid", indexed: true, index_type: "btree" },
+      {
+        name: "created_at",
+        type: "timestamp",
+        indexed: true,
+        index_type: "btree",
+        filter_hint:
+          "Indexed only as a trailing member of composite index events_tenant_created_idx (tenant_id, created_at); filtering on created_at alone is not sargable — also filter on tenant_id to use the index.",
+      },
+      { name: "body", type: "text", indexed: true, index_type: "gin" },
+      { name: "notes", type: "text" }, // not indexed
+    ],
+    indexes: [
+      {
+        name: "events_tenant_created_idx",
+        columns: ["tenant_id", "created_at"],
+        type: "btree",
+      },
+      {
+        name: "events_active",
+        columns: ["status"],
+        type: "btree",
+        predicate: "deleted_at IS NULL",
+      },
+    ],
+  };
+
+  describe("full mode", () => {
+    const out = formatEntity(entity, true, null);
+
+    it("marks an independently sargable indexed column 'indexed'", () => {
+      expect(out).toContain("- tenant_id (uuid, indexed)");
+    });
+
+    it("marks a non-btree index member with its access method", () => {
+      expect(out).toContain("- body (text, indexed gin)");
+    });
+
+    it("warns that a trailing composite member is not sargable alone", () => {
+      expect(out).toContain("created_at (timestamp, indexed (composite — not sargable alone))");
+    });
+
+    it("leaves un-indexed columns untouched", () => {
+      expect(out).toContain("- notes (text)");
+      expect(out).not.toContain("notes (text,");
+    });
+
+    it("emits an entity-level indexes block with leading order + partial predicate", () => {
+      expect(out).toContain("Indexes (leading column is sargable");
+      expect(out).toContain("- events_tenant_created_idx: (tenant_id, created_at) btree");
+      expect(out).toContain("- events_active: (status) btree WHERE deleted_at IS NULL (partial");
+    });
+  });
+
+  describe("summary mode", () => {
+    const out = formatEntity(entity, false, null);
+
+    it("lists the leading column of each composite/partial index", () => {
+      expect(out).toContain("indexes lead: tenant_id, status");
+    });
+  });
+
+  it("emits nothing index-related when no dimension is indexed and no indexes[] present", () => {
+    const bare: ParsedEntity = {
+      table: "plain",
+      dimensions: [{ name: "a", type: "text" }],
+    };
+    const full = formatEntity(bare, true, null);
+    expect(full).not.toContain("indexed");
+    expect(full).not.toContain("Indexes (");
+    expect(formatEntity(bare, false, null)).not.toContain("indexes lead:");
+  });
+});

--- a/packages/api/src/lib/semantic/generate/__tests__/index-awareness.test.ts
+++ b/packages/api/src/lib/semantic/generate/__tests__/index-awareness.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Pure-function coverage for index awareness (#3634, slice A-2):
+ *
+ *  - `deriveColumnIndexFlags` — index grouping + leading-vs-trailing derivation
+ *    over fixture catalog rows (no DB).
+ *  - `generateEntityYAML` — per-dimension `indexed`/`index_type`, entity-level
+ *    `indexes[]`, and `filter_hint` for non-sargable (trailing) dimensions.
+ *
+ * The real-Postgres/real-MySQL harvest coverage lives in
+ * `lib/__tests__/profiler-index-harvest-pg.test.ts` (gated on DB env vars).
+ */
+import { describe, it, expect } from "bun:test";
+import * as yaml from "js-yaml";
+import {
+  analyzeTableProfiles,
+  deriveColumnIndexFlags,
+  isCompositeOrPartialIndex,
+} from "../analyze";
+import { generateEntityYAML } from "../yaml";
+import type { ColumnProfile, IndexProfile, TableProfile } from "@useatlas/types";
+
+function col(name: string, overrides: Partial<ColumnProfile> = {}): ColumnProfile {
+  return {
+    name,
+    type: "text",
+    nullable: true,
+    unique_count: null,
+    null_count: null,
+    sample_values: [],
+    is_primary_key: false,
+    is_foreign_key: false,
+    fk_target_table: null,
+    fk_target_column: null,
+    is_enum_like: false,
+    profiler_notes: [],
+    ...overrides,
+  };
+}
+
+function table(
+  name: string,
+  columns: ColumnProfile[],
+  indexes: IndexProfile[],
+): TableProfile {
+  return {
+    table_name: name,
+    object_type: "table",
+    row_count: 100,
+    columns,
+    primary_key_columns: columns.filter((c) => c.is_primary_key).map((c) => c.name),
+    foreign_keys: [],
+    inferred_foreign_keys: [],
+    indexes,
+    profiler_notes: [],
+    table_flags: { possibly_abandoned: false, possibly_denormalized: false },
+  };
+}
+
+const idx = (over: Partial<IndexProfile> & Pick<IndexProfile, "name" | "columns">): IndexProfile => ({
+  index_type: "btree",
+  is_unique: false,
+  is_primary: false,
+  is_partial: false,
+  predicate: null,
+  ...over,
+});
+
+describe("deriveColumnIndexFlags — leading vs trailing", () => {
+  it("flags a single-column btree index member as leading/sargable", () => {
+    const t = table("orders", [col("id", { is_primary_key: true }), col("status")], [
+      idx({ name: "orders_status_idx", columns: ["status"] }),
+    ]);
+    deriveColumnIndexFlags([t]);
+    const status = t.columns.find((c) => c.name === "status")!;
+    expect(status.indexed).toBe(true);
+    expect(status.index_position).toBe("leading");
+  });
+
+  it("marks the leading column of a composite btree leading and the rest trailing", () => {
+    const t = table(
+      "events",
+      [col("tenant_id"), col("created_at"), col("kind")],
+      [idx({ name: "events_tenant_created_idx", columns: ["tenant_id", "created_at"] })],
+    );
+    deriveColumnIndexFlags([t]);
+    const tenant = t.columns.find((c) => c.name === "tenant_id")!;
+    const created = t.columns.find((c) => c.name === "created_at")!;
+    const kind = t.columns.find((c) => c.name === "kind")!;
+    expect(tenant.indexed).toBe(true);
+    expect(tenant.index_position).toBe("leading");
+    expect(created.indexed).toBe(true);
+    expect(created.index_position).toBe("trailing"); // only a trailing btree member
+    expect(kind.indexed).toBeUndefined(); // not in any index
+  });
+
+  it("promotes a column to leading if it leads ANY index even when trailing in another", () => {
+    const t = table(
+      "events",
+      [col("a"), col("b")],
+      [
+        idx({ name: "ab_idx", columns: ["a", "b"] }),
+        idx({ name: "b_idx", columns: ["b"] }),
+      ],
+    );
+    deriveColumnIndexFlags([t]);
+    expect(t.columns.find((c) => c.name === "b")!.index_position).toBe("leading");
+  });
+
+  it("treats every member of a non-btree (GIN) index as leading regardless of position", () => {
+    const t = table(
+      "docs",
+      [col("title"), col("body")],
+      [idx({ name: "docs_gin", columns: ["title", "body"], index_type: "gin" })],
+    );
+    deriveColumnIndexFlags([t]);
+    expect(t.columns.find((c) => c.name === "title")!.index_position).toBe("leading");
+    expect(t.columns.find((c) => c.name === "body")!.index_position).toBe("leading");
+  });
+
+  it("attributes an expression-index member to the single column it wraps", () => {
+    const t = table("users", [col("email")], [
+      idx({ name: "users_lower_email_idx", columns: ["lower(email)"] }),
+    ]);
+    deriveColumnIndexFlags([t]);
+    const email = t.columns.find((c) => c.name === "email")!;
+    expect(email.indexed).toBe(true);
+    expect(email.index_position).toBe("leading");
+  });
+
+  it("does not flag an expression member that references multiple columns", () => {
+    const t = table("users", [col("first"), col("last")], [
+      idx({ name: "users_full", columns: ["(first || last)"] }),
+    ]);
+    deriveColumnIndexFlags([t]);
+    expect(t.columns.find((c) => c.name === "first")!.indexed).toBeUndefined();
+    expect(t.columns.find((c) => c.name === "last")!.indexed).toBeUndefined();
+  });
+
+  it("is a no-op for tables without harvested indexes", () => {
+    const t = table("plain", [col("x")], []);
+    deriveColumnIndexFlags([t]);
+    expect(t.columns[0].indexed).toBeUndefined();
+  });
+});
+
+describe("analyzeTableProfiles wires in the derivation", () => {
+  it("derives flags on the analyzed clone without mutating input", () => {
+    const input = table("t", [col("a"), col("b")], [
+      idx({ name: "ab", columns: ["a", "b"] }),
+    ]);
+    const [out] = analyzeTableProfiles([input]);
+    expect(out.columns.find((c) => c.name === "a")!.index_position).toBe("leading");
+    expect(out.columns.find((c) => c.name === "b")!.index_position).toBe("trailing");
+    // Input untouched (analyze clones).
+    expect(input.columns.find((c) => c.name === "a")!.indexed).toBeUndefined();
+  });
+});
+
+describe("isCompositeOrPartialIndex", () => {
+  it("keeps composite and partial indexes, drops single-column non-partial", () => {
+    expect(isCompositeOrPartialIndex(idx({ name: "c", columns: ["a", "b"] }))).toBe(true);
+    expect(
+      isCompositeOrPartialIndex(
+        idx({ name: "p", columns: ["a"], is_partial: true, predicate: "deleted_at IS NULL" }),
+      ),
+    ).toBe(true);
+    expect(isCompositeOrPartialIndex(idx({ name: "s", columns: ["a"] }))).toBe(false);
+  });
+});
+
+describe("generateEntityYAML — index awareness emission", () => {
+  function parse(t: TableProfile): Record<string, unknown> {
+    const [analyzed] = analyzeTableProfiles([t]);
+    return yaml.load(generateEntityYAML(analyzed, [analyzed], "postgres")) as Record<string, unknown>;
+  }
+
+  it("emits per-dimension indexed + index_type for a sargable column", () => {
+    const t = table("orders", [col("id", { is_primary_key: true }), col("status")], [
+      idx({ name: "orders_status_idx", columns: ["status"] }),
+    ]);
+    const entity = parse(t);
+    const dims = entity.dimensions as Record<string, unknown>[];
+    const status = dims.find((d) => d.name === "status")!;
+    expect(status.indexed).toBe(true);
+    expect(status.index_type).toBe("btree");
+    expect(status.filter_hint).toBeUndefined();
+  });
+
+  it("emits a filter_hint on a trailing composite member and no index_type duplication", () => {
+    const t = table(
+      "events",
+      [col("tenant_id"), col("created_at")],
+      [idx({ name: "events_tenant_created_idx", columns: ["tenant_id", "created_at"] })],
+    );
+    const entity = parse(t);
+    const dims = entity.dimensions as Record<string, unknown>[];
+    const created = dims.find((d) => d.name === "created_at")!;
+    expect(created.indexed).toBe(true);
+    expect(typeof created.filter_hint).toBe("string");
+    expect(created.filter_hint as string).toContain("tenant_id");
+    expect(created.filter_hint as string).toContain("events_tenant_created_idx");
+  });
+
+  it("emits an entity-level indexes[] block for composite + partial indexes only", () => {
+    const t = table(
+      "events",
+      [col("tenant_id"), col("created_at"), col("status")],
+      [
+        idx({ name: "events_composite", columns: ["tenant_id", "created_at"] }),
+        idx({
+          name: "events_active",
+          columns: ["status"],
+          is_partial: true,
+          predicate: "deleted_at IS NULL",
+        }),
+        idx({ name: "events_status_solo", columns: ["status"] }), // single-column → omitted
+      ],
+    );
+    const entity = parse(t);
+    const indexes = entity.indexes as Record<string, unknown>[];
+    expect(indexes).toHaveLength(2);
+    const composite = indexes.find((i) => i.name === "events_composite")!;
+    expect(composite.columns).toEqual(["tenant_id", "created_at"]);
+    expect(composite.type).toBe("btree");
+    const partial = indexes.find((i) => i.name === "events_active")!;
+    expect(partial.predicate).toBe("deleted_at IS NULL");
+  });
+
+  it("omits index fields entirely for profiles without harvested indexes", () => {
+    const t = table("plain", [col("x")], []);
+    const entity = parse(t);
+    expect(entity.indexes).toBeUndefined();
+    const dims = entity.dimensions as Record<string, unknown>[];
+    expect(dims.find((d) => d.name === "x")!.indexed).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/semantic/generate/__tests__/index-awareness.test.ts
+++ b/packages/api/src/lib/semantic/generate/__tests__/index-awareness.test.ts
@@ -196,6 +196,9 @@ describe("generateEntityYAML — index awareness emission", () => {
     const dims = entity.dimensions as Record<string, unknown>[];
     const created = dims.find((d) => d.name === "created_at")!;
     expect(created.indexed).toBe(true);
+    // A trailing composite member has no single-column access path, so no
+    // index_type is advertised — the filter_hint carries the composite nuance.
+    expect(created.index_type).toBeUndefined();
     expect(typeof created.filter_hint).toBe("string");
     expect(created.filter_hint as string).toContain("tenant_id");
     expect(created.filter_hint as string).toContain("events_tenant_created_idx");

--- a/packages/api/src/lib/semantic/generate/analyze.ts
+++ b/packages/api/src/lib/semantic/generate/analyze.ts
@@ -11,7 +11,7 @@
  * re-exports these for backward compatibility.
  */
 
-import type { TableProfile, ForeignKey } from "@useatlas/types";
+import type { TableProfile, ForeignKey, IndexProfile } from "@useatlas/types";
 import { isViewLike, pluralize, singularize } from "../../profiler-utils";
 import {
   inferSemanticTypes,
@@ -190,6 +190,98 @@ export function detectDenormalizedTables(profiles: TableProfile[]): void {
   }
 }
 
+/**
+ * Derive per-column sargability flags from harvested indexes (#3634).
+ *
+ * Sets `col.indexed` + `col.index_position` on each column from the table's
+ * `indexes[]`. This is the leading-vs-trailing rule the agent relies on:
+ *
+ *  - A column is **leading** (independently sargable) if it is the FIRST member
+ *    of any index, OR a member at any position of a NON-btree index — GIN/BRIN/
+ *    GiST/hash don't depend on column order, so each member is usable on its own.
+ *  - A column that appears in indexes ONLY as a non-first member of a composite
+ *    BTREE is **trailing**: `WHERE trailing_col = ?` can't use an `(a, b)` index
+ *    without also constraining `a`.
+ *
+ * Expression-index members (e.g. `lower(email)`) are matched against the bare
+ * column name they wrap so the underlying column is still considered indexed
+ * when it appears as a clear leading expression part; non-matching expression
+ * members simply don't flag any `ColumnProfile`. Index members are compared to
+ * column names case-insensitively and with surrounding double-quotes stripped,
+ * since Postgres renders quoted identifiers verbatim.
+ *
+ * Mutates the passed profiles in place (called on the fresh clones built by
+ * `analyzeTableProfiles`, never on caller-owned input). Exported for unit tests.
+ */
+export function deriveColumnIndexFlags(profiles: TableProfile[]): void {
+  for (const profile of profiles) {
+    const indexes = profile.indexes ?? [];
+    if (indexes.length === 0) continue;
+
+    // For each column name, track whether it is ever a leading member and
+    // whether it is ever any kind of member at all.
+    const leading = new Set<string>();
+    const member = new Set<string>();
+
+    for (const idx of indexes) {
+      for (const [position, rawMember] of idx.columns.entries()) {
+        const colName = matchIndexMemberToColumn(rawMember, profile);
+        if (!colName) continue;
+        member.add(colName);
+        // First member of ANY index, or any member of a non-btree index, is
+        // independently sargable.
+        if (position === 0 || idx.index_type !== "btree") {
+          leading.add(colName);
+        }
+      }
+    }
+
+    for (const col of profile.columns) {
+      if (!member.has(col.name)) continue;
+      col.indexed = true;
+      col.index_position = leading.has(col.name) ? "leading" : "trailing";
+    }
+  }
+}
+
+/**
+ * Resolve an index member (a column name OR a rendered expression) to one of the
+ * table's column names, or null if it maps to no single column. Used by
+ * {@link deriveColumnIndexFlags} so expression indexes still flag the column
+ * they wrap when it appears unambiguously.
+ */
+function matchIndexMemberToColumn(rawMember: string, profile: TableProfile): string | null {
+  const unquoted = stripIdentifierQuotes(rawMember.trim());
+  const direct = profile.columns.find((c) => c.name === unquoted);
+  if (direct) return direct.name;
+
+  // Expression member (e.g. `lower(email)`, `(email)::text`): flag the column
+  // only when EXACTLY one column name appears as a whole word in the expression,
+  // so a multi-column expression doesn't mis-attribute sargability.
+  const matches = profile.columns.filter((c) =>
+    new RegExp(`(^|[^A-Za-z0-9_])${escapeRegExp(c.name)}([^A-Za-z0-9_]|$)`).test(unquoted)
+  );
+  return matches.length === 1 ? matches[0].name : null;
+}
+
+function stripIdentifierQuotes(s: string): string {
+  return s.startsWith('"') && s.endsWith('"') && s.length >= 2 ? s.slice(1, -1) : s;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True when an index is worth surfacing as an entity-level `indexes[]` entry:
+ * composite (multi-column) or partial. Single-column non-partial indexes are
+ * already conveyed by the per-dimension `indexed` flag, so they're omitted to
+ * keep the YAML compact (#3634).
+ */
+export function isCompositeOrPartialIndex(idx: IndexProfile): boolean {
+  return idx.columns.length > 1 || idx.is_partial;
+}
+
 export function analyzeTableProfiles(profiles: readonly TableProfile[]): TableProfile[] {
   // Create fresh copies with reset analysis fields (no mutation of input).
   // Deep-clone foreign_keys and partition_info to fully isolate from input.
@@ -199,7 +291,15 @@ export function analyzeTableProfiles(profiles: readonly TableProfile[]): TablePr
     inferred_foreign_keys: [],
     profiler_notes: [],
     table_flags: { possibly_abandoned: false, possibly_denormalized: false },
-    columns: p.columns.map((col) => ({ ...col, profiler_notes: [] })),
+    // Strip any stale derived index flags on the clone; deriveColumnIndexFlags
+    // sets them fresh from the harvested indexes[] below.
+    columns: p.columns.map((col) => {
+      const { indexed: _indexed, index_position: _pos, ...rest } = col;
+      return { ...rest, profiler_notes: [] };
+    }),
+    indexes: p.indexes
+      ? p.indexes.map((idx) => ({ ...idx, columns: [...idx.columns] }))
+      : undefined,
     partition_info: p.partition_info
       ? { ...p.partition_info, children: [...p.partition_info.children] }
       : undefined,
@@ -211,6 +311,7 @@ export function analyzeTableProfiles(profiles: readonly TableProfile[]): TablePr
   detectAbandonedTables(analyzed);
   detectEnumInconsistency(analyzed);
   detectDenormalizedTables(analyzed);
+  deriveColumnIndexFlags(analyzed);
 
   return analyzed;
 }

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -28,9 +28,17 @@ import type { ColumnProfile, IndexProfile } from "@useatlas/types";
  * Prefers the type of an index this column LEADS (that's the one a filter on the
  * column can actually use); falls back to any index that contains it. Returns
  * undefined when the column isn't indexed.
+ *
+ * A column flagged `trailing` is only ever a non-first member of a btree
+ * composite (a member of any non-btree index makes it `leading` — those are
+ * position-independent). It has no single-column access path, so we DON'T
+ * advertise an access method: reporting `btree` from the containing composite
+ * would imply `WHERE col = ?` alone is sargable when it isn't. The `filter_hint`
+ * carries the composite nuance instead.
  */
 function dimensionIndexType(col: ColumnProfile, indexes: IndexProfile[]): string | undefined {
   if (!col.indexed) return undefined;
+  if (col.index_position === "trailing") return undefined;
   const leadingIdx = indexes.find((ix) => ix.columns[0] === col.name);
   if (leadingIdx) return leadingIdx.index_type;
   const containingIdx = indexes.find((ix) => ix.columns.includes(col.name));

--- a/packages/api/src/lib/semantic/generate/yaml.ts
+++ b/packages/api/src/lib/semantic/generate/yaml.ts
@@ -19,7 +19,39 @@ import {
 } from "@useatlas/schemas/semantic-entity-yaml";
 import { mapSQLType, isViewLike, singularize, entityName } from "../../profiler-utils";
 import { suggestMeasureType, describeMeasure } from "../../profiler-patterns";
-import { isView, isMatView, mapSalesforceFieldType } from "./analyze";
+import { isView, isMatView, mapSalesforceFieldType, isCompositeOrPartialIndex } from "./analyze";
+import type { ColumnProfile, IndexProfile } from "@useatlas/types";
+
+/**
+ * Pick the index-access-method to report for a single dimension (#3634).
+ *
+ * Prefers the type of an index this column LEADS (that's the one a filter on the
+ * column can actually use); falls back to any index that contains it. Returns
+ * undefined when the column isn't indexed.
+ */
+function dimensionIndexType(col: ColumnProfile, indexes: IndexProfile[]): string | undefined {
+  if (!col.indexed) return undefined;
+  const leadingIdx = indexes.find((ix) => ix.columns[0] === col.name);
+  if (leadingIdx) return leadingIdx.index_type;
+  const containingIdx = indexes.find((ix) => ix.columns.includes(col.name));
+  return containingIdx?.index_type;
+}
+
+/**
+ * Build the human-readable `filter_hint` for a column that is indexed but NOT
+ * independently sargable (a trailing btree member). Names the composite index
+ * and its leading column so the agent knows what to also constrain (#3634).
+ */
+function trailingFilterHint(col: ColumnProfile, indexes: IndexProfile[]): string | undefined {
+  if (col.index_position !== "trailing") return undefined;
+  // Find a composite btree where this column is a non-leading member.
+  const composite = indexes.find(
+    (ix) => ix.index_type === "btree" && ix.columns.length > 1 && ix.columns.indexOf(col.name) > 0
+  );
+  if (!composite) return undefined;
+  const leadCol = composite.columns[0];
+  return `Indexed only as a trailing member of composite index ${composite.name} (${composite.columns.join(", ")}); filtering on ${col.name} alone is not sargable — also filter on ${leadCol} to use the index.`;
+}
 
 /**
  * Decide the `table:` / `FROM` qualifier for a profiled table.
@@ -76,6 +108,20 @@ export function generateEntityYAML(
     if (col.unique_count !== null) dim.unique_count = col.unique_count;
     if (col.null_count !== null && col.null_count > 0)
       dim.null_count = col.null_count;
+
+    // Index awareness (#3634): per-dimension `indexed` + `index_type`, and a
+    // `filter_hint` for columns that are indexed but not independently sargable
+    // (trailing members of a composite btree). Derived flags come from
+    // analyzeTableProfiles; columns profiled before index harvesting have
+    // `indexed === undefined` and emit nothing.
+    if (col.indexed) {
+      dim.indexed = true;
+      const idxType = dimensionIndexType(col, profile.indexes ?? []);
+      if (idxType) dim.index_type = idxType;
+      const hint = trailingFilterHint(col, profile.indexes ?? []);
+      if (hint) dim.filter_hint = hint;
+    }
+
     if (col.sample_values.length > 0) {
       dim.sample_values = col.is_enum_like
         ? col.sample_values
@@ -431,6 +477,24 @@ export function generateEntityYAML(
     entity.partition_strategy = profile.partition_info.strategy;
     entity.partition_key = profile.partition_info.key;
   }
+
+  // Entity-level indexes[] (#3634): only composite/partial indexes — single-
+  // column indexes are already surfaced per-dimension via `indexed`. Composite
+  // order is load-bearing (leading-prefix sargability) and partial predicates
+  // tell the agent the index only covers a subset of rows.
+  const surfacedIndexes = (profile.indexes ?? [])
+    .filter(isCompositeOrPartialIndex)
+    .map((ix) => {
+      const entry: Record<string, unknown> = {
+        name: ix.name,
+        columns: ix.columns,
+        type: ix.index_type,
+      };
+      if (ix.is_unique) entry.unique = true;
+      if (ix.is_partial && ix.predicate) entry.predicate = ix.predicate;
+      return entry;
+    });
+  if (surfacedIndexes.length > 0) entity.indexes = surfacedIndexes;
 
   if (measures.length > 0) entity[ENTITY_YAML_KEYS.measures] = measures;
   if (joins.length > 0) entity[ENTITY_YAML_KEYS.joins] = joins;

--- a/packages/api/src/lib/semantic/search.ts
+++ b/packages/api/src/lib/semantic/search.ts
@@ -46,6 +46,31 @@ interface EntityDimension {
    */
   unique_count?: number;
   null_count?: number;
+  /**
+   * Index awareness mirrored from the entity YAML the profiler emits
+   * (`generate/yaml.ts`, #3634). `indexed` marks the dimension as backed by an
+   * index; `index_type` is the access method (btree/gin/…); `filter_hint`
+   * carries the composite-trailing warning for columns that are indexed but not
+   * independently sargable. All three are spread untyped from `yaml.load`, so
+   * {@link formatEntity} type-narrows before formatting.
+   */
+  indexed?: boolean;
+  index_type?: string;
+  filter_hint?: string;
+}
+
+/**
+ * Entity-level composite/partial index, mirrored from the YAML `indexes[]`
+ * block the profiler emits for composite or partial indexes (#3634). Surfaced
+ * by {@link formatEntity} so the agent knows the leading-prefix order and any
+ * partial predicate. Spread untyped from `yaml.load`; consumers narrow.
+ */
+interface EntityIndex {
+  name?: string;
+  columns?: unknown;
+  type?: string;
+  unique?: boolean;
+  predicate?: string;
 }
 
 interface EntityMeasure {
@@ -80,6 +105,7 @@ export interface ParsedEntity {
   measures?: EntityMeasure[];
   joins?: EntityJoin[];
   query_patterns?: EntityQueryPattern[];
+  indexes?: EntityIndex[];
 }
 
 interface ParsedMetric {
@@ -326,7 +352,50 @@ function cardinalityFragments(dim: EntityDimension): string[] {
   if (typeof dim.null_count === "number" && dim.null_count >= 0) {
     fragments.push(dim.null_count === 0 ? "no nulls" : `${dim.null_count} null`);
   }
+  // Index marker (#3634, building on the A-1 fragment pipeline). A `trailing`
+  // dimension carries a `filter_hint`, so we mark it "indexed (composite)" to
+  // warn the agent that filtering it alone is not sargable; an independently
+  // sargable column reads as "indexed" (with its access method when non-btree).
+  if (dim.indexed === true) {
+    const type =
+      typeof dim.index_type === "string" && dim.index_type && dim.index_type !== "btree"
+        ? ` ${dim.index_type}`
+        : "";
+    if (typeof dim.filter_hint === "string" && dim.filter_hint.length > 0) {
+      fragments.push(`indexed${type} (composite — not sargable alone)`);
+    } else {
+      fragments.push(`indexed${type}`);
+    }
+  }
   return fragments;
+}
+
+/**
+ * Format the entity-level composite/partial indexes block (#3634). Emits the
+ * leading-prefix order (so the agent knows which prefix is sargable) and any
+ * partial-index predicate. `columns` is spread untyped from `yaml.load`, so it
+ * is narrowed to a string list before joining. Returns an empty array when the
+ * entity has no surfaced indexes.
+ */
+function indexLines(indexes: EntityIndex[] | undefined): string[] {
+  if (!Array.isArray(indexes) || indexes.length === 0) return [];
+  const lines: string[] = ["Indexes (leading column is sargable; trailing members need the leading column too):"];
+  for (const ix of indexes) {
+    const cols = Array.isArray(ix.columns)
+      ? ix.columns.filter((c): c is string => typeof c === "string" && c.length > 0)
+      : [];
+    if (cols.length === 0) continue;
+    const name = typeof ix.name === "string" ? ix.name : "index";
+    const type = typeof ix.type === "string" && ix.type ? ` ${ix.type}` : "";
+    const unique = ix.unique === true ? " unique" : "";
+    const partial =
+      typeof ix.predicate === "string" && ix.predicate.length > 0
+        ? ` WHERE ${ix.predicate} (partial — only covers matching rows)`
+        : "";
+    lines.push(`  - ${name}: (${cols.join(", ")})${type}${unique}${partial}`);
+  }
+  // If every index had an unusable column list, drop the header too.
+  return lines.length > 1 ? lines : [];
 }
 
 // Exported for unit testing the cardinality markers (#3630) as a pure
@@ -421,6 +490,10 @@ export function formatEntity(
       }
     }
 
+    // Composite/partial indexes (#3634) — surfaced after joins so the agent
+    // sees sargable prefixes and partial predicates alongside the columns.
+    for (const line of indexLines(entity.indexes)) lines.push(line);
+
     // Query patterns (just names — agent can explore for full SQL)
     if (entity.query_patterns && entity.query_patterns.length > 0) {
       const patternNames = entity.query_patterns
@@ -467,6 +540,16 @@ export function formatEntity(
       parts.push(
         `joins: ${(entity.joins ?? []).map((j) => j.target_entity).join(", ")}`,
       );
+    // Compact composite/partial index summary (#3634) — list the leading column
+    // of each so the agent still sees sargable prefixes in large layers.
+    const idxLeads = (entity.indexes ?? [])
+      .map((ix) =>
+        Array.isArray(ix.columns) && typeof ix.columns[0] === "string"
+          ? (ix.columns[0] as string)
+          : null,
+      )
+      .filter((c): c is string => !!c);
+    if (idxLeads.length > 0) parts.push(`indexes lead: ${[...new Set(idxLeads)].join(", ")}`);
     lines.push(parts.join(" | "));
   }
 
@@ -534,6 +617,7 @@ function loadEntities(semanticRoot: string): ParsedEntity[] {
         measures: Array.isArray(raw.measures) ? (raw.measures as EntityMeasure[]) : undefined,
         joins: Array.isArray(raw.joins) ? (raw.joins as EntityJoin[]) : undefined,
         query_patterns: Array.isArray(raw.query_patterns) ? (raw.query_patterns as EntityQueryPattern[]) : undefined,
+        indexes: Array.isArray(raw.indexes) ? (raw.indexes as EntityIndex[]) : undefined,
       };
     });
 }

--- a/packages/types/src/profiler.ts
+++ b/packages/types/src/profiler.ts
@@ -21,6 +21,30 @@ export type ForeignKeySource = (typeof FK_SOURCES)[number];
 export const PARTITION_STRATEGIES = ["range", "list", "hash"] as const;
 export type PartitionStrategy = (typeof PARTITION_STRATEGIES)[number];
 
+/**
+ * Index access methods we surface to the agent. PostgreSQL exposes these via
+ * `pg_am.amname`; MySQL effectively only has `btree` (and `fulltext`/`spatial`,
+ * mapped to `gin`/`gist` respectively for a uniform vocabulary). `other` is the
+ * catch-all so an unrecognized access method never drops the index entirely.
+ */
+export const INDEX_TYPES = ["btree", "gin", "gist", "brin", "hash", "other"] as const;
+export type IndexType = (typeof INDEX_TYPES)[number];
+
+/**
+ * Marks how a column participates in indexes, for sargability hints (#3634).
+ *
+ * - `leading`  — the column is independently sargable: it is the first column
+ *   of at least one index, OR a member of a non-btree index (GIN/BRIN/etc. do
+ *   not depend on column position). The agent can filter on it cheaply.
+ * - `trailing` — the column appears in indexes ONLY as a non-first member of a
+ *   composite btree. A trailing btree column is NOT independently sargable: an
+ *   index on `(a, b)` does not accelerate `WHERE b = ?` without `a`.
+ *
+ * Derived during profile analysis (`analyzeTableProfiles`), never harvested.
+ */
+export const INDEX_POSITIONS = ["leading", "trailing"] as const;
+export type IndexPosition = (typeof INDEX_POSITIONS)[number];
+
 /** Semantic types inferred from column names, sample values, and SQL types. */
 export const SEMANTIC_TYPES = [
   "currency",
@@ -68,7 +92,46 @@ export interface ColumnProfile {
   fk_target_column: string | null;
   is_enum_like: boolean;
   semantic_type?: SemanticType;
+  /**
+   * Whether the column participates in any index. Derived during profile
+   * analysis from {@link TableProfile.indexes} (#3634), not harvested per-column.
+   * Absent on profiles produced before index harvesting (treat as unknown).
+   */
+  indexed?: boolean;
+  /**
+   * Sargability marker derived alongside {@link indexed}. Present only when
+   * `indexed` is true; see {@link IndexPosition}. A `trailing` column is indexed
+   * but not independently sargable.
+   */
+  index_position?: IndexPosition;
   profiler_notes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Index profile
+// ---------------------------------------------------------------------------
+
+/**
+ * A single index harvested from the database catalog (#3634).
+ *
+ * `columns` is the ORDERED list of index members — for a composite btree the
+ * order is load-bearing (only the leading prefix is independently sargable).
+ * Expression-index members are rendered as their definition text (e.g.
+ * `lower(email)`) rather than a bare column name, so they survive into the YAML
+ * even though they don't map to a single `ColumnProfile`.
+ *
+ * `predicate` is the partial-index WHERE text (PostgreSQL only; null when the
+ * index is not partial). MySQL has no partial indexes, so MySQL-harvested
+ * indexes always carry `is_partial: false` and `predicate: null`.
+ */
+export interface IndexProfile {
+  name: string;
+  columns: string[];
+  index_type: IndexType;
+  is_unique: boolean;
+  is_primary: boolean;
+  is_partial: boolean;
+  predicate: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +165,13 @@ export interface TableProfile {
   primary_key_columns: string[];
   foreign_keys: ForeignKey[];
   inferred_foreign_keys: ForeignKey[];
+  /**
+   * Indexes harvested from the catalog (#3634). Empty when the table has no
+   * (non-implicit) indexes, when the object is a view/matview, or when the
+   * harvest query failed soft (a warning is logged, profiling continues).
+   * Optional so profiles produced before index harvesting still type-check.
+   */
+  indexes?: IndexProfile[];
   profiler_notes: string[];
   table_flags: TableFlags;
   matview_populated?: boolean;


### PR DESCRIPTION
## Summary

Slice **A-2** of milestone *v0.0.17 — Performance-aware Atlas* (PRD #3617). The heavy vertical slice: gives the agent index awareness end-to-end — harvest index metadata during profiling, carry it through the entity YAML, and surface **composite-aware** hints in the prompt so the agent prefers sargable filters.

Closes #3634.

## What changed

**Profiler harvest** (`packages/api/src/lib/profiler.ts`) — one query per table, beside the existing PK/FK harvest, **fail-soft** on catalog-access errors (warn + continue):
- **Postgres** (`queryPostgresIndexes`): `pg_index`/`pg_class`/`pg_am` keyed by `regclass`; ordered columns rendered via `pg_get_indexdef(indexrelid, n, true)` so **composite order** and **expression indexes** (`lower(email)`) survive; captures index type (btree/gin/gist/brin/hash), `is_unique`, `is_primary`, `is_partial`, partial `predicate`.
- **MySQL** (`queryMySQLIndexes`): `information_schema.STATISTICS` grouped by `INDEX_NAME`, ordered by `SEQ_IN_INDEX` (no partial indexes; FULLTEXT/SPATIAL mapped to gin/gist).

**Types** (`packages/types/src/profiler.ts`): new `IndexProfile` on `TableProfile`; `ColumnProfile` gains derived `indexed` + `index_position` (`leading`/`trailing`). A column that is only a *trailing* member of a composite btree is **not** independently sargable. Derived during profile analysis, not harvested.

**Derivation** (`packages/api/src/lib/semantic/generate/analyze.ts`): `deriveColumnIndexFlags` (pure, exported for tests) sets `indexed`/`index_position` from `indexes[]`; wired into `analyzeTableProfiles`.

**YAML generation** (`packages/api/src/lib/semantic/generate/yaml.ts`): per-dimension `indexed` + `index_type`, entity-level `indexes[]` for composite/partial indexes, and a derived `filter_hint` on non-sargable (trailing) dimensions. Entity Zod shape is `.passthrough()` — **no schema-validation change**.

**Surfacing** (`packages/api/src/lib/semantic/search.ts`): extends the A-1 (#3630) semantic-index formatter to emit composite-aware markers — leading vs trailing membership and partial-index predicates, in both full and summary modes.

**Docs**: `apps/docs/content/docs/getting-started/semantic-layer.mdx` — new dimension fields (`indexed`/`index_type`/`filter_hint`) + entity-level Index Fields section.

## Acceptance criteria

- [x] Postgres harvest returns ordered columns, type, `is_unique`, `is_primary`, `is_partial`, `predicate` for single-column, composite, partial, and **expression** indexes — real-Postgres test (`profiler-index-harvest-pg.test.ts`, verified locally against a live DB)
- [x] MySQL harvest returns grouped/ordered index columns — real-MySQL test (`profiler-index-harvest-mysql.test.ts`, gated on `TEST_MYSQL_URL`; grouping/ordering also covered DB-free)
- [x] Index grouping + leading-vs-trailing derivation covered by a pure-function test over fixture catalog rows (`index-awareness.test.ts`)
- [x] Harvest fails soft (warn + continue) on catalog-access errors
- [x] YAML emits per-dimension `indexed`/`index_type`, entity-level `indexes[]`, and `filter_hint` for non-sargable dims
- [x] Semantic index emits composite-aware hints to the prompt (pure-function test, `format-entity-indexes.test.ts`)

No migration: index data is profiler/YAML-only, not a new DB table.

## Gates

| Gate | Result |
|------|--------|
| `bun run lint` | ✅ |
| `bun run type` | ✅ |
| `bun x syncpack lint` | ✅ |
| `check-template-drift.sh` | ✅ (821 files) |
| `check-railway-watch.sh` | ✅ |
| New tests (incl. real-PG against live DB) | ✅ 27 pass / 6 MySQL skipped |
| `--affected` suite | ✅ 281/281 |
| Full `bun run test` | 640/644 — the 4 failures (`admin-model-config`, `discord`, `teams`, `teams-discord-always-mount`) are **unrelated** bun ESM-mock isolation false-negatives; `admin-model-config` fails identically on the clean tree (stashed), the other 3 pass when run individually. None touch index code. Remote CI is the arbiter. |