### PR TITLE
refactor(billing): migrate Stripe price IDs from env to platform settings (#3703)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -623,14 +623,11 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.
+# Only the two genuine secrets live in env. The six per-tier Price IDs are
+# now platform settings (Admin → Settings → Billing) — editable at runtime
+# without a redeploy (#3703). Setting them via env still works as a fallback.
 # STRIPE_SECRET_KEY=sk_test_...                    # Stripe secret key (test or live)
 # STRIPE_WEBHOOK_SECRET=whsec_...                  # Stripe webhook signing secret
-# STRIPE_STARTER_PRICE_ID=price_...                 # Stripe Price ID for Starter plan (monthly, $29/seat)
-# STRIPE_STARTER_ANNUAL_PRICE_ID=price_...          # Stripe Price ID for Starter plan (annual)
-# STRIPE_PRO_PRICE_ID=price_...                     # Stripe Price ID for Pro plan (monthly, $59/seat)
-# STRIPE_PRO_ANNUAL_PRICE_ID=price_...              # Stripe Price ID for Pro plan (annual)
-# STRIPE_BUSINESS_PRICE_ID=price_...                # Stripe Price ID for Business plan (monthly, $99/seat)
-# STRIPE_BUSINESS_ANNUAL_PRICE_ID=price_...         # Stripe Price ID for Business plan (annual)
 
 # === Data Residency ===
 # ATLAS_API_REGION=                   # Region identity of this API instance (e.g. "us-west", "eu-west", "ap-southeast"). Used for misrouting detection. Falls back to residency.defaultRegion from atlas.config.ts if unset.

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -222,17 +222,33 @@ If a Stripe call fails during one of these actions, the operation still complete
 On [app.useatlas.dev](https://app.useatlas.dev), Stripe is pre-configured. Skip this section — manage your subscription from **Admin > Billing** instead.
 </Callout>
 
-Set these environment variables to enable billing:
+Set these two environment variables to enable billing — they are the only
+Stripe **secrets**, so they stay in env:
 
 | Variable | Description |
 |----------|-------------|
 | `STRIPE_SECRET_KEY` | Stripe secret key (test or live). Enables billing routes when set |
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret for verifying events |
+
+The six per-tier **Price IDs** are non-secret constants and live in the
+settings registry under **Admin → Settings → Billing** (platform admins only).
+They are runtime-editable and hot-reloadable — a pricing change takes effect
+without a redeploy ([#3703](https://github.com/AtlasDevHQ/atlas/issues/3703)).
+The matching environment variables still work as a fallback when no settings
+override is present:
+
+| Setting / env fallback | Description |
+|----------|-------------|
 | `STRIPE_STARTER_PRICE_ID` | Price ID for the Starter plan (monthly) |
 | `STRIPE_STARTER_ANNUAL_PRICE_ID` | Price ID for the Starter plan (annual) |
 | `STRIPE_PRO_PRICE_ID` | Price ID for the Pro plan (monthly) |
 | `STRIPE_PRO_ANNUAL_PRICE_ID` | Price ID for the Pro plan (annual) |
-| `STRIPE_BUSINESS_PRICE_ID` | Price ID for the Business plan |
+| `STRIPE_BUSINESS_PRICE_ID` | Price ID for the Business plan (monthly) |
+| `STRIPE_BUSINESS_ANNUAL_PRICE_ID` | Price ID for the Business plan (annual) |
+
+A missing monthly Price ID silently omits that tier from checkout, so it is
+surfaced as an operator-actionable warning in the boot log (not a boot
+failure). Set the missing ID from **Admin → Settings → Billing**.
 
 When `STRIPE_SECRET_KEY` is set:
 
@@ -284,7 +300,7 @@ To run Atlas without any billing:
 ### Plan not syncing after payment
 
 - The `customer.subscription.updated` webhook updates the workspace tier and invalidates the plan cache — changes take effect on the next request
-- If the webhook is arriving but the plan isn't updating, check that `resolvePlanTierFromPriceId()` can map your Stripe price IDs to Atlas tiers — verify the `STRIPE_*_PRICE_ID` environment variables match your Stripe dashboard
+- If the webhook is arriving but the plan isn't updating, check that `resolvePlanTierFromPriceId()` can map your Stripe price IDs to Atlas tiers — verify the Price IDs in **Admin → Settings → Billing** (or their `STRIPE_*_PRICE_ID` env fallback) match your Stripe dashboard
 - Call `GET /api/v1/billing` to check the current billing status for the workspace
 
 ### Workspace suspended after payment failure

--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -86,6 +86,7 @@ Railway:
 - **Intelligence** — semantic-expert scheduler + auto-approve
 - **Appearance** — brand color
 - **Email** — provider + from address (keys via Admin → Email provider)
+- **Billing** — the six Stripe per-tier Price IDs (only `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET` stay env)
 
 Platform-scoped settings require `platform_admin`; workspace-scoped settings are
 editable by workspace admins (filtered by `saasVisible` / `saasWritable` on SaaS).

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -61,8 +61,11 @@ the genuine secrets of Stripe/Turnstile/Twenty/Vercel.
 The headline of the principle. Candidates, by area:
 
 - **Stripe price IDs** (`STRIPE_{STARTER,PRO,BUSINESS}{,_ANNUAL}_PRICE_ID`, 6
-  vars) — non-secret; boot-blocks via `BillingConfigInvalidError`. Operator should
-  set pricing in Admin without a deploy. Only the secret key + webhook secret stay env.
+  vars) — ✅ **done (#3703).** Promoted to platform-scoped, hot-reloadable
+  settings (env is now only a fallback tier); `getStripePlans()` /
+  `resolvePlanTierFromPriceId()` read them via `getSettingAuto` per checkout, and
+  `BillingConfigGuardLive` warns (no longer boot-blocks) on a missing price ID.
+  Only the secret key + webhook secret stay env.
 - **Rate-limit / abuse tuning** — the per-user / chat / admin RPM trio
   (`ATLAS_RATE_LIMIT_RPM`, `_RPM_CHAT`, `_RPM_ADMIN`) is **already** in the registry
   (`_RPM` itself is immutable on SaaS — DDoS floor). The remaining env-only knobs to

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -356,6 +356,37 @@ describe("buildStripePluginOptions — org-scoped configuration (#3416)", () => 
       expect(typeof options.subscription.authorizeReference).toBe("function");
     }
   });
+
+  // #3703 — pin the hot-reload contract: `plans` must be the resolver FUNCTION,
+  // not an eager array snapshot. A revert to `plans: getStripePlans()` would
+  // restore the redeploy-required footgun, and only this assertion would catch
+  // it (every other test exercises behavior, not the handoff shape).
+  it("hands the plugin the plans resolver FUNCTION, re-resolved per call (#3703)", () => {
+    const options = buildStripePluginOptions({
+      stripeClient: makeStripeClient(),
+      webhookSecret: "whsec_test",
+    });
+    expect(options.subscription?.enabled).toBe(true);
+    if (!options.subscription?.enabled) throw new Error("subscription disabled");
+    const plans = options.subscription.plans;
+    expect(typeof plans).toBe("function");
+    if (typeof plans !== "function") throw new Error("plans is not a function");
+
+    // Re-resolution proof: the resolver reads price IDs live (via getSettingAuto
+    // → env fallback here), so mutating the source between calls changes the
+    // output — a snapshot array could not. Restore the env after.
+    const saved = process.env.STRIPE_STARTER_PRICE_ID;
+    try {
+      const first = plans() as Array<{ name: string; priceId: string }>;
+      expect(first.find((p) => p.name === "starter")?.priceId).toBe(STARTER_PRICE);
+      process.env.STRIPE_STARTER_PRICE_ID = "price_starter_rotated";
+      const second = plans() as Array<{ name: string; priceId: string }>;
+      expect(second.find((p) => p.name === "starter")?.priceId).toBe("price_starter_rotated");
+    } finally {
+      if (saved === undefined) delete process.env.STRIPE_STARTER_PRICE_ID;
+      else process.env.STRIPE_STARTER_PRICE_ID = saved;
+    }
+  });
 });
 
 // ── getCheckoutSessionParams — user-scoped checkout guard ───────────

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1998,9 +1998,11 @@ export function buildStripePluginOptions(deps: {
     subscription: {
       enabled: true,
       // Pass the resolver FUNCTION (not its return value) so the plugin
-      // re-resolves plans per checkout — price IDs are hot-reloadable platform
-      // settings (#3703), so a pricing change from Admin → Settings takes
-      // effect without a redeploy / process restart.
+      // re-resolves plans on each subscription operation — price IDs are
+      // hot-reloadable platform settings (#3703), so a pricing change from
+      // Admin → Settings takes effect without a redeploy / process restart.
+      // The function ref (not an eager array) is the durable contract here;
+      // pinned by the buildStripePluginOptions test.
       plans: getStripePlans,
       // Required for org-referenced subscription actions: the plugin 400s
       // org-scoped calls without it (AUTHORIZE_REFERENCE_REQUIRED). Role

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1997,7 +1997,11 @@ export function buildStripePluginOptions(deps: {
     },
     subscription: {
       enabled: true,
-      plans: getStripePlans(),
+      // Pass the resolver FUNCTION (not its return value) so the plugin
+      // re-resolves plans per checkout — price IDs are hot-reloadable platform
+      // settings (#3703), so a pricing change from Admin → Settings takes
+      // effect without a redeploy / process restart.
+      plans: getStripePlans,
       // Required for org-referenced subscription actions: the plugin 400s
       // org-scoped calls without it (AUTHORIZE_REFERENCE_REQUIRED). Role
       // policy (admin/owner for money-moving actions, member for list)

--- a/packages/api/src/lib/billing/__tests__/config-validation.test.ts
+++ b/packages/api/src/lib/billing/__tests__/config-validation.test.ts
@@ -12,6 +12,7 @@ import {
   MONTHLY_PRICE_ID_ENV_VARS,
   ANNUAL_PRICE_ID_ENV_VARS,
   findMissingMonthlyPriceIdEnvVars,
+  findMissingMonthlyPriceIds,
   detectStripeKeyMode,
   isPriceModeConsistent,
 } from "@atlas/api/lib/billing/config-validation";
@@ -80,6 +81,42 @@ describe("billing/config-validation", () => {
           // every annual var deliberately absent
         }),
       ).toEqual([]);
+    });
+  });
+
+  describe("findMissingMonthlyPriceIds (settings-aware, #3703)", () => {
+    it("returns all three when the resolver finds nothing", () => {
+      expect(findMissingMonthlyPriceIds(() => undefined)).toEqual([
+        "STRIPE_STARTER_PRICE_ID",
+        "STRIPE_PRO_PRICE_ID",
+        "STRIPE_BUSINESS_PRICE_ID",
+      ]);
+    });
+
+    it("returns empty when the resolver supplies all three", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_PRICE_ID: "price_a",
+        STRIPE_PRO_PRICE_ID: "price_b",
+        STRIPE_BUSINESS_PRICE_ID: "price_c",
+      };
+      expect(findMissingMonthlyPriceIds((k) => store[k])).toEqual([]);
+    });
+
+    it("flags only the tier the resolver leaves unset (e.g. settings supply the rest)", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_PRICE_ID: "price_a",
+        STRIPE_BUSINESS_PRICE_ID: "price_c",
+      };
+      expect(findMissingMonthlyPriceIds((k) => store[k])).toEqual(["STRIPE_PRO_PRICE_ID"]);
+    });
+
+    it("treats an empty string from the resolver as missing", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_PRICE_ID: "",
+        STRIPE_PRO_PRICE_ID: "price_b",
+        STRIPE_BUSINESS_PRICE_ID: "price_c",
+      };
+      expect(findMissingMonthlyPriceIds((k) => store[k])).toEqual(["STRIPE_STARTER_PRICE_ID"]);
     });
   });
 

--- a/packages/api/src/lib/billing/__tests__/plans-settings.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans-settings.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Settings-backed Stripe price resolution (#3703).
+ *
+ * `getStripePlans()` / `resolvePlanTierFromPriceId()` resolve the six price IDs
+ * through `getSettingAuto` (platform settings → env → default, hot-reloadable in
+ * SaaS) rather than reading `process.env` directly. These tests mock the
+ * settings module so we can assert resolution goes through the registry and that
+ * a settings value WINS over a divergent env var — the property that makes a
+ * pricing change take effect without a redeploy.
+ *
+ * The env-fallback tier is covered by `plans.test.ts` (no settings mock there,
+ * so `getSettingAuto` falls through to `process.env`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// Mutable backing store for the mocked settings registry. Keyed by setting key.
+let settingValues: Record<string, string | undefined> = {};
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string) => settingValues[key],
+}));
+
+const { getStripePlans, resolvePlanTierFromPriceId } = await import(
+  "@atlas/api/lib/billing/plans"
+);
+
+// Ensure no real env var leaks into resolution while the settings mock drives
+// the store. (The mock ignores process.env entirely, but a divergence test
+// below sets an env var deliberately to prove the settings value wins.)
+const PRICE_ENV_KEYS = [
+  "STRIPE_STARTER_PRICE_ID",
+  "STRIPE_STARTER_ANNUAL_PRICE_ID",
+  "STRIPE_PRO_PRICE_ID",
+  "STRIPE_PRO_ANNUAL_PRICE_ID",
+  "STRIPE_BUSINESS_PRICE_ID",
+  "STRIPE_BUSINESS_ANNUAL_PRICE_ID",
+] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  settingValues = {};
+  savedEnv = {};
+  for (const key of PRICE_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of PRICE_ENV_KEYS) {
+    if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+    else delete process.env[key];
+  }
+});
+
+describe("billing/plans settings-backed resolution (#3703)", () => {
+  describe("getStripePlans", () => {
+    it("returns empty when no price IDs resolve from settings", () => {
+      expect(getStripePlans()).toEqual([]);
+    });
+
+    it("builds a plan from a settings-resolved price ID", () => {
+      settingValues = { STRIPE_STARTER_PRICE_ID: "price_starter_from_settings" };
+      const plans = getStripePlans();
+      expect(plans.length).toBe(1);
+      expect(plans[0].name).toBe("starter");
+      expect(plans[0].priceId).toBe("price_starter_from_settings");
+      expect(plans[0].seatPriceId).toBe("price_starter_from_settings");
+    });
+
+    it("picks up the annual discount price ID from settings", () => {
+      settingValues = {
+        STRIPE_PRO_PRICE_ID: "price_pro",
+        STRIPE_PRO_ANNUAL_PRICE_ID: "price_pro_annual",
+      };
+      const plans = getStripePlans();
+      expect(plans[0].annualDiscountPriceId).toBe("price_pro_annual");
+    });
+
+    it("a settings value WINS over a divergent env var (hot-reload property)", () => {
+      // Env says one thing, settings override says another — the override
+      // (Admin → Settings) is authoritative, so a price change needs no redeploy.
+      process.env.STRIPE_BUSINESS_PRICE_ID = "price_from_env";
+      settingValues = { STRIPE_BUSINESS_PRICE_ID: "price_from_settings" };
+      const business = getStripePlans().find((p) => p.name === "business");
+      expect(business?.priceId).toBe("price_from_settings");
+    });
+
+    it("resolves all three tiers when all settings are present", () => {
+      settingValues = {
+        STRIPE_STARTER_PRICE_ID: "price_s",
+        STRIPE_PRO_PRICE_ID: "price_p",
+        STRIPE_BUSINESS_PRICE_ID: "price_b",
+      };
+      expect(getStripePlans().map((p) => p.name)).toEqual(["starter", "pro", "business"]);
+    });
+  });
+
+  describe("resolvePlanTierFromPriceId", () => {
+    it("maps a settings-resolved monthly price ID back to its tier", () => {
+      settingValues = { STRIPE_PRO_PRICE_ID: "price_pro_settings" };
+      expect(resolvePlanTierFromPriceId("price_pro_settings")).toBe("pro");
+    });
+
+    it("maps a settings-resolved annual price ID back to its tier", () => {
+      settingValues = {
+        STRIPE_BUSINESS_PRICE_ID: "price_biz",
+        STRIPE_BUSINESS_ANNUAL_PRICE_ID: "price_biz_annual",
+      };
+      expect(resolvePlanTierFromPriceId("price_biz_annual")).toBe("business");
+    });
+
+    it("returns null for a price ID that matches no configured tier", () => {
+      settingValues = { STRIPE_STARTER_PRICE_ID: "price_s" };
+      expect(resolvePlanTierFromPriceId("price_unknown")).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/lib/billing/config-validation.ts
+++ b/packages/api/src/lib/billing/config-validation.ts
@@ -13,7 +13,10 @@
  *   1. **Missing monthly price IDs.** `getStripePlans()` (`plans.ts`) silently
  *      omits a tier whose monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` is
  *      unset — the plan never appears in checkout and the region looks healthy.
- *      {@link findMissingMonthlyPriceIdEnvVars} names the absent vars.
+ *      {@link findMissingMonthlyPriceIds} (settings-aware, #3703) /
+ *      {@link findMissingMonthlyPriceIdEnvVars} (pure env) name the absent
+ *      keys. Since #3703 these are operator-actionable boot WARNINGS, not boot
+ *      crashes — the price IDs are runtime-editable platform settings.
  *
  *   2. **Secret-key mode.** `sk_test_…` vs `sk_live_…` is the only test/live
  *      signal available locally — a Stripe *price* ID (`price_…`) carries no
@@ -43,6 +46,27 @@ export const ANNUAL_PRICE_ID_ENV_VARS = [
 ] as const;
 
 export type MonthlyPriceIdEnvVar = (typeof MONTHLY_PRICE_ID_ENV_VARS)[number];
+
+/**
+ * Return the subset of {@link MONTHLY_PRICE_ID_ENV_VARS} that resolve to a
+ * missing (undefined or empty-string) value through `resolve` (#3703).
+ *
+ * Price IDs are now platform-scoped SETTINGS (registry-backed, env-fallback,
+ * hot-reloadable) rather than env-only, so the boot guard resolves them via
+ * `getSettingAuto` instead of reading `process.env` directly — a price set
+ * only in the Admin console must NOT register as missing. This is the
+ * settings-aware sibling of {@link findMissingMonthlyPriceIdEnvVars}: same
+ * empty-string-counts-as-missing semantics, but the lookup is injected so the
+ * function stays pure and unit-testable with a stub resolver.
+ */
+export function findMissingMonthlyPriceIds(
+  resolve: (settingKey: MonthlyPriceIdEnvVar) => string | undefined,
+): MonthlyPriceIdEnvVar[] {
+  return MONTHLY_PRICE_ID_ENV_VARS.filter((key) => {
+    const value = resolve(key);
+    return value === undefined || value === "";
+  });
+}
 
 /**
  * Stripe secret-key mode, derived from the `sk_test_` / `sk_live_` prefix.

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -258,11 +258,14 @@ export function computeTokenBudget(tier: PlanTier, seatCount: number): number {
  * of the seat item (double billing).
  *
  * Price IDs resolve via `getSettingAuto` (#3703) — platform-scoped settings
- * registry with `workspace > platform > env > default` precedence and SaaS
- * hot-reload. The env var is the self-host / boot fallback tier. Because this
- * is read PER-CHECKOUT (the `@better-auth/stripe` plugin is handed this
- * function, not its return value), a pricing change set from Admin → Settings
- * takes effect without a redeploy.
+ * registry. These keys are `scope: "platform"` and read with no orgId, so the
+ * effective precedence is `platform DB override > env > default` (the workspace
+ * tier is unreachable for platform-scoped reads). The env var is the self-host
+ * / boot fallback tier. `getSettingAuto` is a synchronous read of the in-process
+ * settings cache (kept fresh by writes + the SaaS refresh tick); because the
+ * `@better-auth/stripe` plugin is handed this FUNCTION (not its return value),
+ * plans are re-resolved on each subscription operation, so a pricing change set
+ * from Admin → Settings takes effect without a redeploy.
  *
  * NOTE (#3435/#3703): each tier below is conditionally pushed only when its
  * monthly price ID resolves, so a missing one SILENTLY OMITS that tier from

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -12,6 +12,7 @@
  */
 
 import type { PlanTier } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -256,13 +257,21 @@ export function computeTokenBudget(tier: PlanTier, seatCount: number): number {
  * pinned by plans.test.ts — a drift would re-add a base line item on top
  * of the seat item (double billing).
  *
- * NOTE (#3435): each tier below is conditionally pushed only when its monthly
- * `STRIPE_*_PRICE_ID` is set, so a missing one SILENTLY OMITS that tier from
+ * Price IDs resolve via `getSettingAuto` (#3703) — platform-scoped settings
+ * registry with `workspace > platform > env > default` precedence and SaaS
+ * hot-reload. The env var is the self-host / boot fallback tier. Because this
+ * is read PER-CHECKOUT (the `@better-auth/stripe` plugin is handed this
+ * function, not its return value), a pricing change set from Admin → Settings
+ * takes effect without a redeploy.
+ *
+ * NOTE (#3435/#3703): each tier below is conditionally pushed only when its
+ * monthly price ID resolves, so a missing one SILENTLY OMITS that tier from
  * checkout. This function deliberately stays silent (it has many legitimate
  * callers that don't want boot noise); the loud check lives at boot in
- * `BillingConfigGuardLive` (`lib/effect/saas-guards.ts`), which fails a SaaS
- * boot when any required monthly price ID is absent. The required-var SSOT
- * is `MONTHLY_PRICE_ID_ENV_VARS` in `lib/billing/config-validation.ts`.
+ * `BillingConfigGuardLive` (`lib/effect/saas-guards.ts`), which WARNS (no
+ * longer crashes) a SaaS boot when any required monthly price ID is absent
+ * after settings resolution. The required-key SSOT is
+ * `MONTHLY_PRICE_ID_ENV_VARS` in `lib/billing/config-validation.ts`.
  */
 export function getStripePlans(): Array<{
   name: string;
@@ -281,13 +290,13 @@ export function getStripePlans(): Array<{
     freeTrial?: { days: number };
   }> = [];
 
-  const starterPriceId = process.env.STRIPE_STARTER_PRICE_ID;
+  const starterPriceId = getSettingAuto("STRIPE_STARTER_PRICE_ID");
   if (starterPriceId) {
     plans.push({
       name: "starter",
       priceId: starterPriceId,
       seatPriceId: starterPriceId,
-      annualDiscountPriceId: process.env.STRIPE_STARTER_ANNUAL_PRICE_ID,
+      annualDiscountPriceId: getSettingAuto("STRIPE_STARTER_ANNUAL_PRICE_ID"),
       limits: {
         tokenBudgetPerSeat: PLANS.starter.limits.tokenBudgetPerSeat,
         seats: PLANS.starter.limits.maxSeats,
@@ -298,13 +307,13 @@ export function getStripePlans(): Array<{
     });
   }
 
-  const proPriceId = process.env.STRIPE_PRO_PRICE_ID;
+  const proPriceId = getSettingAuto("STRIPE_PRO_PRICE_ID");
   if (proPriceId) {
     plans.push({
       name: "pro",
       priceId: proPriceId,
       seatPriceId: proPriceId,
-      annualDiscountPriceId: process.env.STRIPE_PRO_ANNUAL_PRICE_ID,
+      annualDiscountPriceId: getSettingAuto("STRIPE_PRO_ANNUAL_PRICE_ID"),
       limits: {
         tokenBudgetPerSeat: PLANS.pro.limits.tokenBudgetPerSeat,
         seats: PLANS.pro.limits.maxSeats,
@@ -315,13 +324,13 @@ export function getStripePlans(): Array<{
     });
   }
 
-  const businessPriceId = process.env.STRIPE_BUSINESS_PRICE_ID;
+  const businessPriceId = getSettingAuto("STRIPE_BUSINESS_PRICE_ID");
   if (businessPriceId) {
     plans.push({
       name: "business",
       priceId: businessPriceId,
       seatPriceId: businessPriceId,
-      annualDiscountPriceId: process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID,
+      annualDiscountPriceId: getSettingAuto("STRIPE_BUSINESS_ANNUAL_PRICE_ID"),
       limits: {
         tokenBudgetPerSeat: PLANS.business.limits.tokenBudgetPerSeat,
         seats: PLANS.business.limits.maxSeats,
@@ -338,16 +347,17 @@ export function getStripePlans(): Array<{
 /**
  * Resolve a Stripe price ID back to an Atlas PlanTier.
  *
- * Checks both monthly and annual price IDs from environment variables.
+ * Checks both monthly and annual price IDs, resolved via `getSettingAuto`
+ * (#3703) — platform settings with env fallback, hot-reloadable in SaaS.
  * Returns null if the price ID doesn't match any configured plan.
  */
 export function resolvePlanTierFromPriceId(priceId: string): PlanTier | null {
-  const starterPriceId = process.env.STRIPE_STARTER_PRICE_ID;
-  const starterAnnualPriceId = process.env.STRIPE_STARTER_ANNUAL_PRICE_ID;
-  const proPriceId = process.env.STRIPE_PRO_PRICE_ID;
-  const proAnnualPriceId = process.env.STRIPE_PRO_ANNUAL_PRICE_ID;
-  const businessPriceId = process.env.STRIPE_BUSINESS_PRICE_ID;
-  const businessAnnualPriceId = process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID;
+  const starterPriceId = getSettingAuto("STRIPE_STARTER_PRICE_ID");
+  const starterAnnualPriceId = getSettingAuto("STRIPE_STARTER_ANNUAL_PRICE_ID");
+  const proPriceId = getSettingAuto("STRIPE_PRO_PRICE_ID");
+  const proAnnualPriceId = getSettingAuto("STRIPE_PRO_ANNUAL_PRICE_ID");
+  const businessPriceId = getSettingAuto("STRIPE_BUSINESS_PRICE_ID");
+  const businessAnnualPriceId = getSettingAuto("STRIPE_BUSINESS_ANNUAL_PRICE_ID");
 
   if (starterPriceId && (priceId === starterPriceId || (starterAnnualPriceId && priceId === starterAnnualPriceId))) {
     return "starter";

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -891,31 +891,31 @@ describe("buildAppLayer", () => {
   // real-DB-URL workaround for marginal additional coverage beyond the
   // existing unit-level guard tests.
 
-  // #3435 — canary that `billingConfigGuardLayer` is actually wired into
-  // `Layer.mergeAll(...)`. Uses the PURE fail-fast path (missing monthly
-  // price ID) so it never reaches the network price-resolution branch — no
-  // Stripe SDK / mock needed. STRIPE_SECRET_KEY must be set (the guard gates
-  // on it) with at least one tier's price ID absent.
-  test("buildAppLayer wires BillingConfigGuardLive — missing price ID fails the layer in SaaS", async () => {
+  // #3435 + #3703 — canary that `billingConfigGuardLayer` is actually wired
+  // into `Layer.mergeAll(...)`. Uses the env-only fail-fast path (missing
+  // STRIPE_WEBHOOK_SECRET) so it never reaches the network price-resolution
+  // branch — no Stripe SDK / mock needed. Since #3703 a missing PRICE ID is a
+  // warn (not a boot crash), so the webhook-secret gap is the remaining
+  // pure fail-fast trigger. STRIPE_SECRET_KEY must be set (the guard gates on it).
+  test("buildAppLayer wires BillingConfigGuardLive — missing webhook secret fails the layer in SaaS", async () => {
     const savedDb = process.env.DATABASE_URL;
     const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
     const savedRpm = process.env.ATLAS_RATE_LIMIT_RPM;
     const savedProvider = process.env.ATLAS_PROVIDER;
     const savedStripeKey = process.env.STRIPE_SECRET_KEY;
-    const savedStarter = process.env.STRIPE_STARTER_PRICE_ID;
-    const savedPro = process.env.STRIPE_PRO_PRICE_ID;
-    const savedBusiness = process.env.STRIPE_BUSINESS_PRICE_ID;
+    const savedWebhook = process.env.STRIPE_WEBHOOK_SECRET;
+    const savedResend = process.env.RESEND_API_KEY;
     // Satisfy the sibling SaaS guards so the cause carries exclusively the
-    // billing error.
+    // billing error. RESEND_API_KEY satisfies DpaGuardLive, which (like the
+    // billing guard since #3703) is Settings-gated and would otherwise race it.
     process.env.DATABASE_URL = "postgresql://localhost:5432/wiring-test";
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:wiring-regression-test-key-32-bytes-long-aaa";
     process.env.ATLAS_RATE_LIMIT_RPM = "300";
     process.env.ATLAS_PROVIDER = "ollama"; // keyless provider
+    process.env.RESEND_API_KEY = "re_wiring_test";
     process.env.STRIPE_SECRET_KEY = "sk_test_wiring";
-    // All price IDs absent → fail-fast before any network call.
-    delete process.env.STRIPE_STARTER_PRICE_ID;
-    delete process.env.STRIPE_PRO_PRICE_ID;
-    delete process.env.STRIPE_BUSINESS_PRICE_ID;
+    // Webhook secret absent → env-only fail-fast before any network call.
+    delete process.env.STRIPE_WEBHOOK_SECRET;
 
     try {
       const config = { deployMode: "saas" } as Parameters<typeof buildAppLayer>[0];
@@ -938,9 +938,8 @@ describe("buildAppLayer", () => {
       restore("ATLAS_RATE_LIMIT_RPM", savedRpm);
       restore("ATLAS_PROVIDER", savedProvider);
       restore("STRIPE_SECRET_KEY", savedStripeKey);
-      restore("STRIPE_STARTER_PRICE_ID", savedStarter);
-      restore("STRIPE_PRO_PRICE_ID", savedPro);
-      restore("STRIPE_BUSINESS_PRICE_ID", savedBusiness);
+      restore("STRIPE_WEBHOOK_SECRET", savedWebhook);
+      restore("RESEND_API_KEY", savedResend);
     }
   });
 });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -41,8 +41,21 @@ mock.module("@atlas/api/lib/logger", () => ({
 // Individual tests set it (and reset to undefined in `finally`) to exercise the
 // settings-only-misconfig path. Full export surface mocked per mock-all-exports.
 let mockSettingProvider: string | undefined;
+// Optional per-key settings override consulted before the env fallback. Lets the
+// BillingConfigGuardLive tests (#3703) exercise the settings-backed price path
+// (a price set only in the registry, not in env). Cleared per billing test.
+let mockSettingOverrides: Record<string, string> = {};
 mock.module("@atlas/api/lib/settings", () => ({
-  getSettingAuto: (key: string) => (key === "ATLAS_PROVIDER" ? mockSettingProvider : undefined),
+  // Mirror the real `getSetting` tier chain closely enough for the guards:
+  // explicit test override → ATLAS_PROVIDER stub → env fallback. The price-ID
+  // settings are platform-scoped with an env fallback tier, so falling through
+  // to `process.env` keeps the env-driven `withBillingEnv` setup authoritative
+  // while still honoring an injected settings override.
+  getSettingAuto: (key: string) => {
+    if (key in mockSettingOverrides) return mockSettingOverrides[key];
+    if (key === "ATLAS_PROVIDER") return mockSettingProvider;
+    return process.env[key];
+  },
   getSetting: () => undefined,
   getSettingLive: async () => undefined,
   setSetting: async () => {},
@@ -1571,12 +1584,14 @@ function withBillingEnv<T>(
   }
   mockStripePrices = {};
   mockStripeClientNull = false;
+  mockSettingOverrides = {};
   for (const [k, v] of Object.entries(vars)) process.env[k] = v;
   return run().finally(() => {
     for (const key of BILLING_ENV_KEYS) {
       if (saved[key] !== undefined) process.env[key] = saved[key];
       else delete process.env[key];
     }
+    mockSettingOverrides = {};
   });
 }
 
@@ -1585,7 +1600,9 @@ function runBillingGuard(deployMode: string) {
     Effect.void.pipe(
       Effect.provide(
         BillingConfigGuardLive.pipe(
-          Layer.provide(makeTestConfigLayer({ deployMode })),
+          // BillingConfigGuardLive depends on Config + Settings (#3703) — the
+          // Settings edge sequences it after loadSettings warms the cache.
+          Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode }), makeTestSettingsLayer())),
         ),
       ),
     ),
@@ -1613,24 +1630,51 @@ describe("BillingConfigGuardLive", () => {
     });
   });
 
-  test("fails boot in SaaS when a monthly price ID is missing", async () => {
+  test("does NOT fail boot in SaaS when a monthly price ID is missing (warn, not crash — #3703)", async () => {
+    // Price IDs are runtime-editable platform settings since #3703 — a missing
+    // one is a loud, operator-actionable WARNING (logged), never a boot crash,
+    // so the operator can set it from Admin → Settings without a redeploy.
     await withBillingEnv(
       {
         STRIPE_SECRET_KEY: "sk_test_abc",
+        STRIPE_WEBHOOK_SECRET: "whsec_test",
         STRIPE_STARTER_PRICE_ID: "price_starter",
         STRIPE_BUSINESS_PRICE_ID: "price_business",
         // STRIPE_PRO_PRICE_ID deliberately absent
       },
       async () => {
+        mockStripePrices = {
+          price_starter: { livemode: false },
+          price_business: { livemode: false },
+        };
         const exit = await runBillingGuard("saas");
-        expect(Exit.isFailure(exit)).toBe(true);
-        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
-        expect(failure).toBeInstanceOf(BillingConfigInvalidError);
-        const e = failure as TBillingConfigInvalidError;
-        expect(e._tag).toBe("BillingConfigInvalidError");
-        expect(e.missingPriceIdEnvVars).toEqual(["STRIPE_PRO_PRICE_ID"]);
-        expect(e.keyMode).toBe("test");
-        expect(e.message).toContain("#3435");
+        expect(Exit.isSuccess(exit)).toBe(true);
+      },
+    );
+  });
+
+  test("resolves a price ID from settings even when its env var is absent (#3703)", async () => {
+    // Only the env-fallback tier sets starter/business; the pro price exists
+    // ONLY as a platform settings override. The guard must see it via
+    // getSettingAuto and NOT warn it as missing — proving settings-backed
+    // resolution. With all three resolvable and consistent, boot succeeds.
+    await withBillingEnv(
+      {
+        STRIPE_SECRET_KEY: "sk_test_abc",
+        STRIPE_WEBHOOK_SECRET: "whsec_test",
+        STRIPE_STARTER_PRICE_ID: "price_starter",
+        STRIPE_BUSINESS_PRICE_ID: "price_business",
+        // STRIPE_PRO_PRICE_ID absent from env — supplied via settings below
+      },
+      async () => {
+        mockSettingOverrides = { STRIPE_PRO_PRICE_ID: "price_pro_from_settings" };
+        mockStripePrices = {
+          price_starter: { livemode: false },
+          price_business: { livemode: false },
+          price_pro_from_settings: { livemode: false },
+        };
+        const exit = await runBillingGuard("saas");
+        expect(Exit.isSuccess(exit)).toBe(true);
       },
     );
   });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -16,20 +16,25 @@
 import { describe, test, expect, mock } from "bun:test";
 import { Effect, Exit, Layer } from "effect";
 
-// Logger no-op mock — keeps these tests quiet (and isolated from any
-// real logger configuration the test runner has set up). All log calls
-// inside `saas-guards.ts` are observational; nothing in this file
-// asserts log content (the deploy-mode-warning emission test moved to
-// `lib/__tests__/config-deploy-mode-warning.test.ts` when the helper
-// was inlined into `lib/config.ts`).
+// Logger mock — keeps these tests quiet (and isolated from any real logger
+// configuration the test runner has set up) while CAPTURING `log.error` calls.
+// Most log calls inside `saas-guards.ts` are observational, but the warn-vs-
+// crash contract (#3703) hinges on a missing price ID emitting an operator-
+// actionable `log.error` — the BillingConfigGuardLive tests below assert that
+// log fired (event + missing-key payload). `capturedLogErrors` records every
+// `log.error(obj, msg)`; `withBillingEnv` resets it per billing test.
+let capturedLogErrors: Array<{ obj: unknown; msg: unknown }> = [];
+const recordError = (obj: unknown, msg?: unknown) => {
+  capturedLogErrors.push({ obj, msg });
+};
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
-    error: () => {},
+    error: recordError,
     warn: () => {},
     info: () => {},
     debug: () => {},
   }),
-  getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  getLogger: () => ({ error: recordError, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
 }));
@@ -1585,6 +1590,7 @@ function withBillingEnv<T>(
   mockStripePrices = {};
   mockStripeClientNull = false;
   mockSettingOverrides = {};
+  capturedLogErrors = [];
   for (const [k, v] of Object.entries(vars)) process.env[k] = v;
   return run().finally(() => {
     for (const key of BILLING_ENV_KEYS) {
@@ -1649,6 +1655,18 @@ describe("BillingConfigGuardLive", () => {
         };
         const exit = await runBillingGuard("saas");
         expect(Exit.isSuccess(exit)).toBe(true);
+        // The warn-not-crash contract IS the change (#3703): a missing monthly
+        // price ID must emit a loud, operator-actionable log.error naming the
+        // event + the absent key. Asserting boot success alone would let a
+        // regression that silently drops the warn block pass — this pins the
+        // emission, which is the whole justification for downgrading the crash.
+        const priceMissingLog = capturedLogErrors.find(
+          (e) => (e.obj as { event?: string } | undefined)?.event === "billing_config.price_missing",
+        );
+        expect(priceMissingLog).toBeDefined();
+        expect(
+          (priceMissingLog?.obj as { missingMonthlyPriceIds?: string[] } | undefined)?.missingMonthlyPriceIds,
+        ).toEqual(["STRIPE_PRO_PRICE_ID"]);
       },
     );
   });
@@ -1675,6 +1693,13 @@ describe("BillingConfigGuardLive", () => {
         };
         const exit = await runBillingGuard("saas");
         expect(Exit.isSuccess(exit)).toBe(true);
+        // Negative half of the contract: pro is resolvable via settings, so the
+        // guard must NOT warn it as missing — proving the warn keys off the
+        // settings-resolved value, not the env var.
+        const priceMissingLog = capturedLogErrors.find(
+          (e) => (e.obj as { event?: string } | undefined)?.event === "billing_config.price_missing",
+        );
+        expect(priceMissingLog).toBeUndefined();
       },
     );
   });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2996,14 +2996,19 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // only on `Config` and reads env directly, so it runs in parallel with
   // the migration + sync layers alongside the other env-checking guards.
   const chatAdapterEnvGuardLayer = ChatAdapterEnvGuardLive.pipe(Layer.provide(configLayer));
-  // #3435 — billing config validation. Gated on `deployMode === "saas"` AND
-  // `STRIPE_SECRET_KEY` present, so self-hosted and pre-billing SaaS are inert.
-  // Fails boot on the two pure misconfigs (missing monthly price ID, non-standard
-  // key mode) and loudly warns (never crashes) on the network price-resolution /
-  // livemode-mismatch check. `Config`-only; lazy-imports the Stripe SDK + the
-  // config-validation SSOT inside its Effect body so it runs as an env-checking
-  // peer of the migration + sync layers.
-  const billingConfigGuardLayer = BillingConfigGuardLive.pipe(Layer.provide(configLayer));
+  // #3435 + #3703 — billing config validation. Gated on `deployMode === "saas"`
+  // AND `STRIPE_SECRET_KEY` present, so self-hosted and pre-billing SaaS are
+  // inert. Fails boot on the two env-only misconfigs (missing webhook secret,
+  // non-standard key mode) and loudly warns (never crashes) on a missing price
+  // ID (now a runtime-editable platform setting, #3703) and on the network
+  // price-resolution / livemode-mismatch check. Depends on `Config` + `Settings`
+  // (like `DpaGuardLive`): the `Settings` edge sequences it after
+  // `loadSettings()` warms the cache so `getSettingAuto` sees price-ID overrides
+  // rather than falling back to env. Lazy-imports the Stripe SDK + the
+  // config-validation SSOT + settings inside its Effect body.
+  const billingConfigGuardLayer = BillingConfigGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, settingsLayer)),
+  );
   // #1988 C7 + C8 — region routing claim and stale plugin config checks.
   // Both depend only on `Config`. PluginConfigGuardLive lazy-imports the
   // plugin registry + InternalDB inside its Effect body so it can run as

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -330,24 +330,28 @@ export class MigrationsRequiredError extends Data.TaggedError("MigrationsRequire
 }> {}
 
 /**
- * SaaS region booted with `STRIPE_SECRET_KEY` set but one or more paid-tier
- * monthly `STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` env vars unset/empty, OR a
- * secret key whose mode prefix isn't a standard `sk_test_` / `sk_live_`
- * (#3435). Both are pure, network-free misconfigs caught at boot:
+ * SaaS region booted with `STRIPE_SECRET_KEY` set but a genuine env-level
+ * billing misconfig: a missing `STRIPE_WEBHOOK_SECRET`, OR a secret key whose
+ * mode prefix isn't a standard `sk_test_` / `sk_live_` (#3435). Both are pure,
+ * network-free misconfigs of env-only inputs caught at boot:
  *
- *   - A missing monthly price ID silently omits that tier from
- *     `getStripePlans()` — the plan never appears in checkout, the region looks
- *     healthy, and a customer who wanted that tier simply can't buy it.
+ *   - A missing webhook secret makes `auth/server.ts` decline to mount the
+ *     `@better-auth/stripe` plugin (it logs and continues), so checkout, the
+ *     billing portal, and webhook plan-sync are all dead while boot stays green.
  *   - A non-standard key shape (`rk_…` restricted, `pk_…` publishable paste, a
  *     typo) means we can't pin the test/live mode the price-resolution warn
  *     path compares against, and a restricted key may lack `prices.retrieve`
  *     scope outright.
  *
- * `missingPriceIdEnvVars` lists the absent monthly vars (empty when the failure
- * is solely the key shape) and `keyMode` carries the detected mode so the
- * boot-failure log is operator-actionable without re-parsing `message`. The key
- * itself is NEVER placed on the error or in the message — only its mode
- * classification. Self-hosted, and SaaS-without-Stripe, never construct this.
+ * Since #3703 a MISSING PRICE ID no longer constructs this error: price IDs are
+ * runtime-editable platform settings (registry-backed, env-fallback), so an
+ * absent one is an operator-actionable boot WARNING (`BillingConfigGuardLive`
+ * logs it), never a boot crash. `missingPriceIdEnvVars` therefore is always
+ * empty on this error today; it is retained for shape stability and possible
+ * future reuse. `keyMode` carries the detected mode so the boot-failure log is
+ * operator-actionable without re-parsing `message`. The key itself is NEVER
+ * placed on the error or in the message — only its mode classification.
+ * Self-hosted, and SaaS-without-Stripe, never construct this.
  */
 export class BillingConfigInvalidError extends Data.TaggedError("BillingConfigInvalidError")<{
   readonly message: string;
@@ -1133,31 +1137,39 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
  *   3. (Companion fix, not here) `GET /api/v1/billing` reporting a missing
  *      `subscription` table as `subscription: null` — addressed in `billing.ts`.
  *
- * **warn vs fail-fast decision (#3435).** Two pure, network-free checks
- * FAIL-FAST (CLAUDE.md "prefer errors over silent fallbacks"):
- *   - any missing monthly price ID, and
+ * **warn vs fail-fast decision (#3435 + #3703).** The remaining pure,
+ * network-free FAIL-FAST checks are both on env-only inputs:
+ *   - a missing `STRIPE_WEBHOOK_SECRET` (genuine secret, env-only), and
  *   - a secret key whose mode prefix isn't a standard `sk_test_` / `sk_live_`.
+ * A MISSING PRICE ID is NO LONGER fail-fast (#3703): price IDs are now
+ * runtime-editable platform settings, so a boot crash would prevent an operator
+ * from ever fixing pricing without a redeploy — the exact footgun this train of
+ * issues exists to remove. Instead, prices are resolved through `getSettingAuto`
+ * (settings → env → default) and any still-missing monthly tier is a loud,
+ * operator-actionable `log.error` WARNING that does not wedge boot.
  * The "do these price IDs exist in the account, and does each price's
- * `livemode` match the key mode?" check is a network call, so it is a loud
- * `log.error` (with a per-price breakdown) but NEVER fails boot — a transient
- * Stripe outage or rate-limit at deploy time must not wedge a region. The
- * mismatch it detects is still operator-actionable from the log, and the
- * webhook-sync no-op it guards against is itself retryable.
+ * `livemode` match the key mode?" check is a network call, so it is likewise a
+ * loud `log.error` (with a per-price breakdown) but NEVER fails boot — a
+ * transient Stripe outage or rate-limit at deploy time must not wedge a region.
  *
  * Gate: `deployMode === "saas"` AND `STRIPE_SECRET_KEY` present. Self-hosted is
  * untouched (no Stripe), and a SaaS region that hasn't turned on billing yet
  * (no `STRIPE_SECRET_KEY`) boots silently — matching the existing conditional
  * mount of the billing routes and the `@better-auth/stripe` plugin.
  *
- * The Stripe SDK + `config-validation` SSOT are lazy-imported (same wall-off
- * pattern as `EncryptionKeyGuardLive`) so this module stays free of the `stripe`
- * static graph. The network resolution is wrapped so an SDK/import rejection
- * becomes a warn, not a boot-killing defect.
+ * Depends on `Settings` (like `DpaGuardLive` / `ProactiveProviderKeyGuardLive`):
+ * the `yield* Settings` edge sequences it after `loadSettings()` warms the
+ * in-process cache so `getSettingAuto` sees platform DB overrides rather than
+ * falling back to env. The Stripe SDK + `config-validation` SSOT + `settings`
+ * are lazy-imported (same wall-off pattern as `EncryptionKeyGuardLive`) so this
+ * module stays free of the `stripe` static graph. The network resolution is
+ * wrapped so an SDK/import rejection becomes a warn, not a boot-killing defect.
  */
-export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidError, Config> = Layer.effectDiscard(
+export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidError, Config | Settings> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
+    yield* Settings; // sequence after loadSettings warms the in-process cache
 
     // Gate on Stripe being configured at all. A SaaS region can legitimately
     // run pre-billing (no STRIPE_SECRET_KEY) — the billing routes and the
@@ -1175,7 +1187,7 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
       !process.env.STRIPE_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET.length === 0;
 
     const {
-      findMissingMonthlyPriceIdEnvVars,
+      findMissingMonthlyPriceIds,
       detectStripeKeyMode,
       isPriceModeConsistent,
       MONTHLY_PRICE_ID_ENV_VARS,
@@ -1185,21 +1197,19 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.orDie);
 
-    // ── Pure check 1: monthly price-ID presence (fail-fast) ──────────────
-    const missingPriceIdEnvVars = findMissingMonthlyPriceIdEnvVars();
+    const { getSettingAuto } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/settings"),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.orDie);
+
     const keyMode = detectStripeKeyMode(secretKey);
 
-    // ── Pure check 2: secret-key mode shape (fail-fast) ──────────────────
-    // Collected with the price-ID result so a region missing both gets one
-    // boot-failure log naming both, rather than fixing one then re-failing.
-    if (missingPriceIdEnvVars.length > 0 || keyMode === "unknown" || webhookSecretMissing) {
+    // ── Fail-fast check: env-only misconfigs (webhook secret + key shape) ──
+    // Collected together so a region missing both gets one boot-failure log
+    // naming both, rather than fixing one then re-failing. Missing price IDs
+    // are NO LONGER fail-fast (#3703) — they are warned about below.
+    if (keyMode === "unknown" || webhookSecretMissing) {
       const parts: string[] = [];
-      if (missingPriceIdEnvVars.length > 0) {
-        parts.push(
-          `missing required monthly price ID env var(s): [${missingPriceIdEnvVars.join(", ")}] — ` +
-            `getStripePlans() silently omits each absent tier from checkout`,
-        );
-      }
       if (webhookSecretMissing) {
         parts.push(
           `STRIPE_WEBHOOK_SECRET is unset — the @better-auth/stripe plugin declines to mount ` +
@@ -1216,7 +1226,7 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
       }
       return yield* Effect.fail(
         new BillingConfigInvalidError({
-          missingPriceIdEnvVars,
+          missingPriceIdEnvVars: [],
           keyMode,
           message:
             `SaaS region booted with STRIPE_SECRET_KEY set but the billing config is invalid: ` +
@@ -1226,18 +1236,38 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
       );
     }
 
+    // ── Settings-presence WARN: monthly price IDs (#3703) ────────────────
+    // Resolve each monthly price through the settings registry (settings → env
+    // → default). A still-missing tier is silently omitted from checkout by
+    // `getStripePlans()`, so surface it as a loud, operator-actionable warning
+    // — but never crash boot, because the fix is a runtime Admin → Settings
+    // edit, not a redeploy.
+    const missingMonthlyPriceIds = findMissingMonthlyPriceIds((key) => getSettingAuto(key));
+    if (missingMonthlyPriceIds.length > 0) {
+      log.error(
+        {
+          missingMonthlyPriceIds,
+          event: "billing_config.price_missing",
+        },
+        `Stripe billing is enabled but ${missingMonthlyPriceIds.length} monthly price ID(s) are ` +
+          `unset after settings resolution: [${missingMonthlyPriceIds.join(", ")}]. getStripePlans() ` +
+          `silently omits each absent tier from checkout, so customers can't buy it. Set the price ` +
+          `ID(s) in Admin → Settings (Billing) — no redeploy needed. See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
+    }
+
     // ── Network check: price existence + livemode↔key-mode (loud WARN) ───
     // A transient Stripe error here must NOT crash boot, so everything below
     // resolves to a logged warning. We resolve every CONFIGURED price ID
-    // (monthly — guaranteed present by the fail-fast above — plus any annual
-    // vars the operator set) and check each price's livemode against keyMode.
+    // (monthly + annual) through settings and check each price's livemode
+    // against keyMode.
     const configuredPriceVars = [
       ...MONTHLY_PRICE_ID_ENV_VARS,
       ...ANNUAL_PRICE_ID_ENV_VARS,
     ]
       .map((envVar): { envVar: string; priceId: string | undefined } => ({
         envVar,
-        priceId: process.env[envVar],
+        priceId: getSettingAuto(envVar),
       }))
       .filter((p): p is { envVar: string; priceId: string } => Boolean(p.priceId));
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -605,6 +605,80 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     saasVisible: false,
   },
 
+  // Stripe Billing — the six paid-tier price IDs (#3703). These are
+  // NON-SECRET Stripe constants (the genuine secrets — STRIPE_SECRET_KEY,
+  // STRIPE_WEBHOOK_SECRET — stay env-only and are never registry-backed).
+  // Platform-scoped + hot-reloadable: `getStripePlans()` / `resolvePlanTier
+  // FromPriceId()` read them per-checkout via `getSettingAuto`, so an
+  // operator can change pricing from Admin → Settings without a redeploy.
+  // The env var is the self-host / boot fallback tier. `saasVisible: false`
+  // keeps them off the generic workspace-admin settings page (pricing is a
+  // platform-operator concern, not a per-tenant knob); platform admins always
+  // see all settings. The monthly IDs are required for their tier to appear in
+  // checkout — a missing one surfaces as an operator-actionable boot WARNING
+  // (no longer a boot crash; see `BillingConfigGuardLive`). The annual IDs are
+  // optional discount levers.
+  {
+    key: "STRIPE_STARTER_PRICE_ID",
+    section: "Billing",
+    label: "Starter Price ID (monthly)",
+    description: "Stripe Price ID for the Starter plan (monthly, $29/seat). Required for the Starter tier to appear in checkout.",
+    type: "string",
+    envVar: "STRIPE_STARTER_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_STARTER_ANNUAL_PRICE_ID",
+    section: "Billing",
+    label: "Starter Price ID (annual)",
+    description: "Stripe Price ID for the Starter plan (annual). Optional discount lever.",
+    type: "string",
+    envVar: "STRIPE_STARTER_ANNUAL_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_PRO_PRICE_ID",
+    section: "Billing",
+    label: "Pro Price ID (monthly)",
+    description: "Stripe Price ID for the Pro plan (monthly, $59/seat). Required for the Pro tier to appear in checkout.",
+    type: "string",
+    envVar: "STRIPE_PRO_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_PRO_ANNUAL_PRICE_ID",
+    section: "Billing",
+    label: "Pro Price ID (annual)",
+    description: "Stripe Price ID for the Pro plan (annual). Optional discount lever.",
+    type: "string",
+    envVar: "STRIPE_PRO_ANNUAL_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_BUSINESS_PRICE_ID",
+    section: "Billing",
+    label: "Business Price ID (monthly)",
+    description: "Stripe Price ID for the Business plan (monthly, $99/seat). Required for the Business tier to appear in checkout.",
+    type: "string",
+    envVar: "STRIPE_BUSINESS_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_BUSINESS_ANNUAL_PRICE_ID",
+    section: "Billing",
+    label: "Business Price ID (annual)",
+    description: "Stripe Price ID for the Business plan (annual). Optional discount lever.",
+    type: "string",
+    envVar: "STRIPE_BUSINESS_ANNUAL_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+
   // Dynamic Learning — retrieval-time tuning for learned query patterns.
   // Workspace-scoped + hot-reloaded (read per-request via getSettingAuto), so
   // a tenant can tune them from Admin → Settings with no redeploy. The env var


### PR DESCRIPTION
Closes #3703. Part of milestone #69 (SaaS-first env-var reduction, umbrella #3701).

## What

The six Stripe price IDs (`STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID` + `_ANNUAL`) are non-secret constants but were stamped as env vars and boot-blocked via `BillingConfigInvalidError`. An operator changing pricing should not have to redeploy. This promotes them to platform-scoped, hot-reloadable settings in the registry. Only the two genuine secrets — `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` — remain Stripe env vars (8 → 2).

## How

- **`settings.ts`** — register the 6 price IDs as platform-scoped registry entries (new "Billing" section, env as the fallback tier, no `requiresRestart` → hot-reloadable, `saasVisible: false` so they stay a platform-operator concern). Platform admins see/edit them in Admin → Settings.
- **`plans.ts`** — `getStripePlans()` / `resolvePlanTierFromPriceId()` resolve via `getSettingAuto` instead of `process.env`, so a settings change takes effect at runtime (precedence: platform override > env > default).
- **`auth/server.ts`** — pass `getStripePlans` (the function ref, not its return value) to `@better-auth/stripe` so plans re-resolve **per checkout** — a pricing change needs no process restart.
- **`config-validation.ts`** — add a settings-aware `findMissingMonthlyPriceIds(resolve)` sibling to the pure env variant.
- **`saas-guards.ts`** — `BillingConfigGuardLive` no longer boot-blocks on a missing price ID. It resolves prices through settings and surfaces a missing monthly tier as an operator-actionable `log.error` **warning**, not a boot crash. The env-only fail-fast checks (missing `STRIPE_WEBHOOK_SECRET`, non-standard secret-key mode) remain. The guard now depends on `Settings` so `getSettingAuto` sees DB overrides (wired like `DpaGuardLive`).
- **docs + `.env.example`** — drop the 6 price-ID vars from the Stripe env section; document the Admin → Settings → Billing surface; mark the audit item done.

## Acceptance criteria

- [x] 6 price IDs are platform-scoped settings, editable by `platform_admin` from Admin, env as fallback
- [x] A price change takes effect without a redeploy (hot-reload), reflected in `getStripePlans()` / checkout (function-ref handed to the plugin → per-checkout resolution)
- [x] Boot no longer hard-requires the price-ID env vars; missing-price surfaces as an operator-actionable warning, not `BillingConfigInvalidError` on env
- [x] `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET` remain the only Stripe env vars
- [x] Tests cover settings-backed price resolution (`plans-settings.test.ts`, new `findMissingMonthlyPriceIds` cases) + the missing-price warn path (`saas-guards.test.ts`)

## Testing

`/ci` green locally: lint, type (tsgo), full `bun run test`, `syncpack lint`, template drift, railway-watch — all pass.

https://claude.ai/code/session_01AS8YygT9ejXAvAkLM17kXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AS8YygT9ejXAvAkLM17kXN)_