### PR TITLE
test(web): deflake starter-prompts cache contract under parallel runner (#3455)

### DIFF
--- a/packages/web/src/ui/__tests__/starter-prompts-cache-contract.test.tsx
+++ b/packages/web/src/ui/__tests__/starter-prompts-cache-contract.test.tsx
@@ -1,6 +1,18 @@
-import { describe, expect, test, afterEach, mock } from "bun:test";
-import { render, cleanup, waitFor, act } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  afterEach,
+  mock,
+} from "bun:test";
+import { render, cleanup, act } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  notifyManager,
+} from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import { NotebookEmptyState } from "../components/notebook/notebook-empty-state";
@@ -17,6 +29,16 @@ import { NotebookEmptyState } from "../components/notebook/notebook-empty-state"
  * We simulate the pin-side mutation here (no need to mount AtlasChat's
  * full dependency tree) and assert the notebook surface reflects the
  * new data while fetch is only called once.
+ *
+ * Determinism note (#3455): TanStack Query schedules observer notifications
+ * on a `setTimeout(0)` macrotask by default (`notifyManager`'s
+ * `systemSetTimeoutZero`). Under the parallel isolated runner the box is
+ * CPU-saturated and that macrotask can be starved well past the 5s test
+ * timeout, so a `setQueryData` mutation never reaches the reader and the
+ * assertion hangs. We force synchronous notification for the duration of
+ * this file so cache mutations propagate inside `act()`, independent of
+ * event-loop scheduling and machine load. This is a test-only knob — it
+ * does not change the product code path.
  */
 
 const QUERY_KEY = ["atlas", "starter-prompts", ""] as const;
@@ -28,6 +50,15 @@ function buildWrapper(client: QueryClient) {
 }
 
 describe("starter prompts cache contract", () => {
+  beforeAll(() => {
+    notifyManager.setScheduler((cb) => cb());
+  });
+
+  afterAll(() => {
+    // Restore TanStack's documented default (systemSetTimeoutZero).
+    notifyManager.setScheduler((cb) => setTimeout(cb, 0));
+  });
+
   afterEach(() => {
     cleanup();
     mock.restore();
@@ -70,8 +101,10 @@ describe("starter prompts cache contract", () => {
       expect(fetchCalls.length).toBe(1);
 
       // Simulate what AtlasChat.handlePin does after a successful POST —
-      // prepend the new favorite via setQueryData on the shared key.
-      act(() => {
+      // prepend the new favorite via setQueryData on the shared key. With the
+      // synchronous notifyManager scheduler the observer flush happens inside
+      // act(), so the reader updates deterministically before we assert.
+      await act(async () => {
         client.setQueryData<StarterPrompt[]>(QUERY_KEY, (prev) => {
           const base = prev ?? [];
           return [
@@ -81,16 +114,14 @@ describe("starter prompts cache contract", () => {
         });
       });
 
-      // Reader reflects the mutation immediately.
-      expect(await findByText("Freshly pinned")).toBeTruthy();
+      // Reader reflects the mutation; the pre-existing row is untouched.
+      expect(queryByText("Freshly pinned")).toBeTruthy();
       expect(queryByText("Library row")).toBeTruthy();
 
-      // No additional fetch — proves the reader pulled from cache, not
-      // the network. A regression that drops setQueryData in favor of
+      // No additional fetch — proves the reader pulled from cache, not the
+      // network. A regression that drops setQueryData in favor of
       // `invalidate + refetch` would bump this count.
-      await waitFor(() => {
-        expect(fetchCalls.length).toBe(1);
-      });
+      expect(fetchCalls.length).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -131,16 +162,16 @@ describe("starter prompts cache contract", () => {
 
       expect(await findByText("Already pinned")).toBeTruthy();
 
-      // Simulate AtlasChat.handleUnpin — drop the row by id.
-      act(() => {
+      // Simulate AtlasChat.handleUnpin — drop the row by id. The synchronous
+      // scheduler flushes the observer inside act(), so the removal is
+      // observable immediately after.
+      await act(async () => {
         client.setQueryData<StarterPrompt[]>(QUERY_KEY, (prev) =>
           (prev ?? []).filter((p) => p.id !== "favorite:existing"),
         );
       });
 
-      await waitFor(() => {
-        expect(queryByText("Already pinned")).toBeNull();
-      });
+      expect(queryByText("Already pinned")).toBeNull();
       expect(queryByText("Library row")).toBeTruthy();
       expect(fetchCalls.length).toBe(1);
     } finally {


### PR DESCRIPTION
## Summary

`starter-prompts-cache-contract.test.tsx` failed intermittently under the parallel isolated runner (`scripts/test-isolated.ts`) on CPU-saturated boxes, while passing reliably in isolation. This deflakes it by fixing the **root cause** — no retries or timeout bumps.

Closes #3455.

## Root cause

TanStack Query's `notifyManager` schedules observer notifications on a **`setTimeout(0)` macrotask** by default (`systemSetTimeoutZero`). The test mutates the shared cache with `client.setQueryData(...)` inside `act()` and then asserts the reader surface reflects it.

- A synchronous `act()` does **not** drain that macrotask (it's not a microtask either — confirmed: `await act(async)` also leaves the element present).
- Under the parallel runner the machine is oversubscribed, so the `setTimeout(0)` flush — **and** the `waitFor` poll/timeout that was meant to catch up, which is *also* timer-based — get starved well past bun's 5s per-test watchdog.
- Result: the `unpin` test hung until the watchdog killed it. It failed ~100% under load (reproduced **72/72** with 24 procs × 3 rounds) but passed 20/20 in isolation.

The first test survived only because it `await`s `findByText` for an element to *appear* (MutationObserver-driven), dodging the starved timer; the `unpin` test raced a starved `setTimeout`.

## Fix

Force a **synchronous `notifyManager` scheduler** for this file via `beforeAll`/`afterAll` (restoring TanStack's default), so cache mutations flush inside `act()` deterministically, independent of event-loop scheduling and machine load. The now-deterministic flush lets the timer-dependent `waitFor` assertions become plain synchronous reads.

- Test-only knob — the product code path is unchanged.
- Set in a lifecycle hook (not module top-level) per the repo's no-top-level-singleton-mutation testing rule.

## Verification

- **20/20** consecutive runs in isolation (`bun test <file>`)
- **72/72** under heavy parallel load (24 processes × 3 rounds) — the exact reproduction that previously failed **72/72**
- **3/3** via the package isolated runner (`scripts/test-isolated.ts <file>`)
- Local gates green: lint, type, syncpack, template drift, test-discipline

## Test plan

- [x] Reproduce the flake under load before changing anything
- [x] Identify root cause (starved macrotask scheduler, not generic slowness)
- [x] Fix the cause; verify deterministically under load