### PR TITLE
fix(www): reconcile marketing/legal copy with v0.0.19 trial-signup flows

### DIFF
--- a/apps/www/data/sub-processors.json
+++ b/apps/www/data/sub-processors.json
@@ -47,5 +47,19 @@
     "region": "European Union",
     "since": "2026-01",
     "changed_at": "2026-01-15"
+  },
+  {
+    "name": "Cloudflare",
+    "purpose": "Bot mitigation (Turnstile on signup / abuse-sensitive endpoints) + CDN/edge proxy; receives end-user IP address",
+    "region": "Global (edge)",
+    "since": "2026-06",
+    "changed_at": "2026-06-19"
+  },
+  {
+    "name": "Twenty",
+    "purpose": "Customer-relationship management — stores signup and sales-enquiry contact details (name, email) for sales follow-up",
+    "region": "Customer’s selected region — co-located with Atlas infrastructure",
+    "since": "2026-06",
+    "changed_at": "2026-06-19"
   }
 ]

--- a/apps/www/src/app/pricing/page.tsx
+++ b/apps/www/src/app/pricing/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Pricing — Atlas",
     description:
-      "Self-host is free, forever. Cloud adds the things you'd build anyway: SSO, audit, uptime, support. 14-day free trial — no card required.",
+      "Self-host is free, forever. Cloud adds the things you'd build anyway: SSO, audit, uptime, support. 14-day free trial — no card, work email required.",
     url: "https://www.useatlas.dev/pricing",
     siteName: "Atlas",
     type: "website",

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -75,7 +75,7 @@ const TIERS: Tier[] = [
     badge: "14-day free trial",
     cta: "Start free trial",
     ctaHref: "https://app.useatlas.dev/signup?plan=starter",
-    ctaSecondary: "no card required",
+    ctaSecondary: "no card · work email",
     features: [
       "~100 AI queries/seat/mo included",
       "Up to 10 seats",
@@ -95,7 +95,7 @@ const TIERS: Tier[] = [
     badge: "14-day free trial",
     cta: "Start free trial",
     ctaHref: "https://app.useatlas.dev/signup?plan=pro",
-    ctaSecondary: "no card required",
+    ctaSecondary: "no card · work email",
     highlighted: true,
     features: [
       "~250 AI queries/seat/mo included",
@@ -208,7 +208,17 @@ const FAQS: FAQ[] = [
   {
     question: "Is there a free option?",
     answer:
-      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required. Every trial runs at Starter-tier usage limits (2M tokens/seat, up to 10 seats, 1 connection) for 14 days, regardless of the plan you start from.",
+      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required (work email required — see below). Every trial runs at Starter-tier usage limits (2M tokens/seat, up to 10 seats, 1 connection) for 14 days, regardless of the plan you start from.",
+  },
+  {
+    question: "What email can I sign up with?",
+    answer:
+      "Atlas Cloud signup requires a business (work) email. Disposable-mailbox and consumer freemium domains (gmail.com, outlook.com, yahoo.com, and similar) are not accepted, on both the web form and the MCP start_trial flow. Use your company address. Self-hosted Atlas has no such restriction.",
+  },
+  {
+    question: "How does the trial work over MCP?",
+    answer:
+      "You can start a trial directly from your MCP client (Claude Desktop, Cursor, etc.) with the start_trial tool — no web visit needed to begin. That workspace starts metered: you can set it up and run SQL, but Atlas-token Q&A is held until you claim the account on the web (verify your email and set a credential). Claiming starts your full 14-day clock; an unclaimed workspace runs on a short grace window and expires if it's never claimed. Signing up on the web claims the account in the same step.",
   },
   {
     question: "Do you offer annual billing?",

--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -69,10 +69,11 @@ const SECTIONS: LegalSectionData[] = [
       "Configuration data: semantic-layer YAML, validator rules, warehouse connection metadata (host, database, schema names — never credentials in plaintext).",
       "Operational data: query metadata (timestamp, gate outcomes, execution time, row count, error class). Query SQL and natural-language prompts are stored only when audit logging is enabled by the Customer admin.",
       "Telemetry: IP address, browser user-agent, page-load timing, error stack traces. Telemetry is sampled and retained for 30 days.",
+      "Security data: on signup and other abuse-sensitive endpoints we capture the client IP address and a bot-mitigation token to enforce rate limits and verify the request is human. The IP and token are sent to Cloudflare (Turnstile) for verification; per-IP and per-email attempt windows are kept transiently and swept automatically.",
       "Billing data: company name, billing address, tax ID, payment method tokens. We use Stripe as our payment processor; we never store full card numbers.",
     ],
     plain:
-      "Account info, your configuration, query metadata (query text only when your admin enables audit logging), error and performance telemetry, and billing details handled by Stripe.",
+      "Account info, your configuration, query metadata (query text only when your admin enables audit logging), error and performance telemetry, security/anti-abuse signals (IP + a bot-check token, verified by Cloudflare on signup), and billing details handled by Stripe.",
   },
   {
     id: "why",
@@ -81,11 +82,12 @@ const SECTIONS: LegalSectionData[] = [
       "To provide the Service: authenticate users, execute queries, render dashboards, send transactional email.",
       "To improve the Service: aggregate, anonymized telemetry to find slow paths, broken flows, and common errors. We do not use Customer Data to train models.",
       "To bill you: process payments, send invoices, comply with tax law.",
-      "To keep the Service safe: detect abuse, rate-limit attackers, investigate security incidents.",
+      "To keep the Service safe: detect abuse, rate-limit attackers, and verify signups are human. We process the client IP address and a Cloudflare Turnstile bot-check token on signup and abuse-sensitive endpoints for this purpose, and investigate security incidents.",
+      "To follow up on sales interest: when you sign up or contact sales, we record your name and email in our CRM (Twenty) so our team can respond. We do not use it for advertising and we do not sell it.",
       "To support you: respond to email, debug your issue with your explicit permission to read configuration data.",
     ],
     plain:
-      "To operate the Service, improve it through aggregate telemetry, process payments, prevent abuse, and respond to support requests.",
+      "To operate the Service, improve it through aggregate telemetry, process payments, prevent abuse (IP + bot-check via Cloudflare), follow up on signups/sales enquiries via our CRM, and respond to support requests.",
   },
   {
     id: "no-train",
@@ -116,13 +118,13 @@ const SECTIONS: LegalSectionData[] = [
     id: "share",
     title: "Who we share with",
     legal: [
-      "Sub-processors: a small set of vendors that help us run the Service (cloud infrastructure, uptime monitoring, payment processing). The current list is published at useatlas.dev/dpa and customers receive 30 days’ notice of additions.",
+      "Sub-processors: a small set of vendors that help us run the Service (cloud infrastructure, uptime monitoring, payment processing, bot mitigation, and CRM for sales follow-up). The current list is published at useatlas.dev/dpa and customers receive 30 days’ notice of additions.",
       "Model providers: when Customer uses Atlas’s hosted models, prompts are routed through Vercel AI Gateway, which forwards them to the upstream model provider configured for that Customer (e.g. Anthropic, OpenAI). Vercel acts as a sub-processor for routing, observability, and fallback. Where Customer uses BYO model keys, traffic is sent directly to the provider Customer specifies and does not transit Vercel.",
       "Legal: we may disclose information when required by law, court order, or to protect our rights, with notice to Customer where legally permitted.",
       "Successors: in a merger or sale of substantially all assets, the acquirer takes on the same obligations under this Policy.",
     ],
     plain:
-      "A short list of operational vendors (cloud infra, uptime monitoring, payments), the model provider you select, and disclosures required by valid legal process.",
+      "A short list of operational vendors (cloud infra, uptime monitoring, payments, bot mitigation, CRM), the model provider you select, and disclosures required by valid legal process.",
   },
   {
     id: "rights",
@@ -225,9 +227,9 @@ export default function PrivacyPage() {
             it. Aggressively boring on purpose.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-05-02</span>
+            <span>effective 2026-06-19</span>
             <span aria-hidden="true">·</span>
-            <span>v3.1</span>
+            <span>v3.2</span>
             <span aria-hidden="true">·</span>
             <span>questions: privacy@useatlas.dev</span>
           </div>

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -59,7 +59,7 @@ const SECTIONS: LegalSectionData[] = [
     id: "fees",
     title: "Fees & Payment",
     legal: [
-      "Customer agrees to pay all fees stated in the order form or on the pricing page in effect at the time of purchase. Fees are exclusive of taxes; Customer is responsible for sales, use, VAT, and similar taxes. Atlas Cloud paid plans include a 14-day free trial; trial accounts are provided without service-level commitment, support obligation, or liability — see Sections 8 and 9.",
+      "Customer agrees to pay all fees stated in the order form or on the pricing page in effect at the time of purchase. Fees are exclusive of taxes; Customer is responsible for sales, use, VAT, and similar taxes. Atlas Cloud paid plans include a 14-day free trial; trial accounts are provided without service-level commitment, support obligation, or liability — see Sections 8 and 9. The 14-day trial clock begins when the account is claimed (email verified and credentials set). A workspace provisioned but never claimed runs on a short grace window and expires automatically when that window elapses. Signup is limited to business email addresses.",
       "Subscriptions auto-renew for the same term unless either party gives written notice of non-renewal at least 30 days before the renewal date. Atlas may increase prices at renewal with 30 days’ written notice. Bring-your-own-token (BYOK) usage is billed by the LLM provider directly; Atlas charges only for infrastructure under BYOK.",
       "Invoices are due within 30 days. Past-due amounts accrue interest at 1.5%/month or the maximum allowed by law. Atlas may suspend the Service for accounts more than 60 days past due. Refunds are not provided for partial billing periods; cancellation retains access through the end of the current period.",
     ],
@@ -195,9 +195,9 @@ export default function TermsPage() {
             right.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-05-02</span>
+            <span>effective 2026-06-19</span>
             <span aria-hidden="true">·</span>
-            <span>v4.2</span>
+            <span>v4.3</span>
             <span aria-hidden="true">·</span>
             <span>last updated 2026-05-02</span>
           </div>

--- a/apps/www/src/components/webmcp.tsx
+++ b/apps/www/src/components/webmcp.tsx
@@ -51,7 +51,7 @@ const TOOLS: ModelContextTool[] = [
       const url = "https://app.useatlas.dev/signup";
       return openAndReport(
         url,
-        `Opened the Atlas signup page: ${url}. New workspaces include a 14-day free trial (Starter-tier limits); no credit card required.`,
+        `Opened the Atlas signup page: ${url}. New workspaces include a 14-day free trial (Starter-tier limits); no credit card required. Signup requires a business (work) email — consumer/freemium domains aren't accepted. The 14-day clock starts once you verify your email and set a credential (the "claim" step); web signup does this in the same flow.`,
       );
     },
   },


### PR DESCRIPTION
Closes #3793, closes #3794.

Found by `/www-audit` scoped to the **v0.0.18 → v0.0.19** delta. The v0.0.19 milestone (#3649–#3654) shipped a whole new signup/trial/billing model — self-serve MCP `start_trial`, a web claim step, claim-gated metering, business-email-only signup, **Cloudflare Turnstile** + per-IP/email rate-limiting, and **MCP→Twenty CRM** lead capture — **with zero `apps/www` edits.** This PR reconciles the marketing/legal surface with what actually ships.

## Legal (#3793)
- **`sub-processors.json`** — add **Cloudflare** (Turnstile bot-check on signup/abuse endpoints, receives end-user IP; also CDN/edge) and **Twenty** (CRM; stores signup + sales contact details). Both were receiving personal data while absent from the DPA Annex I list the DPA calls "the source of truth." The list auto-renders into the Annex I table and fires the Atom change-feed with `changed_at: 2026-06-19` — the designed 30-day-notice mechanism, so the DPA prose and pre-signed PDF (v2.5) are intentionally left untouched.
- **`privacy/page.tsx`** — disclose IP + bot-check collection for abuse prevention (shared with Cloudflare); disclose CRM use of signup/sales contact details (no ad use, no sale); expand the sub-processor sharing list; bump effective date → **2026-06-19 / v3.2**.

## Marketing (#3794)
- **`pricing-content.tsx`** — trial CTAs now read "no card · work email"; added FAQs covering the **business-email-only** requirement and the **MCP `start_trial` + claim** flow.
- **`pricing/page.tsx`** — OG copy: "no card, work email required".
- **`terms/page.tsx`** — trial clause now states the 14-day clock starts on claim, unclaimed workspaces expire after the grace window, and signup is business-email-only; effective date → **2026-06-19 / v4.3**.
- **`webmcp.tsx`** — `atlas_start_free_trial` tool surfaces the work-email requirement + claim step.

## Source of truth
`packages/api/src/lib/billing/plans.ts` (`TRIAL_DAYS=14`, `TRIAL_GRACE_HOURS=72`), `auth/business-email.ts`, `turnstile.ts:94` (forwards `remoteip` to Cloudflare), `trial-abuse.ts`, `ee/src/saas-crm/`, mirrored against the freshly-updated `apps/docs/content/docs/guides/{signup,mcp}.mdx`.

## Verification
- `sub-processors.json` validates (9 vendors); feed route renders the new `YYYY-MM-DD` entries.
- All 6 changed files transpile clean via `bun build` (fresh worktree has no `node_modules`, so the repo `lint`/`type` scripts aren't wired here — recommend a full `/ci` run in CI).

## Deliberately NOT changed
- DPA prose version / pre-signed PDF — the annex-list + change-feed is the correct vehicle for a sub-processor addition; re-versioning the contract body would desync the countersigned PDF.
- Business-email/disposable detection introduces **no** new sub-processor (bundled in-process domain lists, no third-party API call) — verified, no disclosure owed.