### PR TITLE
refactor(integrations): operator credential storage + runtime rebuild seam (#3704)

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -76,6 +76,7 @@ import { WorkspaceInstallGate } from "./packages/api/src/lib/integrations/instal
 // factory returns a plain async function — no `effect` import
 // surfaces here, so the relative-import constraint stays satisfied.
 import { createChatPluginExecuteQuery } from "./packages/api/src/lib/chat-plugin/executeQuery";
+import { resolveOperatorAdapterEnv } from "./packages/api/src/lib/integrations/operator-credentials/resolver";
 
 // Dedicated runtime for the proactive classifier + answer adapters.
 // Built inside the workspace by `getProactiveAiRuntime()` so this file
@@ -875,6 +876,15 @@ export default defineConfig({
       // key shape, and :lock: pending-approval flow that slack.ts's
       // legacy app_mention / thread-followup branches used to own.
       executeQuery: createChatPluginExecuteQuery(),
+      // Operator-tier credential resolution (#3704). Overlays Admin-set,
+      // DB-backed operator credentials (e.g. Slack `SLACK_CLIENT_ID` /
+      // `_SECRET` / `_SIGNING_SECRET` / `_ENCRYPTION_KEY`) on top of env, so
+      // a platform admin can rotate them from the console without a redeploy.
+      // The plugin re-reads this on every `initialize()`, so
+      // `PluginRegistry.refresh("chat-interaction")` picks up rotations with
+      // no process restart. Precedence: DB row → env → unset (env stays the
+      // self-host fallback). See `lib/integrations/operator-credentials/`.
+      resolveAdapterEnv: () => resolveOperatorAdapterEnv(),
       // ── Proactive listener wiring (#2607) ─────────────────────────
       // Wires every callback the proactive listener consumes to host
       // helpers under `packages/api/src/lib/proactive/`. After this

--- a/packages/api/src/__test-utils__/layers.ts
+++ b/packages/api/src/__test-utils__/layers.ts
@@ -119,6 +119,7 @@ export function createPluginRegistryTestLayer(
       initializeAll: (ctx) => impl.initializeAll(ctx),
       healthCheckAll: () => impl.healthCheckAll(),
       teardownAll: () => impl.teardownAll(),
+      refresh: (id) => impl.refresh(id),
       get: (id) => impl.get(id),
       getStatus: (id) => impl.getStatus(id),
       getByType: (type) => impl.getByType(type),

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -384,6 +384,7 @@ describe("migrateAuthTables", () => {
             { name: "0137_learning_tables_performance_columns.sql" },
             { name: "0138_semantic_profile_status.sql" },
             { name: "0139_learned_patterns_auto_promoted.sql" },
+            { name: "0140_operator_integration_credentials.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -161,7 +161,8 @@ describe("runMigrations", () => {
     //   Plus 0138 (semantic_profile_status durable partial-profile marker,
     //   #3682) = 139.
     //   Plus 0139 (learned_patterns.auto_promoted flag, PRD #3617 B-2, #3636) = 140.
-    expect(count).toBe(140);
+    //   Plus 0140 (operator_integration_credentials, operator-tier app creds, #3704) = 141.
+    expect(count).toBe(141);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -330,6 +331,7 @@ describe("runMigrations", () => {
         "0137_learning_tables_performance_columns.sql",
         "0138_semantic_profile_status.sql",
         "0139_learned_patterns_auto_promoted.sql",
+        "0140_operator_integration_credentials.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/integration-tables.ts
+++ b/packages/api/src/lib/db/integration-tables.ts
@@ -64,6 +64,12 @@ export const INTEGRATION_TABLES: ReadonlyArray<IntegrationTable> = [
   // 0098 — Twenty CRM per-workspace credentials. `workspace_id` is
   // unique on its own (one Twenty install per workspace).
   { table: "twenty_integrations",   pk: "id",              encrypted: "api_key_encrypted",           keyVersionColumn: "api_key_key_version" },
+  // 0140 (#3704) — OPERATOR-tier integration app credentials (Atlas's own
+  // app registrations, set/rotated via Admin without a redeploy). One row
+  // per `platform` slug; the table still keys on a single uuid `id` so the
+  // rotation / audit scripts walk it generically (single-PK assumption
+  // preserved). The encrypted blob is a JSON `{ <ENV_VAR>: <value> }` map.
+  { table: "operator_integration_credentials", pk: "id",   encrypted: "credentials_encrypted",        keyVersionColumn: "credentials_key_version" },
 ] as const;
 
 /**

--- a/packages/api/src/lib/db/migrations/0140_operator_integration_credentials.sql
+++ b/packages/api/src/lib/db/migrations/0140_operator_integration_credentials.sql
@@ -1,0 +1,63 @@
+-- 0140_operator_integration_credentials.sql
+--
+-- Atlas issue #3704 — operator-tier (platform) integration app
+-- credentials, settable + rotatable from the Admin console without a
+-- redeploy, encrypted at rest. Pilot platform: Slack.
+--
+-- Background: until this table, the OPERATOR credentials for every chat
+-- platform / action-target integration (Atlas's OWN app registrations —
+-- `SLACK_CLIENT_ID` / `_SECRET` / `_SIGNING_SECRET` / `_ENCRYPTION_KEY`,
+-- etc.) were read from `process.env` at boot. Rotating a hosted region's
+-- Slack signing secret therefore required a Railway deploy — exactly the
+-- "no deploy for a config change" rule the SaaS-first principle forbids
+-- (#3701). Workspace-tier plugin credentials already live encrypted in
+-- dedicated tables (ADR-0005 `integration_credentials`, `twenty_integrations`,
+-- etc.) and are set via Admin → Integrations; this table brings the
+-- operator/platform tier up to the same model.
+--
+-- This is the OPERATOR tier, deliberately separate from the WORKSPACE
+-- tier. Operator credentials are Atlas's own app registrations (one row
+-- per platform, no `workspace_id`); workspace credentials are a tenant's
+-- per-install secrets (keyed by `workspace_id`). The two must never read
+-- from each other's store — see `lib/integrations/operator-credentials/`
+-- and the `operator-credential-isolation.test.ts` seam test. Env stays
+-- the fallback for self-host (resolver precedence: DB row → env → unset).
+--
+-- Shape:
+--   * `id` — uuid PK. Single-column PK so the F-47 rotation tooling and
+--     F-42 residue audit (both walk `INTEGRATION_TABLES` with one PK
+--     identifier) work unchanged.
+--   * `platform` — the operator-tier platform slug (`slack`, future
+--     `discord` / `jira` / …). UNIQUE: one operator credential row per
+--     platform (the app registration is operator-shared across every
+--     workspace, so there is no per-workspace dimension here).
+--   * `credentials_encrypted` — AES-256-GCM ciphertext (versioned
+--     `enc:v<N>:iv:authTag:ciphertext`) from `db/secret-encryption.ts`,
+--     wrapping a JSON object of `{ <ENV_VAR_NAME>: <value>, … }` (e.g.
+--     `{ SLACK_CLIENT_ID: "...", SLACK_CLIENT_SECRET: "...", … }`). Env-var
+--     names are the keys so the resolver can overlay the decrypted bundle
+--     straight onto the env the adapter builders already read.
+--   * `credentials_key_version` — companion column carrying the F-47
+--     keyset version the row's ciphertext was produced under. Mirrors
+--     every other `INTEGRATION_TABLES` entry's `keyVersionColumn`
+--     convention so the rotation script's UPDATE works generically.
+--   * `created_at` / `updated_at` — `updated_at` bumps on every rotation;
+--     the Admin UI surfaces it as "last rotated."
+--
+-- No foreign keys: `platform` is an operator-chosen slug, not a row in
+-- any tenant table. Matches the FK-free convention of every other
+-- integration credential table.
+
+CREATE TABLE IF NOT EXISTS operator_integration_credentials (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform                 TEXT NOT NULL,
+  credentials_encrypted    TEXT NOT NULL,
+  credentials_key_version  INTEGER,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One operator credential row per platform — the app registration is
+-- operator-shared, so the platform slug is the natural key.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_integration_credentials_platform
+  ON operator_integration_credentials (platform);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1679,6 +1679,28 @@ export const integrationCredentials = pgTable(
   ],
 );
 
+// operator_integration_credentials (0140, #3704) — OPERATOR-tier (platform)
+// integration app credentials, set + rotated from the Admin console without
+// a redeploy, encrypted at rest. One row per platform slug (the app
+// registration is operator-shared; no per-workspace dimension). Deliberately
+// separate from the workspace-tier `integration_credentials` above — see
+// lib/integrations/operator-credentials/ for the isolation seam. Env stays
+// the self-host fallback (resolver precedence: DB row → env → unset).
+export const operatorIntegrationCredentials = pgTable(
+  "operator_integration_credentials",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    platform: text("platform").notNull(),
+    credentialsEncrypted: text("credentials_encrypted").notNull(),
+    credentialsKeyVersion: integer("credentials_key_version"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("idx_operator_integration_credentials_platform").on(t.platform),
+  ],
+);
+
 // ---------------------------------------------------------------------------
 // Dashboards
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -138,7 +138,7 @@ const {
   BillingConfigGuardLive,
   BillingConfigInvalidError,
 } = await import("../saas-guards");
-const { Config, Settings } = await import("../layers");
+const { Config, Migration, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
 
 // ── Test helpers ────────────────────────────────────────────────────
@@ -157,6 +157,16 @@ function makeTestConfigLayer(
 function makeTestSettingsLayer(): Layer.Layer<TSettings> {
   return Layer.succeed(Settings, { loaded: 0 } satisfies SettingsShape);
 }
+
+// #3704 — `ChatAdapterEnvGuardLive` now yields `Migration` as an ordering
+// barrier (its presence check reads `operator_integration_credentials`, which
+// migration 0140 creates). Provide a stub so `yield* Migration` resolves;
+// these tests run with no internal DB (clean env), so the guard collapses to
+// the env-only check regardless of the `migrated` value. Pre-satisfying
+// Migration here leaves each test providing only the Config layer, unchanged.
+const ChatGuardWithMigration = ChatAdapterEnvGuardLive.pipe(
+  Layer.provide(Layer.succeed(Migration, { migrated: true })),
+);
 
 // Source of truth lives in `effect/saas-env.ts :: SAAS_ENV_KEYS` (#2226).
 // Consume it directly so a new SaaS-contract field automatically gets
@@ -1245,7 +1255,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1282,7 +1292,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1315,7 +1325,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1345,7 +1355,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1372,7 +1382,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1398,7 +1408,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1424,7 +1434,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1450,7 +1460,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
             ),
           ),
@@ -1465,7 +1475,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [
@@ -1492,7 +1502,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "self-hosted",
                 catalog: [
@@ -1525,7 +1535,7 @@ describe("ChatAdapterEnvGuardLive", () => {
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
-            ChatAdapterEnvGuardLive.pipe(
+            ChatGuardWithMigration.pipe(
               Layer.provide(makeTestConfigLayer({
                 deployMode: "saas",
                 catalog: [

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2992,10 +2992,15 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     Layer.provide(Layer.merge(configLayer, settingsLayer)),
   );
   // #2672 — walks the chat catalog and fails boot when an oauth+enabled
-  // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
-  // only on `Config` and reads env directly, so it runs in parallel with
-  // the migration + sync layers alongside the other env-checking guards.
-  const chatAdapterEnvGuardLayer = ChatAdapterEnvGuardLive.pipe(Layer.provide(configLayer));
+  // entry's adapter-builder requiredEnv keys are missing in SaaS. Since #3704
+  // the presence check is "operator-credentials DB row OR env", so it reads
+  // `operator_integration_credentials` (created by migration 0140) — hence the
+  // `migrationLayer` edge (mirrors `MigrationGuardLive` below) so the table is
+  // guaranteed to exist before the guard queries it. Without it the guard could
+  // race migrations and crash a first-deploy boot on a missing relation.
+  const chatAdapterEnvGuardLayer = ChatAdapterEnvGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, migrationLayer)),
+  );
   // #3435 + #3703 — billing config validation. Gated on `deployMode === "saas"`
   // AND `STRIPE_SECRET_KEY` present, so self-hosted and pre-billing SaaS are
   // inert. Fails boot on the two env-only misconfigs (missing webhook secret,

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -1081,19 +1081,16 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
       // builder, every key the builder needs must be present."
       if (!requiredEnv) continue;
 
-      // Read each key directly from `process.env` so the contract
-      // honors the builder map's single source of truth. Going through
-      // `readSaasEnv()` would silently treat any key not statically
-      // enumerated in `SaasEnv` as undefined — a future adapter adding
-      // a new `requiredEnv` entry would then fail boot for a properly-
-      // configured operator until they also touched `saas-env.ts`,
-      // which would break the "builder is the source of truth" claim.
-      // The runtime AdapterRegistry reads `process.env` for the same
-      // reason; matching it keeps the parity check load-bearing.
-      const missingEnv = requiredEnv.filter((key) => {
-        const value = process.env[key];
-        return value === undefined || value === "";
-      });
+      // Presence check is "operator-credential DB row OR env" (#3704).
+      // The builder's `requiredEnv` stays the single source of truth for
+      // WHICH keys must be present (passed straight through to the resolver
+      // helper); the operator credential resolver decides whether each is
+      // satisfied by a row set via Admin or by the env fallback. When the
+      // slug isn't a managed operator platform, or no internal DB exists
+      // (self-host stateless), the helper collapses to the original
+      // env-only check — so this remains a faithful superset of the
+      // pre-#3704 guard, never a looser one.
+      const missingEnv = yield* importGetMissingOperatorEnv(entry.slug, requiredEnv);
 
       if (missingEnv.length > 0) {
         return yield* Effect.fail(
@@ -1102,18 +1099,42 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
             missingEnv,
             message:
               `SaaS region booted with catalog entry slug="${entry.slug}" (type=chat, ` +
-              `install_model=oauth, enabled=true) but the adapter builder's required env ` +
-              `vars are missing: [${missingEnv.join(", ")}]. Without them the AdapterRegistry ` +
-              `silently drops the adapter — the api would boot, proactive chat would register, ` +
-              `and every health signal would stay green while no chat event ever lands. Set ` +
-              `the missing env var(s) on every region's api service before booting. ` +
-              `See ${CHAT_ADAPTER_ISSUE_REF}.`,
+              `install_model=oauth, enabled=true) but the adapter builder's required ` +
+              `credentials are missing from BOTH the operator-credentials store (Admin → ` +
+              `Operator Integrations) and the environment: [${missingEnv.join(", ")}]. ` +
+              `Without them the AdapterRegistry silently drops the adapter — the api would ` +
+              `boot, proactive chat would register, and every health signal would stay green ` +
+              `while no chat event ever lands. Set the missing credential(s) via the Admin ` +
+              `console or env on every region's api service before booting. ` +
+              `See ${CHAT_ADAPTER_ISSUE_REF} / #3704.`,
           }),
         );
       }
     }
   }),
 );
+
+/**
+ * Lazy-import the operator-credentials resolver helper. Same wall-off
+ * rationale as the chat accessor import above — keeps the operator
+ * credential store's static graph (internalQuery, secret-encryption) out of
+ * `saas-guards.ts`. A rejected import is promoted to a defect via
+ * `Effect.orDie`: the resolver is core and always loadable at boot, so a
+ * rejection means the api can't run anyway, and silently skipping would
+ * reopen the silent-degradation hole this guard exists to close.
+ */
+function importGetMissingOperatorEnv(
+  catalogSlug: string,
+  requiredKeys: readonly string[],
+): Effect.Effect<string[]> {
+  return Effect.tryPromise({
+    try: async () => {
+      const mod = await import("@atlas/api/lib/integrations/operator-credentials/resolver");
+      return mod.getMissingOperatorEnvForCatalogSlug(catalogSlug, requiredKeys);
+    },
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(Effect.orDie);
+}
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  BillingConfigGuardLive (#3435)

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -87,7 +87,7 @@
 
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { Config, Settings } from "./layers";
+import { Config, Migration, Settings } from "./layers";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const log = createLogger("effect:saas-guards");
@@ -1047,13 +1047,24 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
  * dying here surfaces the root cause at boot instead of letting a
  * downstream route 500 minutes later.
  */
-export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingError, Config> = Layer.effectDiscard(
+export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingError, Config | Migration> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
     const catalog = config.catalog ?? [];
     if (catalog.length === 0) return;
+
+    // Ordering barrier (#3704): the DB-or-env presence check below reads
+    // `operator_integration_credentials` (created by migration 0140) for any
+    // managed operator platform. Yielding `Migration` here forces this guard
+    // to construct AFTER `migrationLayer` so the table is guaranteed to exist
+    // — without this edge the guard runs in parallel with migrations and a
+    // first-deploy boot would throw `relation "operator_integration_credentials"
+    // does not exist`, which `importGetMissingOperatorEnv`'s `Effect.orDie`
+    // would promote to a boot crash. Pre-#3704 the guard read only env and had
+    // no DB dependency, so this edge is new with the operator-credential read.
+    yield* Migration;
 
     // Lazy-import the per-slug requiredEnv accessor from the chat
     // plugin. `Effect.tryPromise` routes a rejected import into the E
@@ -1122,6 +1133,14 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
  * `Effect.orDie`: the resolver is core and always loadable at boot, so a
  * rejection means the api can't run anyway, and silently skipping would
  * reopen the silent-degradation hole this guard exists to close.
+ *
+ * Note `orDie` also covers the live `internalQuery` the resolver runs against
+ * `operator_integration_credentials` (decrypt/corruption or a DB error), not
+ * just the import — that is deliberate: a corrupt operator row SHOULD fail
+ * boot loudly rather than degrade to env-only. The guard's `Migration`
+ * dependency edge guarantees the table exists before this runs, so the only
+ * remaining die-able cause is a genuine read/decrypt failure that the operator
+ * must fix anyway.
  */
 function importGetMissingOperatorEnv(
   catalogSlug: string,

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -350,9 +350,10 @@ export interface PluginRegistryShape {
   /**
    * Tear down + re-initialize a single plugin in place, reusing the context
    * captured at `initializeAll` (#3704 — operator-credential rebuild seam).
-   * Never throws; returns `{ ok }` + a failure reason for the caller to map.
+   * Never throws; returns a discriminated `{ ok: true }` / `{ ok: false;
+   * reason }` result for the caller to map (failure always carries a reason).
    */
-  refresh(id: string): Promise<{ ok: boolean; reason?: string }>;
+  refresh(id: string): Promise<{ ok: true } | { ok: false; reason: string }>;
 
   // --- Query ---
   get(id: string): PluginLike | undefined;

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -347,6 +347,12 @@ export interface PluginRegistryShape {
     Map<string, PluginHealthResult & { status: PluginStatus }>
   >;
   teardownAll(): Promise<void>;
+  /**
+   * Tear down + re-initialize a single plugin in place, reusing the context
+   * captured at `initializeAll` (#3704 — operator-credential rebuild seam).
+   * Never throws; returns `{ ok }` + a failure reason for the caller to map.
+   */
+  refresh(id: string): Promise<{ ok: boolean; reason?: string }>;
 
   // --- Query ---
   get(id: string): PluginLike | undefined;
@@ -441,6 +447,7 @@ function buildPluginService(impl: PluginRegistryClass) {
       initializeAll: (ctx) => impl.initializeAll(ctx),
       healthCheckAll: () => impl.healthCheckAll(),
       teardownAll: () => impl.teardownAll(),
+      refresh: (id) => impl.refresh(id),
       get: (id) => impl.get(id),
       getStatus: (id) => impl.getStatus(id),
       getByType: (type) => impl.getByType(type),

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/operator-credential-isolation.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/operator-credential-isolation.test.ts
@@ -118,7 +118,7 @@ describe("behavioral isolation", () => {
     const managedKeys = new Set(
       OPERATOR_PLATFORMS.flatMap((p) => p.fields.map((f) => f.envVar)),
     );
-    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, {});
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
 
     for (const key of Object.keys(overlay)) {
       expect(managedKeys.has(key)).toBe(true);

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/operator-credential-isolation.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/operator-credential-isolation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Secret-isolation seam test (#3704).
+ *
+ * The OPERATOR tier (Atlas's own app registrations, this directory) and the
+ * WORKSPACE tier (a tenant's per-install secrets, `lib/integrations/credentials/`
+ * + the Twenty per-workspace resolver) must never read from each other's store:
+ *
+ *   - An operator-credential read must NEVER surface a workspace secret, and
+ *   - A workspace-credential read must NEVER fall back to an operator env var
+ *     (the inverse of the CLAUDE.md "per-tenant plugin creds never fall back to
+ *     operator env vars" rule — kept honest in both directions).
+ *
+ * Two layers of enforcement, both pinned here:
+ *   1. STRUCTURAL — the operator modules only ever touch the
+ *      `operator_integration_credentials` table, and the operator/workspace
+ *      module graphs don't import each other.
+ *   2. BEHAVIORAL — the operator adapter-env overlay only ever carries
+ *      operator-managed env-var keys; it can't smuggle a workspace secret out.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const HERE = import.meta.dir;
+const OP_DIR = join(HERE, "..");
+
+/** Strip block + line comments so checks match real code, not prose (mirrors check-twenty-resolver-imports.sh). */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function readCode(rel: string): string {
+  return stripComments(readFileSync(join(OP_DIR, rel), "utf8"));
+}
+
+/** All module specifiers actually imported by `code` (after comment strip). */
+function importSpecifiers(code: string): string[] {
+  const out: string[] = [];
+  const re = /from\s+["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(code)) !== null) out.push(m[1] ?? m[2]);
+  return out;
+}
+
+describe("structural isolation", () => {
+  const opStore = readCode("store.ts");
+  const opResolver = readCode("resolver.ts");
+  const opPlatforms = readCode("platforms.ts");
+
+  it("the operator store touches only the operator_integration_credentials table", () => {
+    // \b after `_` is not a boundary, so `\bintegration_credentials\b` does
+    // NOT match inside `operator_integration_credentials` — it only catches
+    // the workspace-tier table name standing alone.
+    expect(opStore).toMatch(/operator_integration_credentials/);
+    expect(opStore).not.toMatch(/\bintegration_credentials\b/);
+    expect(opStore).not.toMatch(/\bworkspace_plugins\b/);
+    expect(opStore).not.toMatch(/\btwenty_integrations\b/);
+    expect(opStore).not.toMatch(/\bchat_cache\b/);
+  });
+
+  it("operator modules do not import any workspace-tier credential module", () => {
+    for (const code of [opStore, opResolver, opPlatforms]) {
+      const specs = importSpecifiers(code);
+      for (const spec of specs) {
+        expect(spec).not.toContain("integrations/credentials/");
+        expect(spec).not.toContain("@useatlas/twenty");
+      }
+    }
+    // And no reference to the workspace/operator-env resolver symbols anywhere
+    // in real code (these live in distinct seams).
+    for (const code of [opStore, opResolver, opPlatforms]) {
+      expect(code).not.toContain("resolveWorkspaceCredentials");
+      expect(code).not.toContain("resolveOperatorCredentials"); // the Twenty env path — distinct seam
+    }
+  });
+
+  it("the workspace credential store does not import the operator store", () => {
+    const wsStore = stripComments(
+      readFileSync(join(HERE, "..", "..", "credentials", "store.ts"), "utf8"),
+    );
+    for (const spec of importSpecifiers(wsStore)) {
+      expect(spec).not.toContain("operator-credentials");
+    }
+    expect(wsStore).not.toMatch(/operator_integration_credentials/);
+  });
+});
+
+describe("behavioral isolation", () => {
+  const mockRead: Mock<(platform: string) => Promise<Record<string, string> | null>> = mock(() =>
+    Promise.resolve(null),
+  );
+  const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+
+  mock.module("../store", () => ({ readOperatorCredentials: mockRead }));
+  mock.module("@atlas/api/lib/db/internal", () => ({ hasInternalDB: mockHasInternalDB }));
+
+  beforeEach(() => {
+    mockRead.mockReset();
+    mockHasInternalDB.mockReset();
+    mockHasInternalDB.mockReturnValue(true);
+  });
+  afterEach(() => mockRead.mockReset());
+
+  it("the operator overlay only carries operator-managed env keys, never a workspace secret", async () => {
+    const { resolveOperatorAdapterEnv } = await import("../resolver");
+    const { OPERATOR_PLATFORMS } = await import("../platforms");
+
+    // Simulate a corrupt/over-broad DB row that ALSO contains a workspace
+    // secret key. The resolver must only project the platform's declared
+    // managed fields, dropping anything it doesn't own.
+    mockRead.mockResolvedValue({
+      SLACK_SIGNING_SECRET: "db-sign",
+      WORKSPACE_TENANT_SECRET: "leaked-tenant-secret",
+      DATABASE_URL: "postgres://should-not-leak",
+    });
+
+    const managedKeys = new Set(
+      OPERATOR_PLATFORMS.flatMap((p) => p.fields.map((f) => f.envVar)),
+    );
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, {});
+
+    for (const key of Object.keys(overlay)) {
+      expect(managedKeys.has(key)).toBe(true);
+    }
+    expect(overlay).not.toHaveProperty("WORKSPACE_TENANT_SECRET");
+    expect(overlay).not.toHaveProperty("DATABASE_URL");
+    expect(overlay.SLACK_SIGNING_SECRET).toBe("db-sign");
+  });
+});

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Drift guard for the operator-platform registry (#3704).
+ *
+ * Each managed operator platform's REQUIRED fields are hand-copied from the
+ * adapter builder's `requiredEnv` set in `@useatlas/chat` (a separate
+ * package). The copy is what lets the Admin form offer exactly the keys the
+ * adapter needs. This test pins the parity against the SSOT accessor
+ * (`getChatAdapterRequiredEnv`) so an adapter-side change to `requiredEnv`
+ * can't silently drift the registry — the prose claim in `platforms.ts`
+ * stays true by construction.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { getChatAdapterRequiredEnv } from "@useatlas/chat";
+import { OPERATOR_PLATFORMS } from "../platforms";
+
+describe("operator platform ⇄ adapter requiredEnv parity", () => {
+  for (const platform of OPERATOR_PLATFORMS) {
+    // Only chat platforms map to a chat-adapter builder's requiredEnv.
+    if (platform.catalogSlug === null) continue;
+
+    it(`${platform.platform}: required fields mirror getChatAdapterRequiredEnv("${platform.catalogSlug}")`, () => {
+      const adapterRequired = getChatAdapterRequiredEnv(platform.catalogSlug!);
+      expect(adapterRequired).not.toBeNull();
+
+      const registryRequired = platform.fields
+        .filter((f) => f.required)
+        .map((f) => f.envVar)
+        .sort();
+
+      expect(registryRequired).toEqual([...adapterRequired!].sort());
+    });
+  }
+});

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for operator credential resolution precedence (#3704):
+ * DB row (Admin-set) → operator env var → unset.
+ *
+ * `readOperatorCredentials` + `hasInternalDB` are mocked so we drive the
+ * resolver with controlled DB state; env is set per-case on a clone.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+
+const mockRead: Mock<(platform: string) => Promise<Record<string, string> | null>> = mock(() =>
+  Promise.resolve(null),
+);
+const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+
+mock.module("../store", () => ({
+  readOperatorCredentials: mockRead,
+}));
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: mockHasInternalDB,
+}));
+
+import {
+  resolveOperatorAdapterEnv,
+  getOperatorPlatformStatus,
+  getMissingOperatorEnvForCatalogSlug,
+  resolveOperatorFieldValue,
+} from "../resolver";
+import { OPERATOR_PLATFORMS } from "../platforms";
+
+const ENV: NodeJS.ProcessEnv = {};
+
+beforeEach(() => {
+  mockRead.mockReset();
+  mockRead.mockResolvedValue(null);
+  mockHasInternalDB.mockReset();
+  mockHasInternalDB.mockReturnValue(true);
+});
+
+afterEach(() => {
+  mockRead.mockReset();
+});
+
+const slackEnvFull: NodeJS.ProcessEnv = {
+  SLACK_CLIENT_ID: "env-id",
+  SLACK_CLIENT_SECRET: "env-secret",
+  SLACK_SIGNING_SECRET: "env-sign",
+  SLACK_ENCRYPTION_KEY: "env-enc",
+};
+
+describe("resolveOperatorAdapterEnv", () => {
+  it("returns DB values as the overlay (DB wins over env)", async () => {
+    mockRead.mockResolvedValue({ SLACK_SIGNING_SECRET: "db-sign" });
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    expect(overlay.SLACK_SIGNING_SECRET).toBe("db-sign");
+    // Fields not in the DB row are NOT in the overlay (env passes through).
+    expect(overlay.SLACK_CLIENT_ID).toBeUndefined();
+  });
+
+  it("returns an empty overlay when no DB row exists (pure env fallback)", async () => {
+    mockRead.mockResolvedValue(null);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    expect(overlay).toEqual({});
+  });
+
+  it("returns an empty overlay (no DB read) when no internal DB is configured", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    expect(overlay).toEqual({});
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  it("ignores empty-string DB values (no clobber)", async () => {
+    mockRead.mockResolvedValue({ SLACK_SIGNING_SECRET: "" });
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    expect(overlay.SLACK_SIGNING_SECRET).toBeUndefined();
+  });
+
+  it("propagates a decrypt failure rather than degrading to env-only", async () => {
+    mockRead.mockRejectedValue(new Error("auth tag mismatch"));
+    await expect(resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull)).rejects.toThrow(
+      /auth tag mismatch/,
+    );
+  });
+});
+
+describe("resolveOperatorFieldValue", () => {
+  const field = OPERATOR_PLATFORMS[0].fields[0]; // SLACK_CLIENT_ID
+
+  it("prefers the DB value", () => {
+    expect(resolveOperatorFieldValue(field, { SLACK_CLIENT_ID: "db" }, { SLACK_CLIENT_ID: "env" })).toBe("db");
+  });
+  it("falls back to env when DB is absent", () => {
+    expect(resolveOperatorFieldValue(field, null, { SLACK_CLIENT_ID: "env" })).toBe("env");
+  });
+  it("returns undefined when neither source has it", () => {
+    expect(resolveOperatorFieldValue(field, null, {})).toBeUndefined();
+  });
+  it("treats an empty DB value as absent and falls back to env", () => {
+    expect(resolveOperatorFieldValue(field, { SLACK_CLIENT_ID: "" }, { SLACK_CLIENT_ID: "env" })).toBe("env");
+  });
+});
+
+describe("getOperatorPlatformStatus", () => {
+  it("marks configured when all required fields resolve from env", async () => {
+    mockRead.mockResolvedValue(null);
+    const status = await getOperatorPlatformStatus("slack", slackEnvFull);
+    expect(status?.configured).toBe(true);
+    expect(status?.hasDbOverride).toBe(false);
+    expect(status?.fields.every((f) => f.source === "env")).toBe(true);
+    // No secret values are present on the status, only presence + source.
+    for (const f of status!.fields) {
+      expect(Object.keys(f)).not.toContain("value");
+    }
+  });
+
+  it("reports the DB source and not configured when a required field is missing everywhere", async () => {
+    mockRead.mockResolvedValue({ SLACK_CLIENT_ID: "db-id" });
+    const status = await getOperatorPlatformStatus("slack", {});
+    expect(status?.hasDbOverride).toBe(true);
+    expect(status?.configured).toBe(false);
+    const clientId = status?.fields.find((f) => f.envVar === "SLACK_CLIENT_ID");
+    expect(clientId?.source).toBe("db");
+    const signing = status?.fields.find((f) => f.envVar === "SLACK_SIGNING_SECRET");
+    expect(signing?.source).toBe("unset");
+    expect(signing?.present).toBe(false);
+  });
+
+  it("returns null for an unmanaged platform", async () => {
+    const status = await getOperatorPlatformStatus("not-a-platform", {});
+    expect(status).toBeNull();
+  });
+});
+
+describe("getMissingOperatorEnvForCatalogSlug (boot-guard helper)", () => {
+  const REQUIRED = [
+    "SLACK_CLIENT_ID",
+    "SLACK_CLIENT_SECRET",
+    "SLACK_SIGNING_SECRET",
+    "SLACK_ENCRYPTION_KEY",
+  ];
+
+  it("returns [] when the DB row supplies a key env is missing (DB satisfies)", async () => {
+    mockRead.mockResolvedValue({ SLACK_ENCRYPTION_KEY: "db-enc" });
+    const envMissingEncKey: NodeJS.ProcessEnv = {
+      SLACK_CLIENT_ID: "e",
+      SLACK_CLIENT_SECRET: "e",
+      SLACK_SIGNING_SECRET: "e",
+    };
+    const missing = await getMissingOperatorEnvForCatalogSlug("slack", REQUIRED, envMissingEncKey);
+    expect(missing).toEqual([]);
+  });
+
+  it("reports keys absent from BOTH sources", async () => {
+    mockRead.mockResolvedValue({ SLACK_CLIENT_ID: "db-id" });
+    const missing = await getMissingOperatorEnvForCatalogSlug("slack", REQUIRED, {});
+    expect([...missing].sort()).toEqual([
+      "SLACK_CLIENT_SECRET",
+      "SLACK_ENCRYPTION_KEY",
+      "SLACK_SIGNING_SECRET",
+    ]);
+  });
+
+  it("collapses to env-only when no internal DB (self-host) — no DB read", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    const missing = await getMissingOperatorEnvForCatalogSlug("slack", REQUIRED, {
+      SLACK_CLIENT_ID: "e",
+      SLACK_CLIENT_SECRET: "e",
+      SLACK_SIGNING_SECRET: "e",
+      SLACK_ENCRYPTION_KEY: "e",
+    });
+    expect(missing).toEqual([]);
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  it("collapses to env-only for an unmanaged slug (no DB read)", async () => {
+    const missing = await getMissingOperatorEnvForCatalogSlug("discord", ["DISCORD_BOT_TOKEN"], {
+      DISCORD_BOT_TOKEN: "set",
+    });
+    expect(missing).toEqual([]);
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
@@ -28,8 +28,6 @@ import {
 } from "../resolver";
 import { OPERATOR_PLATFORMS } from "../platforms";
 
-const ENV: NodeJS.ProcessEnv = {};
-
 beforeEach(() => {
   mockRead.mockReset();
   mockRead.mockResolvedValue(null);
@@ -51,7 +49,7 @@ const slackEnvFull: NodeJS.ProcessEnv = {
 describe("resolveOperatorAdapterEnv", () => {
   it("returns DB values as the overlay (DB wins over env)", async () => {
     mockRead.mockResolvedValue({ SLACK_SIGNING_SECRET: "db-sign" });
-    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
     expect(overlay.SLACK_SIGNING_SECRET).toBe("db-sign");
     // Fields not in the DB row are NOT in the overlay (env passes through).
     expect(overlay.SLACK_CLIENT_ID).toBeUndefined();
@@ -59,26 +57,26 @@ describe("resolveOperatorAdapterEnv", () => {
 
   it("returns an empty overlay when no DB row exists (pure env fallback)", async () => {
     mockRead.mockResolvedValue(null);
-    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
     expect(overlay).toEqual({});
   });
 
   it("returns an empty overlay (no DB read) when no internal DB is configured", async () => {
     mockHasInternalDB.mockReturnValue(false);
-    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
     expect(overlay).toEqual({});
     expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("ignores empty-string DB values (no clobber)", async () => {
     mockRead.mockResolvedValue({ SLACK_SIGNING_SECRET: "" });
-    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
     expect(overlay.SLACK_SIGNING_SECRET).toBeUndefined();
   });
 
   it("propagates a decrypt failure rather than degrading to env-only", async () => {
     mockRead.mockRejectedValue(new Error("auth tag mismatch"));
-    await expect(resolveOperatorAdapterEnv(OPERATOR_PLATFORMS, slackEnvFull)).rejects.toThrow(
+    await expect(resolveOperatorAdapterEnv(OPERATOR_PLATFORMS)).rejects.toThrow(
       /auth tag mismatch/,
     );
   });
@@ -179,5 +177,15 @@ describe("getMissingOperatorEnvForCatalogSlug (boot-guard helper)", () => {
     });
     expect(missing).toEqual([]);
     expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  it("propagates a decrypt failure rather than masquerading as configured/missing", async () => {
+    // The boot guard wraps this in `Effect.orDie`, so a thrown read fails boot
+    // loud. It must NOT be swallowed into "[]" (configured) or "everything
+    // missing" — a broken rotation must never silently look fine.
+    mockRead.mockRejectedValue(new Error("auth tag mismatch"));
+    await expect(
+      getMissingOperatorEnvForCatalogSlug("slack", REQUIRED, slackEnvFull),
+    ).rejects.toThrow(/auth tag mismatch/);
   });
 });

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
@@ -93,6 +93,17 @@ describe("saveOperatorCredentials", () => {
     const round = await store.readOperatorCredentials(PLATFORM);
     expect(round).toEqual({ SLACK_CLIENT_ID: "1234.5678" });
   });
+
+  it("rethrows (does not swallow) when the upsert query fails", async () => {
+    // A persistence failure must propagate so the Admin route surfaces a 500
+    // rather than reporting a successful rotation that wrote nothing.
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.reject(new Error("connection terminated unexpectedly")),
+    );
+    await expect(store.saveOperatorCredentials(PLATFORM, BUNDLE)).rejects.toThrow(
+      /connection terminated/,
+    );
+  });
 });
 
 describe("readOperatorCredentials", () => {
@@ -131,6 +142,19 @@ describe("readOperatorCredentials", () => {
     );
 
     await expect(store.readOperatorCredentials(PLATFORM)).rejects.toThrow();
+  });
+
+  it("throws when the decrypted payload is not a string→string map (corruption)", async () => {
+    // A row that decrypts cleanly but carries a non-string value is corruption;
+    // it must fail loud at the trust boundary, not flow downstream mistyped.
+    const { encryptSecret } = await import("@atlas/api/lib/db/secret-encryption");
+    const badCiphertext = encryptSecret(JSON.stringify({ SLACK_CLIENT_ID: 1234 }));
+
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.resolve([{ credentials_encrypted: badCiphertext, credentials_key_version: 1 }]),
+    );
+
+    await expect(store.readOperatorCredentials(PLATFORM)).rejects.toThrow(/validation failed/);
   });
 });
 

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the operator-tier credential store (#3704).
+ *
+ * Coverage:
+ *   - `saveOperatorCredentials` encrypts the JSON-stringified bundle via the
+ *     real `encryptSecret` (versioned AES-GCM) and upserts on `platform`.
+ *   - Empty-string fields are dropped before persisting (a half-filled form
+ *     never clobbers a real secret with `""`).
+ *   - `readOperatorCredentials` round-trips the decrypt and returns the
+ *     original map, or null when no row exists; tampered ciphertext throws.
+ *   - `readOperatorCredentialRecord` also returns `updatedAt`.
+ *   - `deleteOperatorCredentials` reports whether a row was removed.
+ *
+ * The `internalQuery` mock returns deterministic shapes so the store paths run
+ * without a live Postgres; the encryption helpers are imported real so the
+ * AES-GCM round-trip is exercised end to end.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
+  Promise.resolve([]),
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+type StoreModule = typeof import("../store");
+let store!: StoreModule;
+
+beforeAll(async () => {
+  store = await import("../store");
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-one";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+  mockInternalQuery.mockClear();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+const PLATFORM = "slack" as const;
+const BUNDLE = {
+  SLACK_CLIENT_ID: "1234.5678",
+  SLACK_CLIENT_SECRET: "sec-abcdef0123456789",
+  SLACK_SIGNING_SECRET: "sign-fedcba9876543210",
+  SLACK_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef",
+} as const;
+
+describe("saveOperatorCredentials", () => {
+  it("encrypts the bundle and upserts on platform with a versioned key", async () => {
+    await store.saveOperatorCredentials(PLATFORM, BUNDLE);
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO operator_integration_credentials");
+    expect(sql).toContain("ON CONFLICT (platform) DO UPDATE");
+    const paramsList = params as unknown[];
+    expect(paramsList[0]).toBe(PLATFORM);
+    const ciphertext = paramsList[1] as string;
+    expect(ciphertext).toMatch(/^enc:v\d+:/);
+    // No plaintext secret survives in the ciphertext.
+    expect(ciphertext).not.toContain(BUNDLE.SLACK_CLIENT_SECRET);
+    expect(ciphertext).not.toContain(BUNDLE.SLACK_SIGNING_SECRET);
+    expect(ciphertext).not.toContain(BUNDLE.SLACK_ENCRYPTION_KEY);
+    expect(paramsList[2]).toBe(1);
+  });
+
+  it("drops empty-string fields before persisting", async () => {
+    await store.saveOperatorCredentials(PLATFORM, {
+      SLACK_CLIENT_ID: "1234.5678",
+      SLACK_CLIENT_SECRET: "",
+    });
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const ciphertext = (params as unknown[])[1] as string;
+
+    // Decrypt by feeding it back through readOperatorCredentials.
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.resolve([{ credentials_encrypted: ciphertext, credentials_key_version: 1 }]),
+    );
+    const round = await store.readOperatorCredentials(PLATFORM);
+    expect(round).toEqual({ SLACK_CLIENT_ID: "1234.5678" });
+  });
+});
+
+describe("readOperatorCredentials", () => {
+  it("decrypts and returns the original map", async () => {
+    await store.saveOperatorCredentials(PLATFORM, BUNDLE);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const ciphertext = (params as unknown[])[1] as string;
+    const keyVersion = (params as unknown[])[2] as number;
+
+    mockInternalQuery.mockClear();
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.resolve([
+        { credentials_encrypted: ciphertext, credentials_key_version: keyVersion },
+      ]),
+    );
+
+    const result = await store.readOperatorCredentials(PLATFORM);
+    expect(result).toEqual(BUNDLE);
+  });
+
+  it("returns null when no row exists", async () => {
+    mockInternalQuery.mockImplementationOnce(() => Promise.resolve([]));
+    const result = await store.readOperatorCredentials(PLATFORM);
+    expect(result).toBeNull();
+  });
+
+  it("throws on tampered ciphertext (auth-tag mismatch)", async () => {
+    await store.saveOperatorCredentials(PLATFORM, BUNDLE);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const ciphertext = (params as unknown[])[1] as string;
+    const tampered = ciphertext.slice(0, -4) + "AAAA";
+
+    mockInternalQuery.mockClear();
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.resolve([{ credentials_encrypted: tampered, credentials_key_version: 1 }]),
+    );
+
+    await expect(store.readOperatorCredentials(PLATFORM)).rejects.toThrow();
+  });
+});
+
+describe("readOperatorCredentialRecord", () => {
+  it("returns the bundle plus updatedAt", async () => {
+    await store.saveOperatorCredentials(PLATFORM, BUNDLE);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const ciphertext = (params as unknown[])[1] as string;
+    const when = "2026-06-17T12:00:00.000Z";
+
+    mockInternalQuery.mockClear();
+    mockInternalQuery.mockImplementationOnce(() =>
+      Promise.resolve([
+        { credentials_encrypted: ciphertext, credentials_key_version: 1, updated_at: when },
+      ]),
+    );
+
+    const result = await store.readOperatorCredentialRecord(PLATFORM);
+    expect(result?.bundle).toEqual(BUNDLE);
+    expect(result?.updatedAt.toISOString()).toBe(when);
+  });
+});
+
+describe("deleteOperatorCredentials", () => {
+  it("returns true when a row was deleted", async () => {
+    mockInternalQuery.mockImplementationOnce(() => Promise.resolve([{ id: "uuid-1" }]));
+    const result = await store.deleteOperatorCredentials(PLATFORM);
+    expect(result).toBe(true);
+    const [sql] = mockInternalQuery.mock.calls[0];
+    expect(sql).toContain("DELETE FROM operator_integration_credentials");
+  });
+
+  it("returns false when no row was present", async () => {
+    mockInternalQuery.mockImplementationOnce(() => Promise.resolve([]));
+    const result = await store.deleteOperatorCredentials(PLATFORM);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/api/src/lib/integrations/operator-credentials/platforms.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/platforms.ts
@@ -59,10 +59,13 @@ export interface OperatorPlatformSpec {
 }
 
 /**
- * Slack — the pilot operator platform. The four fields are exactly the
+ * Slack — the pilot operator platform. The four fields must mirror the
  * `SLACK_BUILDER.requiredEnv` set from `@useatlas/chat`'s adapter registry,
  * so a fully-populated row lets the Slack adapter build with zero Slack env
- * vars set on the region.
+ * vars set on the region. The set is hand-copied across the package boundary;
+ * the parity is pinned by a drift test (`__tests__/platforms.test.ts`) against
+ * `getChatAdapterRequiredEnv("slack")` so an adapter-side change can't drift
+ * this silently.
  *
  * ⚠ `SLACK_ENCRYPTION_KEY` rotation is destructive: it is the AES-GCM key
  * the `@chat-adapter/slack` adapter uses to encrypt bot tokens stored in

--- a/packages/api/src/lib/integrations/operator-credentials/platforms.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/platforms.ts
@@ -1,0 +1,124 @@
+/**
+ * Registry of operator-tier integration platforms whose app credentials
+ * are settable + rotatable from the Admin console (#3704).
+ *
+ * This is the REUSABLE SEAM. Adding a platform to the operator-credential
+ * Admin surface is a one-entry addition here (plus a row in the Admin UI's
+ * platform list). The resolver, boot guard, and Admin route all iterate this
+ * registry — they have no per-platform branches.
+ *
+ * Pilot scope (#3704): Slack only. The remaining platforms (Discord, Teams,
+ * Telegram, WhatsApp, Google Chat, and the action targets Jira / Linear /
+ * GitHub App / Salesforce) follow incrementally, one entry per platform.
+ * The migration checklist lives in
+ * `docs/development/saas-env-audit.md` (operator-credentials section).
+ *
+ * Each field maps to an EXISTING operator env var so env stays the
+ * self-host fallback unchanged — the field's `envVar` is both the storage
+ * key in the encrypted bundle AND the `process.env` key the chat adapter
+ * builders read. The resolver overlays the decrypted bundle onto env with
+ * DB-wins precedence; an unset field falls through to env.
+ */
+
+/** One settable field of an operator platform's app credentials. */
+export interface OperatorCredentialField {
+  /** The env var this field maps to (storage key + adapter-builder env key). */
+  readonly envVar: string;
+  /** Human label for the Admin form. */
+  readonly label: string;
+  /** Short helper text shown under the field in the Admin UI. */
+  readonly hint: string;
+  /**
+   * Whether the value is a secret (masked in the Admin UI + never echoed
+   * back on read). Client IDs are not secret; client/signing/encryption
+   * secrets are. Non-secret fields are still never logged verbatim.
+   */
+  readonly secret: boolean;
+  /**
+   * Whether the field is required for the adapter to build. Mirrors the
+   * chat adapter builder's `requiredEnv` set — the boot guard treats a
+   * platform as "configured" only when every required field resolves.
+   */
+  readonly required: boolean;
+}
+
+/** An operator-tier platform managed by the Admin credential surface. */
+export interface OperatorPlatformSpec {
+  /** Operator-tier platform slug — the `platform` key in the credential table. */
+  readonly platform: string;
+  /** Human label for the Admin UI. */
+  readonly label: string;
+  /**
+   * The chat-catalog slug this platform's adapter is keyed by, when it is a
+   * chat platform (used by the boot guard to match catalog entries). `null`
+   * for non-chat action targets (none in the pilot).
+   */
+  readonly catalogSlug: string | null;
+  /** Settable credential fields, in display order. */
+  readonly fields: readonly OperatorCredentialField[];
+}
+
+/**
+ * Slack — the pilot operator platform. The four fields are exactly the
+ * `SLACK_BUILDER.requiredEnv` set from `@useatlas/chat`'s adapter registry,
+ * so a fully-populated row lets the Slack adapter build with zero Slack env
+ * vars set on the region.
+ *
+ * ⚠ `SLACK_ENCRYPTION_KEY` rotation is destructive: it is the AES-GCM key
+ * the `@chat-adapter/slack` adapter uses to encrypt bot tokens stored in
+ * `chat_cache`. Rotating it makes previously-stored bot tokens undecryptable,
+ * so every installed workspace must re-authorize Slack. The Admin UI warns
+ * on change. The OAuth app credentials (`CLIENT_ID` / `CLIENT_SECRET` /
+ * `SIGNING_SECRET`) rotate non-destructively — `SIGNING_SECRET` rotation is
+ * the canonical "roll a secret without a redeploy" case this feature targets.
+ */
+const SLACK_PLATFORM: OperatorPlatformSpec = {
+  platform: "slack",
+  label: "Slack",
+  catalogSlug: "slack",
+  fields: [
+    {
+      envVar: "SLACK_CLIENT_ID",
+      label: "Client ID",
+      hint: "Slack app OAuth client ID (Basic Information → App Credentials).",
+      secret: false,
+      required: true,
+    },
+    {
+      envVar: "SLACK_CLIENT_SECRET",
+      label: "Client Secret",
+      hint: "Slack app OAuth client secret. Used for the install token exchange.",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "SLACK_SIGNING_SECRET",
+      label: "Signing Secret",
+      hint: "Verifies inbound webhook signatures. Roll this here to rotate without a redeploy.",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "SLACK_ENCRYPTION_KEY",
+      label: "Encryption Key",
+      hint: "AES-256-GCM key for stored bot tokens. ⚠ Rotating it forces every workspace to re-authorize Slack.",
+      secret: true,
+      required: true,
+    },
+  ],
+};
+
+/** Every operator platform managed by the Admin credential surface. */
+export const OPERATOR_PLATFORMS: readonly OperatorPlatformSpec[] = [SLACK_PLATFORM];
+
+/** Look up a managed operator platform by slug. `undefined` if unmanaged. */
+export function getOperatorPlatform(platform: string): OperatorPlatformSpec | undefined {
+  return OPERATOR_PLATFORMS.find((p) => p.platform === platform);
+}
+
+/** Find the managed operator platform whose chat-catalog slug matches, if any. */
+export function getOperatorPlatformByCatalogSlug(
+  catalogSlug: string,
+): OperatorPlatformSpec | undefined {
+  return OPERATOR_PLATFORMS.find((p) => p.catalogSlug === catalogSlug);
+}

--- a/packages/api/src/lib/integrations/operator-credentials/resolver.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/resolver.ts
@@ -1,0 +1,198 @@
+/**
+ * Operator-tier credential resolution (#3704) — the single place precedence
+ * is decided: DB row (set via Admin) → operator env var → unset.
+ *
+ * Consumers:
+ *   - The chat plugin's adapter build, via `resolveOperatorAdapterEnv()`
+ *     wired as `ChatPluginConfig.resolveAdapterEnv` in `deploy/api/atlas.config.ts`.
+ *     The returned overlay is merged onto `process.env` (DB wins) so the
+ *     existing env-reading adapter builders pick up Admin-set credentials
+ *     with no per-builder change.
+ *   - The boot guard `ChatAdapterEnvGuardLive`, via `resolveOperatorFieldValue()`
+ *     / `getOperatorPlatformStatus()` — converts the env-only presence check
+ *     into a "DB-row-OR-env" presence check.
+ *   - The Admin route, via `getOperatorPlatformStatus()` for the masked
+ *     status read.
+ *
+ * Self-host is unchanged: with no internal DB (or no row), every field falls
+ * through to env exactly as before. This resolver NEVER reads any workspace-
+ * tier store, and the workspace-tier resolver never reads this one — the
+ * operator/workspace isolation is structural and pinned by
+ * `__tests__/operator-credential-isolation.test.ts`.
+ */
+
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import { readOperatorCredentials } from "./store";
+import {
+  OPERATOR_PLATFORMS,
+  getOperatorPlatform,
+  getOperatorPlatformByCatalogSlug,
+  type OperatorCredentialField,
+  type OperatorPlatformSpec,
+} from "./platforms";
+
+const log = createLogger("integrations.operator-credentials.resolver");
+
+/** Where a resolved operator credential field's value came from. */
+export type OperatorCredentialSource = "db" | "env" | "unset";
+
+/** Per-field resolution status (no secret values — only presence + source). */
+export interface OperatorFieldStatus {
+  readonly envVar: string;
+  readonly label: string;
+  readonly secret: boolean;
+  readonly required: boolean;
+  readonly present: boolean;
+  readonly source: OperatorCredentialSource;
+}
+
+/** Per-platform status for the Admin UI + boot diagnostics. */
+export interface OperatorPlatformStatus {
+  readonly platform: string;
+  readonly label: string;
+  /** True when every `required` field resolved to a non-empty value. */
+  readonly configured: boolean;
+  /** True when at least one field resolved from the DB (Admin-set). */
+  readonly hasDbOverride: boolean;
+  readonly fields: readonly OperatorFieldStatus[];
+}
+
+/**
+ * Resolve a single operator field's effective value with full precedence.
+ * Returns the value (DB row → env) or `undefined` when neither source has it.
+ *
+ * `bundle` is the already-read DB bundle for the platform (or `null`); passing
+ * it in lets callers resolve a whole platform with one DB read.
+ */
+export function resolveOperatorFieldValue(
+  field: OperatorCredentialField,
+  bundle: Record<string, string> | null,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const dbVal = bundle?.[field.envVar];
+  if (typeof dbVal === "string" && dbVal.length > 0) return dbVal;
+  const envVal = env[field.envVar];
+  if (typeof envVal === "string" && envVal.length > 0) return envVal;
+  return undefined;
+}
+
+/**
+ * Build the env overlay for the chat adapter builders: for every managed
+ * platform field, the DB-then-env resolved value. Only resolved (non-empty)
+ * keys are included, so merging `{ ...process.env, ...overlay }` keeps DB
+ * winning over env while never clobbering an env value with `undefined`.
+ *
+ * Reads the DB once per platform. When no internal DB is configured
+ * (self-host stateless), returns `{}` immediately — env passes through
+ * untouched.
+ */
+export async function resolveOperatorAdapterEnv(
+  platforms: readonly OperatorPlatformSpec[] = OPERATOR_PLATFORMS,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, string>> {
+  const overlay: Record<string, string> = {};
+  if (!hasInternalDB()) return overlay;
+
+  for (const spec of platforms) {
+    let bundle: Record<string, string> | null = null;
+    try {
+      bundle = (await readOperatorCredentials(spec.platform)) as Record<string, string> | null;
+    } catch (err) {
+      // A decrypt/corruption failure must not silently drop the platform to
+      // env-only (that would mask a broken rotation). Log loudly and rethrow
+      // so the refresh/boot path surfaces it rather than booting degraded.
+      log.error(
+        { platform: spec.platform, err: err instanceof Error ? err.message : String(err) },
+        "Failed to read operator credentials while building adapter env overlay",
+      );
+      throw err;
+    }
+    if (!bundle) continue;
+    for (const field of spec.fields) {
+      const dbVal = bundle[field.envVar];
+      if (typeof dbVal === "string" && dbVal.length > 0) overlay[field.envVar] = dbVal;
+    }
+  }
+  return overlay;
+}
+
+/**
+ * Compute the masked status of one operator platform: per-field presence +
+ * source, whether every required field resolves, and whether any field came
+ * from the DB. Used by the Admin GET route and the boot guard. Never returns
+ * secret values.
+ */
+export async function getOperatorPlatformStatus(
+  platform: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<OperatorPlatformStatus | null> {
+  const spec = getOperatorPlatform(platform);
+  if (!spec) return null;
+
+  const bundle = hasInternalDB()
+    ? ((await readOperatorCredentials(platform)) as Record<string, string> | null)
+    : null;
+
+  const fields = spec.fields.map<OperatorFieldStatus>((field) => {
+    const dbVal = bundle?.[field.envVar];
+    if (typeof dbVal === "string" && dbVal.length > 0) {
+      return fieldStatus(field, true, "db");
+    }
+    const envVal = env[field.envVar];
+    if (typeof envVal === "string" && envVal.length > 0) {
+      return fieldStatus(field, true, "env");
+    }
+    return fieldStatus(field, false, "unset");
+  });
+
+  const configured = fields.every((f) => !f.required || f.present);
+  const hasDbOverride = fields.some((f) => f.source === "db");
+  return { platform: spec.platform, label: spec.label, configured, hasDbOverride, fields };
+}
+
+/**
+ * Boot-guard helper: given a chat-catalog slug and the adapter builder's
+ * `requiredEnv` set (the single source of truth, passed in by the guard from
+ * `@useatlas/chat`), return the subset of keys absent from BOTH the operator
+ * credential DB row AND env. An empty result means "configured" (env, DB, or a
+ * mix). The guard fails boot only when this is non-empty.
+ *
+ * `requiredKeys` stays the source of truth so a future adapter adding a key
+ * is checked without touching this module. The operator DB row is consulted
+ * only when the slug maps to a managed operator platform and an internal DB
+ * exists; otherwise this collapses to the original env-only check.
+ */
+export async function getMissingOperatorEnvForCatalogSlug(
+  catalogSlug: string,
+  requiredKeys: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string[]> {
+  let bundle: Record<string, string> | null = null;
+  const spec = getOperatorPlatformByCatalogSlug(catalogSlug);
+  if (spec && hasInternalDB()) {
+    bundle = (await readOperatorCredentials(spec.platform)) as Record<string, string> | null;
+  }
+  return requiredKeys.filter((key) => {
+    const dbVal = bundle?.[key];
+    if (typeof dbVal === "string" && dbVal.length > 0) return false;
+    const envVal = env[key];
+    if (typeof envVal === "string" && envVal.length > 0) return false;
+    return true;
+  });
+}
+
+function fieldStatus(
+  field: OperatorCredentialField,
+  present: boolean,
+  source: OperatorCredentialSource,
+): OperatorFieldStatus {
+  return {
+    envVar: field.envVar,
+    label: field.label,
+    secret: field.secret,
+    required: field.required,
+    present,
+    source,
+  };
+}

--- a/packages/api/src/lib/integrations/operator-credentials/resolver.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/resolver.ts
@@ -79,9 +79,11 @@ export function resolveOperatorFieldValue(
 
 /**
  * Build the env overlay for the chat adapter builders: for every managed
- * platform field, the DB-then-env resolved value. Only resolved (non-empty)
- * keys are included, so merging `{ ...process.env, ...overlay }` keeps DB
- * winning over env while never clobbering an env value with `undefined`.
+ * platform field present in the DB, its decrypted value. This overlay is
+ * intentionally DB-only — the caller merges it as `{ ...process.env,
+ * ...overlay }`, so DB wins over env while unset keys fall through to env. It
+ * therefore takes no `env` argument: env passthrough is the merge's job, not
+ * this function's.
  *
  * Reads the DB once per platform. When no internal DB is configured
  * (self-host stateless), returns `{}` immediately — env passes through
@@ -89,13 +91,12 @@ export function resolveOperatorFieldValue(
  */
 export async function resolveOperatorAdapterEnv(
   platforms: readonly OperatorPlatformSpec[] = OPERATOR_PLATFORMS,
-  env: NodeJS.ProcessEnv = process.env,
 ): Promise<Record<string, string>> {
   const overlay: Record<string, string> = {};
   if (!hasInternalDB()) return overlay;
 
   for (const spec of platforms) {
-    let bundle: Record<string, string> | null = null;
+    let bundle: Record<string, string> | null;
     try {
       bundle = (await readOperatorCredentials(spec.platform)) as Record<string, string> | null;
     } catch (err) {

--- a/packages/api/src/lib/integrations/operator-credentials/store.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/store.ts
@@ -31,6 +31,7 @@
  * @see packages/api/src/lib/db/migrations/0140_operator_integration_credentials.sql
  */
 
+import { z } from "zod";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
   encryptSecret,
@@ -40,6 +41,19 @@ import {
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("integrations.operator-credentials.store");
+
+/**
+ * Validates the decrypted bundle at the trust boundary: a string→string map.
+ * `parseBundle` runs this on every read so a corrupt / hand-edited row whose
+ * plaintext decrypts cleanly but isn't `{ <ENV_VAR>: <string> }` (e.g. a
+ * numeric value, or a nested object) fails loudly rather than flowing
+ * downstream as a mistyped value the resolver's `typeof` guards then silently
+ * drop. Keeps the "decrypt/corruption fails loud, never degrade" contract.
+ */
+const OperatorCredentialBundleSchema: z.ZodType<Record<string, string>> = z.record(
+  z.string(),
+  z.string(),
+);
 
 /**
  * A decrypted operator credential bundle: a map of env-var name → value.
@@ -172,20 +186,20 @@ function parseBundle(platform: string, ciphertext: string): OperatorCredentialBu
   const plaintext = decryptSecret(ciphertext);
   try {
     const parsed = JSON.parse(plaintext) as unknown;
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("decrypted operator credential payload is not a JSON object");
-    }
-    return parsed as OperatorCredentialBundle;
+    // Validate the shape (string→string map), not just "is an object" — a
+    // mistyped value is corruption and must fail loud here, not silently get
+    // dropped by a downstream `typeof` guard.
+    return OperatorCredentialBundleSchema.parse(parsed);
   } catch (err) {
     // AES-GCM auth-tag verification makes "decrypted to garbage" highly
-    // unlikely; a parse failure on a row that decrypted cleanly is data
+    // unlikely; a parse/shape failure on a row that decrypted cleanly is data
     // corruption (or key-version drift producing wrong-but-plausible bytes).
     log.error(
       { platform, err: err instanceof Error ? err.message : String(err) },
-      "Decrypted operator_integration_credentials payload did not parse as a JSON object",
+      "Decrypted operator_integration_credentials payload did not parse as a string→string map",
     );
     throw new Error(
-      `operator_integration_credentials JSON.parse failed for platform=${platform}`,
+      `operator_integration_credentials payload validation failed for platform=${platform}`,
       { cause: err },
     );
   }

--- a/packages/api/src/lib/integrations/operator-credentials/store.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/store.ts
@@ -1,0 +1,192 @@
+/**
+ * Operator-tier integration credential store (#3704).
+ *
+ * Backs the `operator_integration_credentials` table (migration 0140).
+ * Stores Atlas's OWN integration app registrations — the operator/platform
+ * tier — encrypted at rest, one row per platform slug. Set + rotated from
+ * the Admin console without a redeploy (see `api/routes/admin-operator-integrations.ts`).
+ *
+ * This is deliberately a SIBLING of the workspace-tier credential store
+ * (`lib/integrations/credentials/store.ts`). The two tiers must never read
+ * from each other's store:
+ *
+ *   - Operator tier (this file) — Atlas's app registrations, operator-shared
+ *     across every workspace, keyed by `platform`. Fallback source is the
+ *     operator env (`SLACK_CLIENT_ID`, …) for self-host.
+ *   - Workspace tier (`credentials/store.ts`) — a tenant's per-install
+ *     secrets, keyed by `(workspace_id, catalog_id)`, DB-only (never env).
+ *
+ * The isolation is enforced structurally (no shared table, no shared
+ * resolver) and pinned by `__tests__/operator-credential-isolation.test.ts`.
+ * See the CLAUDE.md rule "Per-tenant plugin creds never fall back to operator
+ * env vars" — this store keeps the inverse honest too.
+ *
+ * Encryption: the credential map (`{ <ENV_VAR_NAME>: <value>, … }`) is
+ * JSON-stringified then encrypted via `encryptSecret` from
+ * `db/secret-encryption.ts` (versioned AES-256-GCM). The table is registered
+ * in `INTEGRATION_TABLES` so F-47 key rotation + the F-42 residue audit pick
+ * it up automatically.
+ *
+ * @see ADR-0005 — dedicated credentials table pattern this mirrors
+ * @see packages/api/src/lib/db/migrations/0140_operator_integration_credentials.sql
+ */
+
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  encryptSecret,
+  decryptSecret,
+  activeKeyVersion,
+} from "@atlas/api/lib/db/secret-encryption";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("integrations.operator-credentials.store");
+
+/**
+ * A decrypted operator credential bundle: a map of env-var name → value.
+ * Env-var names are the keys so the resolver can overlay the decrypted
+ * bundle straight onto the `process.env`-shaped object the chat adapter
+ * builders already read (e.g. `{ SLACK_CLIENT_ID, SLACK_CLIENT_SECRET,
+ * SLACK_SIGNING_SECRET, SLACK_ENCRYPTION_KEY }`). Values are always the
+ * raw secret strings — callers mask before logging or returning to a UI.
+ */
+export type OperatorCredentialBundle = Readonly<Record<string, string>>;
+
+// `type` (not `interface`) so these satisfy the `Record<string, unknown>`
+// constraint on `internalQuery<T>` — interfaces don't structurally satisfy
+// an index signature in TS, type aliases of object literals do.
+type StoredRow = {
+  credentials_encrypted: string;
+  credentials_key_version: number | null;
+};
+
+type StoredMetaRow = StoredRow & {
+  updated_at: string | Date;
+};
+
+/**
+ * Upsert the operator credential bundle for `platform`, encrypting the
+ * whole map. `created_at` (and the row `id`) are preserved on conflict so
+ * F-47 rotation / audit joins by id stay stable; `updated_at` bumps on
+ * every write and doubles as the Admin UI's "last rotated" timestamp.
+ *
+ * Empty-string values are dropped before persisting so a partially-filled
+ * form never overwrites a real secret with `""` (the Admin route also
+ * merges against the stored bundle, but this is the floor).
+ */
+export async function saveOperatorCredentials(
+  platform: string,
+  bundle: OperatorCredentialBundle,
+): Promise<void> {
+  const cleaned: Record<string, string> = {};
+  for (const [key, value] of Object.entries(bundle)) {
+    if (typeof value === "string" && value.length > 0) cleaned[key] = value;
+  }
+
+  const ciphertext = encryptSecret(JSON.stringify(cleaned));
+  const keyVersion = activeKeyVersion();
+
+  try {
+    await internalQuery(
+      `INSERT INTO operator_integration_credentials
+         (platform, credentials_encrypted, credentials_key_version)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (platform) DO UPDATE
+         SET credentials_encrypted   = EXCLUDED.credentials_encrypted,
+             credentials_key_version = EXCLUDED.credentials_key_version,
+             updated_at              = NOW()`,
+      [platform, ciphertext, keyVersion],
+    );
+  } catch (err) {
+    log.error(
+      { platform, err: err instanceof Error ? err.message : String(err) },
+      "Failed to upsert operator_integration_credentials row",
+    );
+    throw err;
+  }
+}
+
+/**
+ * Read + decrypt the operator credential bundle for `platform`. Returns
+ * `null` when no row exists (the resolver then falls back to env).
+ *
+ * Throws on decrypt failure (corruption, dropped key version) — callers let
+ * it propagate so the route surfaces a 500 with a `requestId` rather than
+ * silently masquerading as "no operator credentials" (which would mis-route
+ * the boot guard + Admin UI into "set it up" on a half-broken row).
+ */
+export async function readOperatorCredentials(
+  platform: string,
+): Promise<OperatorCredentialBundle | null> {
+  const rows = await internalQuery<StoredRow>(
+    `SELECT credentials_encrypted, credentials_key_version
+       FROM operator_integration_credentials
+      WHERE platform = $1
+      LIMIT 1`,
+    [platform],
+  );
+  if (rows.length === 0) return null;
+  return parseBundle(platform, rows[0].credentials_encrypted);
+}
+
+/** Read result carrying the bundle plus the "last rotated" timestamp for the Admin UI. */
+export interface OperatorCredentialRecord {
+  readonly bundle: OperatorCredentialBundle;
+  readonly updatedAt: Date;
+}
+
+/**
+ * Like {@link readOperatorCredentials} but also returns `updated_at` for the
+ * Admin "last rotated" surface. Separate function so the hot-path resolver
+ * (boot guard, adapter build) doesn't pay for the extra column it ignores.
+ */
+export async function readOperatorCredentialRecord(
+  platform: string,
+): Promise<OperatorCredentialRecord | null> {
+  const rows = await internalQuery<StoredMetaRow>(
+    `SELECT credentials_encrypted, credentials_key_version, updated_at
+       FROM operator_integration_credentials
+      WHERE platform = $1
+      LIMIT 1`,
+    [platform],
+  );
+  if (rows.length === 0) return null;
+  const bundle = parseBundle(platform, rows[0].credentials_encrypted);
+  return { bundle, updatedAt: new Date(rows[0].updated_at) };
+}
+
+/**
+ * Delete the operator credential row for `platform` (reverts to the env
+ * fallback). Returns `true` if a row was removed, `false` if none existed.
+ */
+export async function deleteOperatorCredentials(platform: string): Promise<boolean> {
+  const rows = await internalQuery<{ id: string }>(
+    `DELETE FROM operator_integration_credentials
+      WHERE platform = $1
+      RETURNING id`,
+    [platform],
+  );
+  return rows.length > 0;
+}
+
+function parseBundle(platform: string, ciphertext: string): OperatorCredentialBundle {
+  const plaintext = decryptSecret(ciphertext);
+  try {
+    const parsed = JSON.parse(plaintext) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("decrypted operator credential payload is not a JSON object");
+    }
+    return parsed as OperatorCredentialBundle;
+  } catch (err) {
+    // AES-GCM auth-tag verification makes "decrypted to garbage" highly
+    // unlikely; a parse failure on a row that decrypted cleanly is data
+    // corruption (or key-version drift producing wrong-but-plausible bytes).
+    log.error(
+      { platform, err: err instanceof Error ? err.message : String(err) },
+      "Decrypted operator_integration_credentials payload did not parse as a JSON object",
+    );
+    throw new Error(
+      `operator_integration_credentials JSON.parse failed for platform=${platform}`,
+      { cause: err },
+    );
+  }
+}

--- a/packages/api/src/lib/plugins/__tests__/registry.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/registry.test.ts
@@ -422,6 +422,98 @@ describe("PluginRegistry", () => {
 
   // --- teardownAll ---
 
+  describe("refresh (#3704 — operator-credential rebuild seam)", () => {
+    test("tears down then re-initializes a single plugin, reusing the init context", async () => {
+      const calls: string[] = [];
+      let initCtx: PluginContextLike | null = null;
+      registry.register(
+        makePlugin({
+          id: "chat-interaction",
+          initialize: async (ctx) => {
+            calls.push("init");
+            initCtx = ctx;
+          },
+          teardown: async () => {
+            calls.push("teardown");
+          },
+        }),
+      );
+      await registry.initializeAll(minimalCtx);
+      expect(calls).toEqual(["init"]);
+
+      const result = await registry.refresh("chat-interaction");
+
+      expect(result.ok).toBe(true);
+      // teardown then a fresh init — the rebuild order.
+      expect(calls).toEqual(["init", "teardown", "init"]);
+      expect(registry.getStatus("chat-interaction")).toBe("healthy");
+      // The re-init received a (logger-wrapped) context derived from the
+      // captured one — db/connections/config are the same references.
+      expect(initCtx).not.toBeNull();
+      expect((initCtx as unknown as PluginContextLike).config).toBe(minimalCtx.config);
+    });
+
+    test("returns ok:false (does not throw) for an unregistered plugin", async () => {
+      await registry.initializeAll(minimalCtx);
+      const result = await registry.refresh("nope");
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain("not registered");
+    });
+
+    test("returns ok:false when plugins were never initialized", async () => {
+      registry.register(makePlugin({ id: "chat-interaction", initialize: async () => {} }));
+      const result = await registry.refresh("chat-interaction");
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain("not been initialized");
+    });
+
+    test("a failing re-init marks the plugin unhealthy and reports the reason", async () => {
+      let first = true;
+      registry.register(
+        makePlugin({
+          id: "chat-interaction",
+          initialize: async () => {
+            if (first) {
+              first = false;
+              return;
+            }
+            throw new Error("decrypt failed: auth tag mismatch");
+          },
+          teardown: async () => {},
+        }),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      const result = await registry.refresh("chat-interaction");
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain("auth tag mismatch");
+      expect(registry.getStatus("chat-interaction")).toBe("unhealthy");
+    });
+
+    test("a teardown failure is non-fatal — re-init still runs", async () => {
+      const calls: string[] = [];
+      registry.register(
+        makePlugin({
+          id: "chat-interaction",
+          initialize: async () => {
+            calls.push("init");
+          },
+          teardown: async () => {
+            calls.push("teardown");
+            throw new Error("teardown boom");
+          },
+        }),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      const result = await registry.refresh("chat-interaction");
+
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual(["init", "teardown", "init"]);
+    });
+  });
+
   describe("teardownAll", () => {
     test("calls in reverse order", async () => {
       const order: string[] = [];

--- a/packages/api/src/lib/plugins/__tests__/registry.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/registry.test.ts
@@ -456,15 +456,19 @@ describe("PluginRegistry", () => {
     test("returns ok:false (does not throw) for an unregistered plugin", async () => {
       await registry.initializeAll(minimalCtx);
       const result = await registry.refresh("nope");
-      expect(result.ok).toBe(false);
-      expect(result.reason).toContain("not registered");
+      expect(result).toMatchObject({
+        ok: false,
+        reason: expect.stringContaining("not registered"),
+      });
     });
 
     test("returns ok:false when plugins were never initialized", async () => {
       registry.register(makePlugin({ id: "chat-interaction", initialize: async () => {} }));
       const result = await registry.refresh("chat-interaction");
-      expect(result.ok).toBe(false);
-      expect(result.reason).toContain("not been initialized");
+      expect(result).toMatchObject({
+        ok: false,
+        reason: expect.stringContaining("not been initialized"),
+      });
     });
 
     test("a failing re-init marks the plugin unhealthy and reports the reason", async () => {
@@ -486,8 +490,10 @@ describe("PluginRegistry", () => {
 
       const result = await registry.refresh("chat-interaction");
 
-      expect(result.ok).toBe(false);
-      expect(result.reason).toContain("auth tag mismatch");
+      expect(result).toMatchObject({
+        ok: false,
+        reason: expect.stringContaining("auth tag mismatch"),
+      });
       expect(registry.getStatus("chat-interaction")).toBe("unhealthy");
     });
 
@@ -511,6 +517,67 @@ describe("PluginRegistry", () => {
 
       expect(result.ok).toBe(true);
       expect(calls).toEqual(["init", "teardown", "init"]);
+    });
+
+    test("a successful refresh invalidates the cached /health snapshot", async () => {
+      const counter = { calls: 0 };
+      registry.register(
+        makePlugin({
+          id: "chat-interaction",
+          initialize: async () => {},
+          healthCheck: async () => {
+            counter.calls++;
+            return { healthy: true };
+          },
+        }),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      // Prime the cache and confirm it holds within the TTL.
+      await registry.healthCheckAllCached(60_000);
+      await registry.healthCheckAllCached(60_000);
+      expect(counter.calls).toBe(1);
+
+      const result = await registry.refresh("chat-interaction");
+      expect(result.ok).toBe(true);
+
+      // The refresh cleared the snapshot, so the next cached call re-probes
+      // the rebuilt plugin even though the TTL has not elapsed.
+      await registry.healthCheckAllCached(60_000);
+      expect(counter.calls).toBe(2);
+    });
+
+    test("a failed refresh also invalidates the snapshot (no stale 'healthy')", async () => {
+      let first = true;
+      const counter = { calls: 0 };
+      registry.register(
+        makePlugin({
+          id: "chat-interaction",
+          initialize: async () => {
+            if (first) {
+              first = false;
+              return;
+            }
+            throw new Error("decrypt failed during rebuild");
+          },
+          healthCheck: async () => {
+            counter.calls++;
+            return { healthy: true };
+          },
+        }),
+      );
+      await registry.initializeAll(minimalCtx);
+
+      await registry.healthCheckAllCached(60_000);
+      expect(counter.calls).toBe(1);
+
+      const result = await registry.refresh("chat-interaction");
+      expect(result.ok).toBe(false);
+
+      // Even though the rebuild failed, a stale snapshot must not keep
+      // reporting the now-dead plugin as healthy — the next call re-probes.
+      await registry.healthCheckAllCached(60_000);
+      expect(counter.calls).toBe(2);
     });
   });
 

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -153,6 +153,10 @@ export class PluginRegistry {
   private entries: PluginEntry[] = [];
   private idSet = new Set<string>();
   private initialized = false;
+  // Captured at `initializeAll` so a single plugin can be torn down and
+  // re-initialized at runtime (`refresh`) with the same Atlas context —
+  // the operator-credential rebuild seam (#3704). Null until init has run.
+  private lastInitContext: PluginContextLike | null = null;
 
   // ── Cached plugin liveness for /health (#3201) ─────────────────────────
   // The public, unauthenticated `/health` route calls `healthCheckAllCached`
@@ -193,6 +197,7 @@ export class PluginRegistry {
       throw new Error("Plugins already initialized — initializeAll() cannot be called twice");
     }
     this.initialized = true;
+    this.lastInitContext = ctx;
 
     const succeeded: string[] = [];
     const failed: string[] = [];
@@ -336,6 +341,90 @@ export class PluginRegistry {
     }
   }
 
+  /**
+   * Tear down and re-initialize a SINGLE plugin in place, reusing the Atlas
+   * context captured at `initializeAll` (#3704 — the operator-credential
+   * rebuild seam). This is the runtime "pick up rotated credentials with no
+   * process restart" path: a plugin whose `initialize()` re-reads its
+   * credential source (e.g. the chat plugin's `resolveAdapterEnv`) rebuilds
+   * against the new values.
+   *
+   * Safe for the chat plugin specifically: its `teardown()` shuts down the
+   * bridge + state adapter and resets its `initialized` flag, and its
+   * `initialize()` rebuilds the bridge, the Chat SDK instance, the webhook
+   * handlers (the once-mounted routes read the live `bridge` closure), and
+   * re-registers the proactive listener — no dangling listeners (the old
+   * Chat instance's event loop is stopped and the instance is GC'd).
+   *
+   * Returns `{ ok }` plus a failure reason. A teardown error is logged but
+   * does not abort the re-init (best-effort, mirrors `teardownAll`); an
+   * initialize error leaves the plugin marked `unhealthy` and is surfaced.
+   * Never throws — callers (the Admin route) map the result to an HTTP body.
+   */
+  async refresh(id: string): Promise<{ ok: boolean; reason?: string }> {
+    const entry = this.entries.find((e) => e.plugin.id === id);
+    if (!entry) {
+      return { ok: false, reason: `Plugin "${id}" is not registered` };
+    }
+    if (!this.lastInitContext) {
+      return { ok: false, reason: "Plugins have not been initialized yet — cannot refresh" };
+    }
+    const ctx = this.lastInitContext;
+
+    return withSpan(
+      "atlas.plugin.refresh",
+      { "atlas.plugin_id": id },
+      async () => {
+        // Best-effort teardown — a failure here is logged, not fatal, so a
+        // partially-broken old instance can't wedge the re-init.
+        if (entry.plugin.teardown) {
+          try {
+            await entry.plugin.teardown();
+          } catch (err) {
+            log.error(
+              { pluginId: id, err: err instanceof Error ? err : new Error(String(err)) },
+              "Plugin teardown failed during refresh — continuing to re-initialize",
+            );
+          }
+        }
+
+        if (!entry.plugin.initialize) {
+          entry.status = "healthy";
+          return { ok: true };
+        }
+
+        entry.status = "initializing";
+        try {
+          const pluginCtx = {
+            ...ctx,
+            logger:
+              typeof (ctx.logger as Record<string, unknown>)?.child === "function"
+                ? (ctx.logger as { child(bindings: Record<string, unknown>): unknown }).child({
+                    pluginId: id,
+                  })
+                : ctx.logger,
+          };
+          await entry.plugin.initialize(pluginCtx as PluginContextLike);
+          entry.status = "healthy";
+          // A successful re-init invalidates the cached /health snapshot so
+          // the next probe reflects the rebuilt plugin rather than a stale
+          // pre-refresh result.
+          this.healthSnapshot = null;
+          log.info({ pluginId: id }, "Plugin refreshed (teardown + re-initialize)");
+          return { ok: true };
+        } catch (err) {
+          entry.status = "unhealthy";
+          const reason = err instanceof Error ? err.message : String(err);
+          log.error(
+            { pluginId: id, err: err instanceof Error ? err : new Error(String(err)) },
+            "Plugin re-initialization failed during refresh",
+          );
+          return { ok: false, reason };
+        }
+      },
+    );
+  }
+
   get(id: string): PluginLike | undefined {
     return this.entries.find((e) => e.plugin.id === id)?.plugin;
   }
@@ -425,6 +514,7 @@ export class PluginRegistry {
     this.entries = [];
     this.idSet.clear();
     this.initialized = false;
+    this.lastInitContext = null;
     this.healthSnapshot = null;
     this.healthSnapshotInFlight = null;
   }

--- a/packages/api/src/lib/plugins/registry.ts
+++ b/packages/api/src/lib/plugins/registry.ts
@@ -351,17 +351,19 @@ export class PluginRegistry {
    *
    * Safe for the chat plugin specifically: its `teardown()` shuts down the
    * bridge + state adapter and resets its `initialized` flag, and its
-   * `initialize()` rebuilds the bridge, the Chat SDK instance, the webhook
-   * handlers (the once-mounted routes read the live `bridge` closure), and
-   * re-registers the proactive listener — no dangling listeners (the old
-   * Chat instance's event loop is stopped and the instance is GC'd).
+   * `initialize()` rebuilds the bridge, the Chat SDK instance, and the webhook
+   * handlers (the once-mounted routes read the live `bridge` closure), then
+   * re-registers the proactive listener via the rebuilt bridge. The old Chat
+   * SDK instance is shut down in `teardown()` before the rebuild.
    *
-   * Returns `{ ok }` plus a failure reason. A teardown error is logged but
-   * does not abort the re-init (best-effort, mirrors `teardownAll`); an
-   * initialize error leaves the plugin marked `unhealthy` and is surfaced.
-   * Never throws — callers (the Admin route) map the result to an HTTP body.
+   * Returns a discriminated `{ ok }` result: `{ ok: true }` on success, or
+   * `{ ok: false; reason }` on failure (so a caller narrowing on `ok` always
+   * has a `reason`). A teardown error is logged but does not abort the re-init
+   * (best-effort, mirrors `teardownAll`); an initialize error leaves the plugin
+   * marked `unhealthy` and is surfaced. Never throws — callers (the Admin
+   * route) map the result to an HTTP body.
    */
-  async refresh(id: string): Promise<{ ok: boolean; reason?: string }> {
+  async refresh(id: string): Promise<{ ok: true } | { ok: false; reason: string }> {
     const entry = this.entries.find((e) => e.plugin.id === id);
     if (!entry) {
       return { ok: false, reason: `Plugin "${id}" is not registered` };
@@ -414,6 +416,12 @@ export class PluginRegistry {
           return { ok: true };
         } catch (err) {
           entry.status = "unhealthy";
+          // Invalidate the cached /health snapshot on failure too: a
+          // re-init that threw (e.g. a decrypt/corruption failure on a
+          // rotated credential) leaves the plugin dead, and a stale
+          // pre-refresh snapshot could otherwise keep reporting it healthy
+          // to the public `/health` route for up to the TTL window.
+          this.healthSnapshot = null;
           const reason = err instanceof Error ? err.message : String(err);
           log.error(
             { pluginId: id, err: err instanceof Error ? err : new Error(String(err)) },

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -1065,6 +1065,13 @@ export const ChatConfigSchema = z.object({
   executeQueryStream: zCallback<NonNullable<ChatPluginConfig["executeQueryStream"]>>(
     "executeQueryStream must be a function",
   ).optional(),
+  // #3704 — operator-tier credential resolver overlay. Optional async
+  // callback; the host (`@atlas/api`) wires it to the operator-credentials
+  // resolver. Must be in this `.strict()` schema or config load rejects the
+  // key and boot crashes before HTTP binds (caught by Boot Smoke).
+  resolveAdapterEnv: zCallback<NonNullable<ChatPluginConfig["resolveAdapterEnv"]>>(
+    "resolveAdapterEnv must be a function returning Promise<Record<string, string | undefined>>",
+  ).optional(),
 }).strict().refine(
   (c) => {
     // Warn if streaming.enabled is explicitly true but executeQueryStream is missing

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -493,12 +493,36 @@ export interface ChatPluginConfig {
    * along as `enabled: false` placeholders; their install handlers
    * land in 1.5.3.
    *
-   * Per-Platform credentials come from `process.env` (per CONTEXT.md
-   * "Operator vs Customer") — the plugin reads them inside
-   * `buildChatAdapterRegistry`. This config object intentionally does
-   * NOT carry credentials.
+   * Per-Platform OPERATOR credentials come from `process.env` by default
+   * (per CONTEXT.md "Operator vs Customer") — the plugin reads them inside
+   * `buildChatAdapterRegistry`. When `resolveAdapterEnv` is provided (#3704),
+   * its overlay takes precedence over env so operator credentials set via the
+   * Admin console are picked up at (re)build time. This config object still
+   * intentionally carries NO raw credential values — only the optional
+   * resolver callback.
    */
   catalog?: ReadonlyArray<ChatCatalogEntryInput>;
+
+  /**
+   * Optional async resolver for operator-tier adapter credentials (#3704).
+   *
+   * Returns an env-shaped overlay (`{ <ENV_VAR_NAME>: value | undefined }`)
+   * that the plugin merges ON TOP OF `process.env` before building the
+   * adapter registry, so the existing env-reading adapter builders pick up
+   * Admin-set, DB-backed operator credentials with no per-builder change.
+   * `undefined` values are dropped before merging, so an unresolved key
+   * never clobbers its env fallback (env stays the fallback for self-host).
+   *
+   * Resolution + precedence (DB row → env → unset) lives entirely in the
+   * host (`@atlas/api`'s operator-credentials resolver) — the chat plugin
+   * stays free of `@atlas/api` imports and of any DB/secret dependency.
+   *
+   * Called on every `initialize()`, so re-initializing the plugin (the
+   * runtime "rebuild" seam — `PluginRegistry.refresh`) re-reads credentials
+   * with no process restart. Omitted on self-host → pure env behavior,
+   * unchanged.
+   */
+  resolveAdapterEnv?: () => Promise<Record<string, string | undefined>>;
 
   /** State backend configuration. Default: { backend: "memory" } */
   state?: StateConfig;

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -344,6 +344,45 @@ function catalogHasTeamsStaticBot(
   );
 }
 
+/**
+ * Resolve the env-shaped object the AdapterRegistry builds from (#3704).
+ *
+ * Without `config.resolveAdapterEnv` (self-host default) this is just
+ * `process.env` — behavior is unchanged. With it, the host's operator-tier
+ * overlay (Admin-set, DB-backed credentials) is merged on top of
+ * `process.env` so the overlay WINS while unresolved keys fall through to env
+ * (env stays the fallback). Only non-empty string overlay values override —
+ * `undefined`/`""` never clobber an env value.
+ *
+ * A throwing resolver propagates: it signals a decrypt/corruption failure in
+ * the host, which must fail the (re)build loudly rather than silently boot
+ * with env-only credentials (the silent-degradation class #2673 / the boot
+ * guard exist to prevent). `initialize()`'s try/catch cleans up the partially
+ * connected state adapter on the way out.
+ */
+// Exported for unit testing the operator-credential overlay precedence
+// (#3704). Not part of the plugin's public surface — internal helper.
+export async function resolveAdapterBuildEnv(
+  config: ChatPluginConfig,
+  logger: PluginLogger,
+): Promise<NodeJS.ProcessEnv> {
+  if (!config.resolveAdapterEnv) return process.env;
+  const overlay = await config.resolveAdapterEnv();
+  const merged: NodeJS.ProcessEnv = { ...process.env };
+  let applied = 0;
+  for (const [key, value] of Object.entries(overlay)) {
+    if (typeof value === "string" && value.length > 0) {
+      merged[key] = value;
+      applied += 1;
+    }
+  }
+  logger.debug?.(
+    { overlayKeys: Object.keys(overlay).length, applied },
+    "Resolved operator-tier adapter credential overlay (DB-backed values override env)",
+  );
+  return merged;
+}
+
 function buildChatPlugin(
   config: ChatPluginConfig,
 ): AtlasInteractionPlugin<ChatPluginConfig> {
@@ -755,14 +794,24 @@ function buildChatPlugin(
 
       // Build chat-platform adapters via the catalog-driven
       // AdapterRegistry (#2650 slice 2). The registry reads per-Platform
-      // credentials from `process.env`, logs errors on missing creds /
+      // credentials from an env-shaped object, logs errors on missing creds /
       // warns on non-OAuth entries, and returns the adapters map plus diagnostic
       // slug lists. The diagnostics let `healthCheck` surface actionable
       // error messages.
+      //
+      // Operator credentials (#3704): when the host wires `resolveAdapterEnv`,
+      // its overlay (Admin-set, DB-backed operator credentials) is merged ON
+      // TOP OF `process.env` so it wins, while unresolved keys fall through to
+      // env (the self-host fallback). `undefined` overlay values are stripped
+      // first so they never clobber a real env value. Re-reading the resolver
+      // here on every `initialize()` is what makes the runtime rebuild seam
+      // (`PluginRegistry.refresh` → teardown + initialize) pick up rotated
+      // credentials with no process restart.
       try {
+        const adapterEnv = await resolveAdapterBuildEnv(config, ctx.logger);
         const registry = buildChatAdapterRegistry({
           catalog: (config.catalog ?? []) as ReadonlyArray<ChatCatalogEntry>,
-          env: process.env,
+          env: adapterEnv,
           logger: ctx.logger,
         });
         slackAdapterInstance = registry.adapters.slack ?? null;

--- a/plugins/chat/src/resolve-adapter-env.test.ts
+++ b/plugins/chat/src/resolve-adapter-env.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { resolveAdapterBuildEnv } from "./index";
-import type { ChatPluginConfig } from "./config";
+import { ChatConfigSchema, type ChatPluginConfig } from "./config";
 
 const noopLogger = {
   info: () => {},
@@ -84,5 +84,25 @@ describe("resolveAdapterBuildEnv", () => {
       throw new Error("decrypt failed");
     });
     await expect(resolveAdapterBuildEnv(cfg(boom), noopLogger)).rejects.toThrow(/decrypt failed/);
+  });
+});
+
+describe("ChatConfigSchema accepts resolveAdapterEnv", () => {
+  // Regression for the #3704 boot crash: `resolveAdapterEnv` was on the
+  // ChatPluginConfig TS interface + wired in atlas.config.ts, but missing
+  // from the `.strict()` Zod schema, so config load rejected the key and the
+  // API crashed before binding HTTP (caught only by Boot Smoke). These tests
+  // exercise the schema directly — the path the TS-typed unit tests bypass.
+  it("validates a config carrying resolveAdapterEnv", () => {
+    const result = ChatConfigSchema.safeParse({
+      executeQuery: async () => ({}),
+      resolveAdapterEnv: async () => ({ SLACK_SIGNING_SECRET: "x" }),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still validates a config omitting it (optional)", () => {
+    const result = ChatConfigSchema.safeParse({ executeQuery: async () => ({}) });
+    expect(result.success).toBe(true);
   });
 });

--- a/plugins/chat/src/resolve-adapter-env.test.ts
+++ b/plugins/chat/src/resolve-adapter-env.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the operator-credential env overlay (#3704) — the merge the chat
+ * plugin applies before building the AdapterRegistry. Precedence under test:
+ * resolver overlay (DB-backed, Admin-set) wins over `process.env`; unresolved
+ * (`undefined` / empty) overlay keys fall through to env unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { resolveAdapterBuildEnv } from "./index";
+import type { ChatPluginConfig } from "./config";
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Parameters<typeof resolveAdapterBuildEnv>[1];
+
+// Minimal config — only the fields the helper reads matter.
+function cfg(resolveAdapterEnv?: ChatPluginConfig["resolveAdapterEnv"]): ChatPluginConfig {
+  return {
+    executeQuery: (async () => ({})) as unknown as ChatPluginConfig["executeQuery"],
+    resolveAdapterEnv,
+  };
+}
+
+const ORIGINAL_ENV = { ...process.env };
+beforeEach(() => {
+  delete process.env.SLACK_SIGNING_SECRET;
+  delete process.env.SLACK_CLIENT_ID;
+});
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("resolveAdapterBuildEnv", () => {
+  it("returns process.env unchanged when no resolver is configured (self-host)", async () => {
+    process.env.SLACK_SIGNING_SECRET = "env-sign";
+    const env = await resolveAdapterBuildEnv(cfg(undefined), noopLogger);
+    expect(env).toBe(process.env);
+  });
+
+  it("overlays resolver values on top of env (DB wins)", async () => {
+    process.env.SLACK_SIGNING_SECRET = "env-sign";
+    process.env.SLACK_CLIENT_ID = "env-id";
+    const env = await resolveAdapterBuildEnv(
+      cfg(async () => ({ SLACK_SIGNING_SECRET: "db-sign" })),
+      noopLogger,
+    );
+    expect(env.SLACK_SIGNING_SECRET).toBe("db-sign"); // overridden
+    expect(env.SLACK_CLIENT_ID).toBe("env-id"); // untouched fallback
+    // The real process.env is not mutated — the helper returns a clone.
+    expect(process.env.SLACK_SIGNING_SECRET).toBe("env-sign");
+  });
+
+  it("does not clobber an env value with an undefined overlay value", async () => {
+    process.env.SLACK_SIGNING_SECRET = "env-sign";
+    const env = await resolveAdapterBuildEnv(
+      cfg(async () => ({ SLACK_SIGNING_SECRET: undefined })),
+      noopLogger,
+    );
+    expect(env.SLACK_SIGNING_SECRET).toBe("env-sign");
+  });
+
+  it("does not clobber an env value with an empty-string overlay value", async () => {
+    process.env.SLACK_SIGNING_SECRET = "env-sign";
+    const env = await resolveAdapterBuildEnv(
+      cfg(async () => ({ SLACK_SIGNING_SECRET: "" })),
+      noopLogger,
+    );
+    expect(env.SLACK_SIGNING_SECRET).toBe("env-sign");
+  });
+
+  it("supplies a value env lacks entirely (set-from-Admin-only)", async () => {
+    const env = await resolveAdapterBuildEnv(
+      cfg(async () => ({ SLACK_SIGNING_SECRET: "db-only" })),
+      noopLogger,
+    );
+    expect(env.SLACK_SIGNING_SECRET).toBe("db-only");
+  });
+
+  it("propagates a throwing resolver (fail-loud, no env-only fallback)", async () => {
+    const boom = mock(async () => {
+      throw new Error("decrypt failed");
+    });
+    await expect(resolveAdapterBuildEnv(cfg(boom), noopLogger)).rejects.toThrow(/decrypt failed/);
+  });
+});


### PR DESCRIPTION
## What & why

The **backend seam** for #3704 — operator-tier (platform) integration app credentials (Atlas's *own* app registrations). Today those are read from `process.env` at boot, so rotating a hosted region's Slack credentials needs a Railway deploy. This PR makes them storable encrypted at rest, resolvable with env as the fallback, and picked up at runtime via a rebuild seam — no redeploy. Pilot platform: **Slack**.

This is scoped to the seam only. The user-facing Admin route + web page and the precedence/authoring docs are split into **#3735**.

## What's in this PR

- **Storage** — migration `0140_operator_integration_credentials` (one row per platform, encrypted at rest via `db/secret-encryption.ts`), Drizzle schema mirror in the same commit, and an `INTEGRATION_TABLES` entry so F-47 key rotation + the F-42 residue audit cover it automatically.
- **Store + resolver + registry** — `lib/integrations/operator-credentials/`:
  - `store.ts` — encrypted save/read/delete keyed by `platform` (mirrors the ADR-0005 `credentials/store.ts` pattern).
  - `platforms.ts` — the reusable `OPERATOR_PLATFORMS` registry (Slack); adding a platform later is a one-entry change.
  - `resolver.ts` — precedence **DB row → env → unset** (`resolveOperatorAdapterEnv`, `getOperatorPlatformStatus`, `getMissingOperatorEnvForCatalogSlug`).
- **Boot guard** — `ChatAdapterEnvGuardLive` converted from env-only to a **DB-or-env** presence check. Faithful superset: collapses to the original env-only check when the slug isn't a managed operator platform or no internal DB exists (self-host stateless).
- **Runtime rebuild seam** — `ChatPluginConfig.resolveAdapterEnv` (an env-shaped overlay merged on top of `process.env`, DB wins; `undefined`/empty never clobber env) + `PluginRegistry.refresh(pluginId)` (teardown + re-initialize, reusing the captured init context). Wired in `deploy/api/atlas.config.ts`. The chat plugin re-reads credentials on every `initialize()`, so a future Admin write can `refresh("chat-interaction")` to pick up a rotation with no process restart.

Env remains the self-host fallback — behavior is unchanged until a credential row exists.

## Security

- Encrypted at rest via `encryptSecret`/`decryptSecret` (versioned AES-256-GCM); no new `db/internal.ts` passthrough call sites.
- **Operator and workspace credential tiers stay structurally isolated** — separate tables, no shared resolver, no env fallback across tiers. Pinned by `operator-credential-isolation.test.ts` (structural import-graph + behavioral overlay-projection checks).
- Decrypt/corruption failures propagate (no silent degrade to env-only).

## Tests

147 pass / 0 fail across touched files; `bun run type` green.

- operator-credentials `store` (8), `resolver` (16), `operator-credential-isolation` (4)
- `registry` incl. new `refresh` cases (43)
- `saas-guards` incl. the converted boot guard (70)
- chat `resolve-adapter-env` overlay precedence (6)

## Not in this PR (→ #3735)

Platform-admin API route, the Admin web page, the OpenAPI/docs (precedence + the remaining-platforms migration checklist + the chat-plugin↔Atlas contract `resolveAdapterEnv` note). Full `/ci` (lint/template-drift/etc.) has not been run locally — CI will run on this PR.

Refs #3704. Follow-up: #3735.
