### PR TITLE
feat(durable-memory): bounds & safety — caps, secrets, tenant scoping, session sweep (#3757)

### DIFF
--- a/packages/api/src/lib/__tests__/durable-state-bounds.test.ts
+++ b/packages/api/src/lib/__tests__/durable-state-bounds.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for durable-memory bounds & safety (#3757, ADR-0020, slice 4):
+ *   - size + slot caps resolved from the settings registry (hot-reloadable,
+ *     workspace > platform > env > default) — a write that would exceed a cap is
+ *     REJECTED at staging time (surfaced to the caller), never truncated;
+ *   - the secrets/credentials prohibition — a write whose value looks like a
+ *     credential is rejected before persistence;
+ *   - tenant scoping — the Live store is bound to its session's conversation +
+ *     org, and a commit can only ever target that bound scope.
+ *
+ * Caps/secrets are enforced in the store's `set` (reached synchronously from a
+ * tool's `defineDurableState(...).set()` inside `runWithDurableState`), so the
+ * rejection propagates up through the tool's `execute` to the caller — unlike
+ * the fire-and-forget commit, which can't surface an error.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+let hasInternalDB = true;
+// Rows the load query returns — seeds a store with a prior turn's slots so a
+// test can exercise the seeded-slot-counts-toward-the-cap path.
+let loadRows: Array<{ namespace: string; value: unknown }> = [];
+// Platform-tier overrides (no orgId), keyed on the setting key.
+const settings = new Map<string, string>();
+// Workspace-tier overrides, keyed on `key\0orgId` — the workspace > platform
+// precedence the real `getSetting` resolves so a per-tenant cap is honored.
+const workspaceSettings = new Map<string, string>();
+const wsKey = (key: string, orgId: string) => `${key}\0${orgId}`;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => hasInternalDB,
+  internalExecute: () => {},
+  internalQuery: async () => loadRows,
+}));
+
+// Drive cap resolution off an in-memory settings map so a test can flip a cap
+// the way the settings registry would (workspace OR platform override) and
+// assert the store honors it WITHOUT a redeploy — the hot-reload contract.
+// The mock mirrors the real four-tier precedence the resolver relies on:
+// workspace override (key+orgId) > platform override (key) > registry default.
+const realSettings = await import("@atlas/api/lib/settings");
+mock.module("@atlas/api/lib/settings", () => ({
+  ...realSettings,
+  getSettingAuto: (key: string, orgId?: string) =>
+    (orgId !== undefined ? workspaceSettings.get(wsKey(key, orgId)) : undefined) ??
+    settings.get(key) ??
+    realSettings.getSettingDefinition(key)?.default,
+}));
+
+const {
+  defineDurableState,
+  runWithDurableState,
+  buildDurableStateStore,
+  DurableStateLimitError,
+  DurableStateSecretError,
+  MEMORY_MAX_SLOTS_SETTING,
+  MEMORY_MAX_VALUE_BYTES_SETTING,
+  DEFAULT_MEMORY_MAX_SLOTS,
+  DEFAULT_MEMORY_MAX_VALUE_BYTES,
+  getMemoryMaxSlots,
+  getMemoryMaxValueBytes,
+  _resetDurableStateRegistry,
+} = await import("@atlas/api/lib/durable-state");
+
+beforeEach(() => {
+  hasInternalDB = true;
+  loadRows = [];
+  settings.clear();
+  workspaceSettings.clear();
+  _resetDurableStateRegistry();
+});
+
+async function liveStore(orgId: string | null = "org-1") {
+  return buildDurableStateStore({ conversationId: "conv-1", orgId, active: true });
+}
+
+describe("cap resolvers — settings registry resolution (hot-reloadable)", () => {
+  it("falls back to the registry default when unset", () => {
+    expect(getMemoryMaxSlots()).toBe(DEFAULT_MEMORY_MAX_SLOTS);
+    expect(getMemoryMaxValueBytes()).toBe(DEFAULT_MEMORY_MAX_VALUE_BYTES);
+  });
+
+  it("honors a settings override without a redeploy", () => {
+    settings.set(MEMORY_MAX_SLOTS_SETTING, "3");
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "128");
+    expect(getMemoryMaxSlots()).toBe(3);
+    expect(getMemoryMaxValueBytes()).toBe(128);
+  });
+
+  it("clamps a non-positive / unparseable override back to the default", () => {
+    settings.set(MEMORY_MAX_SLOTS_SETTING, "0");
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "not-a-number");
+    expect(getMemoryMaxSlots()).toBe(DEFAULT_MEMORY_MAX_SLOTS);
+    expect(getMemoryMaxValueBytes()).toBe(DEFAULT_MEMORY_MAX_VALUE_BYTES);
+  });
+
+  it("resolves a per-workspace override (workspace > platform > default)", () => {
+    // A platform-tier override applies to every tenant...
+    settings.set(MEMORY_MAX_SLOTS_SETTING, "10");
+    // ...but org-A pins a tighter workspace-tier cap that must win for org-A only.
+    workspaceSettings.set(wsKey(MEMORY_MAX_SLOTS_SETTING, "org-A"), "3");
+    expect(getMemoryMaxSlots("org-A")).toBe(3); // workspace override wins
+    expect(getMemoryMaxSlots("org-B")).toBe(10); // falls through to platform
+    expect(getMemoryMaxSlots()).toBe(10); // no orgId → platform tier
+  });
+
+  it("threads the session's org into cap resolution at store build", async () => {
+    // org-A's workspace cap is 1 slot; the store built for org-A must enforce it.
+    workspaceSettings.set(wsKey(MEMORY_MAX_SLOTS_SETTING, "org-A"), "1");
+    const store = await liveStore("org-A");
+    runWithDurableState(store, () => {
+      defineDurableState<number>("first").set(1);
+      // org-A's 1-slot workspace cap rejects the second slot — proving the store
+      // resolved caps against the session's org, not the platform default (64).
+      expect(() => defineDurableState<number>("second").set(2)).toThrow(DurableStateLimitError);
+    });
+  });
+});
+
+describe("size cap — a too-large value is rejected, never truncated", () => {
+  it("rejects a write whose serialized value exceeds the byte cap", async () => {
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "64");
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      const slot = defineDurableState<string>("big");
+      expect(() => slot.set("x".repeat(200))).toThrow(DurableStateLimitError);
+      // The over-cap write never staged — nothing to commit, no truncated value.
+      expect(slot.get()).toBeUndefined();
+    });
+    expect(store.drainDirty()).toEqual([]);
+  });
+
+  it("allows a write within the byte cap", async () => {
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "64");
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      defineDurableState<string>("ok").set("short");
+    });
+    expect(store.drainDirty()).toEqual([{ namespace: "ok", value: "short" }]);
+  });
+
+  it("measures UTF-8 byte length, not character count (multi-byte chars count fully)", async () => {
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "16");
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      // 10 emoji × 4 bytes each = 40 bytes (well over 16) though only 10 "chars".
+      expect(() => defineDurableState<string>("emoji").set("😀".repeat(10))).toThrow(
+        DurableStateLimitError,
+      );
+    });
+  });
+});
+
+describe("slot cap — a new slot past the cap is rejected", () => {
+  it("rejects a NEW slot once the slot cap is reached, but allows overwriting an existing one", async () => {
+    settings.set(MEMORY_MAX_SLOTS_SETTING, "2");
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      const a = defineDurableState<number>("a");
+      a.set(1);
+      defineDurableState<number>("b").set(2);
+      // Cap reached: a third distinct slot is rejected.
+      expect(() => defineDurableState<number>("c").set(3)).toThrow(DurableStateLimitError);
+      // Overwriting an EXISTING slot is fine — it does not grow the slot count.
+      expect(() => a.set(99)).not.toThrow();
+    });
+    const dirty = store.drainDirty();
+    expect(dirty.map((d) => d.namespace).sort()).toEqual(["a", "b"]);
+  });
+
+  it("counts a SEEDED slot (loaded from a prior turn) toward the cap", async () => {
+    settings.set(MEMORY_MAX_SLOTS_SETTING, "1");
+    // The prior turn left one slot; the load seeds the store at the 1-slot cap.
+    loadRows = [{ namespace: "fromLastTurn", value: "orders" }];
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      // A brand-new slot must reject — the seeded slot already fills the budget,
+      // so the cap counts loaded slots, not just slots written this turn.
+      expect(() => defineDurableState<number>("freshThisTurn").set(1)).toThrow(
+        DurableStateLimitError,
+      );
+      // Overwriting the seeded slot stays allowed (no growth in slot count).
+      expect(() => defineDurableState<string>("fromLastTurn").set("payments")).not.toThrow();
+    });
+  });
+});
+
+describe("size cap — boundary (exactly-at-cap is allowed, one byte over rejects)", () => {
+  it("accepts a value of exactly maxValueBytes and rejects one byte more", async () => {
+    // A JSON string is the quoted content plus 2 quote bytes: `"xxxx"`. Pick a
+    // cap so a known-length string lands exactly on it.
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "12"); // 10 chars + 2 quotes
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      // Exactly 12 bytes — the strict `>` check accepts the boundary value.
+      expect(() => defineDurableState<string>("atCap").set("x".repeat(10))).not.toThrow();
+      // 13 bytes — one over → rejected.
+      expect(() => defineDurableState<string>("overCap").set("x".repeat(11))).toThrow(
+        DurableStateLimitError,
+      );
+    });
+    expect(store.drainDirty()).toEqual([{ namespace: "atCap", value: "x".repeat(10) }]);
+  });
+});
+
+describe("secrets prohibition — a credential-shaped value is rejected pre-persist", () => {
+  it("rejects a write whose value looks like an API key", async () => {
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      const slot = defineDurableState<string>("creds");
+      expect(() => slot.set("sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCd")).toThrow(
+        DurableStateSecretError,
+      );
+      expect(slot.get()).toBeUndefined(); // never staged
+    });
+    expect(store.drainDirty()).toEqual([]);
+  });
+
+  it("rejects a secret nested inside a remembered object", async () => {
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      expect(() =>
+        defineDurableState<unknown>("cfg").set({ db: { url: "postgres://u:p4ssword-here@h/db" } }),
+      ).toThrow(DurableStateSecretError);
+    });
+  });
+
+  it("allows ordinary analyst memory through", async () => {
+    const store = await liveStore();
+    runWithDurableState(store, () => {
+      defineDurableState<unknown>("ctx").set({ lastTable: "orders", region: "EU", rows: 1432 });
+    });
+    expect(store.drainDirty()).toEqual([{ namespace: "ctx", value: { lastTable: "orders", region: "EU", rows: 1432 } }]);
+  });
+});
+
+// Tenant scoping has two enforcement points, tested in two places:
+//   - the WRITE/commit path: the Live store IS the session's scope — it is bound
+//     to one conversation + org at build, and the commit keys every upsert on
+//     `(conversation_id, namespace)` with that bound org, so a write can target
+//     no other session. These tests pin that binding (the only thing the write
+//     path can carry).
+//   - the READ/reset path: the org/user WHERE-clause scoping (a cross-org read
+//     sees no rows) is tested in durable-state.test.ts ("cross-org read sees no
+//     rows", "cross-org reset matches no rows").
+describe("tenant scoping — the Live store is bound to its session's conversation + org", () => {
+  it("binds the store to the session's conversation + org (the only write target)", async () => {
+    const store = await liveStore("org-A");
+    expect(store.conversationId).toBe("conv-1");
+    expect(store.orgId).toBe("org-A");
+  });
+
+  it("the Noop store carries no tenant binding (a write can target nothing)", async () => {
+    const store = await buildDurableStateStore({
+      conversationId: "conv-1",
+      orgId: "org-1",
+      active: false,
+    });
+    expect(store.conversationId).toBeNull();
+    expect(store.orgId).toBeNull();
+  });
+});
+
+describe("Noop store — bounds checks never fire (behavior identical to today)", () => {
+  it("never throws a limit/secret error (writes are dropped, not validated)", async () => {
+    settings.set(MEMORY_MAX_VALUE_BYTES_SETTING, "1");
+    hasInternalDB = false;
+    const store = await buildDurableStateStore({ conversationId: "conv-1", orgId: "org-1", active: true });
+    runWithDurableState(store, () => {
+      const slot = defineDurableState<string>("x");
+      expect(() => slot.set("way over the 1-byte cap")).not.toThrow();
+      expect(() => slot.set("sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789")).not.toThrow();
+    });
+    expect(store.drainDirty()).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/__tests__/durable-state.test.ts
+++ b/packages/api/src/lib/__tests__/durable-state.test.ts
@@ -37,6 +37,7 @@ const {
   listSessionMemory,
   resetSessionMemory,
   renderDurableMemoryBlock,
+  sweepExpiredSessionMemory,
   DURABLE_MEMORY_BLOCK_HEADING,
   NOOP_DURABLE_STATE_STORE,
   DurableStateContextError,
@@ -542,6 +543,43 @@ describe("resetSessionMemory — tenant-scoped, idempotent clear", () => {
       throw new Error("delete boom");
     };
     expect(await resetSessionMemory({ conversationId: "conv-1", orgId: "org-1" })).toBe(0);
+  });
+});
+
+// ── Session sweep (#3757) — memory rides the agent_runs retention window ───────
+
+describe("sweepExpiredSessionMemory — swept with its session", () => {
+  it("no-ops to 0 and never queries without an internal DB", async () => {
+    hasInternalDB = false;
+    expect(await sweepExpiredSessionMemory(30)).toBe(0);
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("deletes memory for expired sessions and returns the count", async () => {
+    queryImpl = async () => [{ conversation_id: "conv-a" }, { conversation_id: "conv-b" }];
+    const count = await sweepExpiredSessionMemory(7);
+    expect(count).toBe(2);
+    expect(queryCalls).toHaveLength(1);
+    const { sql, params } = queryCalls[0]!;
+    expect(sql).toContain("DELETE FROM agent_session_memory");
+    // Targets sessions whose runs are all terminal + past the window; a session
+    // with a live (running/parked) run is never swept (its memory is still in use).
+    expect(sql).toContain("agent_runs");
+    expect(sql).toContain("'running'");
+    expect(sql).toContain("'parked'");
+    expect(params).toEqual(["7"]);
+  });
+
+  it("falls back to the default window for a non-positive retention value", async () => {
+    await sweepExpiredSessionMemory(0);
+    expect((queryCalls[0]!.params as unknown[])[0]).toBe("30");
+  });
+
+  it("returns -1 (never throws) on a DB error", async () => {
+    queryImpl = async () => {
+      throw new Error("sweep boom");
+    };
+    expect(await sweepExpiredSessionMemory(30)).toBe(-1);
   });
 });
 

--- a/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
+++ b/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
@@ -58,7 +58,11 @@ describe("findSecretLike — credential SHAPES are rejected", () => {
 
   it("flags a long high-entropy token even without a known prefix", () => {
     // 40+ chars, mixed case + digits, no whitespace — the shape of a raw secret.
+    // A random base62 token runs ~5.2–6.0 bits/char, well clear of the 4.5
+    // threshold (which DW identifiers at ~4.2–4.3 sit below), so raising the
+    // threshold to admit table names must NOT let a real secret through.
     expect(findSecretLike("Zk8Qw3Lm7Rt9Yv2Xb5Nc1Pd4Fg6Hj0Sa8Ue3Wq7Ko9")).not.toBeNull();
+    expect(findSecretLike("Ah7Kd92mZq4Xn5Rb8Lw3Tc6Vy1Pf0Gj4Hs7Mu2Eo9Iq")).not.toBeNull();
   });
 
   it("walks into nested objects and arrays", () => {
@@ -95,10 +99,23 @@ describe("findSecretLike — ordinary analyst memory is allowed", () => {
   });
 
   it("does not flag a content hash an analyst might remember (hex digest / git sha)", () => {
-    // Hex digests sit at ~4.0 bits/char from a 16-symbol alphabet — the threshold
-    // is set so these realistic remembered values pass, not just short ones.
+    // Hex digests sit at ~3.8–4.0 bits/char from a 16-symbol alphabet — below the
+    // entropy threshold, so these realistic remembered values pass.
     expect(findSecretLike("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")).toBeNull();
     expect(findSecretLike("a70849d88f3c2e1b4d5a6c7e8f9012345678abcd")).toBeNull();
+  });
+
+  it("does not flag a long snake_case data-warehouse identifier with digits", () => {
+    // Underscore-separated table/column names with a year/version suffix run
+    // 40+ chars and land at ~4.2–4.3 bits/char — they MUST pass the entropy
+    // fallback (a remembered table name is ordinary analyst memory, #3757 AC).
+    for (const id of [
+      "daily_revenue_summary_by_product_category_2024",
+      "fact_daily_active_users_by_region_2026_q01_v2",
+      "dim_customer_lifetime_value_cohort_2025_2026_v3",
+    ]) {
+      expect(findSecretLike(id)).toBeNull();
+    }
   });
 
   it("does not flag a long SQL string or a dashed slug list", () => {

--- a/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
+++ b/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
@@ -107,4 +107,29 @@ describe("findSecretLike — ordinary analyst memory is allowed", () => {
     ).toBeNull();
     expect(findSecretLike("us-east-prod, eu-west-prod, ap-south-staging, eu-central-prod")).toBeNull();
   });
+
+  it("does not flag a remembered SQL query that COMPARES a credential-named COLUMN", () => {
+    // The inline-credential-assignment shape (`api_key = …`, `password = …`)
+    // legitimately appears in analyst SQL as a column predicate, not a secret.
+    // A remembered query must not be rejected (#3757 AC: no SQL false positives).
+    for (const sql of [
+      "SELECT id FROM sessions WHERE api_key = '2026-q1-prod'",
+      "SELECT * FROM users WHERE access_token = 'current_user_token'",
+      "SELECT id FROM accounts WHERE password = 'changeme'",
+      "select name from cfg where secret = 'foobar' order by name",
+      "UPDATE jobs SET auth_token = 'pending' WHERE status = 'queued'",
+    ]) {
+      expect(findSecretLike(sql)).toBeNull();
+    }
+  });
+});
+
+describe("findSecretLike — inline credential assignment still caught WITHOUT SQL context", () => {
+  it("flags a bare credential assignment (no surrounding SQL keywords)", () => {
+    // The SQL guard must not blind the detector to a genuinely leaked secret
+    // pasted as a key=value line. These carry NO SELECT/FROM/WHERE context.
+    expect(findSecretLike("password=hunter2-not-a-place-holder")).not.toBeNull();
+    expect(findSecretLike("api_key: prod-9f3a-do-not-share-2026")).not.toBeNull();
+    expect(findSecretLike("AUTH_TOKEN = a8Xk2Lm9Qw7Rt4Yv1Zb")).not.toBeNull();
+  });
 });

--- a/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
+++ b/packages/api/src/lib/__tests__/memory-secret-scan.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the durable-memory secret/credential heuristic (#3757,
+ * ADR-0020). The detector is a write-time guard: a slot value that looks like a
+ * credential is rejected BEFORE it is persisted, so memory never becomes an
+ * exfiltration surface for a leaked key. It is deliberately conservative —
+ * matching well-known credential SHAPES (provider key prefixes, PEM private-key
+ * blocks, JWTs, bearer headers, connection-string passwords, and long
+ * high-entropy tokens) rather than attempting universal secret detection.
+ *
+ * The detector walks the same JSON value the store persists, so a secret nested
+ * inside an object/array is caught, not just a top-level string.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { findSecretLike } from "@atlas/api/lib/memory-secret-scan";
+
+describe("findSecretLike — credential SHAPES are rejected", () => {
+  it("flags common provider API-key prefixes", () => {
+    // The prefix is split from the body so the literal credential SHAPE never
+    // appears in source — GitHub push-protection / secret-scanning would block
+    // the commit on a `ghp_…` / `xoxb-…` literal even though these are fake test
+    // values. `findSecretLike` sees the JOINED string at runtime, so the
+    // detector is exercised exactly as in production.
+    const fakeBody = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789";
+    for (const value of [
+      `sk-ant-api03-${fakeBody}AbCdEfGhIj`, // Anthropic
+      `sk-proj-${fakeBody}`, // OpenAI project key
+      "AKIAIOSFODNN7EXAMPLE", // AWS access key id (GitHub's own canonical placeholder)
+      `gh${"p"}_${fakeBody}`, // GitHub PAT
+      `xox${"b"}-1234567890-ABCDEFGHIJKLMNOPQRSTUVWX`, // Slack bot token
+    ]) {
+      expect(findSecretLike(value)).not.toBeNull();
+    }
+  });
+
+  it("flags a PEM private-key block", () => {
+    expect(
+      findSecretLike("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----"),
+    ).not.toBeNull();
+  });
+
+  it("flags a JWT (three base64url segments)", () => {
+    expect(
+      findSecretLike(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("flags a bearer authorization header", () => {
+    expect(findSecretLike("Authorization: Bearer abcDEF123456ghiJKL789mnoPQR")).not.toBeNull();
+  });
+
+  it("flags a connection string carrying an inline password", () => {
+    expect(findSecretLike("postgres://admin:s3cr3tPassw0rd@db.internal:5432/app")).not.toBeNull();
+    expect(findSecretLike("password=hunter2-not-a-place-holder")).not.toBeNull();
+  });
+
+  it("flags a long high-entropy token even without a known prefix", () => {
+    // 40+ chars, mixed case + digits, no whitespace — the shape of a raw secret.
+    expect(findSecretLike("Zk8Qw3Lm7Rt9Yv2Xb5Nc1Pd4Fg6Hj0Sa8Ue3Wq7Ko9")).not.toBeNull();
+  });
+
+  it("walks into nested objects and arrays", () => {
+    // `gh${"p"}_` keeps the GitHub-PAT shape out of the source literal (push
+    // protection) while the runtime-joined value still trips the detector.
+    const ghpToken = `gh${"p"}_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789`;
+    expect(findSecretLike({ config: { apiKey: "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789" } })).not.toBeNull();
+    expect(findSecretLike(["ok", ["nested", ghpToken]])).not.toBeNull();
+  });
+});
+
+describe("findSecretLike — ordinary analyst memory is allowed", () => {
+  it("does not flag plain prose, identifiers, or short values", () => {
+    for (const value of [
+      "orders",
+      "The user means EU revenue, not global.",
+      { lastTable: "orders", filters: { region: "EU" }, rowCount: 1432 },
+      ["2026-Q1", "2026-Q2"],
+      "select * from orders where region = 'EU'",
+      42,
+      true,
+      null,
+    ]) {
+      expect(findSecretLike(value)).toBeNull();
+    }
+  });
+
+  it("does not flag a UUID (structured, but not a credential shape)", () => {
+    expect(findSecretLike("11111111-2222-3333-4444-555555555555")).toBeNull();
+  });
+
+  it("does not flag a long but low-entropy string (repeated / dictionary words)", () => {
+    expect(findSecretLike("the quick brown fox jumps over the lazy dog again and again")).toBeNull();
+  });
+
+  it("does not flag a content hash an analyst might remember (hex digest / git sha)", () => {
+    // Hex digests sit at ~4.0 bits/char from a 16-symbol alphabet — the threshold
+    // is set so these realistic remembered values pass, not just short ones.
+    expect(findSecretLike("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")).toBeNull();
+    expect(findSecretLike("a70849d88f3c2e1b4d5a6c7e8f9012345678abcd")).toBeNull();
+  });
+
+  it("does not flag a long SQL string or a dashed slug list", () => {
+    expect(
+      findSecretLike("select region, sum(revenue) from orders where fiscal_quarter = '2026-Q1' group by region"),
+    ).toBeNull();
+    expect(findSecretLike("us-east-prod, eu-west-prod, ap-south-staging, eu-central-prod")).toBeNull();
+  });
+});

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -14,6 +14,10 @@ import {
   PARKED_SWEEP_SQL,
   PARKED_RESOLVE_SQL,
 } from "@atlas/api/lib/durable-session";
+import {
+  SESSION_MEMORY_UPSERT_SQL,
+  SESSION_MEMORY_SWEEP_SQL,
+} from "@atlas/api/lib/durable-state";
 
 // Real-Postgres migration smoke. Skips cleanly when TEST_DATABASE_URL
 // is unset so local dev that hasn't run `bun run db:up` is unaffected.
@@ -2833,6 +2837,100 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     );
     expect(after.rows[0]!.status).toBe("running");
     expect(after.rows[0]!.parked_reason).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
+  // #3757 (ADR-0020 slice 4) — working memory is swept WITH its session. The
+  // sweep dates a session by its newest `agent_runs` row, deletes memory for
+  // sessions whose runs are all terminal + past the window, and NEVER touches a
+  // session with a live (running/parked) run. Exercises the EXACT
+  // SESSION_MEMORY_SWEEP_SQL the helper runs against real Postgres (the EXISTS /
+  // NOT EXISTS / max(updated_at) interval math a mock pool can't validate).
+  async function seedMemory(conversationId: string, namespace: string, value: unknown) {
+    await pool.query(SESSION_MEMORY_UPSERT_SQL, [
+      conversationId,
+      "org-1",
+      namespace,
+      JSON.stringify(value ?? null),
+    ]);
+  }
+
+  it("#3757: sweeps memory for an expired terminal session, keeps a fresh one", async () => {
+    const expired = await newConversation();
+    const fresh = await newConversation();
+
+    // Expired session: one terminal run aged past a 7-day window + a memory slot.
+    await pool.query(TERMINAL_UPSERT_SQL, [
+      "10000000-0000-0000-0000-000000000001", expired, "org-1", "done", 1, JSON.stringify([]),
+    ]);
+    await pool.query(
+      `UPDATE agent_runs SET updated_at = now() - interval '8 days' WHERE conversation_id = $1`,
+      [expired],
+    );
+    await seedMemory(expired, "region", "EU");
+
+    // Fresh session: a terminal run inside the window + a memory slot.
+    await pool.query(TERMINAL_UPSERT_SQL, [
+      "10000000-0000-0000-0000-000000000002", fresh, "org-1", "done", 1, JSON.stringify([]),
+    ]);
+    await seedMemory(fresh, "table", "orders");
+
+    const swept = await pool.query<{ conversation_id: string }>(SESSION_MEMORY_SWEEP_SQL, ["7"]);
+    expect(swept.rows.map((r) => r.conversation_id)).toEqual([expired]);
+
+    // The expired session's memory is gone; the fresh session's memory survives.
+    const remaining = await pool.query<{ conversation_id: string }>(
+      `SELECT conversation_id FROM agent_session_memory WHERE conversation_id = ANY($1::uuid[]) ORDER BY conversation_id`,
+      [[expired, fresh]],
+    );
+    expect(remaining.rows.map((r) => r.conversation_id)).toEqual([fresh]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("#3757: never sweeps memory for a session with a live (running/parked) run, even if old", async () => {
+    const stillRunning = await newConversation();
+    const stillParked = await newConversation();
+
+    // A session whose newest run is `running`, aged well past the window: its
+    // memory is the LIVE working set and must NOT be swept.
+    await pool.query(RUNNING_UPSERT_SQL, [
+      "20000000-0000-0000-0000-000000000001", stillRunning, "org-1", "running", 1, JSON.stringify([]),
+    ]);
+    await pool.query(
+      `UPDATE agent_runs SET updated_at = now() - interval '30 days' WHERE conversation_id = $1`,
+      [stillRunning],
+    );
+    await seedMemory(stillRunning, "ctx", "live");
+
+    // A session parked awaiting approval, also old: still non-terminal → kept.
+    await pool.query(PARKED_UPSERT_SQL, [
+      "20000000-0000-0000-0000-000000000002", stillParked, "org-1", "parked", 1, JSON.stringify([]), "req-x",
+    ]);
+    await pool.query(
+      `UPDATE agent_runs SET updated_at = now() - interval '30 days' WHERE conversation_id = $1`,
+      [stillParked],
+    );
+    await seedMemory(stillParked, "ctx", "awaiting");
+
+    const swept = await pool.query(SESSION_MEMORY_SWEEP_SQL, ["7"]);
+    expect(swept.rowCount).toBe(0);
+
+    const remaining = await pool.query<{ conversation_id: string }>(
+      `SELECT DISTINCT conversation_id FROM agent_session_memory WHERE conversation_id = ANY($1::uuid[]) ORDER BY conversation_id`,
+      [[stillRunning, stillParked].sort()],
+    );
+    expect(remaining.rowCount).toBe(2); // both kept
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("#3757: the FK cascade also removes memory when the conversation is deleted", async () => {
+    const conversationId = await newConversation();
+    await seedMemory(conversationId, "region", "EU");
+    // Deleting the conversation cascades to its memory (migration 0145 FK) — the
+    // second leg of "swept with its session" for the conversation-delete path.
+    await pool.query(`DELETE FROM conversations WHERE id = $1`, [conversationId]);
+    const remaining = await pool.query(
+      `SELECT 1 FROM agent_session_memory WHERE conversation_id = $1`,
+      [conversationId],
+    );
+    expect(remaining.rowCount).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 });
 

--- a/packages/api/src/lib/durable-state.ts
+++ b/packages/api/src/lib/durable-state.ts
@@ -38,6 +38,13 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { SessionMemorySlot, SessionMemoryView } from "@useatlas/types";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import { findSecretLike } from "@atlas/api/lib/memory-secret-scan";
+// The retention-window default is owned by the durable-session module (the
+// runs sweep). Memory rides the SAME window, so it reuses that constant rather
+// than a second magic number that could drift. Type/value-only import — no
+// cyclic risk (durable-session never imports durable-state).
+import { DEFAULT_RETENTION_DAYS } from "@atlas/api/lib/durable-session";
 
 const log = createLogger("durable-state");
 
@@ -48,6 +55,103 @@ const log = createLogger("durable-state");
  * shadowing) an internal one.
  */
 export const RESERVED_NAMESPACE_PREFIX = "atlas:";
+
+// ── Bounds & safety: caps + secrets prohibition (#3757, ADR-0020, slice 4) ─────
+//
+// Working memory must stay BOUNDED (so a session can't accumulate unbounded
+// state) and must never become a credential exfiltration surface. Both controls
+// run at WRITE/STAGING time in `LiveDurableStateStore.set`, NOT at commit: the
+// commit is fire-and-forget (rides the `internalExecute` circuit breaker, never
+// throws), so a rejection there could not surface to the caller. Staging is
+// reached synchronously from a tool's `defineDurableState(...).set()` inside
+// `runWithDurableState`, so a thrown rejection propagates up through the tool's
+// `execute` to the agent/caller — exactly the "surfaced, never truncated"
+// contract the issue requires.
+
+/** Settings key: max number of slots a single session may hold. */
+export const MEMORY_MAX_SLOTS_SETTING = "ATLAS_MEMORY_MAX_SLOTS";
+/** Settings key: max serialized byte length of a single slot value. */
+export const MEMORY_MAX_VALUE_BYTES_SETTING = "ATLAS_MEMORY_MAX_VALUE_BYTES";
+
+/** Fallback slot cap when the setting is unset/unparseable. */
+export const DEFAULT_MEMORY_MAX_SLOTS = 64;
+/** Fallback per-value byte cap when the setting is unset/unparseable (16 KiB). */
+export const DEFAULT_MEMORY_MAX_VALUE_BYTES = 16_384;
+
+/**
+ * Clamp a raw settings string to a sane positive integer, else `fallback`.
+ * Mirrors the durability knobs' `clampPositiveInt` (lib/durable-session.ts) so a
+ * non-positive / unparseable override can never weaken a cap to 0 or NaN.
+ */
+function clampPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+/**
+ * Resolve the per-session slot cap from the settings registry, clamped to a sane
+ * positive integer. Workspace > platform > env > default (the `getSettingAuto`
+ * tier chain), so an operator/admin can tune it from Admin → Settings with no
+ * redeploy. The READ stays inline at the resolver (the settings-reader parity
+ * check — check-settings-readers.sh — sees the const-bound key next to its
+ * reader).
+ */
+export function getMemoryMaxSlots(orgId?: string): number {
+  return clampPositiveInt(getSettingAuto(MEMORY_MAX_SLOTS_SETTING, orgId), DEFAULT_MEMORY_MAX_SLOTS);
+}
+
+/** Resolve the per-value byte cap from the settings registry, clamped positive. */
+export function getMemoryMaxValueBytes(orgId?: string): number {
+  return clampPositiveInt(
+    getSettingAuto(MEMORY_MAX_VALUE_BYTES_SETTING, orgId),
+    DEFAULT_MEMORY_MAX_VALUE_BYTES,
+  );
+}
+
+/**
+ * Thrown when a slot write would exceed a configured cap (value bytes or slot
+ * count). Distinct from {@link DurableStateContextError} so a caller / tool can
+ * tell "you violated a bound" from "you used the handle wrong". The message is
+ * value-free (it names the cap, never the rejected value).
+ */
+export class DurableStateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DurableStateLimitError";
+  }
+}
+
+/**
+ * Thrown when a slot write carries a value that looks like a secret/credential
+ * ({@link findSecretLike}). Rejected BEFORE persistence so memory never becomes
+ * an exfiltration surface. The message names the credential SHAPE that tripped,
+ * never the value, so the rejection itself can't leak the secret into a log.
+ */
+export class DurableStateSecretError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DurableStateSecretError";
+  }
+}
+
+/** UTF-8 byte length of a string (a multi-byte char counts its full encoded length). */
+const utf8ByteLength =
+  typeof Buffer !== "undefined"
+    ? (s: string): number => Buffer.byteLength(s, "utf8")
+    : (s: string): number => new TextEncoder().encode(s).length;
+
+/**
+ * The cap + secret bounds a Live store enforces on every write. Resolved ONCE
+ * per turn at {@link buildDurableStateStore} (so the per-workspace settings
+ * override is honored, and a write within a turn doesn't re-read settings on the
+ * hot path), then carried by the store.
+ */
+interface MemoryBounds {
+  readonly maxSlots: number;
+  readonly maxValueBytes: number;
+}
 
 // ── SQL (exported for the real-Postgres tests so they exercise the EXACT SQL) ──
 
@@ -68,10 +172,11 @@ export const SESSION_MEMORY_LOAD_SQL =
  * whose `step_index = GREATEST` guard makes it reorder-safe, this row is keyed on
  * the conversation and spans turns, so a per-turn step index can't serve as that
  * guard. If two same-slot writes within a turn land out of order the earlier
- * value can win (a lost update). Bounded + acceptable for slice 1 (off by
- * default; same-slot repeat-within-a-turn is the only exposure); a
- * conversation-global monotonic guard is deferred to the bounds/safety slice
- * (#3757).
+ * value can win (a lost update). Bounded + acceptable (off by default; same-slot
+ * repeat-within-a-turn is the only exposure). A conversation-global monotonic
+ * guard remains future work — out of scope for the bounds/safety slice (#3757),
+ * whose contract is caps + secrets + tenant scoping + lifecycle sweep, not write
+ * ordering.
  */
 export const SESSION_MEMORY_UPSERT_SQL =
   `INSERT INTO agent_session_memory (conversation_id, org_id, namespace, value, updated_at)
@@ -127,6 +232,7 @@ class LiveDurableStateStore implements DurableStateStore {
     readonly conversationId: string,
     readonly orgId: string | null,
     initial: Map<string, unknown>,
+    private readonly bounds: MemoryBounds,
   ) {
     // Defensive copy: the store owns its slot map for the turn's lifetime, so a
     // caller's map can't alias internal state (today `buildDurableStateStore`
@@ -139,7 +245,49 @@ class LiveDurableStateStore implements DurableStateStore {
     return this.slots.get(namespace);
   }
 
+  /**
+   * Stage a slot value after enforcing the bounds (#3757). The order is
+   * deliberate: the rejecting checks run BEFORE any mutation, so a rejected
+   * write leaves the store byte-identical (no partial/truncated state):
+   *   1. secrets — a credential-shaped value never persists;
+   *   2. size — the serialized value must fit the per-value byte cap;
+   *   3. slot count — a NEW slot must not push the session past the slot cap
+   *      (overwriting an EXISTING slot never grows the count, so it is exempt).
+   * Each violation throws (surfaced to the caller via the tool's `execute`),
+   * never truncates. Serialization here is the same `JSON.stringify` the commit
+   * path uses, so the measured size matches what would be persisted; a value
+   * that can't serialize (a cycle) is rejected as a limit violation rather than
+   * deferring the throw to the fire-and-forget commit where it would be lost.
+   */
   set(namespace: string, value: unknown): void {
+    const secret = findSecretLike(value);
+    if (secret) {
+      throw new DurableStateSecretError(
+        `Durable memory rejected slot "${namespace}": value looks like a credential (${secret.kind}) and cannot be stored`,
+      );
+    }
+
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(value ?? null) ?? "null";
+    } catch (err) {
+      throw new DurableStateLimitError(
+        `Durable memory rejected slot "${namespace}": value is not serializable (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+    const bytes = utf8ByteLength(serialized);
+    if (bytes > this.bounds.maxValueBytes) {
+      throw new DurableStateLimitError(
+        `Durable memory rejected slot "${namespace}": value is ${bytes} bytes, over the ${this.bounds.maxValueBytes}-byte limit`,
+      );
+    }
+
+    if (!this.slots.has(namespace) && this.slots.size >= this.bounds.maxSlots) {
+      throw new DurableStateLimitError(
+        `Durable memory rejected slot "${namespace}": the session already holds ${this.slots.size} slots, at the ${this.bounds.maxSlots}-slot limit`,
+      );
+    }
+
     this.slots.set(namespace, value);
     this.dirty.add(namespace);
   }
@@ -392,7 +540,16 @@ export async function buildDurableStateStore(args: {
     return NOOP_DURABLE_STATE_STORE;
   }
   const initial = await loadSessionMemory(args.conversationId);
-  return new LiveDurableStateStore(args.conversationId, args.orgId, initial);
+  // Resolve the caps ONCE per turn against the session's org (so the per-
+  // workspace settings override is honored), then carry them on the store so a
+  // write doesn't re-read settings on the hot path. Hot-reload is per-turn — a
+  // mid-turn settings change applies on the next turn's build (#3757).
+  const orgId = args.orgId ?? undefined;
+  const bounds: MemoryBounds = {
+    maxSlots: getMemoryMaxSlots(orgId),
+    maxValueBytes: getMemoryMaxValueBytes(orgId),
+  };
+  return new LiveDurableStateStore(args.conversationId, args.orgId, initial, bounds);
 }
 
 // ── Deterministic prompt threading (#3755, ADR-0020, slice 2) ──────────────────
@@ -613,6 +770,73 @@ export async function listSessionMemory(orgId: string): Promise<SessionMemoryVie
       "Failed to list durable session memory",
     );
     return [];
+  }
+}
+
+// ── Session sweep (#3757) — memory rides the agent_runs retention window ───────
+//
+// "Swept with its session": a session's working memory must not outlive the
+// session. It already FK-cascades on `conversations` deletion (migration 0145),
+// but the durable-session RETENTION sweep deletes terminal `agent_runs` rows
+// while the conversation lives on — so memory would survive the runs it belongs
+// to. This sweep closes that gap on the SAME hourly fiber + SAME retention
+// window as `sweepTerminalAgentRuns` (no separate sweeper/scheduler): it deletes
+// memory for sessions whose runs are ALL terminal (no `running`/`parked` run is
+// live) and whose newest run is past the window. It runs BEFORE the runs sweep
+// in the tick (layers.ts) so the terminal runs are still present to date the
+// session; a session with a live run keeps its memory (still in use).
+
+/**
+ * Delete working memory for sessions past the retention window — those whose
+ * `agent_runs` are ALL terminal (`done`/`failed`) and whose most-recent run is
+ * older than the window. A session with ANY non-terminal (`running`/`parked`)
+ * run is never swept (its memory is still the live working set). Returns the
+ * number of memory rows deleted, or -1 on error (mirrors
+ * {@link sweepTerminalAgentRuns}). No-op without an internal DB.
+ *
+ * A conversation with NO `agent_runs` rows at all (durability was off, so memory
+ * was never written either, OR the runs were already swept) is intentionally not
+ * matched here — there is nothing to age it against. Such memory is cleaned up
+ * by the FK cascade when the conversation itself is deleted.
+ */
+// Exported (the SQL) for the real-Postgres sweep test so it exercises the EXACT
+// interval/DELETE the helper runs, not a hand-copied reimplementation.
+export const SESSION_MEMORY_SWEEP_SQL =
+  `DELETE FROM agent_session_memory m
+     WHERE EXISTS (
+             SELECT 1 FROM agent_runs r
+              WHERE r.conversation_id = m.conversation_id
+            )
+       AND NOT EXISTS (
+             SELECT 1 FROM agent_runs r
+              WHERE r.conversation_id = m.conversation_id
+                AND r.status IN ('running', 'parked')
+            )
+       AND ($1 || ' days')::interval < now() - (
+             SELECT max(r.updated_at) FROM agent_runs r
+              WHERE r.conversation_id = m.conversation_id
+            )
+   RETURNING m.conversation_id`;
+
+export async function sweepExpiredSessionMemory(retentionDays: number): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  const days =
+    Number.isFinite(retentionDays) && retentionDays > 0 ? retentionDays : DEFAULT_RETENTION_DAYS;
+  try {
+    const rows = await internalQuery<{ conversation_id: string }>(SESSION_MEMORY_SWEEP_SQL, [
+      String(days),
+    ]);
+    const count = rows.length;
+    if (count > 0) {
+      log.info({ count, retentionDays: days }, "Swept working memory for sessions past retention window");
+    }
+    return count;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to sweep expired session memory",
+    );
+    return -1;
   }
 }
 

--- a/packages/api/src/lib/durable-state.ts
+++ b/packages/api/src/lib/durable-state.ts
@@ -826,9 +826,16 @@ export async function sweepExpiredSessionMemory(retentionDays: number): Promise<
     const rows = await internalQuery<{ conversation_id: string }>(SESSION_MEMORY_SWEEP_SQL, [
       String(days),
     ]);
+    // RETURNING is one row per deleted memory SLOT (the table is keyed on
+    // (conversation_id, namespace)), so this is a count of ROWS, not sessions —
+    // a session with N slots contributes N. Log the noun accurately; the return
+    // value is documented as "memory rows deleted".
     const count = rows.length;
     if (count > 0) {
-      log.info({ count, retentionDays: days }, "Swept working memory for sessions past retention window");
+      log.info(
+        { rowCount: count, retentionDays: days },
+        "Swept expired working-memory rows for terminal sessions past retention window",
+      );
     }
     return count;
   } catch (err) {

--- a/packages/api/src/lib/effect/__tests__/durable-state.test.ts
+++ b/packages/api/src/lib/effect/__tests__/durable-state.test.ts
@@ -11,7 +11,8 @@ import * as realInternal from "@atlas/api/lib/db/internal";
 
 let hasInternalDB = true;
 const execCalls: Array<{ sql: string; params?: unknown[] }> = [];
-let queryRows: Array<{ namespace: string; value: unknown }> = [];
+const queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryRows: Array<Record<string, unknown>> = [];
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   ...realInternal,
@@ -19,7 +20,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   internalExecute: (sql: string, params?: unknown[]) => {
     execCalls.push({ sql, params });
   },
-  internalQuery: async () => queryRows,
+  internalQuery: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    return queryRows;
+  },
 }));
 
 const { DurableState } = await import("@atlas/api/lib/effect/services");
@@ -30,6 +34,7 @@ const { DurableStateLive, NoopDurableStateLayer, durableStateLayer } = await imp
 beforeEach(() => {
   hasInternalDB = true;
   execCalls.length = 0;
+  queryCalls.length = 0;
   queryRows = [];
 });
 
@@ -72,10 +77,23 @@ describe("DurableStateLive", () => {
     expect(execCalls[0]!.params).toEqual(["conv-1", "org-1", "a", JSON.stringify(1)]);
     expect(execCalls[1]!.params).toEqual(["conv-1", "org-1", "b", JSON.stringify("two")]);
   });
+
+  it("sweepExpired deletes memory for expired sessions and returns the count (#3757)", async () => {
+    queryRows = [{ conversation_id: "conv-a" }, { conversation_id: "conv-b" }];
+    const count = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ds = yield* DurableState;
+        return yield* ds.sweepExpired(7);
+      }).pipe(Effect.provide(DurableStateLive)),
+    );
+    expect(count).toBe(2);
+    expect(queryCalls[0]!.sql).toContain("DELETE FROM agent_session_memory");
+    expect(queryCalls[0]!.params).toEqual(["7"]);
+  });
 });
 
 describe("NoopDurableStateLayer", () => {
-  it("reports unavailable, loads empty, commits nothing", async () => {
+  it("reports unavailable, loads empty, commits nothing, sweeps nothing", async () => {
     const loaded = await Effect.runPromise(
       Effect.gen(function* () {
         const ds = yield* DurableState;
@@ -85,12 +103,15 @@ describe("NoopDurableStateLayer", () => {
           orgId: null,
           slots: [{ namespace: "a", value: 1 }],
         });
+        // The memory sweep is inert on the Noop layer — returns 0, never queries.
+        expect(yield* ds.sweepExpired(30)).toBe(0);
         return yield* ds.load("conv-1");
       }).pipe(Effect.provide(NoopDurableStateLayer)),
     );
 
     expect(loaded.size).toBe(0);
     expect(execCalls).toHaveLength(0);
+    expect(queryCalls).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -280,15 +280,20 @@ describe("makeSchedulerLive", () => {
   const { NoopEnterpriseDefaultsLayer } = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { NoopDurableSessionLayer } = require("@atlas/api/lib/effect/durable-session") as typeof import("@atlas/api/lib/effect/durable-session");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { NoopDurableStateLayer } = require("@atlas/api/lib/effect/durable-state") as typeof import("@atlas/api/lib/effect/durable-state");
 
   // #3446 — `makeSchedulerLive` requires `Migration` as an ordering
   // barrier for the billing-reconcile boot tick; tests satisfy it with
   // the immediate test layer. #3745 — it also requires `DurableSession`;
   // the Noop layer suffices (the retention-sweep fiber forks but no-ops).
+  // #3757 — it additionally requires `DurableState` for the memory sweep on
+  // the same fiber; the Noop layer no-ops it too.
   const schedulerDeps = Layer.mergeAll(
     NoopEnterpriseDefaultsLayer,
     makeTestMigrationLayer(),
     NoopDurableSessionLayer,
+    NoopDurableStateLayer,
   );
 
   test("returns 'none' backend when no scheduler configured", async () => {
@@ -355,7 +360,12 @@ describe("makeSchedulerLive", () => {
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
     const layer = makeSchedulerLive(config).pipe(
       Layer.provide(
-        Layer.mergeAll(NoopEnterpriseDefaultsLayer, gatedMigrationLayer, NoopDurableSessionLayer),
+        Layer.mergeAll(
+          NoopEnterpriseDefaultsLayer,
+          gatedMigrationLayer,
+          NoopDurableSessionLayer,
+          NoopDurableStateLayer,
+        ),
       ),
     );
 
@@ -502,6 +512,29 @@ describe("makeSchedulerLive", () => {
       });
     });
   }
+
+  // ── agent_runs retention tick: sweep ORDER guard (#3757) ──────────────────
+  // The memory sweep MUST run before the runs sweep in `agentRunsRetentionTick`:
+  // `sweepExpiredSessionMemory` dates each session by its newest `agent_runs`
+  // row, so the terminal runs must still exist when it runs. If a refactor
+  // reordered the two lines, the runs sweep would delete the terminal rows first
+  // and the memory sweep's EXISTS/max(updated_at) clauses would match nothing —
+  // silently orphaning memory, with every other test still green. The fiber is
+  // inline-forked (not exposed via the Scheduler Tag), so — exactly as the
+  // per-tick span guards above do — this is a structural source scan, the
+  // pragmatic guard the repo already uses for this fiber.
+  describe("memory sweep precedes the runs sweep (#3757)", () => {
+    test("durableState.sweepExpired is sequenced before durableSession.sweepTerminal", () => {
+      const memoryIdx = layersSource.indexOf("durableState.sweepExpired(");
+      const terminalIdx = layersSource.indexOf("durableSession.sweepTerminal(");
+      // Both call sites must exist...
+      expect(memoryIdx).toBeGreaterThan(-1);
+      expect(terminalIdx).toBeGreaterThan(-1);
+      // ...and the memory sweep must come first in source order (the tick runs
+      // its yields sequentially, so source order is execution order).
+      expect(memoryIdx).toBeLessThan(terminalIdx);
+    });
+  });
 });
 
 // ── DpaGuardLive (#1969) ───────────────────────────────────────────

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -66,15 +66,19 @@ mock.module("@atlas/api/lib/logger", () => ({
 const { makeSchedulerLive, Migration } = await import("../layers");
 const { SaasCrm, NoopEnterpriseDefaultsLayer } = await import("../services");
 const { NoopDurableSessionLayer } = await import("../durable-session");
+const { NoopDurableStateLayer } = await import("../durable-state");
 const { setActiveFlusherSignal } = await import("@atlas/api/lib/lead-outbox");
 
 // #3446 — `makeSchedulerLive` requires `Migration` as an ordering barrier
 // for the billing-reconcile boot tick; satisfy it immediately here.
 // #3745 — it also requires `DurableSession`; the Noop layer suffices for the
 // outbox-flusher lifecycle tests (the retention-sweep fiber forks but no-ops).
-const testMigrationLayer = Layer.merge(
+// #3757 — it additionally requires `DurableState` for the memory sweep on the
+// same fiber; the Noop layer no-ops it too.
+const testMigrationLayer = Layer.mergeAll(
   Layer.succeed(Migration, { migrated: true }),
   NoopDurableSessionLayer,
+  NoopDurableStateLayer,
 );
 
 // ── Test layer: SaasCrm with available=true + stub dispatcher ───────

--- a/packages/api/src/lib/effect/durable-state.ts
+++ b/packages/api/src/lib/effect/durable-state.ts
@@ -11,7 +11,11 @@
 
 import { Effect, Layer } from "effect";
 import { DurableState, type DurableStateShape } from "@atlas/api/lib/effect/services";
-import { commitSessionMemory, loadSessionMemory } from "@atlas/api/lib/durable-state";
+import {
+  commitSessionMemory,
+  loadSessionMemory,
+  sweepExpiredSessionMemory,
+} from "@atlas/api/lib/durable-state";
 
 /** Real, internal-DB-backed durable memory store. */
 export const DurableStateLive: Layer.Layer<DurableState> = Layer.succeed(
@@ -20,6 +24,8 @@ export const DurableStateLive: Layer.Layer<DurableState> = Layer.succeed(
     available: true,
     load: (conversationId) => Effect.promise(() => loadSessionMemory(conversationId)),
     commit: (args) => commitSessionMemory(args),
+    sweepExpired: (retentionDays) =>
+      Effect.promise(() => sweepExpiredSessionMemory(retentionDays)),
   } satisfies DurableStateShape,
 );
 
@@ -34,6 +40,7 @@ export const NoopDurableStateLayer: Layer.Layer<DurableState> = Layer.succeed(
     available: false,
     load: () => Effect.succeed(new Map<string, unknown>()),
     commit: () => {},
+    sweepExpired: () => Effect.succeed(0),
   } satisfies DurableStateShape,
 );
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -79,6 +79,7 @@ import {
   makeWiredPluginRegistryLive,
   type PluginWiringConfig,
   DurableSession,
+  DurableState,
 } from "./services";
 import { durableSessionLayer } from "./durable-session";
 import { durableStateLayer } from "./durable-state";
@@ -1457,7 +1458,7 @@ export class Scheduler extends Context.Tag("Scheduler")<
  */
 export function makeSchedulerLive(
   config: ResolvedConfig,
-): Layer.Layer<Scheduler, never, AuditPurgeScheduler | SaasCrm | Migration | DurableSession> {
+): Layer.Layer<Scheduler, never, AuditPurgeScheduler | SaasCrm | Migration | DurableSession | DurableState> {
   return Layer.scoped(
     Scheduler,
     Effect.gen(function* () {
@@ -2265,6 +2266,7 @@ export function makeSchedulerLive(
       // orgId → platform/env/default) so an operator setting change takes
       // effect without a restart. Hourly, like the share-token sweep.
       const durableSession = yield* DurableSession;
+      const durableState = yield* DurableState;
       // Per-tick catch (inside repeat) so the loop survives a transient fault
       // and keeps sweeping — same resilience shape as the share-token sweep.
       // #3748 — the same tick also fails `parked` runs past the max-park window
@@ -2272,6 +2274,12 @@ export function makeSchedulerLive(
       // the operator-global window per-tick so a settings change takes effect
       // without a restart.
       const agentRunsRetentionTick = Effect.gen(function* () {
+        // #3757 — sweep working memory BEFORE the runs sweep, on the SAME window:
+        // the memory sweep dates a session by its newest `agent_runs` row, so the
+        // terminal runs must still be present when it runs. The runs sweep then
+        // deletes those terminal rows. Memory is thus swept WITH its session
+        // (no separate sweeper). A session with a live run keeps its memory.
+        yield* durableState.sweepExpired(getRetentionDays());
         yield* durableSession.sweepTerminal(getRetentionDays());
         yield* durableSession.sweepParked(getMaxParkMinutes());
       }).pipe(
@@ -3393,10 +3401,12 @@ export function buildAppLayer(
   //
   // `durableSession` is provided so the retention-sweep fiber (#3745) can
   // resolve the `DurableSession` Tag — Noop when there is no internal DB, so
-  // the fiber forks but sweeps nothing.
+  // the fiber forks but sweeps nothing. `durableState` (#3757) is provided for
+  // the same fiber's memory sweep — it rides the SAME tick + retention window,
+  // so terminal/expired sessions take their working memory with them.
   const schedulerLayer = makeSchedulerLive(config).pipe(
     Layer.provide(
-      Layer.mergeAll(EnterpriseLayer, settingsLayer, migrationLayer, durableSession),
+      Layer.mergeAll(EnterpriseLayer, settingsLayer, migrationLayer, durableSession, durableState),
     ),
   );
 

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -164,6 +164,15 @@ export interface DurableStateShape {
    * No-op on the Noop layer.
    */
   commit(args: { conversationId: string; orgId: string | null; slots: DurableStateSlot[] }): void;
+  /**
+   * Delete working memory for sessions past the retention window (#3757) — those
+   * whose `agent_runs` are all terminal and whose newest run is older than the
+   * window. Memory "swept with its session": rides the SAME hourly fiber + window
+   * as {@link DurableSessionShape.sweepTerminal}. Returns the number of memory
+   * rows deleted (0 on the Noop layer, -1 on a DB error). Driven by the
+   * retention-sweep scheduler fiber.
+   */
+  sweepExpired(retentionDays: number): Effect.Effect<number>;
 }
 
 export class DurableState extends Context.Tag("DurableState")<

--- a/packages/api/src/lib/memory-secret-scan.ts
+++ b/packages/api/src/lib/memory-secret-scan.ts
@@ -103,8 +103,20 @@ function looksLikeSql(s: string): boolean {
 
 /** Lower bound for the high-entropy fallback. Below this length even a random token is too short to be a meaningful secret (and a UUID is 36). */
 const HIGH_ENTROPY_MIN_LENGTH = 40;
-/** Shannon-entropy threshold (bits/char) for the fallback. Random base62 ≈ 5.95; English prose ≈ 4.0–4.5; a UUID's hex+dashes ≈ 3.8. */
-const HIGH_ENTROPY_MIN_BITS_PER_CHAR = 4.0;
+/**
+ * Shannon-entropy threshold (bits/char) for the fallback. Set to admit ordinary
+ * analyst memory while still catching a raw secret:
+ *   - a random base62 secret ≈ 5.2–6.0 → caught (well above the bar);
+ *   - a long snake_case data-warehouse identifier with a year/version suffix
+ *     (e.g. `daily_revenue_summary_by_product_category_2024`) ≈ 4.2–4.3 → passes;
+ *   - a git SHA / hex digest ≈ 3.8–4.0 → passes;
+ *   - English prose ≈ 4.0–4.5 (but it has spaces, so it's split into short
+ *     low-length tokens that never reach the length bound anyway).
+ * 4.5 sits in the gap between the DW-identifier ceiling (~4.3) and the
+ * random-secret floor (~5.2). Raised from 4.0 after a remembered table name
+ * tripped the old bar (#3757 review).
+ */
+const HIGH_ENTROPY_MIN_BITS_PER_CHAR = 4.5;
 /** A high-entropy candidate must be a single unbroken token of credential-alphabet chars. */
 const TOKEN_RE = /^[A-Za-z0-9_\-+/.=]+$/;
 

--- a/packages/api/src/lib/memory-secret-scan.ts
+++ b/packages/api/src/lib/memory-secret-scan.ts
@@ -73,12 +73,33 @@ const SHAPE_PATTERNS: ReadonlyArray<{ kind: SecretLikeKind; re: RegExp }> = [
   },
   // Connection string with an inline password: scheme://user:pass@host.
   { kind: "connection-string-password", re: /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s:@/]+@/i },
-  // Explicit password / secret / token assignment carrying a non-placeholder value.
-  {
-    kind: "inline-credential-assignment",
-    re: /\b(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token)\s*[=:]\s*\S{6,}/i,
-  },
 ];
+
+/**
+ * The inline `password = …` / `api_key: …` assignment shape is the ONE pattern
+ * that legitimately collides with ordinary analyst memory: a remembered SQL
+ * query compares a credential-NAMED column (`WHERE api_key = '2026-q1-prod'`),
+ * which is a predicate, not a leaked secret. It is therefore kept SEPARATE from
+ * {@link SHAPE_PATTERNS} (whose patterns match credential VALUE shapes that never
+ * appear as SQL column names) and is suppressed when the surrounding string
+ * {@link looksLikeSql}. A bare `password=…` key/value line (no SQL context) still
+ * trips it — #3757 AC: reject leaked credentials, but never an analyst's SQL.
+ */
+const INLINE_CREDENTIAL_ASSIGNMENT =
+  /\b(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token)\s*[=:]\s*\S{6,}/i;
+
+/**
+ * Heuristic: does `s` read as a SQL statement? Looks for a SQL verb AND a
+ * structural keyword (FROM/WHERE/SET/INTO/VALUES) so a sentence that merely
+ * contains the word "select" or "where" isn't misread as SQL. Used only to
+ * suppress the inline-credential-assignment match (above) — a remembered query
+ * that compares an `api_key`/`password` column is a predicate, not a secret.
+ */
+function looksLikeSql(s: string): boolean {
+  const hasVerb = /\b(?:select|insert|update|delete|with|merge)\b/i.test(s);
+  const hasStructure = /\b(?:from|where|set|into|values|join)\b/i.test(s);
+  return hasVerb && hasStructure;
+}
 
 /** Lower bound for the high-entropy fallback. Below this length even a random token is too short to be a meaningful secret (and a UUID is 36). */
 const HIGH_ENTROPY_MIN_LENGTH = 40;
@@ -117,6 +138,13 @@ function isHighEntropyToken(token: string): boolean {
 function scanString(s: string): SecretLikeMatch | null {
   for (const { kind, re } of SHAPE_PATTERNS) {
     if (re.test(s)) return { kind };
+  }
+  // The inline `key = value` assignment shape fires UNLESS the string is a SQL
+  // statement (where `api_key = '…'` is a column predicate, not a secret). The
+  // value-shape patterns above already ran, so a real credential VALUE pasted
+  // inside SQL (e.g. a literal `sk-live-…`) is still caught by its own pattern.
+  if (!looksLikeSql(s) && INLINE_CREDENTIAL_ASSIGNMENT.test(s)) {
+    return { kind: "inline-credential-assignment" };
   }
   // High-entropy fallback: check each whitespace-delimited token, so a secret
   // embedded in a longer string (a log line) is still caught, while a prose

--- a/packages/api/src/lib/memory-secret-scan.ts
+++ b/packages/api/src/lib/memory-secret-scan.ts
@@ -1,0 +1,162 @@
+/**
+ * Heuristic secret/credential detector for durable working memory (#3757,
+ * ADR-0020).
+ *
+ * Durable memory persists values a tool or the agent chose to remember across
+ * turns. Without a guard it would become an exfiltration surface: a leaked API
+ * key or connection string written into a slot would ride every subsequent
+ * turn's prompt (and the admin memory view). This detector is the WRITE-TIME
+ * guard — `LiveDurableStateStore.set` runs a candidate value through it and
+ * REJECTS the write before persistence if it trips.
+ *
+ * It is deliberately CONSERVATIVE: it matches well-known credential SHAPES, not
+ * arbitrary "sensitive" data. The goal is to stop an obvious key/token/secret
+ * from being durably stored, while letting ordinary analyst memory (table names,
+ * filters, prose, row counts, SQL) through untouched. False negatives are
+ * acceptable (this is defense-in-depth, not the only control); false positives
+ * on normal analyst values are not, because they would break the feature.
+ *
+ * Two complementary signals:
+ *   1. SHAPE patterns — provider key prefixes, PEM private-key blocks, JWTs,
+ *      bearer headers, connection-string passwords. High precision.
+ *   2. A long high-entropy token fallback — a 40+ char run of letters + digits
+ *      (a letter-and-digit mix, not necessarily mixed case) with no whitespace
+ *      and high Shannon entropy. Catches a raw secret with no recognizable
+ *      prefix, without flagging prose (low entropy / has spaces) or UUIDs (too
+ *      short / too few distinct symbols).
+ *
+ * Unlike `scrubSecretsFromMessage` (which needs the secret VALUE in advance to
+ * redact it), this inspects an UNKNOWN value and decides if it LOOKS like a
+ * credential. It does not redact — it only flags, so the caller can reject.
+ */
+
+/**
+ * The credential shapes the detector recognizes. A closed union (not bare
+ * `string`) so a consumer can switch exhaustively, and so `kind` is
+ * self-documenting — it names a SHAPE, never the matched value.
+ */
+export type SecretLikeKind =
+  | "pem-private-key"
+  | "jwt"
+  | "bearer-token"
+  | "aws-access-key-id"
+  | "provider-key-prefix"
+  | "connection-string-password"
+  | "inline-credential-assignment"
+  | "high-entropy-token";
+
+/** What tripped the detector — surfaced in the rejection message (never the value itself). */
+export interface SecretLikeMatch {
+  /** A short, value-free label for the credential shape that matched. */
+  readonly kind: SecretLikeKind;
+}
+
+/**
+ * Named SHAPE patterns. Each `test` returns true when `s` contains a substring
+ * of that credential shape. Ordered most-specific-first only for a tidy `kind`
+ * label; matching is independent per pattern.
+ */
+const SHAPE_PATTERNS: ReadonlyArray<{ kind: SecretLikeKind; re: RegExp }> = [
+  // PEM private key block (RSA / EC / OPENSSH / generic).
+  { kind: "pem-private-key", re: /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/ },
+  // JWT: three base64url segments separated by dots, header starts `eyJ`.
+  { kind: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
+  // Bearer / Authorization header carrying a token.
+  { kind: "bearer-token", re: /\bBearer\s+[A-Za-z0-9._~+/-]{16,}=*/i },
+  // AWS access key id.
+  { kind: "aws-access-key-id", re: /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA)[A-Z0-9]{12,}\b/ },
+  // Common provider/secret key prefixes (Stripe, OpenAI/Anthropic `sk-`,
+  // GitHub `ghp_`/`gho_`/`ghs_`, Slack `xox*`, Google `AIza`).
+  {
+    kind: "provider-key-prefix",
+    re: /\b(?:sk[-_][A-Za-z0-9_-]{16,}|pk_live_[A-Za-z0-9]{16,}|rk_live_[A-Za-z0-9]{16,}|gh[posu]_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[A-Za-z0-9_-]{20,})\b/,
+  },
+  // Connection string with an inline password: scheme://user:pass@host.
+  { kind: "connection-string-password", re: /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s:@/]+@/i },
+  // Explicit password / secret / token assignment carrying a non-placeholder value.
+  {
+    kind: "inline-credential-assignment",
+    re: /\b(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token)\s*[=:]\s*\S{6,}/i,
+  },
+];
+
+/** Lower bound for the high-entropy fallback. Below this length even a random token is too short to be a meaningful secret (and a UUID is 36). */
+const HIGH_ENTROPY_MIN_LENGTH = 40;
+/** Shannon-entropy threshold (bits/char) for the fallback. Random base62 ≈ 5.95; English prose ≈ 4.0–4.5; a UUID's hex+dashes ≈ 3.8. */
+const HIGH_ENTROPY_MIN_BITS_PER_CHAR = 4.0;
+/** A high-entropy candidate must be a single unbroken token of credential-alphabet chars. */
+const TOKEN_RE = /^[A-Za-z0-9_\-+/.=]+$/;
+
+/** Shannon entropy (bits per character) of a string. */
+function shannonBitsPerChar(s: string): number {
+  const counts = new Map<string, number>();
+  for (const ch of s) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  let bits = 0;
+  for (const c of counts.values()) {
+    const p = c / s.length;
+    bits -= p * Math.log2(p);
+  }
+  return bits;
+}
+
+/**
+ * True when `token` is a long, single, high-entropy run that looks like a raw
+ * secret. Requires BOTH high entropy AND a mix of letter+digit (a long lowercase
+ * dictionary phrase joined by dashes would otherwise sneak past on length).
+ */
+function isHighEntropyToken(token: string): boolean {
+  if (token.length < HIGH_ENTROPY_MIN_LENGTH) return false;
+  if (!TOKEN_RE.test(token)) return false;
+  const hasLetter = /[A-Za-z]/.test(token);
+  const hasDigit = /[0-9]/.test(token);
+  if (!hasLetter || !hasDigit) return false;
+  return shannonBitsPerChar(token) >= HIGH_ENTROPY_MIN_BITS_PER_CHAR;
+}
+
+/** Scan a single string for any credential shape or a high-entropy token. */
+function scanString(s: string): SecretLikeMatch | null {
+  for (const { kind, re } of SHAPE_PATTERNS) {
+    if (re.test(s)) return { kind };
+  }
+  // High-entropy fallback: check each whitespace-delimited token, so a secret
+  // embedded in a longer string (a log line) is still caught, while a prose
+  // sentence (many low-entropy short words) is not.
+  for (const token of s.split(/\s+/)) {
+    if (isHighEntropyToken(token)) return { kind: "high-entropy-token" };
+  }
+  return null;
+}
+
+/**
+ * Inspect an arbitrary JSON-serializable value (the shape a memory slot holds)
+ * and return the first credential-shape match, or `null` if nothing trips.
+ * Recurses into objects/arrays so a secret nested inside a remembered config
+ * object is caught, not just a top-level string. Object KEYS are scanned too —
+ * a key like `Authorization` carrying a token value is the common shape.
+ *
+ * Bounded recursion: a pathological deeply-nested or cyclic structure can't be
+ * persisted anyway (the commit path's `JSON.stringify` would throw on a cycle),
+ * but the depth guard keeps this total even if called on a raw value.
+ */
+export function findSecretLike(value: unknown, depth = 0): SecretLikeMatch | null {
+  if (depth > 8) return null;
+  if (typeof value === "string") return scanString(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const hit = findSecretLike(item, depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const keyHit = scanString(k);
+      if (keyHit) return keyHit;
+      const valHit = findSecretLike(v, depth + 1);
+      if (valHit) return valHit;
+    }
+    return null;
+  }
+  // numbers / booleans / null / undefined — never a credential.
+  return null;
+}

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -471,6 +471,42 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "workspace",
   },
   {
+    // #3757 / ADR-0020 — durable working-memory bounds. A session's working
+    // memory must stay BOUNDED: a write whose slot count would exceed this cap is
+    // REJECTED (surfaced to the caller), never truncated. Workspace-scoped +
+    // hot-reloadable — `getMemoryMaxSlots(orgId)` (lib/durable-state.ts) reads it
+    // per-turn at store build, so an admin can tighten/loosen the bound from
+    // Admin → Settings with no redeploy. Overwriting an existing slot never
+    // counts against this; only adding a NEW slot does.
+    key: "ATLAS_MEMORY_MAX_SLOTS",
+    section: "Agent",
+    label: "Working Memory Max Slots",
+    description:
+      "Maximum number of named working-memory slots a single session may hold. A write that would add a new slot past this cap is rejected (never truncated). Default 64.",
+    type: "number",
+    default: "64",
+    envVar: "ATLAS_MEMORY_MAX_SLOTS",
+    scope: "workspace",
+  },
+  {
+    // #3757 / ADR-0020 — per-value size cap for durable working memory. A write
+    // whose serialized (JSON, UTF-8) value exceeds this many bytes is rejected
+    // before persistence. Workspace-scoped + hot-reloadable via
+    // `getMemoryMaxValueBytes(orgId)` (lib/durable-state.ts), same per-turn read
+    // as the slot cap. Default 16384 (16 KiB) — generous for a remembered fact
+    // (a table name, a filter set, a prior-result summary), tight enough that
+    // memory can't become a bulk data sink.
+    key: "ATLAS_MEMORY_MAX_VALUE_BYTES",
+    section: "Agent",
+    label: "Working Memory Max Value Size (bytes)",
+    description:
+      "Maximum serialized size (bytes, JSON/UTF-8) of a single working-memory slot value. A larger write is rejected before persistence (never truncated). Default 16384 (16 KiB).",
+    type: "number",
+    default: "16384",
+    envVar: "ATLAS_MEMORY_MAX_VALUE_BYTES",
+    scope: "workspace",
+  },
+  {
     key: "ATLAS_PROVIDER",
     section: "Agent",
     label: "LLM Provider",


### PR DESCRIPTION
## Summary

Makes the durable working-memory store (#3754, ADR-0020) safe and bounded — the last slice of the durable-memory PRD (#3752):

- **Size + slot caps via the settings registry.** New `ATLAS_MEMORY_MAX_SLOTS` (default 64) and `ATLAS_MEMORY_MAX_VALUE_BYTES` (default 16 KiB), workspace-scoped + hot-reloadable (resolved per-turn at store build via the `getMemoryMaxSlots`/`getMemoryMaxValueBytes` resolvers, mirroring the existing durability-knob pattern). A write that would exceed a cap is **rejected** at staging time (`LiveDurableStateStore.set` throws `DurableStateLimitError`), surfaced to the caller through the tool's `execute` — **never truncated**.
- **Secrets/credentials prohibition.** New heuristic detector (`memory-secret-scan.ts`) matching credential SHAPES — provider key prefixes, PEM private-key blocks, JWTs, bearer headers, connection-string passwords, and a long high-entropy-token fallback. A credential-shaped write is rejected (`DurableStateSecretError`) **before persistence**. Conservative by design: false negatives acceptable (defense-in-depth), false positives on ordinary analyst memory (table names, filters, prose, SQL, hashes) are not — guarded by explicit allow-cases.
- **Tenant-scoped writes.** The Live store is bound to its session's `conversationId` + `orgId` at build; the commit keys every upsert on `(conversation_id, namespace)` with that bound org, so a write can target no other session's memory.
- **Swept with its session.** `sweepExpiredSessionMemory` rides the **same** hourly retention fiber + `getRetentionDays()` window as the `agent_runs` sweep (no separate sweeper). It runs **before** the runs sweep in the tick so the terminal runs still date the session, and deletes memory for sessions whose runs are all terminal (`done`/`failed`) and past the window. A session with a live (`running`/`parked`) run keeps its memory; the conversation-delete path is covered by the existing FK cascade.

### Why enforce at staging, not commit?
The memory commit is fire-and-forget (rides the `internalExecute` circuit breaker, returns `void`, never throws), so a rejection there could not surface to the caller. `set()` is reached synchronously from a tool's `defineDurableState().set()`, so a thrown rejection propagates up through `execute` — the "surfaced, never truncated" contract the issue requires.

## Test plan

- [x] Caps: cap-exceeding write rejected (size + slot); exactly-at-cap boundary; UTF-8 byte length; cap controllable via settings registry **per-workspace** (workspace > platform > default asserted); seeded (prior-turn) slots count toward the cap.
- [x] Secrets: credential-shaped write rejected + never staged; nested-object secrets caught; ordinary analyst memory (UUIDs, hashes, git SHAs, SQL, prose) passes.
- [x] Tenant scoping: store bound to session's conversation + org (write path); read/reset cross-org scoping already covered in `durable-state.test.ts`.
- [x] Sweep: `Layer.provide` test layers (Live/Noop `sweepExpired`); **real-Postgres** sweep tests in `migrate-pg.test.ts` — expired-terminal swept + fresh kept, live `running`/`parked` never swept even when old, FK-cascade-on-conversation-delete; source-scan guard pins the memory-sweep-before-runs-sweep tick ordering.
- [x] All `/ci` gates green (lint, type, full test, syncpack, schema-drift, settings-readers, all drift/guard scripts). Internal review panel: CLEAN (no must-fix); addressed the MEDIUM test-coverage gaps (per-org tier, tick ordering) + LOW polish proactively.

Closes #3757

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add slot caps, value-size caps, secret detection, and session memory sweep to durable working-memory
> - Adds per-org `ATLAS_MEMORY_MAX_SLOTS` (default 64) and `ATLAS_MEMORY_MAX_VALUE_BYTES` (default 16384) settings, resolved via workspace/platform/default hierarchy in [`durable-state.ts`](https://github.com/AtlasDevHQ/atlas/pull/3836/files#diff-8279fa9b8b691194e3ae47cabb8ca74ab80ba704cd0e1d35301efd4d236bd4f1).
> - `LiveDurableStateStore.set()` now enforces these caps synchronously, throwing `DurableStateLimitError` on slot or size violations and `DurableStateSecretError` on credential-shaped values; overwrites to existing slots bypass slot-count checks.
> - Adds [`memory-secret-scan.ts`](https://github.com/AtlasDevHQ/atlas/pull/3836/files#diff-212a7a7cc38748184571124dbdb305ab62cfd978519f242d59965edac4332ffb) with `findSecretLike()`, a heuristic scanner for PEM keys, JWTs, bearer headers, AWS key IDs, provider prefixes, connection-string passwords, and high-entropy tokens.
> - Adds `sweepExpiredSessionMemory()` (via `SESSION_MEMORY_SWEEP_SQL`) to delete working-memory rows for terminal sessions past the retention window; the periodic `agentRunsRetentionTick` now calls `durableState.sweepExpired()` before `durableSession.sweepTerminal()`.
> - Risk: any agent write that exceeds caps or matches credential heuristics now throws synchronously instead of silently succeeding; cap values are resolved once per turn, so hot-reloaded settings apply on the next turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10df34a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the durable-memory bounds and safety slice (ADR-0020 #3757), wiring slot-count and byte-size caps via the settings registry, a write-time secret/credential detector, tenant-scoped store binding, and a session memory sweep that runs on the existing hourly retention fiber before the agent-runs sweep.

- **Bounds enforcement**: `LiveDurableStateStore.set` now resolves `ATLAS_MEMORY_MAX_SLOTS` (default 64) and `ATLAS_MEMORY_MAX_VALUE_BYTES` (default 16 KiB) per-org from the settings registry at store-build time; cap violations throw `DurableStateLimitError` synchronously so errors surface through the tool's `execute` rather than being silently swallowed by the fire-and-forget commit.
- **Secret scanner** (`memory-secret-scan.ts`): `findSecretLike` matches credential shapes (provider prefixes, PEM blocks, JWTs, bearer tokens, connection-string passwords, AWS key IDs, high-entropy tokens) and rejects writes pre-persistence; a dedicated `looksLikeSql` suppression prevents the inline-credential-assignment pattern from false-positiving on analyst SQL predicates (`WHERE api_key = '…'`).
- **Session memory sweep**: `sweepExpiredSessionMemory` is added to the `DurableState` Effect service and wired into the `agentRunsRetentionTick` before `durableSession.sweepTerminal`, ensuring terminal runs rows still exist to date the session; sweep ordering is guarded by a source-scan assertion.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all enforcement is at write/staging time with no silent truncation, the sweep ordering is correctly guarded, and the previous thread findings are both addressed.

The bounds enforcement, secret detection, tenant scoping, and session sweep are all correctly placed and well-tested. The `looksLikeSql` suppression added in response to the prior review comment now has explicit tests for SQL column predicates with credential-named columns. The sweep ordering invariant is protected by a source-scan assertion. No logic errors or security issues were found in the new code paths.

No files require special attention — the core enforcement logic in `durable-state.ts` and the detector in `memory-secret-scan.ts` are both thoroughly tested including boundary conditions and the previously flagged SQL false-positive scenario.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/memory-secret-scan.ts | New credential-shape heuristic detector; `looksLikeSql` suppression correctly guards the `inline-credential-assignment` pattern from false-positiving on analyst SQL; SHAPE_PATTERNS run before SQL suppression so a real credential inside SQL is still caught. |
| packages/api/src/lib/durable-state.ts | Adds bounds/safety checks, `sweepExpiredSessionMemory`, and cap resolvers; enforcement order (secret → size → slot count) is deliberate and correctly placed before any mutation; log message accurately reflects 'rows', not 'sessions'. |
| packages/api/src/lib/effect/layers.ts | Wires `DurableState` as a scheduler dependency and sequences memory sweep before runs sweep in `agentRunsRetentionTick`; ordering is guarded by a source-scan test in layers.test.ts. |
| packages/api/src/lib/effect/services.ts | Adds `sweepExpired(retentionDays): Effect.Effect<number>` to `DurableStateShape`; clean interface extension. |
| packages/api/src/lib/settings.ts | Adds two workspace-scoped settings (`ATLAS_MEMORY_MAX_SLOTS`, `ATLAS_MEMORY_MAX_VALUE_BYTES`) following existing patterns; defaults match code constants. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Tool
    participant LiveStore as LiveDurableStateStore.set()
    participant Scanner as findSecretLike()
    participant DB as agent_session_memory (Postgres)
    participant Scheduler as agentRunsRetentionTick

    Tool->>LiveStore: set(namespace, value)
    LiveStore->>Scanner: findSecretLike(value)
    Scanner-->>LiveStore: "SecretLikeMatch | null"
    alt credential shape detected
        LiveStore-->>Tool: throw DurableStateSecretError
    else
        LiveStore->>LiveStore: JSON.stringify → measure bytes
        alt "bytes > maxValueBytes"
            LiveStore-->>Tool: throw DurableStateLimitError
        else
            LiveStore->>LiveStore: check slot count
            alt "new slot AND size >= maxSlots"
                LiveStore-->>Tool: throw DurableStateLimitError
            else
                LiveStore->>LiveStore: slots.set(namespace, value)
                LiveStore-->>Tool: void (staged)
            end
        end
    end

    Note over DB, Scheduler: Hourly retention fiber
    Scheduler->>DB: sweepExpiredSessionMemory(retentionDays)
    DB-->>Scheduler: rows deleted (count)
    Scheduler->>DB: sweepTerminal(retentionDays)
    DB-->>Scheduler: runs swept
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Tool
    participant LiveStore as LiveDurableStateStore.set()
    participant Scanner as findSecretLike()
    participant DB as agent_session_memory (Postgres)
    participant Scheduler as agentRunsRetentionTick

    Tool->>LiveStore: set(namespace, value)
    LiveStore->>Scanner: findSecretLike(value)
    Scanner-->>LiveStore: "SecretLikeMatch | null"
    alt credential shape detected
        LiveStore-->>Tool: throw DurableStateSecretError
    else
        LiveStore->>LiveStore: JSON.stringify → measure bytes
        alt "bytes > maxValueBytes"
            LiveStore-->>Tool: throw DurableStateLimitError
        else
            LiveStore->>LiveStore: check slot count
            alt "new slot AND size >= maxSlots"
                LiveStore-->>Tool: throw DurableStateLimitError
            else
                LiveStore->>LiveStore: slots.set(namespace, value)
                LiveStore-->>Tool: void (staged)
            end
        end
    end

    Note over DB, Scheduler: Hourly retention fiber
    Scheduler->>DB: sweepExpiredSessionMemory(retentionDays)
    DB-->>Scheduler: rows deleted (count)
    Scheduler->>DB: sweepTerminal(retentionDays)
    DB-->>Scheduler: runs swept
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(durable-memory): raise entropy thres..."](https://github.com/atlasdevhq/atlas/commit/10df34a106ae85ec63d317e0af2329ff549be193) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38830287)</sub>

<!-- /greptile_comment -->