### PR TITLE
feat(durable-sessions): per-step checkpoint progression (#3746)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -142,6 +142,63 @@ function errorThenFinishModel(): InstanceType<typeof MockLanguageModelV3> {
   });
 }
 
+/**
+ * A model that emits N tool-call steps then a final text step, so the agent loop
+ * runs N+1 steps and `onStepFinish` fires once per step. Each tool-call step
+ * grows the transcript (assistant tool-call + tool result), so the per-step
+ * `running` checkpoints (#3746) show the transcript advancing.
+ */
+function sqlStep(marker: string): LanguageModelV3StreamPart[] {
+  return [
+    {
+      type: "tool-call",
+      toolCallId: `call-${marker}`,
+      toolName: "executeSQL",
+      input: JSON.stringify({ sql: `SELECT id AS ${marker} FROM companies`, explanation: marker }),
+    },
+    { type: "finish", usage: STOP_USAGE, finishReason: { unified: "tool-calls", raw: "tool_use" } },
+  ];
+}
+
+const FINAL_TEXT_STEP: LanguageModelV3StreamPart[] = [
+  { type: "text-delta", id: "text-0", delta: "Done." },
+  { type: "finish", usage: STOP_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+];
+
+/** Two tool-call steps + a text step → a 3-step turn. */
+function multiStepModel(): InstanceType<typeof MockLanguageModelV3> {
+  const steps: LanguageModelV3StreamPart[][] = [sqlStep("s0"), sqlStep("s1"), FINAL_TEXT_STEP];
+  let idx = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = idx >= steps.length ? steps[steps.length - 1]! : steps[idx++]!;
+      return { stream: convertArrayToReadableStream(chunks) };
+    },
+  });
+}
+
+/**
+ * A model that completes ONE tool-call step then blocks indefinitely on the next
+ * step until `gate` resolves — simulating a turn interrupted mid-flight after
+ * step 1 (no terminal write can run while blocked). The test asserts the
+ * recoverable `running` checkpoint, then releases the gate so the run winds down.
+ */
+function interruptAfterFirstStepModel(
+  gate: Promise<void>,
+): InstanceType<typeof MockLanguageModelV3> {
+  let call = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      call++;
+      if (call === 1) {
+        return { stream: convertArrayToReadableStream(sqlStep("s0")) };
+      }
+      await gate;
+      return { stream: convertArrayToReadableStream(FINAL_TEXT_STEP) };
+    },
+  });
+}
+
 /** Drain the data stream so the streamText onFinish/onError callback runs. */
 async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
   mockModel = model;
@@ -155,13 +212,40 @@ async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<v
   }
 }
 
-function agentRunInsert() {
-  return internalCalls.find((c) => c.sql.includes("INSERT INTO agent_runs"));
+async function waitFor(pred: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+// --- agent_runs write accessors (params: [runId, conv, org, status, step, transcript]) ---
+function agentRunWrites() {
+  return internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
+}
+function runIdOf(c: { params?: unknown[] }): string {
+  return (c.params as unknown[])[0] as string;
+}
+function statusOf(c: { params?: unknown[] }): string {
+  return (c.params as unknown[])[3] as string;
+}
+function stepIndexOf(c: { params?: unknown[] }): number {
+  return (c.params as unknown[])[4] as number;
+}
+function transcriptOf(c: { params?: unknown[] }): unknown[] {
+  return JSON.parse((c.params as unknown[])[5] as string) as unknown[];
+}
+function runningWrites() {
+  return agentRunWrites().filter((c) => statusOf(c) === "running");
+}
+function terminalWrites() {
+  return agentRunWrites().filter((c) => statusOf(c) === "done" || statusOf(c) === "failed");
 }
 
 const origFlag = process.env.ATLAS_DURABILITY_ENABLED;
 
-describe("agent_runs terminal checkpoint write path (#3745)", () => {
+describe("agent_runs checkpoint write path (#3745 terminal, #3746 per-step)", () => {
   beforeEach(() => {
     internalCalls.length = 0;
     hasInternalDB = true;
@@ -173,61 +257,117 @@ describe("agent_runs terminal checkpoint write path (#3745)", () => {
     else process.env.ATLAS_DURABILITY_ENABLED = origFlag;
   });
 
-  it("writes exactly one row with status 'done' and the transcript on a clean finish", async () => {
+  it("writes exactly one terminal row with status 'done' and the transcript on a clean finish", async () => {
     await drive(textOnlyModel());
 
-    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
-    expect(inserts).toHaveLength(1);
+    const terminals = terminalWrites();
+    expect(terminals).toHaveLength(1);
 
-    const insert = inserts[0]!;
-    // Columns: conversation_id, org_id, status, step_index, transcript
-    expect(insert.sql).toContain("$5::jsonb");
-    const params = insert.params as unknown[];
-    expect(params[0]).toBe("conv-1"); // conversation_id
-    expect(params[2]).toBe("done"); // status
-    expect(params[3]).toBe(1); // step_index — one completed step (steps.length)
-    expect(typeof params[4]).toBe("string"); // transcript is JSON text
+    const t = terminals[0]!;
+    // In-place upsert keyed on the run id (one logical row per turn).
+    expect(t.sql).toContain("ON CONFLICT (id) DO UPDATE");
+    expect(t.sql).toContain("$6::jsonb");
+    expect((t.params as unknown[])[1]).toBe("conv-1"); // conversation_id
+    expect(statusOf(t)).toBe("done");
+    expect(stepIndexOf(t)).toBe(1); // one completed step (steps.length)
     // Transcript is valid JSON carrying the turn's messages (input + response).
-    const transcript = JSON.parse(params[4] as string) as unknown[];
+    const transcript = transcriptOf(t);
     expect(Array.isArray(transcript)).toBe(true);
     expect(transcript.length).toBeGreaterThan(0);
+    // Every write of the turn (per-step + terminal) shares ONE run id → one row.
+    expect(new Set(agentRunWrites().map(runIdOf)).size).toBe(1);
   });
 
-  it("writes a row with status 'failed' when the turn throws", async () => {
+  it("advances the step index 1 → N and grows the transcript across a multi-step turn", async () => {
+    await drive(multiStepModel());
+
+    const running = runningWrites();
+    // onStepFinish fires once per step (2 tool-call steps + 1 text step).
+    expect(running.map(stepIndexOf)).toEqual([1, 2, 3]);
+
+    // Transcript grows monotonically as each step's messages accumulate.
+    const lengths = running.map((c) => transcriptOf(c).length);
+    expect(lengths[0]!).toBeLessThan(lengths[1]!);
+    expect(lengths[1]!).toBeLessThan(lengths[2]!);
+
+    // One logical row: every per-step + terminal write shares the run id.
+    expect(new Set(agentRunWrites().map(runIdOf)).size).toBe(1);
+
+    // Terminal flips that same row to done at the final step index.
+    const terminals = terminalWrites();
+    expect(terminals).toHaveLength(1);
+    expect(statusOf(terminals[0]!)).toBe("done");
+    expect(stepIndexOf(terminals[0]!)).toBe(3);
+
+    // Token accounting unchanged vs pre-1b: exactly one token_usage row, no
+    // double counting from the per-step checkpoints.
+    const tokenWrites = internalCalls.filter((c) => c.sql.includes("INSERT INTO token_usage"));
+    expect(tokenWrites).toHaveLength(1);
+  });
+
+  it("leaves a recoverable 'running' checkpoint at step N when interrupted mid-flight", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = () => r();
+    });
+    mockModel = interruptAfterFirstStepModel(gate);
+    const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+    // Consume in the background; the model blocks on the second step.
+    const consumed = Promise.resolve(result.consumeStream?.()).catch(() => {});
+
+    // While step 2 is blocked, the only persisted state is the mid-flight
+    // checkpoint from the completed first step.
+    await waitFor(() => runningWrites().length >= 1);
+    const running = runningWrites();
+    const last = running[running.length - 1]!;
+    expect(statusOf(last)).toBe("running");
+    expect(stepIndexOf(last)).toBe(1); // one step completed → step index 1
+    // No terminal write while the turn is still mid-flight (the interruption).
+    expect(terminalWrites()).toHaveLength(0);
+
+    // Release the blocked step so the run winds down (no leaked promise).
+    release();
+    await consumed;
+  });
+
+  it("writes a 'failed' terminal row when the turn throws before any step", async () => {
     await drive(throwingModel());
 
-    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
-    expect(inserts).toHaveLength(1);
-    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+    // The model throws on the first doStream call — no step completes, so there
+    // is no per-step checkpoint, just the terminal failure.
+    expect(runningWrites()).toHaveLength(0);
+    const terminals = terminalWrites();
+    expect(terminals).toHaveLength(1);
+    expect(statusOf(terminals[0]!)).toBe("failed");
   });
 
   it("records 'failed' (not 'done') when the turn finishes in-band with finishReason error", async () => {
     await drive(inBandErrorModel());
 
-    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
-    expect(inserts).toHaveLength(1);
-    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+    const terminals = terminalWrites();
+    expect(terminals).toHaveLength(1);
+    expect(statusOf(terminals[0]!)).toBe("failed");
   });
 
-  it("writes exactly one row when both onError and onFinish fire (idempotency guard)", async () => {
+  it("writes exactly one terminal row when both onError and onFinish fire (idempotency guard)", async () => {
     await drive(errorThenFinishModel());
 
-    // Both terminal seams fire on this turn; the guard keeps it to one row and
-    // the first status (onError → 'failed') wins.
-    const inserts = internalCalls.filter((c) => c.sql.includes("INSERT INTO agent_runs"));
-    expect(inserts).toHaveLength(1);
-    expect((inserts[0]!.params as unknown[])[2]).toBe("failed");
+    // Both terminal seams fire on this turn; the guard keeps it to one terminal
+    // write and the first status (onError → 'failed') wins.
+    const terminals = terminalWrites();
+    expect(terminals).toHaveLength(1);
+    expect(statusOf(terminals[0]!)).toBe("failed");
   });
 
-  it("does not write an agent_runs row when no internal DB is configured", async () => {
+  it("does not write any agent_runs row when no internal DB is configured", async () => {
     hasInternalDB = false;
-    await drive(textOnlyModel());
-    expect(agentRunInsert()).toBeUndefined();
+    await drive(multiStepModel());
+    expect(agentRunWrites()).toHaveLength(0);
   });
 
-  it("does not write an agent_runs row when the durability flag is off (default)", async () => {
+  it("does not write any agent_runs row when the durability flag is off (default)", async () => {
     process.env.ATLAS_DURABILITY_ENABLED = "false";
-    await drive(textOnlyModel());
-    expect(agentRunInsert()).toBeUndefined();
+    await drive(multiStepModel());
+    expect(agentRunWrites()).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -285,10 +285,15 @@ describe("agent_runs checkpoint write path (#3745 terminal, #3746 per-step)", ()
     // onStepFinish fires once per step (2 tool-call steps + 1 text step).
     expect(running.map(stepIndexOf)).toEqual([1, 2, 3]);
 
-    // Transcript grows monotonically as each step's messages accumulate.
+    // Transcript grows (non-decreasing) as each step's messages accumulate and
+    // is strictly larger at the end of the turn than at the first step. (Strict
+    // step-over-step growth would be wrong: a final text-only step adds an
+    // assistant message but no tool result, so consecutive checkpoints can tie.
+    // The strong anti-duplication guard is the running==terminal equality below.)
     const lengths = running.map((c) => transcriptOf(c).length);
-    expect(lengths[0]!).toBeLessThan(lengths[1]!);
-    expect(lengths[1]!).toBeLessThan(lengths[2]!);
+    expect(lengths[0]!).toBeLessThanOrEqual(lengths[1]!);
+    expect(lengths[1]!).toBeLessThanOrEqual(lengths[2]!);
+    expect(lengths[2]!).toBeGreaterThan(lengths[0]!);
 
     // One logical row: every per-step + terminal write shares the run id.
     expect(new Set(agentRunWrites().map(runIdOf)).size).toBe(1);
@@ -298,6 +303,14 @@ describe("agent_runs checkpoint write path (#3745 terminal, #3746 per-step)", ()
     expect(terminals).toHaveLength(1);
     expect(statusOf(terminals[0]!)).toBe("done");
     expect(stepIndexOf(terminals[0]!)).toBe(3);
+
+    // Regression guard for the AI SDK 6 cumulative-`response.messages` bug: that
+    // field is the FULL running transcript at each step, not just the step's own
+    // messages, so the final `running` checkpoint must equal the terminal
+    // transcript EXACTLY — not a quadratically-duplicated superset of it.
+    // (Length-growth alone missed this: duplication still grows monotonically.)
+    const lastRunning = running[running.length - 1]!;
+    expect(transcriptOf(lastRunning)).toEqual(transcriptOf(terminals[0]!));
 
     // Token accounting unchanged vs pre-1b: exactly one token_usage row, no
     // double counting from the per-step checkpoints.

--- a/packages/api/src/lib/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/durable-session.test.ts
@@ -10,12 +10,16 @@
 import { describe, expect, it, beforeEach, mock } from "bun:test";
 import type { ModelMessage } from "ai";
 import * as realInternal from "@atlas/api/lib/db/internal";
+import * as realLogger from "@atlas/api/lib/logger";
 
 let hasInternalDB = true;
 const execCalls: Array<{ sql: string; params?: unknown[] }> = [];
 const queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
 let queryRows: Array<{ id: string }> = [];
 let queryThrow: Error | null = null;
+// Captures the fail-soft warn the write helpers must emit so a circular
+// transcript (or any synchronous throw) is observable, not silently swallowed.
+const warnCalls: Array<{ obj: unknown; msg: unknown }> = [];
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   ...realInternal,
@@ -28,6 +32,18 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     if (queryThrow) throw queryThrow;
     return queryRows;
   },
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  ...realLogger,
+  createLogger: () => ({
+    warn: (obj: unknown, msg?: unknown) => {
+      warnCalls.push({ obj, msg });
+    },
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
 }));
 
 let settingValue: Record<string, string | undefined> = {};
@@ -48,6 +64,7 @@ beforeEach(() => {
   hasInternalDB = true;
   execCalls.length = 0;
   queryCalls.length = 0;
+  warnCalls.length = 0;
   queryRows = [];
   queryThrow = null;
   settingValue = {};
@@ -128,6 +145,11 @@ describe("recordTerminalAgentRun", () => {
       }),
     ).not.toThrow();
     expect(execCalls).toHaveLength(0);
+    // Fail-soft, not silent: the catch must log a type-narrowed warn so the
+    // dropped checkpoint is observable.
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]!.msg).toBe("Failed to record terminal agent run checkpoint");
+    expect((warnCalls[0]!.obj as { err: unknown }).err).toBeTypeOf("string");
   });
 });
 
@@ -148,6 +170,9 @@ describe("recordRunCheckpoint", () => {
     expect(call.sql).toContain("ON CONFLICT (id) DO UPDATE");
     // Monotonic step index: a reordered fire-and-forget write can't regress it.
     expect(call.sql).toContain("step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index)");
+    // Transcript is reorder-safe too: only overwritten when the incoming
+    // checkpoint is at least as advanced as the stored row.
+    expect(call.sql).toContain("WHEN EXCLUDED.step_index >= agent_runs.step_index THEN EXCLUDED.transcript");
     // Guard: a stale checkpoint must never resurrect a terminated/parked row.
     expect(call.sql).toContain("WHERE agent_runs.status NOT IN ('done', 'failed', 'parked')");
     expect(call.sql).toContain("$6::jsonb");
@@ -186,6 +211,10 @@ describe("recordRunCheckpoint", () => {
       }),
     ).not.toThrow();
     expect(execCalls).toHaveLength(0);
+    // Fail-soft, not silent: the catch must log a type-narrowed warn.
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]!.msg).toBe("Failed to record agent run checkpoint");
+    expect((warnCalls[0]!.obj as { err: unknown }).err).toBeTypeOf("string");
   });
 });
 

--- a/packages/api/src/lib/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/durable-session.test.ts
@@ -36,6 +36,7 @@ mock.module("@atlas/api/lib/settings", () => ({
 }));
 
 const {
+  recordRunCheckpoint,
   recordTerminalAgentRun,
   sweepTerminalAgentRuns,
   isDurabilityEnabled,
@@ -53,8 +54,9 @@ beforeEach(() => {
 });
 
 describe("recordTerminalAgentRun", () => {
-  it("writes a single INSERT INTO agent_runs with status + transcript params", () => {
+  it("upserts a single agent_runs row keyed on run id with status + transcript params", () => {
     recordTerminalAgentRun({
+      runId: "run-1",
       conversationId: "conv-1",
       orgId: "org-9",
       status: "done",
@@ -65,8 +67,14 @@ describe("recordTerminalAgentRun", () => {
     expect(execCalls).toHaveLength(1);
     const call = execCalls[0]!;
     expect(call.sql).toContain("INSERT INTO agent_runs");
-    expect(call.sql).toContain("$5::jsonb");
+    // In-place update keyed on the run id (one row per turn), not append.
+    expect(call.sql).toContain("ON CONFLICT (id) DO UPDATE");
+    // Terminal write always wins the status; step index never regresses.
+    expect(call.sql).toContain("status = EXCLUDED.status");
+    expect(call.sql).toContain("step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index)");
+    expect(call.sql).toContain("$6::jsonb");
     expect(call.params).toEqual([
+      "run-1",
       "conv-1",
       "org-9",
       "done",
@@ -78,6 +86,7 @@ describe("recordTerminalAgentRun", () => {
   it("is a no-op when no internal DB is configured", () => {
     hasInternalDB = false;
     recordTerminalAgentRun({
+      runId: "run-1",
       conversationId: "conv-1",
       orgId: null,
       status: "failed",
@@ -92,13 +101,14 @@ describe("recordTerminalAgentRun", () => {
     // is a belt-and-suspenders guard for a nullish value crossing an untyped
     // boundary. Cast to exercise that runtime defense.
     recordTerminalAgentRun({
+      runId: "run-1",
       conversationId: "conv-1",
       orgId: null,
       status: "done",
       stepIndex: 0,
       transcript: null as unknown as ModelMessage[],
     });
-    expect((execCalls[0]!.params as unknown[])[4]).toBe("[]");
+    expect((execCalls[0]!.params as unknown[])[5]).toBe("[]");
   });
 
   it("never throws and writes nothing when JSON.stringify fails (circular transcript)", () => {
@@ -109,10 +119,69 @@ describe("recordTerminalAgentRun", () => {
     circular.self = circular;
     expect(() =>
       recordTerminalAgentRun({
+        runId: "run-1",
         conversationId: "conv-1",
         orgId: null,
         status: "done",
         stepIndex: 0,
+        transcript: [circular] as unknown as ModelMessage[],
+      }),
+    ).not.toThrow();
+    expect(execCalls).toHaveLength(0);
+  });
+});
+
+describe("recordRunCheckpoint", () => {
+  it("upserts a `running` checkpoint keyed on run id, advancing step index in place", () => {
+    recordRunCheckpoint({
+      runId: "run-1",
+      conversationId: "conv-1",
+      orgId: "org-9",
+      stepIndex: 2,
+      transcript: [{ role: "user", content: "hi" }],
+    });
+
+    expect(execCalls).toHaveLength(1);
+    const call = execCalls[0]!;
+    expect(call.sql).toContain("INSERT INTO agent_runs");
+    // In-place update keyed on the run id — one row per turn, not append.
+    expect(call.sql).toContain("ON CONFLICT (id) DO UPDATE");
+    // Monotonic step index: a reordered fire-and-forget write can't regress it.
+    expect(call.sql).toContain("step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index)");
+    // Guard: a stale checkpoint must never resurrect a terminated/parked row.
+    expect(call.sql).toContain("WHERE agent_runs.status NOT IN ('done', 'failed', 'parked')");
+    expect(call.sql).toContain("$6::jsonb");
+    expect(call.params).toEqual([
+      "run-1",
+      "conv-1",
+      "org-9",
+      "running",
+      2,
+      JSON.stringify([{ role: "user", content: "hi" }]),
+    ]);
+  });
+
+  it("is a no-op when no internal DB is configured", () => {
+    hasInternalDB = false;
+    recordRunCheckpoint({
+      runId: "run-1",
+      conversationId: "conv-1",
+      orgId: null,
+      stepIndex: 1,
+      transcript: [],
+    });
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it("never throws and writes nothing when JSON.stringify fails (circular transcript)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() =>
+      recordRunCheckpoint({
+        runId: "run-1",
+        conversationId: "conv-1",
+        orgId: null,
+        stepIndex: 1,
         transcript: [circular] as unknown as ModelMessage[],
       }),
     ).not.toThrow();

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -43,6 +43,7 @@ import { hasInternalDB, internalExecute } from "./db/internal";
 import {
   AGENT_RUN_STATUS,
   isDurabilityEnabled,
+  recordRunCheckpoint,
   recordTerminalAgentRun,
   type TerminalAgentRunStatus,
 } from "./durable-session";
@@ -1262,27 +1263,64 @@ export async function runAgent({
   const compactionSettings = resolveCompactionSettings(orgId);
   let compactionSummaryMemo: { olderCount: number; text: string } | undefined;
 
-  // ── Durable-session terminal checkpoint (#3745, ADR-0020, phase 1a) ──
-  // A turn writes exactly ONE durable `agent_runs` row at completion: `done`
-  // on a clean finish, `failed` on an uncaught error. Gated on a conversation
-  // id (a run belongs to a conversation) + the per-workspace durability flag;
-  // `recordTerminalAgentRun` additionally no-ops without an internal DB, so
-  // off / no-DB → behavior identical to today. Fire-and-forget: it rides the
-  // shared circuit breaker and never disrupts the stream. `terminalWritten`
-  // makes the write idempotent across the onFinish/onError/catch seams (first
-  // terminal status wins — one row per turn).
+  // ── Durable-session checkpoints (#3745 phase 1a, #3746 phase 1b, ADR-0020) ──
+  // A turn occupies exactly ONE durable `agent_runs` row, keyed on a stable
+  // per-turn `runId` and advanced IN PLACE:
+  //   - phase 1b: `onStepFinish` upserts a `running` checkpoint at every step
+  //     boundary (monotonic step index, transcript grown to the messages
+  //     accumulated so far), so an interrupted turn leaves a recoverable
+  //     mid-flight row at the last completed step.
+  //   - phase 1a: the terminal write flips that same row to `done`/`failed`.
+  // Gated on a conversation id (a run belongs to a conversation) + the
+  // per-workspace durability flag; the helpers additionally no-op without an
+  // internal DB, so off / no-DB → behavior identical to today. Fire-and-forget:
+  // each write rides the shared circuit breaker and never disrupts the stream.
+  // `terminalWritten` makes the terminal write idempotent across the
+  // onFinish/onError/catch seams (first terminal status wins — one row per turn).
   const durabilityActive = Boolean(conversationId) && isDurabilityEnabled(orgId);
+  const runId = crypto.randomUUID();
   let terminalWritten = false;
   let observedSteps = 0;
+  // Response messages (assistant text, tool calls, tool results) accumulated
+  // across steps. `onStepFinish`'s `response.messages` carries only the current
+  // step's messages, so we concatenate to reconstruct the running transcript for
+  // mid-flight (`running`) and failure checkpoints. The clean `onFinish` path
+  // uses its own cumulative `response.messages` (authoritative for the turn).
+  const accumulatedResponse: ModelMessage[] = [];
+  const currentTranscript = (): ModelMessage[] => [...modelMessages, ...accumulatedResponse];
+  const writeCheckpoint = (stepIndex: number) => {
+    if (!durabilityActive) return;
+    recordRunCheckpoint({
+      runId,
+      conversationId: conversationId as string,
+      orgId: orgId ?? null,
+      stepIndex,
+      transcript: currentTranscript(),
+    });
+    // Per-step observability on the existing atlas.agent span (last-write-wins).
+    span.setAttributes({
+      "atlas.durable.run_id": runId,
+      "atlas.durable.status": AGENT_RUN_STATUS.RUNNING,
+      "atlas.durable.step_index": stepIndex,
+    });
+  };
   const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: ModelMessage[]) => {
     if (!durabilityActive || terminalWritten) return;
     terminalWritten = true;
     recordTerminalAgentRun({
+      runId,
       conversationId: conversationId as string,
       orgId: orgId ?? null,
       status,
       stepIndex,
       transcript,
+    });
+    // Terminal status progression on the span — set before `endSpan` at every
+    // call site so the final span reflects the persisted terminal state.
+    span.setAttributes({
+      "atlas.durable.run_id": runId,
+      "atlas.durable.status": status,
+      "atlas.durable.step_index": stepIndex,
     });
   };
 
@@ -1321,13 +1359,12 @@ export async function runAgent({
           { err: error instanceof Error ? error : new Error(String(error)) },
           "stream error",
         );
-        // Durable terminal checkpoint for the failure path. Records only the
-        // input messages we had at the point of failure; any assistant/tool
-        // messages produced by steps that completed before the error are NOT
-        // captured on this path (per-step persistence lands in a later slice).
-        // Idempotent via `terminalWritten`, so a subsequent onFinish/catch
-        // won't double-write.
-        writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, modelMessages);
+        // Durable terminal checkpoint for the failure path. Records the
+        // transcript accumulated up to the point of failure (input messages +
+        // any assistant/tool messages from steps that completed before the
+        // error, captured by the per-step checkpoints, #3746). Idempotent via
+        // `terminalWritten`, so a subsequent onFinish/catch won't double-write.
+        writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, currentTranscript());
         endSpan(
           SpanStatusCode.ERROR,
           error instanceof Error ? error.message : String(error),
@@ -1410,15 +1447,23 @@ export async function runAgent({
         };
       },
 
-      onStepFinish: ({ stepNumber, finishReason, usage }) => {
+      onStepFinish: ({ stepNumber, finishReason, usage, response }) => {
         // Track the highest observed step so a `failed` checkpoint (onError /
         // outer catch) can record how far the turn got. `stepNumber` is
         // 0-based; +1 gives the count of completed steps.
         observedSteps = stepNumber + 1;
+        // Grow the running transcript with this step's generated messages, then
+        // upsert a mid-flight `running` checkpoint (#3746) keyed on the turn's
+        // run id. In-place update — one row per turn — so an interruption after
+        // this step leaves a recoverable row at step index `observedSteps`.
+        accumulatedResponse.push(...response.messages);
+        writeCheckpoint(observedSteps);
         log.info(
           {
             step: stepNumber,
+            stepIndex: observedSteps,
             finishReason,
+            durableStatus: durabilityActive ? AGENT_RUN_STATUS.RUNNING : undefined,
             inputTokens: usage?.inputTokens,
             outputTokens: usage?.outputTokens,
             cacheRead: usage?.inputTokenDetails?.cacheReadTokens,
@@ -1446,16 +1491,17 @@ export async function runAgent({
           "atlas.total_input_tokens": totalUsage?.inputTokens ?? 0,
           "atlas.total_output_tokens": totalUsage?.outputTokens ?? 0,
         });
-        endSpan(SpanStatusCode.OK);
 
         // Durable terminal checkpoint (#3745, ADR-0020). The full transcript is
         // the input messages plus the messages the model generated this turn
         // (assistant text, tool calls, tool results). `finishReason === "error"`
         // is the AI-SDK's in-band error signal — record it as `failed`, not
-        // `done`. Idempotent via `terminalWritten`.
+        // `done`. Idempotent via `terminalWritten`. Runs BEFORE `endSpan` so its
+        // terminal status attributes land on the still-open span.
         const status: TerminalAgentRunStatus =
           finishReason === "error" ? AGENT_RUN_STATUS.FAILED : AGENT_RUN_STATUS.DONE;
         writeTerminal(status, steps.length, [...modelMessages, ...response.messages]);
+        endSpan(SpanStatusCode.OK);
 
         // Persist token usage to internal DB (fire-and-forget).
         // Shares the internalExecute circuit breaker with audit writes.
@@ -1509,8 +1555,9 @@ export async function runAgent({
     }));
   } catch (err) {
     // Synchronous setup failure before the stream began. Record a `failed`
-    // terminal checkpoint (idempotent) before re-throwing.
-    writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, modelMessages);
+    // terminal checkpoint (idempotent) before re-throwing. `currentTranscript()`
+    // is just the input messages here (no step ran), matching pre-1b behavior.
+    writeTerminal(AGENT_RUN_STATUS.FAILED, observedSteps, currentTranscript());
     endSpan(
       SpanStatusCode.ERROR,
       err instanceof Error ? err.message : String(err),

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -45,6 +45,7 @@ import {
   isDurabilityEnabled,
   recordRunCheckpoint,
   recordTerminalAgentRun,
+  type AgentRunStatus,
   type TerminalAgentRunStatus,
 } from "./durable-session";
 import { loadGroupRoutingContext } from "./env-routing/lookup";
@@ -1281,14 +1282,37 @@ export async function runAgent({
   const runId = crypto.randomUUID();
   let terminalWritten = false;
   let observedSteps = 0;
-  // Response messages (assistant text, tool calls, tool results) accumulated
-  // across steps. `onStepFinish`'s `response.messages` carries only the current
-  // step's messages, so we concatenate to reconstruct the running transcript for
-  // mid-flight (`running`) and failure checkpoints. The clean `onFinish` path
-  // uses its own cumulative `response.messages` (authoritative for the turn).
-  const accumulatedResponse: ModelMessage[] = [];
-  const currentTranscript = (): ModelMessage[] => [...modelMessages, ...accumulatedResponse];
-  const writeCheckpoint = (stepIndex: number) => {
+  // Response messages (assistant text, tool calls, tool results) generated this
+  // turn. In AI SDK 6, `onStepFinish`'s `response.messages` is the CUMULATIVE
+  // running transcript (every step 0..N), NOT just the latest step's messages —
+  // so we keep the most recent snapshot rather than concatenating. (Concatenating
+  // would re-append all prior steps each step and quadratically duplicate the
+  // persisted transcript.) `currentTranscript()` prepends the input messages to
+  // build the running transcript persisted by the mid-flight (`running`) and
+  // failure checkpoints; the clean `onFinish` path uses the same
+  // `response.messages` snapshot directly (authoritative for the turn).
+  let latestResponseMessages: ModelMessage[] = [];
+  const currentTranscript = (): ModelMessage[] => [...modelMessages, ...latestResponseMessages];
+  // Per-step / terminal observability on the existing atlas.agent span
+  // (last-write-wins). Fail-soft: these run inside onStepFinish/onError/onFinish
+  // on the live stream path, so a span-mutation throw must never propagate and
+  // disrupt the turn — the same guarantee the fire-and-forget checkpoint write
+  // already makes for the DB.
+  const setDurableSpanAttrs = (status: AgentRunStatus, stepIndex: number): void => {
+    try {
+      span.setAttributes({
+        "atlas.durable.run_id": runId,
+        "atlas.durable.status": status,
+        "atlas.durable.step_index": stepIndex,
+      });
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), runId },
+        "Failed to set durable-session span attributes",
+      );
+    }
+  };
+  const writeCheckpoint = (stepIndex: number): void => {
     if (!durabilityActive) return;
     recordRunCheckpoint({
       runId,
@@ -1297,14 +1321,9 @@ export async function runAgent({
       stepIndex,
       transcript: currentTranscript(),
     });
-    // Per-step observability on the existing atlas.agent span (last-write-wins).
-    span.setAttributes({
-      "atlas.durable.run_id": runId,
-      "atlas.durable.status": AGENT_RUN_STATUS.RUNNING,
-      "atlas.durable.step_index": stepIndex,
-    });
+    setDurableSpanAttrs(AGENT_RUN_STATUS.RUNNING, stepIndex);
   };
-  const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: ModelMessage[]) => {
+  const writeTerminal = (status: TerminalAgentRunStatus, stepIndex: number, transcript: ModelMessage[]): void => {
     if (!durabilityActive || terminalWritten) return;
     terminalWritten = true;
     recordTerminalAgentRun({
@@ -1317,11 +1336,7 @@ export async function runAgent({
     });
     // Terminal status progression on the span — set before `endSpan` at every
     // call site so the final span reflects the persisted terminal state.
-    span.setAttributes({
-      "atlas.durable.run_id": runId,
-      "atlas.durable.status": status,
-      "atlas.durable.step_index": stepIndex,
-    });
+    setDurableSpanAttrs(status, stepIndex);
   };
 
   let result;
@@ -1452,11 +1467,12 @@ export async function runAgent({
         // outer catch) can record how far the turn got. `stepNumber` is
         // 0-based; +1 gives the count of completed steps.
         observedSteps = stepNumber + 1;
-        // Grow the running transcript with this step's generated messages, then
-        // upsert a mid-flight `running` checkpoint (#3746) keyed on the turn's
-        // run id. In-place update — one row per turn — so an interruption after
-        // this step leaves a recoverable row at step index `observedSteps`.
-        accumulatedResponse.push(...response.messages);
+        // Snapshot this step's cumulative running transcript — AI SDK 6 hands us
+        // every step's messages (0..N) in `response.messages`, not just step N —
+        // then upsert a mid-flight `running` checkpoint (#3746) keyed on the
+        // turn's run id. In-place update — one row per turn — so an interruption
+        // after this step leaves a recoverable row at step index `observedSteps`.
+        latestResponseMessages = [...response.messages];
         writeCheckpoint(observedSteps);
         log.info(
           {

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import { buildStaleCatalogQuery } from "@atlas/api/lib/scheduler/byot-catalog-query";
+import { RUNNING_UPSERT_SQL, TERMINAL_UPSERT_SQL } from "@atlas/api/lib/durable-session";
 
 // Real-Postgres migration smoke. Skips cleanly when TEST_DATABASE_URL
 // is unset so local dev that hasn't run `bun run db:up` is unaffected.
@@ -2444,6 +2445,107 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
       [conversationId],
     );
     expect(after.rows[0]?.c).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // 0143 (#3746, ADR-0020) — phase 1b per-step upsert SEMANTICS, executed
+  // against real Postgres rather than substring-matched on a mocked SQL string.
+  // These are the slice's core safety properties: ON CONFLICT (id) collapses a
+  // turn to one row, GREATEST + the transcript CASE guard make a reordered
+  // fire-and-forget write non-regressing, and the WHERE status guard prevents a
+  // stale checkpoint from resurrecting a terminated row. A `LEAST`-for-`GREATEST`
+  // typo or a missing guard passes the unit substring tests but fails here.
+  it("0143 (1b): running upserts collapse to one row; step_index + transcript reorder-safe", async () => {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO conversations DEFAULT VALUES RETURNING id`,
+    );
+    const conversationId = rows[0]!.id;
+    const runId = "11111111-1111-1111-1111-111111111111";
+
+    // Three in-order per-step `running` checkpoints (steps 1 → 3).
+    for (const step of [1, 2, 3]) {
+      await pool.query(RUNNING_UPSERT_SQL, [
+        runId,
+        conversationId,
+        "org-1",
+        "running",
+        step,
+        JSON.stringify([{ role: "assistant", content: `step ${step}` }]),
+      ]);
+    }
+
+    // A reordered, stale step-1 checkpoint lands LAST. GREATEST must keep the
+    // step index at 3, and the transcript CASE guard must keep the step-3
+    // transcript — the stale write must not pair the higher index with an
+    // older, shorter transcript.
+    await pool.query(RUNNING_UPSERT_SQL, [
+      runId,
+      conversationId,
+      "org-1",
+      "running",
+      1,
+      JSON.stringify([{ role: "assistant", content: "stale" }]),
+    ]);
+
+    const afterRunning = await pool.query<{ step_index: number; transcript: unknown }>(
+      `SELECT step_index, transcript FROM agent_runs WHERE id = $1`,
+      [runId],
+    );
+    // ON CONFLICT (id) → exactly one row for the turn.
+    expect(afterRunning.rowCount).toBe(1);
+    expect(afterRunning.rows[0]!.step_index).toBe(3); // GREATEST held it at 3
+    expect(afterRunning.rows[0]!.transcript).toEqual([{ role: "assistant", content: "step 3" }]);
+
+    // Terminal write flips the SAME row to done with the authoritative
+    // transcript — still one row, terminal transcript wins unconditionally.
+    await pool.query(TERMINAL_UPSERT_SQL, [
+      runId,
+      conversationId,
+      "org-1",
+      "done",
+      3,
+      JSON.stringify([{ role: "assistant", content: "final" }]),
+    ]);
+    const afterTerminal = await pool.query<{ status: string; transcript: unknown }>(
+      `SELECT status, transcript FROM agent_runs WHERE id = $1`,
+      [runId],
+    );
+    expect(afterTerminal.rowCount).toBe(1);
+    expect(afterTerminal.rows[0]!.status).toBe("done");
+    expect(afterTerminal.rows[0]!.transcript).toEqual([{ role: "assistant", content: "final" }]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0143 (1b): a stale running checkpoint can't resurrect a terminated row", async () => {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO conversations DEFAULT VALUES RETURNING id`,
+    );
+    const conversationId = rows[0]!.id;
+    const runId = "22222222-2222-2222-2222-222222222222";
+
+    // running at step 2, then a terminal `done` write at step 2.
+    await pool.query(RUNNING_UPSERT_SQL, [
+      runId, conversationId, "org-1", "running", 2,
+      JSON.stringify([{ role: "assistant", content: "mid" }]),
+    ]);
+    await pool.query(TERMINAL_UPSERT_SQL, [
+      runId, conversationId, "org-1", "done", 2,
+      JSON.stringify([{ role: "assistant", content: "final" }]),
+    ]);
+
+    // A late, higher-step `running` checkpoint arrives AFTER the terminal write.
+    // The WHERE status guard must reject the update entirely: the row stays
+    // `done`, the step index stays 2, and the terminal transcript is preserved.
+    await pool.query(RUNNING_UPSERT_SQL, [
+      runId, conversationId, "org-1", "running", 3,
+      JSON.stringify([{ role: "assistant", content: "late" }]),
+    ]);
+
+    const row = await pool.query<{ status: string; step_index: number; transcript: unknown }>(
+      `SELECT status, step_index, transcript FROM agent_runs WHERE id = $1`,
+      [runId],
+    );
+    expect(row.rows[0]!.status).toBe("done");
+    expect(row.rows[0]!.step_index).toBe(2);
+    expect(row.rows[0]!.transcript).toEqual([{ role: "assistant", content: "final" }]);
   }, PG_TEST_TIMEOUT_MS);
 });
 

--- a/packages/api/src/lib/durable-session.ts
+++ b/packages/api/src/lib/durable-session.ts
@@ -110,7 +110,9 @@ export interface RecordTerminalRunArgs extends AgentRunWrite {
   status: TerminalAgentRunStatus;
 }
 
-const AGENT_RUN_INSERT = `INSERT INTO agent_runs (id, conversation_id, org_id, status, step_index, transcript, updated_at)
+// Exported for the real-Postgres upsert-behavior tests (migrate-pg.test.ts) so
+// they exercise the EXACT SQL the helpers run, not a hand-copied reimplementation.
+export const AGENT_RUN_INSERT = `INSERT INTO agent_runs (id, conversation_id, org_id, status, step_index, transcript, updated_at)
        VALUES ($1, $2, $3, $4, $5, $6::jsonb, now())`;
 
 /**
@@ -120,16 +122,29 @@ const AGENT_RUN_INSERT = `INSERT INTO agent_runs (id, conversation_id, org_id, s
  * flipped to `done`/`failed` (or a future `parked`). `internalExecute` is
  * fire-and-forget and unordered, so the guard, not call order, is what keeps the
  * lifecycle one-directional.
+ *
+ * `transcript` is guarded the same way as `step_index`: it is only overwritten
+ * when the incoming checkpoint is at least as advanced (`EXCLUDED.step_index >=
+ * agent_runs.step_index`). Without this a reordered stale checkpoint would pair
+ * the higher (GREATEST-preserved) step index with its own older, shorter
+ * transcript — leaving step index and transcript mutually inconsistent.
  */
-const RUNNING_UPSERT_SQL = `${AGENT_RUN_INSERT}
+export const RUNNING_UPSERT_SQL = `${AGENT_RUN_INSERT}
        ON CONFLICT (id) DO UPDATE SET
          step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index),
-         transcript = EXCLUDED.transcript,
+         transcript = CASE
+           WHEN EXCLUDED.step_index >= agent_runs.step_index THEN EXCLUDED.transcript
+           ELSE agent_runs.transcript
+         END,
          updated_at = now()
        WHERE agent_runs.status NOT IN ('done', 'failed', 'parked')`;
 
-/** Terminal upsert. Always wins the status; step index never regresses. */
-const TERMINAL_UPSERT_SQL = `${AGENT_RUN_INSERT}
+/**
+ * Terminal upsert. Always wins the status AND the transcript — the terminal
+ * write carries the authoritative full-turn transcript, so (unlike the running
+ * path) it overwrites unconditionally. Step index never regresses (`GREATEST`).
+ */
+export const TERMINAL_UPSERT_SQL = `${AGENT_RUN_INSERT}
        ON CONFLICT (id) DO UPDATE SET
          status = EXCLUDED.status,
          step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index),

--- a/packages/api/src/lib/durable-session.ts
+++ b/packages/api/src/lib/durable-session.ts
@@ -1,10 +1,17 @@
 /**
- * Durable agent sessions — terminal-checkpoint write path + retention sweep
- * (#3745, ADR-0020, phase 1a).
+ * Durable agent sessions — per-step + terminal checkpoint write path + retention
+ * sweep (#3745 phase 1a, #3746 phase 1b, ADR-0020).
  *
- * A *run* is one user turn. Phase 1a writes exactly ONE durable row per turn at
- * completion: `done` on a clean finish, `failed` on an uncaught error. Per-step
- * `running` checkpoints and `parked`/resume land in later slices.
+ * A *run* is one user turn occupying exactly ONE durable row, keyed on a stable
+ * per-turn run id and advanced IN PLACE:
+ *   - phase 1b ({@link recordRunCheckpoint}) upserts a `running` checkpoint at
+ *     every agent step boundary — monotonic step index, transcript grown to the
+ *     accumulated messages as of that step — so an interrupted turn leaves a
+ *     recoverable mid-flight row.
+ *   - phase 1a ({@link recordTerminalAgentRun}) flips that same row to `done` on
+ *     a clean finish or `failed` on an error.
+ * Both target the same row id, so a turn is still one row (in-place update, not
+ * append) and retention pressure is unchanged from 1a.
  *
  * These are plain (non-Effect) helpers so the agent loop (`lib/agent.ts`, a
  * plain async function) can call them directly — the same shape as the
@@ -12,7 +19,7 @@
  * (`lib/effect/durable-session.ts`) wraps the same helpers for Effect callers
  * (the retention-sweep fiber) and for `Layer.provide` test injection.
  *
- * Fail-soft is the contract: the terminal write rides the fire-and-forget
+ * Fail-soft is the contract: every write rides the fire-and-forget
  * `internalExecute` circuit breaker (shared with token_usage / audit), so a
  * persistence failure logs and never disrupts the live stream. When there is no
  * internal DB the write is a no-op and the loop behaves exactly as it does
@@ -26,7 +33,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("durable-session");
 
-/** Run lifecycle statuses. `running`/`parked` arrive in later slices. */
+/** Run lifecycle statuses. `running` is written per-step (1b); `parked` arrives with resume. */
 export const AGENT_RUN_STATUS = {
   RUNNING: "running",
   PARKED: "parked",
@@ -69,59 +76,131 @@ export function getRetentionDays(orgId?: string): number {
 }
 
 /**
- * Arguments for a terminal-checkpoint write. The single source of truth for the
- * write shape — referenced (via `import type`) by `DurableSessionShape`'s
- * `recordTerminal` so the Effect Tag contract can't drift from the helper.
+ * Shared write shape for an agent-run checkpoint. The single source of truth for
+ * the upsert columns — referenced (via `import type`) by `DurableSessionShape`'s
+ * methods so the Effect Tag contract can't drift from the helpers.
  */
-export interface RecordTerminalRunArgs {
+interface AgentRunWrite {
+  /**
+   * Stable per-turn run id (a UUID). Keys the in-place upsert so every
+   * checkpoint of one turn — each per-step `running` write plus the terminal
+   * write — targets the SAME row. One row per turn; retention pressure is
+   * unchanged from 1a.
+   */
+  runId: string;
   conversationId: string;
   orgId: string | null;
-  status: TerminalAgentRunStatus;
   /**
-   * Completed-step COUNT as of this turn (1-based), not a 0-based index:
-   * `onFinish` passes `steps.length`; the failure paths pass `observedSteps`
-   * (`onStepFinish`'s `stepNumber + 1`). Stored in the `step_index` column.
+   * Completed-step COUNT as of this checkpoint (1-based), not a 0-based index:
+   * per-step writes pass `onStepFinish`'s `stepNumber + 1`; the terminal write
+   * passes `steps.length` (clean finish) or `observedSteps` (failure). Stored in
+   * the `step_index` column and advanced with `GREATEST`, so a reordered
+   * fire-and-forget write can never move it backwards.
    */
   stepIndex: number;
-  /** Accumulated transcript as of this turn; serialized to JSONB. */
+  /** Accumulated transcript as of this checkpoint; serialized to JSONB. */
   transcript: ModelMessage[];
 }
 
+/** Arguments for a per-step `running` checkpoint write (#3746, phase 1b). */
+export type RecordRunCheckpointArgs = AgentRunWrite;
+
+/** Arguments for a terminal (`done`/`failed`) checkpoint write (#3745, phase 1a). */
+export interface RecordTerminalRunArgs extends AgentRunWrite {
+  status: TerminalAgentRunStatus;
+}
+
+const AGENT_RUN_INSERT = `INSERT INTO agent_runs (id, conversation_id, org_id, status, step_index, transcript, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, now())`;
+
 /**
- * Persist a single terminal run checkpoint (fire-and-forget).
- *
- * Mirrors the `token_usage` write in the agent loop's `onFinish`: gated on
- * `hasInternalDB()`, routed through `internalExecute` (shared circuit breaker),
- * type-narrowed catch, never throws. The transcript is serialized to JSONB.
+ * Per-step upsert. Advances step index (monotonically) + transcript in place,
+ * but ONLY while the row is still `running` — the `WHERE` guard means a stale,
+ * reordered checkpoint can never resurrect a row a later terminal write already
+ * flipped to `done`/`failed` (or a future `parked`). `internalExecute` is
+ * fire-and-forget and unordered, so the guard, not call order, is what keeps the
+ * lifecycle one-directional.
  */
-export function recordTerminalAgentRun(args: RecordTerminalRunArgs): void {
+const RUNNING_UPSERT_SQL = `${AGENT_RUN_INSERT}
+       ON CONFLICT (id) DO UPDATE SET
+         step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index),
+         transcript = EXCLUDED.transcript,
+         updated_at = now()
+       WHERE agent_runs.status NOT IN ('done', 'failed', 'parked')`;
+
+/** Terminal upsert. Always wins the status; step index never regresses. */
+const TERMINAL_UPSERT_SQL = `${AGENT_RUN_INSERT}
+       ON CONFLICT (id) DO UPDATE SET
+         status = EXCLUDED.status,
+         step_index = GREATEST(agent_runs.step_index, EXCLUDED.step_index),
+         transcript = EXCLUDED.transcript,
+         updated_at = now()`;
+
+/**
+ * Shared write body for both checkpoint helpers (fire-and-forget).
+ *
+ * Mirrors the `token_usage` write in the agent loop: gated on `hasInternalDB()`,
+ * routed through `internalExecute` (shared circuit breaker), type-narrowed
+ * catch, never throws. The transcript is serialized to JSONB inside the `try`
+ * so a synchronous `JSON.stringify` throw (e.g. a circular transcript) is caught
+ * and the stream is never disrupted.
+ */
+function writeAgentRunCheckpoint(
+  sql: string,
+  args: AgentRunWrite,
+  status: AgentRunStatus,
+  failureMessage: string,
+): void {
   if (!hasInternalDB()) return;
   try {
-    internalExecute(
-      `INSERT INTO agent_runs (conversation_id, org_id, status, step_index, transcript, updated_at)
-       VALUES ($1, $2, $3, $4, $5::jsonb, now())`,
-      [
-        args.conversationId,
-        args.orgId,
-        args.status,
-        args.stepIndex,
-        JSON.stringify(args.transcript ?? []),
-      ],
-    );
+    internalExecute(sql, [
+      args.runId,
+      args.conversationId,
+      args.orgId,
+      status,
+      args.stepIndex,
+      JSON.stringify(args.transcript ?? []),
+    ]);
   } catch (err) {
-    // internalExecute is itself fire-and-forget; this guards a synchronous
-    // throw (e.g. JSON.stringify on a circular transcript) so the stream is
-    // never disrupted. ADR-0020: a degraded checkpoint store costs
-    // resumability, never the current answer.
+    // ADR-0020: a degraded checkpoint store costs resumability, never the
+    // current answer.
     log.warn(
       {
         err: err instanceof Error ? err.message : String(err),
         conversationId: args.conversationId,
-        status: args.status,
+        runId: args.runId,
+        status,
       },
-      "Failed to record terminal agent run checkpoint",
+      failureMessage,
     );
   }
+}
+
+/**
+ * Persist a per-step `running` checkpoint (fire-and-forget, #3746). Upserts the
+ * run row in place keyed on {@link AgentRunWrite.runId} so an interrupted turn
+ * leaves a recoverable mid-flight row at the last completed step.
+ */
+export function recordRunCheckpoint(args: RecordRunCheckpointArgs): void {
+  writeAgentRunCheckpoint(
+    RUNNING_UPSERT_SQL,
+    args,
+    AGENT_RUN_STATUS.RUNNING,
+    "Failed to record agent run checkpoint",
+  );
+}
+
+/**
+ * Persist a terminal run checkpoint (`done`/`failed`, fire-and-forget, #3745).
+ * Flips the same per-turn row to its terminal status.
+ */
+export function recordTerminalAgentRun(args: RecordTerminalRunArgs): void {
+  writeAgentRunCheckpoint(
+    TERMINAL_UPSERT_SQL,
+    args,
+    args.status,
+    "Failed to record terminal agent run checkpoint",
+  );
 }
 
 /**

--- a/packages/api/src/lib/effect/__tests__/durable-session.test.ts
+++ b/packages/api/src/lib/effect/__tests__/durable-session.test.ts
@@ -44,6 +44,7 @@ describe("DurableSessionLive", () => {
         const ds = yield* DurableSession;
         expect(ds.available).toBe(true);
         ds.recordTerminal({
+          runId: "run-1",
           conversationId: "conv-1",
           orgId: "org-1",
           status: "done",
@@ -55,6 +56,26 @@ describe("DurableSessionLive", () => {
 
     expect(execCalls).toHaveLength(1);
     expect(execCalls[0]!.sql).toContain("INSERT INTO agent_runs");
+    expect(execCalls[0]!.sql).toContain("status = EXCLUDED.status");
+  });
+
+  it("records a per-step `running` checkpoint via internalExecute", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const ds = yield* DurableSession;
+        ds.recordCheckpoint({
+          runId: "run-1",
+          conversationId: "conv-1",
+          orgId: "org-1",
+          stepIndex: 2,
+          transcript: [],
+        });
+      }).pipe(Effect.provide(DurableSessionLive)),
+    );
+
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0]!.sql).toContain("ON CONFLICT (id) DO UPDATE");
+    expect(execCalls[0]!.params?.[3]).toBe("running");
   });
 
   it("sweepTerminal returns the deleted count", async () => {
@@ -75,7 +96,15 @@ describe("NoopDurableSessionLayer", () => {
       Effect.gen(function* () {
         const ds = yield* DurableSession;
         expect(ds.available).toBe(false);
+        ds.recordCheckpoint({
+          runId: "run-1",
+          conversationId: "conv-1",
+          orgId: null,
+          stepIndex: 1,
+          transcript: [],
+        });
         ds.recordTerminal({
+          runId: "run-1",
           conversationId: "conv-1",
           orgId: null,
           status: "failed",

--- a/packages/api/src/lib/effect/durable-session.ts
+++ b/packages/api/src/lib/effect/durable-session.ts
@@ -12,6 +12,7 @@
 import { Effect, Layer } from "effect";
 import { DurableSession, type DurableSessionShape } from "@atlas/api/lib/effect/services";
 import {
+  recordRunCheckpoint,
   recordTerminalAgentRun,
   sweepTerminalAgentRuns,
 } from "@atlas/api/lib/durable-session";
@@ -21,6 +22,7 @@ export const DurableSessionLive: Layer.Layer<DurableSession> = Layer.succeed(
   DurableSession,
   {
     available: true,
+    recordCheckpoint: (args) => recordRunCheckpoint(args),
     recordTerminal: (args) => recordTerminalAgentRun(args),
     sweepTerminal: (retentionDays) =>
       Effect.promise(() => sweepTerminalAgentRuns(retentionDays)),
@@ -35,6 +37,7 @@ export const NoopDurableSessionLayer: Layer.Layer<DurableSession> = Layer.succee
   DurableSession,
   {
     available: false,
+    recordCheckpoint: () => {},
     recordTerminal: () => {},
     sweepTerminal: () => Effect.succeed(0),
   } satisfies DurableSessionShape,

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -30,7 +30,7 @@ import type {
 import type { PoolMetrics, OrgPoolMetrics } from "@useatlas/types";
 import type { LeadEvent } from "@useatlas/twenty/lead-normalizer";
 import type { ToolRegistry as ToolRegistryClass } from "@atlas/api/lib/tools/registry";
-import type { RecordTerminalRunArgs } from "@atlas/api/lib/durable-session";
+import type { RecordRunCheckpointArgs, RecordTerminalRunArgs } from "@atlas/api/lib/durable-session";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   PluginRegistry as PluginRegistryClass,
@@ -102,6 +102,12 @@ export interface DurableSessionShape {
    * the per-workspace `ATLAS_DURABILITY_ENABLED` settings flag at write time.
    */
   readonly available: boolean;
+  /**
+   * Persist a per-step `running` checkpoint (phase 1b) — upserts the turn's row
+   * in place keyed on `runId`, advancing the step index + transcript. Same
+   * fire-and-forget contract as {@link recordTerminal}. No-op on the Noop layer.
+   */
+  recordCheckpoint(args: RecordRunCheckpointArgs): void;
   /**
    * Persist a single terminal run checkpoint (`done`/`failed`) at turn
    * completion (phase 1a). Fire-and-forget: rides the shared `internalExecute`


### PR DESCRIPTION
## Summary

Durable sessions slice 1b (#3746) — extends the terminal-only checkpoint from 1a to checkpoint at **every** agent step boundary, so an interrupted turn leaves a recoverable mid-flight row. **No resume behavior in this slice** — it only makes the persisted state granular and observable.

- `agent.ts` `onStepFinish` upserts the run row **in place** keyed on a stable per-turn run id: status `running`, monotonic step index (`stepNumber + 1`), transcript grown to the messages accumulated as of that step. The terminal write (`onFinish`/`onError`/catch) flips the **same** row to `done`/`failed`, so a turn is still **one row** (in-place update, not append) — retention pressure unchanged from 1a.
- `durable-session.ts`: `recordRunCheckpoint` (running) + `recordTerminalAgentRun` (terminal) share one `ON CONFLICT (id)` upsert. `step_index` advances via `GREATEST` (monotonic across reordered fire-and-forget writes); the running upsert is guarded by `WHERE status NOT IN ('done','failed','parked')` so a stale checkpoint can never resurrect a terminated run.
- Per-step observability: `atlas.durable.{run_id,status,step_index}` on the existing `atlas.agent` span + the `step complete` log line.
- `DurableSession` Effect shape gains `recordCheckpoint` (mirrors the helper). No schema/migration change — the `agent_runs` table + `id` PK already exist (#3745).

## Acceptance criteria

- [x] A multi-step turn shows the run row's step index advancing 0 → N across the turn, with the transcript growing to include each completed step's assistant/tool messages.
- [x] A turn interrupted after step N leaves a row with status `running` and step index N (asserted at the `runAgent` seam with the mock LLM — a model that blocks the next step mid-flight).
- [x] Token/step accounting for a completed turn is unchanged vs. pre-1b (asserted: exactly one `token_usage` row, no double counting).
- [x] Checkpoint writes remain fire-and-forget and never disrupt the stream.
- [x] Noop degradation still holds (no internal DB → no writes; flag off → no writes).

## Test plan

- [x] `bun test packages/api/src/lib/__tests__/durable-session.test.ts` — helper upsert shape (per-step + terminal), no-DB no-op, circular-transcript fail-soft
- [x] `bun test packages/api/src/lib/__tests__/agent-durable-session.test.ts` — multi-step progression, mid-flight interruption, terminal paths, idempotency, Noop/flag-off
- [x] `bun test packages/api/src/lib/effect/__tests__/durable-session.test.ts` — Live/Noop `recordCheckpoint`
- [x] `/ci` — lint, type, full test suite, syncpack, template/schema/openapi/oauth/settings/saas-env drift, railway-watch, published-symbols — all pass

Closes #3746

---
_Generated by [Claude Code](https://claude.ai/code/session_011r4aaLztCpWoGcRe8QXdrF)_