### PR TITLE
refactor(api): move deploy constants to config + derive per-region origins (#3706)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,13 +142,17 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                         # enroll an MFA device. Default: "Atlas".
 # ATLAS_RPID=app.useatlas.dev             # WebAuthn Relying Party ID — the registrable domain passkeys are
 #                                         # bound to. When UNSET, it is derived from the configured web origin's
-#                                         # host (first ATLAS_CORS_ORIGIN entry, then BETTER_AUTH_TRUSTED_ORIGINS):
-#                                         # prod → app.useatlas.dev, staging → app.staging.useatlas.dev, localhost → localhost.
+#                                         # host (first ATLAS_CORS_ORIGIN entry, then BETTER_AUTH_TRUSTED_ORIGINS,
+#                                         # then the region-derived web origin — ATLAS_API_REGION + residency.regions[].apiUrl,
+#                                         # api host label swapped to app, #3706): prod → app.useatlas.dev,
+#                                         # staging → app.staging.useatlas.dev, localhost → localhost.
 #                                         # If no web origin is configured, falls back to app.useatlas.dev.
 #                                         # Boot FAILS LOUD if the effective rpID isn't valid for the web origin
 #                                         # (must equal the origin host or be a parent domain) — no silent browser breakage.
-#                                         # SaaS multi-region: ALWAYS set this explicitly so a reorder of
-#                                         # ATLAS_CORS_ORIGIN can't shift the derived value. Self-hosted on a custom
+#                                         # SaaS multi-region: no longer stamped per service — the region
+#                                         # derivation yields the same app.useatlas.dev for every prod region.
+#                                         # Pin it explicitly only if a CORS-origin reorder could shift the
+#                                         # derived value. Self-hosted on a custom
 #                                         # domain: set to your auth domain. Changing this AFTER passkeys are
 #                                         # enrolled invalidates every enrolled passkey.
 # ATLAS_RPNAME=Atlas                      # Human-readable string the OS shows in the passkey prompt
@@ -423,7 +427,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 
 # === Networking ===
 # ATLAS_PUBLIC_URL=https://api.example.com    # Public base URL for action approval URLs (derived from request headers when unset)
-# ATLAS_PUBLIC_API_URL=https://api.example.com  # Public origin of the API host itself. resolvePublicApiUrl() (integrations/install/register.ts) builds EVERY OAuth install handler's redirect URI from this (Slack/Jira/Linear/Salesforce/GitHub App). When unset, those handlers log "not registered" at boot and their install routes return 501. ATLAS_CORS_ORIGIN is the WEB app origin and is intentionally NOT a fallback — in split-origin SaaS deploys the two diverge and a CORS-origin fallback would mint a redirect on the wrong host (invalid_redirect_uri). Also read by the MCP/OAuth well-known documents. SaaS bakes a per-region value (e.g. https://api.staging.useatlas.dev on api-staging).
+# ATLAS_PUBLIC_API_URL=https://api.example.com  # Public origin of the API host itself. resolvePublicApiUrl() (integrations/install/register.ts) builds EVERY OAuth install handler's redirect URI from this (Slack/Jira/Linear/Salesforce/GitHub App). When unset, it is derived from ATLAS_API_REGION + residency.regions[].apiUrl (#3706 — so SaaS no longer stamps it per regional service); if no region is configured either, those handlers log "not registered" at boot and their install routes return 501. ATLAS_CORS_ORIGIN is the WEB app origin and is intentionally NOT a fallback — in split-origin SaaS deploys the two diverge and a CORS-origin fallback would mint a redirect on the wrong host (invalid_redirect_uri). Also read by the MCP/OAuth well-known documents.
 
 # === Production Deployment ===
 # Required for production (Railway, etc.):
@@ -445,7 +449,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_RUNTIME=vercel    # Force Vercel Sandbox for explore tool (auto-detected on Vercel)
 
 # === CORS ===
-# ATLAS_CORS_ORIGIN=https://app.example.com  # Required when frontend and API are on different origins. Enables credentials (cookies) for managed auth.
+# ATLAS_CORS_ORIGIN=https://app.example.com  # Required when frontend and API are on different origins. Enables credentials (cookies) for managed auth. Also a runtime registry setting (Admin → Security). When unset, the default derives from ATLAS_API_REGION + residency.regions[].apiUrl (web origin, #3706) on SaaS, else the wildcard "*" (fine for header/API-key auth).
 
 # === API URL (dev rewrite target) ===
 # Used by Next.js rewrites to proxy /api/* to the Hono API server.
@@ -485,12 +489,16 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_SANDBOX_PRIORITY=                        # Custom backend priority (comma-separated: vercel-sandbox,nsjail,sidecar,just-bash)
 # ATLAS_SANDBOX_BACKEND=                         # SaaS admin-facing selector: vercel-sandbox | sidecar | e2b-sandbox | daytona-sandbox | <plugin-id>. Self-hosted operators typically use ATLAS_SANDBOX_PRIORITY instead
 # SIDECAR_AUTH_TOKEN=                            # Shared secret for sidecar auth (set on both API and sidecar). The sidecar refuses to boot without it unless SIDECAR_AUTH_DISABLE=1 (loopback dev only)
-# Vercel Sandbox access tokens — required when calling @vercel/sandbox from
-# off-Vercel hosts (Railway, Fly, external CI, etc.). On Vercel itself, OIDC
-# handles auth via VERCEL_OIDC_TOKEN and these three are unnecessary.
-# VERCEL_TEAM_ID=team_xxx
-# VERCEL_PROJECT_ID=prj_xxx
-# VERCEL_TOKEN=                                  # Vercel access token with sandbox scope
+# Vercel Sandbox access — required when calling @vercel/sandbox from off-Vercel
+# hosts (Railway, Fly, external CI, etc.). On Vercel itself, OIDC handles auth
+# via VERCEL_OIDC_TOKEN and these are unnecessary.
+# The team + project IDs are NOT secret; SaaS bakes them into atlas.config.ts
+# under `sandbox.vercel` (#3706) rather than stamping them per service. These
+# env vars still override the config values when set (self-host points at its
+# own Vercel account this way). Only VERCEL_TOKEN is secret and stays env-only.
+# VERCEL_TEAM_ID=team_xxx                        # Overrides sandbox.vercel.teamId from config when set
+# VERCEL_PROJECT_ID=prj_xxx                      # Overrides sandbox.vercel.projectId from config when set
+# VERCEL_TOKEN=                                  # Vercel access token with sandbox scope (secret — env only)
 # ATLAS_NSJAIL_PATH=      # Explicit path to nsjail binary (auto-detected on PATH otherwise)
 # ATLAS_NSJAIL_TIME_LIMIT and ATLAS_NSJAIL_MEMORY_LIMIT are read by BOTH the explore
 # tool (semantic FS sandbox) and the executePython tool, with different built-in defaults:

--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -44,8 +44,10 @@ boot** if a required one is missing or malformed, rather than degrading silently
 Stripe (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`), Turnstile
 (`TURNSTILE_SECRET_KEY`), Twenty (`TWENTY_API_KEY`), and the Vercel sandbox token
 (`VERCEL_TOKEN`) are also secrets and stay in env — but their **non-secret
-companions** (Stripe price IDs, Vercel team/project IDs, Twenty base URL) should
-not; see the [audit](#why-the-list-is-short).
+companions** do not. The Vercel team/project IDs (`VERCEL_TEAM_ID` /
+`VERCEL_PROJECT_ID`) are baked into `deploy/api/atlas.config.ts` under
+`sandbox.vercel` (#3706); only `VERCEL_TOKEN` remains env. See the
+[audit](#why-the-list-is-short) for the rest (Stripe price IDs, Twenty base URL).
 
 ### Pre-database boot inputs (per instance)
 
@@ -53,8 +55,21 @@ not; see the [audit](#why-the-list-is-short).
 |---|---|
 | `ATLAS_API_REGION` | This instance's region identity (`us` / `eu` / `apac` / `staging`). Genuinely per-service. |
 | `BETTER_AUTH_URL` | Better Auth base URL — read inside the library's plugin init before settings load. |
-| `BETTER_AUTH_TRUSTED_ORIGINS` | Anchors verification / password-reset redirects to the web origin. |
+| `BETTER_AUTH_TRUSTED_ORIGINS` | Anchors verification / password-reset redirects to the web origin. Also the first source `getWebOrigin()` reads, so it transitively anchors the passkey rpID and the CORS default (below). |
 | `ATLAS_DEPLOY_ENV` | Deployment shape (`production` / `staging` / `development`). Drives the [env-profile](/reference/environment-variables) table — one switch, not a dozen per-env flags. |
+
+### Derived per-region origins (no longer stamped)
+
+These were stamped on every regional API service; they are now **derived from
+`ATLAS_API_REGION` + the `residency.regions[].apiUrl` map** in
+`deploy/api/atlas.config.ts` (#3706). Set them explicitly only to override the
+derivation (e.g. a self-hosted custom domain) — an explicit env value always wins.
+
+| Variable | Derived value |
+|---|---|
+| `ATLAS_PUBLIC_API_URL` | The region's `apiUrl` (the API host — used to build OAuth install redirect URIs). `us` → `https://api.useatlas.dev`, `eu` → `https://api-eu.useatlas.dev`, `apac` → `https://api-apac.useatlas.dev`, `staging` → `https://api.staging.useatlas.dev`. |
+| `ATLAS_RPID` | The web origin's host (passkey rpID). Every prod region collapses onto the single `app.useatlas.dev` web service; `staging` → `app.staging.useatlas.dev`. Derived from the region's `apiUrl` with the `api` label swapped to `app`. |
+| `ATLAS_CORS_ORIGIN` | Already a [runtime setting](#what-you-change-at-runtime-instead); its **default** now derives the region's web origin (same value as the rpID host) instead of the wildcard. Stays a registry setting — do not re-add it as an env var. |
 
 ### Boot-guard / immutable inputs
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,7 @@ Each service points to its `railway.json` via the Railway dashboard. Key env var
 - `BETTER_AUTH_SECRET` — min 32 chars
 - `BETTER_AUTH_TRUSTED_ORIGINS=https://app.useatlas.dev` — Read before config in Better Auth init, so it stays env. Also the web origin `getWebOrigin()` reads first (anchors the passkey rpID + CORS default).
 - `ATLAS_SANDBOX_URL` — Internal sidecar URL
-- `ATLAS_API_REGION` — Region identity for this instance (e.g. `us-east`). Required for multi-region deployments. Each regional API service (api, api-eu, api-apac) must set this so the health endpoint reports its region and misrouting detection works correctly
+- `ATLAS_API_REGION` — Region identity for this instance. **Must be a key in the `residency.regions` map** in `deploy/api/atlas.config.ts` (`us` / `eu` / `apac` / `staging`) — not a free-form value. Required for multi-region deployments. Each regional API service (api, api-eu, api-apac) must set this so the health endpoint reports its region, misrouting detection works, and the per-region origin derivation (`ATLAS_PUBLIC_API_URL` / web origin, #3706) resolves; a value absent from the map silently no-ops the derivation
 
 #### Replica cap (read before scaling)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -56,9 +56,9 @@ Each service points to its `railway.json` via the Railway dashboard. Key env var
 - `ATLAS_PROVIDER` / `ANTHROPIC_API_KEY` — LLM provider
 - `DATABASE_URL` — Atlas internal Postgres (auth, audit)
 - `ATLAS_DATASOURCE_URL` — Analytics datasource
-- `ATLAS_CORS_ORIGIN=https://app.useatlas.dev`
+- `ATLAS_CORS_ORIGIN` — No longer stamped: its default derives from `ATLAS_API_REGION` + the `residency.regions[].apiUrl` map (#3706), and it's a runtime registry setting (Admin → Security). Set explicitly only to override.
 - `BETTER_AUTH_SECRET` — min 32 chars
-- `BETTER_AUTH_TRUSTED_ORIGINS=https://app.useatlas.dev`
+- `BETTER_AUTH_TRUSTED_ORIGINS=https://app.useatlas.dev` — Read before config in Better Auth init, so it stays env. Also the web origin `getWebOrigin()` reads first (anchors the passkey rpID + CORS default).
 - `ATLAS_SANDBOX_URL` — Internal sidecar URL
 - `ATLAS_API_REGION` — Region identity for this instance (e.g. `us-east`). Required for multi-region deployments. Each regional API service (api, api-eu, api-apac) must set this so the health endpoint reports its region and misrouting detection works correctly
 

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -1021,6 +1021,14 @@ export default defineConfig({
   // backend that can't enforce multi-tenant boundaries.
   sandbox: {
     priority: ["vercel-sandbox"],
+    // Vercel account identity for off-Vercel (Railway) sandbox auth. Same
+    // non-secret team + project as prod — only VERCEL_TOKEN differs per env and
+    // stays in Railway. Baked here rather than stamped per service (#3706); the
+    // env vars still override when set.
+    vercel: {
+      teamId: "team_jW0mE8T4T5Uodzkz7WlVowNi",
+      projectId: "prj_mIgFJiT56FOffyZ1fxRgFwhgWksI",
+    },
   },
 
   // ── Connection Pool ─────────────────────────────────────────────

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -1024,6 +1024,15 @@ export default defineConfig({
   // providerRuntimeAvailability is the live source of truth.
   sandbox: {
     priority: ["vercel-sandbox"],
+    // Off-Vercel (Railway) auth needs the Vercel account identity. The team +
+    // project IDs are NOT secret and are constant across regions, so they live
+    // here rather than stamped as VERCEL_TEAM_ID / VERCEL_PROJECT_ID on each
+    // regional service (#3706). Only VERCEL_TOKEN stays in env (per-service
+    // secret). The env vars still override these when set.
+    vercel: {
+      teamId: "team_jW0mE8T4T5Uodzkz7WlVowNi",
+      projectId: "prj_mIgFJiT56FOffyZ1fxRgFwhgWksI",
+    },
   },
 
   // ── Connection Pool ─────────────────────────────────────────────

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -78,14 +78,20 @@ The headline of the principle. Candidates, by area:
 - **Observability** — `OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS}` (today a per-service
   footgun: shared scope silently drops telemetry).
 
-### Tier 2 — Move non-secret constants into `atlas.config.ts` (still a deploy, but maintained once)
+### Tier 2 — Move non-secret constants into `atlas.config.ts` ✅ shipped (#3706)
 For things that genuinely can't be runtime (boot-ordering) but are constant
-across regions:
-- `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID` (keep `VERCEL_TOKEN` in env).
-- Per-region origins (`ATLAS_PUBLIC_API_URL`, `ATLAS_RPID`, and
-  `ATLAS_CORS_ORIGIN` — note the last is *already* a platform registry setting,
-  `requiresRestart`, env as fallback) derived from `ATLAS_API_REGION` + the
-  `residency.regions[].apiUrl` map instead of stamped per service.
+across regions. No behavior change across us/eu/apac/staging — explicit env
+still overrides every derivation.
+- `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID` → `sandbox.vercel` in `atlas.config.ts`
+  (`vercelSandboxAccess()` reads config, env overrides). `VERCEL_TOKEN` stays env.
+- `ATLAS_PUBLIC_API_URL` → derived from `ATLAS_API_REGION` +
+  `residency.regions[].apiUrl` (`resolvePublicApiUrl()`); the region's `apiUrl`
+  is exactly the API host, so OAuth redirect URIs are unchanged.
+- `ATLAS_RPID` + the `ATLAS_CORS_ORIGIN` *default* → derived from the same region
+  web origin (`getWebOrigin()` gains a region fallback; the API host's first DNS
+  label is swapped `api` → `app`, folding `api-eu` / `api-apac` onto the single
+  `app.useatlas.dev` web service). `ATLAS_CORS_ORIGIN` stays a registry setting —
+  not re-introduced as an env var.
 
 ### Tier 3 — Delete redundant env vars ✅ shipped (#3702)
 Already covered by `atlas.config.ts`, no behavior change to drop from SaaS env. The two

--- a/packages/api/src/lib/__tests__/web-origin.test.ts
+++ b/packages/api/src/lib/__tests__/web-origin.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `getWebOrigin()` resolution-order tests.
+ *
+ * The web origin anchors the passkey rpID, the `ATLAS_CORS_ORIGIN` default, and
+ * the cross-subdomain cookie domain (`getAuthInstance` in `auth/server.ts`).
+ * #3706 dropped the former `ATLAS_CORS_ORIGIN`-set gate on the cookie-domain
+ * path, so `getWebOrigin()` is now consulted unconditionally — which means the
+ * `BETTER_AUTH_TRUSTED_ORIGINS` fallback (the tier SaaS relies on once
+ * `ATLAS_CORS_ORIGIN` is no longer stamped) and the region fallback must stay
+ * pinned. Self-hosted single-origin deploys still resolve to `null`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+let mockConfig: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfig,
+  configFromEnv: () => ({}),
+  loadConfig: async () => ({}),
+  defineConfig: (c: unknown) => c,
+  validateAndResolve: (r: unknown) => r,
+  _setConfigForTest: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { getWebOrigin } = await import("@atlas/api/lib/web-origin");
+
+const PROD_RESIDENCY = {
+  defaultRegion: "us",
+  regions: {
+    us: { label: "United States", databaseUrl: "x", apiUrl: "https://api.useatlas.dev" },
+    eu: { label: "Europe", databaseUrl: "x", apiUrl: "https://api-eu.useatlas.dev" },
+  },
+};
+
+const ORIGIN_ENV = ["ATLAS_API_REGION", "ATLAS_CORS_ORIGIN", "BETTER_AUTH_TRUSTED_ORIGINS"] as const;
+
+describe("getWebOrigin resolution order", () => {
+  beforeEach(() => {
+    mockConfig = null;
+    for (const key of ORIGIN_ENV) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ORIGIN_ENV) delete process.env[key];
+  });
+
+  it("prefers the first ATLAS_CORS_ORIGIN entry, trimming trailing slashes", () => {
+    process.env.ATLAS_CORS_ORIGIN = "https://app.useatlas.dev/,https://other.useatlas.dev";
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://trusted.useatlas.dev";
+    expect(getWebOrigin()).toBe("https://app.useatlas.dev");
+  });
+
+  it("skips a wildcard ATLAS_CORS_ORIGIN and falls back to BETTER_AUTH_TRUSTED_ORIGINS", () => {
+    process.env.ATLAS_CORS_ORIGIN = "*";
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://app.useatlas.dev";
+    expect(getWebOrigin()).toBe("https://app.useatlas.dev");
+  });
+
+  it("falls back to the first BETTER_AUTH_TRUSTED_ORIGINS entry when CORS is unset (the SaaS post-unstamp path)", () => {
+    // This is the tier the cookie-domain derivation now leans on after #3706
+    // un-stamps ATLAS_CORS_ORIGIN per regional service.
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://app.useatlas.dev/,https://app2.useatlas.dev";
+    expect(getWebOrigin()).toBe("https://app.useatlas.dev");
+  });
+
+  it("falls back to the region-derived web origin when no origin env is set", () => {
+    mockConfig = { residency: PROD_RESIDENCY };
+    process.env.ATLAS_API_REGION = "eu";
+    expect(getWebOrigin()).toBe("https://app.useatlas.dev");
+  });
+
+  it("returns null for a self-hosted single-origin deploy (no origin env, no region)", () => {
+    expect(getWebOrigin()).toBeNull();
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -3298,7 +3298,12 @@ export function getAuthInstance(): AuthInstance {
   // an unrelated allowlisted origin can't veto the shared domain, and so the
   // domain still derives once SaaS stops stamping ATLAS_CORS_ORIGIN per service
   // (BETTER_AUTH_TRUSTED_ORIGINS stays env, so getWebOrigin() still resolves).
-  // See `deriveCookieDomain` for why the env-specific suffix matters.
+  // NB: this dropped the former `ATLAS_CORS_ORIGIN`-set gate. A self-hosted
+  // deploy that sets BETTER_AUTH_TRUSTED_ORIGINS but NOT ATLAS_CORS_ORIGIN now
+  // also derives a parent cookie domain (previously host-scoped) — the intended
+  // cross-subdomain behavior, and a no-op for single-origin deploys where the
+  // API host and app origin share no 2+ label suffix (cookieDomain stays
+  // undefined). See `deriveCookieDomain` for why the env-specific suffix matters.
   const webOrigin = getWebOrigin();
   const cookieDomain = deriveCookieDomain(process.env.BETTER_AUTH_URL, webOrigin ?? undefined);
   // Fail loud on the silent footgun: a cross-origin deploy that yields no

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -3291,12 +3291,15 @@ export function getAuthInstance(): AuthInstance {
 
   // Derive parent domain for cross-subdomain cookies — the longest dotted
   // suffix common to the API host (BETTER_AUTH_URL) and the canonical app
-  // origin. Only for cross-origin deploys (ATLAS_CORS_ORIGIN set); without it,
-  // cookies are host-scoped and won't be sent from the frontend subdomain.
-  // Use getWebOrigin() (the FIRST CORS entry — the app) rather than the whole
-  // allowlist, so an unrelated allowlisted origin can't veto the shared
-  // domain. See `deriveCookieDomain` for why the env-specific suffix matters.
-  const webOrigin = process.env.ATLAS_CORS_ORIGIN ? getWebOrigin() : null;
+  // origin. Only for cross-origin deploys (a web origin is resolvable); without
+  // it, cookies are host-scoped and won't be sent from the frontend subdomain.
+  // Use getWebOrigin() (the FIRST CORS entry, else BETTER_AUTH_TRUSTED_ORIGINS,
+  // else the region-derived origin — #3706) rather than the whole allowlist, so
+  // an unrelated allowlisted origin can't veto the shared domain, and so the
+  // domain still derives once SaaS stops stamping ATLAS_CORS_ORIGIN per service
+  // (BETTER_AUTH_TRUSTED_ORIGINS stays env, so getWebOrigin() still resolves).
+  // See `deriveCookieDomain` for why the env-specific suffix matters.
+  const webOrigin = getWebOrigin();
   const cookieDomain = deriveCookieDomain(process.env.BETTER_AUTH_URL, webOrigin ?? undefined);
   // Fail loud on the silent footgun: a cross-origin deploy that yields no
   // shared domain — usually a malformed BETTER_AUTH_URL or an app origin that
@@ -3306,10 +3309,10 @@ export function getAuthInstance(): AuthInstance {
   if (process.env.BETTER_AUTH_URL && webOrigin && !cookieDomain) {
     log.warn(
       { authUrl: process.env.BETTER_AUTH_URL, webOrigin },
-      "Cross-origin deploy (ATLAS_CORS_ORIGIN set) but no shared cookie domain could be "
+      "Cross-origin deploy (web origin resolved) but no shared cookie domain could be "
         + "derived from the API host and the app origin — session cookies will be host-only "
         + "and won't reach the app subdomain. Verify BETTER_AUTH_URL and the first "
-        + "ATLAS_CORS_ORIGIN entry are valid URLs sharing a 2+ label suffix.",
+        + "ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry are valid URLs sharing a 2+ label suffix.",
     );
   }
 

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -185,6 +185,20 @@ const SandboxConfigSchema = z.object({
       { message: "sandbox.priority must not contain duplicate backend names" },
     )
     .optional(),
+
+  /**
+   * Vercel Sandbox account identity for off-Vercel deploys (e.g. Railway).
+   * The team and project IDs are NOT secret (only `VERCEL_TOKEN` is) and are
+   * constant across regions, so they belong in config rather than stamped as
+   * `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` on every regional service (#3706).
+   * The env vars still override when set, so self-hosted operators can point a
+   * deploy at their own Vercel account without editing config. The token stays
+   * in env on every path. On the Vercel platform these are unused (OIDC auth).
+   */
+  vercel: z.object({
+    teamId: z.string().min(1),
+    projectId: z.string().min(1),
+  }).optional(),
 });
 
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;

--- a/packages/api/src/lib/cors.ts
+++ b/packages/api/src/lib/cors.ts
@@ -12,6 +12,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 
 const log = createLogger("cors");
 
@@ -20,16 +21,30 @@ let corsSettingsWarnLogged = false;
 
 /**
  * Resolve the configured CORS origin. Reads from settings cache (so admin
- * changes take effect without restart) with a fallback to the boot-time env.
- * Defaults to `"*"` when unset — fine for API-key/BYOT auth (header-based).
+ * changes take effect without restart), then the boot-time env.
+ *
+ * When neither yields an explicit origin (the registry default is the wildcard
+ * `"*"`), the default is derived from this instance's region — `getWebOrigin()`
+ * resolves the app origin from `BETTER_AUTH_TRUSTED_ORIGINS` or the
+ * `residency.regions[].apiUrl` map (#3706), so SaaS no longer has to stamp
+ * `ATLAS_CORS_ORIGIN` per regional service. Self-hosted deploys configure no
+ * region, so `getWebOrigin()` returns `null` and the wildcard `"*"` stands —
+ * fine for API-key/BYOT auth (header-based, no credentialed cookies).
+ *
+ * An explicit non-wildcard value (env or a platform/workspace DB override)
+ * always wins; a literal `"*"` is treated as "no explicit origin" and falls
+ * through to the region derivation (a credentialed cookie deploy can't use the
+ * wildcard anyway — the CORS spec forbids it — so deriving the real origin is
+ * strictly more correct).
  */
 export function resolveCorsOrigin(): string {
+  let configured: string | undefined;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency at module load
     const { getSettingAuto } = require("@atlas/api/lib/settings") as {
       getSettingAuto: (key: string) => string | undefined;
     };
-    return getSettingAuto("ATLAS_CORS_ORIGIN") ?? bootCorsOrigin ?? "*";
+    configured = getSettingAuto("ATLAS_CORS_ORIGIN") ?? bootCorsOrigin;
   } catch (err) {
     if (!corsSettingsWarnLogged) {
       log.warn(
@@ -38,8 +53,11 @@ export function resolveCorsOrigin(): string {
       );
       corsSettingsWarnLogged = true;
     }
-    return bootCorsOrigin ?? "*";
+    configured = bootCorsOrigin;
   }
+
+  if (configured && configured !== "*") return configured;
+  return getWebOrigin() ?? configured ?? "*";
 }
 
 /**

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -17,6 +17,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { deriveRegionApiUrl } from "@atlas/api/lib/residency/origins";
 import {
   registerFormHandler,
   registerOAuthDatasourceHandler,
@@ -111,13 +112,19 @@ const log = createLogger("integrations.install.register");
  * host, mismatching the Slack App's registered redirect URI and surfacing
  * as `invalid_redirect_uri` on every install attempt.
  *
- * Returns `null` when unset — the caller logs and skips registration
- * rather than minting tokens with a half-formed redirect.
+ * When unset, the API host is derived from this instance's region +
+ * the `residency.regions[].apiUrl` map (#3706) so SaaS no longer stamps
+ * `ATLAS_PUBLIC_API_URL` per regional service. The derived value is exactly
+ * the region's `apiUrl` (the API host), so no redirect URI changes.
+ *
+ * Returns `null` when neither an explicit value nor a region is configured —
+ * the caller logs and skips registration rather than minting tokens with a
+ * half-formed redirect.
  */
 function resolvePublicApiUrl(): string | null {
   const explicit = process.env.ATLAS_PUBLIC_API_URL;
   if (explicit && explicit.length > 0) return explicit.replace(/\/+$/, "");
-  return null;
+  return deriveRegionApiUrl();
 }
 
 /**

--- a/packages/api/src/lib/residency/__tests__/origins.test.ts
+++ b/packages/api/src/lib/residency/__tests__/origins.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for per-region origin derivation (#3706).
+ *
+ * Locks down the derived public API origin and web origin for each SaaS region
+ * (us / eu / apac / staging), since those feed ATLAS_PUBLIC_API_URL (OAuth
+ * redirect URIs), the ATLAS_CORS_ORIGIN default, and the passkey rpID. The
+ * web-origin transform is what guarantees no behavior change: every prod region
+ * collapses onto the single `app.useatlas.dev` web service, and staging keeps
+ * its own `app.staging.useatlas.dev`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+let mockConfig: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfig,
+  configFromEnv: () => ({}),
+  loadConfig: async () => ({}),
+  defineConfig: (c: unknown) => c,
+  validateAndResolve: (r: unknown) => r,
+  _setConfigForTest: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { deriveRegionApiUrl, deriveRegionWebOrigin } = await import("../origins");
+
+// The prod residency map mirrors deploy/api/atlas.config.ts. Staging ships its
+// own single-region map in deploy/api-staging/atlas.config.ts.
+const PROD_RESIDENCY = {
+  defaultRegion: "us",
+  regions: {
+    us: { label: "United States", databaseUrl: "postgres://us", apiUrl: "https://api.useatlas.dev" },
+    eu: { label: "Europe", databaseUrl: "postgres://eu", apiUrl: "https://api-eu.useatlas.dev" },
+    apac: { label: "Asia Pacific", databaseUrl: "postgres://apac", apiUrl: "https://api-apac.useatlas.dev" },
+    staging: { label: "Staging", databaseUrl: "postgres://staging", apiUrl: "https://api.staging.useatlas.dev" },
+  },
+};
+
+describe("per-region origin derivation", () => {
+  beforeEach(() => {
+    mockConfig = { residency: PROD_RESIDENCY };
+    delete process.env.ATLAS_API_REGION;
+  });
+
+  afterEach(() => {
+    delete process.env.ATLAS_API_REGION;
+  });
+
+  describe("deriveRegionApiUrl — the API host itself (ATLAS_PUBLIC_API_URL)", () => {
+    it("us → https://api.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "us";
+      expect(deriveRegionApiUrl()).toBe("https://api.useatlas.dev");
+    });
+
+    it("eu → https://api-eu.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "eu";
+      expect(deriveRegionApiUrl()).toBe("https://api-eu.useatlas.dev");
+    });
+
+    it("apac → https://api-apac.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "apac";
+      expect(deriveRegionApiUrl()).toBe("https://api-apac.useatlas.dev");
+    });
+
+    it("staging → https://api.staging.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "staging";
+      expect(deriveRegionApiUrl()).toBe("https://api.staging.useatlas.dev");
+    });
+
+    it("falls back to residency.defaultRegion when ATLAS_API_REGION unset", () => {
+      // defaultRegion is "us"
+      expect(deriveRegionApiUrl()).toBe("https://api.useatlas.dev");
+    });
+
+    it("returns null when no region is configured (self-hosted)", () => {
+      mockConfig = null;
+      expect(deriveRegionApiUrl()).toBeNull();
+    });
+
+    it("strips a trailing slash from the configured apiUrl", () => {
+      process.env.ATLAS_API_REGION = "us";
+      mockConfig = {
+        residency: {
+          defaultRegion: "us",
+          regions: { us: { label: "US", databaseUrl: "x", apiUrl: "https://api.useatlas.dev/" } },
+        },
+      };
+      expect(deriveRegionApiUrl()).toBe("https://api.useatlas.dev");
+    });
+  });
+
+  describe("deriveRegionWebOrigin — the web app origin (CORS default + rpID)", () => {
+    it("us → https://app.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "us";
+      expect(deriveRegionWebOrigin()).toBe("https://app.useatlas.dev");
+    });
+
+    it("eu collapses onto the single web service → https://app.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "eu";
+      expect(deriveRegionWebOrigin()).toBe("https://app.useatlas.dev");
+    });
+
+    it("apac collapses onto the single web service → https://app.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "apac";
+      expect(deriveRegionWebOrigin()).toBe("https://app.useatlas.dev");
+    });
+
+    it("staging keeps its own → https://app.staging.useatlas.dev", () => {
+      process.env.ATLAS_API_REGION = "staging";
+      expect(deriveRegionWebOrigin()).toBe("https://app.staging.useatlas.dev");
+    });
+
+    it("returns null when no region is configured (self-hosted)", () => {
+      mockConfig = null;
+      expect(deriveRegionWebOrigin()).toBeNull();
+    });
+
+    it("returns null when the host's first label is not an api label", () => {
+      process.env.ATLAS_API_REGION = "custom";
+      mockConfig = {
+        residency: {
+          defaultRegion: "custom",
+          regions: { custom: { label: "Custom", databaseUrl: "x", apiUrl: "https://gateway.example.com" } },
+        },
+      };
+      expect(deriveRegionWebOrigin()).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
+++ b/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Region-derivation integration (#3706).
+ *
+ * Walks the whole chain that used to require per-service env stamping —
+ * `getWebOrigin()` → the `ATLAS_CORS_ORIGIN` default (`resolveCorsOrigin`) and
+ * the passkey rpID (`resolvePasskeyRpId`) — with NO origin env vars set, only
+ * `ATLAS_API_REGION` + the residency map. Locks the derived CORS origin and
+ * rpID for each SaaS region so a refactor can't silently shift the cookie CORS
+ * allowlist or invalidate enrolled passkeys.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+let mockConfig: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfig,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+// No explicit CORS override — force resolveCorsOrigin through the region default.
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: () => undefined,
+  getSetting: () => undefined,
+}));
+
+const { getWebOrigin } = await import("@atlas/api/lib/web-origin");
+const { resolveCorsOrigin } = await import("@atlas/api/lib/cors");
+const { resolvePasskeyRpId } = await import("@atlas/api/lib/auth/rpid");
+
+const PROD_RESIDENCY = {
+  defaultRegion: "us",
+  regions: {
+    us: { label: "United States", databaseUrl: "x", apiUrl: "https://api.useatlas.dev" },
+    eu: { label: "Europe", databaseUrl: "x", apiUrl: "https://api-eu.useatlas.dev" },
+    apac: { label: "Asia Pacific", databaseUrl: "x", apiUrl: "https://api-apac.useatlas.dev" },
+    staging: { label: "Staging", databaseUrl: "x", apiUrl: "https://api.staging.useatlas.dev" },
+  },
+};
+
+const ORIGIN_ENV = [
+  "ATLAS_API_REGION",
+  "ATLAS_CORS_ORIGIN",
+  "BETTER_AUTH_TRUSTED_ORIGINS",
+  "ATLAS_RPID",
+] as const;
+
+describe("region-derived web origin → CORS default + passkey rpID", () => {
+  beforeEach(() => {
+    mockConfig = { residency: PROD_RESIDENCY };
+    for (const key of ORIGIN_ENV) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ORIGIN_ENV) delete process.env[key];
+  });
+
+  // Every prod region collapses onto the single app.useatlas.dev web service;
+  // staging keeps its own. rpID is the web origin's host (the value enrolled
+  // passkeys are bound to — must NOT drift).
+  it.each([
+    ["us", "https://app.useatlas.dev", "app.useatlas.dev"],
+    ["eu", "https://app.useatlas.dev", "app.useatlas.dev"],
+    ["apac", "https://app.useatlas.dev", "app.useatlas.dev"],
+    ["staging", "https://app.staging.useatlas.dev", "app.staging.useatlas.dev"],
+  ] as const)("region %s derives CORS origin %s and rpID %s", (region, expectedOrigin, expectedRpId) => {
+    process.env.ATLAS_API_REGION = region;
+
+    expect(getWebOrigin()).toBe(expectedOrigin);
+    expect(resolveCorsOrigin()).toBe(expectedOrigin);
+    expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe(expectedRpId);
+  });
+
+  it("explicit ATLAS_RPID overrides the region-derived value", () => {
+    process.env.ATLAS_API_REGION = "us";
+    process.env.ATLAS_RPID = "useatlas.dev"; // parent domain — valid for app.useatlas.dev
+    expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe("useatlas.dev");
+  });
+
+  it("self-hosted (no region) leaves CORS at the wildcard and rpID at the legacy default", () => {
+    mockConfig = null;
+    expect(getWebOrigin()).toBeNull();
+    expect(resolveCorsOrigin()).toBe("*");
+    expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe("app.useatlas.dev");
+  });
+});

--- a/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
+++ b/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
@@ -15,6 +15,11 @@ let mockConfig: Record<string, unknown> | null = null;
 
 mock.module("@atlas/api/lib/config", () => ({
   getConfig: () => mockConfig,
+  configFromEnv: () => ({}),
+  loadConfig: async () => ({}),
+  defineConfig: (c: unknown) => c,
+  validateAndResolve: (r: unknown) => r,
+  _setConfigForTest: () => {},
 }));
 
 mock.module("@atlas/api/lib/logger", () => ({

--- a/packages/api/src/lib/residency/origins.ts
+++ b/packages/api/src/lib/residency/origins.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-region origin derivation (#3706).
+ *
+ * SaaS used to stamp the public API origin (`ATLAS_PUBLIC_API_URL`) and the web
+ * origin (the `ATLAS_CORS_ORIGIN` default + the passkey rpID) on every regional
+ * service. They are not secret and not runtime-tunable (boot-ordering), but they
+ * are derivable from two things this instance already knows: its region identity
+ * (`ATLAS_API_REGION`, via {@link getApiRegion}) and the `residency.regions[].apiUrl`
+ * map baked into `atlas.config.ts`.
+ *
+ * These helpers supply the *default* only. An explicit env value
+ * (`ATLAS_PUBLIC_API_URL`, `ATLAS_CORS_ORIGIN`, `BETTER_AUTH_TRUSTED_ORIGINS`,
+ * `ATLAS_RPID`) always overrides — the derivation never shadows an operator's
+ * stamped value. Self-hosted deploys configure no residency map, so
+ * {@link getApiRegion} returns `null` and every helper here returns `null`,
+ * leaving the historical env/default behavior untouched.
+ */
+
+import { getConfig } from "@atlas/api/lib/config";
+import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
+
+function trimTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * This instance's public API origin from the residency map — the API host
+ * itself (`api.useatlas.dev` / `api-eu.useatlas.dev` / `api-apac.useatlas.dev` /
+ * `api.staging.useatlas.dev`). Returns `null` when no region is configured
+ * (self-hosted) or the region has no `apiUrl` declared.
+ */
+export function deriveRegionApiUrl(): string | null {
+  const region = getApiRegion();
+  if (!region) return null;
+  const apiUrl = getConfig()?.residency?.regions?.[region]?.apiUrl;
+  return apiUrl ? trimTrailingSlashes(apiUrl) : null;
+}
+
+/**
+ * This instance's web app origin, derived from the region's API origin by
+ * swapping the leading `api` DNS label for `app`:
+ *
+ *   - `api.useatlas.dev`         → `https://app.useatlas.dev`
+ *   - `api-eu.useatlas.dev`      → `https://app.useatlas.dev`
+ *   - `api-apac.useatlas.dev`    → `https://app.useatlas.dev`
+ *   - `api.staging.useatlas.dev` → `https://app.staging.useatlas.dev`
+ *
+ * A single web service serves every region, so all prod regions collapse onto
+ * one app origin (`app.useatlas.dev`); staging keeps its own
+ * (`app.staging.useatlas.dev`). Replacing the *entire* first label (not just an
+ * `api` → `app` substring) is what folds `api-eu` / `api-apac` back to the
+ * canonical `app` host.
+ *
+ * Returns `null` when no API origin is derivable, the API origin isn't a
+ * parseable absolute URL, or its first DNS label isn't an `api` label (we don't
+ * guess for hosts that don't follow the `api[-region].<domain>` convention).
+ */
+export function deriveRegionWebOrigin(): string | null {
+  const apiUrl = deriveRegionApiUrl();
+  if (!apiUrl) return null;
+
+  let url: URL;
+  try {
+    url = new URL(apiUrl);
+  } catch {
+    // deriveRegionApiUrl sources this from the residency map; a malformed
+    // apiUrl is an operator config error, not a runtime input. Degrade to null
+    // (callers fall back to env/default) rather than throw at request time.
+    return null;
+  }
+
+  const labels = url.hostname.split(".");
+  const first = labels[0];
+  if (first !== "api" && !first.startsWith("api-")) return null;
+  labels[0] = "app";
+  url.hostname = labels.join(".");
+  return trimTrailingSlashes(url.origin);
+}

--- a/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
@@ -13,6 +13,12 @@ mock.module("@atlas/api/lib/logger", () => ({
   }),
 }));
 
+let mockConfig: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfig,
+}));
+
 const SANDBOX_ENV = [
   "ATLAS_RUNTIME",
   "VERCEL",
@@ -32,6 +38,7 @@ describe("Vercel sandbox detection", () => {
 
   beforeEach(() => {
     _warnCalls = 0;
+    mockConfig = null;
     for (const key of SANDBOX_ENV) {
       delete process.env[key];
     }
@@ -70,6 +77,46 @@ describe("Vercel sandbox detection", () => {
       expect(access?.token.reveal()).toBe("vercel-token");
       expect(String(access?.token)).toBe("[REDACTED]");
       expect(JSON.stringify(access)).not.toContain("vercel-token");
+    });
+
+    it("sources team + project IDs from atlas.config.ts when the env vars are unset (#3706)", async () => {
+      // Only the token is env; the non-secret IDs come from config.
+      process.env.VERCEL_TOKEN = "vercel-token";
+      mockConfig = {
+        sandbox: { vercel: { teamId: "team_cfg", projectId: "prj_cfg" } },
+      };
+
+      const { vercelSandboxAccess } = await detectModule();
+
+      const access = vercelSandboxAccess();
+      expect(access?.teamId).toBe("team_cfg");
+      expect(access?.projectId).toBe("prj_cfg");
+      expect(access?.token.reveal()).toBe("vercel-token");
+    });
+
+    it("lets the env vars override the config IDs", async () => {
+      process.env.VERCEL_TEAM_ID = "team_env";
+      process.env.VERCEL_PROJECT_ID = "prj_env";
+      process.env.VERCEL_TOKEN = "vercel-token";
+      mockConfig = {
+        sandbox: { vercel: { teamId: "team_cfg", projectId: "prj_cfg" } },
+      };
+
+      const { vercelSandboxAccess } = await detectModule();
+
+      const access = vercelSandboxAccess();
+      expect(access?.teamId).toBe("team_env");
+      expect(access?.projectId).toBe("prj_env");
+    });
+
+    it("returns undefined when config supplies IDs but the token (env-only) is missing", async () => {
+      mockConfig = {
+        sandbox: { vercel: { teamId: "team_cfg", projectId: "prj_cfg" } },
+      };
+
+      const { vercelSandboxAccess } = await detectModule();
+
+      expect(vercelSandboxAccess()).toBeUndefined();
     });
 
     it("records the partial-credentials warning only once", async () => {

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { getConfig } from "@atlas/api/lib/config";
 
 const log = createLogger("sandbox-detect");
 
@@ -40,14 +41,21 @@ let _partialCredsWarned = false;
  * (e.g. Railway, Fly, bare metal). When unset, `@vercel/sandbox` falls back
  * to `VERCEL_OIDC_TOKEN` which is only present on the Vercel platform.
  *
- * Emits a one-time warn when some-but-not-all of the three vars are set —
+ * The team and project IDs resolve from env first, then from
+ * `sandbox.vercel` in `atlas.config.ts` (#3706 — they're not secret and are
+ * constant across regions, so SaaS bakes them into config rather than stamping
+ * `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` per regional service). `VERCEL_TOKEN`
+ * is the only secret and stays env-only.
+ *
+ * Emits a one-time warn when some-but-not-all of the three values are set —
  * the most likely cause is a typo or empty Railway service variable, and
  * without the breadcrumb the operator only sees the generic "all backends
  * failed" message far downstream.
  */
 export function vercelSandboxAccess(): VercelSandboxAccess | undefined {
-  const teamId = process.env.VERCEL_TEAM_ID;
-  const projectId = process.env.VERCEL_PROJECT_ID;
+  const vercelConfig = getConfig()?.sandbox?.vercel;
+  const teamId = process.env.VERCEL_TEAM_ID || vercelConfig?.teamId;
+  const projectId = process.env.VERCEL_PROJECT_ID || vercelConfig?.projectId;
   const token = process.env.VERCEL_TOKEN;
   const allSet = !!(teamId && projectId && token);
   if (!allSet) {

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -68,7 +68,7 @@ export function vercelSandboxAccess(): VercelSandboxAccess | undefined {
           hasProjectId: !!projectId,
           hasToken: !!token,
         },
-        "Partial Vercel Sandbox credentials detected — all three of VERCEL_TEAM_ID / VERCEL_PROJECT_ID / VERCEL_TOKEN are required off-Vercel. Treating as unset.",
+        "Partial Vercel Sandbox credentials detected — a team ID + project ID (VERCEL_TEAM_ID / VERCEL_PROJECT_ID, or sandbox.vercel in atlas.config.ts) and VERCEL_TOKEN are all required off-Vercel. Treating as unset.",
       );
     }
     return undefined;

--- a/packages/api/src/lib/web-origin.ts
+++ b/packages/api/src/lib/web-origin.ts
@@ -8,10 +8,16 @@
  *
  * Source of truth: first entry of `ATLAS_CORS_ORIGIN` (the CORS allowlist —
  * `app.useatlas.dev` is always first in SaaS). Falls back to the first entry
- * of `BETTER_AUTH_TRUSTED_ORIGINS`. Returns `null` when neither is set —
- * callers should treat that as "render inline HTML here" rather than emit
- * a malformed redirect.
+ * of `BETTER_AUTH_TRUSTED_ORIGINS`, then to the region-derived web origin
+ * (#3706 — `ATLAS_API_REGION` + the `residency.regions[].apiUrl` map, with the
+ * `api` host label swapped to `app`), so SaaS no longer has to stamp the web
+ * origin on each regional service. Returns `null` when none of these is
+ * available — callers should treat that as "render inline HTML here" rather
+ * than emit a malformed redirect.
  */
+
+import { deriveRegionWebOrigin } from "@atlas/api/lib/residency/origins";
+
 export function getWebOrigin(): string | null {
   const cors = process.env.ATLAS_CORS_ORIGIN?.split(",")[0]?.trim();
   if (cors && cors !== "*") return cors.replace(/\/+$/, "");
@@ -19,5 +25,5 @@ export function getWebOrigin(): string | null {
   const trusted = process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")[0]?.trim();
   if (trusted) return trusted.replace(/\/+$/, "");
 
-  return null;
+  return deriveRegionWebOrigin();
 }


### PR DESCRIPTION
Closes #3706. Tier 2 of the SaaS env-var reduction (#3701 / milestone #69).

Non-secret constants that are boot-ordering-dependent (can't be runtime settings) but constant across regions move out of per-service env stamps — into `atlas.config.ts` (maintained once, in code) or derived from `ATLAS_API_REGION` + the residency map.

## What changed

- **Vercel sandbox IDs → config.** `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` are not secret, so they move into `deploy/api/atlas.config.ts` (+ staging) under a new `sandbox.vercel` block. `vercelSandboxAccess()` reads config with an env override; only `VERCEL_TOKEN` stays env.
- **`ATLAS_PUBLIC_API_URL` → derived.** `resolvePublicApiUrl()` (OAuth install redirect URIs) falls back to the instance region's `residency.regions[region].apiUrl` when unset. The region's `apiUrl` is exactly the API host, so redirect URIs are unchanged.
- **Web origin (passkey rpID + `ATLAS_CORS_ORIGIN` default) → derived.** `getWebOrigin()` gains a final region fallback: the API host's first DNS label is swapped `api` → `app`, folding `api-eu` / `api-apac` onto the single `app.useatlas.dev` web service; `staging` keeps its own `app.staging.useatlas.dev`. The passkey rpID and the CORS default flow from this.
- **`ATLAS_CORS_ORIGIN` stays a registry setting** — only its *default* now derives from the region (the wildcard `"*"` still stands for self-hosted). Not re-introduced as an env var.
- **`BETTER_AUTH_URL` / `BETTER_AUTH_TRUSTED_ORIGINS` stay env** (read before config in Better Auth init); the coupling is documented. The cookie-domain guard in `server.ts` now keys off `getWebOrigin()` so it survives un-stamping `ATLAS_CORS_ORIGIN`.

Explicit env always overrides every derivation. Self-hosted deploys configure no residency map, so `getApiRegion()` returns `null` and every derivation no-ops — historical behavior is untouched.

## Derived per-region values (no behavior change)

| Region | `ATLAS_PUBLIC_API_URL` | web origin (rpID host / CORS default) |
|---|---|---|
| us | `https://api.useatlas.dev` | `https://app.useatlas.dev` |
| eu | `https://api-eu.useatlas.dev` | `https://app.useatlas.dev` |
| apac | `https://api-apac.useatlas.dev` | `https://app.useatlas.dev` |
| staging | `https://api.staging.useatlas.dev` | `https://app.staging.useatlas.dev` |

## Acceptance criteria

- [x] `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` sourced from config; only `VERCEL_TOKEN` remains env.
- [x] `ATLAS_PUBLIC_API_URL` / `ATLAS_RPID` derive from `ATLAS_API_REGION` + residency config when unset (explicit env overrides).
- [x] `ATLAS_CORS_ORIGIN` default derives from the region; stays a registry setting.
- [x] No behavior change to OAuth redirect URIs, CORS, or passkey RP across us/eu/apac/staging — locked by per-region tests.

## Tests

New `residency/__tests__/origins.test.ts` (per-region `deriveRegionApiUrl` / `deriveRegionWebOrigin`) and `region-origins-integration.test.ts` (full chain: `getWebOrigin` → `resolveCorsOrigin` + `resolvePasskeyRpId` per region, plus explicit-override and self-hosted cases). `detect.test.ts` gains config-fallback + env-override cases. Docs updated: SaaS env-vars page, `.env.example`, `deploy/README.md`, `saas-env-audit.md` (Tier 2 → shipped).

All six `/ci` gates green (lint, type, full test, syncpack, template-drift, railway-watch).

https://claude.ai/code/session_01J8G1Qq8bqfjvcGsx37AKKL

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8G1Qq8bqfjvcGsx37AKKL)_