### PR TITLE
feat(auth): business-email-only signup — deny disposable + freemium (#3650)

### DIFF
--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -37,7 +37,11 @@ Each step validates before allowing the user to proceed. The database URL is tes
 
 ## Business-Email-Only Signup
 
-Atlas signup is **business-email only**, with identical policy on the web form and the MCP `start_trial` path (both provision through the same Better Auth signup, so the policy is shared by construction). Two classes of address are hard-denied:
+<Callout type="info" title="SaaS only">
+This policy applies to the hosted Atlas SaaS. Self-hosted deployments do **not** enforce it — operators control who signs up, and the bootstrap admin can use any address (including a consumer domain).
+</Callout>
+
+On the hosted SaaS, Atlas signup is **business-email only**, with identical policy on the web form and the MCP `start_trial` path (both provision through the same Better Auth signup, so the policy is shared by construction). Two classes of address are hard-denied:
 
 - **Disposable / throwaway mailboxes** (mailinator, guerrillamail, 10-minute-mail, …) — detected via the [`better-auth-harmony`](https://github.com/GauBen/better-auth-harmony) `emailHarmony` plugin's `mailchecker` engine (50k+ domains).
 - **Freemium / consumer domains** (gmail, outlook, yahoo, icloud, proton, …) — a maintained denylist in code.
@@ -46,8 +50,8 @@ Both denials surface the same way: an actionable error on the web form ("Please 
 
 The `emailHarmony` plugin also writes a unique `normalizedEmail` column — collapsing `+alias`, dot, and case variants of the same address — so `john.doe+trial@acme.com` and `johndoe@acme.com` can't both claim a separate trial.
 
-<Callout type="info" title="Relaxing the denylist (self-hosted)">
-The freemium-domain denylist lives in code at `packages/api/src/lib/auth/business-email.ts` (`FREEMIUM_EMAIL_DOMAINS`). Self-hosted operators who want to allow consumer domains can trim that set and redeploy.
+<Callout type="info" title="Tuning the denylist (operators)">
+The freemium-domain denylist lives in code at `packages/api/src/lib/auth/business-email.ts` (`FREEMIUM_EMAIL_DOMAINS`). The whole policy is gated to SaaS deploy mode, so self-hosted deployments are unaffected; a SaaS operator who wants to allow specific consumer domains can trim that set and redeploy.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -35,6 +35,23 @@ Each step validates before allowing the user to proceed. The database URL is tes
 
 ---
 
+## Business-Email-Only Signup
+
+Atlas signup is **business-email only**, with identical policy on the web form and the MCP `start_trial` path (both provision through the same Better Auth signup, so the policy is shared by construction). Two classes of address are hard-denied:
+
+- **Disposable / throwaway mailboxes** (mailinator, guerrillamail, 10-minute-mail, …) — detected via the [`better-auth-harmony`](https://github.com/GauBen/better-auth-harmony) `emailHarmony` plugin's `mailchecker` engine (50k+ domains).
+- **Freemium / consumer domains** (gmail, outlook, yahoo, icloud, proton, …) — a maintained denylist in code.
+
+Both denials surface the same way: an actionable error on the web form ("Please sign up with your work email address…") and a typed `business_email_required` envelope on the MCP path. Legitimate business-domain signups are unaffected.
+
+The `emailHarmony` plugin also writes a unique `normalizedEmail` column — collapsing `+alias`, dot, and case variants of the same address — so `john.doe+trial@acme.com` and `johndoe@acme.com` can't both claim a separate trial.
+
+<Callout type="info" title="Relaxing the denylist (self-hosted)">
+The freemium-domain denylist lives in code at `packages/api/src/lib/auth/business-email.ts` (`FREEMIUM_EMAIL_DOMAINS`). Self-hosted operators who want to allow consumer domains can trim that set and redeploy.
+</Callout>
+
+---
+
 ## Region Selection
 
 <Callout type="info" title="SaaS only">

--- a/bun.lock
+++ b/bun.lock
@@ -213,6 +213,7 @@
         "@useatlas/webhook-publisher": "workspace:*",
         "ai": "^6.0.193",
         "better-auth": "^1.6.16",
+        "better-auth-harmony": "^1.3.2",
         "croner": "^10.0.1",
         "diff": "^9.0.0",
         "effect": "^3.21.2",
@@ -2301,6 +2302,8 @@
 
     "better-auth": ["better-auth@1.6.16", "", { "dependencies": { "@better-auth/core": "1.6.16", "@better-auth/drizzle-adapter": "1.6.16", "@better-auth/kysely-adapter": "1.6.16", "@better-auth/memory-adapter": "1.6.16", "@better-auth/mongo-adapter": "1.6.16", "@better-auth/prisma-adapter": "1.6.16", "@better-auth/telemetry": "1.6.16", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.2.2", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.6", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-YlBITnH3LIBRD+JpR1XRIToJAVVpoQvZzRc4sm5W0/bnPZKLbsmtXbVWJF3ypo9TVnF6geczJKprG/CsWT07Wg=="],
 
+    "better-auth-harmony": ["better-auth-harmony@1.3.2", "", { "dependencies": { "libphonenumber-js": "^1.12.37", "mailchecker": "^6.0.19", "validator": "^13.15.26" }, "peerDependencies": { "better-auth": "^1.0.3" } }, "sha512-i79pUPytTxOcN2gfPQ727ZfPY5rI2IPfqsadpy7aA9fhpvgdPxGY6pgYD+zbgpHYPCdElhTA9Q0cqnQZvuVlqg=="],
+
     "better-call": ["better-call@1.3.6", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
@@ -3109,6 +3112,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "libphonenumber-js": ["libphonenumber-js@1.13.6", "", {}, "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q=="],
+
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -3212,6 +3217,8 @@
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mailchecker": ["mailchecker@6.0.20", "", {}, "sha512-mZ3kmtfXzGj06prtNm6d8an7D++Kf1G4jEkPZ1QQyhknYNLkmGoMtfaNPNHJU6E8J+Bm3AcZlIIfq5D6L4MS2g=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
@@ -4112,6 +4119,8 @@
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
+    "validator": ["validator@13.15.35", "", {}, "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -45,6 +45,7 @@
     "@tanstack/react-table": "^8.21.3",
     "ai": "^6.0.193",
     "better-auth": "^1.6.16",
+    "better-auth-harmony": "^1.3.2",
     "drizzle-orm": "^0.45.2",
     "@effect/sql": "^0.51.1",
     "@effect/sql-mysql2": "^0.52.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -42,6 +42,7 @@
     "@tanstack/react-query-devtools": "^5.100.14",
     "@tanstack/react-table": "^8.21.3",
     "better-auth": "^1.6.16",
+    "better-auth-harmony": "^1.3.2",
     "drizzle-orm": "^0.45.2",
     "@effect/sql": "^0.51.1",
     "@effect/sql-mysql2": "^0.52.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,6 +71,7 @@
     "@useatlas/webhook-publisher": "workspace:*",
     "ai": "^6.0.193",
     "better-auth": "^1.6.16",
+    "better-auth-harmony": "^1.3.2",
     "croner": "^10.0.1",
     "diff": "^9.0.0",
     "effect": "^3.21.2",

--- a/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
@@ -7,27 +7,45 @@
  *
  *   • `emailHarmony` in `buildPlugins()` output, declaring a UNIQUE
  *     `normalizedEmail` field + collapsing `+alias`/dot/case variants (the
- *     teeth behind one-trial-per-user).
+ *     teeth behind one-trial-per-user) — and still normalizing through the
+ *     EXACT instance Atlas wires (with `matchers.validation: []` disabling only
+ *     route validation, not normalization).
  *   • `assertBusinessEmail` invoked from `databaseHooks.user.create.before` in
  *     `buildAuthOptions()`, OUTSIDE the bootstrap-role try/catch, so a
  *     disposable/freemium signup is rejected with the typed
- *     `business_email_required` code rather than silently admitted.
+ *     `business_email_required` code rather than silently admitted — and only
+ *     in SaaS deploy mode.
  *
  * This is the same "well-tested logic + missing wiring assertion = silent prod
  * regression" shape that databaseHooks-wiring.test.ts guards. A refactor that
  * dropped the `emailHarmony(...)` push or the `assertBusinessEmail(user.email)`
- * line would pass every unit test yet reopen consumer/disposable signups.
+ * line — or one where a harmony upgrade folded normalization behind the same
+ * disabled matcher — would pass every isolated unit test yet reopen
+ * consumer/disposable signups.
  *
  * No mock.module needed: the deny path throws before any DB/CRM/email side
  * effect, and the allowed path resolves through `computeBootstrapRole` with no
- * internal DB (bootstrapAdmin "none" + database undefined → no query).
+ * internal DB (bootstrapAdmin "none" + database undefined → no query). Deploy
+ * mode is set via `_setConfigForTest` (same pattern as assign-saas-trial.test).
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { APIError } from "better-auth/api";
-import { emailHarmony } from "better-auth-harmony";
 import { buildPlugins, buildAuthOptions, parseAuthSecret } from "../server";
 import { BUSINESS_EMAIL_REQUIRED_CODE } from "../business-email";
+import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
+
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
 
 function authDeps(plugins: ReturnType<typeof buildPlugins>) {
   return {
@@ -70,10 +88,20 @@ describe("emailHarmony plugin wiring", () => {
     expect(field?.returned).toBe(false);
   });
 
-  it("normalizes +alias / dot / case variants to a single normalizedEmail (collapse)", async () => {
-    // The plugin's normalization runs from its init() databaseHook regardless of
-    // the disabled route-validation matcher.
-    const before = emailHarmony().init().options.databaseHooks.user.create.before;
+  it("normalizes +alias / dot / case variants via the COMPOSED instance (matchers.validation:[] disables only route validation)", async () => {
+    // Reach into the exact plugin object Atlas wires — i.e. the one constructed
+    // with `matchers: { validation: [] }` in buildPlugins() — and run ITS
+    // normalization databaseHook (installed via init()). Constructing a fresh
+    // `emailHarmony()` here would test the default plugin, not the one we ship,
+    // and miss a regression where disabling validation also disabled
+    // normalization (the exact risk in this feature's rationale).
+    const harmony = buildPlugins().find((p: { id?: string }) => p.id === "harmony-email");
+    expect(harmony, "emailHarmony must be wired into the Better Auth plugin array").toBeDefined();
+    const before = (harmony as {
+      init: () => {
+        options: { databaseHooks: { user: { create: { before: (u: never) => Promise<unknown> } } } };
+      };
+    }).init().options.databaseHooks.user.create.before;
 
     const norm = async (email: string) => {
       const r = await before({ id: "u", email } as never);
@@ -89,7 +117,14 @@ describe("emailHarmony plugin wiring", () => {
   });
 });
 
-describe("databaseHooks.user.create.before — business-email deny wiring", () => {
+describe("databaseHooks.user.create.before — business-email deny wiring (SaaS)", () => {
+  beforeEach(() => {
+    _setConfigForTest(configWithDeployMode("saas"));
+  });
+  afterAll(() => {
+    _setConfigForTest(null);
+  });
+
   async function rejection(email: string): Promise<unknown> {
     const before = getUserCreateBefore();
     try {
@@ -112,9 +147,43 @@ describe("databaseHooks.user.create.before — business-email deny wiring", () =
     expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
   });
 
+  it("rejects a Google-OAuth-shaped freemium signup (social path goes through the same hook)", async () => {
+    // Social-provider signups provision through the same user.create.before, so
+    // a consumer-domain OAuth identity is denied identically to a web signup.
+    const err = await rejection("person@gmail.com");
+    expect(err, "social-provider freemium signup must be rejected by the composed hook").toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+  });
+
   it("allows a legitimate business-domain signup (no business-email throw)", async () => {
     // bootstrapAdmin "none" + database undefined → computeBootstrapRole returns
     // promote:false with no DB query, so a clean business email falls through.
     expect(await rejection("founder@acme.com")).toBeUndefined();
+  });
+});
+
+describe("databaseHooks.user.create.before — business-email policy is SaaS-only", () => {
+  afterAll(() => {
+    _setConfigForTest(null);
+  });
+
+  async function rejection(email: string): Promise<unknown> {
+    const before = getUserCreateBefore();
+    try {
+      await before({ id: "u_selfhost", email });
+    } catch (err) {
+      return err;
+    }
+    return undefined;
+  }
+
+  it("does NOT deny a freemium signup in self-hosted mode (operator may bootstrap with any domain)", async () => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    expect(await rejection("operator@gmail.com")).toBeUndefined();
+  });
+
+  it("does NOT deny when deploy mode is unresolved (config null → not saas)", async () => {
+    _setConfigForTest(null);
+    expect(await rejection("operator@gmail.com")).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Wiring test for business-email-only signup (#3650, ADR-0018).
+ *
+ * The deny logic (business-email.ts) and the normalizer (the `emailHarmony`
+ * plugin) are each covered in isolation, but their *security value* depends on
+ * the composition actually attaching them to the Better Auth signup path:
+ *
+ *   • `emailHarmony` in `buildPlugins()` output, declaring a UNIQUE
+ *     `normalizedEmail` field + collapsing `+alias`/dot/case variants (the
+ *     teeth behind one-trial-per-user).
+ *   • `assertBusinessEmail` invoked from `databaseHooks.user.create.before` in
+ *     `buildAuthOptions()`, OUTSIDE the bootstrap-role try/catch, so a
+ *     disposable/freemium signup is rejected with the typed
+ *     `business_email_required` code rather than silently admitted.
+ *
+ * This is the same "well-tested logic + missing wiring assertion = silent prod
+ * regression" shape that databaseHooks-wiring.test.ts guards. A refactor that
+ * dropped the `emailHarmony(...)` push or the `assertBusinessEmail(user.email)`
+ * line would pass every unit test yet reopen consumer/disposable signups.
+ *
+ * No mock.module needed: the deny path throws before any DB/CRM/email side
+ * effect, and the allowed path resolves through `computeBootstrapRole` with no
+ * internal DB (bootstrapAdmin "none" + database undefined → no query).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { APIError } from "better-auth/api";
+import { emailHarmony } from "better-auth-harmony";
+import { buildPlugins, buildAuthOptions, parseAuthSecret } from "../server";
+import { BUSINESS_EMAIL_REQUIRED_CODE } from "../business-email";
+
+function authDeps(plugins: ReturnType<typeof buildPlugins>) {
+  return {
+    env: process.env,
+    secret: parseAuthSecret("test-secret-at-least-32-characters-long"),
+    baseURL: undefined,
+    database: undefined,
+    cookieDomain: undefined,
+    cookiePrefix: "atlas",
+    socialProviders: undefined,
+    plugins,
+    trustedOrigins: ["https://app.useatlas.dev"],
+    bootstrapAdmin: { mode: "none" as const },
+  };
+}
+
+function getUserCreateBefore() {
+  const options = buildAuthOptions(authDeps(buildPlugins()));
+  const hook = (options as {
+    databaseHooks?: { user?: { create?: { before?: unknown } } };
+  }).databaseHooks?.user?.create?.before;
+  expect(typeof hook, "user.create.before must be composed in buildAuthOptions").toBe("function");
+  return hook as (user: { id: string; email: string; name?: string }) => Promise<unknown>;
+}
+
+describe("emailHarmony plugin wiring", () => {
+  it("is present in buildPlugins() with a unique, non-returned normalizedEmail field", () => {
+    const plugins = buildPlugins();
+    const harmony = plugins.find((p: { id?: string }) => p.id === "harmony-email");
+    expect(harmony, "emailHarmony must be wired into the Better Auth plugin array").toBeDefined();
+
+    const field = (harmony as {
+      schema?: { user?: { fields?: { normalizedEmail?: { unique?: boolean; input?: boolean; returned?: boolean } } } };
+    }).schema?.user?.fields?.normalizedEmail;
+    expect(field, "emailHarmony must contribute the normalizedEmail schema field").toBeDefined();
+    // UNIQUE is the one-trial-per-user teeth; input:false / returned:false keep
+    // it server-owned and out of the enumeration-safe signup response.
+    expect(field?.unique).toBe(true);
+    expect(field?.input).toBe(false);
+    expect(field?.returned).toBe(false);
+  });
+
+  it("normalizes +alias / dot / case variants to a single normalizedEmail (collapse)", async () => {
+    // The plugin's normalization runs from its init() databaseHook regardless of
+    // the disabled route-validation matcher.
+    const before = emailHarmony().init().options.databaseHooks.user.create.before;
+
+    const norm = async (email: string) => {
+      const r = await before({ id: "u", email } as never);
+      expect(r && typeof r === "object" && "data" in r, `expected normalized data for ${email}`).toBe(true);
+      return (r as { data: { normalizedEmail?: string } }).data.normalizedEmail;
+    };
+
+    // Case variants on a business domain collapse — so a duplicate signup trips
+    // the unique index instead of minting a second trial.
+    expect(await norm("Alice@Acme.com")).toBe(await norm("alice@acme.com"));
+    // +alias / dot variants collapse for known providers (gmail engine).
+    expect(await norm("john.doe+trial@gmail.com")).toBe(await norm("JohnDoe@gmail.com"));
+  });
+});
+
+describe("databaseHooks.user.create.before — business-email deny wiring", () => {
+  async function rejection(email: string): Promise<unknown> {
+    const before = getUserCreateBefore();
+    try {
+      await before({ id: "u_deny", email });
+    } catch (err) {
+      return err;
+    }
+    return undefined;
+  }
+
+  it("rejects a freemium signup with the typed business_email_required code", async () => {
+    const err = await rejection("user@gmail.com");
+    expect(err, "freemium signup must be rejected by the composed hook").toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+  });
+
+  it("rejects a disposable signup with the typed business_email_required code", async () => {
+    const err = await rejection("user@mailinator.com");
+    expect(err, "disposable signup must be rejected by the composed hook").toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+  });
+
+  it("allows a legitimate business-domain signup (no business-email throw)", async () => {
+    // bootstrapAdmin "none" + database undefined → computeBootstrapRole returns
+    // promote:false with no DB query, so a clean business email falls through.
+    expect(await rejection("founder@acme.com")).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/business-email.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit coverage for the business-email-only signup policy (#3650, ADR-0018).
+ *
+ * Pure module — no DB, no Better Auth instance — so these run fast and pin the
+ * deny decision (disposable + freemium), the typed-error contract the web/MCP
+ * layers depend on, and the rejection classifier the MCP `start_trial`
+ * provisioner (#3649) uses to map the shared-signup-path failure to its
+ * `business_email_required` envelope.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { APIError } from "better-auth/api";
+import {
+  BUSINESS_EMAIL_REQUIRED_CODE,
+  BUSINESS_EMAIL_REQUIRED_MESSAGE,
+  FREEMIUM_EMAIL_DOMAINS,
+  assertBusinessEmail,
+  classifyBusinessEmail,
+  extractEmailDomain,
+  isBusinessEmailRejection,
+  isDisposableEmail,
+  isFreemiumEmailDomain,
+} from "../business-email";
+
+describe("extractEmailDomain", () => {
+  it("returns the lower-cased domain after the last @", () => {
+    expect(extractEmailDomain("Alice@Acme.COM")).toBe("acme.com");
+    expect(extractEmailDomain("weird+a@b@corp.example")).toBe("corp.example");
+  });
+
+  it("returns undefined for malformed / domain-less input", () => {
+    expect(extractEmailDomain("no-at-sign")).toBeUndefined();
+    expect(extractEmailDomain("trailing@")).toBeUndefined();
+  });
+});
+
+describe("isFreemiumEmailDomain", () => {
+  it("denies common consumer domains (case-insensitive)", () => {
+    expect(isFreemiumEmailDomain("user@gmail.com")).toBe(true);
+    expect(isFreemiumEmailDomain("user@GMAIL.COM")).toBe(true);
+    expect(isFreemiumEmailDomain("user@outlook.com")).toBe(true);
+    expect(isFreemiumEmailDomain("user@yahoo.co.uk")).toBe(true);
+    expect(isFreemiumEmailDomain("user@icloud.com")).toBe(true);
+    expect(isFreemiumEmailDomain("user@proton.me")).toBe(true);
+  });
+
+  it("allows business domains", () => {
+    expect(isFreemiumEmailDomain("user@acme.com")).toBe(false);
+    expect(isFreemiumEmailDomain("founder@startup.io")).toBe(false);
+  });
+
+  it("matches exactly — a domain that merely ends with a denied host is allowed", () => {
+    // `notgmail.com` / a subdomain must not be swept up by `gmail.com`.
+    expect(isFreemiumEmailDomain("user@notgmail.com")).toBe(false);
+    expect(isFreemiumEmailDomain("user@mail.gmail.com.evil.com")).toBe(false);
+  });
+
+  it("keeps the denylist non-empty and lower-case (maintenance guard)", () => {
+    expect(FREEMIUM_EMAIL_DOMAINS.size).toBeGreaterThan(20);
+    for (const d of FREEMIUM_EMAIL_DOMAINS) {
+      expect(d).toBe(d.toLowerCase());
+    }
+  });
+});
+
+describe("isDisposableEmail", () => {
+  it("flags throwaway mailboxes via the mailchecker engine", () => {
+    expect(isDisposableEmail("foo@mailinator.com")).toBe(true);
+    expect(isDisposableEmail("foo@guerrillamail.com")).toBe(true);
+    expect(isDisposableEmail("foo@10minutemail.com")).toBe(true);
+  });
+
+  it("passes real domains (business and freemium alike — freemium is a separate deny)", () => {
+    expect(isDisposableEmail("alice@acme.com")).toBe(false);
+    expect(isDisposableEmail("alice@gmail.com")).toBe(false);
+  });
+});
+
+describe("classifyBusinessEmail", () => {
+  it("reports disposable, freemium, and ok", () => {
+    expect(classifyBusinessEmail("a@mailinator.com")).toEqual({ ok: false, reason: "disposable" });
+    expect(classifyBusinessEmail("a@gmail.com")).toEqual({ ok: false, reason: "freemium" });
+    expect(classifyBusinessEmail("a@acme.com")).toEqual({ ok: true });
+  });
+});
+
+describe("assertBusinessEmail", () => {
+  function thrownBy(fn: () => void): unknown {
+    try {
+      fn();
+    } catch (err) {
+      return err;
+    }
+    return undefined;
+  }
+
+  it("rejects a freemium domain with a typed 400 APIError", () => {
+    const err = thrownBy(() => assertBusinessEmail("user@gmail.com"));
+    expect(err).toBeInstanceOf(APIError);
+    const apiErr = err as APIError;
+    expect(apiErr.statusCode).toBe(400);
+    expect(apiErr.body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+    expect(apiErr.body?.message).toBe(BUSINESS_EMAIL_REQUIRED_MESSAGE);
+    expect((apiErr.body as { reason?: string })?.reason).toBe("freemium");
+  });
+
+  it("rejects a disposable domain with the same typed code", () => {
+    const err = thrownBy(() => assertBusinessEmail("user@mailinator.com"));
+    expect(err).toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+    expect(((err as APIError).body as { reason?: string })?.reason).toBe("disposable");
+  });
+
+  it("allows a legitimate business domain", () => {
+    expect(thrownBy(() => assertBusinessEmail("founder@acme.com"))).toBeUndefined();
+  });
+
+  it("is a no-op for null/empty email (Better Auth owns the required-field case)", () => {
+    expect(thrownBy(() => assertBusinessEmail(null))).toBeUndefined();
+    expect(thrownBy(() => assertBusinessEmail(undefined))).toBeUndefined();
+    expect(thrownBy(() => assertBusinessEmail(""))).toBeUndefined();
+  });
+});
+
+describe("isBusinessEmailRejection", () => {
+  it("recognizes the thrown business-email rejection by stable code", () => {
+    let caught: unknown;
+    try {
+      assertBusinessEmail("user@gmail.com");
+    } catch (err) {
+      caught = err;
+    }
+    expect(isBusinessEmailRejection(caught)).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isBusinessEmailRejection(new Error("boom"))).toBe(false);
+    expect(isBusinessEmailRejection(new APIError("BAD_REQUEST", { code: "OTHER" }))).toBe(false);
+    expect(isBusinessEmailRejection(undefined)).toBe(false);
+    expect(isBusinessEmailRejection({ body: { code: BUSINESS_EMAIL_REQUIRED_CODE } })).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/business-email.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email.test.ts
@@ -74,6 +74,13 @@ describe("isDisposableEmail", () => {
     expect(isDisposableEmail("alice@acme.com")).toBe(false);
     expect(isDisposableEmail("alice@gmail.com")).toBe(false);
   });
+
+  it("is safe (no throw) on empty input — the underlying validateEmail throws on null", () => {
+    // Hardening for a direct caller that skips assertBusinessEmail's empty guard
+    // (e.g. the MCP start_trial provisioner). Empty is reported not-disposable;
+    // Better Auth owns the required-field case.
+    expect(isDisposableEmail("")).toBe(false);
+  });
 });
 
 describe("classifyBusinessEmail", () => {
@@ -81,6 +88,10 @@ describe("classifyBusinessEmail", () => {
     expect(classifyBusinessEmail("a@mailinator.com")).toEqual({ ok: false, reason: "disposable" });
     expect(classifyBusinessEmail("a@gmail.com")).toEqual({ ok: false, reason: "freemium" });
     expect(classifyBusinessEmail("a@acme.com")).toEqual({ ok: true });
+  });
+
+  it("does not throw on empty input (defers required-field to Better Auth)", () => {
+    expect(classifyBusinessEmail("")).toEqual({ ok: true });
   });
 });
 

--- a/packages/api/src/lib/auth/business-email.ts
+++ b/packages/api/src/lib/auth/business-email.ts
@@ -140,13 +140,24 @@ export function isFreemiumEmailDomain(email: string): boolean {
 
 /**
  * True when the email is a disposable/throwaway mailbox (or otherwise fails the
- * `mailchecker` validity check). Delegates to `better-auth-harmony`'s
+ * `mailchecker` validity check — a syntactically invalid address also returns
+ * `true` here, folded into the same deny). Delegates to `better-auth-harmony`'s
  * `validateEmail` so we share the exact disposable-domain corpus the plugin
  * blocks with.
+ *
+ * `validateEmail` throws on a null/empty input (its underlying `isEmail`
+ * expects a string), so we guard first and report empty as not-disposable —
+ * Better Auth owns the required-field case. This keeps the exported helper safe
+ * for a direct caller (e.g. the MCP `start_trial` provisioner, #3649) that
+ * hasn't already passed through {@link assertBusinessEmail}'s empty guard.
  */
 export function isDisposableEmail(email: string): boolean {
+  if (!email) return false;
   return !validateEmail(email);
 }
+
+/** Why an address fails the business-email policy. */
+export type BusinessEmailReason = "disposable" | "freemium";
 
 /**
  * Why an address was rejected, or `{ ok: true }` when it passes both denies.
@@ -155,7 +166,7 @@ export function isDisposableEmail(email: string): boolean {
  */
 export type BusinessEmailVerdict =
   | { ok: true }
-  | { ok: false; reason: "disposable" | "freemium" };
+  | { ok: false; reason: BusinessEmailReason };
 
 /** Classify an address against the business-email policy. Pure, no throw. */
 export function classifyBusinessEmail(email: string): BusinessEmailVerdict {
@@ -165,24 +176,40 @@ export function classifyBusinessEmail(email: string): BusinessEmailVerdict {
 }
 
 /**
+ * Shape of the {@link APIError} body thrown on a business-email rejection — the
+ * single typed contract shared by the producer ({@link assertBusinessEmail}),
+ * the recognizer ({@link isBusinessEmailRejection}), and the MCP `start_trial`
+ * envelope mapping (#3649). `reason` reuses {@link BusinessEmailReason}, so a new
+ * deny reason can't be emitted on the wire without widening the verdict union in
+ * the same edit.
+ */
+export interface BusinessEmailErrorBody {
+  code: typeof BUSINESS_EMAIL_REQUIRED_CODE;
+  message: typeof BUSINESS_EMAIL_REQUIRED_MESSAGE;
+  reason: BusinessEmailReason;
+}
+
+/**
  * Throw a typed {@link APIError} when `email` violates the business-email policy.
  * No-op for an allowed business address (and for a null/empty email — Better
  * Auth's own validation owns the "email required" case; we only judge domains).
  *
- * Called from `databaseHooks.user.create.before` so it gates EVERY signup path
- * (web, social, MCP `start_trial`) identically. The throw aborts user creation;
- * Better Auth serializes the `APIError` to a 400 whose body carries
+ * Called from `databaseHooks.user.create.before` (SaaS deploy mode only — see
+ * the call site in server.ts) so it gates EVERY SaaS signup path (web, social,
+ * MCP `start_trial`) identically. The throw aborts user creation; Better Auth
+ * serializes the `APIError` to a 400 whose body carries
  * {@link BUSINESS_EMAIL_REQUIRED_CODE} + {@link BUSINESS_EMAIL_REQUIRED_MESSAGE}.
  */
 export function assertBusinessEmail(email: string | null | undefined): void {
   if (!email) return;
   const verdict = classifyBusinessEmail(email);
   if (verdict.ok) return;
-  throw new APIError("BAD_REQUEST", {
+  const body: BusinessEmailErrorBody = {
     code: BUSINESS_EMAIL_REQUIRED_CODE,
     message: BUSINESS_EMAIL_REQUIRED_MESSAGE,
     reason: verdict.reason,
-  });
+  };
+  throw new APIError("BAD_REQUEST", body);
 }
 
 /**
@@ -194,6 +221,6 @@ export function assertBusinessEmail(email: string | null | undefined): void {
  */
 export function isBusinessEmailRejection(err: unknown): boolean {
   if (!(err instanceof APIError)) return false;
-  const body = err.body as { code?: unknown } | undefined;
+  const body = err.body as Partial<BusinessEmailErrorBody> | undefined;
   return body?.code === BUSINESS_EMAIL_REQUIRED_CODE;
 }

--- a/packages/api/src/lib/auth/business-email.ts
+++ b/packages/api/src/lib/auth/business-email.ts
@@ -1,0 +1,199 @@
+/**
+ * Business-email-only signup policy (#3650, ADR-0018).
+ *
+ * Atlas signup — web form AND the MCP `start_trial` path — is business-email
+ * only. Because `start_trial` provisions through the *same* Better Auth signup
+ * (`signUpEmail` → `databaseHooks.user.create.before`), enforcing the policy in
+ * that one hook makes web and MCP identical by construction.
+ *
+ * Two hard denies, both surfaced through a single typed `business_email_required`
+ * rejection so the web layer shows one actionable message and the MCP envelope
+ * (#3649) maps one stable code:
+ *
+ *  1. **Disposable / throwaway mailboxes** — detected via `better-auth-harmony`'s
+ *     `validateEmail` (the same `mailchecker` engine, 50k+ domains, that the
+ *     `emailHarmony` plugin ships). We route the rejection through our own typed
+ *     error rather than the plugin's generic "Invalid email" 400 (the plugin's
+ *     own route validation is disabled in `buildPlugins` for exactly this
+ *     reason — see the `emailHarmony({ matchers: { validation: [] } })` call).
+ *  2. **Freemium / consumer domains** (gmail, outlook, yahoo, icloud, proton, …)
+ *     — a maintained denylist that lives in code ({@link FREEMIUM_EMAIL_DOMAINS}),
+ *     relaxable later without a migration.
+ *
+ * The `normalizedEmail` unique column (collapsing `+alias`/dot/case variants, the
+ * teeth behind one-trial-per-user) is contributed by the `emailHarmony` plugin
+ * itself; this module only owns the *deny* decision.
+ *
+ * Template-synced to create-atlas, so this stays dependency-light: a plain
+ * `APIError` (Better Auth's HTTP error type) is thrown, no Atlas-internal imports.
+ */
+
+import { APIError } from "better-auth/api";
+import { validateEmail } from "better-auth-harmony/email";
+
+/**
+ * Error `code` carried on the thrown {@link APIError} body and the value the MCP
+ * `start_trial` envelope surfaces (#3649). Stable contract — do not rename
+ * without updating the MCP provisioner's envelope mapping.
+ */
+export const BUSINESS_EMAIL_REQUIRED_CODE = "BUSINESS_EMAIL_REQUIRED" as const;
+
+/**
+ * User-facing rejection message. Actionable (tells the user what to do) and
+ * deliberately identical for the disposable and freemium cases — to the person
+ * signing up, "we need your work email" is the single relevant instruction. The
+ * web signup form renders this verbatim (`res.error.message`).
+ */
+export const BUSINESS_EMAIL_REQUIRED_MESSAGE =
+  "Please sign up with your work email address. Personal and disposable email " +
+  "addresses aren't supported for Atlas trials.";
+
+/**
+ * Freemium / consumer email domains denied at signup. Lives in code so the list
+ * is maintained alongside the policy and relaxable without a migration. Lower-case
+ * registrable hosts; regional variants are listed explicitly because the match is
+ * exact (no suffix matching — `notgmail.com` must not be caught by `gmail.com`).
+ */
+export const FREEMIUM_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  // Google
+  "gmail.com",
+  "googlemail.com",
+  // Microsoft
+  "outlook.com",
+  "outlook.co.uk",
+  "hotmail.com",
+  "hotmail.co.uk",
+  "hotmail.fr",
+  "live.com",
+  "live.co.uk",
+  "msn.com",
+  // Yahoo / Oath
+  "yahoo.com",
+  "yahoo.co.uk",
+  "yahoo.co.in",
+  "yahoo.fr",
+  "yahoo.de",
+  "ymail.com",
+  "rocketmail.com",
+  // Apple
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  // Proton
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  // AOL
+  "aol.com",
+  // GMX / mail.com family
+  "gmx.com",
+  "gmx.net",
+  "gmx.de",
+  "mail.com",
+  // Zoho (consumer)
+  "zohomail.com",
+  // Yandex
+  "yandex.com",
+  "yandex.ru",
+  // Fastmail (consumer)
+  "fastmail.com",
+  // HEY
+  "hey.com",
+  // Tutanota / Tuta
+  "tutanota.com",
+  "tuta.io",
+  // Other large consumer providers
+  "aim.com",
+  "hushmail.com",
+  "inbox.com",
+  // Regional consumer webmail
+  "qq.com",
+  "163.com",
+  "126.com",
+  "sina.com",
+  "naver.com",
+  "daum.net",
+  "web.de",
+  "t-online.de",
+  "orange.fr",
+  "free.fr",
+  "libero.it",
+  "mail.ru",
+]);
+
+/**
+ * Extract the lower-cased domain (everything after the last `@`) from an email
+ * address. Returns `undefined` for input with no `@` or an empty domain.
+ */
+export function extractEmailDomain(email: string): string | undefined {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return undefined;
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  return domain.length > 0 ? domain : undefined;
+}
+
+/** True when the email's domain is on the freemium/consumer denylist. */
+export function isFreemiumEmailDomain(email: string): boolean {
+  const domain = extractEmailDomain(email);
+  return domain !== undefined && FREEMIUM_EMAIL_DOMAINS.has(domain);
+}
+
+/**
+ * True when the email is a disposable/throwaway mailbox (or otherwise fails the
+ * `mailchecker` validity check). Delegates to `better-auth-harmony`'s
+ * `validateEmail` so we share the exact disposable-domain corpus the plugin
+ * blocks with.
+ */
+export function isDisposableEmail(email: string): boolean {
+  return !validateEmail(email);
+}
+
+/**
+ * Why an address was rejected, or `{ ok: true }` when it passes both denies.
+ * Disposable is checked first so a disposable freemium address reports the more
+ * specific structural reason.
+ */
+export type BusinessEmailVerdict =
+  | { ok: true }
+  | { ok: false; reason: "disposable" | "freemium" };
+
+/** Classify an address against the business-email policy. Pure, no throw. */
+export function classifyBusinessEmail(email: string): BusinessEmailVerdict {
+  if (isDisposableEmail(email)) return { ok: false, reason: "disposable" };
+  if (isFreemiumEmailDomain(email)) return { ok: false, reason: "freemium" };
+  return { ok: true };
+}
+
+/**
+ * Throw a typed {@link APIError} when `email` violates the business-email policy.
+ * No-op for an allowed business address (and for a null/empty email — Better
+ * Auth's own validation owns the "email required" case; we only judge domains).
+ *
+ * Called from `databaseHooks.user.create.before` so it gates EVERY signup path
+ * (web, social, MCP `start_trial`) identically. The throw aborts user creation;
+ * Better Auth serializes the `APIError` to a 400 whose body carries
+ * {@link BUSINESS_EMAIL_REQUIRED_CODE} + {@link BUSINESS_EMAIL_REQUIRED_MESSAGE}.
+ */
+export function assertBusinessEmail(email: string | null | undefined): void {
+  if (!email) return;
+  const verdict = classifyBusinessEmail(email);
+  if (verdict.ok) return;
+  throw new APIError("BAD_REQUEST", {
+    code: BUSINESS_EMAIL_REQUIRED_CODE,
+    message: BUSINESS_EMAIL_REQUIRED_MESSAGE,
+    reason: verdict.reason,
+  });
+}
+
+/**
+ * Recognize a business-email rejection on a caught error. Used by the MCP
+ * `start_trial` provisioner (#3649) to map the shared-signup-path failure to its
+ * typed `business_email_required` envelope. Matches on the stable
+ * {@link BUSINESS_EMAIL_REQUIRED_CODE}, not a message string, so it survives copy
+ * changes and harmony upgrades.
+ */
+export function isBusinessEmailRejection(err: unknown): boolean {
+  if (!(err instanceof APIError)) return false;
+  const body = err.body as { code?: unknown } | undefined;
+  return body?.code === BUSINESS_EMAIL_REQUIRED_CODE;
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -3130,17 +3130,25 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       user: {
         create: {
           before: async (user: User & Record<string, unknown>) => {
-            // Business-email-only signup (#3650, ADR-0018) — gate EVERY signup
-            // path (web, social, MCP start_trial) identically. Deliberately
-            // OUTSIDE the try/catch below: the rejection is an APIError that
-            // MUST propagate to abort user creation (Better Auth serializes it
-            // to a 400 with the typed `business_email_required` code), exactly
-            // like the session.create.before ban guard. Swallowing it here would
-            // silently admit disposable/freemium signups. Better Auth runs every
-            // create.before hook in sequence (this one plus emailHarmony's
-            // normalization hook); a throw from any of them aborts creation, so
-            // ordering between them doesn't matter here.
-            assertBusinessEmail(user.email);
+            // Business-email-only signup (#3650, ADR-0018) — gate EVERY SaaS
+            // signup path (web, social, MCP start_trial) identically. SaaS-only,
+            // mirroring `assignSaasTrial` above: business-email-only is a
+            // hosted-trial policy, and a self-hosted operator must be able to
+            // bootstrap with any `ATLAS_ADMIN_EMAIL` (a consumer domain
+            // included) without this hook rejecting their first-boot admin.
+            //
+            // Deliberately OUTSIDE the try/catch below: the rejection is an
+            // APIError that MUST propagate to abort user creation (Better Auth
+            // serializes it to a 400 with the typed `business_email_required`
+            // code), exactly like the session.create.before ban guard.
+            // Swallowing it here would silently admit disposable/freemium
+            // signups. Better Auth runs every create.before hook in sequence
+            // (this one plus emailHarmony's normalization hook); a throw from
+            // any of them aborts creation, so ordering between them doesn't
+            // matter here.
+            if (getConfig()?.deployMode === "saas") {
+              assertBusinessEmail(user.email);
+            }
 
             try {
               const decision = await computeBootstrapRole(user, {

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -20,6 +20,7 @@ import { emailOTP } from "better-auth/plugins/email-otp";
 // All pinned to ^1.6.x in package.json — update together (the peer-dep
 // constraint is exact-version per minor on the @better-auth/* side).
 import { apiKey } from "@better-auth/api-key";
+import { emailHarmony } from "better-auth-harmony";
 import { passkey } from "@better-auth/passkey";
 import { scim } from "@better-auth/scim";
 import { stripe as stripePlugin, type StripeOptions } from "@better-auth/stripe";
@@ -64,6 +65,7 @@ import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from
 import { blockNativeMemberRoleUpdate, blockNativeMemberRemoval } from "@atlas/api/lib/auth/org-member-guards";
 import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
+import { assertBusinessEmail } from "@atlas/api/lib/auth/business-email";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { userHasConsumedTrial, claimTrialGrant } from "@atlas/api/lib/billing/trial-eligibility";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
@@ -2173,6 +2175,20 @@ export function buildPlugins() {
   const plugins: any[] = [
     bearer(),
     apiKey(),
+    // Business-email-only signup (#3650, ADR-0018). `emailHarmony` contributes
+    // the unique `normalizedEmail` column + `+alias`/dot/case normalization —
+    // the teeth behind one-trial-per-user — and ships the `mailchecker`
+    // disposable-domain engine. We DISABLE its built-in route validation
+    // (`matchers.validation: []`) on purpose: a disposable address would
+    // otherwise be rejected here with the plugin's generic "Invalid email" 400,
+    // preempting the single typed `business_email_required` rejection we throw
+    // in `databaseHooks.user.create.before` (see `assertBusinessEmail` /
+    // business-email.ts). Disposable blocking still happens — through that hook,
+    // using emailHarmony's own `validateEmail` engine — so web and the MCP
+    // `start_trial` path get one actionable error / one typed envelope for both
+    // disposable AND freemium denies. The normalization databaseHook the plugin
+    // installs via `init()` is unaffected by the matcher and keeps running.
+    emailHarmony({ matchers: { validation: [] } }),
     // #3159 — the Better Auth `admin()` plugin was removed. It authorized the
     // caller by the raw `user.role` column (via `hasPermission`), which after
     // #2890 (single-role, platform-only) was a contained-but-live footgun: any
@@ -3114,6 +3130,18 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       user: {
         create: {
           before: async (user: User & Record<string, unknown>) => {
+            // Business-email-only signup (#3650, ADR-0018) — gate EVERY signup
+            // path (web, social, MCP start_trial) identically. Deliberately
+            // OUTSIDE the try/catch below: the rejection is an APIError that
+            // MUST propagate to abort user creation (Better Auth serializes it
+            // to a 400 with the typed `business_email_required` code), exactly
+            // like the session.create.before ban guard. Swallowing it here would
+            // silently admit disposable/freemium signups. Better Auth runs every
+            // create.before hook in sequence (this one plus emailHarmony's
+            // normalization hook); a throw from any of them aborts creation, so
+            // ordering between them doesn't matter here.
+            assertBusinessEmail(user.email);
+
             try {
               const decision = await computeBootstrapRole(user, {
                 adminEmail,

--- a/packages/api/src/lib/db/__tests__/migrate-pg-with-auth.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg-with-auth.test.ts
@@ -267,6 +267,46 @@ describeIfPg("migrate-pg-with-auth (real Postgres, Better Auth tables present)",
     PG_TEST_TIMEOUT_MS,
   );
 
+  // ── 0142 normalizedEmail unique-index — the one-trial-per-user "teeth" ──
+  //
+  // The whole premise of #3650: `+alias`/dot/case variants collapse to one
+  // normalizedEmail, so a duplicate signup trips a 23505 instead of minting a
+  // second trial. The migration adds the column + a UNIQUE index; this asserts
+  // BOTH halves of the index contract — duplicates reject, and NULLs (legacy
+  // rows that predate the column) stay distinct so they never collide.
+  it(
+    "0142: duplicate normalizedEmail rejects with 23505; NULL normalizedEmail rows stay distinct",
+    async () => {
+      // Two distinct rows that normalize to the same address must collide.
+      await pool.query(
+        `INSERT INTO "user" (id, email, "normalizedEmail") VALUES ($1, $2, $3)`,
+        ["u-0142-a", "John.Doe+trial@acme.com", "johndoe@acme.com"],
+      );
+      let duplicateError: { code?: string } | undefined;
+      try {
+        await pool.query(
+          `INSERT INTO "user" (id, email, "normalizedEmail") VALUES ($1, $2, $3)`,
+          ["u-0142-b", "johndoe@acme.com", "johndoe@acme.com"],
+        );
+      } catch (err) {
+        duplicateError = err as { code?: string };
+      }
+      expect(duplicateError?.code).toBe("23505");
+
+      // NULL normalizedEmail is distinct in a Postgres unique index — two legacy
+      // rows that predate the column must both insert without colliding.
+      await pool.query(
+        `INSERT INTO "user" (id, email) VALUES ($1, $2), ($3, $4)`,
+        ["u-0142-null-1", "legacy1@acme.com", "u-0142-null-2", "legacy2@acme.com"],
+      );
+      const legacy = await pool.query(
+        `SELECT id FROM "user" WHERE id IN ('u-0142-null-1', 'u-0142-null-2')`,
+      );
+      expect(legacy.rows).toHaveLength(2);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
   // ── 0048 FK constraint pins ──
   it(
     "0048: trusted_device FK to user enforces ON DELETE CASCADE",

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -163,7 +163,8 @@ describe("runMigrations", () => {
     //   Plus 0139 (learned_patterns.auto_promoted flag, PRD #3617 B-2, #3636) = 140.
     //   Plus 0140 (operator_integration_credentials, operator-tier app creds, #3704) = 141.
     //   Plus 0141 (stripe_teardown_pending durable teardown outbox, #3679) = 142.
-    expect(count).toBe(142);
+    //   Plus 0142 (user.normalizedEmail business-email/one-trial teeth, #3650) = 143.
+    expect(count).toBe(143);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -334,6 +335,7 @@ describe("runMigrations", () => {
         "0139_learned_patterns_auto_promoted.sql",
         "0140_operator_integration_credentials.sql",
         "0141_stripe_teardown_pending.sql",
+        "0142_user_normalized_email.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -977,6 +977,9 @@ export const MANAGED_AUTH_MIGRATIONS = [
   // Stripe webhook tier sync respects an active platform-admin plan grant
   // instead of clobbering it (#3427).
   "0132_org_plan_override.sql",
+  // Adds normalizedEmail (+ unique index) to Better Auth's "user" table for
+  // business-email-only signup / one-trial-per-user teeth (#3650).
+  "0142_user_normalized_email.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/migrations/0142_user_normalized_email.sql
+++ b/packages/api/src/lib/db/migrations/0142_user_normalized_email.sql
@@ -1,0 +1,43 @@
+-- 0142 — normalizedEmail column for business-email-only signup (#3650).
+--
+-- ALTERs the Better Auth-owned `user` table to add the `normalizedEmail`
+-- column the `better-auth-harmony` `emailHarmony` plugin writes (lower-cased,
+-- `+alias`/dot-collapsed address). The unique index is what restores teeth to
+-- the one-trial-per-user bound: `+alias`/dot/case variants collapse to one
+-- normalized value, so a duplicate signup trips a 23505 instead of minting a
+-- second trial. See ADR-0018.
+--
+-- In managed mode Better Auth's own migrator (`ctx.runMigrations()`) also
+-- materializes this column from the plugin's schema declaration and runs FIRST
+-- (see auth/migrate.ts runBootMigrations) — so the ADD COLUMN below is
+-- idempotent belt-and-suspenders, and the named UNIQUE INDEX pins the
+-- constraint deterministically regardless of how the plugin's auto-migration
+-- spells it.
+--
+-- In non-managed auth modes Better Auth never creates `user`, so the migration
+-- runner skips this file via MANAGED_AUTH_MIGRATIONS (see
+-- packages/api/src/lib/db/internal.ts). The Better Auth `user` table is not a
+-- Drizzle pgTable in db/schema.ts (Better Auth owns it), so there is no
+-- schema.ts mirror to add — same as 0061 (default_landing). scripts/
+-- check-schema-drift.sh only diffs CREATE TABLE statements, so an ALTER on a
+-- non-mirrored table is not drift.
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_name = 'user'
+      AND table_schema = current_schema()
+  ) THEN
+    RAISE EXCEPTION 'Atlas migration 0142 requires the "user" table to exist in the current schema. In managed auth mode, Better Auth migrations must run before Atlas migrations.';
+  END IF;
+END $$;
+
+ALTER TABLE "user"
+  ADD COLUMN IF NOT EXISTS "normalizedEmail" TEXT;
+
+-- Unique on the normalized address. NULLs are distinct in a Postgres unique
+-- index, so legacy rows that predate the column (NULL normalizedEmail) never
+-- collide with each other or with new signups.
+CREATE UNIQUE INDEX IF NOT EXISTS user_normalized_email_unique
+  ON "user" ("normalizedEmail");

--- a/packages/api/src/lib/db/migrations/0142_user_normalized_email.sql
+++ b/packages/api/src/lib/db/migrations/0142_user_normalized_email.sql
@@ -7,12 +7,15 @@
 -- normalized value, so a duplicate signup trips a 23505 instead of minting a
 -- second trial. See ADR-0018.
 --
--- In managed mode Better Auth's own migrator (`ctx.runMigrations()`) also
+-- In managed mode Better Auth's own migrator (`ctx.runMigrations()`) normally
 -- materializes this column from the plugin's schema declaration and runs FIRST
--- (see auth/migrate.ts runBootMigrations) — so the ADD COLUMN below is
--- idempotent belt-and-suspenders, and the named UNIQUE INDEX pins the
--- constraint deterministically regardless of how the plugin's auto-migration
--- spells it.
+-- (the server entry calls runBootMigrations before MigrationLive — see
+-- auth/migrate.ts) — so the ADD COLUMN below is idempotent, and the named
+-- UNIQUE INDEX pins the constraint deterministically regardless of how the
+-- plugin's auto-migration spells it. The `user`-table existence guard below is
+-- NOT decorative belt-and-suspenders: it is the primary safety net for the
+-- degenerate case where that ordering did not hold — it fails loud rather than
+-- silently ADDing a column to a non-existent table.
 --
 -- In non-managed auth modes Better Auth never creates `user`, so the migration
 -- runner skips this file via MANAGED_AUTH_MIGRATIONS (see


### PR DESCRIPTION
## What & why

Closes #3650 (v0.0.19 — Self-serve MCP Trial Signup; parent PRD #3646, [ADR-0018](../blob/main/docs/adr/0018-self-serve-trial-over-mcp.md)).

Makes Atlas signup **business-email only**, with **identical policy on web and the MCP `start_trial` path** — both provision through the same Better Auth signup (`databaseHooks.user.create.before`), so enforcing the policy in that one hook makes the two paths identical by construction. (#3649's provisioner only *calls* `signUpEmail`; it inherits this for free.)

Two hard denies, surfaced through a **single typed `business_email_required` rejection** (an `APIError` whose body carries the stable code) — one actionable message on the web form, one typed code for #3649's MCP envelope to map:

1. **Disposable / throwaway mailboxes** — `better-auth-harmony`'s `mailchecker` engine (50k+ domains).
2. **Freemium / consumer domains** (gmail, outlook, yahoo, icloud, proton, …) — a maintained denylist in code (`business-email.ts` → `FREEMIUM_EMAIL_DOMAINS`), relaxable later without a migration.

## How

- **`emailHarmony` wired into the Better Auth plugin array** for its structural value: the unique `normalizedEmail` column + `+alias`/dot/case normalization (the teeth behind one-trial-per-user — duplicate variants now trip the unique index instead of minting a second trial). Its built-in route validation is disabled (`matchers.validation: []`) so **both** denies route through our single typed rejection rather than the plugin's generic `"Invalid email"` 400; disposable blocking still happens through our hook using emailHarmony's own `validateEmail` engine. The normalization `databaseHook` (installed via the plugin's `init()`) is unaffected and keeps running.
- **Freemium denylist** enforced at the top of `databaseHooks.user.create.before`, deliberately **outside** the bootstrap try/catch so the `APIError` propagates and aborts creation (same pattern as the `session.create.before` ban guard).
- **`normalizedEmail` column** added via migration `0142_user_normalized_email.sql` (ALTER on Better Auth's `user` table + a named UNIQUE index; idempotent, validated against a real Postgres — first run, re-run, NULL-tolerance for legacy rows, and 23505 on a duplicate). Joined to `MANAGED_AUTH_MIGRATIONS` so the `migrate-pg` smoke skips it (the `user` table is Better Auth-owned). **No `schema.ts` mirror** is added because the `user` table is *not* a Drizzle `pgTable` (Better Auth owns it) — same as `0061_user_default_landing`; `check-schema-drift.sh` only diffs `CREATE TABLE`, so an ALTER on a non-mirrored table is not drift.
- **Web**: no web change needed — the signup form already renders `res.error.message`, so the actionable rejection message displays as-is.
- **Docs**: added a "Business-Email-Only Signup" section to `guides/signup.mdx` (notes the denylist location for self-hosted operators).

### On the issue's "schema.ts mirror" line
The issue/CLAUDE.md generic rule expects a `db/schema.ts` mirror for a new column. That rule targets Drizzle-owned `pgTable`s; the Better Auth `user` table is not mirrored in `schema.ts` (no BA tables are), so there is nothing to mirror into and a partial mirror would be dangerous (a future `drizzle-kit generate` would emit `DROP COLUMN`). This follows the established `0061` precedent. The uniqueness/index requested is enforced by the migration + the plugin schema field.

## Tests
- `business-email.test.ts` — disposable deny, freemium deny (exact-match, case-insensitive, no false-positive on `notgmail.com`), allowed business domain, null/empty no-op, typed-error contract, rejection classifier.
- `business-email-signup-wiring.test.ts` — emailHarmony present with a unique non-returned `normalizedEmail` field; normalization-collapse of `+alias`/dot/case variants; the composed `user.create.before` rejects freemium + disposable with the typed code and lets a business domain through.
- `migrate.test.ts` — updated migration count 142 → 143 + already-applied list.

## CI
All six gates green locally: lint · type · **full** `bun run test` (api 671 files + all other packages) · syncpack · template-drift · railway-watch. Migration SQL additionally validated against a real Postgres 16 (idempotent re-run, unique enforcement).

https://claude.ai/code/session_01N6wM1uJ4Eetd3xQNknyvho

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6wM1uJ4Eetd3xQNknyvho)_