### PR TITLE
chore(deps): bump nodemailer 8→9 (Group B major)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "mysql2": "^3.22.4",
         "nanoid": "^5.1.11",
         "next": "^16.2.9",
-        "nodemailer": "^8.0.11",
+        "nodemailer": "^9.0.1",
         "obsidian": "^1.13.1",
         "radix-ui": "^1.6.0",
         "react-dom": "^19.2.6",
@@ -231,7 +231,7 @@
         "just-bash": "^3.0.1",
         "mysql2": "^3.22.4",
         "node-sql-parser": "^5.4.0",
-        "nodemailer": "^8.0.11",
+        "nodemailer": "^9.0.1",
         "pg": "^8.21.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -3441,7 +3441,7 @@
 
     "node-sql-parser": ["node-sql-parser@5.4.0", "", { "dependencies": { "@types/pegjs": "^0.10.0", "big-integer": "^1.6.48" } }, "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw=="],
 
-    "nodemailer": ["nodemailer@8.0.11", "", {}, "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA=="],
+    "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -65,7 +65,7 @@
     "next": "^16.2.9",
     "next-themes": "^0.4.6",
     "node-sql-parser": "^5.4.0",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "^9.0.1",
     "nuqs": "^2.8.9",
     "pg": "^8.21.0",
     "pino": "^10.3.1",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -62,7 +62,7 @@
     "next": "^16.2.9",
     "next-themes": "^0.4.6",
     "node-sql-parser": "^5.4.0",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "^9.0.1",
     "nuqs": "^2.8.9",
     "pg": "^8.21.0",
     "pino": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "mysql2": "^3.22.4",
     "nanoid": "^5.1.11",
     "next": "^16.2.9",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "^9.0.1",
     "obsidian": "^1.13.1",
     "radix-ui": "^1.6.0",
     "react-dom": "^19.2.6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -82,7 +82,7 @@
     "just-bash": "^3.0.1",
     "mysql2": "^3.22.4",
     "node-sql-parser": "^5.4.0",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "^9.0.1",
     "pg": "^8.21.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",


### PR DESCRIPTION
## What

Group B major bump: **`nodemailer` `^8.0.11` → `^9.0.1`** across root, `packages/api`, and both `create-atlas` templates (nextjs-standalone, docker).

One PR per major, per [`/deps-update`](../blob/main/.claude/skills/deps-update) — never mixed into the within-major Group A sweep.

## Why this is a Group B major (not picked up by yesterday's sweep)

`nodemailer` 8→9 stayed out of yesterday's Group A within-major sweep (#3811) because `bun update` (no `--latest`) cannot cross a `^` major. The sweep correctly took it to the latest within-8.x (`8.0.11`); the major jump needs a deliberate range edit — this PR.

## Breaking-change analysis → inert here

The **sole** documented 9.0 breaking change is: HTTPS *remote-content fetch* now validates the server's TLS certificate by default. That affects:
- attachment `href`/`path` URLs
- OAuth2 token endpoints
- HTTP/HTTPS proxy `CONNECT`

**Atlas uses none of these paths.** `packages/api/src/lib/integrations/email-tool.ts` only does plain SMTP:
- `createTransport({ host, port, secure, auth })`
- `sendMail({ from, to, subject, html })`
- `transport.close()`

No remote attachments, no OAuth2 token endpoint, no proxy. So the break does not touch our code path.

`@types/nodemailer` stays at `^8.0.1` — DefinitelyTyped has **no** 9.x published, and nodemailer 9 leaves the consumed type surface (`Transporter`, `SendMailOptions`) unchanged.

## Footprint

| File | Change |
|---|---|
| `package.json` | `nodemailer ^8.0.11 → ^9.0.1` |
| `packages/api/package.json` | `nodemailer ^8.0.11 → ^9.0.1` |
| `create-atlas/templates/nextjs-standalone/package.json` | `nodemailer ^8.0.11 → ^9.0.1` |
| `create-atlas/templates/docker/package.json` | `nodemailer ^8.0.11 → ^9.0.1` |
| `bun.lock` | resolved `nodemailer@8.0.11 → 9.0.1` (single version) |

## Gates (all local, green)

- `bun run type` (tsgo) ✅
- `bun run lint` ✅ (run before example build)
- email-tool integration test (2) + unit test + staging `clamp` test = **40 pass** ✅ — confirms `nodemailer.streamTransport()` + SMTP send survive v9
- `bun install --frozen-lockfile` → no changes ✅
- `scripts/check-template-drift.sh` → 848 files verified ✅
- Standalone Turbopack build (`@atlas/nextjs-standalone`) ✅ (CI-only gate #2)
- syncpack: no issues ✅
- belt-and-suspenders: no held Group-B major leaked into the lockfile ✅

## Release

Ships as part of a `v0.0.x` patch-rollup dep tag (no milestone), per [ADR-0008](../blob/main/docs/adr/0008-versioning-and-release-tags.md).
