### PR TITLE
feat(api): perf-weighted pattern scoring + nightly auto-promote/decay (#3636)

### DIFF
--- a/apps/docs/content/docs/guides/semantic-expert.mdx
+++ b/apps/docs/content/docs/guides/semantic-expert.mdx
@@ -324,3 +324,22 @@ The overall score is a weighted average. Use this to track your semantic layer q
 |--------|------|-------------|
 | `GET` | `/api/v1/admin/semantic-improve/pending-count` | Count of pending proposals |
 | `GET` | `/api/v1/admin/semantic-improve/health` | Semantic layer health score |
+
+## Learned query patterns
+
+Separately from semantic-layer amendments, Atlas learns **successful query patterns** from real usage. When the agent answers a question with SQL that runs cleanly, the shape is captured in the `learned_patterns` table (`type = query_pattern`) and, once approved, injected into future agent prompts as *organizational knowledge* — reference SQL the agent can reuse for similar questions. Each pattern is scoped to its org **and** connection group, so one tenant's or one datasource group's patterns never leak into another's session.
+
+### Performance-weighted retrieval
+
+Every pattern carries a rolling-mean execution time (`avg_duration_ms`). At retrieval time, Atlas ranks patterns by keyword relevance **down-weighted by latency**: a pattern whose average stays at or under the [`ATLAS_LEARN_LATENCY_BUDGET_MS`](/reference/environment-variables#dynamic-learning) budget ranks normally, while slower patterns are pushed down — but never excluded, so a slow-but-uniquely-relevant pattern still surfaces. The injected context shows each pattern's typical latency (`avg ~123ms`) so the agent can prefer a faster pattern when two answer the question equally well.
+
+### Nightly auto-promote / decay
+
+By default every learned query pattern waits for an admin to approve it in **Admin → Learned Patterns**. Enable the nightly job (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED`) to maintain the set automatically:
+
+- **Auto-promote** — a pending pattern is promoted to approved when it clears all three gates: confidence ≥ `ATLAS_LEARN_CONFIDENCE_THRESHOLD`, seen ≥ `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` times, and an average latency at or under `ATLAS_LEARN_LATENCY_BUDGET_MS`. A pattern whose latency has never been measured is **not** auto-promoted.
+- **Decay (demote, never delete)** — a pattern the job itself promoted that then goes unseen for longer than `ATLAS_LEARN_DECAY_UNSEEN_DAYS` is demoted back to pending, so the injected set stays fresh. **Human approvals are never auto-demoted** — only a human removes them.
+
+Auto-promoted patterns are shown with a distinct **Auto-approved** badge in the admin UI so machine approvals are always distinguishable from human ones. Semantic-layer amendments (`type = semantic_amendment`) are out of scope for this job — they always keep human review, as described above.
+
+This job is a single process-global background fiber (like the expert scheduler), so its enable/interval settings are platform-scoped and require a restart; the gate thresholds are read once per run.

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -364,16 +364,28 @@ The cache is automatically flushed on config reload. Manual flush is available v
 
 Tuning for how learned query patterns are retrieved and promoted into agent context.
 
-These are **runtime settings**, not `atlas.config.ts` fields: they resolve as `workspace override > platform override > env var > default`, so each workspace can tune them from **Admin → Settings** with no redeploy (hot-reloaded in SaaS). Set the env var for a self-host default.
+The first three are **workspace-scoped runtime settings**, not `atlas.config.ts` fields: they resolve as `workspace override > platform override > env var > default`, so each workspace can tune them from **Admin → Settings** with no redeploy (hot-reloaded in SaaS). Set the env var for a self-host default. The nightly auto-promote/decay knobs are **platform-scoped** (the job is one process-global fiber) — enable/interval changes require a restart, and the gate is read once per run.
 
-| Setting | Env var | Default | Description |
-|---------|---------|---------|-------------|
-| Pattern Confidence Threshold | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval/auto-promotion. Lower values promote more aggressively; higher values require stronger evidence from the audit log |
-| Pattern Retrieval Turns | `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
+| Setting | Env var | Scope | Default | Description |
+|---------|---------|-------|---------|-------------|
+| Pattern Confidence Threshold | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | Workspace | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval/auto-promotion. Lower values promote more aggressively; higher values require stronger evidence |
+| Pattern Retrieval Turns | `ATLAS_LEARN_RETRIEVAL_TURNS` | Workspace | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
+| Pattern Latency Budget (ms) | `ATLAS_LEARN_LATENCY_BUDGET_MS` | Workspace | `5000` | Patterns at or under this average execution time rank normally; slower patterns are down-weighted in retrieval (never excluded). Also the auto-promotion latency ceiling |
+| Auto-Promote / Decay Job | `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | Platform (restart) | `false` | Enable the nightly job that auto-promotes qualifying pending patterns and demotes stale auto-promoted ones |
+| Auto-Promote / Decay Interval | `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` | Platform (restart) | `24` | Hours between auto-promote/decay runs |
+| Auto-Promote Min Repetitions | `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | Platform | `5` | Minimum times a pending pattern must be seen before auto-promotion |
+| Pattern Decay Window (days) | `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | Platform | `30` | An auto-promoted pattern unseen this long is demoted to pending. Human approvals are never auto-demoted |
+
+See [Learned query patterns](/guides/semantic-expert#learned-query-patterns) for how performance-weighting and the nightly job work together.
 
 ```bash
 ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7
 ATLAS_LEARN_RETRIEVAL_TURNS=3
+ATLAS_LEARN_LATENCY_BUDGET_MS=5000
+ATLAS_LEARN_PROMOTE_DECAY_ENABLED=false
+ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS=24
+ATLAS_LEARN_PROMOTE_MIN_REPETITIONS=5
+ATLAS_LEARN_DECAY_UNSEEN_DAYS=30
 ```
 
 ---

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -621,12 +621,17 @@ Scheduled task execution. Can also be configured via [`atlas.config.ts`](/refere
 
 ## Dynamic Learning
 
-These are the self-host fallback tier for two **workspace-scoped runtime settings** — they also resolve from `workspace override > platform override > env var > default` and can be tuned per-workspace from **Admin → Settings** with no redeploy (see [Dynamic Learning config](/reference/config#dynamic-learning)).
+The first three are the self-host fallback tier for **workspace-scoped runtime settings** — they resolve from `workspace override > platform override > env var > default` and can be tuned per-workspace from **Admin → Settings** with no redeploy (see [Dynamic Learning config](/reference/config#dynamic-learning)). The nightly auto-promote/decay knobs are **platform-scoped**: the job is one process-global background fiber, so its enable/interval changes require a restart and its gate is read once per tick.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Used at retrieval time to filter which approved patterns are injected into the agent prompt |
+| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Also the confidence gate for nightly auto-promotion |
 | `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
+| `ATLAS_LEARN_LATENCY_BUDGET_MS` | `5000` | Patterns whose rolling-mean execution time stays at or under this budget rank normally in retrieval; slower patterns are down-weighted (never excluded). Also the latency ceiling for nightly auto-promotion |
+| `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | `false` | Enable the nightly job that auto-promotes high-confidence, fast, frequently-seen pending patterns to approved and demotes stale auto-promoted ones. Platform-scoped; requires a restart |
+| `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` | `24` | Hours between auto-promote/decay runs. Platform-scoped; requires a restart |
+| `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | `5` | Minimum times a pending pattern must have been seen before the nightly job will auto-promote it (alongside the confidence and latency gates) |
+| `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | `30` | An auto-promoted pattern unseen for longer than this many days is demoted back to pending. Human-approved patterns are never auto-demoted |
 
 ---
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -21745,6 +21745,15 @@
                               "null"
                             ],
                             "additionalProperties": {}
+                          },
+                          "autoPromoted": {
+                            "type": "boolean"
+                          },
+                          "avgDurationMs": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
                           }
                         },
                         "required": [
@@ -21763,7 +21772,9 @@
                           "updatedAt",
                           "reviewedAt",
                           "type",
-                          "amendmentPayload"
+                          "amendmentPayload",
+                          "autoPromoted",
+                          "avgDurationMs"
                         ]
                       }
                     },
@@ -22018,6 +22029,15 @@
                         "null"
                       ],
                       "additionalProperties": {}
+                    },
+                    "autoPromoted": {
+                      "type": "boolean"
+                    },
+                    "avgDurationMs": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
                     }
                   },
                   "required": [
@@ -22036,7 +22056,9 @@
                     "updatedAt",
                     "reviewedAt",
                     "type",
-                    "amendmentPayload"
+                    "amendmentPayload",
+                    "autoPromoted",
+                    "avgDurationMs"
                   ]
                 }
               }
@@ -22269,6 +22291,15 @@
                         "null"
                       ],
                       "additionalProperties": {}
+                    },
+                    "autoPromoted": {
+                      "type": "boolean"
+                    },
+                    "avgDurationMs": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
                     }
                   },
                   "required": [
@@ -22287,7 +22318,9 @@
                     "updatedAt",
                     "reviewedAt",
                     "type",
-                    "amendmentPayload"
+                    "amendmentPayload",
+                    "autoPromoted",
+                    "avgDurationMs"
                   ]
                 }
               }

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -64,6 +64,11 @@ function toLearnedPattern(row: Record<string, unknown>): LearnedPattern {
           }
         })()
       : null,
+    autoPromoted: Boolean(row.auto_promoted),
+    avgDurationMs:
+      row.avg_duration_ms === null || row.avg_duration_ms === undefined
+        ? null
+        : Number(row.avg_duration_ms),
   };
 }
 
@@ -133,6 +138,8 @@ const LearnedPatternSchema = z.object({
   reviewedAt: z.string().nullable(),
   type: z.enum(["query_pattern", "semantic_amendment"]),
   amendmentPayload: z.record(z.string(), z.unknown()).nullable(),
+  autoPromoted: z.boolean(),
+  avgDurationMs: z.number().nullable(),
 });
 
 const ListResponseSchema = createListResponseSchema("patterns", LearnedPatternSchema, {

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -510,7 +510,11 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const updateParams: unknown[] = [];
     let paramIdx = 1;
     if (description !== undefined) { updateParams.push(description); setClauses.push(`description = $${paramIdx}`); paramIdx++; }
-    if (status !== undefined) { updateParams.push(status); setClauses.push(`status = $${paramIdx}`); paramIdx++; updateParams.push(user?.id ?? null); setClauses.push(`reviewed_by = $${paramIdx}`); paramIdx++; setClauses.push(`reviewed_at = now()`); }
+    // A human status change re-attributes the row to that human: clear
+    // `auto_promoted` so a row the nightly job promoted (then perhaps decayed to
+    // pending) no longer renders the machine "Auto-approved" badge once a person
+    // reviews it, and so decay never demotes it out from under the admin (#3636).
+    if (status !== undefined) { updateParams.push(status); setClauses.push(`status = $${paramIdx}`); paramIdx++; updateParams.push(user?.id ?? null); setClauses.push(`reviewed_by = $${paramIdx}`); paramIdx++; setClauses.push(`reviewed_at = now()`); setClauses.push(`auto_promoted = false`); }
 
     updateParams.push(id);
     const idIdx = paramIdx;
@@ -618,7 +622,8 @@ adminLearnedPatterns.openapi(bulkStatusRoute, async (c) => {
 
           const updateParams: unknown[] = [status, user?.id ?? null, id];
           const updateOrg = orgFilter(orgId, updateParams, updateParams.length + 1);
-          await internalQuery(`UPDATE learned_patterns SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now() WHERE id = $3 AND ${updateOrg.clause}`, updateParams);
+          // Clear auto_promoted on a human review (see single-update path, #3636).
+          await internalQuery(`UPDATE learned_patterns SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now(), auto_promoted = false WHERE id = $3 AND ${updateOrg.clause}`, updateParams);
           return "updated" as const;
         },
         catch: (err) => err instanceof Error ? err : new Error(String(err)),

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -382,6 +382,7 @@ describe("migrateAuthTables", () => {
             { name: "0135_approval_rule_type_datasource.sql" },
             { name: "0136_mcp_action_policy_default_allowed.sql" },
             { name: "0137_learning_tables_performance_columns.sql" },
+            { name: "0138_learned_patterns_auto_promoted.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -158,7 +158,8 @@ describe("runMigrations", () => {
     //   Plus 0136 (mcp_action_policy.status DEFAULT 'blocked'→'allowed', #3578) = 137.
     //   Plus 0137 (learned_patterns + query_suggestions latency/staleness
     //   columns, PRD #3617 B-0, #3631) = 138.
-    expect(count).toBe(138);
+    //   Plus 0138 (learned_patterns.auto_promoted flag, PRD #3617 B-2, #3636) = 139.
+    expect(count).toBe(139);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -325,6 +326,7 @@ describe("runMigrations", () => {
         "0135_approval_rule_type_datasource.sql",
         "0136_mcp_action_policy_default_allowed.sql",
         "0137_learning_tables_performance_columns.sql",
+        "0138_learned_patterns_auto_promoted.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1700,9 +1700,12 @@ export interface PromoteDecayCandidateRow {
  * Fetch the rows the nightly promote/decay job evaluates: pending query
  * patterns (promotion candidates) and approved query patterns the job itself
  * promoted (decay candidates). `semantic_amendment` rows are excluded — they
- * keep human review. Rows carry their own `org_id` / `connection_group_id`, and
- * the apply step keys updates by `id` without ever changing scope, so a single
- * global scan can never move a pattern across tenants (#3610/#3611).
+ * keep human review. The apply step (`promoteLearnedPatterns` /
+ * `demoteLearnedPatterns`) keys updates by `id` and never writes `org_id` or
+ * `connection_group_id`, so a single global scan can never move a pattern across
+ * tenants (#3610/#3611) — which is why this projection doesn't even select the
+ * scope columns; each row's own `org_id` (for cache invalidation) is returned by
+ * the apply step's `RETURNING`.
  *
  * Capped at `limit` rows (oldest-touched first) so a runaway table can't make
  * one tick unbounded; the scheduler logs when the cap is hit.

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1600,6 +1600,9 @@ export interface ApprovedPatternRow {
   source_entity: string | null;
   /** Confidence score between 0.0 and 1.0. */
   confidence: number;
+  /** Rolling-mean wall-clock execution time (ms), or null until first observed
+   *  (PRD #3617 B-0). Drives perf-weighted retrieval down-weighting (B-2). */
+  avg_duration_ms: number | null;
   [key: string]: unknown;
 }
 
@@ -1663,13 +1666,115 @@ export async function getApprovedPatterns(
   }
 
   return internalQuery<ApprovedPatternRow>(
-    `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence
+    `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence, avg_duration_ms
      FROM learned_patterns
      WHERE status = 'approved' AND ${orgClause} AND ${groupClause}
      ORDER BY confidence DESC
      LIMIT 100`,
     params,
   );
+}
+
+// ── Auto-promote / decay (PRD #3617 B-2, #3636) ─────────────────────
+
+/** `reviewed_by` stamp the nightly job writes on an auto-promotion, so the
+ *  audit trail and admin UI can tell a machine approval from a human one even
+ *  before reading the `auto_promoted` flag. */
+export const AUTO_PROMOTE_REVIEWER = "atlas-auto-promote";
+
+/** Projection of `learned_patterns` the promote/decay decision needs. */
+export interface PromoteDecayCandidateRow {
+  readonly id: string;
+  readonly org_id: string | null;
+  readonly type: string;
+  readonly status: string;
+  readonly confidence: number;
+  readonly repetition_count: number;
+  readonly avg_duration_ms: number | null;
+  readonly last_seen_at: string | null;
+  readonly auto_promoted: boolean;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Fetch the rows the nightly promote/decay job evaluates: pending query
+ * patterns (promotion candidates) and approved query patterns the job itself
+ * promoted (decay candidates). `semantic_amendment` rows are excluded — they
+ * keep human review. Rows carry their own `org_id` / `connection_group_id`, and
+ * the apply step keys updates by `id` without ever changing scope, so a single
+ * global scan can never move a pattern across tenants (#3610/#3611).
+ *
+ * Capped at `limit` rows (oldest-touched first) so a runaway table can't make
+ * one tick unbounded; the scheduler logs when the cap is hit.
+ */
+export async function getPromoteDecayCandidates(
+  limit = 10000,
+): Promise<PromoteDecayCandidateRow[]> {
+  if (!hasInternalDB()) return [];
+  return internalQuery<PromoteDecayCandidateRow>(
+    `SELECT id, org_id, type, status, confidence, repetition_count,
+            avg_duration_ms, last_seen_at::text AS last_seen_at, auto_promoted
+     FROM learned_patterns
+     WHERE type = 'query_pattern'
+       AND (status = 'pending' OR (status = 'approved' AND auto_promoted = true))
+     ORDER BY updated_at ASC
+     LIMIT $1`,
+    [limit],
+  );
+}
+
+/** Distinct org ids (including a single NULL bucket) from a set of returned
+ *  rows — the cache-invalidation key set for the affected workspaces. */
+function distinctOrgIds(rows: ReadonlyArray<{ org_id: string | null }>): Array<string | null> {
+  const seen = new Set<string | null>();
+  for (const r of rows) seen.add(r.org_id);
+  return [...seen];
+}
+
+/**
+ * Promote a batch of pending query patterns to approved (auto-promotion).
+ *
+ * The WHERE re-asserts `status = 'pending'` / `type = 'query_pattern'` so a
+ * human approve/reject landing between the candidate read and this update can
+ * never be clobbered. Returns the affected-row count and the distinct org ids
+ * for cache invalidation.
+ */
+export async function promoteLearnedPatterns(
+  ids: readonly string[],
+): Promise<{ count: number; orgIds: Array<string | null> }> {
+  if (ids.length === 0 || !hasInternalDB()) return { count: 0, orgIds: [] };
+  const rows = await internalQuery<{ org_id: string | null }>(
+    `UPDATE learned_patterns
+     SET status = 'approved', auto_promoted = true,
+         reviewed_by = $1, reviewed_at = now(), updated_at = now()
+     WHERE id = ANY($2::uuid[]) AND status = 'pending' AND type = 'query_pattern'
+     RETURNING org_id`,
+    [AUTO_PROMOTE_REVIEWER, [...ids]],
+  );
+  return { count: rows.length, orgIds: distinctOrgIds(rows) };
+}
+
+/**
+ * Demote a batch of stale auto-promoted patterns back to pending (decay).
+ *
+ * `auto_promoted` is intentionally left true so the row stays a machine-managed
+ * candidate and can be re-promoted if it's seen again. The WHERE re-asserts
+ * `auto_promoted = true` so a human approval (which clears the flag) is never
+ * demoted out from under the admin.
+ */
+export async function demoteLearnedPatterns(
+  ids: readonly string[],
+): Promise<{ count: number; orgIds: Array<string | null> }> {
+  if (ids.length === 0 || !hasInternalDB()) return { count: 0, orgIds: [] };
+  const rows = await internalQuery<{ org_id: string | null }>(
+    `UPDATE learned_patterns
+     SET status = 'pending', updated_at = now()
+     WHERE id = ANY($1::uuid[]) AND status = 'approved'
+       AND auto_promoted = true AND type = 'query_pattern'
+     RETURNING org_id`,
+    [[...ids]],
+  );
+  return { count: rows.length, orgIds: distinctOrgIds(rows) };
 }
 
 export async function upsertSuggestion(suggestion: {

--- a/packages/api/src/lib/db/migrations/0138_learned_patterns_auto_promoted.sql
+++ b/packages/api/src/lib/db/migrations/0138_learned_patterns_auto_promoted.sql
@@ -1,0 +1,33 @@
+-- 0138 — `auto_promoted` flag on learned_patterns (PRD #3617 B-2, #3636).
+--
+-- The nightly auto-promote/decay job (lib/learn/promote-decay-scheduler.ts)
+-- flips qualifying `query_pattern` rows from pending → approved without a human
+-- in the loop. The admin UI must distinguish those machine-approved rows from
+-- ones a human explicitly approved, and the decay half of the job must only
+-- ever demote rows IT promoted (never undo a human approval) — both need a
+-- durable marker that survives the status round-trip (approved → pending →
+-- approved). `reviewed_by` is free-text and gets overwritten the moment an admin
+-- touches the row, so it can't carry that signal; a dedicated boolean can.
+--
+--   auto_promoted — true once the nightly job promotes the row; stays true
+--                   across a later auto-demote so the row remains an
+--                   auto-managed candidate. A human approve/reject leaves it
+--                   false (or, on override, the admin path may clear it).
+--
+-- Additive-only: one NOT NULL column with a DEFAULT, no constraint changes, no
+-- rewrites of existing semantics — ships safely in a single release (only
+-- DROP COLUMN / DROP TABLE need the two-phase N / N+1 split). The Drizzle mirror
+-- in `db/schema.ts` (`learnedPatterns`) lands in the SAME PR so
+-- `check-schema-drift` stays green and the next `drizzle-kit generate` doesn't
+-- revert the column.
+--
+-- learned_patterns is not Better-Auth-managed, so this file does NOT join
+-- MANAGED_AUTH_MIGRATIONS (db/internal.ts).
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE learned_patterns
+  ADD COLUMN IF NOT EXISTS auto_promoted BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN learned_patterns.auto_promoted IS
+  'True when the nightly auto-promote/decay job (PRD #3617 B-2) promoted this row from pending → approved. Stays true across a later auto-demote so decay only ever demotes machine-promoted rows, never human approvals.';

--- a/packages/api/src/lib/db/migrations/0138_learned_patterns_auto_promoted.sql
+++ b/packages/api/src/lib/db/migrations/0138_learned_patterns_auto_promoted.sql
@@ -10,9 +10,12 @@
 -- touches the row, so it can't carry that signal; a dedicated boolean can.
 --
 --   auto_promoted — true once the nightly job promotes the row; stays true
---                   across a later auto-demote so the row remains an
---                   auto-managed candidate. A human approve/reject leaves it
---                   false (or, on override, the admin path may clear it).
+--                   across a later auto-demote (approved → pending) so the row
+--                   remains an auto-managed candidate that decay can still act
+--                   on. A human approve/reject via the admin route clears it
+--                   back to false, re-attributing the row to that human, so a
+--                   human-reviewed row never reads as machine-approved and decay
+--                   never demotes it out from under the admin.
 --
 -- Additive-only: one NOT NULL column with a DEFAULT, no constraint changes, no
 -- rewrites of existing semantics — ships safely in a single release (only

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -552,6 +552,12 @@ export const learnedPatterns = pgTable(
     avgDurationMs: doublePrecision("avg_duration_ms"),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
     errorCount: integer("error_count").notNull().default(0),
+    // Performance-aware Atlas (PRD #3617 B-2, #3636). True once the nightly
+    // auto-promote/decay job (lib/learn/promote-decay-scheduler.ts) promoted
+    // this row from pending → approved. Stays true across a later auto-demote
+    // so decay only demotes machine-promoted rows, never human approvals, and
+    // so the admin UI can mark them visually distinct.
+    autoPromoted: boolean("auto_promoted").notNull().default(false),
   },
   (t) => [
     index("idx_learned_patterns_org_status").on(t.orgId, t.status),

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -420,6 +420,7 @@ describe("makeSchedulerLive", () => {
         "settings_refresh",
         "onboarding_email",
         "expert_scheduler",
+        "promote_decay",
         "billing_reconcile",
       ],
     },

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -215,6 +215,7 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   settings_refresh: "atlas.scheduler.settings_refresh",
   onboarding_email: "atlas.scheduler.onboarding_email",
   expert_scheduler: "atlas.scheduler.expert_scheduler",
+  promote_decay: "atlas.scheduler.promote_decay",
   billing_reconcile: "atlas.scheduler.billing_reconcile",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
@@ -1461,6 +1462,56 @@ export function makeSchedulerLive(
         log.info({ intervalMs: getExpertSchedulerIntervalMs() }, "Semantic expert scheduler started");
       } else {
         log.debug("Semantic expert scheduler not started — feature disabled");
+      }
+
+      // ── Periodic fiber: learned-pattern auto-promote/decay (#3636) ──
+      const promoteDecayEnabled = yield* Effect.try({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { isPromoteDecaySchedulerEnabled } = require("@atlas/api/lib/learn/promote-decay-scheduler") as {
+            isPromoteDecaySchedulerEnabled: () => boolean;
+          };
+          return isPromoteDecaySchedulerEnabled();
+        },
+        catch: (err) => {
+          log.debug({ err: errorMessage(err) }, "Promote/decay scheduler module not available — skipping");
+          return false;
+        },
+      }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+      if (promoteDecayEnabled) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { getPromoteDecaySchedulerIntervalMs } = require("@atlas/api/lib/learn/promote-decay-scheduler") as {
+          getPromoteDecaySchedulerIntervalMs: () => number;
+        };
+        const promoteDecayTick = Effect.tryPromise({
+          try: async () => {
+            const { runPromoteDecayTick } = await import("@atlas/api/lib/learn/promote-decay-scheduler");
+            await runPromoteDecayTick();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn({ err: errorMessage(err) }, "Promote/decay tick failed");
+            }),
+          ),
+        );
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
+          withFiberDeathLog(
+            "promote_decay",
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.promote_decay, {}, promoteDecayTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(getPromoteDecaySchedulerIntervalMs()))),
+            ),
+          ),
+        );
+        log.info(
+          { intervalMs: getPromoteDecaySchedulerIntervalMs() },
+          "Learned-pattern auto-promote/decay scheduler started",
+        );
+      } else {
+        log.debug("Learned-pattern auto-promote/decay scheduler not started — feature disabled");
       }
 
       // ── Periodic fiber: plan-tier reconciliation sweep (#3423) ──────

--- a/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
+++ b/packages/api/src/lib/learn/__tests__/org-knowledge-section.test.ts
@@ -157,6 +157,7 @@ function pattern(over: Partial<RelevantPattern> = {}): RelevantPattern {
     sourceEntity: "companies",
     description: "Total company revenue",
     patternSql: "SELECT SUM(revenue) FROM companies",
+    avgDurationMs: null,
     ...over,
   };
 }
@@ -183,6 +184,24 @@ describe("buildOrgKnowledgeSection (pure)", () => {
     expect(section).toContain("### Previously successful query patterns");
     expect(section).toContain("[companies]: Total company revenue");
     expect(section).toContain("SQL: SELECT SUM(revenue) FROM companies");
+  });
+
+  test("surfaces a pattern's average latency when measured (PRD #3617 B-2)", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [pattern({ avgDurationMs: 123.4 })],
+      favorites: [],
+      suggestions: [],
+    });
+    expect(section).toContain("(avg ~123ms)");
+  });
+
+  test("omits the latency hint for a never-observed pattern", () => {
+    const section = buildOrgKnowledgeSection({
+      patterns: [pattern({ avgDurationMs: null })],
+      favorites: [],
+      suggestions: [],
+    });
+    expect(section).not.toContain("(avg ~");
   });
 
   test("renders favorites and suggestions alongside patterns", () => {

--- a/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
+++ b/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { ApprovedPatternRow } from "@atlas/api/lib/db/internal";
+
+// pattern-cache imports settings/internal/logger at module load; stub them so
+// the pure ranking helpers can be imported in isolation.
+mock.module("@atlas/api/lib/db/internal", () => ({
+  getApprovedPatterns: async () => [],
+}));
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: () => undefined,
+  getSettingAuto: () => undefined,
+  getSettingLive: async () => undefined,
+}));
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { rankPatterns, perfWeight, DEFAULT_LATENCY_BUDGET_MS } = await import(
+  "@atlas/api/lib/learn/pattern-cache"
+);
+
+function row(over: Partial<ApprovedPatternRow> & { id: string }): ApprovedPatternRow {
+  return {
+    org_id: null,
+    connection_group_id: null,
+    pattern_sql: "SELECT revenue FROM companies",
+    description: "company revenue",
+    source_entity: "companies",
+    confidence: 0.9,
+    avg_duration_ms: null,
+    ...over,
+  };
+}
+
+const KW = new Set(["revenue", "companies"]);
+
+describe("perfWeight", () => {
+  test("unknown / within-budget latency gets a neutral weight of 1", () => {
+    expect(perfWeight(null, 1000)).toBe(1);
+    expect(perfWeight(500, 1000)).toBe(1);
+    expect(perfWeight(1000, 1000)).toBe(1);
+  });
+
+  test("a slow pattern is down-weighted but never to zero", () => {
+    const w2x = perfWeight(2000, 1000);
+    const w10x = perfWeight(10000, 1000);
+    expect(w2x).toBeLessThan(1);
+    expect(w2x).toBeGreaterThan(w10x);
+    expect(w10x).toBeGreaterThanOrEqual(0.5);
+  });
+
+  test("a disabled / non-positive budget disables the penalty", () => {
+    expect(perfWeight(99999, 0)).toBe(1);
+  });
+});
+
+describe("rankPatterns — down-weight slow but keep present", () => {
+  test("a fast pattern outranks an equally-relevant slow one", () => {
+    const fast = row({ id: "fast", avg_duration_ms: 100 });
+    const slow = row({ id: "slow", avg_duration_ms: 8000 });
+    const ranked = rankPatterns([slow, fast], KW, {
+      latencyBudgetMs: 1000,
+      maxPatterns: 10,
+    });
+    expect(ranked.map((r) => r.pattern.id)).toEqual(["fast", "slow"]);
+    // The slow pattern is still PRESENT — down-weighted, not excluded.
+    expect(ranked).toHaveLength(2);
+  });
+
+  test("relevance still dominates: a much-more-relevant slow pattern wins", () => {
+    // slow pattern matches both keywords; fast matches only one.
+    const slowRelevant = row({
+      id: "slow-relevant",
+      avg_duration_ms: 8000,
+      pattern_sql: "SELECT revenue FROM companies",
+      description: "revenue companies",
+    });
+    const fastSparse = row({
+      id: "fast-sparse",
+      avg_duration_ms: 50,
+      pattern_sql: "SELECT 1",
+      description: "companies",
+      source_entity: null,
+    });
+    const ranked = rankPatterns([fastSparse, slowRelevant], KW, {
+      latencyBudgetMs: 1000,
+      maxPatterns: 10,
+    });
+    expect(ranked[0].pattern.id).toBe("slow-relevant");
+  });
+
+  test("never drops a slow relevant pattern (filter is on raw keyword overlap)", () => {
+    const slow = row({ id: "very-slow", avg_duration_ms: 10 ** 9 });
+    const ranked = rankPatterns([slow], KW, { latencyBudgetMs: 1000, maxPatterns: 10 });
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].pattern.id).toBe("very-slow");
+  });
+
+  test("drops patterns with zero keyword overlap", () => {
+    const unrelated = row({
+      id: "unrelated",
+      pattern_sql: "SELECT widgets FROM inventory",
+      description: "widget stock levels",
+      source_entity: "inventory",
+    });
+    const ranked = rankPatterns([unrelated], KW, { latencyBudgetMs: 1000, maxPatterns: 10 });
+    expect(ranked).toHaveLength(0);
+  });
+
+  test("respects maxPatterns", () => {
+    const rows = Array.from({ length: 5 }, (_, i) => row({ id: `p${i}`, avg_duration_ms: i * 100 }));
+    const ranked = rankPatterns(rows, KW, { latencyBudgetMs: 1000, maxPatterns: 3 });
+    expect(ranked).toHaveLength(3);
+  });
+
+  test("ties break toward lower latency", () => {
+    const a = row({ id: "a", avg_duration_ms: 500, confidence: 0.9 });
+    const b = row({ id: "b", avg_duration_ms: 100, confidence: 0.9 });
+    // both within budget → equal perfWeight & score & confidence → latency breaks tie
+    const ranked = rankPatterns([a, b], KW, { latencyBudgetMs: 1000, maxPatterns: 10 });
+    expect(ranked.map((r) => r.pattern.id)).toEqual(["b", "a"]);
+  });
+
+  test("DEFAULT_LATENCY_BUDGET_MS is a sane positive default", () => {
+    expect(DEFAULT_LATENCY_BUDGET_MS).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { loadSettings, _resetSettingsCache } from "@atlas/api/lib/settings";
+
+// ---------------------------------------------------------------------------
+// Mock internal DB. `dbAvailable` / `settingsRows` drive the settings tier
+// chain (same shape as the expert-scheduler test). `candidates` feeds the tick;
+// `promotedIds` / `demotedIds` capture what the tick asked the DB to flip.
+// ---------------------------------------------------------------------------
+let dbAvailable = false;
+let settingsRows: Array<{
+  key: string;
+  value: string;
+  updated_at: string;
+  updated_by: string | null;
+  org_id: string | null;
+}> = [];
+
+let candidates: Array<Record<string, unknown>> = [];
+let promotedIds: readonly string[] = [];
+let demotedIds: readonly string[] = [];
+let invalidatedOrgs: Array<string | null> = [];
+let failPromote = false;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => dbAvailable,
+  getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
+  internalQuery: async () => settingsRows,
+  internalExecute: () => {},
+  getApprovedPatterns: async () => [],
+  getPromoteDecayCandidates: async () => candidates,
+  promoteLearnedPatterns: async (ids: readonly string[]) => {
+    if (failPromote) throw new Error("boom");
+    promotedIds = ids;
+    return { count: ids.length, orgIds: ids.length > 0 ? ["org-a"] : [] };
+  },
+  demoteLearnedPatterns: async (ids: readonly string[]) => {
+    demotedIds = ids;
+    return { count: ids.length, orgIds: ids.length > 0 ? ["org-b"] : [] };
+  },
+  getEncryptionKey: () => null,
+  encryptSecret: (v: string) => v,
+  decryptSecret: (v: string) => v,
+  setWorkspaceRegion: mock(async () => {}),
+}));
+
+// pattern-cache is real except its cache invalidation, which we observe.
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  DEFAULT_LATENCY_BUDGET_MS: 5000,
+  invalidatePatternCache: (orgId: string | null) => {
+    invalidatedOrgs.push(orgId);
+  },
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const {
+  isPromoteDecaySchedulerEnabled,
+  getPromoteDecaySchedulerIntervalMs,
+  resolvePromoteDecayThresholds,
+  runPromoteDecayTick,
+  DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
+} = await import("@atlas/api/lib/learn/promote-decay-scheduler");
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+
+function candidateRow(over: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: "c",
+    type: "query_pattern",
+    status: "pending",
+    confidence: 0.9,
+    repetition_count: 10,
+    avg_duration_ms: 200,
+    last_seen_at: daysAgo(1),
+    auto_promoted: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  delete process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED;
+  delete process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS;
+  _resetSettingsCache();
+  dbAvailable = false;
+  settingsRows = [];
+  candidates = [];
+  promotedIds = [];
+  demotedIds = [];
+  invalidatedOrgs = [];
+  failPromote = false;
+});
+
+afterEach(() => {
+  delete process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED;
+  delete process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS;
+  _resetSettingsCache();
+});
+
+describe("isPromoteDecaySchedulerEnabled", () => {
+  it("is off by default", () => {
+    expect(isPromoteDecaySchedulerEnabled()).toBe(false);
+  });
+
+  it("turns on for 'true' / '1'", () => {
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
+    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "1";
+    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+  });
+
+  it("a platform DB override beats the env var (#3392 pattern)", async () => {
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "false";
+    dbAvailable = true;
+    settingsRows = [
+      { key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED", value: "true", updated_at: "2026-01-01", updated_by: null, org_id: null },
+    ];
+    await loadSettings();
+    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+  });
+});
+
+describe("getPromoteDecaySchedulerIntervalMs", () => {
+  it("defaults to 24h", () => {
+    expect(getPromoteDecaySchedulerIntervalMs()).toBe(DEFAULT_PROMOTE_DECAY_INTERVAL_MS);
+  });
+
+  it("converts hours to ms", () => {
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS = "6";
+    expect(getPromoteDecaySchedulerIntervalMs()).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it("falls back to the default on a non-positive / invalid value", () => {
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS = "0";
+    expect(getPromoteDecaySchedulerIntervalMs()).toBe(DEFAULT_PROMOTE_DECAY_INTERVAL_MS);
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS = "abc";
+    expect(getPromoteDecaySchedulerIntervalMs()).toBe(DEFAULT_PROMOTE_DECAY_INTERVAL_MS);
+  });
+});
+
+describe("resolvePromoteDecayThresholds", () => {
+  it("uses registry defaults when nothing is set", () => {
+    const t = resolvePromoteDecayThresholds();
+    expect(t.confidenceThreshold).toBe(0.7);
+    expect(t.minRepetitions).toBe(5);
+    expect(t.latencyBudgetMs).toBe(5000);
+    expect(t.decayUnseenMs).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("reads platform DB overrides", async () => {
+    dbAvailable = true;
+    settingsRows = [
+      { key: "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS", value: "12", updated_at: "x", updated_by: null, org_id: null },
+      { key: "ATLAS_LEARN_DECAY_UNSEEN_DAYS", value: "7", updated_at: "x", updated_by: null, org_id: null },
+      { key: "ATLAS_LEARN_LATENCY_BUDGET_MS", value: "1500", updated_at: "x", updated_by: null, org_id: null },
+    ];
+    await loadSettings();
+    const t = resolvePromoteDecayThresholds();
+    expect(t.minRepetitions).toBe(12);
+    expect(t.latencyBudgetMs).toBe(1500);
+    expect(t.decayUnseenMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("runPromoteDecayTick", () => {
+  it("no-ops without an internal DB", async () => {
+    dbAvailable = false;
+    const r = await runPromoteDecayTick();
+    expect(r).toEqual({ candidates: 0, promoted: 0, demoted: 0, errors: 0 });
+    expect(promotedIds).toEqual([]);
+    expect(demotedIds).toEqual([]);
+  });
+
+  it("promotes qualifying rows, demotes stale auto-promoted rows, leaves human approvals", async () => {
+    dbAvailable = true;
+    candidates = [
+      candidateRow({ id: "promote-me" }),
+      candidateRow({ id: "demote-me", status: "approved", auto_promoted: true, last_seen_at: daysAgo(60) }),
+      // Human approval — never auto-demoted even if stale.
+      candidateRow({ id: "human", status: "approved", auto_promoted: false, last_seen_at: daysAgo(99) }),
+      // Too slow to promote.
+      candidateRow({ id: "slow", avg_duration_ms: 99999 }),
+    ];
+
+    const r = await runPromoteDecayTick();
+
+    expect(promotedIds).toEqual(["promote-me"]);
+    expect(demotedIds).toEqual(["demote-me"]);
+    expect(r.candidates).toBe(4);
+    expect(r.promoted).toBe(1);
+    expect(r.demoted).toBe(1);
+    expect(r.errors).toBe(0);
+    // Affected workspaces are cache-invalidated.
+    expect(invalidatedOrgs).toContain("org-a");
+    expect(invalidatedOrgs).toContain("org-b");
+  });
+
+  it("records an error instead of throwing when a query rejects", async () => {
+    dbAvailable = true;
+    candidates = [candidateRow({ id: "x" })];
+    failPromote = true;
+    const r = await runPromoteDecayTick();
+    expect(r.errors).toBe(1);
+  });
+});

--- a/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
@@ -20,6 +20,7 @@ let promotedIds: readonly string[] = [];
 let demotedIds: readonly string[] = [];
 let invalidatedOrgs: Array<string | null> = [];
 let failPromote = false;
+let failDemote = false;
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => dbAvailable,
@@ -34,6 +35,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     return { count: ids.length, orgIds: ids.length > 0 ? ["org-a"] : [] };
   },
   demoteLearnedPatterns: async (ids: readonly string[]) => {
+    if (failDemote) throw new Error("kaboom");
     demotedIds = ids;
     return { count: ids.length, orgIds: ids.length > 0 ? ["org-b"] : [] };
   },
@@ -90,6 +92,7 @@ beforeEach(() => {
   demotedIds = [];
   invalidatedOrgs = [];
   failPromote = false;
+  failDemote = false;
 });
 
 afterEach(() => {
@@ -202,5 +205,26 @@ describe("runPromoteDecayTick", () => {
     failPromote = true;
     const r = await runPromoteDecayTick();
     expect(r.errors).toBe(1);
+  });
+
+  it("preserves the successful side when the other batch throws (no Promise.all masking)", async () => {
+    // promote succeeds, demote throws: the committed promotion's count must
+    // survive AND its cache must still be invalidated — a Promise.all would lose
+    // both by unwinding to the outer catch (#3636 review).
+    dbAvailable = true;
+    candidates = [
+      candidateRow({ id: "promote-me" }),
+      candidateRow({ id: "demote-me", status: "approved", auto_promoted: true, last_seen_at: daysAgo(60) }),
+    ];
+    failDemote = true;
+
+    const r = await runPromoteDecayTick();
+
+    expect(r.promoted).toBe(1); // not lost
+    expect(r.demoted).toBe(0); // the failed side
+    expect(r.errors).toBe(1); // exactly the demote failure
+    expect(promotedIds).toEqual(["promote-me"]);
+    // The successful promote still invalidated its workspace's cache.
+    expect(invalidatedOrgs).toContain("org-a");
   });
 });

--- a/packages/api/src/lib/learn/__tests__/promote-decay.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "bun:test";
+import {
+  decidePromoteDecay,
+  type PromoteDecayCandidate,
+  type PromoteDecayThresholds,
+} from "../promote-decay";
+
+const THRESHOLDS: PromoteDecayThresholds = {
+  confidenceThreshold: 0.7,
+  minRepetitions: 5,
+  latencyBudgetMs: 1000,
+  decayUnseenMs: 30 * 24 * 60 * 60 * 1000, // 30 days
+};
+
+// A fixed "now" so staleness math is deterministic (no Date.now()).
+const NOW = Date.parse("2026-06-16T00:00:00.000Z");
+const daysAgo = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
+
+function candidate(overrides: Partial<PromoteDecayCandidate>): PromoteDecayCandidate {
+  return {
+    id: "p-default",
+    type: "query_pattern",
+    status: "pending",
+    confidence: 0.9,
+    repetitionCount: 10,
+    avgDurationMs: 200,
+    lastSeenAt: daysAgo(1),
+    autoPromoted: false,
+    ...overrides,
+  };
+}
+
+describe("decidePromoteDecay — promotion gate", () => {
+  it("promotes a pending row that clears every gate", () => {
+    const { promote, demote } = decidePromoteDecay([candidate({ id: "ok" })], THRESHOLDS, NOW);
+    expect(promote).toEqual(["ok"]);
+    expect(demote).toEqual([]);
+  });
+
+  it("does not promote below the confidence threshold", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "lowconf", confidence: 0.69 })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("does not promote below the repetition floor", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "rare", repetitionCount: 4 })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("does not promote when avg latency exceeds the budget", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "slow", avgDurationMs: 1001 })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("promotes a row exactly at the latency budget (inclusive)", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "edge", avgDurationMs: 1000 })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual(["edge"]);
+  });
+
+  it("does NOT promote a row whose latency was never measured (null avg)", () => {
+    // Unmeasured latency must not be auto-amplified — conservative gate.
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "unmeasured", avgDurationMs: null })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("ignores rows that are already approved for promotion", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "already", status: "approved" })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("never promotes a semantic_amendment (stays human-reviewed)", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "amendment", type: "semantic_amendment" })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+});
+
+describe("decidePromoteDecay — decay/demote gate", () => {
+  it("demotes an auto-promoted row unseen past the decay window", () => {
+    const { promote, demote } = decidePromoteDecay(
+      [candidate({ id: "stale", status: "approved", autoPromoted: true, lastSeenAt: daysAgo(31) })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(demote).toEqual(["stale"]);
+    expect(promote).toEqual([]);
+  });
+
+  it("keeps an auto-promoted row seen within the decay window", () => {
+    const { demote } = decidePromoteDecay(
+      [candidate({ id: "fresh", status: "approved", autoPromoted: true, lastSeenAt: daysAgo(29) })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(demote).toEqual([]);
+  });
+
+  it("never demotes a human-approved row, however stale", () => {
+    // autoPromoted=false → a human vouched for it; only a human removes it.
+    const { demote } = decidePromoteDecay(
+      [candidate({ id: "human", status: "approved", autoPromoted: false, lastSeenAt: daysAgo(999) })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(demote).toEqual([]);
+  });
+
+  it("does not demote an auto-promoted row with no last_seen timestamp", () => {
+    // Can't prove staleness without a timestamp — leave it alone.
+    const { demote } = decidePromoteDecay(
+      [candidate({ id: "noseen", status: "approved", autoPromoted: true, lastSeenAt: null })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(demote).toEqual([]);
+  });
+
+  it("does not demote a pending auto-promoted row (only approved rows decay)", () => {
+    const { demote } = decidePromoteDecay(
+      [candidate({ id: "pending-auto", status: "pending", autoPromoted: true, lastSeenAt: daysAgo(99) })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(demote).toEqual([]);
+  });
+});
+
+describe("decidePromoteDecay — mixed batch", () => {
+  it("partitions a batch into promote and demote sets in one pass", () => {
+    const patterns = [
+      candidate({ id: "promote-me" }),
+      candidate({ id: "demote-me", status: "approved", autoPromoted: true, lastSeenAt: daysAgo(40) }),
+      candidate({ id: "leave-me", status: "approved", autoPromoted: false, lastSeenAt: daysAgo(40) }),
+      candidate({ id: "too-slow", avgDurationMs: 9999 }),
+    ];
+    const { promote, demote } = decidePromoteDecay(patterns, THRESHOLDS, NOW);
+    expect(promote).toEqual(["promote-me"]);
+    expect(demote).toEqual(["demote-me"]);
+  });
+
+  it("returns empty sets for an empty input", () => {
+    expect(decidePromoteDecay([], THRESHOLDS, NOW)).toEqual({ promote: [], demote: [] });
+  });
+});

--- a/packages/api/src/lib/learn/__tests__/promote-decay.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay.test.ts
@@ -100,6 +100,41 @@ describe("decidePromoteDecay — promotion gate", () => {
     );
     expect(promote).toEqual([]);
   });
+
+  it("does NOT promote a pending row unseen past the decay window", () => {
+    // Recency gate — without it, decay is futile: a row demoted for going stale
+    // would clear the other (cumulative) gates and re-promote next tick (#3636).
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "stale-pending", lastSeenAt: daysAgo(31) })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("does NOT promote a pending row with no last_seen timestamp", () => {
+    const { promote } = decidePromoteDecay(
+      [candidate({ id: "noseen", lastSeenAt: null })],
+      THRESHOLDS,
+      NOW,
+    );
+    expect(promote).toEqual([]);
+  });
+
+  it("re-promotes a previously-decayed row once it is seen again (no oscillation)", () => {
+    // Steady state after fix #1: a demoted row (back to pending, autoPromoted
+    // still true) stays pending until a fresh observation updates last_seen_at;
+    // once seen within the window it legitimately re-promotes.
+    const justDemoted = candidate({
+      id: "demoted-then-seen",
+      status: "pending",
+      autoPromoted: true,
+      lastSeenAt: daysAgo(1),
+    });
+    const { promote, demote } = decidePromoteDecay([justDemoted], THRESHOLDS, NOW);
+    expect(promote).toEqual(["demoted-then-seen"]);
+    expect(demote).toEqual([]);
+  });
 });
 
 describe("decidePromoteDecay — decay/demote gate", () => {

--- a/packages/api/src/lib/learn/org-knowledge-section.ts
+++ b/packages/api/src/lib/learn/org-knowledge-section.ts
@@ -24,7 +24,7 @@ import type { AtlasMode } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getPopularSuggestions } from "@atlas/api/lib/db/internal";
 import { listFavorites } from "@atlas/api/lib/starter-prompts/favorite-store";
-import { getRelevantPatterns, type RelevantPattern } from "./pattern-cache";
+import { getRelevantPatterns, formatAvgLatency, type RelevantPattern } from "./pattern-cache";
 
 const log = createLogger("org-knowledge-section");
 
@@ -94,12 +94,15 @@ export function buildOrgKnowledgeSection(input: OrgKnowledgeInput): string {
       const entity = p.sourceEntity ? `[${p.sourceEntity}]` : "[general]";
       const desc = sanitize(p.description ?? "Query pattern", 200);
       const sql = sanitize(p.patternSql, 500);
-      return `- ${entity}: ${desc}\n  SQL: ${sql}`;
+      // Surface the pattern's measured average latency (PRD #3617 B-2) so the
+      // agent can weigh cost; "" when never observed.
+      const latency = formatAvgLatency(p.avgDurationMs);
+      return `- ${entity}: ${desc}${latency}\n  SQL: ${sql}`;
     });
     subsections.push(
       [
         "### Previously successful query patterns",
-        "These patterns have been validated by your organization.",
+        "These patterns have been validated by your organization. The `avg ~Nms` hint on a pattern is its typical execution time — prefer faster patterns when they answer the question equally well.",
         ...lines,
       ].join("\n"),
     );

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -221,6 +221,27 @@ export function getConfidenceThreshold(orgId?: string | null): number {
   return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_CONFIDENCE_THRESHOLD;
 }
 
+/**
+ * Default latency budget (ms) for perf-weighted retrieval. A pattern whose
+ * rolling-mean wall-clock stays at or under this gets no penalty; slower
+ * patterns are down-weighted (never excluded). Also the default budget for the
+ * nightly auto-promote gate. PRD #3617 B-2.
+ */
+export const DEFAULT_LATENCY_BUDGET_MS = 5000;
+
+/**
+ * Resolve the latency budget (ms) for an org, falling back to the default.
+ * Workspace-scoped settings-registry read (see {@link getRetrievalTurns}); the
+ * nightly job reads the same key at platform scope. Non-positive / invalid
+ * values fall back to the default rather than disabling the budget, so a typo
+ * can't silently turn off down-weighting.
+ */
+export function getLatencyBudgetMs(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_LATENCY_BUDGET_MS", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LATENCY_BUDGET_MS;
+}
+
 /** Extract meaningful keywords from a text string. */
 export function extractKeywords(text: string): Set<string> {
   const words = text
@@ -257,10 +278,81 @@ function scorePattern(
 /** Default maximum patterns to inject into the system prompt. */
 const DEFAULT_MAX_PATTERNS = 10;
 
+/**
+ * Floor for the perf weight. A pattern arbitrarily slower than the budget is
+ * down-weighted to at most this factor — never to zero — so slow-but-relevant
+ * patterns stay PRESENT in retrieval as reference, just ranked below faster
+ * peers. Keeping the floor > 0 is what makes this a down-weight, not a filter.
+ */
+const MIN_PERF_WEIGHT = 0.5;
+
 export interface RelevantPattern {
   sourceEntity: string | null;
   description: string | null;
   patternSql: string;
+  /** Rolling-mean wall-clock (ms) of this pattern's runs, or null until first
+   *  observed. Surfaced in the injected context so the agent can judge cost. */
+  avgDurationMs: number | null;
+}
+
+/**
+ * Latency down-weight factor in [{@link MIN_PERF_WEIGHT}, 1].
+ *
+ * - Unknown latency (null / non-finite / negative) → 1.0: we don't penalize a
+ *   pattern whose speed we've never measured.
+ * - At or under budget → 1.0: no penalty.
+ * - Beyond budget → decays toward the floor as `budget / avg` shrinks, so a
+ *   pattern 2× the budget keeps ~0.75 of its weight and one 10× keeps ~0.55.
+ *
+ * Pure helper, exported for direct testing.
+ */
+export function perfWeight(avgDurationMs: number | null, budgetMs: number): number {
+  if (avgDurationMs === null || !Number.isFinite(avgDurationMs) || avgDurationMs < 0) return 1;
+  if (!Number.isFinite(budgetMs) || budgetMs <= 0) return 1;
+  if (avgDurationMs <= budgetMs) return 1;
+  const ratio = budgetMs / avgDurationMs; // in (0, 1)
+  return MIN_PERF_WEIGHT + (1 - MIN_PERF_WEIGHT) * ratio;
+}
+
+/** One scored pattern after keyword + perf weighting. Exported for testing. */
+export interface ScoredPattern {
+  pattern: ApprovedPatternRow;
+  keywordScore: number;
+  perfWeight: number;
+  score: number;
+}
+
+/**
+ * Rank approved patterns for a question, down-weighting slow ones (PRD #3617
+ * B-2). PURE: no DB, no settings — takes the candidate rows, the question
+ * keywords, and the latency budget.
+ *
+ * The eligibility filter stays on RAW keyword overlap (`keywordScore > 0`), so
+ * latency never DROPS a relevant pattern — it only reorders. The combined score
+ * is `keywordScore × perfWeight`, which lets a much-more-relevant slow pattern
+ * still outrank a barely-relevant fast one (relevance dominates), while a fast
+ * pattern wins among similarly-relevant peers. Ties break on confidence, then
+ * on lower latency (unknown latency sorts last).
+ */
+export function rankPatterns(
+  patterns: readonly ApprovedPatternRow[],
+  questionKeywords: Set<string>,
+  opts: { latencyBudgetMs: number; maxPatterns: number },
+): ScoredPattern[] {
+  return patterns
+    .map((pattern): ScoredPattern => {
+      const keywordScore = scorePattern(pattern, questionKeywords);
+      const weight = perfWeight(pattern.avg_duration_ms, opts.latencyBudgetMs);
+      return { pattern, keywordScore, perfWeight: weight, score: keywordScore * weight };
+    })
+    .filter((s) => s.keywordScore > 0)
+    .toSorted(
+      (a, b) =>
+        b.score - a.score ||
+        b.pattern.confidence - a.pattern.confidence ||
+        (a.pattern.avg_duration_ms ?? Infinity) - (b.pattern.avg_duration_ms ?? Infinity),
+    )
+    .slice(0, opts.maxPatterns);
 }
 
 /**
@@ -287,21 +379,33 @@ export async function getRelevantPatterns(
   const aboveThreshold = allPatterns.filter((p) => p.confidence >= threshold);
   if (aboveThreshold.length === 0) return [];
 
-  // Score by keyword relevance
+  // Score by keyword relevance, down-weighting (not excluding) slow patterns.
   const questionKeywords = extractKeywords(question);
   if (questionKeywords.size === 0) return [];
 
-  const scored = aboveThreshold
-    .map((p) => ({ pattern: p, score: scorePattern(p, questionKeywords) }))
-    .filter((s) => s.score > 0)
-    .toSorted((a, b) => b.score - a.score || b.pattern.confidence - a.pattern.confidence)
-    .slice(0, maxPatterns);
+  const scored = rankPatterns(aboveThreshold, questionKeywords, {
+    latencyBudgetMs: getLatencyBudgetMs(orgId),
+    maxPatterns,
+  });
 
   return scored.map((s) => ({
     sourceEntity: s.pattern.source_entity,
     description: s.pattern.description,
     patternSql: s.pattern.pattern_sql,
+    avgDurationMs: s.pattern.avg_duration_ms,
   }));
+}
+
+/**
+ * Format a pattern's average latency as a compact, injectable suffix, e.g.
+ * ` (avg ~123ms)`. Returns `""` for unmeasured latency so a never-observed
+ * pattern doesn't claim a fabricated speed. Exported so the org-knowledge
+ * builder renders latency identically. PRD #3617 B-2 — surfacing this lets the
+ * agent weigh a pattern's cost when choosing which to reuse.
+ */
+export function formatAvgLatency(avgDurationMs: number | null): string {
+  if (avgDurationMs === null || !Number.isFinite(avgDurationMs) || avgDurationMs < 0) return "";
+  return ` (avg ~${Math.round(avgDurationMs)}ms)`;
 }
 
 /** Sanitize text for safe prompt injection — truncate and strip markdown headings. */
@@ -329,7 +433,8 @@ export async function buildLearnedPatternsSection(
       const entity = p.sourceEntity ? `[${p.sourceEntity}]` : "[general]";
       const desc = sanitizeForPrompt(p.description ?? "Query pattern", 200);
       const sql = sanitizeForPrompt(p.patternSql, 500);
-      return `- ${entity}: ${desc}\n  SQL: ${sql}`;
+      const latency = formatAvgLatency(p.avgDurationMs);
+      return `- ${entity}: ${desc}${latency}\n  SQL: ${sql}`;
     });
 
     return [

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -1,0 +1,225 @@
+/**
+ * Nightly auto-promote / decay scheduler for learned query patterns
+ * (PRD #3617 B-2, #3636).
+ *
+ * Once a tick (default 24h) this:
+ *   - PROMOTES pending `query_pattern` rows that clear a tunable gate
+ *     (confidence + repetition + latency budget) from pending → approved, so
+ *     the learning loop maintains itself without an admin in the loop.
+ *   - DECAYS (DEMOTES, never deletes) auto-promoted rows that have gone unseen
+ *     past a tunable window back to pending, so the injected set stays fresh.
+ *
+ * The decision is the pure {@link decidePromoteDecay} function; this module owns
+ * only the I/O — fetching candidates, applying the result, and invalidating the
+ * retrieval cache for affected workspaces. The fiber that calls
+ * {@link runPromoteDecayTick} on a schedule is wired in `lib/effect/layers.ts`,
+ * modeled on the semantic-expert scheduler.
+ *
+ * `semantic_amendment` rows are deliberately out of scope — they rewrite YAML on
+ * approval and keep human review (mirrors the expert auto-approve carve-out).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getSetting } from "@atlas/api/lib/settings";
+import { DEFAULT_LATENCY_BUDGET_MS } from "@atlas/api/lib/learn/pattern-cache";
+// Type-only import — erased at compile time, so it does NOT eagerly load
+// db/internal and the dynamic import + mock seam in runPromoteDecayTick stays
+// intact. Reusing the row type keeps `toCandidate` from drifting from the SQL.
+import type { PromoteDecayCandidateRow } from "@atlas/api/lib/db/internal";
+import {
+  decidePromoteDecay,
+  type PromoteDecayThresholds,
+  type PromoteDecayCandidate,
+} from "@atlas/api/lib/learn/promote-decay";
+
+const log = createLogger("promote-decay-scheduler");
+
+/** Default interval: 24 hours. */
+export const DEFAULT_PROMOTE_DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Gate defaults (mirror the registry defaults in lib/settings.ts). */
+const DEFAULT_PROMOTE_CONFIDENCE = 0.7;
+const DEFAULT_PROMOTE_MIN_REPETITIONS = 5;
+const DEFAULT_DECAY_UNSEEN_DAYS = 30;
+
+/** Upper bound on rows evaluated per tick — a runaway-table backstop. The
+ *  scheduler logs when the cap is hit so a silently-truncated tick is visible. */
+const CANDIDATE_LIMIT = 10000;
+
+/** Summary of a single tick. */
+export interface PromoteDecayTickResult {
+  candidates: number;
+  promoted: number;
+  demoted: number;
+  errors: number;
+}
+
+/**
+ * Whether the nightly promote/decay job is enabled.
+ *
+ * Platform-scoped (like the expert scheduler): a single process-global fiber
+ * forked once at boot by `makeSchedulerLive`, so there is no per-workspace
+ * tick. Resolved via `getSetting()` so a platform DB override (admin settings
+ * page) beats the env var (platform DB override > env > default). Consumed once
+ * at boot — changes require a restart (`requiresRestart` in the registry).
+ */
+export function isPromoteDecaySchedulerEnabled(): boolean {
+  const v = getSetting("ATLAS_LEARN_PROMOTE_DECAY_ENABLED");
+  return v === "true" || v === "1";
+}
+
+/**
+ * Tick interval in milliseconds.
+ *
+ * Resolves `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` through `getSetting()`
+ * (platform DB override > env > default 24). Platform-scoped and boot-consumed —
+ * see {@link isPromoteDecaySchedulerEnabled}.
+ */
+export function getPromoteDecaySchedulerIntervalMs(): number {
+  const raw = getSetting("ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS");
+  if (!raw) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
+  const hours = parseFloat(raw);
+  if (!Number.isFinite(hours) || hours <= 0) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
+  return hours * 60 * 60 * 1000;
+}
+
+/** Parse a platform-scoped numeric setting, falling back to `fallback` on a
+ *  missing / non-finite / out-of-range value (a typo can't silently widen a
+ *  gate). `min` is the inclusive lower bound the value must clear. */
+function numericSetting(key: string, fallback: number, min: number): number {
+  const raw = getSetting(key);
+  if (raw === undefined) return fallback;
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
+}
+
+/**
+ * Resolve the promote/decay gate from the settings registry at platform scope.
+ *
+ * Read once per tick (no orgId), so these are platform-level values — a
+ * workspace override of `ATLAS_LEARN_LATENCY_BUDGET_MS` affects only
+ * retrieval-time down-weighting, not the promotion gate. The confidence
+ * threshold reuses the same `ATLAS_LEARN_CONFIDENCE_THRESHOLD` key that gates
+ * retrieval, so "eligible to inject" and "eligible to auto-promote" share one
+ * knob.
+ */
+export function resolvePromoteDecayThresholds(): PromoteDecayThresholds {
+  const decayUnseenDays = numericSetting(
+    "ATLAS_LEARN_DECAY_UNSEEN_DAYS",
+    DEFAULT_DECAY_UNSEEN_DAYS,
+    1,
+  );
+  return {
+    confidenceThreshold: numericSetting(
+      "ATLAS_LEARN_CONFIDENCE_THRESHOLD",
+      DEFAULT_PROMOTE_CONFIDENCE,
+      0,
+    ),
+    minRepetitions: numericSetting(
+      "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS",
+      DEFAULT_PROMOTE_MIN_REPETITIONS,
+      1,
+    ),
+    latencyBudgetMs: numericSetting(
+      "ATLAS_LEARN_LATENCY_BUDGET_MS",
+      DEFAULT_LATENCY_BUDGET_MS,
+      1,
+    ),
+    decayUnseenMs: decayUnseenDays * 24 * 60 * 60 * 1000,
+  };
+}
+
+/** Project a DB candidate row (snake_case) onto the pure-decision input shape
+ *  (camelCase) — the one place the two representations are bridged. */
+function toCandidate(row: PromoteDecayCandidateRow): PromoteDecayCandidate {
+  return {
+    id: row.id,
+    type: row.type,
+    status: row.status,
+    confidence: row.confidence,
+    repetitionCount: row.repetition_count,
+    avgDurationMs: row.avg_duration_ms,
+    lastSeenAt: row.last_seen_at,
+    autoPromoted: row.auto_promoted,
+  };
+}
+
+/**
+ * Run a single promote/decay tick.
+ *
+ * 1. Bail if there's no internal DB (self-hosted without one).
+ * 2. Fetch promotion + decay candidates (scoped to `query_pattern`).
+ * 3. Apply the pure decision against the resolved gate.
+ * 4. Promote / demote the resulting id sets (each guarded so a concurrent admin
+ *    action can't be clobbered — see the DB helpers).
+ * 5. Invalidate the retrieval cache for every affected workspace.
+ *
+ * Never throws — errors are logged and surfaced in `result.errors`.
+ */
+export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
+  const result: PromoteDecayTickResult = { candidates: 0, promoted: 0, demoted: 0, errors: 0 };
+
+  try {
+    const {
+      hasInternalDB,
+      getPromoteDecayCandidates,
+      promoteLearnedPatterns,
+      demoteLearnedPatterns,
+    } = await import("@atlas/api/lib/db/internal");
+
+    if (!hasInternalDB()) {
+      log.debug("No internal DB — skipping promote/decay tick");
+      return result;
+    }
+
+    const candidates = await getPromoteDecayCandidates(CANDIDATE_LIMIT);
+    result.candidates = candidates.length;
+    if (candidates.length === CANDIDATE_LIMIT) {
+      log.warn(
+        { limit: CANDIDATE_LIMIT },
+        "Promote/decay candidate scan hit its cap — some rows were not evaluated this tick",
+      );
+    }
+    if (candidates.length === 0) {
+      log.debug("Promote/decay tick: no candidates");
+      return result;
+    }
+
+    const thresholds = resolvePromoteDecayThresholds();
+    const { promote, demote } = decidePromoteDecay(
+      candidates.map(toCandidate),
+      thresholds,
+      Date.now(),
+    );
+
+    const [promoteRes, demoteRes] = await Promise.all([
+      promoteLearnedPatterns(promote),
+      demoteLearnedPatterns(demote),
+    ]);
+    result.promoted = promoteRes.count;
+    result.demoted = demoteRes.count;
+
+    // A promotion/demotion changes which patterns the agent sees, so evict the
+    // 5-min retrieval cache for every affected workspace (mirrors the admin
+    // approve/reject path). Imported here, not at module top, to avoid a cycle
+    // through the settings → internal → pattern-cache graph.
+    if (promoteRes.count > 0 || demoteRes.count > 0) {
+      const { invalidatePatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
+      const affected = new Set<string | null>([...promoteRes.orgIds, ...demoteRes.orgIds]);
+      for (const orgId of affected) invalidatePatternCache(orgId);
+    }
+
+    log.info(
+      { candidates: result.candidates, promoted: result.promoted, demoted: result.demoted },
+      "Promote/decay tick complete",
+    );
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Promote/decay tick failed",
+    );
+    result.errors++;
+  }
+
+  return result;
+}

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -34,6 +34,11 @@ import {
 
 const log = createLogger("promote-decay-scheduler");
 
+/** Narrow an unknown thrown value to a log-safe message string. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /** Default interval: 24 hours. */
 export const DEFAULT_PROMOTE_DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
@@ -131,12 +136,16 @@ export function resolvePromoteDecayThresholds(): PromoteDecayThresholds {
 }
 
 /** Project a DB candidate row (snake_case) onto the pure-decision input shape
- *  (camelCase) — the one place the two representations are bridged. */
+ *  (camelCase) — the one place the two representations are bridged. The raw row
+ *  types `type`/`status` as bare `string` (Postgres text); the SELECT in
+ *  `getPromoteDecayCandidates` filters `type = 'query_pattern'` and
+ *  `status IN ('pending','approved')`, so narrowing them to the wire unions here
+ *  is the single, documented `string → union` coercion. */
 function toCandidate(row: PromoteDecayCandidateRow): PromoteDecayCandidate {
   return {
     id: row.id,
-    type: row.type,
-    status: row.status,
+    type: row.type as PromoteDecayCandidate["type"],
+    status: row.status as PromoteDecayCandidate["status"],
     confidence: row.confidence,
     repetitionCount: row.repetition_count,
     avgDurationMs: row.avg_duration_ms,
@@ -193,30 +202,69 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
       Date.now(),
     );
 
-    const [promoteRes, demoteRes] = await Promise.all([
+    // Settle promote and demote INDEPENDENTLY. A `Promise.all` would reject as
+    // soon as either side throws and unwind to the outer catch — losing the
+    // OTHER side's already-committed count AND skipping cache invalidation for
+    // its just-flipped rows, leaving stale agent context until the 5-min TTL
+    // lapses (#3636 review). Each batch DB write is its own transaction, so a
+    // success on one side is durable regardless of the other.
+    const affected = new Set<string | null>();
+    const [promoteRes, demoteRes] = await Promise.allSettled([
       promoteLearnedPatterns(promote),
       demoteLearnedPatterns(demote),
     ]);
-    result.promoted = promoteRes.count;
-    result.demoted = demoteRes.count;
+    if (promoteRes.status === "fulfilled") {
+      result.promoted = promoteRes.value.count;
+      for (const orgId of promoteRes.value.orgIds) affected.add(orgId);
+    } else {
+      result.errors++;
+      log.error(
+        { err: errorMessage(promoteRes.reason), ids: promote.length },
+        "Auto-promote batch failed",
+      );
+    }
+    if (demoteRes.status === "fulfilled") {
+      result.demoted = demoteRes.value.count;
+      for (const orgId of demoteRes.value.orgIds) affected.add(orgId);
+    } else {
+      result.errors++;
+      log.error(
+        { err: errorMessage(demoteRes.reason), ids: demote.length },
+        "Auto-demote batch failed",
+      );
+    }
 
     // A promotion/demotion changes which patterns the agent sees, so evict the
     // 5-min retrieval cache for every affected workspace (mirrors the admin
     // approve/reject path). Imported here, not at module top, to avoid a cycle
-    // through the settings → internal → pattern-cache graph.
-    if (promoteRes.count > 0 || demoteRes.count > 0) {
-      const { invalidatePatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
-      const affected = new Set<string | null>([...promoteRes.orgIds, ...demoteRes.orgIds]);
-      for (const orgId of affected) invalidatePatternCache(orgId);
+    // through the settings → internal → pattern-cache graph. Wrapped on its own
+    // so a cache-import/invalidation failure is logged distinctly rather than
+    // masquerading as a tick-wide failure that discards the committed counts.
+    if (affected.size > 0) {
+      try {
+        const { invalidatePatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
+        for (const orgId of affected) invalidatePatternCache(orgId);
+      } catch (err) {
+        result.errors++;
+        log.error(
+          { err: errorMessage(err) },
+          "Promote/decay cache invalidation failed — rows were flipped but cache stays stale until TTL",
+        );
+      }
     }
 
     log.info(
-      { candidates: result.candidates, promoted: result.promoted, demoted: result.demoted },
+      {
+        candidates: result.candidates,
+        promoted: result.promoted,
+        demoted: result.demoted,
+        errors: result.errors,
+      },
       "Promote/decay tick complete",
     );
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
+      { err: errorMessage(err) },
       "Promote/decay tick failed",
     );
     result.errors++;

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -83,11 +83,12 @@ export function getPromoteDecaySchedulerIntervalMs(): number {
   return hours * 60 * 60 * 1000;
 }
 
-/** Parse a platform-scoped numeric setting, falling back to `fallback` on a
- *  missing / non-finite / out-of-range value (a typo can't silently widen a
- *  gate). `min` is the inclusive lower bound the value must clear. */
-function numericSetting(key: string, fallback: number, min: number): number {
-  const raw = getSetting(key);
+/** Parse a raw setting value, falling back to `fallback` on a missing /
+ *  non-finite / out-of-range value (a typo can't silently widen a gate). `min`
+ *  is the inclusive lower bound the value must clear. The caller reads the key
+ *  with a literal `getSetting("KEY")` so the registry-reader guard (#3382) can
+ *  see each key's reader. */
+function parseNumeric(raw: string | undefined, fallback: number, min: number): number {
   if (raw === undefined) return fallback;
   const parsed = parseFloat(raw);
   return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
@@ -104,24 +105,24 @@ function numericSetting(key: string, fallback: number, min: number): number {
  * knob.
  */
 export function resolvePromoteDecayThresholds(): PromoteDecayThresholds {
-  const decayUnseenDays = numericSetting(
-    "ATLAS_LEARN_DECAY_UNSEEN_DAYS",
+  const decayUnseenDays = parseNumeric(
+    getSetting("ATLAS_LEARN_DECAY_UNSEEN_DAYS"),
     DEFAULT_DECAY_UNSEEN_DAYS,
     1,
   );
   return {
-    confidenceThreshold: numericSetting(
-      "ATLAS_LEARN_CONFIDENCE_THRESHOLD",
+    confidenceThreshold: parseNumeric(
+      getSetting("ATLAS_LEARN_CONFIDENCE_THRESHOLD"),
       DEFAULT_PROMOTE_CONFIDENCE,
       0,
     ),
-    minRepetitions: numericSetting(
-      "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS",
+    minRepetitions: parseNumeric(
+      getSetting("ATLAS_LEARN_PROMOTE_MIN_REPETITIONS"),
       DEFAULT_PROMOTE_MIN_REPETITIONS,
       1,
     ),
-    latencyBudgetMs: numericSetting(
-      "ATLAS_LEARN_LATENCY_BUDGET_MS",
+    latencyBudgetMs: parseNumeric(
+      getSetting("ATLAS_LEARN_LATENCY_BUDGET_MS"),
       DEFAULT_LATENCY_BUDGET_MS,
       1,
     ),

--- a/packages/api/src/lib/learn/promote-decay.ts
+++ b/packages/api/src/lib/learn/promote-decay.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure promote/decay decision for learned query patterns (PRD #3617 B-2, #3636).
+ *
+ * This module holds NO I/O — it takes a snapshot of candidate rows, a set of
+ * thresholds, and the current time, and returns the ids to promote
+ * (pending → approved) and demote (approved → pending). Keeping the policy pure
+ * makes the gate and the decay window testable without the nightly fiber or a
+ * database; the scheduler (`promote-decay-scheduler.ts`) supplies the rows and
+ * applies the result.
+ *
+ * Scope is deliberately narrow:
+ *   - Only `query_pattern` rows are touched. `semantic_amendment` rows keep
+ *     human review (they rewrite YAML on approval) and are never auto-promoted.
+ *   - Decay only ever demotes rows the job itself promoted (`autoPromoted`),
+ *     never a human's explicit approval.
+ */
+
+/** Tunable gates for one promote/decay pass. */
+export interface PromoteDecayThresholds {
+  /** Minimum confidence (0–1) for a pending row to auto-promote. */
+  confidenceThreshold: number;
+  /** Minimum `repetition_count` for a pending row to auto-promote. */
+  minRepetitions: number;
+  /**
+   * Maximum `avg_duration_ms` for a pending row to auto-promote. A row whose
+   * latency was never measured (`avgDurationMs === null`) never clears this
+   * gate — we don't amplify a pattern whose speed we've never observed.
+   */
+  latencyBudgetMs: number;
+  /**
+   * An auto-promoted row unseen for longer than this window (ms) is demoted
+   * back to pending so the injected set stays fresh.
+   */
+  decayUnseenMs: number;
+}
+
+/** Minimal row shape the decision needs — a projection of `learned_patterns`. */
+export interface PromoteDecayCandidate {
+  id: string;
+  /** Row type; only `"query_pattern"` is ever acted on. */
+  type: string;
+  /** Lifecycle status: `"pending"` | `"approved"` | `"rejected"`. */
+  status: string;
+  confidence: number;
+  repetitionCount: number;
+  /** Rolling-mean wall-clock (ms), or null until first observed. */
+  avgDurationMs: number | null;
+  /** ISO timestamp the pattern was last observed running, or null. */
+  lastSeenAt: string | null;
+  /** Whether a prior pass auto-promoted this row. */
+  autoPromoted: boolean;
+}
+
+/** The ids to flip in each direction. */
+export interface PromoteDecayDecision {
+  /** Pending rows clearing the gate → set status `approved`, `auto_promoted`. */
+  promote: string[];
+  /** Stale auto-promoted approved rows → set status back to `pending`. */
+  demote: string[];
+}
+
+/** A finite, non-negative latency measurement we can compare to the budget. */
+function hasMeasuredLatency(avgDurationMs: number | null): avgDurationMs is number {
+  return avgDurationMs !== null && Number.isFinite(avgDurationMs) && avgDurationMs >= 0;
+}
+
+/** Whether a pending row clears every auto-promote gate. */
+function shouldPromote(p: PromoteDecayCandidate, t: PromoteDecayThresholds): boolean {
+  return (
+    p.type === "query_pattern" &&
+    p.status === "pending" &&
+    p.confidence >= t.confidenceThreshold &&
+    p.repetitionCount >= t.minRepetitions &&
+    hasMeasuredLatency(p.avgDurationMs) &&
+    p.avgDurationMs <= t.latencyBudgetMs
+  );
+}
+
+/** Whether an approved, machine-promoted row has gone stale past the window. */
+function shouldDemote(p: PromoteDecayCandidate, t: PromoteDecayThresholds, now: number): boolean {
+  if (p.type !== "query_pattern" || p.status !== "approved" || !p.autoPromoted) return false;
+  if (p.lastSeenAt === null) return false; // can't prove staleness without a timestamp
+  const seen = Date.parse(p.lastSeenAt);
+  if (Number.isNaN(seen)) return false; // unparseable → leave it alone
+  return now - seen > t.decayUnseenMs;
+}
+
+/**
+ * Partition candidate patterns into ids to promote and ids to demote.
+ *
+ * Pure: depends only on its inputs. `now` is epoch milliseconds (caller passes
+ * `Date.now()`) so the decay window is deterministic in tests.
+ */
+export function decidePromoteDecay(
+  patterns: readonly PromoteDecayCandidate[],
+  thresholds: PromoteDecayThresholds,
+  now: number,
+): PromoteDecayDecision {
+  const promote: string[] = [];
+  const demote: string[] = [];
+  for (const p of patterns) {
+    if (shouldPromote(p, thresholds)) promote.push(p.id);
+    else if (shouldDemote(p, thresholds, now)) demote.push(p.id);
+  }
+  return { promote, demote };
+}

--- a/packages/api/src/lib/learn/promote-decay.ts
+++ b/packages/api/src/lib/learn/promote-decay.ts
@@ -15,6 +15,11 @@
  *     never a human's explicit approval.
  */
 
+// Type-only import — erased at compile time, zero runtime coupling. Ties the
+// decision's `type`/`status` discriminants to the wire SSOT so the literal
+// comparisons below can't drift from the canonical value set.
+import type { LearnedPatternStatus, LearnedPatternType } from "@useatlas/types";
+
 /** Tunable gates for one promote/decay pass. */
 export interface PromoteDecayThresholds {
   /** Minimum confidence (0–1) for a pending row to auto-promote. */
@@ -38,9 +43,9 @@ export interface PromoteDecayThresholds {
 export interface PromoteDecayCandidate {
   id: string;
   /** Row type; only `"query_pattern"` is ever acted on. */
-  type: string;
-  /** Lifecycle status: `"pending"` | `"approved"` | `"rejected"`. */
-  status: string;
+  type: LearnedPatternType;
+  /** Lifecycle status. */
+  status: LearnedPatternStatus;
   confidence: number;
   repetitionCount: number;
   /** Rolling-mean wall-clock (ms), or null until first observed. */
@@ -64,25 +69,52 @@ function hasMeasuredLatency(avgDurationMs: number | null): avgDurationMs is numb
   return avgDurationMs !== null && Number.isFinite(avgDurationMs) && avgDurationMs >= 0;
 }
 
+/**
+ * Milliseconds since the pattern was last observed running, or `null` when
+ * there is no usable timestamp (never seen, or an unparseable value). A row
+ * `incrementPatternCount` has measured at least once carries both
+ * `avg_duration_ms` and `last_seen_at` (they're stamped together), so a row
+ * eligible on the latency gate will always have a usable timestamp here.
+ */
+function msSinceLastSeen(p: PromoteDecayCandidate, now: number): number | null {
+  if (p.lastSeenAt === null) return null;
+  const seen = Date.parse(p.lastSeenAt);
+  if (Number.isNaN(seen)) return null;
+  return now - seen;
+}
+
 /** Whether a pending row clears every auto-promote gate. */
-function shouldPromote(p: PromoteDecayCandidate, t: PromoteDecayThresholds): boolean {
-  return (
-    p.type === "query_pattern" &&
-    p.status === "pending" &&
-    p.confidence >= t.confidenceThreshold &&
-    p.repetitionCount >= t.minRepetitions &&
-    hasMeasuredLatency(p.avgDurationMs) &&
-    p.avgDurationMs <= t.latencyBudgetMs
-  );
+function shouldPromote(p: PromoteDecayCandidate, t: PromoteDecayThresholds, now: number): boolean {
+  if (
+    !(
+      p.type === "query_pattern" &&
+      p.status === "pending" &&
+      p.confidence >= t.confidenceThreshold &&
+      p.repetitionCount >= t.minRepetitions &&
+      hasMeasuredLatency(p.avgDurationMs) &&
+      p.avgDurationMs <= t.latencyBudgetMs
+    )
+  ) {
+    return false;
+  }
+  // Recency gate: a pattern unseen past the decay window must NOT be
+  // (re-)promoted until a fresh observation stamps `last_seen_at`. Without this,
+  // decay is futile — the other gates look only at cumulative confidence /
+  // repetition / rolling latency, none of which a decay-demote changes, so a
+  // stale-but-popular row demoted for going unseen would clear the gate again on
+  // the very next tick and flip approved → pending → approved forever (#3636
+  // review). Mirroring the demote window keeps "stale enough to demote" and
+  // "fresh enough to (re-)promote" as exact complements.
+  const sinceSeen = msSinceLastSeen(p, now);
+  return sinceSeen !== null && sinceSeen <= t.decayUnseenMs;
 }
 
 /** Whether an approved, machine-promoted row has gone stale past the window. */
 function shouldDemote(p: PromoteDecayCandidate, t: PromoteDecayThresholds, now: number): boolean {
   if (p.type !== "query_pattern" || p.status !== "approved" || !p.autoPromoted) return false;
-  if (p.lastSeenAt === null) return false; // can't prove staleness without a timestamp
-  const seen = Date.parse(p.lastSeenAt);
-  if (Number.isNaN(seen)) return false; // unparseable → leave it alone
-  return now - seen > t.decayUnseenMs;
+  const sinceSeen = msSinceLastSeen(p, now);
+  if (sinceSeen === null) return false; // can't prove staleness without a timestamp
+  return sinceSeen > t.decayUnseenMs;
 }
 
 /**
@@ -99,7 +131,7 @@ export function decidePromoteDecay(
   const promote: string[] = [];
   const demote: string[] = [];
   for (const p of patterns) {
-    if (shouldPromote(p, thresholds)) promote.push(p.id);
+    if (shouldPromote(p, thresholds, now)) promote.push(p.id);
     else if (shouldDemote(p, thresholds, now)) demote.push(p.id);
   }
   return { promote, demote };

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -631,6 +631,74 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_LEARN_RETRIEVAL_TURNS",
     scope: "workspace",
   },
+  // Workspace-scoped + hot-reloaded: read per-request via getSettingAuto in
+  // perf-weighted retrieval. The nightly auto-promote job reads the SAME key at
+  // platform scope (no orgId) for its latency gate, so a workspace override
+  // affects only retrieval down-weighting, not promotion.
+  {
+    key: "ATLAS_LEARN_LATENCY_BUDGET_MS",
+    section: "Dynamic Learning",
+    label: "Pattern Latency Budget (ms)",
+    description:
+      "Patterns whose average execution time stays at or under this budget rank normally in retrieval; slower patterns are down-weighted (never excluded). Also the default latency ceiling for nightly auto-promotion.",
+    type: "number",
+    default: "5000",
+    envVar: "ATLAS_LEARN_LATENCY_BUDGET_MS",
+    scope: "workspace",
+  },
+  // Nightly auto-promote/decay job (#3636). The enable + interval pair is a
+  // single process-global fiber forked once at boot (makeSchedulerLive), so
+  // they are PLATFORM-scoped + requiresRestart — mirrors the expert scheduler.
+  // The gate knobs below are read once per tick (no orgId), hence platform too.
+  {
+    key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
+    section: "Dynamic Learning",
+    label: "Auto-Promote / Decay Job",
+    description:
+      "Enable the nightly job that auto-promotes high-confidence, fast, frequently-seen learned patterns and demotes stale auto-promoted ones. Human approvals are never demoted; semantic amendments are never auto-promoted.",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
+    section: "Dynamic Learning",
+    label: "Auto-Promote / Decay Interval",
+    description: "Hours between nightly auto-promote/decay runs.",
+    type: "number",
+    default: "24",
+    envVar: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS",
+    section: "Dynamic Learning",
+    label: "Auto-Promote Min Repetitions",
+    description:
+      "Minimum times a pending pattern must have been seen before the nightly job will auto-promote it (alongside the confidence threshold and latency budget).",
+    type: "number",
+    default: "5",
+    envVar: "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_LEARN_DECAY_UNSEEN_DAYS",
+    section: "Dynamic Learning",
+    label: "Pattern Decay Window (days)",
+    description:
+      "An auto-promoted pattern unseen for longer than this many days is demoted back to pending so the injected set stays fresh. Human-approved patterns are never auto-demoted.",
+    type: "number",
+    default: "30",
+    envVar: "ATLAS_LEARN_DECAY_UNSEEN_DAYS",
+    scope: "platform",
+    saasVisible: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/learned-pattern.ts
+++ b/packages/types/src/learned-pattern.ts
@@ -73,4 +73,16 @@ export interface LearnedPattern {
   type: LearnedPatternType;
   /** Structured amendment payload (only for type='semantic_amendment'). */
   amendmentPayload: AmendmentPayload | null;
+  /**
+   * True when the nightly auto-promote/decay job promoted this row from
+   * pending → approved without human review (PRD #3617 B-2). Lets the admin UI
+   * mark machine-approved patterns distinct from human-approved ones.
+   */
+  autoPromoted: boolean;
+  /**
+   * Rolling-mean wall-clock execution time (ms) of the pattern's runs, or null
+   * until first observed (PRD #3617 B-0/B-2). Drives perf-weighted retrieval
+   * down-weighting and is surfaced to the agent in injected context.
+   */
+  avgDurationMs: number | null;
 }

--- a/packages/web/src/app/admin/learned-patterns/columns.tsx
+++ b/packages/web/src/app/admin/learned-patterns/columns.tsx
@@ -16,6 +16,8 @@ import {
   Bot,
   Calendar,
   Layers,
+  Sparkles,
+  Timer,
 } from "lucide-react";
 import { formatDate } from "@/lib/format";
 
@@ -37,6 +39,14 @@ export const statusBadge: Record<string, { variant: "outline"; className: string
     className: "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400",
     label: "Rejected",
   },
+};
+
+/** Distinct badge for a pattern the nightly job auto-approved — violet +
+ *  Sparkles, so machine approvals never read as a human "Approved" (#3636). */
+export const autoApprovedBadge = {
+  variant: "outline" as const,
+  className: "border-violet-300 text-violet-700 dark:border-violet-700 dark:text-violet-400",
+  label: "Auto-approved",
 };
 
 export const typeBadge: Record<string, { variant: "outline"; className: string; label: string }> = {
@@ -103,12 +113,21 @@ export function getLearnedPatternColumns(): ColumnDef<LearnedPattern>[] {
       ),
       cell: ({ row }) => {
         const status = row.getValue<string>("status");
+        // An auto-promoted approved row is shown distinct from a human approval.
+        if (status === "approved" && row.original.autoPromoted) {
+          return (
+            <Badge variant={autoApprovedBadge.variant} className={`${autoApprovedBadge.className} gap-1`}>
+              <Sparkles className="size-3" />
+              {autoApprovedBadge.label}
+            </Badge>
+          );
+        }
         const badge = statusBadge[status] ?? statusBadge.pending;
         return <Badge variant={badge.variant} className={badge.className}>{badge.label}</Badge>;
       },
       meta: { label: "Status", icon: CircleDot },
       enableSorting: false,
-      size: 100,
+      size: 130,
     },
     {
       id: "type",
@@ -203,6 +222,26 @@ export function getLearnedPatternColumns(): ColumnDef<LearnedPattern>[] {
       },
       meta: { label: "Confidence", icon: TrendingUp },
       size: 120,
+    },
+    {
+      id: "avgDurationMs",
+      accessorKey: "avgDurationMs",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Avg latency" />
+      ),
+      cell: ({ row }) => {
+        const ms = row.getValue<number | null>("avgDurationMs");
+        if (ms === null || ms === undefined) {
+          return <span className="text-xs text-muted-foreground">{"—"}</span>;
+        }
+        return (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {Math.round(ms).toLocaleString()}ms
+          </span>
+        );
+      },
+      meta: { label: "Avg latency", icon: Timer },
+      size: 96,
     },
     {
       id: "repetitionCount",

--- a/packages/web/src/app/admin/learned-patterns/page.tsx
+++ b/packages/web/src/app/admin/learned-patterns/page.tsx
@@ -5,7 +5,7 @@ import { useQueryStates } from "nuqs";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { LearnedPattern, LearnedPatternStatus } from "@/ui/lib/types";
 import { learnedPatternsSearchParams } from "./search-params";
-import { getLearnedPatternColumns, statusBadge } from "./columns";
+import { getLearnedPatternColumns, statusBadge, autoApprovedBadge } from "./columns";
 import { useAtlasConfig } from "@/ui/context";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
@@ -544,6 +544,13 @@ export default function LearnedPatternsPage() {
                   <SheetTitle className="flex items-center gap-2">
                     Learned Pattern
                     {(() => {
+                      if (detailPattern.status === "approved" && detailPattern.autoPromoted) {
+                        return (
+                          <Badge variant={autoApprovedBadge.variant} className={autoApprovedBadge.className}>
+                            {autoApprovedBadge.label}
+                          </Badge>
+                        );
+                      }
                       const badge = statusBadge[detailPattern.status] ?? statusBadge.pending;
                       return <Badge variant={badge.variant} className={badge.className}>{badge.label}</Badge>;
                     })()}
@@ -614,6 +621,14 @@ export default function LearnedPatternsPage() {
                     <div className="space-y-1">
                       <span className="text-xs font-medium text-muted-foreground">Times seen</span>
                       <p className="text-xs tabular-nums">{detailPattern.repetitionCount}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <span className="text-xs font-medium text-muted-foreground">Avg latency</span>
+                      <p className="text-xs tabular-nums">
+                        {detailPattern.avgDurationMs === null
+                          ? "—"
+                          : `${Math.round(detailPattern.avgDurationMs).toLocaleString()}ms`}
+                      </p>
                     </div>
                     <div className="space-y-1">
                       <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">


### PR DESCRIPTION
Closes #3636. Workstream B slice **B-2** of PRD #3617 (Performance-aware Atlas). **This is the final open slice of milestone v0.0.17 — merging it closes the milestone.**

Blockers all confirmed on `main` before starting: #3610/#3611 (cross-tenant leak fixes), #3631 B-0 latency columns, #3635 B-1 rolling-average latency.

## What this does

Makes the learned-pattern loop **prefer fast SQL** and **maintain itself**.

### 1. Performance-weighted retrieval (down-weight, not exclude)
- Pure `rankPatterns()` / `perfWeight()` in `pattern-cache.ts`: combined score = keyword overlap × a bounded latency weight (**floored at 0.5**, so a slow pattern is *reordered, never dropped*). Relevance still dominates — a much-more-relevant slow pattern outranks a barely-relevant fast one.
- `getApprovedPatterns` now selects `avg_duration_ms`; `RelevantPattern` carries it.
- Injected **organizational-knowledge context surfaces each pattern's average latency** (`avg ~123ms`) so the agent can judge cost.
- `ATLAS_LEARN_LATENCY_BUDGET_MS` (workspace-scoped) tunes the budget.

### 2. Nightly auto-promote / decay job
- **Pure decision function** `decidePromoteDecay(patterns, thresholds, now) → { promote[], demote[] }` (`learn/promote-decay.ts`) — all policy, zero I/O, tested directly against the gate and decay window.
- **`Layer.scoped`, env-gated fiber** in `layers.ts` modeled on the semantic-expert scheduler, ~24h tick. Promotes pending `query_pattern` rows clearing `confidence ≥ threshold AND repetition_count ≥ min AND avg_duration_ms ≤ budget` (an unmeasured-latency row is **not** promoted). Decay **demotes** (never deletes) auto-promoted rows unseen past a tunable window back to pending.
- **Human approvals are never auto-demoted; semantic amendments are never auto-promoted** (kept human-reviewed).
- New `learned_patterns.auto_promoted` column — migration `0138` + `schema.ts` mirror (additive, single-release-safe).
- Promotion/demotion key by `id` and never change `org_id`/`connection_group_id`, so a global candidate scan can't leak across tenants.
- All gate numbers, decay window, and latency budget are tunable via the **settings registry** (platform-scoped gate knobs, per the B-3 SaaS-first pattern), not new bespoke env handling.

### 3. Admin UI
- Auto-promoted patterns render a distinct **"Auto-approved"** (violet + Sparkles) badge — visually separate from human "Approved" — in both the table and detail sheet. New avg-latency column + detail field.

### 4. Docs
- `guides/semantic-expert.mdx` gains a **"Learned query patterns"** section (perf-weighting + the nightly job). Config + env-var references list the new knobs.

## Acceptance criteria
- [x] Retrieval down-weights slow patterns but keeps them present (pure-function ranking test)
- [x] Injected context surfaces each pattern's average latency
- [x] Promote/decay extracted as a pure `(patterns, thresholds, now) → {promote, demote}` and tested against gate + decay window
- [x] Nightly job wired as a `Layer.scoped`, env-gated fiber; tested env-gated with no top-level singleton mutation, modeled on the expert-scheduler tests
- [x] Auto-promoted patterns visually distinct in admin UI
- [x] Retrieval and promotion respect org **and** connection-group scoping (no cross-tenant leak)

## Testing
- New: `promote-decay.test.ts` (15), `promote-decay-scheduler.test.ts` (11), `pattern-ranking.test.ts` (10), plus org-knowledge latency assertions.
- Updated migration-count + scheduler-span assertions for the new migration/fiber.
- Type-check (api + web) and lint clean on all changed files. Affected suite green (the only failures were the migration-count/span assertions, now updated, plus two known parallel-run flakes that pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)