### PR TITLE
fix(connections): ES install form — optional "Engine" select tolerates unselected

### DIFF
--- a/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
+++ b/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
@@ -257,16 +257,24 @@ describe("buildZodSchema — optional select left unselected", () => {
     expect(schema.safeParse({ engine: "" }).success).toBe(false);
   });
 
-  // Full pipeline at the seam where #3845 actually lived: buildDefaultValues
-  // seeds the undefaulted optional select as "", the schema must accept that ""
-  // (regression), and buildSubmitPayload must drop the empty engine — so an
-  // untouched engine never reaches the server, matching the "auto-detected from
-  // the URL scheme" copy. Locks all three functions together, not in isolation.
+  // Full pipeline at the seam where #3845 actually lived, threaded in the REAL
+  // production order: buildDefaultValues seeds the undefaulted optional select as
+  // "", the schema (regression) accepts it AND its transform yields undefined,
+  // and buildSubmitPayload drops the engine. Critically, react-hook-form's
+  // zodResolver fires the transform BEFORE handleSubmit, so production passes
+  // buildSubmitPayload the PARSED output ({ engine: undefined }), not the raw ""
+  // — feeding parsed.data here exercises the undefined-drop branch the app hits,
+  // not the "" branch. So an untouched engine never reaches the server, matching
+  // the "auto-detected from the URL scheme" copy.
   test("untouched optional engine: default → schema → payload drops it end-to-end", () => {
     const defaults = buildDefaultValues([ENGINE_FIELD]);
     expect(defaults).toEqual({ engine: "" });
     const schema = buildZodSchema([ENGINE_FIELD]);
-    expect(schema.safeParse(defaults).success).toBe(true);
-    expect(buildSubmitPayload([ENGINE_FIELD], defaults)).toEqual({});
+    const parsed = schema.safeParse(defaults);
+    expect(parsed.success).toBe(true);
+    // The transform the resolver applies before handleSubmit sees the values.
+    expect(parsed.success && parsed.data).toEqual({ engine: undefined });
+    // buildSubmitPayload receives the parsed output in production, not raw "".
+    expect(buildSubmitPayload([ENGINE_FIELD], parsed.success ? parsed.data : defaults)).toEqual({});
   });
 });

--- a/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
+++ b/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 import {
   parseConfigSchema,
   buildZodSchema,
+  buildDefaultValues,
   buildSubmitPayload,
   isFieldVisible,
   type FormFieldDescriptor,
@@ -210,5 +211,62 @@ describe("buildZodSchema — conditional required number fields", () => {
     const schema = buildZodSchema(NUM_FIELDS);
     const r = schema.safeParse({ mode: "default", timeout: "" });
     expect(r.success).toBe(true);
+  });
+});
+
+describe("buildZodSchema — optional select left unselected", () => {
+  // Regression for #3845: the Elasticsearch "Engine" field is an OPTIONAL
+  // select (auto-derived from the URL scheme server-side, overridable here).
+  // `buildDefaultValues` seeds an undefaulted field with "", and the Select
+  // submits "" while showing its placeholder. Before the fix, the literal-union
+  // `.optional()` schema rejected "" with the opaque `Invalid input: expected
+  // "elasticsearch"` — an optional override must accept "unselected" instead.
+  const ENGINE_FIELD: FormFieldDescriptor = {
+    key: "engine",
+    type: "select",
+    options: [
+      { value: "elasticsearch", label: "Elasticsearch" },
+      { value: "opensearch", label: "OpenSearch" },
+    ],
+  };
+
+  test('an optional select submitted as "" (unselected) passes and parses to undefined', () => {
+    const schema = buildZodSchema([ENGINE_FIELD]);
+    const r = schema.safeParse({ engine: "" });
+    expect(r.success).toBe(true);
+    // The "" → undefined transform is the load-bearing behavior: an untouched
+    // optional override must not survive into the parsed output as "".
+    expect(r.success && r.data).toEqual({ engine: undefined });
+  });
+
+  test("an optional select still accepts a listed value", () => {
+    const schema = buildZodSchema([ENGINE_FIELD]);
+    expect(schema.safeParse({ engine: "elasticsearch" }).success).toBe(true);
+    expect(schema.safeParse({ engine: "opensearch" }).success).toBe(true);
+  });
+
+  test("an optional select still rejects an off-list value", () => {
+    const schema = buildZodSchema([ENGINE_FIELD]);
+    expect(schema.safeParse({ engine: "mongodb" }).success).toBe(false);
+  });
+
+  // A REQUIRED select left unselected must still fail — the "" tolerance is for
+  // optional fields only, so a genuinely-required choice can't slip past as blank.
+  test('a required select submitted as "" still fails', () => {
+    const schema = buildZodSchema([{ ...ENGINE_FIELD, required: true }]);
+    expect(schema.safeParse({ engine: "" }).success).toBe(false);
+  });
+
+  // Full pipeline at the seam where #3845 actually lived: buildDefaultValues
+  // seeds the undefaulted optional select as "", the schema must accept that ""
+  // (regression), and buildSubmitPayload must drop the empty engine — so an
+  // untouched engine never reaches the server, matching the "auto-detected from
+  // the URL scheme" copy. Locks all three functions together, not in isolation.
+  test("untouched optional engine: default → schema → payload drops it end-to-end", () => {
+    const defaults = buildDefaultValues([ENGINE_FIELD]);
+    expect(defaults).toEqual({ engine: "" });
+    const schema = buildZodSchema([ENGINE_FIELD]);
+    expect(schema.safeParse(defaults).success).toBe(true);
+    expect(buildSubmitPayload([ENGINE_FIELD], defaults)).toEqual({});
   });
 });

--- a/packages/web/src/app/admin/integrations/form-install-modal.tsx
+++ b/packages/web/src/app/admin/integrations/form-install-modal.tsx
@@ -223,7 +223,20 @@ export function buildZodSchema(
             literals.length >= 2
               ? z.union(literals as [z.ZodLiteral<string>, z.ZodLiteral<string>, ...z.ZodLiteral<string>[]])
               : literals[0];
-          if (!baseRequired) schema = schema.optional();
+          // An OPTIONAL select that the operator never touched still submits ""
+          // (its placeholder state, seeded by buildDefaultValues) — and "" is not
+          // a listed literal, so a bare `.optional()` would reject it with Zod's
+          // opaque `Invalid input: expected "<first option>"` (#3845). Map ""
+          // (unselected) to undefined BEFORE the union so an untouched optional
+          // override passes; the transform makes the field arrive as undefined,
+          // which buildSubmitPayload then drops from the payload. A required select
+          // skips this wrapper, so "" stays non-matching against the literal-union
+          // and is rejected — only a real, listed choice passes.
+          if (!baseRequired) {
+            schema = z
+              .union([z.literal("").transform(() => undefined), schema])
+              .optional();
+          }
         } else {
           schema = baseRequired ? z.string().min(1) : z.string().optional();
         }


### PR DESCRIPTION
## Summary
- On the **Install Elasticsearch** admin form, the optional **Engine** select (no default) was seeded as `""` by `buildDefaultValues` and submitted as its placeholder `""`. Because `""` is not a listed literal, the optional literal-union in `buildZodSchema` rejected it with Zod's opaque **`Invalid input: expected "elasticsearch"`** — so an untouched optional override blocked submit, and the field's "Auto-detected from the URL scheme. Override only if the cluster reports otherwise." copy was effectively false.
- Fix is in the **generic web form layer** (`form-install-modal.tsx` `buildZodSchema`): an *optional* select now maps `""` (unselected) → `undefined` **before** the literal-union, so an untouched optional override passes. `buildSubmitPayload` already drops it, and the server already auto-derives engine from the URL scheme (`elasticsearch://` / `opensearch://`) — so the copy is now true and no copy change is needed.
- **Required** selects are unchanged: they skip the wrapper, so `""` stays non-matching against the union and is still rejected — a real, listed choice can't be bypassed as blank.
- Sibling of #3842/#3843 (the `showWhen` server bug); that fix is untouched.

## Test plan
- [x] New regression tests in `form-install-modal.test.ts`: optional select submitted as `""` passes and parses to `undefined`; listed values still pass; off-list value still rejected; required select submitted as `""` still fails; full-pipeline test (`buildDefaultValues` → `buildZodSchema` → `buildSubmitPayload`) locking the seam where the bug lived.
- [x] `bun run type`, `bun run lint`, and the integration-form test suite pass.
- [x] Full `/ci` gate suite green locally (the 3 `explore`/`python` sandbox failures are the known WSL2 dev-shell `VERCEL_*`/`ATLAS_SANDBOX_URL` false-failures — pass with that env unset, green in CI).

Closes #3845

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix optional Engine select in ES install form to accept unselected state
> Optional select fields in the ES connection install form previously failed validation when left unselected. In [`form-install-modal.tsx`](https://github.com/AtlasDevHQ/atlas/pull/3848/files#diff-71a274e58472a04fa107950e54515a3b81d21a5531b8e5c29ce2244db39d3d32), `buildZodSchema` now wraps optional select schemas in a `z.union([z.literal("").transform(() => undefined), schema]).optional()`, mapping an empty-string submission to `undefined` so the field is omitted from the parsed payload. Required selects are unchanged and still reject empty strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf8e8af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the optional "Engine" select on the Elasticsearch install form blocked form submission when left untouched. The Zod schema now maps `""` (the placeholder/unselected state seeded by `buildDefaultValues`) to `undefined` before the literal-union on optional selects, mirroring the identical transform already used for optional number fields.

- **`form-install-modal.tsx`**: Wraps the literal-union for optional selects in `z.union([z.literal("").transform(() => undefined), schema]).optional()`, matching the pre-existing pattern for the `number` type. Required selects are unchanged and continue to reject `""`.
- **`form-install-modal.test.ts`**: Adds a focused regression suite — unselected optional select passes and transforms to `undefined`; listed values still pass; off-list values still fail; required select still rejects `""`; and a full-pipeline test threading `buildDefaultValues → buildZodSchema → buildSubmitPayload` in production order.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-scoped fix that restores consistent behavior between optional selects and the already-working optional number fields.

The fix follows an identical pattern already established for optional number fields, is guarded by targeted regression tests that correctly thread the production data-flow order, and does not alter behavior for required selects or any other field type.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/admin/integrations/form-install-modal.tsx | Adds z.union([z.literal("").transform(() => undefined), schema]).optional() wrapper for optional select fields, consistent with the existing number-field transform; required selects unchanged. |
| packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts | Adds comprehensive regression tests for the optional-select fix, including the full pipeline test correctly threaded through parsed Zod output (not raw defaults) before calling buildSubmitPayload. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildDefaultValues seeds optional select as empty string] --> B[zodResolver fires buildZodSchema]
    B --> C{field.required?}
    C -- yes --> D[literal-union only, empty string rejected]
    C -- no --> E[z.union with empty-string transform, then .optional]
    E --> F{input value}
    F -- empty string --> G[transform to undefined]
    F -- elasticsearch --> H[passes literal-union]
    F -- mongodb --> I[fails both branches, rejected]
    G --> J[handleSubmit receives engine as undefined]
    H --> J
    J --> K[buildSubmitPayload drops undefined]
    K --> L[POST body omits engine key]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[buildDefaultValues seeds optional select as empty string] --> B[zodResolver fires buildZodSchema]
    B --> C{field.required?}
    C -- yes --> D[literal-union only, empty string rejected]
    C -- no --> E[z.union with empty-string transform, then .optional]
    E --> F{input value}
    F -- empty string --> G[transform to undefined]
    F -- elasticsearch --> H[passes literal-union]
    F -- mongodb --> I[fails both branches, rejected]
    G --> J[handleSubmit receives engine as undefined]
    H --> J
    J --> K[buildSubmitPayload drops undefined]
    K --> L[POST body omits engine key]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(connections): thread full-pipeline ..."](https://github.com/atlasdevhq/atlas/commit/bf8e8afb42ce807e44bbb2b932105960907f360b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38923847)</sub>

<!-- /greptile_comment -->