### PR TITLE
chore(mcp): guard collectViolations against empty fixtures (#3825 follow-up)

### DIFF
--- a/packages/api/scripts/check-auth-md-discovery-parity.ts
+++ b/packages/api/scripts/check-auth-md-discovery-parity.ts
@@ -369,20 +369,31 @@ export function endpointParityViolations(label: string, doc: string): string[] {
 /**
  * Run every parity check across all host fixtures + the host-independent scope
  * check, and return the combined violation list. Pure: the caller owns I/O.
+ *
+ * With no fixtures there is nothing to compare against, so there are no
+ * violations — return early. Without this guard the host-independent scope
+ * check would run against an empty `""` document (`fixtures[0]` is undefined)
+ * and report *every* advertised scope as "named in .well-known but absent from
+ * /auth.md" — a false positive, since there is no document to be absent from.
+ * `main()` always passes a non-empty `HOST_FIXTURES`, but this function is
+ * exported, so the empty-input contract is stated explicitly.
  */
 export function collectViolations(input: {
   fixtures: readonly { label: string; doc: string; hosts: ResolvedHosts }[];
   advertisedScopes: readonly string[];
 }): string[] {
+  if (input.fixtures.length === 0) return [];
+
   const out: string[] = [];
   for (const f of input.fixtures) {
     out.push(...hostParityViolations(f.label, f.doc, f.hosts));
     out.push(...endpointParityViolations(f.label, f.doc));
   }
   // Scope parity is host-independent — the `mcp:*` set the prose names doesn't
-  // vary by region — so check it once against the first fixture's doc.
-  const firstDoc = input.fixtures[0]?.doc ?? "";
-  out.push(...scopeParityViolations(firstDoc, input.advertisedScopes));
+  // vary by region — so check it once against the first fixture's doc. The
+  // early return above guarantees at least one fixture, so `fixtures[0]` is
+  // present (no empty-doc fallback needed).
+  out.push(...scopeParityViolations(input.fixtures[0].doc, input.advertisedScopes));
   return out;
 }
 

--- a/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
+++ b/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
@@ -98,6 +98,18 @@ describe("auth-md discovery parity — collectViolations across region fixtures"
     expect(violations).toEqual([]);
   });
 
+  it("returns no violations for an empty fixtures slice (no doc to compare)", () => {
+    // Regression guard: with no fixtures the host-independent scope check used
+    // to run against an empty `""` document and report every advertised scope
+    // as "absent from /auth.md" — a false positive. An empty slice is a misuse,
+    // not a parity failure, so the contract is: no fixtures → no violations.
+    const violations = collectViolations({
+      fixtures: [],
+      advertisedScopes: ADVERTISED_SCOPES,
+    });
+    expect(violations).toEqual([]);
+  });
+
   it("flags a host drift that lives only in the SECOND (eu) fixture", () => {
     // The eu doc names the infra api-eu host where the brand-mirror mcp-eu host
     // is expected — proving host parity runs per-fixture, not just on the first.


### PR DESCRIPTION
## Summary

Post-merge fix-forward for an advisory-bot finding (Greptile P2 / Macroscope Low) on the #3825 drift-parity guard, shipped in #3831. Verification-only, no runtime behavior change.

`collectViolations` (an **exported** pure helper in the parity guard) ran the host-independent scope check against `fixtures[0]?.doc ?? ""`. With an empty `fixtures` slice, that `?? ""` fallback fed an empty document into `scopeParityViolations`, which then reported **every** advertised scope as "named in `.well-known` but absent from `/auth.md`" — a false positive, since there is no document for the scope to be absent from. `main()` always passes a static non-empty `HOST_FIXTURES`, so the live CI gate was never affected — but the exported function's empty-input contract wasn't guaranteed.

Fix: an early `if (input.fixtures.length === 0) return []` (no fixtures = nothing to compare = no violations), which also lets the scope check index `fixtures[0].doc` directly instead of via the empty-doc fallback that was the source of the false positive. Pinned with a regression test (the test fails on the pre-fix code, passes on the fix).

### Reconciliation of the other two #3831 advisory-bot findings (no code change here)
- **CodeQL alert #44** (test assertion using `.includes("https://…")` — `js/incomplete-url-substring-sanitization`): already fixed **pre-merge** in #3831 (reworked to a bare-hostname match; CodeQL went green on the merged SHA, Greptile re-reviewed 5/5).
- **Greptile P2 — multiline scope-source regex `[^\]]*`**: false alarm. `[^\]]` is a negated character class (not `.`), so it matches newlines; a multi-line prettier reformat of `scopes_supported` still parses to `["mcp:read", "mcp:write"]` (verified empirically). No change warranted.

## Test plan
- [x] New regression test: `collectViolations({ fixtures: [], advertisedScopes })` → `[]` (was 2 false violations pre-fix)
- [x] Guard still passes on the tree; all 19 tests green (18 prior + 1 new)
- [x] `bun run lint` · `tsgo --noEmit` · the parity guard itself — all pass
- [x] Internal review panel (pr-test, silent-failure): CLEAN — `return []` is the correct non-dangerous semantic (loud failure correctly lives in `main()`/`parseWellKnownScopes`); removing `?? ""` removes the silent-bad-default; `fixtures[0].doc` is provably safe after the early return

Follow-up to #3825 / #3831.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `collectViolations` against empty fixtures to prevent false-positive violations
> Adds an early return in `collectViolations` when the input fixtures array is empty, preventing scope checks from running against an empty string and returning a false-positive violation list. A test case in [auth-md-discovery-parity.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3835/files#diff-48c246c3e56e23e2b9319c789740f4bfecc4cd317fae58b2439af5c2fcb48586) documents and guards this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77e58f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an early-return guard to `collectViolations` when the input `fixtures` slice is empty, preventing the host-independent scope check from running against an empty string document and producing false-positive violations. The fix also removes the `?? ""` fallback that was the source of the bad default.

- **`check-auth-md-discovery-parity.ts`**: Inserts `if (input.fixtures.length === 0) return [];` before the loop, then accesses `fixtures[0].doc` directly (safe after the guard), with an updated JSDoc block explaining the empty-input contract.
- **`auth-md-discovery-parity.test.ts`**: Adds a regression test that calls `collectViolations` with `fixtures: []` and asserts the result is `[]`, confirming the pre-fix false-positive no longer occurs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted defensive guard on an exported pure function with no runtime path affected in production.

The fix is minimal and correctly scoped: it adds a single early-return for an edge case that was never reachable in the live CI path, removes a silent bad-default fallback, and is backed by a regression test that fails on the pre-fix code. No logic that runs in production is altered.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/scripts/check-auth-md-discovery-parity.ts | Early-return guard added to collectViolations for empty fixtures; removes the ?? "" fallback and accesses fixtures[0].doc directly after the guard. |
| packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts | Regression test added: empty fixtures slice produces [] and not false-positive scope violations; test is placed correctly in the multi-fixture describe block. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["collectViolations(input)"] --> B{fixtures.length === 0?}
    B -- "yes (new guard)" --> C["return []"]
    B -- "no" --> D["for each fixture:\nhostParityViolations +\nendpointParityViolations"]
    D --> E["scopeParityViolations\n(fixtures[0].doc — safe after guard)"]
    E --> F["return out[]"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["collectViolations(input)"] --> B{fixtures.length === 0?}
    B -- "yes (new guard)" --> C["return []"]
    B -- "no" --> D["for each fixture:\nhostParityViolations +\nendpointParityViolations"]
    D --> E["scopeParityViolations\n(fixtures[0].doc — safe after guard)"]
    E --> F["return out[]"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(mcp): guard collectViolations agai..."](https://github.com/atlasdevhq/atlas/commit/77e58f5f111c9b5ae1db2397000c450c19e123ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38817634)</sub>

<!-- /greptile_comment -->