### PR TITLE
feat(mcp): start_trial — self-serve trial provisioning over MCP (#3649)

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -349,6 +349,35 @@ If you connect a client not listed here and it works (or it doesn't), [open an i
 
 ---
 
+## Start a trial from inside your agent
+
+On Atlas SaaS there's a separate, **unauthenticated** onboarding endpoint at `mcp.useatlas.dev/mcp/onboarding/sse` that exposes exactly one tool — `start_trial`. It's how a brand-new prospect goes from *nothing* to a live, connectable Atlas workspace without leaving the agent. You don't need an account, a token, or a workspace to call it.
+
+<Callout type="info">
+`start_trial` is the **only** tool reachable before you have an identity. It runs outside Atlas's MCP dispatch gate (there is no actor or workspace yet) and can do exactly one thing: provision a trial workspace. Every other tool — `explore`, `executeSQL`, datasource lifecycle — lives on the authenticated, per-workspace endpoint and runs the full gate (action policy → `mcp:write` → RBAC → approval). The endpoint exists only on Atlas SaaS; self-hosted has no billing surface to onboard onto.
+</Callout>
+
+### start_trial
+
+Provision a new trial workspace and get a connect URL back. The tool collects a **business email** and a **workspace name** — supply them as arguments, or let your agent prompt you for them via MCP elicitation:
+
+```
+email: "you@yourcompany.com"
+orgName: "Acme Analytics"
+```
+
+It returns:
+
+```json
+{
+  "workspaceId": "org_…",
+  "connectUrl": "https://mcp.useatlas.dev/mcp/org_…/sse",
+  "state": "grace"
+}
+```
+
+Point your agent's MCP client at `connectUrl` to run the normal OAuth 2.1 + DCR + PKCE [connect flow](#path-a--in-product-wizard-recommended) and attach a hosted actor to the new workspace. The workspace starts in a short **unclaimed grace period** (`state: "grace"`) — setup (connect a datasource, build the semantic layer) and client-paid MCP querying work immediately; the full 14-day trial clock starts when you **claim** the account on the web (verify email → set a credential → accept ToS).
+
 ## Available tools
 
 The MCP server exposes six core semantic tools — two general-purpose and four typed accessors over the semantic layer — plus a set of admin [datasource lifecycle tools](#datasource-lifecycle-tools) covered below. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.

--- a/docs/adr/0018-self-serve-trial-over-mcp.md
+++ b/docs/adr/0018-self-serve-trial-over-mcp.md
@@ -28,6 +28,14 @@ Because `start_trial` provisions through the same Better Auth signup path, signu
 
 The one-trial-per-*user* cap is a no-op against fresh-email MCP signups and is **not** the abuse bound — and it doesn't need to be, because the meter removes the thing worth abusing (pre-claim costs Atlas ~nothing: no Atlas tokens, web Q&A claim-gated, MCP querying client-paid). Residual spam is DB-row/provisioning churn, bounded by **Turnstile + per-IP/email rate-limiting + the short unclaimed-grace reaper + the email-quality policy above**. Per-IP *trial* caps were rejected (punish shared NATs).
 
+## Implementation status
+
+The tracer-bullet slice (#3649) lands **end-to-end provisioning + connect** only — the meter (#3651), CRM lead source (#3653), email-quality policy (#3650), grace reaper (#3652), and abuse controls (#3654) are tracked as follow-on slices.
+
+- **Lib seam** — `provisionTrialWorkspace({ email, orgName })` in `ee/src/onboarding/provision-trial.ts` is the single, testable provisioning seam. It runs the same Better Auth path the web uses (`signUpEmail` → `createOrganization`), which fires the existing `afterCreateOrganization` hook (`assignSaasTrial` → the atomic `claimTrialGrant` one-trial-per-user claim + `trial` tier). The provisioner then **narrows `trial_ends_at`** from the full `TRIAL_DAYS` down to the short `TRIAL_GRACE_HOURS` window — the unclaimed-grace state. It refuses when `deployMode !== 'saas'` and never binds an MCP actor. The MCP tool and any future HTTP onboarding face both call it; no new column, no new tier.
+- **Anonymous onboarding caller** — `start_trial` (`packages/mcp/src/onboarding.ts`) is registered on a **separate, unauthenticated** MCP server (`createOnboardingMcpServer`) mounted at `/mcp/onboarding/sse` (`createOnboardingMcpRouter`), ordered before the hosted `/mcp/:workspaceId/sse` router. That server exposes *only* `start_trial`, so the caller is structurally incapable of reaching `runMcpDispatchGate`. Both the server and the route self-gate on `deployMode === 'saas'`. The tool collects `email` + `orgName` (args or MCP elicitation), calls `provisionTrialWorkspace`, and returns `{ workspaceId, connectUrl, state }`; typed failures map to the standard `AtlasMcpToolError` envelope.
+- **Connect handoff** — `connectUrl` is the canonical per-workspace hosted-MCP resource URL (`buildMcpConnectUrl`, `packages/api/src/lib/mcp/connect-url.ts`); the agent runs the existing DCR/PKCE flow against it to attach a normal *hosted* actor, after which every read/write/setup tool runs the full dispatch gate unchanged.
+
 ## Considered and rejected
 
 - **Meter as `tokenBudgetPerSeat: 0`, a new `trial_metered` plan tier, or a `meter_state` column** — rejected; the budget clamp blocks setup + MCP via Gate 0, and a new tier duplicates the whole limit table. The meter is a claim-gate at `executeAgentQuery` keyed on `emailVerified`.

--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+import {
+  provisionTrialWorkspace,
+  TrialProvisioningError,
+  type ProvisionTrialDeps,
+} from "../provision-trial.js";
+
+/**
+ * Build a fully-stubbed deps set so the orchestration is tested at the highest
+ * seam without pulling Better Auth or the internal DB into the graph. Each
+ * field is overridable per-test.
+ */
+function stubDeps(over: Partial<ProvisionTrialDeps> = {}): {
+  deps: Partial<ProvisionTrialDeps>;
+  calls: {
+    signUp: Array<{ email: string; name: string }>;
+    createOrg: Array<{ name: string; slug: string; userId: string }>;
+    grace: Array<{ orgId: string; endsAtIso: string }>;
+  };
+} {
+  const calls = {
+    signUp: [] as Array<{ email: string; name: string }>,
+    createOrg: [] as Array<{ name: string; slug: string; userId: string }>,
+    grace: [] as Array<{ orgId: string; endsAtIso: string }>,
+  };
+  const deps: Partial<ProvisionTrialDeps> = {
+    getDeployMode: () => "saas",
+    signUpEmail: async (b) => {
+      calls.signUp.push({ email: b.email, name: b.name });
+      return { user: { id: "user_new" } };
+    },
+    createOrganization: async (b) => {
+      calls.createOrg.push(b);
+      return { id: "org_new" };
+    },
+    readOrgTier: async () => ({ plan_tier: "trial", trial_ends_at: null }),
+    setGraceWindow: async (orgId, endsAtIso) => {
+      calls.grace.push({ orgId, endsAtIso });
+    },
+    buildConnectUrl: (id) => `https://mcp.test/mcp/${id}/sse`,
+    graceMs: 72 * 60 * 60 * 1000,
+    ...over,
+  };
+  return { deps, calls };
+}
+
+describe("provisionTrialWorkspace", () => {
+  it("provisions a user + Workspace into unclaimed grace and returns the connect URL", async () => {
+    const { deps, calls } = stubDeps();
+    const before = Date.now();
+    const result = await provisionTrialWorkspace(
+      { email: "founder@acme.com", orgName: "Acme Analytics" },
+      deps,
+    );
+    const after = Date.now();
+
+    expect(result.workspaceId).toBe("org_new");
+    expect(result.state).toBe("grace");
+    expect(result.connectUrl).toBe("https://mcp.test/mcp/org_new/sse");
+
+    // signUp ran with a derived name; createOrg used the user id + a slug
+    // derived from the workspace name.
+    expect(calls.signUp).toHaveLength(1);
+    expect(calls.signUp[0]!.email).toBe("founder@acme.com");
+    expect(calls.createOrg).toHaveLength(1);
+    expect(calls.createOrg[0]!.userId).toBe("user_new");
+    expect(calls.createOrg[0]!.name).toBe("Acme Analytics");
+    expect(calls.createOrg[0]!.slug).toMatch(/^acme-analytics-[0-9a-f]{8}$/);
+
+    // grace window narrowed to NOW + ~72h (well short of the 14-day clock).
+    expect(calls.grace).toHaveLength(1);
+    expect(calls.grace[0]!.orgId).toBe("org_new");
+    const graceMs = Date.parse(calls.grace[0]!.endsAtIso);
+    expect(graceMs).toBeGreaterThanOrEqual(before + 72 * 60 * 60 * 1000);
+    expect(graceMs).toBeLessThanOrEqual(after + 72 * 60 * 60 * 1000);
+    expect(graceMs).toBeLessThan(before + 14 * 24 * 60 * 60 * 1000);
+  });
+
+  it("refuses when deployMode !== 'saas'", async () => {
+    const { deps, calls } = stubDeps({ getDeployMode: () => "self-hosted" });
+    await expect(
+      provisionTrialWorkspace(
+        { email: "founder@acme.com", orgName: "Acme" },
+        deps,
+      ),
+    ).rejects.toMatchObject({ name: "TrialProvisioningError", code: "not_saas" });
+    // Nothing was provisioned.
+    expect(calls.signUp).toHaveLength(0);
+    expect(calls.createOrg).toHaveLength(0);
+  });
+
+  it("lands a repeat signup (consumed trial) on locked with no grace narrowing", async () => {
+    const { deps, calls } = stubDeps({
+      readOrgTier: async () => ({
+        plan_tier: "locked",
+        trial_ends_at: new Date().toISOString(),
+      }),
+    });
+    const result = await provisionTrialWorkspace(
+      { email: "founder@acme.com", orgName: "Acme Two" },
+      deps,
+    );
+    expect(result.state).toBe("locked");
+    expect(result.workspaceId).toBe("org_new");
+    // grace narrowing is skipped for the locked arm.
+    expect(calls.grace).toHaveLength(0);
+  });
+
+  it("rejects malformed email before any signup round-trip", async () => {
+    const { deps, calls } = stubDeps();
+    await expect(
+      provisionTrialWorkspace({ email: "not-an-email", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    expect(calls.signUp).toHaveLength(0);
+  });
+
+  it("rejects a blank workspace name", async () => {
+    const { deps } = stubDeps();
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "   " }, deps),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+
+  it("throws signup_failed when Better Auth returns no user id (email already registered)", async () => {
+    const { deps, calls } = stubDeps({
+      signUpEmail: async () => ({ user: {} }),
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "signup_failed" });
+    expect(calls.createOrg).toHaveLength(0);
+  });
+
+  it("throws org_failed when organization creation returns no id", async () => {
+    const { deps } = stubDeps({ createOrganization: async () => ({}) });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "org_failed" });
+  });
+
+  it("throws trial_not_assigned when the org lands on neither trial nor locked", async () => {
+    const { deps } = stubDeps({
+      readOrgTier: async () => ({ plan_tier: "free", trial_ends_at: null }),
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "trial_not_assigned" });
+  });
+
+  it("exposes a typed error class for envelope mapping", () => {
+    const err = new TrialProvisioningError("not_saas", "nope");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("TrialProvisioningError");
+    expect(err.code).toBe("not_saas");
+  });
+});

--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -36,6 +36,7 @@ function stubDeps(over: Partial<ProvisionTrialDeps> = {}): {
     readOrgTier: async () => ({ plan_tier: "trial", trial_ends_at: null }),
     setGraceWindow: async (orgId, endsAtIso) => {
       calls.grace.push({ orgId, endsAtIso });
+      return 1;
     },
     buildConnectUrl: (id) => `https://mcp.test/mcp/${id}/sse`,
     graceMs: 72 * 60 * 60 * 1000,
@@ -136,6 +137,16 @@ describe("provisionTrialWorkspace", () => {
     await expect(
       provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
     ).rejects.toMatchObject({ code: "org_failed" });
+  });
+
+  it("throws trial_not_assigned when the grace-window UPDATE matches no row (TOCTOU)", async () => {
+    // The tier was read as 'trial' but the guarded UPDATE narrows zero rows
+    // (the tier changed under us) — returning grace here would hand back a
+    // full-window trial, so the provisioner must refuse instead.
+    const { deps } = stubDeps({ setGraceWindow: async () => 0 });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "trial_not_assigned" });
   });
 
   it("throws trial_not_assigned when the org lands on neither trial nor locked", async () => {

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -26,7 +26,11 @@
 import { randomBytes } from "node:crypto";
 import { getConfig } from "@atlas/api/lib/config";
 import { TRIAL_GRACE_HOURS } from "@atlas/api/lib/billing/plans";
+import type { PlanTier } from "@atlas/api/lib/db/internal";
 import { buildMcpConnectUrl } from "@atlas/api/lib/mcp/connect-url";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("provision-trial");
 
 export type TrialWorkspaceState = "grace" | "locked";
 
@@ -67,9 +71,13 @@ export class TrialProvisioningError extends Error {
 }
 
 // A type alias (not an interface) so it satisfies the
-// `Record<string, unknown>` constraint on `internalQuery<T>`.
+// `Record<string, unknown>` constraint on `internalQuery<T>`. `plan_tier` is
+// typed as the closed `PlanTier` union (not a widened `string`) so the
+// `planTier === 'trial' | 'locked'` checks below narrow instead of comparing
+// against an open string. `OrgTierRow` is module-private and not part of the
+// ee-stub lockstep surface, so importing `PlanTier` here costs nothing there.
 type OrgTierRow = {
-  plan_tier: string;
+  plan_tier: PlanTier;
   trial_ends_at: string | null;
 };
 
@@ -95,8 +103,13 @@ export interface ProvisionTrialDeps {
   }) => Promise<{ id?: string } | undefined>;
   /** Read the post-hook tier so we know whether the Workspace got the trial. */
   readOrgTier: (orgId: string) => Promise<OrgTierRow | undefined>;
-  /** Narrow `trial_ends_at` to the grace window (guarded on `plan_tier='trial'`). */
-  setGraceWindow: (orgId: string, endsAtIso: string) => Promise<void>;
+  /**
+   * Narrow `trial_ends_at` to the grace window (guarded on `plan_tier='trial'`).
+   * Returns the number of rows actually updated so the caller can detect a
+   * guarded no-op (tier changed under us between read and write) rather than
+   * silently returning a full-window `grace` state.
+   */
+  setGraceWindow: (orgId: string, endsAtIso: string) => Promise<number>;
   /** Build the hosted-MCP connect URL for the new Workspace. */
   buildConnectUrl: (workspaceId: string) => string;
   /** Grace window length in ms. */
@@ -133,11 +146,16 @@ function defaultDeps(): ProvisionTrialDeps {
     },
     setGraceWindow: async (orgId, endsAtIso) => {
       const { internalQuery } = await import("@atlas/api/lib/db/internal");
-      await internalQuery(
+      // `RETURNING id` so we get the affected rows back — `internalQuery`
+      // surfaces rows, not a `rowCount`, so this is how we know the guarded
+      // `plan_tier = 'trial'` UPDATE actually landed.
+      const updated = await internalQuery<{ id: string }>(
         `UPDATE organization SET trial_ends_at = $1
-         WHERE id = $2 AND plan_tier = 'trial'`,
+         WHERE id = $2 AND plan_tier = 'trial'
+         RETURNING id`,
         [endsAtIso, orgId],
       );
+      return updated.length;
     },
     buildConnectUrl: (workspaceId) => buildMcpConnectUrl(workspaceId),
     graceMs: TRIAL_GRACE_HOURS * 60 * 60 * 1000,
@@ -227,9 +245,18 @@ export async function provisionTrialWorkspace(
   });
   const workspaceId = org?.id;
   if (!workspaceId) {
+    // The user account was already created by `signUpEmail` above, so this
+    // leaves an orphaned user with no Workspace. Retrying `start_trial` with
+    // the same email would now hit `signup_failed` ("already registered"), so
+    // the prospect can't self-recover — log it so an operator can find/reap the
+    // orphan, and tell the caller to sign in rather than retry.
+    log.error(
+      { userId },
+      "start_trial: organization creation returned no id — orphaned user with no workspace",
+    );
     throw new TrialProvisioningError(
       "org_failed",
-      "Account created but the workspace could not be provisioned. Please retry.",
+      "Your account was created but the workspace could not be provisioned. Sign in on the web to finish setup, or contact support.",
     );
   }
 
@@ -242,11 +269,29 @@ export async function provisionTrialWorkspace(
   let state: TrialWorkspaceState;
   if (planTier === "trial") {
     const graceEndsAt = new Date(Date.now() + deps.graceMs).toISOString();
-    await deps.setGraceWindow(workspaceId, graceEndsAt);
+    const updated = await deps.setGraceWindow(workspaceId, graceEndsAt);
+    if (updated !== 1) {
+      // The guarded UPDATE matched no row — the tier changed between the
+      // read-back and the write (TOCTOU). Returning `grace` here would hand
+      // back a Workspace still on the full TRIAL_DAYS window, silently
+      // defeating the unclaimed-grace property. Fail loud instead.
+      log.warn(
+        { workspaceId, updated },
+        "start_trial: grace-window narrowing matched no row (tier changed under us); refusing to report grace",
+      );
+      throw new TrialProvisioningError(
+        "trial_not_assigned",
+        "Workspace was created but the trial grace window could not be set. Please contact support.",
+      );
+    }
     state = "grace";
   } else if (planTier === "locked") {
     state = "locked";
   } else {
+    log.error(
+      { workspaceId, planTier: planTier ?? "unknown" },
+      "start_trial: workspace landed on neither trial nor locked after assignSaasTrial",
+    );
     throw new TrialProvisioningError(
       "trial_not_assigned",
       "Workspace was created but did not land on the trial tier. Please contact support.",

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -1,0 +1,261 @@
+/**
+ * Reusable trial-Workspace provisioner — the highest, most testable seam for
+ * self-serve signup (ADR-0018, PRD #3646, #3649).
+ *
+ * `provisionTrialWorkspace({ email, orgName })` orchestrates the same Better
+ * Auth path the web signup uses — `signUpEmail` then `organization.create` —
+ * and lands the new Workspace on the existing `trial` tier in an **unclaimed
+ * grace** state (a short initial `trial_ends_at`). It reuses the existing
+ * `assignSaasTrial` / `claimTrialGrant` path verbatim: creating the
+ * organization fires Better Auth's `afterCreateOrganization` hook, which runs
+ * `assignSaasTrial` (atomic one-trial-per-user claim + tier assignment). This
+ * provisioner then narrows `trial_ends_at` from the full {@link TRIAL_DAYS}
+ * window down to {@link TRIAL_GRACE_HOURS} — the 14-day clock only starts when
+ * a human *claims* the account on the web.
+ *
+ * SaaS-only: it refuses when `deployMode !== 'saas'`. This is the single lib
+ * seam the `start_trial` MCP tool and any future HTTP onboarding face both
+ * call — neither re-implements the signup orchestration.
+ *
+ * It deliberately lives in `ee/` (self-serve trial signup is a hosted-SaaS
+ * concern) and never binds an MCP actor: the caller is the *anonymous
+ * onboarding caller*, and a normal *hosted* actor takes over via the DCR/PKCE
+ * connect using the returned `connectUrl`.
+ */
+
+import { randomBytes } from "node:crypto";
+import { getConfig } from "@atlas/api/lib/config";
+import { TRIAL_GRACE_HOURS } from "@atlas/api/lib/billing/plans";
+import { buildMcpConnectUrl } from "@atlas/api/lib/mcp/connect-url";
+
+export type TrialWorkspaceState = "grace" | "locked";
+
+export interface ProvisionTrialInput {
+  readonly email: string;
+  readonly orgName: string;
+}
+
+export interface ProvisionTrialResult {
+  /** Better Auth `organization.id` of the freshly created Workspace. */
+  readonly workspaceId: string;
+  /** Hosted-MCP connect URL the agent uses to attach a hosted actor (DCR/PKCE). */
+  readonly connectUrl: string;
+  /**
+   * `grace` — provisioned onto `trial` in unclaimed grace (happy path).
+   * `locked` — the user already consumed a trial, so the Workspace lands on
+   * the zero-entitlement `locked` tier (one-trial-per-user, #3426). No grace.
+   */
+  readonly state: TrialWorkspaceState;
+}
+
+/** Discriminating reason codes for a refused / failed provisioning attempt. */
+export type TrialProvisioningCode =
+  | "not_saas"
+  | "invalid_input"
+  | "signup_failed"
+  | "org_failed"
+  | "trial_not_assigned";
+
+/** Typed error so the MCP tool / HTTP face can map to a structured envelope. */
+export class TrialProvisioningError extends Error {
+  override readonly name = "TrialProvisioningError";
+  readonly code: TrialProvisioningCode;
+  constructor(code: TrialProvisioningCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+// A type alias (not an interface) so it satisfies the
+// `Record<string, unknown>` constraint on `internalQuery<T>`.
+type OrgTierRow = {
+  plan_tier: string;
+  trial_ends_at: string | null;
+};
+
+/**
+ * External boundaries the provisioner touches, injectable for testing. Each
+ * default lazily imports the heavy `@atlas/api` module it needs so a test that
+ * supplies stubs never pulls Better Auth / the internal DB into its graph.
+ */
+export interface ProvisionTrialDeps {
+  /** Resolve the configured deploy mode. */
+  getDeployMode: () => "saas" | "self-hosted" | undefined;
+  /** Better Auth server-side `signUpEmail`. */
+  signUpEmail: (body: {
+    email: string;
+    password: string;
+    name: string;
+  }) => Promise<{ user?: { id?: string } } | undefined>;
+  /** Better Auth server-side `createOrganization` (fires `assignSaasTrial`). */
+  createOrganization: (body: {
+    name: string;
+    slug: string;
+    userId: string;
+  }) => Promise<{ id?: string } | undefined>;
+  /** Read the post-hook tier so we know whether the Workspace got the trial. */
+  readOrgTier: (orgId: string) => Promise<OrgTierRow | undefined>;
+  /** Narrow `trial_ends_at` to the grace window (guarded on `plan_tier='trial'`). */
+  setGraceWindow: (orgId: string, endsAtIso: string) => Promise<void>;
+  /** Build the hosted-MCP connect URL for the new Workspace. */
+  buildConnectUrl: (workspaceId: string) => string;
+  /** Grace window length in ms. */
+  graceMs: number;
+}
+
+function defaultDeps(): ProvisionTrialDeps {
+  return {
+    getDeployMode: () => getConfig()?.deployMode,
+    signUpEmail: async (body) => {
+      const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+      const auth = getAuthInstance();
+      const signUp = (auth.api as Record<string, unknown>).signUpEmail as (o: {
+        body: { email: string; password: string; name: string };
+      }) => Promise<{ user?: { id?: string } } | undefined>;
+      return signUp({ body });
+    },
+    createOrganization: async (body) => {
+      const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+      const auth = getAuthInstance();
+      const createOrg = (auth.api as Record<string, unknown>)
+        .createOrganization as (o: {
+        body: { name: string; slug: string; userId: string };
+      }) => Promise<{ id?: string } | undefined>;
+      return createOrg({ body });
+    },
+    readOrgTier: async (orgId) => {
+      const { internalQuery } = await import("@atlas/api/lib/db/internal");
+      const rows = await internalQuery<OrgTierRow>(
+        `SELECT plan_tier, trial_ends_at FROM organization WHERE id = $1 LIMIT 1`,
+        [orgId],
+      );
+      return rows[0];
+    },
+    setGraceWindow: async (orgId, endsAtIso) => {
+      const { internalQuery } = await import("@atlas/api/lib/db/internal");
+      await internalQuery(
+        `UPDATE organization SET trial_ends_at = $1
+         WHERE id = $2 AND plan_tier = 'trial'`,
+        [endsAtIso, orgId],
+      );
+    },
+    buildConnectUrl: (workspaceId) => buildMcpConnectUrl(workspaceId),
+    graceMs: TRIAL_GRACE_HOURS * 60 * 60 * 1000,
+  };
+}
+
+/** A throwaway password — the human sets a real credential when they claim. */
+function generateThrowawayPassword(): string {
+  return `${randomBytes(24).toString("base64url")}Aa1!`;
+}
+
+/** Derive a unique-ish org slug from the workspace name. */
+function deriveSlug(orgName: string): string {
+  const base = orgName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  const suffix = randomBytes(4).toString("hex");
+  return base.length > 0 ? `${base}-${suffix}` : `workspace-${suffix}`;
+}
+
+function isValidEmail(email: string): boolean {
+  // Deliberately permissive — disposable/freemium policy is enforced on the
+  // shared Better Auth signup path (#3650), not here. This only rejects
+  // obviously malformed input before we spend a signup round-trip.
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ * Provision a brand-new trial Workspace and return the hosted-MCP connect URL.
+ *
+ * @throws {TrialProvisioningError} `not_saas` when deploy mode isn't SaaS;
+ *   `invalid_input` for empty/malformed email or name; `signup_failed` /
+ *   `org_failed` when the Better Auth path returns no id; `trial_not_assigned`
+ *   when the org landed on neither `trial` nor `locked`.
+ */
+export async function provisionTrialWorkspace(
+  input: ProvisionTrialInput,
+  overrides: Partial<ProvisionTrialDeps> = {},
+): Promise<ProvisionTrialResult> {
+  const deps: ProvisionTrialDeps = { ...defaultDeps(), ...overrides };
+
+  if (deps.getDeployMode() !== "saas") {
+    throw new TrialProvisioningError(
+      "not_saas",
+      "Self-serve trial provisioning is only available on Atlas SaaS.",
+    );
+  }
+
+  const email = input.email?.trim();
+  const orgName = input.orgName?.trim();
+  if (!email || !isValidEmail(email)) {
+    throw new TrialProvisioningError(
+      "invalid_input",
+      "A valid email address is required to start a trial.",
+    );
+  }
+  if (!orgName) {
+    throw new TrialProvisioningError(
+      "invalid_input",
+      "A workspace name is required to start a trial.",
+    );
+  }
+
+  const name = email.split("@")[0] || orgName;
+  const signup = await deps.signUpEmail({
+    email,
+    password: generateThrowawayPassword(),
+    name,
+  });
+  const userId = signup?.user?.id;
+  if (!userId) {
+    // Better Auth returns an enumeration-safe synthetic response (no real user
+    // id) when the email is already registered, so a missing id here means the
+    // account couldn't be freshly provisioned.
+    throw new TrialProvisioningError(
+      "signup_failed",
+      "Could not create an account for this email. It may already be registered — sign in on the web instead.",
+    );
+  }
+
+  const org = await deps.createOrganization({
+    name: orgName,
+    slug: deriveSlug(orgName),
+    userId,
+  });
+  const workspaceId = org?.id;
+  if (!workspaceId) {
+    throw new TrialProvisioningError(
+      "org_failed",
+      "Account created but the workspace could not be provisioned. Please retry.",
+    );
+  }
+
+  // `assignSaasTrial` already ran in the org-create hook: the Workspace is on
+  // `trial` (full window) or `locked` (consumed trial). Read it back, then
+  // narrow a trial to the short unclaimed-grace window.
+  const tier = await deps.readOrgTier(workspaceId);
+  const planTier = tier?.plan_tier;
+
+  let state: TrialWorkspaceState;
+  if (planTier === "trial") {
+    const graceEndsAt = new Date(Date.now() + deps.graceMs).toISOString();
+    await deps.setGraceWindow(workspaceId, graceEndsAt);
+    state = "grace";
+  } else if (planTier === "locked") {
+    state = "locked";
+  } else {
+    throw new TrialProvisioningError(
+      "trial_not_assigned",
+      "Workspace was created but did not land on the trial tier. Please contact support.",
+    );
+  }
+
+  return {
+    workspaceId,
+    connectUrl: deps.buildConnectUrl(workspaceId),
+    state,
+  };
+}

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -626,6 +626,25 @@ log.info(
 // lifecycle, semantic-tools) into the function bundle would inflate
 // cold starts. The Hono API server (which Bun runs natively, no
 // bundler) resolves the import at runtime via the workspace dep.
+// Anonymous onboarding endpoint (ADR-0018 / #3649) — the single pre-auth
+// carve-out from the dispatch gate. Mounted at /mcp/onboarding/sse and BEFORE
+// the hosted router so the static `onboarding` segment is matched here rather
+// than treated as a workspace id by /mcp/:workspaceId/sse. The router
+// self-gates on deployMode === 'saas' (empty router off-SaaS), so `start_trial`
+// is absent everywhere but the hosted SaaS server.
+try {
+  const { createOnboardingMcpRouter } = await import(
+    /* turbopackIgnore: true */ "@atlas/mcp/onboarding"
+  );
+  app.route("/mcp/onboarding", createOnboardingMcpRouter());
+  log.info("Onboarding MCP endpoint mounted at /mcp/onboarding/sse (SaaS-gated)");
+} catch (err) {
+  log.error(
+    { err: err instanceof Error ? err.message : String(err) },
+    "Onboarding MCP endpoint not available in this build — self-serve start_trial will be unavailable.",
+  );
+}
+
 try {
   const { createHostedMcpRouter } = await import(
     /* turbopackIgnore: true */ "@atlas/mcp/hosted"

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -639,9 +639,14 @@ try {
   app.route("/mcp/onboarding", createOnboardingMcpRouter());
   log.info("Onboarding MCP endpoint mounted at /mcp/onboarding/sse (SaaS-gated)");
 } catch (err) {
+  // Soft-fail to match the hosted-MCP block below: the standalone Vercel
+  // template intentionally doesn't bundle `@atlas/mcp`, so throwing here would
+  // break that build's boot. But on a SaaS deploy that DOES intend self-serve,
+  // this disables the entire trial funnel, so log at error with an operator-
+  // pageable message (don't let a real boot defect look like "not bundled").
   log.error(
     { err: err instanceof Error ? err.message : String(err) },
-    "Onboarding MCP endpoint not available in this build — self-serve start_trial will be unavailable.",
+    "Onboarding MCP endpoint not available in this build — self-serve start_trial will be unavailable. On SaaS this disables the trial signup funnel; verify packages/mcp is shipped in the runtime container.",
   );
 }
 

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -85,6 +85,21 @@ const UNLIMITED = -1;
 export const TRIAL_DAYS = 14;
 
 /**
+ * Initial unclaimed-grace window (hours) for a Workspace provisioned over
+ * MCP by the anonymous onboarding caller (`start_trial`, ADR-0018).
+ *
+ * A self-serve trial is provisioned into a SHORT grace window rather than the
+ * full {@link TRIAL_DAYS}: the 14-day clock only starts when a human *claims*
+ * the account on the web (verify email → set credential → accept ToS). Until
+ * then the Workspace sits on `plan_tier='trial'` with `trial_ends_at = NOW() +
+ * TRIAL_GRACE_HOURS`, so an abandoned signup can't squat on a 14-day free
+ * window and the grace reaper (#3652) has a bounded horizon to sweep. Setup
+ * (datasource connect, semantic layer) stays open during grace because Gate 0
+ * only blocks once `trial_ends_at` lapses.
+ */
+export const TRIAL_GRACE_HOURS = 72;
+
+/**
  * Default duration (days) of a platform-admin plan-override window (#3427).
  *
  * When an operator sets `plan_tier` directly, the Stripe webhook tier sync

--- a/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, afterEach } from "bun:test";
+import { buildMcpConnectUrl, resolveMcpBaseUrl } from "../connect-url.js";
+
+const ORIG_PUBLIC = process.env.ATLAS_PUBLIC_API_URL;
+const ORIG_AUTH = process.env.BETTER_AUTH_URL;
+
+function restoreEnv(): void {
+  if (ORIG_PUBLIC === undefined) delete process.env.ATLAS_PUBLIC_API_URL;
+  else process.env.ATLAS_PUBLIC_API_URL = ORIG_PUBLIC;
+  if (ORIG_AUTH === undefined) delete process.env.BETTER_AUTH_URL;
+  else process.env.BETTER_AUTH_URL = ORIG_AUTH;
+}
+
+describe("buildMcpConnectUrl", () => {
+  afterEach(restoreEnv);
+
+  it("builds /mcp/{workspaceId}/sse from an explicit base override", () => {
+    expect(buildMcpConnectUrl("org_123", "https://example.test")).toBe(
+      "https://example.test/mcp/org_123/sse",
+    );
+  });
+
+  it("trims trailing slashes from the base", () => {
+    expect(buildMcpConnectUrl("org_123", "https://example.test/")).toBe(
+      "https://example.test/mcp/org_123/sse",
+    );
+  });
+
+  it("brands a regional api host onto the public mcp host", () => {
+    expect(resolveMcpBaseUrl("https://api.useatlas.dev")).toBe(
+      "https://mcp.useatlas.dev",
+    );
+    expect(resolveMcpBaseUrl("https://api-eu.useatlas.dev")).toBe(
+      "https://mcp-eu.useatlas.dev",
+    );
+    expect(buildMcpConnectUrl("org_x", "https://api-eu.useatlas.dev")).toBe(
+      "https://mcp-eu.useatlas.dev/mcp/org_x/sse",
+    );
+  });
+
+  it("falls back to ATLAS_PUBLIC_API_URL then BETTER_AUTH_URL", () => {
+    delete process.env.ATLAS_PUBLIC_API_URL;
+    process.env.BETTER_AUTH_URL = "https://auth.example.test";
+    expect(buildMcpConnectUrl("org_a")).toBe(
+      "https://auth.example.test/mcp/org_a/sse",
+    );
+
+    process.env.ATLAS_PUBLIC_API_URL = "https://public.example.test";
+    expect(buildMcpConnectUrl("org_a")).toBe(
+      "https://public.example.test/mcp/org_a/sse",
+    );
+  });
+
+  it("leaves a non-brandable host untouched", () => {
+    expect(resolveMcpBaseUrl("https://atlas.acme.internal")).toBe(
+      "https://atlas.acme.internal",
+    );
+  });
+});

--- a/packages/api/src/lib/mcp/connect-url.ts
+++ b/packages/api/src/lib/mcp/connect-url.ts
@@ -1,0 +1,65 @@
+/**
+ * Build the hosted-MCP connect URL for a Workspace.
+ *
+ * The connect URL is the per-region MCP resource endpoint
+ * (`/mcp/{workspaceId}/sse`). An MCP client pointed at it receives a 401 with
+ * the RFC 9728 `WWW-Authenticate` resource-metadata pointer, runs Dynamic
+ * Client Registration + the authorization-code-with-PKCE flow against the
+ * Better Auth OAuth provider, and attaches a normal *hosted* actor to the
+ * Workspace. It is the handoff seam the anonymous onboarding caller
+ * (`start_trial`, ADR-0018) returns so a brand-new prospect's agent can connect
+ * to the Workspace it just provisioned — without leaving the agent.
+ *
+ * Shared by the `start_trial` MCP tool and any future HTTP onboarding face, so
+ * both hand back an identical, canonical connect URL.
+ */
+
+/**
+ * Map a regional `api[-region].useatlas.dev` host onto the public brand host
+ * `mcp[-region].useatlas.dev`, so a client that never sees the internal
+ * `api.*` URL can still complete DCR. Returns `null` for any host that doesn't
+ * match (self-hosted operators on arbitrary hostnames stay on the resolved
+ * base).
+ *
+ * Mirrors `@atlas/mcp/hosted:brandedMcpHost` and `well-known.ts:brandedMcpHost`
+ * — keep the regex in lockstep with both.
+ */
+function brandedMcpHost(base: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    // intentionally ignored: caller falls back to the trimmed base.
+    return null;
+  }
+  const matched = url.hostname.match(/^api(-[a-z0-9]+)?\.useatlas\.dev$/);
+  if (!matched) return null;
+  const regionSuffix = matched[1] ?? "";
+  return `https://mcp${regionSuffix}.useatlas.dev`;
+}
+
+/**
+ * Resolve the public API base used to address the hosted MCP endpoint.
+ * Precedence mirrors `hosted.ts` (`ATLAS_PUBLIC_API_URL` → `BETTER_AUTH_URL`),
+ * with a final `baseUrl` override for callers/tests that supply one explicitly.
+ */
+export function resolveMcpBaseUrl(baseUrl?: string): string {
+  const raw =
+    baseUrl?.trim() ||
+    process.env.ATLAS_PUBLIC_API_URL?.trim() ||
+    process.env.BETTER_AUTH_URL?.trim() ||
+    "";
+  const trimmed = raw.replace(/\/+$/, "");
+  return brandedMcpHost(trimmed) ?? trimmed;
+}
+
+/**
+ * Build the canonical hosted-MCP connect URL for `workspaceId`.
+ *
+ * @param workspaceId the organization/workspace id (Better Auth `organization.id`)
+ * @param baseUrl optional explicit public API base; falls back to env precedence
+ */
+export function buildMcpConnectUrl(workspaceId: string, baseUrl?: string): string {
+  const base = resolveMcpBaseUrl(baseUrl);
+  return `${base}/mcp/${workspaceId}/sse`;
+}

--- a/packages/api/src/lib/mcp/connect-url.ts
+++ b/packages/api/src/lib/mcp/connect-url.ts
@@ -21,8 +21,11 @@
  * match (self-hosted operators on arbitrary hostnames stay on the resolved
  * base).
  *
- * Mirrors `@atlas/mcp/hosted:brandedMcpHost` and `well-known.ts:brandedMcpHost`
- * — keep the regex in lockstep with both.
+ * The same `^api(-[a-z0-9]+)?\.useatlas\.dev$` regex is duplicated in three
+ * other places — keep all four in lockstep:
+ *   - `@atlas/mcp/hosted:brandedMcpHost`
+ *   - `packages/api/src/api/routes/well-known.ts:brandedMcpHost`
+ *   - `packages/web/src/app/settings/ai-agents/branded-mcp-base.ts:brandedMcpBase`
  */
 function brandedMcpHost(base: string): string | null {
   let url: URL;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,6 +8,7 @@
     "./sse": "./src/sse.ts",
     "./telemetry-bootstrap": "./src/telemetry-bootstrap.ts",
     "./hosted": "./src/hosted.ts",
+    "./onboarding": "./src/onboarding.ts",
     "./prompts/listing": "./src/prompts/listing.ts",
     "./eval/auth": "./src/eval/auth.ts",
     "./eval/client": "./src/eval/client.ts",

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the anonymous onboarding caller (`start_trial`, ADR-0018, #3649).
+ *
+ *   1. The tool provisions into grace and hands back the connect URL, over the
+ *      in-memory Client/Server transport — the same seam `tools.test.ts` uses.
+ *   2. Input is collected via tool args OR MCP elicitation.
+ *   3. Typed provisioning failures surface as `AtlasMcpToolError` envelopes.
+ *   4. The tool + router are SaaS-only: absent off-SaaS.
+ *   5. The onboarding server exposes ONLY `start_trial` — no read/write tools —
+ *      so the anonymous caller can never reach the dispatch gate.
+ */
+
+import { describe, expect, it, mock, beforeAll, afterAll } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+import { TrialProvisioningError } from "@atlas/ee/onboarding/provision-trial";
+
+// Control deployMode via getConfig — mirrors hosted.test.ts. `mockDeployMode`
+// is mutable so individual tests can flip SaaS on/off.
+let mockDeployMode: "saas" | "self-hosted" = "saas";
+const __mockedConfig = () => ({ deployMode: mockDeployMode });
+mock.module("@atlas/api/lib/config", () => ({
+  initializeConfig: mock(async () => __mockedConfig()),
+  getConfig: mock(() => __mockedConfig()),
+  loadConfig: mock(async () => __mockedConfig()),
+  configFromEnv: mock(() => __mockedConfig()),
+  validateAndResolve: mock(() => __mockedConfig()),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
+}));
+
+import {
+  registerStartTrialTool,
+  createOnboardingMcpServer,
+  createOnboardingMcpRouter,
+  type ProvisionTrialFn,
+} from "../onboarding.js";
+
+// The elicitation requestState is HMAC'd from BETTER_AUTH_SECRET; set one for
+// the round-trip test and restore after (self-contained, no top-level mutation).
+const ORIG_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
+beforeAll(() => {
+  process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-at-least-32-chars-long";
+});
+afterAll(() => {
+  if (ORIG_AUTH_SECRET === undefined) delete process.env.BETTER_AUTH_SECRET;
+  else process.env.BETTER_AUTH_SECRET = ORIG_AUTH_SECRET;
+});
+
+const okProvision: ProvisionTrialFn = async (input) => ({
+  workspaceId: "org_new",
+  connectUrl: "https://mcp.test/mcp/org_new/sse",
+  state: input.orgName.includes("locked") ? "locked" : "grace",
+});
+
+async function wireTool(
+  provision: ProvisionTrialFn,
+  opts: { withElicitation?: { email: string; orgName: string } } = {},
+) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerStartTrialTool(server, { provision });
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.1" },
+    opts.withElicitation ? { capabilities: { elicitation: {} } } : undefined,
+  );
+  if (opts.withElicitation) {
+    const reply = opts.withElicitation;
+    client.setRequestHandler(ElicitRequestSchema, async () => ({
+      action: "accept",
+      content: { email: reply.email, orgName: reply.orgName },
+    }));
+  }
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client };
+}
+
+describe("start_trial tool", () => {
+  it("exposes only start_trial (no read/write tools reach the anonymous caller)", async () => {
+    const { client } = await wireTool(okProvision);
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["start_trial"]);
+  });
+
+  it("provisions into grace and returns { workspaceId, connectUrl, state } from args", async () => {
+    const { client } = await wireTool(okProvision);
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "founder@acme.com", orgName: "Acme" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+      workspaceId: "org_new",
+      connectUrl: "https://mcp.test/mcp/org_new/sse",
+      state: "grace",
+    });
+  });
+
+  it("passes a locked state through unchanged", async () => {
+    const { client } = await wireTool(okProvision);
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "founder@acme.com", orgName: "locked-acme" },
+    });
+    expect(
+      (result.structuredContent as { state: string }).state,
+    ).toBe("locked");
+  });
+
+  it("collects email + orgName via MCP elicitation when omitted", async () => {
+    const seen: Array<{ email: string; orgName: string }> = [];
+    const provision: ProvisionTrialFn = async (input) => {
+      seen.push(input);
+      return {
+        workspaceId: "org_elicited",
+        connectUrl: "https://mcp.test/mcp/org_elicited/sse",
+        state: "grace",
+      };
+    };
+    const { client } = await wireTool(provision, {
+      withElicitation: { email: "elicited@acme.com", orgName: "Elicited Co" },
+    });
+    const result = await client.callTool({ name: "start_trial", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(seen).toEqual([{ email: "elicited@acme.com", orgName: "Elicited Co" }]);
+    expect(
+      (result.structuredContent as { workspaceId: string }).workspaceId,
+    ).toBe("org_elicited");
+  });
+
+  it("maps a TrialProvisioningError(invalid_input) to a validation_failed envelope", async () => {
+    const provision: ProvisionTrialFn = async () => {
+      throw new TrialProvisioningError("invalid_input", "bad email");
+    };
+    const { client } = await wireTool(provision);
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "x@y.com", orgName: "Acme" },
+    });
+    expect(result.isError).toBe(true);
+    const arr = result.content as Array<{ type: string; text: string }>;
+    const err = parseAtlasMcpToolError(arr[0]!.text);
+    expect(err?.code).toBe("validation_failed");
+  });
+
+  it("maps an unexpected error to internal_error with a request_id", async () => {
+    const provision: ProvisionTrialFn = async () => {
+      throw new Error("kaboom");
+    };
+    const { client } = await wireTool(provision);
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "x@y.com", orgName: "Acme" },
+    });
+    expect(result.isError).toBe(true);
+    const arr = result.content as Array<{ type: string; text: string }>;
+    const err = parseAtlasMcpToolError(arr[0]!.text);
+    expect(err?.code).toBe("internal_error");
+    expect(err?.request_id).toBeTruthy();
+  });
+});
+
+describe("onboarding SaaS gating", () => {
+  it("createOnboardingMcpServer returns a server on SaaS, null off-SaaS", () => {
+    mockDeployMode = "saas";
+    expect(createOnboardingMcpServer({ provision: okProvision })).not.toBeNull();
+    mockDeployMode = "self-hosted";
+    expect(createOnboardingMcpServer({ provision: okProvision })).toBeNull();
+    mockDeployMode = "saas";
+  });
+
+  it("router has no /sse route off-SaaS (404), present on SaaS (not 404)", async () => {
+    mockDeployMode = "self-hosted";
+    const offRouter = createOnboardingMcpRouter();
+    const off = await offRouter.request("/sse", { method: "POST" });
+    expect(off.status).toBe(404);
+
+    mockDeployMode = "saas";
+    const onRouter = createOnboardingMcpRouter();
+    const on = await onRouter.request("/sse", {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(on.status).not.toBe(404);
+  });
+});

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -63,16 +63,24 @@ const okProvision: ProvisionTrialFn = async (input) => ({
 
 async function wireTool(
   provision: ProvisionTrialFn,
-  opts: { withElicitation?: { email: string; orgName: string } } = {},
+  opts: {
+    withElicitation?: { email: string; orgName: string };
+    /** Raw elicitation reply — lets a test decline/cancel or return partial content. */
+    elicit?: () => { action: string; content?: Record<string, string> };
+  } = {},
 ) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
   registerStartTrialTool(server, { provision });
 
+  const wantsElicit = Boolean(opts.withElicitation || opts.elicit);
   const client = new Client(
     { name: "test-client", version: "0.0.1" },
-    opts.withElicitation ? { capabilities: { elicitation: {} } } : undefined,
+    wantsElicit ? { capabilities: { elicitation: {} } } : undefined,
   );
-  if (opts.withElicitation) {
+  if (opts.elicit) {
+    const reply = opts.elicit;
+    client.setRequestHandler(ElicitRequestSchema, async () => reply());
+  } else if (opts.withElicitation) {
     const reply = opts.withElicitation;
     client.setRequestHandler(ElicitRequestSchema, async () => ({
       action: "accept",
@@ -139,6 +147,93 @@ describe("start_trial tool", () => {
     ).toBe("org_elicited");
   });
 
+  it("returns a validation_failed envelope when the client declines elicitation", async () => {
+    let provisioned = false;
+    const provision: ProvisionTrialFn = async () => {
+      provisioned = true;
+      return {
+        workspaceId: "org_x",
+        connectUrl: "https://mcp.test/mcp/org_x/sse",
+        state: "grace",
+      };
+    };
+    const { client } = await wireTool(provision, {
+      elicit: () => ({ action: "decline" }),
+    });
+    // No args → the tool elicits; the client declines.
+    const result = await client.callTool({ name: "start_trial", arguments: {} });
+    expect(result.isError).toBe(true);
+    const arr = result.content as Array<{ type: string; text: string }>;
+    const err = parseAtlasMcpToolError(arr[0]!.text);
+    expect(err?.code).toBe("validation_failed");
+    // A declined elicitation must never provision.
+    expect(provisioned).toBe(false);
+  });
+
+  it("merges a supplied arg with an elicited field (partial elicitation)", async () => {
+    const seen: Array<{ email: string; orgName: string }> = [];
+    const provision: ProvisionTrialFn = async (input) => {
+      seen.push(input);
+      return {
+        workspaceId: "org_partial",
+        connectUrl: "https://mcp.test/mcp/org_partial/sse",
+        state: "grace",
+      };
+    };
+    // email supplied as an arg; only orgName comes back from elicitation.
+    const { client } = await wireTool(provision, {
+      elicit: () => ({ action: "accept", content: { orgName: "Elicited Co" } }),
+    });
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "supplied@acme.com" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(seen).toEqual([
+      { email: "supplied@acme.com", orgName: "Elicited Co" },
+    ]);
+  });
+
+  it("maps every TrialProvisioningError code to the right envelope", async () => {
+    const cases: Array<{
+      code:
+        | "invalid_input"
+        | "signup_failed"
+        | "not_saas"
+        | "org_failed"
+        | "trial_not_assigned";
+      envelopeCode: "validation_failed" | "forbidden" | "internal_error";
+      expectHint?: boolean;
+      expectRequestId?: boolean;
+    }> = [
+      { code: "invalid_input", envelopeCode: "validation_failed" },
+      { code: "signup_failed", envelopeCode: "validation_failed", expectHint: true },
+      { code: "not_saas", envelopeCode: "forbidden" },
+      { code: "org_failed", envelopeCode: "internal_error", expectRequestId: true },
+      {
+        code: "trial_not_assigned",
+        envelopeCode: "internal_error",
+        expectRequestId: true,
+      },
+    ];
+    for (const tc of cases) {
+      const provision: ProvisionTrialFn = async () => {
+        throw new TrialProvisioningError(tc.code, `boom:${tc.code}`);
+      };
+      const { client } = await wireTool(provision);
+      const result = await client.callTool({
+        name: "start_trial",
+        arguments: { email: "x@y.com", orgName: "Acme" },
+      });
+      expect(result.isError).toBe(true);
+      const arr = result.content as Array<{ type: string; text: string }>;
+      const err = parseAtlasMcpToolError(arr[0]!.text);
+      expect(err?.code).toBe(tc.envelopeCode);
+      if (tc.expectHint) expect(err?.hint).toBeTruthy();
+      if (tc.expectRequestId) expect(err?.request_id).toBeTruthy();
+    }
+  });
+
   it("maps a TrialProvisioningError(invalid_input) to a validation_failed envelope", async () => {
     const provision: ProvisionTrialFn = async () => {
       throw new TrialProvisioningError("invalid_input", "bad email");
@@ -194,5 +289,25 @@ describe("onboarding SaaS gating", () => {
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
     });
     expect(on.status).not.toBe(404);
+  });
+
+  it("returns a structured unknown_session 404 for a bogus mcp-session-id (SaaS)", async () => {
+    mockDeployMode = "saas";
+    const router = createOnboardingMcpRouter();
+    const res = await router.request("/sse", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-session-id": "does-not-exist",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    // A present-but-unknown session id is a different 404 than the off-SaaS
+    // no-route 404 — it carries the structured unknown_session body + requestId.
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string; requestId?: string };
+    expect(body.error).toBe("unknown_session");
+    expect(body.requestId).toBeTruthy();
   });
 });

--- a/packages/mcp/src/onboarding.ts
+++ b/packages/mcp/src/onboarding.ts
@@ -1,0 +1,316 @@
+/**
+ * Anonymous onboarding caller — the single, audited pre-actor carve-out from
+ * the MCP dispatch gate (ADR-0018, PRD #3646, #3649).
+ *
+ * `start_trial` is the *one* tool a brand-new prospect can invoke before any
+ * user, Workspace, or bearer exists. It is **not** an MCP actor (governed /
+ * trusted / hosted) and is structurally incapable of reaching
+ * `runMcpDispatchGate`: it is registered on a SEPARATE, unauthenticated MCP
+ * server (`createOnboardingMcpServer`) mounted on a distinct pre-auth endpoint
+ * (`createOnboardingMcpRouter` → `/mcp/onboarding/sse`). That server exposes
+ * NOTHING else — no `explore`, no `executeSQL`, no datasource tools — so the
+ * anonymous caller can do exactly one thing: provision a trial Workspace.
+ *
+ * The call *produces* a real user + Workspace via `provisionTrialWorkspace`
+ * (the shared lib seam) and returns `{ workspaceId, connectUrl, state }`. A
+ * normal *hosted* actor then takes over via the DCR/PKCE connect against
+ * `connectUrl` — at which point every read/write/setup tool runs the full
+ * dispatch gate (action policy → `mcp:write` → RBAC → approval). This tool
+ * NEVER binds an actor and NEVER calls the gate; eroding that boundary would
+ * reintroduce an unauthenticated mutation inside the actor model.
+ *
+ * SaaS-only: the router and tool exist only when `deployMode === 'saas'`.
+ * Off-SaaS there is no billing surface to onboard onto, so the endpoint is
+ * absent and the underlying provisioner refuses.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { getConfig } from "@atlas/api/lib/config";
+import { withRequestContext, createLogger } from "@atlas/api/lib/logger";
+import {
+  provisionTrialWorkspace as defaultProvision,
+  TrialProvisioningError,
+  type ProvisionTrialInput,
+  type ProvisionTrialResult,
+} from "@atlas/ee/onboarding/provision-trial";
+import { elicitMaskedForm } from "./elicitation.js";
+import { toEnvelopeResult, envelope } from "./error-envelope.js";
+import {
+  McpSessionStore,
+  resolveMaxSessions,
+} from "./session-store.js";
+import pkg from "../package.json" with { type: "json" };
+
+const log = createLogger("mcp-onboarding");
+
+const VERSION: string = pkg.version;
+
+/** Injected for tests; defaults to the real lib provisioner. */
+export type ProvisionTrialFn = (
+  input: ProvisionTrialInput,
+) => Promise<ProvisionTrialResult>;
+
+export interface RegisterStartTrialOptions {
+  /** Override the provisioner (tests inject a stub). */
+  readonly provision?: ProvisionTrialFn;
+}
+
+/** Structured output shape of a successful `start_trial` call. */
+const startTrialOutputShape = {
+  workspaceId: z.string(),
+  connectUrl: z.string(),
+  state: z.enum(["grace", "locked"]),
+} as const;
+
+const startTrialInputShape = {
+  email: z
+    .string()
+    .optional()
+    .describe("Business email for the new account. Elicited if omitted."),
+  orgName: z
+    .string()
+    .optional()
+    .describe("Name for the new workspace. Elicited if omitted."),
+} as const;
+
+/** Map a typed provisioning failure onto the MCP tool-error envelope. */
+function provisioningErrorResult(
+  err: TrialProvisioningError,
+  requestId: string,
+): CallToolResult {
+  switch (err.code) {
+    case "invalid_input":
+      return toEnvelopeResult(envelope("validation_failed", err.message));
+    case "signup_failed":
+      return toEnvelopeResult(
+        envelope("validation_failed", err.message, {
+          hint: "If you already have an Atlas account, sign in on the web instead of starting a new trial.",
+        }),
+      );
+    case "not_saas":
+      // Defensive — the tool isn't registered off-SaaS, but never leak a stack.
+      return toEnvelopeResult(envelope("forbidden", err.message));
+    case "org_failed":
+    case "trial_not_assigned":
+      return toEnvelopeResult(
+        envelope("internal_error", err.message, { request_id: requestId }),
+      );
+  }
+}
+
+/**
+ * Collect `email` + `orgName`, preferring the tool arguments and falling back
+ * to MCP elicitation when either is missing. Returns `null` if the client
+ * declines/cancels the elicitation.
+ */
+async function resolveSignupInput(
+  server: McpServer,
+  args: { email?: string; orgName?: string },
+  requestId: string,
+): Promise<{ email: string; orgName: string } | null> {
+  let email = args.email?.trim();
+  let orgName = args.orgName?.trim();
+  if (email && orgName) return { email, orgName };
+
+  const outcome = await elicitMaskedForm(server, {
+    // No actor exists yet — bind the elicitation requestState to a synthetic,
+    // per-call principal so the single-use / TTL guarantees still hold.
+    principal: `onboarding:${requestId}`,
+    message: "Start your Atlas trial — enter your business email and a name for your workspace.",
+    fields: [
+      {
+        name: "email",
+        title: "Business email",
+        description: "Your work email address.",
+        required: !email,
+      },
+      {
+        name: "orgName",
+        title: "Workspace name",
+        description: "A name for your new Atlas workspace.",
+        required: !orgName,
+      },
+    ],
+  });
+  if (outcome.action !== "accept") return null;
+  email = (outcome.values.email ?? email)?.trim();
+  orgName = (outcome.values.orgName ?? orgName)?.trim();
+  if (!email || !orgName) return null;
+  return { email, orgName };
+}
+
+/**
+ * Register the `start_trial` tool on `server`. The tool runs OUTSIDE
+ * `runMcpDispatchGate` (no actor, no Workspace yet) — it is the anonymous
+ * onboarding caller's only capability.
+ */
+export function registerStartTrialTool(
+  server: McpServer,
+  opts: RegisterStartTrialOptions = {},
+): void {
+  const provision = opts.provision ?? defaultProvision;
+
+  server.registerTool(
+    "start_trial",
+    {
+      title: "Start an Atlas trial",
+      description:
+        "Provision a brand-new Atlas trial workspace and return a connect URL. " +
+        "Collects a business email and workspace name (via elicitation if not supplied), " +
+        "creates the account + workspace on the trial tier in an unclaimed grace period, " +
+        "and returns the URL your agent uses to connect (OAuth). Claim the account on the " +
+        "web to start the full 14-day trial.",
+      inputSchema: startTrialInputShape,
+      outputSchema: startTrialOutputShape,
+      annotations: {
+        // Provisions a new workspace — a creating, world-opening write.
+        readOnlyHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args): Promise<CallToolResult> => {
+      const requestId = crypto.randomUUID();
+      try {
+        const input = await resolveSignupInput(server, args, requestId);
+        if (!input) {
+          return toEnvelopeResult(
+            envelope(
+              "validation_failed",
+              "A business email and workspace name are required to start a trial.",
+            ),
+          );
+        }
+
+        const result = await provision(input);
+        const text =
+          result.state === "grace"
+            ? `Trial workspace created in grace period. Connect your agent at: ${result.connectUrl} — then claim your account on the web to start your full 14-day trial.`
+            : `Workspace created, but this account has already used its trial, so it's locked. Connect at ${result.connectUrl} and subscribe on the web to continue.`;
+        return {
+          content: [{ type: "text" as const, text }],
+          structuredContent: {
+            workspaceId: result.workspaceId,
+            connectUrl: result.connectUrl,
+            state: result.state,
+          },
+        };
+      } catch (err) {
+        if (err instanceof TrialProvisioningError) {
+          log.warn(
+            { requestId, code: err.code },
+            "start_trial provisioning refused",
+          );
+          return provisioningErrorResult(err, requestId);
+        }
+        log.error(
+          { requestId, err: err instanceof Error ? err.message : String(err) },
+          "start_trial provisioning failed unexpectedly",
+        );
+        return toEnvelopeResult(
+          envelope(
+            "internal_error",
+            "Trial provisioning failed unexpectedly. Please retry.",
+            { request_id: requestId },
+          ),
+        );
+      }
+    },
+  );
+}
+
+/**
+ * Build the unauthenticated onboarding MCP server. It exposes ONLY
+ * `start_trial` — no native tools, no datasource tools, no actor. Returns
+ * `null` off-SaaS so the caller can decline to mount the endpoint.
+ */
+export function createOnboardingMcpServer(
+  opts: RegisterStartTrialOptions = {},
+): McpServer | null {
+  if (getConfig()?.deployMode !== "saas") return null;
+  const server = new McpServer(
+    { name: "atlas-onboarding", version: VERSION },
+    { capabilities: { tools: {} } },
+  );
+  registerStartTrialTool(server, opts);
+  return server;
+}
+
+const HANDLED_METHODS = ["POST", "GET", "DELETE"];
+
+/**
+ * Hono router for the pre-auth onboarding MCP endpoint. Mounted at
+ * `/mcp/onboarding` (so the full path is `/mcp/onboarding/sse`), it carries no
+ * bearer verification, no workspace admission, and no residency check — there
+ * is no identity yet. SaaS-only: off-SaaS the router has no routes and every
+ * request 404s.
+ *
+ * Must be mounted BEFORE the hosted `/mcp/:workspaceId/sse` router so the
+ * literal `onboarding` segment is matched here rather than treated as a
+ * workspace id.
+ */
+export function createOnboardingMcpRouter(): Hono {
+  const router = new Hono();
+  if (getConfig()?.deployMode !== "saas") return router;
+
+  // A dedicated session store for the onboarding endpoint — never shared with
+  // the identity-bearing hosted store.
+  const sessions = new McpSessionStore(() => resolveMaxSessions());
+
+  router.on(HANDLED_METHODS, "/sse", async (c) => {
+    const requestId = crypto.randomUUID();
+    const sessionId = c.req.raw.headers.get("mcp-session-id");
+    try {
+      return await withRequestContext(
+        { requestId, atlasMode: "published", agentOrigin: "mcp" },
+        async () => {
+          if (sessionId) {
+            const entry = sessions.get(sessionId);
+            if (!entry) {
+              return c.json(
+                {
+                  error: "unknown_session",
+                  message:
+                    "Session not found. Reconnect with a fresh initialize request.",
+                  requestId,
+                },
+                404,
+              );
+            }
+            return sessions.dispatchExisting(c.req.raw, entry);
+          }
+          return sessions.dispatchNew(c.req.raw, {
+            createServer: async () => {
+              const server = createOnboardingMcpServer();
+              if (!server) {
+                // Unreachable — the router only mounts routes on SaaS — but
+                // fail loud rather than serve a half-built server.
+                throw new Error("onboarding server unavailable");
+              }
+              return server;
+            },
+            tooManyMessage:
+              "Too many onboarding sessions right now. Please try again shortly.",
+          });
+        },
+      );
+    } catch (err) {
+      log.error(
+        { requestId, err: err instanceof Error ? err.message : String(err) },
+        "Onboarding MCP dispatch failed",
+      );
+      return c.json(
+        {
+          error: "internal_error",
+          message: "Onboarding request handling failed.",
+          requestId,
+        },
+        500,
+      );
+    }
+  });
+
+  return router;
+}

--- a/scripts/ee-stub/src/onboarding/provision-trial.ts
+++ b/scripts/ee-stub/src/onboarding/provision-trial.ts
@@ -1,0 +1,55 @@
+/**
+ * Symlink-stub surface for `@atlas/ee/onboarding/provision-trial`. Mirrors the
+ * exports `packages/mcp/src/onboarding.ts` (and its test) import from this path
+ * — `provisionTrialWorkspace`, the typed `TrialProvisioningError`, and the
+ * `ProvisionTrial{Input,Result}` / `TrialProvisioningCode` / `TrialWorkspaceState`
+ * shapes. Self-serve trial provisioning is enterprise-gated (SaaS-only), so the
+ * stub keeps the type surface in lockstep with `ee/src/onboarding/provision-trial.ts`
+ * without any behaviour — the symlink-stub CI job is the only consumer and never
+ * runs it.
+ *
+ * Keep these names + types in lockstep with the real module; the exhaustive
+ * switch over `TrialProvisioningCode` in `onboarding.ts` depends on the literal
+ * union, not a widened `string`.
+ *
+ * Not used at runtime.
+ */
+
+export type TrialWorkspaceState = "grace" | "locked";
+
+export interface ProvisionTrialInput {
+  readonly email: string;
+  readonly orgName: string;
+}
+
+export interface ProvisionTrialResult {
+  readonly workspaceId: string;
+  readonly connectUrl: string;
+  readonly state: TrialWorkspaceState;
+}
+
+export type TrialProvisioningCode =
+  | "not_saas"
+  | "invalid_input"
+  | "signup_failed"
+  | "org_failed"
+  | "trial_not_assigned";
+
+export class TrialProvisioningError extends Error {
+  override readonly name = "TrialProvisioningError";
+  readonly code: TrialProvisioningCode;
+  constructor(code: TrialProvisioningCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export async function provisionTrialWorkspace(
+  _input: ProvisionTrialInput,
+  _overrides?: unknown,
+): Promise<ProvisionTrialResult> {
+  throw new TrialProvisioningError(
+    "not_saas",
+    "Self-serve trial provisioning is enterprise-only (stub).",
+  );
+}


### PR DESCRIPTION
## What

Tracer bullet for **v0.0.19 — Self-serve MCP Trial Signup** (#3649, parent PRD #3646, [ADR-0018](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0018-self-serve-trial-over-mcp.md)).

An agent in an MCP client can now spin up a brand-new Atlas trial Workspace and connect to it **without leaving the agent**.

## How

- **`provisionTrialWorkspace({ email, orgName })`** — the reusable lib seam (`ee/src/onboarding/provision-trial.ts`). Runs the same Better Auth path the web uses (`signUpEmail` → `organization.create`), which fires the existing `afterCreateOrganization` hook (`assignSaasTrial` → the atomic `claimTrialGrant` one-trial-per-user claim + `trial` tier). It then **narrows `trial_ends_at`** from the full `TRIAL_DAYS` down to a short `TRIAL_GRACE_HOURS` window — the unclaimed-grace state. Refuses when `deployMode !== 'saas'`; never binds an MCP actor. The MCP tool and any future HTTP onboarding face both call it — no new column, no new tier.
- **`start_trial` MCP tool** (`packages/mcp/src/onboarding.ts`) — registered on a **separate, unauthenticated** onboarding MCP server (`createOnboardingMcpServer` / `createOnboardingMcpRouter` at `/mcp/onboarding/sse`), the single audited **anonymous-onboarding-caller** carve-out that runs **outside `runMcpDispatchGate`**. That server exposes *only* `start_trial`, so the caller is structurally incapable of reaching the gate. SaaS-gated (absent off-SaaS). Collects `email` + `orgName` via args or MCP elicitation; returns `{ workspaceId, connectUrl, state }`; typed failures map to the standard `AtlasMcpToolError` envelope.
- **`buildMcpConnectUrl`** (`packages/api/src/lib/mcp/connect-url.ts`) — canonical per-workspace hosted-MCP connect URL, shared by the tool and the provisioner. The agent runs the existing DCR/PKCE flow against it to attach a normal *hosted* actor; post-connect, every read/write/setup tool runs the full dispatch gate unchanged.
- Onboarding router mounted **before** the hosted `/mcp/:workspaceId/sse` router so the static `onboarding` segment wins.
- Docs: ADR-0018 implementation-status section + a `start_trial` section in the MCP guide.

## Acceptance criteria (#3649)

- [x] `start_trial` exists on the hosted (SaaS) MCP server only; absent off-SaaS
- [x] valid email + workspace name → provisions user + Workspace on `trial` in unclaimed grace (short `trial_ends_at`), returns `{ workspaceId, connectUrl, state: "grace" }`
- [x] tool runs outside `runMcpDispatchGate` (separate unauthenticated server exposing only `start_trial`); never binds an actor
- [x] after connecting via `connectUrl`, the existing DCR/PKCE flow binds a hosted actor and read tools work (unchanged hosted path)
- [x] post-connect, write/setup tools still run the full dispatch gate (unchanged)
- [x] `provisionTrialWorkspace` is a reusable lib seam
- [x] tests cover provisioning-into-grace, off-SaaS absence, locked repeat-signup, the elicitation round-trip, envelope mapping, and the connect-url handoff

## Scope

Provisioning + connect **only**. Meter enforcement (#3651), CRM lead source (#3653), email-quality policy (#3650), grace reaper (#3652), and abuse controls (#3654) are follow-on slices. The grace window (`TRIAL_GRACE_HOURS`) is in place for the reaper to consume.

## Tests / CI

New tests: `ee/.../provision-trial.test.ts` (9), `packages/mcp/.../onboarding.test.ts` (8), `packages/api/.../connect-url.test.ts` (5).

Local CI gates all green: lint, type, full test (api 670 / web 212 / mcp 31 / ee 28 / cli 30 / react 11, 0 failures), syncpack, template/security-headers/railway/schema/openapi/oauth-helper/saas-env drift, test-discipline, settings-readers, published-symbols.

Closes #3649.

https://claude.ai/code/session_01TnGR1o5s7CmybhkVQkXwaA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnGR1o5s7CmybhkVQkXwaA)_