### PR TITLE
fix(mcp): harden datasource provisioning validation

### DIFF
--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -557,7 +557,13 @@ describe("probePluginDatasourceConnection (#3547)", () => {
     const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://slow/db" }, 20);
     expect(out.ok).toBe(false);
 
-    await new Promise((r) => setTimeout(r, 80));
+    // The close fires only once the late build resolves (~60ms), after the 20ms
+    // deadline already returned `ok: false`. Poll for it rather than sleep a
+    // fixed margin so a loaded parallel runner can't flake on a tight window.
+    const deadline = Date.now() + 2000;
+    while (!closed && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
     expect(closed).toBe(true);
   });
 

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -538,6 +538,29 @@ describe("probePluginDatasourceConnection (#3547)", () => {
     expect(closed).toBe(true);
   });
 
+  it("#3608 — closes a late-built connection even when its probe never settles", async () => {
+    let closed = false;
+    const conn = {
+      query: () => new Promise<unknown>(() => {}),
+      close: async () => { closed = true; },
+    };
+    fakeDatasourcePlugins = [
+      {
+        types: ["datasource"],
+        connection: {
+          dbType: "clickhouse",
+          createFromConfig: () => new Promise((resolve) => setTimeout(() => resolve(conn), 60)),
+        },
+      },
+    ];
+
+    const out = await bridge.probePluginDatasourceConnection("clickhouse", { url: "clickhouse://slow/db" }, 20);
+    expect(out.ok).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(closed).toBe(true);
+  });
+
   it("#3580 — closes an eagerly-built connection whose probe query NEVER settles (infinite hang = pool leak)", async () => {
     // Adapter pattern that triggers the bug: createFromConfig resolves
     // immediately (eager-connect on build), but the probe query returns a

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -198,13 +198,22 @@ export async function probePluginDatasourceConnection(
   // adapter chooses to — so an adapter that eagerly connects on build, or
   // ignores its own probe timeout, must not hang the MCP `create_datasource`
   // call against an unreachable host. On a deadline breach we close any
-  // already-built connection immediately from the timeout callback (#3580) so a
+  // already-built connection from whichever path observes it: the timeout
+  // callback (eager build finished before the deadline, #3580) or the
+  // early-return below (build resolves AFTER the deadline, #3608) — so a
   // slow-but-eternal query that NEVER settles can't leak a pool.
   const probeRun = (async () => {
     built = (await createFromConfig(decryptedConfig)) as ProbeableConnection;
     if (timedOut) {
+      // #3608 — the build resolved after the deadline already fired, so the
+      // timeout callback never saw `built` and couldn't close it. Tear it down
+      // here, before issuing a probe that might never settle (which would
+      // strand the `.finally()` salvage below). `closedByTimeout` keeps this
+      // exclusive with the timeout-callback close.
       if (!closedByTimeout) {
         closedByTimeout = true;
+        // intentionally ignored: best-effort teardown of a throwaway probe
+        // connection — mirrors the in-deadline `finally` close below.
         await built.close().catch(() => {});
       }
       return;

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -202,6 +202,13 @@ export async function probePluginDatasourceConnection(
   // slow-but-eternal query that NEVER settles can't leak a pool.
   const probeRun = (async () => {
     built = (await createFromConfig(decryptedConfig)) as ProbeableConnection;
+    if (timedOut) {
+      if (!closedByTimeout) {
+        closedByTimeout = true;
+        await built.close().catch(() => {});
+      }
+      return;
+    }
     // Prefer the connection's native liveness check (ES/OpenSearch `ping`); fall
     // back to `SELECT 1` for SQL-only adapters that expose no `ping`.
     if (typeof built.ping === "function") {

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -899,6 +899,49 @@ describe("create_datasource", () => {
     expect(mockProvision).not.toHaveBeenCalled();
   });
 
+  it("#3608 — a required field that is whitespace-only is rejected before provisioning", async () => {
+    elicitOutcome = { action: "accept", values: { url: "   " } };
+    const client = await createTestClient();
+
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+
+    expect(res.isError).toBe(true);
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    expect(err?.code).toBe("validation_failed");
+    expect(err?.message).toContain("Connection URL");
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("#3608 — multiple blank required fields are reported together (plural, field-named)", async () => {
+    provisionConfigFields = {
+      kind: "ok",
+      fields: [
+        { key: "url", label: "Connection URL", required: true, secret: false },
+        { key: "apiKey", label: "API Key", required: true, secret: true },
+      ],
+      secretKeys: ["apiKey"],
+    };
+    provisionCapability = { kind: "plugin", dbType: "elasticsearch" };
+    elicitOutcome = { action: "accept", values: { url: "", apiKey: "   " } };
+    const client = await createTestClient();
+
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "elasticsearch", install_id: "logs" },
+    });
+
+    expect(res.isError).toBe(true);
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    expect(err?.code).toBe("validation_failed");
+    expect(err?.message).toContain("Missing required fields:"); // plural
+    expect(err?.message).toContain("Connection URL");
+    expect(err?.message).toContain("API Key");
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
   it("an elicitation failure (unsupported client) → validation_failed, no leak", async () => {
     elicitThrows = true;
     const client = await createTestClient();

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -883,6 +883,22 @@ describe("create_datasource", () => {
     expect(mockProvision).not.toHaveBeenCalled();
   });
 
+  it("#3608 — a required field present as an empty string is rejected before provisioning", async () => {
+    elicitOutcome = { action: "accept", values: { url: "" } };
+    const client = await createTestClient();
+
+    const res = await client.callTool({
+      name: "create_datasource",
+      arguments: { db_type: "postgres", install_id: "new-pg" },
+    });
+
+    expect(res.isError).toBe(true);
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    expect(err?.code).toBe("validation_failed");
+    expect(err?.message).toContain("Connection URL");
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
   it("an elicitation failure (unsupported client) → validation_failed, no leak", async () => {
     elicitThrows = true;
     const client = await createTestClient();

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -320,7 +320,10 @@ export function registerDatasourceTools(
     // Defense-in-depth: a non-spec-compliant client could `accept` with a
     // required field left blank, which would otherwise surface as a confusing
     // pre-flight "could not reach" error. Reject with an actionable,
-    // field-named message instead.
+    // field-named message instead. The compliant path is already covered —
+    // `elicitMaskedForm` drops whitespace-only values (so absent keys are
+    // caught by `!(f.key in values)`); the `.trim()` clause additionally
+    // catches a present-but-empty string a non-compliant client may inject.
     const values = elicited.values;
     const missing = fields
       .filter((f) => f.required && (!(f.key in values) || values[f.key].trim().length === 0))

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -318,11 +318,13 @@ export function registerDatasourceTools(
       };
     }
     // Defense-in-depth: a non-spec-compliant client could `accept` with a
-    // required field left blank (elicitMaskedForm drops empty values), which
-    // would otherwise surface as a confusing pre-flight "could not reach"
-    // error. Reject with an actionable, field-named message instead.
+    // required field left blank, which would otherwise surface as a confusing
+    // pre-flight "could not reach" error. Reject with an actionable,
+    // field-named message instead.
     const values = elicited.values;
-    const missing = fields.filter((f) => f.required && !(f.key in values)).map((f) => f.label);
+    const missing = fields
+      .filter((f) => f.required && (!(f.key in values) || values[f.key].trim().length === 0))
+      .map((f) => f.label);
     if (missing.length > 0) {
       return {
         ok: false,


### PR DESCRIPTION
Fixes #3608.

## Summary

Hardens the MCP datasource provisioning validate-before-persist path for two non-compliant or timing-edge cases.

## Changes

- Close plugin datasource connections that finish building after the probe deadline, before running a probe that might never settle.
- Treat required masked-form fields as missing when a client accepts the form with a blank string value.
- Add regressions for both edge cases while preserving successful in-deadline probes and compliant client behavior.

## Verification

```bash
bun test packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
bun test packages/mcp/src/__tests__/datasource-tools.test.ts
bun run --filter '@atlas/mcp' test
bun run type
bun run lint
```

`bun run --filter '@atlas/api' test` passed 663/664 files; the remaining failure is the existing `src/lib/__tests__/semantic-sync.test.ts` rename-case assertion, which also fails on current `origin/main`.
