### PR TITLE
refactor(learn): centralize ATLAS_LEARN_* + split pattern-cache.ts (#3722, #3721)

### DIFF
--- a/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
+++ b/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
@@ -1,23 +1,10 @@
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import type { ApprovedPatternRow } from "@atlas/api/lib/db/internal";
-
-// pattern-cache imports settings/internal/logger at module load; stub them so
-// the pure ranking helpers can be imported in isolation.
-mock.module("@atlas/api/lib/db/internal", () => ({
-  getApprovedPatterns: async () => [],
-}));
-mock.module("@atlas/api/lib/settings", () => ({
-  getSetting: () => undefined,
-  getSettingAuto: () => undefined,
-  getSettingLive: async () => undefined,
-}));
-mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
-}));
-
-const { rankPatterns, perfWeight, DEFAULT_LATENCY_BUDGET_MS } = await import(
-  "@atlas/api/lib/learn/pattern-cache"
-);
+// pattern-ranking is PURE — zero db/settings/logger imports — so the ranking
+// helpers import directly with no `mock.module()` at all (#3721). The
+// DEFAULT_LATENCY_BUDGET_MS default now lives in learn-settings and is covered
+// by the settings/retrieval suites.
+import { rankPatterns, perfWeight } from "@atlas/api/lib/learn/pattern-ranking";
 
 function row(over: Partial<ApprovedPatternRow> & { id: string }): ApprovedPatternRow {
   return {
@@ -119,9 +106,5 @@ describe("rankPatterns — down-weight slow but keep present", () => {
     // both within budget → equal perfWeight & score & confidence → latency breaks tie
     const ranked = rankPatterns([a, b], KW, { latencyBudgetMs: 1000, maxPatterns: 10 });
     expect(ranked.map((r) => r.pattern.id)).toEqual(["b", "a"]);
-  });
-
-  test("DEFAULT_LATENCY_BUDGET_MS is a sane positive default", () => {
-    expect(DEFAULT_LATENCY_BUDGET_MS).toBeGreaterThan(0);
   });
 });

--- a/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
@@ -45,9 +45,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   setWorkspaceRegion: mock(async () => {}),
 }));
 
-// pattern-cache is real except its cache invalidation, which we observe.
+// The scheduler only touches pattern-cache via a dynamic import of
+// invalidatePatternCache (in runPromoteDecayTick), which we observe here. It no
+// longer reads any default constant from pattern-cache (those moved to
+// learn-settings, #3722), so this mock stubs only the invalidation hook.
 mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
-  DEFAULT_LATENCY_BUDGET_MS: 5000,
   invalidatePatternCache: (orgId: string | null) => {
     invalidatedOrgs.push(orgId);
   },

--- a/packages/api/src/lib/learn/learn-settings.ts
+++ b/packages/api/src/lib/learn/learn-settings.ts
@@ -75,16 +75,6 @@ const DEFAULT_DECAY_UNSEEN_DAYS = 30;
 // Workspace-scoped retrieval knobs
 // ---------------------------------------------------------------------------
 
-/** Resolved per-workspace retrieval tuning. */
-export interface LearnRetrievalSettings {
-  /** Trailing user turns assembled into the retrieval query (≥ 1). */
-  retrievalTurns: number;
-  /** Minimum confidence for a pattern to be eligible (0–1). */
-  confidenceThreshold: number;
-  /** Latency budget (ms) above which patterns are down-weighted (> 0). */
-  latencyBudgetMs: number;
-}
-
 /**
  * Resolve the retrieval-turn count for an org, falling back to the default.
  * Workspace-scoped settings-registry read (see module scope policy).
@@ -115,15 +105,6 @@ export function getLatencyBudgetMs(orgId?: string | null): number {
   const raw = getSettingAuto("ATLAS_LEARN_LATENCY_BUDGET_MS", orgId ?? undefined);
   const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LATENCY_BUDGET_MS;
-}
-
-/** Resolve all workspace-scoped retrieval knobs for an org in one call. */
-export function getLearnRetrievalSettings(orgId?: string | null): LearnRetrievalSettings {
-  return {
-    retrievalTurns: getRetrievalTurns(orgId),
-    confidenceThreshold: getConfidenceThreshold(orgId),
-    latencyBudgetMs: getLatencyBudgetMs(orgId),
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/learn/learn-settings.ts
+++ b/packages/api/src/lib/learn/learn-settings.ts
@@ -1,0 +1,195 @@
+/**
+ * Single resolver seam for every `ATLAS_LEARN_*` tuning knob (#3722).
+ *
+ * Before this module the 7 learn knobs were read at scattered call sites in
+ * `pattern-cache.ts` and `promote-decay-scheduler.ts`, with the workspace-vs-
+ * platform scope policy (and the defaults) duplicated across both files and a
+ * cross-module constant import just to share `DEFAULT_LATENCY_BUDGET_MS`. This
+ * module owns all of it: the literal registry reads, the defaults, and the one
+ * documented statement of which knob is read at which scope and why.
+ *
+ * ## Scope policy (the SSOT this module exists to centralize)
+ *
+ * **Workspace-scoped** (read per-request via `getSettingAuto(key, orgId)`, so a
+ * tenant tunes them from Admin → Settings with no redeploy; tier chain is
+ * `workspace override > platform override > env var > default`):
+ *   - `ATLAS_LEARN_RETRIEVAL_TURNS`
+ *   - `ATLAS_LEARN_CONFIDENCE_THRESHOLD`
+ *   - `ATLAS_LEARN_LATENCY_BUDGET_MS`
+ *
+ * **Platform-scoped** (read with `getSetting(key)` — no orgId — because the
+ * nightly auto-promote/decay job is a single process-global fiber forked once at
+ * boot by `makeSchedulerLive`, so there is no per-workspace tick):
+ *   - `ATLAS_LEARN_PROMOTE_DECAY_ENABLED`     (boot-consumed, requiresRestart)
+ *   - `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` (boot-consumed, requiresRestart)
+ *   - `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS`
+ *   - `ATLAS_LEARN_DECAY_UNSEEN_DAYS`
+ *
+ * **Two keys are read at BOTH scopes — intentionally, not a smell:**
+ *   - `ATLAS_LEARN_CONFIDENCE_THRESHOLD` gates retrieval eligibility (workspace)
+ *     AND auto-promotion eligibility (platform). One knob means "eligible to
+ *     inject" and "eligible to auto-promote" never drift apart.
+ *   - `ATLAS_LEARN_LATENCY_BUDGET_MS` is the retrieval down-weight budget
+ *     (workspace) AND the nightly promotion latency ceiling (platform). A
+ *     workspace override therefore affects only retrieval-time down-weighting,
+ *     never the promotion gate.
+ *
+ * ## #3382 reader-guard contract
+ *
+ * `scripts/check-settings-readers.sh` matches readers by a literal
+ * `getSetting("KEY")` / `getSettingAuto("KEY")` on a single line. Keep every
+ * read below in that shape — never a looped/computed key — or the guard will
+ * report the key as having no runtime reader.
+ */
+
+import { getSetting, getSettingAuto } from "@atlas/api/lib/settings";
+import type { PromoteDecayThresholds } from "@atlas/api/lib/learn/promote-decay";
+
+// ---------------------------------------------------------------------------
+// Defaults — the fallback tier for every learn knob lives here (and only here).
+// ---------------------------------------------------------------------------
+
+/** Default trailing user turns assembled into the retrieval query. */
+export const DEFAULT_RETRIEVAL_TURNS = 3;
+
+/** Default minimum confidence for a learned pattern to be eligible. */
+export const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+
+/**
+ * Default latency budget (ms) for perf-weighted retrieval. A pattern whose
+ * rolling-mean wall-clock stays at or under this gets no penalty; slower
+ * patterns are down-weighted (never excluded). Also the default budget for the
+ * nightly auto-promote gate. PRD #3617 B-2.
+ */
+export const DEFAULT_LATENCY_BUDGET_MS = 5000;
+
+/** Default interval for the nightly promote/decay job: 24 hours. */
+export const DEFAULT_PROMOTE_DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Gate defaults for the nightly promote/decay job (mirror the registry). */
+const DEFAULT_PROMOTE_CONFIDENCE = DEFAULT_CONFIDENCE_THRESHOLD;
+const DEFAULT_PROMOTE_MIN_REPETITIONS = 5;
+const DEFAULT_DECAY_UNSEEN_DAYS = 30;
+
+// ---------------------------------------------------------------------------
+// Workspace-scoped retrieval knobs
+// ---------------------------------------------------------------------------
+
+/** Resolved per-workspace retrieval tuning. */
+export interface LearnRetrievalSettings {
+  /** Trailing user turns assembled into the retrieval query (≥ 1). */
+  retrievalTurns: number;
+  /** Minimum confidence for a pattern to be eligible (0–1). */
+  confidenceThreshold: number;
+  /** Latency budget (ms) above which patterns are down-weighted (> 0). */
+  latencyBudgetMs: number;
+}
+
+/**
+ * Resolve the retrieval-turn count for an org, falling back to the default.
+ * Workspace-scoped settings-registry read (see module scope policy).
+ */
+export function getRetrievalTurns(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_RETRIEVAL_TURNS", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : DEFAULT_RETRIEVAL_TURNS;
+}
+
+/**
+ * Resolve the pattern confidence threshold for an org, falling back to the
+ * default. Workspace-scoped settings-registry read (see module scope policy).
+ */
+export function getConfidenceThreshold(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_CONFIDENCE_THRESHOLD", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_CONFIDENCE_THRESHOLD;
+}
+
+/**
+ * Resolve the latency budget (ms) for an org, falling back to the default.
+ * Workspace-scoped settings-registry read (see module scope policy). Non-positive
+ * / invalid values fall back to the default rather than disabling the budget, so
+ * a typo can't silently turn off down-weighting.
+ */
+export function getLatencyBudgetMs(orgId?: string | null): number {
+  const raw = getSettingAuto("ATLAS_LEARN_LATENCY_BUDGET_MS", orgId ?? undefined);
+  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LATENCY_BUDGET_MS;
+}
+
+/** Resolve all workspace-scoped retrieval knobs for an org in one call. */
+export function getLearnRetrievalSettings(orgId?: string | null): LearnRetrievalSettings {
+  return {
+    retrievalTurns: getRetrievalTurns(orgId),
+    confidenceThreshold: getConfidenceThreshold(orgId),
+    latencyBudgetMs: getLatencyBudgetMs(orgId),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Platform-scoped promote/decay knobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw setting value, falling back to `fallback` on a missing /
+ * non-finite / out-of-range value (a typo can't silently widen a gate). `min`
+ * is the inclusive lower bound the value must clear.
+ */
+function parseNumeric(raw: string | undefined, fallback: number, min: number): number {
+  if (raw === undefined) return fallback;
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
+}
+
+/**
+ * Whether the nightly promote/decay job is enabled. Platform-scoped, consumed
+ * once at boot (requiresRestart): platform DB override > env > default.
+ */
+export function isPromoteDecaySchedulerEnabled(): boolean {
+  const v = getSetting("ATLAS_LEARN_PROMOTE_DECAY_ENABLED");
+  return v === "true" || v === "1";
+}
+
+/**
+ * Tick interval in milliseconds. Platform-scoped, boot-consumed: platform DB
+ * override > env > default 24h.
+ */
+export function getPromoteDecaySchedulerIntervalMs(): number {
+  const raw = getSetting("ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS");
+  if (!raw) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
+  const hours = parseFloat(raw);
+  if (!Number.isFinite(hours) || hours <= 0) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
+  return hours * 60 * 60 * 1000;
+}
+
+/**
+ * Resolve the promote/decay gate from the settings registry at platform scope
+ * (read once per tick, no orgId). The confidence threshold and latency budget
+ * reuse the same keys that gate retrieval — see the dual-scope note in the
+ * module doc comment.
+ */
+export function getPromoteDecayThresholds(): PromoteDecayThresholds {
+  const decayUnseenDays = parseNumeric(
+    getSetting("ATLAS_LEARN_DECAY_UNSEEN_DAYS"),
+    DEFAULT_DECAY_UNSEEN_DAYS,
+    1,
+  );
+  return {
+    confidenceThreshold: parseNumeric(
+      getSetting("ATLAS_LEARN_CONFIDENCE_THRESHOLD"),
+      DEFAULT_PROMOTE_CONFIDENCE,
+      0,
+    ),
+    minRepetitions: parseNumeric(
+      getSetting("ATLAS_LEARN_PROMOTE_MIN_REPETITIONS"),
+      DEFAULT_PROMOTE_MIN_REPETITIONS,
+      1,
+    ),
+    latencyBudgetMs: parseNumeric(
+      getSetting("ATLAS_LEARN_LATENCY_BUDGET_MS"),
+      DEFAULT_LATENCY_BUDGET_MS,
+      1,
+    ),
+    decayUnseenMs: decayUnseenDays * 24 * 60 * 60 * 1000,
+  };
+}

--- a/packages/api/src/lib/learn/pattern-cache-store.ts
+++ b/packages/api/src/lib/learn/pattern-cache-store.ts
@@ -1,0 +1,100 @@
+/**
+ * In-memory store for approved learned patterns: a TTL-expiring, LRU-evicting
+ * cache keyed by (org, connection group), plus its invalidation (#3721).
+ *
+ * Split out of pattern-cache.ts so the eviction/TTL policy is isolated from the
+ * ranking math (`pattern-ranking.ts`) and the retrieval composition
+ * (`pattern-cache.ts`): changing the cache policy touches no ranking code, and
+ * the pure ranking helpers don't drag this module's db/logger imports into their
+ * tests.
+ */
+
+import { getApprovedPatterns, type ApprovedPatternRow } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("pattern-cache-store");
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_ENTRIES = 500;
+
+interface CacheEntry {
+  patterns: ApprovedPatternRow[];
+  expiresAt: number;
+  lastAccessedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Org segment of a cache key — `"__global__"` for null orgId, prefixed to
+ *  avoid collision. */
+function orgKeyPart(orgId: string | null): string {
+  return orgId === null ? "__global__" : `org:${orgId}`;
+}
+
+/** Canonical cache key — scoped by org AND connection group (#3611) so a
+ *  `us-prod` agent session never serves a `eu-prod` group's cached patterns.
+ *  `"__nogroup__"` represents the default (flat `entities/`) scope. */
+function cacheKey(orgId: string | null, connectionGroupId: string | null): string {
+  const groupPart = connectionGroupId === null ? "__nogroup__" : `group:${connectionGroupId}`;
+  return `${orgKeyPart(orgId)}::${groupPart}`;
+}
+
+/** Get approved patterns for an org + connection group, hitting cache first.
+ *  DB failures are logged and return [] without being cached. */
+export async function getCachedPatterns(
+  orgId: string | null,
+  connectionGroupId: string | null,
+): Promise<ApprovedPatternRow[]> {
+  const key = cacheKey(orgId, connectionGroupId);
+  const entry = cache.get(key);
+
+  if (entry && Date.now() < entry.expiresAt) {
+    entry.lastAccessedAt = Date.now();
+    return entry.patterns;
+  }
+
+  try {
+    const patterns = await getApprovedPatterns(orgId, connectionGroupId);
+
+    // Evict oldest entry if cache is at capacity
+    if (cache.size >= MAX_ENTRIES) {
+      let oldestKey: string | undefined;
+      let oldestTime = Infinity;
+      for (const [k, v] of cache) {
+        if (v.lastAccessedAt < oldestTime) {
+          oldestTime = v.lastAccessedAt;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey) cache.delete(oldestKey);
+    }
+
+    const now = Date.now();
+    cache.set(key, { patterns, expiresAt: now + DEFAULT_TTL_MS, lastAccessedAt: now });
+    return patterns;
+  } catch (err) {
+    log.warn(
+      { orgId, connectionGroupId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to load approved patterns (table may not exist yet) — not caching",
+    );
+    return [];
+  }
+}
+
+/**
+ * Invalidate the pattern cache for a specific org, across ALL of its connection
+ * groups. The admin approve/reject path (`admin-learned-patterns.ts`) operates
+ * at org granularity and doesn't know which group a reviewed pattern belongs
+ * to, so a single call must clear every group-scoped entry for the org (#3611).
+ */
+export function invalidatePatternCache(orgId: string | null): void {
+  const prefix = `${orgKeyPart(orgId)}::`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+/** Reset entire cache. For testing only. */
+export function _resetPatternCache(): void {
+  cache.clear();
+}

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -7,9 +7,27 @@
  */
 
 import { getApprovedPatterns, type ApprovedPatternRow } from "@atlas/api/lib/db/internal";
-import { getSettingAuto } from "@atlas/api/lib/settings";
 import { createLogger } from "@atlas/api/lib/logger";
 import { renderPattern } from "./pattern-format";
+import {
+  DEFAULT_RETRIEVAL_TURNS,
+  DEFAULT_LATENCY_BUDGET_MS,
+  getRetrievalTurns,
+  getConfidenceThreshold,
+  getLatencyBudgetMs,
+} from "./learn-settings";
+
+// All ATLAS_LEARN_* reads now live in the single learn-settings resolver
+// (#3722). Re-export the retrieval knobs from this module's public surface so
+// existing consumers (agent.ts) and the test mocks that import them from
+// pattern-cache keep working unchanged.
+export {
+  DEFAULT_RETRIEVAL_TURNS,
+  DEFAULT_LATENCY_BUDGET_MS,
+  getRetrievalTurns,
+  getConfidenceThreshold,
+  getLatencyBudgetMs,
+};
 
 const log = createLogger("pattern-cache");
 
@@ -132,9 +150,6 @@ const STOP_WORDS = new Set([
 // Retrieval-query assembly
 // ---------------------------------------------------------------------------
 
-/** Default number of trailing user turns assembled into the retrieval query. */
-export const DEFAULT_RETRIEVAL_TURNS = 3;
-
 /**
  * Minimal structural shape of a conversation message needed to assemble the
  * retrieval query. Compatible with the AI SDK's `UIMessage` so callers can
@@ -193,54 +208,6 @@ export function buildRetrievalQuery(
   // Reverse to chronological order; order is irrelevant to keyword extraction
   // but keeps the query readable in logs.
   return collected.reverse().join(" ").trim();
-}
-
-/**
- * Resolve the retrieval-turn count for an org, falling back to the default.
- *
- * Read from the settings registry (`getSettingAuto`) so the value is tunable
- * per-workspace at runtime via Admin → Settings and hot-reloaded in SaaS —
- * `workspace override > platform override > env var > default`. The env var is
- * only the self-host fallback tier.
- */
-export function getRetrievalTurns(orgId?: string | null): number {
-  const raw = getSettingAuto("ATLAS_LEARN_RETRIEVAL_TURNS", orgId ?? undefined);
-  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
-  return Number.isInteger(parsed) && parsed >= 1 ? parsed : DEFAULT_RETRIEVAL_TURNS;
-}
-
-/** Default minimum confidence for a learned pattern to be eligible. */
-const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
-
-/**
- * Resolve the pattern confidence threshold for an org, falling back to the
- * default. Workspace-scoped settings-registry read (see {@link getRetrievalTurns}).
- */
-export function getConfidenceThreshold(orgId?: string | null): number {
-  const raw = getSettingAuto("ATLAS_LEARN_CONFIDENCE_THRESHOLD", orgId ?? undefined);
-  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
-  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_CONFIDENCE_THRESHOLD;
-}
-
-/**
- * Default latency budget (ms) for perf-weighted retrieval. A pattern whose
- * rolling-mean wall-clock stays at or under this gets no penalty; slower
- * patterns are down-weighted (never excluded). Also the default budget for the
- * nightly auto-promote gate. PRD #3617 B-2.
- */
-export const DEFAULT_LATENCY_BUDGET_MS = 5000;
-
-/**
- * Resolve the latency budget (ms) for an org, falling back to the default.
- * Workspace-scoped settings-registry read (see {@link getRetrievalTurns}); the
- * nightly job reads the same key at platform scope. Non-positive / invalid
- * values fall back to the default rather than disabling the budget, so a typo
- * can't silently turn off down-weighting.
- */
-export function getLatencyBudgetMs(orgId?: string | null): number {
-  const raw = getSettingAuto("ATLAS_LEARN_LATENCY_BUDGET_MS", orgId ?? undefined);
-  const parsed = raw === undefined ? Number.NaN : Number.parseFloat(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LATENCY_BUDGET_MS;
 }
 
 /** Extract meaningful keywords from a text string. */

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -1,12 +1,20 @@
 /**
- * In-memory cache for approved learned patterns with TTL-based expiry
- * and keyword-based relevance filtering.
+ * Learned-pattern retrieval: compose the cache store, the pure ranking math, and
+ * the settings resolver into the agent-facing API + public barrel.
  *
- * Cache is keyed by orgId (null for global). Invalidated by admin
- * approve/reject actions via `invalidatePatternCache()`.
+ * The concerns this file used to co-locate now live in focused modules (#3721):
+ *   - cache store (TTL/LRU + invalidation) → `pattern-cache-store.ts`
+ *   - keyword + perf-weighted ranking (pure) → `pattern-ranking.ts`
+ *   - ATLAS_LEARN_* settings reads → `learn-settings.ts` (#3722)
+ *   - pattern → prompt rendering → `pattern-format.ts` (#3720)
+ *
+ * This module owns only the retrieval-query assembly and the two retrieval
+ * entry points (`getRelevantPatterns`, `buildLearnedPatternsSection`). It also
+ * re-exports the prior public surface so consumers (agent.ts,
+ * admin-learned-patterns.ts, org-knowledge-section.ts) and existing test mocks
+ * keep importing from `pattern-cache` unchanged.
  */
 
-import { getApprovedPatterns, type ApprovedPatternRow } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { renderPattern } from "./pattern-format";
 import {
@@ -16,135 +24,28 @@ import {
   getConfidenceThreshold,
   getLatencyBudgetMs,
 } from "./learn-settings";
+import { extractKeywords, perfWeight, rankPatterns, type ScoredPattern } from "./pattern-ranking";
+import { getCachedPatterns, invalidatePatternCache, _resetPatternCache } from "./pattern-cache-store";
 
-// All ATLAS_LEARN_* reads now live in the single learn-settings resolver
-// (#3722). Re-export the retrieval knobs from this module's public surface so
-// existing consumers (agent.ts) and the test mocks that import them from
-// pattern-cache keep working unchanged.
+// Public barrel — these moved into focused modules during the #3721 split (and
+// #3722 for the settings reads), but agent.ts, admin-learned-patterns.ts,
+// org-knowledge-section.ts, and a number of test mocks import them from
+// `pattern-cache`, so the names stay stable on this module's surface.
 export {
   DEFAULT_RETRIEVAL_TURNS,
   DEFAULT_LATENCY_BUDGET_MS,
   getRetrievalTurns,
   getConfidenceThreshold,
   getLatencyBudgetMs,
+  extractKeywords,
+  perfWeight,
+  rankPatterns,
+  invalidatePatternCache,
+  _resetPatternCache,
 };
+export type { ScoredPattern };
 
 const log = createLogger("pattern-cache");
-
-// ---------------------------------------------------------------------------
-// Cache
-// ---------------------------------------------------------------------------
-
-const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const MAX_ENTRIES = 500;
-
-interface CacheEntry {
-  patterns: ApprovedPatternRow[];
-  expiresAt: number;
-  lastAccessedAt: number;
-}
-
-const cache = new Map<string, CacheEntry>();
-
-/** Org segment of a cache key — `"__global__"` for null orgId, prefixed to
- *  avoid collision. */
-function orgKeyPart(orgId: string | null): string {
-  return orgId === null ? "__global__" : `org:${orgId}`;
-}
-
-/** Canonical cache key — scoped by org AND connection group (#3611) so a
- *  `us-prod` agent session never serves a `eu-prod` group's cached patterns.
- *  `"__nogroup__"` represents the default (flat `entities/`) scope. */
-function cacheKey(orgId: string | null, connectionGroupId: string | null): string {
-  const groupPart = connectionGroupId === null ? "__nogroup__" : `group:${connectionGroupId}`;
-  return `${orgKeyPart(orgId)}::${groupPart}`;
-}
-
-/** Get approved patterns for an org + connection group, hitting cache first.
- *  DB failures are logged and return [] without being cached. */
-async function getCachedPatterns(
-  orgId: string | null,
-  connectionGroupId: string | null,
-): Promise<ApprovedPatternRow[]> {
-  const key = cacheKey(orgId, connectionGroupId);
-  const entry = cache.get(key);
-
-  if (entry && Date.now() < entry.expiresAt) {
-    entry.lastAccessedAt = Date.now();
-    return entry.patterns;
-  }
-
-  try {
-    const patterns = await getApprovedPatterns(orgId, connectionGroupId);
-
-    // Evict oldest entry if cache is at capacity
-    if (cache.size >= MAX_ENTRIES) {
-      let oldestKey: string | undefined;
-      let oldestTime = Infinity;
-      for (const [k, v] of cache) {
-        if (v.lastAccessedAt < oldestTime) {
-          oldestTime = v.lastAccessedAt;
-          oldestKey = k;
-        }
-      }
-      if (oldestKey) cache.delete(oldestKey);
-    }
-
-    const now = Date.now();
-    cache.set(key, { patterns, expiresAt: now + DEFAULT_TTL_MS, lastAccessedAt: now });
-    return patterns;
-  } catch (err) {
-    log.warn(
-      { orgId, connectionGroupId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to load approved patterns (table may not exist yet) — not caching",
-    );
-    return [];
-  }
-}
-
-/**
- * Invalidate the pattern cache for a specific org, across ALL of its connection
- * groups. The admin approve/reject path (`admin-learned-patterns.ts`) operates
- * at org granularity and doesn't know which group a reviewed pattern belongs
- * to, so a single call must clear every group-scoped entry for the org (#3611).
- */
-export function invalidatePatternCache(orgId: string | null): void {
-  const prefix = `${orgKeyPart(orgId)}::`;
-  for (const key of cache.keys()) {
-    if (key.startsWith(prefix)) cache.delete(key);
-  }
-}
-
-/** Reset entire cache. For testing only. */
-export function _resetPatternCache(): void {
-  cache.clear();
-}
-
-// ---------------------------------------------------------------------------
-// Keyword extraction & relevance scoring
-// ---------------------------------------------------------------------------
-
-/** Common SQL/English stop words to ignore during keyword matching. */
-const STOP_WORDS = new Set([
-  "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
-  "have", "has", "had", "do", "does", "did", "will", "would", "shall",
-  "should", "may", "might", "must", "can", "could", "and", "but", "or",
-  "nor", "not", "so", "yet", "for", "of", "in", "on", "at", "to", "by",
-  "with", "from", "as", "into", "about", "between", "through", "after",
-  "before", "above", "below", "up", "down", "out", "off", "over", "under",
-  "then", "than", "that", "this", "these", "those", "what", "which", "who",
-  "whom", "how", "when", "where", "why", "all", "each", "every", "both",
-  "few", "more", "most", "other", "some", "such", "no", "only", "same",
-  "it", "its", "i", "me", "my", "we", "us", "our", "you", "your", "he",
-  "him", "his", "she", "her", "they", "them", "their",
-  // SQL keywords
-  "select", "from", "where", "join", "left", "right", "inner", "outer",
-  "on", "group", "order", "limit", "offset", "having", "union", "case",
-  "when", "else", "end", "as", "count", "sum", "avg", "min", "max",
-  "distinct", "null", "true", "false", "asc", "desc", "between", "like",
-  "insert", "update", "delete", "create", "alter", "drop", "table",
-  "index", "values", "set", "into", "not", "exists", "if", "and", "or",
-]);
 
 // ---------------------------------------------------------------------------
 // Retrieval-query assembly
@@ -210,49 +111,12 @@ export function buildRetrievalQuery(
   return collected.reverse().join(" ").trim();
 }
 
-/** Extract meaningful keywords from a text string. */
-export function extractKeywords(text: string): Set<string> {
-  const words = text
-    .toLowerCase()
-    .replace(/[^a-z0-9_]/g, " ")
-    .split(/\s+/)
-    .filter((w) => w.length > 1 && !STOP_WORDS.has(w));
-  return new Set(words);
-}
-
-/** Score a pattern's relevance to a set of question keywords. */
-function scorePattern(
-  pattern: ApprovedPatternRow,
-  questionKeywords: Set<string>,
-): number {
-  const patternText = [
-    pattern.pattern_sql,
-    pattern.description ?? "",
-    pattern.source_entity ?? "",
-  ].join(" ");
-
-  const patternKeywords = extractKeywords(patternText);
-  let overlap = 0;
-  for (const kw of questionKeywords) {
-    if (patternKeywords.has(kw)) overlap++;
-  }
-  return overlap;
-}
-
 // ---------------------------------------------------------------------------
-// Public API
+// Retrieval API
 // ---------------------------------------------------------------------------
 
 /** Default maximum patterns to inject into the system prompt. */
 const DEFAULT_MAX_PATTERNS = 10;
-
-/**
- * Floor for the perf weight. A pattern arbitrarily slower than the budget is
- * down-weighted to at most this factor — never to zero — so slow-but-relevant
- * patterns stay PRESENT in retrieval as reference, just ranked below faster
- * peers. Keeping the floor > 0 is what makes this a down-weight, not a filter.
- */
-const MIN_PERF_WEIGHT = 0.5;
 
 export interface RelevantPattern {
   sourceEntity: string | null;
@@ -261,66 +125,6 @@ export interface RelevantPattern {
   /** Rolling-mean wall-clock (ms) of this pattern's runs, or null until first
    *  observed. Surfaced in the injected context so the agent can judge cost. */
   avgDurationMs: number | null;
-}
-
-/**
- * Latency down-weight factor in [{@link MIN_PERF_WEIGHT}, 1].
- *
- * - Unknown latency (null / non-finite / negative) → 1.0: we don't penalize a
- *   pattern whose speed we've never measured.
- * - At or under budget → 1.0: no penalty.
- * - Beyond budget → decays toward the floor as `budget / avg` shrinks, so a
- *   pattern 2× the budget keeps ~0.75 of its weight and one 10× keeps ~0.55.
- *
- * Pure helper, exported for direct testing.
- */
-export function perfWeight(avgDurationMs: number | null, budgetMs: number): number {
-  if (avgDurationMs === null || !Number.isFinite(avgDurationMs) || avgDurationMs < 0) return 1;
-  if (!Number.isFinite(budgetMs) || budgetMs <= 0) return 1;
-  if (avgDurationMs <= budgetMs) return 1;
-  const ratio = budgetMs / avgDurationMs; // in (0, 1)
-  return MIN_PERF_WEIGHT + (1 - MIN_PERF_WEIGHT) * ratio;
-}
-
-/** One scored pattern after keyword + perf weighting. Exported for testing. */
-export interface ScoredPattern {
-  pattern: ApprovedPatternRow;
-  keywordScore: number;
-  perfWeight: number;
-  score: number;
-}
-
-/**
- * Rank approved patterns for a question, down-weighting slow ones (PRD #3617
- * B-2). PURE: no DB, no settings — takes the candidate rows, the question
- * keywords, and the latency budget.
- *
- * The eligibility filter stays on RAW keyword overlap (`keywordScore > 0`), so
- * latency never DROPS a relevant pattern — it only reorders. The combined score
- * is `keywordScore × perfWeight`, which lets a much-more-relevant slow pattern
- * still outrank a barely-relevant fast one (relevance dominates), while a fast
- * pattern wins among similarly-relevant peers. Ties break on confidence, then
- * on lower latency (unknown latency sorts last).
- */
-export function rankPatterns(
-  patterns: readonly ApprovedPatternRow[],
-  questionKeywords: Set<string>,
-  opts: { latencyBudgetMs: number; maxPatterns: number },
-): ScoredPattern[] {
-  return patterns
-    .map((pattern): ScoredPattern => {
-      const keywordScore = scorePattern(pattern, questionKeywords);
-      const weight = perfWeight(pattern.avg_duration_ms, opts.latencyBudgetMs);
-      return { pattern, keywordScore, perfWeight: weight, score: keywordScore * weight };
-    })
-    .filter((s) => s.keywordScore > 0)
-    .toSorted(
-      (a, b) =>
-        b.score - a.score ||
-        b.pattern.confidence - a.pattern.confidence ||
-        (a.pattern.avg_duration_ms ?? Infinity) - (b.pattern.avg_duration_ms ?? Infinity),
-    )
-    .slice(0, opts.maxPatterns);
 }
 
 /**

--- a/packages/api/src/lib/learn/pattern-ranking.ts
+++ b/packages/api/src/lib/learn/pattern-ranking.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure ranking + keyword math for learned query patterns (#3721).
+ *
+ * Split out of pattern-cache.ts so the scoring logic has ZERO runtime imports of
+ * db / settings / logger — only a type-only import of the row shape, which is
+ * erased at compile time. That keeps these helpers trivially testable: their
+ * test imports this module directly with no `mock.module()` at all.
+ *
+ * Nothing here touches I/O. The cache store lives in `pattern-cache-store.ts`;
+ * the retrieval composition + settings reads live in `pattern-cache.ts`.
+ */
+
+import type { ApprovedPatternRow } from "@atlas/api/lib/db/internal";
+
+// ---------------------------------------------------------------------------
+// Keyword extraction
+// ---------------------------------------------------------------------------
+
+/** Common SQL/English stop words to ignore during keyword matching. */
+const STOP_WORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+  "should", "may", "might", "must", "can", "could", "and", "but", "or",
+  "nor", "not", "so", "yet", "for", "of", "in", "on", "at", "to", "by",
+  "with", "from", "as", "into", "about", "between", "through", "after",
+  "before", "above", "below", "up", "down", "out", "off", "over", "under",
+  "then", "than", "that", "this", "these", "those", "what", "which", "who",
+  "whom", "how", "when", "where", "why", "all", "each", "every", "both",
+  "few", "more", "most", "other", "some", "such", "no", "only", "same",
+  "it", "its", "i", "me", "my", "we", "us", "our", "you", "your", "he",
+  "him", "his", "she", "her", "they", "them", "their",
+  // SQL keywords
+  "select", "from", "where", "join", "left", "right", "inner", "outer",
+  "on", "group", "order", "limit", "offset", "having", "union", "case",
+  "when", "else", "end", "as", "count", "sum", "avg", "min", "max",
+  "distinct", "null", "true", "false", "asc", "desc", "between", "like",
+  "insert", "update", "delete", "create", "alter", "drop", "table",
+  "index", "values", "set", "into", "not", "exists", "if", "and", "or",
+]);
+
+/** Extract meaningful keywords from a text string. */
+export function extractKeywords(text: string): Set<string> {
+  const words = text
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 1 && !STOP_WORDS.has(w));
+  return new Set(words);
+}
+
+/** Score a pattern's relevance to a set of question keywords. */
+function scorePattern(
+  pattern: ApprovedPatternRow,
+  questionKeywords: Set<string>,
+): number {
+  const patternText = [
+    pattern.pattern_sql,
+    pattern.description ?? "",
+    pattern.source_entity ?? "",
+  ].join(" ");
+
+  const patternKeywords = extractKeywords(patternText);
+  let overlap = 0;
+  for (const kw of questionKeywords) {
+    if (patternKeywords.has(kw)) overlap++;
+  }
+  return overlap;
+}
+
+// ---------------------------------------------------------------------------
+// Perf-weighted ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Floor for the perf weight. A pattern arbitrarily slower than the budget is
+ * down-weighted to at most this factor — never to zero — so slow-but-relevant
+ * patterns stay PRESENT in retrieval as reference, just ranked below faster
+ * peers. Keeping the floor > 0 is what makes this a down-weight, not a filter.
+ */
+const MIN_PERF_WEIGHT = 0.5;
+
+/**
+ * Latency down-weight factor in [{@link MIN_PERF_WEIGHT}, 1].
+ *
+ * - Unknown latency (null / non-finite / negative) → 1.0: we don't penalize a
+ *   pattern whose speed we've never measured.
+ * - At or under budget → 1.0: no penalty.
+ * - Beyond budget → decays toward the floor as `budget / avg` shrinks, so a
+ *   pattern 2× the budget keeps ~0.75 of its weight and one 10× keeps ~0.55.
+ *
+ * Pure helper, exported for direct testing.
+ */
+export function perfWeight(avgDurationMs: number | null, budgetMs: number): number {
+  if (avgDurationMs === null || !Number.isFinite(avgDurationMs) || avgDurationMs < 0) return 1;
+  if (!Number.isFinite(budgetMs) || budgetMs <= 0) return 1;
+  if (avgDurationMs <= budgetMs) return 1;
+  const ratio = budgetMs / avgDurationMs; // in (0, 1)
+  return MIN_PERF_WEIGHT + (1 - MIN_PERF_WEIGHT) * ratio;
+}
+
+/** One scored pattern after keyword + perf weighting. Exported for testing. */
+export interface ScoredPattern {
+  pattern: ApprovedPatternRow;
+  keywordScore: number;
+  perfWeight: number;
+  score: number;
+}
+
+/**
+ * Rank approved patterns for a question, down-weighting slow ones (PRD #3617
+ * B-2). PURE: no DB, no settings — takes the candidate rows, the question
+ * keywords, and the latency budget.
+ *
+ * The eligibility filter stays on RAW keyword overlap (`keywordScore > 0`), so
+ * latency never DROPS a relevant pattern — it only reorders. The combined score
+ * is `keywordScore × perfWeight`, which lets a much-more-relevant slow pattern
+ * still outrank a barely-relevant fast one (relevance dominates), while a fast
+ * pattern wins among similarly-relevant peers. Ties break on confidence, then
+ * on lower latency (unknown latency sorts last).
+ */
+export function rankPatterns(
+  patterns: readonly ApprovedPatternRow[],
+  questionKeywords: Set<string>,
+  opts: { latencyBudgetMs: number; maxPatterns: number },
+): ScoredPattern[] {
+  return patterns
+    .map((pattern): ScoredPattern => {
+      const keywordScore = scorePattern(pattern, questionKeywords);
+      const weight = perfWeight(pattern.avg_duration_ms, opts.latencyBudgetMs);
+      return { pattern, keywordScore, perfWeight: weight, score: keywordScore * weight };
+    })
+    .filter((s) => s.keywordScore > 0)
+    .toSorted(
+      (a, b) =>
+        b.score - a.score ||
+        b.pattern.confidence - a.pattern.confidence ||
+        (a.pattern.avg_duration_ms ?? Infinity) - (b.pattern.avg_duration_ms ?? Infinity),
+    )
+    .slice(0, opts.maxPatterns);
+}

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -20,17 +20,30 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { getSetting } from "@atlas/api/lib/settings";
-import { DEFAULT_LATENCY_BUDGET_MS } from "@atlas/api/lib/learn/pattern-cache";
 // Type-only import — erased at compile time, so it does NOT eagerly load
 // db/internal and the dynamic import + mock seam in runPromoteDecayTick stays
 // intact. Reusing the row type keeps `toCandidate` from drifting from the SQL.
 import type { PromoteDecayCandidateRow } from "@atlas/api/lib/db/internal";
 import {
   decidePromoteDecay,
-  type PromoteDecayThresholds,
   type PromoteDecayCandidate,
 } from "@atlas/api/lib/learn/promote-decay";
+import {
+  isPromoteDecaySchedulerEnabled,
+  getPromoteDecaySchedulerIntervalMs,
+  getPromoteDecayThresholds,
+  DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
+} from "@atlas/api/lib/learn/learn-settings";
+
+// The ATLAS_LEARN_* reads moved to the single learn-settings resolver (#3722).
+// Re-export them from this module's public surface so layers.ts (the boot
+// fiber) and the scheduler test keep importing them from here unchanged.
+export {
+  isPromoteDecaySchedulerEnabled,
+  getPromoteDecaySchedulerIntervalMs,
+  getPromoteDecayThresholds as resolvePromoteDecayThresholds,
+  DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
+};
 
 const log = createLogger("promote-decay-scheduler");
 
@@ -38,14 +51,6 @@ const log = createLogger("promote-decay-scheduler");
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
-
-/** Default interval: 24 hours. */
-export const DEFAULT_PROMOTE_DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000;
-
-/** Gate defaults (mirror the registry defaults in lib/settings.ts). */
-const DEFAULT_PROMOTE_CONFIDENCE = 0.7;
-const DEFAULT_PROMOTE_MIN_REPETITIONS = 5;
-const DEFAULT_DECAY_UNSEEN_DAYS = 30;
 
 /** Upper bound on rows evaluated per tick — a runaway-table backstop. The
  *  scheduler logs when the cap is hit so a silently-truncated tick is visible. */
@@ -57,82 +62,6 @@ export interface PromoteDecayTickResult {
   promoted: number;
   demoted: number;
   errors: number;
-}
-
-/**
- * Whether the nightly promote/decay job is enabled.
- *
- * Platform-scoped (like the expert scheduler): a single process-global fiber
- * forked once at boot by `makeSchedulerLive`, so there is no per-workspace
- * tick. Resolved via `getSetting()` so a platform DB override (admin settings
- * page) beats the env var (platform DB override > env > default). Consumed once
- * at boot — changes require a restart (`requiresRestart` in the registry).
- */
-export function isPromoteDecaySchedulerEnabled(): boolean {
-  const v = getSetting("ATLAS_LEARN_PROMOTE_DECAY_ENABLED");
-  return v === "true" || v === "1";
-}
-
-/**
- * Tick interval in milliseconds.
- *
- * Resolves `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` through `getSetting()`
- * (platform DB override > env > default 24). Platform-scoped and boot-consumed —
- * see {@link isPromoteDecaySchedulerEnabled}.
- */
-export function getPromoteDecaySchedulerIntervalMs(): number {
-  const raw = getSetting("ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS");
-  if (!raw) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
-  const hours = parseFloat(raw);
-  if (!Number.isFinite(hours) || hours <= 0) return DEFAULT_PROMOTE_DECAY_INTERVAL_MS;
-  return hours * 60 * 60 * 1000;
-}
-
-/** Parse a raw setting value, falling back to `fallback` on a missing /
- *  non-finite / out-of-range value (a typo can't silently widen a gate). `min`
- *  is the inclusive lower bound the value must clear. The caller reads the key
- *  with a literal `getSetting("KEY")` so the registry-reader guard (#3382) can
- *  see each key's reader. */
-function parseNumeric(raw: string | undefined, fallback: number, min: number): number {
-  if (raw === undefined) return fallback;
-  const parsed = parseFloat(raw);
-  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
-}
-
-/**
- * Resolve the promote/decay gate from the settings registry at platform scope.
- *
- * Read once per tick (no orgId), so these are platform-level values — a
- * workspace override of `ATLAS_LEARN_LATENCY_BUDGET_MS` affects only
- * retrieval-time down-weighting, not the promotion gate. The confidence
- * threshold reuses the same `ATLAS_LEARN_CONFIDENCE_THRESHOLD` key that gates
- * retrieval, so "eligible to inject" and "eligible to auto-promote" share one
- * knob.
- */
-export function resolvePromoteDecayThresholds(): PromoteDecayThresholds {
-  const decayUnseenDays = parseNumeric(
-    getSetting("ATLAS_LEARN_DECAY_UNSEEN_DAYS"),
-    DEFAULT_DECAY_UNSEEN_DAYS,
-    1,
-  );
-  return {
-    confidenceThreshold: parseNumeric(
-      getSetting("ATLAS_LEARN_CONFIDENCE_THRESHOLD"),
-      DEFAULT_PROMOTE_CONFIDENCE,
-      0,
-    ),
-    minRepetitions: parseNumeric(
-      getSetting("ATLAS_LEARN_PROMOTE_MIN_REPETITIONS"),
-      DEFAULT_PROMOTE_MIN_REPETITIONS,
-      1,
-    ),
-    latencyBudgetMs: parseNumeric(
-      getSetting("ATLAS_LEARN_LATENCY_BUDGET_MS"),
-      DEFAULT_LATENCY_BUDGET_MS,
-      1,
-    ),
-    decayUnseenMs: decayUnseenDays * 24 * 60 * 60 * 1000,
-  };
 }
 
 /** Project a DB candidate row (snake_case) onto the pure-decision input shape
@@ -195,7 +124,7 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
       return result;
     }
 
-    const thresholds = resolvePromoteDecayThresholds();
+    const thresholds = getPromoteDecayThresholds();
     const { promote, demote } = decidePromoteDecay(
       candidates.map(toCandidate),
       thresholds,


### PR DESCRIPTION
Ships the two remaining learn-subsystem refactors deferred from the **v0.0.17 "Performance-aware Atlas"** milestone into the Architecture Backlog. Both are pure refactors — **no behavior change** — done as two sequential commits because they edit the same files.

Reviewed both issues against current `main` first; two findings updated the plan:
- **#3722's "smell?" question is already answered by the code** — the workspace/platform dual-scope is intentional and was documented in both files, so the right move is *keep dual-scope + centralize*, not collapse.
- **#3721's line count was stale** (429, not 453 — #3720 already extracted `renderPattern`), and the testability smell is real: the ranking test mocked 3 modules just to import pure math.

## #3722 — centralize `ATLAS_LEARN_*` behind one resolver (`867c9b38`)
- New `lib/learn/learn-settings.ts` owns every `ATLAS_LEARN_*` read (literal one-line `getSetting`/`getSettingAuto` so the **#3382 reader guard** stays green), all defaults, and one consolidated doc comment stating which knob is read at which scope and **why** — including the two intentionally dual-scoped keys (`CONFIDENCE_THRESHOLD`, `LATENCY_BUDGET_MS`).
- `pattern-cache.ts` + `promote-decay-scheduler.ts` delegate to the resolver and re-export the prior names, so `agent.ts`, `layers.ts`, and existing test mocks are untouched.
- Removes the cross-module `DEFAULT_LATENCY_BUDGET_MS` import.

**Acceptance:** all `ATLAS_LEARN_*` reads go through one module ✅ · scope documented in one place w/ dual-scope rationale ✅ · no cross-module default-constant import ✅ · behavior unchanged ✅

## #3721 — split `pattern-cache.ts` into ranking / cache-store / retrieval (`5de14fb6`)
- `pattern-ranking.ts` — **pure**: `extractKeywords`/`scorePattern`/`perfWeight`/`rankPatterns`, zero db/settings/logger imports (type-only `ApprovedPatternRow`).
- `pattern-cache-store.ts` — TTL/LRU store + `getCachedPatterns` + `invalidatePatternCache`; eviction policy isolated from ranking.
- `pattern-cache.ts` — slim retrieval composition (`buildRetrievalQuery`, `getRelevantPatterns`, `buildLearnedPatternsSection`) + public barrel re-exporting the prior surface.
- `pattern-ranking.test.ts` rewritten to import the pure module with **no `mock.module()`** (the removal is the win): 3 mocked modules → 0, runtime 58ms → 23ms.

**Acceptance:** pure ranking module has zero db/settings imports, test needs no mocks ✅ · cache store isolated ✅ · consumers unchanged via barrel, no behavior change ✅ · `learn/` suite green ✅

## Gates
- `#3382` reader guard ✅ (46 keys) · `tsgo` type ✅ · ESLint ✅ · syncpack ✅ · template drift ✅ · railway-watch ✅
- Full API suite: **652 files, 0 failures**

Closes #3722
Closes #3721

https://claude.ai/code/session_01WiSTNe7mbMRCW9MGvF1Cya

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiSTNe7mbMRCW9MGvF1Cya)_