### PR TITLE
feat(mcp): host /auth.md agent-onboarding discovery file (#3824)

### DIFF
--- a/packages/api/src/api/__tests__/auth-md.test.ts
+++ b/packages/api/src/api/__tests__/auth-md.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Route tests for `GET /auth.md` (#3824).
+ *
+ * Thin — these cover the HTTP-plumbing contract only: 200 + `text/markdown`
+ * + CORS headers in managed mode; 404 in non-managed mode; the `OPTIONS`
+ * preflight responds like the sibling `.well-known` discovery routes. The
+ * *content* of the document is asserted by the pure-builder unit tests in
+ * `lib/mcp/__tests__/auth-md.test.ts`; here we only confirm the wiring.
+ *
+ * Structure mirrors `well-known.test.ts` — same auth-mode mock, same
+ * gating outcomes (`managed` / `not-managed`), same header expectations.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockDetectAuthMode: { current: "managed" | "none" } = {
+  current: "managed",
+};
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => mockDetectAuthMode.current,
+}));
+
+// ── Import routes after mocks ──────────────────────────────────────
+
+const { authMd } = await import("../routes/auth-md");
+const { Hono } = await import("hono");
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  mockDetectAuthMode.current = "managed";
+});
+
+async function startServer() {
+  const app = new Hono();
+  app.route("/auth.md", authMd);
+  const server = Bun.serve({ port: 0, idleTimeout: 0, fetch: app.fetch });
+  return {
+    url: `http://localhost:${server.port}`,
+    close: () => server.stop(true),
+  };
+}
+
+describe("auth.md — managed auth mode", () => {
+  it("serves GET /auth.md as 200 text/markdown with permissive CORS", async () => {
+    const prev = process.env.ATLAS_PUBLIC_API_URL;
+    process.env.ATLAS_PUBLIC_API_URL = "https://api.useatlas.dev";
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/auth.md`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/markdown");
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("cache-control")).toContain("max-age");
+
+      const body = await res.text();
+      // The hosts are resolved from the shared .well-known helpers, so /auth.md
+      // advertises exactly what machine discovery does: the auth-server issuer
+      // is the api.* host (`buildAuthServerUri`, matching the protected-resource
+      // metadata's `authorization_servers`), and the MCP resource is the
+      // brand-mirror mcp.* host (`buildResourceUri`).
+      expect(body).toContain("https://api.useatlas.dev/api/auth");
+      expect(body).toContain("https://mcp.useatlas.dev/mcp");
+      // Scopes flow from the canonical ATLAS_OAUTH_SCOPES constant.
+      expect(body).toContain("mcp:read");
+      expect(body).toContain("mcp:write");
+      // The onboarding endpoint + start_trial contract are named.
+      expect(body).toContain("/mcp/onboarding/sse");
+      expect(body).toContain("start_trial");
+      // Backstop: no WorkOS conformance endpoint Atlas doesn't serve.
+      expect(body).not.toContain("/agent/identity");
+    } finally {
+      handle.close();
+      if (prev === undefined) delete process.env.ATLAS_PUBLIC_API_URL;
+      else process.env.ATLAS_PUBLIC_API_URL = prev;
+    }
+  });
+
+  it("answers OPTIONS preflight with a CORS-permissive 204", async () => {
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/auth.md`, { method: "OPTIONS" });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toContain("GET");
+    } finally {
+      handle.close();
+    }
+  });
+});
+
+describe("auth.md — non-managed auth mode", () => {
+  it("returns 404 when auth is not managed", async () => {
+    mockDetectAuthMode.current = "none";
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/auth.md`);
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("not_found");
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -41,6 +41,7 @@ import { starterPrompts } from "./routes/starter-prompts";
 import { subProcessorSubscriptions } from "./routes/sub-processor-subscriptions";
 import { contact } from "./routes/contact";
 import { wellKnown } from "./routes/well-known";
+import { authMd } from "./routes/auth-md";
 
 const log = createLogger("api");
 const tracer = trace.getTracer("atlas");
@@ -201,6 +202,12 @@ app.route("/api/v1/contact", contact);
 // hosted MCP endpoint. Public, CORS-permissive — these are discovery
 // documents that any client must be able to fetch unauthenticated.
 app.route("/.well-known", wellKnown);
+
+// /auth.md — agent-onboarding discovery document (#3824). A descriptive
+// Markdown file that narrates Atlas's real registration flow (DCR + PKCE +
+// start_trial) for any auth.md-aware agent. Public, CORS-permissive,
+// SaaS/managed-gated (404 off managed auth) — mirrors the .well-known router.
+app.route("/auth.md", authMd);
 
 // Onboarding routes — self-serve signup flow (test-connection, complete setup).
 try {

--- a/packages/api/src/api/routes/auth-md.ts
+++ b/packages/api/src/api/routes/auth-md.ts
@@ -1,0 +1,130 @@
+/**
+ * `GET /auth.md` — the agent-onboarding discovery document (#3824).
+ *
+ * A static-prose Markdown file hosted at the conventional `/auth.md` path
+ * (e.g. `https://mcp.useatlas.dev/auth.md`) that doubles as human integrator
+ * documentation and a discoverable runtime artifact an `auth.md`-aware agent
+ * can read to self-navigate Atlas's registration flow. It narrates the
+ * "provision a trial, then connect" journey in one place — tying together
+ * the OAuth 2.1 + DCR + PKCE machinery, the RFC 9728/8414 discovery
+ * documents, and the `start_trial` self-serve provisioning path Atlas
+ * already serves. See `lib/mcp/auth-md.ts` for the pure builder.
+ *
+ * Mounted alongside the `.well-known` discovery router and gated the same
+ * way:
+ *   - SaaS/managed-only: returns 404 when `detectAuthMode() !== "managed"`,
+ *     with the same shape the metadata routes use. Off-SaaS there is no
+ *     self-serve onboarding endpoint, so the file must not advertise one.
+ *   - CORS-permissive (`Access-Control-Allow-Origin: *`) + the same cache
+ *     headers, because MCP clients load discovery documents from front-ends
+ *     that aren't same-origin with our API.
+ *
+ * Drift safety: the document's hosts and scopes are resolved from the SAME
+ * helpers that back the `.well-known` router (`buildAuthServerUri` /
+ * `buildResourceUri`, including the `api*.useatlas.dev` → `mcp*.useatlas.dev`
+ * regional brand-mirror) and the canonical `ATLAS_OAUTH_SCOPES` constant.
+ * Sharing the source of truth is what keeps `/auth.md` from advertising
+ * endpoints, hosts, or scopes that disagree with machine discovery.
+ */
+
+import { Hono } from "hono";
+import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
+import { buildAuthMd, type AuthMdScope } from "@atlas/api/lib/mcp/auth-md";
+import {
+  buildAuthServerUri,
+  buildIssuerBaseUri,
+  buildResourceUri,
+} from "./well-known";
+
+/** The `mcp:*` subset of the canonical scope union — the scopes /auth.md documents. */
+type McpScope = Extract<(typeof ATLAS_OAUTH_SCOPES)[number], `mcp:${string}`>;
+
+export const authMd = new Hono();
+
+/** Public docs base an integrator can follow to go deeper. */
+const ATLAS_DOCS_URL = "https://docs.useatlas.dev";
+
+/** Path of the unauthenticated onboarding MCP endpoint hosting `start_trial`. */
+const ONBOARDING_MCP_PATH = "/mcp/onboarding/sse";
+
+/**
+ * Human-readable grants for the MCP scopes, keyed off the canonical scope
+ * token. Only the `mcp:*` scopes are documented in `/auth.md` — the file is
+ * about connecting an MCP actor, not the OIDC sign-in scopes. Deriving the
+ * *set* from `ATLAS_OAUTH_SCOPES` (rather than re-listing the scopes by
+ * hand) is what makes a newly-added `mcp:*` scope surface automatically; a
+ * scope without a grant blurb here still appears, with a generic line.
+ */
+const MCP_SCOPE_GRANTS: Partial<Record<McpScope, string>> = {
+  "mcp:read": "query workspace data through the hosted MCP endpoint",
+  "mcp:write":
+    "perform write operations (reserved for future mutation tools)",
+};
+
+function mcpScopes(): AuthMdScope[] {
+  return ATLAS_OAUTH_SCOPES.filter(
+    (s): s is McpScope => s.startsWith("mcp:"),
+  ).map((name) => ({
+    name,
+    grants: MCP_SCOPE_GRANTS[name] ?? "an Atlas MCP capability",
+  }));
+}
+
+/**
+ * CORS + cache headers for the markdown response. Mirrors the
+ * `.well-known` router's `METADATA_HEADERS` (same CORS + cache policy) but
+ * with the `text/markdown` content type the file is served as.
+ */
+const AUTH_MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Cache-Control":
+    "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400",
+} as const;
+
+/**
+ * 404 for non-managed deployments. Same shape the `.well-known` metadata
+ * routes use so a self-hosted operator sees one consistent "discovery
+ * surface absent off managed auth" story. Off-SaaS there is no onboarding
+ * endpoint, so the file must not exist.
+ */
+function notManagedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "not_found",
+      message:
+        "The /auth.md onboarding discovery file is only available when managed auth is enabled.",
+    }),
+    {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+authMd.get("/", (c) => {
+  if (detectAuthMode() !== "managed") return notManagedResponse();
+
+  const body = buildAuthMd({
+    authServerUri: buildAuthServerUri(c.req.raw),
+    issuerBaseUri: buildIssuerBaseUri(c.req.raw),
+    resourceUri: buildResourceUri(c.req.raw),
+    scopes: mcpScopes(),
+    onboardingPath: ONBOARDING_MCP_PATH,
+    docsUrl: ATLAS_DOCS_URL,
+  });
+
+  return new Response(body, { status: 200, headers: AUTH_MD_HEADERS });
+});
+
+// CORS preflight — same shape as the sibling `.well-known` discovery routes.
+authMd.options("/", (c) => {
+  return c.body(null, 204, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Max-Age": "86400",
+  });
+});

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -84,7 +84,7 @@ const log = createLogger("well-known");
  * function intentionally stops naming the regional surface so new
  * clients walk forward, not back.
  */
-function buildResourceUri(req: Request): string {
+export function buildResourceUri(req: Request): string {
   const base =
     process.env.ATLAS_PUBLIC_API_URL?.trim() ||
     process.env.BETTER_AUTH_URL?.trim() ||
@@ -125,17 +125,34 @@ function brandedMcpHost(base: string): string | null {
 }
 
 /**
- * Build the authorization server URI — the issuer the protected-resource
- * metadata points at. Atlas's auth server lives at `${baseURL}/api/auth`
- * so we append that suffix to the resolved base.
+ * Resolve the public API base the auth server (and the `.well-known`
+ * discovery documents) are served from, e.g. `https://api.useatlas.dev`.
+ * Same resolution precedence as `buildResourceUri` / `buildAuthServerUri`.
+ *
+ * Exported so the `/auth.md` route (#3824) can name the discovery-document
+ * URLs at exactly the host the metadata is served from, without re-deriving
+ * the base by string-stripping the issuer URI.
  */
-function buildAuthServerUri(req: Request): string {
+export function buildIssuerBaseUri(req: Request): string {
   const base =
     process.env.ATLAS_PUBLIC_API_URL?.trim() ||
     process.env.BETTER_AUTH_URL?.trim() ||
     new URL(req.url).origin;
-  const trimmed = base.replace(/\/+$/, "");
-  return `${trimmed}/api/auth`;
+  return base.replace(/\/+$/, "");
+}
+
+/**
+ * Build the authorization server URI — the issuer the protected-resource
+ * metadata points at. Atlas's auth server lives at `${baseURL}/api/auth`
+ * so we append that suffix to the resolved base.
+ *
+ * Exported (alongside `buildResourceUri` / `buildIssuerBaseUri`) so the
+ * `/auth.md` discovery route (#3824) feeds its prose builder the SAME
+ * resolved hosts this router advertises — the human-readable file then
+ * cannot drift from machine discovery.
+ */
+export function buildAuthServerUri(req: Request): string {
+  return `${buildIssuerBaseUri(req)}/api/auth`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/auth/oauth-scopes.ts
+++ b/packages/api/src/lib/auth/oauth-scopes.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonical OAuth scope list for the Atlas authorization server.
+ *
+ * Extracted from `auth/server.ts` (#3824) so consumers that only need the
+ * scope SSOT — notably the `/auth.md` discovery route (`api/routes/auth-md.ts`),
+ * which is pulled into the app's import graph — can read it WITHOUT pulling
+ * the 3k-line Better Auth static graph into their path. Same wall-off
+ * discipline as the `oauth-audiences.ts` extraction (#3687). `auth/server.ts`
+ * re-exports this so the Better Auth `scopes` config and every other consumer
+ * keep a single source of truth.
+ *
+ * Pure value — no imports, no env, no I/O.
+ */
+
+/**
+ * Scopes advertised by the OAuth 2.1 authorization server. Standard OIDC
+ * scopes plus Atlas-specific MCP scopes for the hosted MCP endpoint.
+ *
+ * The MCP authorization spec (2025-03-26) requires the resource server to
+ * declare scopes in `/.well-known/oauth-protected-resource`; the `mcp:*`
+ * scopes here are the ones Atlas-shaped MCP clients (Claude Desktop,
+ * ChatGPT, Cursor, etc.) request when connecting to a hosted MCP endpoint.
+ *
+ * Order matters for the consent UI — declare the high-frequency scopes
+ * first so the rendered list matches user expectations.
+ */
+export const ATLAS_OAUTH_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  // mcp:read = query workspace data through the MCP endpoint. Required
+  // for any agent that wants to use Atlas as a data source.
+  "mcp:read",
+  // mcp:write = reserved for future write paths (run mutations, edit
+  // semantic layer). Currently the hosted MCP surface is read-only, so
+  // a token without mcp:write still works for every shipping MCP tool.
+  // Declared so clients can request it now and the gate flips when we
+  // add write tools.
+  "mcp:write",
+] as const;

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -49,6 +49,7 @@ import { getWebOrigin } from "@atlas/api/lib/web-origin";
 // surface (and its tests) keep a single import site.
 import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
 import { resolveOAuthValidAudiences } from "@atlas/api/lib/auth/oauth-audiences";
+import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 export { resolvePasskeyRpId, DEFAULT_RP_ID } from "@atlas/api/lib/auth/rpid";
 import {
   assertInvitationRoleAllowed,
@@ -1283,33 +1284,12 @@ function encodeAttributeValue(raw: string): string {
 // OAuth 2.1 provider configuration (#2024)
 // ---------------------------------------------------------------------------
 
-/**
- * Scopes advertised by the OAuth 2.1 authorization server. Standard OIDC
- * scopes plus Atlas-specific MCP scopes for the hosted MCP endpoint.
- *
- * The MCP authorization spec (2025-03-26) requires the resource server to
- * declare scopes in `/.well-known/oauth-protected-resource`; the `mcp:*`
- * scopes here are the ones Atlas-shaped MCP clients (Claude Desktop,
- * ChatGPT, Cursor, etc.) request when connecting to a hosted MCP endpoint.
- *
- * Order matters for the consent UI — declare the high-frequency scopes
- * first so the rendered list matches user expectations.
- */
-export const ATLAS_OAUTH_SCOPES = [
-  "openid",
-  "profile",
-  "email",
-  "offline_access",
-  // mcp:read = query workspace data through the MCP endpoint. Required
-  // for any agent that wants to use Atlas as a data source.
-  "mcp:read",
-  // mcp:write = reserved for future write paths (run mutations, edit
-  // semantic layer). Currently the hosted MCP surface is read-only, so
-  // a token without mcp:write still works for every shipping MCP tool.
-  // Declared so clients can request it now and the gate flips when we
-  // add write tools.
-  "mcp:write",
-] as const;
+// `ATLAS_OAUTH_SCOPES` was extracted to `./oauth-scopes` (#3824) so consumers
+// that only need the scope SSOT (e.g. the /auth.md discovery route, pulled into
+// the app graph) can read it without importing this 3k-line Better Auth module.
+// Re-exported here so the Better Auth `scopes` config below (which spreads it)
+// and existing importers of `@atlas/api/lib/auth/server` keep working unchanged.
+export { ATLAS_OAUTH_SCOPES };
 
 // `resolveOAuthValidAudiences` (+ its `brandMcpAudience` helper) was extracted
 // to `./oauth-audiences` (#3687) so the boot-time `McpSpineGuardLive` can assert

--- a/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the pure `/auth.md` document builder (#3824).
+ *
+ * Good tests assert the *content contract* of the returned Markdown — that
+ * it names the resolved auth-server URI, the resolved MCP resource host, the
+ * advertised scopes, the onboarding endpoint, and the `start_trial` field
+ * contract — given controlled inputs. We assert the presence and correctness
+ * of these load-bearing facts, NOT exact prose wording, so copy edits don't
+ * break tests.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildAuthMd, type BuildAuthMdOptions } from "../auth-md";
+
+const BASE_OPTS: BuildAuthMdOptions = {
+  authServerUri: "https://api.useatlas.dev/api/auth",
+  issuerBaseUri: "https://api.useatlas.dev",
+  resourceUri: "https://mcp.useatlas.dev/mcp",
+  scopes: [
+    { name: "mcp:read", grants: "query workspace data through the MCP endpoint" },
+    { name: "mcp:write", grants: "reserved for future write paths" },
+  ],
+  onboardingPath: "/mcp/onboarding/sse",
+  docsUrl: "https://docs.useatlas.dev",
+};
+
+describe("buildAuthMd — content contract", () => {
+  it("names the resolved authorization-server issuer URI", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("https://api.useatlas.dev/api/auth");
+  });
+
+  it("names the resolved MCP resource host", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("https://mcp.useatlas.dev/mcp");
+  });
+
+  it("points at the RFC 8414 authorization-server metadata at the issuer base host", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    // The metadata URL is built from the explicit issuer base, not by
+    // string-stripping the issuer URI — so it names the host the discovery
+    // documents are actually served from.
+    expect(md).toContain(
+      "https://api.useatlas.dev/.well-known/oauth-authorization-server/api/auth",
+    );
+  });
+
+  it("uses the supplied issuer base verbatim for the metadata URL (no /api/auth round-trip)", () => {
+    // A pathological issuer base without the conventional `/api/auth` suffix
+    // must still produce a well-formed metadata URL rooted at the base —
+    // proving the builder no longer reconstructs the base by regex-stripping
+    // the issuer URI (which would silently double the path).
+    const md = buildAuthMd({
+      ...BASE_OPTS,
+      authServerUri: "https://auth.example.test/oauth",
+      issuerBaseUri: "https://auth.example.test",
+    });
+    expect(md).toContain(
+      "https://auth.example.test/.well-known/oauth-authorization-server/api/auth",
+    );
+    expect(md).not.toContain("/oauth/.well-known");
+  });
+
+  it("points at the RFC 9728 protected-resource metadata path", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain(
+      "/.well-known/oauth-protected-resource/mcp/{workspace_id}",
+    );
+  });
+
+  it("resolved hosts flow through to the document verbatim (no hard-coding)", () => {
+    // The builder hard-codes no host — whatever the route resolves (here,
+    // eu-region hosts) must appear verbatim in the output. The auth-server
+    // and resource hosts are supplied independently because machine discovery
+    // advertises them independently (the auth-server is the api.* issuer; the
+    // resource is the mcp.* brand-mirror — see the route + well-known.ts).
+    const md = buildAuthMd({
+      ...BASE_OPTS,
+      authServerUri: "https://api-eu.useatlas.dev/api/auth",
+      issuerBaseUri: "https://api-eu.useatlas.dev",
+      resourceUri: "https://mcp-eu.useatlas.dev/mcp",
+    });
+    expect(md).toContain("https://api-eu.useatlas.dev/api/auth");
+    expect(md).toContain("https://mcp-eu.useatlas.dev/mcp");
+    expect(md).toContain(
+      "https://api-eu.useatlas.dev/.well-known/oauth-authorization-server/api/auth",
+    );
+    // The us-region hosts must not leak in when the eu hosts were supplied.
+    expect(md).not.toContain("https://api.useatlas.dev/api/auth");
+    expect(md).not.toContain("https://mcp.useatlas.dev/mcp");
+  });
+
+  it("lists every advertised scope (add-a-scope shows up)", () => {
+    const md = buildAuthMd({
+      ...BASE_OPTS,
+      scopes: [
+        ...BASE_OPTS.scopes,
+        { name: "mcp:admin", grants: "a brand-new scope" },
+      ],
+    });
+    expect(md).toContain("mcp:read");
+    expect(md).toContain("mcp:write");
+    // A scope added to the canonical constant must surface automatically.
+    expect(md).toContain("mcp:admin");
+  });
+
+  it("names the unauthenticated onboarding endpoint and start_trial", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("/mcp/onboarding/sse");
+    expect(md).toContain("start_trial");
+  });
+
+  it("documents the start_trial input contract (email, orgName, turnstileToken)", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("email");
+    expect(md).toContain("orgName");
+    expect(md).toContain("turnstileToken");
+  });
+
+  it("documents the start_trial output contract (workspaceId, connectUrl, state)", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("workspaceId");
+    expect(md).toContain("connectUrl");
+    expect(md).toContain("state");
+    // The grace/locked state semantics must be present.
+    expect(md).toContain("grace");
+    expect(md).toContain("locked");
+  });
+
+  it("describes DCR + PKCE connect and the web-claim handoff", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("PKCE");
+    expect(md).toMatch(/Dynamic Client Registration|DCR/);
+    // The human-claim handoff that lifts the grace window into the full trial.
+    expect(md.toLowerCase()).toContain("claim");
+    expect(md).toContain("14-day");
+  });
+
+  it("links to the canonical Atlas docs", () => {
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).toContain("https://docs.useatlas.dev");
+  });
+
+  it("does NOT name a /agent/identity endpoint or WorkOS conformance machinery", () => {
+    // The required backstop (#3824 § Testing): the doc must never advertise an
+    // endpoint Atlas does not serve. `/agent/identity`, `identity_assertion`,
+    // and the `urn:workos:*` grant types are explicitly Out of Scope.
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).not.toContain("/agent/identity");
+    expect(md).not.toContain("identity_assertion");
+    expect(md).not.toContain("urn:workos:");
+    expect(md).not.toContain("agent_auth");
+  });
+
+  it("leaks no secrets or connection strings", () => {
+    // Built from already-resolved public configuration. The auth-server issuer
+    // host (an `api*.useatlas.dev` host) is NOT a leak — it is exactly what the
+    // .well-known protected-resource metadata advertises as `authorization_servers`
+    // (#3824 user story #15), and an agent must bind to the same one. What must
+    // never appear is a secret, a connection string, or a credential.
+    const md = buildAuthMd(BASE_OPTS);
+    expect(md).not.toMatch(/postgres(ql)?:\/\//i);
+    expect(md).not.toMatch(/mysql:\/\//i);
+    expect(md).not.toMatch(/\b(secret|api[_-]?key|password|bearer\s+ey)\b/i);
+  });
+});

--- a/packages/api/src/lib/mcp/auth-md.ts
+++ b/packages/api/src/lib/mcp/auth-md.ts
@@ -1,0 +1,221 @@
+/**
+ * `/auth.md` agent-onboarding discovery document (#3824).
+ *
+ * A small Markdown file hosted at the conventional `/auth.md` path that
+ * doubles as (a) human integrator documentation and (b) a discoverable
+ * runtime artifact an agent (Claude Desktop, Cursor, ChatGPT, the Atlas
+ * SDK, any `auth.md`-aware MCP client) can read to self-navigate Atlas's
+ * registration flow. It narrates the end-to-end "provision a trial, then
+ * connect" journey in one place, tying together the OAuth 2.1 + DCR + PKCE
+ * machinery, the RFC 9728/8414 discovery documents, and the `start_trial`
+ * self-serve provisioning path that Atlas already ships.
+ *
+ * Borrowed from WorkOS's emerging `auth.md` convention — we adopt the
+ * file's *name, path, and spirit* (a discoverable Markdown onboarding
+ * artifact) and point agents at the real OAuth/DCR/`start_trial` mechanics.
+ * This file documents ONLY flows Atlas actually serves. It does NOT
+ * describe the WorkOS agent-verified machinery (`POST /agent/identity`,
+ * `identity_assertion`, the `urn:workos:*` grant types, the `agent_auth`
+ * metadata block) — Atlas serves none of those, and a discovery document
+ * must never advertise an endpoint that returns 404. (See #3824 § Out of
+ * Scope; the WorkOS-verified flow is a deliberately deferred future
+ * direction noted as prose only.)
+ *
+ * Drift safety: this is a PURE builder. It hard-codes no host and no scope.
+ * The route feeds it the SAME resolved auth-server issuer URI and MCP
+ * resource host that back the `.well-known` discovery documents
+ * (`well-known.ts:buildAuthServerUri` / `buildResourceUri`, including the
+ * `api*.useatlas.dev` → `mcp*.useatlas.dev` regional brand-mirror) and the
+ * canonical `ATLAS_OAUTH_SCOPES` constant. Sharing the source of truth is
+ * what structurally prevents the human-readable file from advertising
+ * endpoints, hosts, or scopes that disagree with machine discovery.
+ */
+
+/** A single advertised OAuth scope plus its human-readable grant. */
+export interface AuthMdScope {
+  /** The scope token, e.g. `mcp:read`. */
+  readonly name: string;
+  /** One-line description of what requesting the scope grants. */
+  readonly grants: string;
+}
+
+export interface BuildAuthMdOptions {
+  /**
+   * Authorization-server issuer URI — the same value the protected-resource
+   * metadata advertises in `authorization_servers`
+   * (`well-known.ts:buildAuthServerUri`), e.g. `https://api.useatlas.dev/api/auth`.
+   */
+  readonly authServerUri: string;
+  /**
+   * Base host the `.well-known` discovery documents are served from — i.e.
+   * the issuer URI with the `/api/auth` path stripped, e.g.
+   * `https://api.useatlas.dev`. Passed explicitly (rather than re-derived
+   * from `authServerUri`) so the builder carries no hidden "issuer must end
+   * in /api/auth" precondition. The route resolves it from the same base
+   * `buildAuthServerUri` uses, so the discovery-document URL the doc names
+   * stays in lockstep with where the metadata is actually served.
+   */
+  readonly issuerBaseUri: string;
+  /**
+   * MCP resource-server host (the `<host>/mcp` audience the
+   * protected-resource metadata advertises, including the regional
+   * brand-mirror), e.g. `https://mcp.useatlas.dev/mcp`. We surface the
+   * host so the doc names the same audience an agent's token must bind to.
+   */
+  readonly resourceUri: string;
+  /**
+   * Advertised scopes, derived from the canonical scope constant so a scope
+   * added to the OAuth provider surfaces here automatically. Only the MCP
+   * scopes are documented (the doc is about connecting an MCP actor); the
+   * caller filters the canonical list.
+   */
+  readonly scopes: readonly AuthMdScope[];
+  /**
+   * Path of the unauthenticated onboarding MCP endpoint that hosts the
+   * `start_trial` tool, e.g. `/mcp/onboarding/sse`. Named explicitly so an
+   * agent knows where to call it.
+   */
+  readonly onboardingPath: string;
+  /**
+   * Public docs base an integrator can follow to go deeper, e.g.
+   * `https://docs.useatlas.dev`.
+   */
+  readonly docsUrl: string;
+}
+
+/**
+ * Render the `/auth.md` document body. Pure: no I/O, no request object, no
+ * env reads — every host, scope, and path is supplied by the caller. The
+ * route is responsible for resolving the inputs from the shared
+ * `.well-known` host-resolution helpers and the canonical scope constant.
+ */
+export function buildAuthMd(opts: BuildAuthMdOptions): string {
+  const { authServerUri, issuerBaseUri, resourceUri, scopes, onboardingPath, docsUrl } =
+    opts;
+
+  // The auth-server issuer lives at `<issuerBaseUri>/api/auth`; the
+  // `.well-known` discovery documents live at the base, not under the issuer
+  // path. The caller supplies the base so the doc points an agent at the
+  // canonical metadata locations without this builder reconstructing it.
+  const authServerMetadataUrl = `${issuerBaseUri}/.well-known/oauth-authorization-server/api/auth`;
+  const protectedResourceMetadataPath =
+    "/.well-known/oauth-protected-resource/mcp/{workspace_id}";
+
+  const scopeLines = scopes
+    .map((s) => `- \`${s.name}\` — ${s.grants}`)
+    .join("\n");
+
+  return `# Connecting an agent to Atlas
+
+This document is for autonomous agents (and the humans integrating them).
+It describes how to register with Atlas and connect an MCP client, from a
+cold start with no account, workspace, or credentials. Every flow named
+here already exists; this file introduces no new authentication mechanism —
+it is a single discovery surface that ties Atlas's existing OAuth 2.1 + DCR
++ PKCE machinery to its self-serve trial path.
+
+Atlas is a deploy-anywhere text-to-SQL data-analyst agent exposed over the
+Model Context Protocol. An agent connects by attaching a *hosted actor* to a
+workspace via OAuth 2.1 (authorization-code + PKCE), having registered
+itself with Dynamic Client Registration (DCR). If you do not have a
+workspace yet, start with the self-serve trial path below.
+
+## Hosts
+
+- **Authorization server (issuer):** \`${authServerUri}\`
+- **MCP resource server:** \`${resourceUri}\`
+
+Tokens you obtain must bind to the resource-server audience exactly as the
+protected-resource metadata advertises it.
+
+## Discover the machine-readable metadata
+
+Atlas serves standard discovery documents. Read these to locate the
+authorize, token, and DCR registration endpoints — do not hard-code them.
+
+- **Authorization-server metadata (RFC 8414):**
+  \`${authServerMetadataUrl}\`
+  Names the \`authorization_endpoint\`, \`token_endpoint\`, the DCR
+  \`registration_endpoint\`, supported grant types, and PKCE methods.
+- **Protected-resource metadata (RFC 9728):**
+  \`${protectedResourceMetadataPath}\`
+  Per-workspace. Names the resource audience and which authorization server
+  can issue tokens for it. The standard MCP bootstrap is: hit the resource
+  URL, get a \`401\` carrying a \`WWW-Authenticate\` resource-metadata
+  pointer, fetch this document, then redirect to the authorization server's
+  \`authorize\` endpoint.
+
+## Scopes
+
+Request the scopes you need at registration:
+
+${scopeLines}
+
+## Self-serve: provision a trial workspace
+
+If you have no account, workspace, or bearer yet, provision one with the
+\`start_trial\` tool. It lives on the **unauthenticated onboarding MCP
+endpoint** at:
+
+\`\`\`
+${onboardingPath}
+\`\`\`
+
+\`start_trial\` is the only capability that endpoint exposes — it cannot
+query data or bind an actor. Call it with:
+
+- \`email\` — a business email for the new account.
+- \`orgName\` — a name for the new workspace.
+- \`turnstileToken\` — a Cloudflare Turnstile token proving the signup is
+  human-initiated. Required.
+
+On success it returns:
+
+- \`workspaceId\` — the id of the freshly created workspace.
+- \`connectUrl\` — the hosted-MCP connect URL to attach your agent to.
+- \`state\` — \`grace\` while the account is unclaimed, or \`locked\` if the
+  email already consumed a trial.
+
+\`start_trial\` is abuse-controlled: signups are rate-limited per IP and per
+email, and a missing or invalid Turnstile token is rejected. Surface those
+failures to the user rather than retrying blindly.
+
+## Connect: DCR + PKCE against the connect URL
+
+Once you have a \`connectUrl\`, run the standard connect flow against it:
+
+1. Point your MCP client at the \`connectUrl\`. It returns \`401\` with the
+   RFC 9728 resource-metadata pointer.
+2. Fetch the protected-resource metadata, then the authorization-server
+   metadata, to discover the endpoints.
+3. Register your client with **Dynamic Client Registration** at the
+   \`registration_endpoint\`.
+4. Run the **authorization-code flow with PKCE** to obtain a token carrying
+   at least the \`mcp:read\` scope, bound to the MCP resource audience.
+5. Attach as a hosted actor and use the MCP tools.
+
+Only the authorization-code + PKCE path is supported.
+\`client_credentials\` (machine-to-machine) connect is not.
+
+## Hand off to the human to start the full trial
+
+A trial provisioned through \`start_trial\` begins **unclaimed**, in a short
+grace window. To start the full 14-day trial, the human must **claim the
+account on the web** — surface that next step to your user after connecting.
+Until they claim it, the workspace stays in the grace window and is subject
+to the trial's economic limits.
+
+## Go deeper
+
+For the complete integration guide, see the Atlas documentation:
+
+${docsUrl}
+
+---
+
+*Future direction: Atlas may later support provider-attested, agent-verified
+registration. That flow is not implemented today and this document
+describes no endpoint for it — agents should use the DCR + PKCE +
+\`start_trial\` path above.*
+`;
+}


### PR DESCRIPTION
## Summary

Hosts a descriptive Markdown discovery document at the conventional `/auth.md` path (e.g. `https://mcp.useatlas.dev/auth.md`). It doubles as human integrator docs and a runtime artifact an `auth.md`-aware agent (Claude Desktop, Cursor, ChatGPT, the Atlas SDK, any MCP client) can read to self-navigate Atlas's **real** registration flow — DCR + PKCE + `start_trial` — narrating the "provision a trial, then connect" journey in one place.

- **Pure builder** (`lib/mcp/auth-md.ts`): no I/O, no request object, no env reads. Hosts and scopes are supplied by the caller (including an explicit `issuerBaseUri`), so the document can never hard-code a host or scope.
- **Route** (`api/routes/auth-md.ts`): SaaS/managed-gated (404 otherwise), served as `text/markdown` with the same permissive CORS + cache headers and `OPTIONS` preflight as the sibling `.well-known` discovery routes.
- **Drift safety by construction**: the route feeds the builder the *same* resolved hosts the `.well-known` router advertises (`buildAuthServerUri` / `buildIssuerBaseUri` / `buildResourceUri`, now exported, including the `api*.useatlas.dev` → `mcp*.useatlas.dev` regional brand-mirror) and the canonical `ATLAS_OAUTH_SCOPES` constant. `MCP_SCOPE_GRANTS` keys are typed to the `mcp:*` scope subset so a stale key is a compile error.
- **Scope-constant extraction**: moved `ATLAS_OAUTH_SCOPES` to `lib/auth/oauth-scopes.ts` (re-exported from `auth/server.ts`) so the `/auth.md` route — pulled into the app's import graph — reads the scope SSOT without importing the 3k-line Better Auth module. Same wall-off discipline as the `oauth-audiences.ts` extraction (#3687).

### Strictly in scope

Only the descriptive `auth.md`. **No** WorkOS conformance machinery (`/agent/identity`, `identity_assertion`, new grant types, `agent_auth` metadata block) — Atlas serves none of it, and a discovery document must never advertise an endpoint that returns 404. A builder unit test asserting `/agent/identity` is **absent** is the backstop. No new env vars, schema changes, or migrations.

## Test plan

- [x] Builder unit tests (`lib/mcp/__tests__/auth-md.test.ts`) — content contract: resolved auth-server URI, MCP resource host, RFC 8414/9728 metadata paths, advertised scopes (add-a-scope surfaces), `start_trial` input/output contract, grace/locked + 14-day claim handoff, no `/agent/identity`, no secrets leak, explicit-issuer-base round-trip.
- [x] Route tests (`api/__tests__/auth-md.test.ts`) — 200 + `text/markdown` + CORS in managed mode; 404 in non-managed; `OPTIONS` preflight — mirrors `well-known.test.ts`.
- [x] `/ci` green: lint, type, full test (`@atlas/api` 699/699, others 34/34), syncpack, template-drift, openapi-drift, schema-drift, settings-readers, saas-env-doc, security-headers, railway-watch, oauth-helper, twenty-resolver, published-symbols, test-discipline.
- [x] Internal review panel (silent-failure / type-design / test / comment) — CLEAN.

Closes #3824

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add /auth.md agent-onboarding discovery endpoint to the MCP API
> - Adds a new `GET /auth.md` route that returns a Markdown document describing OAuth hosts, scopes, DCR + PKCE flow, and self-serve trial onboarding for MCP agents.
> - The route returns 404 JSON when auth mode is not `managed`, mirroring the shape used by `.well-known` metadata routes.
> - Introduces a pure `buildAuthMd` builder in [`packages/api/src/lib/mcp/auth-md.ts`](https://github.com/AtlasDevHQ/atlas/pull/3828/files#diff-f25253ab064fc0ec7a5ee5b046d25b1d7e5c82b8b88e4df68f810ded83c444ba) that renders the document from caller-supplied hosts, scopes, and paths with no hard-coded values.
> - Extracts `ATLAS_OAUTH_SCOPES` into its own [`oauth-scopes.ts`](https://github.com/AtlasDevHQ/atlas/pull/3828/files#diff-389a6a76b218e423ee9416b5fcbb6dd29512b43691ea585c0d5d0bf6d4b30981) module so the route can consume the canonical scope list without importing the full Better Auth server module.
> - Exports `buildResourceUri`, `buildIssuerBaseUri`, and `buildAuthServerUri` helpers from [`well-known.ts`](https://github.com/AtlasDevHQ/atlas/pull/3828/files#diff-728c48fa64822221f8b53bfdc412dc7e31c9de1a85fb60e8790f6b297c67ac3a) for reuse by the new route.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5746f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hosts a `/auth.md` agent-onboarding discovery document at the conventional path, serving as both human integrator docs and a machine-readable artifact for `auth.md`-aware MCP clients. It adds a pure Markdown builder, a managed-auth-gated Hono route, extracts `ATLAS_OAUTH_SCOPES` into its own lightweight module to avoid importing the 3k-line Better Auth graph, and exports three URI-resolution helpers from `well-known.ts` so the new route shares the exact same host derivation logic as the sibling discovery endpoints.

- **New route** (`api/routes/auth-md.ts`): serves `GET /auth.md` as `text/markdown` with permissive CORS and cache headers, returns 404 in non-managed deployments, and feeds the builder the same resolved hosts and scopes that back `.well-known` machine discovery.
- **Pure builder** (`lib/mcp/auth-md.ts`): no I/O, no env reads — narrates DCR + PKCE + `start_trial` flow and explicitly omits any WorkOS conformance endpoint Atlas does not serve.
- **Scope extraction** (`lib/auth/oauth-scopes.ts`): moves `ATLAS_OAUTH_SCOPES` to a standalone file and re-exports it from `auth/server.ts`, following the same pattern as the prior `oauth-audiences.ts` extraction.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive and gated — non-managed deployments see a 404, and no existing behavior is altered.

The route, builder, and scope extraction are well-structured and thoroughly tested. The one notable gap is that buildAuthMd hardcodes /api/auth in the RFC 8414 metadata URL path rather than deriving it from authServerUri, so the builder silently produces a wrong metadata URL for any caller whose auth server path differs — a constraint not reflected in the function's type signature.

packages/api/src/lib/mcp/auth-md.ts — the metadata URL construction at line 708 carries an implicit Atlas-specific assumption worth making explicit.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/lib/mcp/auth-md.ts | New pure builder for the /auth.md document; accepts all hosts and scopes as inputs but hardcodes "/api/auth" in the RFC 8414 metadata URL path, making the function subtly Atlas-specific despite the "pure, no hard-coding" claim. |
| packages/api/src/api/routes/auth-md.ts | New Hono route serving GET /auth.md; correctly gated to managed-auth mode, imports URI helpers from well-known.ts to prevent drift, CORS/cache headers mirror sibling discovery routes. |
| packages/api/src/api/routes/well-known.ts | Exports buildResourceUri, buildAuthServerUri, and new buildIssuerBaseUri so auth-md.ts can share the same host-resolution logic; buildAuthServerUri refactored to delegate to buildIssuerBaseUri, no behavioral change. |
| packages/api/src/lib/auth/oauth-scopes.ts | ATLAS_OAUTH_SCOPES extracted from auth/server.ts to a lightweight module; clean extraction with no behavioral change, re-exported from server.ts for backward compatibility. |
| packages/api/src/lib/mcp/__tests__/auth-md.test.ts | Thorough unit tests for the builder; one test passes authServerUri with a non-/api/auth path but asserts the metadata URL still contains /api/auth, which validates Atlas-specific behavior but inadvertently confirms the hardcoded path. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/api/src/lib/mcp/auth-md.ts`, line 704-708 ([link](https://github.com/atlasdevhq/atlas/blob/b5746f4d1838fa01f84b319d00b26654aeeb792c/packages/api/src/lib/mcp/auth-md.ts#L704-L708)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Metadata URL hardcodes `/api/auth` path, silently incorrect when `authServerUri` differs**

   `authServerMetadataUrl` is always built as `${issuerBaseUri}/.well-known/oauth-authorization-server/api/auth`, ignoring the path component of the supplied `authServerUri`. If `authServerUri` is ever anything other than `${issuerBaseUri}/api/auth` — e.g., a future path change or an alternative deployment — the advertised metadata URL in the discovery document would silently point to a non-existent endpoint. Per RFC 8414's path-insertion rule the correct derivation is `${issuerBaseUri}/.well-known/oauth-authorization-server${new URL(authServerUri).pathname}`. This is also surfaced by the existing test that passes `authServerUri: "https://auth.example.test/oauth"` yet still expects `/api/auth` in the metadata URL, which validates the wrong RFC 8414 URL for that scenario.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapi%2Fsrc%2Flib%2Fmcp%2Fauth-md.ts%0ALine%3A%20704-708%0A%0AComment%3A%0A**Metadata%20URL%20hardcodes%20%60%2Fapi%2Fauth%60%20path%2C%20silently%20incorrect%20when%20%60authServerUri%60%20differs**%0A%0A%60authServerMetadataUrl%60%20is%20always%20built%20as%20%60%24%7BissuerBaseUri%7D%2F.well-known%2Foauth-authorization-server%2Fapi%2Fauth%60%2C%20ignoring%20the%20path%20component%20of%20the%20supplied%20%60authServerUri%60.%20If%20%60authServerUri%60%20is%20ever%20anything%20other%20than%20%60%24%7BissuerBaseUri%7D%2Fapi%2Fauth%60%20%E2%80%94%20e.g.%2C%20a%20future%20path%20change%20or%20an%20alternative%20deployment%20%E2%80%94%20the%20advertised%20metadata%20URL%20in%20the%20discovery%20document%20would%20silently%20point%20to%20a%20non-existent%20endpoint.%20Per%20RFC%208414's%20path-insertion%20rule%20the%20correct%20derivation%20is%20%60%24%7BissuerBaseUri%7D%2F.well-known%2Foauth-authorization-server%24%7Bnew%20URL%28authServerUri%29.pathname%7D%60.%20This%20is%20also%20surfaced%20by%20the%20existing%20test%20that%20passes%20%60authServerUri%3A%20%22https%3A%2F%2Fauth.example.test%2Foauth%22%60%20yet%20still%20expects%20%60%2Fapi%2Fauth%60%20in%20the%20metadata%20URL%2C%20which%20validates%20the%20wrong%20RFC%208414%20URL%20for%20that%20scenario.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=atlasdevhq%2Fatlas&pr=3828&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapi%2Fsrc%2Flib%2Fmcp%2Fauth-md.ts%3A704-708%0A**Metadata%20URL%20hardcodes%20%60%2Fapi%2Fauth%60%20path%2C%20silently%20incorrect%20when%20%60authServerUri%60%20differs**%0A%0A%60authServerMetadataUrl%60%20is%20always%20built%20as%20%60%24%7BissuerBaseUri%7D%2F.well-known%2Foauth-authorization-server%2Fapi%2Fauth%60%2C%20ignoring%20the%20path%20component%20of%20the%20supplied%20%60authServerUri%60.%20If%20%60authServerUri%60%20is%20ever%20anything%20other%20than%20%60%24%7BissuerBaseUri%7D%2Fapi%2Fauth%60%20%E2%80%94%20e.g.%2C%20a%20future%20path%20change%20or%20an%20alternative%20deployment%20%E2%80%94%20the%20advertised%20metadata%20URL%20in%20the%20discovery%20document%20would%20silently%20point%20to%20a%20non-existent%20endpoint.%20Per%20RFC%208414's%20path-insertion%20rule%20the%20correct%20derivation%20is%20%60%24%7BissuerBaseUri%7D%2F.well-known%2Foauth-authorization-server%24%7Bnew%20URL%28authServerUri%29.pathname%7D%60.%20This%20is%20also%20surfaced%20by%20the%20existing%20test%20that%20passes%20%60authServerUri%3A%20%22https%3A%2F%2Fauth.example.test%2Foauth%22%60%20yet%20still%20expects%20%60%2Fapi%2Fauth%60%20in%20the%20metadata%20URL%2C%20which%20validates%20the%20wrong%20RFC%208414%20URL%20for%20that%20scenario.%0A%0A&repo=atlasdevhq%2Fatlas&pr=3828&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): host /auth.md agent-onboardin..."](https://github.com/atlasdevhq/atlas/commit/b5746f4d1838fa01f84b319d00b26654aeeb792c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38814564)</sub>

<!-- /greptile_comment -->