### PR TITLE
refactor(plugin-sdk): share collectSemanticFiles + health-check timeout

### DIFF
--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -531,8 +531,8 @@ Plugin sandbox backends default to priority 60 (between nsjail and sidecar). Set
 
 Most sandbox plugins need the same two pieces of infrastructure, so `@useatlas/plugin-sdk` ships them — use these instead of re-implementing them per plugin:
 
-- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — recursively walks the local semantic tree and returns `{ path, content: Buffer }[]` ready to upload into the sandbox. It carries a **symlink-escape guard**: a symlink whose real target resolves outside the semantic root is skipped (and logged), never uploaded. This is a security property — single-sourcing it means a fix lands once for every sandbox backend. SDKs that want string content (e.g. E2B's `files.write`) map `f.content.toString("utf-8")` at the call site.
-- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps a `healthCheck()` probe in the `Promise.race` timeout, attaches a measured `latencyMs`, and runs `cleanup` in every failing branch (timeout or throw). The probe owns its happy-path teardown; `cleanup` is the safety net that reaps a sandbox reference the probe captured but could not release (it must be idempotent/guarded). `await using` is intentionally not used — the timeout can win while the SDK is still mid-create with no `AbortSignal`, so an explicit guarded cleanup fires immediately.
+- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — recursively walks the local semantic tree and returns `{ path, content: Uint8Array }[]` ready to upload into the sandbox (the content is a Node `Buffer` at runtime; the type is the portable `Uint8Array`). It carries a **symlink-escape guard**: a symlink whose real target resolves outside the semantic root is skipped (and logged), never uploaded — and symlink cycles are broken so a self-referential tree terminates. This is a security property — single-sourcing it means a fix lands once for every sandbox backend. SDKs that want string content (e.g. E2B's `files.write`) decode via `Buffer.from(f.content).toString("utf-8")` at the call site.
+- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps a `healthCheck()` probe in the `Promise.race` timeout, attaches a measured `latencyMs`, and runs `cleanup` in every failing branch (timeout or throw). The optional `logger.warn` fires on each failing branch (timeout, probe throw, cleanup throw). The probe owns its happy-path teardown; `cleanup` is the safety net that reaps a sandbox reference the probe captured but could not release (it must be idempotent/guarded). `await using` is intentionally not used — the timeout can win while the SDK is still mid-create with no `AbortSignal`, so an explicit guarded cleanup fires immediately.
 
 ```typescript
 import { collectSemanticFiles, runHealthCheckWithTimeout } from "@useatlas/plugin-sdk";
@@ -541,7 +541,7 @@ sandbox: {
   async create(semanticRoot: string): Promise<PluginExploreBackend> {
     const sandbox = await mySdk.create();
     const files = collectSemanticFiles(semanticRoot, "semantic", log);
-    await sandbox.upload(files); // each { path, content: Buffer }
+    await sandbox.upload(files); // each { path, content: Uint8Array }
     return { /* exec, close */ };
   },
 },

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -527,6 +527,26 @@ The `priority` field determines selection order when multiple backends are avail
 
 Plugin sandbox backends default to priority 60 (between nsjail and sidecar). Set a higher value to take precedence over built-in backends, or a lower value to act as a fallback.
 
+#### Shared sandbox helpers
+
+Most sandbox plugins need the same two pieces of infrastructure, so `@useatlas/plugin-sdk` ships them — use these instead of re-implementing them per plugin:
+
+- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — recursively walks the local semantic tree and returns `{ path, content: Buffer }[]` ready to upload into the sandbox. It carries a **symlink-escape guard**: a symlink whose real target resolves outside the semantic root is skipped (and logged), never uploaded. This is a security property — single-sourcing it means a fix lands once for every sandbox backend. SDKs that want string content (e.g. E2B's `files.write`) map `f.content.toString("utf-8")` at the call site.
+- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps a `healthCheck()` probe in the `Promise.race` timeout, attaches a measured `latencyMs`, and runs `cleanup` in every failing branch (timeout or throw). The probe owns its happy-path teardown; `cleanup` is the safety net that reaps a sandbox reference the probe captured but could not release (it must be idempotent/guarded). `await using` is intentionally not used — the timeout can win while the SDK is still mid-create with no `AbortSignal`, so an explicit guarded cleanup fires immediately.
+
+```typescript
+import { collectSemanticFiles, runHealthCheckWithTimeout } from "@useatlas/plugin-sdk";
+
+sandbox: {
+  async create(semanticRoot: string): Promise<PluginExploreBackend> {
+    const sandbox = await mySdk.create();
+    const files = collectSemanticFiles(semanticRoot, "semantic", log);
+    await sandbox.upload(files); // each { path, content: Buffer }
+    return { /* exec, close */ };
+  },
+},
+```
+
 ## `createPlugin` vs `definePlugin`
 
 The SDK exports two helpers for authoring plugins. Choose based on whether your plugin accepts runtime configuration.
@@ -1034,45 +1054,32 @@ async healthCheck(): Promise<PluginHealthResult> {
 }
 ```
 
-Standard pattern for **sandbox** plugins (where probe operations are slow):
+Standard pattern for **sandbox** plugins (where probe operations are slow) — use the SDK's `runHealthCheckWithTimeout` helper so the timeout race, `latencyMs`, and cleanup-in-every-failing-branch are single-sourced (see [Shared sandbox helpers](#shared-sandbox-helpers)):
 
 ```typescript
+import { runHealthCheckWithTimeout } from "@useatlas/plugin-sdk";
+
 async healthCheck(): Promise<PluginHealthResult> {
-  const start = performance.now();
-  const TIMEOUT = 30_000; // sandbox creation can be slow
   let sandbox: SandboxInstance | null = null; // hoist for cleanup on timeout
-  let timer: ReturnType<typeof setTimeout>;
-  try {
-    const result = await Promise.race([
-      (async () => {
-        sandbox = await createSandbox(config); // your SDK's create method
-        await sandbox.close(); // cleanup method varies by SDK (kill, stop, delete, etc.)
-        sandbox = null;
-        return "ok" as const;
-      })(),
-      new Promise<"timeout">((resolve) => {
-        timer = setTimeout(() => resolve("timeout"), TIMEOUT);
-      }),
-    ]).finally(() => clearTimeout(timer!)); // always clean up the timer
-    const latencyMs = Math.round(performance.now() - start);
-    if (result === "timeout") {
-      // Best-effort cleanup — sandbox may still be creating
-      if (sandbox) {
-        try { await sandbox.close(); } catch { /* best-effort */ }
-      }
-      return { healthy: false, message: `Timed out after ${TIMEOUT}ms`, latencyMs };
-    }
-    return { healthy: true, latencyMs };
-  } catch (err) {
-    if (sandbox) {
-      try { await sandbox.close(); } catch { /* best-effort */ }
-    }
-    return {
-      healthy: false,
-      message: err instanceof Error ? err.message : String(err),
-      latencyMs: Math.round(performance.now() - start),
-    };
-  }
+  return runHealthCheckWithTimeout(
+    async () => {
+      sandbox = await createSandbox(config); // your SDK's create method
+      await sandbox.close(); // cleanup method varies by SDK (kill, stop, delete, etc.)
+      sandbox = null;
+      return { healthy: true };
+    },
+    {
+      timeoutMs: 30_000, // sandbox creation can be slow
+      logger: log,
+      cleanup: async () => {
+        // Safety net — runs only on timeout/throw; idempotent + guarded.
+        if (sandbox) {
+          try { await sandbox.close(); } catch { /* best-effort */ }
+          sandbox = null;
+        }
+      },
+    },
+  );
 }
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -316,8 +316,9 @@
     },
     "packages/plugin-sdk": {
       "name": "@useatlas/plugin-sdk",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "devDependencies": {
+        "@types/node": "^25.9.1",
         "ai": "^6.0.193",
         "hono": "^4.12.23",
         "typescript": "^6.0.3",

--- a/docs/guides/plugin-authoring-guide.md
+++ b/docs/guides/plugin-authoring-guide.md
@@ -386,6 +386,11 @@ security: {
 
 The `security` metadata is informational — it's the plugin's self-declaration, not enforced by the host. See [`nsjail`](../plugins/nsjail/index.ts) for Linux namespace isolation, [`vercel-sandbox`](../plugins/vercel-sandbox/index.ts) for Firecracker microVMs, and [`e2b`](../plugins/e2b/index.ts) for managed cloud VMs.
 
+`@useatlas/plugin-sdk` ships two shared helpers for sandbox plugins — prefer them over re-implementing the same boilerplate:
+
+- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — walks the local semantic tree into `{ path, content: Buffer }[]` for upload, with a **symlink-escape guard** (a symlink resolving outside the semantic root is skipped, never uploaded — a single-sourced security property). Map `f.content.toString("utf-8")` at the call site for SDKs that want string content.
+- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps the probe in the timeout race, attaches `latencyMs`, and runs the guarded `cleanup` safety net on timeout/throw. `await using` is intentionally avoided (the timeout can win mid-create with no `AbortSignal`).
+
 ## Common Patterns
 
 ### Health Checks

--- a/docs/guides/plugin-authoring-guide.md
+++ b/docs/guides/plugin-authoring-guide.md
@@ -388,8 +388,8 @@ The `security` metadata is informational — it's the plugin's self-declaration,
 
 `@useatlas/plugin-sdk` ships two shared helpers for sandbox plugins — prefer them over re-implementing the same boilerplate:
 
-- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — walks the local semantic tree into `{ path, content: Buffer }[]` for upload, with a **symlink-escape guard** (a symlink resolving outside the semantic root is skipped, never uploaded — a single-sourced security property). Map `f.content.toString("utf-8")` at the call site for SDKs that want string content.
-- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps the probe in the timeout race, attaches `latencyMs`, and runs the guarded `cleanup` safety net on timeout/throw. `await using` is intentionally avoided (the timeout can win mid-create with no `AbortSignal`).
+- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — walks the local semantic tree into `{ path, content: Uint8Array }[]` for upload (a Node `Buffer` at runtime; the portable `Uint8Array` type keeps the published surface Node-global-free), with a **symlink-escape guard** (a symlink resolving outside the semantic root is skipped, never uploaded — a single-sourced security property) and symlink-cycle breaking. Decode via `Buffer.from(f.content).toString("utf-8")` at the call site for SDKs that want string content.
+- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps the probe in the timeout race, attaches `latencyMs`, and runs the guarded `cleanup` safety net on timeout/throw. `logger.warn` fires on each failing branch (timeout, probe throw, cleanup throw). `await using` is intentionally avoided (the timeout can win mid-create with no `AbortSignal`).
 
 ## Common Patterns
 

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@useatlas/plugin-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Type definitions and helpers for authoring Atlas plugins",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "prepare": "bun run build",
-    "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts && bun test src/__tests__/semantic-whitelist.test.ts"
+    "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts && bun test src/__tests__/semantic-whitelist.test.ts && bun test src/__tests__/sandbox-helpers.test.ts"
   },
   "exports": {
     ".": {
@@ -75,6 +75,7 @@
     }
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "ai": "^6.0.193",
     "hono": "^4.12.23",
     "typescript": "^6.0.3",

--- a/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
+++ b/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
@@ -59,7 +59,8 @@ describe("collectSemanticFiles", () => {
 
     const files = collectSemanticFiles(root, "semantic");
     expect(files).toHaveLength(1);
-    expect(files[0].content.equals(bytes)).toBe(true);
+    // content is typed Uint8Array (a Node Buffer at runtime); wrap to compare.
+    expect(Buffer.from(files[0].content).equals(bytes)).toBe(true);
   });
 
   test("follows symlinks that stay inside the semantic root", () => {
@@ -117,6 +118,66 @@ describe("collectSemanticFiles", () => {
     } finally {
       fs.rmSync(base, { recursive: true, force: true });
     }
+  });
+
+  test("SECURITY: rejects a symlinked DIRECTORY escaping the semantic root", () => {
+    // The escape guard must cover the directory-recursion arm, not just files —
+    // a symlinked dir pointing outside the root would otherwise leak a whole
+    // subtree (e.g. semantic/x -> /etc), the higher-impact exfiltration vector.
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "outside-dir-"));
+    try {
+      fs.mkdirSync(path.join(outside, "secrets"), { recursive: true });
+      fs.writeFileSync(path.join(outside, "secrets", "secret.yml"), "password: hunter2\n");
+      fs.writeFileSync(path.join(root, "real.yml"), "table: real\n");
+      fs.symlinkSync(path.join(outside, "secrets"), path.join(root, "linkdir"));
+
+      const { warnings, logger } = makeLogger();
+      const files = collectSemanticFiles(root, "semantic", logger);
+
+      const paths = files.map((f) => f.path);
+      expect(paths).toContain("semantic/real.yml");
+      expect(paths.some((p) => p.includes("linkdir"))).toBe(false);
+      expect(files.some((f) => f.content.toString().includes("hunter2"))).toBe(false);
+      expect(warnings.some((w) => w.includes("escaping semantic root"))).toBe(true);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("SECURITY: rejects a relative ../ symlink escaping the root", () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "relative-escape-"));
+    try {
+      fs.mkdirSync(path.join(base, "semantic"), { recursive: true });
+      fs.writeFileSync(path.join(base, "secret.yml"), "password: hunter2\n");
+      fs.writeFileSync(path.join(base, "semantic", "real.yml"), "table: real\n");
+      // Relative target climbing out of the root — distinct from the absolute
+      // targets the other escape tests use.
+      fs.symlinkSync("../secret.yml", path.join(base, "semantic", "leak.yml"));
+
+      const { warnings, logger } = makeLogger();
+      const files = collectSemanticFiles(path.join(base, "semantic"), "semantic", logger);
+      const paths = files.map((f) => f.path);
+      expect(paths.some((p) => p.endsWith("real.yml"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("leak.yml"))).toBe(false);
+      expect(files.some((f) => f.content.toString().includes("hunter2"))).toBe(false);
+      expect(warnings.some((w) => w.includes("escaping semantic root"))).toBe(true);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("terminates on a self-referential symlink cycle (no duplicate explosion)", () => {
+    // A directory symlink pointing back at the root is inside the root, so the
+    // escape guard allows it — the cycle-break (visited realpaths) is what
+    // stops it from re-walking the tree until the OS aborts with ELOOP.
+    fs.writeFileSync(path.join(root, "real.yml"), "table: real\n");
+    fs.symlinkSync(root, path.join(root, "selflink"));
+
+    const files = collectSemanticFiles(root, "semantic");
+    const realYmls = files.filter((f) => f.path.endsWith("real.yml"));
+    // real.yml is collected exactly once; the self-link is not re-walked.
+    expect(realYmls).toHaveLength(1);
+    expect(files.some((f) => f.path.includes("selflink"))).toBe(false);
   });
 
   test("returns empty (logs warn) when the semantic root is unreadable/missing", () => {
@@ -233,6 +294,10 @@ describe("runHealthCheckWithTimeout", () => {
     );
     expect(result.healthy).toBe(false);
     expect(result.message).toContain("timed out after 20ms");
+    // latencyMs is attached on the timeout branch too — the branch a refactor
+    // is most likely to forget.
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
     expect(cleaned).toBe(true);
   });
 
@@ -257,7 +322,9 @@ describe("runHealthCheckWithTimeout", () => {
     );
     expect(result.healthy).toBe(false);
     expect(result.message).toContain("timed out after 20ms");
-    expect(cleanup).toHaveBeenCalled();
+    // cleanup is the timeout safety net — it must fire exactly once even though
+    // the probe also nulls its own ref on its (losing) happy path.
+    expect(cleanup).toHaveBeenCalledTimes(1);
     // wait for the slow probe to finish so the ref it set is observable
     await new Promise((r) => setTimeout(r, 250));
     // cleanup nulled it before the probe's create resolved
@@ -305,5 +372,54 @@ describe("runHealthCheckWithTimeout", () => {
     );
     expect(result.healthy).toBe(false);
     expect(result.message).toBe("plain string failure");
+  });
+
+  test("handles a synchronously-throwing probe (not just async rejection)", async () => {
+    // Promise.race invokes fn() synchronously, so a sync throw escapes the race
+    // and is caught only by the outer try/catch — a distinct code path.
+    const cleanup = mock(() => Promise.resolve());
+    const result = await runHealthCheckWithTimeout(
+      (() => {
+        throw new Error("sync boom");
+      }) as unknown as () => Promise<{ healthy: boolean }>,
+      { timeoutMs: 1_000, cleanup },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("sync boom");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs a warning on the probe-throw branch", async () => {
+    const { warnings, logger } = makeLogger();
+    await runHealthCheckWithTimeout(
+      async () => {
+        throw new Error("quota exceeded");
+      },
+      { timeoutMs: 1_000, cleanup: () => {}, logger },
+    );
+    expect(warnings.some((w) => w.includes("probe failed") && w.includes("quota exceeded"))).toBe(
+      true,
+    );
+  });
+
+  test("logs a warning on the timeout branch", async () => {
+    const { warnings, logger } = makeLogger();
+    await runHealthCheckWithTimeout(() => new Promise(() => {}), {
+      timeoutMs: 20,
+      cleanup: () => {},
+      logger,
+    });
+    expect(warnings.some((w) => w.includes("timed out after 20ms"))).toBe(true);
+  });
+
+  test("throws on a non-positive or non-finite timeoutMs", async () => {
+    for (const bad of [0, -5, NaN, Infinity]) {
+      await expect(
+        runHealthCheckWithTimeout(async () => ({ healthy: true }), {
+          timeoutMs: bad,
+          cleanup: () => {},
+        }),
+      ).rejects.toThrow(/timeoutMs must be a positive, finite number/);
+    }
   });
 });

--- a/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
+++ b/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for the shared sandbox helpers (#3373) — `collectSemanticFiles` and
+ * `runHealthCheckWithTimeout`.
+ *
+ * These single-source two blocks that were copy-pasted across the four sandbox
+ * plugins (vercel-sandbox, e2b, daytona, railway-sandbox). The symlink-escape
+ * guard in `collectSemanticFiles` is a SECURITY property — a symlink that
+ * resolves outside the semantic root must never be uploaded into a sandbox.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { collectSemanticFiles, runHealthCheckWithTimeout } from "../helpers";
+
+function makeLogger() {
+  const warnings: string[] = [];
+  return {
+    warnings,
+    logger: { warn: (msg: string) => warnings.push(msg) },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// collectSemanticFiles
+// ---------------------------------------------------------------------------
+
+describe("collectSemanticFiles", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "collect-semantic-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test("collects files into POSIX-style sandbox paths with Buffer content", () => {
+    fs.mkdirSync(path.join(root, "entities"), { recursive: true });
+    fs.writeFileSync(path.join(root, "entities", "users.yml"), "table: users\n");
+    fs.writeFileSync(path.join(root, "glossary.yml"), "term: revenue\n");
+
+    const files = collectSemanticFiles(root, "semantic");
+
+    const byPath = Object.fromEntries(files.map((f) => [f.path, f.content]));
+    expect(Object.keys(byPath).sort()).toEqual([
+      "semantic/entities/users.yml",
+      "semantic/glossary.yml",
+    ]);
+    expect(Buffer.isBuffer(byPath["semantic/glossary.yml"])).toBe(true);
+    expect(byPath["semantic/entities/users.yml"].toString()).toBe("table: users\n");
+  });
+
+  test("preserves binary content unchanged (no encoding round-trip)", () => {
+    const bytes = Buffer.from([0x00, 0xff, 0x10, 0x7f, 0x80]);
+    fs.writeFileSync(path.join(root, "blob.bin"), bytes);
+
+    const files = collectSemanticFiles(root, "semantic");
+    expect(files).toHaveLength(1);
+    expect(files[0].content.equals(bytes)).toBe(true);
+  });
+
+  test("follows symlinks that stay inside the semantic root", () => {
+    fs.mkdirSync(path.join(root, "real"), { recursive: true });
+    fs.writeFileSync(path.join(root, "real", "inner.yml"), "ok: true\n");
+    fs.symlinkSync(path.join(root, "real", "inner.yml"), path.join(root, "link.yml"));
+
+    const files = collectSemanticFiles(root, "semantic");
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toContain("semantic/link.yml");
+    expect(paths).toContain("semantic/real/inner.yml");
+  });
+
+  test("SECURITY: rejects a symlink escaping the semantic root", () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "outside-secret-"));
+    try {
+      fs.writeFileSync(path.join(outside, "secret.yml"), "password: hunter2\n");
+      fs.writeFileSync(path.join(root, "real.yml"), "table: real\n");
+      fs.symlinkSync(path.join(outside, "secret.yml"), path.join(root, "leak.yml"));
+
+      const { warnings, logger } = makeLogger();
+      const files = collectSemanticFiles(root, "semantic", logger);
+
+      const paths = files.map((f) => f.path);
+      expect(paths).toContain("semantic/real.yml");
+      expect(paths).not.toContain("semantic/leak.yml");
+      const contents = files.map((f) => f.content.toString());
+      expect(contents.some((c) => c.includes("hunter2"))).toBe(false);
+      expect(warnings.some((w) => w.includes("escaping semantic root"))).toBe(true);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("SECURITY: rejects a symlink to a prefix-collision sibling of the root", () => {
+    // `${base}/semantic_evil` shares the `${base}/semantic` string prefix — a
+    // bare startsWith() containment check would wrongly accept it. The
+    // path.relative-based guard rejects it.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "prefix-collision-"));
+    try {
+      fs.mkdirSync(path.join(base, "semantic"), { recursive: true });
+      fs.mkdirSync(path.join(base, "semantic_evil"), { recursive: true });
+      fs.writeFileSync(path.join(base, "semantic", "real.yml"), "table: real\n");
+      fs.writeFileSync(path.join(base, "semantic_evil", "secret.yml"), "secret: yes\n");
+      fs.symlinkSync(
+        path.join(base, "semantic_evil", "secret.yml"),
+        path.join(base, "semantic", "leak.yml"),
+      );
+
+      const files = collectSemanticFiles(path.join(base, "semantic"), "semantic");
+      const paths = files.map((f) => f.path);
+      expect(paths.some((p) => p.endsWith("real.yml"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("leak.yml"))).toBe(false);
+      expect(files.some((f) => f.content.toString().includes("secret: yes"))).toBe(false);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("returns empty (logs warn) when the semantic root is unreadable/missing", () => {
+    const { warnings, logger } = makeLogger();
+    const files = collectSemanticFiles(
+      path.join(root, "does-not-exist"),
+      "semantic",
+      logger,
+    );
+    expect(files).toEqual([]);
+    expect(warnings.some((w) => w.includes("unreadable semantic root"))).toBe(true);
+  });
+
+  test("skips an unreadable file but keeps the rest (logs warn)", () => {
+    fs.writeFileSync(path.join(root, "good.yml"), "ok: true\n");
+    fs.writeFileSync(path.join(root, "bad.yml"), "secret: 1\n");
+
+    const realReadFileSync = fs.readFileSync;
+    const spy = spyOn(fs, "readFileSync").mockImplementation(
+      ((p: fs.PathOrFileDescriptor, ...rest: unknown[]) => {
+        if (typeof p === "string" && p.endsWith("bad.yml")) {
+          throw new Error("EACCES: permission denied");
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realReadFileSync as any)(p, ...rest);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    try {
+      const { warnings, logger } = makeLogger();
+      const files = collectSemanticFiles(root, "semantic", logger);
+      const paths = files.map((f) => f.path);
+      expect(paths).toContain("semantic/good.yml");
+      expect(paths).not.toContain("semantic/bad.yml");
+      expect(warnings.some((w) => w.includes("unreadable file") && w.includes("bad.yml"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("skips an unreadable subdirectory but keeps the rest (logs warn)", () => {
+    fs.mkdirSync(path.join(root, "open"), { recursive: true });
+    fs.mkdirSync(path.join(root, "locked"), { recursive: true });
+    fs.writeFileSync(path.join(root, "open", "a.yml"), "a: 1\n");
+    fs.writeFileSync(path.join(root, "locked", "b.yml"), "b: 1\n");
+
+    const realReaddirSync = fs.readdirSync;
+    const spy = spyOn(fs, "readdirSync").mockImplementation(
+      ((p: fs.PathLike, ...rest: unknown[]) => {
+        if (typeof p === "string" && p.endsWith(`${path.sep}locked`)) {
+          throw new Error("EACCES: permission denied");
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realReaddirSync as any)(p, ...rest);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    try {
+      const { warnings, logger } = makeLogger();
+      const files = collectSemanticFiles(root, "semantic", logger);
+      const paths = files.map((f) => f.path);
+      expect(paths).toContain("semantic/open/a.yml");
+      expect(paths).not.toContain("semantic/locked/b.yml");
+      expect(warnings.some((w) => w.includes("unreadable directory"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runHealthCheckWithTimeout
+// ---------------------------------------------------------------------------
+
+describe("runHealthCheckWithTimeout", () => {
+  test("returns the probe result plus a measured latency on success", async () => {
+    const cleanup = mock(() => Promise.resolve());
+    const result = await runHealthCheckWithTimeout(
+      async () => ({ healthy: true }),
+      { timeoutMs: 1_000, cleanup },
+    );
+    expect(result.healthy).toBe(true);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    // Cleanup is the timeout/error safety net — never invoked on success.
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  test("passes through an unhealthy probe result without invoking cleanup", async () => {
+    const cleanup = mock(() => Promise.resolve());
+    const result = await runHealthCheckWithTimeout(
+      async () => ({ healthy: false, message: "exit 1" }),
+      { timeoutMs: 1_000, cleanup },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("exit 1");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  test("times out a hung probe and runs cleanup", async () => {
+    let cleaned = false;
+    // Simulates a create() that hangs past the timeout — the helper must not
+    // wait for it, and must run cleanup so the sandbox reference is reaped.
+    const result = await runHealthCheckWithTimeout(
+      () => new Promise(() => {}),
+      {
+        timeoutMs: 20,
+        cleanup: () => {
+          cleaned = true;
+        },
+      },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("timed out after 20ms");
+    expect(cleaned).toBe(true);
+  });
+
+  test("times out mid-create and cleans up the reference the probe assigned", async () => {
+    // Mirrors the real plugins: the probe assigns a sandbox ref while creating,
+    // the timeout wins before create resolves, and cleanup destroys whatever
+    // the probe left behind.
+    let sandbox: { destroyed: boolean } | null = null;
+    const cleanup = mock(async () => {
+      if (sandbox) {
+        sandbox.destroyed = true;
+        sandbox = null;
+      }
+    });
+    const result = await runHealthCheckWithTimeout(
+      async () => {
+        sandbox = { destroyed: false };
+        await new Promise((r) => setTimeout(r, 200)); // create hangs past timeout
+        return { healthy: true };
+      },
+      { timeoutMs: 20, cleanup },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("timed out after 20ms");
+    expect(cleanup).toHaveBeenCalled();
+    // wait for the slow probe to finish so the ref it set is observable
+    await new Promise((r) => setTimeout(r, 250));
+    // cleanup nulled it before the probe's create resolved
+    expect(sandbox).toBeNull();
+  });
+
+  test("returns unhealthy and runs cleanup when the probe throws", async () => {
+    const cleanup = mock(() => Promise.resolve());
+    const result = await runHealthCheckWithTimeout(
+      async () => {
+        throw new Error("quota exceeded");
+      },
+      { timeoutMs: 1_000, cleanup },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("quota exceeded");
+    expect(cleanup).toHaveBeenCalled();
+  });
+
+  test("a throwing cleanup is logged, not propagated", async () => {
+    const { warnings, logger } = makeLogger();
+    const result = await runHealthCheckWithTimeout(
+      async () => {
+        throw new Error("probe boom");
+      },
+      {
+        timeoutMs: 1_000,
+        cleanup: () => {
+          throw new Error("cleanup boom");
+        },
+        logger,
+      },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("probe boom");
+    expect(warnings.some((w) => w.includes("cleanup") && w.includes("cleanup boom"))).toBe(true);
+  });
+
+  test("normalizes a non-Error probe rejection into a string message", async () => {
+    const result = await runHealthCheckWithTimeout(
+      async () => {
+        throw "plain string failure";
+      },
+      { timeoutMs: 1_000, cleanup: () => {} },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("plain string failure");
+  });
+});

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -298,11 +298,13 @@ export interface CollectedSemanticFile {
   /** POSIX-style path under the sandbox dir, e.g. `"semantic/entities/users.yml"`. */
   path: string;
   /**
-   * Raw file bytes. Sandbox SDKs that want string content can call
-   * `.toString()` (or `.toString("utf-8")`) at the call site — keeping the
-   * shared collector binary-safe avoids an encoding round-trip.
+   * Raw file bytes (binary-safe — the collector does no encoding round-trip).
+   * Typed as the portable `Uint8Array` so the published SDK surface carries no
+   * Node `Buffer` global; the runtime value IS a Node `Buffer`, so call sites
+   * that want string content use `Buffer.from(content).toString("utf-8")` (or
+   * `new TextDecoder().decode(content)`).
    */
-  content: Buffer;
+  content: Uint8Array;
 }
 
 /**
@@ -318,7 +320,10 @@ export interface CollectedSemanticFile {
  * traversal are both rejected — a bare `startsWith(root)` would not catch the
  * former. Unreadable directories/files (and an unreadable/missing root) are
  * skipped with a warning rather than throwing, so a partially-readable tree
- * still yields the files it can.
+ * still yields the files it can. Symlink cycles (a directory symlink resolving
+ * to an already-walked directory, e.g. a self-link back to the root) are broken
+ * via a visited-realpath set, so a self-referential tree terminates instead of
+ * re-uploading the same files until the OS aborts with `ELOOP`.
  *
  * @param localDir   Absolute path to the local semantic directory to walk.
  * @param sandboxDir Remote path prefix for the returned `path` values.
@@ -349,6 +354,13 @@ export function collectSemanticFiles(
     return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
   }
 
+  // Real directories already walked, keyed by realpath. Seeded with the root so
+  // a directory symlink resolving back to an ancestor (a cycle) is skipped
+  // instead of re-walked. Only directory symlinks are tracked — a tree of real
+  // directories cannot cycle, so non-symlink recursion stays as before (and
+  // distinct symlinks to the same in-root dir keep their prior dup behavior).
+  const visitedDirs = new Set<string>([semanticRoot]);
+
   function walk(dir: string, relative: string): void {
     let entries: fs.Dirent[];
     try {
@@ -374,6 +386,12 @@ export function collectSemanticFiles(
           }
           const stat = fs.statSync(entryPath);
           if (stat.isDirectory()) {
+            if (visitedDirs.has(realPath)) {
+              // Symlink cycle — this dir's real path was already walked. Skip so
+              // a self-referential tree terminates instead of looping forever.
+              continue;
+            }
+            visitedDirs.add(realPath);
             walk(entryPath, remotePath);
           } else if (stat.isFile()) {
             results.push({ path: remotePath, content: fs.readFileSync(entryPath) });
@@ -413,7 +431,12 @@ export interface HealthCheckTimeoutOptions {
    * thrown here are logged, never propagated.
    */
   cleanup: () => void | Promise<void>;
-  /** Optional logger; `warn` is called if `cleanup` throws. */
+  /**
+   * Optional logger; `warn` is called on every failing branch — the probe
+   * timing out, the probe throwing, and `cleanup` throwing. (Success and a
+   * returned unhealthy result are not logged; the latter is the probe's to
+   * report.)
+   */
   logger?: SandboxHelperLogger;
 }
 
@@ -439,10 +462,17 @@ const HEALTH_CHECK_TIMEOUT = Symbol("plugin-sdk:health-check-timeout");
  * reference reaped here fires immediately instead.
  */
 export async function runHealthCheckWithTimeout(
-  fn: () => Promise<Omit<PluginHealthResult, "latencyMs">>,
+  fn: () => Promise<Omit<PluginHealthResult, "latencyMs"> & { latencyMs?: never }>,
   options: HealthCheckTimeoutOptions,
 ): Promise<PluginHealthResult> {
   const { timeoutMs, cleanup, logger } = options;
+  // Fail fast on a misconfigured timeout: setTimeout coerces NaN/negative to 0,
+  // which would silently report every probe as timed-out/unhealthy.
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `runHealthCheckWithTimeout: timeoutMs must be a positive, finite number (got ${timeoutMs})`,
+    );
+  }
   const start = performance.now();
   let timer: ReturnType<typeof setTimeout>;
 
@@ -466,6 +496,7 @@ export async function runHealthCheckWithTimeout(
 
     const latencyMs = Math.round(performance.now() - start);
     if (result === HEALTH_CHECK_TIMEOUT) {
+      logger?.warn(`[plugin-sdk] Health check timed out after ${timeoutMs}ms`);
       await runCleanup();
       return {
         healthy: false,
@@ -475,10 +506,12 @@ export async function runHealthCheckWithTimeout(
     }
     return { ...result, latencyMs };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger?.warn(`[plugin-sdk] Health check probe failed: ${message}`);
     await runCleanup();
     return {
       healthy: false,
-      message: err instanceof Error ? err.message : String(err),
+      message,
       latencyMs: Math.round(performance.now() - start),
     };
   }

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -1,7 +1,11 @@
 /**
- * Plugin SDK helpers — factory function, createPlugin, and type guards.
+ * Plugin SDK helpers — factory function, createPlugin, type guards, and the
+ * shared sandbox-plugin infrastructure (`collectSemanticFiles`,
+ * `runHealthCheckWithTimeout`).
  */
 
+import * as fs from "fs";
+import * as path from "path";
 import type {
   AtlasPlugin,
   AtlasPluginBase,
@@ -10,6 +14,7 @@ import type {
   AtlasInteractionPlugin,
   AtlasActionPlugin,
   AtlasSandboxPlugin,
+  PluginHealthResult,
 } from "./types";
 
 const VALID_TYPES: Set<string> = new Set(["datasource", "context", "interaction", "action", "sandbox"]);
@@ -277,4 +282,204 @@ export function isSandboxPlugin(
   plugin: AtlasPlugin,
 ): plugin is AtlasSandboxPlugin {
   return plugin.types.includes("sandbox");
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox helpers — shared infrastructure for AtlasSandboxPlugin authors
+// ---------------------------------------------------------------------------
+
+/** Minimal logger surface used by the sandbox helpers (pino/PluginLogger compatible). */
+export interface SandboxHelperLogger {
+  warn(msg: string): void;
+}
+
+/** A single semantic-layer file collected for upload into a sandbox. */
+export interface CollectedSemanticFile {
+  /** POSIX-style path under the sandbox dir, e.g. `"semantic/entities/users.yml"`. */
+  path: string;
+  /**
+   * Raw file bytes. Sandbox SDKs that want string content can call
+   * `.toString()` (or `.toString("utf-8")`) at the call site — keeping the
+   * shared collector binary-safe avoids an encoding round-trip.
+   */
+  content: Buffer;
+}
+
+/**
+ * Recursively collect every file under `localDir` into `{ path, content }`
+ * tuples, rooting each remote path at `sandboxDir`. The semantic tree is the
+ * payload a sandbox plugin uploads into its microVM so the explore tool can
+ * `cat`/`grep`/`ls` it.
+ *
+ * **Security — symlink-escape guard (single-sourced, #3373):** a symlink whose
+ * real target resolves OUTSIDE the semantic root is skipped (and logged),
+ * never uploaded. Containment is checked with `path.relative` against the
+ * realpath-resolved root, so prefix collisions (`${root}_evil/…`) and `..`
+ * traversal are both rejected — a bare `startsWith(root)` would not catch the
+ * former. Unreadable directories/files (and an unreadable/missing root) are
+ * skipped with a warning rather than throwing, so a partially-readable tree
+ * still yields the files it can.
+ *
+ * @param localDir   Absolute path to the local semantic directory to walk.
+ * @param sandboxDir Remote path prefix for the returned `path` values.
+ * @param logger     Optional logger; `warn` is called for each skipped entry.
+ */
+export function collectSemanticFiles(
+  localDir: string,
+  sandboxDir: string,
+  logger?: SandboxHelperLogger,
+): CollectedSemanticFile[] {
+  const results: CollectedSemanticFile[] = [];
+
+  // Resolve the root once so the containment check compares real paths. If the
+  // root can't be resolved (missing/unreadable), behave like an unreadable
+  // directory: warn and return nothing.
+  let semanticRoot: string;
+  try {
+    semanticRoot = fs.realpathSync(localDir);
+  } catch (err) {
+    logger?.warn(
+      `[plugin-sdk] Skipping unreadable semantic root ${localDir}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return results;
+  }
+
+  function isInsideSemanticRoot(realPath: string): boolean {
+    const rel = path.relative(semanticRoot, realPath);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  }
+
+  function walk(dir: string, relative: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      logger?.warn(
+        `[plugin-sdk] Skipping unreadable directory ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      const remotePath = `${relative}/${entry.name}`;
+
+      if (entry.isSymbolicLink()) {
+        try {
+          const realPath = fs.realpathSync(entryPath);
+          if (!isInsideSemanticRoot(realPath)) {
+            logger?.warn(
+              `[plugin-sdk] Skipping symlink escaping semantic root: ${entryPath} -> ${realPath}`,
+            );
+            continue;
+          }
+          const stat = fs.statSync(entryPath);
+          if (stat.isDirectory()) {
+            walk(entryPath, remotePath);
+          } else if (stat.isFile()) {
+            results.push({ path: remotePath, content: fs.readFileSync(entryPath) });
+          }
+        } catch (err) {
+          logger?.warn(
+            `[plugin-sdk] Skipping unreadable symlink ${entryPath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      } else if (entry.isDirectory()) {
+        walk(entryPath, remotePath);
+      } else if (entry.isFile()) {
+        try {
+          results.push({ path: remotePath, content: fs.readFileSync(entryPath) });
+        } catch (err) {
+          logger?.warn(
+            `[plugin-sdk] Skipping unreadable file ${entryPath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  walk(localDir, sandboxDir);
+  return results;
+}
+
+/** Options for {@link runHealthCheckWithTimeout}. */
+export interface HealthCheckTimeoutOptions {
+  /** Milliseconds before the probe is abandoned and reported as timed out. */
+  timeoutMs: number;
+  /**
+   * Safety-net cleanup, invoked ONLY when the probe times out or throws (never
+   * on a returned result — the probe owns its own happy-path teardown). Must be
+   * idempotent and guarded: it typically destroys a sandbox reference the probe
+   * captured, so it should no-op when that reference is already cleared. Errors
+   * thrown here are logged, never propagated.
+   */
+  cleanup: () => void | Promise<void>;
+  /** Optional logger; `warn` is called if `cleanup` throws. */
+  logger?: SandboxHelperLogger;
+}
+
+// Distinct sentinel so a probe that resolves to a string can never be mistaken
+// for the timeout branch.
+const HEALTH_CHECK_TIMEOUT = Symbol("plugin-sdk:health-check-timeout");
+
+/**
+ * Run a sandbox `healthCheck()` probe under a timeout, attaching a measured
+ * `latencyMs` and running cleanup-in-every-failing-branch (single-sourced,
+ * #3373).
+ *
+ * The probe (`fn`) creates whatever it needs, performs the check, tears down
+ * its own resources on the happy path, and returns a `PluginHealthResult`
+ * without `latencyMs` (added here). When the `Promise.race` timeout wins — or
+ * the probe throws — `cleanup` runs to reap any resource the probe captured but
+ * could not release.
+ *
+ * **Why not `await using`?** The timeout can win while the probe is still
+ * mid-create/exec, and the sandbox SDKs expose no `AbortSignal` on create — a
+ * scope-bound disposer would only fire once the (possibly hung) operation
+ * settled, leaking the microVM past the timeout. An explicit, guarded `cleanup`
+ * reference reaped here fires immediately instead.
+ */
+export async function runHealthCheckWithTimeout(
+  fn: () => Promise<Omit<PluginHealthResult, "latencyMs">>,
+  options: HealthCheckTimeoutOptions,
+): Promise<PluginHealthResult> {
+  const { timeoutMs, cleanup, logger } = options;
+  const start = performance.now();
+  let timer: ReturnType<typeof setTimeout>;
+
+  const runCleanup = async (): Promise<void> => {
+    try {
+      await cleanup();
+    } catch (err) {
+      logger?.warn(
+        `[plugin-sdk] Health-check cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  try {
+    const result = await Promise.race([
+      fn(),
+      new Promise<typeof HEALTH_CHECK_TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(HEALTH_CHECK_TIMEOUT), timeoutMs);
+      }),
+    ]).finally(() => clearTimeout(timer!));
+
+    const latencyMs = Math.round(performance.now() - start);
+    if (result === HEALTH_CHECK_TIMEOUT) {
+      await runCleanup();
+      return {
+        healthy: false,
+        message: `Health check timed out after ${timeoutMs}ms`,
+        latencyMs,
+      };
+    }
+    return { ...result, latencyMs };
+  } catch (err) {
+    await runCleanup();
+    return {
+      healthy: false,
+      message: err instanceof Error ? err.message : String(err),
+      latencyMs: Math.round(performance.now() - start),
+    };
+  }
 }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -82,9 +82,16 @@ export {
   isInteractionPlugin,
   isActionPlugin,
   isSandboxPlugin,
+  collectSemanticFiles,
+  runHealthCheckWithTimeout,
 } from "./helpers";
 
-export type { CreatePluginOptions } from "./helpers";
+export type {
+  CreatePluginOptions,
+  CollectedSemanticFile,
+  SandboxHelperLogger,
+  HealthCheckTimeoutOptions,
+} from "./helpers";
 
 export { gateOnSemanticWhitelist, warnIfStructuralOnly } from "./semantic-whitelist";
 export type { SemanticWhitelistSubject, SemanticWhitelistGate } from "./semantic-whitelist";

--- a/packages/plugin-sdk/tsconfig.build.json
+++ b/packages/plugin-sdk/tsconfig.build.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "types": []
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/__tests__/**"]

--- a/plugins/daytona/src/index.ts
+++ b/plugins/daytona/src/index.ts
@@ -103,7 +103,8 @@ function createDaytonaClient(DaytonaClass: any, config: DaytonaSandboxConfig): a
 
 // The semantic-tree walker (with its symlink-escape guard) now lives in
 // @useatlas/plugin-sdk — `collectSemanticFiles` — returning binary-safe
-// `{ path, content: Buffer }` tuples that daytona uploads via fs.uploadFile.
+// `{ path, content: Uint8Array }` tuples (a Node Buffer at runtime) that
+// daytona uploads via fs.uploadFile.
 
 // ---------------------------------------------------------------------------
 // Plugin builder

--- a/plugins/daytona/src/index.ts
+++ b/plugins/daytona/src/index.ts
@@ -24,15 +24,17 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import {
+  createPlugin,
+  collectSemanticFiles,
+  runHealthCheckWithTimeout,
+} from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
   PluginExecResult,
   PluginHealthResult,
 } from "@useatlas/plugin-sdk";
-import * as path from "path";
-import * as fs from "fs";
 
 // ---------------------------------------------------------------------------
 // Config schema
@@ -99,67 +101,9 @@ function createDaytonaClient(DaytonaClass: any, config: DaytonaSandboxConfig): a
   });
 }
 
-// ---------------------------------------------------------------------------
-// Semantic file collection (copied from explore-sandbox.ts)
-// ---------------------------------------------------------------------------
-
-function collectSemanticFiles(
-  localDir: string,
-  sandboxDir: string,
-  logger?: { warn(msg: string): void },
-): { path: string; content: Buffer }[] {
-  const results: { path: string; content: Buffer }[] = [];
-
-  function walk(dir: string, relative: string) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-      logger?.warn(`[daytona-sandbox] Skipping unreadable directory ${dir}: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
-    for (const entry of entries) {
-      const localPath = path.join(dir, entry.name);
-      const remotePath = `${relative}/${entry.name}`;
-
-      if (entry.isSymbolicLink()) {
-        try {
-          const realPath = fs.realpathSync(localPath);
-          if (!realPath.startsWith(localDir)) {
-            logger?.warn(`[daytona-sandbox] Skipping symlink escaping semantic root: ${localPath} -> ${realPath}`);
-            continue;
-          }
-          const stat = fs.statSync(localPath);
-          if (stat.isDirectory()) {
-            walk(localPath, remotePath);
-          } else if (stat.isFile()) {
-            results.push({
-              path: remotePath,
-              content: fs.readFileSync(localPath),
-            });
-          }
-        } catch (err) {
-          logger?.warn(`[daytona-sandbox] Skipping unreadable symlink ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-          continue;
-        }
-      } else if (entry.isDirectory()) {
-        walk(localPath, remotePath);
-      } else if (entry.isFile()) {
-        try {
-          results.push({
-            path: remotePath,
-            content: fs.readFileSync(localPath),
-          });
-        } catch (err) {
-          logger?.warn(`[daytona-sandbox] Skipping unreadable file ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      }
-    }
-  }
-
-  walk(localDir, sandboxDir);
-  return results;
-}
+// The semantic-tree walker (with its symlink-escape guard) now lives in
+// @useatlas/plugin-sdk — `collectSemanticFiles` — returning binary-safe
+// `{ path, content: Buffer }` tuples that daytona uploads via fs.uploadFile.
 
 // ---------------------------------------------------------------------------
 // Plugin builder
@@ -295,13 +239,10 @@ export function buildDaytonaSandboxPlugin(
     // Note: each health check creates a Daytona sandbox instance.
     // Avoid calling at high frequency to minimize API costs.
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const TIMEOUT = 30_000;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let sandbox: any = null;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let daytonaRef: any = null;
-      let timer: ReturnType<typeof setTimeout>;
 
       const cleanupSandbox = async () => {
         if (sandbox && daytonaRef) {
@@ -314,60 +255,42 @@ export function buildDaytonaSandboxPlugin(
         }
       };
 
-      try {
-        const result = await Promise.race([
-          (async () => {
-            const DaytonaClass = loadDaytonaSdk();
-            daytonaRef = createDaytonaClient(DaytonaClass, config);
+      return runHealthCheckWithTimeout(
+        async () => {
+          const DaytonaClass = loadDaytonaSdk();
+          daytonaRef = createDaytonaClient(DaytonaClass, config);
 
-            try {
-              sandbox = await daytonaRef.create();
-            } catch (err) {
-              return {
-                healthy: false as const,
-                message: `Failed to create sandbox: ${err instanceof Error ? err.message : String(err)}`,
-              };
+          try {
+            sandbox = await daytonaRef.create();
+          } catch (err) {
+            return {
+              healthy: false,
+              message: `Failed to create sandbox: ${err instanceof Error ? err.message : String(err)}`,
+            };
+          }
+
+          try {
+            const response = await sandbox.process.executeCommand(
+              "echo daytona-ok",
+              "/home/daytona",
+              undefined,
+              config.timeoutSec,
+            );
+
+            if (response.exitCode === 0 && (response.result ?? "").includes("daytona-ok")) {
+              return { healthy: true };
             }
 
-            try {
-              const response = await sandbox.process.executeCommand(
-                "echo daytona-ok",
-                "/home/daytona",
-                undefined,
-                config.timeoutSec,
-              );
-
-              if (response.exitCode === 0 && (response.result ?? "").includes("daytona-ok")) {
-                return { healthy: true as const };
-              }
-
-              return {
-                healthy: false as const,
-                message: `Health check command failed (exit ${response.exitCode})`,
-              };
-            } finally {
-              await cleanupSandbox();
-            }
-          })(),
-          new Promise<"timeout">((resolve) => {
-            timer = setTimeout(() => resolve("timeout"), TIMEOUT);
-          }),
-        ]).finally(() => clearTimeout(timer!));
-
-        const latencyMs = Math.round(performance.now() - start);
-        if (result === "timeout") {
-          await cleanupSandbox();
-          return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
-        }
-        return { ...result, latencyMs };
-      } catch (err) {
-        await cleanupSandbox();
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+            return {
+              healthy: false,
+              message: `Health check command failed (exit ${response.exitCode})`,
+            };
+          } finally {
+            await cleanupSandbox();
+          }
+        },
+        { timeoutMs: 30_000, cleanup: cleanupSandbox, logger: log },
+      );
     },
   };
 }

--- a/plugins/e2b/src/index.ts
+++ b/plugins/e2b/src/index.ts
@@ -24,15 +24,17 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import {
+  createPlugin,
+  collectSemanticFiles,
+  runHealthCheckWithTimeout,
+} from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
   PluginExecResult,
   PluginHealthResult,
 } from "@useatlas/plugin-sdk";
-import * as fs from "fs";
-import * as path from "path";
 
 // ---------------------------------------------------------------------------
 // Config schema
@@ -85,68 +87,10 @@ function loadE2BSDK(): { Sandbox: any } {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Semantic file collector (adapted from explore-sandbox.ts)
-// ---------------------------------------------------------------------------
-
-function collectSemanticFiles(
-  localDir: string,
-  sandboxDir: string,
-  logger?: { warn(msg: string): void },
-): { path: string; data: string }[] {
-  const results: { path: string; data: string }[] = [];
-
-  function walk(dir: string, relative: string) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-      logger?.warn(`[e2b-sandbox] Skipping unreadable directory ${dir}: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
-    for (const entry of entries) {
-      const localPath = path.join(dir, entry.name);
-      const remotePath = `${relative}/${entry.name}`;
-
-      if (entry.isSymbolicLink()) {
-        try {
-          const realPath = fs.realpathSync(localPath);
-          if (!realPath.startsWith(localDir)) {
-            logger?.warn(`[e2b-sandbox] Skipping symlink escaping semantic root: ${localPath} -> ${realPath}`);
-            continue;
-          }
-          const stat = fs.statSync(localPath);
-          if (stat.isDirectory()) {
-            walk(localPath, remotePath);
-          } else if (stat.isFile()) {
-            results.push({
-              path: remotePath,
-              data: fs.readFileSync(localPath, "utf-8"),
-            });
-          }
-        } catch (err) {
-          logger?.warn(`[e2b-sandbox] Skipping unreadable symlink ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-          continue;
-        }
-      } else if (entry.isDirectory()) {
-        walk(localPath, remotePath);
-      } else if (entry.isFile()) {
-        try {
-          results.push({
-            path: remotePath,
-            data: fs.readFileSync(localPath, "utf-8"),
-          });
-        } catch (err) {
-          logger?.warn(`[e2b-sandbox] Skipping unreadable file ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-          continue;
-        }
-      }
-    }
-  }
-
-  walk(localDir, sandboxDir);
-  return results;
-}
+// The semantic-tree walker (with its symlink-escape guard) now lives in
+// @useatlas/plugin-sdk — `collectSemanticFiles`. E2B's `files.write` wants
+// `{ path, data: string }`, so the call site maps the shared Buffer content
+// via `.toString("utf-8")`.
 
 // ---------------------------------------------------------------------------
 // Shared helper — create an E2B sandbox instance
@@ -183,8 +127,11 @@ export function buildE2BSandboxPlugin(
         const sandbox = await createE2BSandbox(config);
 
         try {
-          // Collect and upload semantic layer files
-          const files = collectSemanticFiles(semanticRoot, "semantic", log);
+          // Collect and upload semantic layer files. The shared collector is
+          // binary-safe (Buffer content); E2B's files.write wants string data.
+          const files = collectSemanticFiles(semanticRoot, "semantic", log).map(
+            (f) => ({ path: f.path, data: f.content.toString("utf-8") }),
+          );
 
           if (files.length > 0) {
             await sandbox.files.write(files);
@@ -249,41 +196,32 @@ export function buildE2BSandboxPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const TIMEOUT = 30_000;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let sandbox: any = null;
-      let timer: ReturnType<typeof setTimeout>;
-      try {
-        const result = await Promise.race([
-          (async () => {
-            sandbox = await createE2BSandbox(config);
-            await sandbox.kill();
-            sandbox = null;
-            return "ok" as const;
-          })(),
-          new Promise<"timeout">((resolve) => {
-            timer = setTimeout(() => resolve("timeout"), TIMEOUT);
-          }),
-        ]).finally(() => clearTimeout(timer!));
-        const latencyMs = Math.round(performance.now() - start);
-        if (result === "timeout") {
-          if (sandbox) {
-            try { await sandbox.kill(); } catch { /* best-effort cleanup */ }
-          }
-          return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
-        }
-        return { healthy: true, latencyMs };
-      } catch (err) {
-        if (sandbox) {
-          try { await sandbox.kill(); } catch { /* best-effort cleanup */ }
-        }
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+      return runHealthCheckWithTimeout(
+        async () => {
+          sandbox = await createE2BSandbox(config);
+          await sandbox.kill();
+          sandbox = null;
+          return { healthy: true };
+        },
+        {
+          timeoutMs: 30_000,
+          logger: log,
+          cleanup: async () => {
+            if (sandbox) {
+              try {
+                await sandbox.kill();
+              } catch (err) {
+                log?.warn(
+                  `[e2b-sandbox] Failed to kill health-check sandbox: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
+              sandbox = null;
+            }
+          },
+        },
+      );
     },
   };
 }

--- a/plugins/e2b/src/index.ts
+++ b/plugins/e2b/src/index.ts
@@ -89,8 +89,8 @@ function loadE2BSDK(): { Sandbox: any } {
 
 // The semantic-tree walker (with its symlink-escape guard) now lives in
 // @useatlas/plugin-sdk — `collectSemanticFiles`. E2B's `files.write` wants
-// `{ path, data: string }`, so the call site maps the shared Buffer content
-// via `.toString("utf-8")`.
+// `{ path, data: string }`, so the call site decodes the shared `Uint8Array`
+// content via `Buffer.from(content).toString("utf-8")`.
 
 // ---------------------------------------------------------------------------
 // Shared helper — create an E2B sandbox instance
@@ -128,9 +128,10 @@ export function buildE2BSandboxPlugin(
 
         try {
           // Collect and upload semantic layer files. The shared collector is
-          // binary-safe (Buffer content); E2B's files.write wants string data.
+          // binary-safe (Uint8Array content); E2B's files.write wants string
+          // data, so decode each via Buffer.
           const files = collectSemanticFiles(semanticRoot, "semantic", log).map(
-            (f) => ({ path: f.path, data: f.content.toString("utf-8") }),
+            (f) => ({ path: f.path, data: Buffer.from(f.content).toString("utf-8") }),
           );
 
           if (files.length > 0) {

--- a/plugins/railway-sandbox/src/index.ts
+++ b/plugins/railway-sandbox/src/index.ts
@@ -103,12 +103,13 @@ interface RailwayExecResult {
 }
 
 // Native binary-safe file surface (railway >= 3.3.0). We declare only the two
-// operations the upload path needs; `write` accepts a Buffer (a Uint8Array) and
-// auto-creates parent directories, `mkdir` is `mkdir -p`. Optional defensively:
-// an older SDK exposes no `files` getter, which the backend turns into a clear
-// install-hint error rather than a crash.
+// operations the upload path needs; `write` accepts a Uint8Array (a Node Buffer
+// at runtime, which the SDK accepts) and auto-creates parent directories,
+// `mkdir` is `mkdir -p`. Optional defensively: an older SDK exposes no `files`
+// getter, which the backend turns into a clear install-hint error rather than a
+// crash.
 interface RailwaySandboxFiles {
-  write(path: string, content: Buffer): Promise<void>;
+  write(path: string, content: Uint8Array): Promise<void>;
   mkdir(path: string): Promise<void>;
 }
 
@@ -184,7 +185,7 @@ function shellQuote(s: string): string {
 
 async function uploadSemanticFiles(
   sandbox: RailwaySandboxInstance,
-  files: { path: string; content: Buffer }[],
+  files: { path: string; content: Uint8Array }[],
 ): Promise<void> {
   // The native files API (railway >= 3.3.0) is binary-safe, streamed, and
   // creates parent dirs on write — none of the old base64-over-exec machinery
@@ -308,7 +309,7 @@ async function createRailwayExploreBackend(
 
   // 2. Collect semantic layer files BEFORE creating the sandbox — no point
   // paying for a microVM when the semantic dir is empty/unreadable.
-  let files: { path: string; content: Buffer }[];
+  let files: { path: string; content: Uint8Array }[];
   try {
     files = collectSemanticFiles(semanticRoot, "semantic", log);
   } catch (err) {

--- a/plugins/railway-sandbox/src/index.ts
+++ b/plugins/railway-sandbox/src/index.ts
@@ -41,15 +41,17 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import {
+  createPlugin,
+  collectSemanticFiles,
+  runHealthCheckWithTimeout,
+} from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
   PluginExecResult,
   PluginHealthResult,
 } from "@useatlas/plugin-sdk";
-import * as path from "path";
-import * as fs from "fs";
 
 // ---------------------------------------------------------------------------
 // Sensitive pattern regex (subset of @atlas/api/lib/security.ts adapted for
@@ -163,75 +165,9 @@ async function loadRailwaySdk(): Promise<{ Sandbox: RailwaySandboxConstructor }>
   }
 }
 
-// ---------------------------------------------------------------------------
-// Semantic file collection (mirrors explore-sandbox.ts; symlink-escape guarded)
-// ---------------------------------------------------------------------------
-
-export function collectSemanticFiles(
-  localDir: string,
-  sandboxDir: string,
-  logger?: { warn(msg: string): void },
-): { path: string; content: Buffer }[] {
-  const results: { path: string; content: Buffer }[] = [];
-  // Resolve the root once so the symlink containment check compares real
-  // paths via path.relative — a bare startsWith(localDir) would accept
-  // prefix collisions like `${localDir}_evil/…`.
-  const semanticRoot = fs.realpathSync(localDir);
-
-  function isInsideSemanticRoot(realPath: string): boolean {
-    const rel = path.relative(semanticRoot, realPath);
-    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
-  }
-
-  function walk(dir: string, relative: string) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-      logger?.warn(`[railway-sandbox] Skipping unreadable directory ${dir}: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
-    for (const entry of entries) {
-      const localPath = path.join(dir, entry.name);
-      const remotePath = `${relative}/${entry.name}`;
-
-      if (entry.isSymbolicLink()) {
-        try {
-          const realPath = fs.realpathSync(localPath);
-          if (!isInsideSemanticRoot(realPath)) {
-            logger?.warn(`[railway-sandbox] Skipping symlink escaping semantic root: ${localPath} -> ${realPath}`);
-            continue;
-          }
-          const stat = fs.statSync(localPath);
-          if (stat.isDirectory()) {
-            walk(localPath, remotePath);
-          } else if (stat.isFile()) {
-            results.push({
-              path: remotePath,
-              content: fs.readFileSync(localPath),
-            });
-          }
-        } catch (err) {
-          logger?.warn(`[railway-sandbox] Skipping unreadable symlink ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      } else if (entry.isDirectory()) {
-        walk(localPath, remotePath);
-      } else if (entry.isFile()) {
-        try {
-          results.push({
-            path: remotePath,
-            content: fs.readFileSync(localPath),
-          });
-        } catch (err) {
-          logger?.warn(`[railway-sandbox] Skipping unreadable file ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      }
-    }
-  }
-
-  walk(localDir, sandboxDir);
-  return results;
-}
+// The semantic-tree walker (with its symlink-escape guard, the canonical
+// path.relative-based containment check this plugin originated) now lives in
+// @useatlas/plugin-sdk — `collectSemanticFiles` — shared across sandbox plugins.
 
 // ---------------------------------------------------------------------------
 // Upload helpers
@@ -500,61 +436,46 @@ export function buildRailwaySandboxPlugin(
     // Avoid calling at high frequency — creations bill and count toward the
     // per-environment sandbox cap.
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const TIMEOUT = 30_000;
-      // The timeout race can win while the IIFE is still mid-create/exec, so
-      // keep an explicit reference and destroy in every branch (same rationale
-      // as the vercel-sandbox plugin's health check).
+      // The timeout race can win while the probe is still mid-create/exec, so
+      // keep an explicit reference and destroy in every failing branch (same
+      // rationale as the shared runHealthCheckWithTimeout helper's docs).
       let sandbox: RailwaySandboxInstance | null = null;
-      let timer: ReturnType<typeof setTimeout>;
-      try {
-        const result = await Promise.race([
-          (async () => {
-            const { Sandbox } = await loadRailwaySdk();
+      return runHealthCheckWithTimeout(
+        async () => {
+          const { Sandbox } = await loadRailwaySdk();
 
-            // Short backstop — a health-check sandbox should never outlive
-            // its check by more than a minute even if destroy() fails.
-            sandbox = await Sandbox.create(buildCreateOpts(config, 1));
-            const res = await sandbox.exec("echo railway-ok", {
-              timeoutSec: config.timeoutSec,
-            });
-            await destroyQuietly(sandbox, log, "after health check");
-            sandbox = null;
+          // Short backstop — a health-check sandbox should never outlive
+          // its check by more than a minute even if destroy() fails.
+          sandbox = await Sandbox.create(buildCreateOpts(config, 1));
+          const res = await sandbox.exec("echo railway-ok", {
+            timeoutSec: config.timeoutSec,
+          });
+          await destroyQuietly(sandbox, log, "after health check");
+          sandbox = null;
 
-            if (res.exitCode === 0 && (res.stdout ?? "").includes("railway-ok")) {
-              return { healthy: true as const };
+          if (res.exitCode === 0 && (res.stdout ?? "").includes("railway-ok")) {
+            return { healthy: true };
+          }
+          return {
+            healthy: false,
+            message: `Sandbox test command failed (exit ${res.exitCode ?? "unknown"})`,
+          };
+        },
+        {
+          timeoutMs: 30_000,
+          logger: log,
+          cleanup: async () => {
+            // Best-effort cleanup — the probe may still be mid-create. Cast
+            // needed: TS narrows `sandbox` to null (the probe ends with
+            // sandbox = null) but the race means it may not have run.
+            const sb = sandbox as RailwaySandboxInstance | null;
+            if (sb) {
+              await destroyQuietly(sb, log, "after health-check failure");
+              sandbox = null;
             }
-            return {
-              healthy: false as const,
-              message: `Sandbox test command failed (exit ${res.exitCode ?? "unknown"})`,
-            };
-          })(),
-          new Promise<"timeout">((resolve) => {
-            timer = setTimeout(() => resolve("timeout"), TIMEOUT);
-          }),
-        ]).finally(() => clearTimeout(timer!));
-
-        const latencyMs = Math.round(performance.now() - start);
-        if (result === "timeout") {
-          // Best-effort cleanup — the IIFE may still be mid-create. Cast needed:
-          // TS narrows `sandbox` to null (the IIFE ends with sandbox = null) but
-          // the race means it may not have run to completion.
-          const sb = sandbox as RailwaySandboxInstance | null;
-          if (sb) await destroyQuietly(sb, log, "after health-check timeout");
-          return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
-        }
-        return { ...result, latencyMs };
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        log?.warn(`[railway-sandbox] Health check failed: ${msg}`);
-        const sb = sandbox as RailwaySandboxInstance | null;
-        if (sb) await destroyQuietly(sb, log, "after health-check failure");
-        return {
-          healthy: false,
-          message: msg,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+          },
+        },
+      );
     },
   };
 }

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -28,7 +28,11 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import {
+  createPlugin,
+  collectSemanticFiles,
+  runHealthCheckWithTimeout,
+} from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
@@ -36,7 +40,6 @@ import type {
   PluginHealthResult,
 } from "@useatlas/plugin-sdk";
 import * as path from "path";
-import * as fs from "fs";
 
 // ---------------------------------------------------------------------------
 // Sensitive pattern regex (copied from @atlas/api/lib/security.ts —
@@ -86,63 +89,8 @@ export function sandboxErrorDetail(err: unknown): string {
   return detail;
 }
 
-/** Recursively collect all files under `localDir` into `{ path, content }` tuples. */
-export function collectSemanticFiles(
-  localDir: string,
-  sandboxDir: string,
-  logger?: { warn(msg: string): void },
-): { path: string; content: Buffer }[] {
-  const results: { path: string; content: Buffer }[] = [];
-
-  function walk(dir: string, relative: string) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-      logger?.warn(`[vercel-sandbox] Skipping unreadable directory ${dir}: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
-    for (const entry of entries) {
-      const localPath = path.join(dir, entry.name);
-      const remotePath = `${relative}/${entry.name}`;
-
-      if (entry.isSymbolicLink()) {
-        try {
-          const realPath = fs.realpathSync(localPath);
-          if (!realPath.startsWith(localDir)) {
-            logger?.warn(`[vercel-sandbox] Skipping symlink escaping semantic root: ${localPath} -> ${realPath}`);
-            continue;
-          }
-          const stat = fs.statSync(localPath);
-          if (stat.isDirectory()) {
-            walk(localPath, remotePath);
-          } else if (stat.isFile()) {
-            results.push({
-              path: remotePath,
-              content: fs.readFileSync(localPath),
-            });
-          }
-        } catch (err) {
-          logger?.warn(`[vercel-sandbox] Skipping unreadable symlink ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      } else if (entry.isDirectory()) {
-        walk(localPath, remotePath);
-      } else if (entry.isFile()) {
-        try {
-          results.push({
-            path: remotePath,
-            content: fs.readFileSync(localPath),
-          });
-        } catch (err) {
-          logger?.warn(`[vercel-sandbox] Skipping unreadable file ${localPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      }
-    }
-  }
-
-  walk(localDir, sandboxDir);
-  return results;
-}
+// The semantic-tree walker (with its symlink-escape guard) now lives in
+// @useatlas/plugin-sdk — `collectSemanticFiles` — shared across sandbox plugins.
 
 // Prefix for sandbox file paths: the SDK resolves relative paths under /vercel/sandbox/.
 const SANDBOX_SEMANTIC_REL = "semantic";
@@ -416,16 +364,14 @@ export function buildVercelSandboxPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const TIMEOUT = 30_000;
-      // NOTE: `await using` is intentionally NOT used here. The Promise.race
-      // timeout can win while the inner IIFE is still mid-create/runCommand, and
-      // the v2 SDK exposes no AbortSignal on the object-form runCommand or on
-      // create — so a scope-bound disposer would only fire once the (possibly
-      // hung) operation settled, leaking the microVM past the timeout. We keep an
-      // explicit sandbox reference and stop() it in every branch instead.
+      // NOTE: `await using` is intentionally NOT used here (see
+      // runHealthCheckWithTimeout's docs). The race timeout can win while the
+      // probe is still mid-create/runCommand, and the v2 SDK exposes no
+      // AbortSignal on the object-form runCommand or on create — so a
+      // scope-bound disposer would only fire once the (possibly hung) operation
+      // settled, leaking the microVM past the timeout. The shared helper keeps
+      // an explicit sandbox reference and stop()s it in every failing branch.
       let sandbox: SandboxInstance | null = null;
-      let timer: ReturnType<typeof setTimeout>;
       const stopQuietly = async (sb: SandboxInstance) => {
         try {
           await sb.stop();
@@ -437,64 +383,54 @@ export function buildVercelSandboxPlugin(
           );
         }
       };
-      try {
-        const result = await Promise.race([
-          (async () => {
-            const { Sandbox } = await loadSandboxModule();
+      return runHealthCheckWithTimeout(
+        async () => {
+          const { Sandbox } = await loadSandboxModule();
 
-            const createOpts: Record<string, unknown> = {
-              runtime: "node24",
-              networkPolicy: "deny-all",
-              // v2 persists by default — keep the health-check sandbox ephemeral.
-              persistent: false,
-            };
-            if (config.accessToken) {
-              createOpts.accessToken = config.accessToken;
-              createOpts.teamId = config.teamId;
+          const createOpts: Record<string, unknown> = {
+            runtime: "node24",
+            networkPolicy: "deny-all",
+            // v2 persists by default — keep the health-check sandbox ephemeral.
+            persistent: false,
+          };
+          if (config.accessToken) {
+            createOpts.accessToken = config.accessToken;
+            createOpts.teamId = config.teamId;
+          }
+
+          sandbox = await Sandbox.create(createOpts);
+          const res = await sandbox.runCommand({
+            cmd: "sh",
+            args: ["-c", "echo vercel-ok"],
+            cwd: "/tmp",
+          });
+          const stdout = await res.stdout();
+          await stopQuietly(sandbox);
+          sandbox = null;
+
+          if (res.exitCode === 0 && stdout.includes("vercel-ok")) {
+            return { healthy: true };
+          }
+          return {
+            healthy: false,
+            message: `Sandbox test command failed (exit ${res.exitCode})`,
+          };
+        },
+        {
+          timeoutMs: 30_000,
+          logger: log,
+          cleanup: async () => {
+            // Best-effort cleanup — the probe may still be mid-create. Cast
+            // needed: TS narrows `sandbox` to null (the probe ends with
+            // sandbox = null) but the race means it may not have run.
+            const sb = sandbox as SandboxInstance | null;
+            if (sb) {
+              await stopQuietly(sb);
+              sandbox = null;
             }
-
-            sandbox = await Sandbox.create(createOpts);
-            const res = await sandbox.runCommand({
-              cmd: "sh",
-              args: ["-c", "echo vercel-ok"],
-              cwd: "/tmp",
-            });
-            const stdout = await res.stdout();
-            await stopQuietly(sandbox);
-            sandbox = null;
-
-            if (res.exitCode === 0 && stdout.includes("vercel-ok")) {
-              return { healthy: true as const };
-            }
-            return {
-              healthy: false as const,
-              message: `Sandbox test command failed (exit ${res.exitCode})`,
-            };
-          })(),
-          new Promise<"timeout">((resolve) => {
-            timer = setTimeout(() => resolve("timeout"), TIMEOUT);
-          }),
-        ]).finally(() => clearTimeout(timer!));
-
-        const latencyMs = Math.round(performance.now() - start);
-        if (result === "timeout") {
-          // Best-effort cleanup — the IIFE may still be creating if create() is
-          // what's slow. Cast needed: TS narrows `sandbox` to null (the IIFE
-          // ends with sandbox = null) but the race means it may not have run.
-          const sb = sandbox as SandboxInstance | null;
-          if (sb) await stopQuietly(sb);
-          return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
-        }
-        return { ...result, latencyMs };
-      } catch (err) {
-        const sb = sandbox as SandboxInstance | null;
-        if (sb) await stopQuietly(sb);
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+          },
+        },
+      );
     },
   };
 }

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -155,7 +155,9 @@ async function loadSandboxModule(): Promise<{ Sandbox: SandboxConstructor }> {
 // We avoid importing the real types since it's an optional peer dependency.
 interface SandboxInstance {
   mkDir(path: string): Promise<void>;
-  writeFiles(files: { path: string; content: Buffer }[]): Promise<void>;
+  // `collectSemanticFiles` yields `Uint8Array` content (a Node Buffer at
+  // runtime, which the real @vercel/sandbox writeFiles accepts).
+  writeFiles(files: { path: string; content: Uint8Array }[]): Promise<void>;
   runCommand(opts: {
     cmd: string;
     args: string[];
@@ -227,7 +229,7 @@ async function createVercelExploreBackend(
   });
 
   // 3. Collect semantic layer files
-  let files: { path: string; content: Buffer }[];
+  let files: { path: string; content: Uint8Array }[];
   try {
     files = collectSemanticFiles(semanticRoot, SANDBOX_SEMANTIC_REL, log);
   } catch (err) {


### PR DESCRIPTION
## Summary

Single-sources two blocks of sandbox-plugin infrastructure that were copy-pasted across the four sandbox plugins (`vercel-sandbox`, `e2b`, `daytona`, `railway-sandbox`), with only the log prefix differing. Behavior-preserving refactor (~−300 LoC across the plugins).

Adds to `@useatlas/plugin-sdk` (`src/helpers.ts`):

- **`collectSemanticFiles(localDir, sandboxDir, logger?)`** → generic semantic-tree walker returning `{ path, content: Buffer }[]`, **with the symlink-escape guard single-sourced**. Adopts the canonical `path.relative`-based containment check (originated in `railway-sandbox`), which rejects prefix-collision siblings like `${root}_evil/…` that a bare `startsWith(root)` would accept. A fix to this security property now lands once. E2B's string-content variant maps `f.content.toString("utf-8")` at the call site.
- **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** → encapsulates the `Promise.race` timeout + `latencyMs` + cleanup-in-every-failing-branch pattern. `await using` is intentionally avoided (the timeout can win mid-create and the SDKs expose no `AbortSignal` on create — a scope-bound disposer would leak the microVM past the timeout).

All four plugins migrated to the shared helpers; per-plugin behavior unchanged. Plugin authoring guides (`apps/docs/.../plugins/authoring-guide.mdx` + `docs/guides/plugin-authoring-guide.md`) document the helpers for new sandbox plugins.

## Publishing sequence (0.0.x EXACT pins)

- `packages/plugin-sdk/package.json` version bumped **0.0.14 → 0.0.15** in this PR.
- Dependency refs in the plugins / `create-atlas/templates/*` are **intentionally NOT bumped** — they stay at the old version so `scripts/check-published-symbols.ts` stays green (no new export is used before it's published).
- The ref bump is a **separate follow-up PR** after the post-merge publish of `plugin-sdk@0.0.15`.

## Test plan

- [x] New `packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts` (15 cases): symlink escape rejected, prefix-collision sibling rejected, in-root symlink followed, binary content preserved, unreadable root/dir/file skipped-with-warn, timeout-wins-mid-create cleanup, throwing-cleanup logged, non-Error rejection normalized.
- [x] All four sandbox plugin suites stay green (vercel 27, e2b 25, daytona 24, railway 36).
- [x] `/ci` — full `bun run test` (api 686/686, web 212/212, cli, mcp, ee, plugins), lint, type, syncpack, template/security-headers/railway/schema/openapi/oauth/test-discipline/twenty/settings/saas-env drift, published-symbols — all pass.

## Acceptance criteria

- [x] Helpers in `@useatlas/plugin-sdk` with tests (symlink escape, unreadable dir/file, timeout-wins-mid-create cleanup)
- [x] All four sandbox plugins migrated; per-plugin behavior unchanged (existing plugin test suites stay green)
- [x] plugin-sdk version bump sequenced per the publishing discipline (refs follow post-publish)
- [x] Authoring guide mentions the helpers for new sandbox plugins

Closes #3373

https://claude.ai/code/session_01VnyY8YWxTJKXPpQMJNKZmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnyY8YWxTJKXPpQMJNKZmG)_