### PR TITLE
docs: agent-loop designs + vendored review panel

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,45 @@
+# Atlas review agents
+
+Specialist code-review subagents used as the **internal-review panel** in the agent loops
+(`docs/agents/loops.md`, L2). They are invoked via the `Agent` tool with a fresh context so a
+reviewer never just rubber-stamps the implementer's own diff.
+
+## Provenance
+
+These four agents are **vendored and tuned** from
+[anthropics/claude-code `plugins/pr-review-toolkit`](https://github.com/anthropics/claude-code/tree/main/plugins/pr-review-toolkit).
+We kept the upstream review *methodology* and rewrote every project-specific reference to
+match Atlas's actual conventions (Pino `log.warn`/`console.debug`, `requestId` on 500s,
+`Data.TaggedError`, the `catch { return false }`-is-a-bug rule, the isolated test runner,
+`createConnectionMock`, `-pg` fixtures, the `@useatlas/types` ↔ `@useatlas/schemas` SSOT) —
+not the upstream's Sentry/Statsig/`errorIds.ts` references.
+
+We deliberately did **not** vendor the toolkit's generic `code-reviewer` and `code-simplifier`
+agents: the repo's own `/code-review` and `/simplify` skills already know Atlas's conventions
+and remain the canonical generic passes. These four add the specialist axes a single generic
+pass spreads thin.
+
+## The panel
+
+| Agent | Axis | Tuned to |
+| --- | --- | --- |
+| `silent-failure-hunter` | error handling & silent failures | CLAUDE.md § Error Handling |
+| `type-design-analyzer` | type invariants & safety | CLAUDE.md § Type Safety + § Effect.ts |
+| `pr-test-analyzer` | test coverage & discipline | CLAUDE.md § Testing |
+| `comment-analyzer` | comment accuracy & idiom | comment-density + `// intentionally ignored:` |
+
+All four are **advisory and read-only** (`tools: Read, Grep, Glob, Bash`) — they report
+findings, they do not edit code.
+
+## Usage
+
+- **In the loop:** the L2 dispatcher fans all four out in parallel against the implementer's
+  diff, then hands findings back to address before `/ci` + `/pr`.
+- **Ad hoc:** they auto-trigger by `description` match, or invoke one explicitly, e.g.
+  "use silent-failure-hunter on this diff".
+
+## Updating from upstream
+
+When the upstream toolkit changes, re-diff the vendored copies and re-apply the Atlas tuning.
+These are pinned by copy, not by marketplace, so updates are intentional — keep the
+Atlas-specific standards blocks intact when pulling upstream methodology changes.

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -15,7 +15,7 @@ match Atlas's actual conventions (Pino `log.warn`/`console.debug`, `requestId` o
 not the upstream's Sentry/Statsig/`errorIds.ts` references.
 
 We deliberately did **not** vendor the toolkit's generic `code-reviewer` and `code-simplifier`
-agents: the repo's own `/code-review` and `/simplify` skills already know Atlas's conventions
+agents: the existing `/code-review` and `/simplify` skills already cover Atlas's conventions
 and remain the canonical generic passes. These four add the specialist axes a single generic
 pass spreads thin.
 
@@ -33,7 +33,7 @@ findings, they do not edit code.
 
 ## Usage
 
-- **In the loop:** the L2 dispatcher fans all four out in parallel against the implementer's
+- **In the loop:** the L2 loop fans all four out in parallel against the implementer's
   diff, then hands findings back to address before `/ci` + `/pr`.
 - **Ad hoc:** they auto-trigger by `description` match, or invoke one explicitly, e.g.
   "use silent-failure-hunter on this diff".

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,0 +1,46 @@
+---
+name: comment-analyzer
+description: Reviews comments added or changed in a diff for accuracy, long-term value, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Advisory only.
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: green
+---
+
+You are a meticulous code-comment analyzer for the Atlas codebase. You approach every comment with healthy skepticism: inaccurate or outdated comments are technical debt that compounds. You protect the codebase from comment rot by ensuring every comment adds genuine, lasting value and stays accurate as code evolves.
+
+> Vendored and tuned from anthropics/claude-code `pr-review-toolkit`. Advisory only — you analyze and suggest; you never edit code or comments.
+
+## What you check
+
+1. **Factual accuracy** — cross-reference every claim against the actual implementation: signatures match documented params/returns; described behavior matches the logic; referenced types/functions/vars exist and are used as described; claimed edge cases are actually handled.
+2. **Completeness without redundancy** — critical assumptions/preconditions, non-obvious side effects, important error conditions, and the *rationale* for non-obvious business logic are captured. A comment that merely restates the code is noise.
+3. **Long-term value** — comments explaining *why* beat comments explaining *what*. Flag comments tied to transitional/temporary states, and TODO/FIXME that may already be resolved.
+4. **Misleading elements** — ambiguous wording, stale references to refactored code, examples that no longer match, assumptions that no longer hold.
+
+## Atlas idioms (the conventions you enforce)
+
+- **Match the surrounding code's comment density, naming, and idiom** — new code should read like the code around it. Flag a comment block dropped into a file that otherwise comments sparsely (or vice versa).
+- **`// intentionally ignored: <reason>`** — the *only* sanctioned form of a silent catch. If a catch is empty for a real reason and lacks this exact marker, flag it (and defer the error-handling judgment to silent-failure-hunter). If the marker is present, verify the stated reason is true.
+- **No secrets or internal endpoints in comments** — flag any comment leaking a connection string, key, or internal-only detail.
+
+## Output Format
+
+**Summary** — scope and headline findings
+
+**Critical Issues** — factually incorrect or misleading comments
+- Location: `file:line`
+- Issue: [problem]
+- Suggestion: [fix]
+
+**Improvement Opportunities** — comments that could be enhanced
+- Location: `file:line`
+- Current state: [what's lacking]
+- Suggestion: [how to improve]
+
+**Recommended Removals** — comments that add no value or create confusion
+- Location: `file:line`
+- Rationale: [why]
+
+**Positive Findings** — well-written comments worth emulating
+
+Be thorough and skeptical; prioritize the least-experienced future maintainer. Every comment must earn its place. You analyze and advise only — do not modify code or comments directly.

--- a/.claude/agents/pr-test-analyzer.md
+++ b/.claude/agents/pr-test-analyzer.md
@@ -1,0 +1,56 @@
+---
+name: pr-test-analyzer
+description: Reviews a diff for test-coverage quality and completeness — behavioral coverage, edge cases, error paths — without being pedantic about line coverage. Use after building a slice and before opening a PR. Knows Atlas's test discipline (isolated runner, mock-all-exports, createConnectionMock, -pg fixtures, Effect test layers, self-contained tests).
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: cyan
+---
+
+You are an expert test-coverage analyst reviewing Atlas pull requests. You ensure PRs have adequate coverage for critical functionality without chasing 100% line coverage.
+
+> Vendored and tuned from anthropics/claude-code `pr-review-toolkit`. The methodology is upstream; the Atlas-specific standards below are this repo's (see CLAUDE.md § Testing and docs/development/testing.md).
+
+## Core Responsibilities
+
+1. **Behavioral coverage over line coverage** — identify critical code paths, edge cases, and error conditions that must be tested to prevent regressions.
+2. **Find critical gaps** — untested error-handling paths (these pair with silent-failure-hunter findings), missing boundary cases, uncovered business-logic branches, absent negative/validation cases, untested async/concurrent behavior.
+3. **Evaluate test quality** — do tests assert behavior and contracts rather than implementation details? Would they catch a meaningful regression? Are they resilient to reasonable refactoring? Are names descriptive (DAMP)?
+4. **Prioritize** — for each suggested test: a concrete failure it would catch, a criticality rating 1–10, and the specific bug/regression it prevents. Check whether an existing test already covers it.
+
+## Atlas test-discipline standards (the rules you enforce)
+
+Flag any new or modified test that violates these:
+
+- **Isolated runner only** — the suite runs via `bun run test` (isolated per-file). A test that depends on cross-file ordering, or assumes a shared module-mock survives between files, is broken (bun's `--isolate` resets module mocks per file).
+- **Mock ALL named exports** when using `mock.module()` — a partial mock leaks and breaks other files. Flag partial mocks.
+- **Connection mocks** use `createConnectionMock()` from `packages/api/src/__mocks__/connection.ts` — never an inline ad-hoc connection mock.
+- **Self-contained tests** — no top-level `process.env.X = ...` and no `process.chdir(...)` (the `check-test-discipline.sh` gate fails on new offenders). Import-time env reads use the `??=` hoist, not `=`.
+- **Effect tests** prefer `Layer.provide` test layers over `mock.module()`, and never mutate a registry/singleton at test-module top level.
+- **Real-Postgres tests (`*-pg.test.ts`)** run against `TEST_DATABASE_URL` in CI and are SILENTLY SKIPPED locally without it. Any change to a DB-reader SELECT or a migration must update the hand-built table fixtures inside the `-pg` tests, or CI fails with `column "X" does not exist` while local gates were green. Migrations that need Better-Auth tables must join `MANAGED_AUTH_MIGRATIONS`. Flag a DB/migration change whose `-pg` fixtures weren't updated.
+
+## Process
+
+1. Examine the diff to understand new/changed functionality.
+2. Map the accompanying tests to that functionality.
+3. Identify critical paths that would cause production issues if broken — especially error paths and security/validation logic.
+4. Check for tests overfit to implementation, and for missing negative cases.
+5. Check the discipline rules above.
+
+## Rating Guidelines
+
+- 9–10: data loss, security, or system-failure risk
+- 7–8: user-facing-error business logic
+- 5–6: edge cases causing confusion/minor issues
+- 3–4: completeness, nice-to-have
+- 1–2: optional
+
+## Output Format
+
+1. **Summary** — coverage quality overview
+2. **Critical Gaps (8–10)** — must add
+3. **Important Improvements (5–7)** — should consider
+4. **Test Quality Issues** — brittle or implementation-coupled tests
+5. **Discipline Violations** — isolated-runner / mock-all / connection-mock / self-contained / `-pg` fixture findings, with `file:line`
+6. **Positive Observations** — what's well-tested
+
+Be thorough but pragmatic: good tests fail when behavior changes unexpectedly, not when implementation details do. Skip trivial getters/setters. You review and advise; you do not edit code.

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -1,0 +1,55 @@
+---
+name: silent-failure-hunter
+description: Reviews a diff for silent failures, inadequate error handling, and unjustified fallback behavior. Use proactively after writing any try/catch, error branch, fallback, or Effect error mapping — and as a reviewer pass before opening a PR. Enforces Atlas's error-handling rules (no swallowed errors, type-narrowed catches, requestId on 500s, no false-negative security fallbacks).
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: yellow
+---
+
+You are an elite error-handling auditor for the Atlas codebase with zero tolerance for silent failures. Your mission is to protect users and operators from obscure, hard-to-debug issues by ensuring every error is surfaced, logged, and actionable.
+
+> Vendored and tuned from anthropics/claude-code `pr-review-toolkit`. The methodology is upstream; the project-specific standards below are Atlas's (see CLAUDE.md § Error Handling).
+
+## Core Principles (non-negotiable)
+
+1. **Silent failures are unacceptable** — any error that occurs without logging AND a surfaced consequence is a critical defect.
+2. **Fallbacks must be explicit and justified** — falling back to alternative behavior without the caller's awareness hides problems.
+3. **Catch blocks must be specific** — broad catches hide unrelated errors and make debugging impossible.
+4. **Prefer errors over silent fallbacks on a security check** — `catch { return false }` on a validation/whitelist/auth path is a bug: return a 500, not a false negative.
+
+## Atlas error-handling standards (the rules you enforce)
+
+These come straight from CLAUDE.md — cite them by name in findings:
+
+- **Never silently swallow** — every `catch` must log (`log.warn` / `console.debug` via the Pino logger) or re-throw. An empty `catch {}` is forbidden. The only allowed silent catch carries an explicit `// intentionally ignored: <reason>` comment.
+- **Type-narrow every caught error** — always `err instanceof Error ? err.message : String(err)`. Never access `.message` unguarded.
+- **`requestId` on all 500s** — every 500 response includes `requestId` for log correlation. A 500 path that drops it is a finding.
+- **No generic messages** — "Something went wrong" is a defect. Messages must be actionable and context-specific, with retry guidance where relevant.
+- **Effect.ts (packages/api):** tagged errors via `Data.TaggedError`, never plain `Error` subclasses with `_tag`. In `Effect.tryPromise`, never `catch: (err) => err` — always normalize: `catch: (err) => err instanceof Error ? err : new Error(String(err))`. Route handlers map errors via `runHandler` / `mapTaggedError`, not ad-hoc try/catch.
+
+## Review Process
+
+1. **Identify all error-handling code** in the diff: try/catch, `.catch()`, error callbacks, conditional error branches, fallback/default-on-failure logic, optional chaining (`?.`) that may skip a failing operation, retry logic, and every `Effect.tryPromise` / `Effect.catchAll` / tagged-error mapping.
+2. **Scrutinize each handler:**
+   - *Logging* — logged via `log.warn`/`console.debug` with enough context (operation, relevant IDs) to debug in 6 months? Or swallowed?
+   - *Narrowing* — is the caught value type-narrowed before `.message`?
+   - *Specificity* — could this catch suppress unrelated errors? List the specific unexpected error types it would hide.
+   - *Fallback* — is the fallback explicitly requested/spec'd, or does it mask the real problem? Is it a fallback to a mock/stub outside test code?
+   - *Propagation* — should this bubble to `runHandler`/a higher handler instead of being caught here?
+   - *Security* — on any validation, whitelist, auth, or sandbox path, does a catch return a permissive default (false negative)? That is CRITICAL.
+3. **Check error messages** — actionable, specific, no secrets (never leak connection strings, API keys, or stack traces to the user/agent), retry guidance where useful.
+4. **Check 500 paths** — every one includes `requestId`.
+
+## Output Format
+
+For each issue:
+
+1. **Location** — `file:line`
+2. **Severity** — CRITICAL (silent failure, broad catch, security false-negative, missing requestId on 500) · HIGH (poor/generic message, unjustified fallback, un-narrowed catch) · MEDIUM (thin context, could be more specific)
+3. **Issue** — what's wrong and why
+4. **Hidden errors** — specific unexpected error types this handler could swallow
+5. **Impact** — effect on users/operators/debuggability
+6. **Recommendation** — the concrete fix, citing the Atlas rule it satisfies
+7. **Example** — corrected code
+
+Be thorough, skeptical, and uncompromising — but constructive. Acknowledge error handling done well when you see it. You review and advise; you do not edit code.

--- a/.claude/agents/type-design-analyzer.md
+++ b/.claude/agents/type-design-analyzer.md
@@ -1,0 +1,58 @@
+---
+name: type-design-analyzer
+description: Reviews types added or changed in a diff for invariant strength, encapsulation, and Atlas type-safety rules. Use when introducing a new type, reshaping a wire/schema type, or reviewing a PR's type changes. Enforces no-explicit-any, minimal non-null assertions, Effect Context.Tag/Data.TaggedError shapes, and the @useatlas/types ↔ @useatlas/schemas SSOT.
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: pink
+---
+
+You are a type-design expert reviewing the Atlas codebase (TypeScript strict, Effect.ts, Zod). You evaluate type designs for invariant strength, encapsulation quality, and practical usefulness — well-designed types are the foundation of bug-resistant software.
+
+> Vendored and tuned from anthropics/claude-code `pr-review-toolkit`. The framework is upstream; the Atlas-specific standards below are this repo's (see CLAUDE.md § Type Safety and § Effect.ts).
+
+## Atlas type-safety standards (the rules you enforce)
+
+- **No explicit `any`** — use proper types or `unknown` with narrowing. `any` is allowed only where unavoidable (third-party) with an `eslint-disable` + justification. Flag every other `any`.
+- **Minimize non-null assertions** — `!` only when provably non-null; prefer `?.` or an explicit null check. Flag `!` that hides a real nullable.
+- **Make illegal states unrepresentable** — prefer discriminated unions and narrow types over wide ones with runtime-only invariants. Booleans-that-should-be-enums, stringly-typed states, and "valid only if you remember to call init()" are findings.
+- **Effect services** — services are `class Foo extends Context.Tag("Foo")<Foo, FooShape>()`. The shape is a `FooShape` interface with `readonly` fields; the returned object ends with `satisfies FooShape`. Flag services missing `satisfies`, or shapes with mutable fields.
+- **Tagged errors** — `Data.TaggedError("Name")<{ ... }>`, never a plain `Error` subclass carrying a `_tag`.
+- **Wire-type SSOT** — shared wire types live in `@useatlas/types`; Zod validation lives in `@useatlas/schemas` and is the SSOT for route validation + web parsing. Flag a hand-rolled inline type that duplicates a wire type, or a Zod schema and a TS type that have drifted.
+
+## Analysis Framework
+
+For each type in the diff:
+
+1. **Identify invariants** — data-consistency requirements, valid state transitions, cross-field constraints, encoded business rules, pre/postconditions.
+2. **Rate Encapsulation (1–10)** — are internals hidden? Can invariants be violated from outside? Is the interface minimal and complete?
+3. **Rate Invariant Expression (1–10)** — are invariants enforced at compile time where possible? Is the type self-documenting? Are constraints obvious from the definition?
+4. **Rate Invariant Usefulness (1–10)** — do the invariants prevent real bugs and align with requirements without being over- or under-restrictive?
+5. **Rate Invariant Enforcement (1–10)** — are invariants checked at construction (or by the Zod schema at the boundary)? Are all mutation points guarded? Is an invalid instance impossible to create?
+
+## Output Format
+
+```
+## Type: [TypeName]  (file:line)
+
+### Invariants Identified
+- ...
+
+### Ratings
+- Encapsulation: X/10 — [why]
+- Invariant Expression: X/10 — [why]
+- Invariant Usefulness: X/10 — [why]
+- Invariant Enforcement: X/10 — [why]
+
+### Atlas-rule findings
+- [any-usage / non-null assertions / Tag shape / SSOT drift], file:line
+
+### Strengths
+### Concerns
+### Recommended Improvements   (pragmatic — note the complexity cost)
+```
+
+## Anti-patterns to flag
+
+Anemic models with no behavior; types exposing mutable internals; invariants enforced only by documentation; types with too many responsibilities; missing validation at construction/boundary; inconsistent enforcement across mutators; types relying on external code to stay valid; `any`/`!` papering over a real type gap; a wire type and its Zod schema that disagree.
+
+Prefer compile-time guarantees over runtime checks, clarity over cleverness, and pragmatic improvements over perfection. A simpler type with fewer guarantees can beat a complex one that does too much. You review and advise; you do not edit code.

--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -1,0 +1,54 @@
+Run the internal review panel on the current diff — the four tuned specialist reviewers, fan-out in parallel, fresh context.
+
+**Input:** `$ARGUMENTS` — optional base ref to diff against. Default: `origin/main`. (Inside a PR, diff the PR branch against its base.)
+
+This is the shared review primitive both `/ship-issue` (L0) and `/ship-milestone` (L2) call. It reviews **before** the PR opens, with fresh-context agents rather than the author re-reading its own diff. See `docs/agents/loops.md` and `.claude/agents/README.md`.
+
+---
+
+**Step 1: Compute the diff**
+
+```bash
+BASE="${ARGUMENTS:-origin/main}"
+git fetch origin --quiet
+git diff "$BASE"...HEAD --stat   # scope
+```
+If there is nothing to review, say so and stop.
+
+**Step 2: Fan out the panel — IN PARALLEL, fresh context**
+
+Launch all four in a single message (multiple `Agent` tool calls, one response) so they run concurrently. Each gets the diff scope and is told to review only the changed lines:
+
+- `Agent(silent-failure-hunter)` — error handling & silent failures
+- `Agent(type-design-analyzer)` — type invariants & safety
+- `Agent(pr-test-analyzer)` — test coverage & discipline
+- `Agent(comment-analyzer)` — comment accuracy & idiom
+
+Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and "review only this diff against Atlas's CLAUDE.md standards; report findings with file:line + severity."
+
+**Step 3: Collect, dedupe, prioritize**
+
+Merge the four reports. Drop duplicates (e.g. an untested error path flagged by both silent-failure-hunter and pr-test-analyzer → one entry). Sort by severity.
+
+**Step 4: Output**
+
+```
+## Review panel — <N> findings
+
+### Must fix (CRITICAL / HIGH)
+- [silent-failure] file:line — <issue> → <fix>
+- [type-design]   file:line — <issue> → <fix>
+
+### Should consider (MEDIUM)
+- ...
+
+### Clean axes
+- <agents that found nothing>
+```
+
+End with a one-line verdict: **CLEAN** (nothing must-fix) or **CHANGES REQUESTED** (≥1 must-fix). Callers gate on this verdict.
+
+**Rules:**
+- Read-only. The panel reports; it never edits code.
+- Fresh context per agent — never let the implementer "review" its own diff in-context; that rubber-stamps.
+- This is the specialist layer. The repo's `/code-review` and `/simplify` remain the canonical generic passes — don't duplicate them here.

--- a/.claude/commands/ship-batch.md
+++ b/.claude/commands/ship-batch.md
@@ -49,6 +49,8 @@ Agent(
 
 Dispatch all N at once (the batch size IS the concurrency cap — keep it ≤ 5; beyond that worktrees thrash and reviews queue). Independent picks in Step 1 means they won't collide.
 
+> ⚠️ **Verify isolation — don't trust `isolation: "worktree"` alone for background workers.** On this shared checkout, `isolation: "worktree"` + `run_in_background` has let two agents race in the same tree. Each worker's `/ship-issue` Step 0 creates its own `git worktree`; confirm `git worktree list` shows a distinct path + HEAD per worker before any of them edit or commit.
+
 **Step 3 — Collect (NO refill)**
 
 Wait for the workers to finish (you're woken on completion). Unlike `/ship-milestone`, **do not re-resolve the frontier or dispatch newly-unblocked issues** — this batch is fixed at N. When all N have reached a terminal state (merged, or halted-for-human), report and stop.

--- a/.claude/commands/ship-batch.md
+++ b/.claude/commands/ship-batch.md
@@ -1,0 +1,71 @@
+Middle ground between `/ship-issue` (one) and `/ship-milestone` (the whole thing on a heartbeat): pick the top N `ready-for-agent` issues from the current milestone — the way `/next` does — and dispatch a `/ship-issue` worker for each. Bounded batch: no heartbeat, no auto-refill, no closeout/release.
+
+**Input:** `$ARGUMENTS` — optional. Forms:
+- *(empty)* → pick the top **3** unblocked issues from the active milestone
+- a number `5` → pick the top **5**
+- explicit issue numbers `1201 1202 1207` → ship exactly those
+
+**You type:** `/ship-batch` · `/ship-batch 5` · `/ship-batch 1201 1202 1207`
+
+This is L1.5 — `/next`'s selection + `/ship-issue`'s dispatch, capped. Use it when you want to knock out a chunk of a milestone and stop, not grind the whole thing.
+
+---
+
+**Step 1 — Select (skip if explicit issue numbers were given)**
+
+Reuse `/next`'s priority order against the **active milestone**:
+
+```bash
+gh issue list -R AtlasDevHQ/atlas --state open --label ready-for-agent \
+  --json number,title,body,labels,milestone
+```
+Priority: **bugs & security first** → current-milestone features → unblock-others first. Parse `Depends on #M` per issue; only pick from the **unblocked frontier** (deps merged/closed). Prefer issues that touch **different directories** (less worktree contention). Take the top N (default 3).
+
+Present the picks and **wait for confirmation** before dispatching:
+```
+## Batch: <milestone> — shipping N
+| # | title | type | area | independent? |
+|---|-------|------|------|-------------|
+Proceed? (y/n)
+```
+(Skip the confirm prompt only when explicit issue numbers were passed — that's already the user's pick.)
+
+**Step 2 — Dispatch (parallel, one worker per issue)**
+
+For each picked issue, spawn a background L0 worker in its own worktree:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  isolation: "worktree",
+  run_in_background: true,
+  description: "ship #<N>",
+  prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
+           /review-panel until clean (max 3 rounds), /ci, /pr, subscribe_pr_activity,
+           merge only when green AND own-branch. Halt and report if a review can't
+           converge, a gate is broken, or anything is ambiguous. Report PR + outcome."
+)
+```
+
+Dispatch all N at once (the batch size IS the concurrency cap — keep it ≤ 5; beyond that worktrees thrash and reviews queue). Independent picks in Step 1 means they won't collide.
+
+**Step 3 — Collect (NO refill)**
+
+Wait for the workers to finish (you're woken on completion). Unlike `/ship-milestone`, **do not re-resolve the frontier or dispatch newly-unblocked issues** — this batch is fixed at N. When all N have reached a terminal state (merged, or halted-for-human), report and stop.
+
+If a worker halted: unambiguous → offer to re-dispatch with guidance; ambiguous → `AskUserQuestion`.
+
+**Step 4 — Report**
+```
+## Batch done — <milestone>
+- [x] #1201 title — merged (PR #..)
+- [x] #1202 title — merged (PR #..)
+- [!] #1207 title — HALTED: review didn't converge (round 3) — needs you
+```
+Then suggest the obvious next move: another `/ship-batch` for the next 3, or `/ship-milestone` to let the rest run on a heartbeat.
+
+---
+
+**HARD HALTS:** every `/ship-issue` halt applies (fork PR, broken/missing-by-design gate, `--admin` discipline). This command never runs `/closeout` or `/release` — it ships a bounded batch and hands back.
+
+**Rules:** Always `-R AtlasDevHQ/atlas`. Worktree-isolated workers only. Cap at 5. Bounded — no auto-refill (that's `/ship-milestone`'s job). Confirm picks before dispatching unless issue numbers were explicit.

--- a/.claude/commands/ship-batch.md
+++ b/.claude/commands/ship-batch.md
@@ -1,11 +1,13 @@
 Middle ground between `/ship-issue` (one) and `/ship-milestone` (the whole thing on a heartbeat): pick the top N `ready-for-agent` issues from the current milestone — the way `/next` does — and dispatch a `/ship-issue` worker for each. Bounded batch: no heartbeat, no auto-refill, no closeout/release.
 
-**Input:** `$ARGUMENTS` — optional. Forms:
+**Input:** `$ARGUMENTS` — optional. Forms (the batch is hard-capped at **5** — see *Cap* below):
 - *(empty)* → pick the top **3** unblocked issues from the active milestone
-- a number `5` → pick the top **5**
-- explicit issue numbers `1201 1202 1207` → ship exactly those
+- a number `N` from **1–5** → pick the top **N**
+- explicit issue numbers `1201 1202 1207` → ship exactly those, **up to 5**
 
 **You type:** `/ship-batch` · `/ship-batch 5` · `/ship-batch 1201 1202 1207`
+
+**Cap — enforced at parse time:** this batch dispatches **at most 5** workers; that count IS the concurrency cap in Step 2. If the input asks for more — a number `> 5`, or more than 5 explicit issue numbers — **do not truncate and do not dispatch.** Stop and tell the user to split into batches of ≤ 5 (or run `/ship-milestone` to grind the whole milestone on a heartbeat). Never silently drop issues the user explicitly named — explicit-issue input skips the Step 1 confirmation, so an over-cap batch has no other backstop.
 
 This is L1.5 — `/next`'s selection + `/ship-issue`'s dispatch, capped. Use it when you want to knock out a chunk of a milestone and stop, not grind the whole thing.
 

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -1,0 +1,86 @@
+L0 — the inner ship loop. Take ONE issue from nothing to a merged PR, autonomously, halting only at the human boundaries. This is the unit `/ship-milestone` runs per issue.
+
+**Input:** `$ARGUMENTS` — the issue number (e.g. `1234`). Required.
+
+**You type:** `/ship-issue 1234`
+
+---
+
+**Step 0 — Worktree isolation (MANDATORY, before anything else)**
+
+This repo is a SHARED working tree. Create your own worktree off latest `main` and install deps before reading/editing/running anything:
+
+```bash
+git fetch origin
+git worktree add -b <branch> ../atlas-wt-<slug> origin/main
+cd ../atlas-wt-<slug> && bun install --frozen-lockfile
+```
+`<slug>` is slash-free. Commit only explicit paths (`git commit -o <files>`), never `git add -A` / `commit -a`. Don't `/reset` or `git checkout main` in the shared tree.
+
+**Step 1 — Read the issue**
+
+```bash
+gh issue view <N> -R AtlasDevHQ/atlas
+```
+Note the type label, acceptance criteria, and any `Depends on #M`. If a dependency isn't merged yet, STOP and report — this issue isn't ready.
+
+**Step 2 — Pick the craft loop**
+
+- **bug** → `/diagnose` first (reproduce → isolate → fix), THEN `/tdd` to lock the regression test. Never write the test before isolating the cause.
+- **feature, clear shape** → `/tdd` (red-green-refactor, one slice).
+- **feature, uncertain design** → `/prototype` first, then `/tdd`.
+- **domain-heavy** → `/grill-with-docs` first.
+- **docs/chore/trivial** → skip `/tdd`.
+
+Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fast red→green loop.
+
+**Step 3 — Internal review BEFORE the PR**
+
+```
+/review-panel
+```
+- Verdict **CHANGES REQUESTED** → address the must-fix findings, then re-run `/review-panel` on the new diff.
+- Repeat until **CLEAN**, capped at **3 rounds**. If it can't converge in 3 (usually a spec ambiguity), STOP and ask the human.
+
+**Step 4 — CI gate**
+
+```
+/ci
+```
+All gates must pass. Fix anything red (these are usually small). Run full `bun run test` once here even if `--affected` was green.
+
+**Step 5 — Open the PR and watch it**
+
+```
+/pr
+```
+`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`. Then **subscribe to its activity so this session services CI + review bots**:
+
+```
+subscribe_pr_activity for the new PR
+```
+On each event:
+- actionable + unambiguous → push the fix, re-kick CI
+- ambiguous / architectural → `AskUserQuestion`
+- green on the head SHA AND panel was clean → merge
+
+**HARD HALTS (never autonomous):**
+- **Fork PR** (`isCrossRepository: true`) → STOP, surface provenance, get human sign-off. Never `--admin` past `fork-pr-gate`.
+- A required check that's **structurally missing** (e.g. CodeQL on a fork) → stop sign, not an override.
+- `--admin` is only for a genuinely *broken* gate, not a *slow* one — wait for `gh pr checks --watch`.
+
+**Step 6 — Reconcile and clean up**
+
+After merge:
+```
+/tidy            # check off ROADMAP, close the issue if Closes didn't, prune
+git worktree remove ../atlas-wt-<slug>
+```
+
+**Step 7 — Report**
+
+PR URL · issue closed · CI/merge status · panel rounds it took · anything you halted on.
+
+---
+
+**Rules:** Always `-R AtlasDevHQ/atlas`. Worktree-isolated commits only. The panel + `/ci` are mandatory gates, not optional. Respect every merge-discipline halt in CLAUDE.md.

--- a/.claude/commands/ship-milestone.md
+++ b/.claude/commands/ship-milestone.md
@@ -1,0 +1,84 @@
+L2 — the milestone loop. Grind an entire milestone of `ready-for-agent` issues to merged, over and over until complete, dispatching one `/ship-issue` (L0) per issue in its own worktree. The "wake up to merged PRs" loop.
+
+**Input:** `$ARGUMENTS` — the milestone name or number (e.g. `"0.0.5 — REST Datasources"` or `42`). Required.
+
+**You type:** `/ship-milestone "0.0.5 — REST Datasources"`
+
+**Prereq:** the milestone is already broken into issues (via `/kickoff` or `/to-issues`) and they're labeled `ready-for-agent`. This command does NOT plan — it executes. Run it on YOUR OWN issues only; never on a milestone containing fork contributions.
+
+---
+
+**Step 1 — Build the ready set**
+
+```bash
+gh issue list -R AtlasDevHQ/atlas --state open --milestone "<milestone>" \
+  --label ready-for-agent --json number,title,body,labels
+```
+For each issue, parse `Depends on #M` from the body. An issue is **ready** when it's open and all its deps are merged/closed. Build the dependency graph; the ready set is the unblocked frontier.
+
+If the milestone has zero open issues, jump to Step 4 (it's already done).
+
+**Step 2 — Dispatch the frontier (parallel, capped)**
+
+For each ready, not-yet-dispatched issue, spawn an L0 worker — a background sub-agent running the `/ship-issue` flow in its own worktree:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  isolation: "worktree",
+  run_in_background: true,
+  description: "ship #<N>",
+  prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
+           /review-panel until clean (max 3 rounds), /ci, /pr, subscribe_pr_activity,
+           merge only when green AND own-branch. Halt and report if a review can't
+           converge, a gate is broken, or anything is ambiguous. Report the PR + outcome."
+)
+```
+
+**Concurrency cap: 3 in flight.** More than that and the worktrees thrash and reviews queue. Independent issues run in parallel; dependent ones wait in the frontier.
+
+**Step 3 — Heartbeat: drive to completion**
+
+Do NOT `sleep` or poll in a busy loop. You're woken by (a) background worker completions and (b) `subscribe_pr_activity` events. On each wake:
+
+1. **Reconcile** — which PRs merged or closed since last wake?
+2. `git fetch origin main` — pull the new baseline.
+3. **Re-resolve the ready set** — newly-merged deps unblock new issues.
+4. **Dispatch** newly-unblocked issues, respecting the cap.
+5. **Unblock stuck workers** — if a worker halted (review wouldn't converge, ambiguous finding, broken gate), surface it: unambiguous → re-dispatch with guidance; ambiguous → `AskUserQuestion`.
+6. **Loop condition:** repeat until the milestone has **no open `ready-for-agent` issues and no workers in flight.**
+
+If `send_later` (claude-code-remote) is available, schedule a check-in ~1h out as a safety net for transitions the webhooks don't deliver (merge-conflict, CI-success), then re-arm until done. If not, rely on worker-completion + PR events.
+
+**Step 4 — Close out**
+
+When the milestone is empty:
+```
+/closeout    # docs audit + changelog + close GH milestone — verifies completeness; halts if not truly done
+```
+
+**Step 5 — HALT for the human before release**
+
+```
+/release   ← do NOT run autonomously
+```
+Advancing `prod` is a deliberate human act. STOP here and report that the milestone is shipped to `main`/staging and ready for the operator to `/release`.
+
+---
+
+**HARD HALTS (every L0 halt applies, plus):**
+- **Fork PR anywhere in the set** → stop the whole loop and ask. Never autonomous.
+- **`/closeout` reports incomplete** → don't force it; report what's missing.
+- **`/release`** → always human-gated.
+- **Repeated worker thrash** (same issue halts ≥2×) → stop re-dispatching it, report the diagnosis.
+
+**Report (each heartbeat, keep a live checklist):**
+```
+## <milestone> — N issues · M merged · K in flight · J blocked
+- [x] #1 title — merged (PR #..)
+- [~] #2 title — in review (panel round 2)
+- [ ] #3 title — blocked on #2
+```
+Refresh it every wake so the thread shows live state. Stop the loop only when MERGED/CLOSED everything or the human says stop.
+
+**Rules:** Always `-R AtlasDevHQ/atlas`. Worktree-isolated workers only. Never `sleep`-poll for events. Cap concurrency at 3. The loop is not finished until the milestone is empty and closed out — but it never advances `prod` on its own.

--- a/.claude/commands/ship-milestone.md
+++ b/.claude/commands/ship-milestone.md
@@ -37,6 +37,8 @@ Agent(
 
 **Concurrency cap: 3 in flight.** More than that and the worktrees thrash and reviews queue. Independent issues run in parallel; dependent ones wait in the frontier.
 
+> ⚠️ **Verify isolation — don't trust `isolation: "worktree"` alone for background workers.** On this shared checkout, `isolation: "worktree"` + `run_in_background` has let two agents race in the same tree. Each worker's `/ship-issue` Step 0 creates its own `git worktree`, but confirm `git worktree list` shows a distinct path + HEAD per worker before any of them edit or commit — and prefer issues that touch different directories to cut contention.
+
 **Step 3 — Heartbeat: drive to completion**
 
 Do NOT `sleep` or poll in a busy loop. You're woken by (a) background worker completions and (b) `subscribe_pr_activity` events. On each wake:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ next-env.d.ts
 tsconfig.tsbuildinfo
 .claude/*
 !.claude/commands/
+!.claude/agents/
 !.claude/settings.json
 !.claude/research/
 !.claude/skills/

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -11,8 +11,10 @@ giving up the safety boundaries Atlas already enforces. The loops are listed low
 first.
 
 **Shipped commands:** `/review-panel` (the shared review primitive), `/ship-issue <#N>`
-(L0 — one issue to merged), `/ship-milestone "<name>"` (L2 — grind a whole milestone).
-L1 (dispatcher) and L3 (heartbeat) are still design-only.
+(L0 — one issue to merged), `/ship-batch [N]` (pick the top N ready issues from the active
+milestone — `/next`-style — and ship them as a bounded batch), `/ship-milestone "<name>"`
+(L2 — grind a whole milestone on a heartbeat). L1 (dispatcher) and L3 (heartbeat) are still
+design-only.
 
 ---
 

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -1,0 +1,170 @@
+# Agent loops: making the workflow drive itself
+
+`docs/agents/workflow.md` describes Atlas's commands as a five-phase state machine
+(Notice → Plan → Build → Reconcile → Ship). Today **the human is the runtime** that
+executes it: you run `/next`, copy a prompt into a new session, wait for the PR, paste
+review comments back, merge, run `/tidy`, run `/next` again. Every arrow between phases
+is a manual handoff.
+
+This doc captures how to close those arrows — to let agents prompt agents — without
+giving up the safety boundaries Atlas already enforces. It is a **design reference**,
+not yet a set of shipped commands. The loops are listed lowest-risk first.
+
+---
+
+## What's already here
+
+Two of the hardest primitives already exist. The loops below are connective tissue, not
+new machinery.
+
+- **`/next` already emits launch-ready sub-session prompts.** Each prompt is
+  self-contained, opens with the `🚨 STOP` worktree banner, and includes the
+  `git worktree add … && cd … && bun install --frozen-lockfile` step. That is a thread
+  that can spin up threads — it just *prints* the prompts today instead of *launching*
+  them. The `Agent` tool with `isolation: "worktree"` is the launcher.
+- **The PR-watch loop is a first-class primitive.** `/pr` creates the PR;
+  `subscribe_pr_activity` wakes the session on review comments and CI; the harness drives
+  investigate → fix → push → re-kick until the PR is MERGED or CLOSED. No polling, no
+  `sleep`.
+
+So the dispatcher and the reviewer-feedback loop are mostly wiring, not invention.
+
+---
+
+## The hard boundary that makes autonomy safe
+
+Atlas's **Merge discipline** (CLAUDE.md) is not a limitation to route around — it is what
+makes an overnight loop safe to run:
+
+- **Fork PRs (`isCrossRepository: true`) are never agent-mergeable.** The `fork-pr-gate`
+  check stays red by design until a maintainer applies `external-approved` by hand. A loop
+  must stop and ask (`AskUserQuestion`) on a fork PR, never `--admin` past it. See #3772.
+- **`--admin` is for a *broken* gate, not a *slow* one.** A loop waits for
+  `gh pr checks --watch` to go green on the head SHA; it does not force merges because it
+  is impatient (#2206).
+- **Branch protection on `main` is on.** Required checks (`ci`, `api-tests (1/4)`–`(4/4)`,
+  Deploy Validation, CodeQL, Symlink Stub Build, `fork-pr-gate`) gate every merge.
+
+The design rule that falls out: **a loop may run fully autonomous up to the merge gate on
+its own-branch PRs, and must halt for a human at every boundary the merge-discipline rules
+name.** That boundary is precisely why L2 is safe to run while you sleep — the dangerous
+actions are fenced off, so the worst case is wasted tokens, not a bad merge.
+
+---
+
+## L0 — Inner ship loop
+
+> One issue, one PR, autonomous until merge.
+
+```
+build → /ci → /pr → subscribe_pr_activity → address reviews/CI → merge
+```
+
+The pieces all exist; the only missing wire is having `/pr` end by calling
+`subscribe_pr_activity` on the PR it just opened, so the session keeps itself alive to
+service review comments and CI failures.
+
+- **Drives:** the build → ship arc for a single tracked issue.
+- **Halts for a human:** fork PRs; a genuinely broken required check; any review comment
+  whose fix is ambiguous or architecturally significant (per the harness's option-2 rule).
+- **Risk:** low. This is the loop from the "watch the PR for 6 hours addressing review
+  comments" story, except first-class.
+- **Reused by:** L2 (each milestone issue runs an L0 loop).
+
+---
+
+## L1 — The dispatcher
+
+> Turn `/next` from "print 3 prompts" into "spawn 3 worktree agents and report back."
+
+`/next` already produces launch-ready, worktree-isolated prompts. The dispatcher reads
+them and fires one `Agent({ isolation: "worktree" })` per prompt, then collects results.
+
+```
+/next → for each emitted prompt:
+          Agent({ isolation: "worktree", prompt, run_in_background: true })
+        → collect summaries → report
+```
+
+- **Drives:** the Plan → Build handoff. Deletes the copy-paste-into-a-new-session step.
+- **Why worktree isolation:** the repo is a **shared working tree** — sessions share one
+  `.git`, HEAD, and index. `isolation: "worktree"` gives each agent its own checkout, which
+  is exactly what the `/next` banner demands of human-launched sessions.
+- **Halts for a human:** nothing structural — but each spawned agent inherits L0's halts.
+- **Risk:** low–medium. Smallest change, largest leverage. Best first build.
+
+---
+
+## L2 — The milestone loop
+
+> The dynamic, multi-PR "wake up to merged PRs" loop. A heartbeat thread drives a whole
+> milestone to completion.
+
+The commands line up one-to-one with the loop body:
+
+```
+/kickoff  →  for each ready (unblocked) issue:
+               Agent(worktree): implement → /ci → /pr
+               → subscribe_pr_activity → review loop → merge   (= L0)
+               → /tidy   (check off ROADMAP, close issue, prune the worktree)
+             repeat until the milestone has no ready issues
+/closeout →  docs audit + changelog + close GH milestone
+/release  →  tag + push + advance prod
+```
+
+A heartbeat (`/loop`, ~5–10 min) drives it: on each wake it checks which PRs merged,
+dispatches the next unblocked issue, and pulls the latest `main` before the next worktree.
+Dependencies between issues (`Depends on #N` in the Atlas issue body) decide what is
+"ready" — stacked work serializes, independent work parallelizes. `/tidy`'s stale-branch
+and orphan-worktree cleanup is the teardown step.
+
+- **Drives:** an entire milestone, Plan → Ship → Release, mostly unattended.
+- **Halts for a human:** every L0 halt, plus `/closeout` (verifies the milestone is truly
+  complete before closing) and `/release` (advancing `prod` is a deliberate, human-gated
+  act — keep it that way).
+- **Risk:** medium–high. Highest token burn; a wrong path burns longer. Run it on your own
+  branches, never on a milestone full of fork contributions.
+
+---
+
+## L3 — Always-on heartbeat
+
+> The morning-standup loop. A thin `/sitrep` on an interval that acts only on deltas.
+
+```
+/loop 30m:
+  /sitrep (read-only)
+  → CI red on main?            spawn a fix-agent (L0)
+  → inbox has needs-triage?    run /triage
+  → active milestone empty?    notify the human to /kickoff
+  → otherwise                  re-arm silently, say nothing
+```
+
+- **Drives:** continuous repo hygiene and inbound triage.
+- **Halts for a human:** anything that would create or close a milestone; anything `/triage`
+  routes to `ready-for-human`.
+- **Risk:** low if it stays mostly read-only and only spawns bounded fix-agents. The trap is
+  a chatty heartbeat — it must say nothing when nothing changed.
+
+---
+
+## Build order
+
+1. **L0** — wire `/pr` → `subscribe_pr_activity`. Foundational; L2 reuses it.
+2. **L1** — dispatcher on top of `/next`'s existing prompt output. Smallest change, kills
+   the copy-paste.
+3. **L2** — compose L0 inside a `/kickoff … /closeout` heartbeat. The headline loop.
+4. **L3** — the standing heartbeat, once L0's fix-agents are trustworthy.
+
+Each is a thin command/skill over primitives that already exist: the `Agent` tool
+(`isolation: "worktree"`, `run_in_background`), `subscribe_pr_activity`, `/loop`, and the
+phase commands themselves. The work is orchestration and halt-conditions, not new tooling.
+
+---
+
+## See also
+
+- `docs/agents/workflow.md` — the five-phase command × skill map these loops automate.
+- `docs/agents/issue-tracker.md` — the issue body format (`Depends on #N`) the L2 readiness
+  check depends on.
+- CLAUDE.md § **Merge discipline** — the human boundaries every loop must respect.

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -28,12 +28,17 @@ new machinery.
   `git worktree add … && cd … && bun install --frozen-lockfile` step. That is a thread
   that can spin up threads — it just *prints* the prompts today instead of *launching*
   them. The `Agent` tool with `isolation: "worktree"` is the launcher.
-- **The PR-watch loop is a first-class primitive.** `/pr` creates the PR;
+- **The PR-watch loop is a harness primitive.** `/pr` creates the PR; the harness's
   `subscribe_pr_activity` wakes the session on review comments and CI; the harness drives
   investigate → fix → push → re-kick until the PR is MERGED or CLOSED. No polling, no
   `sleep`.
 
 So the dispatcher and the reviewer-feedback loop are mostly wiring, not invention.
+
+> **A note on names.** `subscribe_pr_activity` and `send_later` (below) are *harness/runtime*
+> primitives, not repo commands or skills — don't grep `.claude/` for them. The one piece L0
+> still has to build is the wire that makes `/pr` *end* by subscribing (see L0); the
+> subscription capability itself is the harness's.
 
 ---
 
@@ -49,7 +54,8 @@ makes an overnight loop safe to run:
   `gh pr checks --watch` to go green on the head SHA; it does not force merges because it
   is impatient (#2206).
 - **Branch protection on `main` is on.** Required checks (`ci`, `api-tests (1/4)`–`(4/4)`,
-  Deploy Validation, CodeQL, Symlink Stub Build, `fork-pr-gate`) gate every merge.
+  Deploy Validation, `Analyze (javascript-typescript)`, Symlink Stub Build, `fork-pr-gate`)
+  gate every merge.
 
 The design rule that falls out: **a loop may run fully autonomous up to the merge gate on
 its own-branch PRs, and must halt for a human at every boundary the merge-discipline rules
@@ -147,9 +153,9 @@ Atlas's standards**, and lives in `.claude/agents/` (see `.claude/agents/README.
 | `pr-test-analyzer` | untested error paths, brittle tests, missing `-pg` fixtures | CLAUDE.md § Testing |
 | `comment-analyzer` | comment rot, restate-the-obvious, idiom mismatch | comment-density + `// intentionally ignored:` conventions |
 
-The dispatcher fans these out in **parallel** (`Agent`, fresh context) against the
+The L2 loop fans these out in **parallel** (`Agent`, fresh context) against the
 implementer's diff, collects findings, and hands them back to the implementer to address —
-re-reviewing the new diff until the panel is clean. Then `/ci` and `/pr`. The repo's tuned
+re-reviewing the new diff until the panel is clean. Then `/ci` and `/pr`. The existing
 `/code-review` and `/simplify` skills remain the canonical generic passes — the panel adds
 the four specialist axes the generic pass spreads thin, and because each is tuned to Atlas's
 checklist it produces gate-relevant findings instead of generic-reviewer noise.

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -104,8 +104,10 @@ The commands line up one-to-one with the loop body:
 
 ```
 /kickoff  →  for each ready (unblocked) issue:
-               Agent(worktree): implement → /ci → /pr
-               → subscribe_pr_activity → review loop → merge   (= L0)
+               Agent(worktree): implement
+               → internal-review panel (parallel, fresh context) — see below
+               → address findings → re-review until clean
+               → /ci → /pr → subscribe_pr_activity → service CI/bot events → merge   (= L0)
                → /tidy   (check off ROADMAP, close issue, prune the worktree)
              repeat until the milestone has no ready issues
 /closeout →  docs audit + changelog + close GH milestone
@@ -124,6 +126,31 @@ and orphan-worktree cleanup is the teardown step.
   act — keep it that way).
 - **Risk:** medium–high. Highest token burn; a wrong path burns longer. Run it on your own
   branches, never on a milestone full of fork contributions.
+
+### The internal-review panel
+
+The point of the inner loop is to review **before** the PR opens, with fresh-context agents
+rather than the implementer reading its own diff — and not to block on external review bots.
+The reviewer panel is vendored from anthropics/claude-code's `pr-review-toolkit`, **tuned to
+Atlas's standards**, and lives in `.claude/agents/` (see `.claude/agents/README.md`):
+
+| Reviewer | Catches | Atlas rules it enforces |
+| --- | --- | --- |
+| `silent-failure-hunter` | swallowed errors, broad catches, false-negative security fallbacks | CLAUDE.md § Error Handling — log-or-rethrow, type-narrow, `requestId` on 500s |
+| `type-design-analyzer` | weak invariants, `any`, stray `!`, Tag/SSOT drift | CLAUDE.md § Type Safety + § Effect.ts |
+| `pr-test-analyzer` | untested error paths, brittle tests, missing `-pg` fixtures | CLAUDE.md § Testing |
+| `comment-analyzer` | comment rot, restate-the-obvious, idiom mismatch | comment-density + `// intentionally ignored:` conventions |
+
+The dispatcher fans these out in **parallel** (`Agent`, fresh context) against the
+implementer's diff, collects findings, and hands them back to the implementer to address —
+re-reviewing the new diff until the panel is clean. Then `/ci` and `/pr`. The repo's tuned
+`/code-review` and `/simplify` skills remain the canonical generic passes — the panel adds
+the four specialist axes the generic pass spreads thin, and because each is tuned to Atlas's
+checklist it produces gate-relevant findings instead of generic-reviewer noise.
+
+External bots + CI run **after** `/pr` opens and are serviced asynchronously via
+`subscribe_pr_activity` — a backstop for what the panel missed (cross-PR interactions,
+real-Postgres `-pg` shards, CodeQL), never a blocker the loop sits and waits on.
 
 ---
 

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -7,8 +7,12 @@ review comments back, merge, run `/tidy`, run `/next` again. Every arrow between
 is a manual handoff.
 
 This doc captures how to close those arrows — to let agents prompt agents — without
-giving up the safety boundaries Atlas already enforces. It is a **design reference**,
-not yet a set of shipped commands. The loops are listed lowest-risk first.
+giving up the safety boundaries Atlas already enforces. The loops are listed lowest-risk
+first.
+
+**Shipped commands:** `/review-panel` (the shared review primitive), `/ship-issue <#N>`
+(L0 — one issue to merged), `/ship-milestone "<name>"` (L2 — grind a whole milestone).
+L1 (dispatcher) and L3 (heartbeat) are still design-only.
 
 ---
 

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -82,6 +82,7 @@ When Atlas opens to a community, `/triage` runs first (move new issues through t
 | Milestone is fully shipped | `/closeout` (Atlas) — docs audit, changelog, close GH milestone |
 | Handing the in-flight session to another agent / clone / day | `/handoff` (Matt Pocock — compacts the session into a handoff doc) |
 | Need a recurring run of any of the above | `/loop` or `/schedule` (Claude Code) |
+| Want the phases to drive themselves (agents prompting agents) | See `docs/agents/loops.md` — L0–L3 loop designs over the `Agent` + `subscribe_pr_activity` primitives |
 
 `/handoff` is the missing piece in Atlas's existing flow. Before splitting work across parallel sessions or stepping away mid-task, `/handoff` produces a doc the next session can pick up cold.
 


### PR DESCRIPTION
## Summary

Designs for making the existing command machine drive itself (agents prompting agents), plus the tuned review panel the loops rely on.

- **`docs/agents/loops.md`** — four loop designs (L0–L3) over the primitives Atlas already has (`Agent` worktree isolation, `subscribe_pr_activity`, `/loop`), with the human merge boundaries each must respect. Linked from `workflow.md`.
- **`.claude/agents/`** — four specialist review subagents vendored from anthropics/claude-code `pr-review-toolkit` and **retuned to Atlas's conventions** (Pino `log.warn`/`console.debug`, `requestId` on 500s, `Data.TaggedError`, the `catch { return false }`-is-a-bug rule, isolated test runner, `createConnectionMock`, `-pg` fixtures, `@useatlas/types` ↔ `@useatlas/schemas` SSOT) — not the upstream Sentry/Statsig/`errorIds` references.
  - `silent-failure-hunter` · `type-design-analyzer` · `pr-test-analyzer` · `comment-analyzer`
  - All read-only/advisory (`tools: Read, Grep, Glob, Bash`). Provenance + update policy in `.claude/agents/README.md`.
- Skipped the toolkit's generic `code-reviewer`/`code-simplifier` — the existing `/code-review` and `/simplify` skills stay canonical.
- Wired the panel into the L2 internal-review fan-out (review **before** the PR opens with fresh-context agents; external bots/CI are an async backstop via `subscribe_pr_activity`, not a blocker).
- **`.claude/commands/`** — four shipped command specs that drive the loops: `/review-panel` (the shared review primitive), `/ship-issue` (L0 — one issue to merged), `/ship-batch [N]` (L1.5 — ship a bounded batch of the top N ready issues, then stop), `/ship-milestone` (L2 — grind a whole milestone on a heartbeat). L1 (dispatcher) and L3 (heartbeat) stay design-only in `loops.md`.
- `.gitignore` — unignore `.claude/agents/` so the panel ships to all sessions (incl. web).

Docs + agent/command definitions only — no runtime code changes.

## Test plan

- [ ] `docs/agents/loops.md` renders and links resolve (`workflow.md`, `issue-tracker.md`, `.claude/agents/README.md`)
- [ ] The four agents appear in `/agents`
- [ ] The four commands appear in `/` (`/review-panel`, `/ship-issue`, `/ship-batch`, `/ship-milestone`)
- [ ] Spot-check one agent fires on a relevant diff (e.g. `silent-failure-hunter` on a new try/catch)

https://claude.ai/code/session_01Sa4mKKSPUj9UY569bUJm76

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sa4mKKSPUj9UY569bUJm76)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-loop docs and vendored specialist review-panel agents for Atlas
> - Adds four specialist sub-agent specs ([silent-failure-hunter](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-23baf38e65cf1cec34020df190920ec56890a3d14c2f6ad430daea45a9fcb11e), [type-design-analyzer](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-41acc60b1e197394572309dd7e35fcd5b30ea2e116e0c72d50629f4b8254bc83), [pr-test-analyzer](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-29c4cd14ec132671e2e7b2bbb3988f43b343c2c3eb789e9bb3f512fb27655c0d), [comment-analyzer](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-49df9c6be9febb378f9425aa9b7deaedd3cc3373624e996dd054fbb916bba83e)) encoding Atlas-specific review standards for error handling, type safety, test discipline, and comment quality.
> - Adds a [review-panel](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-3e590092fe6a297b3d6239464f82daa0d137ed46f634cc5594b26e539a1d36f2) command that fans the four agents out in parallel against a diff and produces a deduplicated CLEAN/CHANGES REQUESTED verdict.
> - Adds [ship-issue](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-2ce443f8600dbecd0eb30b794018c0b0bdce63118ce20096b913db08d1db3e6b), [ship-batch](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-7a90b49ea52fc28f08ac48efe15cd5c38651ffac19c33e0ca96f951e31bed899), and [ship-milestone](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-cf3e4b16e9c1d2d37b2c37b107e0f8223a020c21bf66479fbe0b916b3e473f75) command specs defining the L0–L2 agent loops with worktree isolation, CI gating, and concurrency caps.
> - Adds [docs/agents/loops.md](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-9bf90d4ec34954fc865fb393f7ff577599b1763fa9b62ee96623b4c84ba3cb76) documenting the L0–L3 loop hierarchy, merge-discipline boundaries, and review-panel composition.
> - Updates [.gitignore](https://github.com/AtlasDevHQ/atlas/pull/3823/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to track `.claude/agents/` alongside the existing `.claude/commands/` exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0dfd61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Docs-only PR adding agent-loop designs and four Atlas-tuned specialist review subagents vendored from the `anthropics/claude-code` pr-review-toolkit. No runtime code is changed.

- **`docs/agents/loops.md`** documents L0–L3 loop designs over existing primitives (`Agent` worktree isolation, `subscribe_pr_activity`, `/loop`), with the human-merge boundaries each must respect.
- **`.claude/agents/`** adds four read-only specialist reviewers correctly tuned to Atlas's CLAUDE.md conventions (Pino `log.warn`/`console.debug`, `requestId` on 500s, `Data.TaggedError`, `bun run test`, `createConnectionMock`, `-pg` fixtures, `@useatlas/types` ↔ `@useatlas/schemas` SSOT).
- **`.claude/commands/`** ships four orchestration commands wiring the panel into the L2 internal-review fan-out.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Docs and agent/command definitions only — no runtime code changes; safe to merge.

All changed files are Markdown docs and Claude agent/command definitions with no code changes, migrations, or production-affecting configuration. The one inconsistency found (L2 heartbeat description in loops.md vs. the shipped event-driven ship-milestone.md) is a documentation clarity issue, not a functional defect.

docs/agents/loops.md — the L2 heartbeat mechanism description should be reconciled with ship-milestone.md.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents/loops.md | New design doc for L0–L3 agent loops; L2 heartbeat description uses /loop which contradicts the shipped event-driven ship-milestone.md implementation. |
| .claude/commands/ship-issue.md | L0 ship-loop command; well-structured with correct merge-discipline halts. |
| .claude/commands/ship-batch.md | L1.5 bounded-batch command; dispatches up to 5 parallel L0 workers with an explicit over-cap error rather than silent truncation. |
| .claude/commands/ship-milestone.md | L2 milestone-grind command; uses event-driven wakeup which conflicts with the /loop heartbeat described in loops.md. |
| .claude/commands/review-panel.md | Shared review primitive; correctly fans out four specialist agents in parallel with fresh context. |
| .claude/agents/silent-failure-hunter.md | Error-handling specialist; correctly tuned to Atlas Pino/requestId/catch-return-false rules. |
| .claude/agents/pr-test-analyzer.md | Test-coverage specialist; correctly enforces bun run test, createConnectionMock, -pg fixture discipline. |
| .gitignore | Adds !.claude/agents/ exception matching the existing !.claude/commands/ pattern. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `.claude/commands/ship-issue.md`, line 451 ([link](https://github.com/atlasdevhq/atlas/blob/31cff387824268d5f7fee8ae20f666bf83f3ff5c/.claude/commands/ship-issue.md#L451)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`git commit -o` silently drops separately-staged changes**

   `git commit --only <files>` (`-o`) commits *only* the named paths and ignores everything in the staging area. If an agent stages some files with `git add <paths>` before calling `git commit -o <other-paths> -m "…"`, the staged files are silently excluded from the commit — no error, no warning. The worktree still looks dirty in surprising ways and the next commit may double-include those files.

   The idiomatic safe alternative that keeps the same intent — commit nothing that wasn't explicitly named — is `git add <files> && git commit -m "…"`. That pattern also makes the staged vs committed states consistent and is less likely to confuse an LLM that reasons about git state step-by-step.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.claude%2Fcommands%2Fship-issue.md%0ALine%3A%20451%0A%0AComment%3A%0A**%60git%20commit%20-o%60%20silently%20drops%20separately-staged%20changes**%0A%0A%60git%20commit%20--only%20%3Cfiles%3E%60%20%28%60-o%60%29%20commits%20*only*%20the%20named%20paths%20and%20ignores%20everything%20in%20the%20staging%20area.%20If%20an%20agent%20stages%20some%20files%20with%20%60git%20add%20%3Cpaths%3E%60%20before%20calling%20%60git%20commit%20-o%20%3Cother-paths%3E%20-m%20%22%E2%80%A6%22%60%2C%20the%20staged%20files%20are%20silently%20excluded%20from%20the%20commit%20%E2%80%94%20no%20error%2C%20no%20warning.%20The%20worktree%20still%20looks%20dirty%20in%20surprising%20ways%20and%20the%20next%20commit%20may%20double-include%20those%20files.%0A%0AThe%20idiomatic%20safe%20alternative%20that%20keeps%20the%20same%20intent%20%E2%80%94%20commit%20nothing%20that%20wasn't%20explicitly%20named%20%E2%80%94%20is%20%60git%20add%20%3Cfiles%3E%20%26%26%20git%20commit%20-m%20%22%E2%80%A6%22%60.%20That%20pattern%20also%20makes%20the%20staged%20vs%20committed%20states%20consistent%20and%20is%20less%20likely%20to%20confuse%20an%20LLM%20that%20reasons%20about%20git%20state%20step-by-step.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=atlasdevhq%2Fatlas&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `.claude/commands/ship-batch.md`, line 406 ([link](https://github.com/atlasdevhq/atlas/blob/31cff387824268d5f7fee8ae20f666bf83f3ff5c/.claude/commands/ship-batch.md#L406)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Concurrency cap (≤5 here) conflicts with the cap declared elsewhere**

   `ship-batch.md` says "keep it ≤ 5" while `ship-milestone.md` hard-caps at 3 and the rules footer in `docs/agents/loops.md` says "Cap concurrency at 3" with no qualifier limiting that rule to `/ship-milestone`. An agent reading `loops.md` first and then `/ship-batch` will see two different ceilings with no rationale for the difference. If the higher cap for `/ship-batch` is intentional (bounded one-shot vs. sustained heartbeat), stating that reasoning in both the batch command and `loops.md` would prevent misapplication of the stricter cap.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.claude%2Fcommands%2Fship-batch.md%0ALine%3A%20406%0A%0AComment%3A%0A**Concurrency%20cap%20%28%E2%89%A45%20here%29%20conflicts%20with%20the%20cap%20declared%20elsewhere**%0A%0A%60ship-batch.md%60%20says%20%22keep%20it%20%E2%89%A4%205%22%20while%20%60ship-milestone.md%60%20hard-caps%20at%203%20and%20the%20rules%20footer%20in%20%60docs%2Fagents%2Floops.md%60%20says%20%22Cap%20concurrency%20at%203%22%20with%20no%20qualifier%20limiting%20that%20rule%20to%20%60%2Fship-milestone%60.%20An%20agent%20reading%20%60loops.md%60%20first%20and%20then%20%60%2Fship-batch%60%20will%20see%20two%20different%20ceilings%20with%20no%20rationale%20for%20the%20difference.%20If%20the%20higher%20cap%20for%20%60%2Fship-batch%60%20is%20intentional%20%28bounded%20one-shot%20vs.%20sustained%20heartbeat%29%2C%20stating%20that%20reasoning%20in%20both%20the%20batch%20command%20and%20%60loops.md%60%20would%20prevent%20misapplication%20of%20the%20stricter%20cap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=atlasdevhq%2Fatlas&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `.claude/commands/ship-milestone.md`, line 567 ([link](https://github.com/atlasdevhq/atlas/blob/31cff387824268d5f7fee8ae20f666bf83f3ff5c/.claude/commands/ship-milestone.md#L567)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`subscribe_pr_activity` wakeup for the coordinator is underdefined**

   The heartbeat step says "You're woken by (a) background worker completions and (b) `subscribe_pr_activity` events," but each L0 worker already manages its own `subscribe_pr_activity` subscription for the PR it opened. It's unclear whether the milestone coordinator is expected to establish a *separate* subscription at the coordinator level (which would duplicate event handling with the workers), or whether the wording refers only to worker-surfaced signals. Clarifying whether the coordinator subscribes independently, and if so to what scope, would avoid an agent setting up redundant subscriptions or missing events entirely.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.claude%2Fcommands%2Fship-milestone.md%0ALine%3A%20567%0A%0AComment%3A%0A**%60subscribe_pr_activity%60%20wakeup%20for%20the%20coordinator%20is%20underdefined**%0A%0AThe%20heartbeat%20step%20says%20%22You're%20woken%20by%20%28a%29%20background%20worker%20completions%20and%20%28b%29%20%60subscribe_pr_activity%60%20events%2C%22%20but%20each%20L0%20worker%20already%20manages%20its%20own%20%60subscribe_pr_activity%60%20subscription%20for%20the%20PR%20it%20opened.%20It's%20unclear%20whether%20the%20milestone%20coordinator%20is%20expected%20to%20establish%20a%20*separate*%20subscription%20at%20the%20coordinator%20level%20%28which%20would%20duplicate%20event%20handling%20with%20the%20workers%29%2C%20or%20whether%20the%20wording%20refers%20only%20to%20worker-surfaced%20signals.%20Clarifying%20whether%20the%20coordinator%20subscribes%20independently%2C%20and%20if%20so%20to%20what%20scope%2C%20would%20avoid%20an%20agent%20setting%20up%20redundant%20subscriptions%20or%20missing%20events%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=atlasdevhq%2Fatlas&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fagents%2Floops.md%3A134-137%0A**L2%20heartbeat%20mechanism%20contradicts%20the%20shipped%20%60ship-milestone.md%60%20command**%0A%0A%60loops.md%60%20says%20%22A%20heartbeat%20%28%60%2Floop%60%2C%20~5%E2%80%9310%20min%29%20drives%20it%22%20for%20L2%2C%20but%20the%20shipped%20implementation%20in%20%60ship-milestone.md%60%20Step%203%20explicitly%20says%20%22Do%20NOT%20%60sleep%60%20or%20poll%20in%20a%20busy%20loop%20%E2%80%94%20you're%20woken%20by%20%28a%29%20background%20worker%20completions%20and%20%28b%29%20%60subscribe_pr_activity%60%20events%2C%22%20and%20falls%20back%20to%20%60send_later%60%20~1h%20check-ins%20rather%20than%20a%205%E2%80%9310%20min%20%60%2Floop%60.%20An%20agent%20referencing%20%60loops.md%60%20for%20L2%20guidance%20would%20expect%20a%20continuous%20%60%2Floop%60%20heartbeat%2C%20while%20the%20actual%20command%20runs%20event-driven.%20Aligning%20the%20description%20in%20%60loops.md%60%20to%20match%20the%20shipped%20event-driven%20mechanism%20would%20prevent%20this%20mismatch.%0A%0A&repo=atlasdevhq%2Fatlas&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(ship-batch): enforce the ≤5 cap at p..."](https://github.com/atlasdevhq/atlas/commit/f0dfd617577e3125d5ba97538499ac638fb31cf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38805876)</sub>

<!-- /greptile_comment -->