### PR TITLE
feat(crm): MCP signup → CRM as MCP_SIGNUP lead source (#3653)

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -15,6 +15,7 @@ bash scripts/check-openapi-drift.sh  # apps/docs/openapi.json + api-reference MD
 bash scripts/check-oauth-helper-drift.sh  # plugins/mcp/src/_oauth-helper ↔ packages/oauth-helper/src parity
 bash scripts/check-test-discipline.sh  # No new top-level env/chdir mutations in test files
 bash scripts/check-twenty-resolver-imports.sh  # Twenty operator resolver confined to ee/saas-crm (#2850)
+bash scripts/check-lead-union-mirror.sh  # SaasCrmLeadInput ↔ AtlasLeadEvent ExactType mirror assertion present (#3653)
 bash scripts/check-settings-readers.sh  # Every settings-registry key has a non-test runtime reader (#3382)
 bash scripts/check-saas-env-doc.sh  # SaaS env reference table ↔ SAAS_ENV_KEYS SSOT parity (#3707)
 bun run scripts/check-published-symbols.ts  # @useatlas/* imports in scaffold-bound source ↔ pinned-published exports parity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
       - name: Adversarial fixtures for the Twenty-resolver-imports gate (#2850)
         run: bash scripts/__tests__/check-twenty-resolver-imports.test.sh
 
+      - name: Check lead-union mirror assertion is present (#3653)
+        run: bash scripts/check-lead-union-mirror.sh
+
+      - name: Adversarial fixtures for the lead-union-mirror gate (#3653)
+        run: bash scripts/__tests__/check-lead-union-mirror.test.sh
+
       - name: Check the Better Auth admin plugin stays removed (#3159)
         run: bash scripts/check-no-admin-plugin.sh
 

--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -16,12 +16,14 @@ function stubDeps(over: Partial<ProvisionTrialDeps> = {}): {
     signUp: Array<{ email: string; name: string }>;
     createOrg: Array<{ name: string; slug: string; userId: string }>;
     grace: Array<{ orgId: string; endsAtIso: string }>;
+    mcpLead: Array<{ email: string; name?: string }>;
   };
 } {
   const calls = {
     signUp: [] as Array<{ email: string; name: string }>,
     createOrg: [] as Array<{ name: string; slug: string; userId: string }>,
     grace: [] as Array<{ orgId: string; endsAtIso: string }>,
+    mcpLead: [] as Array<{ email: string; name?: string }>,
   };
   const deps: Partial<ProvisionTrialDeps> = {
     getDeployMode: () => "saas",
@@ -39,6 +41,9 @@ function stubDeps(over: Partial<ProvisionTrialDeps> = {}): {
       return 1;
     },
     buildConnectUrl: (id) => `https://mcp.test/mcp/${id}/sse`,
+    enqueueMcpSignupLead: async (email, name) => {
+      calls.mcpLead.push({ email, name });
+    },
     graceMs: 72 * 60 * 60 * 1000,
     ...over,
   };
@@ -75,6 +80,45 @@ describe("provisionTrialWorkspace", () => {
     expect(graceMs).toBeGreaterThanOrEqual(before + 72 * 60 * 60 * 1000);
     expect(graceMs).toBeLessThanOrEqual(after + 72 * 60 * 60 * 1000);
     expect(graceMs).toBeLessThan(before + 14 * 24 * 60 * 60 * 1000);
+
+    // Exactly ONE CRM lead — the MCP_SIGNUP one — is enqueued, carrying the
+    // same derived name the user account got. The competing auto-SIGNUP that
+    // Better Auth's user.create hook would emit is suppressed on this path
+    // (see dispatch-signup-crm-lead.test.ts), so MCP_SIGNUP is the sole
+    // crm_outbox row and wins sticky first-touch (atlasFirstSource = MCP_SIGNUP,
+    // pinned end-to-end in plugins/twenty/__tests__/client.test.ts).
+    expect(calls.mcpLead).toHaveLength(1);
+    expect(calls.mcpLead[0]!.email).toBe("founder@acme.com");
+    expect(calls.mcpLead[0]!.name).toBe("founder");
+  });
+
+  it("enqueues the MCP_SIGNUP lead for the locked (repeat-signup) arm too", async () => {
+    // A successful provision attributes the acquisition channel regardless of
+    // whether the user already consumed a trial — `locked` is still a real
+    // MCP-sourced signup that should be measurable.
+    const { deps, calls } = stubDeps({
+      readOrgTier: async () => ({
+        plan_tier: "locked",
+        trial_ends_at: new Date().toISOString(),
+      }),
+    });
+    const result = await provisionTrialWorkspace(
+      { email: "founder@acme.com", orgName: "Acme Two" },
+      deps,
+    );
+    expect(result.state).toBe("locked");
+    expect(calls.mcpLead).toHaveLength(1);
+    expect(calls.mcpLead[0]!.email).toBe("founder@acme.com");
+  });
+
+  it("does NOT enqueue an MCP_SIGNUP lead when signup itself fails", async () => {
+    const { deps, calls } = stubDeps({
+      signUpEmail: async () => ({ user: {} }),
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "signup_failed" });
+    expect(calls.mcpLead).toHaveLength(0);
   });
 
   it("refuses when deployMode !== 'saas'", async () => {

--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -109,6 +109,30 @@ describe("provisionTrialWorkspace", () => {
     expect(result.state).toBe("locked");
     expect(calls.mcpLead).toHaveLength(1);
     expect(calls.mcpLead[0]!.email).toBe("founder@acme.com");
+    // Symmetric with the grace arm: the lead carries the same derived name.
+    expect(calls.mcpLead[0]!.name).toBe("founder");
+  });
+
+  it("still provisions (grace) when the CRM lead enqueue throws — a CRM outage must not fail provisioning", async () => {
+    // The default `enqueueMcpSignupLead` swallows its own failures, but the
+    // provisioner wraps the call in a seam guard too: even a dep whose contract
+    // regresses to throwing must not abort a successful provision. Attribution
+    // is best-effort; provisioning is not.
+    const { deps, calls } = stubDeps({
+      enqueueMcpSignupLead: async () => {
+        throw new Error("crm down");
+      },
+    });
+    const result = await provisionTrialWorkspace(
+      { email: "founder@acme.com", orgName: "Acme" },
+      deps,
+    );
+    expect(result.state).toBe("grace");
+    expect(result.workspaceId).toBe("org_new");
+    // The throw was swallowed AFTER the user account was created but did not
+    // prevent org creation or grace-window narrowing.
+    expect(calls.createOrg).toHaveLength(1);
+    expect(calls.grace).toHaveLength(1);
   });
 
   it("does NOT enqueue an MCP_SIGNUP lead when signup itself fails", async () => {

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -261,16 +261,29 @@ export async function provisionTrialWorkspace(
   }
 
   // Attribute the acquisition channel as MCP_SIGNUP. Enqueued here — right
-  // after the user account is created, BEFORE org creation — to mirror exactly
-  // where the web path enqueues its SIGNUP lead (Better Auth's
-  // `user.create.after` hook). That auto-SIGNUP is suppressed on this path
-  // (signUpEmail ran under `runWithSignupOrigin("mcp")`), so MCP_SIGNUP is the
-  // sole `crm_outbox` row and wins sticky first-touch. Placing it here (not
-  // after the final return) also guarantees no "user created with zero CRM
-  // lead" gap should org creation fail downstream. Self-contained failure
-  // handling inside `enqueueMcpSignupLead` keeps a CRM outage from failing the
-  // provision.
-  await deps.enqueueMcpSignupLead(email, name);
+  // after the user account is created, BEFORE org creation — to mirror where
+  // the web path enqueues its SIGNUP lead (Better Auth's `user.create.after`
+  // hook), and so there's no "user created with zero CRM lead" gap if org
+  // creation fails downstream. The competing auto-SIGNUP is suppressed on this
+  // path (`signUpEmail` ran under `runWithSignupOrigin("mcp")`), leaving
+  // MCP_SIGNUP the sole `crm_outbox` row — see `lib/auth/signup-origin.ts` for
+  // the sticky-first-touch race that makes suppression load-bearing.
+  //
+  // Wrapped in try/catch as a seam guard, belt-and-suspenders over the
+  // swallow-and-log inside the default `enqueueMcpSignupLead`: a CRM/outbox
+  // outage — or a future dep whose contract regresses — must NEVER fail trial
+  // provisioning. Attribution is best-effort; provisioning is not.
+  try {
+    await deps.enqueueMcpSignupLead(email, name);
+  } catch (err) {
+    log.warn(
+      {
+        event: "mcp_signup_crm.enqueue_threw",
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "enqueueMcpSignupLead threw — swallowed to keep provisioning unblocked",
+    );
+  }
 
   const org = await deps.createOrganization({
     name: orgName,

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -112,6 +112,13 @@ export interface ProvisionTrialDeps {
   setGraceWindow: (orgId: string, endsAtIso: string) => Promise<number>;
   /** Build the hosted-MCP connect URL for the new Workspace. */
   buildConnectUrl: (workspaceId: string) => string;
+  /**
+   * Enqueue the distinct `MCP_SIGNUP` CRM lead (ADR-0018, #3653) through the
+   * existing `SaasCrm.upsertLead` → `crm_outbox` → Twenty pipeline. Mirrors
+   * the web path's `signup` enqueue, but as a measurable acquisition channel.
+   * Swallows its own failures (a CRM/outbox outage must not fail provisioning).
+   */
+  enqueueMcpSignupLead: (email: string, name?: string) => Promise<void>;
   /** Grace window length in ms. */
   graceMs: number;
 }
@@ -121,11 +128,20 @@ function defaultDeps(): ProvisionTrialDeps {
     getDeployMode: () => getConfig()?.deployMode,
     signUpEmail: async (body) => {
       const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+      const { runWithSignupOrigin } = await import(
+        "@atlas/api/lib/auth/signup-origin"
+      );
       const auth = getAuthInstance();
       const signUp = (auth.api as Record<string, unknown>).signUpEmail as (o: {
         body: { email: string; password: string; name: string };
       }) => Promise<{ user?: { id?: string } } | undefined>;
-      return signUp({ body });
+      // Tag the in-flight signup as MCP-originated so Better Auth's
+      // `user.create.after` hook (`dispatchSignupCrmLead`) suppresses the
+      // generic SIGNUP CRM lead — this path emits MCP_SIGNUP itself, and a
+      // second same-email row with an earlier `created_at` would steal the
+      // sticky first-source. The ALS context propagates through the await
+      // chain into the hook.
+      return runWithSignupOrigin("mcp", () => signUp({ body }));
     },
     createOrganization: async (body) => {
       const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
@@ -158,6 +174,12 @@ function defaultDeps(): ProvisionTrialDeps {
       return updated.length;
     },
     buildConnectUrl: (workspaceId) => buildMcpConnectUrl(workspaceId),
+    enqueueMcpSignupLead: async (email, name) => {
+      const { dispatchMcpSignupCrmLead } = await import(
+        "@atlas/api/lib/auth/server"
+      );
+      await dispatchMcpSignupCrmLead({ email, name });
+    },
     graceMs: TRIAL_GRACE_HOURS * 60 * 60 * 1000,
   };
 }
@@ -237,6 +259,18 @@ export async function provisionTrialWorkspace(
       "Could not create an account for this email. It may already be registered — sign in on the web instead.",
     );
   }
+
+  // Attribute the acquisition channel as MCP_SIGNUP. Enqueued here — right
+  // after the user account is created, BEFORE org creation — to mirror exactly
+  // where the web path enqueues its SIGNUP lead (Better Auth's
+  // `user.create.after` hook). That auto-SIGNUP is suppressed on this path
+  // (signUpEmail ran under `runWithSignupOrigin("mcp")`), so MCP_SIGNUP is the
+  // sole `crm_outbox` row and wins sticky first-touch. Placing it here (not
+  // after the final return) also guarantees no "user created with zero CRM
+  // lead" gap should org creation fail downstream. Self-contained failure
+  // handling inside `enqueueMcpSignupLead` keeps a CRM outage from failing the
+  // provision.
+  await deps.enqueueMcpSignupLead(email, name);
 
   const org = await deps.createOrganization({
     name: orgName,

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -359,4 +359,27 @@ describe("dispatchMcpSignupCrmLead — happy path", () => {
     const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
     expect(logCtx.event).toBe("mcp_signup_crm.dispatch_defect");
   });
+
+  it("resolves and logs `mcp_signup_crm.enqueue_failed` when SaasCrm.upsertLead fails with a typed Error", async () => {
+    runEnterpriseImpl = async (program) => {
+      await Effect.runPromise(
+        Effect.provide(
+          program as Effect.Effect<unknown, never, SaasCrm>,
+          failingLayer(new Error("crm_outbox enqueue failed — pg blip")),
+        ),
+      );
+    };
+
+    await expect(
+      dispatchMcpSignupCrmLead({ email: "pgblip@acme.com", name: "X" }),
+    ).resolves.toBeUndefined();
+
+    // The typed `Effect.fail` path goes through `Effect.either` Left, not the
+    // outer catch — pin that branch independently (mirror of the SIGNUP suite's
+    // `signup_crm.enqueue_failed` test) so a refactor dropping the Left-side
+    // log gets caught here for the MCP path too.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("mcp_signup_crm.enqueue_failed");
+  });
 });

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -73,7 +73,8 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 // ── Import the unit under test AFTER mocks ─────────────────────────
 
-const { dispatchSignupCrmLead } = await import("../server");
+const { dispatchSignupCrmLead, dispatchMcpSignupCrmLead } = await import("../server");
+const { runWithSignupOrigin } = await import("../signup-origin");
 
 // `dispatchSignupCrmLead` only calls `upsertLead` — the per-row
 // `dispatcher` hook is flusher-side only. We cast the recording shape
@@ -276,5 +277,86 @@ describe("dispatchSignupCrmLead — Noop / self-hosted shape", () => {
     ).resolves.toBeUndefined();
     expect(runs).toBe(1);
     expect(upsertLeadCalls).toHaveLength(0);
+  });
+});
+
+describe("dispatchSignupCrmLead — MCP-origin suppression (#3653)", () => {
+  // The MCP self-serve path (provisionTrialWorkspace) emits its own
+  // `MCP_SIGNUP` lead. Since `signUpEmail` fires this hook FIRST (earlier
+  // `created_at`) and `atlasFirstSource` is sticky first-touch, letting the
+  // generic SIGNUP enqueue here would steal first-source from MCP_SIGNUP.
+  // So when the signup is MCP-originated, this helper must NOT enqueue.
+  it("suppresses the SIGNUP enqueue when the signup origin is 'mcp'", async () => {
+    await runWithSignupOrigin("mcp", () =>
+      dispatchSignupCrmLead({
+        user: { id: "u12", email: "mcp@founder.com", name: "MCP Founder" },
+      }),
+    );
+    // No lead — the MCP path owns the MCP_SIGNUP enqueue itself.
+    expect(upsertLeadCalls).toHaveLength(0);
+    // The suppression is intentional and logged at debug, not warn/error.
+    expect(mockLogWarn).not.toHaveBeenCalled();
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it("still enqueues a SIGNUP lead for an ordinary (web) signup — no origin bound", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u13", email: "web@founder.com", name: "Web Founder" },
+    });
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toEqual({
+      source: "signup",
+      email: "web@founder.com",
+      name: "Web Founder",
+    });
+  });
+});
+
+describe("dispatchMcpSignupCrmLead — happy path", () => {
+  it("enqueues an mcp-signup lead with email + name", async () => {
+    await dispatchMcpSignupCrmLead({
+      email: "Founder@Acme.com",
+      name: "Founder Acme",
+    });
+
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toEqual({
+      source: "mcp-signup",
+      email: "founder@acme.com",
+      name: "Founder Acme",
+    });
+  });
+
+  it("enqueues without `name` when name is missing / blank", async () => {
+    for (const name of [undefined, "", "   ", "\t"]) {
+      upsertLeadCalls.length = 0;
+      await dispatchMcpSignupCrmLead({ email: "n@acme.com", name });
+      expect(upsertLeadCalls).toHaveLength(1);
+      expect(upsertLeadCalls[0]).toEqual({
+        source: "mcp-signup",
+        email: "n@acme.com",
+      });
+      expect("name" in upsertLeadCalls[0]!).toBe(false);
+    }
+  });
+
+  it("does nothing when email is missing / blank", async () => {
+    for (const email of ["", "   "]) {
+      upsertLeadCalls.length = 0;
+      await dispatchMcpSignupCrmLead({ email });
+      expect(upsertLeadCalls).toHaveLength(0);
+    }
+  });
+
+  it("resolves and logs a defect when runEnterprise rejects — never throws into the provisioner", async () => {
+    runEnterpriseImpl = async () => Promise.reject(new Error("async reject"));
+
+    await expect(
+      dispatchMcpSignupCrmLead({ email: "die@acme.com", name: "X" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("mcp_signup_crm.dispatch_defect");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/signup-origin-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/signup-origin-wiring.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Wiring test (#3653): the AsyncLocalStorage signup-origin actually propagates
+ * from `runWithSignupOrigin("mcp", …)` THROUGH the real composed
+ * `databaseHooks.user.create.after` hook into `dispatchSignupCrmLead`, so the
+ * generic SIGNUP CRM lead is suppressed on the MCP self-serve path.
+ *
+ * Why this exists beyond the helper-level suppression test in
+ * `dispatch-signup-crm-lead.test.ts`: that test calls `dispatchSignupCrmLead`
+ * DIRECTLY inside the ALS scope (same call stack), so it only proves
+ * `getSignupOrigin()` reads back a value set one frame up. It cannot catch the
+ * regression this feature actually fears — a future edit to `buildAuthOptions`'s
+ * `user.create.after` that DEFERS or un-awaits the dispatch (setTimeout /
+ * detached microtask / fire-and-forget). That would drop the ALS context and
+ * silently un-suppress SIGNUP, corrupting MCP_SIGNUP first-touch attribution
+ * with zero test failure.
+ *
+ * This test extracts the EXACT composed `after` hook Atlas ships and drives it
+ * through genuine await boundaries inside the ALS scope (mirroring Better Auth's
+ * internal awaits between `signUpEmail` and the after hook firing). If someone
+ * un-awaits or defers the dispatch, the suppression assertion (mcp → 0 leads)
+ * flips; the paired web assertion (no origin → 1 lead) guards the inverse, so a
+ * deferral that drops BOTH paths can't hide either.
+ *
+ * The welcome-email `setTimeout` inside the after hook has a 2s delay and is
+ * fire-and-forget — it never runs before these synchronous assertions and the
+ * logger is mocked, so the email/internal-DB modules it would touch need no
+ * stubbing.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  SaasCrm,
+  type SaasCrmLeadInput,
+  type SaasCrmShape,
+} from "@atlas/api/lib/effect/services";
+
+// ── Mock storage state (mirrors dispatch-signup-crm-lead.test.ts) ───
+
+let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
+const upsertLeadCalls: SaasCrmLeadInput[] = [];
+
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogError: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogDebug: Mock<(...args: unknown[]) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: (p: unknown) => runEnterpriseImpl(p),
+  getEnterpriseRuntime: () => ({
+    runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
+  }),
+  // CLAUDE.md "Mock all exports" — the canonical module also exports
+  // EnterpriseLayer; a partial mock surfaces as a cross-file SyntaxError under
+  // bun's parallel workers.
+  EnterpriseLayer: Layer.empty,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  getLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  setLogLevel: () => false,
+}));
+
+// ── Import the units under test AFTER mocks ─────────────────────────
+
+const { buildPlugins, buildAuthOptions, parseAuthSecret } = await import("../server");
+const { runWithSignupOrigin } = await import("../signup-origin");
+
+function recordingLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: (input: SaasCrmLeadInput) => {
+      upsertLeadCalls.push(input);
+      return Effect.void;
+    },
+  } as unknown as SaasCrmShape);
+}
+
+function authDeps(plugins: ReturnType<typeof buildPlugins>) {
+  return {
+    env: process.env,
+    secret: parseAuthSecret("test-secret-at-least-32-characters-long"),
+    baseURL: undefined,
+    database: undefined,
+    cookieDomain: undefined,
+    cookiePrefix: "atlas",
+    socialProviders: undefined,
+    plugins,
+    trustedOrigins: ["https://app.useatlas.dev"],
+    bootstrapAdmin: { mode: "none" as const },
+  };
+}
+
+/** Extract the EXACT composed user.create.after hook Atlas ships. */
+function getUserCreateAfter() {
+  const options = buildAuthOptions(authDeps(buildPlugins()));
+  const hook = (
+    options as {
+      databaseHooks?: { user?: { create?: { after?: unknown } } };
+    }
+  ).databaseHooks?.user?.create?.after;
+  expect(
+    typeof hook,
+    "user.create.after must be composed in buildAuthOptions",
+  ).toBe("function");
+  return hook as (user: {
+    id: string;
+    email?: string | null;
+    name?: string | null;
+  }) => Promise<void>;
+}
+
+beforeEach(() => {
+  upsertLeadCalls.length = 0;
+  mockLogWarn.mockClear();
+  mockLogError.mockClear();
+  mockLogInfo.mockClear();
+  mockLogDebug.mockClear();
+  runEnterpriseImpl = async (program) => {
+    await Effect.runPromise(
+      Effect.provide(
+        program as Effect.Effect<unknown, never, SaasCrm>,
+        recordingLayer(),
+      ),
+    );
+  };
+});
+
+describe("user.create.after — ALS signup-origin propagation (#3653)", () => {
+  it("suppresses the SIGNUP lead when the composed hook runs inside runWithSignupOrigin('mcp') across await boundaries", async () => {
+    const after = getUserCreateAfter();
+
+    await runWithSignupOrigin("mcp", async () => {
+      // Genuine async hops between the ALS bind and the hook firing — stands in
+      // for Better Auth's internal awaits between signUpEmail and user.create.after.
+      await Promise.resolve();
+      await Promise.resolve().then(() => Promise.resolve());
+      await after({ id: "u_mcp", email: "mcp@founder.com", name: "MCP Founder" });
+    });
+
+    // The composed hook read origin "mcp" through the ALS context and suppressed
+    // the auto-SIGNUP. If the dispatch were ever deferred off the awaited
+    // continuation, the context would be lost and this would be 1, not 0.
+    expect(upsertLeadCalls).toHaveLength(0);
+  });
+
+  it("still enqueues a SIGNUP lead through the same composed hook with no origin bound (web path)", async () => {
+    const after = getUserCreateAfter();
+
+    await after({ id: "u_web", email: "web@founder.com", name: "Web Founder" });
+
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toEqual({
+      source: "signup",
+      email: "web@founder.com",
+      name: "Web Founder",
+    });
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/signup-origin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/signup-origin.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for the signup-origin AsyncLocalStorage (#3653).
+ *
+ * The MCP_SIGNUP suppression contract rests entirely on the ALS value surviving
+ * the await chain between `runWithSignupOrigin("mcp", …)` (in
+ * `provisionTrialWorkspace`) and the point `getSignupOrigin()` is read inside
+ * Better Auth's `user.create.after` hook. These tests pin that propagation
+ * guarantee directly — independent of Better Auth — so the cross-module wiring
+ * test (`signup-origin-wiring.test.ts`) and the helper suppression test rest on
+ * a proven primitive rather than an assumed one.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { runWithSignupOrigin, getSignupOrigin } from "../signup-origin";
+
+describe("signup-origin AsyncLocalStorage", () => {
+  it("reads back the bound origin synchronously inside the scope", () => {
+    let seen: string | undefined;
+    runWithSignupOrigin("mcp", () => {
+      seen = getSignupOrigin();
+    });
+    expect(seen).toBe("mcp");
+  });
+
+  it("returns undefined outside any scope (the ordinary web-signup case)", () => {
+    expect(getSignupOrigin()).toBeUndefined();
+  });
+
+  it("survives a single await boundary", async () => {
+    const seen = await runWithSignupOrigin("mcp", async () => {
+      await Promise.resolve();
+      return getSignupOrigin();
+    });
+    expect(seen).toBe("mcp");
+  });
+
+  it("survives nested / chained microtask boundaries", async () => {
+    const seen = await runWithSignupOrigin("mcp", async () => {
+      await Promise.resolve();
+      await Promise.resolve().then(() => Promise.resolve());
+      await Promise.all([Promise.resolve(), Promise.resolve()]);
+      return getSignupOrigin();
+    });
+    expect(seen).toBe("mcp");
+  });
+
+  it("survives a macrotask (setTimeout) boundary", async () => {
+    const seen = await runWithSignupOrigin("mcp", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return getSignupOrigin();
+    });
+    expect(seen).toBe("mcp");
+  });
+
+  it("propagates into a nested async helper that never threads the value", async () => {
+    // The hook reads the origin without the provisioner passing it as an arg —
+    // this is the exact shape the suppression relies on.
+    async function deepRead(): Promise<string | undefined> {
+      await Promise.resolve();
+      return getSignupOrigin();
+    }
+    const seen = await runWithSignupOrigin("mcp", () => deepRead());
+    expect(seen).toBe("mcp");
+  });
+
+  it("returns whatever fn resolves to", async () => {
+    const result = await runWithSignupOrigin("mcp", async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("does not leak the value past the scope after it resolves", async () => {
+    await runWithSignupOrigin("mcp", async () => {
+      await Promise.resolve();
+    });
+    expect(getSignupOrigin()).toBeUndefined();
+  });
+
+  it("isolates concurrent scopes (no cross-talk between interleaved runs)", async () => {
+    // An MCP-bound scope and an unbound (web) flow running concurrently must not
+    // see each other's value. "mcp" is the only origin today, so prove
+    // isolation via the bound-vs-unbound pair overlapping in time.
+    const results = await Promise.all([
+      runWithSignupOrigin("mcp", async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return getSignupOrigin();
+      }),
+      (async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return getSignupOrigin();
+      })(),
+    ]);
+    expect(results[0]).toBe("mcp");
+    expect(results[1]).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -79,6 +79,7 @@ import {
 import { getConfig } from "@atlas/api/lib/config";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { getSignupOrigin } from "@atlas/api/lib/auth/signup-origin";
 import { Effect } from "effect";
 
 /**
@@ -330,6 +331,20 @@ export async function dispatchSignupCrmLead(args: {
   const email = user.email?.toLowerCase().trim();
   if (!email) return;
 
+  // MCP self-serve trial signups (ADR-0018, #3653) run this SAME Better Auth
+  // path but want a DISTINCT lead source (`MCP_SIGNUP`). The provisioner emits
+  // that lead itself; suppress the generic SIGNUP here so the two don't both
+  // land in `crm_outbox`. The race matters: this hook fires inside
+  // `signUpEmail` (earlier `created_at`) and `atlasFirstSource` is sticky
+  // first-touch, so a SIGNUP row would steal first-source from MCP_SIGNUP.
+  if (getSignupOrigin() === "mcp") {
+    log.debug(
+      { userId: user.id, event: "signup_crm.suppressed_mcp" },
+      "Suppressing auto SIGNUP CRM lead for MCP-originated signup — provisioner emits MCP_SIGNUP",
+    );
+    return;
+  }
+
   const name = user.name?.trim() || undefined;
 
   try {
@@ -363,6 +378,68 @@ export async function dispatchSignupCrmLead(args: {
         event: "signup_crm.dispatch_defect",
       },
       "Unexpected SaasCrm dispatch error during signup — swallowed to keep auth response unblocked",
+    );
+  }
+}
+
+/**
+ * Twenty CRM dispatch for a self-serve MCP trial signup (ADR-0018, #3653).
+ * Sibling of {@link dispatchSignupCrmLead}: enqueues an `mcp-signup` lead so
+ * the Workspace's acquisition channel is attributable as `MCP_SIGNUP`
+ * (sticky `atlasFirstSource`) rather than the generic `SIGNUP`.
+ *
+ * Called by `provisionTrialWorkspace` (the single self-serve provisioning
+ * seam) AFTER the user account is created. The provisioner wraps its
+ * `signUpEmail` call in `runWithSignupOrigin("mcp", …)` so the auto-`SIGNUP`
+ * enqueue is suppressed in `dispatchSignupCrmLead` above — leaving this the
+ * sole `crm_outbox` row for the email.
+ *
+ * Same swallow-and-log contract as the signup helper: a Twenty/`crm_outbox`
+ * outage must NEVER fail provisioning. Self-hosted resolves to the no-op
+ * `SaasCrm` Layer and produces no Twenty traffic.
+ *
+ * @internal
+ */
+export async function dispatchMcpSignupCrmLead(args: {
+  email: string;
+  name?: string | null;
+}): Promise<void> {
+  const email = args.email?.toLowerCase().trim();
+  if (!email) return;
+
+  const name = args.name?.trim() || undefined;
+
+  try {
+    await runEnterprise(
+      Effect.gen(function* () {
+        const crm = yield* SaasCrm;
+        const result = yield* crm
+          .upsertLead({
+            source: "mcp-signup",
+            email,
+            ...(name ? { name } : {}),
+          })
+          .pipe(Effect.either);
+        if (result._tag === "Left") {
+          log.warn(
+            {
+              email,
+              err: errorMessage(result.left),
+              event: "mcp_signup_crm.enqueue_failed",
+            },
+            "SaasCrm.upsertLead enqueue failed during MCP signup — swallowed to keep provisioning unblocked",
+          );
+        }
+      }),
+    );
+  } catch (err) {
+    log.warn(
+      {
+        email,
+        err: errorMessage(err),
+        event: "mcp_signup_crm.dispatch_defect",
+      },
+      "Unexpected SaasCrm dispatch error during MCP signup — swallowed to keep provisioning unblocked",
     );
   }
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -332,11 +332,10 @@ export async function dispatchSignupCrmLead(args: {
   if (!email) return;
 
   // MCP self-serve trial signups (ADR-0018, #3653) run this SAME Better Auth
-  // path but want a DISTINCT lead source (`MCP_SIGNUP`). The provisioner emits
-  // that lead itself; suppress the generic SIGNUP here so the two don't both
-  // land in `crm_outbox`. The race matters: this hook fires inside
-  // `signUpEmail` (earlier `created_at`) and `atlasFirstSource` is sticky
-  // first-touch, so a SIGNUP row would steal first-source from MCP_SIGNUP.
+  // path but want a DISTINCT lead source (`MCP_SIGNUP`), which the provisioner
+  // emits itself — so suppress the generic SIGNUP here to avoid two competing
+  // `crm_outbox` rows for one email. See `lib/auth/signup-origin.ts` for the
+  // sticky-first-touch race this prevents and why the suppression is correct.
   if (getSignupOrigin() === "mcp") {
     log.debug(
       { userId: user.id, event: "signup_crm.suppressed_mcp" },
@@ -3305,10 +3304,18 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
             }
           },
           after: async (user: User) => {
-            // Awaited deliberately — the helper swallows every failure
-            // mode internally, so the await only blocks on the
-            // outbox INSERT. Not awaiting risks an unhandled rejection
-            // if a future change widens the error channel.
+            // Awaited INLINE deliberately — two reasons:
+            //  1. The helper swallows every failure mode internally, so the
+            //     await only blocks on the outbox INSERT; not awaiting risks an
+            //     unhandled rejection if a future change widens the error channel.
+            //  2. CONTRACT (do not break): MCP_SIGNUP attribution depends on the
+            //     AsyncLocalStorage signup-origin set by `runWithSignupOrigin("mcp")`
+            //     in `provisionTrialWorkspace` propagating INTO this call so
+            //     `dispatchSignupCrmLead` can suppress the generic SIGNUP lead.
+            //     Deferring this (setTimeout / detached microtask / queueMicrotask)
+            //     drops the ALS context, silently un-suppressing SIGNUP and
+            //     corrupting acquisition attribution. `signup-origin-wiring.test.ts`
+            //     pins this — keep it awaited inline.
             await dispatchSignupCrmLead({ user });
 
             // Onboarding welcome email — fire-and-forget after signup.

--- a/packages/api/src/lib/auth/signup-origin.ts
+++ b/packages/api/src/lib/auth/signup-origin.ts
@@ -1,0 +1,56 @@
+/**
+ * Signup-origin context — a tiny AsyncLocalStorage that lets a server-side
+ * caller of Better Auth's `signUpEmail` tag the in-flight signup with the
+ * acquisition channel it originated from, so the `user.create.after` hook
+ * (which fires INSIDE `signUpEmail`, outside Atlas's normal request context)
+ * can react to it.
+ *
+ * Why this exists: the self-serve MCP trial path (`provisionTrialWorkspace`,
+ * ADR-0018, #3653) emits its own `MCP_SIGNUP` CRM lead so the channel is
+ * attributable. But that path runs the *same* Better Auth signup as the web,
+ * whose `user.create.after` hook already enqueues a generic `signup`/`SIGNUP`
+ * lead. Two `crm_outbox` rows for one email is a problem: `atlasFirstSource`
+ * is sticky first-touch and the outbox dispatches same-email rows strictly in
+ * `created_at` order, so the earlier-created `SIGNUP` row would steal the
+ * first-source from `MCP_SIGNUP`. The provisioner therefore wraps its
+ * `signUpEmail` call in `runWithSignupOrigin("mcp", …)`, and
+ * `dispatchSignupCrmLead` skips the auto-enqueue when the origin is `"mcp"` —
+ * leaving `MCP_SIGNUP` as the sole row, which wins first-touch.
+ *
+ * This is the same "bind the ALS that Better Auth hooks fire outside of"
+ * pattern used in `lib/auth/invitations.ts`. It is deliberately NOT persisted
+ * anywhere (ADR-0018 rejects an acquisition/`origin` column on the trial
+ * grant); it lives only for the duration of the signup call.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Acquisition channel a server-side signup originated from. Web HTTP signups
+ * never set this (they don't call the server-side `signUpEmail` seam through
+ * this wrapper), so the absence of a value means "ordinary web signup".
+ */
+export type SignupOrigin = "mcp";
+
+const signupOriginStore = new AsyncLocalStorage<SignupOrigin>();
+
+/**
+ * Run `fn` with the given signup origin bound for the duration of its async
+ * execution. AsyncLocalStorage propagates the value across the `await` chain
+ * inside `signUpEmail`, so Better Auth's `user.create.after` hook observes it
+ * via {@link getSignupOrigin}. Returns whatever `fn` resolves to.
+ */
+export function runWithSignupOrigin<T>(
+  origin: SignupOrigin,
+  fn: () => T,
+): T {
+  return signupOriginStore.run(origin, fn);
+}
+
+/**
+ * The signup origin bound by the nearest enclosing {@link runWithSignupOrigin},
+ * or `undefined` when none is active (the ordinary web-signup case).
+ */
+export function getSignupOrigin(): SignupOrigin | undefined {
+  return signupOriginStore.getStore();
+}

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2753,6 +2753,23 @@ export type SaasCrmLeadInput =
     }
   | {
       /**
+       * Self-serve MCP trial-signup (ADR-0018, #3653). Enqueued by
+       * `provisionTrialWorkspace` on the `start_trial` path. Structurally
+       * identical to `signup`, but a DISTINCT lead source
+       * (`MCP_SIGNUP` → sticky `atlasFirstSource`) so the acquisition channel
+       * is measurable. The provisioner suppresses the auto-`signup` lead the
+       * shared Better Auth `user.create` hook would otherwise emit (see
+       * `lib/auth/signup-origin.ts`), so this is the sole `crm_outbox` row for
+       * the email. Lead source stays separate from `agentOrigin`
+       * (approval/audit) — do not conflate.
+       */
+      readonly source: "mcp-signup";
+      readonly email: string;
+      /** Optional display name — parity with `signup`. */
+      readonly name?: string;
+    }
+  | {
+      /**
        * Stripe → Twenty conversion stamping (#2737). Fired from the
        * `onSubscriptionComplete` Better Auth hook after a paying
        * checkout. The dispatcher stamps `customFields.atlasStripeCustomerId`

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -28,6 +28,7 @@ import {
   type TwentyClientConfig,
   type TwentyPerson,
 } from "../src/client";
+import { normalizeLead } from "../src/lead-normalizer";
 
 // ─────────────────────────────────────────────────────────────────────
 //  Fetch helpers
@@ -144,6 +145,45 @@ describe("upsertPerson — Person absent", () => {
     expect(body.atlasFirstSource).toBe("DEMO");
     expect(body.atlasLastSource).toBe("DEMO");
     expect(body.customFields).toBeUndefined();
+  });
+
+  test("end-to-end: an mcp-signup lead POSTs a Person with atlasFirstSource = MCP_SIGNUP (#3653)", async () => {
+    // Wire the normalizer → upsertPerson the way the outbox dispatcher does,
+    // so this pins the FULL attribution path: lead source MCP_SIGNUP becomes
+    // the sticky first-touch on a brand-new Person. The provisioner suppresses
+    // the competing SIGNUP lead, so for a fresh email this POST IS first-touch.
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { people: [] } } }, // GET — nothing found
+      {
+        status: 200,
+        body: {
+          data: {
+            createPerson: {
+              id: "person_mcp",
+              emails: { primaryEmail: "founder@acme.com" },
+              atlasFirstSource: "MCP_SIGNUP",
+              atlasLastSource: "MCP_SIGNUP",
+            } as TwentyPerson,
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const normalized = normalizeLead({
+      source: "mcp-signup",
+      email: "Founder@Acme.com",
+      name: "Founder Acme",
+    });
+    expect(normalized.eventSource).toBe("MCP_SIGNUP");
+
+    const result = await upsertPerson(config, normalized.person);
+
+    expect(result.id).toBe("person_mcp");
+    expect(calls[1].method).toBe("POST");
+    const body = JSON.parse(calls[1].body ?? "{}");
+    expect(body.atlasFirstSource).toBe("MCP_SIGNUP");
+    expect(body.atlasLastSource).toBe("MCP_SIGNUP");
   });
 });
 

--- a/plugins/twenty/__tests__/lead-normalizer.test.ts
+++ b/plugins/twenty/__tests__/lead-normalizer.test.ts
@@ -7,10 +7,12 @@ import {
   normalizeConversionLead,
   normalizeDemoLead,
   normalizeLead,
+  normalizeMcpSignupLead,
   normalizeSalesFormLead,
   normalizeSignupLead,
   type AtlasConversionLeadEvent,
   type AtlasDemoLeadEvent,
+  type AtlasMcpSignupLeadEvent,
   type AtlasSalesFormLeadEvent,
   type AtlasSignupLeadEvent,
 } from "../src/lead-normalizer";
@@ -309,6 +311,82 @@ describe("normalizeSignupLead", () => {
   });
 });
 
+describe("normalizeMcpSignupLead", () => {
+  test("maps a full MCP-signup event to a Twenty upsert payload (no note)", () => {
+    const event: AtlasMcpSignupLeadEvent = {
+      source: "mcp-signup",
+      email: "Founder@Acme.com",
+      name: "Founder Acme",
+    };
+
+    const result = normalizeMcpSignupLead(event);
+
+    // The distinct lead source is the whole point — MCP signups must be
+    // attributable as their own acquisition channel, never folded into SIGNUP.
+    expect(result.eventSource).toBe("MCP_SIGNUP");
+    expect(result.person.email).toBe("founder@acme.com");
+    expect(result.person.eventSource).toBe("MCP_SIGNUP");
+    expect(result.person.name).toEqual({ firstName: "Founder", lastName: "Acme" });
+    // No request context (IP/UA) and no message → no atlasIp, no Note.
+    expect(result.person.customFields).toEqual({});
+    expect(result.note).toBeUndefined();
+  });
+
+  test("lowercases and trims the email", () => {
+    const result = normalizeMcpSignupLead({
+      source: "mcp-signup",
+      email: "  Bob@ACME.COM ",
+      name: "Bob",
+    });
+    expect(result.person.email).toBe("bob@acme.com");
+  });
+
+  test("single-word name maps to firstName only (no empty lastName)", () => {
+    const result = normalizeMcpSignupLead({
+      source: "mcp-signup",
+      email: "u@t.com",
+      name: "Cher",
+    });
+    expect(result.person.name).toEqual({ firstName: "Cher" });
+  });
+
+  test("omits name when missing — MCP signup is email-first too", () => {
+    const result = normalizeMcpSignupLead({
+      source: "mcp-signup",
+      email: "u@t.com",
+    });
+    expect(result.person.name).toBeUndefined();
+  });
+
+  test("omits name when empty / whitespace-only — never PATCH a stray empty name", () => {
+    for (const name of ["", "   ", "\t"]) {
+      const result = normalizeMcpSignupLead({
+        source: "mcp-signup",
+        email: "u@t.com",
+        name,
+      });
+      expect(result.person.name).toBeUndefined();
+    }
+  });
+
+  test("always stamps eventSource = MCP_SIGNUP for the mcp-signup variant", () => {
+    const result = normalizeMcpSignupLead({ source: "mcp-signup", email: "u@t.com" });
+    expect(result.eventSource).toBe("MCP_SIGNUP");
+    expect(result.person.eventSource).toBe("MCP_SIGNUP");
+  });
+
+  test("never attaches a Note and never round-trips an ip", () => {
+    const result = normalizeMcpSignupLead({
+      source: "mcp-signup",
+      email: "u@t.com",
+      name: "Founder",
+    });
+    expect(result.note).toBeUndefined();
+    expect(result.person.customFields).toEqual({});
+    expect(JSON.stringify(result)).not.toContain("atlasIp");
+  });
+});
+
 describe("normalizeConversionLead", () => {
   test("maps a conversion event to a Twenty upsert payload carrying atlasStripeCustomerId", () => {
     const event: AtlasConversionLeadEvent = {
@@ -416,5 +494,15 @@ describe("normalizeLead — dispatch", () => {
     });
     expect(result.eventSource).toBe("CONVERSION");
     expect(result.person.customFields?.atlasStripeCustomerId).toBe("cus_abc");
+  });
+
+  test("dispatches mcp-signup source to the mcp-signup normalizer", () => {
+    const result = normalizeLead({
+      source: "mcp-signup",
+      email: "u@t.com",
+      name: "Founder Acme",
+    });
+    expect(result.eventSource).toBe("MCP_SIGNUP");
+    expect(result.note).toBeUndefined();
   });
 });

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -2,9 +2,9 @@
  * LeadNormalizer — pure mapping from Atlas lead events to the Twenty
  * upsert input shape.
  *
- * Ships the `demo`, `sales-form`, `signup`, and `conversion` variants.
- * `normalizeLead`'s exhaustive switch surfaces a compile error the moment a
- * new union member lands.
+ * Ships the `demo`, `sales-form`, `signup`, `mcp-signup`, and `conversion`
+ * variants. `normalizeLead`'s exhaustive switch surfaces a compile error the
+ * moment a new union member lands.
  *
  * Design rule: the normalizer outputs a single `eventSource` field;
  * the first-source / last-source translation happens INSIDE
@@ -30,6 +30,7 @@ import type { UpsertPersonInput } from "./client";
 export type AtlasEventSource =
   | "DEMO"
   | "SIGNUP"
+  | "MCP_SIGNUP"
   | "SALES_FORM"
   | "CONVERSION"
   | "OTHER";
@@ -81,6 +82,32 @@ export interface AtlasSignupLeadEvent {
 }
 
 /**
+ * Self-serve MCP trial-signup variant — fired by `provisionTrialWorkspace`
+ * (`ee/src/onboarding/provision-trial.ts`) on the `start_trial` path
+ * (ADR-0018). Structurally identical to the web `signup` variant, but a
+ * DISTINCT lead source so the acquisition channel is measurable in the CRM:
+ * `eventSource = "MCP_SIGNUP"` → sticky `atlasFirstSource = MCP_SIGNUP`.
+ *
+ * Because the same provisioning path also runs Better Auth's `user.create`
+ * hook (which would otherwise emit a `signup`/`SIGNUP` lead), the auto-signup
+ * enqueue is suppressed on the MCP path (see `signup-origin.ts` /
+ * `dispatchSignupCrmLead`) so this is the SOLE `crm_outbox` row for the email
+ * and wins first-touch. Lead source (acquisition attribution) is deliberately
+ * kept separate from Agent origin (approval/audit, ADR-0015): both can say
+ * "mcp", but unifying them would recreate the `surface`→`origin` overload.
+ */
+export interface AtlasMcpSignupLeadEvent {
+  readonly source: "mcp-signup";
+  readonly email: string;
+  /**
+   * Optional display name — parity with `signup`. The provisioner derives a
+   * name from the email local-part, but MCP signup stays email-first, so this
+   * may be absent. Split into first/last at the normalizer seam.
+   */
+  readonly name?: string;
+}
+
+/**
  * Stripe → Twenty conversion stamping variant — fired by the
  * `onSubscriptionComplete` hook in `packages/api/src/lib/auth/server.ts`
  * after a paying checkout. Carries the Stripe `customer.id` so the
@@ -108,6 +135,7 @@ export type AtlasLeadEvent =
   | AtlasDemoLeadEvent
   | AtlasSalesFormLeadEvent
   | AtlasSignupLeadEvent
+  | AtlasMcpSignupLeadEvent
   | AtlasConversionLeadEvent;
 
 /** Note attached to the Person — only emitted by variants that carry a message. */
@@ -224,6 +252,34 @@ export function normalizeSignupLead(event: AtlasSignupLeadEvent): NormalizedLead
 }
 
 /**
+ * Normalize a self-serve MCP trial-signup event to a Twenty upsert payload.
+ * Mirror of `normalizeSignupLead` save for the `MCP_SIGNUP` event source — no
+ * note, no request context, first vs. last source semantics owned by
+ * `upsertPerson`. The distinct source is the whole reason this variant exists
+ * (ADR-0018): it lets the CRM attribute MCP self-serve as its own channel.
+ */
+export function normalizeMcpSignupLead(
+  event: AtlasMcpSignupLeadEvent,
+): NormalizedLead {
+  const email = event.email.toLowerCase().trim();
+  const eventSource: AtlasEventSource = "MCP_SIGNUP";
+
+  const customFields: { atlasIp?: string } = {};
+
+  const name = event.name ? splitName(event.name) : undefined;
+
+  return {
+    person: {
+      email,
+      eventSource,
+      ...(name ? { name } : {}),
+      customFields,
+    },
+    eventSource,
+  };
+}
+
+/**
  * Normalize a Stripe → Twenty conversion event to a Twenty upsert
  * payload. The `atlasStripeCustomerId` rides through `customFields` and
  * is spread inline by `upsertPerson` on every write path (POST + both
@@ -255,6 +311,8 @@ export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
       return normalizeSalesFormLead(event);
     case "signup":
       return normalizeSignupLead(event);
+    case "mcp-signup":
+      return normalizeMcpSignupLead(event);
     case "conversion":
       return normalizeConversionLead(event);
     default: {

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -88,21 +88,23 @@ export interface AtlasSignupLeadEvent {
  * DISTINCT lead source so the acquisition channel is measurable in the CRM:
  * `eventSource = "MCP_SIGNUP"` → sticky `atlasFirstSource = MCP_SIGNUP`.
  *
- * Because the same provisioning path also runs Better Auth's `user.create`
- * hook (which would otherwise emit a `signup`/`SIGNUP` lead), the auto-signup
- * enqueue is suppressed on the MCP path (see `signup-origin.ts` /
- * `dispatchSignupCrmLead`) so this is the SOLE `crm_outbox` row for the email
- * and wins first-touch. Lead source (acquisition attribution) is deliberately
- * kept separate from Agent origin (approval/audit, ADR-0015): both can say
- * "mcp", but unifying them would recreate the `surface`→`origin` overload.
+ * The same provisioning path also runs Better Auth's `user.create` hook, whose
+ * auto-`SIGNUP` lead is suppressed on the MCP path so this is the SOLE
+ * `crm_outbox` row for the email and wins first-touch — see
+ * `lib/auth/signup-origin.ts` for the sticky-first-touch race and why
+ * suppression is load-bearing. Lead source (acquisition attribution) is
+ * deliberately kept separate from Agent origin (approval/audit, ADR-0015):
+ * both can say "mcp", but unifying them would recreate the `surface`→`origin`
+ * overload.
  */
 export interface AtlasMcpSignupLeadEvent {
   readonly source: "mcp-signup";
   readonly email: string;
   /**
-   * Optional display name — parity with `signup`. The provisioner derives a
-   * name from the email local-part, but MCP signup stays email-first, so this
-   * may be absent. Split into first/last at the normalizer seam.
+   * Optional display name — present for type-parity with `signup` and any
+   * future email-only caller. Today's provisioner always derives one from the
+   * email local-part, so in practice it's populated. Split into first/last at
+   * the normalizer seam.
    */
   readonly name?: string;
 }

--- a/scripts/__tests__/check-lead-union-mirror.test.sh
+++ b/scripts/__tests__/check-lead-union-mirror.test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Adversarial fixture suite for scripts/check-lead-union-mirror.sh (#3653).
+#
+# The gate guards a single load-bearing line in ee/src/saas-crm/index.ts:
+#   const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput, AtlasLeadEvent> = true;
+# These fixtures lock in that it (a) passes when the assertion + bivariance
+# ExactType definition are present, and (b) fails on every way the guarantee
+# can silently evaporate: line deleted, commented out, ExactType neutered to a
+# trivial alias, wrong type args, or the SSOT file missing entirely.
+#
+# Each fixture runs in a temporary mirror of the repo layout so the gate runs
+# against it without touching the real codebase.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-lead-union-mirror.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# A valid ExactType definition + assertion, reused by the positive fixtures.
+EXACTTYPE_DEF='type ExactType<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;'
+VALID_ASSERTION='const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput, AtlasLeadEvent> = true;'
+
+# run_fixture EXPECTED FIXTURE_PATH FIXTURE_CONTENT
+#   EXPECTED:        "pass" — gate exits 0; "fail" — gate exits nonzero.
+#   FIXTURE_PATH:    relative path under the tmp repo. Use a NON-target path to
+#                    exercise the "SSOT file missing" branch.
+run_fixture() {
+  local expected="$1"
+  local fixture_path="$2"
+  local fixture_content="$3"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  mkdir -p "$tmp/$(dirname "$fixture_path")"
+  printf '%s\n' "$fixture_content" > "$tmp/$fixture_path"
+
+  local status=0
+  (cd "$tmp" && bash "$SCRIPT" > /dev/null 2>&1) || status=$?
+
+  if [ "$expected" = "pass" ] && [ "$status" -eq 0 ]; then
+    echo "  ok   $fixture_path (expected pass)"
+    PASS=$((PASS + 1))
+  elif [ "$expected" = "fail" ] && [ "$status" -ne 0 ]; then
+    echo "  ok   $fixture_path (expected fail)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $fixture_path — expected $expected, got status=$status" >&2
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+echo "Adversarial fixtures for scripts/check-lead-union-mirror.sh"
+echo "=========================================================="
+
+# --- Positive fixtures (the gate MUST pass) ----------------------------
+
+run_fixture pass "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+$VALID_ASSERTION
+void _leadUnionsAreMirrors;"
+
+# Whitespace tolerance — extra spacing around the type args must still pass.
+run_fixture pass "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+const _leadUnionsAreMirrors :  ExactType< SaasCrmLeadInput , AtlasLeadEvent >  =  true ;"
+
+# --- Negative fixtures (the gate MUST flag) ----------------------------
+
+# Assertion deleted entirely (only the ExactType def remains).
+run_fixture fail "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+// the mirror assertion was removed in a careless refactor"
+
+# Assertion commented out (line-comment) — must not satisfy the gate.
+run_fixture fail "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+// $VALID_ASSERTION"
+
+# Assertion commented out (block comment).
+run_fixture fail "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+/* $VALID_ASSERTION */"
+
+# ExactType neutered to a trivial always-true alias (fails open) — assertion
+# present but the definition no longer enforces equality.
+run_fixture fail "ee/src/saas-crm/index.ts" \
+  "type ExactType<A, B> = true;
+$VALID_ASSERTION"
+
+# Wrong type args — a guard pointed at the wrong unions must not pass.
+run_fixture fail "ee/src/saas-crm/index.ts" \
+  "$EXACTTYPE_DEF
+const _leadUnionsAreMirrors: ExactType<SomeOther, ThingEntirely> = true;"
+
+# SSOT file missing entirely (the file moved / was deleted).
+run_fixture fail "ee/src/saas-crm/other-file.ts" \
+  "$EXACTTYPE_DEF
+$VALID_ASSERTION"
+
+# --- Summary -----------------------------------------------------------
+
+echo "----------------------------------------------------------"
+echo "Passed: $PASS  Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/check-lead-union-mirror.sh
+++ b/scripts/check-lead-union-mirror.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Verify the compile-time lead-union mirror assertion still exists in
+# `ee/src/saas-crm/index.ts` (#3653).
+#
+# `SaasCrmLeadInput` (packages/api/src/lib/effect/services.ts) and
+# `AtlasLeadEvent` (plugins/twenty/src/lead-normalizer.ts) are hand-mirrored
+# wire-shape unions kept identical by one load-bearing line:
+#
+#   const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput, AtlasLeadEvent> = true;
+#
+# `ee/src/saas-crm/` is the single module allowed to depend on both sides (the
+# EE inversion rule), and `dispatchOutboxRow` casts `row.payload as
+# SaasCrmLeadInput` → `normalizeLead(...)` on the strength of that equality. If
+# the assertion line were ever deleted, reworded out of recognition, or the
+# file excluded from `tsgo`, the drift guard would vanish SILENTLY — a variant
+# added to one union but not the other would then dead-letter at flush time
+# (`normalizeLead`'s runtime `Unknown lead source` throw) instead of going red
+# in type-check.
+#
+# This gate closes that one silent-regression path the same way the repo's
+# other structural guards do: a cheap grep that fails loudly if the assertion
+# (or the bivariance `ExactType` definition it depends on) goes missing. It is
+# deliberately NOT a type check — `tsgo` already proves the unions match WHEN
+# the line is present; this proves the line is still there.
+
+set -euo pipefail
+
+TARGET="ee/src/saas-crm/index.ts"
+
+if [ ! -f "$TARGET" ]; then
+  echo "::error::lead-union mirror SSOT file not found at $TARGET — the cross-package union drift guard has no home"
+  echo ""
+  echo "Expected $TARGET to declare the ExactType<SaasCrmLeadInput, AtlasLeadEvent> assertion."
+  echo "If the file moved, update TARGET in $(basename "$0") to follow it."
+  exit 1
+fi
+
+# Strip comments before matching so a commented-out assertion can't satisfy the
+# gate (same three-step sed program as check-twenty-resolver-imports.sh):
+#   1. same-line block comments  2. multi-line block comments  3. trailing //
+STRIPPED="$(sed -E 's#/\*([^*]|\*+[^*/])*\*+/##g; /\/\*/,/\*\// d; s#//.*$##' "$TARGET")"
+
+# The assertion itself: `const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput,
+# AtlasLeadEvent> = true`. Whitespace-tolerant; both type args pinned so a guard
+# pointed at the wrong unions can't pass. The `= true` is load-bearing (a bare
+# `T extends true` helper fails open on `never`), so require it explicitly.
+ASSERTION_RE='const[[:space:]]+_leadUnionsAreMirrors[[:space:]]*:[[:space:]]*ExactType<[[:space:]]*SaasCrmLeadInput[[:space:]]*,[[:space:]]*AtlasLeadEvent[[:space:]]*>[[:space:]]*=[[:space:]]*true'
+
+# The bivariance idiom behind ExactType. Guards against the assertion being
+# neutered to a trivial `type ExactType<A, B> = true` alias that always passes.
+EXACTTYPE_RE='type[[:space:]]+ExactType<.*>[[:space:]]*=[[:space:]]*\(<'
+
+MISSING=""
+if ! printf '%s' "$STRIPPED" | grep -Eq "$ASSERTION_RE"; then
+  MISSING="${MISSING}  - the assertion: const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput, AtlasLeadEvent> = true;"$'\n'
+fi
+if ! printf '%s' "$STRIPPED" | grep -Eq "$EXACTTYPE_RE"; then
+  MISSING="${MISSING}  - the bivariance ExactType<A, B> definition it depends on"$'\n'
+fi
+
+if [ -n "$MISSING" ]; then
+  echo "::error::lead-union mirror assertion missing from $TARGET — cross-package drift is no longer guarded"
+  echo ""
+  echo "Missing:"
+  printf '%s' "$MISSING"
+  echo ""
+  echo "Why this matters:"
+  echo "  SaasCrmLeadInput and AtlasLeadEvent are hand-mirrored unions. The"
+  echo "  ExactType '= true' assertion is the ONLY thing that makes tsgo go red"
+  echo "  when they drift. Without it, a one-sided variant addition dead-letters"
+  echo "  silently at outbox flush instead of failing the build."
+  echo ""
+  echo "Fix:"
+  echo "  Restore the assertion (and ExactType definition) in $TARGET. See #3653"
+  echo "  and the rationale comment above _leadUnionsAreMirrors."
+  exit 1
+fi
+
+echo "Lead-union mirror check passed — ExactType<SaasCrmLeadInput, AtlasLeadEvent> assertion is present in $TARGET."


### PR DESCRIPTION
## What & why

Implements #3653 (ADR-0018 § "CRM attribution rides the existing lead-source pipeline"). A self-serve **MCP** trial signup now shows up in the CRM the same way a **web** signup does — through the existing `SaasCrm.upsertLead` → `crm_outbox` → Twenty pipeline — but tagged as a **distinct lead source** (`MCP_SIGNUP` → sticky `atlasFirstSource`) so the acquisition channel is measurable.

No new pipeline. No acquisition/`origin` column on the trial grant. Lead source (CRM acquisition attribution) stays **separate** from `agentOrigin` (approval/audit) — they are not conflated.

## Changes

- **`plugins/twenty/src/lead-normalizer.ts`** — `MCP_SIGNUP` added to `AtlasEventSource`; new `AtlasMcpSignupLeadEvent` (`source: "mcp-signup"`) added to the `AtlasLeadEvent` union; `normalizeMcpSignupLead` + the `case "mcp-signup":` switch arm (modelled on `signup`).
- **`packages/api/src/lib/effect/services.ts`** — `mcp-signup` arm added to the `SaasCrmLeadInput` union. The cross-package `ExactType<SaasCrmLeadInput, AtlasLeadEvent>` mirror in `ee/src/saas-crm/index.ts` still type-checks (both unions updated symmetrically).
- **`ee/src/onboarding/provision-trial.ts`** — `provisionTrialWorkspace` enqueues an `mcp-signup` lead on a successful signup, via an injected `enqueueMcpSignupLead` dep (default → new `dispatchMcpSignupCrmLead`), the same testable-seam pattern as `signUpEmail`.
- **`packages/api/src/lib/auth/signup-origin.ts`** (new) + **`server.ts`** — the suppression mechanism (below).

## The double-enqueue subtlety (the load-bearing decision)

`provisionTrialWorkspace` calls `signUpEmail`, whose Better Auth `user.create.after` hook **already** emits a generic `SIGNUP` lead. The outbox dispatches same-email rows strictly in `created_at` order (per-email `NOT EXISTS` claim gate) and `atlasFirstSource` is sticky first-touch — so the earlier-created `SIGNUP` row would **steal** first-source from `MCP_SIGNUP`, mis-attributing the channel.

**Fix — suppress the auto-`SIGNUP` on the MCP path** via an `AsyncLocalStorage` signup-origin context (the same "bind the ALS that Better Auth hooks fire outside of" pattern already used in `invitations.ts`): the provisioner wraps its `signUpEmail` call in `runWithSignupOrigin("mcp", …)`, and `dispatchSignupCrmLead` early-returns when the origin is `"mcp"`. `MCP_SIGNUP` is then the **sole** `crm_outbox` row for the email and wins first-touch. Asserted by an explicit `atlasFirstSource = MCP_SIGNUP` end-to-end test plus suppression tests.

## Tests

- `lead-normalizer.test.ts` — `normalizeMcpSignupLead` + dispatch-switch coverage.
- `client.test.ts` — end-to-end `normalizeLead(mcp-signup)` → `upsertPerson` POST asserts `atlasFirstSource = MCP_SIGNUP` / `atlasLastSource = MCP_SIGNUP`.
- `dispatch-signup-crm-lead.test.ts` — origin-`mcp` suppression (no SIGNUP), web signup still enqueues, `dispatchMcpSignupCrmLead` happy/blank/failure-swallow paths.
- `provision-trial.test.ts` — exactly one `mcp-signup` lead enqueued (grace + locked arms), none when signup fails.

## CI

`/ci` gates green locally: type ✓, lint ✓, syncpack ✓, template drift ✓, railway-watch ✓, affected + full suites.

Self-hosted (`deployMode !== 'saas'`) path unchanged — the provisioner already refuses there, and self-hosted resolves to the no-op `SaasCrm` layer.

## Milestone

This is the **last open item in v0.0.19 — Self-serve MCP Trial Signup**. Merging it completes the milestone, so PRD #3646 can be closed and the milestone shut. (Not closing them here — leaving that to a maintainer.)


Closes #3653
