### PR TITLE
fix(profiler): durable partial-profile marker for incomplete semantic layers (#3682)

### DIFF
--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -86,6 +86,12 @@ bun run atlas -- init --org org-123 --no-import
 
 If more than 20% of tables fail to profile, `init` exits with an error — this usually indicates a systemic issue like wrong credentials or missing permissions. Use `--force` to override this threshold.
 
+### Partial profiles
+
+When _fewer_ than 20% of tables fail (or you pass `--force`), `init` continues with the tables it could profile — but it prints an unmissable warning naming the tables that are **NOT queryable** and are excluded from the generated semantic layer. A skipped table is usually a per-table permission gap; the agent will refuse questions about it (the SQL whitelist denies the absent table) rather than silently misroute. Fix the underlying access and re-run `init` to include the missing tables.
+
+The same partial-profile signal is recorded **durably** when profiling through the web wizard or the `profile_datasource` MCP tool (which persist to the org store): the publish flow surfaces the incomplete layers in its response before you make a degraded layer live, so the gap stays visible across restarts ([#3682](https://github.com/AtlasDevHQ/atlas/issues/3682)).
+
 In TTY mode (interactive terminal), `init` presents a table picker. Pass `--tables` to skip the picker for scripted/CI usage.
 
 **What it generates:**

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -14862,6 +14862,28 @@
                         "table_flags"
                       ]
                     }
+                  },
+                  "failedTables": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "table": {
+                          "type": "string"
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "table",
+                        "error"
+                      ]
+                    }
+                  },
+                  "totalTables": {
+                    "type": "integer",
+                    "minimum": 0
                   }
                 },
                 "required": [
@@ -54541,6 +54563,60 @@
                         "connections",
                         "entities",
                         "prompts"
+                      ]
+                    },
+                    "warnings": {
+                      "type": "object",
+                      "properties": {
+                        "incompleteLayers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "connectionGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "totalTables": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "failedCount": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "failedTables": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "table": {
+                                      "type": "string"
+                                    },
+                                    "error": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "table",
+                                    "error"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "connectionGroupId",
+                              "totalTables",
+                              "failedCount",
+                              "failedTables"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "incompleteLayers"
                       ]
                     }
                   },

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -517,6 +517,9 @@ export function createApiTestMocks(
     deleteDraftEntity: mock(() => Promise.resolve(false)),
     countEntities: mock(() => Promise.resolve(0)),
     bulkUpsertEntities: mock(() => Promise.resolve(0)),
+    // Durable partial-profile marker helpers (#3682) — default no-ops / empty.
+    upsertProfileStatus: mock(() => Promise.resolve()),
+    listIncompleteProfileLayers: mock(() => Promise.resolve([])),
     createVersion: mock(() => Promise.resolve("v1")),
     listVersions: mock(() => Promise.resolve({ versions: [], total: 0 })),
     getVersion: mock(() => Promise.resolve(null)),

--- a/packages/api/src/api/__tests__/admin-archive-restore.test.ts
+++ b/packages/api/src/api/__tests__/admin-archive-restore.test.ts
@@ -114,6 +114,8 @@ mock.module("@atlas/api/lib/settings", () => ({
 // cascade-ordering / COMMIT. Other entity helpers stay as no-ops because
 // this test file doesn't exercise them.
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   listEntityRows: mock(() => Promise.resolve([])),
   listEntities: mock(() => Promise.resolve([])),
   getEntity: mock(() => Promise.resolve(null)),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -150,6 +150,8 @@ mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
 }));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   listEntityRows: mock(() => Promise.resolve([])),
   listEntitiesWithOverlay: mock(() => Promise.resolve([])),
   listEntities: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -116,6 +116,10 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   deleteEntity: mock(() => Promise.resolve(false)),
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
+  // #3682 — durable partial-profile marker helpers. The publish route reads
+  // `listIncompleteProfileLayers` post-commit; default to no partial layers.
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   upsertDraftEntity: mock(() => Promise.resolve()),
   upsertTombstone: mock(() => Promise.resolve()),

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -37,6 +37,10 @@ interface MockClient {
 }
 
 let clientQueries: ClientQuery[] = [];
+// #3682 — drives `listIncompleteProfileLayers` per-test. Default: no partial
+// layers (the common case). Tests reassign it to return a partial layer or to
+// reject, exercising the post-commit warning + best-effort read paths.
+let incompleteLayersHandler: () => Promise<unknown[]> = async () => [];
 let clientReleased = false;
 // Captures the argument passed to `client.release(err?)`. node-postgres
 // destroys the socket when this is truthy — asserted for issue #1471.
@@ -119,7 +123,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   // #3682 — durable partial-profile marker helpers. The publish route reads
   // `listIncompleteProfileLayers` post-commit; default to no partial layers.
   upsertProfileStatus: mock(() => Promise.resolve()),
-  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
+  listIncompleteProfileLayers: mock(() => incompleteLayersHandler()),
   resolveGroupIdForConnection: mock(() => Promise.resolve(null)),
   upsertDraftEntity: mock(() => Promise.resolve()),
   upsertTombstone: mock(() => Promise.resolve()),
@@ -208,6 +212,7 @@ function resetClient(): void {
   queryHandler = async () => ({ rows: [] });
   demoIndustryFixture = null;
   throwOnGet = null;
+  incompleteLayersHandler = async () => [];
 }
 
 afterAll(() => {
@@ -901,5 +906,91 @@ describe("POST /api/v1/admin/publish — starter prompts phase (#1478)", () => {
     const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
     expect(sqls.includes("ROLLBACK")).toBe(true);
     expect(sqls.includes("COMMIT")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Durable partial-profile warning (#3682)
+//
+// The publish reads `listIncompleteProfileLayers` AFTER commit and surfaces
+// `warnings.incompleteLayers` so an admin who just promoted a silently-partial
+// layer sees the degraded state instead of an unconditional success. These
+// tests pin the user-visible contract: the warning is present when a layer is
+// partial, the key is OMITTED on a clean publish, and a post-commit read
+// failure must NOT turn an already-committed publish into a 500.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/publish — partial-profile warning (#3682)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.mockInternalQuery.mockResolvedValue([]);
+    resetClient();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("surfaces warnings.incompleteLayers when a promoted layer is partial", async () => {
+    incompleteLayersHandler = async () => [
+      {
+        connectionGroupId: "g_prod",
+        totalTables: 10,
+        failedCount: 1,
+        failedTables: [{ table: "locked", error: "permission denied" }],
+        profiledAt: "2026-06-16T00:00:00.000Z",
+      },
+    ];
+
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      warnings?: {
+        incompleteLayers: Array<{
+          connectionGroupId: string | null;
+          totalTables: number;
+          failedCount: number;
+          failedTables: Array<{ table: string; error: string }>;
+        }>;
+      };
+    };
+
+    expect(body.warnings?.incompleteLayers).toHaveLength(1);
+    const layer = body.warnings!.incompleteLayers[0]!;
+    expect(layer.connectionGroupId).toBe("g_prod");
+    expect(layer.totalTables).toBe(10);
+    expect(layer.failedCount).toBe(1);
+    expect(layer.failedTables).toEqual([{ table: "locked", error: "permission denied" }]);
+
+    // The warning is post-commit — the publish itself still succeeded.
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("COMMIT")).toBe(true);
+    expect(sqls.includes("ROLLBACK")).toBe(false);
+  });
+
+  it("omits the warnings key entirely on a clean publish (no partial layers)", async () => {
+    // resetClient() leaves incompleteLayersHandler returning [].
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    // Schema marks `warnings` optional and the route spreads `{}` when empty —
+    // assert the key is absent, not `{ incompleteLayers: [] }`, since the web
+    // client branches on its presence.
+    expect("warnings" in body).toBe(false);
+  });
+
+  it("does NOT 500 a committed publish when the marker read throws — warning omitted", async () => {
+    incompleteLayersHandler = async () => {
+      throw new Error("status table unavailable");
+    };
+
+    const res = await app.fetch(publishReq());
+    // The publish already committed; a post-commit read failure is best-effort
+    // and must be swallowed (logged) rather than failing the whole request.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect("warnings" in body).toBe(false);
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("COMMIT")).toBe(true);
+    expect(sqls.includes("ROLLBACK")).toBe(false);
   });
 });

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -179,6 +179,8 @@ mock.module("@atlas/api/lib/semantic", () => ({
 }));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   listEntityRows: mock(() => Promise.resolve([])),
   listEntitiesWithOverlay: mock(() => Promise.resolve([])),
   listEntities: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
@@ -142,6 +142,9 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
   bulkUpsertEntities: mockBulkUpsertEntities,
+  // #3682 — durable partial-profile marker helpers (wizard /save + publish read).
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   // #3234: the wizard resolves the connection's group before saving.
   resolveGroupIdForConnection: mock(async (_orgId: string, connectionId?: string | null) =>
     !connectionId || connectionId === "default" ? null : connectionId,

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -240,6 +240,8 @@ mock.module("@atlas/api/lib/semantic", () => ({
 }));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   listEntityRows: mock(() => Promise.resolve([])),
   listEntitiesWithOverlay: mock(() => Promise.resolve([])),
   listEntities: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -396,6 +396,8 @@ const { AmbiguousEntityError: RealAmbiguousEntityError } = await import(
 );
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   AmbiguousEntityError: RealAmbiguousEntityError,
   listEntityRows: mockListEntitiesAdmin,
   listEntitiesWithOverlay: mockListEntitiesWithOverlay,

--- a/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
@@ -156,6 +156,8 @@ mock.module("@atlas/api/lib/semantic", () => ({
 }));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
   bulkUpsertEntities: async () => 0,

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -130,6 +130,8 @@ const mockResolveGroupId: Mock<(orgId: string, connectionId?: string | null) => 
 );
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   // Constants the wizard route imports statically
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -121,6 +121,15 @@ const mockBulkUpsertEntities: Mock<(
   entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
 ) => Promise<number>> = mock(async (_orgId, entities) => entities.length);
 
+// #3682 — durable partial-profile marker write the wizard `/save` makes when the
+// client forwards `failedTables`. A module-level spy so tests can assert the
+// call args and drive a rejection (best-effort path).
+const mockUpsertProfileStatus: Mock<(
+  orgId: string,
+  connectionGroupId: string | null | undefined,
+  input: { totalTables: number; failedTables: Array<{ table: string; error: string }> },
+) => Promise<void>> = mock(async () => {});
+
 // Connection → Connection group resolver (#3234). The wizard scopes saved
 // entities by group: the default/unknown connection → NULL default group
 // (flat root), a non-default connection → its group (group-of-one stand-in
@@ -130,7 +139,7 @@ const mockResolveGroupId: Mock<(orgId: string, connectionId?: string | null) => 
 );
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
-  upsertProfileStatus: mock(() => Promise.resolve()),
+  upsertProfileStatus: mockUpsertProfileStatus,
   listIncompleteProfileLayers: mock(() => Promise.resolve([])),
   // Constants the wizard route imports statically
   DEMO_CONNECTION_ID: "__demo__",
@@ -1662,6 +1671,86 @@ describe("POST /api/v1/wizard/save", () => {
       entityType: "metric",
       name: "orders",
       connectionGroupId: "warehouse",
+    });
+  });
+
+  // ── #3682 — durable partial-profile marker on the wizard /save path ──
+  // The wizard persists via bulkUpsertEntities (not SemanticGenerator.persist),
+  // so it writes the marker directly when the client forwards the `/generate`
+  // failures. These pin the second acceptance criterion (wizard-path persistence).
+  describe("durable partial-profile marker (#3682)", () => {
+    beforeEach(() => {
+      mockUpsertProfileStatus.mockReset();
+      mockUpsertProfileStatus.mockImplementation(async () => {});
+      // Pin the resolver — an earlier test pins it to a constant group and
+      // never restores, so re-establish the default scope mapping here.
+      mockResolveGroupId.mockReset();
+      mockResolveGroupId.mockImplementation(async (_orgId, connectionId) =>
+        !connectionId || connectionId === "default" ? null : connectionId,
+      );
+    });
+
+    it("writes the marker with the forwarded failures + attempted total", async () => {
+      const res = await postJson("/api/v1/wizard/save", {
+        connectionId: "warehouse",
+        entities: [
+          { tableName: "users", yaml: "table: users\n" },
+          { tableName: "orders", yaml: "table: orders\n" },
+        ],
+        failedTables: [{ table: "locked", error: "permission denied" }],
+        totalTables: 3,
+      });
+      expect(res.status).toBe(201);
+
+      expect(mockUpsertProfileStatus).toHaveBeenCalledTimes(1);
+      const [orgIdArg, groupArg, inputArg] = mockUpsertProfileStatus.mock.calls[0];
+      expect(orgIdArg).toBe("org-1");
+      // Scoped by the resolved connection group (#3234), not the raw connectionId.
+      expect(groupArg).toBe("warehouse");
+      expect(inputArg.totalTables).toBe(3);
+      expect(inputArg.failedTables).toEqual([
+        { table: "locked", error: "permission denied" },
+      ]);
+    });
+
+    it("records completeness (empty failedTables) — clears a prior partial marker", async () => {
+      const res = await postJson("/api/v1/wizard/save", {
+        connectionId: "default",
+        entities: [{ tableName: "users", yaml: "table: users\n" }],
+        failedTables: [],
+        totalTables: 1,
+      });
+      expect(res.status).toBe(201);
+      // An empty failedTables write is what CLEARS a stale partial marker, so
+      // the marker is still written (not skipped).
+      expect(mockUpsertProfileStatus).toHaveBeenCalledTimes(1);
+      const [, groupArg, inputArg] = mockUpsertProfileStatus.mock.calls[0];
+      expect(groupArg).toBeNull(); // default group
+      expect(inputArg.failedTables).toEqual([]);
+    });
+
+    it("does not write the marker when failedTables is omitted (back-compat)", async () => {
+      const res = await postJson("/api/v1/wizard/save", {
+        connectionId: "warehouse",
+        entities: [{ tableName: "users", yaml: "table: users\n" }],
+      });
+      expect(res.status).toBe(201);
+      expect(mockUpsertProfileStatus).not.toHaveBeenCalled();
+    });
+
+    it("still returns 201 when the marker write throws (best-effort)", async () => {
+      mockUpsertProfileStatus.mockImplementationOnce(async () => {
+        throw new Error("status table unavailable");
+      });
+      const res = await postJson("/api/v1/wizard/save", {
+        connectionId: "warehouse",
+        entities: [{ tableName: "users", yaml: "table: users\n" }],
+        failedTables: [{ table: "locked", error: "permission denied" }],
+        totalTables: 2,
+      });
+      // Entities ARE persisted — a marker-write failure must not fail the save.
+      expect(res.status).toBe(201);
+      expect(mockUpsertProfileStatus).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -28,6 +28,7 @@ import { getInternalDB } from "@atlas/api/lib/db/internal";
 import { readDemoIndustry } from "@atlas/api/lib/demo-industry";
 import {
   archiveSingleConnection,
+  listIncompleteProfileLayers,
   DEMO_CONNECTION_ID,
 } from "@atlas/api/lib/semantic/entities";
 import { runHandler } from "@atlas/api/lib/effect/hono";
@@ -89,6 +90,29 @@ const PublishResponseSchema = z.object({
     entities: z.number().int().nonnegative(),
     prompts: z.number().int().nonnegative(),
   }),
+  /**
+   * Durable partial-profile warning (#3682). Present (non-empty) when the org
+   * has one or more semantic layers that were profiled INCOMPLETELY — some
+   * tables failed introspection below the abort threshold, so the layer is live
+   * with those tables NOT queryable. Surfaced here so an admin publishing the
+   * layer sees the degraded state instead of an unconditional success. Read from
+   * the durable `semantic_profile_status` marker, so it survives a restart and
+   * reflects layers profiled in any process. Omitted when no layer is partial.
+   */
+  warnings: z
+    .object({
+      incompleteLayers: z.array(
+        z.object({
+          connectionGroupId: z.string().nullable(),
+          totalTables: z.number().int().nonnegative(),
+          failedCount: z.number().int().nonnegative(),
+          failedTables: z.array(
+            z.object({ table: z.string(), error: z.string() }),
+          ),
+        }),
+      ),
+    })
+    .optional(),
 });
 
 export type PublishResponse = z.infer<typeof PublishResponseSchema>;
@@ -375,6 +399,37 @@ adminPublish.openapi(publishRoute, async (c) =>
       "Publish succeeded",
     );
 
+    // #3682 — surface any DURABLE partial-profile markers for the org. The
+    // publish just promoted these layers to `published`; if one was profiled
+    // incompletely (tables failed introspection below the abort threshold), it
+    // is now live with those tables NOT queryable. Read the marker AFTER commit
+    // so an admin sees the degraded state. Best-effort: a read failure must not
+    // turn an already-committed publish into a 500 — log and omit the warning.
+    let incompleteLayers: Awaited<ReturnType<typeof listIncompleteProfileLayers>> = [];
+    try {
+      incompleteLayers = await listIncompleteProfileLayers(orgId);
+    } catch (warnErr) {
+      log.warn(
+        {
+          requestId,
+          orgId,
+          err: warnErr instanceof Error ? warnErr.message : String(warnErr),
+        },
+        "Publish committed, but reading partial-profile markers failed — warning omitted",
+      );
+    }
+    if (incompleteLayers.length > 0) {
+      log.warn(
+        {
+          requestId,
+          orgId,
+          partialLayers: incompleteLayers.length,
+          groups: incompleteLayers.map((l) => l.connectionGroupId),
+        },
+        "Published one or more INCOMPLETE semantic layers — some tables are not queryable",
+      );
+    }
+
     const response: PublishResponse = {
       promoted: {
         connections: promotedConnectionCount,
@@ -388,6 +443,21 @@ adminPublish.openapi(publishRoute, async (c) =>
         entities: archivedEntityCount,
         prompts: archivedPromptCount,
       },
+      ...(incompleteLayers.length > 0
+        ? {
+            warnings: {
+              incompleteLayers: incompleteLayers.map((l) => ({
+                connectionGroupId: l.connectionGroupId,
+                totalTables: l.totalTables,
+                failedCount: l.failedCount,
+                failedTables: l.failedTables.map((f) => ({
+                  table: f.table,
+                  error: f.error,
+                })),
+              })),
+            },
+          }
+        : {}),
     };
     return c.json(response, 200);
   }),

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -28,6 +28,7 @@ import { _resetWhitelists, invalidateOrgWhitelist } from "@atlas/api/lib/semanti
 import {
   bulkUpsertEntities,
   resolveGroupIdForConnection,
+  upsertProfileStatus,
 } from "@atlas/api/lib/semantic/entities";
 import { syncEntityToDisk } from "@atlas/api/lib/semantic/sync";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -237,6 +238,14 @@ const SaveRequestSchema = z.object({
   // wizard frontend, which never sends `profiles`; defaults to "postgres".
   dbType: z.string().optional(),
   profiles: z.array(TableProfileSchema).optional(),
+  // #3682 — the per-table profiling failures the `/generate` step returned, plus
+  // the total tables ATTEMPTED. Forwarded by the wizard so a sub-threshold
+  // partial profile is durably marked incomplete (`semantic_profile_status`),
+  // visible to the publish flow. Optional: a client that omits them skips the
+  // marker (no behaviour change). An empty `failedTables` records completeness,
+  // which CLEARS a prior partial marker after a clean re-profile.
+  failedTables: z.array(z.object({ table: z.string(), error: z.string() })).optional(),
+  totalTables: z.number().int().nonnegative().optional(),
 });
 
 const SaveResponseSchema = z.object({
@@ -1101,6 +1110,32 @@ wizard.openapi(saveRoute, async (c) => {
           }, 500);
         }
         invalidateOrgWhitelist(orgId);
+
+        // #3682 — record the durable partial-profile marker when the wizard
+        // forwarded the `/generate` failures. The wizard path persists via
+        // `bulkUpsertEntities` (not `SemanticGenerator.persist`), so it writes
+        // the marker here directly. Best-effort: the entities ARE persisted, so
+        // a marker-write failure must not fail the save — log and continue.
+        if (body.failedTables !== undefined) {
+          const failedTables = body.failedTables;
+          yield* Effect.tryPromise({
+            try: () =>
+              upsertProfileStatus(orgId, connectionGroupId, {
+                totalTables: body.totalTables ?? entities.length + failedTables.length,
+                failedTables,
+              }),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(
+            Effect.catchAll((err) => {
+              log.error(
+                { err: err.message, requestId, orgId, connectionId, failedCount: failedTables.length },
+                "Wizard save: failed to record durable partial-profile marker — " +
+                  "entities persisted, marker skipped",
+              );
+              return Effect.void;
+            }),
+          );
+        }
       }
 
       // Disk writes happen after DB success. Output dir is org-scoped and

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -382,6 +382,7 @@ describe("migrateAuthTables", () => {
             { name: "0135_approval_rule_type_datasource.sql" },
             { name: "0136_mcp_action_policy_default_allowed.sql" },
             { name: "0137_learning_tables_performance_columns.sql" },
+            { name: "0138_semantic_profile_status.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -1225,6 +1225,15 @@ export async function profileLiveDatasource(opts: {
         connectionGroupId: conn.connectionGroupId,
         entities: result.entities,
         metrics: result.metrics,
+        // #3682 — durably mark the persisted layer incomplete when tables failed
+        // introspection below the abort threshold (so the layer landed with them
+        // ABSENT). `totalTables` is everything ATTEMPTED (profiled + failed);
+        // `failedTables` is already DSN-scrubbed by `profileImpl`. Recorded even
+        // when empty so a clean re-profile clears a prior partial marker.
+        profileStatus: {
+          totalTables: result.profiles.length + result.errors.length,
+          failedTables: result.errors,
+        },
       });
       gen.registerWhitelist(opts.connectionId, result.entities);
       return { result, persisted };

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -158,7 +158,9 @@ describe("runMigrations", () => {
     //   Plus 0136 (mcp_action_policy.status DEFAULT 'blocked'→'allowed', #3578) = 137.
     //   Plus 0137 (learned_patterns + query_suggestions latency/staleness
     //   columns, PRD #3617 B-0, #3631) = 138.
-    expect(count).toBe(138);
+    //   Plus 0138 (semantic_profile_status durable partial-profile marker,
+    //   #3682) = 139.
+    expect(count).toBe(139);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -325,6 +327,7 @@ describe("runMigrations", () => {
         "0135_approval_rule_type_datasource.sql",
         "0136_mcp_action_policy_default_allowed.sql",
         "0137_learning_tables_performance_columns.sql",
+        "0138_semantic_profile_status.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0138_semantic_profile_status.sql
+++ b/packages/api/src/lib/db/migrations/0138_semantic_profile_status.sql
@@ -58,8 +58,10 @@ CREATE TABLE IF NOT EXISTS semantic_profile_status (
 -- NULL-scope (default-group) row unique just like the `semantic_entities`
 -- partial indexes (migration 0063). Drizzle can't represent an expression index,
 -- so this is managed here in raw SQL and mirrored by a NON-unique placeholder
--- index in `db/schema.ts` purely to suppress drift — see the note there. The
--- `ON CONFLICT` target in `upsertProfileStatus` matches this expression exactly.
+-- index in `db/schema.ts` (same name) so `drizzle-kit generate` doesn't emit a
+-- spurious DROP/CREATE INDEX — see the note there. (check-schema-drift.sh only
+-- checks table presence, not indexes.) The `ON CONFLICT` target in
+-- `upsertProfileStatus` matches this expression exactly.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_semantic_profile_status_org_group
   ON semantic_profile_status (org_id, COALESCE(connection_group_id, '__default__'));
 

--- a/packages/api/src/lib/db/migrations/0138_semantic_profile_status.sql
+++ b/packages/api/src/lib/db/migrations/0138_semantic_profile_status.sql
@@ -1,0 +1,72 @@
+-- 0138 — durable partial-profile marker for generated semantic layers (#3682).
+--
+-- The universal profiler fails CLOSED above a 20% table-failure threshold
+-- (ProfilingFailedError reason `threshold_exceeded`), but BELOW it the failed
+-- tables are silently absent from the generated layer and the whitelist +
+-- persist proceed on the partial set. The operator/MCP client gets a success
+-- response; the per-table `errors[]` rides along transiently but nothing durable
+-- records that the persisted layer is INCOMPLETE — so after a restart (or in a
+-- different process: web `/chat` vs a stdio MCP server) the incompleteness is
+-- invisible, and the publish flow promotes a silently-partial layer.
+--
+-- This table is the durable signal: one row per (org, connection group) records
+-- how many tables were attempted, how many failed, and which ones — so the
+-- partial state survives a restart and is readable by the publish flow
+-- (`/api/v1/admin/publish` warns about the layers it just promoted) before an
+-- admin makes a degraded layer live.
+--
+-- NOT content-mode-managed: this is operator-facing DIAGNOSTIC metadata ABOUT a
+-- layer, not agent-queryable content that members see, so it intentionally stays
+-- out of `CONTENT_MODE_TABLES` (it carries no draft/published status and is never
+-- promoted by the publish transaction — the publish flow READS it, not promotes
+-- it). It is upserted in place on every (re)profile, so a clean re-profile after
+-- a permission fix clears a prior partial marker (`partial = false`).
+--
+-- Additive-only: a brand-new table, no constraint changes to existing tables,
+-- so it ships safely in a single release (the two-phase-drop discipline only
+-- governs DROP COLUMN / DROP TABLE). The Drizzle mirror in `db/schema.ts`
+-- (`semanticProfileStatus`) lands in the SAME PR so `check-schema-drift` stays
+-- green and the next `drizzle-kit generate` doesn't emit a DROP for this table.
+--
+-- Not Better-Auth-managed, so this file does NOT join MANAGED_AUTH_MIGRATIONS
+-- (db/internal.ts).
+--
+-- Idempotent: `CREATE TABLE IF NOT EXISTS` + `CREATE ... INDEX IF NOT EXISTS`
+-- are no-ops on re-run.
+
+CREATE TABLE IF NOT EXISTS semantic_profile_status (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL,
+  -- Group scope, mirroring `semantic_entities.connection_group_id`: NULL is the
+  -- flat default group. Uniqueness keys on COALESCE(.., '__default__') so the
+  -- NULL-scope row stays a single bucket (the GROUP_SCOPE_SENTINEL convention).
+  connection_group_id TEXT,
+  total_tables INTEGER NOT NULL,
+  failed_count INTEGER NOT NULL,
+  -- [{ "table": "<name>", "error": "<DSN-scrubbed message>" }]. Already scrubbed
+  -- at the profiler host boundary before it reaches here (#3579).
+  failed_tables JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- Denormalised `failed_count > 0` so the publish-flow read can filter on a
+  -- partial-row index without recomputing.
+  partial BOOLEAN NOT NULL,
+  profiled_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Natural key: one status row per (org, group). The COALESCE sentinel makes the
+-- NULL-scope (default-group) row unique just like the `semantic_entities`
+-- partial indexes (migration 0063). Drizzle can't represent an expression index,
+-- so this is managed here in raw SQL and mirrored by a NON-unique placeholder
+-- index in `db/schema.ts` purely to suppress drift — see the note there. The
+-- `ON CONFLICT` target in `upsertProfileStatus` matches this expression exactly.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_semantic_profile_status_org_group
+  ON semantic_profile_status (org_id, COALESCE(connection_group_id, '__default__'));
+
+-- The publish-flow read only ever wants the PARTIAL layers for an org; a partial
+-- index keeps that scan tiny even when most layers are complete.
+CREATE INDEX IF NOT EXISTS idx_semantic_profile_status_org_partial
+  ON semantic_profile_status (org_id) WHERE partial;
+
+COMMENT ON TABLE semantic_profile_status IS
+  'Durable partial-profile marker (#3682): one row per (org, connection group) recording how many tables were attempted vs. failed during the last profile, so a sub-threshold partial semantic layer is marked incomplete durably (survives restart) and is visible to the publish flow. Diagnostic metadata — NOT content-mode-managed.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -492,6 +492,42 @@ export const semanticEntities = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Semantic profile status (durable partial-profile marker, #3682)
+// ---------------------------------------------------------------------------
+
+export const semanticProfileStatus = pgTable(
+  "semantic_profile_status",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull(),
+    // NULL = flat default group; uniqueness keys on COALESCE(.., '__default__')
+    // via the raw-SQL expression index in migration 0138 (see placeholder note).
+    connectionGroupId: text("connection_group_id"),
+    totalTables: integer("total_tables").notNull(),
+    failedCount: integer("failed_count").notNull(),
+    // [{ table, error }] — DSN-scrubbed per-table profiling failures (#3579).
+    failedTables: jsonb("failed_tables").notNull().default(sql`'[]'::jsonb`),
+    partial: boolean("partial").notNull(),
+    profiledAt: timestamp("profiled_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // IMPORTANT: placeholder stub. The REAL natural-key index is UNIQUE on
+    // (org_id, COALESCE(connection_group_id, '__default__')) and is managed by
+    // raw SQL in migration 0138. Drizzle can't represent the COALESCE expression
+    // index, so this non-unique approximation carries the SAME NAME
+    // (`uq_semantic_profile_status_org_group`) as the real index purely to
+    // suppress drift — mirrors the `semantic_entities` 0063 pattern. The
+    // `ON CONFLICT` target in `upsertProfileStatus` keys on the expression, NOT
+    // this stub.
+    index("uq_semantic_profile_status_org_group").on(t.orgId, t.connectionGroupId),
+    // Real partial index from 0138 — the publish-flow read filters on `partial`.
+    index("idx_semantic_profile_status_org_partial").on(t.orgId).where(sql`partial`),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Semantic entity versions (version history for rollback + diff)
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -517,10 +517,14 @@ export const semanticProfileStatus = pgTable(
     // (org_id, COALESCE(connection_group_id, '__default__')) and is managed by
     // raw SQL in migration 0138. Drizzle can't represent the COALESCE expression
     // index, so this non-unique approximation carries the SAME NAME
-    // (`uq_semantic_profile_status_org_group`) as the real index purely to
-    // suppress drift — mirrors the `semantic_entities` 0063 pattern. The
-    // `ON CONFLICT` target in `upsertProfileStatus` keys on the expression, NOT
-    // this stub.
+    // (`uq_semantic_profile_status_org_group`) as the real index so the next
+    // `drizzle-kit generate` sees a name match and does NOT emit a spurious
+    // DROP/CREATE INDEX for it — mirrors the `semantic_entities` 0063 pattern.
+    // (Note: `check-schema-drift.sh` only diffs TABLE presence, not indexes, so
+    // the table mirror above is what keeps THAT guard green — the same-name stub
+    // is purely for drizzle-kit's index diff.) Never use Drizzle's query builder
+    // for ON CONFLICT on this table: the real target is the expression index and
+    // only exists in raw SQL — `upsertProfileStatus` keys on it, NOT this stub.
     index("uq_semantic_profile_status_org_group").on(t.orgId, t.connectionGroupId),
     // Real partial index from 0138 — the publish-flow read filters on `partial`.
     index("idx_semantic_profile_status_org_partial").on(t.orgId).where(sql`partial`),

--- a/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
+++ b/packages/api/src/lib/effect/__tests__/semantic-generator.test.ts
@@ -29,6 +29,7 @@ import {
   SemanticGeneratorLive,
   createSemanticGeneratorTestLayer,
   type DatasourceProfiler,
+  type ProfileStatusRecordFn,
 } from "../semantic-generator";
 import {
   getWhitelistedTables,
@@ -350,7 +351,7 @@ describe("SemanticGenerator.persist", () => {
         });
       }),
     );
-    expect(result).toEqual({ entitiesPersisted: 2, metricsPersisted: 1 });
+    expect(result).toEqual({ entitiesPersisted: 2, metricsPersisted: 1, partial: false });
     // Two upsert calls: one for entities, one for metrics — both scoped to the
     // group and typed correctly.
     expect(upsert.calls).toHaveLength(2);
@@ -378,7 +379,7 @@ describe("SemanticGenerator.persist", () => {
         });
       }),
     );
-    expect(result).toEqual({ entitiesPersisted: 1, metricsPersisted: 0 });
+    expect(result).toEqual({ entitiesPersisted: 1, metricsPersisted: 0, partial: false });
     expect(upsert.calls).toHaveLength(1); // entities only
     expect(upsert.calls[0].rows[0].connectionGroupId).toBeNull();
   });
@@ -428,6 +429,139 @@ describe("SemanticGenerator.persist", () => {
       expect(json).toContain("persist_error");
       expect(json).toContain("DB pool exhausted");
     }
+  });
+
+  // ── #3682 — durable partial-profile marker ─────────────────────────
+  // A sub-threshold partial profile (some tables failed introspection but
+  // stayed under the 20% abort threshold) persists with those tables ABSENT.
+  // The durable marker is what makes the incompleteness survive a restart and
+  // become visible to the publish flow — not just the transient `errors[]`.
+
+  type StatusCall = {
+    orgId: string;
+    connectionGroupId: string | null;
+    input: { totalTables: number; failedTables: ReadonlyArray<{ table: string; error: string }> };
+  };
+
+  /** A `upsertProfileStatus`-shaped fake that records its calls. */
+  function fakeRecordStatus(
+    behavior?: () => void,
+  ): ProfileStatusRecordFn & { calls: StatusCall[] } {
+    const fn = Object.assign(
+      (orgId: string, connectionGroupId: string | null, input: StatusCall["input"]) => {
+        fn.calls.push({ orgId, connectionGroupId, input });
+        if (behavior) behavior();
+        return Promise.resolve();
+      },
+      { calls: [] as StatusCall[] },
+    );
+    return fn;
+  }
+
+  it("records a durable partial marker when 1 of 10 tables failed", async () => {
+    const recordStatus = fakeRecordStatus();
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_partial",
+          connectionGroupId: "g_prod",
+          // 9 tables generated; 1 failed → 10 attempted, sub-threshold partial.
+          entities: Array.from({ length: 9 }, (_, i) => ({
+            table: `t${i}`,
+            fileName: `t${i}.yml`,
+            yaml: `table: t${i}`,
+          })),
+          profileStatus: {
+            totalTables: 10,
+            failedTables: [{ table: "locked_table", error: "permission denied" }],
+          },
+          upsert: fakeUpsert(),
+          recordStatus,
+        });
+      }),
+    );
+
+    // The persisted layer is flagged incomplete...
+    expect(result.partial).toBe(true);
+    expect(result.entitiesPersisted).toBe(9);
+    // ...and the durable marker was written with the failed table and the
+    // attempted total — the signal that survives restart / reaches publish.
+    expect(recordStatus.calls).toHaveLength(1);
+    const call = recordStatus.calls[0];
+    expect(call.orgId).toBe("org_partial");
+    expect(call.connectionGroupId).toBe("g_prod");
+    expect(call.input.totalTables).toBe(10);
+    expect(call.input.failedTables).toEqual([
+      { table: "locked_table", error: "permission denied" },
+    ]);
+  });
+
+  it("records a complete marker (partial=false) when no tables failed — clears a prior partial", async () => {
+    const recordStatus = fakeRecordStatus();
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_clean",
+          connectionGroupId: null,
+          entities: [{ table: "orders", fileName: "orders.yml", yaml: "table: orders" }],
+          profileStatus: { totalTables: 1, failedTables: [] },
+          upsert: fakeUpsert(),
+          recordStatus,
+        });
+      }),
+    );
+    expect(result.partial).toBe(false);
+    // Still recorded — an empty failedTables write is what CLEARS a stale
+    // partial marker after a fixed-permission re-profile.
+    expect(recordStatus.calls).toHaveLength(1);
+    expect(recordStatus.calls[0].input.failedTables).toEqual([]);
+  });
+
+  it("does not record any marker when profileStatus is omitted (back-compat)", async () => {
+    const recordStatus = fakeRecordStatus();
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_nostatus",
+          connectionGroupId: null,
+          entities: [{ table: "orders", fileName: "orders.yml", yaml: "table: orders" }],
+          upsert: fakeUpsert(),
+          recordStatus,
+        });
+      }),
+    );
+    expect(result.partial).toBe(false);
+    expect(recordStatus.calls).toHaveLength(0);
+  });
+
+  it("does NOT fail the persist when the marker write throws (entities already landed)", async () => {
+    const recordStatus = fakeRecordStatus(() => {
+      throw new Error("status table unavailable");
+    });
+    // The recorder throws synchronously inside the thunk → routed to the error
+    // channel → caught + logged, persist still succeeds (the layer is queryable).
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* SemanticGenerator;
+        return yield* svc.persist({
+          orgId: "org_marker_fail",
+          connectionGroupId: null,
+          entities: [{ table: "orders", fileName: "orders.yml", yaml: "table: orders" }],
+          profileStatus: {
+            totalTables: 2,
+            failedTables: [{ table: "x", error: "boom" }],
+          },
+          upsert: fakeUpsert(),
+          recordStatus,
+        });
+      }),
+    );
+    expect(result.entitiesPersisted).toBe(1);
+    expect(result.partial).toBe(true);
+    expect(recordStatus.calls).toHaveLength(1);
   });
 });
 

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -268,9 +268,13 @@ export interface PersistSemanticLayerResult {
   metricsPersisted: number;
   /**
    * Whether the persisted layer is INCOMPLETE — some tables failed introspection
-   * and are absent. Derived from `profileStatus.failedTables`; `false` when no
-   * `profileStatus` was supplied. Lets callers surface the partial state without
-   * re-deriving it from `errors[]`.
+   * and are absent. Derived from `profileStatus.failedTables`. NOTE the asymmetry:
+   * `false` means "verified complete" OR "not assessed" (no `profileStatus` was
+   * supplied) — it is NOT a guarantee of completeness. Every real call site
+   * supplies `profileStatus`, so in practice `false` ⇒ complete; a caller that
+   * needs to distinguish "complete" from "unknown" must check whether it passed
+   * `profileStatus`. Lets callers surface the partial state without re-deriving
+   * it from `errors[]`.
    */
   partial: boolean;
 }

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -55,7 +55,9 @@ import {
 import { registerPluginEntities, invalidateOrgWhitelist } from "@atlas/api/lib/semantic/whitelist";
 import {
   bulkUpsertEntities,
+  upsertProfileStatus,
   type SemanticEntityType,
+  type ProfileStatusInput,
 } from "@atlas/api/lib/semantic/entities";
 import { safeSemanticRowName } from "@atlas/api/lib/semantic/shapes";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
@@ -210,6 +212,17 @@ export type EntityUpsertFn = (
   }>,
 ) => Promise<number>;
 
+/**
+ * The durable partial-profile recorder {@link SemanticGeneratorShape.persist}
+ * delegates to. Matches {@link upsertProfileStatus} so the live path uses it
+ * verbatim; tests inject a fake to assert the marker without an internal DB.
+ */
+export type ProfileStatusRecordFn = (
+  orgId: string,
+  connectionGroupId: string | null,
+  input: ProfileStatusInput,
+) => Promise<void>;
+
 /** Inputs for {@link SemanticGeneratorShape.persist}. */
 export interface PersistSemanticLayerOptions {
   /** Workspace the generated rows belong to. */
@@ -226,10 +239,25 @@ export interface PersistSemanticLayerOptions {
   /** Generated metric artifacts (omitted profiles produce none). */
   metrics?: ReadonlyArray<GeneratedArtifact>;
   /**
+   * Durable partial-profile marker (#3682). When supplied, persist records a
+   * `semantic_profile_status` row so a sub-threshold partial profile (some
+   * tables failed introspection but stayed below the abort threshold, so the
+   * layer persisted with those tables ABSENT) is durably marked incomplete —
+   * surviving a restart and readable by the publish flow. Recorded on EVERY
+   * profile, so an empty `failedTables` writes `partial = false` and clears a
+   * prior partial marker. Omit to skip the marker entirely (back-compat).
+   */
+  profileStatus?: ProfileStatusInput;
+  /**
    * Upsert override for tests. Defaults to {@link bulkUpsertEntities} — the
    * content-mode-aware draft upsert the wizard `/save` + import endpoint use.
    */
   upsert?: EntityUpsertFn;
+  /**
+   * Partial-profile recorder override for tests. Defaults to
+   * {@link upsertProfileStatus}. Only consulted when `profileStatus` is set.
+   */
+  recordStatus?: ProfileStatusRecordFn;
 }
 
 /** Outcome of {@link SemanticGeneratorShape.persist}. */
@@ -238,6 +266,13 @@ export interface PersistSemanticLayerResult {
   entitiesPersisted: number;
   /** Metric rows successfully persisted (as drafts). */
   metricsPersisted: number;
+  /**
+   * Whether the persisted layer is INCOMPLETE — some tables failed introspection
+   * and are absent. Derived from `profileStatus.failedTables`; `false` when no
+   * `profileStatus` was supplied. Lets callers surface the partial state without
+   * re-deriving it from `errors[]`.
+   */
+  partial: boolean;
 }
 
 /** Outcome of {@link SemanticGeneratorShape.profileAndGenerate}. */
@@ -595,17 +630,55 @@ function persistImpl(
     // cross-surface contract; this just makes the SAME process see them now.
     invalidateOrgWhitelist(opts.orgId);
 
+    // #3682 — record the durable partial-profile marker. This is the deeper,
+    // restart-surviving signal behind the transient MCP `incomplete` flag: a
+    // sub-threshold partial layer persists with the failed tables ABSENT, so the
+    // marker is what makes the incompleteness visible to the publish flow later
+    // (and in a different process than the one that profiled). Recorded on EVERY
+    // profile so a clean re-profile writes `partial = false` and clears it.
+    //
+    // Advisory: the entities ARE already persisted (and queryable) at this point,
+    // so a marker-write failure must NOT fail the whole persist and report the
+    // layer un-generated. We log it loudly (never silently swallowed) and carry
+    // on — the worst case is a degraded layer that isn't flagged, not a lost one.
+    const partial = (opts.profileStatus?.failedTables.length ?? 0) > 0;
+    if (opts.profileStatus !== undefined) {
+      const record = opts.recordStatus ?? upsertProfileStatus;
+      const status = opts.profileStatus;
+      yield* Effect.tryPromise({
+        try: () => record(opts.orgId, opts.connectionGroupId, status),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => {
+          log.error(
+            {
+              orgId: opts.orgId,
+              connectionGroupId: opts.connectionGroupId,
+              failedCount: status.failedTables.length,
+              err: err.message,
+            },
+            "Failed to record durable partial-profile marker — entities persisted, " +
+              "marker skipped. The layer is queryable but its partial state may not " +
+              "surface to the publish flow until the next profile.",
+          );
+          return Effect.void;
+        }),
+      );
+    }
+
     log.info(
       {
         orgId: opts.orgId,
         connectionGroupId: opts.connectionGroupId,
         entitiesPersisted,
         metricsPersisted,
+        partial,
+        failedCount: opts.profileStatus?.failedTables.length ?? 0,
       },
       "Persisted generated semantic layer to the org store as drafts",
     );
 
-    return { entitiesPersisted, metricsPersisted } satisfies PersistSemanticLayerResult;
+    return { entitiesPersisted, metricsPersisted, partial } satisfies PersistSemanticLayerResult;
   });
 }
 

--- a/packages/api/src/lib/semantic/__tests__/profile-status.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/profile-status.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Durable partial-profile marker helpers (#3682).
+ *
+ * `upsertProfileStatus` writes the marker that makes a sub-threshold partial
+ * semantic layer durably incomplete; `listIncompleteProfileLayers` is the read
+ * the publish flow uses to warn before promoting a degraded layer. These tests
+ * pin the SQL contract (so the durable row survives a restart and the publish
+ * read finds it) and the row→shape mapping, mocking `db/internal` so no live DB
+ * is needed — matching the repo's `internalQuery`-spy pattern.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let mockHasDB = true;
+const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
+let nextRows: Record<string, unknown>[] = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasDB,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    dbCalls.push({ sql, params });
+    return nextRows;
+  },
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+}));
+
+const { upsertProfileStatus, listIncompleteProfileLayers } = await import(
+  "../entities"
+);
+
+beforeEach(() => {
+  mockHasDB = true;
+  dbCalls.length = 0;
+  nextRows = [];
+});
+
+describe("upsertProfileStatus", () => {
+  it("writes a partial marker (partial=true) keyed on the COALESCE sentinel", async () => {
+    await upsertProfileStatus("org_1", "g_prod", {
+      totalTables: 10,
+      failedTables: [{ table: "locked", error: "permission denied" }],
+    });
+
+    expect(dbCalls).toHaveLength(1);
+    const { sql, params } = dbCalls[0];
+    // Durable upsert keyed on (org_id, COALESCE(connection_group_id,'__default__'))
+    // so the row survives a restart and a re-profile updates it in place.
+    expect(sql).toContain("INSERT INTO semantic_profile_status");
+    expect(sql).toContain("ON CONFLICT (org_id, COALESCE(connection_group_id, '__default__'))");
+    expect(sql).toContain("DO UPDATE SET");
+    // org, group, totalTables, failedCount, json, partial
+    expect(params[0]).toBe("org_1");
+    expect(params[1]).toBe("g_prod");
+    expect(params[2]).toBe(10);
+    expect(params[3]).toBe(1); // failed_count
+    expect(JSON.parse(params[4] as string)).toEqual([
+      { table: "locked", error: "permission denied" },
+    ]);
+    expect(params[5]).toBe(true); // partial
+  });
+
+  it("writes a complete marker (partial=false) when no tables failed — clears a prior partial", async () => {
+    await upsertProfileStatus("org_1", null, { totalTables: 5, failedTables: [] });
+    const { params } = dbCalls[0];
+    expect(params[1]).toBeNull(); // default group
+    expect(params[3]).toBe(0); // failed_count
+    expect(params[5]).toBe(false); // partial cleared
+  });
+
+  it("normalizes an empty-string group to null (single default-scope bucket)", async () => {
+    await upsertProfileStatus("org_1", "", { totalTables: 1, failedTables: [] });
+    expect(dbCalls[0].params[1]).toBeNull();
+  });
+
+  it("throws when no internal DB is configured", async () => {
+    mockHasDB = false;
+    await expect(
+      upsertProfileStatus("org_1", null, { totalTables: 1, failedTables: [] }),
+    ).rejects.toThrow(/Internal DB required/);
+  });
+});
+
+describe("listIncompleteProfileLayers", () => {
+  it("filters to partial rows and maps them to the publish-flow shape", async () => {
+    nextRows = [
+      {
+        connection_group_id: null,
+        total_tables: 10,
+        failed_count: 2,
+        // pg returns jsonb already parsed.
+        failed_tables: [
+          { table: "a", error: "boom" },
+          { table: "b", error: "nope" },
+        ],
+        profiled_at: new Date("2026-06-16T00:00:00.000Z"),
+      },
+    ];
+
+    const layers = await listIncompleteProfileLayers("org_1");
+
+    // The read filters on `partial = true` in SQL — the publish-flow contract.
+    expect(dbCalls[0].sql).toContain("WHERE org_id = $1 AND partial = true");
+    expect(layers).toEqual([
+      {
+        connectionGroupId: null,
+        totalTables: 10,
+        failedCount: 2,
+        failedTables: [
+          { table: "a", error: "boom" },
+          { table: "b", error: "nope" },
+        ],
+        profiledAt: "2026-06-16T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("tolerates a malformed failed_tables payload (skips bad entries)", async () => {
+    nextRows = [
+      {
+        connection_group_id: "g",
+        total_tables: 3,
+        failed_count: 1,
+        failed_tables: [{ table: "ok", error: "x" }, { notATable: true }, "junk"],
+        profiled_at: "not-a-date",
+      },
+    ];
+    const layers = await listIncompleteProfileLayers("org_1");
+    expect(layers[0].failedTables).toEqual([{ table: "ok", error: "x" }]);
+    expect(layers[0].profiledAt).toBeNull();
+  });
+
+  it("returns [] when no internal DB is configured", async () => {
+    mockHasDB = false;
+    expect(await listIncompleteProfileLayers("org_1")).toEqual([]);
+    expect(dbCalls).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -1574,3 +1574,143 @@ export async function bulkUpsertEntities(
   }
   return upserted;
 }
+
+// ---------------------------------------------------------------------------
+// Durable partial-profile marker (#3682)
+// ---------------------------------------------------------------------------
+//
+// The profiler fails CLOSED above a 20% table-failure threshold, but BELOW it
+// the failed tables are silently absent from the generated layer while persist
+// proceeds on the partial set. `semantic_profile_status` records the durable
+// signal — how many tables were attempted vs. failed, for one (org, connection
+// group) — so a sub-threshold partial layer is marked incomplete in a way that
+// SURVIVES a restart and is readable by the publish flow before an admin makes
+// the degraded layer live. See migration 0138.
+
+/** One failed-table entry — the DSN-scrubbed shape the host surfaces (#3579). */
+export interface ProfileStatusFailedTable {
+  readonly table: string;
+  readonly error: string;
+}
+
+/** Inputs for {@link upsertProfileStatus}. */
+export interface ProfileStatusInput {
+  /** Total tables ATTEMPTED (profiled successfully + failed). */
+  readonly totalTables: number;
+  /** Per-table profiling failures below the abort threshold. Empty = complete. */
+  readonly failedTables: ReadonlyArray<ProfileStatusFailedTable>;
+}
+
+/**
+ * Upsert the durable partial-profile marker for one (org, connection group).
+ *
+ * Called on EVERY (re)profile — when `failedTables` is empty the row is written
+ * with `partial = false`, which CLEARS a prior partial marker (e.g. after a
+ * permission fix and a clean re-profile). Keyed on the same
+ * `COALESCE(connection_group_id, '__default__')` sentinel the `semantic_entities`
+ * partial unique indexes use, so the NULL-scope (default-group) row stays a
+ * single bucket.
+ */
+export async function upsertProfileStatus(
+  orgId: string,
+  connectionGroupId: string | null | undefined,
+  input: ProfileStatusInput,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for semantic profile status");
+  }
+  // Normalise undefined / "" → null so a "no scope" caller can't split rows
+  // across distinct buckets from genuinely NULL-scoped rows (mirrors
+  // `withGroupScope`).
+  const groupId = connectionGroupId == null || connectionGroupId === "" ? null : connectionGroupId;
+  const failedCount = input.failedTables.length;
+  await internalQuery(
+    `INSERT INTO semantic_profile_status
+       (org_id, connection_group_id, total_tables, failed_count, failed_tables, partial)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+     ON CONFLICT (org_id, ${coalescedScopeColumn(GROUP_COLUMN)})
+     DO UPDATE SET total_tables = EXCLUDED.total_tables,
+                   failed_count = EXCLUDED.failed_count,
+                   failed_tables = EXCLUDED.failed_tables,
+                   partial = EXCLUDED.partial,
+                   profiled_at = now(),
+                   updated_at = now()`,
+    [
+      orgId,
+      groupId,
+      input.totalTables,
+      failedCount,
+      JSON.stringify(input.failedTables.map((t) => ({ table: t.table, error: t.error }))),
+      failedCount > 0,
+    ],
+  );
+}
+
+/** A partial (incomplete) semantic layer surfaced to the publish flow (#3682). */
+export interface IncompleteProfileLayer {
+  /** `null` for the flat default group. */
+  readonly connectionGroupId: string | null;
+  readonly totalTables: number;
+  readonly failedCount: number;
+  readonly failedTables: ProfileStatusFailedTable[];
+  /** ISO-8601 timestamp of the profile that produced this marker. */
+  readonly profiledAt: string | null;
+}
+
+/**
+ * List the org's INCOMPLETE (partial) semantic layers — the durable read the
+ * publish flow uses to warn an admin that a layer they're about to publish is
+ * missing tables. Returns `[]` when no internal DB is configured.
+ */
+export async function listIncompleteProfileLayers(
+  orgId: string,
+): Promise<IncompleteProfileLayer[]> {
+  if (!hasInternalDB()) return [];
+  const rows = await internalQuery<{
+    connection_group_id: string | null;
+    total_tables: number;
+    failed_count: number;
+    failed_tables: unknown;
+    profiled_at: unknown;
+  }>(
+    `SELECT connection_group_id, total_tables, failed_count, failed_tables, profiled_at
+       FROM semantic_profile_status
+      WHERE org_id = $1 AND partial = true
+      ORDER BY connection_group_id NULLS FIRST`,
+    [orgId],
+  );
+  return rows.map((r) => ({
+    connectionGroupId: r.connection_group_id ?? null,
+    totalTables: Number(r.total_tables),
+    failedCount: Number(r.failed_count),
+    failedTables: normalizeFailedTables(r.failed_tables),
+    profiledAt: profiledAtToIso(r.profiled_at),
+  }));
+}
+
+/** Coerce a jsonb `failed_tables` value (pg returns it parsed) to the typed shape. */
+function normalizeFailedTables(value: unknown): ProfileStatusFailedTable[] {
+  if (!Array.isArray(value)) return [];
+  const out: ProfileStatusFailedTable[] = [];
+  for (const item of value) {
+    if (item && typeof item === "object") {
+      const rec = item as Record<string, unknown>;
+      const table = typeof rec.table === "string" ? rec.table : null;
+      const error = typeof rec.error === "string" ? rec.error : "";
+      if (table) out.push({ table, error });
+    }
+  }
+  return out;
+}
+
+/** `timestamptz` (Date or string from pg) → ISO-8601, or null when unparseable. */
+function profiledAtToIso(value: unknown): string | null {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+  }
+  return null;
+}

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -1624,6 +1624,12 @@ export async function upsertProfileStatus(
   // `withGroupScope`).
   const groupId = connectionGroupId == null || connectionGroupId === "" ? null : connectionGroupId;
   const failedCount = input.failedTables.length;
+  // `totalTables` is "attempted" (profiled + failed), so it can never be fewer
+  // than the failures we're recording. The wizard path forwards a CLIENT-supplied
+  // count (validated only `nonnegative()` at the route boundary), so clamp at the
+  // write boundary to keep `failed_count > total_tables` — a nonsensical
+  // "N of M failed" with N > M — unrepresentable for every caller (#3682).
+  const totalTables = Math.max(input.totalTables, failedCount);
   await internalQuery(
     `INSERT INTO semantic_profile_status
        (org_id, connection_group_id, total_tables, failed_count, failed_tables, partial)
@@ -1638,7 +1644,7 @@ export async function upsertProfileStatus(
     [
       orgId,
       groupId,
-      input.totalTables,
+      totalTables,
       failedCount,
       JSON.stringify(input.failedTables.map((t) => ({ table: t.table, error: t.error }))),
       failedCount > 0,
@@ -1652,7 +1658,7 @@ export interface IncompleteProfileLayer {
   readonly connectionGroupId: string | null;
   readonly totalTables: number;
   readonly failedCount: number;
-  readonly failedTables: ProfileStatusFailedTable[];
+  readonly failedTables: ReadonlyArray<ProfileStatusFailedTable>;
   /** ISO-8601 timestamp of the profile that produced this marker. */
   readonly profiledAt: string | null;
 }
@@ -1665,7 +1671,16 @@ export interface IncompleteProfileLayer {
 export async function listIncompleteProfileLayers(
   orgId: string,
 ): Promise<IncompleteProfileLayer[]> {
-  if (!hasInternalDB()) return [];
+  if (!hasInternalDB()) {
+    // Not silent: a caller that needs a hard guarantee (rather than "no DB ⇒
+    // assume nothing partial") should gate on `hasInternalDB()` itself. Log so
+    // the "couldn't check because no DB" branch is visible, not a quiet [].
+    log.warn(
+      { orgId },
+      "listIncompleteProfileLayers: no internal DB — returning [] (partial-profile markers are unreadable without a DB)",
+    );
+    return [];
+  }
   const rows = await internalQuery<{
     connection_group_id: string | null;
     total_tables: number;
@@ -1679,13 +1694,27 @@ export async function listIncompleteProfileLayers(
       ORDER BY connection_group_id NULLS FIRST`,
     [orgId],
   );
-  return rows.map((r) => ({
-    connectionGroupId: r.connection_group_id ?? null,
-    totalTables: Number(r.total_tables),
-    failedCount: Number(r.failed_count),
-    failedTables: normalizeFailedTables(r.failed_tables),
-    profiledAt: profiledAtToIso(r.profiled_at),
-  }));
+  return rows.map((r) => {
+    const failedCount = Number(r.failed_count);
+    const failedTables = normalizeFailedTables(r.failed_tables);
+    // `failed_tables` is written by `upsertProfileStatus` from a typed, scrubbed
+    // shape, so a mismatch with the denormalised `failed_count` means the JSONB
+    // payload was corrupted or written out-of-band — surface it rather than
+    // silently rendering "N tables failed" with fewer than N named.
+    if (failedTables.length !== failedCount) {
+      log.warn(
+        { orgId, connectionGroupId: r.connection_group_id, failedCount, recovered: failedTables.length },
+        "Partial-profile marker: failed_count disagrees with the failed_tables payload — possible corruption",
+      );
+    }
+    return {
+      connectionGroupId: r.connection_group_id ?? null,
+      totalTables: Number(r.total_tables),
+      failedCount,
+      failedTables,
+      profiledAt: profiledAtToIso(r.profiled_at),
+    };
+  });
 }
 
 /** Coerce a jsonb `failed_tables` value (pg returns it parsed) to the typed shape. */

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -641,8 +641,20 @@ async function profileDatasource(
           `Use --force to continue anyway.`,
       );
     }
+    // Sub-threshold partial profile (#3682): the failed tables are SILENTLY
+    // absent from the generated layer unless we say so plainly. Make the
+    // consequence unmissable — the agent will not be able to query them.
+    const notQueryable = profilingErrors.map((e) => e.table);
+    const namePreview = notQueryable.slice(0, 10).join(", ");
     console.warn(
-      `Continuing with ${profiles.length} successfully profiled tables.\n`,
+      `\n⚠  ${profilingErrors.length} of ${totalAttempted} table(s) are NOT queryable — ` +
+        `they failed introspection and are EXCLUDED from the generated semantic layer:\n` +
+        `     ${namePreview}${notQueryable.length > 10 ? `, … (+${notQueryable.length - 10} more)` : ""}\n` +
+        `   Fix the underlying access (often a per-table permission gap) and re-run ` +
+        `\`atlas init\` to include them.`,
+    );
+    console.warn(
+      `Continuing with ${profiles.length} successfully profiled table(s).\n`,
     );
   }
 

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -891,7 +891,16 @@ export function registerDatasourceTools(
             // those tables ABSENT. `profiling_errors` alone reads as a side
             // note next to an unconditional success; `incomplete` makes the
             // degraded layer unmissable to the MCP client before it publishes.
+            // When persisted, this transient flag is also recorded DURABLY in
+            // `semantic_profile_status` (#3682) so the publish flow surfaces it
+            // even after a restart / from the web `/chat` process.
             incomplete: r.errors.length > 0,
+            // The specific tables that are NOT queryable — name them so the
+            // client/agent can tell the user exactly what is missing rather than
+            // just a count. Errors are DSN-scrubbed upstream.
+            ...(r.errors.length > 0
+              ? { incomplete_tables: r.errors.map((e) => e.table) }
+              : {}),
             elapsed_ms: r.elapsedMs,
           });
         },

--- a/packages/web/src/app/wizard/page.tsx
+++ b/packages/web/src/app/wizard/page.tsx
@@ -44,6 +44,7 @@ import {
 import { cn } from "@/lib/utils";
 import type {
   ConnectionInfo,
+  ProfileError,
   WizardTableEntry,
   WizardEntityResult,
   WizardEnrichResult,
@@ -112,16 +113,13 @@ function ErrorBanner({ error }: { error: WizardError }) {
   );
 }
 
-/** A table that failed introspection during profiling (#3682). */
-type ProfilingError = { table: string; error: string };
-
 /**
  * Warn that some tables could NOT be profiled and will be ABSENT from the saved
  * semantic layer — the agent won't be able to query them (#3682). The `/generate`
  * step returns these below the fatal threshold; surfacing them here makes the
  * partial state unmissable before the user saves and publishes.
  */
-function PartialProfileBanner({ errors }: { errors: ProfilingError[] }) {
+function PartialProfileBanner({ errors }: { errors: ProfileError[] }) {
   if (errors.length === 0) return null;
   const preview = errors.slice(0, 5);
   return (
@@ -649,8 +647,8 @@ function StepReview({
   onBack: () => void;
   entities: WizardEntityResult[];
   setEntities: Dispatch<SetStateAction<WizardEntityResult[]>>;
-  profilingErrors: ProfilingError[];
-  setProfilingErrors: Dispatch<SetStateAction<ProfilingError[]>>;
+  profilingErrors: ProfileError[];
+  setProfilingErrors: Dispatch<SetStateAction<ProfileError[]>>;
   ignored: Set<string>;
   setIgnored: Dispatch<SetStateAction<Set<string>>>;
   saving: boolean;
@@ -699,7 +697,7 @@ function StepReview({
         // #3682 — capture the sub-threshold per-table failures so the review
         // step warns about them and the save forwards them as the durable
         // partial-profile marker.
-        setProfilingErrors((data.errors ?? []) as ProfilingError[]);
+        setProfilingErrors((data.errors ?? []) as ProfileError[]);
         const yamlMap: Record<string, string> = {};
         for (const entity of generated) yamlMap[entity.tableName] = entity.yaml;
         setEditingYaml(yamlMap);
@@ -1427,7 +1425,7 @@ export default function WizardPage() {
   const [entities, setEntities] = useState<WizardEntityResult[]>([]);
   // #3682 — sub-threshold per-table profiling failures from `/generate`; lifted
   // so the save step can forward them as the durable partial-profile marker.
-  const [profilingErrors, setProfilingErrors] = useState<ProfilingError[]>([]);
+  const [profilingErrors, setProfilingErrors] = useState<ProfileError[]>([]);
   // Tables excluded from enrichment AND from the final save (§ D). Pre-seeded in
   // StepReview from the profiler's possibly-abandoned signal; user-adjustable.
   const [ignored, setIgnored] = useState<Set<string>>(new Set());

--- a/packages/web/src/app/wizard/page.tsx
+++ b/packages/web/src/app/wizard/page.tsx
@@ -72,6 +72,7 @@ import {
 } from "./wizard-enrich";
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowRight,
   Ban,
   CheckCircle2,
@@ -106,6 +107,48 @@ function ErrorBanner({ error }: { error: WizardError }) {
             requestId: {error.requestId}
           </p>
         )}
+      </div>
+    </div>
+  );
+}
+
+/** A table that failed introspection during profiling (#3682). */
+type ProfilingError = { table: string; error: string };
+
+/**
+ * Warn that some tables could NOT be profiled and will be ABSENT from the saved
+ * semantic layer — the agent won't be able to query them (#3682). The `/generate`
+ * step returns these below the fatal threshold; surfacing them here makes the
+ * partial state unmissable before the user saves and publishes.
+ */
+function PartialProfileBanner({ errors }: { errors: ProfilingError[] }) {
+  if (errors.length === 0) return null;
+  const preview = errors.slice(0, 5);
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+    >
+      <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="font-medium">
+          {errors.length} {errors.length === 1 ? "table" : "tables"} could not be profiled and{" "}
+          {errors.length === 1 ? "is" : "are"} NOT queryable
+        </p>
+        <p className="opacity-90">
+          These tables failed introspection (often a permission gap) and are excluded from the
+          generated layer. Fix access and re-run the wizard to include them.
+        </p>
+        <ul className="list-disc space-y-0.5 pl-4 font-mono text-[11px] opacity-80">
+          {preview.map((e) => (
+            <li key={e.table}>
+              {e.table}: {e.error}
+            </li>
+          ))}
+          {errors.length > preview.length && (
+            <li>… and {errors.length - preview.length} more</li>
+          )}
+        </ul>
       </div>
     </div>
   );
@@ -591,6 +634,8 @@ function StepReview({
   onBack,
   entities,
   setEntities,
+  profilingErrors,
+  setProfilingErrors,
   ignored,
   setIgnored,
   saving,
@@ -604,6 +649,8 @@ function StepReview({
   onBack: () => void;
   entities: WizardEntityResult[];
   setEntities: Dispatch<SetStateAction<WizardEntityResult[]>>;
+  profilingErrors: ProfilingError[];
+  setProfilingErrors: Dispatch<SetStateAction<ProfilingError[]>>;
   ignored: Set<string>;
   setIgnored: Dispatch<SetStateAction<Set<string>>>;
   saving: boolean;
@@ -649,6 +696,10 @@ function StepReview({
         const data = await res.json();
         const generated = (data.entities ?? []) as WizardEntityResult[];
         setEntities(generated);
+        // #3682 — capture the sub-threshold per-table failures so the review
+        // step warns about them and the save forwards them as the durable
+        // partial-profile marker.
+        setProfilingErrors((data.errors ?? []) as ProfilingError[]);
         const yamlMap: Record<string, string> = {};
         for (const entity of generated) yamlMap[entity.tableName] = entity.yaml;
         setEditingYaml(yamlMap);
@@ -913,6 +964,7 @@ function StepReview({
       <CardContent className="space-y-3">
         {saveError && <ErrorBanner error={saveError} />}
         {enrichError && <ErrorBanner error={enrichError} />}
+        <PartialProfileBanner errors={profilingErrors} />
 
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-muted/20 p-3">
           <div className="min-w-0 space-y-0.5">
@@ -1373,6 +1425,9 @@ export default function WizardPage() {
   const [connectionId, setConnectionId] = useState(params.connectionId || "");
   const [selectedTables, setSelectedTables] = useState<string[]>([]);
   const [entities, setEntities] = useState<WizardEntityResult[]>([]);
+  // #3682 — sub-threshold per-table profiling failures from `/generate`; lifted
+  // so the save step can forward them as the durable partial-profile marker.
+  const [profilingErrors, setProfilingErrors] = useState<ProfilingError[]>([]);
   // Tables excluded from enrichment AND from the final save (§ D). Pre-seeded in
   // StepReview from the profiler's possibly-abandoned signal; user-adjustable.
   const [ignored, setIgnored] = useState<Set<string>>(new Set());
@@ -1389,6 +1444,7 @@ export default function WizardPage() {
   // The ignore list is regenerated from the fresh profile, so clear it too.
   function goBackFromReview() {
     setEntities([]);
+    setProfilingErrors([]);
     setIgnored(new Set());
     goTo(2);
   }
@@ -1406,6 +1462,11 @@ export default function WizardPage() {
         body: JSON.stringify({
           connectionId,
           entities: entitiesToSave.map((e) => ({ tableName: e.tableName, yaml: e.yaml })),
+          // #3682 — forward the sub-threshold profiling failures so the saved
+          // layer is durably marked incomplete (visible to the publish flow).
+          // `totalTables` is everything ATTEMPTED: generated entities + failures.
+          failedTables: profilingErrors,
+          totalTables: entities.length + profilingErrors.length,
         }),
       });
       if (!res.ok) {
@@ -1467,6 +1528,8 @@ export default function WizardPage() {
           credentials={credentials}
           entities={entities}
           setEntities={setEntities}
+          profilingErrors={profilingErrors}
+          setProfilingErrors={setProfilingErrors}
           ignored={ignored}
           setIgnored={setIgnored}
           onNext={() => {

--- a/packages/web/src/ui/components/admin/publish-modal.tsx
+++ b/packages/web/src/ui/components/admin/publish-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
   Database,
@@ -12,6 +12,7 @@ import {
   Plus,
   Trash2,
   AlertCircle,
+  AlertTriangle,
 } from "lucide-react";
 import {
   Dialog,
@@ -25,7 +26,27 @@ import { Button } from "@/components/ui/button";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
+import type { ProfileError } from "@/ui/lib/types";
 import { relativeOrNull } from "./pending-changes-pill";
+
+/**
+ * A semantic layer that was profiled INCOMPLETELY — some tables failed
+ * introspection below the abort threshold, so the published layer is missing
+ * them (#3682). Mirrors `warnings.incompleteLayers[]` in the `/api/v1/admin/publish`
+ * response. Surfaced after a publish so an admin sees the degraded state rather
+ * than an unconditional success.
+ */
+interface IncompleteLayer {
+  readonly connectionGroupId: string | null;
+  readonly totalTables: number;
+  readonly failedCount: number;
+  readonly failedTables: ReadonlyArray<ProfileError>;
+}
+
+/** Parsed `/api/v1/admin/publish` response — only the field this modal reads. */
+interface PublishResponseData {
+  readonly warnings?: { readonly incompleteLayers: ReadonlyArray<IncompleteLayer> };
+}
 
 interface DraftRow {
   readonly id: string;
@@ -67,22 +88,41 @@ export function PublishModal({
     { enabled: open },
   );
 
-  const { mutate, saving, error: publishError, reset } = useAdminMutation<unknown>({
+  const { mutate, saving, error: publishError, reset } = useAdminMutation<PublishResponseData>({
     path: "/api/v1/admin/publish",
     method: "POST",
   });
 
-  // Reset error state whenever the modal opens — a previous failed attempt
+  // Layers the publish just promoted that are profiled INCOMPLETELY (#3682).
+  // Non-empty keeps the modal open with a warning instead of a silent success.
+  const [incompleteLayers, setIncompleteLayers] = useState<ReadonlyArray<IncompleteLayer>>([]);
+
+  // Reset error + warning state whenever the modal opens — a previous attempt
   // shouldn't leave a banner showing the next time the admin opens the modal.
   useEffect(() => {
-    if (open) reset();
+    if (open) {
+      reset();
+      setIncompleteLayers([]);
+    }
   }, [open, reset]);
 
   async function handlePublish() {
     const result = await mutate({ body: {} });
     if (result.ok) {
-      toast.success("Published successfully");
-      onOpenChange(false);
+      // The publish committed. If any promoted layer is incomplete, keep the
+      // modal open and show the durable warning the API returned (#3682) — an
+      // unconditional "Published successfully" would hide that some tables are
+      // now live but NOT queryable. Otherwise close as before.
+      const layers = result.data?.warnings?.incompleteLayers ?? [];
+      if (layers.length > 0) {
+        setIncompleteLayers(layers);
+        toast.warning(
+          `Published, but ${layers.length === 1 ? "a layer is" : `${layers.length} layers are`} incomplete`,
+        );
+      } else {
+        toast.success("Published successfully");
+        onOpenChange(false);
+      }
     }
     // On failure, leave modal open — the banner below surfaces the error.
   }
@@ -150,29 +190,90 @@ export function PublishModal({
           </div>
         )}
 
+        {incompleteLayers.length > 0 && (
+          <IncompleteLayersBanner layers={incompleteLayers} />
+        )}
+
         <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={saving}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handlePublish}
-            disabled={saving || loading || total === 0}
-          >
-            {saving ? (
-              <>
-                <Loader2 className="mr-2 size-4 animate-spin" /> Publishing…
-              </>
-            ) : (
-              <>Publish all{total > 0 ? ` (${total})` : ""}</>
-            )}
-          </Button>
+          {incompleteLayers.length > 0 ? (
+            // Publish already committed; collapse the footer to a single
+            // acknowledge action so the warning above is read before closing.
+            <Button onClick={() => onOpenChange(false)}>Done</Button>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handlePublish}
+                disabled={saving || loading || total === 0}
+              >
+                {saving ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" /> Publishing…
+                  </>
+                ) : (
+                  <>Publish all{total > 0 ? ` (${total})` : ""}</>
+                )}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * Warns that the publish promoted one or more INCOMPLETE semantic layers —
+ * tables that failed introspection are now live but NOT queryable (#3682). Read
+ * from the durable `semantic_profile_status` marker, so it surfaces even when the
+ * layer was profiled in a different process (web `/chat` vs a stdio MCP server).
+ */
+function IncompleteLayersBanner({
+  layers,
+}: {
+  layers: ReadonlyArray<IncompleteLayer>;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+    >
+      <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <div className="min-w-0 space-y-1">
+        <p className="font-medium">
+          Published, but {layers.length === 1 ? "a layer is" : `${layers.length} layers are`}{" "}
+          incomplete
+        </p>
+        <p className="opacity-90">
+          Some tables failed introspection (often a permission gap) and are excluded from the
+          live semantic layer — the agent can&apos;t query them. Fix access and re-profile to
+          include them.
+        </p>
+        <ul className="space-y-1">
+          {layers.map((layer) => (
+            <li key={layer.connectionGroupId ?? "__default__"}>
+              <span className="font-medium">
+                {layer.connectionGroupId ?? "default"}
+              </span>{" "}
+              — {layer.failedCount} of {layer.totalTables} not queryable:
+              <span className="font-mono text-[11px] opacity-80">
+                {" "}
+                {layer.failedTables.slice(0, 5).map((t) => t.table).join(", ")}
+                {layer.failedTables.length > 5
+                  ? `, … (+${layer.failedTables.length - 5} more)`
+                  : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
   );
 }
 

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -63,6 +63,7 @@ export type {
   PromptIndustry,
   QuerySuggestion,
   ObjectType,
+  ProfileError,
   WizardEntityColumn,
   WizardEnrichResult,
   WizardEntityResult,


### PR DESCRIPTION
Closes #3682.

## Problem

A sub-20% partial profile (some tables fail introspection below the `FAILURE_THRESHOLD = 0.2` abort threshold) persisted as a **complete success**: failed tables were silently absent from the generated layer while the whitelist + persist proceeded on the partial set. The only signal — the transient `result.errors[]` — was gated on by nothing, and no durable marker recorded that the layer was incomplete. After a restart (or in a different process than the one that profiled — web `/chat` vs a stdio MCP server) the incompleteness was invisible, and the publish flow promoted a silently-partial layer. The MCP `incomplete: errors.length > 0` flag added by the audit PR was a transient stop-gap; this is the deeper, durable signal.

## Change

- **New `semantic_profile_status` table** (migration `0138` + Drizzle mirror): one row per `(org, connection group)` recording tables attempted vs. failed, plus the DSN-scrubbed failed set. Upserted in place on every (re)profile, so a clean re-profile writes `partial = false` and **clears** a prior partial marker. It is diagnostic metadata about a layer — intentionally **not** content-mode managed (the publish flow *reads* it, never promotes it).
- **`upsertProfileStatus` / `listIncompleteProfileLayers`** helpers (`semantic/entities.ts`), keyed on the same `COALESCE(connection_group_id, '__default__')` sentinel as `semantic_entities`.
- **`SemanticGenerator.persist`** writes the marker (injectable `recordStatus`; advisory — a marker-write failure logs loudly but never fails an already-persisted, queryable layer) and returns `partial`. **`profileLiveDatasource`** (the MCP durable path) threads the failed tables + attempted total into persist.
- **`/api/v1/admin/publish`** reads the marker post-commit and returns `warnings.incompleteLayers` — the durable "visible to the publish flow" signal that survives restarts and reflects layers profiled in any process.
- **Surfaced before publish on every surface:** MCP `profile_datasource` adds `incomplete_tables`; the wizard `/save` accepts + persists the marker and the web review step warns before save/publish; the CLI `init` prints an unmissable "N tables NOT queryable" warning.

## Acceptance criteria

- [x] Sub-threshold partial profile durably marked incomplete (survives restart / visible to publish), not just transient `errors[]`
- [x] Wizard, CLI, and MCP all surface the partial state before publish
- [x] Tests cover a profile with 1 failed table out of 10 persisting with the incomplete marker set

## Testing

- `semantic-generator.test.ts`: persist records the marker for **1-failed-of-10**; clears at 0 failed; skips when omitted; survives a thrown recorder (layer still persists).
- `profile-status.test.ts`: pins the durable SQL contract (`ON CONFLICT` upsert + `partial = true`-only read + malformed-payload tolerance).
- Migration + `ON CONFLICT` upsert + clear-on-reprofile validated against **live Postgres** (NULL-group bucket collapses to one row; partial read returns 0 after a clean re-profile).
- Green locally: `type`, `lint`, `syncpack lint`, `check-schema-drift`, `check-template-drift`, published-symbol / unpublished-version guards, affected API suite, web wizard suite. (One unrelated `admin-model-config` catalog test is flaky under parallel load — re-ran green.)