### PR TITLE
feat(durable-sessions): extend resume + approval-park to MCP and chat-plugin surfaces (#3750)

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -77,6 +77,15 @@ import { WorkspaceInstallGate } from "./packages/api/src/lib/integrations/instal
 // surfaces here, so the relative-import constraint stays satisfied.
 import { createChatPluginExecuteQuery } from "./packages/api/src/lib/chat-plugin/executeQuery";
 import { resolveOperatorAdapterEnv } from "./packages/api/src/lib/integrations/operator-credentials/resolver";
+// #3750 — chat resume-on-approval delivery. `onBridgeReady` hands us the
+// bridge so we can register a deliverer (built by `buildChatResumeDeliverer`)
+// that re-enters the agent loop (re-resolving auth/scoping LIVE) and posts the
+// continued answer back in-thread when a parked turn's approval is resolved.
+import {
+  registerChatResumeDeliverer,
+  clearChatResumeDeliverer,
+} from "./packages/api/src/lib/chat-plugin/resume-delivery-registry";
+import { buildChatResumeDeliverer } from "./packages/api/src/lib/chat-plugin/resume-deliverer-factory";
 
 // Dedicated runtime for the proactive classifier + answer adapters.
 // Built inside the workspace by `getProactiveAiRuntime()` so this file
@@ -885,6 +894,27 @@ export default defineConfig({
       // no process restart. Precedence: DB row → env → unset (env stays the
       // self-host fallback). See `lib/integrations/operator-credentials/`.
       resolveAdapterEnv: () => resolveOperatorAdapterEnv(),
+      // #3750 — durable approval-park resume for chat threads. On init the
+      // plugin hands us the bridge; we register a deliverer that, when an
+      // approval-review handler resolves a parked chat turn, re-enters the
+      // agent loop under the original chat actor (re-resolving auth/scoping
+      // LIVE — ADR-0020) and posts the continued answer back in-thread. On
+      // teardown the plugin calls back with `null` so the deliverer is cleared
+      // (no stale bridge reference across a refresh).
+      onBridgeReady: (bridge) => {
+        if (!bridge) {
+          clearChatResumeDeliverer();
+          return;
+        }
+        // The deliverer's resume→post mapping lives in a unit-tested factory;
+        // here we only inject the bridge's thread-post capability.
+        registerChatResumeDeliverer(
+          buildChatResumeDeliverer({
+            postToThread: (platform, threadId, message) =>
+              bridge.postToThread(platform, threadId, message),
+          }),
+        );
+      },
       // ── Proactive listener wiring (#2607) ─────────────────────────
       // Wires every callback the proactive listener consumes to host
       // helpers under `packages/api/src/lib/proactive/`. After this

--- a/docs/architecture/chat-plugin-atlas-contract.md
+++ b/docs/architecture/chat-plugin-atlas-contract.md
@@ -94,6 +94,45 @@ stays the self-host fallback unchanged. ⚠ row to watch: any change to the shap
 overlay (e.g. nesting, or a non-string value) breaks the `{ ...process.env, ...overlay }`
 merge contract — the overlay must stay a flat `Record<string, string>`.
 
+### Durable approval-park resume delivery — `ChatPluginConfig.onBridgeReady` + `chat:resume-pending:<conversationId>` (#3750)
+
+Durable sessions (#3742 family) let an agent turn **park** on an approval rule and
+resume later. For a turn initiated from a chat thread, #3750 closes the loop:
+instead of a dead-end ":lock: approve via the console" reply, the thread posts a
+"waiting on approval" notice and is **resumed in-place** once a reviewer resolves
+the request — the continued answer (or a denial) is posted back in the original
+thread. The mechanism rides two boundary points, both **host-side / Atlas-owned**:
+
+| Boundary field | Host wiring | Atlas resolver / store | Fail-loud? | Status |
+|---|---|---|---|---|
+| `ChatPluginConfig.onBridgeReady` (top-level config callback; invoked with the narrow `ChatResumeBridge` after `initialize()`, and `null` on `teardown()`) | wired in `deploy/api/atlas.config.ts` → `registerChatResumeDeliverer(...)` / `clearChatResumeDeliverer()` | `lib/chat-plugin/resume-delivery-registry.ts` (process-local port, mirrors `proactive/announcer-registry.ts`; `NULL_RESUME_DELIVERER` fallback so self-host w/o chat never fails a review). Deliverer re-enters the loop via `lib/chat-plugin/resume-turn.ts:resumeChatTurn()` and posts via `ChatBridge.postToThread()` | ✓ — `onBridgeReady` throw is caught at init (warn, plugin still boots); the deliverer never throws (maps failures to a `failed` outcome the review handler logs at error) | ✓ verified |
+| `ChatBridge.postToThread(platform, threadId, message)` (new bridge method; narrow subset exposed to the host as `ChatResumeBridge`) | bridge impl in `plugins/chat/src/bridge.ts` posts via `adapter.postMessage(threadId, …)` — the same adapter primitive the in-handler `thread.post()` wrapper ultimately calls | called by the registered deliverer (built by `buildChatResumeDeliverer`), wired in `deploy/api/atlas.config.ts` | ✓ — returns `null` (never throws) when the adapter is unconfigured or rejects the post; the deliverer treats `null` as a `failed` delivery | ✓ verified |
+| `chat_cache.value` key `chat:resume-pending:<conversationId>` → `{ platform, threadId, orgId, externalId, externalUserId? }` (**Atlas-extension field**, category 1) | written at park by `lib/chat-plugin/executeQuery.ts` (the `pendingApproval` branch) via `lib/chat-plugin/resume-pending-store.ts:saveResumePending()` | read by `lib/chat-plugin/resume-delivery.ts:deliverChatResumeIfPending()` (`loadResumePending`), deleted on terminal delivery (`clearResumePending`); TTL = max-park window (`getMaxParkMinutes`) so a swept-to-`failed` parked run leaves no dangling row | ✓ — `saveResumePending` is fail-soft (returns false + warns; the turn still parks, just without auto-resume); `loadResumePending` null-returns + warns on a malformed row | ✓ verified |
+
+**Why these are host-side (no `@chat-adapter/*` change).** The chat-adapter never reads
+the `chat:resume-pending:*` key (only Atlas host code writes/reads/deletes it). `saveResumePending`'s
+upsert does a full `value = EXCLUDED.value` overwrite — NOT the `value || EXCLUDED.value`
+JSONB merge the `slack:installation:*` key uses — and Atlas owns both sides of this key,
+so there is no cross-writer to preserve fields for. `onBridgeReady` is a top-level `chatPlugin({ ... })`
+host callback in the same family as `announcementCoordinator` ("host-only — not exposed
+to the plugin"): additive + host-optional (the plugin works unchanged when omitted —
+self-host without durable resume). The security boundary lives in `resumeChatTurn`,
+which re-resolves auth/connection/RLS **live** (rebuilds the original bot actor, re-runs
+the billing gate, claims the single-resumer lease) before re-entering `runAgent({ resume })`
+— a user who lost access while parked fails closed exactly as the web resume route does
+(ADR-0020). ⚠ row to watch: any change to the `ChatResumeBridge` shape (a wider bridge
+surface, or a non-string post payload) — keep it the minimal `postToThread` subset so the
+host wires resume delivery without depending on the full `ChatBridge`.
+
+**MCP note (no boundary):** the MCP surface needs no resume delivery — MCP has no agent
+loop or durable run (each tool call is one synchronous dispatch; the MCP client is the
+loop). A parked MCP `executeSQL`/`runMetric` call surfaces `approval_required` +
+`approval_request_id` (already, pre-#3750) and "resumes" when the client **re-calls** the
+identical tool after approval — the gate's `hasApprovedRequest` dedup lets the re-call
+through, re-resolving auth/scoping live on that fresh dispatch. #3750 only adds an explicit
+resume-hint string (`MCP_APPROVAL_RESUME_HINT`) to those results so the LLM client knows to
+retry the same call. No MCP/chat-adapter boundary field changed.
+
 ### Future platforms (post-1.5.2)
 
 `plugins/chat/src/adapter-registry.ts` keeps catalog rows for Teams, Discord, gchat, Telegram, GitHub, Linear, WhatsApp. Telegram (#2748) is the first to ship a real `StaticBotInstallHandler` — the keystone slice for the remaining Phase D platforms. Each platform that gains an install flow gets a new section in this table — one row per Atlas-extension field. Track:

--- a/packages/api/src/api/routes/__tests__/admin-approval.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-approval.test.ts
@@ -115,6 +115,16 @@ mock.module("@atlas/api/lib/durable-resume", () => ({
   resolveApprovalPark: mockResolveApprovalPark,
 }));
 
+// #3750 — the chat resume-delivery glue the route invokes after a `resumed`
+// re-arm. Mocked so the route test stays at the DB-free seam (the glue itself
+// is covered in lib/chat-plugin/__tests__/resume-delivery.test.ts).
+const mockDeliverChatResume: Mock<(conversationId: string, decision: string) => Promise<string>> = mock(
+  async () => "no_pending",
+);
+mock.module("@atlas/api/lib/chat-plugin/resume-delivery", () => ({
+  deliverChatResumeIfPending: mockDeliverChatResume,
+}));
+
 // Force enterprise on so `ConditionalEELayer` lazy-imports the mocked
 // `@atlas/ee/layers` aggregator below.
 // Module-top env setup — must be set before the dynamic imports below
@@ -332,6 +342,8 @@ describe("POST /queue/:id — approval-park resolution (#3748)", () => {
     );
     mockResolveApprovalPark.mockClear();
     mockResolveApprovalPark.mockImplementation(async () => ({ status: "none" }));
+    mockDeliverChatResume.mockClear();
+    mockDeliverChatResume.mockImplementation(async () => "no_pending");
     loggedErrors.length = 0;
   });
 
@@ -393,5 +405,46 @@ describe("POST /queue/:id — approval-park resolution (#3748)", () => {
     const res = await reviewRequest("req-quiet", { action: "approve" });
     expect(res.status).toBe(200);
     expect(loggedErrors).toHaveLength(0);
+  });
+
+  // #3750 — when a parked turn is re-armed, the route triggers chat resume
+  // delivery for its conversation (a no-op for web turns / no coordinates).
+  it("triggers chat resume delivery with the re-armed conversation when resolveApprovalPark resumes", async () => {
+    mockResolveApprovalPark.mockImplementationOnce(async () => ({
+      status: "resumed",
+      conversationId: "conv-slack-1",
+      runId: "run-1",
+    }));
+    const res = await reviewRequest("req-chat", { action: "approve" });
+    expect(res.status).toBe(200);
+    expect(mockDeliverChatResume).toHaveBeenCalledTimes(1);
+    expect(mockDeliverChatResume.mock.calls[0]![0]).toBe("conv-slack-1");
+    expect(mockDeliverChatResume.mock.calls[0]![1]).toBe("approve");
+  });
+
+  it("does NOT trigger chat resume delivery when nothing was re-armed (none)", async () => {
+    mockResolveApprovalPark.mockImplementationOnce(async () => ({ status: "none" }));
+    await reviewRequest("req-none", { action: "approve" });
+    expect(mockDeliverChatResume).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger chat resume delivery when the re-arm failed", async () => {
+    mockResolveApprovalPark.mockImplementationOnce(async () => ({ status: "failed", runId: "run-x" }));
+    await reviewRequest("req-failed", { action: "approve" });
+    expect(mockDeliverChatResume).not.toHaveBeenCalled();
+  });
+
+  it("is fail-soft: a chat resume-delivery throw does NOT fail the recorded review (still 200)", async () => {
+    mockResolveApprovalPark.mockImplementationOnce(async () => ({
+      status: "resumed",
+      conversationId: "conv-2",
+      runId: "run-2",
+    }));
+    mockDeliverChatResume.mockImplementationOnce(async () => {
+      throw new Error("delivery exploded");
+    });
+    const res = await reviewRequest("req-deliver-boom", { action: "approve" });
+    expect(res.status).toBe(200);
+    expect(loggedErrors.some((e) => e.msg.includes("chat resume delivery threw"))).toBe(true);
   });
 });

--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -22,6 +22,7 @@ import { APPROVAL_STATUSES, APPROVAL_RULE_ORIGINS } from "@useatlas/types";
 import { ApprovalRuleSchema, ApprovalRequestSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { resolveApprovalPark } from "@atlas/api/lib/durable-resume";
+import { deliverChatResumeIfPending } from "@atlas/api/lib/chat-plugin/resume-delivery";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import {
@@ -539,6 +540,31 @@ adminApproval.openapi(reviewRoute, async (c) => {
       log.error(
         { itemId, action: body.action, runId: armOutcome.runId },
         "approval-park: decision recorded but the parked turn was NOT re-armed — it will stay parked until the max-park sweep fails it; investigate",
+      );
+    }
+
+    // #3750 — if the re-armed turn originated from a chat thread (Slack/
+    // Telegram/…), resume it and post the continued answer back in-thread. The
+    // resume-pending store carries the platform + thread coordinates written at
+    // park time; the registered chat deliverer re-enters the agent loop (under
+    // the original chat actor, re-resolving auth/scoping LIVE — ADR-0020) and
+    // posts the answer. Fail-soft and fully decoupled from the review: the
+    // decision is already recorded + audited, so any delivery problem is logged
+    // (not 500'd) and the user can fall back to the admin console / a re-ask.
+    // `none`/`no_deliverer` are benign (web turn, self-hosted w/o chat, or the
+    // user already re-asked); only a genuine `failed` is surfaced.
+    if (armOutcome.status === "resumed") {
+      yield* Effect.promise(() =>
+        deliverChatResumeIfPending(armOutcome.conversationId, body.action).catch((err) => {
+          log.error(
+            {
+              err: err instanceof Error ? err.message : String(err),
+              itemId,
+              conversationId: armOutcome.conversationId,
+            },
+            "approval-park: chat resume delivery threw after review was recorded",
+          );
+        }),
       );
     }
 

--- a/packages/api/src/lib/__tests__/agent-query.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query.test.ts
@@ -30,6 +30,8 @@ mock.module("@atlas/api/lib/agent", () => ({
       ...(ctx?.actor !== undefined ? { actor: ctx.actor } : {}),
     });
     return {
+      // #3750 — the real runAgent Object.assigns a `runId` onto its result.
+      runId: "run-mock-1",
       text: Promise.resolve("done"),
       steps: Promise.resolve([
         {
@@ -119,5 +121,24 @@ describe("executeAgentQuery actor binding", () => {
     expect(result.pendingApproval?.requestId).toBe("req-1");
     expect(result.pendingApproval?.ruleName).toBe("Block PII reads");
     expect(result.pendingApproval?.matchedRules).toEqual(["Block PII reads"]);
+  });
+
+  it("#3750: surfaces the durable runId from runAgent and echoes conversationId for async-approval resume", async () => {
+    const actor = createAtlasUser("user-r", "managed", "user-r@example.com", { activeOrganizationId: "org-r" });
+    const result = await executeAgentQuery("parked query", "req-3", {
+      actor,
+      conversationId: "conv-abc",
+    });
+    // runId comes from runAgent's returned object; conversationId is echoed
+    // from the option. Together they let a chat surface re-arm + resume.
+    expect(result.runId).toBe("run-mock-1");
+    expect(result.conversationId).toBe("conv-abc");
+  });
+
+  it("#3750: omits conversationId when none was supplied (a conversation-less turn has no resumable checkpoint)", async () => {
+    const actor = createAtlasUser("user-r", "managed", "user-r@example.com", { activeOrganizationId: "org-r" });
+    const result = await executeAgentQuery("no-conversation query", "req-4", { actor });
+    expect(result.runId).toBe("run-mock-1");
+    expect(result.conversationId).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -63,6 +63,25 @@ export interface AgentQueryResult {
    * and visible in the admin billing page.
    */
   planWarning?: PlanLimitWarning;
+  /**
+   * #3750 — the durable run id minted (or resumed) for this agent turn,
+   * surfaced from {@link runAgent}'s returned `runId`. Present whenever the
+   * agent loop ran. Async-approval surfaces (chat platforms) pair it with
+   * `conversationId` to re-arm and resume the turn once a parked approval is
+   * resolved (durable-sessions #3748/#3750). Callers that don't resume
+   * (the synchronous `/query` route) simply ignore it. A run id always
+   * exists, but a *resumable* parked checkpoint only exists when durability
+   * is enabled AND a `conversationId` was supplied — so resume callers must
+   * also check `conversationId` + `pendingApproval`.
+   */
+  runId?: string;
+  /**
+   * #3750 — the conversation the turn ran under, echoed back so async
+   * resume callers needn't thread it separately. Equals
+   * `ExecuteAgentQueryOptions.conversationId` when one was supplied; absent
+   * otherwise (a conversation-less turn has no durable checkpoint to resume).
+   */
+  conversationId?: string;
 }
 
 export interface ExecuteAgentQueryOptions {
@@ -372,6 +391,11 @@ export async function executeAgentQuery(
       ...(pendingActions.length > 0 && { pendingActions }),
       ...(pendingApproval ? { pendingApproval } : {}),
       ...(gate.warning ? { planWarning: gate.warning } : {}),
+      // #3750 — surface the durable run id + conversation so async-approval
+      // surfaces can re-arm and resume a parked turn. `result.runId` is always
+      // set by runAgent (Object.assign at the loop's return).
+      ...(result.runId ? { runId: result.runId } : {}),
+      ...(options?.conversationId ? { conversationId: options.conversationId } : {}),
     };
   });
 }

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -84,6 +84,15 @@ mock.module("@atlas/api/lib/agent-query", () => ({
   executeAgentQuery: mockExecuteAgentQuery,
 }));
 
+// #3750 — the park-side coordinate write. Captured so the approval tests can
+// assert WHAT coordinates get persisted (and that nothing is written when the
+// turn isn't durably resumable).
+const mockSaveResumePending: Mock<(conversationId: string, coords: Record<string, unknown>) => Promise<boolean>> =
+  mock(async () => true);
+mock.module("@atlas/api/lib/chat-plugin/resume-pending-store", () => ({
+  saveResumePending: mockSaveResumePending,
+}));
+
 const mockGetInstallation: Mock<(teamId: string) => Promise<{ org_id: string | null } | null>> =
   mock((teamId) => {
     if (teamId === "T999") return Promise.resolve(null);
@@ -446,6 +455,117 @@ describe("chat-plugin executeQuery host helper", () => {
     // the canonical notice the user sees.
     expect(result.answer).toContain("Atlas admin console");
     expect(result.answer).not.toContain("free-form text");
+    // No durable run id ⇒ not auto-resumable ⇒ no coordinate written.
+    expect(mockSaveResumePending).not.toHaveBeenCalled();
+  });
+
+  it("posts a waiting-state notice + persists resume coordinates when the parked turn is durably resumable (#3750)", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+    mockSaveResumePending.mockClear();
+    mockSaveResumePending.mockResolvedValueOnce(true);
+
+    mockExecuteAgentQuery.mockImplementationOnce(async (question, requestId, options) => {
+      capturedAgentCalls.push({
+        question,
+        ...(requestId !== undefined ? { requestId } : {}),
+        ...(options !== undefined ? { options } : {}),
+      });
+      return {
+        answer: "free-form text that should be REPLACED",
+        sql: [],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 5 },
+        // A real approval-queue id AND a durable run id ⇒ auto-resumable.
+        runId: "run-77",
+        conversationId: "conv-new",
+        pendingApproval: {
+          requestId: "req-99",
+          ruleName: "PII-Read",
+          matchedRules: ["PII-Read"],
+          message: "Needs approval",
+        },
+      };
+    });
+
+    const result = await runExecuteQuery("show me PII", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U42", channel: "C1", ts: "1.2" },
+    });
+
+    // Waiting-state copy — promises in-thread continuation, NOT the dead-end
+    // "approve via console" notice.
+    expect(result.answer).toContain("Waiting on a reviewer");
+    expect(result.answer).toContain("this thread");
+    expect(result.answer).not.toContain("Atlas admin console");
+    expect(result.answer).not.toContain("free-form text");
+
+    // Coordinates persisted with the thread anchor + actor binding, keyed by
+    // the turn's conversation (an id minted by the conversation layer).
+    expect(mockSaveResumePending).toHaveBeenCalledTimes(1);
+    const [conversationId, coords] = mockSaveResumePending.mock.calls[0]!;
+    expect(typeof conversationId).toBe("string");
+    expect(conversationId).toBeTruthy();
+    expect(coords).toMatchObject({
+      platform: "slack",
+      threadId: "slack:C1-1.2",
+      orgId: "org-xyz",
+      externalId: "T0ABC",
+      externalUserId: "U42",
+    });
+  });
+
+  it("Telegram parked turn also persists resume coordinates (AC2 names Telegram) (#3750)", async () => {
+    // Telegram resolves tenant via internalQuery (chat_id → workspace_id).
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("workspace_plugins")) {
+        return Promise.resolve([{ workspace_id: "org-tg" }]);
+      }
+      return Promise.resolve([]);
+    });
+    mockSaveResumePending.mockClear();
+    mockSaveResumePending.mockResolvedValueOnce(true);
+
+    mockExecuteAgentQuery.mockImplementationOnce(async (question, requestId, options) => {
+      capturedAgentCalls.push({
+        question,
+        ...(requestId !== undefined ? { requestId } : {}),
+        ...(options !== undefined ? { options } : {}),
+      });
+      return {
+        answer: "replaced",
+        sql: [],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 5 },
+        runId: "run-tg",
+        pendingApproval: {
+          requestId: "req-tg",
+          ruleName: "PII-Read",
+          matchedRules: ["PII-Read"],
+          message: "Needs approval",
+        },
+      };
+    });
+
+    const { runExecuteQuery } = await import("../executeQuery");
+    const result = await runExecuteQuery("show me PII", {
+      threadId: "telegram:12345-7",
+      adapter: { name: "telegram" },
+      rawMessage: { message_id: 7, chat: { id: 12345 }, from: { id: 99 } },
+    });
+
+    expect(result.answer).toContain("Waiting on a reviewer");
+    expect(mockSaveResumePending).toHaveBeenCalledTimes(1);
+    const coords = mockSaveResumePending.mock.calls[0]![1];
+    expect(coords).toMatchObject({
+      platform: "telegram",
+      threadId: "telegram:12345-7",
+      orgId: "org-tg",
+      externalId: "12345",
+      externalUserId: "99",
+    });
   });
 
   it("forwards pendingActions through to the bridge so ephemeral approval prompts can be posted", async () => {

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-deliverer-factory.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-deliverer-factory.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #3750 — chat resume-deliverer factory.
+ *
+ * Pins the integration seam that wires `resumeChatTurn` → `postToThread`:
+ *   - unknown platform slug → `failed` (no actor guess);
+ *   - `answered` → posts the answer, returns `delivered`;
+ *   - `blocked` → posts the user-safe block notice, returns `blocked` (a
+ *     fail-closed security refusal, kept distinct from `delivered`);
+ *   - `nothing_to_resume` / `failed` from resume pass through (no post);
+ *   - a failed post → `failed{thread_post_failed}`;
+ *   - the actor binding (externalId/externalUserId) is forwarded to resume.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { ResumeChatTurnResult } from "../resume-turn";
+import type { PostToThread } from "../resume-deliverer-factory";
+
+const mockResumeChatTurn: Mock<(i: unknown) => Promise<ResumeChatTurnResult>> = mock(async () => ({
+  status: "answered",
+  answer: "the answer",
+}));
+
+mock.module("@atlas/api/lib/chat-plugin/resume-turn", () => ({
+  resumeChatTurn: mockResumeChatTurn,
+}));
+
+const { buildChatResumeDeliverer } = await import("../resume-deliverer-factory");
+
+const INPUT = {
+  conversationId: "conv_1",
+  orgId: "org_1",
+  platform: "slack",
+  threadId: "C1:1.1",
+  externalId: "T0123",
+  externalUserId: "U999",
+};
+
+function delivererWithPost(post: PostToThread) {
+  return buildChatResumeDeliverer({ postToThread: post });
+}
+
+beforeEach(() => {
+  mockResumeChatTurn.mockReset();
+  mockResumeChatTurn.mockResolvedValue({ status: "answered", answer: "the answer" });
+});
+
+describe("buildChatResumeDeliverer (#3750)", () => {
+  it("posts the answer and returns delivered on an answered resume", async () => {
+    const posts: Array<[string, string, string]> = [];
+    const deliverer = delivererWithPost(async (p, t, m) => {
+      posts.push([p, t, m]);
+      return { messageId: "m1" };
+    });
+
+    const outcome = await deliverer.deliverResumedTurn(INPUT);
+    expect(outcome).toEqual({ status: "delivered" });
+    expect(posts).toEqual([["slack", "C1:1.1", "the answer"]]);
+
+    // The actor binding is forwarded to resume.
+    const resumeArg = mockResumeChatTurn.mock.calls[0]![0] as Record<string, unknown>;
+    expect(resumeArg).toMatchObject({
+      conversationId: "conv_1",
+      orgId: "org_1",
+      platform: "slack",
+      externalId: "T0123",
+      externalUserId: "U999",
+    });
+  });
+
+  it("posts the block notice and returns blocked (distinct from delivered) on a blocked resume", async () => {
+    mockResumeChatTurn.mockResolvedValueOnce({ status: "blocked", message: "Workspace suspended." });
+    const posts: string[] = [];
+    const deliverer = delivererWithPost(async (_p, _t, m) => {
+      posts.push(m);
+      return { messageId: "m2" };
+    });
+
+    const outcome = await deliverer.deliverResumedTurn(INPUT);
+    expect(outcome).toEqual({ status: "blocked" });
+    // The user-safe block reason is what gets posted, not an answer.
+    expect(posts).toEqual(["Workspace suspended."]);
+  });
+
+  it("fails on an unknown platform slug without calling resume", async () => {
+    const deliverer = delivererWithPost(async () => ({ messageId: "x" }));
+    const outcome = await deliverer.deliverResumedTurn({ ...INPUT, platform: "irc" });
+    expect(outcome).toEqual({ status: "failed", reason: "unknown_platform:irc" });
+    expect(mockResumeChatTurn).not.toHaveBeenCalled();
+  });
+
+  it("passes through nothing_to_resume without posting", async () => {
+    mockResumeChatTurn.mockResolvedValueOnce({ status: "nothing_to_resume" });
+    let posted = false;
+    const deliverer = delivererWithPost(async () => { posted = true; return { messageId: "x" }; });
+    const outcome = await deliverer.deliverResumedTurn(INPUT);
+    expect(outcome).toEqual({ status: "nothing_to_resume" });
+    expect(posted).toBe(false);
+  });
+
+  it("passes through a failed resume without posting", async () => {
+    mockResumeChatTurn.mockResolvedValueOnce({ status: "failed", reason: "agent_run_error" });
+    const deliverer = delivererWithPost(async () => ({ messageId: "x" }));
+    const outcome = await deliverer.deliverResumedTurn(INPUT);
+    expect(outcome).toEqual({ status: "failed", reason: "agent_run_error" });
+  });
+
+  it("returns failed{thread_post_failed} when the post fails", async () => {
+    const deliverer = delivererWithPost(async () => null);
+    const outcome = await deliverer.deliverResumedTurn(INPUT);
+    expect(outcome).toEqual({ status: "failed", reason: "thread_post_failed" });
+  });
+
+  it("omits externalUserId from the resume call when absent", async () => {
+    const deliverer = delivererWithPost(async () => ({ messageId: "x" }));
+    const { externalUserId: _omit, ...noUser } = INPUT;
+    await deliverer.deliverResumedTurn(noUser);
+    const resumeArg = mockResumeChatTurn.mock.calls[0]![0] as Record<string, unknown>;
+    expect(resumeArg).not.toHaveProperty("externalUserId");
+  });
+});

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-delivery-registry.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-delivery-registry.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #3750 — chat resume-delivery registry port.
+ *
+ * Pins the register/clear/get singleton + the NULL fallback (so a self-hosted
+ * deployment without the chat plugin never fails an approval review for lack
+ * of a deliverer).
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  registerChatResumeDeliverer,
+  clearChatResumeDeliverer,
+  getChatResumeDeliverer,
+  NULL_RESUME_DELIVERER,
+  type ChatResumeDeliverer,
+} from "../resume-delivery-registry";
+
+afterEach(() => {
+  clearChatResumeDeliverer();
+});
+
+describe("chat resume-delivery registry (#3750)", () => {
+  it("returns NULL_RESUME_DELIVERER when nothing is registered", () => {
+    expect(getChatResumeDeliverer()).toBe(NULL_RESUME_DELIVERER);
+  });
+
+  it("NULL deliverer reports no_deliverer so the review still succeeds", async () => {
+    const outcome = await NULL_RESUME_DELIVERER.deliverResumedTurn({
+      conversationId: "c",
+      orgId: "o",
+      platform: "slack",
+      threadId: "t",
+      externalId: "T0",
+    });
+    expect(outcome).toEqual({ status: "no_deliverer" });
+  });
+
+  it("returns the registered deliverer after registration", async () => {
+    const impl: ChatResumeDeliverer = {
+      async deliverResumedTurn() {
+        return { status: "delivered" };
+      },
+    };
+    registerChatResumeDeliverer(impl);
+    expect(getChatResumeDeliverer()).toBe(impl);
+    expect(await getChatResumeDeliverer().deliverResumedTurn({
+      conversationId: "c",
+      orgId: "o",
+      platform: "slack",
+      threadId: "t",
+      externalId: "T0",
+    })).toEqual({ status: "delivered" });
+  });
+
+  it("clear restores the NULL fallback", () => {
+    registerChatResumeDeliverer({ async deliverResumedTurn() { return { status: "delivered" }; } });
+    clearChatResumeDeliverer();
+    expect(getChatResumeDeliverer()).toBe(NULL_RESUME_DELIVERER);
+  });
+});

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-delivery.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-delivery.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #3750 — chat resume-on-approval delivery glue (`deliverChatResumeIfPending`).
+ *
+ * Pins the orchestration the approval-review handler invokes after a parked
+ * turn is re-armed: load coordinates → call the registered deliverer → consume
+ * the pending row on a terminal outcome. Also the benign "no pending" (web
+ * turn) and fail-soft paths.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { ChatResumeCoordinates } from "../resume-pending-store";
+import type {
+  ChatResumeDeliverer,
+  ChatResumeDeliveryOutcome,
+} from "../resume-delivery-registry";
+
+const mockLoad: Mock<(id: string) => Promise<ChatResumeCoordinates | null>> = mock(async () => null);
+const mockClear: Mock<(id: string) => Promise<void>> = mock(async () => {});
+
+mock.module("@atlas/api/lib/chat-plugin/resume-pending-store", () => ({
+  loadResumePending: mockLoad,
+  clearResumePending: mockClear,
+}));
+
+let deliverer: ChatResumeDeliverer;
+mock.module("@atlas/api/lib/chat-plugin/resume-delivery-registry", () => ({
+  getChatResumeDeliverer: () => deliverer,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { deliverChatResumeIfPending } = await import("../resume-delivery");
+
+const COORDS: ChatResumeCoordinates = {
+  platform: "slack",
+  threadId: "C1:1.1",
+  orgId: "org_1",
+  externalId: "T0123",
+  externalUserId: "U999",
+};
+
+function delivererReturning(outcome: ChatResumeDeliveryOutcome): ChatResumeDeliverer {
+  return { deliverResumedTurn: mock(async () => outcome) };
+}
+
+beforeEach(() => {
+  mockLoad.mockReset();
+  mockLoad.mockResolvedValue(null);
+  mockClear.mockReset();
+  mockClear.mockResolvedValue(undefined);
+});
+
+describe("deliverChatResumeIfPending (#3750)", () => {
+  it("returns no_pending and does not call the deliverer when no coordinates exist", async () => {
+    deliverer = delivererReturning({ status: "delivered" });
+    const result = await deliverChatResumeIfPending("conv_web", "approve");
+    expect(result).toBe("no_pending");
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it("delivers and consumes the pending row on success, passing the full actor binding", async () => {
+    mockLoad.mockResolvedValueOnce(COORDS);
+    const impl = delivererReturning({ status: "delivered" });
+    deliverer = impl;
+
+    const result = await deliverChatResumeIfPending("conv_1", "approve");
+    expect(result).toBe("delivered");
+
+    // The deliverer receives the thread target AND the actor binding.
+    const input = (impl.deliverResumedTurn as Mock<(i: unknown) => unknown>).mock.calls[0]![0];
+    expect(input).toEqual({
+      conversationId: "conv_1",
+      orgId: "org_1",
+      platform: "slack",
+      threadId: "C1:1.1",
+      externalId: "T0123",
+      externalUserId: "U999",
+    });
+    // Consumed exactly once.
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockClear).toHaveBeenCalledWith("conv_1");
+  });
+
+  it("clears the coordinate when there is nothing to resume (concurrent resume / re-ask)", async () => {
+    mockLoad.mockResolvedValueOnce(COORDS);
+    deliverer = delivererReturning({ status: "nothing_to_resume" });
+    const result = await deliverChatResumeIfPending("conv_2", "approve");
+    expect(result).toBe("nothing_to_resume");
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the coordinate on a blocked outcome (fail-closed security refusal, no retry)", async () => {
+    mockLoad.mockResolvedValueOnce(COORDS);
+    deliverer = delivererReturning({ status: "blocked" });
+    const result = await deliverChatResumeIfPending("conv_blocked", "approve");
+    expect(result).toBe("blocked");
+    // A billing block won't clear on retry — consume the coordinate.
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the coordinate (for TTL/retry) on a failed delivery", async () => {
+    mockLoad.mockResolvedValueOnce(COORDS);
+    deliverer = delivererReturning({ status: "failed", reason: "thread_post_failed" });
+    const result = await deliverChatResumeIfPending("conv_3", "deny");
+    expect(result).toBe("failed");
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it("leaves the coordinate when no deliverer is registered", async () => {
+    mockLoad.mockResolvedValueOnce(COORDS);
+    deliverer = delivererReturning({ status: "no_deliverer" });
+    const result = await deliverChatResumeIfPending("conv_4", "approve");
+    expect(result).toBe("no_deliverer");
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-pending-store.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-pending-store.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #3750 — chat resume-pending coordinate store.
+ *
+ * Pins the read/write/delete of the `chat:resume-pending:<conversationId>`
+ * `chat_cache` row: round-trips coordinates (incl. the optional
+ * `externalUserId`), the no-DB / malformed-row / expired-row null paths, and
+ * the fail-soft posture (a DB error logs + returns false/null, never throws).
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+
+const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>> =
+  mock(() => Promise.resolve([]));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: mockHasInternalDB,
+  internalQuery: mockInternalQuery,
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+mock.module("@atlas/api/lib/durable-session", () => ({
+  getMaxParkMinutes: () => 1440,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { saveResumePending, loadResumePending, clearResumePending } = await import(
+  "../resume-pending-store"
+);
+
+beforeEach(() => {
+  mockHasInternalDB.mockReset();
+  mockHasInternalDB.mockReturnValue(true);
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockResolvedValue([]);
+});
+
+describe("saveResumePending (#3750)", () => {
+  it("writes the keyed row with coordinates + TTL and returns true", async () => {
+    const ok = await saveResumePending("conv_1", {
+      platform: "slack",
+      threadId: "C123:1700000000.0001",
+      orgId: "org_1",
+      externalId: "T0123",
+      externalUserId: "U999",
+    });
+    expect(ok).toBe(true);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(String(sql)).toContain("INSERT INTO");
+    expect(String(sql)).toContain("ON CONFLICT");
+    expect((params as unknown[])[0]).toBe("chat:resume-pending:conv_1");
+    const value = JSON.parse(String((params as unknown[])[1]));
+    expect(value).toEqual({
+      platform: "slack",
+      threadId: "C123:1700000000.0001",
+      orgId: "org_1",
+      externalId: "T0123",
+      externalUserId: "U999",
+    });
+    expect((params as unknown[])[2]).toBe("1440");
+  });
+
+  it("omits externalUserId from the stored value when absent", async () => {
+    await saveResumePending("conv_2", {
+      platform: "telegram",
+      threadId: "chat_42",
+      orgId: "org_1",
+      externalId: "42",
+    });
+    const value = JSON.parse(String((mockInternalQuery.mock.calls[0]![1] as unknown[])[1]));
+    expect(value).not.toHaveProperty("externalUserId");
+    expect(value.platform).toBe("telegram");
+  });
+
+  it("returns false (fail-soft) when there is no internal DB", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    const ok = await saveResumePending("conv_3", {
+      platform: "slack",
+      threadId: "t",
+      orgId: "org_1",
+      externalId: "T1",
+    });
+    expect(ok).toBe(false);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns false (fail-soft) and does not throw on a DB error", async () => {
+    mockInternalQuery.mockRejectedValueOnce(new Error("write failed"));
+    const ok = await saveResumePending("conv_4", {
+      platform: "slack",
+      threadId: "t",
+      orgId: "org_1",
+      externalId: "T1",
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("loadResumePending (#3750)", () => {
+  it("round-trips stored coordinates", async () => {
+    mockInternalQuery.mockResolvedValueOnce([
+      {
+        value: {
+          platform: "slack",
+          threadId: "C1:1.1",
+          orgId: "org_1",
+          externalId: "T0123",
+          externalUserId: "U999",
+        },
+      },
+    ]);
+    const coords = await loadResumePending("conv_1");
+    expect(coords).toEqual({
+      platform: "slack",
+      threadId: "C1:1.1",
+      orgId: "org_1",
+      externalId: "T0123",
+      externalUserId: "U999",
+    });
+    // The query guards on expiry.
+    expect(String(mockInternalQuery.mock.calls[0]![0])).toContain("expires_at");
+  });
+
+  it("returns null when no row is found", async () => {
+    mockInternalQuery.mockResolvedValueOnce([]);
+    expect(await loadResumePending("missing")).toBeNull();
+  });
+
+  it("returns null and warns on a malformed row (missing externalId)", async () => {
+    mockInternalQuery.mockResolvedValueOnce([
+      { value: { platform: "slack", threadId: "t", orgId: "org_1" } },
+    ]);
+    expect(await loadResumePending("conv_bad")).toBeNull();
+  });
+
+  it("returns null (fail-soft) on a DB error", async () => {
+    mockInternalQuery.mockRejectedValueOnce(new Error("read failed"));
+    expect(await loadResumePending("conv_err")).toBeNull();
+  });
+
+  it("returns null when there is no internal DB", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    expect(await loadResumePending("conv_x")).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearResumePending (#3750)", () => {
+  it("deletes the keyed row", async () => {
+    await clearResumePending("conv_1");
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(String(sql)).toContain("DELETE FROM");
+    expect((params as unknown[])[0]).toBe("chat:resume-pending:conv_1");
+  });
+
+  it("is a no-op without an internal DB and never throws on a DB error", async () => {
+    mockHasInternalDB.mockReturnValue(false);
+    await clearResumePending("conv_1");
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+
+    mockHasInternalDB.mockReturnValue(true);
+    mockInternalQuery.mockRejectedValueOnce(new Error("delete failed"));
+    await expect(clearResumePending("conv_1")).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #3750 — host-side chat resume primitive (`resumeChatTurn`).
+ *
+ * Pins acceptance criterion 3 (resume re-resolves auth/scoping live, same
+ * fail-closed guarantee as web):
+ *   - rebuilds the SAME bot actor that parked (so the approval gate's dedup
+ *     clears on re-run) and binds it onto the RequestContext;
+ *   - re-runs the billing gate — a workspace suspended while parked is
+ *     `blocked`, not resumed;
+ *   - claims the single-resumer lease via `prepareResume` and only proceeds on
+ *     `resumable` (a concurrent `leased`/`none` resume is skipped);
+ *   - re-enters `runAgent({ resume })` with the checkpoint transcript and
+ *     returns the continued answer;
+ *   - releases the lease in every branch (finally);
+ *   - never throws — every failure maps to a result variant.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { PrepareResumeResult } from "../../durable-resume";
+
+const mockRunAgent: Mock<(args: unknown) => Promise<{ text: Promise<string> }>> = mock(
+  async () => ({ text: Promise.resolve("continued answer") }),
+);
+const mockPrepareResume: Mock<() => Promise<PrepareResumeResult>> = mock(async () => ({
+  status: "resumable",
+  handle: { runId: "run_1", transcript: [], priorStepIndex: 2, leaseOwner: "lease_1" },
+}));
+const mockFinishResume: Mock<(h: unknown) => void> = mock(() => {});
+const mockBillingGate: Mock<() => Promise<{ allowed: boolean; errorCode?: string; errorMessage?: string }>> =
+  mock(async () => ({ allowed: true }));
+
+// Capture the bound context so we can assert the actor identity + origin.
+let capturedContext: Record<string, unknown> | undefined;
+
+mock.module("@atlas/api/lib/agent", () => ({ runAgent: mockRunAgent }));
+mock.module("@atlas/api/lib/durable-resume", () => ({
+  prepareResume: mockPrepareResume,
+  finishResume: mockFinishResume,
+}));
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockBillingGate,
+}));
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  withRequestContext: async (ctx: Record<string, unknown>, fn: () => Promise<unknown>) => {
+    capturedContext = ctx;
+    return fn();
+  },
+}));
+
+const { resumeChatTurn } = await import("../resume-turn");
+
+const BASE = {
+  conversationId: "conv_1",
+  orgId: "org_1",
+  platform: "slack" as const,
+  externalId: "T0123",
+};
+
+beforeEach(() => {
+  capturedContext = undefined;
+  mockRunAgent.mockReset();
+  mockRunAgent.mockResolvedValue({ text: Promise.resolve("continued answer") });
+  mockPrepareResume.mockReset();
+  mockPrepareResume.mockResolvedValue({
+    status: "resumable",
+    handle: { runId: "run_1", transcript: [], priorStepIndex: 2, leaseOwner: "lease_1" },
+  });
+  mockFinishResume.mockReset();
+  mockBillingGate.mockReset();
+  mockBillingGate.mockResolvedValue({ allowed: true });
+});
+
+describe("resumeChatTurn (#3750)", () => {
+  it("rebuilds the parked actor + origin and returns the continued answer", async () => {
+    const result = await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+    expect(result).toEqual({ status: "answered", answer: "continued answer" });
+
+    // AC3 — the bound actor is the SAME bot identity that parked.
+    const user = capturedContext?.user as { id: string; activeOrganizationId?: string };
+    expect(user.id).toBe("slack-bot:T0123:U999");
+    expect(user.activeOrganizationId).toBe("org_1");
+    expect(capturedContext?.agentOrigin).toBe("slack");
+
+    // The resumed loop re-enters from the checkpoint transcript.
+    const runArgs = mockRunAgent.mock.calls[0]![0] as { resume?: { runId: string } };
+    expect(runArgs.resume?.runId).toBe("run_1");
+    // Lease released.
+    expect(mockFinishResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks (does not resume) when billing re-resolution refuses", async () => {
+    mockBillingGate.mockResolvedValueOnce({
+      allowed: false,
+      errorCode: "workspace_suspended",
+      errorMessage: "This workspace is suspended.",
+    });
+    const result = await resumeChatTurn(BASE);
+    expect(result).toEqual({ status: "blocked", message: "This workspace is suspended." });
+    expect(mockPrepareResume).not.toHaveBeenCalled();
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  it("skips when there is no resumable run (concurrent resume / nothing armed)", async () => {
+    mockPrepareResume.mockResolvedValueOnce({ status: "leased" });
+    const result = await resumeChatTurn(BASE);
+    expect(result).toEqual({ status: "nothing_to_resume" });
+    expect(mockRunAgent).not.toHaveBeenCalled();
+    // No lease to release — we never claimed one.
+    expect(mockFinishResume).not.toHaveBeenCalled();
+  });
+
+  it("maps a failed agent run to failed and still releases the lease", async () => {
+    mockRunAgent.mockRejectedValueOnce(new Error("agent boom"));
+    const result = await resumeChatTurn(BASE);
+    expect(result).toEqual({ status: "failed", reason: "agent_run_error" });
+    expect(mockFinishResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a billing-gate throw to failed without resuming", async () => {
+    mockBillingGate.mockRejectedValueOnce(new Error("db down"));
+    const result = await resumeChatTurn(BASE);
+    expect(result).toEqual({ status: "failed", reason: "billing_gate_error" });
+    expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -67,6 +67,7 @@ import { ClaimRequiredError, ClaimCheckFailedError } from "@atlas/api/lib/billin
 import { createLogger } from "@atlas/api/lib/logger";
 import { checkRateLimit } from "@atlas/api/lib/auth/middleware";
 import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
+import { saveResumePending } from "@atlas/api/lib/chat-plugin/resume-pending-store";
 import { getInstallation } from "@atlas/api/lib/slack/store";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { DISCORD_GUILD_ID_RE } from "@atlas/api/lib/integrations/install/discord-static-bot-handler";
@@ -539,6 +540,16 @@ async function runSlackExecuteQuery(
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
     tenantLabel: { teamId, threadId },
+    // #3750 — coordinates to resume THIS thread if the turn parks on an
+    // approval rule. `threadId` is the bridge's canonical anchor; the actor
+    // binding (teamId + externalUserId) lets the resume re-enter as the same
+    // requester so the approval dedup clears on re-run.
+    resumeCoordinates: {
+      platform: "slack",
+      threadId,
+      externalId: teamId,
+      ...(externalUserId ? { externalUserId } : {}),
+    },
   });
 }
 
@@ -645,6 +656,13 @@ async function runTelegramExecuteQuery(
     priorMessages: priorMessages ?? null,
     presentationMode: ctx.presentationMode,
     tenantLabel: { chatIdFingerprint: fingerprintChatId(chatId), threadId },
+    // #3750 — resume THIS thread if the turn parks (AC2 names Telegram).
+    resumeCoordinates: {
+      platform: "telegram",
+      threadId,
+      externalId: chatId,
+      ...(externalUserId ? { externalUserId } : {}),
+    },
   });
 }
 
@@ -843,6 +861,13 @@ async function runDiscordExecuteQuery(
       guildIdFingerprint: fingerprintGuildId(guildId),
       threadId,
     },
+    // #3750 — resume THIS thread if the turn parks.
+    resumeCoordinates: {
+      platform: "discord",
+      threadId,
+      externalId: guildId,
+      ...(externalUserId ? { externalUserId } : {}),
+    },
   });
 }
 
@@ -1013,6 +1038,13 @@ async function runGchatExecuteQuery(
     tenantLabel: {
       workspaceIdFingerprint: fingerprintGchatWorkspaceId(workspaceIdent),
       threadId,
+    },
+    // #3750 — resume THIS thread if the turn parks.
+    resumeCoordinates: {
+      platform: "gchat",
+      threadId,
+      externalId: workspaceIdent,
+      ...(externalUserId ? { externalUserId } : {}),
     },
   });
 }
@@ -1190,6 +1222,13 @@ async function runTeamsExecuteQuery(
       tenantIdFingerprint: fingerprintTenantId(tenantId),
       threadId,
     },
+    // #3750 — resume THIS thread if the turn parks.
+    resumeCoordinates: {
+      platform: "teams",
+      threadId,
+      externalId: tenantId,
+      ...(externalUserId ? { externalUserId } : {}),
+    },
   });
 }
 
@@ -1335,6 +1374,20 @@ interface RunAgentArgs {
   readonly presentationMode: ChatExecuteQueryContext["presentationMode"];
   /** Free-form log context — e.g. `{ teamId }` for Slack, `{ chatIdFingerprint }` for Telegram. */
   readonly tenantLabel: Record<string, unknown>;
+  /**
+   * #3750 — coordinates to deliver a resumed answer back to this thread if the
+   * turn parks on an approval rule. Threaded from the per-platform branch
+   * (which alone knows the thread anchor + bot-actor binding). When present and
+   * the turn parks with a real (non-null) approval-queue id and a durable run,
+   * `runAgentAndMap` persists them so the approval-review handler can resume
+   * the thread on resolution. Omit on surfaces that can't be auto-resumed.
+   */
+  readonly resumeCoordinates?: {
+    readonly platform: ChatBotPlatform;
+    readonly threadId: string;
+    readonly externalId: string;
+    readonly externalUserId?: string;
+  };
 }
 
 /**
@@ -1355,6 +1408,7 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
     priorMessages,
     presentationMode,
     tenantLabel,
+    resumeCoordinates,
   } = args;
 
   // Rehydrate history from the Atlas `conversations` table when the
@@ -1468,19 +1522,52 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
   // the message on `answer` means it surfaces in-thread identically to
   // the legacy slack.ts path.
   if (queryResult.pendingApproval) {
+    // #3750 — when the turn parked durably (a real approval-queue id AND a
+    // durable run id, gated by a supplied conversationId), persist this
+    // thread's coordinates so the approval-review handler can resume the
+    // thread on resolution and post the continued answer in-place. The
+    // waiting-state copy then promises that auto-continuation. When any of
+    // those is missing (durability off, no conversation, or the defensive
+    // identity-missing path that yields a null requestId), there is no
+    // resumable run — fall back to the plain "approve via console" notice.
+    const approvalRequestId = queryResult.pendingApproval.requestId;
+    const runId = queryResult.runId;
+    // A resumable coordinate is only written for an actor bound to a real org.
+    // Without one, `resumeChatTurn`'s billing gate would re-resolve against an
+    // empty org (which `checkAgentBillingGate` treats as allowed) — so a
+    // missing org must fail CLOSED to the manual "approve via console" path,
+    // never persist a coordinate that resumes under a bypassed gate.
+    const resumeOrgId = actor.activeOrganizationId;
+    let autoResumable = false;
+    if (resumeCoordinates && conversationId && approvalRequestId && runId && resumeOrgId) {
+      autoResumable = await saveResumePending(conversationId, {
+        platform: resumeCoordinates.platform,
+        threadId: resumeCoordinates.threadId,
+        orgId: resumeOrgId,
+        externalId: resumeCoordinates.externalId,
+        ...(resumeCoordinates.externalUserId !== undefined
+          ? { externalUserId: resumeCoordinates.externalUserId }
+          : {}),
+      });
+    }
     log.info(
       {
-        approvalRequestId: queryResult.pendingApproval.requestId,
+        approvalRequestId,
+        runId,
+        autoResumable,
         requestId,
         ...tenantLabel,
       },
       "Chat plugin executeQuery held for approval",
     );
     return {
-      answer:
-        `:lock: This query requires approval before it can run. ` +
-        `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
-        `Approve via the Atlas admin console.`,
+      answer: autoResumable
+        ? `:hourglass_flowing_sand: This query needs approval before it can run. ` +
+          `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
+          `Waiting on a reviewer — I'll continue here in this thread once it's approved.`
+        : `:lock: This query requires approval before it can run. ` +
+          `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
+          `Approve via the Atlas admin console.`,
       sql: [],
       data: [],
       steps: 0,
@@ -1642,6 +1729,13 @@ async function runWhatsAppExecuteQuery(
     tenantLabel: {
       phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
       threadId,
+    },
+    // #3750 — resume THIS thread if the turn parks.
+    resumeCoordinates: {
+      platform: "whatsapp",
+      threadId,
+      externalId: phoneNumberId,
+      ...(externalUserId ? { externalUserId } : {}),
     },
   });
 }

--- a/packages/api/src/lib/chat-plugin/resume-deliverer-factory.ts
+++ b/packages/api/src/lib/chat-plugin/resume-deliverer-factory.ts
@@ -1,0 +1,81 @@
+/**
+ * Chat resume-deliverer factory (#3750).
+ *
+ * Builds the `ChatResumeDeliverer` the chat plugin registers (via
+ * `onBridgeReady` → `registerChatResumeDeliverer`). Extracted from the deploy
+ * config so the integration seam — platform narrowing, the resume→post
+ * mapping, and the `answered` / `blocked` / `nothing_to_resume` / `failed`
+ * outcome translation — is unit-testable rather than buried in `atlas.config.ts`.
+ *
+ * The factory takes the one bridge capability it needs (`postToThread`) as a
+ * dependency so a test can pass a stub and assert exactly what gets posted and
+ * which outcome each `resumeChatTurn` result maps to.
+ */
+
+import { CHAT_BOT_PLATFORMS, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
+import { resumeChatTurn } from "@atlas/api/lib/chat-plugin/resume-turn";
+import type {
+  ChatResumeDeliverer,
+  ChatResumeDeliveryOutcome,
+} from "@atlas/api/lib/chat-plugin/resume-delivery-registry";
+
+/** Posts a plain message into a thread; returns falsy on failure. The bridge's `postToThread`. */
+export type PostToThread = (
+  platform: string,
+  threadId: string,
+  message: string,
+) => Promise<{ messageId: string } | null>;
+
+function isBotPlatform(p: string): p is ChatBotPlatform {
+  return (CHAT_BOT_PLATFORMS as readonly string[]).includes(p);
+}
+
+/**
+ * Build the resume-deliverer. On a delivery request it:
+ *   1. narrows `platform` to a real bot platform (an unknown slug — which
+ *      shouldn't occur, since we wrote it at park — `failed`s rather than
+ *      guessing an actor identity);
+ *   2. re-enters the agent loop under the original chat actor via
+ *      `resumeChatTurn` (which re-resolves auth/scoping LIVE — ADR-0020);
+ *   3. posts the continued answer (or, on a billing/suspension block, a
+ *      user-safe block notice) back into the thread via `postToThread`;
+ *   4. maps the result: a posted answer → `delivered`, a posted block notice →
+ *      `blocked` (a fail-closed security refusal, kept distinct), a failed post
+ *      → `failed`, and `nothing_to_resume` / `failed` pass through.
+ */
+export function buildChatResumeDeliverer(deps: { postToThread: PostToThread }): ChatResumeDeliverer {
+  return {
+    async deliverResumedTurn({
+      conversationId,
+      orgId,
+      platform,
+      threadId,
+      externalId,
+      externalUserId,
+    }): Promise<ChatResumeDeliveryOutcome> {
+      if (!isBotPlatform(platform)) {
+        return { status: "failed", reason: `unknown_platform:${platform}` };
+      }
+
+      const resumed = await resumeChatTurn({
+        conversationId,
+        orgId,
+        platform,
+        // Rebuild the SAME bot actor that parked (team/workspace id + optional
+        // per-user id) so the approval dedup clears on re-run.
+        externalId,
+        ...(externalUserId !== undefined ? { externalUserId } : {}),
+      });
+
+      if (resumed.status === "nothing_to_resume") return { status: "nothing_to_resume" };
+      if (resumed.status === "failed") return { status: "failed", reason: resumed.reason };
+
+      // `answered` or `blocked` — both carry a user-facing message to post
+      // in-thread (the answer, or the user-safe block reason).
+      const message = resumed.status === "answered" ? resumed.answer : resumed.message;
+      const posted = await deps.postToThread(platform, threadId, message);
+      if (!posted) return { status: "failed", reason: "thread_post_failed" };
+      return resumed.status === "blocked" ? { status: "blocked" } : { status: "delivered" };
+    },
+  };
+}

--- a/packages/api/src/lib/chat-plugin/resume-delivery-registry.ts
+++ b/packages/api/src/lib/chat-plugin/resume-delivery-registry.ts
@@ -1,0 +1,125 @@
+/**
+ * Process-local registry for the chat-surface resume-delivery port (#3750).
+ *
+ * Mirrors `lib/proactive/announcer-registry.ts`. When an approval-parked chat
+ * turn is approved/denied, the surface-agnostic approval-review handler
+ * (`api/routes/admin-approval.ts`) re-arms the run via `resolveApprovalPark`
+ * and must then deliver the continued answer back to the originating chat
+ * thread — but the handler is on the host side of the chat-plugin boundary and
+ * holds no reference to the bridge that can post to the thread. The two ends
+ * agree on this module:
+ *
+ *   - chat plugin → calls `registerChatResumeDeliverer(impl)` from its
+ *     `initialize()` once the bridge has built its adapters; the impl closes
+ *     over the bridge (and the host-side resume helper) so it can re-enter the
+ *     agent loop and post the answer in-thread.
+ *   - admin-approval route → calls `getChatResumeDeliverer()` and falls back to
+ *     `NULL_RESUME_DELIVERER` when no chat plugin has registered (self-hosted
+ *     deployments without the chat plugin still must not fail the review).
+ *
+ * The port deliberately keeps the resume re-entry on the registered (plugin)
+ * side rather than core, because resuming a chat turn requires re-binding the
+ * chat actor + origin (a chat-plugin concern). Core supplies the security-
+ * sensitive primitive (`prepareResume` → `runAgent({ resume })`, which
+ * re-resolves auth/connection/RLS LIVE — the same fail-closed guarantee as the
+ * web resume route) via `lib/chat-plugin/resume-turn.ts`; the deliverer wires
+ * it to the thread post.
+ *
+ * Lifecycle: single-process; plugin teardown calls `clearChatResumeDeliverer()`
+ * so a dev hot-reload / `PluginRegistry.refresh("chat-interaction")` doesn't
+ * leak the old bridge reference.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("chat-resume-delivery-registry");
+
+/**
+ * Outcome of attempting to deliver a resumed chat turn. A tagged union so the
+ * caller can log the rejection class without parsing prose, and so the NULL
+ * fallback's "no plugin" case is distinguishable from a real delivery failure.
+ *
+ * - `delivered` — the turn resumed and the answer was posted in-thread.
+ * - `blocked` — the live re-resolution refused (billing/suspension); a
+ *   user-safe block notice was posted in-thread in place of the answer. The
+ *   query never ran — this is a fail-CLOSED security outcome, surfaced
+ *   distinctly from `delivered` so an operator can see a parked turn was
+ *   refused on resume (not silently answered).
+ * - `nothing_to_resume` — no resumable run for the conversation (already
+ *   resumed by a concurrent path, lease held, expired, or durability off).
+ *   Benign.
+ * - `no_deliverer` — no chat plugin registered (self-hosted / no chat). The
+ *   approval review still succeeds; there is simply no thread to resume.
+ * - `failed` — a resumable turn existed but resume or the thread post failed.
+ *   Operator-actionable (the approver's decision won't reach the user's thread
+ *   unless they retry / check the admin console).
+ */
+export type ChatResumeDeliveryOutcome =
+  | { readonly status: "delivered" }
+  | { readonly status: "blocked" }
+  | { readonly status: "nothing_to_resume" }
+  | { readonly status: "no_deliverer" }
+  | { readonly status: "failed"; readonly reason: string };
+
+/**
+ * Input the approval-review handler hands the deliverer: the conversation +
+ * org to resume, the thread coordinates, and the bot-actor binding — all loaded
+ * from the resume-pending store. `platform` is the chat-plugin platform slug
+ * (string here — the registered impl narrows it to its bot-platform union).
+ *
+ * `externalId` / `externalUserId` are the actor-binding inputs the resume MUST
+ * rebuild from (the workspace/team id, NOT the thread anchor) so it re-enters
+ * as the same requester and the approval dedup clears on re-run. `threadId` is
+ * only the post target.
+ */
+export interface ChatResumeDeliveryInput {
+  readonly conversationId: string;
+  readonly orgId: string;
+  readonly platform: string;
+  readonly threadId: string;
+  readonly externalId: string;
+  readonly externalUserId?: string;
+}
+
+/**
+ * The chat-surface resume-delivery port. The real implementation (registered
+ * by the chat plugin) re-enters the agent loop for the conversation and posts
+ * the continued answer to `threadId` on `platform`. It must NOT throw — it
+ * translates its own failures into a `failed` outcome so the approval-review
+ * handler (which has already recorded + audited the decision) never 500s on a
+ * delivery problem.
+ */
+export interface ChatResumeDeliverer {
+  deliverResumedTurn(input: ChatResumeDeliveryInput): Promise<ChatResumeDeliveryOutcome>;
+}
+
+let registered: ChatResumeDeliverer | null = null;
+
+export function registerChatResumeDeliverer(deliverer: ChatResumeDeliverer): void {
+  registered = deliverer;
+  log.info("Chat resume-deliverer registered");
+}
+
+export function clearChatResumeDeliverer(): void {
+  registered = null;
+}
+
+/**
+ * Returns the registered deliverer or {@link NULL_RESUME_DELIVERER}. Callers
+ * never null-check — the fallback returns `{ status: "no_deliverer" }`, which
+ * the approval-review handler treats as a clean "no chat thread to resume".
+ */
+export function getChatResumeDeliverer(): ChatResumeDeliverer {
+  return registered ?? NULL_RESUME_DELIVERER;
+}
+
+/**
+ * No-op deliverer for self-hosted deployments without the chat plugin (or
+ * tests). The approval-review handler falls back to this so a parked-turn
+ * resolution never fails for lack of a chat surface.
+ */
+export const NULL_RESUME_DELIVERER: ChatResumeDeliverer = {
+  async deliverResumedTurn() {
+    return { status: "no_deliverer" };
+  },
+};

--- a/packages/api/src/lib/chat-plugin/resume-delivery.ts
+++ b/packages/api/src/lib/chat-plugin/resume-delivery.ts
@@ -1,0 +1,111 @@
+/**
+ * Chat resume-on-approval delivery glue (#3750).
+ *
+ * Called by the approval-review handler after a parked turn is re-armed
+ * (`resolveApprovalPark` → `resumed`). Loads the thread coordinates written at
+ * park time, hands them to the registered chat deliverer (which re-enters the
+ * agent loop and posts the continued answer in-thread), and consumes the
+ * pending row on a terminal outcome so a re-review can't double-deliver.
+ *
+ * Runs for BOTH an approve and a deny: on deny, `resolveApprovalPark` rewrites
+ * the transcript with a "denied — do not retry" result and re-arms the run, so
+ * the resumed turn posts the denial back in-thread rather than leaving the user
+ * waiting forever on a thread that never continues.
+ *
+ * Fail-soft: the approval decision is already recorded + audited, so this never
+ * throws into the review handler — it logs and returns. Lives in `lib/` (not
+ * the route) so the route stays thin and this glue is unit-testable.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { ApprovalDecision } from "@atlas/api/lib/approvals/evaluate";
+import {
+  loadResumePending,
+  clearResumePending,
+} from "@atlas/api/lib/chat-plugin/resume-pending-store";
+import { getChatResumeDeliverer } from "@atlas/api/lib/chat-plugin/resume-delivery-registry";
+
+const log = createLogger("chat-resume-delivery");
+
+/**
+ * Deliver a resumed chat turn for `conversationId`, if one is pending. Returns
+ * the deliverer outcome's status (or `"no_pending"` when no chat thread was
+ * waiting on this conversation — the common web-turn / no-coordinates case).
+ *
+ * @param conversationId - The re-armed run's conversation (from
+ *   `resolveApprovalPark`).
+ * @param decision - The recorded approval decision, for log correlation.
+ */
+export async function deliverChatResumeIfPending(
+  conversationId: string,
+  decision: ApprovalDecision,
+): Promise<"delivered" | "blocked" | "nothing_to_resume" | "no_deliverer" | "failed" | "no_pending"> {
+  const coords = await loadResumePending(conversationId);
+  if (!coords) {
+    // No chat thread is waiting on this conversation — a web turn, or
+    // durability/coordinates were never written. Nothing to do.
+    return "no_pending";
+  }
+
+  const outcome = await getChatResumeDeliverer().deliverResumedTurn({
+    conversationId,
+    orgId: coords.orgId,
+    platform: coords.platform,
+    threadId: coords.threadId,
+    externalId: coords.externalId,
+    ...(coords.externalUserId !== undefined ? { externalUserId: coords.externalUserId } : {}),
+  });
+
+  switch (outcome.status) {
+    case "delivered":
+      // Consume the pending row so a duplicate/late review can't re-deliver.
+      await clearResumePending(conversationId);
+      log.info(
+        { conversationId, platform: coords.platform, decision },
+        "Chat thread resumed + answer delivered after approval decision",
+      );
+      return "delivered";
+    case "blocked":
+      // A fail-CLOSED security refusal: the live re-resolution (billing /
+      // suspension) blocked the resume and a user-safe notice was posted
+      // in-thread instead of the answer. Consume the coordinate (a billing
+      // block won't clear on retry) but surface at WARN so an operator sees a
+      // parked turn was refused on resume — not silently answered.
+      await clearResumePending(conversationId);
+      log.warn(
+        { conversationId, platform: coords.platform, decision },
+        "Chat resume BLOCKED by live re-resolution (billing/suspension) — posted a block notice in-thread instead of the answer",
+      );
+      return "blocked";
+    case "nothing_to_resume":
+      // The run was already resumed (a concurrent path, or the user re-asked)
+      // — drop the coordinate so it doesn't linger.
+      await clearResumePending(conversationId);
+      log.info(
+        { conversationId, platform: coords.platform, decision },
+        "Chat resume found nothing to resume — clearing pending coordinate",
+      );
+      return "nothing_to_resume";
+    case "no_deliverer":
+      // No chat plugin registered (shouldn't happen if a coordinate exists, but
+      // a deploy that dropped the plugin could). Leave the coordinate to
+      // TTL-expire in case the plugin re-registers and a manual retry runs.
+      log.warn(
+        { conversationId, platform: coords.platform, decision },
+        "Chat resume coordinate found but no deliverer registered — leaving for TTL",
+      );
+      return "no_deliverer";
+    case "failed":
+      // Operator-actionable: the decision is recorded but the thread did not
+      // get its continuation. Leave the coordinate so a retry path can re-run.
+      log.error(
+        { conversationId, platform: coords.platform, decision, reason: outcome.reason },
+        "Chat resume delivery FAILED after approval decision — thread not continued; investigate",
+      );
+      return "failed";
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/api/src/lib/chat-plugin/resume-pending-store.ts
+++ b/packages/api/src/lib/chat-plugin/resume-pending-store.ts
@@ -1,0 +1,192 @@
+/**
+ * Resume-pending coordinate store for chat-surface approval-park (#3750).
+ *
+ * When an agent turn initiated from a chat platform (Slack/Telegram/…) parks
+ * on an approval rule, the durable engine writes a `parked` checkpoint keyed
+ * on the approval-queue ref (`agent_runs.parked_reason`) — but that row is
+ * deliberately surface-agnostic: it records WHAT the agent was doing, never
+ * WHERE to deliver the answer (ADR-0020). To resume the *thread* once the
+ * approval is resolved, the chat surface needs the platform + thread
+ * coordinates, which it stores HERE, beside the run.
+ *
+ * Storage: a single `chat_cache` row keyed `chat:resume-pending:<conversationId>`
+ * carrying `{ platform, threadId, orgId }`. This is an Atlas-extension field on
+ * an already-Atlas-owned table (the same category as the Slack installation
+ * extension fields in the chat-plugin × Atlas contract). The chat-adapter never
+ * reads it; only host code writes (at park) and reads/deletes (at resume) it.
+ * No new table, no `agent_runs` column — the engine stays surface-neutral.
+ *
+ * Lifecycle: written at park, consumed (read + deleted) on a successful resume
+ * delivery, and TTL-expired (via `expires_at`, mirroring the max-park window)
+ * so a parked run that is swept to `failed` never leaves a dangling coordinate.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getMaxParkMinutes } from "@atlas/api/lib/durable-session";
+
+const log = createLogger("chat-resume-pending-store");
+
+/**
+ * Chat cache table — mirrors `lib/slack/store.ts`'s resolution so a
+ * non-default `state.tablePrefix` deploy lands the coordinate in the same
+ * physical table the rest of the chat-plugin state uses. SaaS pins the
+ * default (`chat_cache`). Import-time env read (permitted by the testing
+ * discipline for import-time config).
+ */
+const CACHE_TABLE = (() => {
+  const raw = process.env.ATLAS_SLACK_INSTALL_TABLE;
+  if (!raw) return "chat_cache";
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(raw)) {
+    throw new Error(
+      `ATLAS_SLACK_INSTALL_TABLE must be a valid SQL identifier (got '${raw}')`,
+    );
+  }
+  return raw;
+})();
+
+const KEY_PREFIX = "chat:resume-pending:";
+
+function keyFor(conversationId: string): string {
+  return `${KEY_PREFIX}${conversationId}`;
+}
+
+/**
+ * Coordinates needed to resume a parked chat turn and deliver the continued
+ * answer back to its originating thread.
+ *
+ * - `platform` — chat-plugin platform slug (`"slack"`, `"telegram"`, …). Typed
+ *   as a string because core cannot import the plugin's `ChatPlatform` union;
+ *   the deliverer impl (registered by the plugin) narrows it.
+ * - `threadId` — the canonical cross-platform thread anchor the bridge uses
+ *   everywhere (Slack `channel:thread_ts`, Telegram `chat:message_thread_id`,
+ *   …); sufficient addressing for a thread post.
+ * - `orgId` — the workspace the turn ran under.
+ * - `externalId` / `externalUserId` — the bot-actor binding inputs
+ *   (`botActorUser({ platform, externalId, orgId, externalUserId })`). Stored
+ *   so the resume re-enters under the SAME actor identity that parked — its
+ *   `userId` (`${platform}-bot:${externalId}[:externalUserId]`) must match for
+ *   the approval gate's `hasApprovedRequest` dedup to clear on re-run. Without
+ *   the exact actor the rewritten "approved, re-run now" transcript would
+ *   re-park (a different requester id ⇒ no prior approval ⇒ a fresh request).
+ */
+export interface ChatResumeCoordinates {
+  readonly platform: string;
+  readonly threadId: string;
+  readonly orgId: string;
+  readonly externalId: string;
+  readonly externalUserId?: string;
+}
+
+/**
+ * Persist the thread coordinates for a parked chat turn, keyed by
+ * conversation. Best-effort and fail-soft: a write failure is logged and
+ * returns `false` (the turn still parks; the user simply won't get an
+ * auto-resumed thread — they fall back to the admin-console approval flow).
+ * Never throws into the chat reply path.
+ *
+ * TTL mirrors the max-park window so the coordinate self-expires in lockstep
+ * with the parked run the sweep would fail.
+ */
+export async function saveResumePending(
+  conversationId: string,
+  coords: ChatResumeCoordinates,
+): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+  const ttlMinutes = getMaxParkMinutes(coords.orgId);
+  try {
+    await internalQuery(
+      `INSERT INTO ${CACHE_TABLE} (key, value, expires_at)
+         VALUES ($1, $2::jsonb, now() + ($3 || ' minutes')::interval)
+       ON CONFLICT (key) DO UPDATE
+         SET value = EXCLUDED.value,
+             expires_at = EXCLUDED.expires_at`,
+      [
+        keyFor(conversationId),
+        JSON.stringify({
+          platform: coords.platform,
+          threadId: coords.threadId,
+          orgId: coords.orgId,
+          externalId: coords.externalId,
+          ...(coords.externalUserId !== undefined
+            ? { externalUserId: coords.externalUserId }
+            : {}),
+        }),
+        String(ttlMinutes),
+      ],
+    );
+    return true;
+  } catch (err) {
+    log.warn(
+      {
+        conversationId,
+        platform: coords.platform,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Failed to persist chat resume-pending coordinates — thread auto-resume will be unavailable for this turn",
+    );
+    return false;
+  }
+}
+
+/**
+ * Load the resume coordinates for a conversation. Returns `null` when there is
+ * no internal DB, no pending row (never parked, already delivered, or expired),
+ * or the stored value is malformed. A DB error is logged and returns `null`
+ * (fail-soft — a failed lookup must not break the approval-review handler).
+ */
+export async function loadResumePending(
+  conversationId: string,
+): Promise<ChatResumeCoordinates | null> {
+  if (!hasInternalDB()) return null;
+  try {
+    const rows = await internalQuery<{ value: unknown }>(
+      `SELECT value FROM ${CACHE_TABLE}
+         WHERE key = $1
+           AND (expires_at IS NULL OR expires_at > now())`,
+      [keyFor(conversationId)],
+    );
+    const value = rows[0]?.value;
+    if (!value || typeof value !== "object") return null;
+    const v = value as Record<string, unknown>;
+    if (
+      typeof v.platform !== "string" ||
+      typeof v.threadId !== "string" ||
+      typeof v.orgId !== "string" ||
+      typeof v.externalId !== "string"
+    ) {
+      log.warn({ conversationId }, "chat resume-pending row has malformed coordinates — ignoring");
+      return null;
+    }
+    return {
+      platform: v.platform,
+      threadId: v.threadId,
+      orgId: v.orgId,
+      externalId: v.externalId,
+      ...(typeof v.externalUserId === "string" ? { externalUserId: v.externalUserId } : {}),
+    };
+  } catch (err) {
+    log.warn(
+      { conversationId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to load chat resume-pending coordinates",
+    );
+    return null;
+  }
+}
+
+/**
+ * Delete the resume-pending row after a successful (or terminally failed)
+ * delivery so it is consumed exactly once. Best-effort: a failed delete leaves
+ * the row to TTL-expire. Never throws.
+ */
+export async function clearResumePending(conversationId: string): Promise<void> {
+  if (!hasInternalDB()) return;
+  try {
+    await internalQuery(`DELETE FROM ${CACHE_TABLE} WHERE key = $1`, [keyFor(conversationId)]);
+  } catch (err) {
+    log.debug(
+      { conversationId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to clear chat resume-pending coordinates — will TTL-expire",
+    );
+  }
+}

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -1,0 +1,182 @@
+/**
+ * Host-side resume primitive for the chat surface (#3750).
+ *
+ * Re-enters a parked chat turn — after its approval has been resolved
+ * (`resolveApprovalPark` rewrote the transcript + flipped the run back to
+ * `running`) — and collects the continued answer, non-streaming. The chat
+ * resume-deliverer (registered by the plugin) calls this, then posts the
+ * returned answer to the originating thread.
+ *
+ * This is the security boundary for chat resume (acceptance criterion 3):
+ * resume re-resolves auth/scoping LIVE, never from the checkpoint. The same
+ * fail-closed guarantee as the web resume route — we:
+ *   1. rebuild the SAME bot actor that parked (so the approval gate's
+ *      `hasApprovedRequest` dedup clears for the same requester id) and bind it
+ *      onto a fresh RequestContext with the chat origin;
+ *   2. re-run the billing gate (a workspace suspended while parked fails
+ *      closed);
+ *   3. claim the single-resumer lease via `prepareResume` (a concurrent
+ *      resume — e.g. the user also re-asked — loses the row race and we skip);
+ *   4. re-enter `runAgent({ resume })`, whose tools re-resolve the
+ *      connection/whitelist/RLS for the live request.
+ *
+ * The gated query itself executes here, in the requester's live context, never
+ * the reviewer's (ADR-0020). A user who lost access while parked fails closed.
+ */
+
+import { runAgent } from "@atlas/api/lib/agent";
+import { prepareResume, finishResume } from "@atlas/api/lib/durable-resume";
+import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
+import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
+import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
+import type { ApprovalRequestOrigin } from "@useatlas/types";
+
+const log = createLogger("chat-resume-turn");
+
+// Compile-time guard: every chat bot platform must be a valid approval-rule
+// origin, so `platform as ApprovalRequestOrigin` below is sound. If a new
+// `CHAT_BOT_PLATFORMS` member is added without a matching `APPROVAL_RULE_ORIGINS`
+// entry, this assignment fails to typecheck rather than silently minting an
+// invalid origin at runtime.
+type _AssertBotPlatformIsOrigin = ChatBotPlatform extends ApprovalRequestOrigin ? true : never;
+const _assertBotPlatformIsOrigin: _AssertBotPlatformIsOrigin = true;
+void _assertBotPlatformIsOrigin;
+
+export interface ResumeChatTurnInput {
+  readonly conversationId: string;
+  readonly orgId: string;
+  /** Chat-plugin platform slug — must be a real bot platform to rebuild the actor. */
+  readonly platform: ChatBotPlatform;
+  /** Bot-actor binding inputs captured at park time. */
+  readonly externalId: string;
+  readonly externalUserId?: string;
+}
+
+/**
+ * Outcome of a chat-turn resume.
+ *
+ * - `answered` — the turn resumed and produced a continued answer to post.
+ * - `nothing_to_resume` — no resumable run (already resumed by a concurrent
+ *   path, lease held by another resumer, expired/swept, or durability off).
+ * - `blocked` — the live re-resolution refused (billing/suspension) — the
+ *   `message` is user-safe and may be delivered in-thread in place of the
+ *   answer.
+ * - `failed` — resume threw. The caller surfaces this; the user must retry.
+ */
+export type ResumeChatTurnResult =
+  | { readonly status: "answered"; readonly answer: string }
+  | { readonly status: "nothing_to_resume" }
+  | { readonly status: "blocked"; readonly message: string }
+  | { readonly status: "failed"; readonly reason: string };
+
+/**
+ * Resume the conversation's parked turn under its original chat actor and
+ * return the continued answer (non-streaming). Never throws — every failure is
+ * mapped to a result variant so the approval-review handler (which has already
+ * recorded the decision) cannot 500 on a resume problem.
+ */
+export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<ResumeChatTurnResult> {
+  const { conversationId, orgId, platform, externalId, externalUserId } = input;
+
+  // Rebuild the SAME actor that parked — same `userId` so the approval gate
+  // recognises the prior approval on re-run (else the rewritten transcript
+  // would re-park as a fresh requester).
+  const actor = botActorUser({
+    platform,
+    externalId,
+    orgId,
+    ...(externalUserId !== undefined ? { externalUserId } : {}),
+  });
+  const agentOrigin = platform as ApprovalRequestOrigin;
+  const requestId = crypto.randomUUID();
+
+  return withRequestContext(
+    {
+      requestId,
+      user: actor,
+      agentOrigin,
+      actor: { kind: "agent" },
+    },
+    async (): Promise<ResumeChatTurnResult> => {
+      // Live billing re-resolution — a workspace suspended/expired while the
+      // turn was parked fails closed exactly as a fresh run would.
+      let gate;
+      try {
+        gate = await checkAgentBillingGate(orgId);
+      } catch (err) {
+        log.error(
+          { conversationId, orgId, err: err instanceof Error ? err.message : String(err) },
+          "Chat resume billing gate threw — not resuming",
+        );
+        return { status: "failed", reason: "billing_gate_error" };
+      }
+      if (!gate.allowed) {
+        log.warn(
+          { conversationId, orgId, errorCode: gate.errorCode },
+          "Chat resume blocked by billing enforcement",
+        );
+        return { status: "blocked", message: gate.errorMessage };
+      }
+
+      // Claim the single-resumer lease on the (now `running`, re-armed) run.
+      let prepared;
+      try {
+        prepared = await prepareResume(conversationId, orgId);
+      } catch (err) {
+        log.error(
+          { conversationId, orgId, err: err instanceof Error ? err.message : String(err) },
+          "Chat resume prepareResume threw — not resuming",
+        );
+        return { status: "failed", reason: "prepare_resume_error" };
+      }
+
+      if (prepared.status !== "resumable") {
+        // `none` (nothing to resume — already delivered / never armed),
+        // `leased` (a concurrent resume holds the lease — that path delivers),
+        // `disabled`/`error` (durability off or claim failed). All map to
+        // "nothing to deliver from here"; only a genuine resumable run proceeds.
+        log.info(
+          { conversationId, orgId, prepareStatus: prepared.status },
+          "Chat resume found no resumable run — skipping delivery",
+        );
+        return { status: "nothing_to_resume" };
+      }
+
+      const handle = prepared.handle;
+      try {
+        // Re-enter the loop from the checkpoint. `messages: []` is inert — the
+        // rewritten transcript (carrying the "approved, re-run now" result) is
+        // the model input. The tools re-resolve connection/whitelist/RLS live.
+        const agentResult = await runAgent({
+          messages: [],
+          conversationId,
+          resume: {
+            runId: handle.runId,
+            transcript: handle.transcript,
+            priorStepIndex: handle.priorStepIndex,
+          },
+        });
+        const answer = await agentResult.text;
+        log.info(
+          { conversationId, orgId, runId: handle.runId },
+          "Chat turn resumed after approval — answer ready for thread delivery",
+        );
+        return { status: "answered", answer };
+      } catch (err) {
+        log.error(
+          {
+            conversationId,
+            orgId,
+            runId: handle.runId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "Chat resume agent run failed",
+        );
+        return { status: "failed", reason: "agent_run_error" };
+      } finally {
+        // Release the single-resumer lease so a later resume can re-claim.
+        finishResume(handle);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/__tests__/mcp-approval-resume.test.ts
+++ b/packages/mcp/src/__tests__/mcp-approval-resume.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #3750 — MCP approval-park + resume-by-re-call.
+ *
+ * MCP has no agent loop or durable run row: each tool call is one synchronous
+ * dispatch and the MCP client is the loop. So a "parked" MCP tool call is one
+ * whose approval gate returned `approval_required` instead of executing, and
+ * the resume is the client RE-CALLING the same tool once the request is
+ * approved. The executeSQL approval gate (`lib/tools/sql.ts`) recognises the
+ * prior approval via `hasApprovedRequest` and lets the re-call execute, with
+ * auth/whitelist/RLS re-resolved live on that fresh dispatch.
+ *
+ * This pins the MCP-boundary contract:
+ *   1. a parked call surfaces a NON-ERROR `approval_required` result carrying
+ *      `approval_request_id`, `matched_rules`, and a resume hint;
+ *   2. the resume hint tells the client to re-run the identical call;
+ *   3. re-calling after approval (modelled by `executeSQL.execute` now
+ *      returning a data result) yields a successful, structured result.
+ *
+ * The SQL-gate dedup itself (`hasApprovedRequest`) is exercised by
+ * `lib/tools/__tests__/sql-approval*.test.ts`; here we mock `executeSQL.execute`
+ * so the test owns the park→approve transition at the MCP relay seam — which is
+ * exactly the behaviour #3750 adds to (and asserts for) the MCP surface.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { MCP_APPROVAL_RESUME_HINT } from "../structured-output.js";
+
+const TEST_ACTOR = createAtlasUser("u_resume", "managed", "resume@test", {
+  role: "member",
+  activeOrganizationId: "org_resume",
+});
+
+const __mockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
+mock.module("@atlas/api/lib/config", () => ({
+  initializeConfig: mock(async () => __mockedConfig),
+  getConfig: mock(() => __mockedConfig),
+  loadConfig: mock(async () => __mockedConfig),
+  configFromEnv: mock(() => __mockedConfig),
+  validateAndResolve: mock(() => __mockedConfig),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
+}));
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  explore: {
+    description: "Explore the semantic layer",
+    execute: mock(async () => "catalog.yml"),
+  },
+}));
+
+// Gate 0 (billing solvency) runs before the tool body. The dev/CI shell may
+// have DATABASE_URL set; without a reachable DB `checkWorkspaceStatus` fails
+// CLOSED (workspace_check_failed) and the dispatch never reaches the tool. We
+// are pinning the MCP approval-relay seam, not billing — so allow the gate.
+// `BillingBlockedError` is re-exported as the REAL class so the dispatch's
+// `instanceof` mapping is preserved (mock-all-exports discipline).
+const { BillingBlockedError: RealBillingBlockedError } = await import(
+  "@atlas/api/lib/billing/agent-gate"
+);
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mock(async () => ({ allowed: true })),
+  BillingBlockedError: RealBillingBlockedError,
+}));
+
+// `executeSQL.execute` parks on the first call (approval_required) and
+// executes on the second (the dedup let the re-call through). The call count
+// drives the park→approve transition deterministically.
+let executeCalls = 0;
+const APPROVAL_REQUEST_ID = "appr_req_3750";
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  executeSQL: {
+    description: "Execute SQL",
+    execute: mock(async () => {
+      executeCalls += 1;
+      if (executeCalls === 1) {
+        // Parked: approval gate returned needs-approval (success:false is how
+        // sql.ts marks the governance outcome; see agent-query.ts:312).
+        return {
+          success: false,
+          approval_required: true,
+          approval_request_id: APPROVAL_REQUEST_ID,
+          matched_rules: ["Production write guard"],
+          message: 'This query requires approval before execution. Rule: "Production write guard".',
+        };
+      }
+      // Resumed by re-call after approval: the gate executed the query.
+      return {
+        success: true,
+        explanation: "Row count of orders",
+        row_count: 1,
+        columns: ["count"],
+        rows: [{ count: 42 }],
+        truncated: false,
+      };
+    }),
+  },
+}));
+
+const { createAtlasMcpServer } = await import("../server.js");
+
+async function connectClient() {
+  const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
+  const client = new Client({ name: "resume-test", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+function parseText(result: unknown): Record<string, unknown> {
+  const content = (result as { content?: unknown }).content as
+    | Array<{ type: string; text: string }>
+    | undefined;
+  return JSON.parse(content?.[0]?.text ?? "{}");
+}
+
+describe("MCP executeSQL approval-park + resume-by-re-call (#3750)", () => {
+  it("a parked call surfaces a non-error approval_required result with id, rules, and the resume hint", async () => {
+    executeCalls = 0;
+    const client = await connectClient();
+
+    const parked = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT count(*) FROM orders", explanation: "count orders" },
+    });
+
+    // Governance outcome is NOT an MCP error — the client must see the payload.
+    expect(parked.isError).toBeFalsy();
+    const body = parseText(parked);
+    expect(body.approval_required).toBe(true);
+    expect(body.approval_request_id).toBe(APPROVAL_REQUEST_ID);
+    expect(body.matched_rules).toEqual(["Production write guard"]);
+    // AC1 / AC3 enablement — the client is told HOW to resume.
+    expect(String(body.message)).toContain(MCP_APPROVAL_RESUME_HINT);
+
+    // structuredContent mirrors the text body (outputSchema is declared).
+    const structured = (parked as { structuredContent?: Record<string, unknown> })
+      .structuredContent;
+    expect(structured?.approval_required).toBe(true);
+    expect(structured?.approval_request_id).toBe(APPROVAL_REQUEST_ID);
+  });
+
+  it("re-calling the identical tool after approval resumes to a successful result", async () => {
+    executeCalls = 0;
+    const client = await connectClient();
+    const args = { sql: "SELECT count(*) FROM orders", explanation: "count orders" };
+
+    // 1st call parks.
+    const parked = await client.callTool({ name: "executeSQL", arguments: args });
+    expect(parseText(parked).approval_required).toBe(true);
+
+    // 2nd call (same arguments) — approval granted between calls; executes.
+    const resumed = await client.callTool({ name: "executeSQL", arguments: args });
+    expect(resumed.isError).toBeFalsy();
+    const body = parseText(resumed);
+    expect(body.approval_required).toBeUndefined();
+    expect(body.row_count).toBe(1);
+    expect(body.columns).toEqual(["count"]);
+    expect(body.rows).toEqual([{ count: 42 }]);
+
+    // Exactly two executions: one park, one resume — no silent re-park or
+    // duplicate approval request.
+    expect(executeCalls).toBe(2);
+  });
+});

--- a/packages/mcp/src/__tests__/resume-hint.test.ts
+++ b/packages/mcp/src/__tests__/resume-hint.test.ts
@@ -1,0 +1,32 @@
+/**
+ * #3750 — `withResumeHint` (MCP approval resume-hint helper).
+ *
+ * Pins the three behaviors the helper guarantees: append to an existing
+ * message, tolerate a missing/non-string upstream message (return the bare
+ * hint), and idempotency (never double-append when the hint is already there).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { withResumeHint, MCP_APPROVAL_RESUME_HINT } from "../structured-output.js";
+
+describe("withResumeHint (#3750)", () => {
+  it("appends the hint to a non-empty message (with a separating space)", () => {
+    const out = withResumeHint("Approval required. Rule: X.");
+    expect(out).toBe(`Approval required. Rule: X. ${MCP_APPROVAL_RESUME_HINT}`);
+  });
+
+  it("returns the bare hint when the message is missing / empty / non-string", () => {
+    expect(withResumeHint(undefined)).toBe(MCP_APPROVAL_RESUME_HINT);
+    expect(withResumeHint("")).toBe(MCP_APPROVAL_RESUME_HINT);
+    expect(withResumeHint(null)).toBe(MCP_APPROVAL_RESUME_HINT);
+    expect(withResumeHint(42)).toBe(MCP_APPROVAL_RESUME_HINT);
+  });
+
+  it("is idempotent — does not double-append when the hint is already present", () => {
+    const once = withResumeHint("Needs approval.");
+    const twice = withResumeHint(once);
+    expect(twice).toBe(once);
+    // Exactly one occurrence of the hint.
+    expect(twice.split(MCP_APPROVAL_RESUME_HINT)).toHaveLength(2);
+  });
+});

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -5,7 +5,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
 import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
-import { runMetricOutputSchema } from "../structured-output.js";
+import { runMetricOutputSchema, MCP_APPROVAL_RESUME_HINT } from "../structured-output.js";
 
 const TEST_ACTOR = createAtlasUser("u_sem", "managed", "sem@test", {
   role: "admin",
@@ -867,6 +867,9 @@ describe("MCP semantic tools", () => {
     expect(parsed.approval_required).toBe(true);
     expect(parsed.approval_request_id).toBe("appr_xyz");
     expect(parsed.message).toContain("appr_xyz");
+    // #3750 — parity with executeSQL: the message carries the resume hint so
+    // the MCP client knows to re-run the identical call once approved.
+    expect(parsed.message).toContain(MCP_APPROVAL_RESUME_HINT);
   });
 
   it("runMetric falls back to internal_error on opaque executeSQL failures", async () => {

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -56,7 +56,7 @@ import {
   toStructuredContent,
 } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
-import { runMetricOutputShape } from "./structured-output.js";
+import { runMetricOutputShape, withResumeHint } from "./structured-output.js";
 import { withProgressAndCancellation } from "./progress.js";
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
@@ -505,7 +505,9 @@ export function registerSemanticTools(
                 approval_required: true,
                 approval_request_id: result.approval_request_id,
                 matched_rules: result.matched_rules,
-                message: result.message,
+                // #3750 — resume hint: re-run this exact runMetric call once
+                // approved (parity with executeSQL's approval branch).
+                message: withResumeHint(result.message),
               });
             }
 

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -38,6 +38,38 @@ const approvalFields = {
 } as const;
 
 /**
+ * #3750 — MCP "resume" hint appended to an `approval_required` message.
+ *
+ * MCP has no agent loop or durable run: each tool call is a single
+ * synchronous dispatch and the MCP CLIENT (Claude Desktop, etc.) is the
+ * loop. So the resume mechanism for a parked MCP tool call is to RE-CALL
+ * the same tool once the request is approved — the executeSQL approval gate
+ * recognises the prior approval via `hasApprovedRequest` (keyed on the same
+ * org/requester/SQL/connection) and lets the re-call through, re-resolving
+ * auth/whitelist/RLS live on that fresh dispatch (the same fail-closed
+ * guarantee as the web resume path). The hint makes that protocol explicit
+ * so the LLM client knows to retry the identical call rather than mutate it
+ * (a mutated call would not match the approved request and would re-park).
+ *
+ * Kept as a string appended to `message` (not a new structured field) so the
+ * `approval_required` output schema stays unchanged.
+ */
+export const MCP_APPROVAL_RESUME_HINT =
+  "To resume once approved, re-run this exact call (same arguments). " +
+  "Atlas recognises the prior approval and continues; changing the arguments starts a new approval.";
+
+/**
+ * Append {@link MCP_APPROVAL_RESUME_HINT} to an `approval_required` message,
+ * tolerating a missing/non-string upstream message. Idempotent — never
+ * double-appends if the hint is already present.
+ */
+export function withResumeHint(message: unknown): string {
+  const base = typeof message === "string" && message.length > 0 ? message : "";
+  if (base.includes(MCP_APPROVAL_RESUME_HINT)) return base;
+  return base ? `${base} ${MCP_APPROVAL_RESUME_HINT}` : MCP_APPROVAL_RESUME_HINT;
+}
+
+/**
  * `executeSQL` output. Data branch: `explanation` + the
  * `{ columns, rows, row_count, truncated }` result. Plus the approval
  * governance branch.

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -278,14 +278,17 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               // declared outputSchema types before assigning to structuredContent
               // so SDK output-schema validation can't throw on a malformed
               // internal payload (e.g. non-string approval_request_id).
-              const { executeSqlOutputSchema: schema } = await import(
+              const { executeSqlOutputSchema: schema, withResumeHint } = await import(
                 "./structured-output.js"
               );
               const raw = {
                 approval_required: true,
                 approval_request_id: obj.approval_request_id,
                 matched_rules: obj.matched_rules,
-                message: obj.message,
+                // #3750 — tell the MCP client how to resume: re-call the
+                // identical tool once approved (the executeSQL gate's
+                // hasApprovedRequest dedup lets the re-call through).
+                message: withResumeHint(obj.message),
               };
               const parsed = schema.safeParse(raw);
               const approval = parsed.success ? parsed.data : {
@@ -293,9 +296,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                 ...(typeof obj.approval_request_id === "string"
                   ? { approval_request_id: obj.approval_request_id }
                   : {}),
-                ...(typeof obj.message === "string"
-                  ? { message: obj.message }
-                  : {}),
+                // Resume hint is always present (withResumeHint tolerates a
+                // missing upstream message) so even the fallback shape tells
+                // the client how to continue.
+                message: withResumeHint(obj.message),
               };
               return {
                 content: [

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -1733,6 +1733,30 @@ describe("ephemeral error delivery", () => {
     }
   });
 
+  it("accepts an onBridgeReady callback at the strict-schema layer (#3750)", async () => {
+    // Regression guard for the Boot-Smoke failure: the strict `.strict()`
+    // ChatConfigSchema rejects unknown keys, so a field added to the TS
+    // ChatPluginConfig interface but NOT to this schema crashes config load
+    // before HTTP binds. The schema must accept `onBridgeReady`.
+    const { ChatConfigSchema } = await import("./config");
+    const result = ChatConfigSchema.safeParse({
+      catalog: SLACK_CATALOG,
+      executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
+      onBridgeReady: () => {},
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-function onBridgeReady at the strict-schema layer (#3750)", async () => {
+    const { ChatConfigSchema } = await import("./config");
+    const result = ChatConfigSchema.safeParse({
+      catalog: SLACK_CATALOG,
+      executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
+      onBridgeReady: "not a function",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("EphemeralConfig validates correctly", async () => {
     const { ChatConfigSchema } = await import("./config");
 

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -2123,6 +2123,77 @@ describe("sendDirectMessage contract", () => {
     expect(result).toBeNull();
     expect(errorLogged).toBe(true);
   });
+
+  // #3750 — postToThread: continue a parked turn's thread after approval.
+  it("postToThread posts via adapter.postMessage(threadId) and returns the messageId", async () => {
+    const { createChatBridge } = await import("./bridge");
+    const mockStateAdapter = (await import("./state")).createStateAdapter({ backend: "memory" }, null);
+    const mockLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+    const postCalls: { threadId: string; message: unknown }[] = [];
+    const mockAdapter = {
+      name: "slack",
+      postMessage: async (threadId: string, message: unknown) => {
+        postCalls.push({ threadId, message });
+        return { id: "msg_thread_1", raw: {} };
+      },
+    };
+    const bridge = createChatBridge(
+      {
+        catalog: [], executeQuery: async () => ({
+          answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
+        }),
+      },
+      mockLogger as import("@useatlas/plugin-sdk").PluginLogger,
+      mockStateAdapter,
+      { slack: mockAdapter as unknown as import("chat").Adapter },
+    );
+
+    const result = await bridge.postToThread("slack", "C1:1700.0001", "Here is the approved result.");
+    expect(result).toEqual({ messageId: "msg_thread_1" });
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].threadId).toBe("C1:1700.0001");
+    expect(postCalls[0].message).toEqual({ markdown: "Here is the approved result." });
+  });
+
+  it("postToThread returns null when the adapter is not configured", async () => {
+    const { createChatBridge } = await import("./bridge");
+    const mockStateAdapter = (await import("./state")).createStateAdapter({ backend: "memory" }, null);
+    const mockLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+    const bridge = createChatBridge(
+      {
+        catalog: [], executeQuery: async () => ({
+          answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
+        }),
+      },
+      mockLogger as import("@useatlas/plugin-sdk").PluginLogger,
+      mockStateAdapter,
+      {},
+    );
+    expect(await bridge.postToThread("slack", "C1:1.1", "hi")).toBeNull();
+  });
+
+  it("postToThread returns null (never throws) when the adapter rejects the post", async () => {
+    const { createChatBridge } = await import("./bridge");
+    const mockStateAdapter = (await import("./state")).createStateAdapter({ backend: "memory" }, null);
+    let errorLogged = false;
+    const mockLogger = { info: () => {}, warn: () => {}, error: () => { errorLogged = true; }, debug: () => {} };
+    const mockAdapter = {
+      name: "slack",
+      postMessage: async () => { throw new Error("thread archived"); },
+    };
+    const bridge = createChatBridge(
+      {
+        catalog: [], executeQuery: async () => ({
+          answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
+        }),
+      },
+      mockLogger as import("@useatlas/plugin-sdk").PluginLogger,
+      mockStateAdapter,
+      { slack: mockAdapter as unknown as import("chat").Adapter },
+    );
+    expect(await bridge.postToThread("slack", "C1:1.1", "hi")).toBeNull();
+    expect(errorLogged).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -431,6 +431,26 @@ export interface ChatBridge {
     channelId: string,
     message: string | { card: CardElement; fallbackText: string },
   ): Promise<{ messageId: string } | null>;
+  /**
+   * Post a message into an existing thread (#3750).
+   *
+   * Used by the host's chat resume-deliverer to continue a parked turn's
+   * thread once its approval is resolved. `threadId` is the canonical
+   * cross-platform thread anchor the bridge handlers already operate on
+   * (Slack `channel:thread_ts`, Telegram `chat:message_thread_id`, …); the
+   * post goes through the adapter's native `postMessage(threadId, …)` — the
+   * same primitive the in-handler `thread.post()` wrapper ultimately calls —
+   * so the reply lands in the originating thread rather than at channel root.
+   *
+   * Returns `{ messageId }` on success, `null` when the adapter is not
+   * configured or the post fails. Never throws — the deliverer treats the
+   * outcome as data so an approval-review handler can't 500 on a post.
+   */
+  postToThread(
+    platform: ChatPlatform,
+    threadId: string,
+    message: string | { card: CardElement; fallbackText: string },
+  ): Promise<{ messageId: string } | null>;
   /** Shut down the Chat SDK instance and clean up resources. */
   shutdown(): Promise<void>;
 }
@@ -2025,6 +2045,35 @@ export function createChatBridge(
             channelId,
           },
           "postChannelAnnouncement: adapter rejected channel post",
+        );
+        return null;
+      }
+    },
+
+    async postToThread(
+      platform: ChatPlatform,
+      threadId: string,
+      message: string | { card: CardElement; fallbackText: string },
+    ): Promise<{ messageId: string } | null> {
+      const adapter = adapters[platform];
+      if (!adapter) {
+        log.warn({ platform, threadId }, "postToThread: adapter not configured");
+        return null;
+      }
+
+      try {
+        const postableMessage = typeof message === "string"
+          ? { markdown: message }
+          : { card: message.card, fallbackText: message.fallbackText };
+        // Native thread post — same primitive an in-handler `thread.post()`
+        // uses; `threadId` carries the platform's thread anchor.
+        const sent = await adapter.postMessage(threadId, postableMessage);
+        log.info({ platform, threadId, messageId: sent.id }, "Thread resume reply posted");
+        return { messageId: sent.id };
+      } catch (err) {
+        log.error(
+          { err: err instanceof Error ? err : new Error(String(err)), platform, threadId },
+          "postToThread: adapter rejected thread post",
         );
         return null;
       }

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -1109,6 +1109,13 @@ export const ChatConfigSchema = z.object({
   resolveAdapterEnv: zCallback<NonNullable<ChatPluginConfig["resolveAdapterEnv"]>>(
     "resolveAdapterEnv must be a function returning Promise<Record<string, string | undefined>>",
   ).optional(),
+  // #3750 — bridge-ready callback for chat resume-on-approval delivery.
+  // Optional callback; the host (`@atlas/api`) wires it to (de)register the
+  // chat resume-deliverer. Must be in this `.strict()` schema or config load
+  // rejects the key and boot crashes before HTTP binds (caught by Boot Smoke).
+  onBridgeReady: zCallback<NonNullable<ChatPluginConfig["onBridgeReady"]>>(
+    "onBridgeReady must be a function",
+  ).optional(),
 }).strict().refine(
   (c) => {
     // Warn if streaming.enabled is explicitly true but executeQueryStream is missing

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -171,6 +171,31 @@ export interface ChatQueryResult {
   pendingActions?: PendingAction[];
 }
 
+/**
+ * Narrow bridge capability exposed to the host's `onBridgeReady` callback
+ * (#3750) — just enough to post a continued answer back into a thread when a
+ * parked turn's approval is resolved. Kept minimal (a structural subset of
+ * `ChatBridge`) so the host wires resume delivery without depending on the
+ * full bridge surface.
+ */
+export interface ChatResumeBridge {
+  /** Platform slug the bridge knows (`"slack"`, `"telegram"`, …). */
+  postToThread(
+    platform: string,
+    threadId: string,
+    message: string,
+  ): Promise<{ messageId: string } | null>;
+}
+
+/**
+ * Host callback invoked when the bridge finishes initializing (with the
+ * bridge) and on shutdown (with `null`) — #3750. Lets the host register a
+ * resume-deliverer that closes over the bridge so an approval-review handler
+ * (on the host side of the plugin boundary) can continue a parked chat thread.
+ * Additive + host-optional: the plugin works unchanged when it's absent.
+ */
+export type OnBridgeReady = (bridge: ChatResumeBridge | null) => void;
+
 /** Adapter-specific credential configuration. */
 export interface SlackAdapterConfig {
   /** Single-workspace bot token (`xoxb-…`). Omit in multi-workspace deploys. */
@@ -607,6 +632,18 @@ export interface ChatPluginConfig {
    * kill switches, admin UI, meter, and feedback.
    */
   proactive?: ProactiveConfig;
+
+  /**
+   * Bridge-ready callback (#3750) — invoked at the end of `initialize()` with
+   * the (narrow) bridge handle, and on `teardown()` with `null`. The host uses
+   * it to (de)register a chat resume-deliverer that posts a parked turn's
+   * continued answer back in-thread once its approval is resolved. Additive +
+   * host-optional: the plugin works unchanged when omitted (self-host without
+   * durable approval-park resume). Top-level (not under `proactive` — resume
+   * delivery is independent of the proactive listener). Host wiring:
+   * `deploy/api/atlas.config.ts` → `registerChatResumeDeliverer`.
+   */
+  onBridgeReady?: OnBridgeReady;
 }
 
 /** Proactive chat configuration. */

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -897,6 +897,23 @@ function buildChatPlugin(
           msg,
         );
       }
+
+      // #3750 — hand the host the (narrow) bridge so it can register a chat
+      // resume-deliverer that posts a parked turn's continued answer in-thread
+      // once its approval is resolved. Host-optional; the plugin works
+      // unchanged when `onBridgeReady` is absent. Best-effort — a host wiring
+      // error must not fail plugin init.
+      if (typeof config.onBridgeReady === "function" && bridge) {
+        try {
+          config.onBridgeReady(bridge);
+        } catch (err) {
+          ctx.logger.warn(
+            { err: err instanceof Error ? err : new Error(String(err)) },
+            "onBridgeReady callback threw — chat resume delivery may be unavailable",
+          );
+        }
+      }
+
       initialized = true;
     },
 
@@ -972,6 +989,19 @@ function buildChatPlugin(
     },
 
     async teardown() {
+      // #3750 — clear the host's resume-deliverer before tearing the bridge
+      // down so a `PluginRegistry.refresh("chat-interaction")` / hot-reload
+      // doesn't leave a deliverer pointing at a shut-down bridge.
+      if (typeof config.onBridgeReady === "function") {
+        try {
+          config.onBridgeReady(null);
+        } catch (err) {
+          (log ?? console).warn(
+            { err: err instanceof Error ? err : new Error(String(err)) },
+            "onBridgeReady(null) callback threw during teardown",
+          );
+        }
+      }
       if (bridge) {
         try {
           await bridge.shutdown();


### PR DESCRIPTION
## What

Brings durable approval-park **resume** to the non-web surfaces. The engine (checkpoint / park / resolve, #3747 / #3748) already operates at the shared \`runAgent\` layer and is surface-agnostic; this slice adds the **surface-specific plumbing** to represent a parked turn and resume it over MCP and the chat plugin.

Closes #3750. Parent PRD #3742 (not closed).

## MCP — no boundary change, resume is re-call-after-approval

MCP has no agent loop or durable run: each tool call is one synchronous dispatch and the MCP **client** is the loop. A parked \`executeSQL\` / \`runMetric\` call already surfaces a non-error \`approval_required\` result with \`approval_request_id\` (pre-#3750). The resume is the client **re-calling the identical tool** once approved — the gate's \`hasApprovedRequest\` dedup lets the re-call through, re-resolving auth/scoping live on that fresh dispatch (the same fail-closed guarantee as web). This PR adds an explicit \`MCP_APPROVAL_RESUME_HINT\` appended to the approval message so the LLM client knows to retry the **same** call (a mutated call would re-park). No MCP / \`@chat-adapter\` boundary field changed.

## Chat plugin — waiting-state + in-thread resume on approval

A parked turn initiated from Slack / Telegram / Discord / Google Chat / Teams / WhatsApp now posts a **"waiting on approval"** thread state (instead of the old dead-end \`:lock: approve via console\` notice) and is **resumed in-place** once a reviewer resolves the request:

1. **Park** — \`executeQuery.ts\` persists this thread's coordinates (\`platform\`, \`threadId\`, \`orgId\`, \`externalId\`, optional \`externalUserId\`) in a \`chat_cache\` key \`chat:resume-pending:<conversationId>\` (TTL = max-park window). This is an **Atlas-extension field on an Atlas-owned table** — the chat-adapter never reads it; no boundary change. Gated on a real bound org so resume can't bypass the billing gate.
2. **Resolve** — the surface-agnostic approval-review handler (\`admin-approval.ts\`), after \`resolveApprovalPark\` re-arms the run, invokes a registered chat resume-deliverer.
3. **Deliver** — the deliverer (registered via a new \`onBridgeReady\` host callback → \`registerChatResumeDeliverer\`, mirroring the proactive \`announcer-registry\` port) calls \`resumeChatTurn\`, which rebuilds the **same bot actor** that parked, re-runs the billing gate, claims the single-resumer lease, and re-enters \`runAgent({ resume })\` — re-resolving auth / connection / RLS **LIVE** (AC3, fail-closed on suspension; ADR-0020). The continued answer (or a user-safe block notice) is posted back via a new \`ChatBridge.postToThread\`.

### Boundary change → contract doc updated (AC4)

Two new top-level \`chatPlugin({...})\` boundary points (\`onBridgeReady\` host callback + \`ChatBridge.postToThread\`) and the \`chat:resume-pending\` extension key are documented in a new section of \`docs/architecture/chat-plugin-atlas-contract.md\`.

## Acceptance criteria

- [x] An approval-required action over MCP parks and, on approval, resumes to a correct result through the MCP path (re-call dedup).
- [x] An approval-required action from Slack/Telegram (+ the other 4 chat platforms) posts a waiting state and resumes the thread on approval.
- [x] Resume over both surfaces re-resolves auth/scoping live (same fail-closed guarantee as web).
- [x] The chat-plugin × Atlas contract doc is updated for the boundary change.

## Tests

New: \`resume-pending-store\`, \`resume-delivery-registry\`, \`resume-delivery\`, \`resume-turn\`, \`resume-deliverer-factory\` (lib), \`mcp-approval-resume\` + \`resume-hint\` (MCP). Extended: \`agent-query\` (runId/conversationId surfacing), \`execute-query\` (Slack + Telegram park → waiting-state + coordinates), \`admin-approval\` (resume-delivery trigger on \`resumed\`, fail-soft), \`bridge\` (\`postToThread\`), \`semantic-tools\` (runMetric resume hint).

## Review

Internal review panel run before PR; all must-fix items addressed in-branch: Telegram + the other chat platforms wired (not Slack-only), \`onBridgeReady\` moved to \`ChatPluginConfig\` (was mis-placed on \`ProactiveConfig\`), the \`orgId ?? ""\` gate-bypass closed, the deploy-config deliverer extracted into a unit-tested factory, a \`blocked\` (fail-closed) delivery outcome added distinct from \`delivered\`, and a compile-time \`ChatBotPlatform extends ApprovalRequestOrigin\` guard added. \`/ci\` gates green locally (lint, type, full test, syncpack, all drift checks).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend durable approval-park resume to MCP and chat-plugin surfaces
> - Adds resume coordinate persistence to all chat-plugin platforms (Slack, Telegram, Discord, Google Chat, Teams, WhatsApp) so that when an agent turn parks for approval, the originating thread context is saved to `chat_cache` via [`resume-pending-store.ts`](https://github.com/AtlasDevHQ/atlas/pull/3832/files#diff-32c8ab45897a9ef022b735c5d1fed23c443311f978818db1b9cb41c7e4c47029).
> - Introduces [`resumeChatTurn`](https://github.com/AtlasDevHQ/atlas/pull/3832/files#diff-9862e7471a17ab75c699225d378e55fa1dc1ec57b95072ed311fc311ea8b6c0e) and [`deliverChatResumeIfPending`](https://github.com/AtlasDevHQ/atlas/pull/3832/files#diff-fa473f8c58d76bb3e70cc3f7ca9bd9ce860627a9746f519a97a0405dbb6ef2d8) to re-enter the agent loop after approval and post the continued answer back to the original thread.
> - The `ChatBridge` gains a `postToThread` method and `ChatPluginConfig` gains an `onBridgeReady` callback; [`atlas.config.ts`](https://github.com/AtlasDevHQ/atlas/pull/3832/files#diff-e6db0c3b52717e74ce220854d51820cab32a3a64d438da05dbcd246e316d0fa2) wires these together to register/clear a process-local resume deliverer on plugin init/teardown.
> - The admin approval review route ([`admin-approval.ts`](https://github.com/AtlasDevHQ/atlas/pull/3832/files#diff-ddc29a3e2cae65ee2badf5a7ba2f10c86e70a28124476fb5b5ff65be636b3b0d)) now calls `deliverChatResumeIfPending` when a parked turn is resumed; failures are logged without affecting the HTTP response.
> - MCP `executeSQL` and `runMetric` tool handlers append a standardized `MCP_APPROVAL_RESUME_HINT` to `approval_required` messages, instructing clients to re-run the identical call once approved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee9380a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires durable approval-park **resume** to MCP and chat-plugin surfaces. The engine (#3747/#3748) already operates surface-agnostically at `runAgent`; this slice adds surface-specific plumbing: persistence of thread coordinates at park time, a registry/factory to re-enter the agent loop after approval, and `ChatBridge.postToThread` to deliver the continued answer back to the originating thread.

- **Chat plugin** — `executeQuery.ts` now writes `chat:resume-pending:<conversationId>` coordinates to `chat_cache` at park time (guarded by real org id, durable run id, and approval request id); `admin-approval.ts` calls `deliverChatResumeIfPending` after `resolveApprovalPark`, which re-enters `runAgent({ resume })` under the original chat actor (live auth/scoping re-resolution) and posts via the new `ChatBridge.postToThread`.
- **MCP** — `withResumeHint` appends `MCP_APPROVAL_RESUME_HINT` to every `approval_required` message in both `executeSQL` (`tools.ts`) and `runMetric` (`semantic-tools.ts`), instructing the LLM client to re-call the identical tool once approved.
- **Config/registry** — `onBridgeReady` added to `ChatPluginConfig` and `ChatConfigSchema` (`.strict()` compatible); a process-local `resume-delivery-registry` mirrors the existing `announcer-registry` pattern; the deploy config `atlas.config.ts` wires init/teardown.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the previously flagged schema crash (onBridgeReady absent from ChatConfigSchema.strict()) is resolved in this diff, all new paths are fail-soft, and the security-sensitive resume re-enters with live auth/billing re-resolution.

The change is purely additive: new modules with comprehensive test coverage, fail-soft error handling throughout, and the one prior blocking schema issue is addressed. The resume path re-resolves auth/scoping live (never from the checkpoint), the single-resumer lease prevents double-delivery, and the process-global registry mirrors an established pattern.

No files require special attention. The core security boundary (resume-turn.ts) and the park-coordinate persistence (resume-pending-store.ts) both follow defensive patterns and have dedicated unit tests.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| plugins/chat/src/config.ts | Adds ChatResumeBridge, OnBridgeReady types and onBridgeReady optional field to both ChatPluginConfig interface and ChatConfigSchema (.strict() compliant — previous P0 is resolved). |
| plugins/chat/src/index.ts | Calls onBridgeReady(bridge) after initialize() and onBridgeReady(null) at the top of teardown() (before bridge.shutdown()), with best-effort error handling in both paths. |
| plugins/chat/src/bridge.ts | Adds postToThread to the ChatBridge interface and implements it via adapter.postMessage(threadId, …) — catches adapter errors and returns null (never throws). |
| packages/api/src/lib/chat-plugin/resume-pending-store.ts | New module: saves/loads/clears chat:resume-pending:<conversationId> rows in chat_cache; table name validated at import; SQL parameterized throughout; TTL mirrors max-park window; all DB ops fail-soft. |
| packages/api/src/lib/chat-plugin/resume-delivery-registry.ts | New process-local singleton registry: registerChatResumeDeliverer / clearChatResumeDeliverer / getChatResumeDeliverer; mirrors announcer-registry pattern; NULL_RESUME_DELIVERER fallback prevents 500s on self-hosted installs without chat. |
| packages/api/src/lib/chat-plugin/resume-turn.ts | New module: re-enters a parked turn under its original bot actor; re-runs billing gate, claims single-resumer lease via prepareResume, then calls runAgent({ resume }); finishResume in finally; all errors mapped to result variants, never throws. |
| packages/api/src/lib/chat-plugin/resume-delivery.ts | New delivery-glue module: loads coordinates, delegates to registered deliverer, clears pending row on terminal outcomes; no_deliverer and failed cases intentionally leave the row for TTL-expiry/retry. |
| packages/api/src/lib/chat-plugin/resume-deliverer-factory.ts | New factory: validates platform slug via isBotPlatform, calls resumeChatTurn, posts answer/block notice via injected postToThread, maps all result variants to ChatResumeDeliveryOutcome. |
| packages/api/src/lib/chat-plugin/executeQuery.ts | Adds resumeCoordinates to all six platform branches and to runAgentAndMap; persists coordinates gated on conversationId && approvalRequestId && runId && resumeOrgId; replaces lock notice with waiting message when auto-resumable. |
| packages/api/src/api/routes/admin-approval.ts | Calls deliverChatResumeIfPending after resolveApprovalPark returns resumed; wrapped in Effect.promise with .catch() so delivery errors are logged but never surface as HTTP 500. |
| packages/mcp/src/structured-output.ts | Adds MCP_APPROVAL_RESUME_HINT constant and withResumeHint helper; idempotent (never double-appends); handles unknown upstream message type gracefully. |
| deploy/api/atlas.config.ts | Wires onBridgeReady to register/clear the deliverer built by buildChatResumeDeliverer; bridge.postToThread injected as the only dependency; null callback clears the deliverer on teardown. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/chat/src/config.ts`, line 1105-1112 ([link](https://github.com/atlasdevhq/atlas/blob/8a34af260a6c872d3e652cb346b8b3aa094ea4fe/plugins/chat/src/config.ts#L1105-L1112)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> `onBridgeReady` is absent from `ChatConfigSchema` but the schema ends with `.strict()`, which rejects any unknown key. The developer's own comment three lines above this section spells it out: "Must be in this `.strict()` schema or config load rejects the key and boot crashes before HTTP binds." Because `createPlugin` calls `configSchema.parse(rawConfig)` at factory-invocation time (see `packages/plugin-sdk/src/helpers.ts` line 234), passing `onBridgeReady` from `atlas.config.ts` will throw `Unrecognized key(s) in object: 'onBridgeReady'` and crash the API process before it binds any port.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fchat%2Fsrc%2Fconfig.ts%0ALine%3A%201105-1112%0A%0AComment%3A%0A%60onBridgeReady%60%20is%20absent%20from%20%60ChatConfigSchema%60%20but%20the%20schema%20ends%20with%20%60.strict%28%29%60%2C%20which%20rejects%20any%20unknown%20key.%20The%20developer's%20own%20comment%20three%20lines%20above%20this%20section%20spells%20it%20out%3A%20%22Must%20be%20in%20this%20%60.strict%28%29%60%20schema%20or%20config%20load%20rejects%20the%20key%20and%20boot%20crashes%20before%20HTTP%20binds.%22%20Because%20%60createPlugin%60%20calls%20%60configSchema.parse%28rawConfig%29%60%20at%20factory-invocation%20time%20%28see%20%60packages%2Fplugin-sdk%2Fsrc%2Fhelpers.ts%60%20line%20234%29%2C%20passing%20%60onBridgeReady%60%20from%20%60atlas.config.ts%60%20will%20throw%20%60Unrecognized%20key%28s%29%20in%20object%3A%20'onBridgeReady'%60%20and%20crash%20the%20API%20process%20before%20it%20binds%20any%20port.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20%233704%20%E2%80%94%20operator-tier%20credential%20resolver%20overlay.%20Optional%20async%0A%20%20%2F%2F%20callback%3B%20the%20host%20%28%60%40atlas%2Fapi%60%29%20wires%20it%20to%20the%20operator-credentials%0A%20%20%2F%2F%20resolver.%20Must%20be%20in%20this%20%60.strict%28%29%60%20schema%20or%20config%20load%20rejects%20the%0A%20%20%2F%2F%20key%20and%20boot%20crashes%20before%20HTTP%20binds%20%28caught%20by%20Boot%20Smoke%29.%0A%20%20resolveAdapterEnv%3A%20zCallback%3CNonNullable%3CChatPluginConfig%5B%22resolveAdapterEnv%22%5D%3E%3E%28%0A%20%20%20%20%22resolveAdapterEnv%20must%20be%20a%20function%20returning%20Promise%3CRecord%3Cstring%2C%20string%20%7C%20undefined%3E%3E%22%2C%0A%20%20%29.optional%28%29%2C%0A%20%20%2F%2F%20%233750%20%E2%80%94%20chat%20resume-on-approval%20delivery.%20Must%20be%20in%20this%20%60.strict%28%29%60%0A%20%20%2F%2F%20schema%20or%20config%20load%20rejects%20the%20key%20and%20boot%20crashes%20%28same%20constraint%0A%20%20%2F%2F%20as%20resolveAdapterEnv%20above%29.%20Host-optional%3B%20omitted%20in%20self-host%20deploys%0A%20%20%2F%2F%20that%20have%20no%20chat%20resume%20wiring.%0A%20%20onBridgeReady%3A%20zCallback%3CNonNullable%3CChatPluginConfig%5B%22onBridgeReady%22%5D%3E%3E%28%0A%20%20%20%20%22onBridgeReady%20must%20be%20a%20function%22%2C%0A%20%20%29.optional%28%29%2C%0A%7D%29.strict%28%29.refine%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=atlasdevhq%2Fatlas&pr=3832&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(chat): add onBridgeReady to strict C..."](https://github.com/atlasdevhq/atlas/commit/ee9380a64a328d0f86b1b756b67e64ce2be58425) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38816633)</sub>

<!-- /greptile_comment -->