### PR TITLE
fix(install): honor showWhen in datasource config-schema validators (#3842)

### DIFF
--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -427,6 +427,62 @@ describe("validateAgainstConfigSchema", () => {
     });
     expect(err).toBeNull();
   });
+
+  // #3842: conditional (`showWhen`-gated) required fields must only be enforced
+  // when their branch is active. ES declares per-auth-mode required fields;
+  // before the fix, basic-auth installs 400'd demanding apiKey + awsRegion.
+  const esSchema = [
+    { key: "url", type: "string", required: true },
+    { key: "authMode", type: "select", required: true },
+    { key: "username", type: "string", required: true, showWhen: { field: "authMode", equals: ["basic"] } },
+    { key: "password", type: "string", required: true, secret: true, showWhen: { field: "authMode", equals: ["basic"] } },
+    { key: "apiKey", type: "string", required: true, secret: true, showWhen: { field: "authMode", equals: ["apiKey"] } },
+    { key: "awsRegion", type: "string", required: true, showWhen: { field: "authMode", equals: ["sigv4"] } },
+  ];
+
+  it("passes basic auth without demanding apiKey/awsRegion (#3842)", () => {
+    const err = mod._testing.validateAgainstConfigSchema("elasticsearch", esSchema, {
+      url: "elasticsearch://host:9200",
+      authMode: "basic",
+      username: "u",
+      password: "p",
+    });
+    expect(err).toBeNull();
+  });
+
+  it("still enforces the active branch's required fields (basic missing password)", () => {
+    const err = mod._testing.validateAgainstConfigSchema("elasticsearch", esSchema, {
+      url: "elasticsearch://host:9200",
+      authMode: "basic",
+      username: "u",
+    });
+    expect(err).not.toBeNull();
+    expect(err?.fieldErrors.password).toBeDefined();
+    // The inactive branches stay silent.
+    expect(err?.fieldErrors.apiKey).toBeUndefined();
+    expect(err?.fieldErrors.awsRegion).toBeUndefined();
+  });
+
+  it("requires apiKey in apiKey mode but not username/awsRegion", () => {
+    const err = mod._testing.validateAgainstConfigSchema("elasticsearch", esSchema, {
+      url: "elasticsearch://host:9200",
+      authMode: "apiKey",
+    });
+    expect(err).not.toBeNull();
+    expect(err?.fieldErrors.apiKey).toBeDefined();
+    expect(err?.fieldErrors.username).toBeUndefined();
+    expect(err?.fieldErrors.awsRegion).toBeUndefined();
+  });
+
+  it("requires awsRegion in sigv4 mode only", () => {
+    const err = mod._testing.validateAgainstConfigSchema("elasticsearch", esSchema, {
+      url: "elasticsearch://host:9200",
+      authMode: "sigv4",
+    });
+    expect(err).not.toBeNull();
+    expect(err?.fieldErrors.awsRegion).toBeDefined();
+    expect(err?.fieldErrors.apiKey).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -55,6 +55,7 @@ import {
   decryptSecretFields,
   encryptSecretFields,
   parseConfigSchema,
+  isConfigFieldActive,
 } from "@atlas/api/lib/plugins/secrets";
 import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
 import { invokeOnUninstallHook } from "@atlas/api/lib/plugins/uninstall-hook";
@@ -543,6 +544,11 @@ function validateAgainstConfigSchema(
   const formErrors: string[] = [];
 
   for (const field of schema.fields) {
+    // A `showWhen`-gated field is only required/type-checked when its branch is
+    // active — mirror the admin UI's `isFieldVisible` and the form-handler
+    // facade. An inactive conditional `required` field (e.g. ES `apiKey` /
+    // `awsRegion` outside their auth mode) must not block install. (#3842)
+    if (!isConfigFieldActive(field, config)) continue;
     const value = config[field.key];
     const present = value !== undefined && value !== null && value !== "";
     if (field.required === true && !present) {

--- a/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
@@ -191,6 +191,53 @@ describe("DatasourceFormInstallHandler — validation", () => {
   });
 });
 
+// ── Conditional (showWhen) fields — #3842 ────────────────────────────────────
+// ES declares per-auth-mode required fields via `showWhen`. Before the fix the
+// form validator demanded apiKey + awsRegion in EVERY mode, so the datasource
+// was un-installable through the admin UI in any auth mode.
+describe("DatasourceFormInstallHandler — conditional showWhen fields (#3842)", () => {
+  const ES_SCHEMA = [
+    { key: "url", type: "string", label: "Connection URL", required: true, secret: true },
+    { key: "authMode", type: "select", label: "Authentication", required: true },
+    { key: "username", type: "string", label: "Username", required: true, showWhen: { field: "authMode", equals: ["basic"] } },
+    { key: "password", type: "string", label: "Password", required: true, secret: true, showWhen: { field: "authMode", equals: ["basic"] } },
+    { key: "apiKey", type: "string", label: "API key", required: true, secret: true, showWhen: { field: "authMode", equals: ["apiKey"] } },
+    { key: "awsRegion", type: "string", label: "AWS region", required: true, showWhen: { field: "authMode", equals: ["sigv4"] } },
+  ];
+
+  it("accepts basic auth without demanding apiKey/awsRegion", async () => {
+    catalogSchemaOverride = { value: ES_SCHEMA };
+    const handler = newHandler("elasticsearch");
+    // Should not throw — apiKey/awsRegion are gated to inactive branches.
+    await handler.validateConfig(WSID, {
+      url: "elasticsearch://host:9200",
+      authMode: "basic",
+      username: "u",
+      password: "p",
+    });
+  });
+
+  it("still rejects the active branch's missing required field (apiKey mode)", async () => {
+    catalogSchemaOverride = { value: ES_SCHEMA };
+    const handler = newHandler("elasticsearch");
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, {
+        url: "elasticsearch://host:9200",
+        authMode: "apiKey",
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const fe = (caught as InstanceType<FormErrCtor>).fieldErrors;
+    expect(fe.apiKey).toBeDefined();
+    // Inactive branches stay silent.
+    expect(fe.username).toBeUndefined();
+    expect(fe.awsRegion).toBeUndefined();
+  });
+});
+
 // ── Persistence + encryption (ClickHouse — the url IS the secret) ─────────────
 
 describe("DatasourceFormInstallHandler — ClickHouse persistence + encryption", () => {

--- a/packages/api/src/lib/integrations/install/datasource-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/datasource-form-handler.ts
@@ -60,6 +60,7 @@ import {
   decryptSecretFields,
   restoreMaskedSecrets,
   parseConfigSchema,
+  isConfigFieldActive,
   type ConfigSchema,
 } from "@atlas/api/lib/plugins/secrets";
 import type { WorkspaceId } from "@useatlas/types";
@@ -311,6 +312,11 @@ function validateAgainstSchema(
   if (schema.state !== "parsed" || schema.fields.length === 0) return {};
   const fieldErrors: Record<string, string[]> = {};
   for (const field of schema.fields) {
+    // A `showWhen`-gated field is only required/type-checked when its branch is
+    // active — mirror the admin UI's `isFieldVisible`. Without this an inactive
+    // conditional `required` field (e.g. ES `apiKey`/`awsRegion` outside their
+    // auth mode) is wrongly demanded, blocking install. (#3842)
+    if (!isConfigFieldActive(field, config)) continue;
     const value = config[field.key];
     const present = value !== undefined && value !== null && value !== "";
     if (field.required === true && !present) {

--- a/packages/api/src/lib/plugins/__tests__/secrets.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/secrets.test.ts
@@ -12,6 +12,7 @@ import type { ConfigSchema } from "../secrets";
 import {
   MASKED_PLACEHOLDER,
   checkStrictPluginSecrets,
+  isConfigFieldActive,
   isStrictPluginSecretsEnabled,
   maskSecretFields,
   parseConfigSchema,
@@ -65,6 +66,51 @@ describe("parseConfigSchema", () => {
       expect(result.fields).toHaveLength(1);
       expect(result.fields[0]!.key).toBe("ok");
     }
+  });
+});
+
+describe("isConfigFieldActive", () => {
+  // Mirrors the admin UI's isFieldVisible so server-side validation only
+  // enforces a `showWhen`-gated field when its branch is active. Regression
+  // guard for #3842 (ES un-installable because apiKey/awsRegion were demanded
+  // in every auth mode).
+  const apiKeyField: ConfigSchemaField = {
+    key: "apiKey",
+    type: "string",
+    required: true,
+    showWhen: { field: "authMode", equals: ["apiKey"] },
+  };
+
+  it("treats a field with no showWhen as always active", () => {
+    const url: ConfigSchemaField = { key: "url", type: "string", required: true };
+    expect(isConfigFieldActive(url, {})).toBe(true);
+    expect(isConfigFieldActive(url, { authMode: "basic" })).toBe(true);
+  });
+
+  it("is active when the controller value is in equals", () => {
+    expect(isConfigFieldActive(apiKeyField, { authMode: "apiKey" })).toBe(true);
+  });
+
+  it("is inactive when the controller value is not in equals (the #3842 case)", () => {
+    expect(isConfigFieldActive(apiKeyField, { authMode: "basic" })).toBe(false);
+    expect(isConfigFieldActive(apiKeyField, { authMode: "sigv4" })).toBe(false);
+  });
+
+  it("is inactive when the controller is absent (coerced to \"\")", () => {
+    expect(isConfigFieldActive(apiKeyField, {})).toBe(false);
+    expect(isConfigFieldActive(apiKeyField, { authMode: null })).toBe(false);
+    expect(isConfigFieldActive(apiKeyField, { authMode: undefined })).toBe(false);
+  });
+
+  it("matches any value in a multi-value equals", () => {
+    const field: ConfigSchemaField = {
+      key: "x",
+      type: "string",
+      showWhen: { field: "mode", equals: ["a", "b"] },
+    };
+    expect(isConfigFieldActive(field, { mode: "a" })).toBe(true);
+    expect(isConfigFieldActive(field, { mode: "b" })).toBe(true);
+    expect(isConfigFieldActive(field, { mode: "c" })).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/plugins/__tests__/secrets.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/secrets.test.ts
@@ -102,6 +102,15 @@ describe("isConfigFieldActive", () => {
     expect(isConfigFieldActive(apiKeyField, { authMode: undefined })).toBe(false);
   });
 
+  it("fails open (active) on a malformed gate — never throws on bad JSONB", () => {
+    // parseConfigSchema only validates `key`, so a hand-edited row could carry
+    // a gate missing `equals` (or `field`). It must fail open, not 500. (#3842)
+    const missingEquals = { key: "x", type: "string", showWhen: { field: "authMode" } } as unknown as ConfigSchemaField;
+    const missingField = { key: "x", type: "string", showWhen: { equals: ["basic"] } } as unknown as ConfigSchemaField;
+    expect(isConfigFieldActive(missingEquals, { authMode: "basic" })).toBe(true);
+    expect(isConfigFieldActive(missingField, {})).toBe(true);
+  });
+
   it("matches any value in a multi-value equals", () => {
     const field: ConfigSchemaField = {
       key: "x",

--- a/packages/api/src/lib/plugins/secrets.ts
+++ b/packages/api/src/lib/plugins/secrets.ts
@@ -83,9 +83,18 @@ export function isConfigFieldActive(
   field: ConfigSchemaField,
   config: Record<string, unknown>,
 ): boolean {
-  if (!field.showWhen) return true;
-  const current = config[field.showWhen.field];
-  return field.showWhen.equals.includes(
+  const gate = field.showWhen;
+  if (!gate) return true;
+  // `parseConfigSchema` only validates each entry's `key`, so a hand-edited or
+  // version-skewed JSONB row could carry a malformed gate (missing `field` /
+  // `equals`). Treat any malformed gate as always-active (fail open) rather
+  // than throwing — matches pre-#3842 behavior, where `showWhen` was never
+  // consulted so a malformed gate was a silent no-op. Only the immediate
+  // controller is resolved (no chained `showWhen`), mirroring the admin UI's
+  // `isFieldVisible`; no current schema nests gates.
+  if (typeof gate.field !== "string" || !Array.isArray(gate.equals)) return true;
+  const current = config[gate.field];
+  return gate.equals.includes(
     typeof current === "string" ? current : String(current ?? ""),
   );
 }

--- a/packages/api/src/lib/plugins/secrets.ts
+++ b/packages/api/src/lib/plugins/secrets.ts
@@ -68,6 +68,28 @@ export function parseConfigSchema(raw: unknown): ConfigSchema {
   return { state: "parsed", fields };
 }
 
+/**
+ * True when `field` is active given the current `config` — i.e. it has no
+ * `showWhen` gate, or its controlling field's current value is one of the
+ * gate's `equals`. Server-side mirror of the admin UI's `isFieldVisible`
+ * (`form-install-modal.tsx`): a `showWhen`-gated field is only required and
+ * type-checked when its branch is active. Without this gate a conditional
+ * `required: true` field (e.g. the Elasticsearch `apiKey` / `awsRegion`
+ * per-auth-mode fields) is wrongly demanded in every branch, making the
+ * datasource un-installable through the form. The controller value is coerced
+ * to a string (absent → `""`) so a missing controller never matches. See #3842.
+ */
+export function isConfigFieldActive(
+  field: ConfigSchemaField,
+  config: Record<string, unknown>,
+): boolean {
+  if (!field.showWhen) return true;
+  const current = config[field.showWhen.field];
+  return field.showWhen.equals.includes(
+    typeof current === "string" ? current : String(current ?? ""),
+  );
+}
+
 /** True iff `entry` has a strict boolean `secret: true` — guards against `"true"` string drift in JSONB. */
 function isSecretField(entry: ConfigSchemaField): boolean {
   return entry.secret === true;


### PR DESCRIPTION
## What

Both server-side catalog `config_schema` validators enforced `required` on **every** field regardless of `showWhen`, so conditional per-branch fields were demanded in every branch. Elasticsearch declares per-auth-mode required fields (`username`/`password`→basic, `apiKey`→apiKey, `awsRegion`/…→sigv4), so it was **un-installable via the admin UI in any auth mode**.

Found live during the staging datasource-matrix soak (#3253): a `Username & password` install returned

```
POST /api/v1/integrations/elasticsearch/install-form → 400
{"error":"invalid_form_data","fieldErrors":{"apiKey":["API key is required"],"awsRegion":["AWS region is required"]}}
```

even though `authMode:"basic"` + username/password were correctly submitted.

## Fix

- New shared helper `isConfigFieldActive(field, config)` in `lib/plugins/secrets.ts` — the server mirror of the admin UI's `isFieldVisible` (`form-install-modal.tsx`): a `showWhen`-gated field is only required/type-checked when its controlling field's value is in `showWhen.equals`.
- Gate both validators on it:
  - `lib/integrations/install/datasource-form-handler.ts` → `validateAgainstSchema` (the form check that 400'd)
  - `lib/effect/workspace-installer.ts` → `validateAgainstConfigSchema` (the persist path — would 400 next otherwise)

Active-branch requireds are preserved. ClickHouse/MySQL (single-URL forms, no `showWhen`) are unaffected; the fix is generic so any future conditional datasource benefits.

## Tests

- `isConfigFieldActive` unit tests (no-gate / match / no-match / absent-controller / multi-value) — `secrets.test.ts`.
- `validateAgainstConfigSchema` (installer): basic passes without apiKey/awsRegion; active-branch missing-required still flagged; apiKey/sigv4 modes require only their own field — `workspace-installer.test.ts`.
- `DatasourceFormInstallHandler.validateConfig` (the form path): ES basic-auth accepted; apiKey mode still rejects missing apiKey while inactive branches stay silent — `datasource-form-handler.test.ts`.

124 pass / 0 fail across the three files; `bun run type` + ESLint clean.

Closes #3842. Surfaced by #3253 (staging soak, milestone #57); unblocks the milestone #63 Elasticsearch UI install path.

https://claude.ai/code/session_01RdA3nUe4XLY9UmdPchgN53

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix datasource config-schema validators to honor `showWhen` conditional fields
> - Adds `isConfigFieldActive` to [secrets.ts](https://github.com/AtlasDevHQ/atlas/pull/3843/files#diff-bb8511d165eb0677769a78c71ccdd277e47d2da57f7f361d61ebe645e7b29037), which returns `true` when a field has no `showWhen` gate or when the controller field's value matches `gate.equals`. Malformed gates fail open.
> - Updates `validateAgainstConfigSchema` in [workspace-installer.ts](https://github.com/AtlasDevHQ/atlas/pull/3843/files#diff-a4f8e8297c732c97f382a6292ac48b8c754dcf77c3ea06fc4af54e8a6709da69) and `validateAgainstSchema` in [datasource-form-handler.ts](https://github.com/AtlasDevHQ/atlas/pull/3843/files#diff-617add5fa1a47dae9f997661966549b7c163aeedcda21d2b2a21a7fc1beec078) to skip required/type checks for inactive `showWhen`-gated fields.
> - Behavioral Change: configs that omit fields from inactive branches (e.g. `apiKey` or `awsRegion` when using basic auth) no longer produce validation errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0178ab2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where both server-side validators enforced `required` on every config field regardless of `showWhen` conditions, causing Elasticsearch installs to fail in all auth modes.

- Adds `isConfigFieldActive(field, config)` to `secrets.ts` as a server-side mirror of the admin UI's `isFieldVisible`, with a fail-open guard for malformed JSONB gates.
- Gates the per-field loop in both `validateAgainstConfigSchema` and `validateAgainstSchema` on the new helper so only active-branch fields are required/type-checked.
- Adds unit and integration tests covering the regression scenario, per-mode boundaries, malformed gates, and absent controllers.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal one-line guard in each validator backed by a well-tested shared helper.

The fix faithfully mirrors the admin UI's `isFieldVisible`, includes a fail-open guard for malformed JSONB gates, and is tested against no-gate, absent-controller, malformed-gate, active-match, inactive-mismatch, and multi-value cases. Both call sites are updated consistently, and tests cover the exact regression scenario plus per-mode boundary conditions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/plugins/secrets.ts | Adds `isConfigFieldActive`: correctly handles no-gate, malformed gate (fail open), missing/null controller, and multi-value `equals` matching. |
| packages/api/src/lib/effect/workspace-installer.ts | Adds one-line `isConfigFieldActive` guard before the required/type-check block; minimal and correctly placed. |
| packages/api/src/lib/integrations/install/datasource-form-handler.ts | Same one-line guard as `workspace-installer.ts`; fixes the 400 path that surfaced in staging. |
| packages/api/src/lib/plugins/__tests__/secrets.test.ts | Comprehensive unit tests for `isConfigFieldActive` including malformed-gate and absent-controller edge cases. |
| packages/api/src/lib/effect/__tests__/workspace-installer.test.ts | ES-schema integration tests for the persist path covering all three auth modes. |
| packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts | Form-handler integration tests: basic-auth accepted; apiKey mode still rejects missing apiKey. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(install): fail open on a malformed s..."](https://github.com/atlasdevhq/atlas/commit/0178ab25628d59748296c341ba942dbaa7fd121d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38920113)</sub>

<!-- /greptile_comment -->