### PR TITLE
feat(billing): claim-gated metering — withhold Atlas-token Q&A pre-claim (#3651)

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -378,6 +378,17 @@ It returns:
 
 Point your agent's MCP client at `connectUrl` to run the normal OAuth 2.1 + DCR + PKCE [connect flow](#path-a--in-product-wizard-recommended) and attach a hosted actor to the new workspace. The workspace starts in a short **unclaimed grace period** (`state: "grace"`) — setup (connect a datasource, build the semantic layer) and client-paid MCP querying work immediately; the full 14-day trial clock starts when you **claim** the account on the web (verify email → set a credential → accept ToS).
 
+#### Metered until claimed
+
+While the workspace is unclaimed, it is **metered**: everything you do over MCP keeps working (your own model pays — no Atlas tokens), but **Atlas-token Q&A is withheld**. Concretely:
+
+- **Open pre-claim:** `start_trial`, the datasource setup/lifecycle tools, `executeSQL`, `runMetric`, and the rest of the MCP surface. The client model pays for MCP querying, so it costs Atlas nothing.
+- **Withheld pre-claim:** Atlas-token Q&A on the web `/api/v1/query` endpoint, chat platforms, and the scheduler. These return a typed `claim_required` response carrying the claim URL (the web OTP interstitial) instead of an answer.
+
+**Claim the account on the web** — open the claim URL, enter the emailed one-time code to verify your email (never a magic link), set a credential or passkey, and accept the Terms. Verifying your email **is** the claim: it flips the workspace metered → full and starts the full 14-day trial clock. No payment is required. Once claimed, Atlas-token Q&A runs within the normal trial budget, and `checksBilling` MCP tool responses include the number of **trial days remaining**.
+
+See [Claiming a Self-Serve (MCP) Trial](/guides/signup#claiming-a-self-serve-mcp-trial) for the full claim flow. Note this is distinct from trial **expiry**: once a trial expires, every surface — MCP included — is blocked with `billing_blocked` until a paid subscription is added.
+
 ## Available tools
 
 The MCP server exposes six core semantic tools — two general-purpose and four typed accessors over the semantic layer — plus a set of admin [datasource lifecycle tools](#datasource-lifecycle-tools) covered below. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.

--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -217,6 +217,40 @@ For most self-serve deployments, the datasource URL comes from the onboarding fl
 
 ---
 
+## Claiming a Self-Serve (MCP) Trial
+
+<Callout type="info" title="SaaS only">
+Applies to workspaces provisioned over MCP by the `start_trial` tool (see [MCP](/guides/mcp#self-serve-trial-signup)). Web signups verify their email as part of the wizard, so they are already claimed.
+</Callout>
+
+A workspace created over MCP starts **unclaimed (metered)**. In that state:
+
+- **Setup** (connect a datasource, build the semantic layer) and **querying over MCP** (your own model pays — no Atlas tokens) work immediately.
+- **Atlas-token Q&A** — the web `/api/v1/query` endpoint, chat platforms, and the scheduler — is **withheld** until the account is claimed. A metered request returns a typed `claim_required` response carrying the **claim URL**:
+
+```json
+{
+  "error": "claim_required",
+  "message": "Asking Atlas questions of your data is paused until you claim this workspace…",
+  "claimUrl": "https://app.useatlas.dev/signup?email=you@acme.com",
+  "retryable": false
+}
+```
+
+**Claiming** = completing the post-signup OTP interstitial on the web: enter the emailed one-time code to verify your email (Atlas never uses magic links), set a credential or passkey, and accept the Terms. Verifying your email **is** the claim. On claim, Atlas:
+
+1. Flips the workspace from metered → full (Atlas-token Q&A is no longer withheld).
+2. Records the owner's `emailVerified` bit — the single signal the claim-gate keys on.
+3. **Starts the full 14-day trial clock** (`trial_ends_at = NOW() + 14 days`). Until claim, the workspace sits on a short unclaimed-grace window, so an abandoned signup can't squat on a free 14-day window.
+
+No payment is required to claim. After claim, Atlas-token Q&A runs within the normal trial budget, and MCP tool responses surface the number of trial days remaining.
+
+<Callout type="warn" title="Expired trials">
+Claiming is distinct from expiry. Once a trial **expires** (claimed or not), the workspace can neither query nor keep setting things up on **any** surface — web, chat, scheduler, **and** MCP — until a paid subscription makes it solvent again. Expiry is the conversion lever.
+</Callout>
+
+---
+
 ## After Signup
 
 Once a user completes onboarding:

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -21,7 +21,7 @@ import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
-import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
+import { ClaimRequiredError, ClaimCheckFailedError } from "@atlas/api/lib/billing/claim-gate";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
@@ -334,6 +334,24 @@ query.openapi(
                 message: err.message,
                 claimUrl: err.claimUrl,
                 retryable: false,
+                requestId,
+              },
+              err.httpStatus,
+            );
+          }
+
+          // Claim status couldn't be verified (lookup error) — fail closed as a
+          // retryable 503, NOT a token-spending allow and NOT a claim prompt.
+          if (err instanceof ClaimCheckFailedError) {
+            log.warn(
+              { requestId, errorCode: err.errorCode, category: "claim_check_failed" },
+              "Query blocked — claim status unverifiable",
+            );
+            return c.json(
+              {
+                error: err.errorCode,
+                message: err.message,
+                retryable: err.retryable,
                 requestId,
               },
               err.httpStatus,

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -21,6 +21,7 @@ import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
+import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
@@ -318,6 +319,26 @@ query.openapi(
           }, 200);
         } catch (err) {
           if (err instanceof HTTPException) throw err;
+
+          // ADR-0018 / #3651 — claim-gate block: an unclaimed (metered) trial
+          // Workspace must claim on the web before Atlas-token Q&A runs. Surface
+          // the typed `claim_required` envelope carrying the claim URL (403).
+          if (err instanceof ClaimRequiredError) {
+            log.warn(
+              { requestId, errorCode: err.errorCode, category: "claim_required" },
+              "Query blocked — workspace unclaimed",
+            );
+            return c.json(
+              {
+                error: err.errorCode,
+                message: err.message,
+                claimUrl: err.claimUrl,
+                retryable: false,
+                requestId,
+              },
+              err.httpStatus,
+            );
+          }
 
           // #3419/#3420 — billing-enforcement block from the seam in
           // `executeAgentQuery`. Map to the same envelope the inline

--- a/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
@@ -65,13 +65,27 @@ class ClaimRequiredErrorStub extends Error {
   }
 }
 
-type ClaimResult = { allowed: true } | { allowed: false; claimUrl: string };
+class ClaimCheckFailedErrorStub extends Error {
+  override readonly name = "ClaimCheckFailedError";
+  readonly errorCode = "claim_check_failed" as const;
+  readonly httpStatus = 503 as const;
+  readonly retryable = true as const;
+  constructor() {
+    super("Unable to verify your workspace's claim status. Please try again.");
+  }
+}
+
+type ClaimResult =
+  | { allowed: true }
+  | { allowed: false; reason: "claim_required"; claimUrl: string }
+  | { allowed: false; reason: "check_failed" };
 let claimResult: ClaimResult = { allowed: true };
 const mockCheckClaimGate = mock(async (_orgId: string | undefined) => claimResult);
 
 mock.module("@atlas/api/lib/billing/claim-gate", () => ({
   checkClaimGate: mockCheckClaimGate,
   ClaimRequiredError: ClaimRequiredErrorStub,
+  ClaimCheckFailedError: ClaimCheckFailedErrorStub,
   buildClaimUrl: (email?: string) => `https://app.useatlas.dev/signup${email ? `?email=${email}` : ""}`,
 }));
 
@@ -97,7 +111,7 @@ describe("executeAgentQuery claim-gate seam", () => {
   });
 
   it("throws ClaimRequiredError and never runs the agent when unclaimed", async () => {
-    claimResult = { allowed: false, claimUrl: "https://app.useatlas.dev/signup?email=owner@acme.com" };
+    claimResult = { allowed: false, reason: "claim_required", claimUrl: "https://app.useatlas.dev/signup?email=owner@acme.com" };
     const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
       activeOrganizationId: "org-metered",
     });
@@ -124,6 +138,24 @@ describe("executeAgentQuery claim-gate seam", () => {
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("fails CLOSED with ClaimCheckFailedError (no agent spend) when claim status can't be verified", async () => {
+    claimResult = { allowed: false, reason: "check_failed" };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-unknown",
+    });
+    const err: unknown = await executeAgentQuery("question", "req-5", { actor }).then(
+      () => {
+        throw new Error("expected executeAgentQuery to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ClaimCheckFailedErrorStub);
+    if (!(err instanceof ClaimCheckFailedErrorStub)) throw new Error("unreachable");
+    expect(err.errorCode).toBe("claim_check_failed");
+    expect(err.httpStatus).toBe(503);
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
   // AC5/AC7 (#3651) — an EXPIRED trial blocks via Gate 0 (`trial_expired`)
   // BEFORE the claim-gate runs, so expiry overrides the meter: an
   // unclaimed-AND-expired workspace gets `trial_expired` (block + pay), never
@@ -139,7 +171,7 @@ describe("executeAgentQuery claim-gate seam", () => {
       retryable: false,
     };
     // Even if the workspace is also unclaimed, expiry must win.
-    claimResult = { allowed: false, claimUrl: "https://app.useatlas.dev/signup" };
+    claimResult = { allowed: false, reason: "claim_required", claimUrl: "https://app.useatlas.dev/signup" };
     const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
       activeOrganizationId: "org-expired",
     });

--- a/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
@@ -22,11 +22,34 @@ mock.module("@atlas/api/lib/agent", () => ({
   runAgent: mockRunAgent,
 }));
 
-// Gate 0 always allows here — we are isolating the claim-gate. (The expiry
-// block via Gate 0 is covered in agent-query-billing.test.ts.)
+// Gate 0 result is controllable so we can assert the expiry block precedes
+// (and overrides) the claim-gate. Default: allow.
+class BillingBlockedErrorStub extends Error {
+  override readonly name = "BillingBlockedError";
+  readonly errorCode: string;
+  readonly httpStatus: number;
+  readonly retryable: boolean;
+  readonly retryAfterSeconds: number | undefined;
+  readonly usage: undefined;
+  constructor(block: { errorCode: string; errorMessage: string; httpStatus: number; retryable: boolean }) {
+    super(block.errorMessage);
+    this.errorCode = block.errorCode;
+    this.httpStatus = block.httpStatus;
+    this.retryable = block.retryable;
+    this.retryAfterSeconds = undefined;
+    this.usage = undefined;
+  }
+}
+
+type GateResult =
+  | { allowed: true }
+  | { allowed: false; errorCode: string; errorMessage: string; httpStatus: number; retryable: boolean };
+let gateResult: GateResult = { allowed: true };
+const mockCheckAgentBillingGate = mock(async (_orgId: string | undefined) => gateResult);
+
 mock.module("@atlas/api/lib/billing/agent-gate", () => ({
-  checkAgentBillingGate: mock(async () => ({ allowed: true })),
-  BillingBlockedError: class extends Error {},
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: BillingBlockedErrorStub,
 }));
 
 // Faithful stand-in — `executeAgentQuery` throws this; callers narrow via
@@ -58,8 +81,10 @@ const { createAtlasUser } = await import("@atlas/api/lib/auth/types");
 describe("executeAgentQuery claim-gate seam", () => {
   beforeEach(() => {
     claimResult = { allowed: true };
+    gateResult = { allowed: true };
     mockRunAgent.mockClear();
     mockCheckClaimGate.mockClear();
+    mockCheckAgentBillingGate.mockClear();
   });
 
   it("consults the claim-gate with the actor's org", async () => {
@@ -97,5 +122,38 @@ describe("executeAgentQuery claim-gate seam", () => {
     const result = await executeAgentQuery("question", "req-3", { actor });
     expect(result.answer).toBe("answer");
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  // AC5/AC7 (#3651) — an EXPIRED trial blocks via Gate 0 (`trial_expired`)
+  // BEFORE the claim-gate runs, so expiry overrides the meter: an
+  // unclaimed-AND-expired workspace gets `trial_expired` (block + pay), never
+  // `claim_required`. This pins the gate ordering this feature introduced;
+  // the cross-surface expiry block (setup + MCP) is covered by Gate 0's own
+  // tests (billing/agent-gate, mcp tools/dispatch-gate/datasource-tools).
+  it("expired trial blocks at Gate 0 before the claim-gate is consulted (expiry overrides metering)", async () => {
+    gateResult = {
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+      httpStatus: 403,
+      retryable: false,
+    };
+    // Even if the workspace is also unclaimed, expiry must win.
+    claimResult = { allowed: false, claimUrl: "https://app.useatlas.dev/signup" };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-expired",
+    });
+    const err: unknown = await executeAgentQuery("question", "req-4", { actor }).then(
+      () => {
+        throw new Error("expected executeAgentQuery to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(BillingBlockedErrorStub);
+    if (!(err instanceof BillingBlockedErrorStub)) throw new Error("unreachable");
+    expect(err.errorCode).toBe("trial_expired");
+    // Claim-gate never consulted — Gate 0 short-circuited first.
+    expect(mockCheckClaimGate).not.toHaveBeenCalled();
+    expect(mockRunAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-claim-gate.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the claim-gate seam in `executeAgentQuery` (ADR-0018 / #3651).
+ *
+ * Pins the contract that the metered claim-gate is consulted AFTER Gate 0 on
+ * the Atlas-token path, and that a block throws `ClaimRequiredError` (carrying
+ * the claim URL) with ZERO agent spend — while an allowed (claimed) workspace
+ * runs the agent normally. The gate's own block-vs-allow matrix lives in
+ * `billing/__tests__/claim-gate.test.ts`; here it is mocked at the module
+ * boundary, alongside an always-allow billing gate so the two seams are
+ * independent.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockRunAgent = mock(async () => ({
+  text: Promise.resolve("answer"),
+  steps: Promise.resolve([]),
+  totalUsage: Promise.resolve({ inputTokens: 10, outputTokens: 5 }),
+}));
+
+mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: mockRunAgent,
+}));
+
+// Gate 0 always allows here — we are isolating the claim-gate. (The expiry
+// block via Gate 0 is covered in agent-query-billing.test.ts.)
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mock(async () => ({ allowed: true })),
+  BillingBlockedError: class extends Error {},
+}));
+
+// Faithful stand-in — `executeAgentQuery` throws this; callers narrow via
+// `instanceof`.
+class ClaimRequiredErrorStub extends Error {
+  override readonly name = "ClaimRequiredError";
+  readonly errorCode = "claim_required" as const;
+  readonly httpStatus = 403 as const;
+  readonly claimUrl: string;
+  constructor(claimUrl: string) {
+    super(`claim required: ${claimUrl}`);
+    this.claimUrl = claimUrl;
+  }
+}
+
+type ClaimResult = { allowed: true } | { allowed: false; claimUrl: string };
+let claimResult: ClaimResult = { allowed: true };
+const mockCheckClaimGate = mock(async (_orgId: string | undefined) => claimResult);
+
+mock.module("@atlas/api/lib/billing/claim-gate", () => ({
+  checkClaimGate: mockCheckClaimGate,
+  ClaimRequiredError: ClaimRequiredErrorStub,
+  buildClaimUrl: (email?: string) => `https://app.useatlas.dev/signup${email ? `?email=${email}` : ""}`,
+}));
+
+const { executeAgentQuery } = await import("@atlas/api/lib/agent-query");
+const { createAtlasUser } = await import("@atlas/api/lib/auth/types");
+
+describe("executeAgentQuery claim-gate seam", () => {
+  beforeEach(() => {
+    claimResult = { allowed: true };
+    mockRunAgent.mockClear();
+    mockCheckClaimGate.mockClear();
+  });
+
+  it("consults the claim-gate with the actor's org", async () => {
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-1",
+    });
+    await executeAgentQuery("how many customers?", "req-1", { actor });
+    expect(mockCheckClaimGate).toHaveBeenCalledWith("org-1");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws ClaimRequiredError and never runs the agent when unclaimed", async () => {
+    claimResult = { allowed: false, claimUrl: "https://app.useatlas.dev/signup?email=owner@acme.com" };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-metered",
+    });
+    const err: unknown = await executeAgentQuery("question", "req-2", { actor }).then(
+      () => {
+        throw new Error("expected executeAgentQuery to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ClaimRequiredErrorStub);
+    if (!(err instanceof ClaimRequiredErrorStub)) throw new Error("unreachable");
+    expect(err.claimUrl).toContain("/signup");
+    expect(err.errorCode).toBe("claim_required");
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  it("runs the agent normally once the workspace is claimed (gate allows)", async () => {
+    claimResult = { allowed: true };
+    const actor = createAtlasUser("user-1", "managed", "user-1@example.com", {
+      activeOrganizationId: "org-claimed",
+    });
+    const result = await executeAgentQuery("question", "req-3", { actor });
+    expect(result.answer).toBe("answer");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -10,6 +10,7 @@ import { runAgent } from "@atlas/api/lib/agent";
 import { createLogger, getRequestContext, withRequestContext } from "@atlas/api/lib/logger";
 import type { ActorKind, RequestActor } from "@atlas/api/lib/logger";
 import { checkAgentBillingGate, BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
+import { checkClaimGate, ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
 import type { PlanLimitWarning } from "@atlas/api/lib/billing/enforcement";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import type { ApprovalRequestOrigin } from "@useatlas/types";
@@ -193,6 +194,22 @@ export async function executeAgentQuery(
         "Agent run blocked by billing enforcement",
       );
       throw new BillingBlockedError(gate);
+    }
+
+    // ADR-0018 / #3651 — claim-gated metering. AFTER Gate 0 (solvency), an
+    // unclaimed (metered) trial Workspace withholds Atlas-token Q&A until a
+    // human claims it on the web. Keyed on the owner's `emailVerified` bit and
+    // placed HERE on the Atlas-token-spending path only — NOT in Gate 0, which
+    // every MCP `checksBilling` tool (incl. setup) routes through, so MCP
+    // executeSQL + setup stay open pre-claim (client model pays, no Atlas
+    // tokens). Off-SaaS / no-org / claimed workspaces pass through untouched.
+    const claim = await checkClaimGate(gateOrgId);
+    if (!claim.allowed) {
+      log.warn(
+        { requestId: id, orgId: gateOrgId, ...(origin ? { agentOrigin: origin } : {}) },
+        "Agent run blocked: workspace unclaimed (claim required)",
+      );
+      throw new ClaimRequiredError(claim.claimUrl);
     }
 
     const priorUIMessages = (options?.priorMessages ?? []).map((m, i) => ({

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -10,7 +10,7 @@ import { runAgent } from "@atlas/api/lib/agent";
 import { createLogger, getRequestContext, withRequestContext } from "@atlas/api/lib/logger";
 import type { ActorKind, RequestActor } from "@atlas/api/lib/logger";
 import { checkAgentBillingGate, BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
-import { checkClaimGate, ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
+import { checkClaimGate, ClaimRequiredError, ClaimCheckFailedError } from "@atlas/api/lib/billing/claim-gate";
 import type { PlanLimitWarning } from "@atlas/api/lib/billing/enforcement";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import type { ApprovalRequestOrigin } from "@useatlas/types";
@@ -205,6 +205,16 @@ export async function executeAgentQuery(
     // tokens). Off-SaaS / no-org / claimed workspaces pass through untouched.
     const claim = await checkClaimGate(gateOrgId);
     if (!claim.allowed) {
+      if (claim.reason === "check_failed") {
+        // Fail closed: claim status couldn't be determined (lookup error).
+        // Surface a retryable 503 rather than spend Atlas tokens on an
+        // unverifiable workspace.
+        log.warn(
+          { requestId: id, orgId: gateOrgId, ...(origin ? { agentOrigin: origin } : {}) },
+          "Agent run blocked: claim status could not be verified",
+        );
+        throw new ClaimCheckFailedError();
+      }
       log.warn(
         { requestId: id, orgId: gateOrgId, ...(origin ? { agentOrigin: origin } : {}) },
         "Agent run blocked: workspace unclaimed (claim required)",

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -67,7 +67,7 @@ import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
 import { assertBusinessEmail } from "@atlas/api/lib/auth/business-email";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
-import { userHasConsumedTrial, claimTrialGrant } from "@atlas/api/lib/billing/trial-eligibility";
+import { userHasConsumedTrial, claimTrialGrant, extendTrialOnClaim } from "@atlas/api/lib/billing/trial-eligibility";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import {
@@ -2991,6 +2991,34 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       // Re-issue a verification code whenever an unverified user attempts
       // sign-in. The plugin's override turns this into an OTP send.
       sendOnSignIn: true,
+      // ADR-0018 / #3651 — verifying email IS the claim. The emailOTP plugin's
+      // verify route calls this after flipping `emailVerified` (never on a
+      // magic-link path — there is none). Start the full 14-day trial clock for
+      // any unclaimed grace-window trial this user owns (metered → full). The
+      // claim-gate keyed on `emailVerified` then lets Atlas-token Q&A through on
+      // the next request. SaaS-only, mirroring `assignSaasTrial`.
+      afterEmailVerification: async (user: User) => {
+        try {
+          if (!hasInternalDB()) return;
+          if (getConfig()?.deployMode !== "saas") return;
+          const extended = await extendTrialOnClaim(user.id);
+          for (const orgId of extended) invalidatePlanCache(orgId);
+          if (extended.length > 0) {
+            log.info(
+              { userId: user.id, orgIds: extended },
+              "Trial claimed via email verification — started full trial clock",
+            );
+          }
+        } catch (err) {
+          // log.error: a sustained failure here means a claimed user stays on
+          // the short grace window and gets reaped early. Verification itself
+          // is unaffected (the hook's throw is swallowed here).
+          log.error(
+            { err: errorMessage(err), userId: user.id },
+            "Failed to start trial clock on claim — workspace stays on grace window",
+          );
+        }
+      },
     },
     socialProviders: deps.socialProviders,
     // F-07 — cookieCache.maxAge bounds the revocation window. Previously

--- a/packages/api/src/lib/billing/__tests__/claim-gate.test.ts
+++ b/packages/api/src/lib/billing/__tests__/claim-gate.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { checkClaimGate, buildClaimUrl, ClaimRequiredError, type ClaimGateDeps } from "../claim-gate";
+import { checkClaimGate, buildClaimUrl, ClaimRequiredError, ClaimCheckFailedError, type ClaimGateDeps } from "../claim-gate";
 import type { PlanTier, WorkspaceRow } from "@atlas/api/lib/db/internal";
 
 function workspace(tier: PlanTier): WorkspaceRow {
@@ -45,10 +45,12 @@ function deps(overrides: Partial<ClaimGateDeps>): Partial<ClaimGateDeps> {
 }
 
 describe("checkClaimGate — block-vs-allow matrix", () => {
-  it("BLOCKS an unclaimed (owner emailVerified=false) SaaS trial", async () => {
+  it("BLOCKS an unclaimed (owner emailVerified=false) SaaS trial with claim_required", async () => {
     const result = await checkClaimGate("org-1", deps({}));
     expect(result.allowed).toBe(false);
     if (result.allowed) throw new Error("unreachable");
+    expect(result.reason).toBe("claim_required");
+    if (result.reason !== "claim_required") throw new Error("unreachable");
     expect(result.claimUrl).toContain("/signup");
     expect(result.claimUrl).toContain("owner@acme.com");
   });
@@ -93,7 +95,7 @@ describe("checkClaimGate — block-vs-allow matrix", () => {
     expect(result.allowed).toBe(true);
   });
 
-  it("fails OPEN (allows) when the owner lookup throws — metering refinement, Gate 0 owns solvency (#3428)", async () => {
+  it("fails CLOSED (check_failed) when the owner lookup throws — no token spend on an unverifiable workspace", async () => {
     const result = await checkClaimGate(
       "org-1",
       deps({
@@ -102,10 +104,12 @@ describe("checkClaimGate — block-vs-allow matrix", () => {
         },
       }),
     );
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("unreachable");
+    expect(result.reason).toBe("check_failed");
   });
 
-  it("fails OPEN (allows) when the workspace lookup throws", async () => {
+  it("fails CLOSED (check_failed) when the workspace lookup throws", async () => {
     const result = await checkClaimGate(
       "org-1",
       deps({
@@ -114,7 +118,9 @@ describe("checkClaimGate — block-vs-allow matrix", () => {
         },
       }),
     );
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("unreachable");
+    expect(result.reason).toBe("check_failed");
   });
 });
 
@@ -127,6 +133,18 @@ describe("ClaimRequiredError", () => {
     expect(err.httpStatus).toBe(403);
     expect(err.claimUrl).toBe("https://app.useatlas.dev/signup");
     expect(err.message).toContain("https://app.useatlas.dev/signup");
+  });
+});
+
+describe("ClaimCheckFailedError", () => {
+  it("is a retryable 503 / claim_check_failed with no claim URL", () => {
+    const err = new ClaimCheckFailedError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ClaimCheckFailedError");
+    expect(err.errorCode).toBe("claim_check_failed");
+    expect(err.httpStatus).toBe(503);
+    expect(err.retryable).toBe(true);
+    expect(err.message).toContain("try again");
   });
 });
 

--- a/packages/api/src/lib/billing/__tests__/claim-gate.test.ts
+++ b/packages/api/src/lib/billing/__tests__/claim-gate.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the claim-gated metering seam (ADR-0018 / #3651).
+ *
+ * The claim-gate withholds Atlas-token Q&A from an UNCLAIMED (metered) trial
+ * Workspace — keyed on the owner's `emailVerified` bit — without touching Gate 0
+ * (solvency) or the MCP `checksBilling` setup/query tools. These tests pin the
+ * block-vs-allow matrix using the injectable-deps seam (no `mock.module`), so
+ * the policy is exercised in isolation from the DB and config.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { checkClaimGate, buildClaimUrl, ClaimRequiredError, type ClaimGateDeps } from "../claim-gate";
+import type { PlanTier, WorkspaceRow } from "@atlas/api/lib/db/internal";
+
+function workspace(tier: PlanTier): WorkspaceRow {
+  return {
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    workspace_status: "active",
+    plan_tier: tier,
+    byot: false,
+    stripe_customer_id: null,
+    trial_ends_at: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+    suspended_at: null,
+    suspension_source: null,
+    plan_override_until: null,
+    deleted_at: null,
+    region: null,
+    region_assigned_at: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/** SaaS + internal-DB defaults with a configurable workspace/owner. */
+function deps(overrides: Partial<ClaimGateDeps>): Partial<ClaimGateDeps> {
+  return {
+    getDeployMode: () => "saas",
+    hasInternalDB: () => true,
+    getWorkspace: async () => workspace("trial"),
+    getOwnerVerification: async () => ({ emailVerified: false, email: "owner@acme.com" }),
+    buildClaimUrl: (email) => `https://app.useatlas.dev/signup${email ? `?email=${email}` : ""}`,
+    ...overrides,
+  };
+}
+
+describe("checkClaimGate — block-vs-allow matrix", () => {
+  it("BLOCKS an unclaimed (owner emailVerified=false) SaaS trial", async () => {
+    const result = await checkClaimGate("org-1", deps({}));
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("unreachable");
+    expect(result.claimUrl).toContain("/signup");
+    expect(result.claimUrl).toContain("owner@acme.com");
+  });
+
+  it("ALLOWS once the owner's email is verified (claimed)", async () => {
+    const result = await checkClaimGate(
+      "org-1",
+      deps({ getOwnerVerification: async () => ({ emailVerified: true, email: "owner@acme.com" }) }),
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ALLOWS a paid tier even with an unverified owner (never metered)", async () => {
+    for (const tier of ["starter", "pro", "business", "locked", "free"] as const) {
+      const result = await checkClaimGate("org-1", deps({ getWorkspace: async () => workspace(tier) }));
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it("ALLOWS off-SaaS (self-hosted) regardless of verification", async () => {
+    const result = await checkClaimGate("org-1", deps({ getDeployMode: () => "self-hosted" }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ALLOWS when there is no internal DB", async () => {
+    const result = await checkClaimGate("org-1", deps({ hasInternalDB: () => false }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ALLOWS when no org is bound (self-hosted / CLI)", async () => {
+    const result = await checkClaimGate(undefined, deps({}));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ALLOWS when the workspace row is absent (pre-migration)", async () => {
+    const result = await checkClaimGate("org-1", deps({ getWorkspace: async () => null }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ALLOWS when no owner membership row exists (defensive)", async () => {
+    const result = await checkClaimGate("org-1", deps({ getOwnerVerification: async () => null }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("fails OPEN (allows) when the owner lookup throws — metering refinement, Gate 0 owns solvency (#3428)", async () => {
+    const result = await checkClaimGate(
+      "org-1",
+      deps({
+        getOwnerVerification: async () => {
+          throw new Error("db down");
+        },
+      }),
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it("fails OPEN (allows) when the workspace lookup throws", async () => {
+    const result = await checkClaimGate(
+      "org-1",
+      deps({
+        getWorkspace: async () => {
+          throw new Error("db down");
+        },
+      }),
+    );
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("ClaimRequiredError", () => {
+  it("carries the claim URL and a 403 / claim_required code", () => {
+    const err = new ClaimRequiredError("https://app.useatlas.dev/signup");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ClaimRequiredError");
+    expect(err.errorCode).toBe("claim_required");
+    expect(err.httpStatus).toBe(403);
+    expect(err.claimUrl).toBe("https://app.useatlas.dev/signup");
+    expect(err.message).toContain("https://app.useatlas.dev/signup");
+  });
+});
+
+describe("buildClaimUrl", () => {
+  it("returns a relative /signup path when no web origin is configured", () => {
+    // No ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS in the test env.
+    const url = buildClaimUrl();
+    expect(url.endsWith("/signup")).toBe(true);
+  });
+
+  it("encodes the email into the path when no origin is configured", () => {
+    const url = buildClaimUrl("a+b@acme.com");
+    expect(url).toContain("/signup?email=");
+    expect(url).toContain(encodeURIComponent("a+b@acme.com"));
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/extend-trial-on-claim.test.ts
+++ b/packages/api/src/lib/billing/__tests__/extend-trial-on-claim.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the claim flip (ADR-0018 / #3651): `extendTrialOnClaim`.
+ *
+ * When a user claims their account (completes the web OTP interstitial,
+ * flipping `emailVerified`), the full 14-day trial clock starts. This pins:
+ *   - The guarded UPDATE extends `trial_ends_at` to ~NOW() + TRIAL_DAYS.
+ *   - It is scoped to the user's OWNED, `trial`-tier, still-in-grace
+ *     Workspaces (owner role + grace-window guard), so a full-window web trial
+ *     and an already-claimed trial are left untouched (idempotent).
+ *   - It returns the extended org ids (for plan-cache invalidation).
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { TRIAL_DAYS, TRIAL_GRACE_HOURS } from "@atlas/api/lib/billing/plans";
+import { extendTrialOnClaim } from "../trial-eligibility";
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+function makeMockPool(returnedIds: string[]): {
+  pool: InternalPool;
+  queries: Array<{ sql: string; params?: unknown[] }>;
+} {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      return { rows: returnedIds.map((id) => ({ id })), rowCount: returnedIds.length };
+    },
+  } as unknown as InternalPool;
+  return { pool, queries };
+}
+
+describe("extendTrialOnClaim", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://test/test";
+  });
+
+  afterAll(() => {
+    _resetPool(null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  });
+
+  it("extends trial_ends_at to ~NOW() + TRIAL_DAYS, guarded on owner + trial + grace window", async () => {
+    const { pool, queries } = makeMockPool(["org-1"]);
+    _resetPool(pool);
+
+    const before = Date.now();
+    const extended = await extendTrialOnClaim("user-1");
+    const after = Date.now();
+
+    expect(extended).toEqual(["org-1"]);
+    expect(queries).toHaveLength(1);
+
+    const q = queries[0];
+    // Guards: owner role, trial tier, grace-window upper bound.
+    expect(q.sql).toMatch(/UPDATE\s+organization/i);
+    expect(q.sql).toMatch(/role\s*=\s*'owner'/i);
+    expect(q.sql).toMatch(/plan_tier\s*=\s*'trial'/i);
+    expect(q.sql).toMatch(/trial_ends_at\s*<=\s*\$3/i);
+    expect(q.sql).toMatch(/RETURNING\s+o\.id/i);
+
+    const [userId, newEnds, graceHorizon] = q.params as [string, string, string];
+    expect(userId).toBe("user-1");
+
+    // New end ≈ NOW() + 14d.
+    const newEndsMs = new Date(newEnds).getTime();
+    expect(newEndsMs).toBeGreaterThanOrEqual(before + TRIAL_DAYS * DAY_MS - 1000);
+    expect(newEndsMs).toBeLessThanOrEqual(after + TRIAL_DAYS * DAY_MS + 1000);
+
+    // Grace horizon ≈ NOW() + 72h — the upper bound that scopes the extension
+    // to still-unclaimed grace workspaces (web full-window trials sit above it).
+    const graceMs = new Date(graceHorizon).getTime();
+    expect(graceMs).toBeGreaterThanOrEqual(before + TRIAL_GRACE_HOURS * HOUR_MS - 1000);
+    expect(graceMs).toBeLessThanOrEqual(after + TRIAL_GRACE_HOURS * HOUR_MS + 1000);
+    // The grace horizon must be well below the new full-window end, or the
+    // guard would re-extend already-claimed trials.
+    expect(graceMs).toBeLessThan(newEndsMs);
+  });
+
+  it("returns an empty list when no owned grace-window trial matches (idempotent no-op)", async () => {
+    const { pool, queries } = makeMockPool([]);
+    _resetPool(pool);
+    const extended = await extendTrialOnClaim("user-no-trial");
+    expect(extended).toEqual([]);
+    expect(queries).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/trial-days-remaining.test.ts
+++ b/packages/api/src/lib/billing/__tests__/trial-days-remaining.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for `getTrialDaysRemaining` (ADR-0018 / #3651) — the days-remaining
+ * value surfaced in MCP tool responses post-claim. Uses the injected mock pool
+ * so the workspace read is deterministic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { invalidatePlanCache, getTrialDaysRemaining } from "../enforcement";
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function poolFor(workspaceRow: Record<string, unknown> | null): InternalPool {
+  return {
+    query: async () => ({
+      rows: workspaceRow ? [workspaceRow] : [],
+      rowCount: workspaceRow ? 1 : 0,
+    }),
+  } as unknown as InternalPool;
+}
+
+function trialWorkspace(trialEndsAt: string | null): Record<string, unknown> {
+  return {
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    workspace_status: "active",
+    plan_tier: "trial",
+    byot: false,
+    stripe_customer_id: null,
+    trial_ends_at: trialEndsAt,
+    suspended_at: null,
+    suspension_source: null,
+    plan_override_until: null,
+    deleted_at: null,
+    region: null,
+    region_assigned_at: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("getTrialDaysRemaining", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://test/test";
+    invalidatePlanCache(); // drop any cached workspace from a prior test
+  });
+
+  afterEach(() => {
+    invalidatePlanCache();
+  });
+
+  afterAll(() => {
+    _resetPool(null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  });
+
+  it("returns whole days until trial_ends_at for a trial workspace", async () => {
+    _resetPool(poolFor(trialWorkspace(new Date(Date.now() + 5 * DAY_MS - 1000).toISOString())));
+    const days = await getTrialDaysRemaining("org-1");
+    expect(days).toBe(5);
+  });
+
+  it("floors a lapsed trial at 0 (never negative)", async () => {
+    _resetPool(poolFor(trialWorkspace(new Date(Date.now() - 2 * DAY_MS).toISOString())));
+    const days = await getTrialDaysRemaining("org-lapsed");
+    expect(days).toBe(0);
+  });
+
+  it("returns null for a non-trial workspace", async () => {
+    _resetPool(poolFor({ ...trialWorkspace(null), plan_tier: "pro" }));
+    const days = await getTrialDaysRemaining("org-pro");
+    expect(days).toBeNull();
+  });
+
+  it("returns null with no org", async () => {
+    expect(await getTrialDaysRemaining(undefined)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/billing/claim-gate.ts
+++ b/packages/api/src/lib/billing/claim-gate.ts
@@ -81,9 +81,30 @@ export class ClaimRequiredError extends Error {
   }
 }
 
+/**
+ * Thrown when the claim-gate cannot DETERMINE claim status because a lookup
+ * failed (e.g. the owner-`emailVerified` query errored transiently). The gate
+ * FAILS CLOSED: rather than allow an unclaimed workspace to spend Atlas tokens
+ * on a blip (a false-negative on a metering gate — CLAUDE.md: "Return 500, not
+ * a false negative"), it surfaces a retryable 503 "try again". Distinct from
+ * {@link ClaimRequiredError} so a genuinely-claimed user is told to retry, not
+ * misdirected to re-claim.
+ */
+export class ClaimCheckFailedError extends Error {
+  override readonly name = "ClaimCheckFailedError";
+  readonly errorCode = "claim_check_failed" as const;
+  readonly httpStatus = 503 as const;
+  readonly retryable = true as const;
+
+  constructor() {
+    super("Unable to verify your workspace's claim status. Please try again.");
+  }
+}
+
 export type ClaimGateResult =
   | { allowed: true }
-  | { allowed: false; claimUrl: string };
+  | { allowed: false; reason: "claim_required"; claimUrl: string }
+  | { allowed: false; reason: "check_failed" };
 
 /** Owner-verification shape resolved per org. */
 interface OwnerVerification {
@@ -142,15 +163,23 @@ function isMeterableTier(tier: PlanTier): boolean {
 
 /**
  * Decide whether the metered claim-gate blocks an Atlas-token agent run for
- * `orgId`. Returns `{ allowed: true }` for every non-metered case and
- * `{ allowed: false, claimUrl }` only for an unclaimed (owner `emailVerified`
- * false) `trial` Workspace on SaaS.
+ * `orgId`. Returns `{ allowed: true }` for every non-metered case,
+ * `{ allowed: false, reason: "claim_required", claimUrl }` for an unclaimed
+ * (owner `emailVerified` false) `trial` Workspace on SaaS, and
+ * `{ allowed: false, reason: "check_failed" }` when a lookup errored and claim
+ * status can't be determined.
  *
  * Short-circuits to `allowed` when: no org (self-hosted / CLI), no internal DB,
  * not SaaS, the workspace row is absent, the tier isn't metered, or no owner
  * row exists. The expiry/solvency concerns (`trial_expired`, `locked`,
  * suspension, hard-cap) are NOT this gate's job — Gate 0
  * (`checkAgentBillingGate`) runs first and owns them on every surface.
+ *
+ * FAILS CLOSED on a lookup error: a metering gate that returned `allowed` on a
+ * DB blip would be a false-negative (let an unclaimed workspace spend Atlas
+ * tokens), which CLAUDE.md forbids ("Return 500, not a false negative"). The
+ * caller surfaces `check_failed` as a retryable 503 — no token spend, and no
+ * misdirecting an already-claimed user to "re-claim".
  */
 export async function checkClaimGate(
   orgId: string | undefined,
@@ -166,19 +195,15 @@ export async function checkClaimGate(
   try {
     // Gate 0 (`checkAgentBillingGate`) already warmed this cache on the
     // `executeAgentQuery` path, so this is a cache hit. A genuine lookup error
-    // would have failed Gate 0 closed (503) before we ever got here.
+    // would have failed Gate 0 closed (503) before we ever got here; fail
+    // closed here too rather than let an unclaimed workspace through.
     workspace = await deps.getWorkspace(orgId);
   } catch (err) {
-    // Mirror enforcement.ts's metering fail-open posture (#3428): the
-    // claim-gate is a metering refinement layered on top of the fail-closed
-    // Gate 0 solvency check. If the meter itself can't be evaluated, allow the
-    // run rather than block a legitimately-provisioned workspace, and make the
-    // bypass operator-visible.
     log.error(
       { err: err instanceof Error ? err.message : String(err), orgId },
-      "Claim-gate workspace lookup failed — allowing run (metering refinement unavailable)",
+      "Claim-gate workspace lookup failed — blocking as precaution (claim status unknown)",
     );
-    return { allowed: true };
+    return { allowed: false, reason: "check_failed" };
   }
 
   // No org row (pre-migration / Better-Auth-only) or a non-metered tier:
@@ -191,13 +216,14 @@ export async function checkClaimGate(
   try {
     owner = await deps.getOwnerVerification(orgId);
   } catch (err) {
-    // Same fail-open rationale as above (#3428): a transient owner-lookup blip
-    // must not misdirect an already-claimed user to "re-claim", nor 500 the run.
+    // Fail CLOSED: we can't tell whether this metered trial is claimed, so we
+    // must not let it spend Atlas tokens. Surfaced as a retryable 503, not a
+    // `claim_required` (which would wrongly tell a claimed user to re-claim).
     log.error(
       { err: err instanceof Error ? err.message : String(err), orgId },
-      "Claim-gate owner lookup failed — allowing run (metering refinement unavailable)",
+      "Claim-gate owner lookup failed — blocking as precaution (claim status unknown)",
     );
-    return { allowed: true };
+    return { allowed: false, reason: "check_failed" };
   }
 
   // No owner row, or owner already verified → claimed (or not a metered trial).
@@ -206,5 +232,9 @@ export async function checkClaimGate(
   }
 
   // Unclaimed metered trial — withhold Atlas-token Q&A.
-  return { allowed: false, claimUrl: deps.buildClaimUrl(owner.email ?? undefined) };
+  return {
+    allowed: false,
+    reason: "claim_required",
+    claimUrl: deps.buildClaimUrl(owner.email ?? undefined),
+  };
 }

--- a/packages/api/src/lib/billing/claim-gate.ts
+++ b/packages/api/src/lib/billing/claim-gate.ts
@@ -1,0 +1,210 @@
+/**
+ * Claim-gated metering for self-serve MCP trials (ADR-0018, #3651).
+ *
+ * A Workspace provisioned over MCP by the anonymous onboarding caller
+ * (`start_trial`, #3649) is **unclaimed** until a human completes the web OTP
+ * interstitial (emailOTP verify — never magic link — set a credential/passkey,
+ * accept ToS), which flips the owner's `emailVerified` bit. Unclaimed =
+ * **metered**: *setup* (connect a datasource, build the semantic layer) and
+ * *MCP querying* (the client's own model pays — no Atlas tokens) stay open, but
+ * *Atlas-token Q&A* — the only thing that actually costs Atlas — is withheld.
+ *
+ * The non-obvious part (recorded in ADR-0018) is **where** the meter lives.
+ * Every MCP datasource tool declares `checksBilling: true` and routes through
+ * Gate 0 (`checkAgentBillingGate`), so implementing "metered" as a
+ * `tokenBudgetPerSeat: 0` clamp would trip Gate 0 and block setup + MCP
+ * querying — the opposite of the intent. So the meter is a SEPARATE claim-gate
+ * placed ONLY on the Atlas-token-spending path (`executeAgentQuery`: web
+ * `/api/v1/query`, chat platforms, scheduler), keyed on the owner's
+ * `emailVerified` bit. MCP `executeSQL` never enters `executeAgentQuery`, and
+ * setup tools only hit Gate-0 solvency, so both keep working pre-claim. No new
+ * plan tier, no `meter_state` column — a gate over the existing `trial` tier
+ * plus an existing bit.
+ *
+ * SaaS-only by construction: `checkClaimGate` short-circuits to `allowed` off
+ * SaaS, with no internal DB, or with no org — the same passthrough posture the
+ * rest of the billing/enforcement subsystem takes (it lives in core, gated on
+ * `deployMode === 'saas'` + `hasInternalDB()`, never importing `isEnterpriseEnabled`).
+ */
+
+import type { PlanTier, WorkspaceRow } from "@atlas/api/lib/db/internal";
+import { hasInternalDB as defaultHasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getConfig } from "@atlas/api/lib/config";
+import { getCachedWorkspace } from "./enforcement";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("billing:claim-gate");
+
+/**
+ * Build the web claim URL — the post-signup OTP interstitial the prospect
+ * completes to claim an unclaimed Workspace. Points at the `/signup` page
+ * (which renders the emailOTP verify form when a pending signup is detected);
+ * `email` is prefilled when known so the form can resume the right account.
+ *
+ * Falls back to a relative `/signup` path when the web origin can't be
+ * resolved (only reachable off-SaaS, where the gate never fires anyway).
+ */
+export function buildClaimUrl(email?: string): string {
+  const origin = getWebOrigin();
+  const path = "/signup";
+  if (!origin) {
+    return email ? `${path}?email=${encodeURIComponent(email)}` : path;
+  }
+  const url = new URL(path, origin);
+  if (email) url.searchParams.set("email", email);
+  return url.toString();
+}
+
+/**
+ * Thrown by `executeAgentQuery` when an unclaimed (metered) Workspace attempts
+ * Atlas-token Q&A. `message` is user-safe (surfaces verbatim on chat platforms
+ * and run rows); `claimUrl` points the human at the web claim interstitial.
+ *
+ * A plain `Error` subclass (not a `Data.TaggedError`) because the
+ * `executeAgentQuery` path is plain async and uses `instanceof` sentinels —
+ * mirrors {@link BillingBlockedError}.
+ */
+export class ClaimRequiredError extends Error {
+  override readonly name = "ClaimRequiredError";
+  readonly claimUrl: string;
+  /** Stable machine-readable code for transport envelopes. */
+  readonly errorCode = "claim_required" as const;
+  readonly httpStatus = 403 as const;
+
+  constructor(claimUrl: string) {
+    super(
+      "Asking Atlas questions of your data is paused until you claim this workspace. " +
+        `Verify your email and finish setup on the web to continue: ${claimUrl}`,
+    );
+    this.claimUrl = claimUrl;
+  }
+}
+
+export type ClaimGateResult =
+  | { allowed: true }
+  | { allowed: false; claimUrl: string };
+
+/** Owner-verification shape resolved per org. */
+interface OwnerVerification {
+  emailVerified: boolean;
+  email: string | null;
+}
+
+/**
+ * Injectable boundaries for {@link checkClaimGate}, so the block-vs-allow
+ * matrix can be exercised without `mock.module`. Mirrors the dependency-
+ * injection seam in `ee/src/onboarding/provision-trial.ts`.
+ */
+export interface ClaimGateDeps {
+  getDeployMode: () => "saas" | "self-hosted" | undefined;
+  hasInternalDB: () => boolean;
+  getWorkspace: (orgId: string) => Promise<WorkspaceRow | null>;
+  getOwnerVerification: (orgId: string) => Promise<OwnerVerification | null>;
+  buildClaimUrl: (email?: string) => string;
+}
+
+/**
+ * Resolve the workspace owner's `emailVerified` bit (and email, for the
+ * claim-URL prefill). The owner is the `member.role = 'owner'` row; on the
+ * rare multi-owner workspace the earliest-created membership wins (the
+ * original creator). Returns `null` when no owner row exists.
+ */
+async function defaultGetOwnerVerification(orgId: string): Promise<OwnerVerification | null> {
+  const rows = await internalQuery<{ emailVerified: boolean; email: string | null }>(
+    `SELECT u."emailVerified" AS "emailVerified", u.email AS email
+       FROM member m
+       JOIN "user" u ON u.id = m."userId"
+      WHERE m."organizationId" = $1 AND m.role = 'owner'
+      ORDER BY m."createdAt" ASC
+      LIMIT 1`,
+    [orgId],
+  );
+  const row = rows[0];
+  if (!row) return null;
+  return { emailVerified: !!row.emailVerified, email: row.email ?? null };
+}
+
+function defaultDeps(): ClaimGateDeps {
+  return {
+    getDeployMode: () => getConfig()?.deployMode,
+    hasInternalDB: defaultHasInternalDB,
+    getWorkspace: getCachedWorkspace,
+    getOwnerVerification: defaultGetOwnerVerification,
+    buildClaimUrl,
+  };
+}
+
+/** Tiers the claim-gate applies to. Only an unclaimed *trial* is metered. */
+function isMeterableTier(tier: PlanTier): boolean {
+  return tier === "trial";
+}
+
+/**
+ * Decide whether the metered claim-gate blocks an Atlas-token agent run for
+ * `orgId`. Returns `{ allowed: true }` for every non-metered case and
+ * `{ allowed: false, claimUrl }` only for an unclaimed (owner `emailVerified`
+ * false) `trial` Workspace on SaaS.
+ *
+ * Short-circuits to `allowed` when: no org (self-hosted / CLI), no internal DB,
+ * not SaaS, the workspace row is absent, the tier isn't metered, or no owner
+ * row exists. The expiry/solvency concerns (`trial_expired`, `locked`,
+ * suspension, hard-cap) are NOT this gate's job — Gate 0
+ * (`checkAgentBillingGate`) runs first and owns them on every surface.
+ */
+export async function checkClaimGate(
+  orgId: string | undefined,
+  overrides: Partial<ClaimGateDeps> = {},
+): Promise<ClaimGateResult> {
+  const deps = { ...defaultDeps(), ...overrides };
+
+  if (!orgId || !deps.hasInternalDB() || deps.getDeployMode() !== "saas") {
+    return { allowed: true };
+  }
+
+  let workspace: WorkspaceRow | null;
+  try {
+    // Gate 0 (`checkAgentBillingGate`) already warmed this cache on the
+    // `executeAgentQuery` path, so this is a cache hit. A genuine lookup error
+    // would have failed Gate 0 closed (503) before we ever got here.
+    workspace = await deps.getWorkspace(orgId);
+  } catch (err) {
+    // Mirror enforcement.ts's metering fail-open posture (#3428): the
+    // claim-gate is a metering refinement layered on top of the fail-closed
+    // Gate 0 solvency check. If the meter itself can't be evaluated, allow the
+    // run rather than block a legitimately-provisioned workspace, and make the
+    // bypass operator-visible.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Claim-gate workspace lookup failed — allowing run (metering refinement unavailable)",
+    );
+    return { allowed: true };
+  }
+
+  // No org row (pre-migration / Better-Auth-only) or a non-metered tier:
+  // nothing to meter. Paid/locked/free workspaces are never claim-gated.
+  if (!workspace || !isMeterableTier(workspace.plan_tier)) {
+    return { allowed: true };
+  }
+
+  let owner: OwnerVerification | null;
+  try {
+    owner = await deps.getOwnerVerification(orgId);
+  } catch (err) {
+    // Same fail-open rationale as above (#3428): a transient owner-lookup blip
+    // must not misdirect an already-claimed user to "re-claim", nor 500 the run.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Claim-gate owner lookup failed — allowing run (metering refinement unavailable)",
+    );
+    return { allowed: true };
+  }
+
+  // No owner row, or owner already verified → claimed (or not a metered trial).
+  if (!owner || owner.emailVerified) {
+    return { allowed: true };
+  }
+
+  // Unclaimed metered trial — withhold Atlas-token Q&A.
+  return { allowed: false, claimUrl: deps.buildClaimUrl(owner.email ?? undefined) };
+}

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -456,6 +456,40 @@ export function severityOf(status: OverageStatus): number {
   return SEVERITY_ORDER[status];
 }
 
+/**
+ * Days remaining in a workspace's trial, for surfacing in MCP tool responses
+ * (ADR-0018 / #3651). Returns `null` when there is nothing to surface: no
+ * internal DB, no org, the workspace is absent, or it isn't on the `trial`
+ * tier. Otherwise the whole-days count until `trial_ends_at`, floored at 0
+ * (an already-lapsed trial reports 0, not a negative).
+ *
+ * Never throws — a lookup failure logs and returns `null`, so a caller can
+ * attach the line opportunistically without risking the underlying response.
+ */
+export async function getTrialDaysRemaining(
+  orgId: string | undefined,
+): Promise<number | null> {
+  if (!orgId || !hasInternalDB()) return null;
+  let workspace: WorkspaceRow | null;
+  try {
+    workspace = await getCachedWorkspace(orgId);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to read workspace for trial days-remaining — omitting from response",
+    );
+    return null;
+  }
+  if (!workspace || workspace.plan_tier !== "trial") return null;
+
+  const endsAt = workspace.trial_ends_at
+    ? new Date(workspace.trial_ends_at)
+    : new Date(new Date(workspace.createdAt).getTime() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+  const msRemaining = endsAt.getTime() - Date.now();
+  if (!Number.isFinite(msRemaining)) return null;
+  return Math.max(0, Math.ceil(msRemaining / (24 * 60 * 60 * 1000)));
+}
+
 function isTrialExpired(workspace: WorkspaceRow): boolean {
   if (!workspace.trial_ends_at) {
     // No trial_ends_at set — check if the workspace was created more than TRIAL_DAYS ago

--- a/packages/api/src/lib/billing/trial-eligibility.ts
+++ b/packages/api/src/lib/billing/trial-eligibility.ts
@@ -31,6 +31,7 @@
  */
 
 import { internalQuery } from "@atlas/api/lib/db/internal";
+import { TRIAL_DAYS, TRIAL_GRACE_HOURS } from "./plans";
 
 /**
  * Whether `userId` has already consumed a SaaS trial via some org other
@@ -100,4 +101,46 @@ export async function claimTrialGrant(
     [userId],
   );
   return existing[0]?.org_id === orgId;
+}
+
+/**
+ * Start the full trial clock when a user *claims* their account (ADR-0018 /
+ * #3651). Claiming = completing the web OTP interstitial, which fires Better
+ * Auth's `emailVerification.afterEmailVerification` hook; that hook calls this
+ * with the verifying user's id.
+ *
+ * Extends `trial_ends_at` to `NOW() + TRIAL_DAYS` for every `trial`-tier
+ * Workspace this user OWNS that is still inside the short unclaimed-grace
+ * window — i.e. an MCP-provisioned trial (`start_trial` narrowed it to
+ * {@link TRIAL_GRACE_HOURS}). The `trial_ends_at <= NOW() + TRIAL_GRACE_HOURS`
+ * guard makes this idempotent and scoped:
+ *   - A normal web-signup trial already carries the full {@link TRIAL_DAYS}
+ *     window (`assignSaasTrial` stamped it at org creation), so it is OUTSIDE
+ *     the grace horizon and left untouched — its clock already started.
+ *   - Once a grace trial is extended to the full window here, a re-fire of the
+ *     verification hook (a later profile/credential update re-verifying) finds
+ *     it outside the grace horizon and is a no-op — no free clock resets.
+ *
+ * Returns the ids of the Workspaces whose clock was started so the caller can
+ * invalidate their plan cache. Throws on query failure — the caller
+ * (`afterEmailVerification`) logs and leaves the grace window in place.
+ */
+export async function extendTrialOnClaim(userId: string): Promise<string[]> {
+  const now = Date.now();
+  const trialEndsAt = new Date(now + TRIAL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const graceHorizon = new Date(now + TRIAL_GRACE_HOURS * 60 * 60 * 1000).toISOString();
+  const rows = await internalQuery<{ id: string }>(
+    `UPDATE organization o
+        SET trial_ends_at = $2
+       FROM member m
+      WHERE m."organizationId" = o.id
+        AND m."userId" = $1
+        AND m.role = 'owner'
+        AND o.plan_tier = 'trial'
+        AND o.trial_ends_at IS NOT NULL
+        AND o.trial_ends_at <= $3
+      RETURNING o.id`,
+    [userId, trialEndsAt, graceHorizon],
+  );
+  return rows.map((r) => r.id);
 }

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -63,7 +63,7 @@ import type {
 import type { ApprovalRequestOrigin } from "@useatlas/types";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
-import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
+import { ClaimRequiredError, ClaimCheckFailedError } from "@atlas/api/lib/billing/claim-gate";
 import { createLogger } from "@atlas/api/lib/logger";
 import { checkRateLimit } from "@atlas/api/lib/auth/middleware";
 import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
@@ -1422,10 +1422,10 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
     // (metered) workspace's Atlas-token Q&A is a policy outcome, not a
     // failure. Its `message` carries the user-safe claim prompt + URL, so
     // rethrow UNCHANGED for the bridge to deliver in-thread.
-    if (err instanceof ClaimRequiredError) {
+    if (err instanceof ClaimRequiredError || err instanceof ClaimCheckFailedError) {
       log.warn(
         { errorCode: err.errorCode, requestId, ...tenantLabel },
-        "Chat plugin executeQuery blocked — workspace unclaimed",
+        "Chat plugin executeQuery blocked — claim gate",
       );
       throw err;
     }

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -63,6 +63,7 @@ import type {
 import type { ApprovalRequestOrigin } from "@useatlas/types";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
+import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
 import { createLogger } from "@atlas/api/lib/logger";
 import { checkRateLimit } from "@atlas/api/lib/auth/middleware";
 import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
@@ -1414,6 +1415,17 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
       log.warn(
         { errorCode: err.errorCode, requestId, ...tenantLabel },
         "Chat plugin executeQuery blocked by billing enforcement",
+      );
+      throw err;
+    }
+    // ADR-0018 / #3651 — same posture for the claim-gate: an unclaimed
+    // (metered) workspace's Atlas-token Q&A is a policy outcome, not a
+    // failure. Its `message` carries the user-safe claim prompt + URL, so
+    // rethrow UNCHANGED for the bridge to deliver in-thread.
+    if (err instanceof ClaimRequiredError) {
+      log.warn(
+        { errorCode: err.errorCode, requestId, ...tenantLabel },
+        "Chat plugin executeQuery blocked — workspace unclaimed",
       );
       throw err;
     }

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -22,6 +22,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getScheduledTask, updateRunDeliveryStatus } from "@atlas/api/lib/scheduled-tasks";
 import { executeAgentQuery, type AgentQueryResult } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
+import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
 import { loadActorUser } from "@atlas/api/lib/auth/actor";
 import { SchedulerTaskTimeoutError, SchedulerExecutionError } from "@atlas/api/lib/effect/errors";
 import { causeToError } from "@atlas/api/lib/audit/error-scrub";
@@ -62,9 +63,14 @@ function agentQueryEffect(
         message:
           err instanceof BillingBlockedError
             ? `Blocked by billing enforcement [${err.errorCode}]: ${err.message}`
-            : err instanceof Error
-              ? err.message
-              : String(err),
+            : // ADR-0018 / #3651 — an unclaimed (metered) workspace blocks
+              // scheduler Atlas-token runs too; record the claim reason + URL
+              // on the run row so the owner knows to claim on the web.
+              err instanceof ClaimRequiredError
+              ? `Workspace not yet claimed [${err.errorCode}]: ${err.message}`
+              : err instanceof Error
+                ? err.message
+                : String(err),
         taskId,
       }),
   }).pipe(

--- a/packages/mcp/src/__tests__/trial-footer.test.ts
+++ b/packages/mcp/src/__tests__/trial-footer.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for `withTrialFooter` (ADR-0018 / #3651) — the additive trial
+ * days-remaining advisory appended to successful billing-gated MCP tool
+ * responses. Pins that the annotation is purely additive, never mutates an
+ * error envelope, and is a no-op when there is no trial info.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { withTrialFooter } from "../mcp-dispatch.js";
+
+const ok: CallToolResult = {
+  content: [{ type: "text", text: "rows: 3" }],
+};
+
+describe("withTrialFooter", () => {
+  it("appends a days-remaining line to a successful result", () => {
+    const out = withTrialFooter(ok, 5);
+    expect(out.content).toHaveLength(2);
+    const footer = out.content[1] as { type: string; text: string };
+    expect(footer.text).toContain("5 days remaining");
+    // Original content is preserved, footer is appended last.
+    expect((out.content[0] as { text: string }).text).toBe("rows: 3");
+  });
+
+  it("uses the singular for one day", () => {
+    const out = withTrialFooter(ok, 1);
+    expect((out.content[1] as { text: string }).text).toContain("1 day remaining");
+  });
+
+  it("renders 0 days remaining (lapsed but not yet expired)", () => {
+    const out = withTrialFooter(ok, 0);
+    expect((out.content[1] as { text: string }).text).toContain("0 days remaining");
+  });
+
+  it("is a no-op when days is null (off-SaaS / no-org / non-trial)", () => {
+    const out = withTrialFooter(ok, null);
+    expect(out).toBe(ok);
+    expect(out.content).toHaveLength(1);
+  });
+
+  it("never annotates an error envelope", () => {
+    const err: CallToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ code: "billing_blocked" }) }],
+      isError: true,
+    };
+    const out = withTrialFooter(err, 5);
+    expect(out).toBe(err);
+    expect(out.content).toHaveLength(1);
+  });
+});

--- a/packages/mcp/src/mcp-dispatch.ts
+++ b/packages/mcp/src/mcp-dispatch.ts
@@ -109,6 +109,32 @@ export function errorMessage(err: unknown, fallback: string): string {
 }
 
 /**
+ * Append a trial days-remaining advisory to a successful tool result (ADR-0018
+ * / #3651). Returns the result unchanged when `days` is null (off-SaaS /
+ * no-org / non-trial) or the result is an error envelope — so the annotation is
+ * purely additive and never converts a success into an error. Pure + exported
+ * for unit testing without the full dispatch machinery.
+ */
+export function withTrialFooter(
+  result: CallToolResult,
+  days: number | null,
+): CallToolResult {
+  if (days === null || result.isError) return result;
+  return {
+    ...result,
+    content: [
+      ...result.content,
+      {
+        type: "text" as const,
+        text:
+          `Atlas trial: ${days} day${days === 1 ? "" : "s"} remaining. ` +
+          `Subscribe on the web before it ends to keep querying.`,
+      },
+    ],
+  };
+}
+
+/**
  * Build a dispatcher bound to one MCP server's actor/transport/workspace. Every
  * tool file constructs one (`const { dispatch } = createMcpDispatch(opts)`) and
  * routes each `server.registerTool` handler through it.
@@ -191,7 +217,25 @@ export function createMcpDispatch(opts: McpDispatchOptions): McpDispatcher {
               );
               if (gateBlock) return gateBlock;
 
-              return await body(requestId);
+              const result = await body(requestId);
+              // ADR-0018 / #3651 — surface trial days-remaining on successful
+              // billing-gated tool responses (executeSQL / runMetric / setup),
+              // so post-claim Q&A and setup over MCP keep the trial clock
+              // visible. `getTrialDaysRemaining` never throws and returns null
+              // off-SaaS / no-org / non-trial, so this is a no-op for stdio and
+              // self-hosted. `withTrialFooter` skips error envelopes.
+              //
+              // Lazy-imported for the same reason the dispatch gate is (see the
+              // module header): keep MCP tool *registration* off the
+              // billing/enforcement graph. enforcement.ts is already pulled by
+              // the gate on any `checksBilling` dispatch, so this adds no new
+              // static coupling.
+              if (!reqs.checksBilling) return result;
+              const { getTrialDaysRemaining } = await import(
+                "@atlas/api/lib/billing/enforcement"
+              );
+              const days = await getTrialDaysRemaining(actor.activeOrganizationId);
+              return withTrialFooter(result, days);
             } catch (err) {
               // Client-initiated cancellation (#3500) is not a tool failure —
               // the SDK already suppressed the response, so propagate it.


### PR DESCRIPTION
Implements #3651 (milestone v0.0.19), designed in [ADR-0018](../blob/main/docs/adr/0018-self-serve-trial-over-mcp.md). Builds on #3649 (`start_trial`).

## What & why

An unclaimed (metered) trial Workspace provisioned over MCP can be **set up** and **queried over MCP** (client model pays — no Atlas tokens), but **Atlas-token Q&A is withheld** until a human **claims** the account on the web.

## The meter is a claim-gate at `executeAgentQuery`, NOT Gate 0, NOT a budget clamp

- New `checkClaimGate(orgId)` (`packages/api/src/lib/billing/claim-gate.ts`) runs on the **`executeAgentQuery`** path (web `/api/v1/query`, chat, scheduler) **after** Gate 0, keyed on the **owner's `emailVerified`** bit. Pre-claim it throws a typed `ClaimRequiredError`; the `/query` route maps it to a `claim_required` 403 envelope carrying the **claim URL**, and chat/scheduler surface the user-safe message (parity with `BillingBlockedError`).
- It is **not** in `checkAgentBillingGate`/Gate 0 and **not** a `tokenBudgetPerSeat: 0` clamp — every MCP `checksBilling` tool (incl. setup) routes through Gate 0, so a clamp would wrongly block MCP setup + querying (the exact trap ADR-0018 records). **MCP `executeSQL` + setup tools are unaffected** pre-claim.
- SaaS-only by construction: short-circuits to *allowed* off-SaaS / no internal DB / no org / non-`trial` tier / claimed owner — same passthrough posture as the rest of `billing/enforcement.ts` (gated on `getConfig()?.deployMode === "saas"`, never importing `isEnterpriseEnabled`). Owner/workspace lookup fails **open** with a loud log, mirroring enforcement.ts's metering-unavailable posture (#3428).

## The claim starts the clock

- Verifying email **is** the claim. Better Auth's emailOTP verify route fires `emailVerification.afterEmailVerification` (never a magic-link path — there is none); the hook runs `extendTrialOnClaim(userId)`, which extends `trial_ends_at` to `NOW() + TRIAL_DAYS` for the user's **owned, `trial`-tier, still-in-grace** Workspaces (metered → full) and invalidates the plan cache. The `trial_ends_at <= NOW() + TRIAL_GRACE_HOURS` guard makes it idempotent and scoped — full-window web trials and already-claimed trials are untouched. **No payment at claim. No new tier, no `meter_state` column.**

## Days-remaining in MCP responses

- `getTrialDaysRemaining(orgId)` + `withTrialFooter` append a trial days-remaining line to successful `checksBilling` MCP tool responses. Lazy-imported in the dispatcher to keep tool registration off the billing graph (same pattern as the dispatch-gate loader).

## Expiry (existing behavior, asserted)

An **expired** trial is a Gate 0 (`trial_expired`) concern, distinct from the meter — it blocks query **and** setup **and** MCP on every surface until paid. Already asserted in `billing/__tests__/agent-gate.test.ts`, `mcp tools.test.ts`, `mcp dispatch-gate.test.ts`, `mcp datasource-tools.test.ts`.

## Tests

- `billing/__tests__/claim-gate.test.ts` — pre-claim **block-vs-allow matrix** (unclaimed trial blocks; verified allows; paid/locked/free allow; off-SaaS / no-DB / no-org / no-owner allow; lookup errors fail open) + `ClaimRequiredError` + `buildClaimUrl`.
- `billing/__tests__/extend-trial-on-claim.test.ts` — the **claim flip + clock extension** (guarded UPDATE, `NOW()+TRIAL_DAYS`, grace-window scoping).
- `billing/__tests__/trial-days-remaining.test.ts` — days-remaining computation.
- `__tests__/agent-query-claim-gate.test.ts` — `executeAgentQuery` throws `ClaimRequiredError` pre-claim (zero agent spend), runs once claimed.
- `mcp/__tests__/trial-footer.test.ts` — additive footer, no-op on null/error.

## Docs

`apps/docs/content/docs/guides/signup.mdx` (new "Claiming a Self-Serve (MCP) Trial" section) + `guides/mcp.mdx` ("Metered until claimed").

## CI

Local `/ci` green: lint, type, **full** `bun run test` (@atlas/api 676/676 + all other packages, 0 failures), syncpack, template/schema/openapi/oauth-helper/twenty/saas-env/security-headers/settings-readers/test-discipline/published-symbols drift gates, railway-watch.

Closes #3651.

https://claude.ai/code/session_01VDtN43WX4oQfFWVqsbCaD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDtN43WX4oQfFWVqsbCaD1)_