### PR TITLE
chore(ci): guard publish.yml ↔ package coverage; drop orphaned slack-v* trigger (#3815)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,6 @@ on:
       - 'railway-sandbox-v*'
       # Plugins — interaction
       - 'chat-v*'
-      - 'slack-v*'
       - 'webhook-v*'
       - 'teams-v*'
       - 'email-digest-v*'

--- a/scripts/check-unpublished-versions.ts
+++ b/scripts/check-unpublished-versions.ts
@@ -25,9 +25,14 @@
 // Network/registry hiccups are non-fatal (warn + skip that package) so a blip
 // can't block merges; a definite "unpublished + not introduced here" is fatal.
 //
+// This script ALSO runs a network-free structural guard (checkWorkflowCoverage)
+// that keeps publish.yml's triggers + steps, the PREFIX_TO_DIR map, and the
+// publishable packages on disk in lockstep — catching a package that is wired in
+// one place but not the others (the silent-no-publish class, #3815).
+//
 // Usage: bun scripts/check-unpublished-versions.ts
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
@@ -36,11 +41,13 @@ const execFileAsync = promisify(execFile);
 const repoRoot = join(import.meta.dir, "..");
 
 // SSOT for publishable packages: tag prefix (the part before `-v`) -> package
-// dir, mirroring .github/workflows/publish.yml. `null` = a reserved tag prefix
-// with no package yet. The publish.yml-sync guard below asserts this map covers
-// every prefix publish.yml declares, so a newly publishable package can't be
-// wired into publish.yml without being covered here.
-const PREFIX_TO_DIR: Record<string, string | null> = {
+// dir, mirroring .github/workflows/publish.yml. The workflow-coverage guard
+// (checkWorkflowCoverage, below) keeps this map, publish.yml's `on.push.tags`
+// triggers, publish.yml's per-package steps, and the actual publishable
+// workspace packages all in lockstep — so a new package can't be half-wired and
+// silently never publish, and a tag prefix can't linger without a step and
+// silently no-op when pushed.
+const PREFIX_TO_DIR: Record<string, string> = {
   types: "packages/types",
   "atlas-agent": "create-atlas",
   "atlas-plugin": "create-atlas-plugin",
@@ -62,7 +69,6 @@ const PREFIX_TO_DIR: Record<string, string | null> = {
   "vercel-sandbox": "plugins/vercel-sandbox",
   "railway-sandbox": "plugins/railway-sandbox",
   chat: "plugins/chat",
-  slack: null, // reserved prefix, no package dir yet
   webhook: "plugins/webhook",
   teams: "plugins/teams",
   "email-digest": "plugins/email-digest",
@@ -92,6 +98,116 @@ function declaredPrefixes(): string[] {
   const out = new Set<string>();
   for (const m of yml.matchAll(/^\s*-\s*'([a-z0-9-]+)-v\*'/gm)) out.add(m[1]);
   return [...out];
+}
+
+/** Tag prefixes a publish step is gated on (`if: ...refs/tags/<prefix>-v`). */
+function stepPrefixes(): string[] {
+  const yml = readFileSync(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
+  const out = new Set<string>();
+  for (const m of yml.matchAll(/refs\/tags\/([a-z0-9-]+)-v/g)) out.add(m[1]);
+  return [...out];
+}
+
+/**
+ * Publishable workspace packages under packages/ and plugins/: those whose
+ * package.json is not `private` and not in the internal `@atlas/*` scope.
+ * Returns repo-relative dirs (e.g. "plugins/bigquery"). These MUST be covered by
+ * PREFIX_TO_DIR — a new one with no mapping would silently never publish.
+ */
+function publishablePackageDirs(): string[] {
+  const out: string[] = [];
+  for (const base of ["packages", "plugins"]) {
+    let entries: string[];
+    try {
+      entries = readdirSync(join(repoRoot, base));
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const dir = `${base}/${name}`;
+      let pkg: Pkg;
+      try {
+        pkg = readPkg(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+      } catch {
+        continue; // no package.json (e.g. a stray dir) — not a package
+      }
+      if (pkg.private) continue;
+      if (!pkg.name || pkg.name.startsWith("@atlas/")) continue;
+      out.push(dir);
+    }
+  }
+  return out;
+}
+
+/**
+ * Network-free structural guard. Keeps four lists in lockstep so a publishable
+ * package can't be half-wired:
+ *   1. publish.yml `on.push.tags` trigger prefixes
+ *   2. publish.yml per-package step prefixes (`if: ...refs/tags/<prefix>-v`)
+ *   3. PREFIX_TO_DIR (the SSOT map)
+ *   4. the actual publishable workspace packages on disk
+ * Returns a list of human-readable problems (empty = all in sync).
+ */
+function checkWorkflowCoverage(): string[] {
+  const problems: string[] = [];
+  const triggers = new Set(declaredPrefixes());
+  const steps = new Set(stepPrefixes());
+  const mapped = new Set(Object.keys(PREFIX_TO_DIR));
+
+  // 1. Every trigger prefix must be in the SSOT map.
+  for (const p of triggers) {
+    if (!mapped.has(p)) {
+      problems.push(
+        `publish.yml declares tag prefix "${p}-v*" but PREFIX_TO_DIR has no entry. Add it pointing at the package dir.`,
+      );
+    }
+  }
+  // 2. Every map entry must be a real trigger (no stale/reserved prefixes).
+  for (const p of mapped) {
+    if (!triggers.has(p)) {
+      problems.push(
+        `PREFIX_TO_DIR has "${p}" but publish.yml's on.push.tags has no "${p}-v*" trigger. Remove the map entry or add the trigger.`,
+      );
+    }
+  }
+  // 3. Triggers and steps must match exactly — a trigger with no step silently
+  //    no-ops on push; a step with no trigger never runs.
+  for (const p of triggers) {
+    if (!steps.has(p)) {
+      problems.push(
+        `publish.yml triggers on "${p}-v*" but has no publish step gated on refs/tags/${p}-v — pushing that tag fires the workflow but publishes nothing.`,
+      );
+    }
+  }
+  for (const p of steps) {
+    if (!triggers.has(p)) {
+      problems.push(
+        `publish.yml has a publish step for "${p}-v*" but no matching on.push.tags trigger — that step can never run.`,
+      );
+    }
+  }
+  // 4. Every publishable package on disk must be covered by the map — a new
+  //    package with no mapping (so no trigger/step) would silently never publish.
+  const mappedDirs = new Set(Object.values(PREFIX_TO_DIR));
+  for (const dir of publishablePackageDirs()) {
+    if (!mappedDirs.has(dir)) {
+      problems.push(
+        `${dir} is a publishable workspace package (not private, not @atlas/*) but no PREFIX_TO_DIR entry points at it — it would never publish. Add a "<prefix>: ${dir}" entry plus the matching publish.yml trigger + step.`,
+      );
+    }
+  }
+  // 5. Every map entry must point at a real package.json — catches a
+  //    renamed/removed package leaving a dangling map entry.
+  for (const [prefix, dir] of Object.entries(PREFIX_TO_DIR)) {
+    try {
+      readPkg(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+    } catch {
+      problems.push(
+        `PREFIX_TO_DIR["${prefix}"] points at "${dir}" but there is no package.json there — fix the path or remove the entry (and its publish.yml trigger + step).`,
+      );
+    }
+  }
+  return problems;
 }
 
 function refExists(ref: string): boolean {
@@ -167,15 +283,14 @@ async function publishedVersions(name: string): Promise<string[] | null> {
 }
 
 async function main(): Promise<void> {
-  // ── publish.yml-sync guard ────────────────────────────────────────────
-  const declared = declaredPrefixes();
-  const unmapped = declared.filter((p) => !(p in PREFIX_TO_DIR));
-  if (unmapped.length > 0) {
-    for (const p of unmapped) {
-      console.error(
-        `::error::publish.yml declares tag prefix "${p}-v*" but scripts/check-unpublished-versions.ts has no PREFIX_TO_DIR entry. Add it (point it at the package dir, or null if reserved).`,
-      );
-    }
+  // ── workflow-coverage guard (structural, no network) ──────────────────
+  const coverageProblems = checkWorkflowCoverage();
+  if (coverageProblems.length > 0) {
+    for (const p of coverageProblems) console.error(`::error::${p}`);
+    console.error(
+      "\npublish.yml / PREFIX_TO_DIR / workspace packages are out of lockstep " +
+        "(see scripts/check-unpublished-versions.ts). Fix the mismatches above so no package silently fails to publish.",
+    );
     process.exit(1);
   }
 
@@ -187,9 +302,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const targets = Object.entries(PREFIX_TO_DIR).filter(
-    (e): e is [string, string] => e[1] !== null,
-  );
+  const targets = Object.entries(PREFIX_TO_DIR);
 
   const results = await Promise.all(
     targets.map(async ([prefix, dir]) => {

--- a/scripts/check-unpublished-versions.ts
+++ b/scripts/check-unpublished-versions.ts
@@ -104,37 +104,58 @@ function declaredPrefixes(): string[] {
 function stepPrefixes(): string[] {
   const yml = readFileSync(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
   const out = new Set<string>();
-  for (const m of yml.matchAll(/refs\/tags\/([a-z0-9-]+)-v/g)) out.add(m[1]);
+  // Anchored to real `if:` step lines (leading indent then `if:`), like
+  // declaredPrefixes — so a comment that mentions a removed `refs/tags/<x>-v`
+  // can't inject a phantom step prefix and trip the trigger<->step check.
+  for (const m of yml.matchAll(
+    /^\s*if:\s*startsWith\(github\.ref,\s*['"]refs\/tags\/([a-z0-9-]+)-v/gm,
+  )) {
+    out.add(m[1]);
+  }
   return [...out];
 }
 
 /**
- * Publishable workspace packages under packages/ and plugins/: those whose
+ * Publishable workspace packages: every dir under the root `workspaces` globs
+ * (plus `create-atlas`, which is published but not a workspace member) whose
  * package.json is not `private` and not in the internal `@atlas/*` scope.
- * Returns repo-relative dirs (e.g. "plugins/bigquery"). These MUST be covered by
- * PREFIX_TO_DIR — a new one with no mapping would silently never publish.
+ * Returns repo-relative dirs (e.g. "plugins/bigquery", "create-atlas"). These
+ * MUST be covered by PREFIX_TO_DIR — a new one with no mapping would silently
+ * never publish. Deriving from the workspace globs (not a fixed packages/+plugins/
+ * scan) keeps root-level packages in scope.
  */
 function publishablePackageDirs(): string[] {
-  const out: string[] = [];
-  for (const base of ["packages", "plugins"]) {
-    let entries: string[];
-    try {
-      entries = readdirSync(join(repoRoot, base));
-    } catch {
-      continue;
-    }
-    for (const name of entries) {
-      const dir = `${base}/${name}`;
-      let pkg: Pkg;
+  const rootPkg = JSON.parse(
+    readFileSync(join(repoRoot, "package.json"), "utf8"),
+  ) as { workspaces?: string[] };
+
+  const candidates = new Set<string>(["create-atlas"]);
+  for (const entry of rootPkg.workspaces ?? []) {
+    if (entry.endsWith("/*")) {
+      const base = entry.slice(0, -2);
+      let children: string[];
       try {
-        pkg = readPkg(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+        children = readdirSync(join(repoRoot, base));
       } catch {
-        continue; // no package.json (e.g. a stray dir) — not a package
+        continue;
       }
-      if (pkg.private) continue;
-      if (!pkg.name || pkg.name.startsWith("@atlas/")) continue;
-      out.push(dir);
+      for (const c of children) candidates.add(`${base}/${c}`);
+    } else {
+      candidates.add(entry);
     }
+  }
+
+  const out: string[] = [];
+  for (const dir of candidates) {
+    let pkg: Pkg;
+    try {
+      pkg = readPkg(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+    } catch {
+      continue; // no package.json (a glob dir without one, or a stray entry)
+    }
+    if (pkg.private) continue;
+    if (!pkg.name || pkg.name.startsWith("@atlas/")) continue;
+    out.push(dir);
   }
   return out;
 }


### PR DESCRIPTION
## What

Closes #3815.

`.github/workflows/publish.yml` duplicates per-package config in two hand-enumerated places that must stay in lockstep with the publishable packages on disk:

1. the `on.push.tags` trigger list (~30 `<name>-v*` patterns)
2. a per-package publish step gated on `if: startsWith(github.ref, 'refs/tags/<name>-v')`

Forgetting one is **silent**: a new package missing from `on.push.tags` fires **no** workflow run when its tag is pushed (nothing goes red), and an orphaned trigger with no step fires the workflow but publishes nothing.

This was a live bug: **`slack-v*`** was an orphan trigger — its publish step was removed in #2687 but the trigger was left behind, and `plugins/slack` has no `package.json`, so pushing `slack-v*` silently no-ops.

## How

Extends the **existing** structural guard in `scripts/check-unpublished-versions.ts` (already the SSOT for `PREFIX_TO_DIR` + the publish.yml trigger list, already run in the CI drift step) with a network-free `checkWorkflowCoverage()` asserting five invariants:

1. every `on.push.tags` trigger prefix is in `PREFIX_TO_DIR`
2. every `PREFIX_TO_DIR` entry is a real trigger (no stale/reserved prefixes)
3. triggers === per-package step prefixes (no orphan trigger / dead step)
4. every publishable workspace package (not `private`, not `@atlas/*`) under `packages/` and `plugins/` is covered by `PREFIX_TO_DIR`
5. every `PREFIX_TO_DIR` entry points at a real `package.json`

Also removes the `slack-v*` trigger and its `slack: null` reserved map entry, and drops the now-unused `null` branch (`PREFIX_TO_DIR` is `Record<string, string>`).

The `private`-aware, scope-aware check (4) correctly excludes intentionally-unpublished `@useatlas/schemas` (`private: true`) and all internal `@atlas/*` packages.

## Acceptance criteria (#3815)

- [x] A new publishable workspace package cannot silently fail to publish — loud guard, check (4)
- [x] Per-package special cases preserved — publish steps are untouched (react sdk-pre-build, sdk/plugin-sdk/webhook-publisher build+test, salesforce/elasticsearch peer-ordering guard, non-`plugins/<name>` dir mappings all intact)
- [x] Verifiable without cutting real prod tags — pure static lint, runs locally

## Verification

- Clean run: structural checks pass silently, all 32 packages confirmed on npm, exit 0
- Negative test — re-add `slack-v*` orphan: caught (checks 1 + 3), exit 1
- Negative test — remove a publishable package's map entry: caught (checks 1 + 4), exit 1
- `eslint` clean, `bun run type` (tsgo --noEmit) exit 0

https://claude.ai/code/session_01RdA3nUe4XLY9UmdPchgN53

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard publish.yml workflow coverage and drop orphaned `slack-v*` tag trigger
> - Removes the `slack-v*` tag from the `on.push.tags` list in [publish.yml](.github/workflows/publish.yml), as it had no corresponding package.
> - Adds `checkWorkflowCoverage()` to [check-unpublished-versions.ts](scripts/check-unpublished-versions.ts), which validates that `on.push.tags` triggers, step-level `if:` prefix guards, the `PREFIX_TO_DIR` map, and publishable workspace packages all stay in sync.
> - Removes `null` support from `PREFIX_TO_DIR`; every prefix must now map to a real package directory.
> - The script exits with `::error` log messages and a non-zero exit code if any mismatch is detected, before performing any network checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 617696c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates a class of silent publish failures by extending the existing `check-unpublished-versions.ts` script with a network-free `checkWorkflowCoverage()` guard, and removes the orphaned `slack-v*` trigger that had no corresponding publish step.

- **New `checkWorkflowCoverage()` function** adds five bidirectional checks keeping `publish.yml` triggers, per-package step conditions, the `PREFIX_TO_DIR` map, and publishable workspace packages on disk all in lockstep — any mismatch now causes an explicit CI failure instead of a silent no-op.
- **`publishablePackageDirs()`** derives its candidate list from the root `workspaces` field in `package.json` (plus the hardcoded `create-atlas` non-member), so root-level publishable packages are in scope.
- **`slack-v*` trigger removed** from `publish.yml` and `slack: null` removed from `PREFIX_TO_DIR`, cleaning up the orphan left by #2687; `PREFIX_TO_DIR` is now typed as `Record<string, string>` with no `null` placeholder support.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes a confirmed orphan trigger and adds a structural guard that makes future misconfigurations loud instead of silent.

The changes are purely additive static checks and a one-line YAML deletion of a confirmed dead trigger. The new guard functions are self-contained, read-only, and exit-on-failure before any network calls, so they cannot affect the existing publish logic when clean. The stepPrefixes() regex is now line-anchored and publishablePackageDirs() derives candidates from the repo's own workspace manifest so new root-level members are automatically in scope.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-unpublished-versions.ts | Adds stepPrefixes(), publishablePackageDirs(), and checkWorkflowCoverage() with five bidirectional invariant checks; removes null-branch handling; all logic is correct and addressed concerns from prior review threads. |
| .github/workflows/publish.yml | Removes the orphaned slack-v* on.push.tags trigger; no other publish steps or conditions changed. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[checkWorkflowCoverage] --> B[declaredPrefixes\npublish.yml on.push.tags]
    A --> C[stepPrefixes\npublish.yml if: conditions]
    A --> D[PREFIX_TO_DIR keys\nSSOT map]
    A --> E[publishablePackageDirs\nworkspace globs on disk]

    B -- check 1: every trigger in map --> D
    D -- check 2: every map entry has trigger --> B
    B -- check 3a: every trigger has step --> C
    C -- check 3b: every step has trigger --> B
    E -- check 4: every publishable dir in map --> D
    D -- check 5: every map dir has package.json --> F[filesystem]

    A --> G{problems?}
    G -- yes --> H[::error:: + exit 1]
    G -- no --> I[continue to npm version checks]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[checkWorkflowCoverage] --> B[declaredPrefixes\npublish.yml on.push.tags]
    A --> C[stepPrefixes\npublish.yml if: conditions]
    A --> D[PREFIX_TO_DIR keys\nSSOT map]
    A --> E[publishablePackageDirs\nworkspace globs on disk]

    B -- check 1: every trigger in map --> D
    D -- check 2: every map entry has trigger --> B
    B -- check 3a: every trigger has step --> C
    C -- check 3b: every step has trigger --> B
    E -- check 4: every publishable dir in map --> D
    D -- check 5: every map dir has package.json --> F[filesystem]

    A --> G{problems?}
    G -- yes --> H[::error:: + exit 1]
    G -- no --> I[continue to npm version checks]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): address Greptile review on th..."](https://github.com/atlasdevhq/atlas/commit/617696ca20ea647e2c2450e18a5e588ee2f8faf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38888520)</sub>

<!-- /greptile_comment -->