### PR TITLE
fix(trial-signup): resolve MCP start_trial envelope contract gaps (#3800)

### DIFF
--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -46,7 +46,7 @@ On the hosted SaaS, Atlas signup is **business-email only**, with identical poli
 - **Disposable / throwaway mailboxes** (mailinator, guerrillamail, 10-minute-mail, …) — detected via the [`better-auth-harmony`](https://github.com/GauBen/better-auth-harmony) `emailHarmony` plugin's `mailchecker` engine (50k+ domains).
 - **Freemium / consumer domains** (gmail, outlook, yahoo, icloud, proton, …) — a maintained denylist in code.
 
-Both denials surface the same way: an actionable error on the web form ("Please sign up with your work email address…") and a typed `business_email_required` envelope on the MCP path. Legitimate business-domain signups are unaffected.
+Both denials carry the same actionable message — "Please sign up with your work email address…". On the **web form** it arrives as a Better Auth `400` whose body carries `code: "business_email_required"`. On the **MCP `start_trial`** path it arrives as a [`validation_failed`](/reference/error-codes#self-serve-trial-signup-over-mcp-start_trial) envelope carrying that message plus a "use your work email" `hint` (the closed MCP envelope catalog has no dedicated business-email code, and a personal address is invalid trial input). Legitimate business-domain signups are unaffected.
 
 The `emailHarmony` plugin also writes a unique `normalizedEmail` column — collapsing `+alias`, dot, and case variants of the same address — so `john.doe+trial@acme.com` and `johndoe@acme.com` can't both claim a separate trial.
 

--- a/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
+++ b/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
@@ -121,3 +121,16 @@ Abuse prevention is separate from [rate limiting](/guides/rate-limiting):
 - **Abuse prevention** is per-workspace, uses a longer sliding window, and applies graduated response
 
 Both can be active simultaneously. Rate limiting catches individual users making too many requests; abuse prevention catches workspace-level patterns that may involve multiple users or automated access.
+
+---
+
+## Unclaimed-grace reaper (self-serve MCP trials)
+
+A workspace provisioned over MCP by [`start_trial`](/guides/mcp#start_trial) lands on the `trial` tier in a short **unclaimed grace** window (`TRIAL_GRACE_HOURS`, default 72h) rather than the full 14-day clock — the clock only starts when the owner **claims** the account on the web (verifies their email). This bounds the free pre-claim window so abandoned and spam signups can't sit on a free MCP-querying workspace indefinitely.
+
+A background sweep (`reapUnclaimedGraceWorkspaces`) demotes any **unclaimed** workspace whose grace window has lapsed to the `locked` churn tier, after which Gate 0 (`checkPlanLimits`) blocks it on every surface — MCP included — with `subscription_required`. Operator-relevant properties:
+
+- **Runs on every SaaS region, hourly.** It is gated on `deployMode === "saas"` + an internal DB only — deliberately **independent** of `ATLAS_SCHEDULER_ENABLED` (unlike the proactive/report scheduler), so it sweeps even in regions where the task scheduler is off.
+- **Never touches a claimed trial.** The sweep matches only an unverified owner (`emailVerified = false`), so a claimed trial runs its normal 14-day expiry untouched. It also honors active operator `plan_override_until` grants.
+- **Idempotent + concurrency-safe.** A guarded `UPDATE` on `plan_tier = 'trial'`; a second pass or a peer region finds zero candidates. A failed sweep is logged and swallowed — candidates simply remain on `trial` until the next interval retries.
+- **Observability.** A non-zero reap logs `reapedCount` + `orgIds` at `info` (logger `billing.reap-unclaimed-grace`); failures log at `error`. No metric is emitted today.

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -168,6 +168,21 @@ A workspace provisioned over MCP by `start_trial` starts **unclaimed (metered)**
 | `claim_required` | `ClaimRequiredError` | 403 | Atlas-token Q&A was attempted on an unclaimed (metered) trial workspace. The response body carries `claimUrl` (the web OTP interstitial) alongside `message` | Open `claimUrl`, verify the owner's email (enter the emailed one-time code), set a credential, and accept the Terms. Verifying email **is** the claim — it flips the workspace metered → full | No |
 | `claim_check_failed` | `ClaimCheckFailedError` | 503 | The claim-gate could not read the owner's `emailVerified` state (e.g. internal DB transiently unavailable). Surfaced as a retryable 503 rather than spending Atlas tokens on an unverifiable request | Retry after a short backoff. If it persists, check internal-DB (`DATABASE_URL`) health | Yes |
 
+### Self-serve trial signup over MCP (`start_trial`)
+
+The anonymous onboarding tool [`start_trial`](/guides/mcp#start_trial) (#3649/#3654) provisions a trial workspace before any actor or bearer exists. Because it runs outside the MCP dispatch gate, its failures are returned as the structured MCP tool-error envelope (`{ code, message, hint?, request_id?, retry_after? }`, an `isError: true` tool result parsed by `parseAtlasMcpToolError`) — **not** the HTTP `{ error, message, requestId }` shape. The `code` is always one of the closed [`AtlasMcpToolErrorCode`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/types/src/mcp.ts) catalog; `start_trial` emits the four below.
+
+| Code | Trigger | `hint` / extras | Agent recovery |
+|------|---------|-----------------|----------------|
+| `validation_failed` | Missing/malformed email or workspace name, a missing Turnstile token, a declined elicitation, an already-registered email, **or a business-email denial** (freemium/disposable address — the shared [business-email policy](/guides/signup#business-email-only-signup)). The business-email case carries a "use your work email" `hint` so it's distinguishable from a malformed-email rejection | `hint` on the business-email and already-registered cases | Permanent — fix the input. For the business-email hint, retry with a work email; for "already registered", sign in on the web instead |
+| `rate_limited` | Per-IP / per-email creation-attempt limit tripped (#3654) | `retry_after` (seconds) | Wait `retry_after` seconds, then retry. Self-serve signups are throttled per IP and per email |
+| `forbidden` | Cloudflare Turnstile `siteverify` failed (bot-check), or the tool was reached off-SaaS (where it isn't registered) | — | Refresh the Turnstile challenge and retry. Never leaks the secret, the token, or Cloudflare error codes |
+| `internal_error` | Account created but the workspace/grace-window couldn't be provisioned (`org_failed` / `trial_not_assigned`), or an unexpected failure | `request_id` | Retry once; if it persists, quote `request_id` to support. The orphaned account may need an operator to reap it |
+
+<Callout>
+The wire `code` is intentionally **not** `business_email_required` on the MCP path — that string is only the Better Auth `400` body code on the web form. The MCP envelope catalog is closed and versioned with the SDK, so business-email denials reuse `validation_failed` (semantically: a personal address is invalid trial input) and lean on the `hint` for the work-email guidance.
+</Callout>
+
 ### Backups (#2989)
 
 Platform backup verify/restore routes (`/api/v1/admin/backups/*`, SaaS/EE). Structural `_tag` mapping replaced the routes' earlier `message.includes(...)` classification. All three messages are admin-safe (no secrets, no connection strings).

--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -145,14 +145,14 @@ describe("provisionTrialWorkspace", () => {
     expect(calls.mcpLead).toHaveLength(0);
   });
 
-  it("maps a business-email rejection from the signup hook to invalid_input (actionable, not internal_error)", async () => {
+  it("maps a business-email rejection from the signup hook to business_email (actionable, not internal_error)", async () => {
     // #3650 enforces business-email-only signup in the SHARED Better Auth
     // `user.create.before` hook, so a freemium/disposable address throws a typed
     // BUSINESS_EMAIL_REQUIRED APIError out of `signUpEmail`. The provisioner must
-    // recognize it and surface `invalid_input` (→ validation_failed envelope at
-    // the MCP layer) carrying the actionable message — NOT the generic
-    // `internal_error`/"please retry" a bare rethrow would produce. A deny is
-    // permanent, not transient.
+    // recognize it and surface the distinct `business_email` code (→ a
+    // validation_failed envelope WITH a work-email hint at the MCP layer)
+    // carrying the actionable message — NOT the generic `internal_error`/"please
+    // retry" a bare rethrow would produce. A deny is permanent, not transient.
     const { APIError } = await import("better-auth/api");
     const { BUSINESS_EMAIL_REQUIRED_CODE, BUSINESS_EMAIL_REQUIRED_MESSAGE } =
       await import("@atlas/api/lib/auth/business-email");
@@ -168,7 +168,7 @@ describe("provisionTrialWorkspace", () => {
     await expect(
       provisionTrialWorkspace({ email: "user@gmail.com", orgName: "Acme" }, deps),
     ).rejects.toMatchObject({
-      code: "invalid_input",
+      code: "business_email",
       message: BUSINESS_EMAIL_REQUIRED_MESSAGE,
     });
     // A denied signup provisions nothing: no org, no grace, no CRM lead.

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -56,6 +56,7 @@ export interface ProvisionTrialResult {
 export type TrialProvisioningCode =
   | "not_saas"
   | "invalid_input"
+  | "business_email"
   | "signup_failed"
   | "org_failed"
   | "trial_not_assigned";
@@ -219,9 +220,10 @@ function isValidEmail(email: string): boolean {
  * Provision a brand-new trial Workspace and return the hosted-MCP connect URL.
  *
  * @throws {TrialProvisioningError} `not_saas` when deploy mode isn't SaaS;
- *   `invalid_input` for empty/malformed email or name; `signup_failed` /
- *   `org_failed` when the Better Auth path returns no id; `trial_not_assigned`
- *   when the org landed on neither `trial` nor `locked`.
+ *   `invalid_input` for empty/malformed email or name; `business_email` when the
+ *   address is freemium/disposable (the shared #3650 signup-hook deny);
+ *   `signup_failed` / `org_failed` when the Better Auth path returns no id;
+ *   `trial_not_assigned` when the org landed on neither `trial` nor `locked`.
  */
 export async function provisionTrialWorkspace(
   input: ProvisionTrialInput,
@@ -263,8 +265,10 @@ export async function provisionTrialWorkspace(
     // The business-email-only policy (#3650) is enforced in the SHARED Better
     // Auth `user.create.before` hook, so a freemium/disposable address throws
     // a typed `business_email_required` APIError out of `signUpEmail`. Map it to
-    // `invalid_input` so the MCP `start_trial` envelope surfaces the actionable
-    // "use your work email" message — NOT the generic `internal_error`/"please
+    // the distinct `business_email` code so the MCP `start_trial` envelope
+    // surfaces the actionable "use your work email" message + a tailored hint
+    // (a `validation_failed` envelope on the wire, but distinguishable from a
+    // malformed-email `invalid_input`) — NOT the generic `internal_error`/"please
     // retry" a bare rethrow would produce (a deny is permanent, not transient).
     // Lazily imported so the heavy `better-auth-harmony` graph this recognizer
     // pulls stays out of stub-injected unit tests (mirrors the dep philosophy).
@@ -286,7 +290,7 @@ export async function provisionTrialWorkspace(
     }
     if (recognizer?.isBusinessEmailRejection(err)) {
       throw new TrialProvisioningError(
-        "invalid_input",
+        "business_email",
         recognizer.BUSINESS_EMAIL_REQUIRED_MESSAGE,
       );
     }

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -217,6 +217,7 @@ describe("start_trial tool", () => {
     const cases: Array<{
       code:
         | "invalid_input"
+        | "business_email"
         | "signup_failed"
         | "not_saas"
         | "org_failed"
@@ -226,6 +227,7 @@ describe("start_trial tool", () => {
       expectRequestId?: boolean;
     }> = [
       { code: "invalid_input", envelopeCode: "validation_failed" },
+      { code: "business_email", envelopeCode: "validation_failed", expectHint: true },
       { code: "signup_failed", envelopeCode: "validation_failed", expectHint: true },
       { code: "not_saas", envelopeCode: "forbidden" },
       { code: "org_failed", envelopeCode: "internal_error", expectRequestId: true },

--- a/packages/mcp/src/onboarding.ts
+++ b/packages/mcp/src/onboarding.ts
@@ -123,6 +123,18 @@ function provisioningErrorResult(
   switch (err.code) {
     case "invalid_input":
       return toEnvelopeResult(envelope("validation_failed", err.message));
+    case "business_email":
+      // A freemium/disposable address (the shared #3650 signup-hook deny). Wire
+      // code stays `validation_failed` — the closed MCP envelope catalog has no
+      // dedicated business-email code, and a personal email IS invalid trial
+      // input — but the tailored hint lets an agent tell the user to switch to a
+      // work email rather than re-typing the same address. Distinguished from a
+      // malformed-email `invalid_input` only by the message + hint, not the code.
+      return toEnvelopeResult(
+        envelope("validation_failed", err.message, {
+          hint: "Personal and disposable email addresses aren't supported for Atlas trials — start the trial again with your work email.",
+        }),
+      );
     case "signup_failed":
       return toEnvelopeResult(
         envelope("validation_failed", err.message, {

--- a/scripts/ee-stub/src/onboarding/provision-trial.ts
+++ b/scripts/ee-stub/src/onboarding/provision-trial.ts
@@ -39,6 +39,7 @@ export interface ProvisionTrialResult {
 export type TrialProvisioningCode =
   | "not_saas"
   | "invalid_input"
+  | "business_email"
   | "signup_failed"
   | "org_failed"
   | "trial_not_assigned";


### PR DESCRIPTION
Closes #3800 — the three findings from the v0.0.19 trial-signup docs audit.

## Decision on finding 1 (the owner-decision item)

The docs claimed the MCP `start_trial` business-email denial emits a typed `business_email_required` envelope. That code **isn't** in the closed `AtlasMcpToolErrorCode` catalog (a **published**, SDK-versioned union in `@useatlas/types`). Two ways to close the mismatch:

- **Mint `business_email_required` as a wire code** — requires a published-types bump + the publish-first sequencing dance, and every already-shipped SDK would reject the new code as unknown (`parseAtlasMcpToolError` → `null`) until it upgrades.
- **Keep `validation_failed`, make the contract honest** ✅ — a personal/disposable address *is* invalid trial input, and every SDK already handles `validation_failed`.

Chose the second, refined to match the issue's "(preferred) map to a typed `TrialProvisioningError` (e.g. a `business_email` code)": add an **internal** `business_email` `TrialProvisioningCode` (ee/ + ee-stub surface only — never on the wire) that maps to a `validation_failed` envelope carrying a tailored **"use your work email" hint**, distinguishable from a malformed-email rejection. Zero published-package churn; the exhaustive `provisioningErrorResult` switch + the ee-stub lockstep enforce handling on both type-check builds.

## Changes

**Code**
- `ee/.../provision-trial.ts` — new `business_email` code; business-email rejection now throws it (was `invalid_input`).
- `scripts/ee-stub/.../provision-trial.ts` — lockstep union update.
- `packages/mcp/src/onboarding.ts` — `business_email` → `validation_failed` envelope + work-email hint.

**Docs (the three findings)**
1. `guides/signup.mdx` — corrected to describe web (`400` body `business_email_required`) vs MCP (`validation_failed` + hint) precisely.
2. `reference/error-codes.mdx` — new "Self-serve trial signup over MCP (`start_trial`)" section documenting all four envelope codes.
3. `platform-ops/abuse-prevention.mdx` — new unclaimed-grace reaper operator section.

## Verification
- `bun test` — `packages/mcp` onboarding (19 pass) + `ee` provision-trial (16 pass).
- `bun run type` — clean (EXIT 0), including the ee-stub lockstep both ways.
- `bun run lint` — clean.