### PR TITLE
observability(api): add OTel spans to profiler seam + Stripe webhook (#3684)

### DIFF
--- a/packages/api/src/lib/__tests__/profiler-span.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-span.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the `atlas.profile.*` span attribute builder (#3684).
+ *
+ * The profiler seam is wrapped in `withSpan`/`withEffectSpan` so a slow/hanging
+ * profile gets latency attribution. Capturing live spans would mean wiring an
+ * `InMemorySpanExporter` into the global tracer provider — heavier than the typo
+ * it would catch (same precedent as the `atlas.sql.execute` attribute builder),
+ * so the pure attribute builder is the load-bearing piece under test. The no-op
+ * behaviour of the wrap itself is covered by `tracing.test.ts`.
+ */
+import { describe, it, expect } from "bun:test";
+import { profileSpanAttributes } from "../profiler";
+
+describe("profileSpanAttributes", () => {
+  it("always emits the db_type attribute", () => {
+    expect(profileSpanAttributes("postgres")).toEqual({
+      "atlas.profile.db_type": "postgres",
+    });
+  });
+
+  it("emits schema when provided", () => {
+    expect(profileSpanAttributes("postgres", { schema: "analytics" })).toEqual({
+      "atlas.profile.db_type": "postgres",
+      "atlas.profile.schema": "analytics",
+    });
+  });
+
+  it("emits connection_id when provided", () => {
+    expect(
+      profileSpanAttributes("clickhouse", { connectionId: "warehouse" }),
+    ).toEqual({
+      "atlas.profile.db_type": "clickhouse",
+      "atlas.profile.connection_id": "warehouse",
+    });
+  });
+
+  it("emits the selected-table COUNT (not the names — keeps cardinality bounded)", () => {
+    expect(
+      profileSpanAttributes("mysql", { selectedTables: ["orders", "users", "events"] }),
+    ).toEqual({
+      "atlas.profile.db_type": "mysql",
+      "atlas.profile.selected_table_count": 3,
+    });
+  });
+
+  it("combines every attribute when all inputs are present", () => {
+    expect(
+      profileSpanAttributes("postgres", {
+        schema: "public",
+        connectionId: "default",
+        selectedTables: ["orders"],
+      }),
+    ).toEqual({
+      "atlas.profile.db_type": "postgres",
+      "atlas.profile.schema": "public",
+      "atlas.profile.connection_id": "default",
+      "atlas.profile.selected_table_count": 1,
+    });
+  });
+
+  it("omits optional attributes rather than emitting undefined values", () => {
+    const attrs = profileSpanAttributes("postgres", {});
+    expect(Object.keys(attrs)).toEqual(["atlas.profile.db_type"]);
+  });
+});

--- a/packages/api/src/lib/__tests__/profiler-span.test.ts
+++ b/packages/api/src/lib/__tests__/profiler-span.test.ts
@@ -58,6 +58,13 @@ describe("profileSpanAttributes", () => {
     });
   });
 
+  it("emits a zero count for a present-but-empty selectedTables array", () => {
+    expect(profileSpanAttributes("postgres", { selectedTables: [] })).toEqual({
+      "atlas.profile.db_type": "postgres",
+      "atlas.profile.selected_table_count": 0,
+    });
+  });
+
   it("omits optional attributes rather than emitting undefined values", () => {
     const attrs = profileSpanAttributes("postgres", {});
     expect(Object.keys(attrs)).toEqual(["atlas.profile.db_type"]);

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-span.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-span.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test";
+import { buildStripeWebhookSpanAttributes } from "../server";
+
+/**
+ * Tests for the `stripe.webhook.process` span attribute builder (#3684).
+ *
+ * The classify→sync→record sequence under `withStripeSubscriptionLock` is
+ * wrapped in `withSpan` so slow processing (multi-second advisory-lock waits,
+ * tier-write failures → 400 → Stripe retry storm) is attributable in traces.
+ * Capturing live spans would mean wiring an `InMemorySpanExporter` — heavier
+ * than the typo it would catch — so the pure attribute builder is the
+ * load-bearing piece under test (the applied-tier result attribute and no-op
+ * wrap behaviour are exercised by `stripe-webhook-lifecycle.test.ts` and
+ * `tracing.test.ts` respectively).
+ */
+describe("buildStripeWebhookSpanAttributes", () => {
+  it("emits event id + type, and the subscription id when present", () => {
+    expect(
+      buildStripeWebhookSpanAttributes({
+        eventId: "evt_123",
+        eventType: "customer.subscription.updated",
+        subscriptionId: "sub_456",
+      }),
+    ).toEqual({
+      "stripe.event_id": "evt_123",
+      "stripe.event_type": "customer.subscription.updated",
+      "stripe.subscription_id": "sub_456",
+    });
+  });
+
+  it("omits the subscription id for an event with no subscription (e.g. null)", () => {
+    expect(
+      buildStripeWebhookSpanAttributes({
+        eventId: "evt_789",
+        eventType: "checkout.session.completed",
+        subscriptionId: null,
+      }),
+    ).toEqual({
+      "stripe.event_id": "evt_789",
+      "stripe.event_type": "checkout.session.completed",
+    });
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1790,6 +1790,25 @@ async function handleSubscriptionStatusPolicy(subscription: Stripe.Subscription)
 }
 
 /**
+ * Build the OTel attribute set for the `stripe.webhook.process` span (#3684).
+ *
+ * Pure + exported for unit coverage of the attribute keys (capturing live spans
+ * would mean wiring an `InMemorySpanExporter` — heavier than the typo it would
+ * catch; mirrors the `atlas.sql.execute` / `atlas.profile.*` builder precedent).
+ */
+export function buildStripeWebhookSpanAttributes(args: {
+  eventId: string;
+  eventType: string;
+  subscriptionId: string | null;
+}): Attributes {
+  return {
+    "stripe.event_id": args.eventId,
+    "stripe.event_type": args.eventType,
+    ...(args.subscriptionId ? { "stripe.subscription_id": args.subscriptionId } : {}),
+  };
+}
+
+/**
  * The must-not-be-lost Stripe sync (#3423): plan-tier writes + the Twenty
  * CRM conversion stamp, keyed on the four subscription-lifecycle event
  * types. Runs inside `onEvent` (behind the event ledger), so internal-DB
@@ -1818,25 +1837,6 @@ async function handleSubscriptionStatusPolicy(subscription: Stripe.Subscription)
  *
  * @internal — exported for testing.
  */
-/**
- * Build the OTel attribute set for the `stripe.webhook.process` span (#3684).
- *
- * Pure + exported for unit coverage of the attribute keys (capturing live spans
- * would mean wiring an `InMemorySpanExporter` — heavier than the typo it would
- * catch; mirrors the `atlas.sql.execute` / `atlas.profile.*` builder precedent).
- */
-export function buildStripeWebhookSpanAttributes(args: {
-  eventId: string;
-  eventType: string;
-  subscriptionId: string | null;
-}): Attributes {
-  return {
-    "stripe.event_id": args.eventId,
-    "stripe.event_type": args.eventType,
-    ...(args.subscriptionId ? { "stripe.subscription_id": args.subscriptionId } : {}),
-  };
-}
-
 export async function syncStripeEventToWorkspace(
   event: Stripe.Event,
   stripeClient: Stripe,

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -36,6 +36,8 @@ import { getSettingOverride } from "@atlas/api/lib/settings";
 import Stripe from "stripe";
 import { getInternalDB, getWorkspaceDetails, hasInternalDB, internalQuery, isPlanOverrideActive, updateWorkspacePlanTier, updateWorkspaceStatus, withStripeSubscriptionLock, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { withSpan } from "@atlas/api/lib/tracing";
+import { type Attributes } from "@opentelemetry/api";
 import {
   resolveRequireEmailVerification as envProfileResolveRequireEmailVerification,
   resolveCookiePrefix,
@@ -69,6 +71,7 @@ import {
   classifyStripeEvent,
   recordStripeEvent,
   type StripeLedgerEvent,
+  type StripeEventDisposition,
 } from "@atlas/api/lib/billing/stripe-event-ledger";
 import { getConfig } from "@atlas/api/lib/config";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
@@ -1815,6 +1818,25 @@ async function handleSubscriptionStatusPolicy(subscription: Stripe.Subscription)
  *
  * @internal — exported for testing.
  */
+/**
+ * Build the OTel attribute set for the `stripe.webhook.process` span (#3684).
+ *
+ * Pure + exported for unit coverage of the attribute keys (capturing live spans
+ * would mean wiring an `InMemorySpanExporter` — heavier than the typo it would
+ * catch; mirrors the `atlas.sql.execute` / `atlas.profile.*` builder precedent).
+ */
+export function buildStripeWebhookSpanAttributes(args: {
+  eventId: string;
+  eventType: string;
+  subscriptionId: string | null;
+}): Attributes {
+  return {
+    "stripe.event_id": args.eventId,
+    "stripe.event_type": args.eventType,
+    ...(args.subscriptionId ? { "stripe.subscription_id": args.subscriptionId } : {}),
+  };
+}
+
 export async function syncStripeEventToWorkspace(
   event: Stripe.Event,
   stripeClient: Stripe,
@@ -2172,50 +2194,70 @@ export function buildStripePluginOptions(deps: {
       // re-throw → 400 → Stripe redelivers). Different subscriptions use
       // different lock keys and stay concurrent; events with no
       // subscription id skip the lock.
-      await withStripeSubscriptionLock(ledgerEvent.stripeSubscriptionId, async () => {
-        const disposition = await classifyStripeEvent(ledgerEvent);
-        if (disposition !== "fresh") {
-          billingLog.info(
-            { eventId: event.id, eventType: event.type, disposition },
-            "Skipping Stripe webhook event (%s)",
-            disposition,
-          );
-          return;
-        }
+      // #3684 — span the classify→sync→record sequence so slow processing
+      // (multi-second advisory-lock waits, tier-write failures → 400 → Stripe
+      // retry storm) is attributable in traces. The span records the applied
+      // tier (or `none` for a skipped/no-tier event) via setResultAttributes.
+      // No-op when OTel is uninitialized (zero overhead).
+      await withStripeSubscriptionLock(ledgerEvent.stripeSubscriptionId, () =>
+        withSpan(
+          "stripe.webhook.process",
+          buildStripeWebhookSpanAttributes({
+            eventId: event.id,
+            eventType: event.type,
+            subscriptionId: ledgerEvent.stripeSubscriptionId,
+          }),
+          async (): Promise<{ disposition: StripeEventDisposition; appliedTier: PlanTier | null }> => {
+            const disposition = await classifyStripeEvent(ledgerEvent);
+            if (disposition !== "fresh") {
+              billingLog.info(
+                { eventId: event.id, eventType: event.type, disposition },
+                "Skipping Stripe webhook event (%s)",
+                disposition,
+              );
+              return { disposition, appliedTier: null };
+            }
 
-        const appliedTier = await syncStripeEventToWorkspace(event, stripeClient);
+            const appliedTier = await syncStripeEventToWorkspace(event, stripeClient);
 
-        // Delinquency ladder (#3424). All branches are best-effort side
-        // effects of the durable sync above — each helper swallows + logs
-        // and never throws, so it cannot force a redelivery of an
-        // already-applied event.
-        switch (event.type) {
-          case "invoice.payment_failed":
-            await handlePaymentFailure(event.data.object as Stripe.Invoice);
-            break;
-          case "invoice.payment_succeeded":
-          case "invoice.paid":
-            await handleInvoicePaid(event.data.object as Stripe.Invoice);
-            break;
-          case "customer.subscription.updated":
-            await handleSubscriptionStatusPolicy(event.data.object as Stripe.Subscription);
-            break;
-          default:
-            break;
-        }
+            // Delinquency ladder (#3424). All branches are best-effort side
+            // effects of the durable sync above — each helper swallows + logs
+            // and never throws, so it cannot force a redelivery of an
+            // already-applied event.
+            switch (event.type) {
+              case "invoice.payment_failed":
+                await handlePaymentFailure(event.data.object as Stripe.Invoice);
+                break;
+              case "invoice.payment_succeeded":
+              case "invoice.paid":
+                await handleInvoicePaid(event.data.object as Stripe.Invoice);
+                break;
+              case "customer.subscription.updated":
+                await handleSubscriptionStatusPolicy(event.data.object as Stripe.Subscription);
+                break;
+              default:
+                break;
+            }
 
-        await recordStripeEvent(ledgerEvent, appliedTier);
+            await recordStripeEvent(ledgerEvent, appliedTier);
 
-        // Observability: the skip path logged, but a SUCCESSFULLY-processed
-        // event (tier write applied + ledger recorded) was silent — so a
-        // tier-write storm or slow processing left no positive audit trail of
-        // which subscription events were actually applied. Log the applied
-        // disposition (no PII — ids + tier only).
-        billingLog.info(
-          { eventId: event.id, eventType: event.type, appliedTier: appliedTier ?? null },
-          "Processed Stripe webhook event",
-        );
-      });
+            // Observability: the skip path logged, but a SUCCESSFULLY-processed
+            // event (tier write applied + ledger recorded) was silent — so a
+            // tier-write storm or slow processing left no positive audit trail of
+            // which subscription events were actually applied. Log the applied
+            // disposition (no PII — ids + tier only).
+            billingLog.info(
+              { eventId: event.id, eventType: event.type, appliedTier: appliedTier ?? null },
+              "Processed Stripe webhook event",
+            );
+            return { disposition, appliedTier };
+          },
+          (result) => ({
+            "stripe.webhook.disposition": result.disposition,
+            "stripe.webhook.applied_tier": result.appliedTier ?? "none",
+          }),
+        ),
+      );
     },
   };
 }

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -81,7 +81,8 @@ import {
   type ProfileAndGenerateResult,
 } from "@atlas/api/lib/effect/semantic-generator";
 import { ProfilingFailedError, IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
-import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
+import { profileSpanAttributes, type ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
+import { withSpan } from "@atlas/api/lib/tracing";
 
 const log = createLogger("datasources:mcp-lifecycle");
 
@@ -1168,7 +1169,23 @@ export type RunSemanticProfileOutcome =
  * tagged `ProfilingFailedError` is returned as a typed `error` outcome; an
  * unexpected defect re-throws for the caller's `internal_error` path.
  */
-export async function profileLiveDatasource(opts: {
+export function profileLiveDatasource(
+  opts: Parameters<typeof profileLiveDatasourceImpl>[0],
+): Promise<RunSemanticProfileOutcome> {
+  // Span the whole profile→generate→persist seam so a slow/hanging live-DB
+  // profile (large table, slow remote DB, profile-over-MCP) has latency
+  // attribution (#3684). No-op when OTel is uninitialized (zero overhead).
+  return withSpan(
+    "atlas.profile.live_datasource",
+    profileSpanAttributes(opts.connection.dbType, {
+      connectionId: opts.connectionId,
+      ...(opts.schema !== undefined ? { schema: opts.schema } : {}),
+    }),
+    () => profileLiveDatasourceImpl(opts),
+  );
+}
+
+async function profileLiveDatasourceImpl(opts: {
   connection: LiveDatasourceConnection;
   /**
    * Connection-group identifier — the whitelist key + entity `connection:` field.

--- a/packages/api/src/lib/effect/semantic-generator.ts
+++ b/packages/api/src/lib/effect/semantic-generator.ts
@@ -41,10 +41,12 @@ import type { DBType } from "@atlas/api/lib/db/connection";
 import {
   profilePostgres,
   profileMySQL,
+  profileSpanAttributes,
   checkFailureThreshold,
   type ProfileLogger,
   type ProfileProgressCallbacks,
 } from "@atlas/api/lib/profiler";
+import { withEffectSpan } from "@atlas/api/lib/tracing";
 import {
   analyzeTableProfiles,
   generateSemanticLayer,
@@ -377,6 +379,25 @@ function resolveProfiler(
 }
 
 function profileImpl(
+  opts: ProfileConnectionOptions,
+): Effect.Effect<ProfileConnectionResult, ProfilingFailedError> {
+  // Span the Effect-path profiler seam (the MCP/wizard profile entry point) so a
+  // slow/hanging profile is attributable in traces (#3684). `withEffectSpan`
+  // keeps the typed `ProfilingFailedError` in the error channel and no-ops when
+  // OTel is uninitialized.
+  return withEffectSpan(
+    "atlas.profile.connection",
+    profileSpanAttributes(opts.dbType, { schema: opts.schema, selectedTables: opts.selectedTables }),
+    profileImplInner(opts),
+    (result) => ({
+      "atlas.profile.profiled_count": result.profiles.length,
+      "atlas.profile.error_count": result.errors.length,
+      "atlas.profile.elapsed_ms": result.elapsedMs,
+    }),
+  );
+}
+
+function profileImplInner(
   opts: ProfileConnectionOptions,
 ): Effect.Effect<ProfileConnectionResult, ProfilingFailedError> {
   return Effect.gen(function* () {

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -6,7 +6,9 @@
  * re-exported here for convenience.
  */
 
+import { type Attributes } from "@opentelemetry/api";
 import { createLogger } from "@atlas/api/lib/logger";
+import { withSpan } from "@atlas/api/lib/tracing";
 // Re-export shared utilities so existing consumers (e.g. @atlas/cli) don't break.
 export { mapSQLType, isViewLike, pluralize, singularize, entityName } from "./profiler-utils";
 
@@ -454,7 +456,49 @@ export async function queryPostgresIndexes(
   );
 }
 
-export async function profilePostgres({
+/**
+ * Build the OTel attribute set for an `atlas.profile.*` profiler span (#3684).
+ *
+ * Pure + exported for unit coverage of the attribute keys. Capturing live spans
+ * would mean wiring an `InMemorySpanExporter` into the global tracer provider —
+ * heavier than the typo it would catch — so the pure builder is the load-bearing
+ * piece, mirroring the `atlas.sql.execute` attribute-builder precedent.
+ */
+export function profileSpanAttributes(
+  dbType: string,
+  opts: { schema?: string; selectedTables?: string[]; connectionId?: string } = {},
+): Attributes {
+  return {
+    "atlas.profile.db_type": dbType,
+    ...(opts.schema !== undefined ? { "atlas.profile.schema": opts.schema } : {}),
+    ...(opts.connectionId !== undefined ? { "atlas.profile.connection_id": opts.connectionId } : {}),
+    ...(opts.selectedTables !== undefined
+      ? { "atlas.profile.selected_table_count": opts.selectedTables.length }
+      : {}),
+  };
+}
+
+/** Result attributes for a profiler span — the profiled/error table counts. */
+function profileResultAttributes(result: ProfilingResult): Attributes {
+  return {
+    "atlas.profile.profiled_count": result.profiles.length,
+    "atlas.profile.error_count": result.errors.length,
+  };
+}
+
+export async function profilePostgres(opts: NativeProfileOptions): Promise<ProfilingResult> {
+  // Span the profiler seam so a slow/hanging profile (large table, slow remote
+  // DB) gets latency attribution — the entry point was previously a trace
+  // black-box (#3684). No-op when OTel is uninitialized (zero overhead).
+  return withSpan(
+    "atlas.profile.postgres",
+    profileSpanAttributes("postgres", { schema: opts.schema ?? "public", selectedTables: opts.selectedTables }),
+    () => profilePostgresImpl(opts),
+    profileResultAttributes,
+  );
+}
+
+async function profilePostgresImpl({
   url,
   schema = "public",
   selectedTables: filterTables,
@@ -914,7 +958,18 @@ export async function queryMySQLIndexes(
   return [...grouped.values()];
 }
 
-export async function profileMySQL({
+export async function profileMySQL(opts: NativeProfileOptions): Promise<ProfilingResult> {
+  // Span the profiler seam so a slow/hanging profile gets latency attribution
+  // (#3684). No-op when OTel is uninitialized (zero overhead).
+  return withSpan(
+    "atlas.profile.mysql",
+    profileSpanAttributes("mysql", { selectedTables: opts.selectedTables }),
+    () => profileMySQLImpl(opts),
+    profileResultAttributes,
+  );
+}
+
+async function profileMySQLImpl({
   url,
   selectedTables: filterTables,
   prefetchedObjects,

--- a/packages/api/src/lib/tools/profile-table.ts
+++ b/packages/api/src/lib/tools/profile-table.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { connections, getDB, isConnectionVisibleInMode } from "@atlas/api/lib/db/connection";
 import { getWhitelistedTables, getOrgWhitelistedTables } from "@atlas/api/lib/semantic";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { withSpan } from "@atlas/api/lib/tracing";
 
 const log = createLogger("tool:profile-table");
 
@@ -30,6 +31,26 @@ export const profileTable = tool({
   execute: async ({ table, columns, connectionId }) => {
     const connId = connectionId ?? "default";
 
+    // Span the profileTable tool seam so a slow per-column profile is
+    // attributable in traces (#3684). No-op when OTel is uninitialized.
+    return withSpan(
+      "atlas.profile.table",
+      { "atlas.profile.table": table, "atlas.profile.connection_id": connId },
+      () => profileTableImpl({ table, columns, connId }),
+    );
+  },
+});
+
+async function profileTableImpl({
+  table,
+  columns,
+  connId,
+}: {
+  table: string;
+  columns?: string[];
+  connId: string;
+}) {
+  {
     try {
       // Whitelist + mode visibility check
       const reqCtx = getRequestContext();
@@ -159,8 +180,8 @@ export const profileTable = tool({
         error: `Failed to profile table "${table}": ${err instanceof Error ? err.message : String(err)}`,
       };
     }
-  },
-});
+  }
+}
 
 function quoteIdent(name: string): string {
   // Simple identifier quoting — prevents SQL injection in column/table names

--- a/packages/api/src/lib/tools/profile-table.ts
+++ b/packages/api/src/lib/tools/profile-table.ts
@@ -32,7 +32,7 @@ export const profileTable = tool({
     const connId = connectionId ?? "default";
 
     // Span the profileTable tool seam so a slow per-column profile is
-    // attributable in traces (#3684). No-op when OTel is uninitialized.
+    // attributable in traces (#3684). No-op when OTel is uninitialized (zero overhead).
     return withSpan(
       "atlas.profile.table",
       { "atlas.profile.table": table, "atlas.profile.connection_id": connId },
@@ -50,136 +50,134 @@ async function profileTableImpl({
   columns?: string[];
   connId: string;
 }) {
-  {
-    try {
-      // Whitelist + mode visibility check
-      const reqCtx = getRequestContext();
-      const atlasMode = reqCtx?.atlasMode ?? "published";
-      const authOrgId = reqCtx?.user?.activeOrganizationId;
-      const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
+  try {
+    // Whitelist + mode visibility check
+    const reqCtx = getRequestContext();
+    const atlasMode = reqCtx?.atlasMode ?? "published";
+    const authOrgId = reqCtx?.user?.activeOrganizationId;
+    const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
 
-      // Mode isolation: reject non-visible connections before touching pools.
-      // Mirrors the gate in executeSQL.
-      if (authOrgId) {
-        const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
-        if (!visible) {
-          return {
-            error: `Connection "${connId}" is not available in ${atlasMode} mode.`,
-          };
-        }
-      }
-
-      const whitelist = authOrgId
-        ? getOrgWhitelistedTables(authOrgId, connId, atlasMode)
-        : getWhitelistedTables(connId);
-
-      if (!whitelist.has(table.toLowerCase())) {
+    // Mode isolation: reject non-visible connections before touching pools.
+    // Mirrors the gate in executeSQL.
+    if (authOrgId) {
+      const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
+      if (!visible) {
         return {
-          error: `Table "${table}" is not in the semantic layer whitelist. Only tables defined in entity YAML files can be profiled.`,
+          error: `Connection "${connId}" is not available in ${atlasMode} mode.`,
         };
       }
+    }
 
-      // Get connection info. When org pooling is off we still route per
-      // (workspace, install_id) via getForWorkspace so a shared install_id
-      // resolves the querying workspace's DB, not a sibling's (#3109).
-      const db = poolOrgId
-        ? connections.getForOrg(poolOrgId, connId)
-        : connId === "default"
-          ? getDB()
-          : authOrgId
-            ? connections.getForWorkspace(authOrgId, connId)
-            : connections.get(connId);
+    const whitelist = authOrgId
+      ? getOrgWhitelistedTables(authOrgId, connId, atlasMode)
+      : getWhitelistedTables(connId);
 
-      const dbType = connections.getDBType(connId, authOrgId);
-
-      // Profile using direct SQL queries through the connection
-      const rowCountResult = await db.query(
-        `SELECT COUNT(*) AS cnt FROM ${quoteIdent(table)}`,
-        30000,
-      );
-      const rowCount = parseInt(String(rowCountResult.rows[0]?.cnt ?? "0"), 10);
-
-      // Get column info (table name is whitelist-verified above, escape for defense-in-depth)
-      const safeTable = escapeLiteral(table);
-      const columnInfoSql = dbType === "mysql"
-        ? `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ${safeTable} ORDER BY ordinal_position`
-        : `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ${safeTable} AND table_schema = 'public' ORDER BY ordinal_position`;
-
-      const colInfoResult = await db.query(columnInfoSql, 30000);
-      const allColumns = colInfoResult.rows as Array<{
-        column_name: string;
-        data_type: string;
-        is_nullable: string;
-      }>;
-
-      // Filter to requested columns if specified
-      const targetColumns = columns
-        ? allColumns.filter((c) => columns.includes(c.column_name))
-        : allColumns;
-
-      // Profile each column
-      const profiledColumns = await Promise.all(
-        targetColumns.map(async (col) => {
-          try {
-            const colName = quoteIdent(col.column_name);
-            const tableName = quoteIdent(table);
-
-            // Combined query: distinct count, null count, min, max
-            const textCast = dbType === "mysql" ? `CAST(${colName} AS CHAR)` : `${colName}::text`;
-            const statsResult = await db.query(
-              `SELECT COUNT(DISTINCT ${colName}) AS distinct_count, SUM(CASE WHEN ${colName} IS NULL THEN 1 ELSE 0 END) AS null_count, MIN(${textCast}) AS min_val, MAX(${textCast}) AS max_val FROM ${tableName}`,
-              30000,
-            );
-            const stats = statsResult.rows[0] ?? {};
-
-            // Top values
-            const topResult = await db.query(
-              `SELECT ${textCast} AS val, COUNT(*) AS cnt FROM ${tableName} WHERE ${colName} IS NOT NULL GROUP BY ${colName} ORDER BY cnt DESC LIMIT 10`,
-              30000,
-            );
-
-            const distinctCount = parseInt(String(stats.distinct_count ?? "0"), 10);
-            const nullCount = parseInt(String(stats.null_count ?? "0"), 10);
-
-            return {
-              name: col.column_name,
-              sqlType: col.data_type,
-              nullRate: rowCount > 0 ? nullCount / rowCount : 0,
-              distinctCount,
-              topValues: (topResult.rows as Array<{ val: string; cnt: string | number }>).map((r) => ({
-                value: String(r.val),
-                count: parseInt(String(r.cnt), 10),
-              })),
-              minValue: stats.min_val != null ? String(stats.min_val) : undefined,
-              maxValue: stats.max_val != null ? String(stats.max_val) : undefined,
-            };
-          } catch (err) {
-            log.warn(
-              { err: err instanceof Error ? err.message : String(err), column: col.column_name, table },
-              "Failed to profile column",
-            );
-            return {
-              name: col.column_name,
-              sqlType: col.data_type,
-              nullRate: null,
-              distinctCount: null,
-              topValues: [],
-              error: `Failed to profile: ${err instanceof Error ? err.message : String(err)}`,
-            };
-          }
-        }),
-      );
-
-      return { rowCount, columns: profiledColumns };
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err), table },
-        "profileTable failed",
-      );
+    if (!whitelist.has(table.toLowerCase())) {
       return {
-        error: `Failed to profile table "${table}": ${err instanceof Error ? err.message : String(err)}`,
+        error: `Table "${table}" is not in the semantic layer whitelist. Only tables defined in entity YAML files can be profiled.`,
       };
     }
+
+    // Get connection info. When org pooling is off we still route per
+    // (workspace, install_id) via getForWorkspace so a shared install_id
+    // resolves the querying workspace's DB, not a sibling's (#3109).
+    const db = poolOrgId
+      ? connections.getForOrg(poolOrgId, connId)
+      : connId === "default"
+        ? getDB()
+        : authOrgId
+          ? connections.getForWorkspace(authOrgId, connId)
+          : connections.get(connId);
+
+    const dbType = connections.getDBType(connId, authOrgId);
+
+    // Profile using direct SQL queries through the connection
+    const rowCountResult = await db.query(
+      `SELECT COUNT(*) AS cnt FROM ${quoteIdent(table)}`,
+      30000,
+    );
+    const rowCount = parseInt(String(rowCountResult.rows[0]?.cnt ?? "0"), 10);
+
+    // Get column info (table name is whitelist-verified above, escape for defense-in-depth)
+    const safeTable = escapeLiteral(table);
+    const columnInfoSql = dbType === "mysql"
+      ? `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ${safeTable} ORDER BY ordinal_position`
+      : `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ${safeTable} AND table_schema = 'public' ORDER BY ordinal_position`;
+
+    const colInfoResult = await db.query(columnInfoSql, 30000);
+    const allColumns = colInfoResult.rows as Array<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+    }>;
+
+    // Filter to requested columns if specified
+    const targetColumns = columns
+      ? allColumns.filter((c) => columns.includes(c.column_name))
+      : allColumns;
+
+    // Profile each column
+    const profiledColumns = await Promise.all(
+      targetColumns.map(async (col) => {
+        try {
+          const colName = quoteIdent(col.column_name);
+          const tableName = quoteIdent(table);
+
+          // Combined query: distinct count, null count, min, max
+          const textCast = dbType === "mysql" ? `CAST(${colName} AS CHAR)` : `${colName}::text`;
+          const statsResult = await db.query(
+            `SELECT COUNT(DISTINCT ${colName}) AS distinct_count, SUM(CASE WHEN ${colName} IS NULL THEN 1 ELSE 0 END) AS null_count, MIN(${textCast}) AS min_val, MAX(${textCast}) AS max_val FROM ${tableName}`,
+            30000,
+          );
+          const stats = statsResult.rows[0] ?? {};
+
+          // Top values
+          const topResult = await db.query(
+            `SELECT ${textCast} AS val, COUNT(*) AS cnt FROM ${tableName} WHERE ${colName} IS NOT NULL GROUP BY ${colName} ORDER BY cnt DESC LIMIT 10`,
+            30000,
+          );
+
+          const distinctCount = parseInt(String(stats.distinct_count ?? "0"), 10);
+          const nullCount = parseInt(String(stats.null_count ?? "0"), 10);
+
+          return {
+            name: col.column_name,
+            sqlType: col.data_type,
+            nullRate: rowCount > 0 ? nullCount / rowCount : 0,
+            distinctCount,
+            topValues: (topResult.rows as Array<{ val: string; cnt: string | number }>).map((r) => ({
+              value: String(r.val),
+              count: parseInt(String(r.cnt), 10),
+            })),
+            minValue: stats.min_val != null ? String(stats.min_val) : undefined,
+            maxValue: stats.max_val != null ? String(stats.max_val) : undefined,
+          };
+        } catch (err) {
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err), column: col.column_name, table },
+            "Failed to profile column",
+          );
+          return {
+            name: col.column_name,
+            sqlType: col.data_type,
+            nullRate: null,
+            distinctCount: null,
+            topValues: [],
+            error: `Failed to profile: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      }),
+    );
+
+    return { rowCount, columns: profiledColumns };
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), table },
+      "profileTable failed",
+    );
+    return {
+      error: `Failed to profile table "${table}": ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #3684. The profiler entry points and Stripe webhook processing were trace black-boxes — a slow/hanging profile (large table, slow live DB, profile-over-MCP) or slow webhook processing (multi-second advisory-lock waits, tier-write failures → 400 → Stripe retry storm) had zero latency attribution. This adds OTel spans to both seams, matching the existing `atlas.plugin.*` / `billing.agent_gate` span conventions and the no-op-when-uninitialized contract in `lib/tracing.ts`.

### Profiler seam
Each entry point now emits an `atlas.profile.*` span with db/connection/table attributes:
- `profiler.ts` — `profilePostgres` / `profileMySQL` (`atlas.profile.postgres` | `atlas.profile.mysql`), via `withSpan` (Impl split to avoid re-indenting the bodies)
- `effect/semantic-generator.ts` — `profileImpl` Effect path via `withEffectSpan` (`atlas.profile.connection`), keeping the typed `ProfilingFailedError` in the error channel
- `datasources/mcp-lifecycle.ts` — `profileLiveDatasource` (`atlas.profile.live_datasource`)
- `tools/profile-table.ts` — the `profileTable` tool (`atlas.profile.table`)

A shared `profileSpanAttributes` builder keeps the attribute keys consistent and bounds cardinality (selected-table **count**, not names). Result attributes record profiled/error table counts.

### Stripe webhook
`auth/server.ts` — the classify→sync→record sequence under `withStripeSubscriptionLock` is wrapped in a `stripe.webhook.process` span recording `eventId` / `eventType` / `subscriptionId` plus the applied tier (or `none`) via `setResultAttributes`. The record-last protocol and all original logic/comments are preserved.

## Acceptance criteria
- [x] Profile/listObjects entry points emit OTel spans with db/connection/table attributes
- [x] Stripe webhook processing emits a span recording eventId/type/applied tier
- [x] No-op when OTel is not initialized (zero overhead, per `tracing.ts`)

## Tests
Following the `atlas.sql.execute` precedent (the codebase deliberately avoids wiring an `InMemorySpanExporter` into the global tracer provider), the pure attribute builders are exported and unit-tested:
- `profiler-span.test.ts` — `profileSpanAttributes` key/omission/cardinality behaviour
- `stripe-webhook-span.test.ts` — `buildStripeWebhookSpanAttributes` event-id/type/subscription-id behaviour

The no-op wrap behaviour is exercised by the existing `tracing`, `semantic-generator`, and `stripe-webhook-lifecycle` suites (all still green through the new wraps).

## CI
All six gates pass locally: `lint`, `type`, full `bun run test`, `syncpack lint`, template-drift, railway-watch.

No docs impact (internal observability only).

https://claude.ai/code/session_01KYu9p7Qm4Th8AN7fhcM1Dr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYu9p7Qm4Th8AN7fhcM1Dr)_