### PR TITLE
fix(billing): drift detection gates on active local rows, not empty table (#3679)

### DIFF
--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -699,12 +699,25 @@ describe("drift detection — zero local rows but a live customer (#3679)", () =
     expect(enqueued.map((e) => e.stripeSubId)).toEqual(["sub_live"]);
   });
 
-  it("does NOT query Stripe for drift when local rows exist", async () => {
+  it("does NOT query Stripe for drift when an ACTIVE local row exists", async () => {
     captureOutbox([subRow("sub_1", "active")]);
 
     await cancelStripeSubscriptionsForWorkspace(ORG, "cus_acme");
 
     expect(subscriptionsList).not.toHaveBeenCalled();
+  });
+
+  it("detects drift when local rows are all terminal (a stale canceled row is no protection)", async () => {
+    // Local table holds only a terminal row, but Stripe has a live sub the
+    // webhook never synced — the literal-empty guard would have missed this.
+    const enqueued = captureOutbox([subRow("sub_old", "canceled")]);
+    liveStripeSubs = { cus_drift: [{ id: "sub_live", status: "active" }] };
+
+    const outcome = await cancelStripeSubscriptionsForWorkspace(ORG, "cus_drift");
+
+    expect(subscriptionsList).toHaveBeenCalledTimes(1);
+    expect(enqueued.map((e) => e.stripeSubId)).toEqual(["sub_live"]);
+    expect(outcome.warnings.some((w) => w.includes("no local record"))).toBe(true);
   });
 
   it("does NOT query Stripe for drift when no customer id is supplied", async () => {

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -94,6 +94,17 @@ interface SubscriptionRow {
 }
 
 /**
+ * Whether any local `subscription` row is still non-terminal. Drift detection
+ * gates on the ABSENCE of an active local row, not on the table being literally
+ * empty: a stale terminal row (e.g. a `canceled` row the webhook left behind)
+ * offers no protection against a live Stripe subscription the local table never
+ * synced, so it must not suppress the Stripe cross-check (#3679).
+ */
+function hasActiveLocalSubscription(rows: SubscriptionRow[]): boolean {
+  return rows.some((row) => !(row.status && TERMINAL_STATUSES.has(row.status)));
+}
+
+/**
  * Stripe "the object no longer exists" — treat as already torn down.
  * Exported so the durable-outbox sweep (`reconcile-stripe-teardown.ts`) shares
  * the exact same terminal-success predicate as the inline teardown path.
@@ -419,8 +430,10 @@ export async function cancelStripeSubscriptionsForWorkspace(
     );
   }
 
-  // Drift: no local rows but a live Stripe customer — query Stripe directly.
-  if (rows.length === 0 && stripeCustomerId) {
+  // Drift: no active local rows but a live Stripe customer — query Stripe
+  // directly. Terminal-only local rows don't count as protection (see
+  // hasActiveLocalSubscription).
+  if (!hasActiveLocalSubscription(rows) && stripeCustomerId) {
     await detectCustomerSubscriptionDrift(orgId, stripeCustomerId, actions, warnings, pending);
   }
 
@@ -470,9 +483,10 @@ export async function purgeStripeBillingForWorkspace(
     );
   }
 
-  // Drift: no local rows but a live Stripe customer — query Stripe directly so
-  // a purge can't leave a live subscription the drifted local table hid.
-  if (rows.length === 0 && stripeCustomerId) {
+  // Drift: no active local rows but a live Stripe customer — query Stripe
+  // directly so a purge can't leave a live subscription a drifted local table
+  // hid (terminal-only rows don't count; see hasActiveLocalSubscription).
+  if (!hasActiveLocalSubscription(rows) && stripeCustomerId) {
     await detectCustomerSubscriptionDrift(orgId, stripeCustomerId, actions, warnings, pending);
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #3781 (durable Stripe teardown outbox). A PR review surfaced one correctness gap in the new drift detection.

The drift check in both `cancelStripeSubscriptionsForWorkspace` and `purgeStripeBillingForWorkspace` guarded on `rows.length === 0` — it only queried Stripe when the local `subscription` table was **literally empty**. A stale **terminal** local row (e.g. a `canceled` row the webhook left behind) made `rows.length > 0`, suppressing the Stripe cross-check. If Stripe then held a **live** subscription the local table never synced, a workspace delete/purge would leave it invoicing a deleted workspace — defeating #3781's own stated guarantee ("a drifted local table can't leave a live subscription invoicing"). A terminal local row offers zero protection against a live Stripe sub.

## What changed

- New shared `hasActiveLocalSubscription(rows)` helper: drift detection now gates on the absence of any **non-terminal** local row, not on the table being empty. Used by both the cancel and purge paths so they stay identical.
- Regression test: terminal-only local rows (`canceled`) + a live Stripe customer → drift detected, live sub enqueued, warning surfaced.

The extra Stripe `subscriptions.list` call now also fires when the local table holds only terminal rows — correct (we *want* the cross-check there), and teardown is a rare operation, so the cost profile is unchanged in practice.

## Out of scope (consciously, per #3679)

- Partial drift (active local rows *plus* an orphan Stripe sub) — would require a Stripe list call on every teardown.
- No max-attempts/dead-letter on the sweep — #3679 specifies retry until success or `resource_missing`.

## Testing

- `workspace-teardown.test.ts`: 39 pass (+1 new regression test).
- Affected suite (workspace-teardown + admin-orgs + platform-admin teardown route tests): 3/3 pass.
- `bun run type` + `bun run lint` clean.