### PR TITLE
fix(trial-signup): close cross-PR gaps from v0.0.19 milestone review

### DIFF
--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -145,6 +145,78 @@ describe("provisionTrialWorkspace", () => {
     expect(calls.mcpLead).toHaveLength(0);
   });
 
+  it("maps a business-email rejection from the signup hook to invalid_input (actionable, not internal_error)", async () => {
+    // #3650 enforces business-email-only signup in the SHARED Better Auth
+    // `user.create.before` hook, so a freemium/disposable address throws a typed
+    // BUSINESS_EMAIL_REQUIRED APIError out of `signUpEmail`. The provisioner must
+    // recognize it and surface `invalid_input` (→ validation_failed envelope at
+    // the MCP layer) carrying the actionable message — NOT the generic
+    // `internal_error`/"please retry" a bare rethrow would produce. A deny is
+    // permanent, not transient.
+    const { APIError } = await import("better-auth/api");
+    const { BUSINESS_EMAIL_REQUIRED_CODE, BUSINESS_EMAIL_REQUIRED_MESSAGE } =
+      await import("@atlas/api/lib/auth/business-email");
+    const { deps, calls } = stubDeps({
+      signUpEmail: async () => {
+        throw new APIError("BAD_REQUEST", {
+          code: BUSINESS_EMAIL_REQUIRED_CODE,
+          message: BUSINESS_EMAIL_REQUIRED_MESSAGE,
+          reason: "freemium",
+        });
+      },
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "user@gmail.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      message: BUSINESS_EMAIL_REQUIRED_MESSAGE,
+    });
+    // A denied signup provisions nothing: no org, no grace, no CRM lead.
+    expect(calls.createOrg).toHaveLength(0);
+    expect(calls.grace).toHaveLength(0);
+    expect(calls.mcpLead).toHaveLength(0);
+  });
+
+  it("rethrows a non-business-email signup throw unchanged (a generic failure stays generic)", async () => {
+    // Anything other than the business-email rejection propagates untouched, so
+    // the MCP layer maps it to internal_error — only the recognized deny is
+    // re-tagged to invalid_input.
+    const { deps } = stubDeps({
+      signUpEmail: async () => {
+        throw new Error("better auth exploded");
+      },
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "a@b.com", orgName: "Acme" }, deps),
+    ).rejects.toThrow("better auth exploded");
+  });
+
+  it("is idempotent for a duplicate email — a repeat provision is refused before any org creation", async () => {
+    // Simulate Better Auth's enumeration-safe dedup: the first signup returns a
+    // real user id; a second signup for the same email returns the synthetic
+    // no-id response. The provisioner must refuse the second BEFORE org creation
+    // so a repeat call can't mint a second workspace for one account.
+    let seen = false;
+    const { deps, calls } = stubDeps({
+      signUpEmail: async () => {
+        if (seen) return { user: {} }; // duplicate → no id
+        seen = true;
+        return { user: { id: "user_first" } };
+      },
+    });
+    const first = await provisionTrialWorkspace(
+      { email: "dup@acme.com", orgName: "Acme" },
+      deps,
+    );
+    expect(first.workspaceId).toBe("org_new");
+    await expect(
+      provisionTrialWorkspace({ email: "dup@acme.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({ code: "signup_failed" });
+    // Only the first provision created an org and enqueued a lead.
+    expect(calls.createOrg).toHaveLength(1);
+    expect(calls.mcpLead).toHaveLength(1);
+  });
+
   it("refuses when deployMode !== 'saas'", async () => {
     const { deps, calls } = stubDeps({ getDeployMode: () => "self-hosted" });
     await expect(

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -60,7 +60,15 @@ export type TrialProvisioningCode =
   | "org_failed"
   | "trial_not_assigned";
 
-/** Typed error so the MCP tool / HTTP face can map to a structured envelope. */
+/**
+ * Typed error so the MCP tool / HTTP face can map to a structured envelope.
+ *
+ * A plain `Error` subclass (not a `Data.TaggedError`) on purpose: the consumer
+ * is the plain-async MCP `start_trial` tool seam, which recognizes it with
+ * `instanceof TrialProvisioningError` (see `packages/mcp/src/onboarding.ts`).
+ * Converting it to a tagged error would break that `instanceof` check — mirrors
+ * the same deliberate choice in `ClaimRequiredError` (`billing/claim-gate.ts`).
+ */
 export class TrialProvisioningError extends Error {
   override readonly name = "TrialProvisioningError";
   readonly code: TrialProvisioningCode;
@@ -244,11 +252,32 @@ export async function provisionTrialWorkspace(
   }
 
   const name = email.split("@")[0] || orgName;
-  const signup = await deps.signUpEmail({
-    email,
-    password: generateThrowawayPassword(),
-    name,
-  });
+  let signup: { user?: { id?: string } } | undefined;
+  try {
+    signup = await deps.signUpEmail({
+      email,
+      password: generateThrowawayPassword(),
+      name,
+    });
+  } catch (err) {
+    // The business-email-only policy (#3650) is enforced in the SHARED Better
+    // Auth `user.create.before` hook, so a freemium/disposable address throws
+    // a typed `business_email_required` APIError out of `signUpEmail`. Map it to
+    // `invalid_input` so the MCP `start_trial` envelope surfaces the actionable
+    // "use your work email" message — NOT the generic `internal_error`/"please
+    // retry" a bare rethrow would produce (a deny is permanent, not transient).
+    // Lazily imported so the heavy `better-auth-harmony` graph this recognizer
+    // pulls stays out of stub-injected unit tests (mirrors the dep philosophy).
+    const { isBusinessEmailRejection, BUSINESS_EMAIL_REQUIRED_MESSAGE } =
+      await import("@atlas/api/lib/auth/business-email");
+    if (isBusinessEmailRejection(err)) {
+      throw new TrialProvisioningError(
+        "invalid_input",
+        BUSINESS_EMAIL_REQUIRED_MESSAGE,
+      );
+    }
+    throw err;
+  }
   const userId = signup?.user?.id;
   if (!userId) {
     // Better Auth returns an enumeration-safe synthetic response (no real user

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -252,7 +252,7 @@ export async function provisionTrialWorkspace(
   }
 
   const name = email.split("@")[0] || orgName;
-  let signup: { user?: { id?: string } } | undefined;
+  let signup: Awaited<ReturnType<ProvisionTrialDeps["signUpEmail"]>>;
   try {
     signup = await deps.signUpEmail({
       email,
@@ -268,12 +268,26 @@ export async function provisionTrialWorkspace(
     // retry" a bare rethrow would produce (a deny is permanent, not transient).
     // Lazily imported so the heavy `better-auth-harmony` graph this recognizer
     // pulls stays out of stub-injected unit tests (mirrors the dep philosophy).
-    const { isBusinessEmailRejection, BUSINESS_EMAIL_REQUIRED_MESSAGE } =
-      await import("@atlas/api/lib/auth/business-email");
-    if (isBusinessEmailRejection(err)) {
+    //
+    // The import is wrapped so a (realistically impossible — already loaded on
+    // the real signup path) module-evaluation failure can't *substitute* the
+    // original signup error: on import failure we log and rethrow `err`, the
+    // genuine failure, rather than letting the import rejection mask it.
+    let recognizer:
+      | typeof import("@atlas/api/lib/auth/business-email")
+      | undefined;
+    try {
+      recognizer = await import("@atlas/api/lib/auth/business-email");
+    } catch (importErr) {
+      log.warn(
+        { err: importErr instanceof Error ? importErr.message : String(importErr) },
+        "business-email recognizer import failed; rethrowing original signup error",
+      );
+    }
+    if (recognizer?.isBusinessEmailRejection(err)) {
       throw new TrialProvisioningError(
         "invalid_input",
-        BUSINESS_EMAIL_REQUIRED_MESSAGE,
+        recognizer.BUSINESS_EMAIL_REQUIRED_MESSAGE,
       );
     }
     throw err;

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -211,6 +211,45 @@ mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   BillingBlockedError: BillingBlockedErrorStub,
 }));
 
+// ADR-0018 / #3651 — the claim-gate seam lives inside `executeAgentQuery`; the
+// route's job is mapping the typed claim errors to HTTP envelopes (403/503).
+// Mock the gate so tests control the verdict; the stub error classes mirror the
+// real ones (the route + executeAgentQuery both narrow via `instanceof`, and
+// both resolve the class from this same mocked module).
+class ClaimRequiredErrorStub extends Error {
+  override readonly name = "ClaimRequiredError";
+  readonly errorCode = "claim_required" as const;
+  readonly httpStatus = 403 as const;
+  readonly claimUrl: string;
+  constructor(claimUrl: string) {
+    super(`Claim required: ${claimUrl}`);
+    this.claimUrl = claimUrl;
+  }
+}
+class ClaimCheckFailedErrorStub extends Error {
+  override readonly name = "ClaimCheckFailedError";
+  readonly errorCode = "claim_check_failed" as const;
+  readonly httpStatus = 503 as const;
+  readonly retryable = true as const;
+  constructor() {
+    super("Unable to verify your workspace's claim status. Please try again.");
+  }
+}
+type ClaimGateVerdict =
+  | { allowed: true }
+  | { allowed: false; reason: "claim_required"; claimUrl: string }
+  | { allowed: false; reason: "check_failed" };
+let claimGateVerdict: ClaimGateVerdict = { allowed: true };
+const mockCheckClaimGate = mock(async (_orgId?: string) => claimGateVerdict);
+
+mock.module("@atlas/api/lib/billing/claim-gate", () => ({
+  checkClaimGate: mockCheckClaimGate,
+  ClaimRequiredError: ClaimRequiredErrorStub,
+  ClaimCheckFailedError: ClaimCheckFailedErrorStub,
+  buildClaimUrl: (email?: string) =>
+    `https://app.useatlas.dev/signup${email ? `?email=${email}` : ""}`,
+}));
+
 // Import after mocks are registered
 const { app } = await import("../index");
 
@@ -255,6 +294,8 @@ describe("POST /api/v1/query", () => {
     mockGetConversationQuery.mockResolvedValue({ ok: false, reason: "not_found" });
     billingGateVerdict = { allowed: true };
     mockCheckAgentBillingGate.mockClear();
+    claimGateVerdict = { allowed: true };
+    mockCheckClaimGate.mockClear();
   });
 
   afterEach(() => {
@@ -276,6 +317,42 @@ describe("POST /api/v1/query", () => {
     expect(body.data).toEqual([{ columns: ["count"], rows: [{ count: 42 }] }]);
     expect(body.steps).toBe(1);
     expect(body.usage).toEqual({ totalTokens: 150 });
+  });
+
+  // ADR-0018 / #3651 — route-level mapping of the claim-gate's typed errors.
+  // The block-vs-allow matrix is tested at the gate (billing/claim-gate.test.ts)
+  // and seam (agent-query-claim-gate.test.ts) levels; these pin the HTTP
+  // envelope the route emits, which nothing else exercised.
+  it("maps a claim-gate block to a 403 claim_required envelope carrying the claim URL", async () => {
+    claimGateVerdict = {
+      allowed: false,
+      reason: "claim_required",
+      claimUrl: "https://app.useatlas.dev/signup?email=owner@acme.com",
+    };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("claim_required");
+    expect(body.claimUrl).toBe(
+      "https://app.useatlas.dev/signup?email=owner@acme.com",
+    );
+    expect(body.retryable).toBe(false);
+    expect(body.requestId).toBeTruthy();
+    // A withheld query must not spend Atlas tokens.
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  it("maps an unverifiable claim status to a retryable 503 (fails closed, no claim URL, no token spend)", async () => {
+    claimGateVerdict = { allowed: false, reason: "check_failed" };
+    const response = await app.fetch(makeQueryRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("claim_check_failed");
+    expect(body.retryable).toBe(true);
+    // 503/check_failed is NOT a claim prompt — no claimUrl on this arm.
+    expect(body.claimUrl).toBeUndefined();
+    expect(body.requestId).toBeTruthy();
+    expect(mockRunAgent).not.toHaveBeenCalled();
   });
 
   // ── #3419/#3420: billing blocks from the seam map to the HTTP envelope ──

--- a/packages/api/src/lib/__tests__/trial-abuse.test.ts
+++ b/packages/api/src/lib/__tests__/trial-abuse.test.ts
@@ -13,7 +13,21 @@ import {
   getTrialEmailRpmLimit,
   resetTrialAttemptRateLimits,
   trialAttemptCleanupTick,
+  type TrialAttemptRateLimitResult,
 } from "../trial-abuse";
+
+/**
+ * Assert a result is the blocked arm and return it narrowed so `bucket` +
+ * `retryAfterMs` are readable (the result is a discriminated union — present
+ * IFF blocked — so a plain `expect(allowed).toBe(false)` doesn't narrow).
+ */
+function expectBlocked(
+  r: TrialAttemptRateLimitResult,
+): Extract<TrialAttemptRateLimitResult, { allowed: false }> {
+  expect(r.allowed).toBe(false);
+  if (r.allowed) throw new Error("unreachable: expected a blocked result");
+  return r;
+}
 
 const ORIG_IP = process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM;
 const ORIG_EMAIL = process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM;
@@ -66,8 +80,9 @@ describe("per-IP attempt window", () => {
     expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" }).allowed).toBe(true);
     expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" }).allowed).toBe(true);
     expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "c@x.com" }).allowed).toBe(true);
-    const blocked = checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "d@x.com" });
-    expect(blocked.allowed).toBe(false);
+    const blocked = expectBlocked(
+      checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "d@x.com" }),
+    );
     expect(blocked.bucket).toBe("ip");
     expect(blocked.retryAfterMs).toBeGreaterThan(0);
   });
@@ -83,8 +98,9 @@ describe("per-IP attempt window", () => {
   test("null IP collapses to a single shared bucket", () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
     expect(checkTrialAttemptRateLimit({ ip: null, email: "a@x.com" }).allowed).toBe(true);
-    const blocked = checkTrialAttemptRateLimit({ ip: null, email: "b@x.com" });
-    expect(blocked.allowed).toBe(false);
+    const blocked = expectBlocked(
+      checkTrialAttemptRateLimit({ ip: null, email: "b@x.com" }),
+    );
     expect(blocked.bucket).toBe("ip");
   });
 });
@@ -95,8 +111,9 @@ describe("per-email attempt window", () => {
     // Distinct IPs so only the email bucket can trip.
     expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "spam@x.com" }).allowed).toBe(true);
     expect(checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "spam@x.com" }).allowed).toBe(true);
-    const blocked = checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "spam@x.com" });
-    expect(blocked.allowed).toBe(false);
+    const blocked = expectBlocked(
+      checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "spam@x.com" }),
+    );
     expect(blocked.bucket).toBe("email");
     expect(blocked.retryAfterMs).toBeGreaterThan(0);
   });
@@ -104,8 +121,9 @@ describe("per-email attempt window", () => {
   test("email matching is case-insensitive + trimmed", () => {
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "1";
     expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "Spam@X.com" }).allowed).toBe(true);
-    const blocked = checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "  spam@x.com " });
-    expect(blocked.allowed).toBe(false);
+    const blocked = expectBlocked(
+      checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "  spam@x.com " }),
+    );
     expect(blocked.bucket).toBe("email");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/business-email-fail-closed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email-fail-closed.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Fail-closed coverage for {@link isDisposableEmail} (#3803 milestone review).
+ *
+ * The real `validateEmail` (mailchecker corpus) never throws on a string, so
+ * the fail-closed catch in `isDisposableEmail` is unreachable with the genuine
+ * dependency. We stub `better-auth-harmony/email` so `validateEmail` THROWS,
+ * proving the abuse-control denies (returns `true`) rather than letting an
+ * unclassified throw escape `assertBusinessEmail` as an opaque 500.
+ *
+ * Lives in its own file: the module-level `mock.module` below would otherwise
+ * poison the corpus-based assertions in `business-email.test.ts`. The isolated
+ * per-file runner keeps the stub scoped to this process.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+// Mock ALL runtime exports of `better-auth-harmony/email` (CLAUDE.md rule):
+// `validateEmail` (the throwing stub under test) + `default` (the
+// `emailHarmony` plugin factory). The type-only exports are erased at runtime.
+mock.module("better-auth-harmony/email", () => ({
+  default: () => ({}),
+  validateEmail: () => {
+    throw new Error("validator boom");
+  },
+}));
+
+const { isDisposableEmail } = await import("../business-email");
+
+describe("isDisposableEmail — fail closed", () => {
+  it("denies (returns true) when validateEmail throws", () => {
+    // A throwing validator must be treated as disposable/deny, never admitted.
+    expect(isDisposableEmail("attacker@some-domain.example")).toBe(true);
+  });
+
+  it("still short-circuits empty input before reaching the validator", () => {
+    // The empty guard returns false BEFORE calling validateEmail, so a throwing
+    // validator can't flip empty into a deny (Better Auth owns required-field).
+    expect(isDisposableEmail("")).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -252,9 +252,10 @@ describe("dispatchSignupCrmLead — failure swallow contract", () => {
     // The typed `Effect.fail` path goes through `Effect.either` Left,
     // not the outer catch — pin that branch independently so a future
     // refactor that drops the Left-side log gets caught here, not by
-    // relying on EE's `tapError` for the audit trail.
-    expect(mockLogWarn).toHaveBeenCalledTimes(1);
-    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    // relying on EE's `tapError` for the audit trail. Logged at `error`
+    // (not warn): a failed durable enqueue is a permanent lead loss (S-1).
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogError.mock.calls[0] as [Record<string, unknown>, string];
     expect(logCtx.event).toBe("signup_crm.enqueue_failed");
     expect(logCtx.userId).toBe("u10");
   });
@@ -377,9 +378,10 @@ describe("dispatchMcpSignupCrmLead — happy path", () => {
     // The typed `Effect.fail` path goes through `Effect.either` Left, not the
     // outer catch — pin that branch independently (mirror of the SIGNUP suite's
     // `signup_crm.enqueue_failed` test) so a refactor dropping the Left-side
-    // log gets caught here for the MCP path too.
-    expect(mockLogWarn).toHaveBeenCalledTimes(1);
-    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    // log gets caught here for the MCP path too. Logged at `error` (not warn):
+    // a failed durable enqueue is a permanent MCP_SIGNUP lead loss (S-1).
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogError.mock.calls[0] as [Record<string, unknown>, string];
     expect(logCtx.event).toBe("mcp_signup_crm.enqueue_failed");
   });
 });

--- a/packages/api/src/lib/auth/business-email.ts
+++ b/packages/api/src/lib/auth/business-email.ts
@@ -150,10 +150,26 @@ export function isFreemiumEmailDomain(email: string): boolean {
  * Better Auth owns the required-field case. This keeps the exported helper safe
  * for a direct caller (e.g. the MCP `start_trial` provisioner, #3649) that
  * hasn't already passed through {@link assertBusinessEmail}'s empty guard.
+ *
+ * If `validateEmail` itself THROWS on hostile input (a pathological/over-length
+ * address, or a future `mailchecker` that throws instead of returning false),
+ * we fail CLOSED — treat the address as disposable (deny) rather than let an
+ * unclassified throw escape `assertBusinessEmail` as an opaque 500. An
+ * abuse/eligibility check must never admit an address it couldn't validate.
+ * Logged via `console` to keep this module dependency-light (template-synced;
+ * no Atlas-internal imports — see the file header).
  */
 export function isDisposableEmail(email: string): boolean {
   if (!email) return false;
-  return !validateEmail(email);
+  try {
+    return !validateEmail(email);
+  } catch (err) {
+    console.warn(
+      "[business-email] validateEmail threw; denying address as disposable (fail closed):",
+      err instanceof Error ? err.message : String(err),
+    );
+    return true;
+  }
 }
 
 /** Why an address fails the business-email policy. */

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -312,8 +312,9 @@ export async function assignSaasTrial(args: {
  * defense:
  *  - inner `.pipe(Effect.either)` absorbs `upsertLead`'s typed `Error`
  *    channel (e.g. a `crm_outbox` Postgres blip), with a structured
- *    `log.warn` so the failure surfaces in this module's logs — does
- *    NOT rely on the EE-side `tapError` for the audit trail.
+ *    `log.error` (a failed durable enqueue is a permanent lead loss) so the
+ *    failure surfaces in this module's logs — does NOT rely on the EE-side
+ *    `tapError` for the audit trail.
  *  - outer `try/catch` absorbs runtime defects (a stuck `runPromise`,
  *    an unhandled rejection from a future Layer change).
  *
@@ -358,13 +359,18 @@ export async function dispatchSignupCrmLead(args: {
           })
           .pipe(Effect.either);
         if (result._tag === "Left") {
-          log.warn(
+          // `log.error`, not warn: the Left channel here means the durable
+          // `crm_outbox` enqueue itself failed (not a downstream Twenty hiccup
+          // the flusher would retry), so this signup's acquisition lead is
+          // permanently lost. Pageable — the swallow keeps auth unblocked, but
+          // the loss must alert. (#3653 review S-1.)
+          log.error(
             {
               userId: user.id,
               err: errorMessage(result.left),
               event: "signup_crm.enqueue_failed",
             },
-            "SaasCrm.upsertLead enqueue failed during signup — swallowed to keep auth response unblocked",
+            "SaasCrm.upsertLead enqueue failed during signup — lead lost; swallowed to keep auth response unblocked",
           );
         }
       }),
@@ -420,13 +426,16 @@ export async function dispatchMcpSignupCrmLead(args: {
           })
           .pipe(Effect.either);
         if (result._tag === "Left") {
-          log.warn(
+          // `log.error`, not warn — see the sibling enqueue_failed branch in
+          // dispatchSignupCrmLead: a failed durable `crm_outbox` enqueue means
+          // this MCP_SIGNUP acquisition lead is permanently lost. Pageable.
+          log.error(
             {
               email,
               err: errorMessage(result.left),
               event: "mcp_signup_crm.enqueue_failed",
             },
-            "SaasCrm.upsertLead enqueue failed during MCP signup — swallowed to keep provisioning unblocked",
+            "SaasCrm.upsertLead enqueue failed during MCP signup — lead lost; swallowed to keep provisioning unblocked",
           );
         }
       }),

--- a/packages/api/src/lib/billing/__tests__/reap-unclaimed-grace.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reap-unclaimed-grace.test.ts
@@ -150,6 +150,42 @@ describe("reapUnclaimedGraceWorkspaces", () => {
 
   // ── Mixed fixture + defensive guards ─────────────────────────────────
 
+  it("evicts each reaped org from the plan cache so the lock takes effect before TTL", async () => {
+    // The DB demotion alone isn't enough: a request hitting THIS replica would
+    // keep serving the cached 'trial' tier until the ≤60s TTL. Assert the reaper
+    // invalidates the cache for exactly the reaped ids (and nothing else).
+    const { pool } = makeMockPool([
+      { id: "org_reap_a", plan_tier: "trial", trialEndsInMs: -2 * HOUR_MS, ownerEmailVerified: false },
+      { id: "org_reap_b", plan_tier: "trial", trialEndsInMs: -3 * HOUR_MS, ownerEmailVerified: false },
+      { id: "org_claimed", plan_tier: "trial", trialEndsInMs: -2 * HOUR_MS, ownerEmailVerified: true },
+    ]);
+    _resetPool(pool);
+
+    const invalidated: string[] = [];
+    const result = await reapUnclaimedGraceWorkspaces({
+      invalidatePlanCache: (id) => invalidated.push(id),
+    });
+
+    expect(result.orgIds).toEqual(["org_reap_a", "org_reap_b"]);
+    // One eviction per reaped org — the claimed (un-reaped) org is never touched.
+    expect(invalidated).toEqual(["org_reap_a", "org_reap_b"]);
+  });
+
+  it("does not invalidate any cache entry when nothing is reaped", async () => {
+    const { pool } = makeMockPool([
+      { id: "org_in_grace", plan_tier: "trial", trialEndsInMs: 5 * HOUR_MS, ownerEmailVerified: false },
+    ]);
+    _resetPool(pool);
+
+    const invalidated: string[] = [];
+    const result = await reapUnclaimedGraceWorkspaces({
+      invalidatePlanCache: (id) => invalidated.push(id),
+    });
+
+    expect(result.reapedCount).toBe(0);
+    expect(invalidated).toEqual([]);
+  });
+
   it("reaps only the unclaimed past-grace rows from a mixed fixture", async () => {
     const { pool } = makeMockPool([
       { id: "org_reap_me", plan_tier: "trial", trialEndsInMs: -2 * HOUR_MS, ownerEmailVerified: false },

--- a/packages/api/src/lib/billing/reap-unclaimed-grace.ts
+++ b/packages/api/src/lib/billing/reap-unclaimed-grace.ts
@@ -53,13 +53,25 @@ export interface ReapResult {
 const SKIPPED: ReapResult = { reapedCount: 0, orgIds: [] };
 
 /**
+ * Injectable boundary so the per-org cache eviction can be verified without
+ * `mock.module` (mirrors the DI seam in `claim-gate.ts` / `provision-trial.ts`).
+ */
+export interface ReapDeps {
+  /** Evict one org from this replica's plan cache. */
+  invalidatePlanCache: (orgId: string) => void;
+}
+
+/**
  * Run one reaping pass.
  *
  * Returns `SKIPPED` synchronously when deploy mode isn't SaaS or no internal DB
  * is configured. Errors during the UPDATE are logged and swallowed — a failed
  * sweep must not crash the scheduler fiber; the next interval retries.
  */
-export async function reapUnclaimedGraceWorkspaces(): Promise<ReapResult> {
+export async function reapUnclaimedGraceWorkspaces(
+  overrides: Partial<ReapDeps> = {},
+): Promise<ReapResult> {
+  const invalidate = overrides.invalidatePlanCache ?? invalidatePlanCache;
   if (getConfig()?.deployMode !== "saas") return SKIPPED;
   if (!hasInternalDB()) return SKIPPED;
 
@@ -97,7 +109,7 @@ export async function reapUnclaimedGraceWorkspaces(): Promise<ReapResult> {
     // this instance sees the lock immediately rather than after TTL (≤60s).
     // Per-replica only (#3432) — peers self-heal on TTL expiry, same contract
     // as `reconcilePlanTiers`.
-    for (const id of orgIds) invalidatePlanCache(id);
+    for (const id of orgIds) invalidate(id);
 
     if (orgIds.length > 0) {
       log.info(

--- a/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it, afterEach } from "bun:test";
-import { buildMcpConnectUrl, resolveMcpBaseUrl } from "../connect-url.js";
+import { describe, expect, it, afterEach, mock, type Mock } from "bun:test";
+
+// Capture the warn `buildMcpConnectUrl` emits on an unresolved base. Mock the
+// logger before importing the SUT so its module-level `createLogger` call binds
+// to these spies. Mock the full logger surface (CLAUDE.md "mock all exports").
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const stubLogger = {
+  info: mock(() => {}),
+  warn: mockLogWarn,
+  error: mock(() => {}),
+  debug: mock(() => {}),
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  setLogLevel: () => false,
+}));
+
+const { buildMcpConnectUrl, resolveMcpBaseUrl } = await import("../connect-url.js");
 
 const ORIG_PUBLIC = process.env.ATLAS_PUBLIC_API_URL;
 const ORIG_AUTH = process.env.BETTER_AUTH_URL;
@@ -12,7 +32,10 @@ function restoreEnv(): void {
 }
 
 describe("buildMcpConnectUrl", () => {
-  afterEach(restoreEnv);
+  afterEach(() => {
+    restoreEnv();
+    mockLogWarn.mockClear();
+  });
 
   it("builds /mcp/{workspaceId}/sse from an explicit base override", () => {
     expect(buildMcpConnectUrl("org_123", "https://example.test")).toBe(
@@ -73,5 +96,17 @@ describe("buildMcpConnectUrl", () => {
     delete process.env.ATLAS_PUBLIC_API_URL;
     delete process.env.BETTER_AUTH_URL;
     expect(buildMcpConnectUrl("org_z")).toBe("/mcp/org_z/sse");
+    // The warn is the actual point of the fix — surface the misconfiguration
+    // rather than silently handing back a relative path. Assert it fired with
+    // the workspace id so a regression that drops the warn is caught.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    expect(mockLogWarn.mock.calls[0]?.[0]).toEqual({ workspaceId: "org_z" });
+  });
+
+  it("does NOT warn when a base resolves", () => {
+    expect(buildMcpConnectUrl("org_ok", "https://example.test")).toBe(
+      "https://example.test/mcp/org_ok/sse",
+    );
+    expect(mockLogWarn).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/connect-url.test.ts
@@ -56,4 +56,22 @@ describe("buildMcpConnectUrl", () => {
       "https://atlas.acme.internal",
     );
   });
+
+  it("resolves to an empty base when no source is set", () => {
+    delete process.env.ATLAS_PUBLIC_API_URL;
+    delete process.env.BETTER_AUTH_URL;
+    expect(resolveMcpBaseUrl()).toBe("");
+  });
+
+  it("yields a relative (unusable) connect URL when no base resolves — and warns", () => {
+    // SaaS boot requires a public API base, so this is unreachable in a
+    // correctly configured region. The function does NOT throw (a missing base
+    // shouldn't crash provisioning), but it emits a warn so the misconfiguration
+    // surfaces rather than silently handing back a relative path. We assert the
+    // documented degenerate shape so a future regression to a thrown error or a
+    // different fallback is caught.
+    delete process.env.ATLAS_PUBLIC_API_URL;
+    delete process.env.BETTER_AUTH_URL;
+    expect(buildMcpConnectUrl("org_z")).toBe("/mcp/org_z/sse");
+  });
 });

--- a/packages/api/src/lib/mcp/connect-url.ts
+++ b/packages/api/src/lib/mcp/connect-url.ts
@@ -14,6 +14,10 @@
  * both hand back an identical, canonical connect URL.
  */
 
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("mcp-connect-url");
+
 /**
  * Map a regional `api[-region].useatlas.dev` host onto the public brand host
  * `mcp[-region].useatlas.dev`, so a client that never sees the internal
@@ -64,5 +68,16 @@ export function resolveMcpBaseUrl(baseUrl?: string): string {
  */
 export function buildMcpConnectUrl(workspaceId: string, baseUrl?: string): string {
   const base = resolveMcpBaseUrl(baseUrl);
+  if (!base) {
+    // No public API base resolved (ATLAS_PUBLIC_API_URL / BETTER_AUTH_URL both
+    // unset). SaaS boot requires these, so this is unreachable in a correctly
+    // configured region — but a bare relative `/mcp/{id}/sse` would be the
+    // trial's entire payoff handed back unusable. Surface the misconfiguration
+    // at provision time rather than as a confusing client-side connect failure.
+    log.warn(
+      { workspaceId },
+      "buildMcpConnectUrl: no public API base resolved — connect URL is relative and unusable; check ATLAS_PUBLIC_API_URL/BETTER_AUTH_URL",
+    );
+  }
   return `${base}/mcp/${workspaceId}/sse`;
 }

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -280,6 +280,31 @@ describe("executor", () => {
     expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
   });
 
+  it("records a claim-required block on the run with the claim reason (#3651)", async () => {
+    const { ClaimRequiredError } = await import("@atlas/api/lib/billing/claim-gate");
+    mockExecuteAgentQuery.mockImplementationOnce(() =>
+      Promise.reject(new ClaimRequiredError("https://app.example.test/claim")),
+    );
+    const promise = executeScheduledTask("task-1", "run-1", 30_000);
+    await expect(promise).rejects.toThrow(/Workspace not yet claimed \[claim_required\]/);
+    expect(mockDeliverResult).not.toHaveBeenCalled();
+    expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
+  });
+
+  it("labels a transient claim-check failure on the run for parity (#3803)", async () => {
+    const { ClaimCheckFailedError } = await import("@atlas/api/lib/billing/claim-gate");
+    mockExecuteAgentQuery.mockImplementationOnce(() =>
+      Promise.reject(new ClaimCheckFailedError()),
+    );
+    // A fail-closed 503 claim-status lookup failure: the run must be recorded
+    // failed with the labeled, user-safe reason (parity with query/chat paths)
+    // rather than an unattributed error. The next tick retries.
+    const promise = executeScheduledTask("task-1", "run-1", 30_000);
+    await expect(promise).rejects.toThrow(/Claim status check failed \[claim_check_failed\]/);
+    expect(mockDeliverResult).not.toHaveBeenCalled();
+    expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
+  });
+
   it("skips delivery status when no recipients attempted", async () => {
     mockDeliverResult.mockResolvedValueOnce({ attempted: 0, succeeded: 0, failed: 0, permanentFailures: 0, firstPermanentError: null });
     await executeScheduledTask("task-1", "run-1", 30_000);

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -22,7 +22,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getScheduledTask, updateRunDeliveryStatus } from "@atlas/api/lib/scheduled-tasks";
 import { executeAgentQuery, type AgentQueryResult } from "@atlas/api/lib/agent-query";
 import { BillingBlockedError } from "@atlas/api/lib/billing/agent-gate";
-import { ClaimRequiredError } from "@atlas/api/lib/billing/claim-gate";
+import { ClaimRequiredError, ClaimCheckFailedError } from "@atlas/api/lib/billing/claim-gate";
 import { loadActorUser } from "@atlas/api/lib/auth/actor";
 import { SchedulerTaskTimeoutError, SchedulerExecutionError } from "@atlas/api/lib/effect/errors";
 import { causeToError } from "@atlas/api/lib/audit/error-scrub";
@@ -68,9 +68,15 @@ function agentQueryEffect(
               // on the run row so the owner knows to claim on the web.
               err instanceof ClaimRequiredError
               ? `Workspace not yet claimed [${err.errorCode}]: ${err.message}`
-              : err instanceof Error
-                ? err.message
-                : String(err),
+              : // A transient claim-status lookup failure (fail-closed 503). Its
+                // message is user-safe; label it for parity with the query/chat
+                // paths so the owner's run history isn't an unattributed error.
+                // The run is recorded failed and retries on the next tick.
+                err instanceof ClaimCheckFailedError
+                ? `Claim status check failed [${err.errorCode}]: ${err.message}`
+                : err instanceof Error
+                  ? err.message
+                  : String(err),
         taskId,
       }),
   }).pipe(

--- a/packages/api/src/lib/trial-abuse.ts
+++ b/packages/api/src/lib/trial-abuse.ts
@@ -107,7 +107,7 @@ function peek(
   key: string,
   limit: number,
   now: number,
-): { allowed: boolean; retryAfterMs?: number } {
+): { allowed: true } | { allowed: false; retryAfterMs: number } {
   if (limit === 0) return { allowed: true };
 
   const cutoff = now - WINDOW_MS;
@@ -140,13 +140,20 @@ function record(windows: Map<string, number[]>, key: string, limit: number, now:
 /** Which bucket tripped — surfaced for structured logging, never to the caller's user. */
 export type TrialAttemptBucket = "ip" | "email";
 
-export interface TrialAttemptRateLimitResult {
-  readonly allowed: boolean;
-  /** The bucket that tripped (only when `allowed === false`). */
-  readonly bucket?: TrialAttemptBucket;
-  /** Milliseconds until the tripped bucket frees a slot. */
-  readonly retryAfterMs?: number;
-}
+/**
+ * Discriminated on `allowed` so `bucket` + `retryAfterMs` are present IFF the
+ * attempt was blocked — a `{ allowed: true }` result can't carry a stray bucket,
+ * and a consumer that branches on `!allowed` reads both fields without a fallback.
+ */
+export type TrialAttemptRateLimitResult =
+  | { readonly allowed: true }
+  | {
+      /** The bucket that tripped. */
+      readonly allowed: false;
+      readonly bucket: TrialAttemptBucket;
+      /** Milliseconds until the tripped bucket frees a slot. */
+      readonly retryAfterMs: number;
+    };
 
 /**
  * Check a trial creation attempt against BOTH the per-IP and per-email windows.

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -248,8 +248,12 @@ describe("start_trial tool", () => {
       const arr = result.content as Array<{ type: string; text: string }>;
       const err = parseAtlasMcpToolError(arr[0]!.text);
       expect(err?.code).toBe(tc.envelopeCode);
-      if (tc.expectHint) expect(err?.hint).toBeTruthy();
-      if (tc.expectRequestId) expect(err?.request_id).toBeTruthy();
+      if (tc.expectHint) expect(typeof err?.hint).toBe("string");
+      if (tc.expectRequestId) {
+        // Assert the shape, not mere truthiness — the literal string
+        // "undefined" would pass `toBeTruthy()`. request_id is a UUID.
+        expect(err?.request_id).toMatch(/^[0-9a-f-]{36}$/i);
+      }
     }
   });
 
@@ -281,7 +285,7 @@ describe("start_trial tool", () => {
     const arr = result.content as Array<{ type: string; text: string }>;
     const err = parseAtlasMcpToolError(arr[0]!.text);
     expect(err?.code).toBe("internal_error");
-    expect(err?.request_id).toBeTruthy();
+    expect(err?.request_id).toMatch(/^[0-9a-f-]{36}$/i);
   });
 });
 
@@ -367,6 +371,37 @@ describe("start_trial abuse controls (#3654)", () => {
     });
     expect(result.isError).toBeFalsy();
     expect(seen).toEqual([{ token: "good-token", remoteIp: null }]);
+    // The pass must actually reach provisioning — assert the payoff, not just
+    // that the verifier was called.
+    expect(
+      (result.structuredContent as { workspaceId: string }).workspaceId,
+    ).toBe("org_new");
+  });
+
+  it("fails CLOSED (forbidden) when the verifier THROWS — an abuse control denies on a verifier defect", async () => {
+    // The real verifier never throws (it folds every failure into ok:false), so
+    // this pins the defensive contract: an unexpected verifier throw must deny
+    // as a failed bot-check (forbidden), NOT fall through to an internal_error
+    // that invites endless retries — and must NEVER provision.
+    let provisioned = false;
+    const provision: ProvisionTrialFn = async () => {
+      provisioned = true;
+      return okProvision({ email: "x@y.com", orgName: "Acme" });
+    };
+    const verifyTurnstile: VerifyTurnstileFn = async () => {
+      throw new Error("siteverify client blew up");
+    };
+    const { client } = await wireTool(provision, { verifyTurnstile });
+    const result = await client.callTool({
+      name: "start_trial",
+      arguments: { email: "founder@acme.com", orgName: "Acme", turnstileToken: "tok" },
+    });
+    expect(result.isError).toBe(true);
+    const err = parseAtlasMcpToolError(
+      (result.content as Array<{ text: string }>)[0]!.text,
+    );
+    expect(err?.code).toBe("forbidden");
+    expect(provisioned).toBe(false);
   });
 
   // ── Rate limiting ─────────────────────────────────────────────────────────

--- a/packages/mcp/src/onboarding.ts
+++ b/packages/mcp/src/onboarding.ts
@@ -238,7 +238,7 @@ export function registerStartTrialTool(
         // NOT trials per IP (shared NATs must keep signing up).
         const rate = checkRateLimit({ ip: clientIp, email: input.email });
         if (!rate.allowed) {
-          const retryAfter = Math.ceil((rate.retryAfterMs ?? 60_000) / 1000);
+          const retryAfter = Math.ceil(rate.retryAfterMs / 1000);
           log.warn(
             { requestId, bucket: rate.bucket, retryAfter, event: "start_trial.rate_limited" },
             "start_trial creation attempt rate-limited",
@@ -278,7 +278,24 @@ export function registerStartTrialTool(
         // Turnstile siteverify — fails closed (missing secret, network error,
         // and explicit rejection all return ok:false). Never leak the secret,
         // the token, or Cloudflare error codes to the caller; log them only.
-        const verify = await verifyTurnstileFn({ token, remoteIp: clientIp, requestId });
+        // The real verifier never throws (it folds every failure into ok:false),
+        // but an abuse control must fail CLOSED even on an unexpected verifier
+        // defect: a throw is treated as a failed bot-check (forbidden/deny), not
+        // a generic internal_error that would invite endless retries.
+        let verify: VerifyTurnstileResult;
+        try {
+          verify = await verifyTurnstileFn({ token, remoteIp: clientIp, requestId });
+        } catch (err) {
+          log.error(
+            {
+              requestId,
+              err: err instanceof Error ? err.message : String(err),
+              event: "start_trial.turnstile_threw",
+            },
+            "start_trial Turnstile verifier threw — failing closed (deny)",
+          );
+          verify = { ok: false, errorCodes: [], reason: "verifier_threw" };
+        }
         if (!verify.ok) {
           log.warn(
             {

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -237,6 +237,58 @@ describe("upsertPerson — Person exists with atlasFirstSource set", () => {
     expect(body.atlasFirstSource).toBeUndefined();
   });
 
+  test("end-to-end: an mcp-signup lead for an EXISTING Person PATCHes only atlasLastSource — first-touch (DEMO) is sticky (#3653)", async () => {
+    // The companion test pins MCP_SIGNUP as first-touch on a NEW Person; this
+    // pins the inverse — the whole point of the suppression machinery. A prospect
+    // who demoed first, then self-served via MCP, must keep atlasFirstSource=DEMO
+    // and only flip atlasLastSource to MCP_SIGNUP. A regression that stamped
+    // firstSource here would silently steal the original acquisition attribution.
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_demoed",
+                emails: { primaryEmail: "founder@acme.com" },
+                atlasFirstSource: "DEMO",
+                atlasLastSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: {
+          data: {
+            updatePerson: {
+              id: "person_demoed",
+              atlasFirstSource: "DEMO",
+              atlasLastSource: "MCP_SIGNUP",
+            },
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const normalized = normalizeLead({
+      source: "mcp-signup",
+      email: "founder@acme.com",
+      name: "Founder Acme",
+    });
+    const result = await upsertPerson(config, normalized.person);
+
+    expect(result.id).toBe("person_demoed");
+    expect(calls[1].method).toBe("PATCH");
+    const mcpBody = JSON.parse(calls[1].body ?? "{}");
+    expect(mcpBody.atlasLastSource).toBe("MCP_SIGNUP");
+    // CRITICAL: the sticky first-touch must NOT be overwritten.
+    expect(mcpBody.atlasFirstSource).toBeUndefined();
+  });
+
   test("PATCH includes name when provided (input.name merges into every write path)", async () => {
     const { fetch, calls } = makeScriptedFetch([
       {

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -26,6 +26,13 @@ import type { UpsertPersonInput } from "./client";
  * Sticky / last-touch source attribution stamped on Twenty Person
  * records. Narrow literal union: a typo here persists in Twenty
  * forever, so the type must reject misspellings at compile time.
+ *
+ * `OTHER` is intentionally NOT produced by any `AtlasLeadEvent` variant — it's
+ * the catch-all the agent-facing `upsertTwentyPerson` tool exposes (see the
+ * `eventSource` enum in `index.ts`) for an agent stamping a Person that doesn't
+ * fit a tracked acquisition channel. `MCP_SIGNUP` is deliberately the inverse:
+ * an internal channel the provisioner sets but agents must NOT stamp by hand,
+ * so it's absent from that tool enum.
  */
 export type AtlasEventSource =
   | "DEMO"

--- a/scripts/ee-stub/src/onboarding/provision-trial.ts
+++ b/scripts/ee-stub/src/onboarding/provision-trial.ts
@@ -12,6 +12,14 @@
  * switch over `TrialProvisioningCode` in `onboarding.ts` depends on the literal
  * union, not a widened `string`.
  *
+ * Drift is type-enforced across two builds, so no separate mirror-assertion is
+ * needed (unlike the cross-package CRM lead union, which has `check-lead-union-
+ * mirror.sh`): normal CI type-checks `packages/mcp` against the REAL union (a
+ * new code → onboarding.ts's exhaustive switch fails to compile), and the
+ * `ee-stub-build` job type-checks it against THIS stub (a switch case for a code
+ * the stub lacks → `tsgo` rejects the comparison). A divergence fails one build
+ * or the other.
+ *
  * Not used at runtime.
  */
 


### PR DESCRIPTION
## Summary

A whole-milestone review of the v0.0.19 trial-signup work (`v0.0.18..HEAD` — the 6 PRs #3649–#3654) surfaced seams that per-PR review missed. This PR fixes them with regression tests. **18 files, +482/−46; type-check + lint + all affected tests green.**

### Critical / Important
- **Business-email seam (the headline gap).** `provisionTrialWorkspace` now recognizes the typed business-email `APIError` thrown by the shared Better Auth signup hook and maps it to `invalid_input` → `validation_failed` ("use your work email"), instead of the generic `internal_error`/"please retry" a Gmail/disposable signer-up was getting. Wires the previously-dead `isBusinessEmailRejection` recognizer (lazy-imported to preserve stubbed-test isolation). + tests.
- **`validateEmail` fail-closed.** `isDisposableEmail` now catches a validator throw and denies (fail-closed, logged) rather than letting an unclassified throw escape `assertBusinessEmail` as an opaque 500.
- **Claim-gate route mapping (was untested).** Added a controllable claim-gate mock + 2 `query.test.ts` tests pinning the 403 `claim_required` (with `claimUrl`) and retryable 503 `claim_check_failed` envelopes, asserting zero token spend.
- **Provisioning idempotency.** Explicit duplicate-email test — a repeat provision is refused before any org creation.
- **MCP_SIGNUP first-touch stickiness.** Test that an `mcp-signup` arriving at an existing (DEMO) Person PATCHes only `atlasLastSource`, leaving sticky `atlasFirstSource` intact.

> Two findings the review flagged were already covered and needed no code: the BYO-key/self-hosted claim-gate bypass (covered by `claim-gate.test.ts`) and the ee-stub union drift (already type-enforced by the dual real/stub builds — now documented).

### Suggestions
- `TrialAttemptRateLimitResult` → discriminated union (`bucket`/`retryAfterMs` present iff blocked).
- CRM enqueue-failure → `log.error` (a failed durable-outbox INSERT is a permanent lead loss), both signup + mcp-signup branches.
- `buildMcpConnectUrl` warns on an unresolved public base + degenerate-input test.
- Turnstile verifier throw now fails **closed (forbidden)**, not `internal_error`.
- `ClaimCheckFailedError` labeled in the scheduler executor for run-history parity.
- Reaper gained a DI seam + a test that the plan cache is invalidated per reaped org.
- Docs: justify plain-Error `TrialProvisioningError`; document the `OTHER` event source and the ee-stub dual-build drift guard.

## Test plan
- `bun run type` — clean
- `bun run lint` — clean
- All affected test files pass (provision-trial, onboarding, twenty/client, trial-abuse, connect-url, reaper, agent-query-claim-gate, query route, business-email, dispatch-crm, executor, signup-origin, claim-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)