### PR TITLE
chore(mcp): drift-parity guard for /auth.md vs .well-known (#3825)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
       - name: Check SaaS env reference ↔ SAAS_ENV_KEYS drift (#3707)
         run: bash scripts/check-saas-env-doc.sh
 
+      - name: Check /auth.md ↔ .well-known discovery parity (#3825)
+        # Runs from packages/api so the guard's `@atlas/api/*` imports resolve.
+        run: cd packages/api && bun scripts/check-auth-md-discovery-parity.ts
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/packages/api/scripts/check-auth-md-discovery-parity.ts
+++ b/packages/api/scripts/check-auth-md-discovery-parity.ts
@@ -1,0 +1,429 @@
+#!/usr/bin/env bun
+// check-auth-md-discovery-parity.ts — CI gate (#3825) that asserts the
+// human-readable `/auth.md` agent-onboarding document (#3824) never advertises
+// a host, scope, or endpoint that disagrees with Atlas's machine-discovery
+// documents (`/.well-known/oauth-authorization-server/api/auth` and
+// `/.well-known/oauth-protected-resource/mcp/{workspace_id}`).
+//
+// Why this exists on top of #3824's structural sharing:
+//   #3824 already feeds the `/auth.md` builder the SAME host-resolution helpers
+//   (`buildAuthServerUri` / `buildResourceUri`, incl. the `api*` → `mcp*`
+//   regional brand-mirror) and the SAME canonical scope constant
+//   (`ATLAS_OAUTH_SCOPES`) the `.well-known` router uses. That structurally
+//   prevents the *most likely* drift. This guard is defense-in-depth against
+//   the failure that structural sharing can't catch: a maintainer HARDCODING a host, scope,
+//   or endpoint path into the `auth.md` prose (or a doc copy-edit) that
+//   silently diverges from machine discovery. An agent that trusts `/auth.md`
+//   and a divergent client that trusts `.well-known` would then bootstrap
+//   differently — exactly the interop failure the discovery file exists to
+//   prevent.
+//
+// Strategy: render `/auth.md` from a fixed sample base URL using the REAL pure
+// builder + shared helpers + canonical scopes, then reconstruct the
+// `.well-known` advertised facts from the SAME fixed inputs, and assert parity
+// of:
+//   1. the authorization-server issuer URI,
+//   2. the MCP resource host (including the `api*` → `mcp*` brand-mirror),
+//   3. the advertised scope set,
+// and that `/auth.md` names no endpoint `.well-known` does not advertise (in
+// particular never a WorkOS-conformance endpoint such as `/agent/identity`).
+//
+// A divergence exits non-zero with an actionable message naming the divergent
+// value. Wired into the existing `drift` CI job (the same gate that runs
+// schema-drift / template-drift), so a divergence blocks merge.
+//
+// Verification-only: imports the real modules, changes no runtime behavior.
+//
+// Lives under `packages/api/scripts/` (not the repo-root `scripts/`) because it
+// imports the real `@atlas/api/*` modules, which only resolve from inside the
+// workspace package. The drift CI job invokes it via
+// `cd packages/api && bun scripts/check-auth-md-discovery-parity.ts`.
+//
+// The parity logic is pure and exported (`collectViolations` + the per-aspect
+// checkers) so the adversarial-fixture suite
+// (`packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts`) can prove
+// each drift vector fails with a value-naming message without mutating real
+// source. (That suite lives under `src/` — not next to this script — so the
+// api-tests shards pick it up; it imports the pure checkers from here.)
+//
+// Usage: bun packages/api/scripts/check-auth-md-discovery-parity.ts
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildAuthMd, type AuthMdScope } from "@atlas/api/lib/mcp/auth-md";
+import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
+import {
+  buildAuthServerUri,
+  buildIssuerBaseUri,
+  buildResourceUri,
+} from "@atlas/api/api/routes/well-known";
+
+/** `packages/api` — this script lives one level down in `scripts/`. */
+const apiRoot = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Fixed inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * The doc constants the `/auth.md` route (`api/routes/auth-md.ts`) feeds the
+ * builder that are NOT host/scope-derived (docs URL, onboarding endpoint).
+ * They exist so `buildAuthMd` produces a faithful document to scan; they are
+ * not part of `.well-known` parity. The docs host is exempted from the
+ * foreign-host check (it is a legitimate "go deeper" link, not a discovery
+ * host).
+ */
+export const ATLAS_DOCS_URL = "https://docs.useatlas.dev";
+const ONBOARDING_MCP_PATH = "/mcp/onboarding/sse";
+
+/**
+ * `.well-known` host fixtures. Each entry drives both the rendered `/auth.md`
+ * and the reconstructed `.well-known` facts from the SAME resolved base, so
+ * the parity is checked per region. The eu entry exercises the `api*` → `mcp*`
+ * regional brand-mirror — the resolved resource host must be the `mcp-eu.*`
+ * brand, not the `api-eu.*` infra host.
+ */
+const HOST_FIXTURES = [
+  { label: "us region", apiBase: "https://api.useatlas.dev" },
+  { label: "eu region", apiBase: "https://api-eu.useatlas.dev" },
+] as const;
+
+/**
+ * Endpoint fragments that must NEVER appear in `/auth.md`: the WorkOS
+ * agent-verified conformance machinery Atlas serves none of. A discovery
+ * document must not name an endpoint that 404s. This mirrors the existing
+ * backstop unit tests (`lib/mcp/__tests__/auth-md.test.ts`) as defense in
+ * depth — the parity guard fails the build in the SAME job as the other drift
+ * gates, independent of the per-file test shard running.
+ */
+export const FORBIDDEN_FRAGMENTS = [
+  "/agent/identity",
+  "identity_assertion",
+  "urn:workos:",
+  "agent_auth",
+] as const;
+
+/**
+ * The `.well-known` discovery paths the router (`well-known.ts`) actually
+ * mounts. `/auth.md` may point at these (it tells agents where to read machine
+ * metadata); naming a `.well-known` path the router does NOT serve is drift.
+ * The `{workspace_id}` segment is the doc's placeholder for the router's
+ * `:workspace_id` param.
+ */
+export const SERVED_WELL_KNOWN_PATHS = [
+  "/.well-known/oauth-authorization-server/api/auth",
+  "/.well-known/openid-configuration/api/auth",
+  "/.well-known/oauth-protected-resource/mcp/{workspace_id}",
+] as const;
+
+/** The resolved host pair `.well-known` advertises for a given fixed input. */
+export interface ResolvedHosts {
+  /** Auth-server issuer URI — `.well-known`'s `authorization_servers[0]`. */
+  readonly authServerUri: string;
+  /** MCP resource host (brand-mirror applied) — `.well-known`'s `resource`. */
+  readonly resourceUri: string;
+}
+
+// ---------------------------------------------------------------------------
+// `.well-known` source-of-truth extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * The protected-resource metadata's `scopes_supported` is a hardcoded literal
+ * in `well-known.ts` (it lists the `mcp:*` subset the MCP resource server
+ * advertises). It is not exported, so we extract the literal from source — the
+ * same read-the-source discipline every other drift gate uses. The set the
+ * `.well-known` document advertises must equal the set `/auth.md` names, or an
+ * agent and a `.well-known`-trusting client disagree on which scopes to
+ * request.
+ *
+ * Verification-only constraint: we deliberately do NOT refactor `well-known.ts`
+ * to export the literal (that would touch runtime code). Reading it here keeps
+ * the guard purely additive. Exported so the fixture suite can exercise the
+ * extraction against synthetic source.
+ */
+export function parseWellKnownScopes(source: string, sourceLabel: string): string[] {
+  const match = source.match(/scopes_supported:\s*\[([^\]]*)\]/);
+  if (!match) {
+    fail(
+      `Could not locate the \`scopes_supported\` literal in ${sourceLabel}. ` +
+        `The .well-known protected-resource scope source moved — update ` +
+        `parseWellKnownScopes() in this guard to track it.`,
+    );
+  }
+  const scopes = match[1]
+    .split(",")
+    .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+    .filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    fail(
+      `The \`scopes_supported\` literal in ${sourceLabel} parsed to an empty ` +
+        `set — the .well-known protected-resource document would advertise no ` +
+        `scopes. Refusing to treat that as parity.`,
+    );
+  }
+  return scopes;
+}
+
+function wellKnownAdvertisedScopes(): string[] {
+  const wellKnownPath = join(apiRoot, "src/api/routes/well-known.ts");
+  return parseWellKnownScopes(readFileSync(wellKnownPath, "utf8"), rel(wellKnownPath));
+}
+
+// ---------------------------------------------------------------------------
+// auth.md rendering (mirrors api/routes/auth-md.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * The `mcp:*` subset of the canonical scope union, mapped to the
+ * `AuthMdScope` shape the builder expects — the same derivation
+ * `api/routes/auth-md.ts:mcpScopes()` performs. Grant blurbs are irrelevant to
+ * parity (they're prose), so we pass a placeholder; only scope *names* matter.
+ */
+function mcpScopesFromCanonical(): AuthMdScope[] {
+  return ATLAS_OAUTH_SCOPES.filter((s) => s.startsWith("mcp:")).map((name) => ({
+    name,
+    grants: "—",
+  }));
+}
+
+/**
+ * Drive the shared host helpers + builder for a fixed resolved API base. The
+ * route resolves hosts from the request via the shared helpers; we drive the
+ * SAME helpers through the env var the route's resolution honors, then hand the
+ * resolved values to the SAME builder. `req` is a placeholder — the env var
+ * wins in the helpers' resolution precedence.
+ */
+function withResolvedBase<T>(apiBase: string, fn: (req: Request) => T): T {
+  const prev = process.env.ATLAS_PUBLIC_API_URL;
+  process.env.ATLAS_PUBLIC_API_URL = apiBase;
+  try {
+    return fn(new Request(`${apiBase}/auth.md`));
+  } finally {
+    if (prev === undefined) delete process.env.ATLAS_PUBLIC_API_URL;
+    else process.env.ATLAS_PUBLIC_API_URL = prev;
+  }
+}
+
+/** Render the document the route would serve for a given resolved API base. */
+function renderAuthMd(apiBase: string): string {
+  return withResolvedBase(apiBase, (req) =>
+    buildAuthMd({
+      authServerUri: buildAuthServerUri(req),
+      issuerBaseUri: buildIssuerBaseUri(req),
+      resourceUri: buildResourceUri(req),
+      scopes: mcpScopesFromCanonical(),
+      onboardingPath: ONBOARDING_MCP_PATH,
+      docsUrl: ATLAS_DOCS_URL,
+    }),
+  );
+}
+
+/** Resolve the `.well-known`-advertised hosts for a given resolved API base. */
+function resolvedHosts(apiBase: string): ResolvedHosts {
+  return withResolvedBase(apiBase, (req) => ({
+    authServerUri: buildAuthServerUri(req),
+    resourceUri: buildResourceUri(req),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Parity checkers (pure — return violation strings, no shared state, no exit)
+// ---------------------------------------------------------------------------
+
+function rel(p: string): string {
+  return p.startsWith(apiRoot) ? `packages/api/${p.slice(apiRoot.length + 1)}` : p;
+}
+
+/** Hard, immediate failure (config/parse errors that invalidate the run). */
+function fail(message: string): never {
+  console.error(`\ncheck-auth-md-discovery-parity: ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * Scope-set parity. Catches BOTH directions of drift: a scope hardcoded into
+ * the prose that machine discovery omits, and a `.well-known` scope the doc
+ * forgets to mention. Independent of host fixtures, so it runs once.
+ */
+export function scopeParityViolations(doc: string, advertised: readonly string[]): string[] {
+  const out: string[] = [];
+  const advertisedSet = new Set(advertised);
+  // Every `mcp:<word>` token the prose names. The brand host `.../mcp` is not a
+  // scope (no colon), so this pattern can't false-match it.
+  const namedInDoc = new Set(doc.match(/mcp:[a-z][a-z0-9_]*/g) ?? []);
+
+  for (const scope of namedInDoc) {
+    if (!advertisedSet.has(scope)) {
+      out.push(
+        `/auth.md names scope \`${scope}\` that the .well-known ` +
+          `protected-resource metadata does NOT advertise ` +
+          `(scopes_supported = [${advertised.join(", ")}]). ` +
+          `An agent reading /auth.md would request a scope machine discovery ` +
+          `omits. Either add it to scopes_supported in well-known.ts, or stop ` +
+          `naming it in the /auth.md builder.`,
+      );
+    }
+  }
+  for (const scope of advertised) {
+    if (!namedInDoc.has(scope)) {
+      out.push(
+        `The .well-known protected-resource metadata advertises scope ` +
+          `\`${scope}\` that /auth.md never names. A client trusting machine ` +
+          `discovery and an agent trusting /auth.md would request different ` +
+          `scopes. Surface \`${scope}\` in the /auth.md builder, or remove it ` +
+          `from scopes_supported in well-known.ts.`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Host parity for one fixture. Asserts the resolved auth-server issuer URI and
+ * the resolved MCP resource host (incl. the brand-mirror) appear verbatim in
+ * the doc — i.e. the prose names exactly what `.well-known` advertises, not a
+ * hardcoded look-alike — AND that no OTHER `useatlas.dev` host literal leaks
+ * in (the "maintainer hardcodes a host" vector).
+ */
+export function hostParityViolations(
+  label: string,
+  doc: string,
+  hosts: ResolvedHosts,
+): string[] {
+  const out: string[] = [];
+
+  if (!doc.includes(hosts.authServerUri)) {
+    out.push(
+      `[${label}] /auth.md does not name the resolved authorization-server ` +
+        `issuer URI \`${hosts.authServerUri}\` that .well-known advertises as ` +
+        `\`authorization_servers\`. A host was likely hardcoded in the prose ` +
+        `instead of resolved from buildAuthServerUri().`,
+    );
+  }
+  if (!doc.includes(hosts.resourceUri)) {
+    out.push(
+      `[${label}] /auth.md does not name the resolved MCP resource host ` +
+        `\`${hosts.resourceUri}\` that .well-known advertises as \`resource\` ` +
+        `(this is the api*→mcp* brand-mirror output of buildResourceUri()). ` +
+        `A host was likely hardcoded in the prose, or the brand-mirror was ` +
+        `bypassed.`,
+    );
+  }
+
+  // No `useatlas.dev` host literal in the doc may be a host OTHER than the two
+  // resolved ones (plus the docs link): a stray `https://api-apac.useatlas.dev`
+  // baked into the prose that machine discovery, resolved from the same input,
+  // never advertises.
+  const allowedOrigins = new Set(
+    [hosts.authServerUri, hosts.resourceUri, ATLAS_DOCS_URL].map((u) => new URL(u).origin),
+  );
+  for (const literal of doc.match(/https?:\/\/[a-z0-9.-]*useatlas\.dev/gi) ?? []) {
+    if (!allowedOrigins.has(new URL(literal).origin)) {
+      out.push(
+        `[${label}] /auth.md names the host \`${literal}\` that is neither the ` +
+          `resolved auth-server issuer (\`${hosts.authServerUri}\`) nor the ` +
+          `resolved MCP resource host (\`${hosts.resourceUri}\`) nor the docs ` +
+          `link. A host appears hardcoded in the prose and diverges from ` +
+          `machine discovery.`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Endpoint parity for one fixture: the doc names no forbidden WorkOS-conformance
+ * endpoint, and every `/.well-known/...` path it points at is one the router
+ * actually serves (so the doc can't send an agent to a path that 404s).
+ */
+export function endpointParityViolations(label: string, doc: string): string[] {
+  const out: string[] = [];
+
+  for (const fragment of FORBIDDEN_FRAGMENTS) {
+    if (doc.includes(fragment)) {
+      out.push(
+        `[${label}] /auth.md names \`${fragment}\` — a WorkOS agent-verified ` +
+          `endpoint Atlas does not serve and .well-known does not advertise. ` +
+          `A discovery document must never point an agent at an endpoint that ` +
+          `404s. Remove it from the /auth.md builder.`,
+      );
+    }
+  }
+
+  const served = new Set<string>(SERVED_WELL_KNOWN_PATHS);
+  for (const path of doc.match(/\/\.well-known\/[^\s`)]+/g) ?? []) {
+    if (!served.has(path)) {
+      out.push(
+        `[${label}] /auth.md points at the discovery path \`${path}\` that the ` +
+          `.well-known router does not serve (served: ${[...served].join(", ")}). ` +
+          `Either the doc hardcoded a wrong path or a route was renamed without ` +
+          `updating the doc.`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Run every parity check across all host fixtures + the host-independent scope
+ * check, and return the combined violation list. Pure: the caller owns I/O.
+ */
+export function collectViolations(input: {
+  fixtures: readonly { label: string; doc: string; hosts: ResolvedHosts }[];
+  advertisedScopes: readonly string[];
+}): string[] {
+  const out: string[] = [];
+  for (const f of input.fixtures) {
+    out.push(...hostParityViolations(f.label, f.doc, f.hosts));
+    out.push(...endpointParityViolations(f.label, f.doc));
+  }
+  // Scope parity is host-independent — the `mcp:*` set the prose names doesn't
+  // vary by region — so check it once against the first fixture's doc.
+  const firstDoc = input.fixtures[0]?.doc ?? "";
+  out.push(...scopeParityViolations(firstDoc, input.advertisedScopes));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const advertisedScopes = wellKnownAdvertisedScopes();
+
+  const fixtures = HOST_FIXTURES.map((f) => ({
+    label: f.label,
+    doc: renderAuthMd(f.apiBase),
+    hosts: resolvedHosts(f.apiBase),
+  }));
+
+  const violations = collectViolations({ fixtures, advertisedScopes });
+
+  if (violations.length > 0) {
+    console.error(
+      "\ncheck-auth-md-discovery-parity: /auth.md DIVERGES from machine " +
+        "discovery (.well-known). The human-readable onboarding doc must name " +
+        "exactly the hosts, scopes, and endpoints machine discovery advertises " +
+        "from the same inputs.\n",
+    );
+    for (const v of violations) console.error(`  ✗ ${v}\n`);
+    console.error(
+      `${violations.length} divergence(s). Fix the /auth.md builder ` +
+        "(packages/api/src/lib/mcp/auth-md.ts) or the .well-known router " +
+        "(packages/api/src/api/routes/well-known.ts) so the two agree.\n",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    "OK: /auth.md advertises exactly the hosts, scopes, and endpoints the " +
+      ".well-known discovery documents advertise from the same inputs " +
+      `(${HOST_FIXTURES.length} region fixtures, scopes ` +
+      `[${advertisedScopes.join(", ")}]).`,
+  );
+}
+
+// Only run when invoked as the script, not when imported by the fixture suite.
+if (import.meta.main) main();

--- a/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
+++ b/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Adversarial-fixture suite for the `/auth.md` ⇄ `.well-known` drift-parity
+ * guard (#3825) — `scripts/check-auth-md-discovery-parity.ts`.
+ *
+ * The guard is defense-in-depth on top of #3824's structural sharing: it fails
+ * the build when a maintainer HARDCODES a host, scope, or endpoint into the
+ * `/auth.md` prose that diverges from what machine discovery (`.well-known`)
+ * advertises from the same inputs.
+ *
+ * This suite locks in the two halves of that contract by driving the guard's
+ * PURE checkers (`scopeParityViolations` / `hostParityViolations` /
+ * `endpointParityViolations` / `collectViolations`) directly:
+ *   - the guard PASSES (no violations) on a faithful, in-parity document, and
+ *   - each drift vector PRODUCES a violation whose message NAMES the divergent
+ *     value (acceptance criterion #3).
+ *
+ * Driving the pure checkers (rather than mutating real source and shelling out)
+ * lets us inject every drift vector deterministically. The guard's end-to-end
+ * pass on the real tree is covered by the script itself running in the `drift`
+ * CI job.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  scopeParityViolations,
+  hostParityViolations,
+  endpointParityViolations,
+  collectViolations,
+  parseWellKnownScopes,
+  FORBIDDEN_FRAGMENTS,
+  type ResolvedHosts,
+} from "../../../scripts/check-auth-md-discovery-parity";
+
+// A minimal in-parity document: it names exactly the resolved hosts, exactly
+// the advertised scopes, and only `.well-known` paths the router serves. The
+// real builder's output is far richer, but parity is a property of the *facts*
+// the doc names, so a compact faithful fixture exercises the checkers fully.
+// The protected-resource path below uses the `{workspace_id}` placeholder
+// verbatim because that is the literal in the guard's SERVED_WELL_KNOWN_PATHS;
+// the real builder must emit the same placeholder (the script's live run
+// against `buildAuthMd` is what guards that, not this hand-written fixture).
+const HOSTS: ResolvedHosts = {
+  authServerUri: "https://api.useatlas.dev/api/auth",
+  resourceUri: "https://mcp.useatlas.dev/mcp",
+};
+
+const ADVERTISED_SCOPES = ["mcp:read", "mcp:write"] as const;
+
+const FAITHFUL_DOC = [
+  "# Connecting an agent to Atlas",
+  "- Authorization server (issuer): `https://api.useatlas.dev/api/auth`",
+  "- MCP resource server: `https://mcp.useatlas.dev/mcp`",
+  "Metadata: `https://api.useatlas.dev/.well-known/oauth-authorization-server/api/auth`",
+  "Per-workspace: `/.well-known/oauth-protected-resource/mcp/{workspace_id}`",
+  "Scopes: `mcp:read`, `mcp:write`.",
+  "Go deeper: https://docs.useatlas.dev",
+].join("\n");
+
+describe("auth-md discovery parity — faithful document passes", () => {
+  it("reports no violations when hosts, scopes, and endpoints all agree", () => {
+    const violations = collectViolations({
+      fixtures: [{ label: "us region", doc: FAITHFUL_DOC, hosts: HOSTS }],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it("each per-aspect checker is clean on the faithful document", () => {
+    expect(scopeParityViolations(FAITHFUL_DOC, ADVERTISED_SCOPES)).toEqual([]);
+    expect(hostParityViolations("us region", FAITHFUL_DOC, HOSTS)).toEqual([]);
+    expect(endpointParityViolations("us region", FAITHFUL_DOC)).toEqual([]);
+  });
+});
+
+// The eu fixture mirrors the second region `main()` passes, so the host/endpoint
+// checks must fire per-fixture, while scope parity is deliberately checked once
+// (it's region-invariant). These tests pin both halves of that contract so a
+// later "iterate all fixtures for scopes too" change is a conscious one.
+const EU_HOSTS: ResolvedHosts = {
+  authServerUri: "https://api-eu.useatlas.dev/api/auth",
+  resourceUri: "https://mcp-eu.useatlas.dev/mcp",
+};
+const EU_FAITHFUL_DOC = FAITHFUL_DOC.replaceAll(
+  "https://api.useatlas.dev",
+  "https://api-eu.useatlas.dev",
+).replaceAll("https://mcp.useatlas.dev", "https://mcp-eu.useatlas.dev");
+
+describe("auth-md discovery parity — collectViolations across region fixtures", () => {
+  it("is clean when every region fixture and the shared scope set agree", () => {
+    const violations = collectViolations({
+      fixtures: [
+        { label: "us region", doc: FAITHFUL_DOC, hosts: HOSTS },
+        { label: "eu region", doc: EU_FAITHFUL_DOC, hosts: EU_HOSTS },
+      ],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it("flags a host drift that lives only in the SECOND (eu) fixture", () => {
+    // The eu doc names the infra api-eu host where the brand-mirror mcp-eu host
+    // is expected — proving host parity runs per-fixture, not just on the first.
+    const driftedEuDoc = EU_FAITHFUL_DOC.replace(
+      "https://mcp-eu.useatlas.dev/mcp",
+      "https://api-eu.useatlas.dev/mcp",
+    );
+    const violations = collectViolations({
+      fixtures: [
+        { label: "us region", doc: FAITHFUL_DOC, hosts: HOSTS },
+        { label: "eu region", doc: driftedEuDoc, hosts: EU_HOSTS },
+      ],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(violations.some((v) => v.includes("[eu region]"))).toBe(true);
+    expect(violations.some((v) => v.includes(EU_HOSTS.resourceUri))).toBe(true);
+  });
+
+  it("checks scope parity once (host-independent) against the first fixture's doc", () => {
+    // Scope drift placed ONLY in the second fixture's doc is NOT reported,
+    // because the set of `mcp:*` scopes the prose names does not vary by region
+    // — collectViolations checks scopes against fixtures[0] alone. This pins the
+    // intentional shortcut so changing it is a deliberate decision, not a slip.
+    const euDocWithExtraScope = `${EU_FAITHFUL_DOC}\nAlso request \`mcp:admin\`.`;
+    const violations = collectViolations({
+      fixtures: [
+        { label: "us region", doc: FAITHFUL_DOC, hosts: HOSTS },
+        { label: "eu region", doc: euDocWithExtraScope, hosts: EU_HOSTS },
+      ],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(violations.some((v) => v.includes("mcp:admin"))).toBe(false);
+    // But the SAME drift in the first fixture's doc IS caught.
+    const usDocWithExtraScope = `${FAITHFUL_DOC}\nAlso request \`mcp:admin\`.`;
+    const caught = collectViolations({
+      fixtures: [
+        { label: "us region", doc: usDocWithExtraScope, hosts: HOSTS },
+        { label: "eu region", doc: EU_FAITHFUL_DOC, hosts: EU_HOSTS },
+      ],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(caught.some((v) => v.includes("mcp:admin"))).toBe(true);
+  });
+});
+
+describe("auth-md discovery parity — scope drift fails, naming the scope", () => {
+  it("fails when the prose names a scope .well-known does not advertise", () => {
+    // A maintainer hardcodes `mcp:admin` into the prose; machine discovery only
+    // lists mcp:read / mcp:write.
+    const doc = `${FAITHFUL_DOC}\nAlso request \`mcp:admin\` for elevated access.`;
+    const violations = scopeParityViolations(doc, ADVERTISED_SCOPES);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.includes("mcp:admin"))).toBe(true);
+    expect(violations.join("\n")).toContain("does NOT advertise");
+  });
+
+  it("fails when .well-known advertises a scope the prose never names", () => {
+    // The prose only names mcp:read; machine discovery advertises mcp:write too.
+    const doc = FAITHFUL_DOC.replace("`mcp:read`, `mcp:write`", "`mcp:read`");
+    const violations = scopeParityViolations(doc, ADVERTISED_SCOPES);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.includes("mcp:write"))).toBe(true);
+    expect(violations.join("\n")).toContain("never names");
+  });
+});
+
+describe("auth-md discovery parity — host drift fails, naming the host", () => {
+  it("fails when a foreign host literal is hardcoded into the prose", () => {
+    // A stray, un-advertised regional host baked into the doc.
+    const foreignHost = "api-apac.useatlas.dev";
+    const doc = `${FAITHFUL_DOC}\nFor APAC use \`https://${foreignHost}/api/auth\`.`;
+    const violations = hostParityViolations("us region", doc, HOSTS);
+    expect(violations.length).toBeGreaterThan(0);
+    // Assert on the bare host (no scheme) plus the foreign-host phrasing so the
+    // message is the right violation. (Matching the hostname rather than a full
+    // URL literal also keeps this a string-assertion, not a URL-substring check.)
+    expect(
+      violations.some((v) => v.includes(foreignHost) && v.includes("neither the")),
+    ).toBe(true);
+  });
+
+  it("fails when the prose omits the resolved auth-server issuer URI", () => {
+    const doc = FAITHFUL_DOC.replace(
+      "https://api.useatlas.dev/api/auth",
+      "https://auth.example.test/api/auth",
+    );
+    const violations = hostParityViolations("us region", doc, HOSTS);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(
+      violations.some((v) => v.includes(HOSTS.authServerUri) && v.includes("does not name")),
+    ).toBe(true);
+  });
+
+  it("fails when the prose omits the resolved MCP resource (brand-mirror) host", () => {
+    // The infra `api.*` host where the brand-mirror `mcp.*` resource is expected.
+    const doc = FAITHFUL_DOC.replace(
+      "https://mcp.useatlas.dev/mcp",
+      "https://api.useatlas.dev/mcp",
+    );
+    const violations = hostParityViolations("us region", doc, HOSTS);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(
+      violations.some((v) => v.includes(HOSTS.resourceUri) && v.includes("brand-mirror")),
+    ).toBe(true);
+  });
+});
+
+describe("auth-md discovery parity — endpoint drift fails, naming the endpoint", () => {
+  it("fails when the prose names a WorkOS-conformance endpoint Atlas does not serve", () => {
+    const doc = `${FAITHFUL_DOC}\nVerified agents: \`POST /agent/identity\` with an \`identity_assertion\`.`;
+    const violations = endpointParityViolations("us region", doc);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.includes("/agent/identity"))).toBe(true);
+    expect(violations.some((v) => v.includes("identity_assertion"))).toBe(true);
+  });
+
+  // Iterate the exported set so EVERY listed fragment is exercised by the
+  // checker — not just the two (`/agent/identity`, `identity_assertion`) that
+  // co-occur in the fixture above. (Test and checker share the same
+  // FORBIDDEN_FRAGMENTS constant, so this can't catch a typo'd entry — both
+  // would move together — but it does catch a checker change that stops
+  // honoring the full set, e.g. `urn:workos:` / `agent_auth` going unguarded.)
+  it.each([...FORBIDDEN_FRAGMENTS])(
+    "fails when the prose names the forbidden fragment %p",
+    (fragment) => {
+      const doc = `${FAITHFUL_DOC}\nDo not do this: ${fragment}`;
+      const violations = endpointParityViolations("us region", doc);
+      expect(violations.some((v) => v.includes(fragment))).toBe(true);
+    },
+  );
+
+  it("fails when the prose points at a .well-known path the router does not serve", () => {
+    const doc = `${FAITHFUL_DOC}\nSee \`/.well-known/oauth-protected-resource/mcp\` (no workspace).`;
+    const violations = endpointParityViolations("us region", doc);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(
+      violations.some((v) => v.includes("/.well-known/oauth-protected-resource/mcp")),
+    ).toBe(true);
+  });
+});
+
+describe("auth-md discovery parity — .well-known scope extraction", () => {
+  it("parses the scopes_supported literal the protected-resource metadata advertises", () => {
+    const source = `scopes_supported: ["mcp:read", "mcp:write"],`;
+    expect(parseWellKnownScopes(source, "fixture")).toEqual(["mcp:read", "mcp:write"]);
+  });
+
+  it("tracks a scope added to the .well-known literal", () => {
+    const source = `scopes_supported: ["mcp:read", "mcp:write", "mcp:admin"],`;
+    expect(parseWellKnownScopes(source, "fixture")).toEqual([
+      "mcp:read",
+      "mcp:write",
+      "mcp:admin",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Defense-in-depth CI guard (verification-only) that fails when the human-readable `/auth.md` agent-onboarding document (#3824) advertises a host, scope, or endpoint that disagrees with Atlas's machine-discovery documents (`.well-known`).

#3824 already feeds the `/auth.md` builder the **same** host-resolution helpers (`buildAuthServerUri` / `buildResourceUri`, incl. the `api*` → `mcp*` regional brand-mirror) and the **same** canonical scope constant (`ATLAS_OAUTH_SCOPES`) the `.well-known` router uses — structurally preventing the *most likely* drift. This guard covers the failure structure can't catch: a maintainer **hardcoding** a host/scope/endpoint into the `/auth.md` prose (or a doc copy-edit) that silently diverges. An agent that trusts `/auth.md` and a client that trusts `.well-known` would then bootstrap differently.

The guard renders `/auth.md` from a fixed sample base URL using the real builder + shared helpers + canonical scopes, reconstructs the `.well-known` advertised facts from the **same inputs**, and asserts parity of:
- the authorization-server issuer URI,
- the MCP resource host (incl. the `api*` → `mcp*` regional brand-mirror),
- the advertised scope set (the `mcp:*` subset derived from `ATLAS_OAUTH_SCOPES` vs the hardcoded `scopes_supported` literal in `well-known.ts`),

and that `/auth.md` names **no** endpoint `.well-known` doesn't advertise — never `/agent/identity` or the rest of the WorkOS-conformance machinery, and no unserved `.well-known` path. A divergence exits non-zero with an actionable message **naming the divergent value**.

Verification-only: imports the real modules, changes no runtime behavior, adds no endpoint.

### Files
- **`packages/api/scripts/check-auth-md-discovery-parity.ts`** — the guard. Pure, exported checkers (`scopeParityViolations` / `hostParityViolations` / `endpointParityViolations` / `collectViolations` / `parseWellKnownScopes`) + a thin I/O `main()`. Lives under `packages/api/scripts/` (not repo-root `scripts/`) so its `@atlas/api/*` imports resolve.
- **`packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts`** — adversarial fixtures proving each drift vector fails with a value-naming message (both scope directions, host hardcode/omission incl. brand-mirror, forbidden WorkOS fragments via the full `FORBIDDEN_FRAGMENTS` set, unserved `.well-known` paths, multi-region `collectViolations`), and that the faithful document passes.
- **`.github/workflows/ci.yml`** — runs the guard in the existing `drift` job (the same gate as schema-drift / template-drift), so a divergence blocks merge.

## Test plan
- [x] Guard passes on the current tree (`cd packages/api && bun scripts/check-auth-md-discovery-parity.ts` → OK, 2 region fixtures)
- [x] Adversarial fixture suite (18 tests) proves each injected drift fails with a clear, value-naming message and the faithful doc passes
- [x] Manually verified the guard fails (exit 1, names `mcp:write`) when a divergent `scopes_supported` literal is injected into `well-known.ts`
- [x] `bun run lint` · `bun run type` · `bun x syncpack lint` · `check-test-discipline.sh` — all pass
- [x] Full `bun run test:api` — 700/700 (3 explore/python files are the documented WSL2 dev-shell `VERCEL_*`/`ATLAS_SANDBOX_*` false-failures; green with those unset and in CI)
- [x] Internal review panel: CLEAN after 2 rounds (silent-failure, type-design, pr-test, comment)

Closes #3825

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI drift guard to detect parity divergence between `/auth.md` and `.well-known`
> - Adds [check-auth-md-discovery-parity.ts](https://github.com/AtlasDevHQ/atlas/pull/3831/files#diff-fec64cb1986119e7d2981adc83412ffeef95add74a7f129863aca6f9bc9c1690), a script that renders `/auth.md` and compares it against `.well-known` source data, checking for mismatches in scopes, hosts, and endpoint paths across US and EU API bases.
> - Adds a new step in the `drift` CI job in [ci.yml](https://github.com/AtlasDevHQ/atlas/pull/3831/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs the script, failing the job if any divergence is detected.
> - Adds an adversarial test suite in [auth-md-discovery-parity.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3831/files#diff-48c246c3e56e23e2b9319c789740f4bfecc4cd317fae58b2439af5c2fcb48586) covering scope, host, and endpoint drift scenarios using the script's pure checker functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f922f84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a verification-only CI guard that fails when `/auth.md` advertises a host, scope, or endpoint that disagrees with Atlas's `.well-known` discovery documents — defense-in-depth on top of #3824's structural sharing, catching the remaining drift vector of a maintainer hardcoding values into prose.

- **`packages/api/scripts/check-auth-md-discovery-parity.ts`**: pure exported checkers (`scopeParityViolations`, `hostParityViolations`, `endpointParityViolations`, `collectViolations`) + thin I/O `main()` that renders `/auth.md` via the real builders across two region fixtures and asserts parity of issuer URI, MCP resource host (including the `api*`→`mcp*` brand-mirror), scope set, and served `.well-known` paths.
- **`packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts`**: 18-test adversarial fixture suite covering scope drift in both directions, per-region host drift (including brand-mirror omission and stray host injection), all `FORBIDDEN_FRAGMENTS`, and unserved `.well-known` paths.
- **`.github/workflows/ci.yml`**: wires the guard into the existing `drift` job so a divergence blocks merge.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Verification-only change with no runtime code modifications — safe to merge.

All three files are additive and touch no runtime paths. The guard imports real modules but calls no side-effectful endpoints, correctly restores process.env in a finally block, and its pure checkers are exercised by 18 adversarial tests covering every drift vector in both directions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/scripts/check-auth-md-discovery-parity.ts | New CI guard: pure exported checkers + main() that renders /auth.md via real builders and asserts host/scope/endpoint parity against .well-known. Well-structured, verification-only, no runtime impact. |
| packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts | 18-test adversarial fixture suite covering all drift vectors. Intentional scope-checked-once shortcut is clearly documented and pinned by a dedicated test. |
| .github/workflows/ci.yml | Minimal, correct addition wiring the guard into the existing drift job. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(mcp): drift-parity guard for /auth..."](https://github.com/atlasdevhq/atlas/commit/f922f849b35192b7a02447407014459bf8602f05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38816345)</sub>

<!-- /greptile_comment -->