### PR TITLE
prod(api): operational verifications — scheduler region intent, MCP-spine guard, prod-floor warn (#3687)

### DIFF
--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -605,9 +605,25 @@ ATLAS_EMAIL_ALLOWED_DOMAINS=example.com,trusted-partner.com
 
 Scheduled task execution. Can also be configured via [`atlas.config.ts`](/reference/config#scheduler). See [Scheduled Tasks](/guides/scheduled-tasks) for the full guide.
 
+<Callout type="info">
+**Multi-region (SaaS): run a single global scheduler.** In a multi-region SaaS
+deployment the scheduler is intended to run on **one region only** (US). Set
+`ATLAS_SCHEDULER_ENABLED=true` on that region's api service and leave it unset on
+the others — they will report `scheduler: "disabled"` at `/health` by design.
+This is safe because `ATLAS_SCHEDULER_ENABLED` **co-gates task creation and task
+execution**: the `POST /api/v1/scheduled-tasks` route is mounted only when the
+flag is set, so a region without the scheduler fiber also returns `404` for task
+creation. A customer in a scheduler-disabled region therefore cannot create a
+task that would silently never fire. (The scheduler fiber reads/writes
+`scheduled_tasks` in the shared internal database, so the single US fiber
+executes every workspace's tasks regardless of the workspace's region.) Do **not**
+enable the flag on more than one region — multiple fibers would double-execute the
+same shared task rows.
+</Callout>
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_SCHEDULER_ENABLED` | — | Set `true` to enable scheduled task execution |
+| `ATLAS_SCHEDULER_ENABLED` | — | Set `true` to enable scheduled task execution. **In SaaS, enable on exactly one region (US)** — see the multi-region callout above; it co-gates the `/api/v1/scheduled-tasks` creation route |
 | `ATLAS_SCHEDULER_BACKEND` | `bun` | Execution backend: `bun`, `webhook`, or `vercel` |
 | `ATLAS_SCHEDULER_SECRET` | — | Shared secret for the `/tick` endpoint (non-Vercel). On Vercel, use `CRON_SECRET` instead |
 | `CRON_SECRET` | — | Vercel-native alternative to `ATLAS_SCHEDULER_SECRET`. When set, the `/tick` endpoint requires `Authorization: Bearer <secret>`. Takes precedence over `ATLAS_SCHEDULER_SECRET` |

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -263,6 +263,15 @@ if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
 }
 
 // Scheduled tasks routes — lazy import, only loaded if ATLAS_SCHEDULER_ENABLED is set.
+//
+// CO-GATING INVARIANT (#3687): this is the ONLY customer-facing path that INSERTs
+// into `scheduled_tasks` (via createScheduledTask), and it is gated on the exact
+// same `ATLAS_SCHEDULER_ENABLED === "true"` flag that drives the scheduler fiber
+// (config.scheduler.backend → makeSchedulerLive in lib/effect/layers.ts) and the
+// `/health` scheduler reporter. The single global (US) scheduler design is
+// therefore safe: a region without the scheduler fiber (EU/APAC) does not mount
+// this route either, so customers there get a 404 on creation rather than a task
+// that is written but never fires. Keep these three sites flag-coherent.
 if (process.env.ATLAS_SCHEDULER_ENABLED === "true") {
   const { scheduledTasks } = await import("./routes/scheduled-tasks");
   app.route("/api/v1/scheduled-tasks", scheduledTasks);

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -526,7 +526,16 @@ health.openapi(healthRoute, async (c) => {
         lastCheckedAt: now,
         ...(hasKeyError && { message: "MISSING_API_KEY" }),
       },
-      // Config-level status only — does not probe the scheduler engine at runtime
+      // Config-level status only — does not probe the scheduler engine at runtime.
+      //
+      // `disabled` is EXPECTED and SAFE on EU/APAC regions (#3687): the scheduler
+      // is a single global (US) fiber by design. Crucially, the customer-facing
+      // task-creation route `POST /api/v1/scheduled-tasks` is mounted behind the
+      // SAME `ATLAS_SCHEDULER_ENABLED === "true"` flag that starts the fiber
+      // (api/index.ts) — so a region reporting `scheduler: "disabled"` also
+      // returns 404 for task creation. Creation and execution are co-gated, so an
+      // EU/APAC customer can never create a scheduled task that silently never
+      // fires.
       scheduler: {
         status: schedulerEnabled ? "healthy" as const : "disabled" as const,
         lastCheckedAt: now,

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -64,8 +64,8 @@ const log = createLogger("well-known");
  * Three sites must derive the same value:
  *   - `well-known.ts` (here) — advertised in the protected-resource doc
  *   - `hosted.ts:resourceAudience()` — passed to `verifyAccessToken`
- *   - `server.ts:resolveOAuthValidAudiences()` — added to the issuer's
- *     `validAudiences` allow-list so the token endpoint accepts it
+ *   - `oauth-audiences.ts:resolveOAuthValidAudiences()` — added to the
+ *     issuer's `validAudiences` allow-list so the token endpoint accepts it
  *
  * Resolution priority is identical across all three:
  *   1. ATLAS_PUBLIC_API_URL (per-region API host, e.g.

--- a/packages/api/src/lib/auth/__tests__/chat-rpm-floor-warn.test.ts
+++ b/packages/api/src/lib/auth/__tests__/chat-rpm-floor-warn.test.ts
@@ -1,0 +1,141 @@
+/**
+ * #3687 — integration coverage for the SaaS prod-floor chat-RPM warn.
+ *
+ * The pure decision is unit-tested via `isLowSaasChatRpm` in `middleware.test.ts`.
+ * This file exercises the WIRING in `getRpmLimitForBucket`: that an explicit
+ * `ATLAS_RATE_LIMIT_RPM_CHAT` in (0, 5) on a SaaS region actually fires the
+ * `log.warn`, that the `lastWarnedChatRpmFloorValue` dedup slot suppresses a
+ * repeat for the same value, that `resetRateLimits()` clears that slot, and that
+ * the resolved limit is still honored (warn, never throw).
+ *
+ * It lives in its own file because the logger must be mocked BEFORE the
+ * module-under-test is imported (middleware captures `createLogger("auth")` at
+ * module load) — the same mock-then-dynamic-import pattern as `saas-guards.test.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mock } from "bun:test";
+import type { ResolvedConfig } from "@atlas/api/lib/config";
+
+// ── logger capture ───────────────────────────────────────────────────
+let capturedWarns: Array<{ obj: unknown; msg: unknown }> = [];
+const recordWarn = (obj: unknown, msg?: unknown) => {
+  capturedWarns.push({ obj, msg });
+};
+const noop = () => {};
+const stubLogger = {
+  warn: recordWarn,
+  error: noop,
+  info: noop,
+  debug: noop,
+  trace: noop,
+  fatal: noop,
+  level: "info",
+  child: () => stubLogger,
+};
+// Full export surface mocked (mock-all-exports). Middleware only uses
+// `createLogger`, but transitive imports may touch the rest at load time.
+mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"],
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (o: unknown) => o,
+  getLogger: () => stubLogger,
+  createLogger: () => stubLogger,
+  hashShareToken: (t: string) => t,
+  setLogLevel: () => true,
+}));
+
+const { checkRateLimit, resetRateLimits } = await import("../middleware");
+const { _setConfigForTest, _resetConfig } = await import("@atlas/api/lib/config");
+const { _resetSettingsCache } = await import("@atlas/api/lib/settings");
+
+function makeConfig(deployMode: ResolvedConfig["deployMode"]): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "none",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+function floorWarns(): Array<{ obj: unknown; msg: unknown }> {
+  return capturedWarns.filter(
+    (w) => typeof w.msg === "string" && (w.msg as string).includes("#3687"),
+  );
+}
+
+describe("chat RPM prod-floor warn — getRpmLimitForBucket wiring (#3687)", () => {
+  const origRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+  const origChatRpm = process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+
+  beforeEach(() => {
+    capturedWarns = [];
+    resetRateLimits();
+    _resetSettingsCache();
+    // A non-zero base RPM is required, else `getRpmLimitForBucket` early-returns
+    // 0 (rate-limiting disabled) before reaching the chat branch + warn.
+    process.env.ATLAS_RATE_LIMIT_RPM = "100";
+    delete process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+  });
+
+  afterEach(() => {
+    if (origRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = origRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM;
+    if (origChatRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM_CHAT = origChatRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+    _setConfigForTest(null);
+    _resetConfig();
+    resetRateLimits();
+    _resetSettingsCache();
+  });
+
+  it("warns once on SaaS for an explicit (0,5) override and still honors the limit", () => {
+    _setConfigForTest(makeConfig("saas"));
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+
+    // First call: warn fires, and the ceiling is the explicit 2 (honored).
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false); // 3rd > limit 2
+
+    const warns = floorWarns();
+    expect(warns.length).toBe(1);
+    expect(warns[0].obj).toMatchObject({ value: "2", resolved: 2 });
+  });
+
+  it("dedups repeat warns for the same value, and re-warns after resetRateLimits()", () => {
+    _setConfigForTest(makeConfig("saas"));
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "3";
+
+    checkRateLimit("u", { bucket: "chat" });
+    checkRateLimit("u", { bucket: "chat" });
+    expect(floorWarns().length).toBe(1); // dedup slot suppresses the second
+
+    // resetRateLimits() clears `lastWarnedChatRpmFloorValue`.
+    resetRateLimits();
+    capturedWarns = [];
+    checkRateLimit("u", { bucket: "chat" });
+    expect(floorWarns().length).toBe(1);
+  });
+
+  it("does NOT warn on self-hosted for the same low override", () => {
+    _setConfigForTest(makeConfig("self-hosted"));
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+
+    checkRateLimit("u", { bucket: "chat" });
+    expect(floorWarns().length).toBe(0);
+  });
+
+  it("does NOT warn on SaaS when the explicit value is at/above the floor", () => {
+    _setConfigForTest(makeConfig("saas"));
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "5";
+
+    checkRateLimit("u", { bucket: "chat" });
+    expect(floorWarns().length).toBe(0);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -7,6 +7,7 @@ import {
   resetRateLimits,
   rateLimitCleanupTick,
   getClientIP,
+  isLowSaasChatRpm,
   _setValidatorOverrides,
   _setSSOEnforcementOverride,
   _setAuditEnforcementBlockOverride,
@@ -819,6 +820,33 @@ describe("checkRateLimit() — chat bucket (F-74)", () => {
       expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
     }
     expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3687 — prod-floor warn predicate for an explicit low chat RPM
+// ---------------------------------------------------------------------------
+describe("isLowSaasChatRpm() — prod-floor warn decision (#3687)", () => {
+  it("flags an explicit (0, 5) override on SaaS", () => {
+    expect(isLowSaasChatRpm(2, "saas")).toBe(true);
+    expect(isLowSaasChatRpm(4, "saas")).toBe(true);
+    expect(isLowSaasChatRpm(4.9, "saas")).toBe(true);
+  });
+
+  it("does NOT flag values at or above the recommended floor", () => {
+    expect(isLowSaasChatRpm(5, "saas")).toBe(false);
+    expect(isLowSaasChatRpm(100, "saas")).toBe(false);
+  });
+
+  it("does NOT flag zero / negative / non-finite (handled by the fallback branch)", () => {
+    expect(isLowSaasChatRpm(0, "saas")).toBe(false);
+    expect(isLowSaasChatRpm(-3, "saas")).toBe(false);
+    expect(isLowSaasChatRpm(Number.NaN, "saas")).toBe(false);
+  });
+
+  it("does NOT flag on self-hosted or unknown deploy mode (operator may pin a tiny ceiling)", () => {
+    expect(isLowSaasChatRpm(2, "self-hosted")).toBe(false);
+    expect(isLowSaasChatRpm(2, undefined)).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/oauth-config.test.ts
+++ b/packages/api/src/lib/auth/__tests__/oauth-config.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { describe, it, expect } from "bun:test";
+import { resolveOAuthValidAudiences } from "../oauth-audiences";
 import {
-  resolveOAuthValidAudiences,
   resolveAllowUnauthDcr,
   ATLAS_OAUTH_SCOPES,
 } from "../server";

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -17,6 +17,7 @@ import { checkPasswordChangeGate } from "@atlas/api/lib/auth/password-gate";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSetting } from "@atlas/api/lib/settings";
 import { resolveRateLimitRpm } from "@atlas/api/lib/env-profile";
+import { getConfig } from "@atlas/api/lib/config";
 import { Effect } from "effect";
 import { SSOPolicy } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
@@ -56,6 +57,12 @@ const windows = new Map<string, number[]>();
 let lastWarnedRpmValue: string | undefined;
 let lastWarnedChatRpmValue: string | undefined;
 let lastWarnedAdminRpmValue: string | undefined;
+// Separate dedup slot for the SaaS prod-floor warn (#3687): an explicit
+// `ATLAS_RATE_LIMIT_RPM_CHAT` in (0, 5) is a VALID-but-suspiciously-low
+// override that's silently accepted (unlike the `n <= 0` branch which falls
+// back). Kept distinct from `lastWarnedChatRpmValue` so the two warn lines
+// don't suppress each other.
+let lastWarnedChatRpmFloorValue: string | undefined;
 
 function getRpmLimit(orgId?: string): number {
   // Precedence: workspace DB override > platform DB override > env var >
@@ -103,6 +110,18 @@ function getRpmLimit(orgId?: string): number {
  * default bucket); when the global limit is disabled all sub-buckets are
  * also disabled regardless of override.
  */
+/**
+ * #3687 — does an EXPLICIT `ATLAS_RATE_LIMIT_RPM_CHAT` override resolve to a
+ * suspiciously-low value on a SaaS region? Only the explicit-override path can
+ * land below 5 (`Math.floor(n)`); the derived default floors at 5. Pure so the
+ * warn decision is unit-testable without mocking the logger or config singleton.
+ * `0 < n < 5` only — `n <= 0` is already handled (it falls back to the derived
+ * default), and self-hosted operators may legitimately pin a tiny ceiling.
+ */
+export function isLowSaasChatRpm(n: number, deployMode: string | undefined): boolean {
+  return deployMode === "saas" && Number.isFinite(n) && n > 0 && n < 5;
+}
+
 function getRpmLimitForBucket(bucket: RateLimitBucket, orgId?: string): number {
   const baseLimit = getRpmLimit(orgId);
   if (bucket === "default") return baseLimit;
@@ -127,6 +146,20 @@ function getRpmLimitForBucket(bucket: RateLimitBucket, orgId?: string): number {
         lastWarnedChatRpmValue = raw;
       }
       return Math.max(5, Math.floor(baseLimit / 4));
+    }
+    // Prod-floor soft warn (#3687): an explicit value in (0, 5) is accepted as
+    // written (unlike the default path, which floors at 5). On SaaS this is most
+    // likely a typo'd per-region knob — a chat ceiling under 5/min throttles a
+    // single multi-step agent run. Warn (never throw — these are operator-tuned
+    // knobs) so a fat-fingered Railway override surfaces in the logs instead of
+    // silently degrading chat. Self-hosted is intentionally exempt: operators
+    // there may legitimately pin a tiny ceiling for an evaluation deploy.
+    if (isLowSaasChatRpm(n, getConfig()?.deployMode) && raw !== lastWarnedChatRpmFloorValue) {
+      log.warn(
+        { value: raw, resolved: Math.floor(n) },
+        "ATLAS_RATE_LIMIT_RPM_CHAT resolves to <5/min on a SaaS region — a single multi-step agent run can exhaust this ceiling. Confirm the per-region override is intentional (a value of 5+ is recommended). See #3687.",
+      );
+      lastWarnedChatRpmFloorValue = raw;
     }
     return Math.floor(n);
   }
@@ -264,6 +297,7 @@ export function resetRateLimits(): void {
   windows.clear();
   lastWarnedRpmValue = undefined;
   lastWarnedChatRpmValue = undefined;
+  lastWarnedChatRpmFloorValue = undefined;
   lastWarnedAdminRpmValue = undefined;
 }
 

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -117,8 +117,15 @@ function getRpmLimit(orgId?: string): number {
  * warn decision is unit-testable without mocking the logger or config singleton.
  * `0 < n < 5` only — `n <= 0` is already handled (it falls back to the derived
  * default), and self-hosted operators may legitimately pin a tiny ceiling.
+ *
+ * `deployMode` is typed as the exact domain of `getConfig()?.deployMode` (its
+ * sole caller) so a typo'd literal is a compile error rather than a silent
+ * false-negative on this warn path.
  */
-export function isLowSaasChatRpm(n: number, deployMode: string | undefined): boolean {
+export function isLowSaasChatRpm(
+  n: number,
+  deployMode: "saas" | "self-hosted" | undefined,
+): boolean {
   return deployMode === "saas" && Number.isFinite(n) && n > 0 && n < 5;
 }
 

--- a/packages/api/src/lib/auth/oauth-audiences.ts
+++ b/packages/api/src/lib/auth/oauth-audiences.ts
@@ -1,0 +1,108 @@
+/**
+ * OAuth valid-audience derivation for the MCP security spine.
+ *
+ * Extracted from `auth/server.ts` (#3687) so the boot-time
+ * `McpSpineGuardLive` (lib/effect/saas-guards.ts) can assert audiences are
+ * derivable WITHOUT pulling the 3k-line Better Auth static graph into the
+ * boot-guard module's import path — the same wall-off discipline the rest of
+ * the guard family follows. Both `auth/server.ts` (the Better Auth
+ * `validAudiences` config) and the boot guard import from here, so the
+ * derivation stays a single source of truth.
+ *
+ * Pure env reads + the `URL` global only — no other module dependencies.
+ */
+
+/**
+ * Resolve the OAuth `validAudiences` list the issuer accepts when verifying
+ * MCP bearer tokens.
+ *
+ * Resolution priority:
+ *   1. ATLAS_OAUTH_VALID_AUDIENCES — comma-separated explicit list.
+ *      Used verbatim, no `/mcp` suffix appended (operator owns the
+ *      values and may want non-MCP audiences too).
+ *   2. ATLAS_PUBLIC_API_URL — same env var well-known.ts and hosted.ts
+ *      prefer; we suffix `/mcp` here so the issuer accepts the verifier's
+ *      expected audience.
+ *   3. BETTER_AUTH_URL — last fallback, `/mcp` suffix appended.
+ *
+ * Empty string in the env var → no override → fall back to (2)/(3).
+ * Returns `[]` when no base URL can be resolved — a SaaS region in that state
+ * would verify every MCP token against an empty audience set, which the boot
+ * guard treats as an incoherent MCP spine.
+ *
+ * #2068 — when the resolved base is one of the canonical SaaS regional
+ * `api*.useatlas.dev` hosts (`api`, `api-eu`, `api-apac`), the
+ * brand-mirror `mcp*.useatlas.dev/mcp` audience is appended so tokens
+ * minted post-cutover (advertised on the new canonical hostname)
+ * verify here, AND tokens minted just before the cutover (against the
+ * regional `<region>.api.useatlas.dev/mcp` host) keep verifying.
+ * Self-hosted operators on arbitrary hostnames are unaffected — the
+ * mirror only synthesises for `*.useatlas.dev`.
+ */
+export function resolveOAuthValidAudiences(env: NodeJS.ProcessEnv): string[] {
+  const explicit = env.ATLAS_OAUTH_VALID_AUDIENCES?.trim();
+  if (explicit) {
+    return explicit
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  const base =
+    env.ATLAS_PUBLIC_API_URL?.trim() || env.BETTER_AUTH_URL?.trim();
+  if (!base) return [];
+  const trimmed = base.replace(/\/+$/, "");
+  const audiences = [`${trimmed}/mcp`];
+  const brand = brandMcpAudience(trimmed);
+  if (brand) audiences.push(brand);
+  return audiences;
+}
+
+/**
+ * Map a SaaS regional `api*.useatlas.dev` host to its brand
+ * counterpart, OR a SaaS brand `mcp*.useatlas.dev` host to its
+ * regional counterpart (#2068). The mapping is symmetric so the
+ * audience-synthesis invariant doesn't depend on which hostname an
+ * operator chose for `ATLAS_PUBLIC_API_URL`:
+ *
+ *   `api.useatlas.dev`      → `mcp.useatlas.dev`
+ *   `api-eu.useatlas.dev`   → `mcp-eu.useatlas.dev`
+ *   `api-apac.useatlas.dev` → `mcp-apac.useatlas.dev`
+ *   `mcp.useatlas.dev`      → `api.useatlas.dev`
+ *   `mcp-eu.useatlas.dev`   → `api-eu.useatlas.dev`
+ *   `mcp-apac.useatlas.dev` → `api-apac.useatlas.dev`
+ *
+ * Anything else (self-hosted, dev, custom-domain SaaS, `apiv2`,
+ * `api.eu.useatlas.dev`, etc.) returns null — synthesising a
+ * `.useatlas.dev` mirror for an unrelated host would be wrong. The
+ * match is anchored on hostname only, so a `BETTER_AUTH_URL` with an
+ * unusual port or path still maps cleanly.
+ *
+ * Symmetry rationale: pre-#2068 every site used the regional host as
+ * the canonical base; post-#2068 docs/CLI/registry use the brand. An
+ * operator who flips `ATLAS_PUBLIC_API_URL` to the brand (reasonable —
+ * it's what the CLI default writes) must still see both audiences
+ * synthesised so pre-cutover tokens bound to the regional audience
+ * keep verifying. Closing that footgun is cheaper than documenting it
+ * as a deployment invariant.
+ */
+function brandMcpAudience(base: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    // intentionally ignored: a non-URL `ATLAS_PUBLIC_API_URL` falls
+    // back to BETTER_AUTH_URL one layer up; if that fails too, the
+    // outer caller returns an empty audience list. Surfacing the
+    // parse failure here would double-log on every request.
+    return null;
+  }
+  // Strict match: `api.useatlas.dev` / `api-<region>.useatlas.dev` /
+  // `mcp.useatlas.dev` / `mcp-<region>.useatlas.dev`. `apiv2`,
+  // `api.eu.useatlas.dev`, etc. are intentionally excluded — we only
+  // mirror the documented regional surfaces.
+  const matched = url.hostname.match(/^(api|mcp)(-[a-z0-9]+)?\.useatlas\.dev$/);
+  if (!matched) return null;
+  const flipped = matched[1] === "api" ? "mcp" : "api";
+  const regionSuffix = matched[2] ?? "";
+  return `https://${flipped}${regionSuffix}.useatlas.dev/mcp`;
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -47,6 +47,7 @@ import { getWebOrigin } from "@atlas/api/lib/web-origin";
 // eagerly without importing better-auth (#3045). Re-exported here so the auth
 // surface (and its tests) keep a single import site.
 import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
+import { resolveOAuthValidAudiences } from "@atlas/api/lib/auth/oauth-audiences";
 export { resolvePasskeyRpId, DEFAULT_RP_ID } from "@atlas/api/lib/auth/rpid";
 import {
   assertInvitationRoleAllowed,
@@ -1223,105 +1224,10 @@ export const ATLAS_OAUTH_SCOPES = [
   "mcp:write",
 ] as const;
 
-/**
- * Resolve the list of valid OAuth audiences from the environment.
- *
- * The MCP spec wants each MCP endpoint to be its own resource (with an
- * audience URI) so a token issued to the SaaS US region cannot replay
- * against the EU region. Per-region API hosts provide that natively.
- *
- * The audience the issuer accepts MUST equal what the resource server
- * advertises and what the verifier checks. All three sites resolve to
- * `<base>/mcp` (region-scoped, NOT workspace-scoped — see well-known.ts
- * `buildResourceUri` for the rationale and the spec citation).
- *
- * Resolution priority:
- *   1. ATLAS_OAUTH_VALID_AUDIENCES — comma-separated explicit list.
- *      Used verbatim, no `/mcp` suffix appended (operator owns the
- *      values and may want non-MCP audiences too).
- *   2. ATLAS_PUBLIC_API_URL — same env var well-known.ts and hosted.ts
- *      prefer; we suffix `/mcp` here so the issuer accepts the verifier's
- *      expected audience.
- *   3. BETTER_AUTH_URL — last fallback, `/mcp` suffix appended.
- *
- * Empty string in the env var → no override → fall back to (2)/(3).
- *
- * #2068 — when the resolved base is one of the canonical SaaS regional
- * `api*.useatlas.dev` hosts (`api`, `api-eu`, `api-apac`), the
- * brand-mirror `mcp*.useatlas.dev/mcp` audience is appended so tokens
- * minted post-cutover (advertised on the new canonical hostname)
- * verify here, AND tokens minted just before the cutover (against the
- * regional `<region>.api.useatlas.dev/mcp` host) keep verifying.
- * Self-hosted operators on arbitrary hostnames are unaffected — the
- * mirror only synthesises for `*.useatlas.dev`.
- */
-export function resolveOAuthValidAudiences(env: NodeJS.ProcessEnv): string[] {
-  const explicit = env.ATLAS_OAUTH_VALID_AUDIENCES?.trim();
-  if (explicit) {
-    return explicit
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
-  const base =
-    env.ATLAS_PUBLIC_API_URL?.trim() || env.BETTER_AUTH_URL?.trim();
-  if (!base) return [];
-  const trimmed = base.replace(/\/+$/, "");
-  const audiences = [`${trimmed}/mcp`];
-  const brand = brandMcpAudience(trimmed);
-  if (brand) audiences.push(brand);
-  return audiences;
-}
-
-/**
- * Map a SaaS regional `api*.useatlas.dev` host to its brand
- * counterpart, OR a SaaS brand `mcp*.useatlas.dev` host to its
- * regional counterpart (#2068). The mapping is symmetric so the
- * audience-synthesis invariant doesn't depend on which hostname an
- * operator chose for `ATLAS_PUBLIC_API_URL`:
- *
- *   `api.useatlas.dev`      → `mcp.useatlas.dev`
- *   `api-eu.useatlas.dev`   → `mcp-eu.useatlas.dev`
- *   `api-apac.useatlas.dev` → `mcp-apac.useatlas.dev`
- *   `mcp.useatlas.dev`      → `api.useatlas.dev`
- *   `mcp-eu.useatlas.dev`   → `api-eu.useatlas.dev`
- *   `mcp-apac.useatlas.dev` → `api-apac.useatlas.dev`
- *
- * Anything else (self-hosted, dev, custom-domain SaaS, `apiv2`,
- * `api.eu.useatlas.dev`, etc.) returns null — synthesising a
- * `.useatlas.dev` mirror for an unrelated host would be wrong. The
- * match is anchored on hostname only, so a `BETTER_AUTH_URL` with an
- * unusual port or path still maps cleanly.
- *
- * Symmetry rationale: pre-#2068 every site used the regional host as
- * the canonical base; post-#2068 docs/CLI/registry use the brand. An
- * operator who flips `ATLAS_PUBLIC_API_URL` to the brand (reasonable —
- * it's what the CLI default writes) must still see both audiences
- * synthesised so pre-cutover tokens bound to the regional audience
- * keep verifying. Closing that footgun is cheaper than documenting it
- * as a deployment invariant.
- */
-function brandMcpAudience(base: string): string | null {
-  let url: URL;
-  try {
-    url = new URL(base);
-  } catch {
-    // intentionally ignored: a non-URL `ATLAS_PUBLIC_API_URL` falls
-    // back to BETTER_AUTH_URL one layer up; if that fails too, the
-    // outer caller returns an empty audience list. Surfacing the
-    // parse failure here would double-log on every request.
-    return null;
-  }
-  // Strict match: `api.useatlas.dev` / `api-<region>.useatlas.dev` /
-  // `mcp.useatlas.dev` / `mcp-<region>.useatlas.dev`. `apiv2`,
-  // `api.eu.useatlas.dev`, etc. are intentionally excluded — we only
-  // mirror the documented regional surfaces.
-  const matched = url.hostname.match(/^(api|mcp)(-[a-z0-9]+)?\.useatlas\.dev$/);
-  if (!matched) return null;
-  const flipped = matched[1] === "api" ? "mcp" : "api";
-  const regionSuffix = matched[2] ?? "";
-  return `https://${flipped}${regionSuffix}.useatlas.dev/mcp`;
-}
+// `resolveOAuthValidAudiences` (+ its `brandMcpAudience` helper) was extracted
+// to `./oauth-audiences` (#3687) so the boot-time `McpSpineGuardLive` can assert
+// audiences are derivable without importing this 3k-line Better Auth module.
+// Imported at the top of this file and used in the Better Auth config below.
 
 /**
  * Resolve `allowUnauthenticatedClientRegistration` from the environment.

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Effect, Layer, Exit, ManagedRuntime } from "effect";
@@ -690,6 +690,23 @@ describe("MigrationGuardLive", () => {
 // ── buildAppLayer ──────────────────────────────────────────────────
 
 describe("buildAppLayer", () => {
+  // #3687 — the SaaS canary tests below assert that exactly ONE sibling guard
+  // fails in `Layer.mergeAll`. `McpSpineGuardLive` is a new SaaS fail-fast guard
+  // that fails when no OAuth valid-audiences are derivable, so satisfy that input
+  // here (a derivable `BETTER_AUTH_URL`) the same way these tests already satisfy
+  // every other sibling guard — otherwise it would race the guard-under-test to
+  // the failure channel. (Its policy-store probe is warn-only, so it never
+  // competes.) Self-hosted canary tests are unaffected — the guard skips.
+  let savedBetterAuthUrl: string | undefined;
+  beforeEach(() => {
+    savedBetterAuthUrl = process.env.BETTER_AUTH_URL;
+    process.env.BETTER_AUTH_URL = "https://api.useatlas.dev";
+  });
+  afterEach(() => {
+    if (savedBetterAuthUrl !== undefined) process.env.BETTER_AUTH_URL = savedBetterAuthUrl;
+    else delete process.env.BETTER_AUTH_URL;
+  });
+
   test("composes all layers into a single app layer", async () => {
     const config = {} as Parameters<typeof buildAppLayer>[0];
     const layer = buildAppLayer(config);

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -1923,6 +1923,10 @@ describe("McpSpineGuardLive", () => {
       const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
       expect(failure).toBeInstanceOf(McpSpineIncoherentError);
       expect((failure as TMcpSpineIncoherentError)._tag).toBe("McpSpineIncoherentError");
+      // Assert on structure (the discriminant + count), not just prose, so a
+      // copy edit can't silently weaken the test.
+      expect((failure as TMcpSpineIncoherentError).check).toBe("audiences");
+      expect((failure as TMcpSpineIncoherentError).resolvedAudienceCount).toBe(0);
       expect((failure as TMcpSpineIncoherentError).message).toContain("audience");
       expect((failure as TMcpSpineIncoherentError).message).toContain("#3687");
     });
@@ -1936,20 +1940,25 @@ describe("McpSpineGuardLive", () => {
       // A live-DB-probe failure must NOT wedge boot (runtime is already
       // fail-closed) — it surfaces as a loud, event-tagged warning instead.
       expect(Exit.isSuccess(exit)).toBe(true);
-      const warned = capturedLogWarns.some(
+      const warn = capturedLogWarns.find(
         (w) =>
           typeof w.obj === "object" &&
           w.obj !== null &&
           (w.obj as { event?: string }).event === "mcp_spine.policy_store_unreachable",
       );
-      expect(warned).toBe(true);
+      expect(warn).toBeDefined();
+      // The underlying cause must ride along on the warn — it's the
+      // operator-actionable part of the signal, not just the event tag.
+      const cause = (warn?.obj as { err?: unknown }).err;
+      expect(cause).toBeInstanceOf(Error);
+      expect((cause as Error).message).toContain("mcp_action_policy");
     });
   });
 
   test("skips entirely on self-hosted (no audiences, policy store throwing)", async () => {
     await withMcpEnv(async () => {
       // Worst-case inputs that WOULD fail in SaaS — self-hosted must ignore them
-      // because hosted MCP is a SaaS-only surface.
+      // because the guard only enforces spine coherence in SaaS.
       mockPolicyStoreThrows = true;
       const exit = await runMcpGuard("self-hosted");
       expect(Exit.isSuccess(exit)).toBe(true);

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -27,14 +27,21 @@ let capturedLogErrors: Array<{ obj: unknown; msg: unknown }> = [];
 const recordError = (obj: unknown, msg?: unknown) => {
   capturedLogErrors.push({ obj, msg });
 };
+// `log.warn` capture — McpSpineGuardLive's policy-store probe warns (never
+// fails) when the store is unreachable (#3687), so the test asserts the warn
+// fired rather than a boot failure.
+let capturedLogWarns: Array<{ obj: unknown; msg: unknown }> = [];
+const recordWarn = (obj: unknown, msg?: unknown) => {
+  capturedLogWarns.push({ obj, msg });
+};
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     error: recordError,
-    warn: () => {},
+    warn: recordWarn,
     info: () => {},
     debug: () => {},
   }),
-  getLogger: () => ({ error: recordError, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  getLogger: () => ({ error: recordError, warn: recordWarn, info: () => {}, debug: () => {}, level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
 }));
@@ -90,6 +97,7 @@ import type {
   RegionMisconfiguredError as TRegionMisconfiguredError,
   ChatAdapterEnvMissingError as TChatAdapterEnvMissingError,
   BillingConfigInvalidError as TBillingConfigInvalidError,
+  McpSpineIncoherentError as TMcpSpineIncoherentError,
 } from "../saas-guards";
 
 // ── Stripe client mock for BillingConfigGuardLive (#3435) ────────────
@@ -117,6 +125,27 @@ mock.module("@atlas/api/lib/billing/stripe-client", () => ({
   _resetStripeClientCache: () => {},
 }));
 
+// ── mcp_action_policy store mock for McpSpineGuardLive (#3687) ────────
+// The guard lazy-imports `loadMcpActionPolicy` and runs it against a sentinel
+// org id to prove the policy store is reachable. `mockPolicyStoreThrows` forces
+// that probe to throw (the "store unreachable at boot" path); the default
+// returns an all-allowed policy (reachable). Reset per test. Full export
+// surface mocked per mock-all-exports.
+let mockPolicyStoreThrows = false;
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  MCP_ACTION_CATEGORIES: [],
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: () => false,
+  loadMcpActionPolicy: async () => {
+    if (mockPolicyStoreThrows) {
+      throw new Error('relation "mcp_action_policy" does not exist');
+    }
+    return { isBlocked: () => false };
+  },
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 const {
   EnterpriseGuardLive,
   EnterpriseRequiredError,
@@ -137,6 +166,8 @@ const {
   ChatAdapterEnvMissingError,
   BillingConfigGuardLive,
   BillingConfigInvalidError,
+  McpSpineGuardLive,
+  McpSpineIncoherentError,
 } = await import("../saas-guards");
 const { Config, Migration, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
@@ -1818,5 +1849,110 @@ describe("BillingConfigGuardLive", () => {
         expect(Exit.isSuccess(exit)).toBe(true);
       },
     );
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  McpSpineGuardLive (#3687)
+// ══════════════════════════════════════════════════════════════════════
+
+// `ATLAS_PUBLIC_API_URL` / `ATLAS_OAUTH_VALID_AUDIENCES` are NOT part of the
+// SaaS boot contract (`SAAS_ENV_KEYS`), so `withCleanEnv` doesn't touch them —
+// clean them here too so the audience-derivation assertion can't pass for the
+// wrong reason on a leaked env var. `withCleanEnv` already clears
+// `BETTER_AUTH_URL`, the third input to `resolveOAuthValidAudiences`.
+const MCP_EXTRA_ENV_KEYS = ["ATLAS_PUBLIC_API_URL", "ATLAS_OAUTH_VALID_AUDIENCES"] as const;
+function withMcpEnv<T>(run: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of MCP_EXTRA_ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  mockPolicyStoreThrows = false;
+  capturedLogWarns = [];
+  return withCleanEnv(run).finally(() => {
+    for (const k of MCP_EXTRA_ENV_KEYS) {
+      if (saved[k] !== undefined) process.env[k] = saved[k];
+      else delete process.env[k];
+    }
+    mockPolicyStoreThrows = false;
+    capturedLogWarns = [];
+  });
+}
+
+function runMcpGuard(deployMode: "saas" | "self-hosted") {
+  return Effect.runPromiseExit(
+    Effect.void.pipe(
+      Effect.provide(
+        McpSpineGuardLive.pipe(
+          Layer.provide(
+            Layer.merge(
+              makeTestConfigLayer({ deployMode }),
+              Layer.succeed(Migration, { migrated: true }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+describe("McpSpineGuardLive", () => {
+  test("succeeds in SaaS when audiences are derivable and the policy store is reachable", async () => {
+    await withMcpEnv(async () => {
+      process.env.ATLAS_PUBLIC_API_URL = "https://api.useatlas.dev";
+      const exit = await runMcpGuard("saas");
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS with an explicit ATLAS_OAUTH_VALID_AUDIENCES list", async () => {
+    await withMcpEnv(async () => {
+      process.env.ATLAS_OAUTH_VALID_AUDIENCES = "https://api.useatlas.dev/mcp";
+      const exit = await runMcpGuard("saas");
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("fails boot in SaaS when no OAuth valid-audiences are derivable", async () => {
+    await withMcpEnv(async () => {
+      // No ATLAS_PUBLIC_API_URL / BETTER_AUTH_URL / ATLAS_OAUTH_VALID_AUDIENCES
+      // → resolveOAuthValidAudiences returns [].
+      const exit = await runMcpGuard("saas");
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(McpSpineIncoherentError);
+      expect((failure as TMcpSpineIncoherentError)._tag).toBe("McpSpineIncoherentError");
+      expect((failure as TMcpSpineIncoherentError).message).toContain("audience");
+      expect((failure as TMcpSpineIncoherentError).message).toContain("#3687");
+    });
+  });
+
+  test("WARNS (does not fail boot) in SaaS when the mcp_action_policy store is unreachable", async () => {
+    await withMcpEnv(async () => {
+      process.env.ATLAS_PUBLIC_API_URL = "https://api.useatlas.dev";
+      mockPolicyStoreThrows = true;
+      const exit = await runMcpGuard("saas");
+      // A live-DB-probe failure must NOT wedge boot (runtime is already
+      // fail-closed) — it surfaces as a loud, event-tagged warning instead.
+      expect(Exit.isSuccess(exit)).toBe(true);
+      const warned = capturedLogWarns.some(
+        (w) =>
+          typeof w.obj === "object" &&
+          w.obj !== null &&
+          (w.obj as { event?: string }).event === "mcp_spine.policy_store_unreachable",
+      );
+      expect(warned).toBe(true);
+    });
+  });
+
+  test("skips entirely on self-hosted (no audiences, policy store throwing)", async () => {
+    await withMcpEnv(async () => {
+      // Worst-case inputs that WOULD fail in SaaS — self-hosted must ignore them
+      // because hosted MCP is a SaaS-only surface.
+      mockPolicyStoreThrows = true;
+      const exit = await runMcpGuard("self-hosted");
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
   });
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -61,6 +61,7 @@ import {
   PluginConfigGuardLive,
   ChatAdapterEnvGuardLive,
   BillingConfigGuardLive,
+  McpSpineGuardLive,
   MigrationsRequiredError,
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
@@ -1456,7 +1457,17 @@ export function makeSchedulerLive(
         ? (raw as SchedulerShape["backend"])
         : "none";
 
-      // Start main scheduler
+      // Start main scheduler.
+      //
+      // SINGLE GLOBAL (US) SCHEDULER (#3687): `config.scheduler.backend` is `bun`
+      // only when `ATLAS_SCHEDULER_ENABLED === "true"` (config.ts), which in SaaS
+      // is set on the US region only. EU/APAC report `scheduler: "disabled"` at
+      // `/health` by design. This is SAFE because the customer-facing task-creation
+      // route (`POST /api/v1/scheduled-tasks` in api/index.ts) is gated on the SAME
+      // flag — so a region without this fiber also rejects task creation with a 404
+      // rather than persisting a task that would never fire. The fiber reads/writes
+      // `scheduled_tasks` in the shared internal DB, so the US fiber executes every
+      // workspace's tasks regardless of the workspace's region.
       if (backend === "bun") {
         yield* Effect.tryPromise({
           try: async () => {
@@ -3192,6 +3203,19 @@ export function buildAppLayer(
   const billingConfigGuardLayer = BillingConfigGuardLive.pipe(
     Layer.provide(Layer.merge(configLayer, settingsLayer)),
   );
+  // #3687 — MCP-spine boot coherence guard. Gated on `deployMode === "saas"`
+  // (hosted MCP is unconditionally mounted in SaaS, so SaaS IS the MCP-exposed
+  // predicate); self-hosted is inert. FAILS boot when OAuth valid-audiences are
+  // not derivable (deterministic env check) and WARNS when the
+  // `mcp_action_policy` store is unreachable (live DB probe — warn, not fail, to
+  // avoid wedging a region on a transient blip; runtime is already fail-closed).
+  // Depends on `Config` + `Migration` (the policy table is created by migration
+  // 0134 — same `migrationLayer` edge as `chatAdapterEnvGuardLayer` so the probe
+  // can't race the migration). Lazy-imports oauth-audiences + the policy store
+  // inside its Effect body.
+  const mcpSpineGuardLayer = McpSpineGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, migrationLayer)),
+  );
   // #1988 C7 + C8 — region routing claim and stale plugin config checks.
   // Both depend only on `Config`. PluginConfigGuardLive lazy-imports the
   // plugin registry + InternalDB inside its Effect body so it can run as
@@ -3245,6 +3269,7 @@ export function buildAppLayer(
     pluginConfigGuardLayer,
     chatAdapterEnvGuardLayer,
     billingConfigGuardLayer,
+    mcpSpineGuardLayer,
     migrationGuardLayer,
     EnterpriseLayer,
   );

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -384,10 +384,20 @@ export class BillingConfigInvalidError extends Data.TaggedError("BillingConfigIn
  * surfaces the misconfig before any HTTP listener starts. The companion
  * `mcp_action_policy` store reachability check is a boot WARNING (not a boot
  * failure) — see `McpSpineGuardLive` for why that half is warn-only. Self-hosted
- * never constructs this — hosted MCP is a SaaS surface and self-host runs stdio
- * MCP, which uses neither spine component.
+ * never constructs this — the guard only *enforces* spine coherence in SaaS,
+ * where hosted MCP is always mounted and the audience set is operator-critical.
+ * (A self-hoster who opts into hosted MCP on their own host owns their audience
+ * config; the guard deliberately doesn't police that surface.)
+ *
+ * Carries a `check` discriminant + `resolvedAudienceCount` (mirrors the
+ * structured-field convention of `BillingConfigInvalidError` above) so the
+ * boot-failure log and tests are actionable without re-parsing `message`. Only
+ * `check: "audiences"` is constructed today; the field leaves room for a future
+ * check to fail-boot under the same tag.
  */
 export class McpSpineIncoherentError extends Data.TaggedError("McpSpineIncoherentError")<{
+  readonly check: "audiences";
+  readonly resolvedAudienceCount: number;
   readonly message: string;
 }> {}
 
@@ -1463,8 +1473,10 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
  * **MCP-enabled predicate.** Hosted MCP is mounted UNCONDITIONALLY on every SaaS
  * api instance (`api/index.ts` mounts `/mcp/{workspace_id}/sse` with no toggle),
  * so `deployMode === "saas"` IS the "MCP is exposed" gate — there is no separate
- * enable flag to consult. Self-hosted runs stdio MCP, which uses neither the
- * OAuth audience set nor the hosted policy store, so it skips entirely.
+ * enable flag to consult. The guard only *enforces* spine coherence in SaaS and
+ * skips self-hosted entirely: a self-hoster who opts into hosted MCP on their own
+ * host owns their audience/policy config, and the common self-host path is stdio
+ * MCP, which uses neither spine component.
  *
  * Depends on `Config` + `Migration` (`mcp_action_policy` is created by migration
  * 0134; the `Migration` edge mirrors `ChatAdapterEnvGuardLive` so the table
@@ -1492,6 +1504,8 @@ export const McpSpineGuardLive: Layer.Layer<never, McpSpineIncoherentError, Conf
     if (audiences.length === 0) {
       return yield* Effect.fail(
         new McpSpineIncoherentError({
+          check: "audiences",
+          resolvedAudienceCount: audiences.length,
           message:
             `SaaS region exposes hosted MCP but no OAuth valid-audiences are derivable — ` +
             `resolveOAuthValidAudiences() returned an empty list because neither ` +

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -99,6 +99,15 @@ const ISSUE_REF_1988 = "#1988";
 const CHAT_ADAPTER_ISSUE_REF = "#2672";
 const PROVIDER_KEY_ISSUE_REF = "#3178";
 const BILLING_CONFIG_ISSUE_REF = "#3435";
+const MCP_SPINE_ISSUE_REF = "#3687";
+
+/**
+ * Sentinel org id for the boot-time `mcp_action_policy` reachability probe. It
+ * is never a real workspace, so the `WHERE org_id = $1` SELECT returns zero rows
+ * and the probe only proves the table + query path is reachable — it asserts
+ * nothing about any tenant's policy.
+ */
+const MCP_POLICY_PROBE_ORG_ID = "__mcp_spine_boot_probe__";
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Tagged errors
@@ -358,6 +367,28 @@ export class BillingConfigInvalidError extends Data.TaggedError("BillingConfigIn
   readonly message: string;
   readonly missingPriceIdEnvVars: readonly string[];
   readonly keyMode: "test" | "live" | "unknown";
+}> {}
+
+/**
+ * SaaS region exposes hosted MCP (always mounted in SaaS — see `api/index.ts`'s
+ * unconditional `/mcp/{workspace_id}/sse` mount) but the v0.0.15 MCP security
+ * spine's OAuth audience set is not derivable at boot (#3687):
+ * `resolveOAuthValidAudiences(process.env)` returns an EMPTY list because neither
+ * `ATLAS_OAUTH_VALID_AUDIENCES` nor a base URL (`ATLAS_PUBLIC_API_URL` /
+ * `BETTER_AUTH_URL`) is set. Better Auth would then validate every MCP bearer
+ * token against an empty `validAudiences`, so all OAuth-authenticated MCP calls
+ * 401 while boot and `/health` stay green.
+ *
+ * This is the FAIL-FAST half of the MCP-spine coherence check — it is a
+ * deterministic, env-only assertion (no I/O), so failing boot is safe and
+ * surfaces the misconfig before any HTTP listener starts. The companion
+ * `mcp_action_policy` store reachability check is a boot WARNING (not a boot
+ * failure) — see `McpSpineGuardLive` for why that half is warn-only. Self-hosted
+ * never constructs this — hosted MCP is a SaaS surface and self-host runs stdio
+ * MCP, which uses neither spine component.
+ */
+export class McpSpineIncoherentError extends Data.TaggedError("McpSpineIncoherentError")<{
+  readonly message: string;
 }> {}
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1393,6 +1424,111 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
         `One or more configured Stripe prices resolved with a livemode inconsistent with the ` +
           `secret key's ${keyMode} mode — checkout / webhook plan sync will silently no-op for the ` +
           `affected tier(s). See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
+    }
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  McpSpineGuardLive (#3687)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Surface MCP-spine incoherence at BOOT in SaaS when hosted MCP is exposed
+ * (#3687). Two checks with deliberately DIFFERENT severities:
+ *
+ *   1. OAuth valid-audiences DERIVABLE — `resolveOAuthValidAudiences` returns a
+ *      non-empty list. An empty list means Better Auth validates MCP bearer
+ *      tokens against `validAudiences: []`, so every OAuth MCP call 401s at first
+ *      I/O while boot stays green. This is a deterministic, env-only check (no
+ *      I/O), so a violation FAILS BOOT ({@link McpSpineIncoherentError}) — the
+ *      same fail-fast posture as the rest of the guard family.
+ *   2. `mcp_action_policy` STORE reachable — a cheap sentinel-org SELECT
+ *      succeeds. The dispatch gate's action-policy check fails CLOSED on a read
+ *      error, so an unreachable store turns every hosted MCP action into an
+ *      opaque `internal_error` at first call. This is a live DB probe, so a
+ *      failure is a loud `log.warn` (operator-actionable, event-tagged) — NOT a
+ *      boot failure.
+ *
+ * **Why check 2 warns instead of failing boot.** A boot-time DB probe that fails
+ * the boot Layer would (a) wedge a whole region on a transient DB blip at deploy
+ * time — even though `InternalDbGuardLive` + the SaaS migration guard already
+ * fail boot when the DB is genuinely absent — and (b) compete non-deterministically
+ * with the other guards in the parallel `Layer.mergeAll`. It mirrors
+ * `PluginConfigGuardLive`'s non-strict posture (a DB read error there warns and
+ * continues rather than wedging boot). The runtime is ALSO already fail-closed on
+ * a policy read error (dispatch Gate 1), so the security property holds regardless
+ * — the warn just moves DISCOVERY of an unreachable store to boot.
+ *
+ * **MCP-enabled predicate.** Hosted MCP is mounted UNCONDITIONALLY on every SaaS
+ * api instance (`api/index.ts` mounts `/mcp/{workspace_id}/sse` with no toggle),
+ * so `deployMode === "saas"` IS the "MCP is exposed" gate — there is no separate
+ * enable flag to consult. Self-hosted runs stdio MCP, which uses neither the
+ * OAuth audience set nor the hosted policy store, so it skips entirely.
+ *
+ * Depends on `Config` + `Migration` (`mcp_action_policy` is created by migration
+ * 0134; the `Migration` edge mirrors `ChatAdapterEnvGuardLive` so the table
+ * exists before the probe runs and the warn can't false-positive on first boot).
+ * Both modules are lazy-imported (same wall-off rationale as
+ * `EncryptionKeyGuardLive`) so this file stays free of the auth-server / MCP
+ * static graphs. A rejected `oauth-audiences` import is promoted to a defect via
+ * `Effect.orDie` (it is core and always loadable at boot); a rejected
+ * `action-policy` import or query is caught and folded into the same warn as a
+ * live read failure.
+ */
+export const McpSpineGuardLive: Layer.Layer<never, McpSpineIncoherentError, Config | Migration> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+    yield* Migration; // mcp_action_policy created by migration 0134 — order after migrations
+
+    // ── Check 1 (FAIL BOOT): OAuth valid-audiences derivable ─────────────
+    const { resolveOAuthValidAudiences } = yield* Effect.tryPromise({
+      try: () => import("@atlas/api/lib/auth/oauth-audiences"),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.orDie);
+
+    const audiences = resolveOAuthValidAudiences(process.env);
+    if (audiences.length === 0) {
+      return yield* Effect.fail(
+        new McpSpineIncoherentError({
+          message:
+            `SaaS region exposes hosted MCP but no OAuth valid-audiences are derivable — ` +
+            `resolveOAuthValidAudiences() returned an empty list because neither ` +
+            `ATLAS_OAUTH_VALID_AUDIENCES nor a base URL (ATLAS_PUBLIC_API_URL / BETTER_AUTH_URL) ` +
+            `is set. Better Auth would then verify every MCP bearer token against an empty ` +
+            `audience set, 401-ing all OAuth-authenticated MCP calls while boot and /health stay ` +
+            `green. Set ATLAS_PUBLIC_API_URL (or BETTER_AUTH_URL) on every region's api service ` +
+            `before booting. See ${MCP_SPINE_ISSUE_REF}.`,
+        }),
+      );
+    }
+
+    // ── Check 2 (WARN): mcp_action_policy store reachable ────────────────
+    // Live DB probe — a failure WARNS (never fails boot). The inner try/catch
+    // converts a rejected import OR a query failure into a discriminated result.
+    const probe = yield* Effect.promise(
+      async (): Promise<{ ok: true } | { ok: false; cause: Error }> => {
+        try {
+          const { loadMcpActionPolicy } = await import("@atlas/api/lib/mcp/action-policy");
+          // Sentinel org — proves the table + query path is reachable without
+          // asserting anything about a real tenant's policy.
+          await loadMcpActionPolicy(MCP_POLICY_PROBE_ORG_ID);
+          return { ok: true };
+        } catch (err) {
+          return { ok: false, cause: err instanceof Error ? err : new Error(String(err)) };
+        }
+      },
+    );
+
+    if (!probe.ok) {
+      log.warn(
+        { err: probe.cause, event: "mcp_spine.policy_store_unreachable" },
+        `SaaS region exposes hosted MCP but the mcp_action_policy store could not be reached at ` +
+          `boot: ${probe.cause.message}. The dispatch gate's action-policy check fails CLOSED on a ` +
+          `read error, so until this is resolved every hosted MCP action returns an opaque ` +
+          `internal_error at first call. Verify the internal DB is reachable and migration 0134 ` +
+          `(mcp_action_policy) has applied. See ${MCP_SPINE_ISSUE_REF}.`,
       );
     }
   }),


### PR DESCRIPTION
Closes #3687 (milestone v0.0.18 — Production Hardening II). A bundle of three lower-severity verification / hardening items from the v0.0.13–v0.0.16 production-readiness audit.

## Decisions taken (one per item)

### 1. EU/APAC `scheduler:disabled` intent → **CONFIRMED safe, documented, no code change, no follow-up**
Traced the full task-creation path. The customer-facing creation route `POST /api/v1/scheduled-tasks` is the **only** non-test caller of `createScheduledTask` (the only `INSERT INTO scheduled_tasks`), and it is mounted behind the **exact same** `ATLAS_SCHEDULER_ENABLED === "true"` flag that starts the scheduler fiber (`config.scheduler.backend` → `makeSchedulerLive`) and drives the `/health` reporter. So a region with the scheduler disabled (EU/APAC) **does not mount the creation route either** — a customer there gets a `404` on creation, never a task that is written but never fires. The single global (US) scheduler reading/writing the shared internal DB is intended and safe.

Documented the co-gating invariant at all three flag sites — scheduler boot (`layers.ts`), route mount (`api/index.ts`), `/health` reporter (`health.ts`) — plus an operator callout in `reference/environment-variables.mdx` (enable on exactly one region; do not enable on more than one or fibers double-execute).

### 2. MCP-spine boot coherence guard → **DEFAULT: added `McpSpineGuardLive`** (gated SaaS + hosted-MCP-exposed; self-host inert)
Hosted MCP is mounted unconditionally in SaaS (`api/index.ts`, no toggle), so `deployMode === "saas"` **is** the "MCP exposed" predicate. The guard runs two checks with deliberately different severities:
- **OAuth valid-audiences derivable → FAILS boot.** Deterministic env-only check (`resolveOAuthValidAudiences(process.env)` non-empty); an empty set means Better Auth verifies MCP tokens against `validAudiences: []` → all OAuth MCP calls 401 while boot/health stay green.
- **`mcp_action_policy` store reachable → loud WARN, not fail.** A live DB probe. Warn-not-fail because (a) failing boot on a transient deploy-time DB blip would wedge a whole region even though `InternalDbGuardLive`/migration guard already fail boot when the DB is genuinely absent, (b) it mirrors `PluginConfigGuardLive`'s non-strict DB-error posture, and (c) the runtime is **already fail-closed** on a policy read error (dispatch Gate 1), so the security property holds — the warn just moves *discovery* of an unreachable store to boot. This matches the issue's "degraded-discoverability, not insecure-execution" framing.

Wired as a `Config + Migration` peer layer (the `Migration` edge mirrors `ChatAdapterEnvGuardLive` — `mcp_action_policy` is created by migration 0134).

### 3. Prod-floor config warnings → **DEFAULT: soft `log.warn` for `ATLAS_RATE_LIMIT_RPM_CHAT`**
Only the **explicit-override** path can resolve below 5 (`Math.floor(n)`; the derived default floors at 5), and `getRpmLimitForBucket` previously accepted e.g. `2` silently. Added a SaaS-gated soft warn when an explicit value resolves to `0 < n < 5` (the issue's explicit suggestion) — never a hard fail (operator-tuned per-region knobs). The decision is factored into a pure, unit-tested `isLowSaasChatRpm()` predicate so it needs no logger/config mocking.

## Supporting refactor
Extracted `resolveOAuthValidAudiences` (+ its `brandMcpAudience` helper) from the 3k-line `auth/server.ts` into a light `auth/oauth-audiences.ts` (pure env reads only), so the boot guard can assert audiences **without** pulling the Better Auth static graph into the boot-guard import path — the same wall-off discipline the rest of the guard family follows. Single SSOT; `auth/server.ts` and the existing `oauth-config.test.ts` updated to import from the new module.

## Follow-ups
None filed — item 1 is a confirmed-safe design (no gap), items 2 & 3 are implemented here.

## Tests / gates
- New unit tests: `McpSpineGuardLive` (success, explicit-audiences, audiences-empty→fail, policy-store-unreachable→warn-not-fail, self-host skip); `isLowSaasChatRpm()` predicate; `buildAppLayer` SaaS canary tests updated to satisfy the new fail-fast guard.
- `bun run type` (api): 0 errors · `eslint`: clean · `syncpack lint`: clean · template-drift: pass · railway-watch: pass.
- All directly-affected test files pass in isolation (`saas-guards`, `layers`, `middleware`, `oauth-config`, `health`, `well-known`, `server`).