### PR TITLE
refactor(mcp): dedupe success-content helpers + declarative requiresBoundOrg (#3609)

### DIFF
--- a/packages/api/src/lib/mcp/dispatch-gate-contract.ts
+++ b/packages/api/src/lib/mcp/dispatch-gate-contract.ts
@@ -80,17 +80,6 @@ export interface McpDispatchGateRequirements {
   readonly actionCategory?: McpActionCategory;
   /** Gate 2: the tool mutates data → require the `mcp:write` scope (hosted). */
   readonly requiresWrite: boolean;
-  /**
-   * A MUTATING tool that must operate on a bound workspace
-   * (`actor.activeOrganizationId`). When `true`, a no-org session is refused
-   * with a `forbidden` envelope before the tool body runs — so the mutation
-   * keys on the SAME org the gates evaluated, never the `actor.id` OTel
-   * fallback. Enforced ONCE in the MCP dispatcher (`mcp-dispatch.ts`, #3609),
-   * downstream of the gate order so a destructive tool's gate-4 approval
-   * identity guard still surfaces first. Omit for read tools and for callers
-   * (e.g. the plugin MCP path) with no bound-workspace precondition.
-   */
-  readonly requiresBoundOrg?: boolean;
   /** Gate 3: minimum RBAC role on the bound actor (e.g. `"admin"`). */
   readonly minRole: AtlasRole;
   /**

--- a/packages/api/src/lib/mcp/dispatch-gate-contract.ts
+++ b/packages/api/src/lib/mcp/dispatch-gate-contract.ts
@@ -80,6 +80,17 @@ export interface McpDispatchGateRequirements {
   readonly actionCategory?: McpActionCategory;
   /** Gate 2: the tool mutates data → require the `mcp:write` scope (hosted). */
   readonly requiresWrite: boolean;
+  /**
+   * A MUTATING tool that must operate on a bound workspace
+   * (`actor.activeOrganizationId`). When `true`, a no-org session is refused
+   * with a `forbidden` envelope before the tool body runs — so the mutation
+   * keys on the SAME org the gates evaluated, never the `actor.id` OTel
+   * fallback. Enforced ONCE in the MCP dispatcher (`mcp-dispatch.ts`, #3609),
+   * downstream of the gate order so a destructive tool's gate-4 approval
+   * identity guard still surfaces first. Omit for read tools and for callers
+   * (e.g. the plugin MCP path) with no bound-workspace precondition.
+   */
+  readonly requiresBoundOrg?: boolean;
   /** Gate 3: minimum RBAC role on the bound actor (e.g. `"admin"`). */
   readonly minRole: AtlasRole;
   /**

--- a/packages/mcp/src/__tests__/content-helpers-shared.test.ts
+++ b/packages/mcp/src/__tests__/content-helpers-shared.test.ts
@@ -28,12 +28,22 @@ describe("success-content helpers are shared, not copy-pasted (#3609)", () => {
     expect(envelope).toContain("export function toStructuredContent");
   });
 
+  // Catch a re-inlined local definition in EITHER form: a `function toJsonContent`
+  // declaration OR an arrow assigned to a `const`/`let`/`var` of that name. A
+  // bare `.not.toContain("function …")` would miss the arrow form.
+  function definesLocally(source: string, name: string): boolean {
+    return (
+      new RegExp(String.raw`function\s+${name}\b`).test(source) ||
+      new RegExp(String.raw`\b(?:const|let|var)\s+${name}\s*[:=]`).test(source)
+    );
+  }
+
   test("datasource-tools.ts imports toJsonContent and keeps no local copy", () => {
     const source = read("datasource-tools.ts");
     // Imports the shared helper from the envelope module…
     expect(source).toMatch(/import\s+\{[^}]*\btoJsonContent\b[^}]*\}\s+from\s+"\.\/error-envelope\.js"/s);
-    // …and no longer defines its own.
-    expect(source).not.toContain("function toJsonContent");
+    // …and no longer defines its own (function or arrow form).
+    expect(definesLocally(source, "toJsonContent")).toBe(false);
   });
 
   test("semantic-tools.ts imports both helpers and keeps no local copies", () => {
@@ -41,7 +51,7 @@ describe("success-content helpers are shared, not copy-pasted (#3609)", () => {
     expect(source).toMatch(
       /import\s+\{[^}]*\btoJsonContent\b[^}]*\btoStructuredContent\b[^}]*\}\s+from\s+"\.\/error-envelope\.js"/s,
     );
-    expect(source).not.toContain("function toJsonContent");
-    expect(source).not.toContain("function toStructuredContent");
+    expect(definesLocally(source, "toJsonContent")).toBe(false);
+    expect(definesLocally(source, "toStructuredContent")).toBe(false);
   });
 });

--- a/packages/mcp/src/__tests__/content-helpers-shared.test.ts
+++ b/packages/mcp/src/__tests__/content-helpers-shared.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Structural guard (#3609): the MCP success-content helpers `toJsonContent`
+ * and `toStructuredContent` live in ONE shared module (`error-envelope.ts`),
+ * the same place the failure shape (`toEnvelopeResult`) is defined — so a
+ * change to the success envelope lands once.
+ *
+ * Before #3609 these helpers were copy-pasted into `datasource-tools.ts` and
+ * `semantic-tools.ts`. This encodes the "the copies are gone" acceptance
+ * criterion as a test: the tool files must IMPORT the helpers from
+ * `error-envelope.js` and define no local copy, so the class of regression
+ * ("someone re-inlines the helper") can't slip past CI.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SRC = resolve(import.meta.dir, "..");
+
+function read(rel: string): string {
+  return readFileSync(resolve(SRC, rel), "utf8");
+}
+
+describe("success-content helpers are shared, not copy-pasted (#3609)", () => {
+  test("error-envelope.ts is the single home of toJsonContent + toStructuredContent", () => {
+    const envelope = read("error-envelope.ts");
+    expect(envelope).toContain("export function toJsonContent");
+    expect(envelope).toContain("export function toStructuredContent");
+  });
+
+  test("datasource-tools.ts imports toJsonContent and keeps no local copy", () => {
+    const source = read("datasource-tools.ts");
+    // Imports the shared helper from the envelope module…
+    expect(source).toMatch(/import\s+\{[^}]*\btoJsonContent\b[^}]*\}\s+from\s+"\.\/error-envelope\.js"/s);
+    // …and no longer defines its own.
+    expect(source).not.toContain("function toJsonContent");
+  });
+
+  test("semantic-tools.ts imports both helpers and keeps no local copies", () => {
+    const source = read("semantic-tools.ts");
+    expect(source).toMatch(
+      /import\s+\{[^}]*\btoJsonContent\b[^}]*\btoStructuredContent\b[^}]*\}\s+from\s+"\.\/error-envelope\.js"/s,
+    );
+    expect(source).not.toContain("function toJsonContent");
+    expect(source).not.toContain("function toStructuredContent");
+  });
+});

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -244,7 +244,6 @@ interface GateCall {
     toolName: string;
     checksBilling?: boolean;
     requiresWrite: boolean;
-    requiresBoundOrg?: boolean;
     minRole: string;
     actionCategory?: string;
     destructive?: { resource: string; description: string };
@@ -647,11 +646,13 @@ describe("no bound workspace → mutations refused (consistency with gate orgId)
     expect(mockRunInstaller).not.toHaveBeenCalled();
   });
 
-  // #3609 — the precondition is now declarative: every mutating tool passes
-  // `requiresBoundOrg: true` to the gate requirement set so a new mutating tool
-  // that omits it can't silently key the mutation on the `actor.id` fallback.
-  it("#3609 — every mutating tool declares requiresBoundOrg; read tools do not", async () => {
-    const client = await createTestClient();
+  // #3609 — `requiresBoundOrg` is now a REQUIRED, dispatcher-enforced flag (a
+  // dispatcher-only concern, no longer handed to the gate), so assert the
+  // BEHAVIOR it guarantees rather than peeking at what the gate received: every
+  // mutating tool refuses a no-org session with the byte-identical `forbidden`
+  // envelope, and read tools proceed to their body with no bound workspace.
+  it("#3609 — every mutating tool refuses a no-org session with the identical envelope; read tools proceed", async () => {
+    const client = await createTestClient(NO_ORG_ACTOR);
     const mutating = [
       ["archive_datasource", { id: "prod-us" }],
       ["restore_datasource", { id: "prod-us" }],
@@ -661,14 +662,52 @@ describe("no bound workspace → mutations refused (consistency with gate orgId)
       ["profile_datasource", { id: "prod-us" }],
     ] as const;
     for (const [tool, args] of mutating) {
-      await client.callTool({ name: tool, arguments: args });
-      expect(gateCallFor(tool)?.reqs.requiresBoundOrg).toBe(true);
+      const res = await client.callTool({ name: tool, arguments: args });
+      const err = parseAtlasMcpToolError(getContentText(res.content));
+      expect(err?.code).toBe("forbidden");
+      expect(err?.message).toBe(
+        "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
+      );
+      expect(err?.hint).toBe("Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) on the MCP server.");
     }
-    // Read tools carry no bound-workspace precondition.
-    await client.callTool({ name: "list_datasources", arguments: {} });
-    await client.callTool({ name: "test_datasource", arguments: { id: "prod-us" } });
-    expect(gateCallFor("list_datasources")?.reqs.requiresBoundOrg).toBeUndefined();
-    expect(gateCallFor("test_datasource")?.reqs.requiresBoundOrg).toBeUndefined();
+    // Read tools carry no bound-workspace precondition — they reach their body
+    // even with no bound org (no `forbidden` refusal).
+    const list = await client.callTool({ name: "list_datasources", arguments: {} });
+    expect(parseAtlasMcpToolError(getContentText(list.content))?.code).not.toBe("forbidden");
+    expect(mockListDatasources).toHaveBeenCalled();
+    const test = await client.callTool({ name: "test_datasource", arguments: { id: "prod-us" } });
+    expect(parseAtlasMcpToolError(getContentText(test.content))?.code).not.toBe("forbidden");
+  });
+
+  // #3609 — the bound-org refusal sits AFTER the gate in dispatch order, so for
+  // a no-org DESTRUCTIVE tool the gate's verdict (e.g. the gate-4 approval
+  // identity guard) surfaces FIRST. Pin the ordering against a future reorder:
+  // a non-null gate block wins over the dispatcher's bound-org envelope.
+  it("#3609 — a gate block surfaces before the bound-org refusal (dispatch order preserved)", async () => {
+    gateReturn = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            code: "forbidden",
+            message:
+              "This action requires approval but the requester identity could not be determined.",
+          }),
+        },
+      ],
+      isError: true,
+    };
+    const client = await createTestClient(NO_ORG_ACTOR);
+    const res = await client.callTool({ name: "delete_datasource", arguments: { id: "prod-us" } });
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    // The GATE verdict surfaces, NOT the dispatcher's bound-org refusal — both
+    // are `forbidden`, so the message is what distinguishes the order.
+    expect(err?.message).toBe(
+      "This action requires approval but the requester identity could not be determined.",
+    );
+    expect(err?.message).not.toBe(
+      "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
+    );
   });
 });
 

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -244,6 +244,7 @@ interface GateCall {
     toolName: string;
     checksBilling?: boolean;
     requiresWrite: boolean;
+    requiresBoundOrg?: boolean;
     minRole: string;
     actionCategory?: string;
     destructive?: { resource: string; description: string };
@@ -627,6 +628,47 @@ describe("no bound workspace → mutations refused (consistency with gate orgId)
     expect(parseAtlasMcpToolError(getContentText(res.content))?.code).toBe("forbidden");
     expect(mockElicit).not.toHaveBeenCalled();
     expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  // #3609 — `requireBoundOrg`'s per-body guard was promoted to a declarative
+  // `requiresBoundOrg: true` requirement enforced ONCE in the dispatcher. The
+  // refusal envelope (code + message + hint) must stay byte-identical to the
+  // pre-refactor block so agents that branch on it don't regress.
+  it("#3609 — a no-bound-org mutation is refused with the identical forbidden envelope", async () => {
+    const client = await createTestClient(NO_ORG_ACTOR);
+    const res = await client.callTool({ name: "archive_datasource", arguments: { id: "prod-us" } });
+    const err = parseAtlasMcpToolError(getContentText(res.content));
+    expect(err?.code).toBe("forbidden");
+    expect(err?.message).toBe(
+      "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
+    );
+    expect(err?.hint).toBe("Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) on the MCP server.");
+    // The bound-org refusal short-circuits BEFORE the tool body's lib calls.
+    expect(mockRunInstaller).not.toHaveBeenCalled();
+  });
+
+  // #3609 — the precondition is now declarative: every mutating tool passes
+  // `requiresBoundOrg: true` to the gate requirement set so a new mutating tool
+  // that omits it can't silently key the mutation on the `actor.id` fallback.
+  it("#3609 — every mutating tool declares requiresBoundOrg; read tools do not", async () => {
+    const client = await createTestClient();
+    const mutating = [
+      ["archive_datasource", { id: "prod-us" }],
+      ["restore_datasource", { id: "prod-us" }],
+      ["delete_datasource", { id: "prod-us" }],
+      ["create_datasource", { db_type: "postgres", install_id: "new-pg" }],
+      ["create_rest_datasource", {}],
+      ["profile_datasource", { id: "prod-us" }],
+    ] as const;
+    for (const [tool, args] of mutating) {
+      await client.callTool({ name: tool, arguments: args });
+      expect(gateCallFor(tool)?.reqs.requiresBoundOrg).toBe(true);
+    }
+    // Read tools carry no bound-workspace precondition.
+    await client.callTool({ name: "list_datasources", arguments: {} });
+    await client.callTool({ name: "test_datasource", arguments: { id: "prod-us" } });
+    expect(gateCallFor("list_datasources")?.reqs.requiresBoundOrg).toBeUndefined();
+    expect(gateCallFor("test_datasource")?.reqs.requiresBoundOrg).toBeUndefined();
   });
 });
 

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -357,7 +357,7 @@ export function registerDatasourceTools(
     async ({ include_archived, filter }): Promise<CallToolResult> =>
       dispatch(
         "list_datasources",
-        { checksBilling: true, requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
+        { checksBilling: true, requiresWrite: false, requiresBoundOrg: false, minRole: DATASOURCE_MIN_ROLE },
         async () => {
           // Developer-mode view: these are admin tools (gate-3 requires admin),
           // and create_datasource lands a datasource as `draft` — a published
@@ -398,7 +398,7 @@ export function registerDatasourceTools(
     async ({ id }): Promise<CallToolResult> =>
       dispatch(
         "test_datasource",
-        { checksBilling: true, requiresWrite: false, minRole: DATASOURCE_MIN_ROLE },
+        { checksBilling: true, requiresWrite: false, requiresBoundOrg: false, minRole: DATASOURCE_MIN_ROLE },
         async () => {
           if (!(await lifecycle()).isDatasourceRegistered(id)) {
             return toEnvelopeResult(

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -52,7 +52,7 @@ import { MCP_PROVISIONABLE_CATALOG_SLUGS } from "@atlas/api/lib/datasources/prov
 import type { DatasourceInstallerOutcome } from "@atlas/api/lib/datasources/mcp-lifecycle";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import type { McpTransport, McpDeployMode } from "./telemetry.js";
-import { envelope, toEnvelopeResult } from "./error-envelope.js";
+import { envelope, toEnvelopeResult, toJsonContent } from "./error-envelope.js";
 import { createMcpDispatch, errorMessage } from "./mcp-dispatch.js";
 import { elicitMaskedForm } from "./elicitation.js";
 import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
@@ -106,12 +106,6 @@ export interface RegisterDatasourceToolsOptions {
   clientId?: string;
   /** #3504 — OAuth token scopes, threaded onto each dispatch's RequestContext. */
   scopes?: readonly string[];
-}
-
-function toJsonContent(value: unknown): CallToolResult {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
-  };
 }
 
 /**
@@ -223,33 +217,27 @@ export function registerDatasourceTools(
   // (which falls back to `actor.id` purely for OTel attribution when no org is
   // bound), this is the REAL workspace the dispatch gate keys on — so every
   // mutation operates on the same id the gate (and gate-1 kill-switch /
-  // approval) evaluated. A mutating tool with no bound org is refused via
-  // {@link requireBoundOrg} rather than silently keyed on `actor.id`.
+  // approval) evaluated. Mutating tools declare `requiresBoundOrg: true`, which
+  // the dispatcher enforces ONCE (#3609) — a no-org session is refused with a
+  // `forbidden` envelope before any mutating body runs, rather than silently
+  // keyed on `actor.id`.
   const boundOrgId = actor.activeOrganizationId;
 
   /**
-   * Resolve the bound workspace for a MUTATING tool, or a `forbidden` block.
-   * Keeps mutations and the dispatch gate on ONE workspace identity
-   * (`actor.activeOrganizationId`) — a no-org session (trusted-transport
-   * `system:mcp`) can't mutate, and can't slip past the gate-1 kill-switch /
-   * approval gate that key on the same id.
+   * The bound workspace for a MUTATING tool body. The `requiresBoundOrg: true`
+   * dispatch requirement (enforced once in `mcp-dispatch.ts`, #3609) guarantees
+   * a bound workspace before the body runs, so this never throws in practice —
+   * the throw is a defensive backstop for a future mutating tool that forgets to
+   * declare `requiresBoundOrg`, and it keeps mutations and the dispatch gate on
+   * ONE workspace identity (`actor.activeOrganizationId`).
    */
-  function requireBoundOrg():
-    | { readonly ok: true; readonly orgId: string }
-    | { readonly ok: false; readonly block: CallToolResult } {
+  function boundOrg(): string {
     if (!boundOrgId) {
-      return {
-        ok: false,
-        block: toEnvelopeResult(
-          envelope(
-            "forbidden",
-            "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
-            { hint: "Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) on the MCP server." },
-          ),
-        ),
-      };
+      throw new Error(
+        "Mutating datasource tool reached its body without a bound workspace — the requiresBoundOrg dispatch requirement is missing.",
+      );
     }
-    return { ok: true, orgId: boundOrgId };
+    return boundOrgId;
   }
 
   /**
@@ -450,11 +438,14 @@ export function registerDatasourceTools(
     async ({ id }): Promise<CallToolResult> =>
       dispatch(
         "archive_datasource",
-        { checksBilling: true, requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
-        async () => {
-          const org = requireBoundOrg();
-          return org.ok ? archiveOrRestore(org.orgId, id, "archive") : org.block;
+        {
+          checksBilling: true,
+          requiresWrite: true,
+          requiresBoundOrg: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          actionCategory: "datasource",
         },
+        async () => archiveOrRestore(boundOrg(), id, "archive"),
       ),
   );
 
@@ -474,11 +465,14 @@ export function registerDatasourceTools(
     async ({ id }): Promise<CallToolResult> =>
       dispatch(
         "restore_datasource",
-        { checksBilling: true, requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
-        async () => {
-          const org = requireBoundOrg();
-          return org.ok ? archiveOrRestore(org.orgId, id, "restore") : org.block;
+        {
+          checksBilling: true,
+          requiresWrite: true,
+          requiresBoundOrg: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          actionCategory: "datasource",
         },
+        async () => archiveOrRestore(boundOrg(), id, "restore"),
       ),
   );
 
@@ -501,6 +495,7 @@ export function registerDatasourceTools(
         {
           checksBilling: true,
           requiresWrite: true,
+          requiresBoundOrg: true,
           minRole: DATASOURCE_MIN_ROLE,
           // Gate 1 (#3509): the datasource action-policy kill-switch blocks
           // this outright when the workspace disables datasource actions.
@@ -514,13 +509,12 @@ export function registerDatasourceTools(
           },
         },
         async () => {
-          const org = requireBoundOrg();
-          if (!org.ok) return org.block;
+          const orgId = boundOrg();
           // Resolve the catalog slug first so a non-existent id returns a
           // clean `unknown_entity` rather than an installer defect. (The
           // approval gate already ran in `dispatch`; reaching here means the
           // requester is approved or no rule matched.)
-          const catalogSlug = await (await lifecycle()).resolveDatasourceCatalogSlug(org.orgId, id);
+          const catalogSlug = await (await lifecycle()).resolveDatasourceCatalogSlug(orgId, id);
           if (catalogSlug === null) {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -532,7 +526,7 @@ export function registerDatasourceTools(
           // drains the pool. The reversible path is archive_datasource.
           const outcome = await (await lifecycle()).runDatasourceInstaller((installer) =>
             installer.uninstallDatasource(
-              org.orgId as WorkspaceId,
+              orgId as WorkspaceId,
               catalogSlug,
               id,
               { hard: true },
@@ -586,11 +580,15 @@ export function registerDatasourceTools(
         // Gate 0 billing + gate 1 (#3509) datasource kill-switch + mcp:write +
         // admin. NOT approval-gated (provisioning is additive, lands draft);
         // the human-in-the-loop is the masked credential entry below.
-        { checksBilling: true, requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        {
+          checksBilling: true,
+          requiresWrite: true,
+          requiresBoundOrg: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          actionCategory: "datasource",
+        },
         async (requestId) => {
-          const org = requireBoundOrg();
-          if (!org.ok) return org.block;
-          const orgId = org.orgId;
+          const orgId = boundOrg();
           const lib = await lifecycle();
 
           // Capability check BEFORE prompting for credentials — don't ask the
@@ -721,11 +719,15 @@ export function registerDatasourceTools(
         // Gate 0 billing + gate 1 kill-switch + mcp:write + admin. NOT
         // approval-gated — additive, the human-in-the-loop is the masked
         // spec-URL/credential entry below.
-        { checksBilling: true, requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        {
+          checksBilling: true,
+          requiresWrite: true,
+          requiresBoundOrg: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          actionCategory: "datasource",
+        },
         async (requestId) => {
-          const org = requireBoundOrg();
-          if (!org.ok) return org.block;
-          const orgId = org.orgId;
+          const orgId = boundOrg();
           const lib = await lifecycle();
 
           // The openapi-generic config_schema (spec URL + auth_kind + auth_value
@@ -797,15 +799,20 @@ export function registerDatasourceTools(
     async ({ id }, extra): Promise<CallToolResult> =>
       dispatch(
         "profile_datasource",
-        { checksBilling: true, requiresWrite: true, minRole: DATASOURCE_MIN_ROLE, actionCategory: "datasource" },
+        {
+          checksBilling: true,
+          requiresWrite: true,
+          requiresBoundOrg: true,
+          minRole: DATASOURCE_MIN_ROLE,
+          actionCategory: "datasource",
+        },
         async () => {
-          const org = requireBoundOrg();
-          if (!org.ok) return org.block;
+          const orgId = boundOrg();
           // #3667 — ONE RESOLVER. Profiling rides the SAME connection resolution
           // querying uses (registry / createFromConfig / OAuth LazyPluginLoader);
           // there is no URL-shape gate to fail closed. The live connection carries
           // its own creds — only the connectionId + progress counts surface here.
-          const resolved = await (await lifecycle()).resolveLiveConnection(org.orgId, id);
+          const resolved = await (await lifecycle()).resolveLiveConnection(orgId, id);
           if (resolved.kind === "not_found") {
             return toEnvelopeResult(
               envelope("unknown_entity", `Datasource "${id}" not found.`, {
@@ -845,7 +852,7 @@ export function registerDatasourceTools(
                   // #3546 — persist the generated layer to the org store as drafts
                   // so the whitelist survives a restart and is visible to the API
                   // process (web `/chat`), not just this MCP process.
-                  orgId: org.orgId,
+                  orgId,
                   progress,
                 });
               },

--- a/packages/mcp/src/error-envelope.ts
+++ b/packages/mcp/src/error-envelope.ts
@@ -44,6 +44,33 @@ export function toEnvelopeResult(error: AtlasMcpToolError): CallToolResult {
 }
 
 /**
+ * Build a SUCCESS `CallToolResult` whose single `text` content block is the
+ * pretty-printed JSON of `value`. The success counterpart to
+ * {@link toEnvelopeResult}: it lives here so the success envelope shape is
+ * defined ONCE (the datasource + semantic tool files import it) and a change to
+ * how success bodies are serialized lands in a single place (#3609).
+ */
+export function toJsonContent(value: unknown): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+/**
+ * Like {@link toJsonContent} but also attaches `structuredContent` (#3498).
+ * Used by tools that declare an `outputSchema` (e.g. `runMetric`): the MCP SDK
+ * requires `structuredContent` on every non-error result once an output schema
+ * is present. The text block is retained for clients that don't consume
+ * structured output; both are built from the same object so they can't drift.
+ */
+export function toStructuredContent(value: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+/**
  * Convenience constructor — assemble an envelope from positional args
  * without forcing every call site to spell out the object literal. Empty
  * `hint` / `request_id` / `retry_after` arguments are omitted from the

--- a/packages/mcp/src/mcp-dispatch.ts
+++ b/packages/mcp/src/mcp-dispatch.ts
@@ -70,8 +70,24 @@ export interface McpDispatchOptions {
   readonly scopes?: readonly string[];
 }
 
-/** The per-dispatch requirement set, minus `toolName` (supplied per call). */
-export type McpToolRequirements = Omit<McpDispatchGateRequirements, "toolName">;
+/**
+ * The per-dispatch requirement set: the gate-contract fields minus `toolName`
+ * (supplied per call), plus the dispatcher-only `requiresBoundOrg` precondition.
+ *
+ * `requiresBoundOrg` is deliberately NOT a {@link McpDispatchGateRequirements}
+ * field: it is enforced HERE in the dispatcher (downstream of
+ * `runMcpDispatchGate`, #3609), not by the gate composer — so it lives on this
+ * MCP-side type and the shared gate contract the composer (and the plugin MCP
+ * path) speak never advertises a flag they would silently ignore. It is
+ * REQUIRED so every tool states its stance: a MUTATING tool sets `true` (a
+ * no-org session is refused with a `forbidden` envelope before the body runs,
+ * keying the mutation on the SAME org the gates evaluated, never the `actor.id`
+ * OTel fallback); a read tool sets `false`. A new mutating tool therefore can't
+ * silently omit the precondition — the type forces the choice.
+ */
+export type McpToolRequirements = Omit<McpDispatchGateRequirements, "toolName"> & {
+  readonly requiresBoundOrg: boolean;
+};
 
 export interface McpDispatcher {
   /**
@@ -172,6 +188,10 @@ export function createMcpDispatch(opts: McpDispatchOptions): McpDispatcher {
     body: (requestId: string) => Promise<CallToolResult>,
     spanAttributes?: Readonly<Record<string, string | number | boolean>>,
   ): Promise<CallToolResult> {
+    // `requiresBoundOrg` is a dispatcher-only precondition (#3609), not a gate
+    // field — split it off so it is enforced below but never handed to the gate
+    // composer (which speaks only `McpDispatchGateRequirements`).
+    const { requiresBoundOrg, ...gateReqs } = reqs;
     return traceMcpToolCall(
       {
         toolName,
@@ -213,18 +233,27 @@ export function createMcpDispatch(opts: McpDispatchOptions): McpDispatcher {
                   requesterEmail: actor.label,
                   requestId,
                 },
-                { toolName, ...reqs },
+                { toolName, ...gateReqs },
               );
               if (gateBlock) return gateBlock;
 
               // #3609 — declarative bound-workspace precondition for mutating
-              // tools. Enforced ONCE here (downstream of the gate order, so a
+              // tools. A dispatcher-only required flag (not a gate-contract
+              // field), enforced ONCE here — downstream of the gate order, so a
               // destructive tool's gate-4 approval identity guard still surfaces
-              // first) rather than a per-body `requireBoundOrg()` guard a new
+              // first — rather than a per-body `requireBoundOrg()` guard a new
               // mutating tool could forget. A no-org session is refused with the
               // SAME `forbidden` envelope, so the mutation can't silently key on
               // the `actor.id` OTel fallback instead of the gated workspace.
-              if (reqs.requiresBoundOrg && !actor.activeOrganizationId) {
+              if (requiresBoundOrg && !actor.activeOrganizationId) {
+                // Observability parity with the gate-2/gate-3 denials
+                // (`dispatch-gate.ts`): a no-org mutation attempt is the
+                // "probing / misconfigured client" signal, so leave a
+                // server-side breadcrumb alongside the caller-facing envelope.
+                log.warn(
+                  { toolName, requestId },
+                  "MCP mutation refused — session not bound to a workspace",
+                );
                 return toEnvelopeResult(
                   envelope(
                     "forbidden",

--- a/packages/mcp/src/mcp-dispatch.ts
+++ b/packages/mcp/src/mcp-dispatch.ts
@@ -217,6 +217,23 @@ export function createMcpDispatch(opts: McpDispatchOptions): McpDispatcher {
               );
               if (gateBlock) return gateBlock;
 
+              // #3609 — declarative bound-workspace precondition for mutating
+              // tools. Enforced ONCE here (downstream of the gate order, so a
+              // destructive tool's gate-4 approval identity guard still surfaces
+              // first) rather than a per-body `requireBoundOrg()` guard a new
+              // mutating tool could forget. A no-org session is refused with the
+              // SAME `forbidden` envelope, so the mutation can't silently key on
+              // the `actor.id` OTel fallback instead of the gated workspace.
+              if (reqs.requiresBoundOrg && !actor.activeOrganizationId) {
+                return toEnvelopeResult(
+                  envelope(
+                    "forbidden",
+                    "This MCP session is not bound to a workspace; datasource changes require a bound workspace.",
+                    { hint: "Set ATLAS_MCP_ORG_ID (and ATLAS_MCP_USER_ID) on the MCP server." },
+                  ),
+                );
+              }
+
               const result = await body(requestId);
               // ADR-0018 / #3651 — surface trial days-remaining on successful
               // billing-gated tool responses (executeSQL / runMetric / setup),

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -145,7 +145,7 @@ export function registerSemanticTools(
     async ({ filter }): Promise<CallToolResult> =>
       dispatch(
         "listEntities",
-        { requiresWrite: false, minRole: "member" },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member" },
         async () => {
           // Bind orgId + published mode so MCP discovery reads the same
           // universe `executeSQL`'s published-mode whitelist sees. External MCP
@@ -197,7 +197,7 @@ export function registerSemanticTools(
     async ({ name, names }): Promise<CallToolResult> =>
       dispatch(
         "describeEntity",
-        { requiresWrite: false, minRole: "member" },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member" },
         async () => {
           // The MCP raw-shape inputSchema can't express a cross-field
           // "exactly one of" refinement, so enforce it here. Both-or-neither
@@ -295,7 +295,7 @@ export function registerSemanticTools(
     async ({ term }): Promise<CallToolResult> =>
       dispatch(
         "searchGlossary",
-        { requiresWrite: false, minRole: "member" },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member" },
         async () => {
           const matches = searchGlossary(term);
 
@@ -393,7 +393,7 @@ export function registerSemanticTools(
         // runMetric executes datasource SQL via executeSQL.execute → gate-0
         // billing (#3437/#3601), like executeSQL. Metadata-only tools above are
         // deliberately not billing-gated. Member-callable read.
-        { requiresWrite: false, minRole: "member", checksBilling: true },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member", checksBilling: true },
         async (requestId) => {
           if (filters && Object.keys(filters).length > 0) {
             return toEnvelopeResult(

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -52,6 +52,8 @@ import {
   classifyExecuteSqlError,
   envelope,
   toEnvelopeResult,
+  toJsonContent,
+  toStructuredContent,
 } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
 import { runMetricOutputShape } from "./structured-output.js";
@@ -96,27 +98,6 @@ export interface RegisterSemanticToolsOptions {
   clientId?: string;
   /** #3504 — OAuth token scopes, threaded onto each dispatch's RequestContext. */
   scopes?: readonly string[];
-}
-
-function toJsonContent(value: unknown): CallToolResult {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
-  };
-}
-
-/**
- * Like {@link toJsonContent} but also attaches `structuredContent` (#3498).
- * Used by tools that declare an `outputSchema` (runMetric): the MCP SDK
- * requires `structuredContent` on every non-error result once an output
- * schema is present. The text block is retained for clients that don't
- * consume structured output; both are built from the same object so they
- * can't drift.
- */
-function toStructuredContent(value: Record<string, unknown>): CallToolResult {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
-    structuredContent: value,
-  };
 }
 
 export function registerSemanticTools(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -174,7 +174,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
     async ({ command }): Promise<CallToolResult> =>
       dispatch(
         "explore",
-        { requiresWrite: false, minRole: "member" },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member" },
         async (requestId) => {
           const result = await explore.execute!(
             { command },
@@ -237,7 +237,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         // Reaches a datasource → gate-0 billing (#3437/#3601). SELECT-only
         // (the 4-layer validator rejects DML/DDL) so it is read-only — no
         // mcp:write — and member-callable.
-        { requiresWrite: false, minRole: "member", checksBilling: true },
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member", checksBilling: true },
         async (requestId) => {
           // #3500 — progress + cancellation around the query work.
           // #3575 — `executeSQL.execute` does not read `abortSignal` from the


### PR DESCRIPTION
## Summary

Two strictly behavior-preserving tool-dispatch tidy-ups in the MCP layer, deferred from #3607.

1. **Dedupe the success-content helpers.** `toJsonContent` / `toStructuredContent` were copy-pasted across `datasource-tools.ts` and `semantic-tools.ts`. Moved them into `error-envelope.ts` — the module that already owns the failure shape (`toEnvelopeResult`) — so a change to the success envelope lands once. Both files now import them; the local copies are gone.

2. **Promote `requireBoundOrg` to a declarative requirement.** The six mutating datasource tools each opened with `const org = requireBoundOrg(); if (!org.ok) return org.block;` — a cross-cutting precondition a new tool could silently forget (keying the mutation on the `actor.id` OTel fallback). Promoted to `requiresBoundOrg: true` in `McpToolRequirements`, enforced **once** in the MCP dispatcher (`mcp-dispatch.ts`), downstream of the gate order. The body now reads the gate-guaranteed org via a small `boundOrg()` accessor.

### Behavior preservation
- A no-bound-org mutation is still refused with the **identical** `forbidden` envelope (same code + message + hint) — asserted by a new test.
- Enforcement sits **after** the gate order, so a destructive tool's gate-4 approval identity-guard envelope still surfaces first for no-org delete.
- Enforcement lives in the dispatcher (not the mocked-out gate), so the existing no-org tests stay green.

## Test plan
- [x] `toJsonContent`/`toStructuredContent` live in one shared module; both files import them — deletion test (`content-helpers-shared.test.ts`) confirms the copies are gone
- [x] `requireBoundOrg` is a declarative requirement enforced once (no per-body repetition); a no-bound-org mutation still refused with the same `forbidden` envelope — new guard-enforcement tests in `datasource-tools.test.ts`
- [x] No behavior change — existing mcp suites stay green (`bun run --filter '@atlas/mcp' test`: 33/33 files pass)
- [x] `/ci` green: lint, type, full test, syncpack, template/schema/openapi/oauth-helper/saas-env/security-headers/railway drift, test-discipline, settings-readers, published-symbols, twenty-resolver

## Acceptance criteria (from #3609)
- [x] `toJsonContent`/`toStructuredContent` live in one shared module; `datasource-tools`/`semantic-tools` import them (deletion test: the copies are gone)
- [x] `requireBoundOrg` becomes a declarative requirement enforced once (no per-body repetition); behavior identical — a no-bound-org mutation is still refused with the same `forbidden` envelope
- [x] No behavior change

Closes #3609

https://claude.ai/code/session_016VrfJCYATbVSrjoRodgveV

---
_Generated by [Claude Code](https://claude.ai/code/session_016VrfJCYATbVSrjoRodgveV)_