### PR TITLE
chore(commands): bake worktree dep-install into session-spawning slash commands

### DIFF
--- a/.claude/commands/investigate.md
+++ b/.claude/commands/investigate.md
@@ -94,7 +94,7 @@ Output a summary:
 Then ask the user to choose:
 
 1. **Park it** — Issue is filed. Pick it up later via `/next`. Done.
-2. **Fix it now** — Output a session prompt (same format as `/next`) so the user can start immediately.
+2. **Fix it now** — Output a session prompt (same format as `/next`) so the user can start immediately. Use the full `/next` prompt template, **including the loud worktree banner and the `git worktree add ... && cd ... && bun install --frozen-lockfile` step ZERO** — the session shares this checkout and a fresh worktree has no `node_modules`. Don't drop it.
 
 ---
 

--- a/.claude/commands/kickoff.md
+++ b/.claude/commands/kickoff.md
@@ -111,7 +111,7 @@ After creating all issues, recommend 2-3 issues to start with (same format as `/
 - Prefer foundational work that unblocks other items
 - Consider parallelizability (can multiple sessions work on different items?)
 
-Output session prompts in the same format as `/next` — detailed enough for a fresh Claude Code session.
+Output session prompts in the same format as `/next` — detailed enough for a fresh Claude Code session. This **includes the loud worktree banner and the `bun install --frozen-lockfile` step**: every emitted prompt opens with the `🚨 STOP — work in your own git worktree` block and its `git worktree add ... && cd ... && bun install --frozen-lockfile` step ZERO, because these sessions share one checkout and a fresh worktree has no `node_modules`. Do not drop it.
 
 ---
 

--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -61,8 +61,9 @@ The user runs up to 3 Claude Code sessions in parallel, **all sharing this one w
 [
 🚨🚨🚨 STOP — YOU MUST WORK IN YOUR OWN GIT WORKTREE. 🚨🚨🚨
 This repo is a SHARED working tree. Other sessions are on this exact checkout RIGHT NOW.
-Before you read, edit, run, or commit ANYTHING, create your own worktree off the latest main:
-    git fetch origin && git worktree add -b <branch> ../atlas-wt-<slug> origin/main && cd ../atlas-wt-<slug>
+Before you read, edit, run, or commit ANYTHING, create your own worktree off the latest main
+AND install deps into it (a fresh worktree has NO node_modules — tests/builds fail until you do):
+    git fetch origin && git worktree add -b <branch> ../atlas-wt-<slug> origin/main && cd ../atlas-wt-<slug> && bun install --frozen-lockfile
 Do NOT `/reset`, `git checkout main`, `git add -A`, or `git commit -a` in the shared tree — you will
 clobber another session's branch and stage their files. Full rules are in the Worktree isolation block
 at the bottom of this prompt. Do this step ZERO, before anything else.
@@ -126,6 +127,7 @@ IMPORTANT — Worktree isolation (this repo is a SHARED working tree — you mus
 - You are NOT in a pre-made worktree. Other sessions share this exact checkout (same HEAD + index). Before making ANY change, create a dedicated worktree + branch off the latest main and do all work from there:
     `git fetch origin && git worktree add -b <branch> ../atlas-wt-<slug> origin/main && cd ../atlas-wt-<slug>`
     (`<slug>` = a slash-free short name; the branch name may contain slashes but the directory must not.)
+- **Install deps into the fresh worktree before running anything** — a brand-new `git worktree add` has NO `node_modules`. The first thing you do after `cd` into it is `bun install --frozen-lockfile`. Skip this and you'll hit a confusing failure loop: tests/builds error on missing `@useatlas/types/*` (unbuilt dist) and then missing `pino` and other deps until install has run in the worktree once. Run it before any `bun run test`, `bun run type`, `bun run lint`, or `/ci`. Use `--frozen-lockfile` (matches CI) so the install can't mutate `bun.lock` and pollute your worktree's `git status`. If frozen install *fails*, your branch's `package.json` is out of sync with the lockfile — fix that (a deliberate dep change is the only valid reason to run a plain `bun install` and commit the updated `bun.lock`), don't just drop the flag to paper over it.
 - Why: if you commit on the shared checkout, your commit can land on another session's branch (and `git add -A` can stage their files). A private worktree gives you an isolated HEAD + index.
 - Commit only your explicit paths: `git commit -o <file1> <file2> -m ...`. NEVER `git add -A` / `git add .` / `git commit -a`.
 - Do NOT run `/reset`, `git checkout main`, or switch/reset branches in the shared tree.

--- a/.claude/commands/revamp.md
+++ b/.claude/commands/revamp.md
@@ -8,6 +8,20 @@ Revamp a cluttered admin or SaaS page using the `.impeccable.md` toolkit — the
 
 ---
 
+## Step 0 — Worktree isolation (do this FIRST)
+
+This repo is a **shared working tree** — other Claude sessions may be on this exact checkout right now. Revamp edits source files and then branches, so do all of it in your own worktree, not the shared tree.
+
+1. Derive a slash-free `<page-slug>` from the target page (e.g. `/admin/integrations` → `admin-integrations`).
+2. Create the worktree off the latest main **and install deps into it** (a fresh worktree has NO `node_modules`):
+   ```bash
+   git fetch origin && git worktree add -b <user>/revamp-<page-slug> ../atlas-wt-revamp-<page-slug> origin/main \
+     && cd ../atlas-wt-revamp-<page-slug> && bun install --frozen-lockfile
+   ```
+   Use `--frozen-lockfile` (matches CI) so the install can't mutate `bun.lock`. If it *fails*, the branch's `package.json` is out of sync with the lockfile — fix that, don't drop the flag.
+3. Do **all** subsequent steps from inside this worktree. The dev server in Step 1 must run from here too — a dev server started in the shared tree serves the shared tree's code, so Playwright would show stale output and miss your edits. If another session already holds `:3000`, start yours on a free port (`PORT=3010 bun run dev`) and point Playwright at that port.
+4. Never `git checkout main`, `git add -A`, or `git commit -a` in the shared tree. Commit only your explicit changed paths. After the PR merges, remove the worktree (`git worktree remove ../atlas-wt-revamp-<page-slug>`).
+
 ## Step 1 — Baseline
 
 Read context and take a before-snapshot so we can compare.
@@ -18,7 +32,7 @@ Read context and take a before-snapshot so we can compare.
    ```
    Glob: packages/web/src/**/{page,layout}.tsx matching the URL
    ```
-4. Start the dev server if it isn't running (`bun run dev`), then navigate Playwright to the target page (log in as **admin@useatlas.dev / atlas-dev** if it's behind admin auth — if that password has drifted, reseed via `Bun.password.hash` + `UPDATE "account" SET password = ...`).
+4. Start the dev server **from your Step 0 worktree** if it isn't running (`bun run dev`, or `PORT=3010 bun run dev` if `:3000` is taken by another session), then navigate Playwright to the target page on that port (log in as **admin@useatlas.dev / atlas-dev** if it's behind admin auth — if that password has drifted, reseed via `Bun.password.hash` + `UPDATE "account" SET password = ...`).
 5. Take `page-before-top.png` and `page-before-bottom.png` full-viewport screenshots at **1440×900**.
 
 ## Step 2 — Critique
@@ -92,8 +106,9 @@ Skip this step entirely if the page already has prominent teal buttons/accents t
 
 Branch, commit, push, PR — per `feedback_always_branch` and `feedback_pr_before_merge`. Don't merge without review.
 
+You're already on `<user>/revamp-<page-slug>` in your Step 0 worktree — do NOT `git checkout -b` again, and do NOT branch in the shared tree.
+
 ```bash
-git checkout -b <user>/revamp-<page-slug>
 git add <changed files only — never the screenshot PNGs>
 git commit -m "$(cat <<'EOF'
 refactor(web/admin): redesign <page> with compact rows + deeper teal


### PR DESCRIPTION
## What

A fresh `git worktree add` checkout has no `node_modules` of its own, so sessions spawned by our worktree-spanning slash commands hit a confusing failure loop (missing `@useatlas/types` dist subpaths, then missing `pino`) until `bun install` runs once in the worktree.

This bakes `bun install --frozen-lockfile` into the worktree-creation step across the commands that span worktrees.

## Changes

- **`/next`** — banner step ZERO and the Worktree isolation block now run `... && cd ... && bun install --frozen-lockfile`. `--frozen-lockfile` matches CI and won't mutate `bun.lock` (so it can't pollute the worktree's `git status`); a frozen-install failure signals `package.json`↔lockfile drift to fix rather than paper over.
- **`/kickoff`, `/investigate`** — both emit "same format as `/next`" prompts; made the worktree banner + install step ZERO explicit so the agent can't drop it.
- **`/revamp`** — added **Step 0 — Worktree isolation** (create worktree + install), made the dev server run from the worktree (a shared-tree server serves stale code, so Playwright would miss edits), and removed the in-shared-tree `git checkout -b` that collided with parallel sessions.

Docs/prompt-only change — no code or test impact.