### PR TITLE
docs: replace stale Team/Enterprise tier vocabulary with real plan names (#3486)

### DIFF
--- a/apps/docs/content/docs/architecture/entitlements.mdx
+++ b/apps/docs/content/docs/architecture/entitlements.mdx
@@ -177,7 +177,7 @@ The gate-deny log is a pino info line, not a row in the `admin_action_log` DB ta
 
 ---
 
-## Worked example: starter-plan workspace clicks Connect on a Team-tier integration
+## Worked example: starter-plan workspace clicks Connect on a business-tier integration
 
 Setup: workspace `ws_acme` is on `starter`; the operator declares a catalog row for a hypothetical `pagerduty` integration with `min_plan: "business"`.
 

--- a/apps/docs/content/docs/comparisons/thoughtspot.mdx
+++ b/apps/docs/content/docs/comparisons/thoughtspot.mdx
@@ -13,7 +13,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 |---|---|---|
 | **Category** | Open-source embeddable text-to-SQL agent + hosted SaaS | Enterprise agentic analytics platform |
 | **License** | AGPL-3.0 core, MIT client libs | Proprietary (SaaS + on-prem) |
-| **Pricing** | Self-hosted free (AGPL), Atlas Cloud starts at Team tier | Enterprise pricing (typically six-figure contracts) |
+| **Pricing** | Self-hosted free (AGPL), Atlas Cloud starts at Starter tier | Enterprise pricing (typically six-figure contracts) |
 | **Semantic layer** | YAML files (code-first, auto-generated) + web editor with autocomplete/version history + dynamic learning | TML + Spotter Semantics (governed Metrics Catalog, NL search tokens, dbt/Snowflake/Databricks integration) |
 | **AI agent** | Multi-step agent with tool use (SQL, Python, explore), Effect.ts + @effect/ai | Spotter 3 (data scientist w/ Python + forecasting), SpotterModel (semantic modeling), SpotterViz (automated dashboards), SpotterCode (IDE code generation) |
 | **Embeddable** | Script tag, React component, SDK with streaming | ThoughtSpot Embedded (SDK) |

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -39,7 +39,7 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Chat-platform reach",
     atlas:
-      "Slack-native — answers questions in opt-in channels with a reaction-first tracer, fail-closed kill switch (Enterprise tier)",
+      "Slack-native — answers questions in opt-in channels with a reaction-first tracer, fail-closed kill switch (paid plans)",
     bi: "Web app only — context-switch out of Slack",
     textToSql: "Web app only",
   },


### PR DESCRIPTION
Closes #3486.

Atlas plan tiers are `free / trial / starter / pro / business` (+ internal `locked`) per `PLAN_TIERS` in `packages/types/src/platform.ts`. "Team" is not a tier, and "Enterprise" is a feature-set label, not a plan name. This PR replaces the stale vocabulary with accurate copy.

## Changes
- **`apps/docs/content/docs/comparisons/thoughtspot.mdx`** — "Atlas Cloud starts at **Team tier**" → "**Starter tier**" (the entry paid tier).
- **`apps/docs/content/docs/architecture/entitlements.mdx`** — worked-example heading "clicks Connect on a **Team-tier** integration" → "**business-tier** integration", matching the example body's own `min_plan: "business"`.
- **`apps/www/src/components/landing/comparison.tsx`** — Slack-native kill-switch gated "(**Enterprise tier**)" → "(**paid plans**)". Verified against `billing/plans.ts`: chat integrations are available from Starter (1) / Pro (3) / Business (unlimited), so it is not an Enterprise-only feature — "paid plans" is the accurate generic label.

## Left unchanged
- **`apps/docs/content/docs/comparisons/cube.mdx:27`** — its "Enterprise tier" sits in the competitor (Cube) column, not an Atlas claim, exactly as the issue specifies.

## Verification
Re-ran `grep -rniE "team[- ]tier|enterprise tier" apps/docs/content apps/www/` — only the intentional `cube.mdx` competitor-column hit remains. Every replacement matches the actual billing plan names + ee gating; no claim is made that isn't true today (self-hosted remains free/AGPL).

Docs/copy only — no logic change.

## CI
Local gates all pass: lint, type, syncpack, template/schema/openapi/oauth/security-headers/saas-env/settings drift, test-discipline, twenty-resolver, published-symbols, railway-watch, affected tests.

https://claude.ai/code/session_01Tmxwz4kPTfyCNMECg89evm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tmxwz4kPTfyCNMECg89evm)_