### PR TITLE
feat(agent): context compaction — summarize older turn history (#3759)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -272,6 +272,14 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                           # crosses this value the chat handler returns 429
 #                                           # `conversation_budget_exceeded` and the UI offers to start
 #                                           # a new conversation. Set 0 to disable.
+# Context compaction (#3759). Workspace-scoped; admin-UI configurable. When a turn's assembled context
+# crosses the fill fraction of the (coarse) window, older history folds into one generated summary while
+# the most-recent N steps + the system prompt stay pinned. Default OFF — off = no behavior change.
+# ATLAS_COMPACTION_ENABLED=false            # Master on/off. Default false.
+# ATLAS_COMPACTION_FILL_FRACTION=0.85       # Trigger threshold as a fraction (0–1] of the window. Default 0.85.
+# ATLAS_COMPACTION_PINNED_RECENT_STEPS=6    # Most-recent steps pinned verbatim (1–100). Default 6.
+# ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS=200000 # Coarse window (tokens) for the trigger. Default 200000
+#                                           # (accurate per-model resolution is a follow-up, #3760).
 # ATLAS_DASHBOARD_DRAFTS_ENABLED=true       # Default: true (flipped ON in #2521 alongside the Publish UI).
 #                                           # When ON, every dashboard edit via chat ("Edit with chat")
 #                                           # lands on a per-user draft instead of writing straight to

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -173,6 +173,10 @@ ATLAS_DEMO_DATA=true
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAS_AGENT_MAX_STEPS` | `25` | Maximum tool-call steps per agent run. Range: 1–100. Increase for complex multi-step queries; decrease to limit token spend |
+| `ATLAS_COMPACTION_ENABLED` | `false` | Context compaction (#3759). When `true`, a long agent turn whose assembled context crosses the [fill fraction](#agent) is compacted — older history is replaced by a generated summary while the most-recent N steps + the system prompt stay pinned, and the turn continues instead of erroring. **Default off ⇒ no behavior change.** Workspace-scoped: also settable per-workspace in Admin → Settings |
+| `ATLAS_COMPACTION_FILL_FRACTION` | `0.85` | Trigger threshold as a fraction `(0–1]` of the context window. A compaction pass runs once the assembled context (system prompt + messages) crosses this fraction. Out-of-range values fall back to the default |
+| `ATLAS_COMPACTION_PINNED_RECENT_STEPS` | `6` | How many of the most-recent agent steps to pin verbatim (never summarize) during a pass. Range `1–100`; out-of-range falls back to the default |
+| `ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS` | `200000` | Coarse context-window size (tokens) used to compute the trigger. A single configured value in this slice; accurate per-model resolution is a follow-up (#3760) |
 | `ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS` | `60000` (60s) | Overall wall-clock budget for a headless dashboard PDF/PNG export. Clamped to `[5000, 180000]`; a lower override degrades to a documented **partial** capture rather than a 504. Source: `packages/api/src/lib/dashboard-screenshot.ts` |
 | `ATLAS_EXPERT_SCHEDULER_ENABLED` | `false` | Enable periodic semantic layer analysis. When true, the expert engine runs on a schedule and proposes improvements automatically |
 | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | `24` | Hours between scheduled expert analysis runs |

--- a/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
@@ -192,6 +192,8 @@ const MOCK_USAGE = {
 let capturedPrompts: unknown[] = [];
 /** How many times the summarizer (`doGenerate`) ran. */
 let summarizerCalls = 0;
+/** Captured `prompt` from each summarizer (`doGenerate`) call. */
+let summarizerPrompts: unknown[] = [];
 
 function sqlStep(marker: string): LanguageModelV3StreamPart[] {
   return [
@@ -230,8 +232,9 @@ function buildModel(): InstanceType<typeof MockLanguageModelV3> {
       return { stream: convertArrayToReadableStream(chunks) };
     },
     // Summarizer path (generateText → doGenerate).
-    doGenerate: async () => {
+    doGenerate: async (options) => {
       summarizerCalls++;
+      summarizerPrompts.push(options.prompt);
       return {
         content: [{ type: "text", text: "GENERATED CONTEXT SUMMARY" }],
         finishReason: { unified: "stop", raw: "end_turn" },
@@ -264,6 +267,7 @@ describe("agent compaction — runAgent seam (#3759)", () => {
     callId = 0;
     capturedPrompts = [];
     summarizerCalls = 0;
+    summarizerPrompts = [];
     recordedSpans.length = 0;
     invalidateExploreBackend();
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
@@ -335,6 +339,22 @@ describe("agent compaction — runAgent seam (#3759)", () => {
     // Older steps are gone from the verbatim context (folded into the summary).
     expect(lastPrompt).not.toContain("marker0");
     expect(lastPrompt).not.toContain("marker1");
+  });
+
+  it("rolls the summary forward incrementally rather than re-reading the whole older slice each step", async () => {
+    enableCompaction();
+
+    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    await result.steps;
+
+    // The threshold trips on multiple steps, so the summarizer runs more than
+    // once. The FIRST pass summarizes the full older slice; every later pass
+    // takes the rolling path — folding only the newly-aged-out steps into the
+    // prior running summary (prompt carries the "Existing running summary"
+    // frame), keeping per-step summarization input bounded.
+    expect(summarizerCalls).toBeGreaterThanOrEqual(2);
+    const laterPrompts = JSON.stringify(summarizerPrompts.slice(1));
+    expect(laterPrompts).toContain("Existing running summary");
   });
 
   it("flag off (default) → no compaction regardless of context size", async () => {

--- a/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Integration tests for context compaction at the `runAgent` seam (#3759).
+ *
+ * Drives a real `runAgent` turn through the AI SDK `streamText` loop with a
+ * MockLanguageModelV3 (tool-call steps for the turn loop, `doGenerate` for the
+ * summarizer) and asserts the compaction pass:
+ *   - fires when an enabled turn crosses the fill-fraction threshold and the
+ *     turn completes instead of erroring,
+ *   - pins the system prompt + the most-recent N steps and replaces older
+ *     history with ONE generated summary,
+ *   - records the `atlas.compaction.ran` attribute on the `atlas.agent` span,
+ *   - does NONE of this when the flag is off (default).
+ *
+ * Mocks mirror agent-integration.test.ts (provider / semantic / connection /
+ * just-bash / cache). A recording global TracerProvider captures the
+ * `atlas.agent` span — the API's proxy tracer delegates to it lazily, so
+ * registering before the turn runs is enough to observe the live span.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { trace, type Span, type Tracer, type TracerProvider } from "@opentelemetry/api";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+// ---------------------------------------------------------------------------
+// Recording tracer — capture atlas.agent span attributes
+// ---------------------------------------------------------------------------
+
+interface RecordedSpan {
+  name: string;
+  attributes: Record<string, unknown>;
+}
+const recordedSpans: RecordedSpan[] = [];
+
+function makeRecordingSpan(name: string): Span {
+  const attributes: Record<string, unknown> = {};
+  const span = {
+    setAttribute(k: string, v: unknown) {
+      attributes[k] = v;
+      return span;
+    },
+    setAttributes(a: Record<string, unknown>) {
+      Object.assign(attributes, a);
+      return span;
+    },
+    addEvent() {
+      return span;
+    },
+    addLink() {
+      return span;
+    },
+    addLinks() {
+      return span;
+    },
+    setStatus() {
+      return span;
+    },
+    updateName() {
+      return span;
+    },
+    end() {},
+    isRecording() {
+      return true;
+    },
+    recordException() {},
+    spanContext() {
+      return { traceId: "0".repeat(32), spanId: "0".repeat(16), traceFlags: 1 };
+    },
+  } as unknown as Span;
+  recordedSpans.push({ name, attributes });
+  return span;
+}
+
+const recordingTracer = {
+  startSpan: (name: string) => makeRecordingSpan(name),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal startActiveSpan shim across the API overloads
+  startActiveSpan: (name: string, ...args: any[]) => {
+    const fn = args[args.length - 1];
+    return fn(makeRecordingSpan(name));
+  },
+} as unknown as Tracer;
+
+const recordingProvider: TracerProvider = {
+  getTracer: () => recordingTracer,
+};
+
+// Register BEFORE importing the agent graph so this provider wins: the API's
+// proxy tracer (captured at agent.ts module load) delegates to whatever global
+// provider is registered, and a registration here pre-empts any provider the
+// agent graph might register at import time.
+trace.disable();
+trace.setGlobalTracerProvider(recordingProvider);
+
+function agentSpan(): RecordedSpan | undefined {
+  return recordedSpans.find((s) => s.name === "atlas.agent");
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockModel: InstanceType<typeof MockLanguageModelV3>;
+
+mock.module("@atlas/api/lib/providers", () => ({
+  getModel: () => mockModel,
+  getProviderType: () => "anthropic" as const,
+  getModelFromWorkspaceConfig: () => mockModel,
+  getWorkspaceProviderType: () => "anthropic" as const,
+  getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies", "people"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+const mockDBConnectionObj = {
+  query: async () => ({ columns: ["id"], rows: [{ id: 1 }] }),
+  close: async () => {},
+};
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockDBConnectionObj,
+    connections: {
+      get: () => mockDBConnectionObj,
+      getDefault: () => mockDBConnectionObj,
+      getTargetHost: () => "localhost:5432",
+      describe: () => [{ id: "default", dbType: "postgres" as const }],
+      getForOrg: () => mockDBConnectionObj,
+    },
+  }),
+);
+
+mock.module("just-bash", () => ({
+  Bash: class MockBash {
+    constructor(_: unknown) {}
+    async exec() {
+      return { stdout: "catalog.yml\n", stderr: "", exitCode: 0 };
+    }
+  },
+  OverlayFs: class MockOverlayFs {
+    constructor(_: unknown) {}
+  },
+}));
+
+mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({ get: () => null, set: () => {}, stats: () => ({ hits: 0, misses: 0, entryCount: 0, maxSize: 1000, ttl: 300000 }) }),
+  buildCacheKey: () => "mock-key",
+  cacheEnabled: () => false,
+  getDefaultTtl: () => 300000,
+  flushCache: () => {},
+  setCacheBackend: () => {},
+  _resetCache: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
+const { COMPACTION_SUMMARY_PREFIX } = await import("@atlas/api/lib/agent-compaction");
+const { _resetSettingsCache } = await import("@atlas/api/lib/settings");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let callId = 0;
+const MOCK_USAGE = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 20, text: 20, reasoning: undefined },
+};
+
+/** Captured `prompt` (provider-format messages) from each turn-loop model call. */
+let capturedPrompts: unknown[] = [];
+/** How many times the summarizer (`doGenerate`) ran. */
+let summarizerCalls = 0;
+
+function sqlStep(marker: string): LanguageModelV3StreamPart[] {
+  return [
+    {
+      type: "tool-call",
+      toolCallId: `call-${++callId}`,
+      toolName: "executeSQL",
+      input: JSON.stringify({ sql: `SELECT id AS ${marker} FROM companies`, explanation: marker }),
+    },
+    { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "tool-calls", raw: "tool_use" } },
+  ];
+}
+
+const TEXT_STEP: LanguageModelV3StreamPart[] = [
+  { type: "text-delta", id: "text-0", delta: "Done." },
+  { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+];
+
+/**
+ * Build a model that emits 4 distinct SQL steps then a text step, capturing
+ * each turn-loop prompt and counting summarizer calls.
+ */
+function buildModel(): InstanceType<typeof MockLanguageModelV3> {
+  const steps: LanguageModelV3StreamPart[][] = [
+    sqlStep("marker0"),
+    sqlStep("marker1"),
+    sqlStep("marker2"),
+    sqlStep("marker3"),
+    TEXT_STEP,
+  ];
+  let idx = 0;
+  return new MockLanguageModelV3({
+    doStream: async (options) => {
+      capturedPrompts.push(options.prompt);
+      const chunks = idx >= steps.length ? steps[steps.length - 1] : steps[idx++];
+      return { stream: convertArrayToReadableStream(chunks) };
+    },
+    // Summarizer path (generateText → doGenerate).
+    doGenerate: async () => {
+      summarizerCalls++;
+      return {
+        content: [{ type: "text", text: "GENERATED CONTEXT SUMMARY" }],
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: MOCK_USAGE,
+        warnings: [],
+      };
+    },
+  });
+}
+
+function userMessages(content: string): UIMessage[] {
+  return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text: content }] }];
+}
+
+const COMPACTION_ENV_KEYS = [
+  "ATLAS_COMPACTION_ENABLED",
+  "ATLAS_COMPACTION_FILL_FRACTION",
+  "ATLAS_COMPACTION_PINNED_RECENT_STEPS",
+  "ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("agent compaction — runAgent seam (#3759)", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    callId = 0;
+    capturedPrompts = [];
+    summarizerCalls = 0;
+    recordedSpans.length = 0;
+    invalidateExploreBackend();
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.ATLAS_TABLE_WHITELIST;
+    delete process.env.ATLAS_SANDBOX_URL;
+    for (const k of COMPACTION_ENV_KEYS) saved[k] = process.env[k];
+    _resetSettingsCache();
+    mockModel = buildModel();
+  });
+
+  afterEach(() => {
+    for (const k of COMPACTION_ENV_KEYS) {
+      if (saved[k] !== undefined) process.env[k] = saved[k];
+      else delete process.env[k];
+    }
+    _resetSettingsCache();
+  });
+
+  function enableCompaction(): void {
+    process.env.ATLAS_COMPACTION_ENABLED = "true";
+    process.env.ATLAS_COMPACTION_FILL_FRACTION = "0.1"; // trip easily — system prompt alone crosses
+    process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "2";
+    process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "1000";
+    _resetSettingsCache();
+  }
+
+  it("enabled + past threshold → compaction fires and the turn completes", async () => {
+    enableCompaction();
+
+    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const steps = await result.steps;
+
+    // Turn ran to natural completion (4 SQL steps + 1 text step), not an error.
+    expect(steps.length).toBe(5);
+
+    // The summarizer ran on the turn model at least once.
+    expect(summarizerCalls).toBeGreaterThanOrEqual(1);
+
+    // A model call received the injected summary (older history was compacted in).
+    const allPrompts = JSON.stringify(capturedPrompts);
+    expect(allPrompts).toContain(COMPACTION_SUMMARY_PREFIX);
+    expect(allPrompts).toContain("GENERATED CONTEXT SUMMARY");
+
+    // The atlas.agent span recorded the compaction attribute.
+    const span = agentSpan();
+    expect(span).toBeDefined();
+    expect(span!.attributes["atlas.compaction.ran"]).toBe(true);
+    expect(span!.attributes["atlas.compaction.before_tokens"]).toBeGreaterThan(0);
+  });
+
+  it("pins the system prompt + most-recent N steps and drops older steps verbatim", async () => {
+    enableCompaction();
+
+    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    await result.steps;
+
+    // The final turn-loop model call is the text step. By then the loop has 4
+    // assistant steps; with N=2 the two most-recent steps (marker2, marker3) are
+    // pinned and the older ones (marker0, marker1) are folded into the summary.
+    const lastPrompt = JSON.stringify(capturedPrompts[capturedPrompts.length - 1]);
+
+    // System prompt is pinned (sent as a system message, never summarized).
+    expect(lastPrompt).toContain("expert data analyst");
+    // Summary stands in for older history.
+    expect(lastPrompt).toContain(COMPACTION_SUMMARY_PREFIX);
+    // Most-recent N steps survive verbatim.
+    expect(lastPrompt).toContain("marker3");
+    expect(lastPrompt).toContain("marker2");
+    // Older steps are gone from the verbatim context (folded into the summary).
+    expect(lastPrompt).not.toContain("marker0");
+    expect(lastPrompt).not.toContain("marker1");
+  });
+
+  it("flag off (default) → no compaction regardless of context size", async () => {
+    // Default off: do not set ATLAS_COMPACTION_ENABLED.
+    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const steps = await result.steps;
+
+    expect(steps.length).toBe(5); // identical loop behaviour
+    expect(summarizerCalls).toBe(0); // summarizer never ran
+    expect(JSON.stringify(capturedPrompts)).not.toContain(COMPACTION_SUMMARY_PREFIX);
+
+    const span = agentSpan();
+    expect(span).toBeDefined();
+    expect(span!.attributes["atlas.compaction.ran"]).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-compaction.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for context compaction (#3759 — PRD #3751).
+ *
+ * Covers the pure pieces of the compaction pass — token estimation, the
+ * trigger decision, the older-history → summary rewrite (pinning the most
+ * recent N steps), and the `atlas.compaction.*` span-attribute builder — plus
+ * the settings-registry resolution (precedence + hot-reload) of the three
+ * operator knobs. The end-to-end behaviour at the `runAgent` seam (a turn
+ * driven past the threshold compacts and completes) is covered by
+ * `agent-compaction-integration.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ModelMessage } from "ai";
+
+import {
+  resolveCompactionSettings,
+  estimateContextTokens,
+  shouldCompact,
+  pinBoundaryIndex,
+  compactOlderHistory,
+  compactionSpanAttributes,
+  COMPACTION_SUMMARY_PREFIX,
+  type CompactionSettings,
+} from "@atlas/api/lib/agent-compaction";
+import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENABLED: CompactionSettings = {
+  enabled: true,
+  fillFraction: 0.85,
+  pinnedRecentSteps: 2,
+  contextWindowTokens: 1000,
+};
+
+/** Build a flat user→(assistant→tool)* transcript with `steps` agent steps. */
+function transcript(steps: number): ModelMessage[] {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "What is the revenue trend?" },
+  ];
+  for (let i = 1; i <= steps; i++) {
+    messages.push({ role: "assistant", content: `assistant step ${i}` });
+    messages.push({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: `call-${i}`,
+          toolName: "executeSQL",
+          output: { type: "text", value: `tool result ${i}` },
+        },
+      ],
+    });
+  }
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation + trigger
+// ---------------------------------------------------------------------------
+
+describe("estimateContextTokens", () => {
+  it("counts the system prompt plus every message (coarse chars/4)", () => {
+    const system = "x".repeat(400); // ~100 tokens
+    const messages: ModelMessage[] = [{ role: "user", content: "y".repeat(400) }];
+    const est = estimateContextTokens(system, messages);
+    // system 400 chars + JSON.stringify(message) > 400 chars, all / 4
+    expect(est).toBeGreaterThanOrEqual(200);
+  });
+
+  it("accepts a SystemModelMessage object for the system prompt", () => {
+    const est = estimateContextTokens({ content: "z".repeat(400) }, []);
+    expect(est).toBe(100);
+  });
+
+  it("returns 0 for an empty context", () => {
+    expect(estimateContextTokens(undefined, [])).toBe(0);
+  });
+});
+
+describe("shouldCompact", () => {
+  it("fires once tokens cross fillFraction × window", () => {
+    // threshold = 0.85 × 1000 = 850
+    expect(shouldCompact(849, ENABLED)).toBe(false);
+    expect(shouldCompact(850, ENABLED)).toBe(true);
+    expect(shouldCompact(2000, ENABLED)).toBe(true);
+  });
+
+  it("never fires when disabled, regardless of size", () => {
+    const disabled = { ...ENABLED, enabled: false };
+    expect(shouldCompact(1_000_000, disabled)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pin boundary
+// ---------------------------------------------------------------------------
+
+describe("pinBoundaryIndex", () => {
+  it("points at the N-th-from-last assistant message", () => {
+    // user, a1, t1, a2, t2, a3, t3  → indices 0..6
+    const messages = transcript(3);
+    // pin last 2 steps → boundary at a2 (index 3)
+    expect(pinBoundaryIndex(messages, 2)).toBe(3);
+    expect(messages[3]).toMatchObject({ role: "assistant", content: "assistant step 2" });
+  });
+
+  it("returns 0 when there are fewer than N assistant turns (nothing to pin past)", () => {
+    expect(pinBoundaryIndex(transcript(1), 2)).toBe(0); // 1 step < N=2 → nothing older
+  });
+
+  it("treats the leading user turn as older history once N steps exist", () => {
+    // transcript(2) = [user, a1, t1, a2, t2]; pin both steps → only the user
+    // question is older (boundary at a1, index 1), so it gets summarized.
+    expect(pinBoundaryIndex(transcript(2), 2)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compaction rewrite
+// ---------------------------------------------------------------------------
+
+describe("compactOlderHistory", () => {
+  it("replaces older history with ONE summary message and pins the recent N steps", async () => {
+    const messages = transcript(4); // user + 4×(assistant,tool) = 9 messages
+    const result = await compactOlderHistory({
+      messages,
+      pinnedRecentSteps: 2,
+      summarize: async () => "SUMMARY OF EARLIER WORK",
+    });
+
+    expect(result).not.toBeNull();
+    const out = result!;
+
+    // First message is the single generated summary, framed for the model.
+    expect(out.messages[0]).toMatchObject({ role: "user" });
+    expect(out.messages[0].content).toContain(COMPACTION_SUMMARY_PREFIX);
+    expect(out.messages[0].content).toContain("SUMMARY OF EARLIER WORK");
+
+    // Exactly one summary message + the pinned recent slice (2 steps → 4 msgs).
+    expect(out.messages.length).toBe(1 + 4);
+    expect(out.pinnedMessageCount).toBe(4);
+
+    // The pinned recent steps survive verbatim…
+    expect(out.messages).toContainEqual({ role: "assistant", content: "assistant step 3" });
+    expect(out.messages).toContainEqual({ role: "assistant", content: "assistant step 4" });
+    // …and the older steps are folded into the summary, not present verbatim.
+    const serialized = JSON.stringify(out.messages);
+    expect(serialized).not.toContain("assistant step 1");
+    expect(serialized).not.toContain("assistant step 2");
+    expect(serialized).not.toContain("What is the revenue trend?");
+
+    // Older history was summarized, not dropped: count is reported.
+    expect(out.summarizedMessageCount).toBe(messages.length - 4);
+  });
+
+  it("pins a recent slice that begins with an assistant message (valid ordering)", async () => {
+    const messages = transcript(3);
+    const out = await compactOlderHistory({
+      messages,
+      pinnedRecentSteps: 1,
+      summarize: async () => "s",
+    });
+    // [summary(user), assistant step 3, tool result 3]
+    expect(out!.messages[1]).toMatchObject({ role: "assistant" });
+  });
+
+  it("returns null when there is nothing older to summarize (fewer than N steps)", async () => {
+    const out = await compactOlderHistory({
+      messages: transcript(1), // 1 step, pin 2 → nothing older
+      pinnedRecentSteps: 2,
+      summarize: async () => "should not be called",
+    });
+    expect(out).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Span attributes
+// ---------------------------------------------------------------------------
+
+describe("compactionSpanAttributes", () => {
+  it("emits the before/after token + message counts under atlas.compaction.*", () => {
+    expect(
+      compactionSpanAttributes({
+        beforeTokens: 900,
+        afterTokens: 300,
+        beforeMessages: 9,
+        afterMessages: 5,
+        summarizedMessages: 4,
+      }),
+    ).toEqual({
+      "atlas.compaction.ran": true,
+      "atlas.compaction.before_tokens": 900,
+      "atlas.compaction.after_tokens": 300,
+      "atlas.compaction.before_messages": 9,
+      "atlas.compaction.after_messages": 5,
+      "atlas.compaction.summarized_messages": 4,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings resolution — precedence + hot-reload (workspace > platform > env > default)
+// ---------------------------------------------------------------------------
+
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+const ORG = "org-compaction-test";
+
+describe("resolveCompactionSettings — registry precedence + hot-reload", () => {
+  const origEnabled = process.env.ATLAS_COMPACTION_ENABLED;
+  const origFraction = process.env.ATLAS_COMPACTION_FILL_FRACTION;
+  const origSteps = process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    delete process.env.ATLAS_COMPACTION_ENABLED;
+    delete process.env.ATLAS_COMPACTION_FILL_FRACTION;
+    delete process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS;
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+    _resetSettingsCache();
+  });
+
+  afterEach(() => {
+    if (origEnabled !== undefined) process.env.ATLAS_COMPACTION_ENABLED = origEnabled;
+    else delete process.env.ATLAS_COMPACTION_ENABLED;
+    if (origFraction !== undefined) process.env.ATLAS_COMPACTION_FILL_FRACTION = origFraction;
+    else delete process.env.ATLAS_COMPACTION_FILL_FRACTION;
+    if (origSteps !== undefined) process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = origSteps;
+    else delete process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS;
+    if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+    _resetSettingsCache();
+  });
+
+  it("defaults to OFF with sane defaults when nothing is set", () => {
+    const s = resolveCompactionSettings();
+    expect(s.enabled).toBe(false);
+    expect(s.fillFraction).toBe(0.85);
+    expect(s.pinnedRecentSteps).toBe(6);
+    expect(s.contextWindowTokens).toBe(200_000);
+  });
+
+  it("reads the env-var tier (Tier 3)", () => {
+    process.env.ATLAS_COMPACTION_ENABLED = "true";
+    process.env.ATLAS_COMPACTION_FILL_FRACTION = "0.5";
+    process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "3";
+    const s = resolveCompactionSettings();
+    expect(s.enabled).toBe(true);
+    expect(s.fillFraction).toBe(0.5);
+    expect(s.pinnedRecentSteps).toBe(3);
+  });
+
+  it("workspace override beats platform override beats env (precedence)", async () => {
+    process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "3"; // env
+    await setSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", "10"); // platform
+    await setSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", "20", "tester", ORG); // workspace
+
+    expect(resolveCompactionSettings(ORG).pinnedRecentSteps).toBe(20); // workspace wins
+    expect(resolveCompactionSettings().pinnedRecentSteps).toBe(10); // platform wins over env
+  });
+
+  it("hot-reloads — a new override is visible without restart", async () => {
+    expect(resolveCompactionSettings(ORG).enabled).toBe(false);
+    await setSetting("ATLAS_COMPACTION_ENABLED", "true", "tester", ORG);
+    expect(resolveCompactionSettings(ORG).enabled).toBe(true);
+  });
+
+  it("falls back to defaults for out-of-range / unparseable values", () => {
+    process.env.ATLAS_COMPACTION_FILL_FRACTION = "2"; // > 1
+    process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "0"; // < min
+    const s = resolveCompactionSettings();
+    expect(s.fillFraction).toBe(0.85);
+    expect(s.pinnedRecentSteps).toBe(6);
+  });
+});

--- a/packages/api/src/lib/agent-compaction.ts
+++ b/packages/api/src/lib/agent-compaction.ts
@@ -20,6 +20,10 @@
  * - The summary runs on the active TURN model; a cheaper dedicated summary model
  *   is #3761.
  * - Default OFF. With the flag off the loop behaves exactly as before.
+ * - Single pass per step, no second loop: if the older slice is so large that
+ *   summary + pinned-N steps still exceed the window, the turn can still over-
+ *   fill it. Accurate windows (#3760) + the cheaper summary model (#3761) shrink
+ *   that gap; a re-trigger loop is out of scope for the thinnest slice.
  *
  * All knobs resolve through the settings registry (workspace > platform > env >
  * default, hot-reloadable) — see `ATLAS_COMPACTION_*` in `settings.ts`.
@@ -27,7 +31,7 @@
 
 import { generateText, type LanguageModel, type ModelMessage } from "ai";
 import type { Attributes } from "@opentelemetry/api";
-import { createLogger } from "./logger";
+import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
 
 const log = createLogger("agent:compaction");
@@ -75,9 +79,13 @@ function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
  * platform override > env var > registry default, matching `getAgentMaxSteps`.
  */
 export function resolveCompactionSettings(orgId?: string): CompactionSettings {
-  const enabled = parseBoolean(getSetting("ATLAS_COMPACTION_ENABLED", orgId), false);
+  // Fall back to the request-context org when the caller omits it, matching
+  // getAgentMaxSteps — so a future caller that forgets to thread orgId still
+  // hits the workspace tier instead of silently resolving platform-wide.
+  const effectiveOrgId = orgId ?? getRequestContext()?.user?.activeOrganizationId;
+  const enabled = parseBoolean(getSetting("ATLAS_COMPACTION_ENABLED", effectiveOrgId), false);
 
-  const fillRaw = getSetting("ATLAS_COMPACTION_FILL_FRACTION", orgId);
+  const fillRaw = getSetting("ATLAS_COMPACTION_FILL_FRACTION", effectiveOrgId);
   let fillFraction = fillRaw !== undefined ? Number(fillRaw) : DEFAULT_FILL_FRACTION;
   if (!Number.isFinite(fillFraction) || fillFraction <= 0 || fillFraction > 1) {
     warnInvalidOnce(
@@ -88,7 +96,7 @@ export function resolveCompactionSettings(orgId?: string): CompactionSettings {
     fillFraction = DEFAULT_FILL_FRACTION;
   }
 
-  const stepsRaw = getSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", orgId);
+  const stepsRaw = getSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", effectiveOrgId);
   let pinnedRecentSteps = stepsRaw !== undefined ? parseInt(stepsRaw, 10) : DEFAULT_PINNED_RECENT_STEPS;
   if (
     !Number.isFinite(pinnedRecentSteps) ||
@@ -103,7 +111,7 @@ export function resolveCompactionSettings(orgId?: string): CompactionSettings {
     pinnedRecentSteps = DEFAULT_PINNED_RECENT_STEPS;
   }
 
-  const windowRaw = getSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", orgId);
+  const windowRaw = getSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", effectiveOrgId);
   let contextWindowTokens = windowRaw !== undefined ? parseInt(windowRaw, 10) : DEFAULT_CONTEXT_WINDOW_TOKENS;
   if (!Number.isFinite(contextWindowTokens) || contextWindowTokens < MIN_CONTEXT_WINDOW_TOKENS) {
     warnInvalidOnce(
@@ -266,6 +274,16 @@ const SUMMARY_SYSTEM_PROMPT = `You compress the earlier portion of a data-analys
 Do not invent facts. Do not add commentary. Output only the summary.`;
 
 /**
+ * Incremental (rolling) variant. Folds only the steps that crossed the pin
+ * boundary since the last pass into the existing running summary, instead of
+ * re-reading the entire older slice every step. Same fidelity contract as the
+ * full prompt above.
+ */
+const SUMMARY_INCREMENTAL_SYSTEM_PROMPT = `${SUMMARY_SYSTEM_PROMPT}
+
+You are given an existing running summary of the agent's earlier work followed by additional newer steps that have since aged out of the live context. Produce an UPDATED running summary that folds the new steps into the existing one — preserve every still-relevant fact from the prior summary and integrate the new steps. Do not drop facts from the prior summary just because they are old.`;
+
+/**
  * Render a transcript of older messages for the summarizer prompt. Coarse but
  * lossless-enough: each message becomes a role-tagged block; non-text content
  * (tool calls/results) is JSON-serialized so the summarizer sees what ran.
@@ -278,6 +296,15 @@ function renderTranscript(messages: readonly ModelMessage[]): string {
     })
     .join("\n");
 }
+
+/**
+ * Hard ceiling on a single summarization call. runAgent threads no abort signal
+ * into the turn (so a client disconnect can't cancel an in-flight summary), and
+ * `prepareStep` latency eats into the step budget — so bound the call itself: a
+ * stuck summary fails fast and the fail-soft branch in `agent.ts` continues the
+ * turn with full context rather than hanging the step.
+ */
+const SUMMARY_TIMEOUT_MS = 25_000;
 
 /**
  * Summarize older history using the active turn model (this slice runs on the
@@ -293,6 +320,31 @@ export async function summarizeOlderHistory(
     prompt: `Summarize the earlier portion of this agent transcript:\n\n${renderTranscript(older)}`,
     temperature: 0,
     maxOutputTokens: 1024,
+    abortSignal: AbortSignal.timeout(SUMMARY_TIMEOUT_MS),
+  });
+  return text.trim();
+}
+
+/**
+ * Roll a prior running summary forward over only the `newer` steps that have
+ * aged past the pin boundary since the last pass. Keeps per-step summarization
+ * input bounded by (prior summary + delta) instead of re-reading the whole
+ * older slice each step — older history grows monotonically within a turn, so
+ * the delta is just the steps that crossed the boundary. Same turn model and
+ * timeout discipline as {@link summarizeOlderHistory}.
+ */
+export async function summarizeIncremental(
+  model: LanguageModel,
+  priorSummary: string,
+  newer: readonly ModelMessage[],
+): Promise<string> {
+  const { text } = await generateText({
+    model,
+    system: SUMMARY_INCREMENTAL_SYSTEM_PROMPT,
+    prompt: `Existing running summary:\n\n${priorSummary}\n\nNewer steps to fold in:\n\n${renderTranscript(newer)}`,
+    temperature: 0,
+    maxOutputTokens: 1024,
+    abortSignal: AbortSignal.timeout(SUMMARY_TIMEOUT_MS),
   });
   return text.trim();
 }

--- a/packages/api/src/lib/agent-compaction.ts
+++ b/packages/api/src/lib/agent-compaction.ts
@@ -1,0 +1,298 @@
+/**
+ * Context compaction for long agent turns (PRD #3751, slice 1 / #3759).
+ *
+ * When a single agent turn accumulates enough history that the assembled
+ * context crosses a configurable fill fraction of the model's context window,
+ * the older portion of the message history is collapsed into ONE generated
+ * summary message while the most-recent N steps are pinned verbatim. The
+ * system prompt (which carries the semantic index + glossary) is passed to the
+ * model separately and is therefore inherently pinned — it never enters the
+ * message array this module rewrites.
+ *
+ * This is **summarization, not eviction**: nothing is dropped, the older turns
+ * are folded into a summary the model still sees. The pass lives at the shared
+ * `runAgent` layer (wired via `streamText`'s `prepareStep`), so web / MCP /
+ * chat-plugin turns inherit it with no per-surface wiring.
+ *
+ * Scope of THIS slice:
+ * - The context window is resolved COARSELY — a single configured/default value.
+ *   Accurate per-model window resolution lands in #3760.
+ * - The summary runs on the active TURN model; a cheaper dedicated summary model
+ *   is #3761.
+ * - Default OFF. With the flag off the loop behaves exactly as before.
+ *
+ * All knobs resolve through the settings registry (workspace > platform > env >
+ * default, hot-reloadable) — see `ATLAS_COMPACTION_*` in `settings.ts`.
+ */
+
+import { generateText, type LanguageModel, type ModelMessage } from "ai";
+import type { Attributes } from "@opentelemetry/api";
+import { createLogger } from "./logger";
+import { getSetting } from "./settings";
+
+const log = createLogger("agent:compaction");
+
+// ── Settings resolution ──────────────────────────────────────────────
+
+/** Resolved, validated compaction knobs for a single turn. */
+export interface CompactionSettings {
+  /** Master on/off. Default off — no compaction unless explicitly enabled. */
+  readonly enabled: boolean;
+  /** Trigger threshold as a fraction (0,1] of the context window. */
+  readonly fillFraction: number;
+  /** How many of the most-recent steps to pin verbatim (never summarize). */
+  readonly pinnedRecentSteps: number;
+  /** Coarse context-window size in tokens for this slice (see #3760). */
+  readonly contextWindowTokens: number;
+}
+
+const DEFAULT_FILL_FRACTION = 0.85;
+const DEFAULT_PINNED_RECENT_STEPS = 6;
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+
+// Bounds — clamp/reject obviously-broken operator values, mirroring the
+// warn-once discipline of getAgentMaxSteps().
+const MIN_PINNED_RECENT_STEPS = 1;
+const MAX_PINNED_RECENT_STEPS = 100;
+const MIN_CONTEXT_WINDOW_TOKENS = 1_000;
+
+const warnedOnce = new Set<string>();
+function warnInvalidOnce(key: string, raw: string, fallbackMsg: string): void {
+  const sig = `${key}=${raw}`;
+  if (warnedOnce.has(sig)) return;
+  warnedOnce.add(sig);
+  log.warn({ key, value: raw }, fallbackMsg);
+}
+
+function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined) return fallback;
+  return raw === "true" || raw === "1";
+}
+
+/**
+ * Resolve the compaction knobs for a turn. `orgId` threads the workspace tier
+ * (the keys are workspace-scoped); when omitted resolution falls back through
+ * platform override > env var > registry default, matching `getAgentMaxSteps`.
+ */
+export function resolveCompactionSettings(orgId?: string): CompactionSettings {
+  const enabled = parseBoolean(getSetting("ATLAS_COMPACTION_ENABLED", orgId), false);
+
+  const fillRaw = getSetting("ATLAS_COMPACTION_FILL_FRACTION", orgId);
+  let fillFraction = fillRaw !== undefined ? Number(fillRaw) : DEFAULT_FILL_FRACTION;
+  if (!Number.isFinite(fillFraction) || fillFraction <= 0 || fillFraction > 1) {
+    warnInvalidOnce(
+      "ATLAS_COMPACTION_FILL_FRACTION",
+      String(fillRaw),
+      `Invalid ATLAS_COMPACTION_FILL_FRACTION; using default ${DEFAULT_FILL_FRACTION}`,
+    );
+    fillFraction = DEFAULT_FILL_FRACTION;
+  }
+
+  const stepsRaw = getSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", orgId);
+  let pinnedRecentSteps = stepsRaw !== undefined ? parseInt(stepsRaw, 10) : DEFAULT_PINNED_RECENT_STEPS;
+  if (
+    !Number.isFinite(pinnedRecentSteps) ||
+    pinnedRecentSteps < MIN_PINNED_RECENT_STEPS ||
+    pinnedRecentSteps > MAX_PINNED_RECENT_STEPS
+  ) {
+    warnInvalidOnce(
+      "ATLAS_COMPACTION_PINNED_RECENT_STEPS",
+      String(stepsRaw),
+      `Invalid ATLAS_COMPACTION_PINNED_RECENT_STEPS; using default ${DEFAULT_PINNED_RECENT_STEPS}`,
+    );
+    pinnedRecentSteps = DEFAULT_PINNED_RECENT_STEPS;
+  }
+
+  const windowRaw = getSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", orgId);
+  let contextWindowTokens = windowRaw !== undefined ? parseInt(windowRaw, 10) : DEFAULT_CONTEXT_WINDOW_TOKENS;
+  if (!Number.isFinite(contextWindowTokens) || contextWindowTokens < MIN_CONTEXT_WINDOW_TOKENS) {
+    warnInvalidOnce(
+      "ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS",
+      String(windowRaw),
+      `Invalid ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS; using default ${DEFAULT_CONTEXT_WINDOW_TOKENS}`,
+    );
+    contextWindowTokens = DEFAULT_CONTEXT_WINDOW_TOKENS;
+  }
+
+  return { enabled, fillFraction, pinnedRecentSteps, contextWindowTokens };
+}
+
+// ── Token estimation (coarse) ────────────────────────────────────────
+
+/**
+ * Characters-per-token heuristic. Deliberately coarse for this slice: a true
+ * tokenizer is not worth the dependency when the window itself is approximate
+ * (#3760). ~4 chars/token is the standard rough estimate for English + JSON.
+ */
+const CHARS_PER_TOKEN = 4;
+
+function systemText(system: string | { content: string } | undefined): string {
+  if (system === undefined) return "";
+  return typeof system === "string" ? system : system.content;
+}
+
+/**
+ * Estimate the assembled-context size (system prompt + all messages) in tokens.
+ * Coarse — serializes each message to JSON so tool calls/results count toward
+ * the total, then applies the chars-per-token heuristic.
+ */
+export function estimateContextTokens(
+  system: string | { content: string } | undefined,
+  messages: readonly ModelMessage[],
+): number {
+  let chars = systemText(system).length;
+  for (const m of messages) chars += JSON.stringify(m).length;
+  return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+/** True when an enabled turn has crossed its fill-fraction trigger. */
+export function shouldCompact(estimatedTokens: number, settings: CompactionSettings): boolean {
+  if (!settings.enabled) return false;
+  return estimatedTokens >= settings.fillFraction * settings.contextWindowTokens;
+}
+
+// ── Compaction ───────────────────────────────────────────────────────
+
+/**
+ * Index of the first message belonging to the most-recent `n` steps. Steps are
+ * counted by assistant messages from the end (each agent step emits one
+ * assistant message plus its tool results); the returned index points AT the
+ * n-th-from-last assistant message, so `messages.slice(index)` is the pinned
+ * recent slice and `messages.slice(0, index)` is the older history.
+ *
+ * Returns 0 when there are fewer than `n` assistant turns — there is no older
+ * history to summarize, so the caller treats it as "nothing to compact".
+ */
+export function pinBoundaryIndex(messages: readonly ModelMessage[], n: number): number {
+  if (n <= 0) return messages.length;
+  let assistantCount = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "assistant") {
+      assistantCount++;
+      if (assistantCount >= n) return i;
+    }
+  }
+  return 0;
+}
+
+/** Prefix that frames the injected summary message for the model. */
+export const COMPACTION_SUMMARY_PREFIX =
+  "[Earlier conversation summary — the start of this turn was compacted to fit the context window. The summary below stands in for the older steps; the most recent steps follow verbatim.]";
+
+export interface CompactionOutcome {
+  /** The rewritten message array: one summary message + the pinned recent slice. */
+  readonly messages: ModelMessage[];
+  /** The generated summary text. */
+  readonly summary: string;
+  /** How many older messages were folded into the summary. */
+  readonly summarizedMessageCount: number;
+  /** How many messages were pinned verbatim. */
+  readonly pinnedMessageCount: number;
+}
+
+/**
+ * Collapse the older portion of `messages` into one summary message, pinning
+ * the most-recent `pinnedRecentSteps` steps verbatim. Returns `null` when there
+ * is nothing to compact (fewer than `pinnedRecentSteps` steps of history).
+ *
+ * The summary is injected as a `user` message so the pinned slice (which begins
+ * with an assistant message) follows a valid user→assistant ordering. The
+ * assistant→tool-result pairing inside the pinned slice is preserved because the
+ * boundary always lands on an assistant message whose tool results are pinned
+ * alongside it.
+ */
+export async function compactOlderHistory(opts: {
+  messages: readonly ModelMessage[];
+  pinnedRecentSteps: number;
+  summarize: (older: ModelMessage[]) => Promise<string>;
+}): Promise<CompactionOutcome | null> {
+  const { messages, pinnedRecentSteps, summarize } = opts;
+  const boundary = pinBoundaryIndex(messages, pinnedRecentSteps);
+  if (boundary <= 0) return null;
+
+  const older = messages.slice(0, boundary);
+  const pinned = messages.slice(boundary);
+  const summary = await summarize(older);
+
+  const summaryMessage: ModelMessage = {
+    role: "user",
+    content: `${COMPACTION_SUMMARY_PREFIX}\n\n${summary}`,
+  };
+
+  return {
+    messages: [summaryMessage, ...pinned],
+    summary,
+    summarizedMessageCount: older.length,
+    pinnedMessageCount: pinned.length,
+  };
+}
+
+// ── Observability ────────────────────────────────────────────────────
+
+/** Inputs for the `atlas.compaction.*` span attributes. */
+export interface CompactionSpanInput {
+  readonly beforeTokens: number;
+  readonly afterTokens: number;
+  readonly beforeMessages: number;
+  readonly afterMessages: number;
+  readonly summarizedMessages: number;
+}
+
+/**
+ * Build the `atlas.compaction.*` attributes recorded on the enclosing
+ * `atlas.agent` span when a compaction pass runs. Pure (precedent:
+ * `profileSpanAttributes`, `buildStripeWebhookSpanAttributes`) so the contract
+ * is unit-testable without wiring an in-memory span exporter. Only ever called
+ * inside the "a pass ran" branch — a non-compacting turn records none of these.
+ */
+export function compactionSpanAttributes(input: CompactionSpanInput): Attributes {
+  return {
+    "atlas.compaction.ran": true,
+    "atlas.compaction.before_tokens": input.beforeTokens,
+    "atlas.compaction.after_tokens": input.afterTokens,
+    "atlas.compaction.before_messages": input.beforeMessages,
+    "atlas.compaction.after_messages": input.afterMessages,
+    "atlas.compaction.summarized_messages": input.summarizedMessages,
+  };
+}
+
+// ── Summarization on the turn model ──────────────────────────────────
+
+const SUMMARY_SYSTEM_PROMPT = `You compress the earlier portion of a data-analyst AI agent's working transcript so the agent can keep going within its context window. Produce a faithful, information-dense summary that preserves everything the agent needs to continue the current task:
+- The user's original question(s) and any clarifications or constraints they gave.
+- Which tables/columns and semantic-layer entities were explored, and what was learned about them.
+- SQL that was run, whether it succeeded, and the key results/figures returned (keep concrete numbers).
+- Decisions, assumptions, and dead-ends already taken, so the agent does not repeat them.
+Do not invent facts. Do not add commentary. Output only the summary.`;
+
+/**
+ * Render a transcript of older messages for the summarizer prompt. Coarse but
+ * lossless-enough: each message becomes a role-tagged block; non-text content
+ * (tool calls/results) is JSON-serialized so the summarizer sees what ran.
+ */
+function renderTranscript(messages: readonly ModelMessage[]): string {
+  return messages
+    .map((m) => {
+      const body = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+      return `<${m.role}>\n${body}\n</${m.role}>`;
+    })
+    .join("\n");
+}
+
+/**
+ * Summarize older history using the active turn model (this slice runs on the
+ * turn model; a dedicated cheaper model is #3761).
+ */
+export async function summarizeOlderHistory(
+  model: LanguageModel,
+  older: readonly ModelMessage[],
+): Promise<string> {
+  const { text } = await generateText({
+    model,
+    system: SUMMARY_SYSTEM_PROMPT,
+    prompt: `Summarize the earlier portion of this agent transcript:\n\n${renderTranscript(older)}`,
+    temperature: 0,
+    maxOutputTokens: 1024,
+  });
+  return text.trim();
+}

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -58,6 +58,7 @@ import {
   shouldCompact,
   compactOlderHistory,
   summarizeOlderHistory,
+  summarizeIncremental,
   compactionSpanAttributes,
 } from "./agent-compaction";
 import { ModelRouter } from "./effect/services";
@@ -1245,9 +1246,13 @@ export async function runAgent({
 
   // #3759 — context compaction. Resolved once per turn (knobs hot-reload at the
   // next turn via the settings cache). Off by default ⇒ the prepareStep below
-  // behaves exactly as before. The in-turn memo avoids re-summarizing an
-  // unchanged older slice across steps (prepareStep re-receives the full,
-  // growing history each step — the AI SDK does not persist our override).
+  // behaves exactly as before. `prepareStep` re-receives the full, growing
+  // history each step (the AI SDK does not persist our override), so once a turn
+  // crosses the threshold every subsequent step would re-summarize. The in-turn
+  // memo holds the running summary + how many older messages it covers: an
+  // identical older slice is reused verbatim, and a grown one folds only the
+  // newly-aged-out delta into the prior summary (rolling summary) — keeping the
+  // per-step summarization cost bounded instead of O(full older slice).
   const compactionSettings = resolveCompactionSettings(orgId);
   let compactionSummaryMemo: { olderCount: number; text: string } | undefined;
 
@@ -1309,10 +1314,16 @@ export async function runAgent({
                 messages: stepMessages,
                 pinnedRecentSteps: compactionSettings.pinnedRecentSteps,
                 summarize: async (older) => {
-                  if (compactionSummaryMemo?.olderCount === older.length) {
-                    return compactionSummaryMemo.text;
-                  }
-                  const text = await summarizeOlderHistory(model, older);
+                  const memo = compactionSummaryMemo;
+                  // Same older slice as last step → reuse the summary verbatim.
+                  if (memo?.olderCount === older.length) return memo.text;
+                  // Older grew (history only appends within a turn) → roll the
+                  // prior summary forward over just the delta, not the whole
+                  // slice. First pass (no memo) summarizes the full older slice.
+                  const text =
+                    memo && memo.olderCount < older.length
+                      ? await summarizeIncremental(model, memo.text, older.slice(memo.olderCount))
+                      : await summarizeOlderHistory(model, older);
                   compactionSummaryMemo = { olderCount: older.length, text };
                   return text;
                 },
@@ -1335,7 +1346,9 @@ export async function runAgent({
                 );
                 // OTel attributes on the enclosing atlas.agent span. Only set
                 // when a pass actually runs — a non-compacting turn emits
-                // neither this nor the log line above.
+                // neither this nor the log line above. Last-write-wins across
+                // steps: on a multi-pass turn the span reflects the FINAL pass's
+                // counts; the per-pass detail lives in the log line above.
                 span.setAttributes(
                   compactionSpanAttributes({
                     beforeTokens,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -52,6 +52,14 @@ import {
   context as otelContext,
 } from "@opentelemetry/api";
 import { AtlasAiModel, type AtlasAiModelShape } from "./effect/ai";
+import {
+  resolveCompactionSettings,
+  estimateContextTokens,
+  shouldCompact,
+  compactOlderHistory,
+  summarizeOlderHistory,
+  compactionSpanAttributes,
+} from "./agent-compaction";
 import { ModelRouter } from "./effect/services";
 import { runEnterprise } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
@@ -1230,11 +1238,24 @@ export async function runAgent({
   const rawTools = activeRegistry.getAll();
   const tools = wrapToolsWithHooks(rawTools, { userId: userId ?? undefined, conversationId });
 
+  // System prompt is built once and pinned: it carries the semantic index +
+  // glossary and is passed to the model separately, so it never enters the
+  // message array compaction rewrites (#3759).
+  const systemParam = buildSystemParam(providerType, activeRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext, presentationMode ?? "developer", restRepresentation, resolvedModelId);
+
+  // #3759 — context compaction. Resolved once per turn (knobs hot-reload at the
+  // next turn via the settings cache). Off by default ⇒ the prepareStep below
+  // behaves exactly as before. The in-turn memo avoids re-summarizing an
+  // unchanged older slice across steps (prepareStep re-receives the full,
+  // growing history each step — the AI SDK does not persist our override).
+  const compactionSettings = resolveCompactionSettings(orgId);
+  let compactionSummaryMemo: { olderCount: number; text: string } | undefined;
+
   let result;
   try {
     result = otelContext.with(agentCtx, () => streamText({
       model,
-      system: buildSystemParam(providerType, activeRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext, presentationMode ?? "developer", restRepresentation, resolvedModelId),
+      system: systemParam,
       messages: modelMessages,
       tools,
       temperature: 0.2,
@@ -1271,9 +1292,71 @@ export async function runAgent({
         );
       },
 
-      prepareStep: ({ messages: stepMessages }) => {
+      prepareStep: async ({ messages: stepMessages }) => {
+        let effectiveMessages: ModelMessage[] = stepMessages;
+
+        // #3759 — compaction trigger. When the assembled context (system prompt
+        // + messages) crosses the configured fill fraction of the coarse context
+        // window, collapse older history into one generated summary on the turn
+        // model and keep going, instead of letting the turn blow the window.
+        // Fail-soft: a summarization failure logs and continues with full
+        // context — compaction never costs the turn its answer.
+        if (compactionSettings.enabled) {
+          const beforeTokens = estimateContextTokens(systemParam, stepMessages);
+          if (shouldCompact(beforeTokens, compactionSettings)) {
+            try {
+              const compacted = await compactOlderHistory({
+                messages: stepMessages,
+                pinnedRecentSteps: compactionSettings.pinnedRecentSteps,
+                summarize: async (older) => {
+                  if (compactionSummaryMemo?.olderCount === older.length) {
+                    return compactionSummaryMemo.text;
+                  }
+                  const text = await summarizeOlderHistory(model, older);
+                  compactionSummaryMemo = { olderCount: older.length, text };
+                  return text;
+                },
+              });
+              if (compacted) {
+                effectiveMessages = compacted.messages;
+                const afterTokens = estimateContextTokens(systemParam, effectiveMessages);
+                log.info(
+                  {
+                    beforeTokens,
+                    afterTokens,
+                    beforeMessages: stepMessages.length,
+                    afterMessages: effectiveMessages.length,
+                    summarizedMessages: compacted.summarizedMessageCount,
+                    pinnedMessages: compacted.pinnedMessageCount,
+                    fillFraction: compactionSettings.fillFraction,
+                    contextWindowTokens: compactionSettings.contextWindowTokens,
+                  },
+                  "context compaction pass ran",
+                );
+                // OTel attributes on the enclosing atlas.agent span. Only set
+                // when a pass actually runs — a non-compacting turn emits
+                // neither this nor the log line above.
+                span.setAttributes(
+                  compactionSpanAttributes({
+                    beforeTokens,
+                    afterTokens,
+                    beforeMessages: stepMessages.length,
+                    afterMessages: effectiveMessages.length,
+                    summarizedMessages: compacted.summarizedMessageCount,
+                  }),
+                );
+              }
+            } catch (err) {
+              log.warn(
+                { err: err instanceof Error ? err.message : String(err) },
+                "context compaction pass failed — continuing with full context",
+              );
+            }
+          }
+        }
+
         return {
-          messages: applyCacheControl(stepMessages, providerType, resolvedModelId),
+          messages: applyCacheControl(effectiveMessages, providerType, resolvedModelId),
         };
       },
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -347,6 +347,54 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_CONVERSATION_STEP_CAP",
     scope: "workspace",
   },
+  // Context Compaction (#3759 — PRD #3751). When a turn's assembled context
+  // crosses the fill fraction of the (coarsely-resolved) context window, older
+  // history is collapsed into one generated summary while the most-recent N
+  // steps + the system prompt are pinned. Default OFF — flag off = no change.
+  {
+    key: "ATLAS_COMPACTION_ENABLED",
+    section: "Context Compaction",
+    label: "Context Compaction",
+    description:
+      "When on, a long agent turn whose assembled context crosses the fill fraction is compacted — older history is replaced by a generated summary and the turn continues instead of erroring. Default off.",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_COMPACTION_ENABLED",
+    scope: "workspace",
+  },
+  {
+    key: "ATLAS_COMPACTION_FILL_FRACTION",
+    section: "Context Compaction",
+    label: "Compaction Fill Fraction",
+    description:
+      "Trigger threshold as a fraction (0–1] of the model context window. When the assembled context crosses this fraction, a compaction pass runs. Default 0.85.",
+    type: "number",
+    default: "0.85",
+    envVar: "ATLAS_COMPACTION_FILL_FRACTION",
+    scope: "workspace",
+  },
+  {
+    key: "ATLAS_COMPACTION_PINNED_RECENT_STEPS",
+    section: "Context Compaction",
+    label: "Compaction Pinned Recent Steps",
+    description:
+      "How many of the most-recent agent steps to pin verbatim (never summarize) during a compaction pass (1–100). Default 6.",
+    type: "number",
+    default: "6",
+    envVar: "ATLAS_COMPACTION_PINNED_RECENT_STEPS",
+    scope: "workspace",
+  },
+  {
+    key: "ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS",
+    section: "Context Compaction",
+    label: "Compaction Context Window (tokens)",
+    description:
+      "Coarse context-window size (tokens) used to compute the compaction trigger. A single configured value in this slice; accurate per-model resolution lands in a follow-up. Default 200000.",
+    type: "number",
+    default: "200000",
+    envVar: "ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS",
+    scope: "workspace",
+  },
   {
     key: "ATLAS_PROVIDER",
     section: "Agent",


### PR DESCRIPTION
## Summary

First slice of the context-compaction PRD (#3751, design ADR-0020) — independent of the durable-sessions work (no dependency on #3742/#3745).

- **Thinnest end-to-end compaction pass at the shared `runAgent` seam.** When a turn's assembled context (system prompt + messages) crosses a configurable fill fraction of the coarsely-resolved context window, older message history is collapsed into **one generated summary** on the **active turn model** while the system prompt + most-recent **N** steps are pinned. The turn then continues instead of erroring. Wired via `streamText`'s `prepareStep`, so web / MCP / chat-plugin inherit it with no per-surface wiring.
- **Summarization, not eviction.** Older turns fold into a summary message the model still sees; nothing is dropped. The system prompt (which carries the semantic index + glossary) is passed separately and is therefore inherently pinned.
- **Default OFF.** Flag off ⇒ `prepareStep` behaves exactly as before — asserted at the seam.
- **Coarse window this slice.** A single configured/default window value; accurate per-model resolution is #3760, a cheaper dedicated summary model is #3761.
- **3 knobs (+ coarse window) in the settings registry** — workspace-scoped, `workspace > platform > env > default`, hot-reloadable: `ATLAS_COMPACTION_ENABLED`, `ATLAS_COMPACTION_FILL_FRACTION`, `ATLAS_COMPACTION_PINNED_RECENT_STEPS`, `ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS`.
- **Observability.** A log line + `atlas.compaction.*` attributes (incl. `atlas.compaction.ran`, before/after token & message counts) on the existing `atlas.agent` span. A non-compacting turn emits neither. The pure attribute builder follows the repo precedent (`profileSpanAttributes`, `buildStripeWebhookSpanAttributes`).

New module: `packages/api/src/lib/agent-compaction.ts` (settings resolution, coarse token estimation, trigger decision, older-history→summary rewrite, turn-model summarizer, span-attribute builder). Wiring + hoisted system param in `agent.ts`; 4 registry keys in `settings.ts`.

## Test plan

- [x] **Unit** (`agent-compaction.test.ts`): token estimation, `shouldCompact` trigger boundary, `pinBoundaryIndex` (incl. leading user-turn-as-older), the older→summary rewrite (one summary message + pinned recent N, older folded not dropped), span-attribute builder, and settings precedence + hot-reload (workspace > platform > env > default).
- [x] **Integration at the `runAgent` seam** (`agent-compaction-integration.test.ts`, MockLanguageModelV3): enabled + driven past threshold ⇒ pass fires, summarizer runs on the turn model, turn completes; post-compaction context keeps the system prompt + most-recent N steps and drops older steps verbatim into the summary; `atlas.agent` span carries `atlas.compaction.ran`; flag off ⇒ no compaction, no summarizer call, no span attribute.
- [x] `/ci`: lint, type, full test (6 known WSL flaky false-negatives — #3490 — all green re-run in isolation; unrelated to this change), syncpack, all drift/discipline scripts (settings-readers now 76 keys), published-symbols — all pass.

Closes #3759