### PR TITLE
fix(api): run core migrations before plugin init — fixes first-boot race (#3741)

### DIFF
--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -155,6 +155,23 @@ if (config.plugins?.length) {
     config: config as unknown as Record<string, unknown>,
   };
 
+  // #3741 — run CORE schema migrations before any plugin initialize(). A
+  // plugin's init can read a core table created by migrations: the chat
+  // adapter's operator-credential resolver reads `operator_integration_credentials`
+  // (migration 0140) via #3704's `resolveAdapterEnv`. The Effect Layer DAG's
+  // `MigrationLive` (in `buildAppLayer`, below) runs these migrations LATER, so
+  // without this a first-deploy boot races: plugin init hits the not-yet-created
+  // table and aborts (one-shot, no retry), taking the adapter down until a
+  // restart. `runBootMigrations` is idempotent (`_bootMigrated` guard), so
+  // `MigrationLive` (via `migrateAuthTables`) is a no-op backstop that still
+  // provides the `Migration` Tag for the boot guards. Schema-only — the
+  // settings/abuse/bootstrap steps stay in `migrateAuthTables` at their existing
+  // point in the DAG, so nothing else reorders relative to plugin wiring.
+  if (hasInternalDB()) {
+    const { runBootMigrations } = await import("@atlas/api/lib/auth/migrate");
+    await runBootMigrations();
+  }
+
   // Run plugin schema migrations before initialize()
   const pluginsWithSchema = plugins.getAll().filter((p) => p.schema != null);
   if (pluginsWithSchema.length > 0) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -5,6 +5,7 @@ import { _resetPool } from "@atlas/api/lib/db/internal";
 import { _setAuthInstance } from "@atlas/api/lib/auth/server";
 import {
   migrateAuthTables,
+  runBootMigrations,
   resetMigrationState,
   getMigrationError,
   resolveSeedAdminPassword,
@@ -581,6 +582,77 @@ describe("migrateAuthTables", () => {
 // ---------------------------------------------------------------------------
 // Seed admin password resolution (#3334 — no default credential in production)
 // ---------------------------------------------------------------------------
+
+// #3741 — schema migrations must be runnable BEFORE plugin init, separately
+// from the bootstrap/seed steps, and the two call sites must not double-run.
+describe("runBootMigrations", () => {
+  it("runs the internal schema migrations when DATABASE_URL is set", async () => {
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    await runBootMigrations();
+
+    // Versioned migration runner ran (advisory lock + baseline SQL).
+    expect(queries[0]).toContain("pg_advisory_lock");
+    expect(queries.find((q) => q.includes("CREATE TABLE IF NOT EXISTS audit_log"))).toBeDefined();
+  });
+
+  it("runs Better Auth migration before the internal migration", async () => {
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+    let authMigratedAtQueryCount = -1;
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+    const { instance } = createTrackingAuth({
+      onMigrate: () => {
+        authMigratedAtQueryCount = queries.length;
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial auth mock
+    _setAuthInstance(instance as any);
+
+    await runBootMigrations();
+
+    // Better Auth migrated before any internal-migration query landed (#1472).
+    expect(authMigratedAtQueryCount).toBe(0);
+  });
+
+  it("is idempotent — a second call runs no further queries", async () => {
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    await runBootMigrations();
+    const afterFirst = queries.length;
+    await runBootMigrations();
+
+    expect(queries.length).toBe(afterFirst);
+  });
+
+  it("makes a later migrateAuthTables() migration a no-op backstop (early-call + backstop)", async () => {
+    // Mirrors the server boot path: server.ts runs runBootMigrations() before
+    // plugin init; MigrationLive later calls migrateAuthTables(). The schema
+    // migration must run exactly once across both.
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+    const { instance, getMigrationCount } = createTrackingAuth();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial auth mock
+    _setAuthInstance(instance as any);
+
+    await runBootMigrations();
+    const afterEarlyCall = queries.length;
+    expect(afterEarlyCall).toBeGreaterThan(0);
+
+    await migrateAuthTables();
+
+    // migrateAuthTables ran its step 3/4 (settings, abuse, bootstrap/seed) but
+    // did NOT re-run the schema migration — Better Auth migrated exactly once.
+    expect(getMigrationCount()).toBe(1);
+  });
+});
 
 describe("resolveSeedAdminPassword", () => {
   const SEED_ENV_VARS = ["NODE_ENV", "ATLAS_DEPLOY_MODE"] as const;

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -21,6 +21,7 @@ import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/s
 const log = createLogger("auth-migrate");
 
 let _migrated = false;
+let _bootMigrated = false;
 let _migrationError: string | null = null;
 
 /** Return the last migration error message, or null if migrations succeeded (or haven't run). */
@@ -29,35 +30,35 @@ export function getMigrationError(): string | null {
 }
 
 /**
- * Run Better Auth table migrations (user, session, account, etc.)
- * if managed auth mode is active and DATABASE_URL is configured.
+ * Schema-only boot migrations: Better Auth tables, THEN Atlas internal
+ * migrations (#1472 ordering). Separately idempotent (`_bootMigrated`) and
+ * exported so the server entry point can run it BEFORE plugin `initialize()`
+ * (#3741).
  *
- * Safe to call multiple times — only runs once (idempotent guard).
- * Also runs the internal DB migration (audit_log table).
+ * Why early: a plugin's `initialize()` can read a core table created by these
+ * migrations — e.g. the chat adapter's operator-credential resolver reads
+ * `operator_integration_credentials` (migration 0140) via #3704's
+ * `resolveAdapterEnv`. The Effect Layer DAG's `MigrationLive` runs migrations
+ * LATER, so without an early call a first-deploy boot races: plugin init hits a
+ * not-yet-created table and aborts (one-shot, no retry). `MigrationLive` (via
+ * `migrateAuthTables`) remains the idempotent backstop that still provides the
+ * `Migration` Tag for the boot guards.
  *
- * Boot ordering (managed auth, with internal DB):
- *   1. Better Auth migrations — create `organization`, `user`, `session`, etc.
- *   2. Atlas internal DB migrations — can ALTER `organization` (e.g. 0027) now
- *      that Better Auth has created it.
- *   3. Load plugin settings, abuse state.
- *   4. Bootstrap admin, seed dev user, backfill password-change flag.
- *
- * Step 1 must precede step 2 — see #1472. In non-managed mode step 1 is
- * skipped; the Atlas migration runner independently skips org-dependent
- * files based on `detectAuthMode()`, so 0027 is not attempted without
- * Better Auth having created the table.
+ * Scope is deliberately schema-only — plugin-settings load, abuse-state
+ * restore, and admin bootstrap/seed stay in `migrateAuthTables` so their
+ * ordering relative to plugin wiring is unchanged.
  */
-export async function migrateAuthTables(): Promise<void> {
-  if (_migrated) return;
+export async function runBootMigrations(): Promise<void> {
+  if (_bootMigrated) return;
+  _bootMigrated = true;
 
   const authMode = detectAuthMode();
-  let auth: Awaited<ReturnType<typeof getAuthInstanceLazy>> | null = null;
 
   // 1. Better Auth migrations — must run BEFORE Atlas internal migrations so
   //    that Atlas's organization-table ALTERs (e.g. 0027) find the table.
   if (authMode === "managed" && hasInternalDB()) {
     try {
-      auth = await getAuthInstanceLazy();
+      const auth = await getAuthInstanceLazy();
       const ctx = await auth.$context;
       await ctx.runMigrations();
       log.info("Better Auth migration complete");
@@ -97,6 +98,38 @@ export async function migrateAuthTables(): Promise<void> {
       _migrationError = "Connected to the internal database but migration failed. Check database permissions (CREATE TABLE, CREATE INDEX).";
       // Don't block server start — audit will fall back to pino-only
     }
+  }
+}
+
+/**
+ * Full boot migration + bootstrap sequence — runs once at server boot.
+ *
+ * Safe to call multiple times — only runs once (idempotent guard). Delegates
+ * schema migration to `runBootMigrations()`; when the server entry point has
+ * already run that before plugin init (#3741), the delegated call is a no-op.
+ *
+ * Boot ordering (managed auth, with internal DB):
+ *   1. Better Auth migrations — create `organization`, `user`, `session`, etc.
+ *   2. Atlas internal DB migrations — can ALTER `organization` (e.g. 0027) now
+ *      that Better Auth has created it.   (1 + 2 via `runBootMigrations`)
+ *   3. Load plugin settings, abuse state.
+ *   4. Bootstrap admin, seed dev user, backfill password-change flag.
+ *
+ * Step 1 must precede step 2 — see #1472. In non-managed mode step 1 is
+ * skipped; the Atlas migration runner independently skips org-dependent
+ * files based on `detectAuthMode()`, so 0027 is not attempted without
+ * Better Auth having created the table.
+ */
+export async function migrateAuthTables(): Promise<void> {
+  if (_migrated) return;
+
+  // 1 + 2 — schema migrations. Idempotent: a no-op if the server entry point
+  // already ran them before plugin init (#3741).
+  await runBootMigrations();
+
+  // 3. Load post-migration DB state. Kept here (not in `runBootMigrations`) so
+  //    its ordering relative to plugin wiring is unchanged.
+  if (hasInternalDB()) {
 
     // Load plugin settings (enabled/disabled state from DB)
     try {
@@ -116,10 +149,23 @@ export async function migrateAuthTables(): Promise<void> {
     }
   }
 
-  // 4. Bootstrap + seed (managed mode only — needs Better Auth `user` table).
-  //    Each phase has its own internal try/catch; the wrappers here catch
-  //    unexpected programming errors (e.g. API surface drift) so a failure in
-  //    one phase doesn't skip the next.
+  // 4. Bootstrap + seed (managed mode only — needs the Better Auth `user`
+  //    table, created in step 1 by `runBootMigrations`). Re-acquire the auth
+  //    instance here since the schema-migration step now owns it;
+  //    `getAuthInstance` returns the same cached singleton, so this is cheap and
+  //    does NOT re-run migrations. Each phase has its own internal try/catch;
+  //    the wrappers here catch unexpected programming errors (e.g. API surface
+  //    drift) so a failure in one phase doesn't skip the next.
+  const auth =
+    detectAuthMode() === "managed" && hasInternalDB()
+      ? await getAuthInstanceLazy().catch((err) => {
+          log.error(
+            { err: err instanceof Error ? err.message : String(err) },
+            "Could not acquire auth instance for bootstrap/seed — admin bootstrap and dev seed skipped",
+          );
+          return null;
+        })
+      : null;
   if (auth) {
     try {
       await bootstrapAdminUser();
@@ -428,5 +474,6 @@ async function backfillPasswordChangeFlag(): Promise<void> {
 /** Reset migration state. For testing only. */
 export function resetMigrationState(): void {
   _migrated = false;
+  _bootMigrated = false;
   _migrationError = null;
 }

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
@@ -80,6 +80,39 @@ describe("resolveOperatorAdapterEnv", () => {
       /auth tag mismatch/,
     );
   });
+
+  // #3741 — a not-yet-migrated table (first boot before migration 0140) is
+  // benign: degrade to env-fallback instead of taking the adapter down.
+  it("tolerates a missing table (pg 42P01) and degrades to env-fallback", async () => {
+    const undefinedTable = Object.assign(
+      new Error('relation "operator_integration_credentials" does not exist'),
+      { code: "42P01" },
+    );
+    mockRead.mockRejectedValue(undefinedTable);
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
+    // No throw; empty overlay → callers fall through to env exactly as an
+    // empty table would.
+    expect(overlay).toEqual({});
+  });
+
+  it("tolerates a missing table identified by message alone (no .code)", async () => {
+    mockRead.mockRejectedValue(
+      new Error('relation "operator_integration_credentials" does not exist'),
+    );
+    const overlay = await resolveOperatorAdapterEnv(OPERATOR_PLATFORMS);
+    expect(overlay).toEqual({});
+  });
+
+  it("still propagates a decrypt failure even after the missing-table carve-out", async () => {
+    // A wrapped payload-validation error carries no 42P01 code and does not
+    // match the relation-missing message → must still rethrow.
+    mockRead.mockRejectedValue(
+      new Error("operator_integration_credentials payload validation failed for platform=slack"),
+    );
+    await expect(resolveOperatorAdapterEnv(OPERATOR_PLATFORMS)).rejects.toThrow(
+      /payload validation failed/,
+    );
+  });
 });
 
 describe("resolveOperatorFieldValue", () => {

--- a/packages/api/src/lib/integrations/operator-credentials/resolver.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/resolver.ts
@@ -100,6 +100,21 @@ export async function resolveOperatorAdapterEnv(
     try {
       bundle = (await readOperatorCredentials(spec.platform)) as Record<string, string> | null;
     } catch (err) {
+      // #3741 — a not-yet-migrated table (first boot before migration 0140
+      // applies) is benign: there are no operator rows to read yet, so fall
+      // through to the env fallback exactly as an empty table would. This stays
+      // NARROW — only Postgres `undefined_table` (SQLSTATE 42P01). The boot
+      // entry point now runs `runBootMigrations()` before plugin init so this
+      // should not trigger in practice; it is graceful-degradation defense so a
+      // future boot-ordering regression degrades to env-only rather than taking
+      // the adapter down.
+      if (isUndefinedTableError(err)) {
+        log.warn(
+          { platform: spec.platform },
+          "operator_integration_credentials not yet migrated — using env fallback for this platform (expected only on a first boot before migration 0140 applies)",
+        );
+        continue;
+      }
       // A decrypt/corruption failure must not silently drop the platform to
       // env-only (that would mask a broken rotation). Log loudly and rethrow
       // so the refresh/boot path surfaces it rather than booting degraded.
@@ -116,6 +131,22 @@ export async function resolveOperatorAdapterEnv(
     }
   }
   return overlay;
+}
+
+/**
+ * True when `err` is Postgres `undefined_table` (SQLSTATE 42P01) — the
+ * `operator_integration_credentials` table does not exist yet. Distinguishes
+ * the benign first-boot "migration 0140 hasn't applied" race (#3741) from a
+ * real read failure (decrypt/corruption), which must still propagate. Matches
+ * on the driver-stable SQLSTATE code, with a message fallback for any wrapper
+ * that drops `.code`.
+ */
+function isUndefinedTableError(err: unknown): boolean {
+  if (err && typeof err === "object" && "code" in err) {
+    if ((err as { code?: unknown }).code === "42P01") return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return /relation .* does not exist/i.test(msg);
 }
 
 /**


### PR DESCRIPTION
Fixes #3741. Follow-up structural refactor tracked in #3743.

## What happened
Cutting `v0.0.17`, prod's chat adapter went down across all three regions (`chat-interaction: "not initialized"`, overall `degraded`) while health still returned 200. Root cause from prod logs:

```
17:09:59.528  Chat plugin init FAILED: relation "operator_integration_credentials" does not exist
17:10:00.324  Applying migration 0140_operator_integration_credentials.sql   ← 0.8s LATER
17:10:00.417  Migrations complete
```

Plugin `initializeAll()` runs **imperatively in `server.ts` before** the Effect Layer DAG's `MigrationLive`. The chat adapter's operator-credential resolver (#3704) reads `operator_integration_credentials` (migration 0140) at init and — by design — **rethrows** rather than falling back to env. On the *first* boot with both the new code and the new migration, init raced ahead of the migration, threw, and aborted (one-shot, no retry). Staging never showed it (it cleared the race on an earlier boot when the table already existed). Recovered in prod by restarting the api services.

## Fix (targeted tier; see #3743 for the structural follow-up)
1. **Ordering (root cause).** Extract an idempotent `runBootMigrations()` (Better Auth → internal schema, preserving the #1472 order) from `migrateAuthTables`, and call it in `server.ts` **before** plugin init. `MigrationLive` (via `migrateAuthTables`) stays the idempotent backstop that still provides the `Migration` Tag for the boot guards. **Schema-only** — `loadPluginSettings`/abuse-restore/admin-bootstrap/dev-seed stay in `migrateAuthTables` at their existing point, so nothing reorders relative to plugin wiring (`loadPluginSettings` calls `registry.disable()`, so its timing matters — deliberately left untouched).
2. **Graceful degradation (defense).** Narrow `resolveOperatorAdapterEnv`'s rethrow: a not-yet-migrated table (pg `42P01`) degrades to env-fallback; decrypt/corruption still rethrows loudly. So a *future* ordering regression degrades to env-only instead of downing the adapter.

## Why not the structural fix now
The deeper cause is that plugin init is imperative/pre-Layer. The proper fix is to move plugin init into the DAG with a type-level `Migration` dependency (`server.ts` already imports the unused `makeWiredPluginRegistryLive` built for this) — a boot-sequence refactor that wants a staging soak, not a same-day change on the heels of an incident. Tracked as #3743.

## Tests
- `runBootMigrations`: runs internal migrations, Better-Auth-before-internal, idempotent, and an **early-call + backstop** test asserting a later `migrateAuthTables()` does not re-run the schema migration.
- resolver: `42P01` (with code + message-only) tolerated → env-fallback; a wrapped decrypt/validation error still propagates.

Local: type, lint, affected suite (55 files) green.