### PR TITLE
fix(connections): surface per-workspace plugin datasources in admin list + /health

### DIFF
--- a/packages/api/src/__mocks__/connection.ts
+++ b/packages/api/src/__mocks__/connection.ts
@@ -32,6 +32,8 @@ export interface ConnectionsOverrides {
   getForbiddenPatterns?: AnyFn;
   list?: AnyFn;
   describe?: AnyFn;
+  describeForWorkspace?: AnyFn;
+  describeAllWorkspacePlugins?: AnyFn;
   has?: AnyFn;
   _reset?: AnyFn;
   healthCheck?: AnyFn;
@@ -90,6 +92,14 @@ export function createConnectionMock(overrides?: ConnectionMockOverrides) {
     getParserDialect: () => undefined,
     getForbiddenPatterns: () => [] as RegExp[],
     list: () => ["default"],
+    // Default to empty so callers that spread these (admin list, /health
+    // sources, #3844) don't blow up on `undefined`. Tests that exercise the
+    // describe surface override `describe` / `describeForWorkspace`; the
+    // workspace-scoped variants default to bare `describe` so an override of
+    // just `describe` still flows through the workspace path.
+    describe: () => [],
+    describeForWorkspace: (_workspaceId: string) => connections.describe(),
+    describeAllWorkspacePlugins: () => [],
     has: () => true,
     isOrgPoolingEnabled: () => false,
     getForOrg: () => dbConn,
@@ -205,6 +215,8 @@ export function createConnectionTestLayer(
     has: () => true,
     list: () => ["default"],
     describe: () => [],
+    describeForWorkspace: () => [],
+    describeAllWorkspacePlugins: () => [],
     getDBType: () => "postgres" as const,
     getTargetHost: () => "localhost",
     getValidator: () => undefined,

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -70,6 +70,17 @@ const mocks = createApiTestMocks({
         { id: "warehouse", dbType: "postgres", description: "Warehouse" },
         { id: "other-org-conn", dbType: "mysql", description: "Other org connection" },
       ],
+      // The list route reads through `describeForWorkspace(orgId)` (#3844) so
+      // a published plugin datasource — which lives ONLY in the per-workspace
+      // direct-plugin map — appears alongside native pools. The fixture unions
+      // the bare entries with one such plugin pool (`clickhouse-staging`) so a
+      // test can assert it survives the `visible ∩ describe` intersection.
+      describeForWorkspace: () => [
+        { id: "default", dbType: "postgres", description: "Default config connection" },
+        { id: "warehouse", dbType: "postgres", description: "Warehouse" },
+        { id: "other-org-conn", dbType: "mysql", description: "Other org connection" },
+        { id: "clickhouse-staging", dbType: "clickhouse", description: "ClickHouse" },
+      ],
       healthCheck: mockHealthCheck,
       register: mockRegister,
       unregister: mock(() => false),
@@ -437,6 +448,37 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       expect(warehouse).toBeDefined();
       expect(warehouse.groupId).toBeNull();
       expect(warehouse.groupName).toBeNull();
+    });
+
+    it("#3844 — a published plugin datasource (clickhouse) appears in the list", async () => {
+      // The plugin pool registers ONLY in the per-workspace direct-plugin map,
+      // never in the bare `entries` — so it's absent from `describe()` but
+      // present in `describeForWorkspace()`. `getVisibleConnectionIds` lists it
+      // (it owns a `workspace_plugins` row), so the `visible ∩ describe`
+      // intersection in the route keeps it only because the route now reads the
+      // workspace-scoped describe. Pre-fix it was dropped (invisible-but-queryable).
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) {
+          return Promise.resolve([{ install_id: "warehouse" }, { install_id: "clickhouse-staging" }]);
+        }
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([
+            { install_id: "warehouse", group_id: null },
+            { install_id: "clickhouse-staging", group_id: null },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const clickhouse = body.connections.find((c: { id: string }) => c.id === "clickhouse-staging");
+      expect(clickhouse).toBeDefined();
+      expect(clickhouse.dbType).toBe("clickhouse");
+      // It owns a workspace_plugins row, so it counts toward the plan/billing.
+      expect(clickhouse.billable).toBe(true);
     });
   });
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -49,6 +49,10 @@ mock.module("@atlas/api/lib/startup", () => ({
 
 // Mutable connection metadata — tests push entries to simulate different states
 let connMetadata: ConnectionMetadata[] = [];
+// Mutable per-workspace plugin-pool metadata — the bare `describe()` omits
+// these (they live in the per-workspace direct-plugin map), so the /health
+// `sources` section unions them in via `describeAllWorkspacePlugins()` (#3844).
+let pluginMetadata: ConnectionMetadata[] = [];
 
 const mockDBConnection = {
   query: async () => ({ columns: ["?column?"], rows: [{ "?column?": 1 }] }),
@@ -63,6 +67,7 @@ mock.module("@atlas/api/lib/db/connection", () =>
       getDefault: () => mockDBConnection,
       list: () => connMetadata.map((m) => m.id),
       describe: () => connMetadata,
+      describeAllWorkspacePlugins: () => pluginMetadata,
       getForOrg: () => mockDBConnection,
     },
     resolveDatasourceUrl: () => process.env.ATLAS_DATASOURCE_URL || null,
@@ -252,6 +257,7 @@ describe("GET /api/health — sources section", () => {
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
     delete process.env.DATABASE_URL;
     connMetadata = [];
+    pluginMetadata = [];
     mockValidateEnvironment.mockReset();
     mockValidateEnvironment.mockResolvedValue([]);
     mockGetStartupWarnings.mockReset();
@@ -357,6 +363,48 @@ describe("GET /api/health — sources section", () => {
     expect(Object.keys(sources)).toContain("default");
     expect(Object.keys(sources)).toContain("warehouse");
     expect((sources.warehouse as Record<string, unknown>).dbType).toBe("mysql");
+  });
+
+  it("#3844 — includes per-workspace plugin pools (clickhouse) in sources", async () => {
+    // The plugin pool lives ONLY in the per-workspace direct-plugin map, absent
+    // from bare `describe()` — so the sources section unions in
+    // `describeAllWorkspacePlugins()`. Without that union the operator fleet
+    // view (and `NN / NN live` count) silently omitted every plugin datasource.
+    connMetadata = [
+      { id: "default", dbType: "postgres", health: { status: "healthy", latencyMs: 3, checkedAt: new Date() } },
+    ];
+    pluginMetadata = [
+      { id: "clickhouse-staging", dbType: "clickhouse", description: "ClickHouse" },
+    ];
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+
+    expect(Object.keys(sources)).toContain("clickhouse-staging");
+    const ch = sources["clickhouse-staging"] as Record<string, unknown>;
+    expect(ch.dbType).toBe("clickhouse");
+    // No cached health on plugin entries → "unknown", same as any native
+    // source with no health-check result yet.
+    expect(ch.status).toBe("unknown");
+  });
+
+  it("#3844 — builds the sources section from plugin pools alone (no bare entries)", async () => {
+    // A workspace whose only datasource is a plugin (no `default` registered).
+    // The union must still produce a `sources` section off the plugin pools so
+    // the operator sees them and the count isn't `0 / 0`.
+    connMetadata = [];
+    pluginMetadata = [
+      { id: "snowflake-prod", dbType: "snowflake", description: "Snowflake" },
+    ];
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const sources = body.sources as Record<string, unknown>;
+
+    expect(sources).toBeDefined();
+    expect(Object.keys(sources)).toEqual(["snowflake-prod"]);
+    expect((sources["snowflake-prod"] as Record<string, unknown>).dbType).toBe("snowflake");
   });
 
   it("returns status 'unknown' when non-default source has no health check result", async () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -489,7 +489,12 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   const { orgId } = c.get("orgContext");
   const authResult = c.get("authResult");
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  const connList = connections.describe();
+  // Workspace-scoped describe so published plugin datasources (clickhouse /
+  // snowflake / bigquery / elasticsearch) — which register ONLY in the
+  // per-workspace direct-plugin map, never in the bare `entries` — appear in
+  // the list. Bare `describe()` omitted them, so the `visible` ∩ `connList`
+  // filter below silently dropped every plugin pool (#3844).
+  const connList = connections.describeForWorkspace(orgId);
   const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   const filtered = visible ? connList.filter((conn) => visible.has(conn.id)) : connList;
 

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -352,10 +352,23 @@ health.openapi(healthRoute, async (c) => {
 
     const warnings = [...getStartupWarnings()];
 
-    // Per-source health from ConnectionRegistry
+    // Per-source health from ConnectionRegistry. The bare `describe()`
+    // enumerates only native/bare pools; published plugin datasources
+    // (clickhouse / snowflake / bigquery / elasticsearch) register in a
+    // separate per-workspace map, so we union them in via
+    // `describeAllWorkspacePlugins()` — otherwise the operator fleet view (and
+    // the `NN / NN live` count) silently omitted them (#3844). The breakdown is
+    // operator-gated below (#3685); anonymous callers are stripped to the
+    // region's own `default` (or nothing if none is registered).
     let sourcesSection: Record<string, { status: string; latencyMs?: number; message?: string; checkedAt?: string; dbType: string }> | undefined;
     try {
-      const connMeta = connRegistry2.describe();
+      // Plugin pools first, bare entries last: on a NON-`default` install_id
+      // collision the bare entry's cached health wins the last write into
+      // `sourcesSection[meta.id]`. (`default` is protected independently by the
+      // live-probe precedence below — `liveStatus ?? h?.status` — not by this
+      // order.) Plugin install_ids are clickhouse/snowflake/etc., so a collision
+      // with a bare entry is rare in practice.
+      const connMeta = [...connRegistry2.describeAllWorkspacePlugins(), ...connRegistry2.describe()];
       if (connMeta.length > 0) {
         sourcesSection = {};
         for (const meta of connMeta) {

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -309,4 +309,70 @@ describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () 
     expect(registry.unregisterDirectForWorkspace("ws-1", "ch")).toBe(false);
     registry._reset();
   });
+
+  it("describe() omits per-workspace plugin pools (bare entries only)", () => {
+    // describe() is the agent/system-prompt + legacy path: it must keep
+    // enumerating ONLY bare `entries`. The workspace-scoped enumerations below
+    // are what surface plugin pools — #3844 (the admin list / health gap) is a
+    // missing union there, not a change to this method.
+    const registry = new ConnectionRegistry();
+    registry.registerDirect("warehouse", fakeConn("pg"), "postgres", "PG");
+    registry.registerDirectForWorkspace("ws-1", "ch", fakeConn("ch"), "clickhouse", "ClickHouse");
+    expect(registry.describe().map((m) => m.id)).toEqual(["warehouse"]);
+    registry._reset();
+  });
+
+  it("describeForWorkspace unions bare entries with the workspace's plugin pools", () => {
+    // #3844 — a published ClickHouse install registers ONLY in the per-workspace
+    // direct-plugin map, so the admin Connections list (which filters
+    // describe() ∩ visible install_ids) dropped it. The workspace-scoped
+    // describe surfaces it so the intersection keeps it.
+    const registry = new ConnectionRegistry();
+    registry.registerDirect("warehouse", fakeConn("pg"), "postgres", "PG");
+    registry.registerDirectForWorkspace("ws-1", "ch", fakeConn("ch"), "clickhouse", "ClickHouse");
+    const meta = registry.describeForWorkspace("ws-1");
+    const byId = new Map(meta.map((m) => [m.id, m]));
+    expect(byId.has("warehouse")).toBe(true);
+    expect(byId.get("ch")).toMatchObject({ id: "ch", dbType: "clickhouse", description: "ClickHouse" });
+    registry._reset();
+  });
+
+  it("describeForWorkspace: a workspace plugin pool wins an install_id collision with a bare entry", () => {
+    // The documented precedence: when a workspace's plugin pool shares an
+    // install_id with a bare entry (e.g. self-hosted `default`), the plugin
+    // pool is the one actually routing this workspace's queries, so the
+    // describe must surface its dbType — not the bare entry's. Guards the
+    // `byId.set` override order in describeForWorkspace.
+    const registry = new ConnectionRegistry();
+    registry.registerDirect("default", fakeConn("pg"), "postgres", "Native default");
+    registry.registerDirectForWorkspace("ws-1", "default", fakeConn("ch"), "clickhouse", "Plugin default");
+    const meta = registry.describeForWorkspace("ws-1").find((m) => m.id === "default");
+    expect(meta?.dbType).toBe("clickhouse");
+    registry._reset();
+  });
+
+  it("describeForWorkspace scopes plugin pools to the requested workspace", () => {
+    // Two workspaces share an install_id but own distinct plugin pools — each
+    // describe must surface only its own, never the sibling's.
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-a", "ch", fakeConn("a"), "clickhouse");
+    registry.registerDirectForWorkspace("ws-b", "snow", fakeConn("b"), "snowflake");
+    expect(registry.describeForWorkspace("ws-a").map((m) => m.id)).toContain("ch");
+    expect(registry.describeForWorkspace("ws-a").map((m) => m.id)).not.toContain("snow");
+    expect(registry.describeForWorkspace("ws-b").map((m) => m.id)).toContain("snow");
+    expect(registry.describeForWorkspace("ws-b").map((m) => m.id)).not.toContain("ch");
+    registry._reset();
+  });
+
+  it("describeAllWorkspacePlugins enumerates every plugin pool flat (operator /health fleet view)", () => {
+    // /health has no per-request workspace; the operator fleet view enumerates
+    // EVERY plugin pool the same way it already enumerates every bare entry.
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-a", "ch", fakeConn("a"), "clickhouse", "ClickHouse");
+    registry.registerDirectForWorkspace("ws-b", "snow", fakeConn("b"), "snowflake", "Snowflake");
+    const ids = registry.describeAllWorkspacePlugins().map((m) => m.id);
+    expect(ids).toContain("ch");
+    expect(ids).toContain("snow");
+    registry._reset();
+  });
 });

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -375,4 +375,19 @@ describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () 
     expect(ids).toContain("snow");
     registry._reset();
   });
+
+  it("describeAllWorkspacePlugins keeps a per-workspace entry on a cross-workspace install_id collision", () => {
+    // Two workspaces install a plugin under the SAME install_id. The flat fleet
+    // view is keyed by (workspace, install_id), so the array must carry BOTH
+    // entries — it is NOT deduplicated by `.id`. The /health route collapses
+    // them by id (last-write-wins) by design; the registry method itself keeps
+    // both so a future per-workspace consumer isn't silently handed one.
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-a", "clickhouse", fakeConn("a"), "clickhouse");
+    registry.registerDirectForWorkspace("ws-b", "clickhouse", fakeConn("b"), "clickhouse");
+    const all = registry.describeAllWorkspacePlugins();
+    expect(all).toHaveLength(2);
+    expect(all.every((m) => m.id === "clickhouse")).toBe(true);
+    registry._reset();
+  });
 });

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -459,6 +459,14 @@ interface WorkspaceBaseEntry {
  * native per-workspace configs do).
  */
 interface WorkspacePluginEntry {
+  /**
+   * The (workspace, install_id) this pool belongs to. Stored on the entry so
+   * the workspace-scoped describe paths ({@link ConnectionRegistry.describeForWorkspace}
+   * / {@link ConnectionRegistry.describeAllWorkspacePlugins}) recover them
+   * directly instead of re-parsing the NUL-delimited map key (#3844).
+   */
+  workspaceId: string;
+  installId: string;
   conn: DBConnection;
   dbType: DBType;
   description?: string;
@@ -1045,6 +1053,8 @@ export class ConnectionRegistry {
     const key = this._workspaceKey(workspaceId, installId);
     const existing = this.workspacePluginEntries.get(key);
     this.workspacePluginEntries.set(key, {
+      workspaceId,
+      installId,
       conn,
       dbType,
       description,
@@ -1353,7 +1363,12 @@ export class ConnectionRegistry {
     return Array.from(this.entries.keys());
   }
 
-  /** Metadata for all registered connections. Used by the agent system prompt. */
+  /**
+   * Metadata for the bare/native registrations only. Used by the agent system
+   * prompt and legacy callers. Does NOT include per-(workspace, install_id)
+   * plugin pools — those live in {@link workspacePluginEntries} and are surfaced
+   * by {@link describeForWorkspace} / {@link describeAllWorkspacePlugins}.
+   */
   describe(): ConnectionMetadata[] {
     return Array.from(this.entries.entries()).map(([id, entry]) => ({
       id,
@@ -1361,6 +1376,51 @@ export class ConnectionRegistry {
       description: entry.description,
       ...(entry.lastHealth ? { health: entry.lastHealth } : {}),
     }));
+  }
+
+  /** {@link ConnectionMetadata} for a per-workspace plugin pool (no `lastHealth` tracked on these entries). */
+  private _pluginMeta(entry: WorkspacePluginEntry): ConnectionMetadata {
+    return {
+      id: entry.installId,
+      dbType: entry.dbType,
+      ...(entry.description !== undefined ? { description: entry.description } : {}),
+    };
+  }
+
+  /**
+   * Metadata for everything a single workspace can see: the bare/native
+   * registrations ({@link describe}) unioned with that workspace's DB-stored
+   * plugin pools ({@link workspacePluginEntries}). The admin Connections list
+   * reads through this so a published plugin datasource (clickhouse / snowflake /
+   * bigquery / elasticsearch) — which registers ONLY in the per-workspace
+   * plugin map, never in `entries` — appears alongside native pools (#3844).
+   *
+   * On an install_id collision (a workspace's plugin pool shares an id with a
+   * bare entry — e.g. self-hosted `default`), the plugin pool wins: it's the one
+   * actually routing this workspace's queries. Two workspaces never collide here
+   * because the filter is scoped to `workspaceId`.
+   */
+  describeForWorkspace(workspaceId: string): ConnectionMetadata[] {
+    const byId = new Map<string, ConnectionMetadata>(this.describe().map((m) => [m.id, m]));
+    for (const entry of this.workspacePluginEntries.values()) {
+      if (entry.workspaceId !== workspaceId) continue;
+      byId.set(entry.installId, this._pluginMeta(entry));
+    }
+    return Array.from(byId.values());
+  }
+
+  /**
+   * Metadata for EVERY DB-stored plugin pool across all workspaces, flat (keyed
+   * by install_id). The public `/api/health` route has no per-request workspace,
+   * so its OPERATOR fleet view (anonymous callers are stripped to the region's
+   * own `default`, or nothing if none is registered, upstream — #3685)
+   * enumerates plugin pools the same way it already enumerates every bare entry.
+   * Returns one entry per (workspace, install_id); install_id collisions across
+   * workspaces are expected and the last write wins for the flat health map
+   * (latency/status, not routing).
+   */
+  describeAllWorkspacePlugins(): ConnectionMetadata[] {
+    return Array.from(this.workspacePluginEntries.values()).map((entry) => this._pluginMeta(entry));
   }
 
   /** Run a health check for a specific connection. */

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1410,14 +1410,21 @@ export class ConnectionRegistry {
   }
 
   /**
-   * Metadata for EVERY DB-stored plugin pool across all workspaces, flat (keyed
-   * by install_id). The public `/api/health` route has no per-request workspace,
-   * so its OPERATOR fleet view (anonymous callers are stripped to the region's
-   * own `default`, or nothing if none is registered, upstream — #3685)
-   * enumerates plugin pools the same way it already enumerates every bare entry.
-   * Returns one entry per (workspace, install_id); install_id collisions across
-   * workspaces are expected and the last write wins for the flat health map
-   * (latency/status, not routing).
+   * Metadata for EVERY DB-stored plugin pool across all workspaces. The public
+   * `/api/health` route has no per-request workspace, so its OPERATOR fleet view
+   * (anonymous callers are stripped to the region's own `default`, or nothing if
+   * none is registered, upstream — #3685) enumerates plugin pools the same way
+   * it already enumerates every bare entry.
+   *
+   * Returns one entry per (workspace, install_id) — the array's IDENTITY is the
+   * tuple, but each `ConnectionMetadata.id` carries only the `install_id`. Two
+   * workspaces that both install a plugin named `clickhouse` therefore yield TWO
+   * entries with `id: "clickhouse"`. This is NOT deduplicated: a caller that
+   * collapses the array by `.id` (as `/health` does, `sourcesSection[meta.id]`,
+   * last-write-wins) gets one health row per id, which is the intended
+   * region-fleet display behaviour. Any consumer needing per-workspace identity
+   * must NOT treat `.id` as unique — use {@link describeForWorkspace} (scoped to
+   * one workspace, so collisions can't occur) instead.
    */
   describeAllWorkspacePlugins(): ConnectionMetadata[] {
     return Array.from(this.workspacePluginEntries.values()).map((entry) => this._pluginMeta(entry));


### PR DESCRIPTION
## Summary
- `ConnectionRegistry.describe()` enumerated only the bare/native `this.entries` map, never the per-`(workspace, install_id)` direct-plugin pools registered via `registerDirectForWorkspace`. A **published** plugin datasource (ClickHouse / Snowflake / BigQuery / Elasticsearch) was therefore queryable but invisible: dropped by the admin Connections list's `visible ∩ describe()` intersection and omitted from `/api/health` `sources` (and the `NN / NN live` count). Reproduced live on staging during the #3253 soak.
- Added two workspace-aware enumerations on the registry:
  - **`describeForWorkspace(workspaceId)`** — bare entries unioned with that workspace's plugin pools (the plugin pool wins an `install_id` collision, e.g. self-hosted `default`). The admin list reads this with the request's `orgId`.
  - **`describeAllWorkspacePlugins()`** — every plugin pool flat. The public `/health` `sources` **operator** fleet view unions it in; anonymous callers stay stripped to the region's own `default` (#3685).
- `WorkspacePluginEntry` now carries `workspaceId`/`installId` so the describe paths read identity directly instead of re-parsing the NUL-delimited map key.

Scope note: this is a **visibility/management** fix. The per-connection live health-check action (`POST /:id/test`) and `delete` for plugin pools route through DB-backed paths already (`unregisterDatasourceInstall` handles plugin teardown); the registry's `healthCheck(id)` still only health-checks bare entries, so plugin pools surface with `status: "unknown"` (no cached health) — same as any native source not yet probed.

## Test plan
- [x] Registry unit tests (`connection.test.ts`): `describe()` stays bare-only (regression lock); `describeForWorkspace` unions + scopes per-workspace + plugin-wins-collision; `describeAllWorkspacePlugins` flat enumeration
- [x] Admin route test (`admin-connections.test.ts`): a published ClickHouse plugin pool appears in the list (survives the `visible ∩ describe` intersection) with `dbType` + `billable: true`
- [x] Health route tests (`health.test.ts`): plugin pool appears in `/health` `sources` with `dbType` + `status: "unknown"`; sources section builds from plugin pools alone (no bare entries)
- [x] `/ci`: lint, type, full test suite, syncpack, schema/openapi/template/oauth-helper drift, test-discipline, settings-readers, saas-env-doc, railway-watch, published-symbols — all pass (the 3 explore/python failures are the documented WSL2 vercel-sandbox false-failures, green in CI)

Closes #3844

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface per-workspace plugin datasources in admin connections list and `/health`
> - Adds `describeForWorkspace(workspaceId)` and `describeAllWorkspacePlugins()` to `ConnectionRegistry` in [connection.ts](https://github.com/AtlasDevHQ/atlas/pull/3849/files#diff-5eaba92c5b51e2c4bc40c73644391e6c59c62320f39d189f9999981cb472be9f); bare `describe()` continues to exclude plugin pools.
> - The admin connections list in [admin-connections.ts](https://github.com/AtlasDevHQ/atlas/pull/3849/files#diff-f6bfef41590fe265b86518b43c7543c707e1f44ae7a3fefd8dce760e01589f1d) now calls `describeForWorkspace(orgId)` instead of `describe()`, so per-workspace plugin datasources appear and are decorated/billed correctly.
> - The `/health` route in [health.ts](https://github.com/AtlasDevHQ/atlas/pull/3849/files#diff-b66b14bcec9a4dedaf769953071256234d031205e3f290457c996e7f1cd29546) builds its `sources` section from the union of `describeAllWorkspacePlugins()` and `describe()`, so plugin pools appear alongside native connections.
> - On `installId` collisions, workspace plugin entries take precedence over bare entries in `describeForWorkspace`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23cf22c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a visibility gap where per-workspace plugin datasources (ClickHouse, Snowflake, BigQuery, Elasticsearch) were queryable but invisible — dropped from the admin Connections list and `/health` sources because both read only from the bare `entries` map rather than the per-`(workspace, install_id)` plugin pools.

- **`ConnectionRegistry`** gains `describeForWorkspace(workspaceId)` (bare entries ∪ workspace plugin pools, plugin wins on `install_id` collision) and `describeAllWorkspacePlugins()` (flat fleet view across all workspaces, non-deduplicated by `id`). `describe()` is unchanged — still bare-only.
- **Admin connections list** now reads `describeForWorkspace(orgId)` instead of `describe()`, so plugin pools survive the `visible ∩ connList` intersection. **`/health`** unions `describeAllWorkspacePlugins()` with `describe()` (plugin pools first, bare entries last so cached health wins on collision); the existing operator gate (#3685) strips non-`default` sources from anonymous callers unchanged.
- `WorkspacePluginEntry` now stores `workspaceId`/`installId` directly to avoid re-parsing the NUL-delimited map key on every describe call.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted visibility fix with no changes to query routing, health-check probing, or auth/billing logic.

The change is additive: two new read-only methods on the registry, a one-line swap in the admin list route, and a union expression in the health route. Existing describe() contract is regression-locked by a dedicated unit test. Collision precedence in both directions is documented, unit-tested, and consistent with how each caller uses the data. The operator gate on /health (#3685) is untouched, so anonymous callers continue to receive only the default source. No mutations to stored state, no schema changes, no new async paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/db/connection.ts | Adds workspaceId/installId fields to WorkspacePluginEntry and new describeForWorkspace / describeAllWorkspacePlugins public methods backed by a private _pluginMeta helper; describe() unchanged (bare-only). Logic and collision precedence are correct and thoroughly documented. |
| packages/api/src/api/routes/admin-connections.ts | Single-line change: describe() → describeForWorkspace(orgId). Correct fix; downstream visible ∩ connList filter, billing decoration, and group-info query are all unaffected. |
| packages/api/src/api/routes/health.ts | Unions describeAllWorkspacePlugins() with describe() for the sources section; plugin pools come first so bare-entry cached health wins on collision. Operator gating (#3685) and ownRegionSources anonymous-caller stripping are untouched. |
| packages/api/src/lib/db/__tests__/connection.test.ts | Six new unit tests covering: describe() stays bare-only, describeForWorkspace union + collision precedence + workspace scoping, describeAllWorkspacePlugins flat enumeration and cross-workspace same-id case. |
| packages/api/src/api/__tests__/admin-connections.test.ts | Adds describeForWorkspace fixture and a regression test verifying a published ClickHouse plugin pool appears in the admin list with correct dbType and billable: true. |
| packages/api/src/api/__tests__/health.test.ts | Adds pluginMetadata fixture and two new tests: plugin pool appears in sources with status: unknown, and sources section builds correctly from plugin pools alone when no bare entries exist. |
| packages/api/src/__mocks__/connection.ts | Adds describeForWorkspace (delegates to connections.describe() by default for backwards-compatible test override) and describeAllWorkspacePlugins (empty default) stubs to both mock factories. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConnectionRegistry] --> B["entries map\nbare/native pools"]
    A --> C["workspacePluginEntries map\nper-workspace+installId pools"]

    B --> D["describe()\nbare only"]
    B --> E["describeForWorkspace(wsId)\nplugin wins on id collision"]
    C --> E
    C --> F["describeAllWorkspacePlugins()\nflat fleet view"]

    E --> G["Admin Connections List\nGET /api/v1/admin/connections"]
    D --> H["/health sources union"]
    F --> H

    H --> I{isOperator?}
    I -- yes --> J["Full sourcesSection\nall pools"]
    I -- no --> K["ownRegionSources\nonly default"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ConnectionRegistry] --> B["entries map\nbare/native pools"]
    A --> C["workspacePluginEntries map\nper-workspace+installId pools"]

    B --> D["describe()\nbare only"]
    B --> E["describeForWorkspace(wsId)\nplugin wins on id collision"]
    C --> E
    C --> F["describeAllWorkspacePlugins()\nflat fleet view"]

    E --> G["Admin Connections List\nGET /api/v1/admin/connections"]
    D --> H["/health sources union"]
    F --> H

    H --> I{isOperator?}
    I -- yes --> J["Full sourcesSection\nall pools"]
    I -- no --> K["ownRegionSources\nonly default"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/atlasdevhq/atlas/commit/23cf22cca5dcf8ebba81938c4d9b37e660bd6941) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38924410)</sub>

<!-- /greptile_comment -->