### PR TITLE
docs(mcp): link the hosted /auth.md discovery file (#3826)

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -810,6 +810,10 @@ The MCP SDK handles dispatch automatically — clients pointed at the URL above 
 
 ### Authentication
 
+<Callout type="info" title="One file, human- and machine-readable">
+Atlas hosts the whole agent-registration story — the OAuth 2.1 + DCR + PKCE flow, the discovery documents, the scopes, and the `start_trial` self-serve path — as a single document at [`mcp.useatlas.dev/auth.md`](https://mcp.useatlas.dev/auth.md). It's the canonical end-to-end description of how an agent registers with Atlas: an integrator can read it, and an `auth.md`-aware agent can fetch it at that conventional path to self-navigate the flow. The sections below restate the same flow in context; the hosted file is the source of truth.
+</Callout>
+
 Atlas's authorization server lives at `/api/auth`. Three discovery documents drive the OAuth flow:
 
 | Document | URL |


### PR DESCRIPTION
## Summary

Surfaces the hosted `/auth.md` agent-onboarding discovery file (#3824) to **humans** by linking it from the docs site. #3824 made the file discoverable to *agents* (they fetch it at the conventional path); this closes the human side.

- Adds a thin `<Callout>` under the MCP guide's **Hosted protocol reference → Authentication** section (`apps/docs/content/docs/guides/mcp.mdx`) pointing at the canonical production URL **`https://mcp.useatlas.dev/auth.md`**, framed as the single human- and machine-readable end-to-end description of how an agent registers with Atlas.
- **Pointer, not a copy.** The callout names the categories that already appear in the surrounding prose (OAuth 2.1 + DCR + PKCE, discovery documents, scopes, `start_trial`) and defers to the hosted file as the source of truth. It reproduces no endpoint paths, no scope-grant table, and no numbered flow steps — so there's no second source of truth to drift from `/auth.md` (the whole point of the #3825 parity guard).
- **Canonical brand host.** The URL uses `mcp.useatlas.dev`, matching what the `/auth.md` route advertises: `well-known.ts:brandedMcpHost()` maps the regional `api.useatlas.dev` API host to its `mcp.useatlas.dev` brand-mirror, and the route's own doc comment names `https://mcp.useatlas.dev/auth.md` as the canonical example.

## Placement rationale

The **Authentication** subsection is the docs' existing end-to-end agent-registration narrative — it enumerates the DCR + PKCE bootstrap, the three discovery documents, and the scope table directly below the callout. `/auth.md` is the hosted single-URL equivalent of exactly that story, so the pointer sits where a reader is already learning the registration flow.

## Landing-page placement: intentionally omitted

The issue marks a landing-page (`apps/www`) mention **optional**, and only if there's a *natural* existing agent/MCP-onboarding surface — "do not manufacture a placement." There isn't one. The landing page's MCP mentions are feature-marketing (hero/comparison/yaml sections) and a WebMCP doc-search widget; its docs links all point at general entry points (quick-start, semantic-layer, getting-started), not an agent-registration surface. Adding an `/auth.md` link there would manufacture a placement, so it is intentionally omitted.

## Test plan

- [x] `apps/docs` build passes (`bun run build` — 1886 static pages generated, MCP guide rendered)
- [x] Fresh-context correctness review: URL matches the brand host `/auth.md` advertises; stays a pointer (no duplicated endpoint/scope detail); "sections below restate the flow" claim verified true; `Callout` idiom + import correct
- [x] `/ci` gates: lint, type, full test suite (696 pass; 3 known WSL2 sandbox false-positives verified green with `VERCEL_*`/`ATLAS_SANDBOX*` unset), syncpack, template/schema/security-header/railway/oauth-helper/test-discipline/twenty/settings/saas-env/openapi/published-symbols drift — all pass

Closes #3826

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link hosted auth discovery file in MCP documentation
> Adds an info callout under the Authentication heading in [mcp.mdx](https://github.com/AtlasDevHQ/atlas/pull/3830/files#diff-a3c182056bd206ed0dbd990546b188912fececb7c70dbdeb578d9b73c67afb5c) that links to the canonical agent-registration document at `mcp.useatlas.dev/auth.md`. The callout clarifies that the hosted file is the source of truth for OAuth 2.1, DCR, PKCE, discovery documents, scopes, and the `start_trial` flow, while the existing sections restate the same information.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e14a6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single `<Callout>` block to the **Authentication** section of the hosted MCP guide, pointing readers at the canonical `https://mcp.useatlas.dev/auth.md` file that was surfaced to agents in #3824.

- Adds a `type="info"` callout using the already-imported `Callout` component — no new imports or component changes required.
- Keeps the change as a pointer only, deferring all endpoint/scope detail to the hosted file to avoid a second source of truth.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — one callout block added to an MDX doc, no logic or config touched.

The change is a four-line documentation addition using an already-imported component. The URL matches the brand host documented in the surrounding prose, the callout pattern is identical to several others in the same file, and no code, configuration, or API surface is modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/docs/content/docs/guides/mcp.mdx | Adds a single `<Callout type="info">` block under the Authentication section; uses the already-imported Callout component correctly and is consistent with the existing callout patterns throughout the file. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Human reader visits MCP guide] --> B[Authentication section]
    B --> C[Callout: link to mcp.useatlas.dev/auth.md]
    C --> D{Reader choice}
    D -->|Read hosted file| E[mcp.useatlas.dev/auth.md\nOAuth 2.1 + DCR + PKCE\nsingle source of truth]
    D -->|Continue in docs| F[Inline prose: discovery docs,\nscopes, flow steps]
    E -.->|same content| F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Human reader visits MCP guide] --> B[Authentication section]
    B --> C[Callout: link to mcp.useatlas.dev/auth.md]
    C --> D{Reader choice}
    D -->|Read hosted file| E[mcp.useatlas.dev/auth.md\nOAuth 2.1 + DCR + PKCE\nsingle source of truth]
    D -->|Continue in docs| F[Inline prose: discovery docs,\nscopes, flow steps]
    E -.->|same content| F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): link the hosted /auth.md disc..."](https://github.com/atlasdevhq/atlas/commit/0e14a6d8124343e0e0114a52174cb686a53a13d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38816111)</sub>

<!-- /greptile_comment -->