### PR TITLE
Fix /use-demo atomicity: lock phases 2+3 in single transaction

### DIFF
--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -72,6 +72,14 @@ const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>> = mock(
   async () => [{ id: "default" }],
 );
+// Fake `withDemoSeedLock` (#3683): synchronously runs the seed callback with a
+// `tx.query` bound to `mockInternalQuery`, so the in-transaction phase-3 upsert
+// lands on the same spy and a throwing callback rejects (matching the real
+// rollback path) without a Postgres connection.
+const mockWithDemoSeedLock = mock(
+  (_orgId: string, fn: (tx: { query: typeof mockInternalQuery }) => Promise<unknown>): Promise<unknown> =>
+    fn({ query: mockInternalQuery }),
+);
 const mockEncryptUrl: Mock<(url: string) => string> = mock((url: string) => `encrypted:${url}`);
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -79,6 +87,12 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),
+  // The /use-demo seed (#3683) runs phases 2+3 inside `withDemoSeedLock`. The
+  // fake invokes the callback with a `tx.query` bound to `mockInternalQuery`, so
+  // the in-transaction `workspace_plugins` upsert is recorded on the same spy
+  // existing assertions read. (Real lock/transaction mechanics — BEGIN, the
+  // advisory lock, ROLLBACK — are covered in `demo-seed-lock.test.ts`.)
+  withDemoSeedLock: mockWithDemoSeedLock,
   internalExecute: () => {},
   encryptSecret: mockEncryptUrl,
   decryptSecret: (url: string) => url,
@@ -106,8 +120,8 @@ mock.module("@atlas/api/lib/semantic", () => ({
   _resetWhitelists: () => {},
 }));
 
-const mockImportFromDisk: Mock<(orgId: string, options?: { connectionId?: string; sourceDir?: string }) => Promise<{ imported: number; skipped: number; errors: unknown[]; total: number }>> = mock(
-  async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }),
+const mockImportFromDisk: Mock<(orgId: string, options?: { connectionId?: string; sourceDir?: string; exec?: unknown }) => Promise<{ imported: number; skipped: number; errors: unknown[]; total: number; dbFailures: number }>> = mock(
+  async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }),
 );
 
 mock.module("@atlas/api/lib/semantic/sync", () => ({
@@ -660,13 +674,15 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       }
       return [{ id: "__demo__" }];
     });
+    mockWithDemoSeedLock.mockClear();
+    mockWithDemoSeedLock.mockImplementation((_orgId, fn) => fn({ query: mockInternalQuery }));
     mockEncryptUrl.mockClear();
     mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
     mockRegister.mockClear();
     mockUnregister.mockClear();
     mockHas.mockImplementation(() => true);
     mockImportFromDisk.mockClear();
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
     mockSetSetting.mockClear();
     mockLogInfo.mockClear();
     mockLogWarn.mockClear();
@@ -1015,7 +1031,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(res.status).toBe(500);
     const data = await json(res);
     expect(data.error).toBe("import_failed");
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("ATOMICITY: import failure leaves no connection row committed", async () => {
@@ -1040,7 +1056,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     );
     expect(connectionInsert).toBeUndefined();
     expect(mockRegister).not.toHaveBeenCalled();
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("ATOMICITY: import returning zero imports out of N total fails before writing connection", async () => {
@@ -1052,6 +1068,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       skipped: 13,
       errors: [{ file: "users.yml", reason: "broken yaml" }],
       total: 13,
+      dbFailures: 13,
     }));
     const res = await request("/api/v1/onboarding/use-demo", {
       method: "POST",
@@ -1066,7 +1083,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeUndefined();
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("ATOMICITY: bundled YAML scan returning zero entities fails before writing connection (dharma-class)", async () => {
@@ -1087,6 +1104,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       skipped: 0,
       errors: [],
       total: 0,
+      dbFailures: 0,
     }));
     const res = await request("/api/v1/onboarding/use-demo", {
       method: "POST",
@@ -1105,7 +1123,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     // Settings/prompt seeding must NOT have run either — those are
     // post-commit decorations and shouldn't fire on a failed install.
     expect(mockSetSetting).not.toHaveBeenCalled();
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("ATOMICITY: missing bundled YAML fails before writing connection", async () => {
@@ -1138,7 +1156,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     let counter = 0;
     mockImportFromDisk.mockImplementation(async () => {
       importInvocationOrder = ++counter;
-      return { imported: 13, skipped: 0, errors: [], total: 13 };
+      return { imported: 13, skipped: 0, errors: [], total: 13, dbFailures: 0 };
     });
     const baseImpl = mockInternalQuery.getMockImplementation();
     mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
@@ -1160,7 +1178,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(importInvocationOrder).toBeLessThan(connectionInsertOrder);
 
     if (baseImpl) mockInternalQuery.mockImplementation(baseImpl);
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("PARTIAL: imported > 0 && imported < total still commits the connection (lenient contract)", async () => {
@@ -1172,6 +1190,10 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       skipped: 5,
       errors: [{ file: "broken.yml", reason: "yaml parse" }],
       total: 13,
+      // The gap here is YAML-parse skips, not DB write failures — the lenient
+      // contract still commits. A `dbFailures > 0` gap is the fatal case,
+      // covered separately (#3683).
+      dbFailures: 0,
     }));
     const res = await request("/api/v1/onboarding/use-demo", {
       method: "POST",
@@ -1186,7 +1208,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
       (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeDefined();
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5, dbFailures: 0 }));
   });
 
   it("RACE: idempotent UPSERT — ON CONFLICT DO UPDATE returns the install_id even on re-run (#2304)", async () => {
@@ -1248,7 +1270,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     });
     expect(firstRes.status).toBe(500);
 
-    mockImportFromDisk.mockImplementation(async () => ({ imported: 13, skipped: 0, errors: [], total: 13 }));
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 13, skipped: 0, errors: [], total: 13, dbFailures: 0 }));
     const secondRes = await request("/api/v1/onboarding/use-demo", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1258,6 +1280,93 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     const data = await json(secondRes);
     expect(data.connectionId).toBe("__demo__");
     expect(data.entitiesImported).toBe(13);
+  });
+
+  it("MUTUAL EXCLUSION: runs phases 2+3 inside a single per-workspace withDemoSeedLock transaction (#3683)", async () => {
+    // The seed must be serialized + atomic per workspace: the import (phase 2)
+    // and the workspace_plugins published flip (phase 3) both run inside one
+    // `withDemoSeedLock(orgId, …)` transaction. Assert the lock wraps the seed,
+    // is keyed on the caller's org, and that the entity import runs on the
+    // transaction-bound executor (not a stray pooled connection).
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+
+    expect(mockWithDemoSeedLock).toHaveBeenCalledTimes(1);
+    expect(mockWithDemoSeedLock.mock.calls[0][0]).toBe("org-1");
+
+    // importFromDisk received the transaction-bound executor so its upserts
+    // commit (or roll back) with the phase-3 flip.
+    const importCall = mockImportFromDisk.mock.calls.at(-1);
+    expect(importCall?.[1]).toMatchObject({ connectionId: "__demo__" });
+    expect(typeof importCall?.[1]?.exec).toBe("function");
+
+    // The published flip landed inside the locked section (recorded on the
+    // tx-bound spy).
+    const flip = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
+    );
+    expect(flip).toBeDefined();
+  });
+
+  it("PARTIAL SEED: a sub-total DB import (dbFailures > 0) fails the request instead of 201'ing (#3683)", async () => {
+    // The MEDIUM finding: a 7-of-13 seed where the missing rows are DB write
+    // failures used to return a clean 201. It must now hard-fail before the
+    // published flip so no half-seeded workspace is committed.
+    mockImportFromDisk.mockImplementation(async () => ({
+      imported: 7,
+      skipped: 6,
+      errors: [],
+      total: 13,
+      dbFailures: 6,
+    }));
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("import_failed");
+
+    // The published flip and the post-commit decorations never ran.
+    const flip = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
+    );
+    expect(flip).toBeUndefined();
+    expect(mockSetSetting).not.toHaveBeenCalled();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("ATOMICITY: a phase-3 published-flip failure rolls back the whole seed (#3683)", async () => {
+    // A DB error on the workspace_plugins flip (inside the locked transaction)
+    // must propagate so the transaction rolls back — the phase-2 entity import
+    // can't be left committed without the published install that makes it
+    // visible. The error surfaces as a 500, and no post-commit decoration runs.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("FROM plugin_catalog") && sql.includes("demo-postgres")) {
+        return [{ id: "cat_demo_postgres" }];
+      }
+      if (typeof sql === "string" && sql.includes("INSERT INTO workspace_plugins")) {
+        throw new Error("deadlock detected");
+      }
+      return [{ id: "__demo__" }];
+    });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("import_failed");
+    expect(data.requestId).toBeDefined();
+    // Post-commit decorations must not run on a rolled-back seed.
+    expect(mockSetSetting).not.toHaveBeenCalled();
+    expect(mockRegister).not.toHaveBeenCalled();
   });
 
   it("returns 500 with requestId when encryption fails", async () => {

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -817,9 +817,14 @@ onboarding.openapi(
             );
           }
           if (importResult.imported === 0) {
-            // Scan found entities but the first upsert failed (and rolled the
-            // batch back). A connection without entities is the exact partial
-            // state we're preventing.
+            // Defensive: unreachable on the transactional path — a first-row
+            // upsert failure re-throws out of `bulkUpsertEntities` (rolling the
+            // batch back), so `importFromDisk` never returns `imported: 0` with
+            // `total > 0` here; that case is caught by the generic rollback
+            // branch below. Kept because a connection without entities is the
+            // exact partial state we're preventing, so if the executor contract
+            // ever changes to return a 0 count instead of throwing, this still
+            // fails the seed (#3683).
             throw new DemoSeedFailure(
               "import_failed",
               "Failed to import the demo semantic layer. Retry in a moment.",
@@ -856,6 +861,7 @@ onboarding.openapi(
           }
 
           return {
+            ok: true as const,
             entitiesImported: importResult.imported,
             skipped: importResult.skipped,
           };
@@ -865,6 +871,7 @@ onboarding.openapi(
         if (err instanceof DemoSeedFailure) {
           log.error({ code: err.code, requestId, orgId }, "Demo seed aborted — transaction rolled back");
           return Effect.succeed({
+            ok: false as const,
             failure: { code: err.code, message: err.httpMessage } as const,
           });
         }
@@ -873,6 +880,7 @@ onboarding.openapi(
         // so no partial phase-2/phase-3 state is committed.
         log.error({ err: err.message, requestId, orgId, semanticDir }, "Demo seed transaction failed — rolled back");
         return Effect.succeed({
+          ok: false as const,
           failure: {
             code: "import_failed",
             message: "Failed to import the demo semantic layer. No queryable demo state was committed — retry in a moment.",
@@ -880,7 +888,7 @@ onboarding.openapi(
         });
       }));
 
-      if ("failure" in seedOutcome) {
+      if (!seedOutcome.ok) {
         return c.json({ error: seedOutcome.failure.code, message: seedOutcome.failure.message, requestId }, 500);
       }
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -22,7 +22,7 @@ import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { connections, detectDBType, resolveDatasourceUrl } from "@atlas/api/lib/db/connection";
 import { isAuthEmailDeliveryConfigured } from "@atlas/api/lib/email/delivery";
-import { hasInternalDB, internalQuery, queryEffect, encryptSecret } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, internalQuery, queryEffect, encryptSecret, withDemoSeedLock } from "@atlas/api/lib/db/internal";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { importFromDisk } from "@atlas/api/lib/semantic/sync";
@@ -625,6 +625,24 @@ onboarding.openapi(
 // POST /use-demo — connect workspace to the default datasource + import semantic layer
 // ---------------------------------------------------------------------------
 
+/**
+ * Sentinel for a /use-demo seed step that must abort the locked transaction
+ * (rolling it back) AND map to a specific HTTP error envelope. Thrown inside the
+ * {@link withDemoSeedLock} callback so the failure rolls back phases 2+3
+ * together; caught once outside, where `code` + `httpMessage` select the 500
+ * response shape. Keeps the rollback trigger and the response shape in one place
+ * (#3683).
+ */
+class DemoSeedFailure extends Error {
+  constructor(
+    readonly code: string,
+    readonly httpMessage: string,
+  ) {
+    super(httpMessage);
+    this.name = "DemoSeedFailure";
+  }
+}
+
 onboarding.openapi(
   useDemoRoute,
   async (c) => {
@@ -731,85 +749,11 @@ onboarding.openapi(
         return c.json({ error: "encryption_failed", message: "Failed to encrypt connection URL.", requestId }, 500);
       }
 
-      // ---------------------------------------------------------------
-      // Phase 2 — import demo semantic entities. Post-0096 cutover
-      // (#2744 / ADR-0007) there's no longer a pre-created
-      // `connection_groups` row to anchor the entities against; the
-      // per-workspace demo install (auto-created by `loadSavedConnections`
-      // / 0096 step 3) typically has no `config.group_id`, so the
-      // entities import with `connection_group_id = NULL` and the
-      // visibility join's `connection_group_id IS NULL` branch keeps
-      // them visible. The phase-3 connection upsert below remains the
-      // commit point that flips the demo install to `status='published'`.
-      // ---------------------------------------------------------------
-
-      const importResult = yield* Effect.tryPromise({
-        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: DEMO_CONNECTION_ID }),
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      }).pipe(Effect.catchAll((err) => {
-        log.error({ err: err.message, requestId, semanticDir }, "Demo semantic layer import failed");
-        return Effect.succeed(null);
-      }));
-
-      if (importResult === null) {
-        return c.json({
-          error: "import_failed",
-          message: "Failed to import the demo semantic layer. No queryable demo state was committed — retry in a moment.",
-          requestId,
-        }, 500);
-      }
-      if (importResult.total === 0) {
-        // Scan returned zero candidates — the bundled YAML isn't on the
-        // API container even though `getDemoSemanticDir()` resolved a path
-        // (e.g., the directory exists but is empty). This is a deploy-time
-        // misconfiguration, not user error. Older /use-demo absorbed this
-        // case silently: it set `ATLAS_DEMO_INDUSTRY`, committed the
-        // connection, and 201'd a workspace with no queryable semantic
-        // layer. Fail loudly so the install is all-or-nothing.
-        log.error(
-          { orgId, requestId, semanticDir },
-          "Demo semantic import scan returned zero entities — bundled YAML missing on this server",
-        );
-        return c.json({
-          error: "demo_not_available",
-          message: "The canonical demo semantic layer is missing on this server. Contact the platform administrator.",
-          requestId,
-        }, 500);
-      }
-      if (importResult.imported === 0) {
-        // Scan found entities but every row failed the upsert. Treat as
-        // a hard failure — a connection without entities is the exact
-        // partial state we're trying to prevent.
-        log.error(
-          { orgId, requestId, total: importResult.total, errors: importResult.errors },
-          "Demo semantic import found entities but persisted zero",
-        );
-        return c.json({
-          error: "import_failed",
-          message: "Failed to import the demo semantic layer. Retry in a moment.",
-          requestId,
-        }, 500);
-      }
-
-      const entitiesImported = importResult.imported;
-      log.info(
-        { orgId, imported: importResult.imported, skipped: importResult.skipped, requestId },
-        "Imported demo semantic layer",
-      );
-
-      // ---------------------------------------------------------------
-      // Phase 3 — commit point. Once the per-workspace demo install is
-      // flipped to `status='published'`, the entities imported in phase
-      // 2 become visible to the agent and the semantic page.
-      //
-      // Post-0096 cutover (#2744 / ADR-0007) every workspace owns its
-      // own `__demo__` install row (auto-created at boot via
-      // `loadSavedConnections` / 0096 step 3). Onboarding simply
-      // upserts the row's config + status for THIS workspace; the
-      // shared-singleton `__global__` model is gone. Workspaces that
-      // already onboarded will hit ON CONFLICT and the row is updated
-      // in place with the latest demo URL.
-      // ---------------------------------------------------------------
+      // Resolve the demo catalog row up front (a read, kept off the locked
+      // transaction). Post-0096 cutover (#2744 / ADR-0007) every workspace owns
+      // its own `__demo__` install row (auto-created at boot via
+      // `loadSavedConnections` / 0096 step 3); onboarding upserts that row's
+      // config + status for THIS workspace.
       const demoLabel = DEMO_LABEL;
       const demoCatalogRows = yield* Effect.tryPromise({
         try: () => internalQuery<{ id: string }>(
@@ -829,40 +773,129 @@ onboarding.openapi(
         description: `${demoLabel} — demo ${dbType} datasource`,
         db_type: dbType,
       });
-      const upsertResult = yield* Effect.tryPromise({
-        try: () => internalQuery<{ id: string }>(
-          `INSERT INTO workspace_plugins
-             (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at, status)
-           VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, NOW(), 'published')
-           ON CONFLICT (workspace_id, catalog_id, install_id)
-             DO UPDATE SET config = EXCLUDED.config, status = 'published', updated_at = NOW()
-           RETURNING install_id AS id`,
-          [`cn_${orgId}_${id}`, orgId, demoCatalogRows[0].id, id, demoConfigJson],
-        ),
+
+      // ---------------------------------------------------------------
+      // Phases 2+3 — atomic, mutually-exclusive seed (#3683).
+      //
+      // `withDemoSeedLock` opens ONE transaction holding a per-workspace
+      // advisory lock and hands a `tx.query` runner. Both the semantic-entity
+      // import (phase 2) and the `workspace_plugins` published flip (phase 3)
+      // run on that single connection, so:
+      //   • Atomicity — a blip / pool exhaustion / process kill between the two
+      //     phases rolls the whole seed back; draft `semantic_entities` are
+      //     never committed without the published install that makes them
+      //     visible (the orphaned-partial-demo state this fixes).
+      //   • Mutual exclusion — concurrent same-`orgId` POSTs serialize on the
+      //     advisory lock instead of interleaving `ON CONFLICT DO UPDATE`
+      //     upserts on the same rows, which deadlock → intermittent 500s.
+      //
+      // Post-0096 the per-workspace demo install typically has no
+      // `config.group_id`, so entities import with `connection_group_id = NULL`
+      // and the visibility join's `IS NULL` branch keeps them visible. A
+      // `DemoSeedFailure` thrown inside the callback rolls back and selects the
+      // HTTP envelope; any other throw (raw DB error, deadlock) rolls back too
+      // and maps to a generic `import_failed`.
+      // ---------------------------------------------------------------
+      const seedOutcome = yield* Effect.tryPromise({
+        try: () => withDemoSeedLock(orgId, async (tx) => {
+          // Phase 2 — import demo semantic entities on the transaction
+          // connection so they commit (or roll back) with phase 3.
+          const importResult = await importFromDisk(orgId, {
+            sourceDir: semanticDir,
+            connectionId: DEMO_CONNECTION_ID,
+            exec: tx.query,
+          });
+
+          if (importResult.total === 0) {
+            // Scan returned zero candidates — the bundled YAML isn't on the API
+            // container even though `getDemoSemanticDir()` resolved a path. A
+            // deploy-time misconfiguration, not user error. Fail loudly so the
+            // install stays all-or-nothing.
+            throw new DemoSeedFailure(
+              "demo_not_available",
+              "The canonical demo semantic layer is missing on this server. Contact the platform administrator.",
+            );
+          }
+          if (importResult.imported === 0) {
+            // Scan found entities but the first upsert failed (and rolled the
+            // batch back). A connection without entities is the exact partial
+            // state we're preventing.
+            throw new DemoSeedFailure(
+              "import_failed",
+              "Failed to import the demo semantic layer. Retry in a moment.",
+            );
+          }
+          if (importResult.dbFailures > 0) {
+            // Defensive: on the transactional path `bulkUpsertEntities` throws
+            // on the first failure (so `dbFailures` is 0 here), but if a future
+            // change re-enables partial tolerance this stops a partial seed from
+            // 201'ing as a clean success (#3683).
+            throw new DemoSeedFailure(
+              "import_failed",
+              "Failed to import the full demo semantic layer. Retry in a moment.",
+            );
+          }
+
+          // Phase 3 — commit point: flip THIS workspace's `__demo__` install to
+          // `status='published'`, making the phase-2 entities visible. Already
+          // onboarded workspaces hit ON CONFLICT and the row updates in place.
+          const upsertRows = await tx.query<{ id: string }>(
+            `INSERT INTO workspace_plugins
+               (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at, status)
+             VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, NOW(), 'published')
+             ON CONFLICT (workspace_id, catalog_id, install_id)
+               DO UPDATE SET config = EXCLUDED.config, status = 'published', updated_at = NOW()
+             RETURNING install_id AS id`,
+            [`cn_${orgId}_${id}`, orgId, demoCatalogRows[0].id, id, demoConfigJson],
+          );
+          if (upsertRows.length === 0) {
+            throw new DemoSeedFailure(
+              "internal_error",
+              "Demo connection write did not confirm. Retry the request — the operation is idempotent.",
+            );
+          }
+
+          return {
+            entitiesImported: importResult.imported,
+            skipped: importResult.skipped,
+          };
+        }),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
-        log.error({ err: err.message, requestId }, "Failed to persist demo connection");
-        return Effect.succeed(null);
+        if (err instanceof DemoSeedFailure) {
+          log.error({ code: err.code, requestId, orgId }, "Demo seed aborted — transaction rolled back");
+          return Effect.succeed({
+            failure: { code: err.code, message: err.httpMessage } as const,
+          });
+        }
+        // Any other throw — a raw DB error from the import or the published flip,
+        // a deadlock, pool exhaustion. The transaction has already rolled back,
+        // so no partial phase-2/phase-3 state is committed.
+        log.error({ err: err.message, requestId, orgId, semanticDir }, "Demo seed transaction failed — rolled back");
+        return Effect.succeed({
+          failure: {
+            code: "import_failed",
+            message: "Failed to import the demo semantic layer. No queryable demo state was committed — retry in a moment.",
+          } as const,
+        });
       }));
 
-      if (upsertResult === null) {
-        return c.json({ error: "internal_error", message: "Failed to save connection.", requestId }, 500);
+      if ("failure" in seedOutcome) {
+        return c.json({ error: seedOutcome.failure.code, message: seedOutcome.failure.message, requestId }, 500);
       }
-      if (upsertResult.length === 0) {
-        log.error({ connectionId: id, orgId, requestId }, "Demo connection upsert returned 0 rows");
-        return c.json({
-          error: "internal_error",
-          message: "Demo connection write may have succeeded but the database did not confirm. Retry the request — the operation is idempotent.",
-          requestId,
-        }, 500);
-      }
+
+      const entitiesImported = seedOutcome.entitiesImported;
+      log.info(
+        { orgId, imported: seedOutcome.entitiesImported, skipped: seedOutcome.skipped, requestId },
+        "Imported demo semantic layer",
+      );
 
       // Skip re-registration if the in-memory pool already has this id —
       // concurrent onboarders would otherwise needlessly drain and recreate
-      // the pool. The DB-level race (two onboarders racing to commit) is
-      // resolved by the `(workspace_id, catalog_id, install_id)` unique index
-      // backing the `ON CONFLICT DO UPDATE` above — last write wins on the same
-      // demo config, so no duplicate rows result.
+      // the pool. The DB-level race is resolved by the per-workspace advisory
+      // lock + the `(workspace_id, catalog_id, install_id)` unique index backing
+      // the `ON CONFLICT DO UPDATE` above — last write wins on the same demo
+      // config, so no duplicate rows result.
       try {
         if (!connections.has(id)) {
           connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -800,6 +800,25 @@ describe("importFromDisk", () => {
     expect(result.imported).toBe(1);
     expect(result.dbFailures).toBe(0);
   });
+
+  it("propagates (does not swallow) a bulkUpsertEntities throw on the transactional path, and still invalidates the whitelist (#3683)", async () => {
+    const orgId = testOrgId();
+    await syncEntityToDisk(orgId, "users", "entity", "table: users\n");
+
+    // On the transactional path (`exec` supplied) `bulkUpsertEntities` re-throws
+    // on the first row failure so the enclosing seed transaction rolls back —
+    // `importFromDisk` must surface that rejection rather than returning a
+    // partial `{ imported: 0, dbFailures: N }` result the caller mistakes for a
+    // tolerated partial. The `finally` whitelist invalidation must still run.
+    mockInvalidateOrgWhitelist.mockClear();
+    mockBulkUpsertEntities.mockImplementationOnce(() =>
+      Promise.reject(new Error("upsert rejected — transaction aborted")),
+    );
+
+    const exec = async <T extends Record<string, unknown>>(): Promise<T[]> => [] as T[];
+    await expect(importFromDisk(orgId, { exec })).rejects.toThrow("upsert rejected");
+    expect(mockInvalidateOrgWhitelist).toHaveBeenCalledWith(orgId);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -774,6 +774,32 @@ describe("importFromDisk", () => {
     // The mock bulkUpsertEntities doesn't check connectionId,
     // but we verify it doesn't error
   });
+
+  it("surfaces dbFailures when bulkUpsertEntities persists fewer rows than scanned (#3683)", async () => {
+    const orgId = testOrgId();
+    await syncEntityToDisk(orgId, "users", "entity", "table: users\n");
+    await syncEntityToDisk(orgId, "orders", "entity", "table: orders\n");
+    await syncEntityToDisk(orgId, "events", "entity", "table: events\n");
+
+    // The MEDIUM finding (#3683): bulkUpsertEntities swallowed per-row failures
+    // and returned only a count, so a partial DB write looked clean. Simulate
+    // the DB rejecting one of the three valid rows and assert the gap surfaces.
+    mockBulkUpsertEntities.mockImplementationOnce(() => Promise.resolve(2));
+    const result = await importFromDisk(orgId);
+
+    expect(result.imported).toBe(2);
+    expect(result.dbFailures).toBe(1); // 3 scanned, 2 persisted
+  });
+
+  it("reports dbFailures: 0 when every scanned entity persists (#3683)", async () => {
+    const orgId = testOrgId();
+    await syncEntityToDisk(orgId, "users", "entity", "table: users\n");
+
+    const result = await importFromDisk(orgId);
+
+    expect(result.imported).toBe(1);
+    expect(result.dbFailures).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/db/__tests__/demo-seed-lock.test.ts
+++ b/packages/api/src/lib/db/__tests__/demo-seed-lock.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit coverage for the lock-acquisition + transaction mechanics of
+ * `withDemoSeedLock` (#3683) against an injected fake pool — no real Postgres.
+ * Mirrors `workspace-admin-locks.test.ts` / `stripe-subscription-lock.test.ts`.
+ *
+ * Pinned mechanics — the two properties the /use-demo seed depends on:
+ *   1. Mutual exclusion — phases 2+3 run inside ONE transaction holding a
+ *      per-workspace advisory lock in the #3683 namespace keyed on the org id
+ *      (BEGIN → pg_advisory_xact_lock → callback on the locked connection →
+ *      COMMIT). Two concurrent same-org seeds serialize on this lock instead of
+ *      interleaving `ON CONFLICT DO UPDATE` upserts (which deadlock).
+ *   2. Atomicity — a throwing callback ROLLBACKs + releases the client +
+ *      re-throws, so a blip between the entity import and the published flip
+ *      can never leave half-committed seed state.
+ *
+ * Real cross-connection serialization is Postgres semantics
+ * (`pg_advisory_xact_lock` blocks until the holder commits) and is proved by the
+ * route-level wiring in `onboarding.test.ts`.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  _resetPool,
+  withDemoSeedLock,
+  type InternalPool,
+  type InternalPoolClient,
+} from "@atlas/api/lib/db/internal";
+
+interface RecordedQuery {
+  sql: string;
+  params?: unknown[];
+}
+
+/** A fake pool that records every query its single client receives. */
+function makeRecordingPool(opts: { failLock?: boolean } = {}): {
+  pool: InternalPool;
+  queries: RecordedQuery[];
+  releases: Array<Error | undefined>;
+  connects: { count: number };
+} {
+  const queries: RecordedQuery[] = [];
+  const releases: Array<Error | undefined> = [];
+  const connects = { count: 0 };
+  const client: InternalPoolClient = {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (opts.failLock && sql.includes("pg_advisory_xact_lock")) {
+        throw new Error("simulated lock acquisition failure");
+      }
+      return { rows: [] as Record<string, unknown>[] };
+    },
+    release: (err?: Error) => {
+      releases.push(err);
+    },
+  };
+  const pool: InternalPool = {
+    query: async () => ({ rows: [] as Record<string, unknown>[] }),
+    connect: async () => {
+      connects.count += 1;
+      return client;
+    },
+    end: async () => {},
+    on: () => {},
+  };
+  return { pool, queries, releases, connects };
+}
+
+function lockQueries(queries: RecordedQuery[]): RecordedQuery[] {
+  return queries.filter((q) => q.sql.includes("pg_advisory_xact_lock"));
+}
+
+describe("withDemoSeedLock — lock + transaction mechanics (#3683)", () => {
+  afterEach(() => {
+    _resetPool(null, null);
+  });
+
+  it("brackets the callback with BEGIN → advisory lock keyed on the org id → COMMIT", async () => {
+    const { pool, queries } = makeRecordingPool();
+    _resetPool(pool as unknown as InternalPool, null);
+
+    const ran: string[] = [];
+    const result = await withDemoSeedLock("org-1", async () => {
+      ran.push("callback");
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    expect(ran).toEqual(["callback"]);
+    expect(queries[0]?.sql).toBe("BEGIN");
+    const locks = lockQueries(queries);
+    expect(locks).toHaveLength(1);
+    // Distinct two-arg namespace (the issue number) + the org id.
+    expect(locks[0]?.params).toEqual([3683, "org-1"]);
+    expect(queries.at(-1)?.sql).toBe("COMMIT");
+    expect(queries.some((q) => q.sql === "ROLLBACK")).toBe(false);
+  });
+
+  it("runs the callback's writes on the locked connection, after the lock is held", async () => {
+    const { pool, queries } = makeRecordingPool();
+    _resetPool(pool as unknown as InternalPool, null);
+
+    const result = await withDemoSeedLock("org-1", async (tx) => {
+      await tx.query("INSERT INTO semantic_entities");
+      await tx.query("INSERT INTO workspace_plugins");
+      return "seeded";
+    });
+
+    expect(result).toBe("seeded");
+    const lastLockIdx = queries.findLastIndex((q) => q.sql.includes("pg_advisory_xact_lock"));
+    const entityIdx = queries.findIndex((q) => q.sql === "INSERT INTO semantic_entities");
+    const flipIdx = queries.findIndex((q) => q.sql === "INSERT INTO workspace_plugins");
+    // Both phases run after the lock and before COMMIT, in order.
+    expect(entityIdx).toBeGreaterThan(lastLockIdx);
+    expect(flipIdx).toBeGreaterThan(entityIdx);
+    expect(queries.at(-1)?.sql).toBe("COMMIT");
+  });
+
+  it("ROLLBACKs, releases the client, and re-throws when the callback throws (no partial commit)", async () => {
+    const { pool, queries, releases } = makeRecordingPool();
+    _resetPool(pool as unknown as InternalPool, null);
+
+    const boom = new Error("phase-3 published flip failed");
+    await expect(
+      withDemoSeedLock("org-1", async (tx) => {
+        await tx.query("INSERT INTO semantic_entities");
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    // The entity write happened on the connection, but the transaction rolled
+    // back — nothing is committed, so no orphaned draft entities survive.
+    expect(queries.some((q) => q.sql === "ROLLBACK")).toBe(true);
+    expect(queries.some((q) => q.sql === "COMMIT")).toBe(false);
+    // Rollback succeeded, so the client is released cleanly (no destroy arg).
+    expect(releases).toHaveLength(1);
+    expect(releases[0]).toBeUndefined();
+  });
+
+  it("propagates a lock-acquisition failure — never runs the seed unserialized", async () => {
+    const { pool, releases } = makeRecordingPool({ failLock: true });
+    _resetPool(pool as unknown as InternalPool, null);
+
+    let callbackRan = false;
+    await expect(
+      withDemoSeedLock("org-1", async () => {
+        callbackRan = true;
+      }),
+    ).rejects.toThrow("simulated lock acquisition failure");
+
+    expect(callbackRan).toBe(false);
+    expect(releases).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/db/__tests__/demo-seed-lock.test.ts
+++ b/packages/api/src/lib/db/__tests__/demo-seed-lock.test.ts
@@ -32,7 +32,7 @@ interface RecordedQuery {
 }
 
 /** A fake pool that records every query its single client receives. */
-function makeRecordingPool(opts: { failLock?: boolean } = {}): {
+function makeRecordingPool(opts: { failLock?: boolean; failRollback?: boolean } = {}): {
   pool: InternalPool;
   queries: RecordedQuery[];
   releases: Array<Error | undefined>;
@@ -46,6 +46,9 @@ function makeRecordingPool(opts: { failLock?: boolean } = {}): {
       queries.push({ sql, params });
       if (opts.failLock && sql.includes("pg_advisory_xact_lock")) {
         throw new Error("simulated lock acquisition failure");
+      }
+      if (opts.failRollback && sql === "ROLLBACK") {
+        throw new Error("simulated ROLLBACK failure — dirty socket");
       }
       return { rows: [] as Record<string, unknown>[] };
     },
@@ -134,6 +137,31 @@ describe("withDemoSeedLock — lock + transaction mechanics (#3683)", () => {
     // Rollback succeeded, so the client is released cleanly (no destroy arg).
     expect(releases).toHaveLength(1);
     expect(releases[0]).toBeUndefined();
+  });
+
+  it("destroys the client (passes the rollback error to release) when ROLLBACK itself fails — and still re-throws the original error", async () => {
+    // The poison-the-client safety path: if ROLLBACK rejects, the connection's
+    // socket is dirty and must NOT return to the pool. `withDemoSeedLock` passes
+    // the rollback error to `client.release(err)` (node-pg destroys rather than
+    // recycles), while still re-throwing the ORIGINAL callback error — the
+    // rollback failure is logged, never masks what actually went wrong.
+    const { pool, queries, releases } = makeRecordingPool({ failRollback: true });
+    _resetPool(pool as unknown as InternalPool, null);
+
+    const boom = new Error("phase-3 published flip failed");
+    await expect(
+      withDemoSeedLock("org-1", async (tx) => {
+        await tx.query("INSERT INTO semantic_entities");
+        throw boom;
+      }),
+    ).rejects.toBe(boom); // original error propagates, not the ROLLBACK failure
+
+    expect(queries.some((q) => q.sql === "ROLLBACK")).toBe(true);
+    expect(queries.some((q) => q.sql === "COMMIT")).toBe(false);
+    // Client destroyed: release got the rollback error, not undefined.
+    expect(releases).toHaveLength(1);
+    expect(releases[0]).toBeInstanceOf(Error);
+    expect(releases[0]?.message).toContain("simulated ROLLBACK failure");
   });
 
   it("propagates a lock-acquisition failure — never runs the seed unserialized", async () => {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2326,9 +2326,21 @@ export async function setWorkspaceRegion(
  */
 const LAST_ADMIN_LOCK_NAMESPACE = 3158;
 
+/**
+ * A parameterized-query runner. Structurally satisfied by {@link internalQuery}
+ * (pooled, one connection per call) and by the transaction-bound `tx.query`
+ * handed to {@link withWorkspaceAdminLock} / {@link withDemoSeedLock} callbacks.
+ * Lets a helper that normally runs on the pool be threaded onto a single
+ * transaction connection so a multi-statement sequence commits atomically.
+ */
+export type InternalQueryExecutor = <T extends Record<string, unknown>>(
+  sql: string,
+  params?: unknown[],
+) => Promise<T[]>;
+
 /** Query bound to the {@link withWorkspaceAdminLock} transaction connection. */
 export interface WorkspaceAdminLockTx {
-  query<T extends Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+  query: InternalQueryExecutor;
 }
 
 /**
@@ -2438,6 +2450,87 @@ export async function withWorkspaceAdminLock<T>(
   fn: (tx: WorkspaceAdminLockTx) => Promise<T>,
 ): Promise<T> {
   return withWorkspaceAdminLocks([orgId], fn);
+}
+
+/**
+ * Numeric namespace for the per-workspace demo-seed advisory lock — the
+ * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Distinct
+ * from the last-admin (`3158`), chat-install (`3001`), lead-outbox (`2870`) and
+ * Stripe webhook (`3445`) two-arg namespaces; pairwise distinct so a demo seed
+ * never serializes against an unrelated guard on the same workspace. Value is
+ * this guard's issue number (#3683).
+ */
+const DEMO_SEED_LOCK_NAMESPACE = 3683;
+
+/** Query bound to the {@link withDemoSeedLock} transaction connection. */
+export interface DemoSeedTx {
+  query: InternalQueryExecutor;
+}
+
+/**
+ * Run `fn` inside a single transaction holding a per-workspace advisory lock, so
+ * the `/use-demo` seed (semantic-entity import → `workspace_plugins` published
+ * flip) is BOTH mutually exclusive per workspace AND atomic (#3683).
+ *
+ * Atomicity: every write `fn` issues through `tx.query` runs on the one
+ * transaction connection, so a blip / pool exhaustion / process kill between the
+ * entity import and the published flip rolls the whole seed back — there is no
+ * window where draft `semantic_entities` are committed with no published
+ * datasource install (the orphaned-partial-demo state). Throwing anywhere in
+ * `fn` rolls back and re-throws so the caller surfaces a 5xx.
+ *
+ * Mutual exclusion: two concurrent same-`orgId` POSTs (double-click, two tabs,
+ * retry-while-pending) serialize on `pg_advisory_xact_lock(namespace,
+ * hashtext(orgId))` instead of interleaving `ON CONFLICT DO UPDATE` upserts on
+ * the same rows — which deadlock under Postgres row-lock ordering → intermittent
+ * 500s. The lock is transaction-scoped, released automatically on
+ * COMMIT/ROLLBACK. A cross-workspace `hashtext` collision only costs extra
+ * serialization, never correctness.
+ *
+ * `fn`'s writes MUST go through `tx.query` (the locked connection) to be in the
+ * transaction — a stray `internalQuery` lands on a different pooled connection,
+ * outside both the lock and the transaction. Uses the main internal pool (one
+ * dedicated connection per call) with the same manual BEGIN/COMMIT/ROLLBACK +
+ * destroy-on-failed-rollback mechanics as {@link withWorkspaceAdminLocks}; never
+ * nest another lock-holding pool checkout inside `fn` (the bounded-pool
+ * nested-checkout deadlock — see {@link withWorkspaceAdminLocks}). Caller must
+ * have already confirmed {@link hasInternalDB}.
+ */
+export async function withDemoSeedLock<T>(
+  orgId: string,
+  fn: (tx: DemoSeedTx) => Promise<T>,
+): Promise<T> {
+  const client = await getInternalDB().connect();
+  // Destroy the client on a failed ROLLBACK so a dirty socket doesn't poison
+  // the next borrower (matches withWorkspaceAdminLocks).
+  let rollbackErr: Error | null = null;
+  const tx: DemoSeedTx = {
+    query: async <R extends Record<string, unknown>>(sql: string, params?: unknown[]) => {
+      const res = await client.query(sql, params);
+      return res.rows as R[];
+    },
+  };
+  try {
+    await client.query("BEGIN");
+    await client.query("SELECT pg_advisory_xact_lock($1, hashtext($2))", [
+      DEMO_SEED_LOCK_NAMESPACE,
+      orgId,
+    ]);
+    const result = await fn(tx);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.warn(
+        { orgId, err: rollbackErr.message },
+        "ROLLBACK failed during withDemoSeedLock — client will be destroyed",
+      );
+    });
+    throw err;
+  } finally {
+    client.release(rollbackErr ?? undefined);
+  }
 }
 
 /**

--- a/packages/api/src/lib/semantic/__tests__/bulk-upsert-atomicity.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/bulk-upsert-atomicity.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit coverage for `bulkUpsertEntities`'s all-or-nothing behavior under a
+ * transaction-bound executor (#3683).
+ *
+ * The pooled default path tolerates partial imports (a bad row is logged,
+ * skipped, and counted as a failure) — wizard `/save` and the admin import rely
+ * on one bad row not sinking the good ones. But when a caller threads its own
+ * executor (the /use-demo seed, via `withDemoSeedLock`), the batch is part of
+ * that caller's transaction: a row failure has already aborted the transaction
+ * in Postgres, so it MUST propagate (rolling the whole seed back) instead of
+ * being silently counted as a partial. That is the mechanism that stops the
+ * "7-of-13 seed returns a clean 201" bug.
+ *
+ * No DB is touched: `hasInternalDB()` only reads `DATABASE_URL`, and a supplied
+ * executor means the upsert helpers never reach the pool.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { bulkUpsertEntities } from "@atlas/api/lib/semantic/entities";
+
+const rows = [
+  { entityType: "entity" as const, name: "users", yamlContent: "table: users\n", connectionId: "__demo__" },
+  { entityType: "entity" as const, name: "orders", yamlContent: "table: orders\n", connectionId: "__demo__" },
+  { entityType: "entity" as const, name: "events", yamlContent: "table: events\n", connectionId: "__demo__" },
+];
+
+describe("bulkUpsertEntities — transactional atomicity (#3683)", () => {
+  let savedDbUrl: string | undefined;
+
+  beforeEach(() => {
+    savedDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://fake:fake@localhost:5432/fake";
+  });
+
+  afterEach(() => {
+    if (savedDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedDbUrl;
+  });
+
+  it("re-throws on the first row failure under a transactional executor (no partial count)", async () => {
+    let calls = 0;
+    const exec = async <T extends Record<string, unknown>>(): Promise<T[]> => {
+      calls += 1;
+      if (calls === 2) throw new Error("upsert rejected — schema drift");
+      return [] as T[];
+    };
+
+    await expect(bulkUpsertEntities("org-1", rows, exec)).rejects.toThrow("upsert rejected");
+    // Stopped at the failing row — the third was never attempted, and no
+    // partial count leaked out for the caller to mistake for success.
+    expect(calls).toBe(2);
+  });
+
+  it("returns the full count when every row succeeds under a transactional executor", async () => {
+    let calls = 0;
+    const exec = async <T extends Record<string, unknown>>(): Promise<T[]> => {
+      calls += 1;
+      return [] as T[];
+    };
+
+    const n = await bulkUpsertEntities("org-1", rows, exec);
+    expect(n).toBe(3);
+    expect(calls).toBe(3);
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -23,7 +23,7 @@
 
 import * as fs from "fs";
 import * as yaml from "js-yaml";
-import { internalQuery, hasInternalDB } from "@atlas/api/lib/db/internal";
+import { internalQuery, hasInternalDB, type InternalQueryExecutor } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { Effect, Duration } from "effect";
 import { normalizeError, AmbiguousEntityError } from "@atlas/api/lib/effect/errors";
@@ -280,11 +280,15 @@ export async function upsertDraftEntity(
   name: string,
   yamlContent: string,
   connectionId?: string,
+  // Optional transaction-bound executor so a multi-entity import can commit
+  // atomically with its caller (the /use-demo seed, #3683). Defaults to the
+  // pooled `internalQuery` — one connection per call, the standalone path.
+  exec: InternalQueryExecutor = internalQuery,
 ): Promise<void> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
-  await internalQuery(
+  await exec(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
      VALUES ($1, $2, $3, $4, ${inlineConnectionGroupSql("$5", "$1")}, 'draft')
      ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'draft'
@@ -315,11 +319,13 @@ export async function upsertDraftEntityForGroup(
   name: string,
   yamlContent: string,
   connectionGroupId?: string | null,
+  // See {@link upsertDraftEntity} — optional transaction-bound executor (#3683).
+  exec: InternalQueryExecutor = internalQuery,
 ): Promise<void> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
-  await internalQuery(
+  await exec(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
      VALUES ($1, $2, $3, $4, $5, 'draft')
      ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'draft'
@@ -1531,21 +1537,34 @@ export async function restoreSingleConnection(
 
 /**
  * Bulk upsert entities for an org. Each entity is upserted individually —
- * failures are logged and skipped (partial imports are expected).
- * Used by the import endpoint.
+ * on the pooled default path, failures are logged and skipped (partial imports
+ * are expected). Used by the import endpoint.
  *
  * Imports stage as drafts (#2177) so the admin reviews them via the
  * pending-changes pill and publishes via `/api/v1/admin/publish`. The
  * published surface is untouched until that publish runs.
+ *
+ * Pass `exec` (a transaction-bound executor from {@link withDemoSeedLock}) to
+ * make the whole batch atomic with its caller (#3683). On that path the
+ * swallow-and-continue tolerance is OFF: the first row failure re-throws so the
+ * enclosing transaction rolls back all-or-nothing — Postgres has already aborted
+ * the transaction after the failed statement, so continuing would error every
+ * subsequent upsert anyway, with no partial commit to salvage.
  */
 export async function bulkUpsertEntities(
   orgId: string,
   entities: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
+  exec: InternalQueryExecutor = internalQuery,
 ): Promise<number> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
   if (entities.length === 0) return 0;
+
+  // A caller-supplied executor means the batch runs inside that caller's
+  // transaction — partial commits are not on the table, so a row failure must
+  // propagate rather than be counted as a skip.
+  const atomic = exec !== internalQuery;
 
   let upserted = 0;
   for (const e of entities) {
@@ -1554,9 +1573,9 @@ export async function bulkUpsertEntities(
       // carries its group directly; the flat default dir keeps resolving the
       // connection/install id through `inlineConnectionGroupSql` (#3245).
       if (e.connectionGroupId !== undefined) {
-        await upsertDraftEntityForGroup(orgId, e.entityType, e.name, e.yamlContent, e.connectionGroupId);
+        await upsertDraftEntityForGroup(orgId, e.entityType, e.name, e.yamlContent, e.connectionGroupId, exec);
       } else {
-        await upsertDraftEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId);
+        await upsertDraftEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId, exec);
       }
       upserted++;
     } catch (err) {
@@ -1568,8 +1587,9 @@ export async function bulkUpsertEntities(
       // such drift visible in any log aggregator.
       log.error(
         { orgId, entityType: e.entityType, name: e.name, err: err instanceof Error ? err.message : String(err), cause: err instanceof Error ? err.cause : undefined },
-        "Failed to upsert semantic entity — skipping",
+        atomic ? "Failed to upsert semantic entity — rolling back batch" : "Failed to upsert semantic entity — skipping",
       );
+      if (atomic) throw err;
     }
   }
   return upserted;

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -582,6 +582,16 @@ interface ImportResult {
   skipped: number;
   errors: ImportError[];
   total: number;
+  /**
+   * Entities that passed YAML validation but failed the DB upsert
+   * (`entities.length - imported`). Distinct from `skipped`, which also folds in
+   * benign YAML-parse errors and lower-precedence duplicate drops. Callers that
+   * require an all-or-nothing import (the /use-demo seed, #3683) treat
+   * `dbFailures > 0` as a hard failure instead of a clean partial. On the
+   * transactional path this is always 0 — the first failure rolls the batch
+   * back before `importFromDisk` returns.
+   */
+  dbFailures: number;
 }
 
 /**
@@ -614,7 +624,18 @@ type CollectedEntity = {
  */
 export async function importFromDisk(
   orgId: string,
-  options?: { connectionId?: string; sourceDir?: string },
+  options?: {
+    connectionId?: string;
+    sourceDir?: string;
+    /**
+     * Transaction-bound executor (from {@link withDemoSeedLock}) that threads
+     * every entity upsert onto a single transaction connection so the import
+     * commits atomically with the caller's other writes (the /use-demo seed,
+     * #3683). Omit for the standalone pooled path (admin import, auth migrate),
+     * where partial imports are tolerated and counted via `dbFailures`.
+     */
+    exec?: import("@atlas/api/lib/db/internal").InternalQueryExecutor;
+  },
 ): Promise<ImportResult> {
   const { bulkUpsertEntities } = await import("@atlas/api/lib/semantic/entities");
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
@@ -665,12 +686,15 @@ export async function importFromDisk(
   const total = entities.length + errors.length + duplicateSkips;
 
   if (entities.length === 0) {
-    return { imported: 0, skipped: errors.length + duplicateSkips, errors, total };
+    return { imported: 0, skipped: errors.length + duplicateSkips, errors, total, dbFailures: 0 };
   }
 
   let imported: number;
   try {
-    imported = await bulkUpsertEntities(orgId, entities);
+    // On the transactional path (`options.exec` set) this throws on the first
+    // row failure so the enclosing transaction rolls back — `dbFailures` below
+    // is then unreachable and always 0 on the value that does return (#3683).
+    imported = await bulkUpsertEntities(orgId, entities, options?.exec);
   } finally {
     // Always invalidate — partial writes may have occurred
     invalidateOrgWhitelist(orgId);
@@ -695,6 +719,7 @@ export async function importFromDisk(
     skipped,
     errors,
     total,
+    dbFailures,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #3683: The `/use-demo` endpoint's semantic-entity import (phase 2) and `workspace_plugins` published flip (phase 3) now run atomically inside a single transaction with a per-workspace advisory lock. This prevents the "orphaned partial demo" state where draft entities are committed without the published datasource install that makes them visible.

**The problem:** Concurrent same-workspace `/use-demo` POSTs could interleave `ON CONFLICT DO UPDATE` upserts on the same rows, causing Postgres deadlocks → intermittent 500s. Additionally, a blip between phases 2 and 3 could leave draft `semantic_entities` committed with no published install.

**The solution:**
- New `withDemoSeedLock(orgId, fn)` helper wraps phases 2+3 in a single transaction holding a per-workspace advisory lock (namespace 3683, keyed on org id)
- Both the entity import and the connection upsert run on the locked connection via `tx.query`, so they commit or roll back together
- A new `DemoSeedFailure` sentinel lets phase-2 validation errors (missing YAML, zero imports) abort the locked transaction and map to specific HTTP envelopes
- `importFromDisk` now accepts an optional `exec` parameter to thread writes onto a transaction connection; `bulkUpsertEntities` re-throws on the first failure when a transactional executor is supplied (all-or-nothing), vs. the default pooled path which tolerates partial imports

**Behavioral changes:**
- If the entity import fails (zero scanned, zero persisted, or DB write failures), the connection row is never written — the seed is all-or-nothing
- Concurrent same-workspace seeds serialize on the advisory lock instead of deadlocking
- A `dbFailures > 0` gap (entities that passed YAML but failed DB upsert) now surfaces in the result and is treated as a hard failure on the transactional path

Closes #3683

## Test Plan

- Added `demo-seed-lock.test.ts`: Unit tests for lock acquisition, transaction bracketing, atomicity (ROLLBACK on throw), and mutual exclusion mechanics against a fake pool
- Added `bulk-upsert-atomicity.test.ts`: Unit tests for `bulkUpsertEntities` re-throwing on first failure under a transactional executor
- Updated `onboarding.test.ts`: Mocked `withDemoSeedLock` to invoke the callback with `tx.query` bound to `mockInternalQuery`; updated existing atomicity tests to verify the new `dbFailures` field and confirm no partial commits on import failure
- Updated `semantic-sync.test.ts`: Added tests for `dbFailures` surfacing and the distinction between YAML-parse skips (tolerated) vs. DB write failures (fatal on transactional path)

All existing tests pass; new tests cover the lock/transaction mechanics and the all-or-nothing import contract.

## Checklist

- [x] Types pass
- [x] Tests pass (new unit tests + updated integration tests)
- [x] Lint passes
- [x] No dependency changes
- [ ] CHANGELOG.md — not a user-facing change (internal reliability fix)

https://claude.ai/code/session_01X3spLbVKQJwUK12PjxJXzh