### PR TITLE
feat(integrations): operator-settable creds for remaining chat platforms

### DIFF
--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -180,10 +180,16 @@ installed workspace re-authorize Slack. The OAuth app credentials
 (`CLIENT_ID` / `CLIENT_SECRET` / `SIGNING_SECRET`) rotate non-destructively. The
 console warns before a destructive rotation.
 
-The pilot covers Slack; the remaining platforms (Discord, Teams, Telegram,
-WhatsApp, Google Chat, and the action targets Jira / Linear / GitHub App /
-Salesforce) follow one registry entry at a time — see the migration checklist in
-`docs/development/saas-env-audit.md`.
+All chat platforms are now console-managed: **Slack**, **Discord**, **Microsoft
+Teams**, **Telegram**, **WhatsApp**, and **Google Chat** each expose their
+operator app credentials on the page (e.g. `DISCORD_BOT_TOKEN` /
+`DISCORD_CLIENT_ID` / `DISCORD_PUBLIC_KEY`, `TEAMS_APP_ID` / `TEAMS_APP_PASSWORD`,
+`TELEGRAM_BOT_TOKEN` / `TELEGRAM_WEBHOOK_SECRET`, the WhatsApp Meta Cloud API
+quartet, and the Google Chat service-account JSON + Pub/Sub topic). None of these
+has a destructive-rotation key (only Slack's `SLACK_ENCRYPTION_KEY` is). The
+action targets (Jira / Linear / GitHub App / Salesforce) are not yet
+console-managed — they need a per-workspace credential design pass first (#3765).
+See the migration checklist in `docs/development/saas-env-audit.md`.
 
 ## Why the list is short
 

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -273,10 +273,12 @@ entry:
    renders every managed platform from the list endpoint; the route's `GET` / `PUT`
    / `DELETE` are platform-agnostic. No new migration, route, or UI code.
 
-Pilot: **Slack** (`#3704`/`#3735`). Remaining chat platforms: **Discord, Teams,
-Telegram, WhatsApp, Google Chat**. Remaining action targets: **Jira, Linear,
-GitHub App, Salesforce** (set `catalogSlug: null`). Each is an independent,
-one-entry follow-up.
+Pilot: **Slack** (`#3704`/`#3735`). All chat platforms now ship: **Discord**
+(`#3767`), **Teams** (`#3768`), **Telegram** (`#3769`), **WhatsApp** (`#3770`),
+**Google Chat** (`#3771`) — children of umbrella `#3765`, each a one-entry
+addition. Remaining action targets: **Jira, Linear, GitHub App, Salesforce** (set
+`catalogSlug: null`) — these need a per-workspace credential design pass first
+(`#3765`) and are not yet in the registry.
 
 ## Tracked work
 

--- a/packages/api/src/api/routes/__tests__/admin-operator-integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-operator-integrations.test.ts
@@ -246,7 +246,7 @@ describe("PUT /:platform — merge + refresh + audit", () => {
   });
 
   it("404s a write to an unmanaged platform", async () => {
-    const res = await adminOperatorIntegrations.request("/discord", {
+    const res = await adminOperatorIntegrations.request("/nope", {
       method: "PUT",
       headers: JSON_HEADERS,
       body: JSON.stringify({ fields: { FOO: "bar" } }),
@@ -313,7 +313,7 @@ describe("DELETE /:platform — revert to env", () => {
   });
 
   it("404s a delete on an unmanaged platform", async () => {
-    const res = await adminOperatorIntegrations.request("/discord", { method: "DELETE" });
+    const res = await adminOperatorIntegrations.request("/nope", { method: "DELETE" });
     expect(res.status).toBe(404);
   });
 });
@@ -365,7 +365,7 @@ describe("internal DB absent — write guards return not_configured", () => {
   });
 
   it("still distinguishes an unmanaged slug as 404 `not_found`, not `not_configured`", async () => {
-    const res = await adminOperatorIntegrations.request("/discord", { method: "DELETE" });
+    const res = await adminOperatorIntegrations.request("/nope", { method: "DELETE" });
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("not_found");

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
@@ -69,3 +69,39 @@ describe("managed operator chat platforms", () => {
     });
   }
 });
+
+describe("operator platform secret classification", () => {
+  // The `secret` flag drives UI masking (and signals which fields carry real
+  // credentials vs. public identifiers). Pin the expected secret env vars per
+  // platform so a misclassification — e.g. marking a bot token or service-
+  // account JSON `secret: false`, or a public app/client ID `secret: true` —
+  // fails loudly here. The parity tests above only cover field membership, not
+  // this flag. Every env var NOT listed for a platform must be `secret: false`.
+  const EXPECTED_SECRET_FIELDS: Record<string, readonly string[]> = {
+    slack: ["SLACK_CLIENT_SECRET", "SLACK_SIGNING_SECRET", "SLACK_ENCRYPTION_KEY"],
+    discord: ["DISCORD_BOT_TOKEN"],
+    teams: ["TEAMS_APP_PASSWORD"],
+    telegram: ["TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET"],
+    whatsapp: ["META_BUSINESS_ACCESS_TOKEN", "WHATSAPP_APP_SECRET", "WHATSAPP_VERIFY_TOKEN"],
+    gchat: ["GCHAT_SERVICE_ACCOUNT_JSON"],
+  };
+
+  for (const platform of OPERATOR_PLATFORMS) {
+    const expected = EXPECTED_SECRET_FIELDS[platform.platform];
+    // A new platform without a pinned expectation should fail the suite, not
+    // be silently skipped — assert we have one for every managed platform.
+    it(`pins secret-field expectations for "${platform.platform}"`, () => {
+      expect(expected).toBeDefined();
+    });
+
+    if (!expected) continue;
+
+    it(`classifies secret fields correctly for "${platform.platform}"`, () => {
+      const actualSecretVars = platform.fields
+        .filter((f) => f.secret)
+        .map((f) => f.envVar)
+        .sort();
+      expect(actualSecretVars).toEqual([...expected].sort());
+    });
+  }
+});

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/platforms.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { getChatAdapterRequiredEnv } from "@useatlas/chat";
-import { OPERATOR_PLATFORMS } from "../platforms";
+import { OPERATOR_PLATFORMS, getOperatorPlatform } from "../platforms";
 
 describe("operator platform ⇄ adapter requiredEnv parity", () => {
   for (const platform of OPERATOR_PLATFORMS) {
@@ -29,6 +29,43 @@ describe("operator platform ⇄ adapter requiredEnv parity", () => {
         .sort();
 
       expect(registryRequired).toEqual([...adapterRequired!].sort());
+    });
+  }
+});
+
+describe("managed operator chat platforms", () => {
+  // The full set of chat platforms that ship a `@useatlas/chat` adapter
+  // builder and are managed from Admin → Platform Integrations. Pinned
+  // explicitly so dropping a registry entry (or forgetting to add one when a
+  // new adapter lands) fails loudly here rather than silently shrinking the
+  // Admin surface. `catalogSlug === platform` for every chat platform, so the
+  // slug doubles as the `getChatAdapterRequiredEnv` key.
+  const EXPECTED_CHAT_PLATFORMS = [
+    "slack",
+    "discord",
+    "teams",
+    "telegram",
+    "whatsapp",
+    "gchat",
+  ] as const;
+
+  for (const slug of EXPECTED_CHAT_PLATFORMS) {
+    it(`registers "${slug}" with a chat catalog slug and adapter-mirrored required fields`, () => {
+      const spec = getOperatorPlatform(slug);
+      expect(spec).toBeDefined();
+      // Chat platforms key their catalog slug to the platform slug.
+      expect(spec!.catalogSlug).toBe(slug);
+
+      const adapterRequired = getChatAdapterRequiredEnv(slug);
+      expect(adapterRequired).not.toBeNull();
+
+      // Every adapter-required env var has a matching required field, and the
+      // field's `envVar` is the storage/env key the adapter reads.
+      const requiredFieldVars = spec!.fields
+        .filter((f) => f.required)
+        .map((f) => f.envVar)
+        .sort();
+      expect(requiredFieldVars).toEqual([...adapterRequired!].sort());
     });
   }
 });

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/resolver.test.ts
@@ -205,8 +205,12 @@ describe("getMissingOperatorEnvForCatalogSlug (boot-guard helper)", () => {
   });
 
   it("collapses to env-only for an unmanaged slug (no DB read)", async () => {
-    const missing = await getMissingOperatorEnvForCatalogSlug("discord", ["DISCORD_BOT_TOKEN"], {
-      DISCORD_BOT_TOKEN: "set",
+    // "imessage" is not in OPERATOR_PLATFORMS, so the helper finds no managed
+    // operator platform and never reads the credential store — it falls back to
+    // the env-only presence check. (Every shipped chat slug is now managed, so
+    // the unmanaged case is exercised with a slug Atlas ships no adapter for.)
+    const missing = await getMissingOperatorEnvForCatalogSlug("imessage", ["IMESSAGE_TOKEN"], {
+      IMESSAGE_TOKEN: "set",
     });
     expect(missing).toEqual([]);
     expect(mockRead).not.toHaveBeenCalled();

--- a/packages/api/src/lib/integrations/operator-credentials/platforms.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/platforms.ts
@@ -7,11 +7,12 @@
  * platform list). The resolver, boot guard, and Admin route all iterate this
  * registry — they have no per-platform branches.
  *
- * Pilot scope (#3704): Slack only. The remaining platforms (Discord, Teams,
- * Telegram, WhatsApp, Google Chat, and the action targets Jira / Linear /
- * GitHub App / Salesforce) follow incrementally, one entry per platform.
- * The migration checklist lives in
- * `docs/development/saas-env-audit.md` (operator-credentials section).
+ * Pilot scope (#3704): Slack. The remaining chat platforms (Discord #3767,
+ * Teams #3768, Telegram #3769, WhatsApp #3770, Google Chat #3771 — children of
+ * umbrella #3765) followed as one-entry additions. The action targets (Jira /
+ * Linear / GitHub App / Salesforce) need a per-workspace credential design
+ * pass first (#3765) and are not in this registry yet. The migration checklist
+ * lives in `docs/development/saas-env-audit.md` (operator-credentials section).
  *
  * Each field maps to an EXISTING operator env var so env stays the
  * self-host fallback unchanged — the field's `envVar` is both the storage
@@ -122,8 +123,188 @@ const SLACK_PLATFORM: OperatorPlatformSpec = {
   ],
 };
 
+/**
+ * Discord (#3767). The three required fields mirror `DISCORD_BUILDER.requiredEnv`
+ * from `@useatlas/chat`. `DISCORD_CLIENT_ID` is the application id (public, also
+ * used by the install flow to build the bot-install URL) and `DISCORD_PUBLIC_KEY`
+ * is the Ed25519 *public* verification key — neither is a secret. The bot token
+ * authenticates outbound API calls and is the only secret here. No field's
+ * rotation invalidates stored data (the static-bot adapter stores no
+ * per-platform-key-encrypted token), so none is a destructive rotation.
+ */
+const DISCORD_PLATFORM: OperatorPlatformSpec = {
+  platform: "discord",
+  label: "Discord",
+  catalogSlug: "discord",
+  fields: [
+    {
+      envVar: "DISCORD_BOT_TOKEN",
+      label: "Bot Token",
+      hint: "Discord bot token (Developer Portal → Bot). Authenticates outbound API calls.",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "DISCORD_CLIENT_ID",
+      label: "Client ID",
+      hint: "Discord application (client) ID. Used to build the bot-install URL.",
+      secret: false,
+      required: true,
+    },
+    {
+      envVar: "DISCORD_PUBLIC_KEY",
+      label: "Public Key",
+      hint: "Ed25519 public key (Developer Portal → General Information). Verifies inbound webhook signatures.",
+      secret: false,
+      required: true,
+    },
+  ],
+};
+
+/**
+ * Microsoft Teams (#3768). The two required fields mirror
+ * `TEAMS_BUILDER.requiredEnv` from `@useatlas/chat` — one Microsoft Entra ID app
+ * registration. `TEAMS_APP_ID` is the app (client) id (public); `TEAMS_APP_PASSWORD`
+ * is the client secret. `TEAMS_TENANT_ID` is intentionally omitted: the adapter
+ * runs MultiTenant by default and the tenant id is only set for single-tenant
+ * Azure Bots, so it isn't required and isn't an operator-credential field here.
+ */
+const TEAMS_PLATFORM: OperatorPlatformSpec = {
+  platform: "teams",
+  label: "Microsoft Teams",
+  catalogSlug: "teams",
+  fields: [
+    {
+      envVar: "TEAMS_APP_ID",
+      label: "App ID",
+      hint: "Microsoft Entra ID app (client) ID for the Azure Bot.",
+      secret: false,
+      required: true,
+    },
+    {
+      envVar: "TEAMS_APP_PASSWORD",
+      label: "App Password",
+      hint: "Entra ID client secret. Authenticates the Bot Framework connector.",
+      secret: true,
+      required: true,
+    },
+  ],
+};
+
+/**
+ * Telegram (#3769). The two required fields mirror `TELEGRAM_BUILDER.requiredEnv`
+ * from `@useatlas/chat`. Both are secret: the bot token authenticates outbound
+ * Bot API calls, and the webhook secret is the shared token Telegram echoes back
+ * in the `x-telegram-bot-api-secret-token` header — the only thing standing
+ * between the public webhook URL and a forged update (mandatory since #3154).
+ * Rotating the webhook secret requires re-running `setWebhook` on Telegram's side
+ * but invalidates no stored data, so it is not a destructive rotation.
+ */
+const TELEGRAM_PLATFORM: OperatorPlatformSpec = {
+  platform: "telegram",
+  label: "Telegram",
+  catalogSlug: "telegram",
+  fields: [
+    {
+      envVar: "TELEGRAM_BOT_TOKEN",
+      label: "Bot Token",
+      hint: "Telegram bot token from @BotFather. Authenticates outbound Bot API calls.",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "TELEGRAM_WEBHOOK_SECRET",
+      label: "Webhook Secret",
+      hint: "Shared secret Telegram echoes in the x-telegram-bot-api-secret-token header. Verifies inbound updates.",
+      secret: true,
+      required: true,
+    },
+  ],
+};
+
+/**
+ * WhatsApp (#3770). The four required fields mirror `WHATSAPP_BUILDER.requiredEnv`
+ * from `@useatlas/chat` (Meta Cloud API). `META_BUSINESS_APP_ID` is the Meta App
+ * ID (public); the access token, app secret (HMAC-SHA256 webhook verification),
+ * and verify token (echoed in the GET challenge handshake) are all secrets. No
+ * field's rotation invalidates stored data, so none is a destructive rotation.
+ */
+const WHATSAPP_PLATFORM: OperatorPlatformSpec = {
+  platform: "whatsapp",
+  label: "WhatsApp",
+  catalogSlug: "whatsapp",
+  fields: [
+    {
+      envVar: "META_BUSINESS_ACCESS_TOKEN",
+      label: "System User Access Token",
+      hint: "Meta System User access token for Cloud API calls (whatsapp_business_management + _messaging scopes).",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "META_BUSINESS_APP_ID",
+      label: "Meta App ID",
+      hint: "Meta App ID (App Dashboard → Settings → Basic).",
+      secret: false,
+      required: true,
+    },
+    {
+      envVar: "WHATSAPP_APP_SECRET",
+      label: "App Secret",
+      hint: "Meta App Secret for HMAC-SHA256 webhook signature verification (X-Hub-Signature-256).",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "WHATSAPP_VERIFY_TOKEN",
+      label: "Verify Token",
+      hint: "Random string pasted into the Meta webhook config; mirrored back in the GET challenge handshake.",
+      secret: true,
+      required: true,
+    },
+  ],
+};
+
+/**
+ * Google Chat (#3771). The two required fields mirror `GCHAT_BUILDER.requiredEnv`
+ * from `@useatlas/chat`. `GCHAT_SERVICE_ACCOUNT_JSON` is the raw service-account
+ * JSON (it contains the private key) — a secret. `GCHAT_PUBSUB_TOPIC` is the
+ * fully-qualified Pub/Sub topic path (`projects/<project>/topics/<topic>`) — not
+ * a secret. The optional impersonation / project-number / audience env vars are
+ * not required fields and are omitted here (they fall through to env). Rotating
+ * the service account invalidates no stored data, so neither is destructive.
+ */
+const GCHAT_PLATFORM: OperatorPlatformSpec = {
+  platform: "gchat",
+  label: "Google Chat",
+  catalogSlug: "gchat",
+  fields: [
+    {
+      envVar: "GCHAT_SERVICE_ACCOUNT_JSON",
+      label: "Service Account JSON",
+      hint: "Raw GCP service-account JSON. Mints Pub/Sub tokens and authenticates outbound Google Chat API calls.",
+      secret: true,
+      required: true,
+    },
+    {
+      envVar: "GCHAT_PUBSUB_TOPIC",
+      label: "Pub/Sub Topic",
+      hint: "Fully-qualified topic path the Workspace Events subscription publishes to (projects/<project>/topics/<topic>).",
+      secret: false,
+      required: true,
+    },
+  ],
+};
+
 /** Every operator platform managed by the Admin credential surface. */
-export const OPERATOR_PLATFORMS: readonly OperatorPlatformSpec[] = [SLACK_PLATFORM];
+export const OPERATOR_PLATFORMS: readonly OperatorPlatformSpec[] = [
+  SLACK_PLATFORM,
+  DISCORD_PLATFORM,
+  TEAMS_PLATFORM,
+  TELEGRAM_PLATFORM,
+  WHATSAPP_PLATFORM,
+  GCHAT_PLATFORM,
+];
 
 /** Look up a managed operator platform by slug. `undefined` if unmanaged. */
 export function getOperatorPlatform(platform: string): OperatorPlatformSpec | undefined {

--- a/packages/api/src/lib/integrations/operator-credentials/platforms.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/platforms.ts
@@ -226,7 +226,9 @@ const TELEGRAM_PLATFORM: OperatorPlatformSpec = {
  * WhatsApp (#3770). The four required fields mirror `WHATSAPP_BUILDER.requiredEnv`
  * from `@useatlas/chat` (Meta Cloud API). `META_BUSINESS_APP_ID` is the Meta App
  * ID (public); the access token, app secret (HMAC-SHA256 webhook verification),
- * and verify token (echoed in the GET challenge handshake) are all secrets. No
+ * and verify token (echoed in the GET challenge handshake) are all secrets.
+ * `META_BUSINESS_APP_ID` is in `requiredEnv` as an Atlas-side boot-consistency
+ * gate, not because `@chat-adapter/whatsapp` consumes it at activation time. No
  * field's rotation invalidates stored data, so none is a destructive rotation.
  */
 const WHATSAPP_PLATFORM: OperatorPlatformSpec = {
@@ -282,7 +284,7 @@ const GCHAT_PLATFORM: OperatorPlatformSpec = {
     {
       envVar: "GCHAT_SERVICE_ACCOUNT_JSON",
       label: "Service Account JSON",
-      hint: "Raw GCP service-account JSON. Mints Pub/Sub tokens and authenticates outbound Google Chat API calls.",
+      hint: "Raw GCP service-account JSON. Used to obtain Pub/Sub access tokens and authenticate outbound Google Chat API calls.",
       secret: true,
       required: true,
     },


### PR DESCRIPTION
Adds Discord, Microsoft Teams, Telegram, WhatsApp, and Google Chat to the
operator-credential registry so their OAuth app credentials are settable +
rotatable from **Admin → Platform Integrations** with **zero `<PLATFORM>_*` env
on a region** — no Railway redeploy. Per-tenant install already worked for all
of these; this closes the operator-convenience gap, mirroring the shipped Slack
pilot.

Closes #3767 (Discord), #3768 (Teams), #3769 (Telegram), #3770 (WhatsApp),
#3771 (Google Chat). Children of umbrella #3765.

## Why one PR

All five issues edit the same files (`operator-credentials/platforms.ts` + its
drift test), so they ship together per the umbrella's instruction.

## What changed

- **`operator-credentials/platforms.ts`** — five new `OperatorPlatformSpec`
  entries appended to `OPERATOR_PLATFORMS`, each copying the `SLACK_PLATFORM`
  shape (label/hint/`secret`/`required` per field). Required fields mirror
  `getChatAdapterRequiredEnv(<platform>)` **exactly**:
  - discord → `DISCORD_BOT_TOKEN` (secret), `DISCORD_CLIENT_ID`, `DISCORD_PUBLIC_KEY`
  - teams → `TEAMS_APP_ID`, `TEAMS_APP_PASSWORD` (secret)
  - telegram → `TELEGRAM_BOT_TOKEN` (secret), `TELEGRAM_WEBHOOK_SECRET` (secret)
  - whatsapp → `META_BUSINESS_ACCESS_TOKEN` (secret), `META_BUSINESS_APP_ID`, `WHATSAPP_APP_SECRET` (secret), `WHATSAPP_VERIFY_TOKEN` (secret)
  - gchat → `GCHAT_SERVICE_ACCOUNT_JSON` (secret), `GCHAT_PUBSUB_TOPIC`

  No field is a destructive rotation — only Slack's `SLACK_ENCRYPTION_KEY`
  encrypts stored data; the new platforms' adapters store no per-platform-key
  encrypted tokens.
- **`__tests__/platforms.test.ts`** — drift pin extended: the existing parity
  loop auto-covers the new entries, plus an explicit `EXPECTED_CHAT_PLATFORMS`
  membership pin so dropping an entry (or forgetting one when a new adapter
  lands) fails loudly.
- **docs** — `saas-env-audit.md` checklist + `saas-environment-variables.mdx`
  updated to reflect all chat platforms now console-managed.

## Branch-free seam confirmed

The resolver, boot guard, Admin route, and Admin page all iterate
`OPERATOR_PLATFORMS` with **no per-platform branches** — verified end to end.
No finding to file. Two notes:

- **`page.tsx` needed no edit.** The operator-integrations page renders rows
  generically from the `GET /api/v1/platform/operator-integrations` list
  endpoint (which iterates the registry), so the new rows appear automatically.
  The issues' "rendered generically — no new route/UI logic" expectation holds:
  adding the registry entry *is* the UI change.
- **Two pre-existing tests** used `"discord"` as their fixture for an
  *unmanaged* slug (it wasn't managed before this PR). Swapped to a slug Atlas
  ships no adapter for (`resolver.test.ts` → `"imessage"`, route test → `"nope"`)
  so the unmanaged-slug paths stay covered.

## Acceptance criteria (per platform)

- [x] App creds settable + rotatable from Admin with zero `<PLATFORM>_*` env
- [x] Boot guard / resolver treat a fully-populated row as configured; unset
      fields fall through to `process.env` (self-host fallback unchanged)
- [x] Secret fields masked + never echoed on read (existing route behavior)
- [x] `platforms.test.ts` drift pin extended for each platform

## CI

All six `/ci` gates pass locally: lint, type, full isolated test (664/664 API
files green), syncpack, template drift, railway-watch.

https://claude.ai/code/session_01Bc4mH4NAfWB8DUrCfcGkh8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc4mH4NAfWB8DUrCfcGkh8)_