### PR TITLE
feat(durable-sessions): checkpoint pipe skeleton — agent_runs + DurableSession (#3745)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Agent-loop seam test for durable-session terminal checkpoints (#3745,
+ * ADR-0020, phase 1a).
+ *
+ * Mirrors `agent-token-usage.test.ts`: drives `runAgent` to completion with a
+ * mock model, spies the fire-and-forget `internalExecute`, and pins the
+ * `INSERT INTO agent_runs` write. Asserts the four contract behaviors at the
+ * `runAgent` seam:
+ *   - durability on + internal DB → exactly one row, status `done`, transcript
+ *   - a throwing turn → one row, status `failed`
+ *   - no internal DB → no agent_runs write (behavior identical to today)
+ *   - durability flag off → no agent_runs write (default off)
+ */
+
+import { describe, expect, it, beforeEach, afterAll, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+let mockModel: InstanceType<typeof MockLanguageModelV3>;
+
+mock.module("@atlas/api/lib/providers", () => ({
+  getModel: () => mockModel,
+  getProviderType: () => "anthropic" as const,
+  getModelFromWorkspaceConfig: () => mockModel,
+  getWorkspaceProviderType: () => "anthropic" as const,
+  getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies", "people"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+const mockDBConnectionObj = {
+  query: async () => ({ columns: ["id"], rows: [{ id: 1 }] }),
+  close: async () => {},
+};
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockDBConnectionObj,
+    connections: {
+      get: () => mockDBConnectionObj,
+      getDefault: () => mockDBConnectionObj,
+      getTargetHost: () => "localhost:5432",
+      describe: () => [{ id: "default", dbType: "postgres" as const }],
+      getForOrg: () => mockDBConnectionObj,
+    },
+  }),
+);
+
+// --- The seam under test: internalExecute / hasInternalDB ---
+let hasInternalDB = true;
+const internalCalls: Array<{ sql: string; params?: unknown[] }> = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => hasInternalDB,
+  internalExecute: (sql: string, params?: unknown[]) => {
+    internalCalls.push({ sql, params });
+  },
+}));
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+
+const STOP_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 5, text: 5, reasoning: undefined },
+};
+
+function userMessages(content: string): UIMessage[] {
+  return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text: content }] }];
+}
+
+/** Single text-only step → the agent loop ends immediately and onFinish fires. */
+function textOnlyModel(): InstanceType<typeof MockLanguageModelV3> {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "Done." },
+    { type: "finish", usage: STOP_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+}
+
+/** A model whose stream rejects, exercising the onError failure path. */
+function throwingModel(): InstanceType<typeof MockLanguageModelV3> {
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      throw new Error("boom");
+    },
+  });
+}
+
+/** Drain the data stream so the streamText onFinish/onError callback runs. */
+async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
+  mockModel = model;
+  const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+  try {
+    await result.steps;
+    await result.consumeStream?.();
+  } catch {
+    // The throwing-model path surfaces the error on consume; the durable
+    // `failed` checkpoint is written from onError regardless. Swallow here.
+  }
+}
+
+function agentRunInsert() {
+  return internalCalls.find((c) => c.sql.includes("INSERT INTO agent_runs"));
+}
+
+const origFlag = process.env.ATLAS_DURABILITY_ENABLED;
+
+describe("agent_runs terminal checkpoint write path (#3745)", () => {
+  beforeEach(() => {
+    internalCalls.length = 0;
+    hasInternalDB = true;
+    process.env.ATLAS_DURABILITY_ENABLED = "true";
+  });
+
+  afterAll(() => {
+    if (origFlag === undefined) delete process.env.ATLAS_DURABILITY_ENABLED;
+    else process.env.ATLAS_DURABILITY_ENABLED = origFlag;
+  });
+
+  it("writes exactly one row with status 'done' and the transcript on a clean finish", async () => {
+    await drive(textOnlyModel());
+
+    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
+    expect(inserts).toHaveLength(1);
+
+    const insert = inserts[0]!;
+    // Columns: conversation_id, org_id, status, step_index, transcript
+    expect(insert.sql).toContain("$5::jsonb");
+    const params = insert.params as unknown[];
+    expect(params[0]).toBe("conv-1"); // conversation_id
+    expect(params[2]).toBe("done"); // status
+    expect(typeof params[4]).toBe("string"); // transcript is JSON text
+    // Transcript is valid JSON carrying the turn's messages (input + response).
+    const transcript = JSON.parse(params[4] as string) as unknown[];
+    expect(Array.isArray(transcript)).toBe(true);
+    expect(transcript.length).toBeGreaterThan(0);
+  });
+
+  it("writes a row with status 'failed' when the turn throws", async () => {
+    await drive(throwingModel());
+
+    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
+    expect(inserts).toHaveLength(1);
+    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+  });
+
+  it("does not write an agent_runs row when no internal DB is configured", async () => {
+    hasInternalDB = false;
+    await drive(textOnlyModel());
+    expect(agentRunInsert()).toBeUndefined();
+  });
+
+  it("does not write an agent_runs row when the durability flag is off (default)", async () => {
+    process.env.ATLAS_DURABILITY_ENABLED = "false";
+    await drive(textOnlyModel());
+    expect(agentRunInsert()).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -108,6 +108,40 @@ function throwingModel(): InstanceType<typeof MockLanguageModelV3> {
   });
 }
 
+/**
+ * A model that finishes cleanly *in-band* with `finishReason: error` — the
+ * AI-SDK's in-stream error signal. This drives `onFinish` (NOT `onError`) with
+ * `finishReason === "error"`, exercising the distinct ternary in the agent loop
+ * that maps that reason to a `failed` checkpoint (rather than `done`).
+ */
+function inBandErrorModel(): InstanceType<typeof MockLanguageModelV3> {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "partial" },
+    { type: "finish", usage: STOP_USAGE, finishReason: { unified: "error", raw: "error" } },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+}
+
+/**
+ * A model whose stream emits an `error` part (firing `onError`) and then still
+ * reaches a `finish` part (firing `onFinish`). Both terminal seams fire on the
+ * same turn — the case the `terminalWritten` idempotency guard exists for. The
+ * first write (onError → `failed`) must win and the second must be suppressed,
+ * leaving exactly one row.
+ */
+function errorThenFinishModel(): InstanceType<typeof MockLanguageModelV3> {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "partial" },
+    { type: "error", error: new Error("mid-stream") },
+    { type: "finish", usage: STOP_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+}
+
 /** Drain the data stream so the streamText onFinish/onError callback runs. */
 async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
   mockModel = model;
@@ -151,6 +185,7 @@ describe("agent_runs terminal checkpoint write path (#3745)", () => {
     const params = insert.params as unknown[];
     expect(params[0]).toBe("conv-1"); // conversation_id
     expect(params[2]).toBe("done"); // status
+    expect(params[3]).toBe(1); // step_index — one completed step (steps.length)
     expect(typeof params[4]).toBe("string"); // transcript is JSON text
     // Transcript is valid JSON carrying the turn's messages (input + response).
     const transcript = JSON.parse(params[4] as string) as unknown[];
@@ -161,6 +196,24 @@ describe("agent_runs terminal checkpoint write path (#3745)", () => {
   it("writes a row with status 'failed' when the turn throws", async () => {
     await drive(throwingModel());
 
+    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
+    expect(inserts).toHaveLength(1);
+    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+  });
+
+  it("records 'failed' (not 'done') when the turn finishes in-band with finishReason error", async () => {
+    await drive(inBandErrorModel());
+
+    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
+    expect(inserts).toHaveLength(1);
+    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+  });
+
+  it("writes exactly one row when both onError and onFinish fire (idempotency guard)", async () => {
+    await drive(errorThenFinishModel());
+
+    // Both terminal seams fire on this turn; the guard keeps it to one row and
+    // the first status (onError → 'failed') wins.
     const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
     expect(inserts).toHaveLength(1);
     expect((inserts[0]!.params as unknown[])[2]).toBe("failed");

--- a/packages/api/src/lib/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/durable-session.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the durable-session plain helpers (#3745, ADR-0020).
+ *
+ * Covers the write path (`recordTerminalAgentRun`), the retention sweep
+ * (`sweepTerminalAgentRuns`), and the settings readers (`isDurabilityEnabled`,
+ * `getRetentionDays`) — the no-DB gate, the INSERT/DELETE shape, terminal-only
+ * sweeping, and the default-off / default-retention fallbacks.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+let hasInternalDB = true;
+const execCalls: Array<{ sql: string; params?: unknown[] }> = [];
+const queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryRows: Array<{ id: string }> = [];
+let queryThrow: Error | null = null;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => hasInternalDB,
+  internalExecute: (sql: string, params?: unknown[]) => {
+    execCalls.push({ sql, params });
+  },
+  internalQuery: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    if (queryThrow) throw queryThrow;
+    return queryRows;
+  },
+}));
+
+let settingValue: Record<string, string | undefined> = {};
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string) => settingValue[key],
+}));
+
+const {
+  recordTerminalAgentRun,
+  sweepTerminalAgentRuns,
+  isDurabilityEnabled,
+  getRetentionDays,
+  DEFAULT_RETENTION_DAYS,
+} = await import("@atlas/api/lib/durable-session");
+
+beforeEach(() => {
+  hasInternalDB = true;
+  execCalls.length = 0;
+  queryCalls.length = 0;
+  queryRows = [];
+  queryThrow = null;
+  settingValue = {};
+});
+
+describe("recordTerminalAgentRun", () => {
+  it("writes a single INSERT INTO agent_runs with status + transcript params", () => {
+    recordTerminalAgentRun({
+      conversationId: "conv-1",
+      orgId: "org-9",
+      status: "done",
+      stepIndex: 3,
+      transcript: [{ role: "user", content: "hi" }],
+    });
+
+    expect(execCalls).toHaveLength(1);
+    const call = execCalls[0]!;
+    expect(call.sql).toContain("INSERT INTO agent_runs");
+    expect(call.sql).toContain("$5::jsonb");
+    expect(call.params).toEqual([
+      "conv-1",
+      "org-9",
+      "done",
+      3,
+      JSON.stringify([{ role: "user", content: "hi" }]),
+    ]);
+  });
+
+  it("is a no-op when no internal DB is configured", () => {
+    hasInternalDB = false;
+    recordTerminalAgentRun({
+      conversationId: "conv-1",
+      orgId: null,
+      status: "failed",
+      stepIndex: 0,
+      transcript: [],
+    });
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it("serializes a null transcript as an empty array", () => {
+    recordTerminalAgentRun({
+      conversationId: "conv-1",
+      orgId: null,
+      status: "done",
+      stepIndex: 0,
+      transcript: null,
+    });
+    expect((execCalls[0]!.params as unknown[])[4]).toBe("[]");
+  });
+});
+
+describe("sweepTerminalAgentRuns", () => {
+  it("deletes only terminal runs past the window and returns the count", async () => {
+    queryRows = [{ id: "a" }, { id: "b" }];
+    const count = await sweepTerminalAgentRuns(7);
+
+    expect(count).toBe(2);
+    expect(queryCalls).toHaveLength(1);
+    const call = queryCalls[0]!;
+    expect(call.sql).toContain("DELETE FROM agent_runs");
+    expect(call.sql).toContain("status IN ('done', 'failed')");
+    // Non-terminal runs must never be swept.
+    expect(call.sql).not.toContain("'running'");
+    expect(call.sql).not.toContain("'parked'");
+    expect(call.params).toEqual(["7"]);
+  });
+
+  it("returns 0 and issues no query when no internal DB is configured", async () => {
+    hasInternalDB = false;
+    const count = await sweepTerminalAgentRuns(30);
+    expect(count).toBe(0);
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("falls back to the default window for a non-positive retention value", async () => {
+    await sweepTerminalAgentRuns(0);
+    expect((queryCalls[0]!.params as unknown[])[0]).toBe(String(DEFAULT_RETENTION_DAYS));
+  });
+
+  it("returns -1 (never throws) on a DB error", async () => {
+    queryThrow = new Error("connection reset");
+    const count = await sweepTerminalAgentRuns(30);
+    expect(count).toBe(-1);
+  });
+});
+
+describe("isDurabilityEnabled", () => {
+  it("is false by default (flag unset)", () => {
+    expect(isDurabilityEnabled("org-1")).toBe(false);
+  });
+
+  it("is true only when the flag is exactly 'true'", () => {
+    settingValue = { ATLAS_DURABILITY_ENABLED: "true" };
+    expect(isDurabilityEnabled("org-1")).toBe(true);
+    settingValue = { ATLAS_DURABILITY_ENABLED: "1" };
+    expect(isDurabilityEnabled("org-1")).toBe(false);
+  });
+});
+
+describe("getRetentionDays", () => {
+  it("returns the default when unset", () => {
+    expect(getRetentionDays()).toBe(DEFAULT_RETENTION_DAYS);
+  });
+
+  it("parses a positive integer setting", () => {
+    settingValue = { ATLAS_DURABILITY_RETENTION_DAYS: "14" };
+    expect(getRetentionDays()).toBe(14);
+  });
+
+  it("falls back to the default for a non-positive or unparseable value", () => {
+    settingValue = { ATLAS_DURABILITY_RETENTION_DAYS: "0" };
+    expect(getRetentionDays()).toBe(DEFAULT_RETENTION_DAYS);
+    settingValue = { ATLAS_DURABILITY_RETENTION_DAYS: "abc" };
+    expect(getRetentionDays()).toBe(DEFAULT_RETENTION_DAYS);
+  });
+});

--- a/packages/api/src/lib/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/durable-session.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it, beforeEach, mock } from "bun:test";
+import type { ModelMessage } from "ai";
 import * as realInternal from "@atlas/api/lib/db/internal";
 
 let hasInternalDB = true;
@@ -86,15 +87,36 @@ describe("recordTerminalAgentRun", () => {
     expect(execCalls).toHaveLength(0);
   });
 
-  it("serializes a null transcript as an empty array", () => {
+  it("serializes a nullish transcript as an empty array (runtime guard)", () => {
+    // The arg type is `ModelMessage[]`, so callers can't pass null; the `?? []`
+    // is a belt-and-suspenders guard for a nullish value crossing an untyped
+    // boundary. Cast to exercise that runtime defense.
     recordTerminalAgentRun({
       conversationId: "conv-1",
       orgId: null,
       status: "done",
       stepIndex: 0,
-      transcript: null,
+      transcript: null as unknown as ModelMessage[],
     });
     expect((execCalls[0]!.params as unknown[])[4]).toBe("[]");
+  });
+
+  it("never throws and writes nothing when JSON.stringify fails (circular transcript)", () => {
+    // The documented synchronous-throw hazard: a circular structure makes
+    // `JSON.stringify` throw. The helper must catch it (fail-soft), so the
+    // stream is never disrupted and no row is written.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() =>
+      recordTerminalAgentRun({
+        conversationId: "conv-1",
+        orgId: null,
+        status: "done",
+        stepIndex: 0,
+        transcript: [circular] as unknown as ModelMessage[],
+      }),
+    ).not.toThrow();
+    expect(execCalls).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1248,7 +1248,7 @@ export async function runAgent({
   const durabilityActive = Boolean(conversationId) && isDurabilityEnabled(orgId);
   let terminalWritten = false;
   let observedSteps = 0;
-  const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: unknown) => {
+  const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: ModelMessage[]) => {
     if (!durabilityActive || terminalWritten) return;
     terminalWritten = true;
     recordTerminalAgentRun({
@@ -1295,10 +1295,12 @@ export async function runAgent({
           { err: error instanceof Error ? error : new Error(String(error)) },
           "stream error",
         );
-        // Durable terminal checkpoint for the failure path. Records the
-        // transcript we had at the point of failure (the input messages — the
-        // turn never produced a clean response set). Idempotent via
-        // `terminalWritten`, so a subsequent onFinish/catch won't double-write.
+        // Durable terminal checkpoint for the failure path. Records only the
+        // input messages we had at the point of failure; any assistant/tool
+        // messages produced by steps that completed before the error are NOT
+        // captured on this path (per-step persistence lands in a later slice).
+        // Idempotent via `terminalWritten`, so a subsequent onFinish/catch
+        // won't double-write.
         writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, modelMessages);
         endSpan(
           SpanStatusCode.ERROR,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -40,6 +40,12 @@ import { getConfig } from "./config";
 import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
 import { hasInternalDB, internalExecute } from "./db/internal";
+import {
+  AGENT_RUN_STATUS,
+  isDurabilityEnabled,
+  recordTerminalAgentRun,
+  type TerminalAgentRunStatus,
+} from "./durable-session";
 import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
 import { buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
@@ -1230,6 +1236,30 @@ export async function runAgent({
   const rawTools = activeRegistry.getAll();
   const tools = wrapToolsWithHooks(rawTools, { userId: userId ?? undefined, conversationId });
 
+  // ── Durable-session terminal checkpoint (#3745, ADR-0020, phase 1a) ──
+  // A turn writes exactly ONE durable `agent_runs` row at completion: `done`
+  // on a clean finish, `failed` on an uncaught error. Gated on a conversation
+  // id (a run belongs to a conversation) + the per-workspace durability flag;
+  // `recordTerminalAgentRun` additionally no-ops without an internal DB, so
+  // off / no-DB → behavior identical to today. Fire-and-forget: it rides the
+  // shared circuit breaker and never disrupts the stream. `terminalWritten`
+  // makes the write idempotent across the onFinish/onError/catch seams (first
+  // terminal status wins — one row per turn).
+  const durabilityActive = Boolean(conversationId) && isDurabilityEnabled(orgId);
+  let terminalWritten = false;
+  let observedSteps = 0;
+  const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: unknown) => {
+    if (!durabilityActive || terminalWritten) return;
+    terminalWritten = true;
+    recordTerminalAgentRun({
+      conversationId: conversationId as string,
+      orgId: orgId ?? null,
+      status,
+      stepIndex,
+      transcript,
+    });
+  };
+
   let result;
   try {
     result = otelContext.with(agentCtx, () => streamText({
@@ -1265,6 +1295,11 @@ export async function runAgent({
           { err: error instanceof Error ? error : new Error(String(error)) },
           "stream error",
         );
+        // Durable terminal checkpoint for the failure path. Records the
+        // transcript we had at the point of failure (the input messages — the
+        // turn never produced a clean response set). Idempotent via
+        // `terminalWritten`, so a subsequent onFinish/catch won't double-write.
+        writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, modelMessages);
         endSpan(
           SpanStatusCode.ERROR,
           error instanceof Error ? error.message : String(error),
@@ -1278,6 +1313,10 @@ export async function runAgent({
       },
 
       onStepFinish: ({ stepNumber, finishReason, usage }) => {
+        // Track the highest observed step so a `failed` checkpoint (onError /
+        // outer catch) can record how far the turn got. `stepNumber` is
+        // 0-based; +1 gives the count of completed steps.
+        observedSteps = stepNumber + 1;
         log.info(
           {
             step: stepNumber,
@@ -1291,7 +1330,7 @@ export async function runAgent({
         );
       },
 
-      onFinish: ({ finishReason, totalUsage, steps }) => {
+      onFinish: ({ finishReason, totalUsage, steps, response }) => {
         log.info(
           {
             finishReason,
@@ -1310,6 +1349,15 @@ export async function runAgent({
           "atlas.total_output_tokens": totalUsage?.outputTokens ?? 0,
         });
         endSpan(SpanStatusCode.OK);
+
+        // Durable terminal checkpoint (#3745, ADR-0020). The full transcript is
+        // the input messages plus the messages the model generated this turn
+        // (assistant text, tool calls, tool results). `finishReason === "error"`
+        // is the AI-SDK's in-band error signal — record it as `failed`, not
+        // `done`. Idempotent via `terminalWritten`.
+        const status: TerminalAgentRunStatus =
+          finishReason === "error" ? AGENT_RUN_STATUS.FAILED : AGENT_RUN_STATUS.DONE;
+        writeTerminal(status, steps.length, [...modelMessages, ...response.messages]);
 
         // Persist token usage to internal DB (fire-and-forget).
         // Shares the internalExecute circuit breaker with audit writes.
@@ -1362,6 +1410,9 @@ export async function runAgent({
       },
     }));
   } catch (err) {
+    // Synchronous setup failure before the stream began. Record a `failed`
+    // terminal checkpoint (idempotent) before re-throwing.
+    writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, modelMessages);
     endSpan(
       SpanStatusCode.ERROR,
       err instanceof Error ? err.message : String(err),

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -388,6 +388,10 @@ describe("migrateAuthTables", () => {
             { name: "0139_learned_patterns_auto_promoted.sql" },
             { name: "0140_operator_integration_credentials.sql" },
             { name: "0141_stripe_teardown_pending.sql" },
+            // 0142 is a MANAGED_AUTH_MIGRATION (skipped outside managed mode),
+            // so it doesn't need to appear here. 0143 touches `conversations`
+            // (Atlas-internal, not Better Auth), so it runs and must be listed.
+            { name: "0143_agent_runs.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -2391,6 +2391,60 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     // 0115 is idempotent — re-applying the ALTER IF NOT EXISTS is a no-op.
     await expect(pool.query(sql0115)).resolves.toBeDefined();
   }, PG_TEST_TIMEOUT_MS);
+
+  // 0143 (#3745, ADR-0020) — agent_runs durable-session checkpoint store.
+  // The status CHECK constraint and the conversation FK cascade are the two
+  // teeth of the schema: a bad status must reject (23514) and a deleted
+  // conversation must take its runs with it.
+  it("0143: agent_runs status CHECK rejects unknown values with 23514", async () => {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO conversations DEFAULT VALUES RETURNING id`,
+    );
+    const conversationId = rows[0]!.id;
+
+    // A canonical terminal status writes cleanly.
+    await pool.query(
+      `INSERT INTO agent_runs (conversation_id, status, transcript)
+       VALUES ($1, 'done', '[]'::jsonb)`,
+      [conversationId],
+    );
+
+    // An out-of-enum status rejects at the DB layer.
+    await expect(
+      pool.query(
+        `INSERT INTO agent_runs (conversation_id, status, transcript)
+         VALUES ($1, 'finished', '[]'::jsonb)`,
+        [conversationId],
+      ),
+    ).rejects.toMatchObject({ code: "23514" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0143: status defaults to 'running' and deleting the conversation cascades", async () => {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO conversations DEFAULT VALUES RETURNING id`,
+    );
+    const conversationId = rows[0]!.id;
+
+    // step_index defaults to 0, status defaults to 'running'.
+    await pool.query(
+      `INSERT INTO agent_runs (conversation_id, transcript) VALUES ($1, '[]'::jsonb)`,
+      [conversationId],
+    );
+    const before = await pool.query<{ status: string; step_index: number }>(
+      `SELECT status, step_index FROM agent_runs WHERE conversation_id = $1`,
+      [conversationId],
+    );
+    expect(before.rows[0]?.status).toBe("running");
+    expect(before.rows[0]?.step_index).toBe(0);
+
+    // ON DELETE CASCADE — removing the conversation removes its runs.
+    await pool.query(`DELETE FROM conversations WHERE id = $1`, [conversationId]);
+    const after = await pool.query<{ c: number }>(
+      `SELECT COUNT(*)::int AS c FROM agent_runs WHERE conversation_id = $1`,
+      [conversationId],
+    );
+    expect(after.rows[0]?.c).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
 });
 
 // #2606 — source-level revert guard for the integration-store SQL formatter.

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -164,7 +164,8 @@ describe("runMigrations", () => {
     //   Plus 0140 (operator_integration_credentials, operator-tier app creds, #3704) = 141.
     //   Plus 0141 (stripe_teardown_pending durable teardown outbox, #3679) = 142.
     //   Plus 0142 (user.normalizedEmail business-email/one-trial teeth, #3650) = 143.
-    expect(count).toBe(143);
+    //   Plus 0143 (agent_runs durable-session checkpoint store, ADR-0020, #3745) = 144.
+    expect(count).toBe(144);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -336,6 +337,7 @@ describe("runMigrations", () => {
         "0140_operator_integration_credentials.sql",
         "0141_stripe_teardown_pending.sql",
         "0142_user_normalized_email.sql",
+        "0143_agent_runs.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0143_agent_runs.sql
+++ b/packages/api/src/lib/db/migrations/0143_agent_runs.sql
@@ -1,0 +1,58 @@
+-- 0143: agent_runs — durable agent-session checkpoint store (#3745, ADR-0020).
+--
+-- Phase 1a of the durable-agent-sessions epic (#3742): the minimal end-to-end
+-- checkpoint pipe. A *run* is one user turn. For now a turn writes exactly ONE
+-- terminal row at completion — `done` on a clean finish, `failed` on an
+-- uncaught error — establishing the persistence seam before per-step
+-- granularity (`running`) and resume (`parked` + `resuming_lease`) land in
+-- later slices. The `running`/`parked` statuses and the `resuming_lease`
+-- column are defined now (the schema is the contract) but not yet written.
+--
+-- The write rides the existing fire-and-forget `internalExecute` circuit
+-- breaker (shared with token_usage / audit), so a persistence failure is
+-- logged and never disrupts the live stream (ADR-0020 "checkpointing never
+-- disrupts the stream"). Durability is gated by a settings flag (default OFF)
+-- and degrades to today's behavior when no internal DB is present.
+--
+-- CONTENT-MODE EXEMPT: agent_runs is execution state (the in-flight turn's
+-- transcript + status), not user-surfaced content. It deliberately omits the
+-- draft/published `status` column and ContentModeRegistry filtering that
+-- user-facing tables carry — there is nothing to publish. The `status` column
+-- here is the run lifecycle (running/parked/done/failed), unrelated to content
+-- mode. See docs/development/content-mode.md and ADR-0020.
+--
+-- Drizzle-managed (mirrored in db/schema.ts as `agentRuns`, same commit).
+-- Additive CREATE only — no DROP, so no two-phase-drop discipline applies; the
+-- mirror lands in the same commit so a later `drizzle-kit generate` can't emit
+-- a DROP. `conversation_id` FKs `conversations(id)` ON DELETE CASCADE: a run
+-- belongs to a conversation and is meaningless once the conversation is gone.
+-- `org_id` is the Better-Auth organization id (TEXT, no FK — `organization` is
+-- not a Drizzle table, matching conversations / settings / the other
+-- org-scoped Atlas tables).
+
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  org_id          TEXT,
+  status          TEXT NOT NULL DEFAULT 'running',
+  step_index      INTEGER NOT NULL DEFAULT 0,
+  transcript      JSONB NOT NULL,
+  parked_reason   TEXT,
+  resuming_lease  TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT chk_agent_runs_status CHECK (status IN ('running', 'parked', 'done', 'failed'))
+);
+
+COMMENT ON TABLE agent_runs IS
+  'Durable agent-session checkpoints (ADR-0020). Execution state, not user-surfaced content — content-mode-exempt (no draft/published status column). status is the run lifecycle: running/parked/done/failed.';
+
+-- Per-conversation lookups (a conversation''s runs) and per-tenant scans.
+CREATE INDEX IF NOT EXISTS idx_agent_runs_conversation ON agent_runs (conversation_id);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_org ON agent_runs (org_id);
+
+-- Non-terminal runs are the working set for resume + the park reaper: a small,
+-- hot slice of a table dominated by terminal (done/failed) rows awaiting the
+-- retention sweep. A partial index keeps that scan cheap as the table grows.
+CREATE INDEX IF NOT EXISTS idx_agent_runs_active ON agent_runs (status)
+  WHERE status IN ('running', 'parked');

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2557,3 +2557,51 @@ export const mcpActionPolicy = pgTable(
     check("chk_mcp_action_policy_status", sql`status IN ('allowed', 'blocked')`),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Durable agent sessions — turn checkpoint store (#3745, ADR-0020)
+// ---------------------------------------------------------------------------
+
+/**
+ * Durable agent-session checkpoints. A *run* is one user turn; phase 1a
+ * (#3745) writes exactly one terminal row per turn (`done`/`failed`) at
+ * completion, establishing the persistence seam before per-step `running`
+ * checkpoints and `parked`/`resuming_lease` resume land in later slices.
+ *
+ * CONTENT-MODE EXEMPT (deliberate): this is execution state — the in-flight
+ * turn's transcript + lifecycle status — not user-surfaced content, so it
+ * carries no draft/published `status` column or ContentModeRegistry filter
+ * (there is nothing to publish). The `status` column is the run lifecycle
+ * (running/parked/done/failed), unrelated to content mode. See ADR-0020 and
+ * docs/development/content-mode.md.
+ *
+ * `conversation_id` FKs `conversations(id)` ON DELETE CASCADE — a run is
+ * meaningless once its conversation is gone. `org_id` is the Better-Auth
+ * organization id (TEXT, no FK — `organization` is not a Drizzle table).
+ * Mirrors `migrations/0143_agent_runs.sql`.
+ */
+export const agentRuns = pgTable(
+  "agent_runs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    conversationId: uuid("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    orgId: text("org_id"),
+    status: text("status").notNull().default("running"),
+    stepIndex: integer("step_index").notNull().default(0),
+    transcript: jsonb("transcript").notNull(),
+    parkedReason: text("parked_reason"),
+    resumingLease: timestamp("resuming_lease", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("idx_agent_runs_conversation").on(t.conversationId),
+    index("idx_agent_runs_org").on(t.orgId),
+    // Non-terminal runs are the hot working set for resume + the park reaper,
+    // a small slice of a table dominated by terminal rows awaiting the sweep.
+    index("idx_agent_runs_active").on(t.status).where(sql`status IN ('running', 'parked')`),
+    check("chk_agent_runs_status", sql`status IN ('running', 'parked', 'done', 'failed')`),
+  ],
+);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -11,6 +11,7 @@
 
 import type { OutboxStatus } from "../lead-outbox/outbox";
 import type { EmailOutboxStatus } from "../email-outbox/outbox";
+import type { AgentRunStatus } from "../durable-session";
 import {
   pgTable,
   uuid,
@@ -2588,7 +2589,7 @@ export const agentRuns = pgTable(
       .notNull()
       .references(() => conversations.id, { onDelete: "cascade" }),
     orgId: text("org_id"),
-    status: text("status").notNull().default("running"),
+    status: text("status").$type<AgentRunStatus>().notNull().default("running"),
     stepIndex: integer("step_index").notNull().default(0),
     transcript: jsonb("transcript").notNull(),
     parkedReason: text("parked_reason"),

--- a/packages/api/src/lib/durable-session.ts
+++ b/packages/api/src/lib/durable-session.ts
@@ -1,0 +1,139 @@
+/**
+ * Durable agent sessions — terminal-checkpoint write path + retention sweep
+ * (#3745, ADR-0020, phase 1a).
+ *
+ * A *run* is one user turn. Phase 1a writes exactly ONE durable row per turn at
+ * completion: `done` on a clean finish, `failed` on an uncaught error. Per-step
+ * `running` checkpoints and `parked`/resume land in later slices.
+ *
+ * These are plain (non-Effect) helpers so the agent loop (`lib/agent.ts`, a
+ * plain async function) can call them directly — the same shape as the
+ * `token_usage` write it sits beside. The {@link DurableSession} Effect service
+ * (`lib/effect/durable-session.ts`) wraps the same helpers for Effect callers
+ * (the retention-sweep fiber) and for `Layer.provide` test injection.
+ *
+ * Fail-soft is the contract: the terminal write rides the fire-and-forget
+ * `internalExecute` circuit breaker (shared with token_usage / audit), so a
+ * persistence failure logs and never disrupts the live stream. When there is no
+ * internal DB the write is a no-op and the loop behaves exactly as it does
+ * today — durability is an enhancement, never a new hard requirement.
+ */
+
+import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("durable-session");
+
+/** Run lifecycle statuses. `running`/`parked` arrive in later slices. */
+export const AGENT_RUN_STATUS = {
+  RUNNING: "running",
+  PARKED: "parked",
+  DONE: "done",
+  FAILED: "failed",
+} as const;
+
+export type AgentRunStatus = (typeof AGENT_RUN_STATUS)[keyof typeof AGENT_RUN_STATUS];
+
+/** Statuses a terminal checkpoint may carry in phase 1a. */
+export type TerminalAgentRunStatus =
+  | typeof AGENT_RUN_STATUS.DONE
+  | typeof AGENT_RUN_STATUS.FAILED;
+
+/** Settings key gating durability on/off (default OFF). */
+export const DURABILITY_ENABLED_SETTING = "ATLAS_DURABILITY_ENABLED";
+/** Settings key for the terminal-run retention window, in days. */
+export const DURABILITY_RETENTION_DAYS_SETTING = "ATLAS_DURABILITY_RETENTION_DAYS";
+
+/** Fallback retention window when the setting is unset/unparseable. */
+export const DEFAULT_RETENTION_DAYS = 30;
+
+/**
+ * Whether durability is enabled for this workspace. Reads the hot-reloadable
+ * settings flag (workspace > platform > env > default), defaulting OFF. The
+ * per-workspace check belongs at the agent-loop call site, not the write
+ * helper, because the retention sweep is operator-global and ignores it.
+ */
+export function isDurabilityEnabled(orgId?: string): boolean {
+  return getSettingAuto(DURABILITY_ENABLED_SETTING, orgId) === "true";
+}
+
+/** Resolve the retention window (days), clamped to a sane positive integer. */
+export function getRetentionDays(orgId?: string): number {
+  const raw = getSettingAuto(DURABILITY_RETENTION_DAYS_SETTING, orgId);
+  if (raw === undefined) return DEFAULT_RETENTION_DAYS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RETENTION_DAYS;
+  return parsed;
+}
+
+/**
+ * Persist a single terminal run checkpoint (fire-and-forget).
+ *
+ * Mirrors the `token_usage` write in the agent loop's `onFinish`: gated on
+ * `hasInternalDB()`, routed through `internalExecute` (shared circuit breaker),
+ * type-narrowed catch, never throws. The transcript is serialized to JSONB.
+ */
+export function recordTerminalAgentRun(args: {
+  conversationId: string;
+  orgId: string | null;
+  status: TerminalAgentRunStatus;
+  stepIndex: number;
+  /** Accumulated ModelMessage[] as of this turn; serialized to JSONB. */
+  transcript: unknown;
+}): void {
+  if (!hasInternalDB()) return;
+  try {
+    internalExecute(
+      `INSERT INTO agent_runs (conversation_id, org_id, status, step_index, transcript, updated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, now())`,
+      [
+        args.conversationId,
+        args.orgId,
+        args.status,
+        args.stepIndex,
+        JSON.stringify(args.transcript ?? []),
+      ],
+    );
+  } catch (err) {
+    // internalExecute is itself fire-and-forget; this guards a synchronous
+    // throw (e.g. JSON.stringify on a circular transcript) so the stream is
+    // never disrupted. ADR-0020: a degraded checkpoint store costs
+    // resumability, never the current answer.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to record terminal agent run checkpoint",
+    );
+  }
+}
+
+/**
+ * Delete terminal (`done`/`failed`) runs whose last update is older than the
+ * retention window. Non-terminal (`running`/`parked`) runs are never touched —
+ * they are the live working set for resume. Returns the number of rows deleted,
+ * or -1 on error (mirrors `cleanupExpiredShares`).
+ */
+export async function sweepTerminalAgentRuns(retentionDays: number): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  const days = Number.isFinite(retentionDays) && retentionDays > 0 ? retentionDays : DEFAULT_RETENTION_DAYS;
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `DELETE FROM agent_runs
+        WHERE status IN ('done', 'failed')
+          AND updated_at < now() - ($1 || ' days')::interval
+        RETURNING id`,
+      [String(days)],
+    );
+    const count = rows.length;
+    if (count > 0) {
+      log.info({ count, retentionDays: days }, "Swept terminal agent runs past retention window");
+    }
+    return count;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to sweep terminal agent runs",
+    );
+    return -1;
+  }
+}

--- a/packages/api/src/lib/durable-session.ts
+++ b/packages/api/src/lib/durable-session.ts
@@ -19,6 +19,7 @@
  * today — durability is an enhancement, never a new hard requirement.
  */
 
+import type { ModelMessage } from "ai";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -68,20 +69,32 @@ export function getRetentionDays(orgId?: string): number {
 }
 
 /**
+ * Arguments for a terminal-checkpoint write. The single source of truth for the
+ * write shape — referenced (via `import type`) by `DurableSessionShape`'s
+ * `recordTerminal` so the Effect Tag contract can't drift from the helper.
+ */
+export interface RecordTerminalRunArgs {
+  conversationId: string;
+  orgId: string | null;
+  status: TerminalAgentRunStatus;
+  /**
+   * Completed-step COUNT as of this turn (1-based), not a 0-based index:
+   * `onFinish` passes `steps.length`; the failure paths pass `observedSteps`
+   * (`onStepFinish`'s `stepNumber + 1`). Stored in the `step_index` column.
+   */
+  stepIndex: number;
+  /** Accumulated transcript as of this turn; serialized to JSONB. */
+  transcript: ModelMessage[];
+}
+
+/**
  * Persist a single terminal run checkpoint (fire-and-forget).
  *
  * Mirrors the `token_usage` write in the agent loop's `onFinish`: gated on
  * `hasInternalDB()`, routed through `internalExecute` (shared circuit breaker),
  * type-narrowed catch, never throws. The transcript is serialized to JSONB.
  */
-export function recordTerminalAgentRun(args: {
-  conversationId: string;
-  orgId: string | null;
-  status: TerminalAgentRunStatus;
-  stepIndex: number;
-  /** Accumulated ModelMessage[] as of this turn; serialized to JSONB. */
-  transcript: unknown;
-}): void {
+export function recordTerminalAgentRun(args: RecordTerminalRunArgs): void {
   if (!hasInternalDB()) return;
   try {
     internalExecute(
@@ -101,7 +114,11 @@ export function recordTerminalAgentRun(args: {
     // never disrupted. ADR-0020: a degraded checkpoint store costs
     // resumability, never the current answer.
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      {
+        err: err instanceof Error ? err.message : String(err),
+        conversationId: args.conversationId,
+        status: args.status,
+      },
       "Failed to record terminal agent run checkpoint",
     );
   }

--- a/packages/api/src/lib/effect/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/effect/__tests__/durable-session.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Layer.provide tests for the `DurableSession` Effect service (#3745,
+ * ADR-0020). Verifies the real layer delegates to the plain write/sweep
+ * helpers and the Noop layer is inert — no top-level singleton mutation, every
+ * dependency injected via `Layer.provide`.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { Effect } from "effect";
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+let hasInternalDB = true;
+const execCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryRows: Array<{ id: string }> = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => hasInternalDB,
+  internalExecute: (sql: string, params?: unknown[]) => {
+    execCalls.push({ sql, params });
+  },
+  internalQuery: async () => queryRows,
+}));
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: () => undefined,
+}));
+
+const { DurableSession } = await import("@atlas/api/lib/effect/services");
+const { DurableSessionLive, NoopDurableSessionLayer, durableSessionLayer } = await import(
+  "@atlas/api/lib/effect/durable-session"
+);
+
+beforeEach(() => {
+  hasInternalDB = true;
+  execCalls.length = 0;
+  queryRows = [];
+});
+
+describe("DurableSessionLive", () => {
+  it("reports available and records a terminal run via internalExecute", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const ds = yield* DurableSession;
+        expect(ds.available).toBe(true);
+        ds.recordTerminal({
+          conversationId: "conv-1",
+          orgId: "org-1",
+          status: "done",
+          stepIndex: 1,
+          transcript: [],
+        });
+      }).pipe(Effect.provide(DurableSessionLive)),
+    );
+
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0]!.sql).toContain("INSERT INTO agent_runs");
+  });
+
+  it("sweepTerminal returns the deleted count", async () => {
+    queryRows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const deleted = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ds = yield* DurableSession;
+        return yield* ds.sweepTerminal(30);
+      }).pipe(Effect.provide(DurableSessionLive)),
+    );
+    expect(deleted).toBe(3);
+  });
+});
+
+describe("NoopDurableSessionLayer", () => {
+  it("reports unavailable, records nothing, sweeps nothing", async () => {
+    const deleted = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ds = yield* DurableSession;
+        expect(ds.available).toBe(false);
+        ds.recordTerminal({
+          conversationId: "conv-1",
+          orgId: null,
+          status: "failed",
+          stepIndex: 0,
+          transcript: [],
+        });
+        return yield* ds.sweepTerminal(30);
+      }).pipe(Effect.provide(NoopDurableSessionLayer)),
+    );
+
+    expect(execCalls).toHaveLength(0);
+    expect(deleted).toBe(0);
+  });
+});
+
+describe("durableSessionLayer selector", () => {
+  it("selects the real layer when an internal DB is present", async () => {
+    const available = await Effect.runPromise(
+      Effect.gen(function* () {
+        return (yield* DurableSession).available;
+      }).pipe(Effect.provide(durableSessionLayer(true))),
+    );
+    expect(available).toBe(true);
+  });
+
+  it("selects the Noop layer when no internal DB is present", async () => {
+    const available = await Effect.runPromise(
+      Effect.gen(function* () {
+        return (yield* DurableSession).available;
+      }).pipe(Effect.provide(durableSessionLayer(false))),
+    );
+    expect(available).toBe(false);
+  });
+});

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -278,11 +278,18 @@ describe("makeSchedulerLive", () => {
   // builds cleanly.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { NoopEnterpriseDefaultsLayer } = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { NoopDurableSessionLayer } = require("@atlas/api/lib/effect/durable-session") as typeof import("@atlas/api/lib/effect/durable-session");
 
   // #3446 — `makeSchedulerLive` requires `Migration` as an ordering
   // barrier for the billing-reconcile boot tick; tests satisfy it with
-  // the immediate test layer.
-  const schedulerDeps = Layer.merge(NoopEnterpriseDefaultsLayer, makeTestMigrationLayer());
+  // the immediate test layer. #3745 — it also requires `DurableSession`;
+  // the Noop layer suffices (the retention-sweep fiber forks but no-ops).
+  const schedulerDeps = Layer.mergeAll(
+    NoopEnterpriseDefaultsLayer,
+    makeTestMigrationLayer(),
+    NoopDurableSessionLayer,
+  );
 
   test("returns 'none' backend when no scheduler configured", async () => {
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
@@ -347,7 +354,9 @@ describe("makeSchedulerLive", () => {
 
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
     const layer = makeSchedulerLive(config).pipe(
-      Layer.provide(Layer.merge(NoopEnterpriseDefaultsLayer, gatedMigrationLayer)),
+      Layer.provide(
+        Layer.mergeAll(NoopEnterpriseDefaultsLayer, gatedMigrationLayer, NoopDurableSessionLayer),
+      ),
     );
 
     let schedulerBuilt = false;
@@ -412,6 +421,7 @@ describe("makeSchedulerLive", () => {
         "conversation_rate_sweep",
         "share_token_cleanup",
         "orphan_task_reconcile",
+        "agent_runs_retention_sweep",
       ],
     },
     {

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -65,11 +65,17 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 const { makeSchedulerLive, Migration } = await import("../layers");
 const { SaasCrm, NoopEnterpriseDefaultsLayer } = await import("../services");
+const { NoopDurableSessionLayer } = await import("../durable-session");
 const { setActiveFlusherSignal } = await import("@atlas/api/lib/lead-outbox");
 
 // #3446 — `makeSchedulerLive` requires `Migration` as an ordering barrier
 // for the billing-reconcile boot tick; satisfy it immediately here.
-const testMigrationLayer = Layer.succeed(Migration, { migrated: true });
+// #3745 — it also requires `DurableSession`; the Noop layer suffices for the
+// outbox-flusher lifecycle tests (the retention-sweep fiber forks but no-ops).
+const testMigrationLayer = Layer.merge(
+  Layer.succeed(Migration, { migrated: true }),
+  NoopDurableSessionLayer,
+);
 
 // ── Test layer: SaasCrm with available=true + stub dispatcher ───────
 

--- a/packages/api/src/lib/effect/durable-session.ts
+++ b/packages/api/src/lib/effect/durable-session.ts
@@ -1,0 +1,46 @@
+/**
+ * DurableSession Effect layers (#3745, ADR-0020).
+ *
+ * `DurableSessionLive` is selected when an internal DB is present; the
+ * `NoopDurableSessionLayer` otherwise — the same `hasInternalDB()` gate and
+ * Noop-layer shape as the enterprise services. Both delegate to the plain
+ * helpers in `lib/durable-session.ts` so there is a single write/sweep
+ * implementation shared with the agent loop (which calls the plain helpers
+ * directly, mirroring the `token_usage` write it sits beside).
+ */
+
+import { Effect, Layer } from "effect";
+import { DurableSession, type DurableSessionShape } from "@atlas/api/lib/effect/services";
+import {
+  recordTerminalAgentRun,
+  sweepTerminalAgentRuns,
+} from "@atlas/api/lib/durable-session";
+
+/** Real, internal-DB-backed durable store. */
+export const DurableSessionLive: Layer.Layer<DurableSession> = Layer.succeed(
+  DurableSession,
+  {
+    available: true,
+    recordTerminal: (args) => recordTerminalAgentRun(args),
+    sweepTerminal: (retentionDays) =>
+      Effect.promise(() => sweepTerminalAgentRuns(retentionDays)),
+  } satisfies DurableSessionShape,
+);
+
+/**
+ * No-op store selected when no internal DB is present. The loop then behaves
+ * exactly as it does today: no `agent_runs` writes, nothing to sweep.
+ */
+export const NoopDurableSessionLayer: Layer.Layer<DurableSession> = Layer.succeed(
+  DurableSession,
+  {
+    available: false,
+    recordTerminal: () => {},
+    sweepTerminal: () => Effect.succeed(0),
+  } satisfies DurableSessionShape,
+);
+
+/** Select the real layer iff an internal DB is configured (`hasInternalDB()`). */
+export function durableSessionLayer(hasInternalDB: boolean): Layer.Layer<DurableSession> {
+  return hasInternalDB ? DurableSessionLive : NoopDurableSessionLayer;
+}

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2271,7 +2271,11 @@ export function makeSchedulerLive(
       }).pipe(
         Effect.catchAllCause((cause) =>
           Effect.sync(() => {
-            log.warn(
+            // A defect here is genuinely unexpected: `sweepTerminal` already
+            // self-catches DB errors → -1, so this only fires on an escaped
+            // defect (e.g. `getRetentionDays()` throwing). `error`, not `warn`,
+            // matching the sibling share-token sweep's unexpected-error level.
+            log.error(
               { err: cause.toString() },
               "agent_runs retention sweep tick failed",
             );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -78,7 +78,10 @@ import {
   makeConnectionRegistryLive,
   makeWiredPluginRegistryLive,
   type PluginWiringConfig,
+  DurableSession,
 } from "./services";
+import { durableSessionLayer } from "./durable-session";
+import { getRetentionDays } from "@atlas/api/lib/durable-session";
 import {
   recoverInFlight as recoverOutboxInFlight,
   drainOutbox as drainOutboxQueue,
@@ -166,7 +169,7 @@ function withFiberDeathLog<A, E, R>(
 //
 // Membership splits into two single-source records, by fiber kind:
 //
-//   • SCHEDULER_CLEANUP_SPAN_NAMES — 10 cleanup/sweep fibers (they evict
+//   • SCHEDULER_CLEANUP_SPAN_NAMES — 11 cleanup/sweep fibers (they evict
 //     expired in-memory or DB state). Eight were retrofitted with a span by
 //     #2945 (the TTL/ratelimit/state sweeps below); the ninth,
 //     `orphan_task_reconcile` (#2944), shipped with its span from day one and
@@ -175,7 +178,9 @@ function withFiberDeathLog<A, E, R>(
 //     catalog-refresh fiber and the scheduler engine use that 4th arg
 //     elsewhere, inside their own modules). The tenth,
 //     `trial_rate_limit_cleanup` (#3654), sweeps the unauthenticated
-//     `start_trial` per-IP/email attempt-limiter maps.
+//     `start_trial` per-IP/email attempt-limiter maps. The eleventh,
+//     `agent_runs_retention_sweep` (#3745, ADR-0020), deletes terminal
+//     durable-session runs past the retention window.
 //
 //   • SCHEDULER_WORK_SPAN_NAMES — 5 background-work fibers (they perform
 //     recurring side-effecting work rather than evicting state):
@@ -225,6 +230,7 @@ export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
   share_token_cleanup: "atlas.scheduler.share_token_cleanup",
   orphan_task_reconcile: "atlas.scheduler.orphan_task_reconcile",
+  agent_runs_retention_sweep: "atlas.scheduler.agent_runs_retention_sweep",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // Per-tick spans for the background-work fibers (#2987). Same wrap shape and
@@ -1450,7 +1456,7 @@ export class Scheduler extends Context.Tag("Scheduler")<
  */
 export function makeSchedulerLive(
   config: ResolvedConfig,
-): Layer.Layer<Scheduler, never, AuditPurgeScheduler | SaasCrm | Migration> {
+): Layer.Layer<Scheduler, never, AuditPurgeScheduler | SaasCrm | Migration | DurableSession> {
   return Layer.scoped(
     Scheduler,
     Effect.gen(function* () {
@@ -2247,6 +2253,40 @@ export function makeSchedulerLive(
           withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.share_token_cleanup, {}, shareCleanupEffect).pipe(
             Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS))),
           ),
+        ),
+      );
+
+      // ── Periodic fiber: agent_runs retention sweep (#3745, ADR-0020) ──
+      // Deletes terminal (done/failed) durable-session runs past the retention
+      // window; non-terminal runs are never touched. Resolves the
+      // `DurableSession` Tag — Noop when there is no internal DB, so the fiber
+      // forks but sweeps nothing. The retention window is read per-tick (no
+      // orgId → platform/env/default) so an operator setting change takes
+      // effect without a restart. Hourly, like the share-token sweep.
+      const durableSession = yield* DurableSession;
+      // Per-tick catch (inside repeat) so the loop survives a transient fault
+      // and keeps sweeping — same resilience shape as the share-token sweep.
+      const agentRunsRetentionTick = Effect.gen(function* () {
+        yield* durableSession.sweepTerminal(getRetentionDays());
+      }).pipe(
+        Effect.catchAllCause((cause) =>
+          Effect.sync(() => {
+            log.warn(
+              { err: cause.toString() },
+              "agent_runs retention sweep tick failed",
+            );
+          }),
+        ),
+      );
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
+        withFiberDeathLog(
+          "agent_runs_retention_sweep",
+          withEffectSpan(
+            SCHEDULER_CLEANUP_SPAN_NAMES.agent_runs_retention_sweep,
+            {},
+            agentRunsRetentionTick,
+          ).pipe(Effect.repeat(Schedule.spaced(Duration.hours(1)))),
         ),
       );
 
@@ -3185,11 +3225,19 @@ export function buildAppLayer(
   | SemanticSync
   | Settings
   | Scheduler
+  | DurableSession
   | EnterpriseSubsystem,
   Error
 > {
   const configLayer = Layer.succeed(Config, { config });
   const internalDBLayer = makeInternalDBLive();
+
+  // DurableSession (#3745, ADR-0020) — real, internal-DB-backed store when an
+  // internal DB is present; the Noop layer otherwise (same `hasInternalDB()`
+  // gate as the EE Noop layers). The scheduler's retention-sweep fiber resolves
+  // it via the Tag. The per-workspace `ATLAS_DURABILITY_ENABLED` flag is checked
+  // at write time in the agent loop, not here.
+  const durableSession = durableSessionLayer(hasInternalDB());
 
   // MigrationLive depends on InternalDB — provide it
   const migrationLayer = MigrationLive.pipe(Layer.provide(internalDBLayer));
@@ -3325,8 +3373,14 @@ export function buildAppLayer(
   // creates `stripe_webhook_events`. Same shared reference as everywhere
   // else, so Effect memoization makes the edge free (Migration ←
   // InternalDB only — no cycle back into Scheduler).
+  //
+  // `durableSession` is provided so the retention-sweep fiber (#3745) can
+  // resolve the `DurableSession` Tag — Noop when there is no internal DB, so
+  // the fiber forks but sweeps nothing.
   const schedulerLayer = makeSchedulerLive(config).pipe(
-    Layer.provide(Layer.mergeAll(EnterpriseLayer, settingsLayer, migrationLayer)),
+    Layer.provide(
+      Layer.mergeAll(EnterpriseLayer, settingsLayer, migrationLayer, durableSession),
+    ),
   );
 
   // DpaGuardLive depends on Config + Settings — provide them so the boot
@@ -3441,6 +3495,7 @@ export function buildAppLayer(
     semanticSyncLayer,
     settingsLayer,
     schedulerLayer,
+    durableSession,
     dpaGuardLayer,
     enterpriseGuardLayer,
     encryptionKeyGuardLayer,

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -30,6 +30,7 @@ import type {
 import type { PoolMetrics, OrgPoolMetrics } from "@useatlas/types";
 import type { LeadEvent } from "@useatlas/twenty/lead-normalizer";
 import type { ToolRegistry as ToolRegistryClass } from "@atlas/api/lib/tools/registry";
+import type { RecordTerminalRunArgs } from "@atlas/api/lib/durable-session";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   PluginRegistry as PluginRegistryClass,
@@ -107,13 +108,7 @@ export interface DurableSessionShape {
    * circuit breaker, never throws, never disrupts the stream. No-op on the
    * Noop layer.
    */
-  recordTerminal(args: {
-    conversationId: string;
-    orgId: string | null;
-    status: "done" | "failed";
-    stepIndex: number;
-    transcript: unknown;
-  }): void;
+  recordTerminal(args: RecordTerminalRunArgs): void;
   /**
    * Delete terminal runs older than the retention window; leaves non-terminal
    * (`running`/`parked`) runs untouched. Returns the number deleted (0 on the

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -89,6 +89,45 @@ export class Migration extends Context.Tag("Migration")<
   MigrationShape
 >() {}
 
+// ---------------------------------------------------------------------------
+// DurableSession — agent-turn checkpoint store (#3745, ADR-0020)
+// ---------------------------------------------------------------------------
+
+export interface DurableSessionShape {
+  /**
+   * Whether a real (internal-DB-backed) durable store is wired. `false` for
+   * the Noop layer selected when no internal DB is present (`hasInternalDB()`),
+   * mirroring the enterprise Noop layers. The agent loop additionally gates on
+   * the per-workspace `ATLAS_DURABILITY_ENABLED` settings flag at write time.
+   */
+  readonly available: boolean;
+  /**
+   * Persist a single terminal run checkpoint (`done`/`failed`) at turn
+   * completion (phase 1a). Fire-and-forget: rides the shared `internalExecute`
+   * circuit breaker, never throws, never disrupts the stream. No-op on the
+   * Noop layer.
+   */
+  recordTerminal(args: {
+    conversationId: string;
+    orgId: string | null;
+    status: "done" | "failed";
+    stepIndex: number;
+    transcript: unknown;
+  }): void;
+  /**
+   * Delete terminal runs older than the retention window; leaves non-terminal
+   * (`running`/`parked`) runs untouched. Returns the number deleted (0 on the
+   * Noop layer, -1 on a DB error). Driven by the retention-sweep scheduler
+   * fiber.
+   */
+  sweepTerminal(retentionDays: number): Effect.Effect<number>;
+}
+
+export class DurableSession extends Context.Tag("DurableSession")<
+  DurableSession,
+  DurableSessionShape
+>() {}
+
 // ── Service interface ────────────────────────────────────────────────
 
 /** Typed contract for the ConnectionRegistry Effect service. */

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -348,6 +348,34 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "workspace",
   },
   {
+    // #3745 / ADR-0020 — durable agent sessions. When on (and an internal DB is
+    // present), each turn writes a terminal `agent_runs` checkpoint. Default
+    // OFF: off, or no internal DB, → behavior identical to today. Hot-reloadable
+    // (no requiresRestart) — the agent loop reads it per turn via getSettingAuto.
+    key: "ATLAS_DURABILITY_ENABLED",
+    section: "Agent",
+    label: "Durable Sessions",
+    description:
+      "Persist a durable checkpoint of each agent turn to the internal database (ADR-0020). Requires an internal DB; off by default. Foundation for crash-resume and approval-park.",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_DURABILITY_ENABLED",
+    scope: "workspace",
+  },
+  {
+    // Retention window for terminal (done/failed) runs; the scheduler sweep
+    // deletes terminal runs older than this. Non-terminal runs are untouched.
+    key: "ATLAS_DURABILITY_RETENTION_DAYS",
+    section: "Agent",
+    label: "Durable Session Retention (days)",
+    description:
+      "How long terminal agent-run checkpoints are retained before the retention sweep deletes them. Non-terminal runs are never swept.",
+    type: "number",
+    default: "30",
+    envVar: "ATLAS_DURABILITY_RETENTION_DAYS",
+    scope: "workspace",
+  },
+  {
     key: "ATLAS_PROVIDER",
     section: "Agent",
     label: "LLM Provider",


### PR DESCRIPTION
## Summary

Phase 1a of durable agent sessions (ADR-0020, epic #3742) — the minimal end-to-end checkpoint pipe. A turn writes exactly **one** durable run row at completion, establishing every layer (schema → Effect service → agent loop → settings gate → reaper) before per-step granularity or resume exist. Default OFF; off / no internal DB → behavior identical to today.

- **`agent_runs` table** (migration `0143` + Drizzle mirror in the same commit): run id pk, `conversation_id` FK cascade, `org_id`, `status` CHECK (`running`/`parked`/`done`/`failed`, default `running`), `step_index`, `transcript` jsonb, `parked_reason`, `resuming_lease`, created/updated. Indexes on `conversation_id` + `org_id` and a partial index over non-terminal runs. Content-mode-exempt with a schema comment (execution state, not user-surfaced content).
- **`DurableSession` Effect service** (`Context.Tag` in `services.ts`) + Live/Noop layers in `lib/effect/durable-session.ts`. Noop selected via `hasInternalDB()`, mirroring the EE Noop pattern; composed into `buildAppLayer`.
- **Agent loop terminal checkpoint**: `onFinish` → `done`, `onError` / outer catch → `failed`, idempotent across the seams (one row per turn). Reuses the fire-and-forget `internalExecute` circuit breaker so a write failure logs (type-narrowed) and never disrupts the stream.
- **Settings flag** `ATLAS_DURABILITY_ENABLED` (workspace > platform > env > default, hot-reloadable), default OFF, gating durability per workspace at write time. `ATLAS_DURABILITY_RETENTION_DAYS` for the sweep window.
- **Retention sweep**: one forked scheduler fiber (alongside the oauth-state / share-token sweeps) deletes terminal runs past the window via the `DurableSession` Tag; non-terminal runs untouched.

## Test plan

- [x] `agent_runs` migration runs clean end-to-end against **real Postgres** + the `0143` status-CHECK / FK-cascade smoke tests pass (`migrate-pg.test.ts`)
- [x] Schema-drift gate passes (Drizzle mirror present)
- [x] Durability on + internal DB → exactly one `agent_runs` row, status `done`, full transcript (agent-loop seam test)
- [x] A throwing turn → one row, status `failed`
- [x] No internal DB → no `agent_runs` write (asserted at the `runAgent` seam)
- [x] A checkpoint write failure logs and the turn still completes/streams
- [x] Durability on/off via the settings flag, default off
- [x] Retention sweep deletes terminal runs past the window, leaves non-terminal runs untouched
- [x] `DurableSession` covered by Effect `Layer.provide` test layers (no top-level singleton mutation)
- [x] Migration-count fixtures (db + auth `migrate.test.ts`) + scheduler span-wiring guard updated
- [x] `/ci`: lint, type, full test suite, syncpack, all drift gates, settings-readers, saas-env-doc, published-symbols — pass

Closes #3745