### PR TITLE
refactor(settings): promote SaaS tuning knobs into the settings registry (#3705)

### DIFF
--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -86,19 +86,26 @@ them — changing them *is* a deploy:
 
 ## What you change at runtime instead
 
-Roughly 40 settings are **already runtime-controllable** through the settings
+Roughly 55 settings are **already runtime-controllable** through the settings
 registry (`lib/settings.ts`) — the env var, if any, is only a fallback. Precedence
 is `workspace DB override > platform DB override > env var > default`, and SaaS
 hot-reloads within ~30s (no redeploy). Edit these in the **Admin console**, not in
 Railway:
 
 - **Query limits** — row limit, query timeout, delivery max rows
-- **Rate limiting** — per-user / chat / admin RPM (the base RPM floor excepted)
+- **Rate limiting** — per-user / chat / admin RPM (the base RPM floor excepted), contact-form RPM
+- **Demo** — demo RPM + demo agent max steps
+- **Abuse prevention** — query-rate / window / error-rate / unique-tables / throttle-delay / escalation-cooldown thresholds
 - **Agent** — max steps, conversation step cap, provider, model, log level
 - **Security** — RLS column/claim, table whitelist, CORS origin, allowed email domains, SCIM policy
 - **Sessions** — idle / absolute timeout
+- **OAuth** — access / refresh token TTLs (restart-applied), install state-token TTL
+- **Model catalog** — BYOT catalog cache TTL
+- **MCP** — session idle timeout, max held-stream age, rate-limit cache max keys
+- **Dashboards** — export render timeout
 - **Sandbox** — backend (via Admin → Sandbox, incl. BYOC), URL
 - **Intelligence** — semantic-expert scheduler + auto-approve
+- **Observability** — plugin-health cache TTL (the OTEL exporter endpoint/headers stay env — they are read before the settings DB loads)
 - **Appearance** — brand color
 - **Email** — provider + from address (keys via Admin → Email provider)
 - **Billing** — the six Stripe per-tier Price IDs (only `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET` stay env)

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -66,20 +66,42 @@ The headline of the principle. Candidates, by area:
   `resolvePlanTierFromPriceId()` read them via `getSettingAuto` per checkout, and
   `BillingConfigGuardLive` warns (no longer boot-blocks) on a missing price ID.
   Only the secret key + webhook secret stay env.
-- **Rate-limit / abuse tuning** — the per-user / chat / admin RPM trio
-  (`ATLAS_RATE_LIMIT_RPM`, `_RPM_CHAT`, `_RPM_ADMIN`) is **already** in the registry
-  (`_RPM` itself is immutable on SaaS — DDoS floor). The remaining env-only knobs to
-  promote are `ATLAS_CONTACT_RATE_LIMIT_RPM`, `ATLAS_DEMO_RATE_LIMIT_RPM`,
-  `ATLAS_DEMO_MAX_STEPS`, and the `ATLAS_ABUSE_*` family. Relates to #3687.
-- **OAuth / token TTLs** — `ATLAS_OAUTH_*_TTL_SECONDS`, MCP session caps
-  (`ATLAS_MCP_MAX_SESSIONS` is already env-profile-centralized, not registry).
+- **Rate-limit / abuse tuning** — ✅ **done (#3705).** The per-user / chat / admin RPM trio
+  (`ATLAS_RATE_LIMIT_RPM`, `_RPM_CHAT`, `_RPM_ADMIN`) was **already** in the registry
+  (`_RPM` itself is immutable on SaaS — DDoS floor). #3705 promoted the remaining env-only
+  knobs to platform-scoped, hot-reloadable settings (env is now only a fallback tier):
+  `ATLAS_CONTACT_RATE_LIMIT_RPM`, `ATLAS_DEMO_RATE_LIMIT_RPM`, `ATLAS_DEMO_MAX_STEPS`, and
+  the `ATLAS_ABUSE_*` family (`getContactRpmLimit` / `getDemoRpmLimit` / `getDemoMaxSteps` /
+  `getAbuseConfig` read via `getSettingAuto` per request/event). Platform scope is
+  load-bearing — a tenant must never weaken the abuse thresholds that defend the region
+  against it. Relates to #3687.
+- **OAuth / token TTLs** — ✅ **done (#3705).** `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS` /
+  `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS` are platform-scoped `requiresRestart` settings
+  (baked into the Better Auth instance at boot; the resolvers prefer a DB override over the
+  injected env via `getSettingOverride`). `ATLAS_OAUTH_STATE_TTL_SECONDS` (the install-flow
+  state token — the issue mis-named it `*_STATE_TOKEN_TTL_SECONDS`) is hot-reloadable
+  (read per-mint). The MCP knobs `ATLAS_BYOT_CATALOG_TTL_MS`, `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS`,
+  `ATLAS_MCP_MAX_HELD_STREAM_AGE_MS`, and `ATLAS_MCP_RATE_LIMIT_MAX_KEYS` are likewise
+  platform-scoped + hot-reloadable (the hosted MCP transport mounts on the per-region API
+  server, which runs the settings-refresh fiber). `ATLAS_MCP_MAX_SESSIONS` stays
+  env-profile-centralized (not registry).
 - **Operator integration credentials** — Slack/Discord/Teams/Telegram/WhatsApp/
   gchat/Jira/Linear/GitHub-App/Salesforce env creds read at boot. Today **adding a
   chat platform or action target to a region requires a Railway deploy**. These
   should be operator-settable (encrypted) via an Admin → Platform Integrations
   surface, the same way *workspace* plugin creds already work.
-- **Observability** — `OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS}` (today a per-service
-  footgun: shared scope silently drops telemetry).
+- **Observability** — `OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS}` — ⚠️ **consciously LEFT as env
+  (#3705).** Evaluated for promotion and deliberately kept env-only: `TelemetryLive` is the
+  *first* layer in `buildAppLayer` (so it can trace the rest of boot) and has no dependency
+  edge to `SettingsLive`, so the settings DB cache is provably cold at telemetry init on
+  every boot — a DB-backed OTEL value could never apply at boot, even after a restart, and a
+  silently-ignored override is worse than an env var (CLAUDE.md: "prefer errors over silent
+  fallbacks"; the OTel SDK also reads `OTEL_EXPORTER_OTLP_HEADERS` directly from the process
+  env). This is exactly the documented carve-out for "the process needs the value before the
+  internal DB exists." The per-service footgun (shared scope silently drops telemetry) is
+  better solved by setting it once as a region-constant via shared platform config, not the
+  runtime registry. `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS` (plugin-liveness cache) *was* promoted
+  — it is read per health-probe, not at boot.
 
 ### Tier 2 — Move non-secret constants into `atlas.config.ts` ✅ shipped (#3706)
 For things that genuinely can't be runtime (boot-ordering) but are constant
@@ -160,7 +182,9 @@ children rather than new issues:
   (`lib/dashboard-screenshot.ts`), `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`
   (`lib/plugins/registry.ts`), `ATLAS_MCP_MAX_HELD_STREAM_AGE_MS`
   (`packages/mcp/src/session-store.ts`). None are in the registry or boot-ordering-dependent,
-  so they're Tier-1 promote candidates (added to #3705) and Tier-4 doc gaps (added to #3710).
+  so they were Tier-1 promote candidates (added to #3705) and Tier-4 doc gaps (added to #3710).
+  ✅ **All three promoted in #3705** — platform-scoped, hot-reloadable settings read per
+  export / per probe / per sweep; env stays the fallback tier.
 - **Two registry-backed learn knobs landed after the audit** (#3636) —
   `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` / `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS`.
   These are correctly registry-backed (`settings.ts:654/667`) so the principle held;

--- a/packages/api/src/lib/__tests__/tuning-knobs-settings.test.ts
+++ b/packages/api/src/lib/__tests__/tuning-knobs-settings.test.ts
@@ -1,0 +1,167 @@
+/**
+ * #3705 — SaaS tuning knobs promoted into the settings registry.
+ *
+ * Each knob below was env-only before this change. The contract being
+ * verified is the registry precedence chain for these platform-scoped keys:
+ *
+ *   platform DB override > env var > registry default
+ *
+ * Uses the real settings module with the `_resetPool` + `setSetting`
+ * injection pattern from settings.test.ts / agent-max-steps.test.ts, so the
+ * full resolution path (not a mock of `getSettingAuto`) is exercised.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { getContactRpmLimit } from "@atlas/api/lib/contact";
+import { getDemoRpmLimit, getDemoMaxSteps } from "@atlas/api/lib/demo";
+import { getAbuseConfig } from "@atlas/api/lib/security/abuse";
+import {
+  resolveAccessTokenTtlSeconds,
+  resolveRefreshTokenTtlSeconds,
+} from "@atlas/api/lib/auth/server";
+import { getPluginHealthCacheTtlMs } from "@atlas/api/lib/plugins/registry";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
+
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+// Keys touched here, so the env tier can be isolated per test.
+const ENV_KEYS = [
+  "ATLAS_CONTACT_RATE_LIMIT_RPM",
+  "ATLAS_DEMO_RATE_LIMIT_RPM",
+  "ATLAS_DEMO_MAX_STEPS",
+  "ATLAS_ABUSE_QUERY_RATE",
+  "ATLAS_ABUSE_ERROR_RATE",
+  "ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS",
+  "ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS",
+] as const;
+
+const origEnv = new Map<string, string | undefined>();
+const origDbUrl = process.env.DATABASE_URL;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    origEnv.set(k, process.env[k]);
+    delete process.env[k];
+  }
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+  _resetSettingsCache();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = origEnv.get(k);
+    if (v !== undefined) process.env[k] = v;
+    else delete process.env[k];
+  }
+  if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+  else delete process.env.DATABASE_URL;
+  _resetPool(null);
+  _resetSettingsCache();
+});
+
+describe("contact form RPM — registry precedence (#3705)", () => {
+  it("falls back to the registry default when nothing is set", () => {
+    expect(getContactRpmLimit()).toBe(5);
+  });
+
+  it("reads the env var when no DB override exists", () => {
+    process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "20";
+    expect(getContactRpmLimit()).toBe(20);
+  });
+
+  it("platform DB override wins over the env var", async () => {
+    process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "20";
+    await setSetting("ATLAS_CONTACT_RATE_LIMIT_RPM", "7", "test");
+    expect(getContactRpmLimit()).toBe(7);
+  });
+});
+
+describe("demo knobs — registry precedence (#3705)", () => {
+  it("default RPM + max steps when nothing is set", () => {
+    expect(getDemoRpmLimit()).toBe(10);
+    expect(getDemoMaxSteps()).toBe(10);
+  });
+
+  it("DB override wins over env for both knobs", async () => {
+    process.env.ATLAS_DEMO_RATE_LIMIT_RPM = "99";
+    process.env.ATLAS_DEMO_MAX_STEPS = "99";
+    await setSetting("ATLAS_DEMO_RATE_LIMIT_RPM", "3", "test");
+    await setSetting("ATLAS_DEMO_MAX_STEPS", "20", "test");
+    expect(getDemoRpmLimit()).toBe(3);
+    expect(getDemoMaxSteps()).toBe(20);
+  });
+});
+
+describe("abuse thresholds — registry precedence (#3705)", () => {
+  it("uses registry defaults when unset", () => {
+    const cfg = getAbuseConfig();
+    expect(cfg.queryRateLimit).toBe(200);
+    expect(cfg.errorRateThreshold).toBeCloseTo(0.5);
+  });
+
+  it("DB override retunes thresholds without a redeploy", async () => {
+    await setSetting("ATLAS_ABUSE_QUERY_RATE", "500", "test");
+    await setSetting("ATLAS_ABUSE_ERROR_RATE", "0.8", "test");
+    const cfg = getAbuseConfig();
+    expect(cfg.queryRateLimit).toBe(500);
+    expect(cfg.errorRateThreshold).toBeCloseTo(0.8);
+  });
+
+  it("the escalation cooldown still honors its allow-zero override", async () => {
+    await setSetting("ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS", "0", "test");
+    expect(getAbuseConfig().escalationCooldownMs).toBe(0);
+  });
+});
+
+describe("OAuth token TTLs — boot-consumed, registry override (#3705)", () => {
+  it("DB override wins over the injected env (override-only read)", async () => {
+    await setSetting("ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS", "30", "test");
+    await setSetting("ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS", "120", "test");
+    // The injected env carries different values — the registry must win.
+    expect(
+      resolveAccessTokenTtlSeconds({
+        ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "3600",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30);
+    expect(
+      resolveRefreshTokenTtlSeconds({
+        ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS: "3600",
+      } as NodeJS.ProcessEnv),
+    ).toBe(120);
+  });
+
+  it("falls back to the injected env when no DB override exists", () => {
+    expect(
+      resolveAccessTokenTtlSeconds({
+        ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "45",
+      } as NodeJS.ProcessEnv),
+    ).toBe(45);
+  });
+
+  it("falls back to the default when neither is set", () => {
+    expect(resolveAccessTokenTtlSeconds({} as NodeJS.ProcessEnv)).toBe(3600);
+    expect(resolveRefreshTokenTtlSeconds({} as NodeJS.ProcessEnv)).toBe(2592000);
+  });
+});
+
+describe("plugin health cache TTL — registry precedence (#3705)", () => {
+  it("default when unset", () => {
+    expect(getPluginHealthCacheTtlMs()).toBe(15000);
+  });
+
+  it("DB override wins over env", async () => {
+    process.env.ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS = "99999";
+    await setSetting("ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS", "5000", "test");
+    expect(getPluginHealthCacheTtlMs()).toBe(5000);
+  });
+});

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -27,6 +27,7 @@ import {
   storeToDB,
 } from "./byot-catalog-store";
 import { createLogger } from "./logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("anthropic-catalog");
 
@@ -94,7 +95,8 @@ const cache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<CacheEntry>>();
 
 function ttlMs(): number {
-  const raw = process.env.ATLAS_BYOT_CATALOG_TTL_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_BYOT_CATALOG_TTL_MS");
   if (!raw) return DEFAULT_TTL_MS;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1355,6 +1355,13 @@ export function resolveAllowUnauthDcr(env: NodeJS.ProcessEnv): boolean {
  * operators rarely need to change these — the override exists so a
  * Playwright spec can mint a 30-second JWT instead of waiting an hour.
  */
+// Keep these in sync with the registry `default` for
+// ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS / ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS
+// in lib/settings.ts (#3705). The resolvers below read via `getSettingOverride`
+// (DB-override-only tier), so the registry's own `default` is NOT consulted at
+// resolution time — these constants are the live default. If they drift, the
+// value shown in the Admin console (registry default) and the value actually
+// baked into the auth instance (these) diverge.
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
 const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -32,6 +32,7 @@ import {
 } from "@atlas/api/lib/auth/oauth-claims";
 import { listUserWorkspaceIds } from "@atlas/api/lib/auth/oauth-workspace-grants";
 import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit";
+import { getSettingOverride } from "@atlas/api/lib/settings";
 import Stripe from "stripe";
 import { getInternalDB, getWorkspaceDetails, hasInternalDB, internalQuery, isPlanOverrideActive, updateWorkspacePlanTier, updateWorkspaceStatus, withStripeSubscriptionLock, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -1372,12 +1373,21 @@ function resolveTtlSeconds(raw: string | undefined, fallback: number): number {
   return parsed;
 }
 
+// Platform settings registry (#3705): a platform DB override wins over the
+// injected `env` (which stays the boot/fallback tier), then the default.
+// `getSettingOverride` reads ONLY the DB tier — using `getSettingAuto` here
+// would read the live `process.env` and shadow the synthetic `env` the unit
+// tests inject. Both TTLs are baked into the Better Auth instance at boot
+// (`accessTokenExpiresIn` / `refreshTokenExpiresIn`), so the registry entries
+// carry `requiresRestart: true` — a change takes effect on the next restart.
 export function resolveAccessTokenTtlSeconds(env: NodeJS.ProcessEnv): number {
-  return resolveTtlSeconds(env.ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS, DEFAULT_ACCESS_TOKEN_TTL_SECONDS);
+  const override = getSettingOverride("ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS");
+  return resolveTtlSeconds(override ?? env.ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS, DEFAULT_ACCESS_TOKEN_TTL_SECONDS);
 }
 
 export function resolveRefreshTokenTtlSeconds(env: NodeJS.ProcessEnv): number {
-  return resolveTtlSeconds(env.ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS, DEFAULT_REFRESH_TOKEN_TTL_SECONDS);
+  const override = getSettingOverride("ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS");
+  return resolveTtlSeconds(override ?? env.ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS, DEFAULT_REFRESH_TOKEN_TTL_SECONDS);
 }
 
 /**

--- a/packages/api/src/lib/bedrock-catalog.ts
+++ b/packages/api/src/lib/bedrock-catalog.ts
@@ -36,6 +36,7 @@ import {
   storeToDB,
 } from "./byot-catalog-store";
 import { createLogger } from "./logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("bedrock-catalog");
 
@@ -108,7 +109,8 @@ const cache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<CacheEntry>>();
 
 function ttlMs(): number {
-  const raw = process.env.ATLAS_BYOT_CATALOG_TTL_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_BYOT_CATALOG_TTL_MS");
   if (!raw) return DEFAULT_TTL_MS;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;

--- a/packages/api/src/lib/contact.ts
+++ b/packages/api/src/lib/contact.ts
@@ -11,6 +11,7 @@
  */
 
 import { createLogger } from "./logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("contact");
 
@@ -21,7 +22,8 @@ let lastWarnedRpm: string | undefined;
 
 /** Requests per minute per IP. Default 5. 0 = disabled. */
 export function getContactRpmLimit(): number {
-  const raw = process.env.ATLAS_CONTACT_RATE_LIMIT_RPM ?? String(CONTACT_DEFAULT_RPM);
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_CONTACT_RATE_LIMIT_RPM") ?? String(CONTACT_DEFAULT_RPM);
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) {
     if (raw !== lastWarnedRpm) {

--- a/packages/api/src/lib/dashboard-screenshot.ts
+++ b/packages/api/src/lib/dashboard-screenshot.ts
@@ -33,6 +33,7 @@
 
 import { createHash } from "node:crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getDashboard } from "@atlas/api/lib/dashboards";
 import { resolveDashboardParameterValues } from "@atlas/api/lib/dashboard-parameters";
@@ -619,7 +620,8 @@ const EXPORT_TIMEOUT_MAX_MS = 180_000;
 const EXPORT_TIMEOUT_SENTINEL = "atlas_export_timed_out";
 
 function getExportTimeoutMs(): number {
-  const raw = process.env.ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS");
   if (!raw) return EXPORT_TIMEOUT_DEFAULT_MS;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return EXPORT_TIMEOUT_DEFAULT_MS;

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -12,6 +12,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("demo");
 
@@ -32,7 +33,8 @@ let lastWarnedDemoMaxSteps: string | undefined;
 
 /** Max agent steps for demo sessions. Default 10. */
 export function getDemoMaxSteps(): number {
-  const raw = process.env.ATLAS_DEMO_MAX_STEPS ?? String(DEMO_DEFAULT_MAX_STEPS);
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_DEMO_MAX_STEPS") ?? String(DEMO_DEFAULT_MAX_STEPS);
   const n = parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 1 || n > 100) {
     if (raw !== lastWarnedDemoMaxSteps) {
@@ -48,7 +50,8 @@ let lastWarnedDemoRpm: string | undefined;
 
 /** Requests per minute for demo users. Default 10. 0 = disabled. */
 export function getDemoRpmLimit(): number {
-  const raw = process.env.ATLAS_DEMO_RATE_LIMIT_RPM ?? String(DEMO_DEFAULT_RPM);
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_DEMO_RATE_LIMIT_RPM") ?? String(DEMO_DEFAULT_RPM);
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) {
     if (raw !== lastWarnedDemoRpm) {

--- a/packages/api/src/lib/integrations/install/oauth-state-token.ts
+++ b/packages/api/src/lib/integrations/install/oauth-state-token.ts
@@ -45,6 +45,7 @@
 
 import * as crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 
 const log = createLogger("integrations.install.oauth-state-token");
@@ -243,7 +244,8 @@ function resolveTtlSeconds(override: number | undefined): number {
     if (override >= 1 && Number.isFinite(override)) return Math.floor(override);
     return DEFAULT_TTL_SECONDS;
   }
-  const envRaw = process.env.ATLAS_OAUTH_STATE_TTL_SECONDS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const envRaw = getSettingAuto("ATLAS_OAUTH_STATE_TTL_SECONDS");
   if (!envRaw) return DEFAULT_TTL_SECONDS;
   const parsed = Number.parseInt(envRaw, 10);
   if (!Number.isFinite(parsed) || parsed < MIN_TTL_SECONDS || parsed > MAX_TTL_SECONDS) {

--- a/packages/api/src/lib/openai-catalog.ts
+++ b/packages/api/src/lib/openai-catalog.ts
@@ -20,6 +20,7 @@ import {
   storeToDB,
 } from "./byot-catalog-store";
 import { createLogger } from "./logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("openai-catalog");
 
@@ -123,7 +124,8 @@ const cache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<CacheEntry>>();
 
 function ttlMs(): number {
-  const raw = process.env.ATLAS_BYOT_CATALOG_TTL_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_BYOT_CATALOG_TTL_MS");
   if (!raw) return DEFAULT_TTL_MS;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import { withSpan } from "@atlas/api/lib/tracing";
 
 const log = createLogger("plugins");
@@ -39,7 +40,8 @@ let lastWarnedHealthTtl: string | undefined;
  * caching (every call re-probes upstream).
  */
 export function getPluginHealthCacheTtlMs(): number {
-  const raw = process.env.ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS");
   if (raw === undefined || raw === "") return DEFAULT_PLUGIN_HEALTH_CACHE_TTL_MS;
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 0 || n > MAX_PLUGIN_HEALTH_CACHE_TTL_MS) {

--- a/packages/api/src/lib/rate-limit/oauth-client.ts
+++ b/packages/api/src/lib/rate-limit/oauth-client.ts
@@ -36,6 +36,8 @@
  * single-region case, which is the production hot path today.
  */
 
+import { getSettingAuto } from "@atlas/api/lib/settings";
+
 const WINDOW_MS = 60_000;
 export { WINDOW_MS };
 
@@ -144,7 +146,8 @@ const buckets = new Map<string, BucketEntry[]>();
 const DEFAULT_LIMITS_CACHE_MAX_KEYS = 10_000;
 
 function resolveLimitsCacheMaxKeys(): number {
-  const raw = process.env.ATLAS_MCP_RATE_LIMIT_MAX_KEYS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_MCP_RATE_LIMIT_MAX_KEYS");
   if (raw === undefined) return DEFAULT_LIMITS_CACHE_MAX_KEYS;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_LIMITS_CACHE_MAX_KEYS;

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -16,6 +16,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { abuseEscalations } from "@atlas/api/lib/metrics";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
 import { isLoadTestWorkspace } from "@atlas/api/lib/auth/load-test-allowlist";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
@@ -112,15 +113,21 @@ function coerceAbuseEnums(
 // Configuration — env var thresholds
 // ---------------------------------------------------------------------------
 
+// Thresholds resolve through the platform settings registry (#3705): a
+// platform DB override wins, env is the fallback tier, registry default last.
+// `getSettingAuto` is read per query-event via `getAbuseConfig`, so an
+// operator can retune abuse defense from Admin without a redeploy. Platform
+// scope is load-bearing — a tenant must never tune the thresholds that defend
+// the region against it.
 function envInt(key: string, fallback: number): number {
-  const raw = process.env[key];
+  const raw = getSettingAuto(key);
   if (!raw) return fallback;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
 function envFloat(key: string, fallback: number): number {
-  const raw = process.env[key];
+  const raw = getSettingAuto(key);
   if (!raw) return fallback;
   const n = parseFloat(raw);
   return Number.isFinite(n) && n > 0 ? n : fallback;
@@ -159,7 +166,7 @@ export function getAbuseConfig(): AbuseThresholdConfig {
  * truncating to `0` and reopening the fast-walk path.
  */
 function envIntAllowZero(key: string, fallback: number): number {
-  const raw = process.env[key];
+  const raw = getSettingAuto(key);
   if (raw === undefined || raw === "") return fallback;
   const n = Number(raw);
   return Number.isInteger(n) && n >= 0 ? n : fallback;

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -115,19 +115,18 @@ function coerceAbuseEnums(
 
 // Thresholds resolve through the platform settings registry (#3705): a
 // platform DB override wins, env is the fallback tier, registry default last.
-// `getSettingAuto` is read per query-event via `getAbuseConfig`, so an
-// operator can retune abuse defense from Admin without a redeploy. Platform
-// scope is load-bearing — a tenant must never tune the thresholds that defend
-// the region against it.
-function envInt(key: string, fallback: number): number {
-  const raw = getSettingAuto(key);
+// `getAbuseConfig` reads each via `getSettingAuto` per query-event with the key
+// as a literal (so the parity-contract reader check sees it), then hands the
+// raw value to a pure parser. An operator can retune abuse defense from Admin
+// without a redeploy. Platform scope is load-bearing — a tenant must never tune
+// the thresholds that defend the region against it.
+function parsePosInt(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
-function envFloat(key: string, fallback: number): number {
-  const raw = getSettingAuto(key);
+function parsePosFloat(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
   const n = parseFloat(raw);
   return Number.isFinite(n) && n > 0 ? n : fallback;
@@ -135,25 +134,26 @@ function envFloat(key: string, fallback: number): number {
 
 export function getAbuseConfig(): AbuseThresholdConfig {
   return {
-    queryRateLimit: envInt("ATLAS_ABUSE_QUERY_RATE", 200),
-    queryRateWindowSeconds: envInt("ATLAS_ABUSE_WINDOW_SECONDS", 300),
-    // Env-var value is already a 0–1 fraction (e.g. ATLAS_ABUSE_ERROR_RATE=0.5);
+    queryRateLimit: parsePosInt(getSettingAuto("ATLAS_ABUSE_QUERY_RATE"), 200),
+    queryRateWindowSeconds: parsePosInt(getSettingAuto("ATLAS_ABUSE_WINDOW_SECONDS"), 300),
+    // Value is already a 0–1 fraction (e.g. ATLAS_ABUSE_ERROR_RATE=0.5);
     // `asRatio` brands it so the cross-scale guard in `checkThresholds` +
     // detail-panel comparisons type-checks (#1685).
-    errorRateThreshold: asRatio(envFloat("ATLAS_ABUSE_ERROR_RATE", 0.5)),
-    uniqueTablesLimit: envInt("ATLAS_ABUSE_UNIQUE_TABLES", 50),
-    throttleDelayMs: envInt("ATLAS_ABUSE_THROTTLE_DELAY_MS", 2000),
-    // `envInt` rejects `≤ 0` and falls back to the default, so the only way
+    errorRateThreshold: asRatio(parsePosFloat(getSettingAuto("ATLAS_ABUSE_ERROR_RATE"), 0.5)),
+    uniqueTablesLimit: parsePosInt(getSettingAuto("ATLAS_ABUSE_UNIQUE_TABLES"), 50),
+    throttleDelayMs: parsePosInt(getSettingAuto("ATLAS_ABUSE_THROTTLE_DELAY_MS"), 2000),
+    // `parsePosInt` rejects `≤ 0` and falls back to the default, so the only way
     // to bypass the cooldown (e.g. for the abuse engine's own unit tests)
-    // is `envIntAllowZero` below — a deliberate two-helper split so a typo
-    // in a SaaS env file (`ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS=0`)
+    // is `parseNonNegInt` below — a deliberate two-helper split so a typo
+    // in a SaaS env file / setting (`ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS=0`)
     // doesn't silently turn the dwell-time guard off in prod.
-    escalationCooldownMs: envIntAllowZero("ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS", 60) * 1000,
+    escalationCooldownMs:
+      parseNonNegInt(getSettingAuto("ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS"), 60) * 1000,
   };
 }
 
 /**
- * Variant of `envInt` that accepts `0` as a valid value. Only the
+ * Variant of `parsePosInt` that accepts `0` as a valid value. Only the
  * escalation cooldown is allowed to be disabled this way — explicit opt-in
  * for the abuse engine's own unit tests, where the ladder behaviour is
  * exercised in a tight loop. Production deployments must set a positive
@@ -165,8 +165,7 @@ export function getAbuseConfig(): AbuseThresholdConfig {
  * like `"0.5"` or `"0s"` fall back to the default instead of silently
  * truncating to `0` and reopening the fast-walk path.
  */
-function envIntAllowZero(key: string, fallback: number): number {
-  const raw = getSettingAuto(key);
+function parseNonNegInt(raw: string | undefined, fallback: number): number {
   if (raw === undefined || raw === "") return fallback;
   const n = Number(raw);
   return Number.isInteger(n) && n >= 0 ? n : fallback;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -912,6 +912,11 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   // Access/refresh TTLs are baked into the Better Auth instance at boot
   // (`requiresRestart`); the install state-token TTL is read per-mint and is
   // hot-reloadable.
+  //
+  // NB: the access/refresh resolvers in lib/auth/server.ts read via
+  // `getSettingOverride` (DB-override-only tier), so the `default` values below
+  // are display-only — the live default is `DEFAULT_{ACCESS,REFRESH}_TOKEN_TTL_SECONDS`
+  // in that file. Keep the two in sync (3600 / 2592000).
   {
     key: "ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS",
     section: "OAuth",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -773,6 +773,267 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+
+  // ───────────────────────────────────────────────────────────────────────
+  // SaaS tuning knobs promoted from env-only (#3705, Tier 1 of #3701).
+  //
+  // All platform-scoped + `saasVisible: false`: these are operator/region
+  // infra knobs (public-surface rate limits, abuse-defense thresholds, cache
+  // TTLs, OAuth token lifetimes), not per-tenant product settings — a tenant
+  // must never be able to weaken their own abuse thresholds or the contact /
+  // demo rate limits. `getSettingsForAdmin` only returns workspace-scoped keys
+  // to workspace admins, so platform scope already keeps these off the tenant
+  // settings page; `saasVisible: false` makes the operator-only intent explicit
+  // (matches the RLS / deploy-mode / Stripe precedent above).
+  //
+  // The env var stays the fallback tier in every case (precedence:
+  // platform DB override > env > registry default). Knobs read per-request /
+  // per-event through `getSettingAuto` are hot-reloadable (no `requiresRestart`);
+  // knobs consumed once at boot carry an honest `requiresRestart` hint.
+  // (`OTEL_EXPORTER_OTLP_*` was evaluated and consciously LEFT as env — see
+  // docs/development/saas-env-audit.md: telemetry inits before the settings
+  // cache warms, so a DB-backed value could never apply at boot.)
+  // ───────────────────────────────────────────────────────────────────────
+
+  // Rate Limiting (continued) — public-surface limiters. Hot-reloadable:
+  // `getContactRpmLimit()` reads per request.
+  {
+    key: "ATLAS_CONTACT_RATE_LIMIT_RPM",
+    section: "Rate Limiting",
+    label: "Contact Form Rate Limit (RPM)",
+    description:
+      "Max contact-form submissions per minute per IP (0 = disabled). Tighter than the chat limit — a real visitor submits a handful per minute; 30+ is abuse.",
+    type: "number",
+    default: "5",
+    envVar: "ATLAS_CONTACT_RATE_LIMIT_RPM",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // Demo (continued) — public email-gated demo. Hot-reloadable:
+  // `getDemoRpmLimit()` / `getDemoMaxSteps()` read per request.
+  {
+    key: "ATLAS_DEMO_RATE_LIMIT_RPM",
+    section: "Demo",
+    label: "Demo Rate Limit (RPM)",
+    description: "Max requests per minute per demo user (0 = disabled).",
+    type: "number",
+    default: "10",
+    envVar: "ATLAS_DEMO_RATE_LIMIT_RPM",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_DEMO_MAX_STEPS",
+    section: "Demo",
+    label: "Demo Agent Max Steps",
+    description: "Maximum tool-call steps per demo agent run (1–100).",
+    type: "number",
+    default: "10",
+    envVar: "ATLAS_DEMO_MAX_STEPS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // Abuse Prevention — anomaly-detection thresholds (lib/security/abuse.ts).
+  // Hot-reloadable: `getAbuseConfig()` reads per query-event. Platform-only and
+  // hidden from tenants by design — a workspace must not tune the thresholds
+  // that defend the region against it.
+  {
+    key: "ATLAS_ABUSE_QUERY_RATE",
+    section: "Abuse Prevention",
+    label: "Query Rate Limit",
+    description: "Queries per workspace within the window before escalation triggers.",
+    type: "number",
+    default: "200",
+    envVar: "ATLAS_ABUSE_QUERY_RATE",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_ABUSE_WINDOW_SECONDS",
+    section: "Abuse Prevention",
+    label: "Detection Window (seconds)",
+    description: "Sliding-window length (seconds) over which abuse counters accumulate.",
+    type: "number",
+    default: "300",
+    envVar: "ATLAS_ABUSE_WINDOW_SECONDS",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_ABUSE_ERROR_RATE",
+    section: "Abuse Prevention",
+    label: "Error Rate Threshold",
+    description:
+      "Failure ratio (0–1, e.g. 0.5 = 50%) above which a workspace with ≥10 queries in the window escalates.",
+    type: "number",
+    default: "0.5",
+    envVar: "ATLAS_ABUSE_ERROR_RATE",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_ABUSE_UNIQUE_TABLES",
+    section: "Abuse Prevention",
+    label: "Unique Tables Limit",
+    description: "Distinct tables a workspace may touch within the window before escalation triggers.",
+    type: "number",
+    default: "50",
+    envVar: "ATLAS_ABUSE_UNIQUE_TABLES",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_ABUSE_THROTTLE_DELAY_MS",
+    section: "Abuse Prevention",
+    label: "Throttle Delay (ms)",
+    description: "Injected per-request delay (ms) while a workspace sits at the 'throttled' level.",
+    type: "number",
+    default: "2000",
+    envVar: "ATLAS_ABUSE_THROTTLE_DELAY_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS",
+    section: "Abuse Prevention",
+    label: "Escalation Cooldown (seconds)",
+    description:
+      "Dwell time (seconds) required at a level before the ladder advances to the next one. 0 disables the cooldown (test-only — a stray 0 in prod reopens the fast-walk regression, so a non-integer falls back to the default).",
+    type: "number",
+    default: "60",
+    envVar: "ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // OAuth — token lifetimes for the MCP OAuth 2.1 provider + install state.
+  // Access/refresh TTLs are baked into the Better Auth instance at boot
+  // (`requiresRestart`); the install state-token TTL is read per-mint and is
+  // hot-reloadable.
+  {
+    key: "ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS",
+    section: "OAuth",
+    label: "Access Token TTL (seconds)",
+    description: "Lifetime of OAuth 2.1 access tokens (default 1 hour). Baked into the auth instance at boot.",
+    type: "number",
+    default: "3600",
+    envVar: "ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS",
+    section: "OAuth",
+    label: "Refresh Token TTL (seconds)",
+    description: "Lifetime of OAuth 2.1 refresh tokens (default 30 days). Baked into the auth instance at boot.",
+    type: "number",
+    default: "2592000",
+    envVar: "ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    // The issue named this `ATLAS_OAUTH_STATE_TOKEN_TTL_SECONDS`; the actual
+    // env var is `ATLAS_OAUTH_STATE_TTL_SECONDS` (integration-install OAuth
+    // state token, lib/integrations/install/oauth-state-token.ts). Read
+    // per-mint, so hot-reloadable. Clamped to [60, 3600] by the consumer.
+    key: "ATLAS_OAUTH_STATE_TTL_SECONDS",
+    section: "OAuth",
+    label: "Install State Token TTL (seconds)",
+    description: "Lifetime of integration-install OAuth state tokens (default 600, clamped to 60–3600).",
+    type: "number",
+    default: "600",
+    envVar: "ATLAS_OAUTH_STATE_TTL_SECONDS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // Model Catalog — TTL of the BYOT provider model-list cache (Anthropic /
+  // OpenAI / Bedrock). Hot-reloadable: `ttlMs()` reads per cache check.
+  {
+    key: "ATLAS_BYOT_CATALOG_TTL_MS",
+    section: "Model Catalog",
+    label: "Catalog Cache TTL (ms)",
+    description: "How long fetched provider model catalogs are cached before re-fetch (default 6 hours).",
+    type: "number",
+    default: "21600000",
+    envVar: "ATLAS_BYOT_CATALOG_TTL_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // MCP (continued) — hosted session-store + rate-limit caps. Hot-reloadable:
+  // the hosted MCP transport mounts on the per-region API server (which runs
+  // the SettingsLive refresh fiber) and re-reads these per sweep / per insert.
+  {
+    key: "ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS",
+    section: "MCP",
+    label: "Session Idle Timeout (ms)",
+    description: "Idle time before an MCP session is reaped (default 30 min, 1-minute floor).",
+    type: "number",
+    default: "1800000",
+    envVar: "ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_MCP_MAX_HELD_STREAM_AGE_MS",
+    section: "MCP",
+    label: "Max Held Stream Age (ms)",
+    description:
+      "How long a held GET SSE notification stream may stay open before the sweep reclaims its session under cap pressure (default 2 hours; 0 disables age-based reclaim).",
+    type: "number",
+    default: "7200000",
+    envVar: "ATLAS_MCP_MAX_HELD_STREAM_AGE_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_MCP_RATE_LIMIT_MAX_KEYS",
+    section: "MCP",
+    label: "Rate-Limit Cache Max Keys",
+    description:
+      "Soft cap on the per-client rate-limit cache map (default 10000; values below 100 are clamped to 100).",
+    type: "number",
+    default: "10000",
+    envVar: "ATLAS_MCP_RATE_LIMIT_MAX_KEYS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // Dashboards — dashboard PDF/PNG export render budget. Hot-reloadable:
+  // `getExportTimeoutMs()` reads per export. Clamped to [5s, 180s].
+  {
+    key: "ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS",
+    section: "Dashboards",
+    label: "Export Render Timeout (ms)",
+    description: "Overall wall-clock budget for a dashboard export render (default 60000, clamped to 5000–180000).",
+    type: "number",
+    default: "60000",
+    envVar: "ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
+
+  // Observability — plugin-health probe cache TTL. Hot-reloadable:
+  // `getPluginHealthCacheTtlMs()` reads per health probe. (OTEL exporter
+  // endpoint/headers are intentionally NOT here — see the block header above.)
+  {
+    key: "ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS",
+    section: "Observability",
+    label: "Plugin Health Cache TTL (ms)",
+    description:
+      "How long plugin-liveness results are cached before re-probing (default 15000, 0 disables caching, max 300000).",
+    type: "number",
+    default: "15000",
+    envVar: "ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS",
+    scope: "platform",
+    saasVisible: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1045,6 +1306,26 @@ export function getSetting(key: string, orgId?: string): string | undefined {
 
   // Tier 4: registry default
   return def?.default;
+}
+
+/**
+ * Read ONLY the DB-override tier for a key (no env / default fallback).
+ *
+ * For boot-consumed knobs whose resolver already takes an injected `env`
+ * object (e.g. the OAuth token-TTL resolvers, which accept a synthetic env
+ * in unit tests): layering `getSettingOverride(key) ?? env.KEY` preserves the
+ * platform DB override > env > default precedence without `getSettingAuto`'s
+ * read of the live `process.env` shadowing the injected one. Returns the
+ * workspace override first for workspace-scoped keys when an orgId is given,
+ * else the platform override; `undefined` when no override is set.
+ */
+export function getSettingOverride(key: string, orgId?: string): string | undefined {
+  const def = SETTINGS_MAP.get(key);
+  if (orgId && def?.scope === "workspace") {
+    const wsOverride = _cache.get(cacheKey(key, orgId));
+    if (wsOverride) return wsOverride.value;
+  }
+  return _cache.get(cacheKey(key))?.value;
 }
 
 /**

--- a/packages/mcp/src/__tests__/session-store-settings.test.ts
+++ b/packages/mcp/src/__tests__/session-store-settings.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #3705 — MCP session-store tuning knobs promoted into the settings registry.
+ *
+ * `sessionIdleTimeoutMs` and `maxHeldStreamAgeMs` were env-only. The hosted
+ * MCP transport mounts on the per-region API server, which loads (and, in
+ * SaaS, periodically refreshes) the settings cache — so these now resolve
+ * through the platform settings registry: DB override > env > default.
+ *
+ * Seeds the real settings cache via `setSetting` + the `_resetPool` mock-pool
+ * pattern (same as the @atlas/api precedence tests) rather than mocking
+ * `getSettingAuto`, so the full resolution path is exercised.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { sessionIdleTimeoutMs, maxHeldStreamAgeMs } from "../session-store.js";
+
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+const ENV_KEYS = [
+  "ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS",
+  "ATLAS_MCP_MAX_HELD_STREAM_AGE_MS",
+] as const;
+
+const origEnv = new Map<string, string | undefined>();
+const origDbUrl = process.env.DATABASE_URL;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    origEnv.set(k, process.env[k]);
+    delete process.env[k];
+  }
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+  _resetSettingsCache();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = origEnv.get(k);
+    if (v !== undefined) process.env[k] = v;
+    else delete process.env[k];
+  }
+  if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+  else delete process.env.DATABASE_URL;
+  _resetPool(null);
+  _resetSettingsCache();
+});
+
+describe("sessionIdleTimeoutMs — registry precedence (#3705)", () => {
+  it("defaults to 30 minutes when nothing is set", () => {
+    expect(sessionIdleTimeoutMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("platform DB override wins over the env var", async () => {
+    process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS = "600000";
+    await setSetting("ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS", "120000", "test");
+    expect(sessionIdleTimeoutMs()).toBe(120000);
+  });
+
+  it("a DB override below the 1-minute floor falls back to the default", async () => {
+    await setSetting("ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS", "1000", "test");
+    expect(sessionIdleTimeoutMs()).toBe(30 * 60 * 1000);
+  });
+});
+
+describe("maxHeldStreamAgeMs — registry precedence (#3705)", () => {
+  it("defaults to 2 hours when nothing is set", () => {
+    expect(maxHeldStreamAgeMs()).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it("platform DB override wins over the env var", async () => {
+    process.env.ATLAS_MCP_MAX_HELD_STREAM_AGE_MS = "999999";
+    await setSetting("ATLAS_MCP_MAX_HELD_STREAM_AGE_MS", "1000", "test");
+    expect(maxHeldStreamAgeMs()).toBe(1000);
+  });
+
+  it("0 is a valid override (disables age-based reclaim)", async () => {
+    await setSetting("ATLAS_MCP_MAX_HELD_STREAM_AGE_MS", "0", "test");
+    expect(maxHeldStreamAgeMs()).toBe(0);
+  });
+});

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -48,6 +48,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { resolveMcpMaxSessions } from "@atlas/api/lib/env-profile";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import { trackResponseStreamLifetime } from "./stream-liveness.js";
 
 const log = createLogger("mcp-session-store");
@@ -175,7 +176,10 @@ export function sessionIdleTimeoutMs(): number {
     // is unreachable in production — the setter would have thrown at startup.
     return _idleTimeoutOverrideMs;
   }
-  const raw = process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  // The hosted MCP transport mounts on the per-region API server, which runs
+  // the SettingsLive refresh fiber, so this re-reads per sweep and hot-reloads.
+  const raw = getSettingAuto("ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS");
   if (!raw) return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < MIN_SESSION_IDLE_TIMEOUT_MS) {
@@ -206,7 +210,8 @@ export function sessionIdleTimeoutMs(): number {
 const DEFAULT_MAX_HELD_STREAM_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 export function maxHeldStreamAgeMs(): number {
-  const raw = process.env.ATLAS_MCP_MAX_HELD_STREAM_AGE_MS;
+  // Platform-scoped settings registry (#3705): DB override > env > default.
+  const raw = getSettingAuto("ATLAS_MCP_MAX_HELD_STREAM_AGE_MS");
   if (!raw) return DEFAULT_MAX_HELD_STREAM_AGE_MS;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 0) {

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -11,6 +11,9 @@
 #
 #   R1 — direct literal read:
 #          getSetting("KEY") / getSettingAuto("KEY") / getSettingLive("KEY")
+#          / getSettingOverride("KEY") (the DB-override-only tier, #3705 —
+#          used by boot-consumed resolvers that take an injected env and
+#          layer the override over it, e.g. the OAuth token-TTL resolvers).
 #   R2 — const-indirected read: a const is bound to the key literal
 #          (`const FOO_SETTING = "KEY"`) and that const is passed to
 #          getSetting/getSettingAuto/getSettingLive. This is the
@@ -195,7 +198,7 @@ while IFS='|' read -r key envvar scope; do
   fi
 
   # R1 — direct literal read.
-  if grep -qE "getSetting(Auto|Live)?\(\s*[\"']${key}[\"']" <<<"$EVIDENCE"; then
+  if grep -qE "getSetting(Auto|Live|Override)?\(\s*[\"']${key}[\"']" <<<"$EVIDENCE"; then
     R1_COUNT=$((R1_COUNT + 1))
     continue
   fi
@@ -205,7 +208,7 @@ while IFS='|' read -r key envvar scope; do
     | awk '{print $2}' | sort -u || true)
   FOUND_VIA_CONST=0
   for name in $CONST_NAMES; do
-    if grep -qE "getSetting(Auto|Live)?\(\s*${name}\b" <<<"$EVIDENCE"; then
+    if grep -qE "getSetting(Auto|Live|Override)?\(\s*${name}\b" <<<"$EVIDENCE"; then
       FOUND_VIA_CONST=1
       break
     fi


### PR DESCRIPTION
## What

Tier 1 of the SaaS env-var audit (#3701). Promotes **16 operator tuning knobs** from env-only to platform-scoped **settings-registry** entries so a hosted operator can retune them from the Admin console without a redeploy. The env var stays the fallback tier (precedence: **platform DB override > env > registry default**); hot-reloadable knobs are read per request/event through `getSettingAuto`, so changes take effect within the SaaS refresh window.

Closes #3705.

## Promoted knobs (all platform-scoped, `saasVisible: false`)

| Cluster | Keys | `requiresRestart` |
|---|---|---|
| Rate limiting | `ATLAS_CONTACT_RATE_LIMIT_RPM` | no (read per request) |
| Demo | `ATLAS_DEMO_RATE_LIMIT_RPM`, `ATLAS_DEMO_MAX_STEPS` | no |
| Abuse | `ATLAS_ABUSE_{QUERY_RATE,WINDOW_SECONDS,ERROR_RATE,UNIQUE_TABLES,THROTTLE_DELAY_MS,ESCALATION_COOLDOWN_SECONDS}` | no (read per query-event) |
| OAuth TTLs | `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS`, `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS` | **yes** (baked into the Better Auth instance at boot) |
| OAuth state | `ATLAS_OAUTH_STATE_TTL_SECONDS` | no (read per-mint) |
| Caches / caps | `ATLAS_BYOT_CATALOG_TTL_MS`, `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS`, `ATLAS_MCP_MAX_HELD_STREAM_AGE_MS`, `ATLAS_MCP_RATE_LIMIT_MAX_KEYS` | no |
| Misc (sweep-missed trio) | `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS`, `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS`, `ATLAS_MCP_MAX_HELD_STREAM_AGE_MS` | no |

**All platform-scoped + `saasVisible: false`** — these are operator/region infra knobs, not per-tenant product settings. Platform scope is load-bearing for the abuse family: a tenant must never be able to weaken the thresholds that defend the region against it.

## Reconciliation with the issue
- The already-registered RPM trio (`ATLAS_RATE_LIMIT_RPM` / `_RPM_CHAT` / `_RPM_ADMIN`) is **untouched**; `ATLAS_RATE_LIMIT_RPM` stays in `SAAS_IMMUTABLE_KEYS`.
- The issue named `ATLAS_OAUTH_STATE_TOKEN_TTL_SECONDS`, which **does not exist** — the real var is `ATLAS_OAUTH_STATE_TTL_SECONDS` (integration-install state token). Promoted that one; noted in the audit doc.

## `OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS}` — consciously LEFT as env (documented)
Evaluated and deliberately kept env-only. `TelemetryLive` is the **first** layer in `buildAppLayer` (so it can trace the rest of boot) and has **no dependency edge to `SettingsLive`**, so the settings DB cache is provably cold at telemetry init on every boot — a DB-backed OTEL value could never apply, even after a restart, and a silently-ignored override is worse than an env var ("prefer errors over silent fallbacks"). The OTel SDK also reads `OTEL_EXPORTER_OTLP_HEADERS` directly from the process env. This is exactly CLAUDE.md's pre-DB-boot-input carve-out. Rationale documented in `docs/development/saas-env-audit.md`; the per-service footgun is better solved via shared region-constant platform config.

## Implementation notes
- Hot-reloadable knobs: consumption sites now read `getSettingAuto("KEY")` (env fallback baked into the tier chain). The hosted MCP session-store knobs hot-reload because the hosted transport mounts on the per-region API server, which runs the `SettingsLive` refresh fiber.
- Boot-consumed OAuth TTL resolvers take an injected `env` (for unit tests), so they layer a new **`getSettingOverride`** (DB-override-only tier) over the injected env — `getSettingAuto` would read the live `process.env` and shadow the synthetic test env.
- The abuse threshold parsers were refactored to take the **raw value** (so `getSettingAuto("KEY")` appears as a literal at each call site), satisfying the settings-reader parity check; the check now also recognizes `getSettingOverride` as a first-class reader.

## Tests
- `packages/api/src/lib/__tests__/tuning-knobs-settings.test.ts` — settings-backed resolution + precedence (default → env → DB override) for contact / demo / abuse / OAuth TTLs / plugin health.
- `packages/mcp/src/__tests__/session-store-settings.test.ts` — same for the MCP session-store knobs (incl. the idle-timeout floor and `0`-disables-reclaim).

## CI
lint, type (api/mcp/web), full api + mcp test suites, syncpack, template/security-header/railway/schema/openapi/oauth-helper drift, test-discipline, twenty-resolver, published-symbols, **settings-readers (70 keys)** — all green. (The handful of full-suite failures were WSL `bun 1.3.13` parallel-load / nsjail-unavailable flakes — all pass in isolation; none touch this change.)
