### PR TITLE
refactor(api): plugin init in boot DAG with type-level Migration dep (#3743)

### DIFF
--- a/docs/adr/0020-plugin-init-in-boot-dag.md
+++ b/docs/adr/0020-plugin-init-in-boot-dag.md
@@ -15,7 +15,7 @@ An audit of every plugin's `initialize()` and the boot guards confirmed the chat
 
 ## Decision
 
-**Move plugin registration/init/wiring into the boot DAG as `makeWiredPluginRegistryLive`, gated at the TYPE LEVEL on the `Migration` Tag (and `ConnectionRegistry`). The compiler now guarantees core migrations run before any plugin `initialize()` — the race is unrepresentable, not merely avoided by call placement.**
+**Move plugin registration/init/wiring into the boot DAG as `makeWiredPluginRegistryLive`, gated at the TYPE LEVEL on the `Migration` Tag (and `ConnectionRegistry`). In the production boot DAG the compiler now guarantees core migrations run before any plugin `initialize()` — the race can no longer be reintroduced by moving an imperative call. (The stdio-MCP boot and the operator-credential `refresh()` path run plugin init outside this DAG; they remain covered by the resolver's `42P01` carve-out — see Consequences.)**
 
 Concretely:
 
@@ -27,7 +27,8 @@ Concretely:
 
 ## Consequences
 
-- The #3741 boot race is **unrepresentable**: `makeWiredPluginRegistryLive` cannot be constructed without a `Migration` dependency. A compile-time test (`@ts-expect-error`) pins this.
+- The #3741 boot race cannot be reintroduced in the production boot DAG: `makeWiredPluginRegistryLive` cannot be constructed without a `Migration` dependency. A compile-time test (`@ts-expect-error`) pins the type edge.
+- **The `Migration` Tag gates on outcome, not just ordering.** The wired layer reads `migration.error`: a core migration that was *attempted and failed* (half-applied schema) **fails the Layer fatally** so the supervisor restarts and retries migrations, rather than initializing plugins against a missing table and leaning on the resolver carve-out. `migrated: false` with **no** `error` (no `DATABASE_URL` — a stateless self-host boot) is a legitimate boot and proceeds to init. This mirrors `MigrationGuardLive`'s promote-soft-failure-to-fatal stance and makes the type-level edge back a real runtime guarantee in both deploy modes.
 - The #3744 defenses are reconsidered: the early `runBootMigrations()` call is **removed** (subsumed by the type-level edge — it lived inside the retired imperative block); the resolver's **`42P01` carve-out is kept** as defense-in-depth, because the stdio-MCP boot (`plugins/mcp-boot.ts`, a separate process) and the operator-credential `refresh()` path do not go through this DAG.
 - Plugin schema-migration failure stays **fatal** (the wired layer fails the Layer → server exits), matching the prior imperative `process.exit(1)`.
 - A plugin health-check fiber now runs at boot (the wired layer's `buildPluginService`) — previously unused; this is the intended P5 behavior.

--- a/docs/adr/0020-plugin-init-in-boot-dag.md
+++ b/docs/adr/0020-plugin-init-in-boot-dag.md
@@ -1,0 +1,35 @@
+# ADR-0020: Plugin initialization moves into the Effect Layer boot DAG with a type-level Migration dependency
+
+**Status:** Accepted
+**Date:** 2026-06-17
+**Context milestone:** Performance-aware Atlas follow-up — structural fix for #3741 (tracked in #3743)
+**Depends on:** [ADR-0013](./0013-db-stored-plugin-datasource-connections.md) (DB-stored plugin datasource connections / `loadSavedConnections`)
+
+## Context
+
+Plugin lifecycle (`register → plugin-schema-migrate → initialize → wire datasources/actions/context/interactions → MCP tools → cache backend`) ran **imperatively in `server.ts` BEFORE** the Effect Layer DAG (`buildAppLayer`) that runs `MigrationLive`. A plugin's `initialize()` can read a core (migration-created) table — the chat adapter's operator-credential resolver reads `operator_integration_credentials` (migration 0140, #3704). On the *first* boot where new code and a new migration land together, plugin init raced ahead of the migration, hit a not-yet-created table, and aborted (one-shot, no retry), taking the chat adapter down across all prod regions while `/health` still returned 200. That was the #3741 incident, cutting `v0.0.17`.
+
+The targeted fix (#3744) made the race non-fatal: an early idempotent `runBootMigrations()` call in `server.ts` before plugin init, plus a `42P01` (undefined-table) carve-out in the resolver. But ordering was still enforced **by hand** — a correctly-placed imperative call. Any refactor that moved or removed that call silently reintroduced the whole race class.
+
+An audit of every plugin's `initialize()` and the boot guards confirmed the chat adapter is the only init-time core-table read; `wireDatasourcePlugins` itself is DB-free at wiring time (DB-stored connections load later in `ConnectionsHydrate`, which already gated on `Migration`).
+
+## Decision
+
+**Move plugin registration/init/wiring into the boot DAG as `makeWiredPluginRegistryLive`, gated at the TYPE LEVEL on the `Migration` Tag (and `ConnectionRegistry`). The compiler now guarantees core migrations run before any plugin `initialize()` — the race is unrepresentable, not merely avoided by call placement.**
+
+Concretely:
+
+- **`Migration` Tag moves to `services.ts`** (from `layers.ts`) so the wired plugin layer can depend on it without importing the heavyweight boot module. `MigrationLive` (the implementation) stays in `layers.ts` and is re-exported.
+- **`MigrationLive` now runs `runBootMigrations()` (schema only)**, not the full `migrateAuthTables()`. The post-schema bootstrap (`loadPluginSettings`, abuse restore, admin bootstrap, dev seed) is extracted to `runPostMigrationBootstrap()` and runs as **`AuthBootstrapLive`**, which depends on the wired plugin layer — so `loadPluginSettings`'s `registry.disable()` still runs AFTER plugin wiring, preserving the established order (wiring's `getByType` filters on `enabled`, so a DB-disabled datasource plugin stays wired-then-disabled exactly as before).
+- **New ordering edges:** `ConnectionsHydrate` now also depends on `PluginRegistry` (DB-stored datasource plugins must be registered before `loadSavedConnections` builds their pools via the global registry); `PluginConfigGuardLive` gains the same edge (it validates stored configs against the registered registry); a new `PoolWarmupLive` replaces the imperative `connections.warmup()`, running after both config and DB-stored connections register.
+- **Global singletons are wrapped, not replaced:** the wired layer registers into the global `plugins` (`createImpl: () => plugins`) and the `ConnectionRegistry` Tag binds the global `connections` (`makeConnectionRegistryLive(() => connections, { manageLifecycle: false })`). The rest of the app, `loadSavedConnections`, and the guards all read those globals, so a fresh instance would make plugin datasources invisible. `manageLifecycle: false` avoids double-forking the health fiber the global already starts in `initializeConfig` and double-running its shutdown.
+- **`server.ts`** retains only the construction of the plugin context object + tool registry (the DAG inputs) and passes them as `buildAppLayer(config, pluginWiring)`. Plugin `teardownAll()` is now the wired layer's scope finalizer (the imperative call is removed; the 10s teardown timeout now guards the whole `runtime.dispose()`).
+
+## Consequences
+
+- The #3741 boot race is **unrepresentable**: `makeWiredPluginRegistryLive` cannot be constructed without a `Migration` dependency. A compile-time test (`@ts-expect-error`) pins this.
+- The #3744 defenses are reconsidered: the early `runBootMigrations()` call is **removed** (subsumed by the type-level edge — it lived inside the retired imperative block); the resolver's **`42P01` carve-out is kept** as defense-in-depth, because the stdio-MCP boot (`plugins/mcp-boot.ts`, a separate process) and the operator-credential `refresh()` path do not go through this DAG.
+- Plugin schema-migration failure stays **fatal** (the wired layer fails the Layer → server exits), matching the prior imperative `process.exit(1)`.
+- A plugin health-check fiber now runs at boot (the wired layer's `buildPluginService`) — previously unused; this is the intended P5 behavior.
+- Pool warmup now also warms DB-hydrated connections (it runs after `ConnectionsHydrate`) — strictly more complete than the pre-#3743 imperative call.
+- **Out of scope:** `plugins/mcp-boot.ts` (stdio MCP) keeps its own lightweight init; it is a separate process, not the API boot DAG.

--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -23,26 +23,9 @@ import { initializeConfig } from "@atlas/api/lib/config";
 import { connections } from "@atlas/api/lib/db/connection";
 import { getWhitelistedTablesStrict } from "@atlas/api/lib/semantic";
 import { closeInternalDB } from "@atlas/api/lib/db/internal";
-import {
-  plugins,
-  type PluginContextLike,
-} from "@atlas/api/lib/plugins/registry";
-import {
-  wireDatasourcePlugins,
-  wireActionPlugins,
-  wireInteractionPlugins,
-  wireContextPlugins,
-} from "@atlas/api/lib/plugins/wiring";
-import {
-  wireMcpToolPlugins,
-  pluginMcpToolRegistry,
-} from "@atlas/api/lib/plugins/mcp-tools";
-import {
-  setPluginTools,
-  setContextFragments,
-  setDialectHints,
-} from "@atlas/api/lib/plugins/tools";
+import { type PluginContextLike } from "@atlas/api/lib/plugins/registry";
 import { buildAppLayer } from "@atlas/api/lib/effect/layers";
+import type { PluginWiringConfig } from "@atlas/api/lib/effect/services";
 
 const log = createLogger("server");
 
@@ -73,42 +56,27 @@ const config = await initializeConfig().catch((err) => {
   process.exit(1);
 });
 
-// Register, initialize, and wire plugins (only when config contains plugins).
+// Build the plugin-wiring INPUTS the Layer DAG needs (only when config contains
+// plugins). #3743 — registration / plugin-schema-migration / initialize / wiring
+// (datasources, actions + tool-shadow check, MCP tools, context, interactions,
+// cache backend) and the post-wiring `loadPluginSettings`/bootstrap + pool warmup
+// now ALL run INSIDE the DAG via `makeWiredPluginRegistryLive` + `AuthBootstrapLive`
+// + `PoolWarmupLive`. The wired layer depends on `Migration` (and `ConnectionRegistry`)
+// at the TYPE LEVEL, so a plugin `initialize()` can never run before core migrations
+// — the #3741 race is now unrepresentable, not just avoided by call placement.
+// This block only constructs the context object + tool registry the DAG consumes.
+let pluginWiring: PluginWiringConfig | undefined;
 if (config.plugins?.length) {
-  let registrationFailed = false;
-  for (const raw of config.plugins) {
-    try {
-      plugins.register(raw as Parameters<typeof plugins.register>[0]);
-    } catch (err) {
-      log.error(
-        { err: err instanceof Error ? err : new Error(String(err)) },
-        "Plugin registration failed",
-      );
-      registrationFailed = true;
-    }
-  }
-
-  if (registrationFailed) {
-    log.error(
-      "Aborting startup — one or more plugins failed to register. Fix your atlas.config.ts plugins array.",
-    );
-    process.exit(1);
-  }
-
-  // Build plugin context — gives plugins typed access to Atlas internals
   const { connections } = await import("@atlas/api/lib/db/connection");
-  const {
-    ToolRegistry,
-    defaultRegistry,
-    buildRegistry,
-    INTENTIONAL_TOOL_SHADOWS,
-    TOOL_SHADOW_REMEDIATIONS,
-  } = await import("@atlas/api/lib/tools/registry");
+  const { ToolRegistry } = await import("@atlas/api/lib/tools/registry");
   const { hasInternalDB, internalQuery, getInternalDB } = await import(
     "@atlas/api/lib/db/internal"
   );
   const { getLogger } = await import("@atlas/api/lib/logger");
 
+  // The plugin tool registry is shared between `context.tools.register` (plugins
+  // register tools during `initialize`) and the wired layer's action wiring +
+  // tool-shadow check — pass the SAME instance to both via `pluginWiring`.
   const pluginToolRegistry = new ToolRegistry();
 
   const pluginContext: PluginContextLike = {
@@ -155,214 +123,48 @@ if (config.plugins?.length) {
     config: config as unknown as Record<string, unknown>,
   };
 
-  // #3741 — run CORE schema migrations before any plugin initialize(). A
-  // plugin's init can read a core table created by migrations: the chat
-  // adapter's operator-credential resolver reads `operator_integration_credentials`
-  // (migration 0140) via #3704's `resolveAdapterEnv`. The Effect Layer DAG's
-  // `MigrationLive` (in `buildAppLayer`, below) runs these migrations LATER, so
-  // without this a first-deploy boot races: plugin init hits the not-yet-created
-  // table and aborts (one-shot, no retry), taking the adapter down until a
-  // restart. `runBootMigrations` is idempotent (`_bootMigrated` guard), so
-  // `MigrationLive` (via `migrateAuthTables`) is a no-op backstop that still
-  // provides the `Migration` Tag for the boot guards. Schema-only — the
-  // settings/abuse/bootstrap steps stay in `migrateAuthTables` at their existing
-  // point in the DAG, so nothing else reorders relative to plugin wiring.
-  if (hasInternalDB()) {
-    const { runBootMigrations } = await import("@atlas/api/lib/auth/migrate");
-    await runBootMigrations();
-  }
-
-  // Run plugin schema migrations before initialize()
-  const pluginsWithSchema = plugins.getAll().filter((p) => p.schema != null);
-  if (pluginsWithSchema.length > 0) {
-    if (hasInternalDB()) {
-      try {
-        const { runPluginMigrations } = await import(
-          "@atlas/api/lib/plugins/migrate"
-        );
-        const migrationResult = await runPluginMigrations(
-          getInternalDB(),
-          plugins.getAll(),
-        );
-        if (migrationResult.applied.length > 0) {
-          log.info(
-            { applied: migrationResult.applied },
-            "Plugin schema migrations applied",
-          );
-        }
-      } catch (err) {
+  pluginWiring = {
+    plugins: config.plugins as unknown as PluginWiringConfig["plugins"],
+    context: pluginContext,
+    app: app as unknown as PluginWiringConfig["app"],
+    toolRegistry: pluginToolRegistry,
+    // Plugin schema migrations — run by the wired layer BEFORE initialize() so
+    // plugins can use their tables. FATAL on failure (the wired layer fails the
+    // Layer → server exits), preserving the prior imperative `process.exit(1)`.
+    runMigrations: async (allPlugins) => {
+      const pluginsWithSchema = allPlugins.filter((p) => p.schema != null);
+      if (pluginsWithSchema.length === 0) return;
+      if (!hasInternalDB()) {
         log.error(
-          { err: err instanceof Error ? err : new Error(String(err)) },
-          "Plugin schema migration failed — aborting startup",
+          { plugins: pluginsWithSchema.map((p) => p.id) },
+          "Plugins declare schema but DATABASE_URL is not set — plugin tables will not be created",
         );
-        process.exit(1);
+        return;
       }
-    } else {
-      log.error(
-        { plugins: pluginsWithSchema.map((p) => p.id) },
-        "Plugins declare schema but DATABASE_URL is not set — plugin tables will not be created",
+      const { runPluginMigrations } = await import(
+        "@atlas/api/lib/plugins/migrate"
       );
-    }
-  }
-
-  const { succeeded, failed } = await plugins.initializeAll(pluginContext);
-  if (failed.length > 0) {
-    log.error(
-      { succeeded, failed },
-      `Plugin initialization completed with ${failed.length} failure(s)`,
-    );
-  } else {
-    log.info({ succeeded }, "All plugins initialized successfully");
-  }
-
-  const dsResult = await wireDatasourcePlugins(plugins);
-  if (dsResult.failed.length > 0) {
-    log.error(
-      { failed: dsResult.failed },
-      "Some datasource plugins failed to wire",
-    );
-  }
-  if (dsResult.entityFailures.length > 0) {
-    log.error(
-      { entityFailures: dsResult.entityFailures },
-      "Some plugin entities failed to load",
-    );
-  }
-  if (dsResult.dialectHints.length > 0) {
-    setDialectHints(dsResult.dialectHints);
-  }
-
-  const actionResult = await wireActionPlugins(plugins, pluginToolRegistry);
-  if (actionResult.failed.length > 0) {
-    log.error(
-      { failed: actionResult.failed },
-      "Some action plugins failed to wire",
-    );
-  }
-
-  if (pluginToolRegistry.size > 0) {
-    // #3326 — a plugin tool that reuses a core tool's name is silently
-    // shadowed: the chat route merges with `ToolRegistry.merge(base, plugin)`
-    // and the base (core/action) entry wins, so the plugin tool never
-    // executes. Known instance: static-url `querySalesforce` (plugin) vs the
-    // OAuth `querySalesforce` (core, gated on SALESFORCE_CLIENT_ID/SECRET) —
-    // in single-tenant self-host the OAuth tool returns `no_workspace` on
-    // every call, making static Salesforce unqueryable. The configurations
-    // are meant to be mutually exclusive, so surface the conflict loudly at
-    // boot instead of resolving it. Per-name remediation copy and the
-    // intentional-overlap allowlist live next to the registration sites in
-    // tools/registry.ts.
-    //
-    // The base mirrors what chat.ts actually merges against: the action-
-    // augmented registry when ATLAS_ACTIONS_ENABLED, else defaultRegistry —
-    // so action-tool collisions (e.g. a plugin reusing an action name) are
-    // covered too.
-    let shadowBase = defaultRegistry;
-    if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
-      try {
-        const { registry } = await buildRegistry({ includeActions: true });
-        shadowBase = registry;
-      } catch (err) {
-        // Non-fatal here — chat.ts handles (and reports) the same failure per
-        // request; the shadow check just degrades to the core-tool base.
-        log.warn(
-          { err: err instanceof Error ? err.message : String(err) },
-          "Tool-shadow check: buildRegistry failed — checking against core tools only",
-        );
-      }
-    }
-    for (const name of ToolRegistry.shadowedNames(shadowBase, pluginToolRegistry)) {
-      if (INTENTIONAL_TOOL_SHADOWS.has(name)) continue;
-      const remediation = TOOL_SHADOW_REMEDIATIONS[name];
-      log.error(
-        { tool: name },
-        `Plugin tool "${name}" is shadowed by a core tool with the same name — the core tool takes precedence and the plugin tool will never run.${remediation ? ` ${remediation}` : ""}`,
-      );
-    }
-    pluginToolRegistry.freeze();
-    setPluginTools(pluginToolRegistry);
-  }
-
-  // #2078 — collect plugin MCP tools into the global registry. The MCP
-  // server reads from the same singleton at boot via
-  // `packages/mcp/src/plugin-tools.ts`, so when the SSE / hosted MCP
-  // server runs in the same process as the Hono API the wiring is
-  // shared. Stdio MCP boots `createAtlasMcpServer` separately and does
-  // its own wiring there. Failures don't abort the API server.
-  const mcpToolResult = wireMcpToolPlugins(plugins, pluginMcpToolRegistry);
-  if (mcpToolResult.failed.length > 0) {
-    log.error(
-      { failed: mcpToolResult.failed },
-      "Some plugin MCP tools failed to register",
-    );
-  }
-  if (mcpToolResult.wired.length > 0) {
-    log.info(
-      { count: mcpToolResult.wired.length },
-      `Plugin MCP tools registered (${mcpToolResult.wired.length})`,
-    );
-  }
-
-  const ctxResult = await wireContextPlugins(plugins);
-  if (ctxResult.failed.length > 0) {
-    log.error(
-      { failed: ctxResult.failed },
-      "Some context plugins failed to load",
-    );
-  }
-  if (ctxResult.fragments.length > 0) {
-    setContextFragments(ctxResult.fragments);
-  }
-
-  const intResult = await wireInteractionPlugins(plugins, app);
-  if (intResult.failed.length > 0) {
-    log.error(
-      { failed: intResult.failed },
-      "Some interaction plugins failed to wire",
-    );
-  }
-
-  // Wire plugin cache backend if any plugin provides one
-  for (const plugin of plugins.getAll()) {
-    if (plugin.cacheBackend) {
-      try {
-        const { setCacheBackend } = await import(
-          "@atlas/api/lib/cache/index"
-        );
-        setCacheBackend(
-          plugin.cacheBackend as import("@atlas/api/lib/cache/index").CacheBackend,
-        );
+      // Spread to a mutable array — `runPluginMigrations` takes `PluginLike[]`
+      // and the wired layer hands us a `ReadonlyArray`.
+      const migrationResult = await runPluginMigrations(getInternalDB(), [...allPlugins]);
+      if (migrationResult.applied.length > 0) {
         log.info(
-          { pluginId: plugin.id },
-          "Plugin-provided cache backend registered",
-        );
-      } catch (err) {
-        log.error(
-          {
-            err: err instanceof Error ? err.message : String(err),
-            pluginId: plugin.id,
-          },
-          "Failed to wire plugin cache backend — falling back to in-memory LRU",
+          { applied: migrationResult.applied },
+          "Plugin schema migrations applied",
         );
       }
-      break;
-    }
-  }
+    },
+  };
 }
 
-// Pre-warm connection pools after all datasources (config + plugins) are registered.
-await connections.warmup().catch((err) => {
-  log.error(
-    { err: err instanceof Error ? err.message : String(err) },
-    "Pool warmup failed — datasource may be unreachable",
-  );
-});
-
 // ── Effect Layer DAG (P6) ───────────────────────────────────────────
-// Remaining startup steps (telemetry, migrations, semantic sync, settings,
-// schedulers) run as an Effect Layer DAG. Shutdown is automatic via Scope.
+// All startup steps — telemetry, CORE migrations, plugin register/init/wire,
+// connections hydrate, post-migration bootstrap, pool warmup, semantic sync,
+// settings, schedulers, boot guards — run as an Effect Layer DAG. The type-level
+// dependency edges enforce ordering (notably Migration → plugin init). Shutdown
+// is automatic via Scope finalizers (plugin teardown included).
 
-const appLayer = buildAppLayer(config);
+const appLayer = buildAppLayer(config, pluginWiring);
 const runtime = ManagedRuntime.make(appLayer);
 
 // Eagerly boot the Layer DAG — startup errors surface here, not on first request.
@@ -401,37 +203,33 @@ async function shutdown(signal: string) {
     );
   }
 
-  // Dispose the Effect runtime — tears down schedulers, telemetry via finalizers
+  // Dispose the Effect runtime — tears down schedulers, telemetry AND plugin
+  // lifecycle via finalizers. #3743 — plugin `teardownAll()` is now the wired
+  // PluginRegistry layer's scope finalizer (no longer an imperative call here).
+  // The 10s timeout that previously guarded the imperative plugin teardown now
+  // guards the whole disposal so a hung plugin teardown can't wedge shutdown.
+  const disposeTimeout = setTimeout(() => {
+    log.error(
+      "Runtime disposal (incl. plugin teardown) timed out after 10s — forcing exit",
+    );
+    process.exit(1);
+  }, 10_000);
+  disposeTimeout.unref();
   try {
     await runtime.dispose();
+    log.info("Effect runtime disposed (schedulers, plugins, telemetry torn down)");
   } catch (err) {
     log.error(
       { err: err instanceof Error ? err.message : String(err) },
       "Effect runtime disposal failed",
     );
+  } finally {
+    clearTimeout(disposeTimeout);
   }
 
-  // Teardown plugin lifecycle (still imperative pending full P5 wiring integration)
-  if (config.plugins?.length) {
-    const timeout = setTimeout(() => {
-      log.error("Plugin teardown timed out after 10s — forcing exit");
-      process.exit(1);
-    }, 10_000);
-    timeout.unref();
-    try {
-      await plugins.teardownAll();
-      log.info("Plugin teardown complete");
-    } catch (err) {
-      log.error(
-        { err: err instanceof Error ? err : new Error(String(err)) },
-        "Unexpected error during plugin teardown",
-      );
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  // Imperative singleton cleanup
+  // Imperative singleton cleanup. The global `connections` registry is
+  // lifecycle-unmanaged by the DAG (#3743 — `manageLifecycle: false`), so its
+  // shutdown stays here.
   try {
     await connections.shutdown();
   } catch (err) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -6,6 +6,7 @@ import { _setAuthInstance } from "@atlas/api/lib/auth/server";
 import {
   migrateAuthTables,
   runBootMigrations,
+  runPostMigrationBootstrap,
   resetMigrationState,
   getMigrationError,
   resolveSeedAdminPassword,
@@ -650,6 +651,43 @@ describe("runBootMigrations", () => {
 
     // migrateAuthTables ran its step 3/4 (settings, abuse, bootstrap/seed) but
     // did NOT re-run the schema migration — Better Auth migrated exactly once.
+    expect(getMigrationCount()).toBe(1);
+  });
+});
+
+describe("runPostMigrationBootstrap (#3743 split)", () => {
+  it("is idempotent — a second call runs no further queries", async () => {
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    await runPostMigrationBootstrap();
+    const afterFirst = queries.length;
+    await runPostMigrationBootstrap();
+
+    expect(queries.length).toBe(afterFirst);
+  });
+
+  it("split boot paths make a later migrateAuthTables() a full no-op (DAG parity)", async () => {
+    // Mirrors the #3743 boot DAG: `MigrationLive` runs `runBootMigrations()`
+    // (schema), `AuthBootstrapLive` runs `runPostMigrationBootstrap()`
+    // (post-schema). The composed `migrateAuthTables()` backstop must re-run
+    // NOTHING — schema migrated exactly once, no duplicate bootstrap queries.
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+    const { instance, getMigrationCount } = createTrackingAuth();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial auth mock
+    _setAuthInstance(instance as any);
+
+    await runBootMigrations();
+    await runPostMigrationBootstrap();
+    const afterSplit = queries.length;
+
+    await migrateAuthTables();
+
+    expect(queries.length).toBe(afterSplit);
     expect(getMigrationCount()).toBe(1);
   });
 });

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -22,6 +22,7 @@ const log = createLogger("auth-migrate");
 
 let _migrated = false;
 let _bootMigrated = false;
+let _bootstrapped = false;
 let _migrationError: string | null = null;
 
 /** Return the last migration error message, or null if migrations succeeded (or haven't run). */
@@ -123,12 +124,34 @@ export async function runBootMigrations(): Promise<void> {
 export async function migrateAuthTables(): Promise<void> {
   if (_migrated) return;
 
-  // 1 + 2 — schema migrations. Idempotent: a no-op if the server entry point
-  // already ran them before plugin init (#3741).
+  // 1 + 2 — schema migrations. Idempotent: a no-op if `runBootMigrations` was
+  // already run (e.g. by `MigrationLive`).
   await runBootMigrations();
 
-  // 3. Load post-migration DB state. Kept here (not in `runBootMigrations`) so
-  //    its ordering relative to plugin wiring is unchanged.
+  // 3 + 4 — post-schema bootstrap (plugin settings, abuse state, admin/seed).
+  await runPostMigrationBootstrap();
+
+  _migrated = true;
+}
+
+/**
+ * Post-schema boot bootstrap: load plugin settings, restore abuse state, then
+ * (managed mode) bootstrap the admin user, seed the dev user, and backfill the
+ * password-change flag.
+ *
+ * Split out of `migrateAuthTables` (#3743) so the boot DAG can run it as its
+ * OWN layer (`AuthBootstrapLive`) AFTER plugin wiring — `loadPluginSettings`
+ * calls `registry.disable()`, and wiring's `getByType` filters on `enabled`, so
+ * this step MUST run after plugins are registered+wired to preserve the
+ * established order. Separately idempotent (`_bootstrapped`) so the DAG layer
+ * and the composed `migrateAuthTables` (tests / non-DAG callers) never
+ * double-run it.
+ */
+export async function runPostMigrationBootstrap(): Promise<void> {
+  if (_bootstrapped) return;
+  _bootstrapped = true;
+
+  // 3. Load post-migration DB state.
   if (hasInternalDB()) {
 
     // Load plugin settings (enabled/disabled state from DB)
@@ -192,8 +215,6 @@ export async function migrateAuthTables(): Promise<void> {
       );
     }
   }
-
-  _migrated = true;
 }
 
 async function getAuthInstanceLazy() {
@@ -475,5 +496,6 @@ async function backfillPasswordChangeFlag(): Promise<void> {
 export function resetMigrationState(): void {
   _migrated = false;
   _bootMigrated = false;
+  _bootstrapped = false;
   _migrationError = null;
 }

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -30,6 +30,7 @@ import {
   type SettingsShape,
 } from "../layers";
 import { MigrationsRequiredError } from "../saas-guards";
+import { createPluginTestLayer } from "../services";
 import { createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
 import { DpaInconsistencyError } from "@atlas/api/lib/email/dpa-guard";
 
@@ -142,9 +143,12 @@ describe("ConnectionsHydrateLive", () => {
   ) {
     const layer = makeConnectionsHydrateLive(load).pipe(
       Layer.provide(
-        Layer.merge(
+        Layer.mergeAll(
           createInternalDBTestLayer({ available: gates.available }),
           makeTestMigrationLayer({ migrated: gates.migrated }),
+          // #3743 — ConnectionsHydrate now also depends on PluginRegistry as an
+          // ordering barrier (datasource plugins must be registered first).
+          createPluginTestLayer({}),
         ),
       ),
     );

--- a/packages/api/src/lib/effect/__tests__/plugin-config-guard.test.ts
+++ b/packages/api/src/lib/effect/__tests__/plugin-config-guard.test.ts
@@ -54,6 +54,7 @@ const {
   PluginConfigCheckFailedError,
 } = await import("../saas-guards");
 const { Config } = await import("../layers");
+const { createPluginTestLayer } = await import("../services");
 
 function makeTestConfigLayer(
   config: Record<string, unknown> = {},
@@ -61,6 +62,13 @@ function makeTestConfigLayer(
   return Layer.succeed(Config, {
     config: config as unknown as ConfigShape["config"],
   });
+}
+
+// #3743 — PluginConfigGuardLive now also depends on PluginRegistry (ordering
+// barrier so it validates against a registered registry). Provide an empty
+// plugin test layer alongside Config; the guard only `yield*`s the Tag.
+function guardDeps(config: Record<string, unknown> = {}) {
+  return Layer.merge(makeTestConfigLayer(config), createPluginTestLayer({}));
 }
 
 const ENV_KEYS = ["ATLAS_DEPLOY_MODE", "ATLAS_STRICT_PLUGIN_SECRETS"] as const;
@@ -115,7 +123,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),
@@ -136,7 +144,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),
@@ -159,7 +167,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),
@@ -180,7 +188,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "self-hosted" })),
+              Layer.provide(guardDeps({ deployMode: "self-hosted" })),
             ),
           ),
         ),
@@ -202,7 +210,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),
@@ -222,7 +230,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),
@@ -255,7 +263,7 @@ describe("PluginConfigGuardLive", () => {
         Effect.void.pipe(
           Effect.provide(
             PluginConfigGuardLive.pipe(
-              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+              Layer.provide(guardDeps({ deployMode: "saas" })),
             ),
           ),
         ),

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1,31 +1,35 @@
 /**
  * Effect Layer DAG for Atlas server startup.
  *
- * Replaces a subset of the sequential startup steps in server.ts
- * (telemetry, migrations, semantic sync, settings, schedulers) with
- * composable Layers. Config and plugin wiring remain imperative in
- * server.ts because they produce the config object the DAG needs.
+ * Expresses the startup steps as composable Layers. Only the plugin-wiring
+ * INPUTS (the plugin context object + tool registry) are built imperatively in
+ * server.ts and passed in as `pluginWiring` — registration / init / wiring
+ * themselves now run INSIDE the DAG (#3743).
  *
- * Layer dependency graph:
+ * Layer dependency graph (key ordering edges):
  *
  *   InternalDBLayer         (no deps — creates pg.Pool via PgClient.layerFromPool)
- *   MigrationLayer          (depends on InternalDB — pool must be ready first)
- *   ConnectionsHydrateLayer (depends on InternalDB + Migration — connections table must exist)
- *   TelemetryLayer          (no deps)
- *   ConfigLayer             (no deps — receives pre-resolved config via Layer.succeed)
- *   SemanticSyncLayer       (no deps)
- *   SettingsLayer           (no deps)
- *   SchedulerLayer          (no deps — receives config as function param)
+ *   MigrationLayer          (← InternalDB — pool ready first; SCHEMA migrations only)
+ *   ConnectionRegistryLayer (no deps — binds the GLOBAL `connections` Tag,
+ *                            lifecycle-unmanaged: `manageLifecycle: false`)
+ *   PluginRegistryLayer     (← ConnectionRegistry + Migration — the #3741
+ *                            structural fix: plugin initialize() can't run before
+ *                            core migrations. Wired variant when plugins exist;
+ *                            empty PluginRegistryLive as an ordering barrier otherwise)
+ *   ConnectionsHydrateLayer (← InternalDB + Migration + PluginRegistry — DB-stored
+ *                            datasource plugins must be registered before hydrate)
+ *   AuthBootstrapLayer      (← Migration + PluginRegistry — post-schema bootstrap
+ *                            AFTER wiring, preserving loadPluginSettings order)
+ *   PoolWarmupLayer         (← PluginRegistry + ConnectionsHydrate)
+ *   TelemetryLayer / ConfigLayer / SemanticSyncLayer / SettingsLayer / SchedulerLayer
+ *                            (independent peers)
  *
- *   AppLayer = mergeAll(Telemetry, Config, InternalDB, Migration, ConnectionsHydrate, SemanticSync, Settings, Scheduler)
+ *   AppLayer = mergeAll(... all of the above + the SaaS boot guards ...)
  *
- * Note: ConnectionLayer (P4) and PluginLayer (P5) live in services.ts
- * and are not yet part of AppLayer — they are wired imperatively in server.ts.
- *
- * Each layer wraps an imperative startup step with Effect.addFinalizer
- * for cleanup. On shutdown, Effect disposes scoped layers via their
- * finalizers. Order among independent layers is unspecified (except
- * MigrationLayer which depends on InternalDB).
+ * Each layer wraps a startup step with Effect.addFinalizer for cleanup. On
+ * shutdown, Effect disposes scoped layers via their finalizers (the wired
+ * PluginRegistry layer's finalizer runs `plugins.teardownAll()`). Order among
+ * independent layers is unspecified; the edges above are the only guarantees.
  *
  * SettingsLive and SchedulerLayer fork long-lived periodic fibers
  * (settings refresh, OAuth cleanup, rate-limit cleanup, email scheduler,
@@ -61,7 +65,18 @@ import {
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
 import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
-import { AuditPurgeScheduler, SaasCrm } from "./services";
+import {
+  AuditPurgeScheduler,
+  SaasCrm,
+  Migration,
+  type MigrationShape,
+  ConnectionRegistry,
+  PluginRegistry,
+  PluginRegistryLive,
+  makeConnectionRegistryLive,
+  makeWiredPluginRegistryLive,
+  type PluginWiringConfig,
+} from "./services";
 import {
   recoverInFlight as recoverOutboxInFlight,
   drainOutbox as drainOutboxQueue,
@@ -338,28 +353,25 @@ export const ConfigLive: Layer.Layer<Config, Error> = Layer.effect(
 // ██  Migration Layer
 // ══════════════════════════════════════════════════════════════════════
 
-export interface MigrationShape {
-  /** Whether migrations ran successfully. */
-  readonly migrated: boolean;
-  /**
-   * When `migrated === false`, the error message captured from the
-   * `Effect.catchAll` in `MigrationLive`. `MigrationGuardLive` threads
-   * this into `MigrationsRequiredError.cause` so the SaaS boot-failure
-   * log line names the actual Drizzle / pg error rather than telling
-   * the operator to "see the prior log".
-   */
-  readonly error?: string;
-}
-
-export class Migration extends Context.Tag("Migration")<
-  Migration,
-  MigrationShape
->() {}
+// The `Migration` Tag + `MigrationShape` moved to `./services` (#3743) so the
+// wired plugin layer there can depend on Migration without importing this
+// heavyweight boot module. Re-exported here so existing importers of `./layers`
+// (and `effect/index.ts`) keep working unchanged.
+export { Migration, type MigrationShape };
 
 /**
- * Run auth + internal DB migrations at boot.
- * Depends on InternalDB — ensures pool is ready before migrations run.
+ * Run CORE SCHEMA migrations at boot (Better Auth → Atlas internal, #1472
+ * order). Depends on InternalDB — ensures pool is ready before migrations run.
  * Non-fatal: logs errors but does not fail the Layer.
+ *
+ * #3743 — runs `runBootMigrations()` (schema only), NOT the full
+ * `migrateAuthTables()`. The post-schema bootstrap (loadPluginSettings, abuse
+ * restore, admin/seed) moved to `AuthBootstrapLive`, which depends on the wired
+ * plugin layer so `loadPluginSettings`'s `registry.disable()` still runs AFTER
+ * plugin wiring (preserving the established order — wiring's `getByType` filters
+ * on `enabled`). The `Migration` Tag here means "schema migrated", which is
+ * exactly what every downstream consumer (seeds, hydrate, guards, the wired
+ * plugin layer) actually gates on.
  */
 export const MigrationLive: Layer.Layer<Migration, never, InternalDB> = Layer.effect(
   Migration,
@@ -375,10 +387,10 @@ export const MigrationLive: Layer.Layer<Migration, never, InternalDB> = Layer.ef
 
     const result = yield* Effect.tryPromise({
       try: async () => {
-        const { migrateAuthTables } = await import(
+        const { runBootMigrations } = await import(
           "@atlas/api/lib/auth/migrate"
         );
-        await migrateAuthTables();
+        await runBootMigrations();
         return { migrated: true } satisfies MigrationShape;
       },
       catch: (err) => (err instanceof Error ? err.message : String(err)),
@@ -1022,13 +1034,21 @@ const defaultLoadSavedConnections = async (): Promise<number> => {
  */
 export function makeConnectionsHydrateLive(
   load: () => Promise<number> = defaultLoadSavedConnections,
-): Layer.Layer<ConnectionsHydrate, never, InternalDB | Migration> {
+): Layer.Layer<ConnectionsHydrate, never, InternalDB | Migration | PluginRegistry> {
   return Layer.effect(
     ConnectionsHydrate,
     Effect.gen(function* () {
       const start = performance.now();
       const db = yield* InternalDB;
       const migration = yield* Migration;
+      // #3743 — ordering barrier: `loadSavedConnections` builds DB-stored plugin
+      // datasource connections via `findDatasourcePluginConnection`, which reads
+      // the GLOBAL plugin registry (`plugins.getAll()`). So datasource plugins
+      // must be REGISTERED + wired before hydrate runs. In the imperative boot
+      // this held because wiring ran before `buildAppLayer`; now the wired plugin
+      // layer is part of the DAG, so this edge makes the dependency explicit. The
+      // value is unused — the dependency ordering is the point.
+      yield* PluginRegistry;
       if (!db.available || !migration.migrated) {
         const durationMs = Math.round(performance.now() - start);
         log.info(
@@ -1088,8 +1108,99 @@ export function makeConnectionsHydrateLive(
 export const ConnectionsHydrateLive: Layer.Layer<
   ConnectionsHydrate,
   never,
-  InternalDB | Migration
+  InternalDB | Migration | PluginRegistry
 > = makeConnectionsHydrateLive();
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  Auth Bootstrap Layer (#3743)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Post-schema boot bootstrap: plugin settings, abuse-state restore, admin
+ * bootstrap + dev seed (via `runPostMigrationBootstrap`).
+ *
+ * Split out of `MigrationLive` (#3743). Depends on:
+ *   - `Migration` — schema must exist before bootstrap reads/writes it.
+ *   - `PluginRegistry` (the wired plugin layer) — `loadPluginSettings` calls
+ *     `registry.disable()`, and wiring's `getByType` filters on `enabled`, so
+ *     this step MUST run AFTER plugin wiring to preserve the established order
+ *     (a DB-disabled datasource plugin stays wired-then-disabled, exactly as in
+ *     the pre-#3743 imperative boot — NOT excluded from wiring).
+ *
+ * Non-fatal: `runPostMigrationBootstrap` self-gates on `hasInternalDB()` /
+ * `detectAuthMode()` and each phase catches its own errors. A dynamic-import
+ * failure here is logged, never crashes boot.
+ */
+export const AuthBootstrapLive: Layer.Layer<
+  never,
+  never,
+  Migration | PluginRegistry
+> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    // Ordering barriers — values unused; the dependency edges are the point.
+    yield* Migration;
+    yield* PluginRegistry;
+
+    yield* Effect.tryPromise({
+      try: async () => {
+        const { runPostMigrationBootstrap } = await import(
+          "@atlas/api/lib/auth/migrate"
+        );
+        await runPostMigrationBootstrap();
+      },
+      catch: (err) => (err instanceof Error ? err.message : String(err)),
+    }).pipe(
+      Effect.catchAll((errMsg) => {
+        log.error({ err: new Error(errMsg) }, "Post-migration bootstrap failed");
+        return Effect.void;
+      }),
+    );
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  Pool Warmup Layer (#3743)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Pre-warm connection pools after all datasources are registered. Replaces the
+ * imperative `connections.warmup()` that ran in server.ts before the DAG.
+ *
+ * Depends on:
+ *   - `PluginRegistry` (wired plugin layer) — config-declared plugin datasources
+ *     registered.
+ *   - `ConnectionsHydrate` — DB-stored connections registered.
+ *
+ * Because it now runs after BOTH, warmup covers DB-hydrated connections too
+ * (the pre-#3743 imperative call ran before hydrate and warmed only config /
+ * already-registered pools) — strictly more complete. Non-fatal.
+ */
+export const PoolWarmupLive: Layer.Layer<
+  never,
+  never,
+  PluginRegistry | ConnectionsHydrate
+> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    yield* PluginRegistry;
+    yield* ConnectionsHydrate;
+
+    yield* Effect.tryPromise({
+      try: async () => {
+        const { connections } = await import("@atlas/api/lib/db/connection");
+        await connections.warmup();
+      },
+      catch: (err) => (err instanceof Error ? err.message : String(err)),
+    }).pipe(
+      Effect.catchAll((errMsg) => {
+        log.error(
+          { err: new Error(errMsg) },
+          "Pool warmup failed — datasource may be unreachable",
+        );
+        return Effect.void;
+      }),
+    );
+  }),
+);
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Staging Seed Layer (#2914 — staging slice 7)
@@ -2844,20 +2955,39 @@ export const MigrationGuardLive: Layer.Layer<never, MigrationsRequiredError, Con
 /**
  * Build the full application Layer DAG.
  *
- * Layer dependency graph:
+ * Layer dependency graph (key #3743 edges marked):
  *   InternalDB          (no deps — creates pg.Pool via PgClient.layerFromPool)
- *   MigrationLayer      (depends on InternalDB — pool must be ready first)
+ *   Migration           (← InternalDB — pool ready first; SCHEMA migrations only)
+ *   ConnectionRegistry  (no deps — binds the global `connections` Tag, lifecycle-unmanaged)
+ *   PluginRegistry      (← ConnectionRegistry + Migration — #3741 type-level edge:
+ *                        plugin initialize() can't run before core migrations)
+ *   ConnectionsHydrate  (← InternalDB + Migration + PluginRegistry — datasource
+ *                        plugins must be registered before DB-stored conns load)
+ *   AuthBootstrap       (← Migration + PluginRegistry — loadPluginSettings.disable
+ *                        AFTER wiring, preserving pre-#3743 order)
+ *   PoolWarmup          (← PluginRegistry + ConnectionsHydrate)
  *   All other layers    (independent peers)
  *
- * On shutdown, Effect disposes scoped layers via their finalizers.
- * InternalDB scope finalizer closes the pg.Pool automatically.
- * Connection and plugin shutdown is handled imperatively in server.ts.
+ * On shutdown, Effect disposes scoped layers via their finalizers. The wired
+ * PluginRegistry layer's finalizer runs `plugins.teardownAll()`. InternalDB's
+ * finalizer closes the pg.Pool. The global `connections` registry is
+ * lifecycle-unmanaged here (its health fiber starts in `initializeConfig`, its
+ * shutdown stays imperative in server.ts) — see `manageLifecycle: false` below.
+ *
+ * `pluginWiring` is provided by server.ts when `config.plugins?.length`. When
+ * absent, an empty `PluginRegistryLive` backs the Tag purely as an ordering
+ * barrier for ConnectionsHydrate / AuthBootstrap / PoolWarmup.
  */
-export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
+export function buildAppLayer(
+  config: ResolvedConfig,
+  pluginWiring?: PluginWiringConfig,
+): Layer.Layer<
   | Telemetry
   | Config
   | InternalDB
   | Migration
+  | ConnectionRegistry
+  | PluginRegistry
   | BackfillSaasTrial
   | CatalogSeed
   | BuiltinDatasourceCatalogSeed
@@ -2875,6 +3005,35 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
 
   // MigrationLive depends on InternalDB — provide it
   const migrationLayer = MigrationLive.pipe(Layer.provide(internalDBLayer));
+
+  // ConnectionRegistry Tag bound to the GLOBAL `connections` singleton (#3743).
+  // `manageLifecycle: false` — the global already runs its own health fiber
+  // (started in `initializeConfig`) and is shut down imperatively in server.ts,
+  // so this binding adds NO second fiber/finalizer; it only exposes the Tag for
+  // the wired plugin layer's type-level dependency. Lazy `require` keeps the
+  // heavyweight connection module out of layers.ts's eager import graph.
+  const connectionRegistryLayer = makeConnectionRegistryLive(
+    () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { connections } = require("@atlas/api/lib/db/connection");
+      return connections;
+    },
+    { manageLifecycle: false },
+  );
+
+  // PluginRegistry layer. When plugins are configured, the WIRED layer registers
+  // + migrates + initializes + wires them — gated at the type level on
+  // ConnectionRegistry + Migration (the #3741 structural fix). The wired layer
+  // backs the GLOBAL `plugins` singleton (the rest of the app + the hydrate
+  // bridge read the global), so pass `() => plugins`. Without configured
+  // plugins, an empty `PluginRegistryLive` backs the Tag as an ordering barrier.
+  const pluginRegistryLayer = pluginWiring
+    ? makeWiredPluginRegistryLive(pluginWiring, () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { plugins } = require("@atlas/api/lib/plugins/registry");
+        return plugins;
+      }).pipe(Layer.provide(Layer.merge(connectionRegistryLayer, migrationLayer)))
+    : PluginRegistryLive;
 
   // BackfillSaasTrialLive depends on Migration (so the `organization`
   // table is guaranteed to exist) and InternalDB. Independent peer of
@@ -2925,8 +3084,27 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     ),
   );
 
+  // ConnectionsHydrate now also depends on PluginRegistry (#3743): the wired
+  // plugin layer must register datasource plugins before `loadSavedConnections`
+  // builds DB-stored plugin datasource pools (which look the plugin up in the
+  // global registry). Same shared `pluginRegistryLayer` reference everywhere, so
+  // Effect memoization keeps the wired layer built once (one `initializeAll`).
   const connectionsHydrateLayer = ConnectionsHydrateLive.pipe(
-    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+    Layer.provide(Layer.mergeAll(internalDBLayer, migrationLayer, pluginRegistryLayer)),
+  );
+
+  // AuthBootstrap (#3743) — post-schema bootstrap (plugin settings, abuse,
+  // admin/seed) AFTER plugin wiring, preserving the pre-#3743 loadPluginSettings
+  // order. Depends on Migration + the wired PluginRegistry.
+  const authBootstrapLayer = AuthBootstrapLive.pipe(
+    Layer.provide(Layer.merge(migrationLayer, pluginRegistryLayer)),
+  );
+
+  // PoolWarmup (#3743) — replaces the imperative `connections.warmup()`. Runs
+  // after config datasources (PluginRegistry) AND DB-stored connections
+  // (ConnectionsHydrate) are registered.
+  const poolWarmupLayer = PoolWarmupLive.pipe(
+    Layer.provide(Layer.merge(pluginRegistryLayer, connectionsHydrateLayer)),
   );
 
   // StagingSeedLive (#2914) — depends on Migration (so 0093's demo-postgres
@@ -3019,7 +3197,11 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // plugin registry + InternalDB inside its Effect body so it can run as
   // a peer of migrationLayer without a static cycle.
   const regionGuardLayer = RegionGuardLive.pipe(Layer.provide(configLayer));
-  const pluginConfigGuardLayer = PluginConfigGuardLive.pipe(Layer.provide(configLayer));
+  // #3743 — PluginConfigGuardLive now carries a PluginRegistry ordering edge so
+  // it validates stored configs AFTER the wired plugin layer registers plugins.
+  const pluginConfigGuardLayer = PluginConfigGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, pluginRegistryLayer)),
+  );
   // #1988 C9 — depends on Migration so it can read its `migrated` flag.
   const migrationGuardLayer = MigrationGuardLive.pipe(
     Layer.provide(Layer.merge(configLayer, migrationLayer)),
@@ -3038,12 +3220,16 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     configLayer,
     internalDBLayer,
     migrationLayer,
+    connectionRegistryLayer,
+    pluginRegistryLayer,
     backfillSaasTrialLayer,
     catalogSeedLayer,
     builtinDatasourceCatalogSeedLayer,
     openApiDatasourceCatalogSeedLayer,
     implementationStatusOverrideLayer,
     connectionsHydrateLayer,
+    authBootstrapLayer,
+    poolWarmupLayer,
     stagingSeedLayer,
     semanticSyncLayer,
     settingsLayer,

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -87,7 +87,8 @@
 
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { Config, Migration, Settings } from "./layers";
+import { Config, Settings } from "./layers";
+import { Migration, PluginRegistry } from "./services";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const log = createLogger("effect:saas-guards");
@@ -907,9 +908,17 @@ function isStrictPluginMode(env: SaasEnv): boolean {
  * `InternalDbGuardLive` in SaaS, and self-hosted may legitimately run
  * without persisted plugin configs.
  */
-export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | PluginConfigCheckFailedError, Config> = Layer.effectDiscard(
+export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | PluginConfigCheckFailedError, Config | PluginRegistry> = Layer.effectDiscard(
   Effect.gen(function* () {
     yield* Config;
+    // #3743 — ordering barrier: this guard validates stored plugin configs
+    // against each plugin's `getConfigSchema()`, so it must run AFTER the wired
+    // plugin layer registers plugins into the global registry. In the pre-#3743
+    // imperative boot plugins were registered before `buildAppLayer`; now the
+    // wired layer is part of the DAG, so this edge prevents the guard from
+    // racing registration and validating against an empty registry. Value
+    // unused — the dependency ordering is the point.
+    yield* PluginRegistry;
     const env = readSaasEnv();
 
     // The inner async function catches every synchronous throw and the

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -28,6 +28,7 @@ import type {
   OrgPoolSettings,
 } from "@atlas/api/lib/db/connection";
 import type { PoolMetrics, OrgPoolMetrics } from "@useatlas/types";
+import type { ToolRegistry as ToolRegistryClass } from "@atlas/api/lib/tools/registry";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   PluginRegistry as PluginRegistryClass,
@@ -58,6 +59,34 @@ function makeNotAvailable(message: string): () => import("@atlas/api/lib/effect/
   };
   return () => new EnterpriseError(message);
 }
+
+// ── Migration service Tag (#3743) ────────────────────────────────────
+//
+// Defined here (not in layers.ts) so `makeWiredPluginRegistryLive` below can
+// declare a type-level dependency on it WITHOUT services.ts importing the
+// heavyweight boot module `layers.ts` (which would balloon every services.ts
+// consumer's import graph). `MigrationLive` — the implementation — stays in
+// layers.ts. The Tag means "core schema migrations completed" (the `migrated`
+// flag); plugin `initialize()` reads core tables, so the wired plugin layer
+// gates on it to make the #3741 migration race unrepresentable.
+
+export interface MigrationShape {
+  /** Whether migrations ran successfully. */
+  readonly migrated: boolean;
+  /**
+   * When `migrated === false`, the error message captured from the
+   * `Effect.catchAll` in `MigrationLive`. `MigrationGuardLive` threads
+   * this into `MigrationsRequiredError.cause` so the SaaS boot-failure
+   * log line names the actual Drizzle / pg error rather than telling
+   * the operator to "see the prior log".
+   */
+  readonly error?: string;
+}
+
+export class Migration extends Context.Tag("Migration")<
+  Migration,
+  MigrationShape
+>() {}
 
 // ── Service interface ────────────────────────────────────────────────
 
@@ -147,7 +176,16 @@ const HEALTH_CHECK_INTERVAL_MS = 60_000;
  */
 export function makeConnectionRegistryLive(
   createImpl?: () => ConnectionRegistryClass,
+  options?: { readonly manageLifecycle?: boolean },
 ): Layer.Layer<ConnectionRegistry> {
+  // `manageLifecycle: false` binds the Tag to an already-managed instance
+  // WITHOUT forking a health-check fiber or registering a shutdown finalizer.
+  // Used by `buildAppLayer` (#3743) to expose the GLOBAL `connections` singleton
+  // as the `ConnectionRegistry` Tag for the wired plugin layer's type-level
+  // dependency: the global already starts its own health fiber in
+  // `initializeConfig` (config.ts) and is shut down imperatively in server.ts,
+  // so a second fiber/finalizer here would double both.
+  const manageLifecycle = options?.manageLifecycle ?? true;
   return Layer.scoped(
     ConnectionRegistry,
     Effect.gen(function* () {
@@ -180,42 +218,44 @@ export function makeConnectionRegistryLive(
         );
       });
 
-      // Shutdown finalizer — registered BEFORE the forkScoped health
-      // fiber below. Effect scope finalizers run LIFO; `forkScoped`
-      // registers an implicit fiber-interrupt finalizer at its fork
-      // point, so this ordering guarantees the health fiber is
-      // interrupted (and `Fiber.interrupt` awaits cleanup completion)
-      // BEFORE `impl.shutdown()` tears down pools. Registered the
-      // other way around, the shutdown would race a concurrent health
-      // cycle against pools being torn down (Codex P2 on #2864).
-      yield* Effect.addFinalizer(() =>
-        Effect.gen(function* () {
-          yield* Effect.promise(() => impl.shutdown());
-          log.info("ConnectionRegistry shut down via Effect scope");
-        }),
-      );
-
-      // forkScoped, not fork — the bare `fork` API links the child fiber
-      // to the parent fiber's lifetime, and the parent here is this gen
-      // which returns the service shape immediately. With `Effect.fork`
-      // the periodic health-check never runs because the child is
-      // interrupted at gen completion (verified by repro; diagnosed in
-      // #2864 on the outbox flusher). forkScoped binds to the
-      // Layer scope, so the fiber lives until layer shutdown.
-      yield* Effect.forkScoped(
-        healthCheckAll.pipe(
-          // Catch expected failures but let defects (programming errors) crash the fiber.
-          // The inner forEach already catches individual health check failures, so this
-          // outer handler is a safety net for unexpected errors in the cycle itself.
-          Effect.catchAllCause((cause) => {
-            const msg = cause.toString();
-            log.warn({ err: msg }, "Health check cycle failed");
-            return Effect.void;
+      if (manageLifecycle) {
+        // Shutdown finalizer — registered BEFORE the forkScoped health
+        // fiber below. Effect scope finalizers run LIFO; `forkScoped`
+        // registers an implicit fiber-interrupt finalizer at its fork
+        // point, so this ordering guarantees the health fiber is
+        // interrupted (and `Fiber.interrupt` awaits cleanup completion)
+        // BEFORE `impl.shutdown()` tears down pools. Registered the
+        // other way around, the shutdown would race a concurrent health
+        // cycle against pools being torn down (Codex P2 on #2864).
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            yield* Effect.promise(() => impl.shutdown());
+            log.info("ConnectionRegistry shut down via Effect scope");
           }),
-          Effect.repeat(Schedule.spaced(Duration.millis(HEALTH_CHECK_INTERVAL_MS))),
-          Effect.asVoid,
-        ),
-      );
+        );
+
+        // forkScoped, not fork — the bare `fork` API links the child fiber
+        // to the parent fiber's lifetime, and the parent here is this gen
+        // which returns the service shape immediately. With `Effect.fork`
+        // the periodic health-check never runs because the child is
+        // interrupted at gen completion (verified by repro; diagnosed in
+        // #2864 on the outbox flusher). forkScoped binds to the
+        // Layer scope, so the fiber lives until layer shutdown.
+        yield* Effect.forkScoped(
+          healthCheckAll.pipe(
+            // Catch expected failures but let defects (programming errors) crash the fiber.
+            // The inner forEach already catches individual health check failures, so this
+            // outer handler is a safety net for unexpected errors in the cycle itself.
+            Effect.catchAllCause((cause) => {
+              const msg = cause.toString();
+              log.warn({ err: msg }, "Health check cycle failed");
+              return Effect.void;
+            }),
+            Effect.repeat(Schedule.spaced(Duration.millis(HEALTH_CHECK_INTERVAL_MS))),
+            Effect.asVoid,
+          ),
+        );
+      }
 
       // --- Build service interface ---
       const service: ConnectionRegistryShape = {
@@ -520,8 +560,13 @@ export interface PluginWiringConfig {
   readonly context: PluginContextLike;
   /** Hono app instance for mounting interaction plugin routes. */
   readonly app?: { route(path: string, subApp: unknown): void };
-  /** Tool registry for action plugin tools. */
-  readonly toolRegistry?: { register(tool: unknown): void };
+  /**
+   * Tool registry for action plugin tools. Pass the SAME instance referenced by
+   * `context.tools.register` (plugins register tools during `initialize`, and
+   * action wiring adds more), so the boot-time tool-shadow check + `freeze()` +
+   * `setPluginTools()` see the complete set.
+   */
+  readonly toolRegistry?: ToolRegistryClass;
   /** Schema migration callback (runs before initialize). */
   readonly runMigrations?: (
     allPlugins: ReadonlyArray<PluginLike>,
@@ -531,26 +576,40 @@ export interface PluginWiringConfig {
 /**
  * Create a Layer that registers, initializes, and wires plugins.
  *
- * Declares ConnectionRegistry as a dependency — the type system enforces
- * that connections must be available before plugin datasources can be wired.
- * This replaces the imperative startup sequence in server.ts with type-safe
- * Layer composition where dependency ordering is enforced at the type level.
+ * Declares ConnectionRegistry AND Migration as type-level dependencies — the
+ * compiler enforces that connections are available AND that core schema
+ * migrations have run before any plugin `initialize()`. The Migration edge is
+ * the structural fix for #3741: a plugin's `initialize()` can read a core
+ * (migration-created) table (e.g. the chat adapter's operator-credential
+ * resolver reads `operator_integration_credentials`, mig 0140), so gating plugin
+ * init on Migration at the type level makes the boot race **unrepresentable** —
+ * it can no longer be reintroduced by moving an imperative call.
  *
- * Startup sequence:
- *   register → migrate → initialize → wire datasources → wire actions →
- *   wire context → wire interactions → health check loop → teardown
+ * Startup sequence (server.ts parity):
+ *   register → plugin-schema-migrate → initialize → wire datasources (+dialect
+ *   hints) → wire actions (+tool-shadow check + setPluginTools) → wire MCP tools
+ *   → wire context (+context fragments) → wire interactions → cache backend →
+ *   health-check loop → teardown
+ *
+ * Pass the GLOBAL singletons via `createImpl` (`() => plugins`) and the
+ * ConnectionRegistry layer wrapping `() => connections` — the rest of the app
+ * (agent tools, `loadSavedConnections`, warmup, guards) reads those globals, so
+ * wiring into a fresh instance would make plugin datasources invisible.
  */
 export function makeWiredPluginRegistryLive(
   config: PluginWiringConfig,
   createImpl?: () => PluginRegistryClass,
-): Layer.Layer<PluginRegistry, never, ConnectionRegistry> {
+): Layer.Layer<PluginRegistry, Error, ConnectionRegistry | Migration> {
   return Layer.scoped(
     PluginRegistry,
     Effect.gen(function* () {
-      // Dependency: ConnectionRegistry must be provided before wiring.
-      // This is enforced at the type level — the Layer won't compile
-      // without ConnectionRegistry in the provided context.
+      // Dependencies: ConnectionRegistry must be provided before wiring, and
+      // Migration (core schema migrated) before any plugin initialize(). Both
+      // are enforced at the type level — the Layer won't compile without them
+      // in the provided context. `yield* Migration` is the load-bearing #3741
+      // edge (its value is unused; the dependency ordering is the point).
       const connRegistry = yield* ConnectionRegistry;
+      yield* Migration;
 
       const impl = yield* createPluginImpl(createImpl);
 
@@ -560,14 +619,18 @@ export function makeWiredPluginRegistryLive(
       }
 
       // --- Schema migrations (before initialize so plugins can use their tables) ---
+      // FATAL on failure (server.ts parity, #3741): a plugin whose schema
+      // didn't apply would `initialize()` against missing tables. Fail the Layer
+      // so `buildAppLayer` fails and the server exits non-zero, rather than
+      // booting a half-migrated plugin.
       if (config.runMigrations) {
         yield* Effect.tryPromise({
           try: () => config.runMigrations!(impl.getAll()),
           catch: (err) => (err instanceof Error ? err.message : String(err)),
         }).pipe(
           Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Plugin schema migrations failed");
-            return Effect.void;
+            pluginLog.error({ err: errMsg }, "Plugin schema migrations failed — aborting startup");
+            return Effect.fail(new Error(`Plugin schema migrations failed: ${errMsg}`));
           }),
         );
       }
@@ -613,15 +676,33 @@ export function makeWiredPluginRegistryLive(
       if (dsResult.failed.length > 0) {
         pluginLog.error({ failed: dsResult.failed }, "Some datasource plugins failed to wire");
       }
+      if (dsResult.entityFailures.length > 0) {
+        pluginLog.error({ entityFailures: dsResult.entityFailures }, "Some plugin entities failed to load");
+      }
+      if (dsResult.dialectHints.length > 0) {
+        yield* Effect.tryPromise({
+          try: async () => {
+            const { setDialectHints } = await import("@atlas/api/lib/plugins/tools");
+            setDialectHints(dsResult.dialectHints);
+          },
+          catch: (err) => (err instanceof Error ? err.message : String(err)),
+        }).pipe(
+          Effect.catchAll((errMsg) => {
+            pluginLog.error({ err: errMsg }, "Failed to set plugin dialect hints");
+            return Effect.void;
+          }),
+        );
+      }
 
-      // --- Wire actions ---
+      // --- Wire actions (+ tool-shadow check + setPluginTools) ---
       if (config.toolRegistry) {
+        const toolRegistry = config.toolRegistry;
         const actResult = yield* Effect.tryPromise({
           try: async () => {
             const { wireActionPlugins } = await import(
               "@atlas/api/lib/plugins/wiring"
             );
-            return wireActionPlugins(impl, config.toolRegistry as never);
+            return wireActionPlugins(impl, toolRegistry as never);
           },
           catch: (err) => (err instanceof Error ? err.message : String(err)),
         }).pipe(
@@ -633,9 +714,87 @@ export function makeWiredPluginRegistryLive(
         if (actResult.failed.length > 0) {
           pluginLog.error({ failed: actResult.failed }, "Some action plugins failed to wire");
         }
+
+        // #3326 — surface plugin tools silently shadowed by a same-named core
+        // (or action) tool, then freeze + publish the plugin tool registry.
+        // The base mirrors what chat.ts merges against: the action-augmented
+        // registry when ATLAS_ACTIONS_ENABLED, else defaultRegistry. (server.ts
+        // parity — moved verbatim into the wired layer.)
+        if (toolRegistry.size > 0) {
+          yield* Effect.tryPromise({
+            try: async () => {
+              const {
+                ToolRegistry,
+                defaultRegistry,
+                buildRegistry,
+                INTENTIONAL_TOOL_SHADOWS,
+                TOOL_SHADOW_REMEDIATIONS,
+              } = await import("@atlas/api/lib/tools/registry");
+              let shadowBase = defaultRegistry;
+              if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
+                try {
+                  const { registry } = await buildRegistry({ includeActions: true });
+                  shadowBase = registry;
+                } catch (err) {
+                  pluginLog.warn(
+                    { err: err instanceof Error ? err.message : String(err) },
+                    "Tool-shadow check: buildRegistry failed — checking against core tools only",
+                  );
+                }
+              }
+              for (const name of ToolRegistry.shadowedNames(shadowBase, toolRegistry)) {
+                if (INTENTIONAL_TOOL_SHADOWS.has(name)) continue;
+                const remediation = TOOL_SHADOW_REMEDIATIONS[name];
+                pluginLog.error(
+                  { tool: name },
+                  `Plugin tool "${name}" is shadowed by a core tool with the same name — the core tool takes precedence and the plugin tool will never run.${remediation ? ` ${remediation}` : ""}`,
+                );
+              }
+              toolRegistry.freeze();
+              const { setPluginTools } = await import("@atlas/api/lib/plugins/tools");
+              setPluginTools(toolRegistry);
+            },
+            catch: (err) => (err instanceof Error ? err.message : String(err)),
+          }).pipe(
+            Effect.catchAll((errMsg) => {
+              pluginLog.error({ err: errMsg }, "Tool-shadow check / setPluginTools failed");
+              return Effect.void;
+            }),
+          );
+        }
       }
 
-      // --- Wire context ---
+      // --- Wire MCP tools (#2078) ---
+      // Collect plugin MCP tools into the global registry the in-process SSE /
+      // hosted MCP server reads at boot. Non-fatal. (server.ts parity.)
+      const mcpToolResult = yield* Effect.tryPromise({
+        try: async () => {
+          const { wireMcpToolPlugins, pluginMcpToolRegistry } = await import(
+            "@atlas/api/lib/plugins/mcp-tools"
+          );
+          return wireMcpToolPlugins(impl, pluginMcpToolRegistry);
+        },
+        catch: (err) => (err instanceof Error ? err.message : String(err)),
+      }).pipe(
+        Effect.catchAll((errMsg) => {
+          pluginLog.error({ err: errMsg }, "Plugin MCP tool wiring failed entirely");
+          return Effect.succeed({
+            wired: [] as Array<{ pluginId: string; qualifiedName: string }>,
+            failed: [] as Array<{ pluginId: string; tool?: string; error: string }>,
+          });
+        }),
+      );
+      if (mcpToolResult.failed.length > 0) {
+        pluginLog.error({ failed: mcpToolResult.failed }, "Some plugin MCP tools failed to register");
+      }
+      if (mcpToolResult.wired.length > 0) {
+        pluginLog.info(
+          { count: mcpToolResult.wired.length },
+          `Plugin MCP tools registered (${mcpToolResult.wired.length})`,
+        );
+      }
+
+      // --- Wire context (+ context fragments) ---
       const ctxResult = yield* Effect.tryPromise({
         try: async () => {
           const { wireContextPlugins } = await import(
@@ -652,6 +811,20 @@ export function makeWiredPluginRegistryLive(
       );
       if (ctxResult.failed.length > 0) {
         pluginLog.error({ failed: ctxResult.failed }, "Some context plugins failed to load");
+      }
+      if (ctxResult.fragments.length > 0) {
+        yield* Effect.tryPromise({
+          try: async () => {
+            const { setContextFragments } = await import("@atlas/api/lib/plugins/tools");
+            setContextFragments(ctxResult.fragments);
+          },
+          catch: (err) => (err instanceof Error ? err.message : String(err)),
+        }).pipe(
+          Effect.catchAll((errMsg) => {
+            pluginLog.error({ err: errMsg }, "Failed to set plugin context fragments");
+            return Effect.void;
+          }),
+        );
       }
 
       // --- Wire interaction routes ---
@@ -674,6 +847,32 @@ export function makeWiredPluginRegistryLive(
           pluginLog.error({ failed: intResult.failed }, "Some interaction plugins failed to wire");
         }
       }
+
+      // --- Wire plugin cache backend (first plugin that provides one) ---
+      // server.ts parity. Non-fatal: a failure falls back to the in-memory LRU.
+      yield* Effect.tryPromise({
+        try: async () => {
+          for (const plugin of impl.getAll()) {
+            if (plugin.cacheBackend) {
+              const { setCacheBackend } = await import("@atlas/api/lib/cache/index");
+              setCacheBackend(
+                plugin.cacheBackend as import("@atlas/api/lib/cache/index").CacheBackend,
+              );
+              pluginLog.info({ pluginId: plugin.id }, "Plugin-provided cache backend registered");
+              break;
+            }
+          }
+        },
+        catch: (err) => (err instanceof Error ? err.message : String(err)),
+      }).pipe(
+        Effect.catchAll((errMsg) => {
+          pluginLog.error(
+            { err: errMsg },
+            "Failed to wire plugin cache backend — falling back to in-memory LRU",
+          );
+          return Effect.void;
+        }),
+      );
 
       return yield* buildPluginService(impl);
     }),

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -607,15 +607,56 @@ export function makeWiredPluginRegistryLive(
       // Migration (core schema migrated) before any plugin initialize(). Both
       // are enforced at the type level — the Layer won't compile without them
       // in the provided context. `yield* Migration` is the load-bearing #3741
-      // edge (its value is unused; the dependency ordering is the point).
+      // edge: it both orders plugin init after core migrations AND gates on the
+      // outcome below.
       const connRegistry = yield* ConnectionRegistry;
-      yield* Migration;
+      const migration = yield* Migration;
+
+      // #3741 outcome gate: if core migrations were ATTEMPTED and FAILED
+      // (`error` set), the core schema is half-applied. A plugin `initialize()`
+      // that reads a migration-created table (e.g. the chat adapter's
+      // operator-credential resolver reads `operator_integration_credentials`,
+      // mig 0140) would run against a missing/partial table. Fail the Layer so
+      // boot aborts and the supervisor restarts (retrying migrations) rather
+      // than initializing plugins against a broken schema and relying on the
+      // resolver's `42P01` carve-out. `migrated: false` with NO `error` means
+      // "no DATABASE_URL" — a legitimate stateless self-host boot — so we gate
+      // on an actual migration failure, not on the bare `migrated` flag. This
+      // mirrors `MigrationGuardLive`'s promote-soft-failure-to-fatal stance.
+      if (migration.error !== undefined) {
+        pluginLog.error(
+          { err: migration.error },
+          "Core schema migrations failed — refusing to initialize plugins against a half-migrated database; aborting startup",
+        );
+        return yield* Effect.fail(
+          new Error(`Core schema migrations failed; plugin init aborted: ${migration.error}`),
+        );
+      }
 
       const impl = yield* createPluginImpl(createImpl);
 
       // --- Registration ---
+      // Aggregate failures (server.ts parity): register every plugin so a
+      // misconfigured `atlas.config.ts` surfaces ALL bad IDs in one boot, then
+      // fail the Layer with the actionable remediation message — rather than
+      // letting the first `register()` throw escape as an opaque Layer defect.
+      const registrationFailures: string[] = [];
       for (const plugin of config.plugins) {
-        impl.register(plugin);
+        try {
+          impl.register(plugin);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          pluginLog.error({ err: msg }, "Plugin registration failed");
+          registrationFailures.push(msg);
+        }
+      }
+      if (registrationFailures.length > 0) {
+        return yield* Effect.fail(
+          new Error(
+            `Aborting startup — ${registrationFailures.length} plugin(s) failed to register. ` +
+              `Fix your atlas.config.ts plugins array. Failures: ${registrationFailures.join("; ")}`,
+          ),
+        );
       }
 
       // --- Schema migrations (before initialize so plugins can use their tables) ---

--- a/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { Effect, Layer, Exit } from "effect";
+import { Effect, Layer, Exit, Cause } from "effect";
 import {
   PluginRegistry,
   Migration,
@@ -29,6 +29,15 @@ const minimalCtx: PluginContextLike = {
   logger: {},
   config: {},
 };
+
+// Extract the failure message from a failed Exit so assertions can pin the
+// operator-facing remediation text (not just `isFailure`).
+function failureMessage(exit: Exit.Exit<unknown, unknown>): string {
+  if (Exit.isSuccess(exit)) return "";
+  const err = Cause.failureOption(exit.cause);
+  if (err._tag === "Some" && err.value instanceof Error) return err.value.message;
+  return Cause.pretty(exit.cause);
+}
 
 function makePlugin(overrides: Partial<PluginLike> = {}): PluginLike {
   return {
@@ -384,6 +393,162 @@ describe("PluginRegistry Effect Service", () => {
       );
 
       expect(Exit.isFailure(exit)).toBe(true);
+      // The operator-facing message is preserved — a `catch: (err) => err`
+      // regression or message reshaping must not pass unnoticed.
+      expect(failureMessage(exit)).toContain("Plugin schema migrations failed");
+      expect(failureMessage(exit)).toContain("DDL boom");
+    });
+
+    // ── #3741 — core-migration outcome gate ────────────────────────
+
+    test("ABORTS plugin init when core migrations FAILED (error set)", async () => {
+      let initialized = false;
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "reads-core-table",
+            initialize: async () => {
+              initialized = true;
+            },
+          }),
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+      // Migration ran but FAILED — half-migrated core schema.
+      const migrationFailed = Layer.succeed(Migration, {
+        migrated: false,
+        error: "relation \"operator_integration_credentials\" does not exist",
+      });
+      const deps = Layer.merge(
+        createTestLayer({ list: () => [], registerDirect: () => {} }),
+        migrationFailed,
+      );
+
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, deps))),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(failureMessage(exit)).toContain("Core schema migrations failed");
+      // Critically: the plugin's initialize() must NOT have run against the
+      // half-migrated schema — this is the #3741 race made unrepresentable.
+      expect(initialized).toBe(false);
+    });
+
+    test("PROCEEDS with plugin init when migrated:false has NO error (no-DB self-host)", async () => {
+      let initialized = false;
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "no-db-plugin",
+            initialize: async () => {
+              initialized = true;
+            },
+          }),
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+      // No DATABASE_URL: migrations skipped, NO error — a legitimate boot.
+      const migrationSkipped = Layer.succeed(Migration, { migrated: false });
+      const deps = Layer.merge(
+        createTestLayer({ list: () => [], registerDirect: () => {} }),
+        migrationSkipped,
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, deps))),
+      );
+
+      expect(initialized).toBe(true);
+    });
+
+    // ── #3743 — aggregated registration diagnostics ────────────────
+
+    test("aggregates ALL registration failures + actionable message", async () => {
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({ id: "ok-1" }),
+          makePlugin({ id: "" }), // empty id → register() throws
+          makePlugin({ id: "ok-1" }), // duplicate id → register() throws
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const msg = failureMessage(exit);
+      // Both bad IDs surfaced in one boot (count is 2), with remediation.
+      expect(msg).toContain("2 plugin(s) failed to register");
+      expect(msg).toContain("Fix your atlas.config.ts plugins array");
+    });
+
+    // ── #3743 — single-build memoization across consumers ──────────
+
+    test("wired layer builds ONCE despite multiple consumers (initializeAll not doubled)", async () => {
+      let initCount = 0;
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "counted",
+            initialize: async () => {
+              initCount += 1;
+            },
+          }),
+        ],
+        context: minimalCtx,
+      };
+      // Single shared reference, exactly as `buildAppLayer` holds
+      // `pluginRegistryLayer` and feeds it to ConnectionsHydrate / AuthBootstrap /
+      // PoolWarmup / PluginConfigGuard + the final mergeAll. Effect memoizes by
+      // reference within one build, so `initializeAll` must run once — a stray
+      // `Layer.fresh` or a second `makeWired...` call would double it and
+      // `registry.initializeAll` throws "cannot be called twice" (loud backstop).
+      const wired = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+      const consumerA = Layer.effectDiscard(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }),
+      ).pipe(Layer.provide(wired));
+      const consumerB = Layer.effectDiscard(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }),
+      ).pipe(Layer.provide(wired));
+      const composed = Layer.mergeAll(consumerA, consumerB, wired).pipe(
+        Layer.provide(wiredDeps()),
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(composed)),
+      );
+
+      expect(initCount).toBe(1);
     });
 
     // ── #3743 — ported wiring side-effects ─────────────────────────

--- a/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/effect-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { Effect, Layer, Exit } from "effect";
 import {
   PluginRegistry,
+  Migration,
   makePluginRegistryLive,
   makeWiredPluginRegistryLive,
   createPluginTestLayer,
@@ -13,6 +14,13 @@ import type {
   PluginLike,
   PluginContextLike,
 } from "@atlas/api/lib/plugins/registry";
+import { ToolRegistry } from "@atlas/api/lib/tools/registry";
+import {
+  getPluginTools,
+  getContextFragments,
+  getDialectHints,
+} from "@atlas/api/lib/plugins/tools";
+import { getCache, _resetCache } from "@atlas/api/lib/cache/index";
 
 const minimalCtx: PluginContextLike = {
   db: null,
@@ -29,6 +37,15 @@ function makePlugin(overrides: Partial<PluginLike> = {}): PluginLike {
     version: "1.0.0",
     ...overrides,
   };
+}
+
+// #3743 — the wired layer now depends on ConnectionRegistry AND Migration.
+const migrationOk = Layer.succeed(Migration, { migrated: true });
+function wiredDeps() {
+  return Layer.merge(
+    createTestLayer({ list: () => [], registerDirect: () => {} }),
+    migrationOk,
+  );
 }
 
 describe("PluginRegistry Effect Service", () => {
@@ -195,11 +212,7 @@ describe("PluginRegistry Effect Service", () => {
       );
 
       // Provide the ConnectionRegistry dependency via test layer
-      const connLayer = createTestLayer({
-        list: () => [],
-        registerDirect: () => {},
-      });
-      const fullLayer = Layer.provide(pluginLayer, connLayer);
+      const fullLayer = Layer.provide(pluginLayer, wiredDeps());
 
       const result = await Effect.runPromise(
         Effect.gen(function* () {
@@ -235,11 +248,7 @@ describe("PluginRegistry Effect Service", () => {
         config,
         () => new PluginRegistryClass(),
       );
-      const connLayer = createTestLayer({
-        list: () => [],
-        registerDirect: () => {},
-      });
-      const fullLayer = Layer.provide(pluginLayer, connLayer);
+      const fullLayer = Layer.provide(pluginLayer, wiredDeps());
 
       await Effect.runPromise(
         Effect.gen(function* () {
@@ -275,11 +284,7 @@ describe("PluginRegistry Effect Service", () => {
         config,
         () => new PluginRegistryClass(),
       );
-      const connLayer = createTestLayer({
-        list: () => [],
-        registerDirect: () => {},
-      });
-      const fullLayer = Layer.provide(pluginLayer, connLayer);
+      const fullLayer = Layer.provide(pluginLayer, wiredDeps());
 
       await Effect.runPromise(
         Effect.gen(function* () {
@@ -311,11 +316,7 @@ describe("PluginRegistry Effect Service", () => {
         config,
         () => new PluginRegistryClass(),
       );
-      const connLayer = createTestLayer({
-        list: () => [],
-        registerDirect: () => {},
-      });
-      const fullLayer = Layer.provide(pluginLayer, connLayer);
+      const fullLayer = Layer.provide(pluginLayer, wiredDeps());
 
       const result = await Effect.runPromise(
         Effect.gen(function* () {
@@ -333,6 +334,195 @@ describe("PluginRegistry Effect Service", () => {
       expect(
         result.descriptions.find((d) => d.id === "bad")?.status,
       ).toBe("unhealthy");
+    });
+
+    // ── #3743 — type-level Migration dependency ────────────────────
+
+    test("requires Migration at the type level (#3741 structural fix)", () => {
+      const config: PluginWiringConfig = {
+        plugins: [makePlugin({ id: "needs-migration" })],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+      const connOnly = createTestLayer({ list: () => [], registerDirect: () => {} });
+
+      // Providing ONLY ConnectionRegistry leaves `Migration` unsatisfied, so the
+      // result still carries `Migration` in its requirements (R) — it is NOT
+      // `never`. The @ts-expect-error below is the compile-time assertion that
+      // the Migration edge exists: if the edge is ever dropped, R becomes
+      // `never`, this assignment type-checks, and the unused-directive turns into
+      // a tsgo error. This is the structural guarantee from #3743 — plugin init
+      // can no longer be expressed without a Migration dependency.
+      // @ts-expect-error — Migration is unsatisfied here; R is `Migration`, not `never`.
+      const incomplete: Layer.Layer<PluginRegistry, Error, never> =
+        Layer.provide(pluginLayer, connOnly);
+      expect(incomplete).toBeDefined();
+    });
+
+    // ── #3743 — fatal plugin schema-migration failure ──────────────
+
+    test("schema migration failure is FATAL — fails the layer", async () => {
+      const config: PluginWiringConfig = {
+        plugins: [makePlugin({ id: "schema-plugin" })],
+        context: minimalCtx,
+        runMigrations: async () => {
+          throw new Error("DDL boom");
+        },
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    // ── #3743 — ported wiring side-effects ─────────────────────────
+
+    test("publishes plugin tools + freezes the registry after wiring", async () => {
+      const toolRegistry = new ToolRegistry();
+      const ctx: PluginContextLike = {
+        ...minimalCtx,
+        tools: {
+          register: (tool) =>
+            toolRegistry.register(
+              tool as Parameters<typeof toolRegistry.register>[0],
+            ),
+        },
+      };
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "tooly",
+            types: ["action"],
+            initialize: async (c: PluginContextLike) => {
+              c.tools.register({
+                name: "pluginTool",
+                description: "a plugin tool",
+                tool: {} as never,
+              } as never);
+            },
+          }),
+        ],
+        context: ctx,
+        toolRegistry,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      // setPluginTools published the registry...
+      expect(getPluginTools()?.get("pluginTool")).toBeDefined();
+      // ...and freeze() ran (further registration throws).
+      expect(() =>
+        toolRegistry.register({
+          name: "late",
+          description: "x",
+          tool: {} as never,
+        } as never),
+      ).toThrow(/frozen/);
+    });
+
+    test("publishes context fragments from context plugins", async () => {
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "ctx-plugin",
+            types: ["context"],
+            contextProvider: { load: async () => "FRAGMENT-3743" },
+          } as Partial<PluginLike>),
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      expect(getContextFragments()).toContain("FRAGMENT-3743");
+    });
+
+    test("registers a plugin-provided cache backend", async () => {
+      _resetCache();
+      const cacheStub = {
+        get: async () => undefined,
+        set: async () => {},
+        delete: async () => {},
+        flush: () => {},
+        stats: () => ({ hits: 0, misses: 0, size: 0 }),
+      };
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "cache-plugin",
+            cacheBackend: cacheStub,
+          } as Partial<PluginLike>),
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      expect(getCache()).toBe(cacheStub as never);
+      _resetCache();
+    });
+
+    test("publishes datasource dialect hints", async () => {
+      const config: PluginWiringConfig = {
+        plugins: [
+          makePlugin({
+            id: "ds-dialect",
+            types: ["datasource"],
+            connection: { dbType: "test-db", create: async () => ({}) },
+            dialect: "spark-sql-3743",
+          } as Partial<PluginLike>),
+        ],
+        context: minimalCtx,
+      };
+      const pluginLayer = makeWiredPluginRegistryLive(
+        config,
+        () => new PluginRegistryClass(),
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* PluginRegistry;
+        }).pipe(Effect.provide(Layer.provide(pluginLayer, wiredDeps()))),
+      );
+
+      expect(
+        getDialectHints().some((h) => h.dialect === "spark-sql-3743"),
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Structural fix for **#3741** (the `v0.0.17` chat outage). Plugin lifecycle ran imperatively in `server.ts` **before** the Effect Layer DAG's `MigrationLive`, so a plugin `initialize()` that reads a core (migration-created) table — the chat adapter's operator-credential resolver, `operator_integration_credentials` / mig 0140 — could race migrations on a first-deploy boot. #3744 made it non-fatal; this makes the ordering **enforced by the type system** (the race becomes unrepresentable).

- `makeWiredPluginRegistryLive` now depends on `Migration` (+ `ConnectionRegistry`) at the **type level**. Ported the remaining `server.ts` wiring steps into the layer: dialect hints, tool-shadow check + `setPluginTools`, MCP tools, context fragments, cache backend. Plugin schema-migration failure stays **fatal**.
- Split `migrateAuthTables` → `runBootMigrations` (schema; `MigrationLive`) + `runPostMigrationBootstrap` (`AuthBootstrapLive`, depends on the wired plugin layer so `loadPluginSettings.disable()` still runs **after** wiring — preserving the established order).
- `buildAppLayer(config, pluginWiring)`: binds the **global** `plugins`/`connections` singletons; the `ConnectionRegistry` Tag is lifecycle-unmanaged (`manageLifecycle: false`) so it doesn't double the health fiber/shutdown the global already owns. New edges: `ConnectionsHydrate` + `PluginConfigGuard` depend on `PluginRegistry`; new `PoolWarmupLive` replaces the imperative `connections.warmup()`.
- `server.ts` retires the ~245-line imperative block (keeps only the DAG inputs); plugin teardown is now the wired layer's scope finalizer (10s timeout guards `runtime.dispose()`). `Migration` Tag moved to `services.ts` (re-exported from `layers.ts`).
- Kept the resolver `42P01` carve-out as defense-in-depth (covers stdio-MCP + `refresh()` paths that bypass the DAG); removed the now-subsumed early `runBootMigrations()` call.
- ADR-0020 documents the boot-DAG decision.

## Audit (mandate, run before coding)

- **Only** the chat adapter reads a core table at init — no second instance of the race class across `plugins/**` + `lib/plugins/**`.
- `wireDatasourcePlugins` is DB-free at wiring time; DB-stored connections load later in `ConnectionsHydrate` (already `Migration`-gated) — but it reads the **global** plugin registry, which forced the new `ConnectionsHydrate → PluginRegistry` ordering edge.
- All DB-reading boot guards carry the `Migration` edge; `PluginConfigGuard` gained a `PluginRegistry` edge (it reads the registry).

## Test plan

- [x] `lint` (whole repo) — 0 errors
- [x] `type` (full monorepo gate) — green
- [x] All 15 drift/check gates + `syncpack` — green
- [x] Affected test graph via isolated runner — **95/95 files**
- [x] New tests: type-level `Migration` dependency (`@ts-expect-error`), each ported step (tools/shadow, MCP, context fragments, cache, dialect hints), fatal schema migration, `runPostMigrationBootstrap` split + DAG-parity no-op
- [ ] Full suite + real-Postgres shards — **via remote CI** (the arbiter)
- [ ] **Staging soak before any `/release`** — the race only reproduces on a first boot where new code + new migration land together

Closes #3743