### PR TITLE
fix(api): address full-release review findings for v0.0.17

### DIFF
--- a/packages/api/src/api/__tests__/audit-slow-pg.test.ts
+++ b/packages/api/src/api/__tests__/audit-slow-pg.test.ts
@@ -18,7 +18,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test"
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
-import { buildSlowQuerySql } from "../routes/admin-audit";
+import { buildSlowQuerySql, buildFrequentQuerySql, buildUserStatsQuerySql } from "../routes/admin-audit";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -133,6 +133,96 @@ describeIfPg("/analytics/slow aggregate (real Postgres, #3616)", () => {
       expect(rows[1].query).toBe("SELECT * FROM mid_table");
       expect(rows[2].query).toBe("SELECT * FROM zero_only");
       expect(Number(rows[2].avg_duration)).toBe(0);
+    },
+    PG_TIMEOUT_MS,
+  );
+});
+
+/**
+ * The `/analytics/frequent` and `/analytics/users` aggregates carry the SAME
+ * `duration_ms > 0` FILTER (#3616) — the original fix only patched `/slow`, so
+ * the sibling endpoints still skewed their averages with zero-duration rows.
+ * These run the exact production builders against real Postgres.
+ */
+describeIfPg("/analytics/frequent + /users avg duration filter (real Postgres, #3616)", () => {
+  let pool: Pool;
+  const schemaName = `freq_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`audit-freq-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query("TRUNCATE audit_log CASCADE");
+  });
+
+  async function insertAudit(sqlText: string, durationMs: number): Promise<void> {
+    await pool.query(
+      `INSERT INTO audit_log (auth_mode, sql, duration_ms, success, org_id)
+       VALUES ('none', $1, $2, true, $3)`,
+      [sqlText, durationMs, ORG],
+    );
+  }
+
+  it(
+    "frequent: avg_duration excludes zero-duration rows; count keeps them",
+    async () => {
+      await insertAudit("SELECT * FROM t", 3000);
+      await insertAudit("SELECT * FROM t", 1500);
+      await insertAudit("SELECT * FROM t", 0); // fanout parent — excluded from AVG only
+
+      const { rows } = await pool.query<{ count: string; avg_duration: string }>(
+        buildFrequentQuerySql(WHERE),
+        [ORG],
+      );
+      expect(rows).toHaveLength(1);
+      expect(Number(rows[0].count)).toBe(3); // all rows counted (count-ranked)
+      expect(Number(rows[0].avg_duration)).toBe(2250); // not 1500
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "frequent: an all-zero prefix COALESCEs avg_duration to 0, not NULL",
+    async () => {
+      await insertAudit("SELECT now()", 0);
+      await insertAudit("SELECT now()", 0);
+      const { rows } = await pool.query<{ avg_duration: string }>(buildFrequentQuerySql(WHERE), [ORG]);
+      expect(rows[0].avg_duration).not.toBeNull();
+      expect(Number(rows[0].avg_duration)).toBe(0);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "users: avg_duration excludes zero-duration rows; count keeps them",
+    async () => {
+      await insertAudit("SELECT 1", 4000);
+      await insertAudit("SELECT 1", 2000);
+      await insertAudit("SELECT 1", 0); // excluded from AVG only
+
+      const { rows } = await pool.query<{ count: string; avg_duration: string }>(
+        buildUserStatsQuerySql(WHERE),
+        [ORG],
+      );
+      // All three rows have NULL user_id → one 'anonymous' bucket.
+      expect(rows).toHaveLength(1);
+      expect(Number(rows[0].count)).toBe(3);
+      expect(Number(rows[0].avg_duration)).toBe(3000); // (4000+2000)/2, not /3
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/api/__tests__/audit-slow-pg.test.ts
+++ b/packages/api/src/api/__tests__/audit-slow-pg.test.ts
@@ -158,6 +158,10 @@ describeIfPg("/analytics/frequent + /users avg duration filter (real Postgres, #
     });
     await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
     await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // buildUserStatsQuerySql LEFT JOINs "user" (email lookup). That table is
+    // created by a Better-Auth-managed migration, which the skip-list above
+    // excludes — so stub a minimal one for the JOIN to resolve.
+    await pool.query(`CREATE TABLE IF NOT EXISTS "user" (id text PRIMARY KEY, email text)`);
   }, PG_TIMEOUT_MS);
 
   afterAll(async () => {

--- a/packages/api/src/api/routes/admin-audit.ts
+++ b/packages/api/src/api/routes/admin-audit.ts
@@ -86,6 +86,40 @@ export function buildSlowQuerySql(whereClause: string): string {
    ORDER BY AVG(duration_ms) FILTER (WHERE duration_ms > 0) DESC NULLS LAST LIMIT 20`;
 }
 
+/**
+ * SQL for `/analytics/frequent` — top 20 query prefixes by execution count.
+ *
+ * Same `duration_ms > 0` FILTER as {@link buildSlowQuerySql} (#3616): the avg
+ * here is a secondary stat on a count-ranked list, but zero-duration housekeeping
+ * rows would skew it identically, so it must use the same filter for consistency.
+ * Exported so the real-PG test exercises the exact production SQL (no drift).
+ */
+export function buildFrequentQuerySql(whereClause: string): string {
+  return `SELECT LEFT(sql, 200) as query, COUNT(*) as count,
+          COALESCE(ROUND(AVG(duration_ms) FILTER (WHERE duration_ms > 0)), 0) as avg_duration,
+          COUNT(*) FILTER (WHERE NOT success) as error_count
+   FROM audit_log ${whereClause}
+   GROUP BY LEFT(sql, 200) ORDER BY COUNT(*) DESC LIMIT 20`;
+}
+
+/**
+ * SQL for `/analytics/users` — top 50 users by execution count, with per-user
+ * average duration. Same `duration_ms > 0` FILTER as {@link buildSlowQuerySql}
+ * (#3616) on the `a.duration_ms` alias. Exported so the real-PG test runs the
+ * exact production SQL (the JOIN + alias make a duplicated string drift-prone).
+ */
+export function buildUserStatsQuerySql(whereClause: string): string {
+  return `SELECT COALESCE(a.user_id, 'anonymous') as user_id, u.email as user_email,
+          COUNT(*) as count,
+          COALESCE(ROUND(AVG(a.duration_ms) FILTER (WHERE a.duration_ms > 0)), 0) as avg_duration,
+          COUNT(*) FILTER (WHERE NOT a.success) as error_count
+   FROM audit_log a
+   LEFT JOIN "user" u ON a.user_id = u.id
+   ${whereClause}
+   GROUP BY COALESCE(a.user_id, 'anonymous'), u.email
+   ORDER BY COUNT(*) DESC LIMIT 50`;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -487,11 +521,7 @@ adminAudit.openapi(auditFrequentRoute, async (c) => {
     const rows = yield* queryEffect<{
       query: string; count: string; avg_duration: string; error_count: string;
     }>(
-      `SELECT LEFT(sql, 200) as query, COUNT(*) as count,
-              ROUND(AVG(duration_ms)) as avg_duration,
-              COUNT(*) FILTER (WHERE NOT success) as error_count
-       FROM audit_log ${range.where}
-       GROUP BY LEFT(sql, 200) ORDER BY COUNT(*) DESC LIMIT 20`,
+      buildFrequentQuerySql(range.where),
       range.params,
     );
 
@@ -546,14 +576,7 @@ adminAudit.openapi(auditUsersRoute, async (c) => {
       user_id: string; user_email: string | null; count: string;
       avg_duration: string; error_count: string;
     }>(
-      `SELECT COALESCE(a.user_id, 'anonymous') as user_id, u.email as user_email,
-              COUNT(*) as count, ROUND(AVG(a.duration_ms)) as avg_duration,
-              COUNT(*) FILTER (WHERE NOT a.success) as error_count
-       FROM audit_log a
-       LEFT JOIN "user" u ON a.user_id = u.id
-       ${range.where}
-       GROUP BY COALESCE(a.user_id, 'anonymous'), u.email
-       ORDER BY COUNT(*) DESC LIMIT 50`,
+      buildUserStatsQuerySql(range.where),
       range.params,
     );
 

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -24,6 +24,7 @@ import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 import { getConfig } from "@atlas/api/lib/config";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
+import { getUserRole } from "@atlas/api/lib/auth/permissions";
 import type { PluginStatus } from "@atlas/api/lib/plugins/registry";
 
 // Canonical plugin lifecycle states for the /health wire format. The
@@ -187,7 +188,12 @@ async function isOperatorHealthRequest(req: Request): Promise<boolean> {
     const auth = await authenticateRequest(req);
     if (!auth.authenticated) return false;
     if (auth.mode === "none") return true;
-    return !!auth.user.role && OPERATOR_ROLES.has(auth.user.role);
+    // Resolve the EFFECTIVE role, not the raw field: simple-key auth leaves
+    // `user.role` undefined unless ATLAS_API_KEY_ROLE is set, and the documented
+    // `admin` default is applied by getUserRole (AUTH_MODE_DEFAULT_ROLE), not
+    // stamped on the user. Reading the raw field treated the common self-hosted
+    // operator (bare ATLAS_API_KEY) as anonymous, stripping the fleet view (#3685).
+    return OPERATOR_ROLES.has(getUserRole(auth.user));
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -90,7 +90,7 @@ describe("pattern-proposer", () => {
     // First query: findPatternBySQL SELECT
     expect(queryCalls.length).toBeGreaterThanOrEqual(1);
     const selectCall = queryCalls[0];
-    expect(selectCall.sql).toContain("SELECT id, confidence, repetition_count FROM learned_patterns");
+    expect(selectCall.sql).toContain("SELECT id, confidence, repetition_count, status FROM learned_patterns");
     expect(selectCall.params?.[0]).toBeTypeOf("string"); // normalized SQL
 
     // Second query: insertLearnedPattern INSERT (fire-and-forget via internalExecute)
@@ -124,6 +124,32 @@ describe("pattern-proposer", () => {
     expect(updateCall!.sql).toContain("repetition_count = repetition_count + 1");
     expect(updateCall!.sql).toContain("LEAST(1.0, confidence + 0.1)");
     expect(updateCall!.params?.[0]).toBe("existing-123");
+  });
+
+  test("leaves a REJECTED match frozen — no bump, no duplicate insert (#3636)", async () => {
+    // findPatternBySQL returns a match whose status is 'rejected'. Repeat
+    // traffic must neither bump it nor insert a fresh pending duplicate.
+    setResults({
+      rows: [
+        { id: "rejected-1", confidence: 0.9, repetition_count: 12, status: "rejected" },
+      ],
+    });
+
+    await _analyzeAndPropose(defaultInput);
+
+    // Only the findPatternBySQL SELECT ran — no UPDATE, no INSERT.
+    expect(queryCalls.length).toBe(1);
+    expect(queryCalls[0].sql).toContain("SELECT id, confidence, repetition_count, status");
+    expect(queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"))).toBeUndefined();
+    expect(queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"))).toBeUndefined();
+  });
+
+  test("incrementPatternCount UPDATE never touches a rejected row (backstop #3636)", () => {
+    enableInternalDB();
+    incrementPatternCount("pat-rej", "fp-1", 100);
+    const updateCall = queryCalls.find((c) => c.sql.includes("UPDATE learned_patterns SET"));
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.sql).toContain("status <> 'rejected'");
   });
 
   // ── Org-scoping ────────────────────────────────────────────────────

--- a/packages/api/src/lib/__tests__/profiler-index-harvest-unit.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-index-harvest-unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * DB-free unit coverage for the index-harvest helpers (#3634).
+ *
+ * The live-DB tests (`profiler-index-harvest-pg.test.ts`,
+ * `profiler-index-harvest-mysql.test.ts`) `describe.skip` unless
+ * `TEST_DATABASE_URL` / `TEST_MYSQL_URL` are set — and there is no MySQL
+ * container in CI — so the catalog queries and their row→IndexProfile mapping
+ * had no guaranteed CI coverage. These stub the pool's `query`/`execute` so the
+ * version-branch column selection (PG `indnkeyatts` vs `indnatts`) and the
+ * MySQL functional-key-part skipping run on every CI pass.
+ */
+import { describe, test, expect } from "bun:test";
+import { queryPostgresIndexes, queryMySQLIndexes } from "@atlas/api/lib/profiler";
+
+// ---------------------------------------------------------------------------
+// Postgres
+// ---------------------------------------------------------------------------
+
+/** Minimal pg.Pool stub that records the SQL it was handed and returns canned rows. */
+function makePgPool(rows: unknown[]) {
+  const calls: string[] = [];
+  const pool = {
+    query: async (sql: string) => {
+      calls.push(sql);
+      return { rows };
+    },
+  };
+  return { pool: pool as unknown as import("pg").Pool, calls };
+}
+
+describe("queryPostgresIndexes — version branch (C2)", () => {
+  test("PG 11+ counts key columns via indnkeyatts (excludes INCLUDE/covering cols)", async () => {
+    const { pool, calls } = makePgPool([]);
+    await queryPostgresIndexes(pool, "orders", "public", 110000);
+    expect(calls[0]).toContain("ix.indnkeyatts");
+    expect(calls[0]).not.toContain("ix.indnatts AS key_count");
+  });
+
+  test("pre-11 / unknown server falls back to the portable indnatts", async () => {
+    const { pool, calls } = makePgPool([]);
+    await queryPostgresIndexes(pool, "orders", "public", 100000);
+    expect(calls[0]).toContain("ix.indnatts");
+    expect(calls[0]).not.toContain("indnkeyatts");
+
+    const { pool: pool0, calls: calls0 } = makePgPool([]);
+    await queryPostgresIndexes(pool0, "orders", "public", 0); // version undetected
+    expect(calls0[0]).toContain("ix.indnatts");
+    expect(calls0[0]).not.toContain("indnkeyatts");
+  });
+});
+
+describe("queryPostgresIndexes — row mapping", () => {
+  test("orders columns, normalizes type, and nulls the predicate on non-partial indexes", async () => {
+    const { pool } = makePgPool([
+      {
+        index_name: "orders_pkey",
+        index_type: "btree",
+        is_unique: true,
+        is_primary: true,
+        is_partial: false,
+        predicate: null,
+        key_defs: ["id"],
+      },
+      {
+        index_name: "orders_customer_created_idx",
+        index_type: "btree",
+        is_unique: false,
+        is_primary: false,
+        is_partial: true,
+        predicate: "(status = 'active'::text)",
+        // generate_series ordering preserved; blank/whitespace members dropped.
+        key_defs: ["customer_id", "  created_at  ", ""],
+      },
+    ]);
+
+    const indexes = await queryPostgresIndexes(pool, "orders", "public", 110000);
+    expect(indexes).toHaveLength(2);
+
+    const pk = indexes[0];
+    expect(pk.is_primary).toBe(true);
+    expect(pk.is_unique).toBe(true);
+    expect(pk.is_partial).toBe(false);
+    expect(pk.predicate).toBeNull();
+
+    const composite = indexes[1];
+    // Leading-prefix order preserved; trimmed; empty member filtered out.
+    expect(composite.columns).toEqual(["customer_id", "created_at"]);
+    expect(composite.is_partial).toBe(true);
+    expect(composite.predicate).toBe("(status = 'active'::text)");
+  });
+
+  test("a partial-flag-false row drops a stray predicate (defensive)", async () => {
+    const { pool } = makePgPool([
+      {
+        index_name: "i",
+        index_type: "gin",
+        is_unique: false,
+        is_primary: false,
+        is_partial: false,
+        predicate: "(x > 0)", // present but is_partial=false → must be nulled
+        key_defs: ["doc"],
+      },
+    ]);
+    const [idx] = await queryPostgresIndexes(pool, "t", "public", 110000);
+    expect(idx.predicate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/** Minimal mysql2 pool stub: `execute` returns the [rows, fields] tuple. */
+function makeMySqlPool(rows: unknown[]) {
+  return {
+    execute: async (): Promise<[unknown[], unknown]> => [rows, undefined],
+  };
+}
+
+describe("queryMySQLIndexes — functional/expression key parts (C3)", () => {
+  test("skips null COLUMN_NAME parts; a wholly-functional index drops out", async () => {
+    const pool = makeMySqlPool([
+      // A normal composite index.
+      { INDEX_NAME: "idx_a", COLUMN_NAME: "x", SEQ_IN_INDEX: 1, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+      { INDEX_NAME: "idx_a", COLUMN_NAME: "y", SEQ_IN_INDEX: 2, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+      // A wholly-functional index — every part has a null COLUMN_NAME.
+      { INDEX_NAME: "idx_fn", COLUMN_NAME: null, SEQ_IN_INDEX: 1, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+    ]);
+
+    const indexes = await queryMySQLIndexes(pool, "orders");
+    // idx_fn drops out entirely; only idx_a survives with both columns in order.
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0].name).toBe("idx_a");
+    expect(indexes[0].columns).toEqual(["x", "y"]);
+    expect(indexes[0].is_unique).toBe(false); // NON_UNIQUE=1
+  });
+
+  test("PRIMARY is is_primary+is_unique; NON_UNIQUE=0 is unique", async () => {
+    const pool = makeMySqlPool([
+      { INDEX_NAME: "PRIMARY", COLUMN_NAME: "id", SEQ_IN_INDEX: 1, NON_UNIQUE: 0, INDEX_TYPE: "BTREE" },
+      { INDEX_NAME: "uq_email", COLUMN_NAME: "email", SEQ_IN_INDEX: 1, NON_UNIQUE: 0, INDEX_TYPE: "BTREE" },
+    ]);
+    const indexes = await queryMySQLIndexes(pool, "users");
+    const pk = indexes.find((i) => i.name === "PRIMARY")!;
+    expect(pk.is_primary).toBe(true);
+    expect(pk.is_unique).toBe(true);
+    const uq = indexes.find((i) => i.name === "uq_email")!;
+    expect(uq.is_primary).toBe(false);
+    expect(uq.is_unique).toBe(true);
+  });
+
+  test("an index with one functional part among real columns keeps the real columns", async () => {
+    const pool = makeMySqlPool([
+      { INDEX_NAME: "idx_mix", COLUMN_NAME: "a", SEQ_IN_INDEX: 1, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+      { INDEX_NAME: "idx_mix", COLUMN_NAME: null, SEQ_IN_INDEX: 2, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+      { INDEX_NAME: "idx_mix", COLUMN_NAME: "b", SEQ_IN_INDEX: 3, NON_UNIQUE: 1, INDEX_TYPE: "BTREE" },
+    ]);
+    const [idx] = await queryMySQLIndexes(pool, "t");
+    expect(idx.columns).toEqual(["a", "b"]);
+  });
+});

--- a/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
@@ -43,8 +43,14 @@ interface StatusRow {
 describeIfPg("promote/decay DB helpers (real Postgres, #3636)", () => {
   let pool: Pool;
   const schemaName = `promote_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  // promoteLearnedPatterns / demoteLearnedPatterns / getPromoteDecayCandidates
+  // gate on hasInternalDB() === !!process.env.DATABASE_URL (unlike the latency
+  // helpers, which don't), so point DATABASE_URL at the test DB for the run.
+  let origDbUrl: string | undefined;
 
   beforeAll(async () => {
+    origDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
     pool = new Pool({ connectionString: TEST_DB_URL });
     pool.on("connect", (client) => {
       void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
@@ -58,6 +64,8 @@ describeIfPg("promote/decay DB helpers (real Postgres, #3636)", () => {
   }, PG_TIMEOUT_MS);
 
   afterAll(async () => {
+    if (origDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = origDbUrl;
     if (!pool) return;
     _resetPool(null);
     await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);

--- a/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Real-Postgres tests for the promote/decay DB helpers (#3636, PRD #3617 B-2).
+ *
+ * The nightly scheduler has NO concurrent-run mutex — `Schedule.spaced` can
+ * overlap a slow tick with the next one. The ENTIRE idempotency + concurrent-
+ * admin-safety story therefore rests on the `status` / `auto_promoted` WHERE
+ * clauses in `promoteLearnedPatterns` / `demoteLearnedPatterns` and the
+ * candidate-selection filter in `getPromoteDecayCandidates`. The unit/scheduler
+ * tests mock those helpers away, so the SQL guarantees were untested. These run
+ * the exact production SQL against real Postgres and assert:
+ *   - a double promote/demote is a no-op the second time (idempotency),
+ *   - a human approval (auto_promoted=false) is never demoted by decay,
+ *   - candidate selection includes pending + machine-promoted rows only,
+ *     excluding rejected, human-approved, and non-query_pattern rows.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches `audit-slow-pg`
+ * / `pattern-latency-pg`). CI's api-tests workflow provides the Postgres service.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  promoteLearnedPatterns,
+  demoteLearnedPatterns,
+  getPromoteDecayCandidates,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+const ORG = "org-promote-decay-test";
+
+interface StatusRow {
+  status: string;
+  auto_promoted: boolean;
+}
+
+describeIfPg("promote/decay DB helpers (real Postgres, #3636)", () => {
+  let pool: Pool;
+  const schemaName = `promote_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`promote-decay-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM learned_patterns");
+  });
+
+  /** Insert a pattern row and return its generated uuid. */
+  async function seed(opts: {
+    sql: string;
+    status: string;
+    autoPromoted?: boolean;
+    type?: string;
+    confidence?: number;
+    repetitionCount?: number;
+  }): Promise<string> {
+    const res = await pool.query<{ id: string }>(
+      `INSERT INTO learned_patterns
+        (org_id, pattern_sql, status, type, auto_promoted, confidence, repetition_count)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id`,
+      [
+        ORG,
+        opts.sql,
+        opts.status,
+        opts.type ?? "query_pattern",
+        opts.autoPromoted ?? false,
+        opts.confidence ?? 0.9,
+        opts.repetitionCount ?? 10,
+      ],
+    );
+    return res.rows[0].id;
+  }
+
+  async function statusOf(id: string): Promise<StatusRow> {
+    const res = await pool.query<StatusRow>(
+      `SELECT status, auto_promoted FROM learned_patterns WHERE id = $1`,
+      [id],
+    );
+    return res.rows[0];
+  }
+
+  it(
+    "promote is idempotent — the second run on an already-promoted row is a no-op",
+    async () => {
+      const id = await seed({ sql: "SELECT 1", status: "pending" });
+
+      const first = await promoteLearnedPatterns([id]);
+      expect(first.count).toBe(1);
+      const after = await statusOf(id);
+      expect(after.status).toBe("approved");
+      expect(after.auto_promoted).toBe(true);
+
+      // Re-run (simulating an overlapping tick): the row is no longer pending,
+      // so the WHERE matches nothing — count 0, state unchanged.
+      const second = await promoteLearnedPatterns([id]);
+      expect(second.count).toBe(0);
+      expect((await statusOf(id)).status).toBe("approved");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "decay is idempotent and NEVER demotes a human approval (auto_promoted=false)",
+    async () => {
+      const machine = await seed({ sql: "SELECT 2", status: "approved", autoPromoted: true });
+      const human = await seed({ sql: "SELECT 3", status: "approved", autoPromoted: false });
+
+      const first = await demoteLearnedPatterns([machine, human]);
+      // Only the machine-promoted row is demoted; the human approval is untouched.
+      expect(first.count).toBe(1);
+      expect((await statusOf(machine)).status).toBe("pending");
+      expect((await statusOf(machine)).auto_promoted).toBe(true); // survives the round-trip
+      expect((await statusOf(human)).status).toBe("approved");
+
+      // Re-run: machine row is now pending, human still approved-but-not-auto →
+      // neither matches the demote WHERE. No-op.
+      const second = await demoteLearnedPatterns([machine, human]);
+      expect(second.count).toBe(0);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "a concurrent admin approval (clears auto_promoted) is protected from decay",
+    async () => {
+      const id = await seed({ sql: "SELECT 4", status: "approved", autoPromoted: true });
+      // Admin reviews it between candidate selection and the decay UPDATE: the
+      // approve path sets auto_promoted=false. Decay must then skip it.
+      await pool.query(`UPDATE learned_patterns SET auto_promoted = false WHERE id = $1`, [id]);
+
+      const res = await demoteLearnedPatterns([id]);
+      expect(res.count).toBe(0);
+      expect((await statusOf(id)).status).toBe("approved");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "candidate selection includes pending + machine-promoted only; excludes rejected, human-approved, and non-query rows",
+    async () => {
+      const pending = await seed({ sql: "SELECT 10", status: "pending" });
+      const machine = await seed({ sql: "SELECT 11", status: "approved", autoPromoted: true });
+      await seed({ sql: "SELECT 12", status: "approved", autoPromoted: false }); // human — excluded
+      await seed({ sql: "SELECT 13", status: "rejected" }); // excluded
+      await seed({ sql: "SELECT 14", status: "pending", type: "semantic_amendment" }); // excluded
+
+      const candidates = await getPromoteDecayCandidates();
+      const ids = candidates.map((c) => c.id).sort();
+      expect(ids).toEqual([pending, machine].sort());
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1201,13 +1201,16 @@ function isPgError(err: unknown): err is Error & { code: string } {
  * must not collide. A NULL group (the default flat `entities/` scope) is matched
  * with `IS NULL`, not `=`.
  *
- * Returns the pattern's id, confidence, and repetition count, or null if not found.
+ * Returns the pattern's id, confidence, repetition count, and status, or null
+ * if not found. `status` lets the caller honour a prior admin reject: a rejected
+ * row is matched (so dedup still suppresses a duplicate insert) but the proposer
+ * must NOT bump it, otherwise repeat traffic silently erodes the reject (#3636).
  */
 export async function findPatternBySQL(
   orgId: string | null | undefined,
   connectionGroupId: string | null | undefined,
   patternSql: string,
-): Promise<{ id: string; confidence: number; repetitionCount: number } | null> {
+): Promise<{ id: string; confidence: number; repetitionCount: number; status: string } | null> {
   const params: unknown[] = [patternSql];
   let orgClause: string;
   if (orgId) {
@@ -1225,8 +1228,8 @@ export async function findPatternBySQL(
     groupClause = `connection_group_id IS NULL`;
   }
 
-  const rows = await internalQuery<{ id: string; confidence: number; repetition_count: number }>(
-    `SELECT id, confidence, repetition_count FROM learned_patterns WHERE pattern_sql = $1 AND ${orgClause} AND ${groupClause} LIMIT 1`,
+  const rows = await internalQuery<{ id: string; confidence: number; repetition_count: number; status: string }>(
+    `SELECT id, confidence, repetition_count, status FROM learned_patterns WHERE pattern_sql = $1 AND ${orgClause} AND ${groupClause} LIMIT 1`,
     params,
   );
 
@@ -1236,6 +1239,7 @@ export async function findPatternBySQL(
     id: row.id,
     confidence: row.confidence,
     repetitionCount: row.repetition_count,
+    status: row.status,
   };
 }
 
@@ -1541,6 +1545,10 @@ export async function reviewSemanticAmendment(
  * A first-ever observation (`avg_duration_ms IS NULL`) seeds directly to `d`. A
  * missing/invalid measurement leaves both latency columns untouched.
  *
+ * Never mutates a `rejected` row (`AND status <> 'rejected'`): the proposer
+ * already skips rejected matches, but this is the durable backstop so no caller
+ * can resurrect an admin-rejected pattern by bumping its confidence (#3636).
+ *
  * Fire-and-forget — errors are logged, never thrown.
  */
 export function incrementPatternCount(
@@ -1573,7 +1581,7 @@ export function incrementPatternCount(
           ELSE source_queries || $2::jsonb
         END,
         updated_at = now()
-      WHERE id = $1`,
+      WHERE id = $1 AND status <> 'rejected'`,
       [id, newEntry, observation],
     );
   } else {
@@ -1582,7 +1590,7 @@ export function incrementPatternCount(
         repetition_count = repetition_count + 1,
         confidence = LEAST(1.0, confidence + 0.1),${latencyAssignments.replaceAll("$LAT", "$2")}
         updated_at = now()
-      WHERE id = $1`,
+      WHERE id = $1 AND status <> 'rejected'`,
       [id, observation],
     );
   }

--- a/packages/api/src/lib/learn/pattern-proposer.ts
+++ b/packages/api/src/lib/learn/pattern-proposer.ts
@@ -84,6 +84,17 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
 
   const existing = await findPatternBySQL(orgId, connectionGroupId, normalized);
   if (existing) {
+    // An admin reject is sticky: the row stays frozen, and we neither bump it
+    // (which would inflate its confidence/repetition and resurrect it as a
+    // re-proposal candidate) nor insert a fresh duplicate (the match already
+    // suppresses that). Repeat traffic on a rejected pattern is a no-op (#3636).
+    if (existing.status === "rejected") {
+      log.debug(
+        { patternId: existing.id },
+        "Query matches a rejected learned pattern — leaving it frozen",
+      );
+      return;
+    }
     // Duplicate — bump count and confidence, append source fingerprint, and
     // fold this execution's latency into the pattern's rolling average (#3635).
     incrementPatternCount(existing.id, fingerprint, durationMs);

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -395,7 +395,10 @@ function normalizeIndexType(amname: string | null | undefined): IndexType {
  * version falls back to the portable `indnatts`, so harvest never throws on the
  * column reference (it would otherwise be lost to the fail-soft catch).
  */
-async function queryPostgresIndexes(
+// Exported for DB-free unit coverage of the version-branch column selection and
+// the row→IndexProfile mapping (profiler-index-harvest-unit.test.ts); the
+// live-Postgres path is covered separately by profiler-index-harvest-pg.test.ts.
+export async function queryPostgresIndexes(
   pool: import("pg").Pool,
   tableName: string,
   schema: string = "public",
@@ -853,7 +856,10 @@ function mysqlIndexType(indexType: string | null | undefined): IndexType {
  * flagged `is_primary`. MySQL has no partial indexes (`is_partial: false`,
  * `predicate: null`).
  */
-async function queryMySQLIndexes(
+// Exported for DB-free unit coverage of functional/expression key-part skipping
+// and the row-grouping logic (profiler-index-harvest-unit.test.ts); the
+// live-MySQL path is covered separately by profiler-index-harvest-mysql.test.ts.
+export async function queryMySQLIndexes(
   pool: { execute: (sql: string, params?: unknown[]) => Promise<[unknown[], unknown]> },
   tableName: string,
   log: ProfileLogger = defaultLog,

--- a/packages/api/src/lib/semantic/expert/__tests__/apply.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/apply.test.ts
@@ -170,4 +170,64 @@ describe("applyAmendment", () => {
     applyAmendment(baseEntity, result);
     expect(baseEntity).toEqual(original);
   });
+
+  // ── Idempotency / re-apply (#3636 review) ──────────────────────────
+  // The add_* handlers must not produce duplicate entries when the same
+  // amendment is approved twice, and must converge (last-write-wins on
+  // identity) when an updated version of the same-named entry is approved.
+
+  it("re-applying the same add_dimension does not duplicate it", () => {
+    const result = makeResult("orders", "add_dimension", {
+      name: "total_cents", sql: "total_cents", type: "number",
+    });
+    const once = applyAmendment(baseEntity, result);
+    const twice = applyAmendment(once, result);
+    const dims = twice.dimensions as Array<Record<string, unknown>>;
+    expect(dims).toHaveLength(3); // not 4
+    expect(dims.filter((d) => d.name === "total_cents")).toHaveLength(1);
+  });
+
+  it("re-applying an updated add_dimension replaces the prior entry (last-write-wins)", () => {
+    const v1 = applyAmendment(baseEntity, makeResult("orders", "add_dimension", {
+      name: "total_cents", sql: "total_cents", type: "number",
+    }));
+    const v2 = applyAmendment(v1, makeResult("orders", "add_dimension", {
+      name: "total_cents", sql: "amount_cents", type: "number", description: "fixed",
+    }));
+    const dims = v2.dimensions as Array<Record<string, unknown>>;
+    expect(dims.filter((d) => d.name === "total_cents")).toHaveLength(1);
+    const target = dims.find((d) => d.name === "total_cents")!;
+    expect(target.sql).toBe("amount_cents");
+    expect(target.description).toBe("fixed");
+  });
+
+  it("re-applying the same add_join (by target_entity) does not duplicate it", () => {
+    const result = makeResult("orders", "add_join", {
+      target_entity: "customers", relationship: "many_to_one",
+    });
+    const twice = applyAmendment(applyAmendment(baseEntity, result), result);
+    const joins = twice.joins as Array<Record<string, unknown>>;
+    expect(joins.filter((j) => j.target_entity === "customers")).toHaveLength(1);
+  });
+
+  it("re-applying the same add_virtual_dimension does not duplicate it", () => {
+    const result = makeResult("orders", "add_virtual_dimension", {
+      name: "revenue_bucket", sql: "CASE WHEN total_cents > 10000 THEN 'high' ELSE 'low' END", type: "string",
+    });
+    const twice = applyAmendment(applyAmendment(baseEntity, result), result);
+    const dims = twice.dimensions as Array<Record<string, unknown>>;
+    const matches = dims.filter((d) => d.name === "revenue_bucket");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].virtual).toBe(true);
+  });
+
+  it("appends when the entry has no identity value (cannot dedup)", () => {
+    // A query_pattern with no `name` can't be deduped — appending twice is
+    // the documented fallback, not a silent drop.
+    const result = makeResult("orders", "add_query_pattern", {
+      description: "top orders", sql: "SELECT * FROM orders LIMIT 10",
+    });
+    const twice = applyAmendment(applyAmendment(baseEntity, result), result);
+    expect(twice.query_patterns as unknown[]).toHaveLength(2);
+  });
 });

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -239,6 +239,43 @@ const ADD_AMENDMENT_KEYS: Record<string, string> = {
   add_query_pattern: "query_patterns",
 };
 
+/**
+ * Identity field per entity-array key, used to make re-applying an amendment
+ * idempotent. Dimensions/measures/query-patterns are keyed by `name`; joins by
+ * their `target_entity`.
+ */
+const ADD_AMENDMENT_IDENTITY: Record<string, string> = {
+  dimensions: "name",
+  measures: "name",
+  joins: "target_entity",
+  query_patterns: "name",
+};
+
+/**
+ * Append `entry` to the `arrayKey` array, or REPLACE an existing element with
+ * the same identity (last-write-wins) so re-approving the same amendment — or
+ * approving an updated version of it — converges instead of pushing a duplicate
+ * dimension/measure/join. The `add_*` handlers previously used a blind push, so
+ * a second approval of the same name silently produced two identical entries.
+ * When the entry carries no identity value we can't dedup it, so we append.
+ */
+function upsertByIdentity(
+  arr: Record<string, unknown>[],
+  arrayKey: string,
+  entry: Record<string, unknown>,
+): void {
+  const idField = ADD_AMENDMENT_IDENTITY[arrayKey];
+  const idVal = idField ? entry[idField] : undefined;
+  if (idVal !== undefined && idVal !== null) {
+    const idx = arr.findIndex((e) => e[idField] === idVal);
+    if (idx >= 0) {
+      arr[idx] = entry;
+      return;
+    }
+  }
+  arr.push(entry);
+}
+
 /** Apply an amendment to a parsed entity object. Returns a new object. */
 export function applyAmendment(
   entity: Record<string, unknown>,
@@ -247,11 +284,12 @@ export function applyAmendment(
   const updated = structuredClone(entity);
   const amendment = result.amendment;
 
-  // Handle the four simple "push to array" amendment types
+  // Handle the four simple "push to array" amendment types. Idempotent: a
+  // re-approval of the same name replaces rather than duplicates.
   const arrayKey = ADD_AMENDMENT_KEYS[result.amendmentType];
   if (arrayKey) {
     const arr = (updated[arrayKey] ?? []) as Record<string, unknown>[];
-    arr.push(amendment);
+    upsertByIdentity(arr, arrayKey, amendment);
     updated[arrayKey] = arr;
     return updated;
   }
@@ -289,7 +327,7 @@ export function applyAmendment(
     }
     case "add_virtual_dimension": {
       const dims = (updated.dimensions ?? []) as Record<string, unknown>[];
-      dims.push({ ...amendment, virtual: true });
+      upsertByIdentity(dims, "dimensions", { ...amendment, virtual: true });
       updated.dimensions = dims;
       break;
     }


### PR DESCRIPTION
## Summary

Correctness + test-coverage fixes surfaced by the comprehensive `v0.0.16..HEAD` PR review run ahead of the **v0.0.17** tag (8 specialized review agents). No new schema, no wire-shape changes.

**Correctness (4):**
- **`/health` operator gate** — resolve the effective role via `getUserRole()` instead of the raw `auth.user.role`. A self-hosted operator using a bare `ATLAS_API_KEY` (simple-key, no `ATLAS_API_KEY_ROLE`) was treated as anonymous and got the stripped single-`default` health view. Fails closed, but contradicts #3685.
- **Incomplete `duration_ms=0` filter** — `/analytics/frequent` + `/analytics/users` still averaged `duration_ms` without the `FILTER (WHERE duration_ms > 0)` the `/slow` fix added (#3616), so zero-duration housekeeping/cache-serve rows still skewed them. Extracted `buildFrequentQuerySql` / `buildUserStatsQuerySql` (mirroring `buildSlowQuerySql`) so the real-PG test runs the exact production SQL.
- **Rejected-pattern resurrection** — an admin reject is now sticky: `findPatternBySQL` returns `status`, the proposer leaves a rejected match frozen, and `incrementPatternCount` guards every UPDATE with `AND status <> 'rejected'`. Previously repeat traffic re-inflated a rejected pattern's confidence/repetition and resurfaced it as a re-proposal candidate (#3636).
- **Amendment re-apply duplicates** — `add_*` and `add_virtual_dimension` now upsert by identity (last-write-wins) instead of a blind `push`, so re-approving an amendment no longer silently duplicates a dimension/measure/join.

**Test coverage the review flagged as missing:**
- `promote-decay-pg.test.ts` (real-PG) — the scheduler has no concurrent-run mutex; the entire idempotency + concurrent-admin-safety story rests on the `status`/`auto_promoted` WHERE clauses, which were mocked away. Covers double-run idempotency, never-demote-a-human-approval, concurrent-approve protection, and candidate selection.
- `profiler-index-harvest-unit.test.ts` (DB-free) — PG `indnkeyatts`/`indnatts` version branch and MySQL functional-key-part skipping were only covered by skip-by-default real-DB tests (no MySQL container in CI), so they ran in no CI pass.
- `audit-slow-pg.test.ts` — frequent/users avg-filter boundary coverage.
- `pattern-proposer` / `apply` — rejected-skip backstop + amendment idempotency unit coverage.

Related shipped slices: #3685, #3616, #3636, #3634. No `Closes` — these are post-review fixes to already-merged work, not a new issue.

## Test plan
- [x] `bun run lint` — 0
- [x] `bun run type` — 0
- [x] `bun run test` — full suite (2 transient bun-1.3.13 false-negatives, pass individually; remote CI is the arbiter)
- [x] `bun run test --affected` — 262 files, 0 failures
- [x] syncpack + all drift/discipline/published-symbol gates
- [ ] CI `api-tests (1/4)–(4/4)` exercise the new `*-pg.test.ts` against real Postgres