### PR TITLE
refactor(api): drop redundant SaaS env vars covered by atlas.config.ts (#3702)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -638,7 +638,8 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_INTERNAL_SECRET=              # Shared secret for cross-region service-to-service auth (required for region migration).
 
 # === Deploy Mode ===
-# ATLAS_DEPLOY_MODE=                          # Deploy mode: self-hosted | saas (auto-detected when unset)
+# ATLAS_DEPLOY_MODE=                          # Deploy mode: self-hosted | saas (auto-detected when unset). Self-host only —
+#                                             # the hosted SaaS sets deployMode in deploy/api/atlas.config.ts, not this env var (#3702).
 # ATLAS_DEPLOY_ENV=production                 # Deployment shape: production | staging | development (unset = production).
 #                                             # Drives non-secret per-env defaults via packages/api/src/lib/env-profile.ts —
 #                                             # prod defaults email-verification ON + onboarding-emails ON; staging/dev default both OFF;
@@ -670,7 +671,8 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # the staging-smoke workflow (set in GitHub Actions, not in this file).
 
 # === Enterprise Features ===
-# ATLAS_ENTERPRISE_ENABLED=false      # Enable enterprise features (SSO, SCIM, PII detection, custom roles)
+# ATLAS_ENTERPRISE_ENABLED=false      # Enable enterprise features (SSO, SCIM, PII detection, custom roles). Self-host only —
+#                                     # the hosted SaaS sets enterprise.enabled in deploy/api/atlas.config.ts, not this env var (#3702).
 # ATLAS_ENTERPRISE_LICENSE_KEY=       # License key for enterprise features (https://www.useatlas.dev/enterprise)
 # ATLAS_APPROVAL_EXPIRY_HOURS=24     # Hours before pending approval requests auto-expire
 # ATLAS_SCIM_OVERRIDE_POLICY=strict  # F-57 SCIM provenance gate. "strict" blocks admin mutations on

--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -65,8 +65,9 @@ them — changing them *is* a deploy:
 | Variable | Why it's deploy-time |
 |---|---|
 | `ATLAS_RATE_LIMIT_RPM` | `RateLimitGuardLive` refuses to boot a region without a positive value (DDoS floor). Hot-reload would re-open the hole. |
-| `ATLAS_DEPLOY_MODE` *(see audit)* | Deploy mode can't change at runtime. **Already set by `atlas.config.ts` (`deployMode: "saas"`) — the env var is redundant.** |
 | `ATLAS_EMAIL_PROVIDER` | DPA guard runs at boot; hot-reload would bypass it. (Changed via Admin → Email provider, takes effect next boot.) |
+
+> `ATLAS_DEPLOY_MODE` and `ATLAS_ENTERPRISE_ENABLED` are **not** set on SaaS — `deploy/api/atlas.config.ts` resolves both (`deployMode: "saas"`, `enterprise.enabled: true`) and the resolution paths consult the config file first. Dropped from the Railway services in #3702.
 
 ## What you change at runtime instead
 

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -88,9 +88,11 @@ across regions:
   `residency.regions[].apiUrl` map instead of stamped per service.
 
 ### Tier 3 — Delete redundant env vars ✅ shipped (#3702)
-Already covered by `atlas.config.ts`, no behavior change to drop from SaaS env. All
-three removed from `SAAS_ENV_KEYS`/the boot-smoke fixture (which now proves a region
-boots green with them unset, relying on `atlas.config.ts`):
+Already covered by `atlas.config.ts`, no behavior change to drop from SaaS env. The two
+boot-contract vars (`ATLAS_DEPLOY_MODE`, `ATLAS_ENTERPRISE_ENABLED`) left
+`SAAS_ENV_KEYS`/the boot-smoke fixture (which now proves a region boots green with them
+unset, relying on `atlas.config.ts`); `TWENTY_BASE_URL` was never part of the typed boot
+contract and is dropped from the Railway services only:
 - `ATLAS_DEPLOY_MODE=saas` — config sets `deployMode: "saas"`; `config.ts` reads
   `process.env.ATLAS_DEPLOY_MODE ?? configFileValue`. `EnterpriseGuardLive` now reads
   the raw `process.env` directly (footgun probe, not a SaaS-required input).
@@ -98,6 +100,7 @@ boots green with them unset, relying on `atlas.config.ts`):
   `config.enterprise?.enabled` first; config sets `enterprise.enabled: true`. Confirmed
   no pre-config read path needs it.
 - `TWENTY_BASE_URL` — its default already *is* the SaaS hostname (`crm.useatlas.dev`).
+  Never in `SAAS_ENV_KEYS`/the boot-smoke fixture — a Railway-only var removal.
 
 ### Tier 4 — Documentation hygiene
 - `.env.example` (718 lines) stays the self-host reference, but should be clearly

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -87,14 +87,17 @@ across regions:
   `requiresRestart`, env as fallback) derived from `ATLAS_API_REGION` + the
   `residency.regions[].apiUrl` map instead of stamped per service.
 
-### Tier 3 — Delete redundant env vars
-Already covered by `atlas.config.ts`, no behavior change to drop from SaaS env:
+### Tier 3 — Delete redundant env vars ✅ shipped (#3702)
+Already covered by `atlas.config.ts`, no behavior change to drop from SaaS env. All
+three removed from `SAAS_ENV_KEYS`/the boot-smoke fixture (which now proves a region
+boots green with them unset, relying on `atlas.config.ts`):
 - `ATLAS_DEPLOY_MODE=saas` — config sets `deployMode: "saas"`; `config.ts` reads
-  `process.env.ATLAS_DEPLOY_MODE ?? configFileValue`.
+  `process.env.ATLAS_DEPLOY_MODE ?? configFileValue`. `EnterpriseGuardLive` now reads
+  the raw `process.env` directly (footgun probe, not a SaaS-required input).
 - `ATLAS_ENTERPRISE_ENABLED=true` — `isEnterpriseEnabledLocal` reads
-  `config.enterprise?.enabled` first; config sets `enterprise.enabled: true`.
-  (Verify no pre-config read path needs it.)
-- `TWENTY_BASE_URL` — its default already *is* the SaaS hostname.
+  `config.enterprise?.enabled` first; config sets `enterprise.enabled: true`. Confirmed
+  no pre-config read path needs it.
+- `TWENTY_BASE_URL` — its default already *is* the SaaS hostname (`crm.useatlas.dev`).
 
 ### Tier 4 — Documentation hygiene
 - `.env.example` (718 lines) stays the self-host reference, but should be clearly

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -90,7 +90,12 @@ describe("makeBootSmokeFixture", () => {
     // gate can't pass.
     // ATLAS_DEPLOY_MODE / ATLAS_ENTERPRISE_ENABLED are intentionally NOT in the
     // fixture (#3702) — SaaS resolves both from atlas.config.ts, so the boot
-    // gate proves the region boots green with them unset.
+    // gate proves the region boots green with them unset. Pin the omission so
+    // re-adding either key to the fixture (and the SaasEnv interface) is a
+    // failing test, not a silent regression of the config-only boot proof.
+    const emitted = fixture as unknown as Record<string, string | undefined>;
+    expect(emitted.ATLAS_DEPLOY_MODE).toBeUndefined();
+    expect(emitted.ATLAS_ENTERPRISE_ENABLED).toBeUndefined();
     expect(fixture.DATABASE_URL).toMatch(/^postgresql:\/\//);
     expect(fixture.ATLAS_DATASOURCE_URL).toMatch(/^postgresql:\/\//);
     expect(fixture.ATLAS_ENCRYPTION_KEYS).toMatch(/^v1:/);

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -37,8 +37,6 @@ describe("SAAS_ENV_KEYS", () => {
     // missing key is a compile error here. The runtime check then
     // confirms SAAS_ENV_KEYS lists each one.
     const exhaustive: SaasEnv = {
-      ATLAS_DEPLOY_MODE: undefined,
-      ATLAS_ENTERPRISE_ENABLED: undefined,
       DATABASE_URL: undefined,
       ATLAS_DATASOURCE_URL: undefined,
       ATLAS_ENCRYPTION_KEYS: undefined,
@@ -75,10 +73,10 @@ describe("SAAS_ENV_KEYS", () => {
 describe("readSaasEnv", () => {
   test("reads from a custom env object when provided", () => {
     const env = readSaasEnv({
-      ATLAS_DEPLOY_MODE: "saas",
+      ATLAS_API_REGION: "us",
       DATABASE_URL: "postgresql://x/y",
     } as NodeJS.ProcessEnv);
-    expect(env.ATLAS_DEPLOY_MODE).toBe("saas");
+    expect(env.ATLAS_API_REGION).toBe("us");
     expect(env.DATABASE_URL).toBe("postgresql://x/y");
     expect(env.RESEND_API_KEY).toBeUndefined();
   });
@@ -90,8 +88,9 @@ describe("makeBootSmokeFixture", () => {
     // Each of these is read by a guard that fails boot when missing or
     // misshapen. If any is dropped from the fixture, the boot-smoke
     // gate can't pass.
-    expect(fixture.ATLAS_DEPLOY_MODE).toBe("saas");
-    expect(fixture.ATLAS_ENTERPRISE_ENABLED).toBe("true");
+    // ATLAS_DEPLOY_MODE / ATLAS_ENTERPRISE_ENABLED are intentionally NOT in the
+    // fixture (#3702) — SaaS resolves both from atlas.config.ts, so the boot
+    // gate proves the region boots green with them unset.
     expect(fixture.DATABASE_URL).toMatch(/^postgresql:\/\//);
     expect(fixture.ATLAS_DATASOURCE_URL).toMatch(/^postgresql:\/\//);
     expect(fixture.ATLAS_ENCRYPTION_KEYS).toMatch(/^v1:/);

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -146,7 +146,16 @@ function makeTestSettingsLayer(): Layer.Layer<TSettings> {
 // prior process could let a later "succeeds when …" assertion pass for
 // the wrong reason.
 const { SAAS_ENV_KEYS } = await import("../saas-env");
-const GUARD_ENV_KEYS = SAAS_ENV_KEYS;
+// `ATLAS_DEPLOY_MODE` / `ATLAS_ENTERPRISE_ENABLED` left the SaaS boot
+// contract in #3702 (atlas.config.ts covers them), but `EnterpriseGuardLive`
+// still inspects the raw `process.env.ATLAS_DEPLOY_MODE` and several cases
+// below set it — so they must still be cleaned between cases to keep the
+// "succeeds when …" assertions from passing for the wrong reason.
+const GUARD_ENV_KEYS = [
+  ...SAAS_ENV_KEYS,
+  "ATLAS_DEPLOY_MODE",
+  "ATLAS_ENTERPRISE_ENABLED",
+] as const;
 
 function withCleanEnv<T>(run: () => Promise<T>): Promise<T> {
   const saved: Record<string, string | undefined> = {};

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -21,12 +21,21 @@
  * read site lives outside `effect/`.
  */
 
-/** Every env var the SaaS-mode boot contract reads. */
+/**
+ * Every env var the SaaS-mode boot contract reads.
+ *
+ * `ATLAS_DEPLOY_MODE` and `ATLAS_ENTERPRISE_ENABLED` are intentionally
+ * NOT in this contract (#3702): on SaaS, `deploy/api/atlas.config.ts`
+ * sets `deployMode: "saas"` and `enterprise.enabled: true`, and both
+ * resolution paths consult the config file first (`applyDeployMode`'s
+ * `process.env.ATLAS_DEPLOY_MODE ?? configFileValue`;
+ * `isEnterpriseEnabled*`'s `config.enterprise?.enabled` before env). So
+ * a SaaS region boots correctly with both unset. `EnterpriseGuardLive`
+ * still inspects the raw `process.env.ATLAS_DEPLOY_MODE` directly to
+ * catch the self-host footgun (env requests saas, no `@atlas/ee`) — that
+ * is a misconfiguration probe, not a SaaS-required input.
+ */
 export interface SaasEnv {
-  // Deploy mode + enterprise (EnterpriseGuardLive)
-  readonly ATLAS_DEPLOY_MODE: string | undefined;
-  readonly ATLAS_ENTERPRISE_ENABLED: string | undefined;
-
   // Internal DB (InternalDbGuardLive, MigrationGuardLive short-circuit)
   readonly DATABASE_URL: string | undefined;
 
@@ -114,8 +123,6 @@ export interface SaasEnv {
  * (clearing every SaaS env var between cases).
  */
 export const SAAS_ENV_KEYS = [
-  "ATLAS_DEPLOY_MODE",
-  "ATLAS_ENTERPRISE_ENABLED",
   "DATABASE_URL",
   "ATLAS_DATASOURCE_URL",
   "ATLAS_ENCRYPTION_KEYS",
@@ -153,8 +160,6 @@ void _exhaustive;
 /** Read `process.env` (or an injected env object) into a typed `SaasEnv`. */
 export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
   return {
-    ATLAS_DEPLOY_MODE: env.ATLAS_DEPLOY_MODE,
-    ATLAS_ENTERPRISE_ENABLED: env.ATLAS_ENTERPRISE_ENABLED,
     DATABASE_URL: env.DATABASE_URL,
     ATLAS_DATASOURCE_URL: env.ATLAS_DATASOURCE_URL,
     ATLAS_ENCRYPTION_KEYS: env.ATLAS_ENCRYPTION_KEYS,
@@ -222,8 +227,6 @@ export function makeBootSmokeFixture(
   const databaseUrl =
     opts.databaseUrl ?? "postgresql://atlas:atlas@127.0.0.1:5432/atlas";
   const fixture: SaasEnv = {
-    ATLAS_DEPLOY_MODE: "saas",
-    ATLAS_ENTERPRISE_ENABLED: "true",
     DATABASE_URL: databaseUrl,
     ATLAS_DATASOURCE_URL: databaseUrl,
     ATLAS_ENCRYPTION_KEYS: "v1:ci-fixture-key-not-a-secret-do-not-use-in-prod",

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -27,9 +27,11 @@
  * `ATLAS_DEPLOY_MODE` and `ATLAS_ENTERPRISE_ENABLED` are intentionally
  * NOT in this contract (#3702): on SaaS, `deploy/api/atlas.config.ts`
  * sets `deployMode: "saas"` and `enterprise.enabled: true`, and both
- * resolution paths consult the config file first (`applyDeployMode`'s
- * `process.env.ATLAS_DEPLOY_MODE ?? configFileValue`;
- * `isEnterpriseEnabled*`'s `config.enterprise?.enabled` before env). So
+ * resolve from the config file when the env vars are unset. The two
+ * precedences differ: `applyDeployMode` is `process.env.ATLAS_DEPLOY_MODE
+ * ?? configFileValue` (env wins if set; config supplies the value only
+ * because the env var is absent), whereas `isEnterpriseEnabled*` checks
+ * `config.enterprise?.enabled` *before* env (config wins outright). So
  * a SaaS region boots correctly with both unset. `EnterpriseGuardLive`
  * still inspects the raw `process.env.ATLAS_DEPLOY_MODE` directly to
  * catch the self-host footgun (env requests saas, no `@atlas/ee`) — that

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -365,8 +365,13 @@ export class BillingConfigInvalidError extends Data.TaggedError("BillingConfigIn
  * is unambiguous operator intent — config-file and `auto` can fall
  * through to `self-hosted` quietly.
  */
-function explicitSaasFromEnv(env: SaasEnv): boolean {
-  return env.ATLAS_DEPLOY_MODE === "saas";
+function explicitSaasFromEnv(): boolean {
+  // Read raw `process.env` directly — `ATLAS_DEPLOY_MODE` is deliberately not
+  // part of the `SaasEnv` boot contract (#3702; SaaS resolves it from
+  // `atlas.config.ts`). This guard inspects the operator's raw env intent to
+  // catch the self-host footgun (env requests saas, no `@atlas/ee`), which is
+  // independent of the SaaS-required input set.
+  return process.env.ATLAS_DEPLOY_MODE === "saas";
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -390,9 +395,8 @@ function explicitSaasFromEnv(env: SaasEnv): boolean {
 export const EnterpriseGuardLive: Layer.Layer<never, EnterpriseRequiredError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
-    const env = readSaasEnv();
 
-    const requestedSaas = explicitSaasFromEnv(env);
+    const requestedSaas = explicitSaasFromEnv();
     const resolvedSaas = config.deployMode === "saas";
 
     if (requestedSaas && !resolvedSaas) {


### PR DESCRIPTION
Tier 3 of the SaaS env audit (#3701) — the lowest-risk win.

`ATLAS_DEPLOY_MODE`, `ATLAS_ENTERPRISE_ENABLED`, and `TWENTY_BASE_URL` are already fully covered by `deploy/api/atlas.config.ts` (`deployMode: "saas"`, `enterprise.enabled: true`, Twenty base defaults to `crm.useatlas.dev`), and every resolution path consults the config file first. So a SaaS region boots correctly with all three unset.

## Changes
- **`saas-env.ts`** — drop `ATLAS_DEPLOY_MODE` / `ATLAS_ENTERPRISE_ENABLED` from `SaasEnv`, `SAAS_ENV_KEYS`, `readSaasEnv`, and `makeBootSmokeFixture`. The boot-smoke gate now boots from the baked-in `atlas.config.ts` with both unset — directly proving AC1.
- **`saas-guards.ts`** — `EnterpriseGuardLive` reads raw `process.env.ATLAS_DEPLOY_MODE` directly. It's a self-host misconfiguration probe (env requests saas, no `@atlas/ee`), not a SaaS-required input, so it shouldn't ride the SaaS boot contract.
- **tests** — guard-test cleanup set keeps both vars (still env-inspected); contract + fixture assertions updated.
- **docs** — operator reference drops the row + adds an explanatory note; `.env.example` marks both self-host-only; audit Tier 3 marked shipped.

## Acceptance criteria
- [x] SaaS boots green with `ATLAS_DEPLOY_MODE` + `ATLAS_ENTERPRISE_ENABLED` unset, relying on `atlas.config.ts` (boot-smoke fixture no longer emits them)
- [x] Boot-smoke fixture + `saas-env.ts` updated (keys left the contract)
- [x] `.env.example` comments note these are self-host-only / config-covered
- [ ] Remove the two vars from the Railway service definitions — **operator action** (AC2)

Verification: `bun run type` clean; `saas-env.test.ts` + `saas-guards.test.ts` (77 tests) + `config-deploy-mode-warning.test.ts` (7) pass.

Part of #3701.