### PR TITLE
refactor(effect): remove runPromise re-entry, lift inline provides, normalize error channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Guidance for Claude Code when working in this repository.
 - [ ] **Layer.effect vs Layer.scoped** — `Layer.scoped` when the service has a finalizer (cleanup on shutdown); `Layer.effect` for stateless
 - [ ] **Tagged errors via Data.TaggedError** — Never plain `Error` subclasses with `_tag`. Use `Data.TaggedError("ErrorName")<{ ... }>`
 - [ ] **runHandler for route handlers** — `runHandler(c, "label", async () => { ... })` bridges Hono → Effect Context and centralizes error-to-HTTP mapping
-- [ ] **No `catch: (err) => err`** — In `Effect.tryPromise`, always normalize: `catch: (err) => err instanceof Error ? err : new Error(String(err))`
+- [ ] **No `catch: (err) => err`** — In `Effect.tryPromise`, always normalize: `catch: (err) => err instanceof Error ? err : new Error(String(err))`. **Carve-out:** `lib/effect/semantic-generator.ts`'s profile `tryPromise` intentionally uses `catch: (err) => err` to preserve the raw rejection's identity (a cooperative `OperationCancelledError` from the MCP progress bridge) so the downstream `catchAll` can route cancellation → defect; normalizing there would erase the identity and surface a spurious `validation_failed`. Don't "fix" it
 - [ ] **satisfies on service returns** — Always `satisfies FooShape` on returned service objects
 - [ ] **Effect test layers + no top-level singleton mutation** — Prefer `Layer.provide` test layers over `mock.module()`; never mutate a registry/singleton at test module top-level. See [docs/development/testing.md](docs/development/testing.md)
 

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -113,6 +113,11 @@ async function runInstaller<A>(
     return yield* body(installer);
   });
 
+  // #3764 — accepted: the per-call `Effect.provide(WorkspaceInstallerLive)`
+  // lives at the route boundary (this bridge), not deep in lib code.
+  // `WorkspaceInstallerLive` is a dependency-free, finalizer-free `Layer.effect`,
+  // so re-providing it per request is cheap and the route stays its own
+  // composition root rather than reaching into the app `ManagedRuntime`.
   const exit = await Effect.runPromiseExit(
     program.pipe(Effect.provide(WorkspaceInstallerLive)),
   );

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -462,6 +462,9 @@ adminIntegrations.openapi(disconnectSlackRoute, async (c) => {
         yield* installer.uninstall(orgId as WorkspaceId, "slack");
         return "ok" as const;
       }).pipe(
+        // #3764 — accepted: per-route boundary provide of the dependency-free,
+        // finalizer-free WorkspaceInstallerLive; the route stays its own
+        // composition root rather than reaching into the app ManagedRuntime.
         Effect.provide(WorkspaceInstallerLive),
         Effect.catchTag("InstallNotFoundError", () =>
           Effect.succeed("not_found" as const),

--- a/packages/api/src/api/routes/admin-proactive-analytics.ts
+++ b/packages/api/src/api/routes/admin-proactive-analytics.ts
@@ -155,6 +155,8 @@ adminProactiveAnalytics.get("/", async (c) => {
         },
         200,
       );
+      // #3764 — accepted: per-route boundary provide of a small, finalizer-free
+      // Live layer; the route stays its own composition root.
     }).pipe(Effect.provide(AnswerMeterLive)),
     { label: "proactive analytics summary" },
   );

--- a/packages/api/src/api/routes/admin-proactive-events.ts
+++ b/packages/api/src/api/routes/admin-proactive-events.ts
@@ -247,6 +247,8 @@ adminProactiveEvents.get("/", async (c) =>
         },
         200,
       );
+      // #3764 — accepted: per-route boundary provide of a small, finalizer-free
+      // Live layer; the route stays its own composition root.
     }).pipe(Effect.provide(AnswerMeterLive)),
     { label: "proactive events drill-down" },
   ),

--- a/packages/api/src/api/routes/integrations-catalog.ts
+++ b/packages/api/src/api/routes/integrations-catalog.ts
@@ -226,6 +226,8 @@ integrationsCatalog.openapi(listCatalogRoute, async (c) => {
     // with the InternalDB shim so the route can call into it without
     // pulling the AppLayer's ManagedRuntime down here. Same pattern as
     // `admin-proactive-analytics.ts` (#2622) for `AnswerMeterLive`.
+    // #3764 — accepted: this per-route boundary provide is the intended shape
+    // (route as its own composition root), not a lib-level provide to lift.
     const rows = await Effect.runPromise(
       Effect.gen(function* () {
         const facade = yield* PillarCatalogQuery;

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -1772,6 +1772,9 @@ integrations.openapi(disconnectRoute, async (c) =>
       Effect.gen(function* () {
         const installer = yield* WorkspaceInstaller;
         yield* installer.uninstall(workspaceId, platform);
+        // #3764 — accepted: per-route boundary provide of the dependency-free,
+        // finalizer-free WorkspaceInstallerLive; the route stays its own
+        // composition root.
       }).pipe(Effect.provide(WorkspaceInstallerLive)),
       { label: "platform disconnect" },
     );

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -229,6 +229,9 @@ const mode = new OpenAPIHono<AuthEnv>();
 mode.use("/", standardAuth);
 mode.use("/", requestContext);
 
+// #3764 — accepted: this layer is provided at the route boundary (per call,
+// below) rather than via the app ManagedRuntime. The route is its own small
+// composition root; the merged Live layers are dependency-free/finalizer-free.
 const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
 
 mode.openapi(getModeRoute, async (c) => {

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -450,17 +450,31 @@ async function checkSSOEnforcement(
   authMode: SSOEnforceableMode,
 ): Promise<AuthResult | null> {
   try {
-    const sso = await runEnterprise(
+    // Resolve the policy and run the enforcement lookup inside ONE
+    // enterprise-runtime entry — `isSSOEnforcedForDomain` is composed with
+    // `yield*` instead of a second ad-hoc `Effect.runPromise`, so the lookup
+    // shares the request fiber/tracing context with the Tag resolution
+    // (#3764). The test override (`_ssoEnforcementOverride`) replaces only the
+    // DB-backed lookup, so it's applied after the Effect resolves the domain.
+    const resolved = await runEnterprise(
       Effect.gen(function* () {
-        return yield* SSOPolicy;
+        const sso = yield* SSOPolicy;
+        const domain = sso.extractEmailDomain(userLabel);
+        // No domain, or a test override is installed: skip the DB-backed
+        // lookup here (the override replaces it below). Otherwise compose
+        // the enforcement lookup into the same Effect.
+        if (!domain || _ssoEnforcementOverride) {
+          return { domain, enforcement: null as SSOEnforcementResult };
+        }
+        return { domain, enforcement: yield* sso.isSSOEnforcedForDomain(domain) };
       }),
     );
-    const domain = sso.extractEmailDomain(userLabel);
+    const domain = resolved.domain;
     if (!domain) return null;
 
     const enforcement = _ssoEnforcementOverride
       ? await _ssoEnforcementOverride(domain)
-      : await Effect.runPromise(sso.isSSOEnforcedForDomain(domain));
+      : resolved.enforcement;
     if (!enforcement || !enforcement.enforced) return null;
 
     log.warn(

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -25,7 +25,7 @@
  * from its `message`.
  */
 
-import { Cause, Effect } from "effect";
+import { Cause, Effect, ManagedRuntime } from "effect";
 import type { AtlasMode } from "@useatlas/types/auth";
 import type { WorkspaceId } from "@useatlas/types";
 import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
@@ -90,6 +90,28 @@ const log = createLogger("datasources:mcp-lifecycle");
 // `api/routes/admin-connections.ts`. `readFilter` is a pure function of the
 // static `CONTENT_MODE_TABLES` tuple, so `Effect.runSync` is safe (no I/O).
 const contentModeRegistry = makeService(CONTENT_MODE_TABLES);
+
+// Shared, process-lifetime runtimes for the two dependency-free Live layers
+// this module's MCP-transport bridges run against (#3764). Built once and
+// reused so the `Effect.provide(...Live)` lives at a single composition point
+// instead of being re-applied inline on every `runDatasourceInstaller` /
+// `profileLiveDatasource` call. Mirrors `enterprise-layer.ts`'s
+// `getEnterpriseRuntime()`: both `WorkspaceInstallerLive` (`Layer.effect`) and
+// `SemanticGeneratorLive` (`Layer.succeed`) are stateless with no scoped
+// finalizers, so leaking the runtime at process exit is fine. Lazy so a test's
+// `mock.module(".../workspace-installer")` (or `.../semantic-generator`) takes
+// effect before the first build.
+let _installerRuntime: ManagedRuntime.ManagedRuntime<WorkspaceInstaller, never> | null = null;
+function getInstallerRuntime(): ManagedRuntime.ManagedRuntime<WorkspaceInstaller, never> {
+  if (_installerRuntime === null) _installerRuntime = ManagedRuntime.make(WorkspaceInstallerLive);
+  return _installerRuntime;
+}
+
+let _semanticGeneratorRuntime: ManagedRuntime.ManagedRuntime<SemanticGenerator, never> | null = null;
+function getSemanticGeneratorRuntime(): ManagedRuntime.ManagedRuntime<SemanticGenerator, never> {
+  if (_semanticGeneratorRuntime === null) _semanticGeneratorRuntime = ManagedRuntime.make(SemanticGeneratorLive);
+  return _semanticGeneratorRuntime;
+}
 
 // ── List ──────────────────────────────────────────────────────────────
 
@@ -303,9 +325,7 @@ export async function runDatasourceInstaller<A>(
     return yield* body(installer);
   });
 
-  const exit = await Effect.runPromiseExit(
-    program.pipe(Effect.provide(WorkspaceInstallerLive)),
-  );
+  const exit = await getInstallerRuntime().runPromiseExit(program);
 
   if (exit._tag === "Success") return { kind: "ok", value: exit.value };
 
@@ -1258,7 +1278,7 @@ async function profileLiveDatasourceImpl(opts: {
     return { result, persisted: null };
   });
 
-  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(SemanticGeneratorLive)));
+  const exit = await getSemanticGeneratorRuntime().runPromiseExit(program);
   if (exit._tag === "Success") {
     return {
       kind: "ok",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -41,6 +41,7 @@ import { Context, Duration, Effect, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { normalizeError } from "@atlas/api/lib/effect/errors";
 import { InternalDB, makeInternalDBLive, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
 import {
@@ -292,11 +293,11 @@ export const TelemetryLive: Layer.Layer<Telemetry> = Layer.scoped(
           // Defaults service.name to "atlas-api" (or OTEL_SERVICE_NAME).
           return await initTelemetry();
         },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
+        Effect.catchAll((err) => {
           log.error(
-            { err: new Error(errMsg) },
+            { err },
             "Failed to initialize OpenTelemetry — tracing disabled for this process",
           );
           return Effect.succeed(null);
@@ -309,10 +310,10 @@ export const TelemetryLive: Layer.Layer<Telemetry> = Layer.scoped(
       shutdownFn
         ? Effect.tryPromise({
             try: () => shutdownFn!(),
-            catch: (err) => (err instanceof Error ? err.message : String(err)),
+            catch: normalizeError,
           }).pipe(
-            Effect.catchAll((errMsg) => {
-              log.error({ err: new Error(errMsg) }, "Failed to shut down OTel SDK");
+            Effect.catchAll((err) => {
+              log.error({ err }, "Failed to shut down OTel SDK");
               return Effect.void;
             }),
           )
@@ -408,18 +409,18 @@ export const MigrationLive: Layer.Layer<Migration, never, InternalDB> = Layer.ef
         await runBootMigrations();
         return { migrated: true } satisfies MigrationShape;
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
+      Effect.catchAll((err) => {
         log.error(
-          { err: new Error(errMsg) },
+          { err },
           "Boot migration failed",
         );
         // Carry the underlying error message through the Migration Tag
         // so `MigrationGuardLive` can surface it on the boot-failure
         // log line in SaaS — review-flagged "MigrationsRequiredError
         // shouldn't punt to 'see prior log'" (#1988 PR review).
-        return Effect.succeed({ migrated: false, error: errMsg } satisfies MigrationShape);
+        return Effect.succeed({ migrated: false, error: err.message } satisfies MigrationShape);
       }),
     );
 
@@ -1163,10 +1164,10 @@ export const AuthBootstrapLive: Layer.Layer<
         );
         await runPostMigrationBootstrap();
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
-        log.error({ err: new Error(errMsg) }, "Post-migration bootstrap failed");
+      Effect.catchAll((err) => {
+        log.error({ err }, "Post-migration bootstrap failed");
         return Effect.void;
       }),
     );
@@ -1204,11 +1205,11 @@ export const PoolWarmupLive: Layer.Layer<
         const { connections } = await import("@atlas/api/lib/db/connection");
         await connections.warmup();
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
+      Effect.catchAll((err) => {
         log.error(
-          { err: new Error(errMsg) },
+          { err },
           "Pool warmup failed — datasource may be unreachable",
         );
         return Effect.void;
@@ -1310,10 +1311,10 @@ export const SemanticSyncLive: Layer.Layer<SemanticSync> = Layer.effect(
         await reconcileAllOrgs();
         return true;
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
-        log.error({ err: new Error(errMsg) }, "Semantic sync failed");
+      Effect.catchAll((err) => {
+        log.error({ err }, "Semantic sync failed");
         return Effect.succeed(false);
       }),
     );
@@ -1370,10 +1371,10 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
         const { loadSettings } = await import("@atlas/api/lib/settings");
         return loadSettings();
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
-        log.error({ err: new Error(errMsg) }, "Settings load failed");
+      Effect.catchAll((err) => {
+        log.error({ err }, "Settings load failed");
         return Effect.succeed(0);
       }),
     );
@@ -1883,7 +1884,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.debug(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err },
               "Audit purge scheduler did not start — enterprise required or backend error",
             );
           }),

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -33,6 +33,7 @@ import type { ToolRegistry as ToolRegistryClass } from "@atlas/api/lib/tools/reg
 import type { RecordRunCheckpointArgs, RecordTerminalRunArgs } from "@atlas/api/lib/durable-session";
 import type { DurableStateSlot } from "@atlas/api/lib/durable-state";
 import { createLogger } from "@atlas/api/lib/logger";
+import { normalizeError } from "@atlas/api/lib/effect/errors";
 import type {
   PluginRegistry as PluginRegistryClass,
   PluginLike,
@@ -298,11 +299,10 @@ export function makeConnectionRegistryLive(
           (id) =>
             Effect.tryPromise({
               try: () => impl.healthCheck(id),
-              catch: (err) =>
-                err instanceof Error ? err.message : String(err),
+              catch: normalizeError,
             }).pipe(
-              Effect.catchAll((errMsg) => {
-                log.warn({ connectionId: id, err: errMsg }, "Periodic health check failed");
+              Effect.catchAll((err) => {
+                log.warn({ connectionId: id, err }, "Periodic health check failed");
                 return Effect.void;
               }),
             ),
@@ -527,10 +527,10 @@ function buildPluginService(impl: PluginRegistryClass) {
     // --- Health check fiber (replaces on-demand-only checks) ---
     const healthCheckCycle = Effect.tryPromise({
       try: () => impl.healthCheckAll(),
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      catch: normalizeError,
     }).pipe(
-      Effect.catchAll((errMsg) => {
-        pluginLog.warn({ err: errMsg }, "Periodic plugin health check failed");
+      Effect.catchAll((err) => {
+        pluginLog.warn({ err }, "Periodic plugin health check failed");
         return Effect.void;
       }),
     );
@@ -546,10 +546,10 @@ function buildPluginService(impl: PluginRegistryClass) {
       Effect.gen(function* () {
         yield* Effect.tryPromise({
           try: () => impl.teardownAll(),
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "PluginRegistry teardownAll failed during shutdown");
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "PluginRegistry teardownAll failed during shutdown");
             return Effect.void;
           }),
         );
@@ -759,11 +759,11 @@ export function makeWiredPluginRegistryLive(
       if (config.runMigrations) {
         yield* Effect.tryPromise({
           try: () => config.runMigrations!(impl.getAll()),
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Plugin schema migrations failed — aborting startup");
-            return Effect.fail(new Error(`Plugin schema migrations failed: ${errMsg}`));
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "Plugin schema migrations failed — aborting startup");
+            return Effect.fail(new Error(`Plugin schema migrations failed: ${err.message}`));
           }),
         );
       }
@@ -771,10 +771,10 @@ export function makeWiredPluginRegistryLive(
       // --- Initialize all ---
       const { succeeded, failed } = yield* Effect.tryPromise({
         try: () => impl.initializeAll(config.context),
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
-          pluginLog.error({ err: errMsg }, "Plugin initializeAll threw unexpectedly");
+        Effect.catchAll((err) => {
+          pluginLog.error({ err }, "Plugin initializeAll threw unexpectedly");
           return Effect.succeed({ succeeded: [] as string[], failed: [] as string[] });
         }),
       );
@@ -799,10 +799,10 @@ export function makeWiredPluginRegistryLive(
             connRegistry as unknown as ConnectionRegistryClass,
           );
         },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
-          pluginLog.error({ err: errMsg }, "Datasource wiring failed entirely");
+        Effect.catchAll((err) => {
+          pluginLog.error({ err }, "Datasource wiring failed entirely");
           return Effect.succeed({ wired: [] as string[], failed: [] as Array<{ pluginId: string; error: string }>, dialectHints: [] as Array<{ pluginId: string; dialect: string }>, entityFailures: [] as Array<{ pluginId: string; error: string }> });
         }),
       );
@@ -818,10 +818,10 @@ export function makeWiredPluginRegistryLive(
             const { setDialectHints } = await import("@atlas/api/lib/plugins/tools");
             setDialectHints(dsResult.dialectHints);
           },
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Failed to set plugin dialect hints");
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "Failed to set plugin dialect hints");
             return Effect.void;
           }),
         );
@@ -837,10 +837,10 @@ export function makeWiredPluginRegistryLive(
             );
             return wireActionPlugins(impl, toolRegistry as never);
           },
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Action wiring failed entirely");
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "Action wiring failed entirely");
             return Effect.succeed({ wired: [] as string[], failed: [] as Array<{ pluginId: string; error: string }> });
           }),
         );
@@ -887,10 +887,10 @@ export function makeWiredPluginRegistryLive(
               const { setPluginTools } = await import("@atlas/api/lib/plugins/tools");
               setPluginTools(toolRegistry);
             },
-            catch: (err) => (err instanceof Error ? err.message : String(err)),
+            catch: normalizeError,
           }).pipe(
-            Effect.catchAll((errMsg) => {
-              pluginLog.error({ err: errMsg }, "Tool-shadow check / setPluginTools failed");
+            Effect.catchAll((err) => {
+              pluginLog.error({ err }, "Tool-shadow check / setPluginTools failed");
               return Effect.void;
             }),
           );
@@ -907,10 +907,10 @@ export function makeWiredPluginRegistryLive(
           );
           return wireMcpToolPlugins(impl, pluginMcpToolRegistry);
         },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
-          pluginLog.error({ err: errMsg }, "Plugin MCP tool wiring failed entirely");
+        Effect.catchAll((err) => {
+          pluginLog.error({ err }, "Plugin MCP tool wiring failed entirely");
           return Effect.succeed({
             wired: [] as Array<{ pluginId: string; qualifiedName: string }>,
             failed: [] as Array<{ pluginId: string; tool?: string; error: string }>,
@@ -935,10 +935,10 @@ export function makeWiredPluginRegistryLive(
           );
           return wireContextPlugins(impl);
         },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
-          pluginLog.error({ err: errMsg }, "Context wiring failed entirely");
+        Effect.catchAll((err) => {
+          pluginLog.error({ err }, "Context wiring failed entirely");
           return Effect.succeed({ fragments: [] as string[], failed: [] as Array<{ pluginId: string; error: string }> });
         }),
       );
@@ -951,10 +951,10 @@ export function makeWiredPluginRegistryLive(
             const { setContextFragments } = await import("@atlas/api/lib/plugins/tools");
             setContextFragments(ctxResult.fragments);
           },
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Failed to set plugin context fragments");
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "Failed to set plugin context fragments");
             return Effect.void;
           }),
         );
@@ -969,10 +969,10 @@ export function makeWiredPluginRegistryLive(
             );
             return wireInteractionPlugins(impl, config.app);
           },
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
+          catch: normalizeError,
         }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "Interaction wiring failed entirely");
+          Effect.catchAll((err) => {
+            pluginLog.error({ err }, "Interaction wiring failed entirely");
             return Effect.succeed({ wired: [] as string[], failed: [] as Array<{ pluginId: string; error: string }> });
           }),
         );
@@ -996,11 +996,11 @@ export function makeWiredPluginRegistryLive(
             }
           }
         },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
+        catch: normalizeError,
       }).pipe(
-        Effect.catchAll((errMsg) => {
+        Effect.catchAll((err) => {
           pluginLog.error(
-            { err: errMsg },
+            { err },
             "Failed to wire plugin cache backend — falling back to in-memory LRU",
           );
           return Effect.void;

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -665,6 +665,25 @@ function emitCycleAudit(result: ByotRefreshCycleResult): void {
 // ---------------------------------------------------------------------------
 // Lifecycle (setInterval-based, mirrors ee/audit/purge-scheduler.ts)
 // ---------------------------------------------------------------------------
+//
+// #3764 — deliberately NOT on `engine.ts`'s `Effect.runFork` + `Schedule`
+// fiber pattern, by the same reasoning as `openapi-install-rediscover.ts` +
+// `openapi-spec-refresh.ts` + `ee/audit/purge-scheduler.ts` (which all share
+// this `setInterval` + `unref()` shape and cross-reference each other):
+//   • The cycle is self-contained and idempotent — it emits an audit row and
+//     mutates catalog staleness; there are no per-tick "running" rows that a
+//     mid-flight interrupt must clean up. `engine.ts` needs the fiber pattern
+//     ONLY because its `Effect.onInterrupt` finalizer must release orphaned
+//     `task_run` rows on shutdown (see engine.ts:306). Nothing here is
+//     interrupt-sensitive, so the fiber pattern would add machinery for a
+//     guarantee we don't need.
+//   • `_timer.unref()` keeps the timer from pinning the process — the desired
+//     posture for a best-effort background refresher.
+//   • `{ concurrency: 1 }` inside the cycle (see `runByotCatalogRefreshCycle`)
+//     already prevents a slow cycle from overlapping the next tick.
+// `Effect.runPromise` here boots a fresh default-runtime fiber per cycle, which
+// is fine: each cycle is a fully self-contained program, not a re-entry into a
+// surrounding Effect.
 
 let _timer: ReturnType<typeof setInterval> | null = null;
 let _running = false;

--- a/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
+++ b/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
@@ -657,6 +657,16 @@ export const runOpenApiInstallRediscoverCycle = (
 // ---------------------------------------------------------------------------
 // Lifecycle (setInterval-based, mirrors byot-catalog-refresh.ts + openapi-spec-refresh.ts)
 // ---------------------------------------------------------------------------
+//
+// #3764 — deliberately NOT on `engine.ts`'s `Effect.runFork` + `Schedule`
+// fiber pattern, by the same reasoning as `byot-catalog-refresh.ts` +
+// `openapi-spec-refresh.ts` + `ee/audit/purge-scheduler.ts` (all sharing this
+// `setInterval` + `unref()` shape): the cycle is self-contained and idempotent
+// (re-probes install status), with no per-tick rows a mid-flight interrupt
+// must release — so it doesn't need `engine.ts`'s `Effect.onInterrupt`
+// task_run cleanup (engine.ts:306). `_inFlight` already prevents overlap and
+// `unref()` keeps the timer from pinning the process; `Effect.runPromise` per
+// cycle is a self-contained program, not a re-entry into a surrounding Effect.
 
 let _timer: ReturnType<typeof setInterval> | null = null;
 let _running = false;

--- a/packages/api/src/lib/tools/__tests__/sql-approval.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-approval.test.ts
@@ -378,6 +378,51 @@ describe("F-54/F-55 executeSQL approval gate", () => {
     expect(mockCreateApprovalRequest).toHaveBeenCalled();
   });
 
+  it("Phase 2 fail-CLOSED: synchronous throw from createApprovalRequest blocks the query", async () => {
+    // #3764 — the CREATE region composes the gate's hasApprovedRequest +
+    // createApprovalRequest Effects via `yield*` and recovers via
+    // `Effect.catchAllCause` (NOT `catchAll`). A synchronous throw inside the
+    // EE create helper surfaces as a DEFECT, not a typed failure; `catchAll`
+    // would let it escape as an uncaught 500 (and risk fail-OPEN). This pins
+    // that a sync throw on the write path is blocked, mirroring the Phase 1
+    // check-region test above. Governance bypass is worse than a failed query.
+    mockCheckApprovalRequired.mockImplementation(() =>
+      Effect.succeed({ required: true, matchedRules: [{ id: "rule-1", name: "PII tables" }] }),
+    );
+    mockHasApprovedRequest.mockImplementation(() => Effect.succeed(false));
+    mockCreateApprovalRequest.mockImplementation(() => {
+      throw new Error("simulated DB outage during approval request creation");
+    });
+    const result = await executeTool(
+      { sql: "SELECT id FROM companies", explanation: "test" },
+      toolCtx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Approval workflow failed");
+  });
+
+  it("Phase 2 fail-CLOSED: rejected Effect from createApprovalRequest also blocks", async () => {
+    mockCheckApprovalRequired.mockImplementation(() =>
+      Effect.succeed({ required: true, matchedRules: [{ id: "rule-1", name: "PII tables" }] }),
+    );
+    mockHasApprovedRequest.mockImplementation(() => Effect.succeed(false));
+    // The mock's typed return pins the error channel to `never` (happy-path
+    // shape); a failing Effect is the real gate's `ApprovalError | … | Error`
+    // channel, so cast to the declared return type to model a rejection.
+    mockCreateApprovalRequest.mockImplementation(
+      () =>
+        Effect.fail(new Error("simulated transient write failure")) as unknown as ReturnType<
+          typeof mockCreateApprovalRequest
+        >,
+    );
+    const result = await executeTool(
+      { sql: "SELECT id FROM companies", explanation: "test" },
+      toolCtx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Approval workflow failed");
+  });
+
   it("passes requesterId to checkApprovalRequired so demo / single-user mode passes through cleanly", async () => {
     requestContextValue = {
       requestId: "test-approval",

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -15,7 +15,7 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import { Parser } from "node-sql-parser";
 import { connections, detectDBType, getRegionAwareConnection, isConnectionVisibleInMode, ConnectionNotRegisteredError, NoDatasourceConfiguredError, PoolCapacityExceededError } from "@atlas/api/lib/db/connection";
 import type { DBConnection, DBType } from "@atlas/api/lib/db/connection";
@@ -1495,92 +1495,121 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
 
     // Approval gate — fail closed.
     if (classification) {
-      const approvalOutcome = yield* Effect.tryPromise({
-        try: async (): Promise<UserQueryOutcome | null> => {
-          let approvalMatch:
-            | { required: boolean; matchedRules: { id: string; name: string }[]; identityMissing?: boolean };
-          let approvalGate: ApprovalGateShape;
-          try {
-            approvalGate = await loadApprovalGate();
-            const checkReqCtx = getRequestContext();
-            const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
-            const checkUserId = checkReqCtx?.user?.id;
-            const checkOrigin = checkReqCtx?.agentOrigin;
-            approvalMatch = await Effect.runPromise(approvalGate.checkApprovalRequired(
-              checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
-              {
-                ...(checkUserId ? { requesterId: checkUserId } : {}),
-                ...(checkOrigin ? { origin: checkOrigin } : {}),
-              },
-            ));
-          } catch (err) {
-            log.error(
-              { err: err instanceof Error ? err.message : String(err), connectionId: connId },
-              "Approval check failed — blocking query (fail-closed)",
-            );
-            return {
-              kind: "approval_unavailable" as const,
-              message: "Approval system unavailable — query blocked. Contact your administrator.",
-            };
-          }
+      // #3764 — compose the gate's per-method Effects with `yield*` instead of
+      // dropping out to `async`/`Effect.runPromise` per call. `loadApprovalGate()`
+      // resolves the EE-bound gate via the shared enterprise runtime (a legit
+      // Promise→Effect boundary, NOT the re-entry smell), then the gate's
+      // already-resolved Effects thread onto the surrounding pipeline fiber.
+      //
+      // Two distinct fail-closed regions are preserved exactly:
+      //   1. CHECK (gate load + checkApprovalRequired) → on failure, surface
+      //      `approval_unavailable` (block the query, don't bypass governance).
+      //   2. CREATE (hasApprovedRequest + createApprovalRequest) → on failure,
+      //      surface `QueryExecutionError` ("Approval workflow failed: …") so a
+      //      governance-write failure blocks rather than silently executes.
+      const check = yield* Effect.gen(function* () {
+        const approvalGate = yield* Effect.tryPromise({
+          try: () => loadApprovalGate(),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        });
+        const checkReqCtx = getRequestContext();
+        const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
+        const checkUserId = checkReqCtx?.user?.id;
+        const checkOrigin = checkReqCtx?.agentOrigin;
+        const approvalMatch = yield* approvalGate.checkApprovalRequired(
+          checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
+          {
+            ...(checkUserId ? { requesterId: checkUserId } : {}),
+            ...(checkOrigin ? { origin: checkOrigin } : {}),
+          },
+        );
+        return { approvalGate, approvalMatch } as const;
+      }).pipe(
+        // `catchAllCause` (not `catchAll`): `checkApprovalRequired`'s typed
+        // error channel is `never`, so its only failure mode is a SYNCHRONOUS
+        // throw (a packaging glitch / unexpected DB schema inside the EE
+        // helper), which surfaces as a DEFECT — invisible to `catchAll`. The
+        // pre-#3764 `async`/`try-catch` body caught both; we must too, or a
+        // sync throw would escape the fail-closed gate as a 500.
+        Effect.catchAllCause((cause) => {
+          const err = Cause.squash(cause);
+          log.error(
+            { err: err instanceof Error ? err.message : String(err), connectionId: connId },
+            "Approval check failed — blocking query (fail-closed)",
+          );
+          return Effect.succeed({
+            kind: "approval_unavailable" as const,
+            message: "Approval system unavailable — query blocked. Contact your administrator.",
+          });
+        }),
+      );
+      // The catch branch returns the failure outcome with no `approvalGate`;
+      // discriminate on its presence to know the check succeeded.
+      if (!("approvalGate" in check)) return check;
+      const { approvalGate, approvalMatch } = check;
 
-          if (approvalMatch?.required) {
-            const reqCtxForApproval = getRequestContext();
-            const approvalOrgId = reqCtxForApproval?.user?.activeOrganizationId;
-            const userId = reqCtxForApproval?.user?.id;
-            const userEmail = reqCtxForApproval?.user?.label ?? null;
+      if (approvalMatch?.required) {
+        const reqCtxForApproval = getRequestContext();
+        const approvalOrgId = reqCtxForApproval?.user?.activeOrganizationId;
+        const userId = reqCtxForApproval?.user?.id;
+        const userEmail = reqCtxForApproval?.user?.label ?? null;
 
-            if (!userId || !approvalOrgId) {
-              log.warn(
-                { connectionId: connId, orgId: approvalOrgId, identityMissing: approvalMatch.identityMissing === true },
-                "Approval required but user identity unavailable — blocking query",
-              );
-              return {
-                kind: "approval_identity_missing" as const,
-                message: "This query requires approval but the requester identity could not be determined. Please sign in and try again.",
-              };
-            }
+        if (!userId || !approvalOrgId) {
+          log.warn(
+            { connectionId: connId, orgId: approvalOrgId, identityMissing: approvalMatch.identityMissing === true },
+            "Approval required but user identity unavailable — blocking query",
+          );
+          return {
+            kind: "approval_identity_missing" as const,
+            message: "This query requires approval but the requester identity could not be determined. Please sign in and try again.",
+          };
+        }
 
-            const alreadyApproved = await Effect.runPromise(approvalGate.hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId));
-            if (!alreadyApproved) {
-              const firstRule = approvalMatch.matchedRules[0];
-              const approvalReq = await Effect.runPromise(approvalGate.createApprovalRequest({
-                orgId: approvalOrgId,
-                ruleId: firstRule.id,
-                ruleName: firstRule.name,
-                requesterId: userId,
-                requesterEmail: userEmail,
-                querySql: normalizedSql,
-                explanation,
-                connectionId: connId,
-                tablesAccessed: classification.tablesAccessed,
-                columnsAccessed: classification.columnsAccessed,
-                origin: reqCtxForApproval?.agentOrigin ?? null,
-              }));
-              logQueryAudit({
-                sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
-                error: `Approval required: ${firstRule.name}`,
-                sourceId: connId, sourceType: dbType, targetHost,
-              });
-              return {
-                kind: "approval_required" as const,
-                approvalRequestId: approvalReq.id,
-                matchedRules: approvalMatch.matchedRules.map((r) => r.name),
-                message:
-                  `This query requires approval before execution. Rule: "${firstRule.name}". ` +
-                  `An approval request has been submitted (ID: ${approvalReq.id}).`,
-              };
-            }
-          }
-          return null;
-        },
-        catch: (err) => {
-          const message = err instanceof Error ? err.message : String(err);
-          log.error({ err, connectionId: connId }, "Approval workflow failed — blocking query");
-          return new QueryExecutionError({ message: `Approval workflow failed: ${message}` });
-        },
-      });
-      if (approvalOutcome !== null) return approvalOutcome;
+        const createOutcome = yield* Effect.gen(function* () {
+          const alreadyApproved = yield* approvalGate.hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId);
+          if (alreadyApproved) return null;
+          const firstRule = approvalMatch.matchedRules[0];
+          const approvalReq = yield* approvalGate.createApprovalRequest({
+            orgId: approvalOrgId,
+            ruleId: firstRule.id,
+            ruleName: firstRule.name,
+            requesterId: userId,
+            requesterEmail: userEmail,
+            querySql: normalizedSql,
+            explanation,
+            connectionId: connId,
+            tablesAccessed: classification.tablesAccessed,
+            columnsAccessed: classification.columnsAccessed,
+            origin: reqCtxForApproval?.agentOrigin ?? null,
+          });
+          logQueryAudit({
+            sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
+            error: `Approval required: ${firstRule.name}`,
+            sourceId: connId, sourceType: dbType, targetHost,
+          });
+          return {
+            kind: "approval_required" as const,
+            approvalRequestId: approvalReq.id,
+            matchedRules: approvalMatch.matchedRules.map((r) => r.name),
+            message:
+              `This query requires approval before execution. Rule: "${firstRule.name}". ` +
+              `An approval request has been submitted (ID: ${approvalReq.id}).`,
+          } satisfies UserQueryOutcome;
+        }).pipe(
+          // `catchAllCause`, like the check region: map BOTH typed failures
+          // (createApprovalRequest's ApprovalError | EnterpriseError | Error)
+          // AND defects (a sync throw inside the gate) to a typed
+          // `QueryExecutionError` so a governance-write failure blocks the
+          // query rather than escaping — the pre-#3764 outer `catch` did both.
+          Effect.catchAllCause((cause) => {
+            const err = Cause.squash(cause);
+            const message = err instanceof Error ? err.message : String(err);
+            log.error({ err, connectionId: connId }, "Approval workflow failed — blocking query");
+            return Effect.fail(new QueryExecutionError({ message: `Approval workflow failed: ${message}` }));
+          }),
+        );
+        if (createOutcome !== null) return createOutcome;
+      }
     }
 
     // Source-slot wrapper: plugin beforeQuery → re-validate → RLS → LIMIT → execute.
@@ -1819,114 +1848,131 @@ async function executeSqlForConnection({
       // rule exists in the database; the Phase 2 user-identity gate
       // below routes that into the "approve via the Atlas web app" error.
       if (classification) {
-        const approvalResult = yield* Effect.tryPromise({
-          try: async () => {
-            let approvalMatch:
-              | { required: boolean; matchedRules: { id: string; name: string }[]; identityMissing?: boolean };
-            let approvalGate: ApprovalGateShape;
-            try {
-              approvalGate = await loadApprovalGate();
-              const checkReqCtx = getRequestContext();
-              const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
-              const checkUserId = checkReqCtx?.user?.id;
-              // #2072 — propagate the request's agent origin so
-              // origin-scoped rules only fire on the matching transport.
-              // Routes stamp this on `withRequestContext`; an unstamped
-              // route (or a legacy caller) reaches checkApprovalRequired
-              // with `origin: undefined` and only triggers `'any'`
-              // rules — scope isolation rather than governance bypass,
-              // since the `'any'` migration default still fires.
-              const checkOrigin = checkReqCtx?.agentOrigin;
-              // Pass requesterId so the defensive identity-missing check
-              // distinguishes "scheduler/Slack/MCP forgot to bind anything"
-              // (fail-closed) from "demo / single-user mode bound a user
-              // but no org" (pass-through, no rule can match anyway).
-              approvalMatch = await Effect.runPromise(approvalGate.checkApprovalRequired(
-                checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
-                {
-                  ...(checkUserId ? { requesterId: checkUserId } : {}),
-                  ...(checkOrigin ? { origin: checkOrigin } : {}),
-                },
-              ));
-            } catch (err) {
-              log.error(
-                { err: err instanceof Error ? err.message : String(err), connectionId: connId },
-                "Approval check failed — blocking query (fail-closed)",
-              );
-              return {
-                success: false,
-                error: "Approval system unavailable — query blocked. Contact your administrator.",
-                executionMs: 0,
-              };
-            }
+        // #3764 — same `yield*` composition as the live path above: resolve the
+        // EE-bound gate via `loadApprovalGate()` (Promise→Effect boundary) and
+        // thread its already-resolved Effects onto the pipeline fiber rather
+        // than re-entering via `Effect.runPromise` per call. The two
+        // fail-closed regions are preserved: a CHECK failure (gate load /
+        // checkApprovalRequired) → `approval system unavailable`; a CREATE
+        // failure → `QueryExecutionError` (governance bypass is worse than a
+        // failed query). `identityMissing` is a value branch, not a failure.
+        const check = yield* Effect.gen(function* () {
+          const approvalGate = yield* Effect.tryPromise({
+            try: () => loadApprovalGate(),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          });
+          const checkReqCtx = getRequestContext();
+          const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
+          const checkUserId = checkReqCtx?.user?.id;
+          // #2072 — propagate the request's agent origin so
+          // origin-scoped rules only fire on the matching transport.
+          // Routes stamp this on `withRequestContext`; an unstamped
+          // route (or a legacy caller) reaches checkApprovalRequired
+          // with `origin: undefined` and only triggers `'any'`
+          // rules — scope isolation rather than governance bypass,
+          // since the `'any'` migration default still fires.
+          const checkOrigin = checkReqCtx?.agentOrigin;
+          // Pass requesterId so the defensive identity-missing check
+          // distinguishes "scheduler/Slack/MCP forgot to bind anything"
+          // (fail-closed) from "demo / single-user mode bound a user
+          // but no org" (pass-through, no rule can match anyway).
+          const approvalMatch = yield* approvalGate.checkApprovalRequired(
+            checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
+            {
+              ...(checkUserId ? { requesterId: checkUserId } : {}),
+              ...(checkOrigin ? { origin: checkOrigin } : {}),
+            },
+          );
+          return { approvalGate, approvalMatch } as const;
+        }).pipe(
+          // `catchAllCause`: a sync throw from the gate surfaces as a defect,
+          // which `catchAll` would miss — block fail-closed on both (see the
+          // live-path region above for the full rationale).
+          Effect.catchAllCause((cause) => {
+            const err = Cause.squash(cause);
+            log.error(
+              { err: err instanceof Error ? err.message : String(err), connectionId: connId },
+              "Approval check failed — blocking query (fail-closed)",
+            );
+            return Effect.succeed({
+              success: false as const,
+              error: "Approval system unavailable — query blocked. Contact your administrator.",
+              executionMs: 0,
+            });
+          }),
+        );
+        if (!("approvalGate" in check)) return check;
+        const { approvalGate, approvalMatch } = check;
 
-            // Phase 2: create request (hard fail — governance bypass is worse than a failed query)
-            if (approvalMatch?.required) {
-              const reqCtxForApproval = getRequestContext();
-              const approvalOrgId = reqCtxForApproval?.user?.activeOrganizationId;
-              const userId = reqCtxForApproval?.user?.id;
-              const userEmail = reqCtxForApproval?.user?.label ?? null;
+        // Phase 2: create request (hard fail — governance bypass is worse than a failed query)
+        if (approvalMatch?.required) {
+          const reqCtxForApproval = getRequestContext();
+          const approvalOrgId = reqCtxForApproval?.user?.activeOrganizationId;
+          const userId = reqCtxForApproval?.user?.id;
+          const userEmail = reqCtxForApproval?.user?.label ?? null;
 
-              if (!userId || !approvalOrgId) {
-                log.warn(
-                  { connectionId: connId, orgId: approvalOrgId, identityMissing: approvalMatch.identityMissing === true },
-                  "Approval required but user identity unavailable — blocking query",
-                );
-                return {
-                  success: false,
-                  error: "This query requires approval but the requester identity could not be determined. Please sign in and try again.",
-                  executionMs: 0,
-                };
-              }
+          if (!userId || !approvalOrgId) {
+            log.warn(
+              { connectionId: connId, orgId: approvalOrgId, identityMissing: approvalMatch.identityMissing === true },
+              "Approval required but user identity unavailable — blocking query",
+            );
+            return {
+              success: false,
+              error: "This query requires approval but the requester identity could not be determined. Please sign in and try again.",
+              executionMs: 0,
+            };
+          }
 
-              const alreadyApproved = await Effect.runPromise(approvalGate.hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId));
-              if (!alreadyApproved) {
-                const firstRule = approvalMatch.matchedRules[0];
-                const approvalReq = await Effect.runPromise(approvalGate.createApprovalRequest({
-                  orgId: approvalOrgId,
-                  ruleId: firstRule.id,
-                  ruleName: firstRule.name,
-                  requesterId: userId,
-                  requesterEmail: userEmail,
-                  querySql: normalizedSql,
-                  explanation,
-                  connectionId: connId,
-                  tablesAccessed: classification.tablesAccessed,
-                  columnsAccessed: classification.columnsAccessed,
-                  // #2072 — stamp the agent origin on the queue row
-                  // for the audit dimension (queryable via direct SQL
-                  // until an origin filter ships in /admin/audit).
-                  origin: reqCtxForApproval?.agentOrigin ?? null,
-                }));
-                logQueryAudit({
-                  sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
-                  error: `Approval required: ${firstRule.name}`,
-                  sourceId: connId, sourceType: dbType, targetHost,
-                  parentAuditId,
-                });
-                return {
-                  success: false,
-                  approval_required: true,
-                  approval_request_id: approvalReq.id,
-                  matched_rules: approvalMatch.matchedRules.map((r: { name: string }) => r.name),
-                  message: `This query requires approval before execution. Rule: "${firstRule.name}". ` +
-                    `An approval request has been submitted (ID: ${approvalReq.id}). ` +
-                    `An admin must approve it before the query can run.`,
-                  executionMs: 0,
-                };
-              }
-            }
-            return null; // proceed to execution
-          },
-          catch: (err) => {
+          const createResult = yield* Effect.gen(function* () {
+            const alreadyApproved = yield* approvalGate.hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId);
+            if (alreadyApproved) return null;
+            const firstRule = approvalMatch.matchedRules[0];
+            const approvalReq = yield* approvalGate.createApprovalRequest({
+              orgId: approvalOrgId,
+              ruleId: firstRule.id,
+              ruleName: firstRule.name,
+              requesterId: userId,
+              requesterEmail: userEmail,
+              querySql: normalizedSql,
+              explanation,
+              connectionId: connId,
+              tablesAccessed: classification.tablesAccessed,
+              columnsAccessed: classification.columnsAccessed,
+              // #2072 — stamp the agent origin on the queue row
+              // for the audit dimension (queryable via direct SQL
+              // until an origin filter ships in /admin/audit).
+              origin: reqCtxForApproval?.agentOrigin ?? null,
+            });
+            logQueryAudit({
+              sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
+              error: `Approval required: ${firstRule.name}`,
+              sourceId: connId, sourceType: dbType, targetHost,
+              parentAuditId,
+            });
+            return {
+              success: false,
+              approval_required: true,
+              approval_request_id: approvalReq.id,
+              matched_rules: approvalMatch.matchedRules.map((r: { name: string }) => r.name),
+              message: `This query requires approval before execution. Rule: "${firstRule.name}". ` +
+                `An approval request has been submitted (ID: ${approvalReq.id}). ` +
+                `An admin must approve it before the query can run.`,
+              executionMs: 0,
+            };
+          }).pipe(
             // Phase 2 failure — governance bypass is worse than a failed query.
-            // Surface as a typed error so it reaches the agent as {success: false}.
-            const message = err instanceof Error ? err.message : String(err);
-            log.error({ err, connectionId: connId }, "Approval request creation failed — blocking query");
-            return new QueryExecutionError({ message: `Approval workflow failed: ${message}` });
-          },
-        });
-        if (approvalResult !== null) return approvalResult;
+            // `catchAllCause` so a sync throw (defect) from the gate is mapped
+            // too, not just typed failures. Surface as a typed error so it
+            // reaches the agent as {success: false}.
+            Effect.catchAllCause((cause) => {
+              const err = Cause.squash(cause);
+              const message = err instanceof Error ? err.message : String(err);
+              log.error({ err, connectionId: connId }, "Approval request creation failed — blocking query");
+              return Effect.fail(new QueryExecutionError({ message: `Approval workflow failed: ${message}` }));
+            }),
+          );
+          if (createResult !== null) return createResult;
+        }
       }
 
       // Step 4: Cache check (short-circuit on hit)

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1532,9 +1532,12 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
         // pre-#3764 `async`/`try-catch` body caught both; we must too, or a
         // sync throw would escape the fail-closed gate as a 500.
         Effect.catchAllCause((cause) => {
-          const err = Cause.squash(cause);
+          // Log the squashed Error object (a `FiberFailure` for a defect — an
+          // Error subclass) so pino's `err` serializer keeps the stack, matching
+          // the CREATE handler below + the P4 normalization (don't strip via
+          // `.message`).
           log.error(
-            { err: err instanceof Error ? err.message : String(err), connectionId: connId },
+            { err: Cause.squash(cause), connectionId: connId },
             "Approval check failed — blocking query (fail-closed)",
           );
           return Effect.succeed({
@@ -1889,9 +1892,10 @@ async function executeSqlForConnection({
           // which `catchAll` would miss — block fail-closed on both (see the
           // live-path region above for the full rationale).
           Effect.catchAllCause((cause) => {
-            const err = Cause.squash(cause);
+            // Log the squashed Error object (stack-preserving) to match the
+            // live-path CHECK handler + the CREATE handler below (#3764 P4).
             log.error(
-              { err: err instanceof Error ? err.message : String(err), connectionId: connId },
+              { err: Cause.squash(cause), connectionId: connId },
               "Approval check failed — blocking query (fail-closed)",
             );
             return Effect.succeed({


### PR DESCRIPTION
## Summary

Effect.ts usage cleanup (#3764) — five priorities, no v3→v4 migration (`Context.Tag` / `Data.TaggedError` / `Layer.scoped` / bun-test all kept). Behavior-preserving except where it strengthens fail-closed enforcement.

- **P1 — `Effect → Promise → runPromise` re-entry**
  - `tools/sql.ts` approval gate (live + legacy/cache paths): `yield*`-compose the gate's per-method Effects instead of `Effect.runPromise` inside an `async` `tryPromise` body. Resolution still crosses the enterprise-runtime boundary via `loadApprovalGate()`. Uses `Effect.catchAllCause` (not `catchAll`) so a **synchronous throw** from the gate — a *defect*, since `checkApprovalRequired`/`hasApprovedRequest` have a `never` error channel — stays fail-closed exactly as the pre-refactor `try/catch` did.
  - `datasources/mcp-lifecycle.ts`: inline `Effect.provide(...Live)` → shared module-level `ManagedRuntime`s (mirrors `enterprise-layer.ts`'s `getEnterpriseRuntime`). The runtime **composes** `WorkspaceInstallerLive` / `SemanticGeneratorLive` (both dependency-free, finalizer-free) — not a bare relocation; real-runtime service resolution is exercised by `mcp-lifecycle.test.ts` (28) + `mcp-profile-plugin.test.ts` (14), which do **not** mock the Live layers.
  - `auth/middleware.ts`: fold the per-request `isSSOEnforcedForDomain` `runPromise` into the `runEnterprise` Effect that resolves `SSOPolicy` (one runtime entry; `_ssoEnforcementOverride` test seam preserved).
- **P2 — schedulers**: `byot-catalog-refresh` + `openapi-install-rediscover` **stay** on `setInterval`+`unref` with a documented rationale (see below).
- **P3 — route-level `Effect.provide`**: accepted as the request-boundary pattern with a one-line rationale at each of the 7 sites (see below).
- **P4 — string-error-channel catches** in `effect/{services,layers}.ts`: normalized to `Error` via `normalizeError` and log the `Error` object so pino's `err` serializer preserves the stack (`layers.ts` previously re-wrapped `string → new Error(...)`, discarding the original stack).
- **P5 — CLAUDE.md**: carve-out on the "No `catch: (err) => err`" rule for `semantic-generator.ts`'s intentional cancellation-identity preservation.

Also adds two CREATE-phase fail-closed tests (sync throw + rejected Effect from `createApprovalRequest`) to pin the new `catchAllCause` on the approval write path.

## Rationale for the two "documented reason" decisions (reviewers: read these)

**P2 — why schedulers stay on `setInterval` instead of moving to `engine.ts`'s fiber pattern.** `byot-catalog-refresh` + `openapi-install-rediscover` deliberately share a `setInterval` + `unref()` convention with `openapi-spec-refresh` + `ee/audit/purge-scheduler` (they cross-reference each other in their headers). `engine.ts` is the *only* scheduler on the `Effect.runFork` + `Schedule` fiber pattern, and only because it needs an `Effect.onInterrupt` finalizer to release orphaned `running` `task_run` rows on shutdown (engine.ts:306). These refreshers are idempotent, `unref`'d, and have **no per-tick rows an interrupt must clean up**, so the fiber pattern would add machinery for a guarantee they don't need — and would break an intentional 4-file convention. P2's acceptance criterion explicitly allows "a documented reason not to." Rationale added to each refresher's lifecycle section.

**P1/P3 tiebreak — why `mcp-lifecycle` lifts the provide but routes keep theirs.** `mcp-lifecycle`'s `runDatasourceInstaller` is structurally the MCP-transport analog of the route bridge `admin-connections.ts`'s `runInstaller`, so by symmetry one could argue it's also an accepted boundary. But P1's acceptance criterion is *explicit* ("`mcp-lifecycle.ts` no longer calls `Effect.provide` inside library functions"), so the criterion wins the tiebreak over the structural-symmetry argument: `mcp-lifecycle` lifts to a shared runtime, while the 7 route-level provides are accepted under P3 ("explicitly accepted with a one-line rationale") since routes are the request boundary.

## Acceptance criteria (from #3764)

- [x] **P1**: `tools/sql.ts` approval-gate calls compose with `yield*` (no `Effect.runPromise` inside an `async` `tryPromise` body); `mcp-lifecycle.ts` no longer calls `Effect.provide` inside library functions; `auth/middleware.ts` SSO check no longer spins an ad-hoc `runPromise` per request.
- [x] **P2**: scheduler refresh cycles use the `runFork` + `Schedule` fiber pattern consistent with `engine.ts` — **documented reason not to** (intentional `setInterval`/`unref` convention shared with `openapi-spec-refresh` + `ee/audit/purge-scheduler`; only `engine.ts` needs the fiber pattern, for `onInterrupt` `task_run` cleanup). Rationale in each refresher's lifecycle section.
- [x] **P3**: route-level `Effect.provide` — **explicitly accepted with a one-line rationale** at all 7 sites (route is its own composition root; the Live layers are dependency-free/finalizer-free).
- [x] **P4**: string-error-channel catches in `effect/services.ts` + `effect/layers.ts` **normalized to `Error`** (via `normalizeError`) and the paired `catchAll` logs the Error object so pino's `err` serializer captures the stack.
- [x] **P5**: CLAUDE.md "No `catch: (err) => err`" rule has a carve-out referencing `semantic-generator.ts`'s cancellation-identity case.
- [x] `bun run type` + `bun run lint` + affected tests green (150/150); OpenAPI drift check unaffected (`check-openapi-drift.sh` passes).

## Test plan
- [x] `bun run lint` — 0
- [x] `bun run type` — 0 (incl. `@atlas/web`)
- [x] Affected suite: 150/150 pass (`test-isolated.ts --affected`), incl. sql-approval (13), auth/middleware (70), effect/layers, mcp-lifecycle (28, real `WorkspaceInstallerLive`), mcp-profile-plugin (14, real `SemanticGeneratorLive`)
- [x] All CI drift/discipline scripts pass (template, security-headers, railway-watch, schema, openapi, oauth-helper, test-discipline, twenty-resolver, settings-readers, saas-env-doc, published-symbols)
- [x] syncpack clean
- Note: full `bun run test` shows the 5 documented WSL2/dev-shell false failures (3 explore/python vercel-sandbox env artifacts — pass with `VERCEL_*`/`ATLAS_SANDBOX_URL` unset; 2 under-load flakes — pass in isolation); none touch this diff.

Closes #3764

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SQL approval gate to block execution on defects and remove nested `runPromise` calls
> - Refactors the SQL approval gate in [`sql.ts`](https://github.com/AtlasDevHQ/atlas/pull/3839/files#diff-aff638412280e753f8b324c261136e133472c2e24d24882f34736d3700920e17) to stay within the pipeline fiber using `Effect.catchAllCause`, so synchronous throws and rejected Effects from `checkApprovalRequired`/`createApprovalRequest` now reliably block query execution instead of escaping as uncaught errors.
> - Introduces lazy-initialized `ManagedRuntime` singletons in [`mcp-lifecycle.ts`](https://github.com/AtlasDevHQ/atlas/pull/3839/files#diff-6e517407fb49bdc285404e4802c8c563106d99164b96ee90ddb52e2cd6b8a733) for `WorkspaceInstallerLive` and `SemanticGeneratorLive`, replacing per-call `Effect.provide` + `Effect.runPromise` pairs.
> - Normalizes `Effect.tryPromise` catch handlers across [`layers.ts`](https://github.com/AtlasDevHQ/atlas/pull/3839/files#diff-5ad84a2ea26a190f9b35b153e10849be5e0c9feb4622b1587b7ecdb74715a12c) and [`services.ts`](https://github.com/AtlasDevHQ/atlas/pull/3839/files#diff-11b664638df1998c3ac26237ca0ec855ad834e2bff23c16399b010293d1355d3) to use `normalizeError`, passing `Error` objects to structured logging instead of raw strings.
> - Refactors SSO enforcement in [`middleware.ts`](https://github.com/AtlasDevHQ/atlas/pull/3839/files#diff-1d6382b1eebf0133940a49eadaaaec8725c307e31b02a25d4c767bc48b1c8079) to compose the full resolution chain in a single `Effect.gen` instead of a nested `Effect.runPromise` call.
> - Behavioral Change: SQL approval failures that previously risked being silently swallowed now surface as `approval_unavailable` or `QueryExecutionError` responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04cf843.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors Effect.ts usage across five areas: eliminating `Effect.runPromise` re-entry inside `async`/`tryPromise` bodies in `tools/sql.ts` and `auth/middleware.ts`, lifting per-call `Effect.provide` to module-level `ManagedRuntime` singletons in `mcp-lifecycle.ts`, and normalizing string error channels to `Error` objects via `normalizeError` across `effect/layers.ts` and `effect/services.ts`. Behavior is preserved throughout; the changes strengthen fail-closed enforcement on the approval gate paths by using `catchAllCause` instead of `catchAll` to capture synchronous defects.

- **`tools/sql.ts`**: Both approval-gate regions now compose gate Effects via `yield*` with a two-region `catchAllCause` guard; two new tests pin the sync-throw and rejected-Effect fail-closed behavior on the CREATE path.
- **`auth/middleware.ts`**: `isSSOEnforcedForDomain` is folded into the single `runEnterprise` call; the test override seam (`_ssoEnforcementOverride`) is preserved by an early-return branch inside the Effect.
- **`effect/layers.ts` + `effect/services.ts`**: ~15 `tryPromise` `catch:` clauses normalized from string-returning lambdas to `normalizeError`, with paired `catchAll` handlers updated to log `{ err }` so pino retains the stack.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are behavior-preserving refactors with the sole exception of strengthened fail-closed enforcement on the approval gate, which is the desired direction.

The approval-gate refactoring in sql.ts is the highest-stakes change: switching from async/runPromise re-entry to yield* composition with catchAllCause. The two new fail-closed tests directly pin the invariant. Both CHECK handlers now log Cause.squash(cause) as the full Error object — the concern from the prior review thread has been resolved in this version. The middleware SSO fold is straightforward with the test override seam intact. The mcp-lifecycle lazy singletons follow the established getEnterpriseRuntime() pattern. The normalizeError sweep across layers.ts and services.ts is mechanical and consistent.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/tools/sql.ts | Approval gate refactored to compose Effects via yield* with catchAllCause guards; both CHECK handlers log Cause.squash(cause) as the Error object, both CREATE handlers use the same pattern. Two-region fail-closed contract preserved. |
| packages/api/src/lib/auth/middleware.ts | SSO enforcement lookup folded into the single runEnterprise Effect; test override seam preserved via early-return when _ssoEnforcementOverride is set; domain null-check still fires after the Effect resolves. |
| packages/api/src/lib/datasources/mcp-lifecycle.ts | Per-call Effect.provide replaced with two lazy module-level ManagedRuntime singletons; laziness ensures test mock.module() intercepts before first build; both layers are stateless/finalizer-free. |
| packages/api/src/lib/effect/layers.ts | All tryPromise catch: clauses normalized to normalizeError; paired catchAll handlers updated to log { err } so pino retains the full stack. MigrationShape.error correctly uses err.message. |
| packages/api/src/lib/effect/services.ts | Same normalizeError normalization applied across all ~12 tryPromise catch: sites; consistent and complete. |
| packages/api/src/lib/tools/__tests__/sql-approval.test.ts | Two new Phase 2 fail-closed tests added for sync throw and rejected Effect from createApprovalRequest — both verify the query is blocked. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(effect): log squashed Error (no..."](https://github.com/atlasdevhq/atlas/commit/04cf8432d2d4bd8d917483e619173ca79c878343) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38840892)</sub>

<!-- /greptile_comment -->