### PR TITLE
fix(billing): route dunning emails through the durable email_outbox (#3680)

### DIFF
--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -427,6 +427,7 @@ describe("sendTransactionalEmail", () => {
         send: async () => ({ success: false, provider: "resend", error: "503" }),
         enqueueFailed: async (_m, o) => {
           captured.push({ emailType: o.emailType, ttlMs: o.ttlMs });
+          return true;
         },
       },
     );
@@ -441,11 +442,13 @@ describe("sendTransactionalEmail", () => {
         send: async () => {
           throw new Error("sendEmail blew up unexpectedly");
         },
-        enqueueFailed: async () => {},
+        enqueueFailed: async () => false,
       },
     );
     expect(result.success).toBe(false);
     expect(result.provider).toBe("log");
+    // A thrown send becomes a log-provider failure — nowhere to queue, so lost.
+    expect(result.durable).toBe(false);
   });
 
   it("returns the send result and does NOT enqueue on success", async () => {
@@ -457,10 +460,12 @@ describe("sendTransactionalEmail", () => {
         send: async () => ({ success: true, provider: "resend", messageId: "m1" }),
         enqueueFailed: async () => {
           enqueued++;
+          return true;
         },
       },
     );
     expect(result.success).toBe(true);
+    expect(result.durable).toBe(true);
     expect(enqueued).toBe(0);
   });
 
@@ -473,27 +478,46 @@ describe("sendTransactionalEmail", () => {
         send: async () => ({ success: false, provider: "resend", error: "Resend 503" }),
         enqueueFailed: async (m, o) => {
           enqueuedWith.push({ to: m.to, emailType: o.emailType });
+          return true;
         },
       },
     );
-    // Caller still sees the original failed result (it stays 200-safe).
+    // Caller still sees the original failed result (it stays 200-safe)...
     expect(result.success).toBe(false);
+    // ...but the row landed, so the send is durable (committed for retry).
+    expect(result.durable).toBe(true);
     expect(enqueuedWith).toEqual([{ to: "user@example.com", emailType: "password-reset" }]);
+  });
+
+  it("reports a non-durable result when a real-transport failure cannot be enqueued", async () => {
+    const result = await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset", orgId: "org-1" },
+      {
+        send: async () => ({ success: false, provider: "resend", error: "Resend 503" }),
+        // The outbox enqueue itself fails (no DB / DB blip) — the row did not land.
+        enqueueFailed: async () => false,
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.durable).toBe(false);
   });
 
   it("does NOT enqueue when no transport is configured (provider=log)", async () => {
     let enqueued = 0;
-    await sendTransactionalEmail(
+    const result = await sendTransactionalEmail(
       MSG,
       { emailType: "password-reset" },
       {
         send: async () => ({ success: false, provider: "log", error: "no backend" }),
         enqueueFailed: async () => {
           enqueued++;
+          return true;
         },
       },
     );
     expect(enqueued).toBe(0);
+    expect(result.durable).toBe(false);
   });
 
   it("never throws even if enqueue throws — preserves the enumeration-safe 200 (F-09)", async () => {
@@ -510,16 +534,19 @@ describe("sendTransactionalEmail", () => {
     // Resolved (not rejected) with the original result.
     expect(result.success).toBe(false);
     expect(result.provider).toBe("resend");
+    // The enqueue threw, so the row did not land — not durable.
+    expect(result.durable).toBe(false);
   });
 });
 
 describe("enqueueFailedTransactionalEmail", () => {
-  it("does not throw and skips enqueue when no internal DB is configured", async () => {
+  it("does not throw and returns false (skips enqueue) when no internal DB is configured", async () => {
     // No DATABASE_URL in the unit-test env → hasInternalDB() is false →
-    // the function warns and returns rather than throwing. This pins the
-    // F-09 no-throw contract on the real (non-injected) path.
+    // the function warns and returns false rather than throwing. This pins the
+    // F-09 no-throw contract AND the "row did not land" signal on the real
+    // (non-injected) path.
     await expect(
       enqueueFailedTransactionalEmail(MSG, { emailType: "password-reset" }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
   });
 });

--- a/packages/api/src/lib/email/__tests__/dunning.test.ts
+++ b/packages/api/src/lib/email/__tests__/dunning.test.ts
@@ -22,13 +22,25 @@ let mockRecipients: Array<{ user_id: string; email: string }> = [];
 let mockSentRows: Array<{ step: string }> = [];
 const recordedInserts: unknown[][] = [];
 const recordedDeletes: unknown[][] = [];
+// `${user_id}:${step}` recorded via a prior INSERT this run, so the
+// `alreadySent` SELECT reflects records the dispatcher itself wrote — letting a
+// dedup-across-redelivery test exercise the real once-per-customer guard.
+const sentSteps = new Set<string>();
 
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
   (sql: string, params?: unknown[]) => {
     if (sql.includes("FROM member")) return Promise.resolve(mockRecipients);
-    if (sql.includes("SELECT step FROM onboarding_emails")) return Promise.resolve(mockSentRows);
+    if (sql.includes("SELECT step FROM onboarding_emails")) {
+      // An explicit preload (mockSentRows) wins; otherwise honour records this
+      // dispatcher wrote earlier in the same run (Stripe redelivery path).
+      if (mockSentRows.length > 0) return Promise.resolve(mockSentRows);
+      const [userId, step] = (params ?? []) as [string, string];
+      return Promise.resolve(sentSteps.has(`${userId}:${step}`) ? [{ step }] : []);
+    }
     if (sql.includes("INSERT INTO onboarding_emails")) {
       recordedInserts.push(params ?? []);
+      const [userId, , step] = (params ?? []) as [string, string, string];
+      sentSteps.add(`${userId}:${step}`);
       return Promise.resolve([]);
     }
     if (sql.includes("DELETE FROM onboarding_emails")) {
@@ -48,17 +60,47 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 // --- Mock email delivery ---
+//
+// Dunning routes through the DURABLE wrapper `sendTransactionalEmail` (#3680),
+// which on a REAL transport failure enqueues the notice to `email_outbox` for
+// retry. This faithful stand-in mirrors that contract: it returns the
+// configured `DeliveryResult` and, when `shouldEnqueueFailedSend` is true,
+// records an outbox enqueue — so the dunning durability + dedup behaviour is
+// exercised without reaching the real outbox machinery (its own enqueue is
+// covered by delivery.test.ts).
 
-let mockDeliveryResult: { success: boolean; provider: "log"; error?: string } = {
-  success: true,
-  provider: "log",
-};
-const mockSendEmail: Mock<(msg: unknown, orgId?: string) => Promise<unknown>> = mock(() =>
+type Result = { success: boolean; provider: string; error?: string };
+type Msg = { to: string; subject: string; html: string };
+type Opts = { emailType: string; orgId?: string };
+
+let mockDeliveryResult: Result = { success: true, provider: "log" };
+const enqueuedOutbox: Array<{ to: string; emailType: string }> = [];
+
+// Mirror of delivery.ts: only a REAL transport (provider !== "log") failure is
+// durably enqueued; a log-provider failure has nowhere to deliver.
+const realShouldEnqueue = (r: Result): boolean => !r.success && r.provider !== "log";
+
+const mockSendTransactional: Mock<(msg: Msg, opts: Opts) => Promise<Result>> = mock(
+  (msg: Msg, opts: Opts) => {
+    const result = mockDeliveryResult;
+    if (realShouldEnqueue(result)) {
+      enqueuedOutbox.push({ to: msg.to, emailType: opts.emailType });
+    }
+    return Promise.resolve(result);
+  },
+);
+
+// `sendEmail` is unused by the dunning dispatcher (it routes through the
+// durable wrapper) but `engine.ts` — loaded transitively via dunning — imports
+// it, so the mock must export it too or the whole graph fails to resolve.
+const mockSendEmail: Mock<(msg: Msg, orgId?: string) => Promise<Result>> = mock(() =>
   Promise.resolve(mockDeliveryResult),
 );
 
 mock.module("../delivery", () => ({
   sendEmail: mockSendEmail,
+  sendTransactionalEmail: mockSendTransactional,
+  shouldEnqueueFailedSend: realShouldEnqueue,
 }));
 
 // --- Mock logger ---
@@ -97,9 +139,11 @@ beforeEach(() => {
   mockSentRows = [];
   recordedInserts.length = 0;
   recordedDeletes.length = 0;
+  sentSteps.clear();
+  enqueuedOutbox.length = 0;
   mockDeliveryResult = { success: true, provider: "log" };
   mockInternalQuery.mockClear();
-  mockSendEmail.mockClear();
+  mockSendTransactional.mockClear();
 });
 
 describe("dispatchDunningEmail", () => {
@@ -113,7 +157,7 @@ describe("dispatchDunningEmail", () => {
       const sent = await dispatchDunningEmail("org-1", "dunning_past_due");
 
       expect(sent).toBe(2);
-      expect(mockSendEmail).toHaveBeenCalledTimes(2);
+      expect(mockSendTransactional).toHaveBeenCalledTimes(2);
       // Each send recorded the once-per-customer step.
       expect(recordedInserts).toHaveLength(2);
       for (const params of recordedInserts) {
@@ -128,7 +172,7 @@ describe("dispatchDunningEmail", () => {
 
       await dispatchDunningEmail("org-1", "dunning_suspended");
 
-      const [[message]] = mockSendEmail.mock.calls as Array<[{ subject: string; html: string }]>;
+      const [[message]] = mockSendTransactional.mock.calls;
       expect(message.subject).toMatch(/suspended/i);
       expect(message.html).toMatch(/Update payment method/);
     }));
@@ -141,7 +185,7 @@ describe("dispatchDunningEmail", () => {
       const sent = await dispatchDunningEmail("org-1", "dunning_past_due");
 
       expect(sent).toBe(0);
-      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendTransactional).not.toHaveBeenCalled();
     }));
 
   it("no-ops when onboarding/dunning emails are disabled", () =>
@@ -149,7 +193,7 @@ describe("dispatchDunningEmail", () => {
       mockRecipients = [{ user_id: "u1", email: "owner@example.com" }];
       const sent = await dispatchDunningEmail("org-1", "dunning_unpaid");
       expect(sent).toBe(0);
-      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendTransactional).not.toHaveBeenCalled();
     }));
 
   it("no-ops (no throw) when there are no owner/admin recipients", () =>
@@ -157,18 +201,61 @@ describe("dispatchDunningEmail", () => {
       mockRecipients = [];
       const sent = await dispatchDunningEmail("org-1", "dunning_unpaid");
       expect(sent).toBe(0);
-      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendTransactional).not.toHaveBeenCalled();
     }));
 
-  it("does not record the step when delivery fails", () =>
+  it("does not record (or enqueue) a no-transport failure — nowhere to deliver", () =>
     withProdEmailEnv(async () => {
       mockRecipients = [{ user_id: "u1", email: "owner@example.com" }];
+      // provider "log" = no transport configured; the durable wrapper can't
+      // queue it, so the step must stay unrecorded and retryable.
       mockDeliveryResult = { success: false, provider: "log", error: "no transport" };
 
       const sent = await dispatchDunningEmail("org-1", "dunning_recovered");
 
       expect(sent).toBe(0);
       expect(recordedInserts).toHaveLength(0);
+      expect(enqueuedOutbox).toHaveLength(0);
+    }));
+
+  it("survives a transient transport failure — enqueues to the outbox and records the deferred send (#3680)", () =>
+    withProdEmailEnv(async () => {
+      mockRecipients = [{ user_id: "u1", email: "owner@example.com" }];
+      // A REAL transport (resend) exhausted its in-process retries. Pre-fix
+      // this was logged and dropped; now the durable wrapper queues it.
+      mockDeliveryResult = { success: false, provider: "resend", error: "Resend 503" };
+
+      const sent = await dispatchDunningEmail("org-1", "dunning_past_due");
+
+      // Routed through the durable wrapper, which enqueued the notice for the
+      // Scheduler-backed flusher to re-send — not dropped.
+      expect(mockSendTransactional).toHaveBeenCalledTimes(1);
+      expect(enqueuedOutbox).toEqual([{ to: "owner@example.com", emailType: "dunning_past_due" }]);
+      // Recorded at dispatch time so the deferred send is tracked exactly once.
+      expect(recordedInserts).toHaveLength(1);
+      expect(recordedInserts[0]?.[2]).toBe("dunning_past_due");
+      expect(sent).toBe(1);
+    }));
+
+  it("dedup holds across a deferred send — Stripe redelivery neither re-sends nor re-enqueues (#3680)", () =>
+    withProdEmailEnv(async () => {
+      mockRecipients = [{ user_id: "u1", email: "owner@example.com" }];
+      // First webhook: a real transport failed, so the wrapper enqueued it.
+      mockDeliveryResult = { success: false, provider: "resend", error: "Resend 503" };
+
+      const first = await dispatchDunningEmail("org-1", "dunning_past_due");
+      expect(first).toBe(1);
+      expect(enqueuedOutbox).toHaveLength(1);
+      expect(recordedInserts).toHaveLength(1);
+
+      // Stripe redelivers the same event. The deferred send was already
+      // recorded at dispatch time, so the (user_id, step) guard skips it — no
+      // second transport attempt, no second outbox row, no double-send.
+      const second = await dispatchDunningEmail("org-1", "dunning_past_due");
+      expect(second).toBe(0);
+      expect(mockSendTransactional).toHaveBeenCalledTimes(1);
+      expect(enqueuedOutbox).toHaveLength(1);
+      expect(recordedInserts).toHaveLength(1);
     }));
 
   it("never throws — a DB failure is swallowed and logged", () =>

--- a/packages/api/src/lib/email/__tests__/dunning.test.ts
+++ b/packages/api/src/lib/email/__tests__/dunning.test.ts
@@ -63,30 +63,39 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 //
 // Dunning routes through the DURABLE wrapper `sendTransactionalEmail` (#3680),
 // which on a REAL transport failure enqueues the notice to `email_outbox` for
-// retry. This faithful stand-in mirrors that contract: it returns the
-// configured `DeliveryResult` and, when `shouldEnqueueFailedSend` is true,
-// records an outbox enqueue — so the dunning durability + dedup behaviour is
-// exercised without reaching the real outbox machinery (its own enqueue is
-// covered by delivery.test.ts).
+// retry and reports the actual outcome via `result.durable` (delivered now OR
+// row committed). This faithful stand-in mirrors that contract — including the
+// failure mode the dunning dedup hinges on: a real-transport failure whose
+// outbox enqueue ITSELF fails (`mockEnqueueSucceeds = false`) is NOT durable,
+// so dunning must leave it unrecorded and retryable. Exercises the dunning
+// durability + dedup behaviour without reaching the real outbox machinery (its
+// own enqueue is covered by delivery.test.ts).
 
 type Result = { success: boolean; provider: string; error?: string };
+type TxResult = Result & { durable: boolean };
 type Msg = { to: string; subject: string; html: string };
 type Opts = { emailType: string; orgId?: string };
 
 let mockDeliveryResult: Result = { success: true, provider: "log" };
+// Whether a REAL transport failure's outbox enqueue lands (the real wrapper's
+// enqueue can no-op on a missing DB or throw). Default true = enqueue succeeds.
+let mockEnqueueSucceeds = true;
 const enqueuedOutbox: Array<{ to: string; emailType: string }> = [];
 
 // Mirror of delivery.ts: only a REAL transport (provider !== "log") failure is
-// durably enqueued; a log-provider failure has nowhere to deliver.
+// eligible for a durable enqueue; a log-provider failure has nowhere to deliver.
 const realShouldEnqueue = (r: Result): boolean => !r.success && r.provider !== "log";
 
-const mockSendTransactional: Mock<(msg: Msg, opts: Opts) => Promise<Result>> = mock(
+const mockSendTransactional: Mock<(msg: Msg, opts: Opts) => Promise<TxResult>> = mock(
   (msg: Msg, opts: Opts) => {
     const result = mockDeliveryResult;
-    if (realShouldEnqueue(result)) {
+    let enqueued = false;
+    if (realShouldEnqueue(result) && mockEnqueueSucceeds) {
       enqueuedOutbox.push({ to: msg.to, emailType: opts.emailType });
+      enqueued = true;
     }
-    return Promise.resolve(result);
+    // `durable` mirrors the real wrapper: delivered now OR row actually committed.
+    return Promise.resolve({ ...result, durable: result.success || enqueued });
   },
 );
 
@@ -100,7 +109,6 @@ const mockSendEmail: Mock<(msg: Msg, orgId?: string) => Promise<Result>> = mock(
 mock.module("../delivery", () => ({
   sendEmail: mockSendEmail,
   sendTransactionalEmail: mockSendTransactional,
-  shouldEnqueueFailedSend: realShouldEnqueue,
 }));
 
 // --- Mock logger ---
@@ -141,6 +149,7 @@ beforeEach(() => {
   recordedDeletes.length = 0;
   sentSteps.clear();
   enqueuedOutbox.length = 0;
+  mockEnqueueSucceeds = true;
   mockDeliveryResult = { success: true, provider: "log" };
   mockInternalQuery.mockClear();
   mockSendTransactional.mockClear();
@@ -256,6 +265,52 @@ describe("dispatchDunningEmail", () => {
       expect(mockSendTransactional).toHaveBeenCalledTimes(1);
       expect(enqueuedOutbox).toHaveLength(1);
       expect(recordedInserts).toHaveLength(1);
+    }));
+
+  it("does NOT record a lost send when the outbox enqueue itself fails — stays retryable (#3680)", () =>
+    withProdEmailEnv(async () => {
+      mockRecipients = [{ user_id: "u1", email: "owner@example.com" }];
+      // A REAL transport failed AND the outbox enqueue could not persist the
+      // row (DB blip / pool exhaustion / schema drift). The send is genuinely
+      // lost — `result.durable` is false — so recording the dedup step here
+      // would permanently suppress the customer's payment-failure notice.
+      mockDeliveryResult = { success: false, provider: "resend", error: "Resend 503" };
+      mockEnqueueSucceeds = false;
+
+      const sent = await dispatchDunningEmail("org-1", "dunning_past_due");
+
+      expect(sent).toBe(0);
+      expect(enqueuedOutbox).toHaveLength(0);
+      // Not recorded — the (user_id, step) guard stays open for redelivery.
+      expect(recordedInserts).toHaveLength(0);
+
+      // Stripe redelivers the same event: because nothing was recorded, the
+      // dispatcher retries the send rather than silently dropping it forever.
+      const retry = await dispatchDunningEmail("org-1", "dunning_past_due");
+      expect(mockSendTransactional).toHaveBeenCalledTimes(2);
+      expect(retry).toBe(0);
+    }));
+
+  it("isolates a per-recipient failure — a lost send for one owner does not drop the rest (#3680)", () =>
+    withProdEmailEnv(async () => {
+      mockRecipients = [
+        { user_id: "u1", email: "owner@example.com" },
+        { user_id: "u2", email: "admin@example.com" },
+      ];
+      // First recipient's send throws mid-loop; the second must still go out.
+      mockSendTransactional.mockImplementationOnce(() =>
+        Promise.reject(new Error("transport blew up")),
+      );
+
+      const sent = await dispatchDunningEmail("org-1", "dunning_past_due");
+
+      // Loop continued: the second recipient was attempted and delivered.
+      expect(mockSendTransactional).toHaveBeenCalledTimes(2);
+      // Only the durable (delivered) recipient is counted and recorded; the
+      // thrown one is neither counted nor recorded (retryable on redelivery).
+      expect(sent).toBe(1);
+      expect(recordedInserts).toHaveLength(1);
+      expect(recordedInserts[0]?.[0]).toBe("u2");
     }));
 
   it("never throws — a DB failure is swallowed and logged", () =>

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -541,12 +541,17 @@ export function computeExpiresAt(ttlMs: number | undefined): Date | null {
  * unchanged (no cycle with email-outbox, which the flusher's dispatcher
  * wires back to `sendEmail`).
  *
+ * @returns `true` only when a row was actually committed to `email_outbox`;
+ *   `false` when the send was lost (no internal DB, or the enqueue itself
+ *   threw). Callers that gate once-per-X bookkeeping on durability MUST key
+ *   off this outcome, not off {@link shouldEnqueueFailedSend} (which is an
+ *   *intent* predicate that says nothing about whether the row landed).
  * @internal — exported for testing.
  */
 export async function enqueueFailedTransactionalEmail(
   message: EmailMessage,
   opts: TransactionalEmailOptions,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
     if (!hasInternalDB()) {
@@ -554,7 +559,7 @@ export async function enqueueFailedTransactionalEmail(
         { to: message.to, emailType: opts.emailType },
         "Failed transactional email NOT enqueued — no internal DB configured for the durable outbox; send is lost",
       );
-      return;
+      return false;
     }
     const { enqueue } = await import("@atlas/api/lib/email-outbox");
     const expiresAt = computeExpiresAt(opts.ttlMs);
@@ -566,6 +571,7 @@ export async function enqueueFailedTransactionalEmail(
       { to: message.to, emailType: opts.emailType, outboxId },
       "Transactional email send failed — enqueued to email_outbox for durable retry",
     );
+    return true;
   } catch (err) {
     // Never rethrow — a failure to even queue the row must not break the
     // enumeration-safe 200. Loud error so the lost send is observable.
@@ -577,13 +583,27 @@ export async function enqueueFailedTransactionalEmail(
       },
       "Failed to enqueue transactional email to the outbox — send is lost",
     );
+    return false;
   }
 }
 
 /** Injection seam for {@link sendTransactionalEmail} — test-only. */
 export interface TransactionalEmailDeps {
   send?: (message: EmailMessage, orgId?: string) => Promise<DeliveryResult>;
-  enqueueFailed?: (message: EmailMessage, opts: TransactionalEmailOptions) => Promise<void>;
+  /** Returns whether a row was actually committed to the outbox (see {@link enqueueFailedTransactionalEmail}). */
+  enqueueFailed?: (message: EmailMessage, opts: TransactionalEmailOptions) => Promise<boolean>;
+}
+
+/**
+ * {@link sendTransactionalEmail}'s result, widened with a `durable` outcome:
+ * was this send safely persisted (delivered now, OR committed to `email_outbox`
+ * for retry), or was it lost (no transport, or the outbox enqueue itself
+ * failed)? Auth callers (enumeration-safe, fire-and-forget) can ignore it; a
+ * caller that suppresses future retries on a successful dispatch (e.g. dunning's
+ * once-per-customer dedup record) MUST gate that bookkeeping on `durable`.
+ */
+export interface TransactionalEmailResult extends DeliveryResult {
+  durable: boolean;
 }
 
 /**
@@ -602,15 +622,16 @@ export interface TransactionalEmailDeps {
  * dispatcher also re-sends via raw `sendEmail`, so a re-send failure
  * does NOT re-enqueue (no duplication loop).
  *
- * Enumeration safety (F-09): never throws and always returns the
- * original `DeliveryResult`. The caller's response stays 200 whether the
- * send succeeded, failed-then-queued, or failed-then-couldn't-queue.
+ * Enumeration safety (F-09): never throws and always returns the original
+ * {@link DeliveryResult}, widened with a `durable` flag. The caller's response
+ * stays 200 whether the send succeeded, failed-then-queued, or
+ * failed-then-couldn't-queue.
  */
 export async function sendTransactionalEmail(
   message: EmailMessage,
   opts: TransactionalEmailOptions,
   deps: TransactionalEmailDeps = {},
-): Promise<DeliveryResult> {
+): Promise<TransactionalEmailResult> {
   const send = deps.send ?? sendEmail;
   const enqueueFailed = deps.enqueueFailed ?? enqueueFailedTransactionalEmail;
   // Enforce the F-09 never-throw contract LOCALLY rather than depending on
@@ -628,12 +649,18 @@ export async function sendTransactionalEmail(
     );
     result = { success: false, provider: "log", error };
   }
+  // Track whether the failed send was ACTUALLY persisted to the outbox — not
+  // merely that it *should* have been (`shouldEnqueueFailedSend` is an intent
+  // predicate). A caller gating retry-suppression on dispatch (dunning's dedup
+  // record) needs the real outcome, or it would suppress a lost send.
+  let enqueued = false;
   if (shouldEnqueueFailedSend(result)) {
     try {
-      await enqueueFailed(message, opts);
+      enqueued = await enqueueFailed(message, opts);
     } catch (err) {
       // `enqueueFailed` already swallows; this is defense-in-depth so a
       // future refactor that drops its try/catch can't break the 200.
+      // `enqueued` stays false — a throw means the row did NOT land.
       log.error(
         {
           to: message.to,
@@ -644,7 +671,7 @@ export async function sendTransactionalEmail(
       );
     }
   }
-  return result;
+  return { ...result, durable: result.success || enqueued };
 }
 
 /**

--- a/packages/api/src/lib/email/dunning.ts
+++ b/packages/api/src/lib/email/dunning.ts
@@ -23,7 +23,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { isOnboardingEmailEnabled, getBrandingForOrg, getBaseUrl } from "./engine";
 import { renderDunningEmail } from "./templates";
-import { sendEmail } from "./delivery";
+import { sendTransactionalEmail, shouldEnqueueFailedSend } from "./delivery";
 import {
   DUNNING_DELINQUENCY_STEPS,
   type DunningEmailStep,
@@ -77,8 +77,9 @@ async function alreadySent(userId: string, step: DunningEmailStep): Promise<bool
  *
  * @param orgId - The Atlas organization the delinquent subscription belongs to.
  * @param step  - Which dunning rung to send.
- * @returns the number of emails actually sent (0 when disabled, no recipients,
- *   or already sent). Never throws.
+ * @returns the number of emails durably dispatched — delivered now OR enqueued
+ *   to `email_outbox` for retry (0 when disabled, no recipients, already sent,
+ *   or a no-transport failure that couldn't be queued). Never throws.
  */
 export async function dispatchDunningEmail(
   orgId: string,
@@ -106,22 +107,40 @@ export async function dispatchDunningEmail(
       try {
         if (await alreadySent(recipient.user_id, step)) continue;
 
-        const result = await sendEmail(
+        // Durable send (#3680): sendTransactionalEmail enqueues the rendered
+        // notice to email_outbox when a REAL transport fails its in-process
+        // retries, so a transient provider outage no longer permanently drops
+        // the dunning email — the Scheduler-backed flusher re-sends it later.
+        const result = await sendTransactionalEmail(
           { to: recipient.email, subject: rendered.subject, html: rendered.html },
-          orgId,
+          { emailType: step, orgId },
         );
 
-        if (result.success) {
+        // Record the dedup step at DISPATCH time — as soon as the send was
+        // delivered OR durably enqueued — so the (user_id, step) guard fires on
+        // Stripe's redelivery and a deferred send is recorded exactly once (no
+        // double-send, no missed record). A log-provider failure (no transport
+        // configured) is neither delivered nor queued, so we intentionally do
+        // NOT record it; a later attempt can still retry.
+        if (result.success || shouldEnqueueFailedSend(result)) {
           await recordDunningEmail(recipient.user_id, orgId, step);
           sent++;
           log.info(
-            { orgId, userId: recipient.user_id, step, provider: result.provider },
-            "Dunning email sent",
+            {
+              orgId,
+              userId: recipient.user_id,
+              step,
+              provider: result.provider,
+              deferred: !result.success,
+            },
+            result.success
+              ? "Dunning email sent"
+              : "Dunning email transport failed — enqueued to email_outbox for durable retry",
           );
         } else {
           log.error(
             { orgId, userId: recipient.user_id, step, error: result.error },
-            "Dunning email delivery failed",
+            "Dunning email delivery failed and could not be enqueued (no transport) — not recorded",
           );
         }
       } catch (err) {

--- a/packages/api/src/lib/email/dunning.ts
+++ b/packages/api/src/lib/email/dunning.ts
@@ -23,7 +23,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { isOnboardingEmailEnabled, getBrandingForOrg, getBaseUrl } from "./engine";
 import { renderDunningEmail } from "./templates";
-import { sendTransactionalEmail, shouldEnqueueFailedSend } from "./delivery";
+import { sendTransactionalEmail } from "./delivery";
 import {
   DUNNING_DELINQUENCY_STEPS,
   type DunningEmailStep,
@@ -77,9 +77,10 @@ async function alreadySent(userId: string, step: DunningEmailStep): Promise<bool
  *
  * @param orgId - The Atlas organization the delinquent subscription belongs to.
  * @param step  - Which dunning rung to send.
- * @returns the number of emails durably dispatched — delivered now OR enqueued
- *   to `email_outbox` for retry (0 when disabled, no recipients, already sent,
- *   or a no-transport failure that couldn't be queued). Never throws.
+ * @returns the number of emails durably dispatched — delivered now OR confirmed
+ *   committed to `email_outbox` for retry (0 when disabled, no recipients,
+ *   already sent, or a lost send: no transport configured, or the outbox
+ *   enqueue itself failed). Never throws.
  */
 export async function dispatchDunningEmail(
   orgId: string,
@@ -116,13 +117,17 @@ export async function dispatchDunningEmail(
           { emailType: step, orgId },
         );
 
-        // Record the dedup step at DISPATCH time — as soon as the send was
-        // delivered OR durably enqueued — so the (user_id, step) guard fires on
-        // Stripe's redelivery and a deferred send is recorded exactly once (no
-        // double-send, no missed record). A log-provider failure (no transport
-        // configured) is neither delivered nor queued, so we intentionally do
-        // NOT record it; a later attempt can still retry.
-        if (result.success || shouldEnqueueFailedSend(result)) {
+        // Record the dedup step at DISPATCH time — but ONLY when the send was
+        // actually durable: delivered now, OR confirmed committed to
+        // email_outbox (`result.durable`, the real enqueue outcome — NOT the
+        // `shouldEnqueueFailedSend` intent predicate). Recording on durability
+        // makes the (user_id, step) guard fire on Stripe's redelivery and a
+        // deferred send recorded exactly once (no double-send, no missed
+        // record). A send that was lost — no transport configured, or the
+        // outbox enqueue itself failed — is intentionally NOT recorded, so the
+        // next redelivery still retries it rather than the customer silently
+        // never learning their card failed.
+        if (result.durable) {
           await recordDunningEmail(recipient.user_id, orgId, step);
           sent++;
           log.info(
@@ -140,7 +145,7 @@ export async function dispatchDunningEmail(
         } else {
           log.error(
             { orgId, userId: recipient.user_id, step, error: result.error },
-            "Dunning email delivery failed and could not be enqueued (no transport) — not recorded",
+            "Dunning email not durably dispatched (no transport, or outbox enqueue failed) — not recorded; will retry on Stripe redelivery",
           );
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #3680. Dunning (payment-failure) emails were sent via raw `sendEmail`, **not** the durable `sendTransactionalEmail` (`email_outbox`) path that auth flows use. After the 3 in-process `fetchWithRetry` attempts were exhausted the send was **permanently dropped** — no outbox row, and the Stripe webhook returns 2xx regardless (`sendDunning` swallows), so there was no redelivery either. A customer whose card failed never learned it, then got auto-suspended at the end of the grace period with no warning.

## What changed

`packages/api/src/lib/email/dunning.ts` — `dispatchDunningEmail`:

- **Route through the durable path.** Send via `sendTransactionalEmail({ emailType: step, orgId })` instead of raw `sendEmail`. On a *real* transport failure it enqueues the rendered notice to `email_outbox`, so the Scheduler-backed flusher re-sends it on a later tick — a transient provider outage no longer drops the email.
- **Move dedup bookkeeping to dispatch time.** `recordDunningEmail` now fires as soon as the send was **delivered OR durably enqueued** (`result.success || shouldEnqueueFailedSend(result)`). This records a deferred send exactly once, so Stripe's webhook redelivery neither double-sends nor re-enqueues. A no-transport (`log` provider) failure is neither delivered nor queued, so it stays unrecorded and retryable — preserving the existing "don't record when there's nowhere to deliver" semantics.

Contained to `dunning.ts`; the callers in `auth/server.ts` (`sendDunning`, `handlePaymentFailure`) are thin wrappers and need no change.

## Tests

`packages/api/src/lib/email/__tests__/dunning.test.ts`:

- **transport-failure-then-redeliver** — a real transport (`resend`) failure now enqueues to the outbox and records the deferred send (not dropped).
- **dedup across a deferred send** — Stripe redelivery of the same event neither re-sends nor re-enqueues (the dispatch-time record makes the `(user_id, step)` guard fire).
- Existing tests updated for the durable wrapper; the no-transport-failure case is clarified (not recorded, not enqueued).

The mock is a faithful stand-in for `sendTransactionalEmail` (mirrors `shouldEnqueueFailedSend` to track outbox enqueues); the real outbox enqueue machinery stays covered by `delivery.test.ts`.

## Acceptance criteria (#3680)

- [x] Dunning emails enqueue to `email_outbox` and survive a transient transport failure (retried by the dispatcher, not dropped)
- [x] Dedup bookkeeping correct under deferred send — no double-send, no missed record
- [x] Tests cover transport-failure-then-redeliver and dedup across a deferred send

## CI

Local gates green: lint, type, full test (dunning suite passes; 5 unrelated files flagged by the isolated runner all pass individually — known WSL-runner flakiness #3490), syncpack, template/security-header/railway/schema/openapi/oauth drift, test-discipline, settings-readers, published-symbols.