### PR TITLE
fix(billing): durable Stripe teardown outbox + reconcile sweep (#3679)

### DIFF
--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -750,8 +750,12 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     // fails, and the @better-auth/stripe plugin's own guard blocks
     // user-initiated org deletion while subscriptions exist — this
     // direct-DB path honors the same ordering rather than bypassing it.
-    // Stripe failures join the existing `warnings` array; delete proceeds.
-    const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(orgId));
+    // Stripe failures join the existing `warnings` array AND are persisted to
+    // the durable teardown outbox for retry (#3679); delete proceeds. The
+    // customer id enables drift detection over a drifted-empty local table.
+    const billing = yield* Effect.promise(() =>
+      cancelStripeSubscriptionsForWorkspace(orgId, workspace.stripe_customer_id),
+    );
     warnings.push(...billing.warnings);
 
     const cascade = yield* Effect.tryPromise({

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -733,8 +733,13 @@ platformAdmin.openapi(deleteWorkspaceRoute, async (c) => {
     // @better-auth/stripe plugin's own guard blocks user-initiated org
     // deletion while subscriptions exist — this direct-DB path honors the
     // same ordering rather than bypassing it. Stripe failures surface as
-    // operator warnings on the response; the delete proceeds.
-    const billing = yield* Effect.promise(() => cancelStripeSubscriptionsForWorkspace(workspaceId));
+    // operator warnings on the response AND are persisted to the durable
+    // teardown outbox for retry (#3679); the delete proceeds. The customer
+    // id enables drift detection — if the local subscription table drifted
+    // empty, Stripe is queried directly so a live sub can't survive.
+    const billing = yield* Effect.promise(() =>
+      cancelStripeSubscriptionsForWorkspace(workspaceId, workspace.stripe_customer_id),
+    );
 
     // Cascade cleanup first, then mark as deleted — if cleanup fails,
     // the workspace remains in its current state and can be retried.

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -387,6 +387,7 @@ describe("migrateAuthTables", () => {
             { name: "0138_semantic_profile_status.sql" },
             { name: "0139_learned_patterns_auto_promoted.sql" },
             { name: "0140_operator_integration_credentials.sql" },
+            { name: "0141_stripe_teardown_pending.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/billing/__tests__/reconcile-stripe-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-stripe-teardown.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the Stripe teardown outbox sweep (#3679).
+ *
+ * The sweep drains `stripe_teardown_pending`, retrying each op until success
+ * or `resource_missing`. Covers:
+ *   - cancel-fails-then-sweep-succeeds (the headline durability guarantee)
+ *   - GDPR purge customer-delete retry
+ *   - resource_missing → resolved (target already gone)
+ *   - non-terminal failure → attempts bumped, row kept
+ *   - no Stripe / no internal DB → clean no-op
+ *   - internal-DB failure propagates so the scheduler tick retries
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+// ── In-memory outbox the mocked internalQuery operates over ─────────
+
+interface StoredRow {
+  id: string;
+  workspace_id: string;
+  stripe_sub_id: string | null;
+  stripe_customer_id: string | null;
+  op: string;
+  attempts: number;
+}
+let store: StoredRow[] = [];
+let hasDb = true;
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    const p = params ?? [];
+    const trimmed = sql.trimStart();
+    // Order matters: DELETE/UPDATE statements also contain
+    // "FROM stripe_teardown_pending", so match the verb first.
+    if (trimmed.startsWith("DELETE")) {
+      store = store.filter((r) => r.id !== String(p[0]));
+      return [];
+    }
+    if (trimmed.startsWith("UPDATE")) {
+      const row = store.find((r) => r.id === String(p[0]));
+      if (row) row.attempts += 1;
+      return [];
+    }
+    if (trimmed.startsWith("SELECT")) {
+      // SELECT … ORDER BY attempts ASC, created_at ASC LIMIT $1
+      return [...store].sort((a, b) => a.attempts - b.attempts).slice(0, Number(p[0]));
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({
+    internalQuery: mockInternalQuery,
+    hasInternalDB: () => hasDb,
+  }),
+}));
+
+const stubLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  setLogLevel: () => false,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [] as string[],
+  hashShareToken: (token: string) => token,
+}));
+
+// ── Mocked Stripe client ────────────────────────────────────────────
+
+const subscriptionsCancel: Mock<(id: string) => Promise<unknown>> = mock(async (id: string) => ({
+  id,
+  status: "canceled",
+}));
+const customersDel: Mock<(id: string) => Promise<unknown>> = mock(async (id: string) => ({
+  id,
+  deleted: true,
+}));
+let stripeAvailable = true;
+mock.module("@atlas/api/lib/billing/stripe-client", () => ({
+  getStripeClient: () =>
+    stripeAvailable
+      ? { subscriptions: { cancel: subscriptionsCancel }, customers: { del: customersDel } }
+      : null,
+  _resetStripeClientCache: () => {},
+}));
+
+// Real `isStripeResourceMissing` (a pure predicate) is imported transitively
+// by the sweep — NOT mocked, so the resource_missing branch is exercised
+// end-to-end.
+const { sweepStripeTeardownPending } = await import("../reconcile-stripe-teardown");
+
+class FakeStripeError extends Error {
+  code: string | undefined;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function cancelRow(id: string, subId: string, attempts = 0): StoredRow {
+  return {
+    id,
+    workspace_id: "org-acme",
+    stripe_sub_id: subId,
+    stripe_customer_id: "cus_acme",
+    op: "cancel_subscription",
+    attempts,
+  };
+}
+function customerRow(id: string, customerId: string, attempts = 0): StoredRow {
+  return {
+    id,
+    workspace_id: "org-acme",
+    stripe_sub_id: null,
+    stripe_customer_id: customerId,
+    op: "delete_customer",
+    attempts,
+  };
+}
+
+beforeEach(() => {
+  store = [];
+  hasDb = true;
+  stripeAvailable = true;
+  mockInternalQuery.mockClear();
+  subscriptionsCancel.mockReset();
+  subscriptionsCancel.mockImplementation(async (id: string) => ({ id, status: "canceled" }));
+  customersDel.mockReset();
+  customersDel.mockImplementation(async (id: string) => ({ id, deleted: true }));
+});
+
+describe("sweepStripeTeardownPending", () => {
+  it("no-ops without an internal DB", async () => {
+    hasDb = false;
+    await expect(sweepStripeTeardownPending()).resolves.toEqual({ scanned: 0, resolved: 0, failed: 0 });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when Stripe is not configured", async () => {
+    stripeAvailable = false;
+    store = [cancelRow("r1", "sub_1")];
+    await expect(sweepStripeTeardownPending()).resolves.toEqual({ scanned: 0, resolved: 0, failed: 0 });
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending subscription and removes the row", async () => {
+    store = [cancelRow("r1", "sub_1")];
+
+    const result = await sweepStripeTeardownPending();
+
+    expect(subscriptionsCancel).toHaveBeenCalledWith("sub_1");
+    expect(result).toEqual({ scanned: 1, resolved: 1, failed: 0 });
+    expect(store).toEqual([]); // row removed
+  });
+
+  it("deletes a pending Stripe customer and removes the row (GDPR purge retry)", async () => {
+    store = [customerRow("r1", "cus_acme")];
+
+    const result = await sweepStripeTeardownPending();
+
+    expect(customersDel).toHaveBeenCalledWith("cus_acme");
+    expect(result).toEqual({ scanned: 1, resolved: 1, failed: 0 });
+    expect(store).toEqual([]);
+  });
+
+  it("cancel-fails-then-sweep-succeeds: keeps + bumps the row on failure, removes it once it succeeds", async () => {
+    store = [cancelRow("r1", "sub_flaky")];
+    subscriptionsCancel.mockImplementationOnce(async () => {
+      throw new FakeStripeError("stripe 503");
+    });
+
+    // First pass: Stripe is down → row kept, attempts bumped.
+    const first = await sweepStripeTeardownPending();
+    expect(first).toEqual({ scanned: 1, resolved: 0, failed: 1 });
+    expect(store).toHaveLength(1);
+    expect(store[0].attempts).toBe(1);
+
+    // Second pass: Stripe recovers → cancel succeeds, row removed.
+    const second = await sweepStripeTeardownPending();
+    expect(second).toEqual({ scanned: 1, resolved: 1, failed: 0 });
+    expect(store).toEqual([]);
+  });
+
+  it("treats resource_missing as resolved and removes the row (target already gone)", async () => {
+    store = [cancelRow("r1", "sub_gone")];
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("No such subscription", "resource_missing");
+    });
+
+    const result = await sweepStripeTeardownPending();
+
+    expect(result).toEqual({ scanned: 1, resolved: 1, failed: 0 });
+    expect(store).toEqual([]);
+  });
+
+  it("keeps a row failing for a non-terminal reason, bumping its attempts", async () => {
+    store = [cancelRow("r1", "sub_1"), customerRow("r2", "cus_1")];
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("rate_limited");
+    });
+    customersDel.mockImplementation(async () => {
+      throw new FakeStripeError("api_error");
+    });
+
+    const result = await sweepStripeTeardownPending();
+
+    expect(result).toEqual({ scanned: 2, resolved: 0, failed: 2 });
+    expect(store).toHaveLength(2);
+    expect(store.every((r) => r.attempts === 1)).toBe(true);
+  });
+
+  it("drops a malformed row instead of retrying a no-op forever", async () => {
+    store = [
+      { id: "bad", workspace_id: "o", stripe_sub_id: null, stripe_customer_id: null, op: "cancel_subscription", attempts: 0 },
+    ];
+
+    const result = await sweepStripeTeardownPending();
+
+    expect(subscriptionsCancel).not.toHaveBeenCalled();
+    expect(result.resolved).toBe(1);
+    expect(store).toEqual([]);
+  });
+
+  it("requests a bounded batch ordered by attempts", async () => {
+    store = [cancelRow("r1", "sub_1")];
+    await sweepStripeTeardownPending();
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("ORDER BY attempts ASC");
+    expect(sql).toContain("LIMIT $1");
+    expect(typeof params[0]).toBe("number");
+  });
+
+  it("propagates an internal-DB read failure so the scheduler tick retries", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM stripe_teardown_pending")) throw new Error("pg down");
+      return [];
+    });
+    await expect(sweepStripeTeardownPending()).rejects.toThrow("pg down");
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -70,6 +70,17 @@ const customersDel: Mock<(id: string) => Promise<unknown>> = mock(async (id: str
   return { id, deleted: true };
 });
 
+/** Live Stripe subscriptions returned by `subscriptions.list` per customer id
+ *  for drift detection (#3679). Default empty — only drift tests populate it. */
+let liveStripeSubs: Record<string, { id: string; status: string; customer?: string }[]> = {};
+const subscriptionsList: Mock<(params: Record<string, unknown>) => Promise<unknown>> = mock(
+  async (params: Record<string, unknown>) => {
+    callOrder.push(`subscriptions.list:${String(params.customer)}`);
+    const subs = liveStripeSubs[String(params.customer)] ?? [];
+    return { data: subs, has_more: false };
+  },
+);
+
 /** Open invoices returned by `invoices.list` per subscription id (#3467). */
 let openInvoices: Record<string, string[]> = {};
 
@@ -88,7 +99,7 @@ const invoicesVoid: Mock<(id: string) => Promise<unknown>> = mock(async (id: str
 let stripeAvailable = true;
 function makeStripeStub() {
   return {
-    subscriptions: { cancel: subscriptionsCancel, update: subscriptionsUpdate },
+    subscriptions: { cancel: subscriptionsCancel, update: subscriptionsUpdate, list: subscriptionsList },
     customers: { del: customersDel },
     invoices: { list: invoicesList, voidInvoice: invoicesVoid },
   };
@@ -105,6 +116,48 @@ const {
   pauseStripeCollectionForWorkspace,
   resumeStripeCollectionForWorkspace,
 } = await import("../workspace-teardown");
+
+/** Rows captured by the outbox INSERT — pins durable persistence (#3679). */
+interface EnqueuedOp {
+  workspaceId: string;
+  op: string;
+  stripeSubId: string | null;
+  stripeCustomerId: string | null;
+  lastError: string | null;
+}
+
+/**
+ * Route `mockInternalQuery` so `FROM subscription` returns `rows` and the
+ * outbox INSERTs are captured into `enqueued`. Returns the capture array.
+ */
+function captureOutbox(rows: Record<string, unknown>[]): EnqueuedOp[] {
+  const enqueued: EnqueuedOp[] = [];
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("FROM subscription")) return rows;
+    if (sql.includes("INSERT INTO stripe_teardown_pending")) {
+      const p = params ?? [];
+      if (sql.includes("'cancel_subscription'")) {
+        enqueued.push({
+          workspaceId: String(p[0]),
+          op: "cancel_subscription",
+          stripeSubId: (p[1] as string | null) ?? null,
+          stripeCustomerId: (p[2] as string | null) ?? null,
+          lastError: (p[3] as string | null) ?? null,
+        });
+      } else {
+        enqueued.push({
+          workspaceId: String(p[0]),
+          op: "delete_customer",
+          stripeSubId: null,
+          stripeCustomerId: (p[1] as string | null) ?? null,
+          lastError: (p[2] as string | null) ?? null,
+        });
+      }
+    }
+    return [];
+  });
+  return enqueued;
+}
 
 // ── Fixtures ────────────────────────────────────────────────────────
 
@@ -138,14 +191,21 @@ beforeEach(() => {
   stripeAvailable = true;
   callOrder = [];
   openInvoices = {};
+  liveStripeSubs = {};
   mockInternalQuery.mockReset();
   mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   subscriptionsCancel.mockClear();
   subscriptionsUpdate.mockClear();
+  subscriptionsList.mockClear();
   customersDel.mockClear();
   invoicesList.mockClear();
   invoicesVoid.mockClear();
   mockLogError.mockClear();
+  subscriptionsList.mockImplementation(async (params: Record<string, unknown>) => {
+    callOrder.push(`subscriptions.list:${String(params.customer)}`);
+    const subs = liveStripeSubs[String(params.customer)] ?? [];
+    return { data: subs, has_more: false };
+  });
   // Restore default success implementations after failure-path tests.
   subscriptionsCancel.mockImplementation(async (id: string) => {
     callOrder.push(`cancel:${id}`);
@@ -517,5 +577,166 @@ describe("pauseStripeCollectionForWorkspace — voids open invoices (#3467)", ()
 
     expect(invoicesList).not.toHaveBeenCalled();
     expect(invoicesVoid).not.toHaveBeenCalled();
+  });
+});
+
+// ── Durable teardown outbox: persist failed ops for retry (#3679) ───
+
+describe("durable teardown outbox (#3679)", () => {
+  it("persists a failed cancel to the outbox (cancel-fails → enqueue → swept later)", async () => {
+    const enqueued = captureOutbox([subRow("sub_boom", "active", "cus_acme")]);
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("stripe is down");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
+
+    // Warning still surfaced (legacy fallback), AND the op is durable.
+    expect(outcome.warnings).toHaveLength(1);
+    expect(enqueued).toEqual([
+      {
+        workspaceId: ORG,
+        op: "cancel_subscription",
+        stripeSubId: "sub_boom",
+        stripeCustomerId: "cus_acme",
+        lastError: "stripe is down",
+      },
+    ]);
+  });
+
+  it("does NOT enqueue a resource_missing cancel (already gone, nothing to retry)", async () => {
+    const enqueued = captureOutbox([subRow("sub_gone", "active")]);
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("No such subscription", "resource_missing");
+    });
+
+    await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
+
+    expect(enqueued).toEqual([]);
+  });
+
+  it("does NOT enqueue when every cancel succeeds", async () => {
+    const enqueued = captureOutbox([subRow("sub_1", "active"), subRow("sub_2", "active")]);
+
+    await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
+
+    expect(enqueued).toEqual([]);
+  });
+
+  it("GDPR purge: persists a failed customer delete to the outbox for retry", async () => {
+    const enqueued = captureOutbox([]);
+    customersDel.mockImplementation(async () => {
+      throw new FakeStripeError("api_error");
+    });
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_acme");
+
+    expect(outcome.warnings).toHaveLength(1);
+    expect(enqueued).toEqual([
+      {
+        workspaceId: ORG,
+        op: "delete_customer",
+        stripeSubId: null,
+        stripeCustomerId: "cus_acme",
+        lastError: "api_error",
+      },
+    ]);
+  });
+
+  it("falls back to a warning when the outbox INSERT itself fails — never throws", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM subscription")) return [subRow("sub_boom", "active")];
+      if (sql.includes("INSERT INTO stripe_teardown_pending")) {
+        throw new Error("internal db down");
+      }
+      return [];
+    });
+    subscriptionsCancel.mockImplementation(async () => {
+      throw new FakeStripeError("stripe is down");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
+
+    // The cancel-failure warning PLUS the persistence-failure fallback warning.
+    expect(outcome.attempted).toBe(true);
+    expect(outcome.warnings.some((w) => w.includes("automatic retry"))).toBe(true);
+    expect(mockLogError).toHaveBeenCalled();
+  });
+});
+
+// ── Drift detection: zero local rows but a live Stripe customer (#3679) ─
+
+describe("drift detection — zero local rows but a live customer (#3679)", () => {
+  it("queries Stripe and enqueues live subscriptions found with no local record", async () => {
+    const enqueued = captureOutbox([]); // no local subscription rows
+    liveStripeSubs = {
+      cus_drift: [
+        { id: "sub_live_a", status: "active" },
+        { id: "sub_live_b", status: "trialing" },
+      ],
+    };
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG, "cus_drift");
+
+    expect(subscriptionsList).toHaveBeenCalledTimes(1);
+    expect(enqueued.map((e) => e.stripeSubId).toSorted()).toEqual(["sub_live_a", "sub_live_b"]);
+    expect(enqueued.every((e) => e.op === "cancel_subscription")).toBe(true);
+    // A warning surfaces the drift rather than silently no-op'ing.
+    expect(outcome.warnings.some((w) => w.includes("no local record"))).toBe(true);
+  });
+
+  it("skips terminal Stripe subscriptions during drift detection", async () => {
+    const enqueued = captureOutbox([]);
+    liveStripeSubs = {
+      cus_drift: [
+        { id: "sub_live", status: "active" },
+        { id: "sub_done", status: "canceled" },
+      ],
+    };
+
+    await cancelStripeSubscriptionsForWorkspace(ORG, "cus_drift");
+
+    expect(enqueued.map((e) => e.stripeSubId)).toEqual(["sub_live"]);
+  });
+
+  it("does NOT query Stripe for drift when local rows exist", async () => {
+    captureOutbox([subRow("sub_1", "active")]);
+
+    await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
+
+    expect(subscriptionsList).not.toHaveBeenCalled();
+  });
+
+  it("does NOT query Stripe for drift when no customer id is supplied", async () => {
+    captureOutbox([]);
+
+    await cancelStripeSubscriptionsForWorkspace(ORG);
+
+    expect(subscriptionsList).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a warning (and logs) when the drift query itself fails — never throws", async () => {
+    captureOutbox([]);
+    subscriptionsList.mockImplementation(async () => {
+      throw new FakeStripeError("stripe list down");
+    });
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG, "cus_drift");
+
+    expect(outcome.attempted).toBe(true);
+    expect(outcome.warnings.some((w) => w.includes("Could not check Stripe"))).toBe(true);
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("GDPR purge: detects drift, enqueues the live sub, AND still deletes the customer", async () => {
+    const enqueued = captureOutbox([]); // local table drifted empty
+    liveStripeSubs = { cus_drift: [{ id: "sub_orphan", status: "active" }] };
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, "cus_drift");
+
+    expect(enqueued.some((e) => e.op === "cancel_subscription" && e.stripeSubId === "sub_orphan")).toBe(true);
+    // Customer is still deleted — a purge must leave no billable linkage.
+    expect(customersDel.mock.calls.map((c) => c[0])).toEqual(["cus_drift"]);
+    expect(outcome.warnings.some((w) => w.includes("no local record"))).toBe(true);
   });
 });

--- a/packages/api/src/lib/billing/reconcile-stripe-teardown.ts
+++ b/packages/api/src/lib/billing/reconcile-stripe-teardown.ts
@@ -1,0 +1,209 @@
+/**
+ * Stripe teardown outbox sweep (#3679) — the symmetric counterpart to the
+ * plan-tier reconcile sweep (`reconcile-plan-tiers.ts`).
+ *
+ * Workspace delete/purge cancels the org's Stripe subscriptions (and, on a
+ * GDPR purge, deletes the Stripe customer) BEFORE the DB cascade runs. Those
+ * Stripe calls used to be "total" — a transient Stripe 5xx/timeout at that
+ * instant folded into a free-text warnings string and the cascade proceeded
+ * regardless, leaving a live subscription invoicing a workspace that no longer
+ * exists (and, for a purge, a billable customer/PII linkage surviving a
+ * "hard delete"). `workspace-teardown.ts` now persists every failed (or
+ * drift-detected) op into the `stripe_teardown_pending` outbox; this sweep is
+ * the durable retry that drains it.
+ *
+ * Each tick reads a batch of pending rows and retries the op:
+ *  - `cancel_subscription` → `subscriptions.cancel`
+ *  - `delete_customer`     → `customers.del`
+ * On success OR `resource_missing` (Stripe never resurrects an id, so a
+ * missing target IS the desired end state) the row is removed. On any other
+ * failure the row's `attempts`/`last_error` are bumped and it is left for the
+ * next tick — retrying until success or `resource_missing`, per the issue.
+ *
+ * Gating: needs `STRIPE_SECRET_KEY` (to act on Stripe) + an internal DB (to
+ * hold the outbox). No-ops cleanly otherwise — self-hosted deployments without
+ * Stripe never accrue outbox rows. Forked as a periodic fiber in
+ * `lib/effect/layers.ts`, alongside the plan-tier reconcile.
+ *
+ * Internal-DB failures propagate so the scheduler tick logs and retries next
+ * interval (same contract as `reconcilePlanTiers`); per-row Stripe failures
+ * are caught and recorded, never thrown.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
+import { isStripeResourceMissing } from "@atlas/api/lib/billing/workspace-teardown";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("billing:teardown-sweep");
+
+/**
+ * How often the teardown sweep ticks. A stranded subscription keeps invoicing
+ * a deleted customer, so this is more urgent than the 6-hour plan-tier sweep —
+ * but Stripe outages resolve in minutes, the table is normally empty, and the
+ * scan is a cheap indexed read, so 15 minutes balances promptness against load.
+ * Exported so `layers.ts` references the same value the fiber is documented
+ * around. `Effect.repeat(Schedule.spaced)` runs the tick once eagerly on boot,
+ * so a deploy also drains any backlog immediately.
+ */
+export const STRIPE_TEARDOWN_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Per-tick batch cap. The table is normally empty; a bound keeps a large
+ * backlog (mass-delete during a long Stripe outage) from monopolizing one
+ * tick — the remainder drains on the next. Ordered by `attempts` so the
+ * least-tried rows are processed first and a single stuck row can't starve
+ * fresh ones.
+ */
+const SWEEP_BATCH_SIZE = 100;
+
+export interface StripeTeardownSweepResult {
+  /** Rows examined this tick. */
+  readonly scanned: number;
+  /** Rows whose Stripe op succeeded or was already gone — removed. */
+  readonly resolved: number;
+  /** Rows still failing — `attempts`/`last_error` bumped, kept for retry. */
+  readonly failed: number;
+}
+
+// Type alias (not interface): internalQuery's generic is constrained to
+// Record<string, unknown>, satisfied by an object-literal alias's implicit
+// index signature.
+type PendingRow = {
+  id: string;
+  workspace_id: string;
+  stripe_sub_id: string | null;
+  stripe_customer_id: string | null;
+  op: string;
+  attempts: number;
+};
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function deletePendingRow(id: string): Promise<void> {
+  await internalQuery(`DELETE FROM stripe_teardown_pending WHERE id = $1`, [id]);
+}
+
+async function bumpAttempt(id: string, lastError: string): Promise<void> {
+  await internalQuery(
+    `UPDATE stripe_teardown_pending
+        SET attempts = attempts + 1, last_error = $2, updated_at = NOW()
+      WHERE id = $1`,
+    [id, lastError],
+  );
+}
+
+/**
+ * Retry one outbox row. Returns whether it was resolved (removed) or left for
+ * the next tick. The Stripe call is the ONLY thing wrapped in the try — the
+ * subsequent DB write runs outside it, so an internal-DB error propagates to
+ * the sweep (and the scheduler retries) instead of being misread as a Stripe
+ * failure that bumps `attempts` for an op that actually succeeded.
+ */
+async function processPendingRow(
+  stripe: NonNullable<ReturnType<typeof getStripeClient>>,
+  row: PendingRow,
+): Promise<"resolved" | "failed"> {
+  // Drop structurally-invalid rows rather than retry a no-op forever. The
+  // CHECK constraint makes these unreachable in practice, but a defensive
+  // drop keeps a malformed row from pinning the sweep.
+  if (row.op === "cancel_subscription" && !row.stripe_sub_id) {
+    await deletePendingRow(row.id);
+    log.warn({ id: row.id }, "Dropped malformed teardown row: cancel_subscription with no stripe_sub_id");
+    return "resolved";
+  }
+  if (row.op === "delete_customer" && !row.stripe_customer_id) {
+    await deletePendingRow(row.id);
+    log.warn({ id: row.id }, "Dropped malformed teardown row: delete_customer with no stripe_customer_id");
+    return "resolved";
+  }
+  if (row.op !== "cancel_subscription" && row.op !== "delete_customer") {
+    await deletePendingRow(row.id);
+    log.warn({ id: row.id, op: row.op }, "Dropped teardown row with unknown op");
+    return "resolved";
+  }
+
+  let opError: unknown = null;
+  try {
+    if (row.op === "cancel_subscription") {
+      await stripe.subscriptions.cancel(row.stripe_sub_id as string);
+    } else {
+      await stripe.customers.del(row.stripe_customer_id as string);
+    }
+  } catch (err) {
+    opError = err;
+  }
+
+  if (opError !== null && !isStripeResourceMissing(opError)) {
+    const msg = errMessage(opError);
+    await bumpAttempt(row.id, msg);
+    log.warn(
+      {
+        id: row.id,
+        workspaceId: row.workspace_id,
+        op: row.op,
+        attempts: row.attempts + 1,
+        err: msg,
+      },
+      "Stripe teardown op still failing — will retry next sweep",
+    );
+    return "failed";
+  }
+
+  await deletePendingRow(row.id);
+  log.info(
+    {
+      id: row.id,
+      workspaceId: row.workspace_id,
+      op: row.op,
+      alreadyGone: opError !== null,
+    },
+    opError !== null
+      ? "Stripe teardown target already absent — outbox row resolved"
+      : "Completed stranded Stripe teardown op via outbox sweep",
+  );
+  return "resolved";
+}
+
+/**
+ * One sweep pass. Idempotent; safe to run concurrently across pods — each row
+ * is claimed-and-removed by id, and a row processed by another pod between the
+ * SELECT and the per-row op simply no-ops (the Stripe call hits
+ * `resource_missing`, the DELETE matches zero rows). No-ops without Stripe or
+ * an internal DB. Throws on internal-DB failure so the scheduler tick logs and
+ * retries.
+ */
+export async function sweepStripeTeardownPending(): Promise<StripeTeardownSweepResult> {
+  if (!hasInternalDB()) return { scanned: 0, resolved: 0, failed: 0 };
+  const stripe = getStripeClient();
+  if (!stripe) return { scanned: 0, resolved: 0, failed: 0 };
+
+  const rows = await internalQuery<PendingRow>(
+    `SELECT id, workspace_id, stripe_sub_id, stripe_customer_id, op, attempts
+       FROM stripe_teardown_pending
+      ORDER BY attempts ASC, created_at ASC
+      LIMIT $1`,
+    [SWEEP_BATCH_SIZE],
+  );
+
+  let resolved = 0;
+  let failed = 0;
+  // Sequential, not Promise.all: a background sweep over a normally-empty
+  // table — serializing the per-row Stripe calls + DB writes keeps the sweep
+  // from bursting either the internal pool or the Stripe rate limit.
+  for (const row of rows) {
+    const outcome = await processPendingRow(stripe, row);
+    if (outcome === "resolved") resolved += 1;
+    else failed += 1;
+  }
+
+  if (resolved > 0 || failed > 0) {
+    log.info(
+      { scanned: rows.length, resolved, failed },
+      "Stripe teardown outbox sweep pass complete",
+    );
+  }
+  return { scanned: rows.length, resolved, failed };
+}

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -93,8 +93,12 @@ interface SubscriptionRow {
   [key: string]: unknown;
 }
 
-/** Stripe "the object no longer exists" — treat as already torn down. */
-function isResourceMissing(err: unknown): boolean {
+/**
+ * Stripe "the object no longer exists" — treat as already torn down.
+ * Exported so the durable-outbox sweep (`reconcile-stripe-teardown.ts`) shares
+ * the exact same terminal-success predicate as the inline teardown path.
+ */
+export function isStripeResourceMissing(err: unknown): boolean {
   return (
     typeof err === "object"
     && err !== null
@@ -104,6 +108,189 @@ function isResourceMissing(err: unknown): boolean {
 
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** A Stripe teardown op that outlived its inline attempt — durably retried. */
+export type StripeTeardownOp = "cancel_subscription" | "delete_customer";
+
+/**
+ * One row to persist into the `stripe_teardown_pending` outbox. The operative
+ * id depends on `op` (subscription id for a cancel, customer id for a delete);
+ * the migration's CHECK enforces the right one is present.
+ */
+export interface PendingTeardownOp {
+  workspaceId: string;
+  op: StripeTeardownOp;
+  stripeSubId: string | null;
+  stripeCustomerId: string | null;
+  lastError: string | null;
+}
+
+/**
+ * Persist failed/drift-detected Stripe teardown ops into the durable outbox so
+ * the scheduler sweep can retry them until success or `resource_missing`.
+ * Idempotent: a Stripe id can only be pending once per op (partial unique
+ * indexes), so re-running a teardown refreshes `last_error` instead of growing
+ * duplicate rows. Returns the number of ops written. No-ops without an internal
+ * DB. Throws on internal-DB failure — callers wrap it so the teardown helper
+ * stays total (see {@link persistPendingTeardown}).
+ */
+export async function enqueueStripeTeardownOps(ops: PendingTeardownOp[]): Promise<number> {
+  if (ops.length === 0 || !hasInternalDB()) return 0;
+
+  let enqueued = 0;
+  for (const op of ops) {
+    if (op.op === "cancel_subscription") {
+      if (!op.stripeSubId) continue;
+      await internalQuery(
+        `INSERT INTO stripe_teardown_pending (workspace_id, stripe_sub_id, stripe_customer_id, op, last_error)
+         VALUES ($1, $2, $3, 'cancel_subscription', $4)
+         ON CONFLICT (stripe_sub_id) WHERE op = 'cancel_subscription'
+         DO UPDATE SET
+           last_error = EXCLUDED.last_error,
+           stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, stripe_teardown_pending.stripe_customer_id),
+           updated_at = NOW()`,
+        [op.workspaceId, op.stripeSubId, op.stripeCustomerId, op.lastError],
+      );
+    } else {
+      if (!op.stripeCustomerId) continue;
+      await internalQuery(
+        `INSERT INTO stripe_teardown_pending (workspace_id, stripe_customer_id, op, last_error)
+         VALUES ($1, $2, 'delete_customer', $3)
+         ON CONFLICT (stripe_customer_id) WHERE op = 'delete_customer'
+         DO UPDATE SET last_error = EXCLUDED.last_error, updated_at = NOW()`,
+        [op.workspaceId, op.stripeCustomerId, op.lastError],
+      );
+    }
+    enqueued += 1;
+  }
+  return enqueued;
+}
+
+/**
+ * Flush collected pending ops to the durable outbox without breaking the
+ * teardown helper's total contract: an internal-DB failure here is logged and
+ * surfaced as a warning (the legacy manual-follow-up fallback) rather than
+ * thrown — the lifecycle op must still proceed.
+ */
+async function persistPendingTeardown(
+  orgId: string,
+  pending: PendingTeardownOp[],
+  warnings: string[],
+): Promise<void> {
+  if (pending.length === 0) return;
+  try {
+    const enqueued = await enqueueStripeTeardownOps(pending);
+    log.info(
+      { orgId, enqueued },
+      "Persisted Stripe teardown ops to durable outbox for automatic retry",
+    );
+  } catch (err) {
+    const msg = errMessage(err);
+    log.error(
+      { orgId, err: msg },
+      "Failed to persist Stripe teardown ops to durable outbox — falling back to manual-follow-up warnings",
+    );
+    warnings.push(
+      `Could not record failed Stripe teardown operations for automatic retry (${msg}). `
+      + "Follow up manually in the Stripe dashboard using the ids above.",
+    );
+  }
+}
+
+/**
+ * Page through a customer's Stripe subscriptions and return the ones still
+ * live (non-terminal). Used for drift detection — when teardown finds zero
+ * LOCAL subscription rows but the org carries a `stripeCustomerId`, a drifted
+ * local table (manual row delete, sync gap) could otherwise hide a live
+ * subscription that keeps invoicing a deleted workspace.
+ */
+async function listLiveStripeSubscriptionsForCustomer(
+  stripe: NonNullable<ReturnType<typeof getStripeClient>>,
+  stripeCustomerId: string,
+): Promise<{ id: string; customerId: string | null }[]> {
+  const live: { id: string; customerId: string | null }[] = [];
+  let startingAfter: string | undefined;
+  // Cap the page walk defensively (mirrors the open-invoice walk) so a
+  // mis-paging Stripe response can't spin forever; a customer realistically
+  // carries a handful of subscriptions, so this rarely loops more than once.
+  for (let page = 0; page < 1000; page++) {
+    const res = await stripe.subscriptions.list({
+      customer: stripeCustomerId,
+      status: "all",
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    for (const sub of res.data) {
+      if (typeof sub.id !== "string") continue;
+      const status = typeof sub.status === "string" ? sub.status : null;
+      if (status && TERMINAL_STATUSES.has(status)) continue;
+      const customerId = typeof sub.customer === "string" ? sub.customer : stripeCustomerId;
+      live.push({ id: sub.id, customerId });
+    }
+    if (!res.has_more || res.data.length === 0) break;
+    const lastId = res.data[res.data.length - 1]?.id;
+    if (typeof lastId !== "string") break;
+    startingAfter = lastId;
+  }
+  return live;
+}
+
+/**
+ * Drift detection (#3679, audit Part A #7/#8): teardown found NO local
+ * subscription rows, but the org has a `stripeCustomerId`. Query Stripe
+ * directly; any live subscription found is enqueued for durable cancellation
+ * and surfaced as a warning, rather than silently no-op'ing. A Stripe read
+ * failure here is logged + warned, never thrown (the helper stays total).
+ */
+async function detectCustomerSubscriptionDrift(
+  orgId: string,
+  stripeCustomerId: string,
+  actions: string[],
+  warnings: string[],
+  pending: PendingTeardownOp[],
+): Promise<void> {
+  const stripe = getStripeClient();
+  if (!stripe) return; // callers gate before reaching here
+
+  let liveSubs: { id: string; customerId: string | null }[];
+  try {
+    liveSubs = await listLiveStripeSubscriptionsForCustomer(stripe, stripeCustomerId);
+  } catch (err) {
+    const msg = errMessage(err);
+    log.error(
+      { orgId, stripeCustomerId, err: msg },
+      "Failed to query Stripe for live subscriptions during teardown drift detection",
+    );
+    warnings.push(
+      `Could not check Stripe for live subscriptions on customer ${stripeCustomerId} (${msg}). `
+      + "Check the Stripe dashboard manually for subscriptions that should be canceled.",
+    );
+    return;
+  }
+
+  if (liveSubs.length === 0) return;
+
+  for (const sub of liveSubs) {
+    pending.push({
+      workspaceId: orgId,
+      op: "cancel_subscription",
+      stripeSubId: sub.id,
+      stripeCustomerId: sub.customerId ?? stripeCustomerId,
+      lastError: "drift: live in Stripe with no local subscription row at teardown",
+    });
+    actions.push(
+      `detected live Stripe subscription ${sub.id} with no local record — enqueued for cancellation`,
+    );
+    log.warn(
+      { orgId, stripeSubscriptionId: sub.id, stripeCustomerId },
+      "Drift detected: live Stripe subscription with no local subscription row — enqueued for durable cancellation",
+    );
+  }
+  warnings.push(
+    `Found ${liveSubs.length} live Stripe subscription(s) on customer ${stripeCustomerId} with no local record — `
+    + "enqueued for automatic cancellation.",
+  );
 }
 
 /**
@@ -146,12 +333,19 @@ async function listStripeSubscriptions(
   }
 }
 
-/** Cancel one Stripe subscription, folding the result into actions/warnings. */
+/**
+ * Cancel one Stripe subscription, folding the result into actions/warnings.
+ * On a (non-`resource_missing`) failure the op is ALSO appended to `pending`
+ * so the caller can persist it to the durable outbox — the warning is the
+ * legacy manual-follow-up fallback, the outbox is the retry mechanism (#3679).
+ */
 async function cancelOneSubscription(
   orgId: string,
   stripeSubscriptionId: string,
+  stripeCustomerId: string | null,
   actions: string[],
   warnings: string[],
+  pending: PendingTeardownOp[],
 ): Promise<void> {
   const stripe = getStripeClient();
   if (!stripe) return; // callers gate before reaching here
@@ -163,7 +357,7 @@ async function cancelOneSubscription(
       "Canceled Stripe subscription during workspace teardown",
     );
   } catch (err) {
-    if (isResourceMissing(err)) {
+    if (isStripeResourceMissing(err)) {
       actions.push(`Stripe subscription ${stripeSubscriptionId} already absent in Stripe`);
       log.info(
         { orgId, stripeSubscriptionId },
@@ -176,9 +370,16 @@ async function cancelOneSubscription(
       { orgId, stripeSubscriptionId, err: msg },
       "Failed to cancel Stripe subscription during workspace teardown",
     );
+    pending.push({
+      workspaceId: orgId,
+      op: "cancel_subscription",
+      stripeSubId: stripeSubscriptionId,
+      stripeCustomerId,
+      lastError: msg,
+    });
     warnings.push(
       `Failed to cancel Stripe subscription ${stripeSubscriptionId}: ${msg}. `
-      + "Cancel it manually in the Stripe dashboard.",
+      + "It has been queued for automatic retry; cancel it manually in the Stripe dashboard if it persists.",
     );
   }
 }
@@ -186,22 +387,44 @@ async function cancelOneSubscription(
 /**
  * Workspace delete: cancel every non-terminal Stripe subscription for the
  * org. Call BEFORE the DB cascade (see module doc for the ordering
- * rationale). Total — never throws; failures land in `warnings`.
+ * rationale). Total — never throws; failures land in `warnings` AND are
+ * persisted to the durable outbox for retry (#3679).
+ *
+ * `stripeCustomerId` (the org's `organization."stripeCustomerId"`, read by the
+ * caller before the cascade) enables drift detection: when there are no local
+ * subscription rows but the org has a customer, Stripe is queried directly so
+ * a drifted local table can't leave a live subscription invoicing.
  */
 export async function cancelStripeSubscriptionsForWorkspace(
   orgId: string,
+  stripeCustomerId: string | null = null,
 ): Promise<StripeTeardownOutcome> {
   if (!hasInternalDB() || !getStripeClient()) return noopOutcome();
 
   const actions: string[] = [];
   const warnings: string[] = [];
+  const pending: PendingTeardownOp[] = [];
   const { rows, warning } = await listStripeSubscriptions(orgId);
   if (warning) warnings.push(warning);
 
   for (const row of rows) {
     if (row.status && TERMINAL_STATUSES.has(row.status)) continue;
-    await cancelOneSubscription(orgId, row.stripeSubscriptionId, actions, warnings);
+    await cancelOneSubscription(
+      orgId,
+      row.stripeSubscriptionId,
+      row.stripeCustomerId ?? stripeCustomerId,
+      actions,
+      warnings,
+      pending,
+    );
   }
+
+  // Drift: no local rows but a live Stripe customer — query Stripe directly.
+  if (rows.length === 0 && stripeCustomerId) {
+    await detectCustomerSubscriptionDrift(orgId, stripeCustomerId, actions, warnings, pending);
+  }
+
+  await persistPendingTeardown(orgId, pending, warnings);
 
   return { attempted: true, actions, warnings };
 }
@@ -228,6 +451,7 @@ export async function purgeStripeBillingForWorkspace(
 
   const actions: string[] = [];
   const warnings: string[] = [];
+  const pending: PendingTeardownOp[] = [];
   const { rows, warning } = await listStripeSubscriptions(orgId);
   if (warning) warnings.push(warning);
 
@@ -236,7 +460,20 @@ export async function purgeStripeBillingForWorkspace(
   // org deletion (#3425 plugin-review note).
   for (const row of rows) {
     if (row.status && TERMINAL_STATUSES.has(row.status)) continue;
-    await cancelOneSubscription(orgId, row.stripeSubscriptionId, actions, warnings);
+    await cancelOneSubscription(
+      orgId,
+      row.stripeSubscriptionId,
+      row.stripeCustomerId ?? stripeCustomerId,
+      actions,
+      warnings,
+      pending,
+    );
+  }
+
+  // Drift: no local rows but a live Stripe customer — query Stripe directly so
+  // a purge can't leave a live subscription the drifted local table hid.
+  if (rows.length === 0 && stripeCustomerId) {
+    await detectCustomerSubscriptionDrift(orgId, stripeCustomerId, actions, warnings, pending);
   }
 
   const customerIds = new Set<string>();
@@ -254,7 +491,7 @@ export async function purgeStripeBillingForWorkspace(
         "Deleted Stripe customer during GDPR purge",
       );
     } catch (err) {
-      if (isResourceMissing(err)) {
+      if (isStripeResourceMissing(err)) {
         actions.push(`Stripe customer ${customerId} already absent in Stripe`);
         log.info(
           { orgId, stripeCustomerId: customerId },
@@ -267,12 +504,21 @@ export async function purgeStripeBillingForWorkspace(
         { orgId, stripeCustomerId: customerId, err: msg },
         "Failed to delete Stripe customer during GDPR purge",
       );
+      pending.push({
+        workspaceId: orgId,
+        op: "delete_customer",
+        stripeSubId: null,
+        stripeCustomerId: customerId,
+        lastError: msg,
+      });
       warnings.push(
         `Failed to delete Stripe customer ${customerId}: ${msg}. `
-        + "Delete it manually in the Stripe dashboard — a GDPR purge must not leave a billable customer record.",
+        + "It has been queued for automatic retry; delete it manually in the Stripe dashboard if it persists — a GDPR purge must not leave a billable customer record.",
       );
     }
   }
+
+  await persistPendingTeardown(orgId, pending, warnings);
 
   return { attempted: true, actions, warnings };
 }
@@ -344,7 +590,7 @@ async function voidOpenInvoicesForSubscription(
         "Voided open invoice during workspace suspend",
       );
     } catch (err) {
-      if (isResourceMissing(err)) {
+      if (isStripeResourceMissing(err)) {
         actions.push(`invoice ${invoiceId} already absent in Stripe`);
         log.info(
           { orgId, stripeSubscriptionId, invoiceId },
@@ -409,7 +655,7 @@ async function updateCollectionForWorkspace(
         await voidOpenInvoicesForSubscription(orgId, id, actions, warnings);
       }
     } catch (err) {
-      if (isResourceMissing(err)) {
+      if (isStripeResourceMissing(err)) {
         actions.push(`Stripe subscription ${id} already absent in Stripe`);
         log.info(
           { orgId, stripeSubscriptionId: id, mode },

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -162,7 +162,8 @@ describe("runMigrations", () => {
     //   #3682) = 139.
     //   Plus 0139 (learned_patterns.auto_promoted flag, PRD #3617 B-2, #3636) = 140.
     //   Plus 0140 (operator_integration_credentials, operator-tier app creds, #3704) = 141.
-    expect(count).toBe(141);
+    //   Plus 0141 (stripe_teardown_pending durable teardown outbox, #3679) = 142.
+    expect(count).toBe(142);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -332,6 +333,7 @@ describe("runMigrations", () => {
         "0138_semantic_profile_status.sql",
         "0139_learned_patterns_auto_promoted.sql",
         "0140_operator_integration_credentials.sql",
+        "0141_stripe_teardown_pending.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0141_stripe_teardown_pending.sql
+++ b/packages/api/src/lib/db/migrations/0141_stripe_teardown_pending.sql
@@ -1,0 +1,85 @@
+-- 0141_stripe_teardown_pending.sql
+--
+-- Atlas issue #3679 — durable Stripe teardown outbox.
+--
+-- Background: platform-admin workspace delete/purge cancels the org's
+-- Stripe subscriptions (and, for a GDPR purge, deletes the Stripe
+-- customer) BEFORE the DB cascade runs (see lib/billing/workspace-teardown.ts).
+-- Those Stripe calls were "total" — a transient Stripe 5xx/timeout at that
+-- instant was folded into a free-text `warnings[]` string and the cascade
+-- proceeded regardless. Once the cascade ran, the local `subscription` rows
+-- carrying the `stripeSubscriptionId` were gone, so the cancel target
+-- survived only in the admin-action audit JSON. Net: a delete during a
+-- Stripe outage left a live subscription invoicing a customer for a
+-- workspace that no longer exists, and a GDPR purge could leave a billable
+-- customer/PII linkage behind — recoverable only by manual dashboard cleanup.
+--
+-- This table is the durable outbox that closes that gap. Before the cascade,
+-- any Stripe op that failed (or that drift detection found live in Stripe but
+-- absent locally) is persisted here. A scheduler sweep
+-- (lib/billing/reconcile-stripe-teardown.ts, the symmetric counterpart to
+-- reconcile-plan-tiers.ts) retries `subscriptions.cancel` / `customers.del`
+-- until success or `resource_missing`, then deletes the row.
+--
+-- Shape:
+--   * `id` — uuid PK.
+--   * `workspace_id` — the org/workspace whose teardown stranded this op.
+--     TEXT, no FK: the workspace row is (or is about to be) gone — that is
+--     the whole reason this outbox exists.
+--   * `stripe_sub_id` / `stripe_customer_id` — the Stripe target of the op.
+--     Exactly one is the operative id per `op` (enforced by the CHECK below).
+--     `stripe_customer_id` is also carried on `cancel_subscription` rows for
+--     operator context when present, but is not the conflict key there.
+--   * `op` — `cancel_subscription` (retry `subscriptions.cancel`) or
+--     `delete_customer` (retry `customers.del`).
+--   * `attempts` — incremented by the sweep on each non-terminal failure;
+--     surfaces a stuck op to operators via the sweep's structured log.
+--   * `last_error` — most recent failure message (never a full secret;
+--     Stripe ids are not secrets but are logged sparingly).
+--   * `created_at` / `updated_at` — `updated_at` bumps on re-enqueue and on
+--     each sweep attempt.
+--
+-- Idempotent enqueue: a Stripe id can only be pending once per op. The two
+-- partial unique indexes below let the enqueue `ON CONFLICT ... DO UPDATE`
+-- refresh `last_error`/`updated_at` instead of growing a duplicate row when
+-- the same workspace teardown is retried.
+--
+-- Additive `CREATE TABLE IF NOT EXISTS` — N-1 deploy-safe, no two-phase drop
+-- needed for the add. The legacy warnings-string path is intentionally left
+-- in place (a manual-follow-up fallback); retiring it is an N+1 follow-up.
+
+CREATE TABLE IF NOT EXISTS stripe_teardown_pending (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id        TEXT NOT NULL,
+  stripe_sub_id       TEXT,
+  stripe_customer_id  TEXT,
+  op                  TEXT NOT NULL,
+  attempts            INTEGER NOT NULL DEFAULT 0,
+  last_error          TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_stripe_teardown_pending_op
+    CHECK (op IN ('cancel_subscription', 'delete_customer')),
+  -- The op's operative id must be present: a cancel needs a subscription id,
+  -- a customer delete needs a customer id.
+  CONSTRAINT chk_stripe_teardown_pending_target
+    CHECK (
+      (op = 'cancel_subscription' AND stripe_sub_id IS NOT NULL)
+      OR (op = 'delete_customer' AND stripe_customer_id IS NOT NULL)
+    )
+);
+
+-- One pending cancel per Stripe subscription id (globally unique in Stripe).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stripe_teardown_pending_sub
+  ON stripe_teardown_pending (stripe_sub_id)
+  WHERE op = 'cancel_subscription';
+
+-- One pending customer delete per Stripe customer id.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stripe_teardown_pending_customer
+  ON stripe_teardown_pending (stripe_customer_id)
+  WHERE op = 'delete_customer';
+
+-- Sweep scans the whole (normally empty) table ordered by attempts; an index
+-- on attempts keeps the oldest/least-tried rows cheap to surface first.
+CREATE INDEX IF NOT EXISTS idx_stripe_teardown_pending_attempts
+  ON stripe_teardown_pending (attempts, created_at);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2472,6 +2472,46 @@ export const stripePurgedSubscriptions = pgTable(
 );
 
 /**
+ * Durable Stripe teardown outbox (#3679) — the symmetric counterpart to the
+ * plan-tier reconcile sweep. Workspace delete/purge cancels Stripe
+ * subscriptions (and deletes the customer on GDPR purge) BEFORE the DB
+ * cascade; a Stripe outage at that instant used to fold into a warnings
+ * string and the cascade proceeded, stranding a live subscription invoicing a
+ * deleted workspace. Failed (or drift-detected) ops are persisted here and
+ * retried by `reconcile-stripe-teardown.ts` until success or `resource_missing`.
+ * The two partial unique indexes make enqueue idempotent (one pending op per
+ * Stripe id). Mirrors `migrations/0141_stripe_teardown_pending.sql`.
+ */
+export const stripeTeardownPending = pgTable(
+  "stripe_teardown_pending",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workspaceId: text("workspace_id").notNull(),
+    stripeSubId: text("stripe_sub_id"),
+    stripeCustomerId: text("stripe_customer_id"),
+    op: text("op").notNull(),
+    attempts: integer("attempts").notNull().default(0),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    check("chk_stripe_teardown_pending_op", sql`op IN ('cancel_subscription', 'delete_customer')`),
+    check(
+      "chk_stripe_teardown_pending_target",
+      sql`(op = 'cancel_subscription' AND stripe_sub_id IS NOT NULL) OR (op = 'delete_customer' AND stripe_customer_id IS NOT NULL)`,
+    ),
+    uniqueIndex("idx_stripe_teardown_pending_sub")
+      .on(t.stripeSubId)
+      .where(sql`op = 'cancel_subscription'`),
+    uniqueIndex("idx_stripe_teardown_pending_customer")
+      .on(t.stripeCustomerId)
+      .where(sql`op = 'delete_customer'`),
+    index("idx_stripe_teardown_pending_attempts").on(t.attempts, t.createdAt),
+  ],
+);
+
+/**
  * Durable + atomic one-trial-per-user marker (#3469/#3470) — one row per
  * user, stamped at grant time. The PRIMARY KEY makes
  * `INSERT ... ON CONFLICT (user_id) DO NOTHING` an atomic claim under

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -426,6 +426,7 @@ describe("makeSchedulerLive", () => {
         "expert_scheduler",
         "promote_decay",
         "billing_reconcile",
+        "stripe_teardown_sweep",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -232,6 +232,7 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   expert_scheduler: "atlas.scheduler.expert_scheduler",
   promote_decay: "atlas.scheduler.promote_decay",
   billing_reconcile: "atlas.scheduler.billing_reconcile",
+  stripe_teardown_sweep: "atlas.scheduler.stripe_teardown_sweep",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1708,6 +1709,77 @@ export function makeSchedulerLive(
       } else {
         log.debug(
           "Plan-tier reconciliation sweep not started — Stripe billing or internal DB not configured",
+        );
+      }
+
+      // ── Periodic fiber: Stripe teardown outbox sweep (#3679) ────────
+      // Symmetric counterpart to the plan-tier reconcile above: drains the
+      // `stripe_teardown_pending` outbox, retrying the subscription-cancel /
+      // customer-delete ops a Stripe outage stranded during workspace
+      // delete/purge until success or `resource_missing`. Unlike the
+      // plan-tier sweep it does NOT need the webhook secret — only
+      // `STRIPE_SECRET_KEY` (to act on Stripe) + an internal DB (to hold the
+      // outbox). The `yield* Migration` barrier above already sequences this
+      // after `MigrationLive`, so the eager boot tick can't race migration
+      // 0141 creating the table.
+      const teardownSweepEnabled = yield* Effect.try({
+        try: () => {
+          if (!process.env.STRIPE_SECRET_KEY) return false;
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+          const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+            hasInternalDB: () => boolean;
+          };
+          return hasInternalDB();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.debug({ err: errorMessage(err) }, "Stripe teardown sweep gate check failed — skipping");
+            return false;
+          }),
+        ),
+      );
+
+      if (teardownSweepEnabled) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- read the interval constant synchronously at build time (same pattern as orphan_task_reconcile)
+        const { STRIPE_TEARDOWN_SWEEP_INTERVAL_MS } = require("@atlas/api/lib/billing/reconcile-stripe-teardown") as {
+          STRIPE_TEARDOWN_SWEEP_INTERVAL_MS: number;
+        };
+        const teardownSweepTick = Effect.tryPromise({
+          try: async () => {
+            const { sweepStripeTeardownPending } = await import(
+              "@atlas/api/lib/billing/reconcile-stripe-teardown"
+            );
+            await sweepStripeTeardownPending();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn(
+                { err: errorMessage(err) },
+                "Stripe teardown sweep tick failed — will retry next interval",
+              );
+            }),
+          ),
+        );
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
+          withFiberDeathLog(
+            "stripe_teardown_sweep",
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.stripe_teardown_sweep, {}, teardownSweepTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(STRIPE_TEARDOWN_SWEEP_INTERVAL_MS))),
+            ),
+          ),
+        );
+        log.info(
+          { intervalMs: STRIPE_TEARDOWN_SWEEP_INTERVAL_MS },
+          "Stripe teardown outbox sweep started",
+        );
+      } else {
+        log.debug(
+          "Stripe teardown outbox sweep not started — Stripe or internal DB not configured",
         );
       }
 


### PR DESCRIPTION
## Summary

Closes #3679 (milestone *v0.0.18 — Production Hardening II*).

Workspace delete/purge cancels the org's Stripe subscriptions (and, on a GDPR purge, deletes the Stripe customer) **before** the DB cascade. Those calls were *total* — a transient Stripe 5xx/timeout at that instant folded into a free-text `warnings[]` string and the cascade proceeded regardless. Once the cascade ran, the local `subscription` rows carrying the `stripeSubscriptionId` were gone, so a Stripe outage during a delete left a **live subscription invoicing a workspace that no longer exists** (and, for a purge, a billable customer/PII linkage surviving a "hard delete"). A second blind spot (audit Part A #7/#8): teardown **silently no-op'd** when the local `subscription` table had drifted empty, even with a live `stripeCustomerId`.

## What changed

1. **Durable outbox** — new `stripe_teardown_pending` table (migration `0141`, mirrored in `db/schema.ts` same-PR; additive `CREATE TABLE IF NOT EXISTS`, partial unique indexes so enqueue is idempotent). Failed cancel / customer-delete ops are persisted **before** the cascade.
2. **Reconcile sweep** — `lib/billing/reconcile-stripe-teardown.ts`, the symmetric counterpart to `reconcile-plan-tiers.ts`. Retries `subscriptions.cancel` / `customers.del` until success or `resource_missing`, then removes the row. Forked as a 15-min scheduler fiber in `layers.ts`, gated on `STRIPE_SECRET_KEY` + internal DB; Noop-safe on self-host with no Stripe.
3. **Drift detection** — when teardown finds zero local subscription rows but the org has a `stripeCustomerId`, Stripe is queried directly and any live subscription is enqueued + warned, rather than silently no-op'ing. Wired into both platform-admin and admin-orgs delete + the GDPR purge path.
4. Legacy warnings-string path left **intact** (manual-follow-up fallback); retiring it is an N+1 follow-up per the issue.

## Acceptance criteria

- [x] Stripe cancel/customer-delete failure during teardown persisted durably + retried by a sweep until success or `resource_missing`
- [x] Teardown with zero local subscription rows but a live `stripeCustomerId` detects the drift (enqueue + warn)
- [x] `stripe_teardown_pending` migration mirrored in `db/schema.ts` same-PR; additive `CREATE TABLE IF NOT EXISTS`
- [x] Tests: cancel-fails-then-sweep-succeeds, GDPR purge customer-delete retry, zero-local-rows-but-live-customer drift (+ outbox-INSERT-failure fallback)

## Testing

- New `reconcile-stripe-teardown.test.ts` (sweep) + expanded `workspace-teardown.test.ts` (outbox + drift); `layers.test.ts` span-registry assertion updated for the new fiber.
- `/ci` gates green locally: lint · type · affected tests (42 files) · syncpack · template drift · railway-watch.
- Migration DDL, partial-index `ON CONFLICT` upsert idempotency, and both CHECK constraints validated against a real Postgres instance.