### PR TITLE
fix(staging-seed): demo-postgres install persists url at canonical __demo__ id

### DIFF
--- a/packages/api/src/lib/staging/__tests__/seed.test.ts
+++ b/packages/api/src/lib/staging/__tests__/seed.test.ts
@@ -112,10 +112,10 @@ describe("ensureStagingSeed — region gate (no DB)", () => {
 
 // ───────────────────────────────────────────────────────────────────
 // 1b. Demo-datasource skip paths — no DB. The #3847 failure mode is
-//     persisting a urless demo install; these two branches refuse to
-//     persist when there's no resolvable dataset, returning a non-fatal
-//     `false` and issuing ZERO queries (they return before any
-//     `internalQuery`). Pure unit tests — no Postgres needed.
+//     persisting a urless / contradictory demo install; these branches
+//     refuse to persist when there's no resolvable postgres dataset,
+//     returning a non-fatal `false` and issuing ZERO queries (they return
+//     before any `internalQuery`). Pure unit tests — no Postgres needed.
 // ───────────────────────────────────────────────────────────────────
 
 describe("_seedDemoDatasource — skip paths (no DB)", () => {
@@ -152,6 +152,21 @@ describe("_seedDemoDatasource — skip paths (no DB)", () => {
 
   it("skips (no INSERT, returns false) when the demo URL has an unsupported scheme", async () => {
     process.env.ATLAS_DATASOURCE_URL = "redis://localhost:6379";
+    delete process.env.ATLAS_DEMO_DATA;
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    const installed = await _seedDemoDatasource("org_test");
+
+    expect(installed).toBe(false);
+    expect(queries.length).toBe(0);
+  });
+
+  it("skips (no INSERT, returns false) when the demo URL is a valid-but-non-Postgres scheme", async () => {
+    // `mysql://` parses as a supported dbType, but the demo-postgres catalog is
+    // postgres-only — persisting `db_type:"mysql"` under it would contradict the
+    // slug and fail the boot resolver, so we skip before the catalog SELECT.
+    process.env.ATLAS_DATASOURCE_URL = "mysql://user:pw@localhost:3306/demo";
     delete process.env.ATLAS_DEMO_DATA;
     const { pool, queries } = createTrackingPool();
     _resetPool(pool);

--- a/packages/api/src/lib/staging/__tests__/seed.test.ts
+++ b/packages/api/src/lib/staging/__tests__/seed.test.ts
@@ -35,6 +35,7 @@ import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
 import { _setAuthInstance, getAuthInstance } from "@atlas/api/lib/auth/server";
 import { migrateAuthTables, resetMigrationState } from "@atlas/api/lib/auth/migrate";
 import {
+  _seedDemoDatasource,
   ensureStagingSeed,
   STAGING_ADMIN_EMAIL,
   STAGING_ORG_SLUG,
@@ -110,6 +111,59 @@ describe("ensureStagingSeed — region gate (no DB)", () => {
 });
 
 // ───────────────────────────────────────────────────────────────────
+// 1b. Demo-datasource skip paths — no DB. The #3847 failure mode is
+//     persisting a urless demo install; these two branches refuse to
+//     persist when there's no resolvable dataset, returning a non-fatal
+//     `false` and issuing ZERO queries (they return before any
+//     `internalQuery`). Pure unit tests — no Postgres needed.
+// ───────────────────────────────────────────────────────────────────
+
+describe("_seedDemoDatasource — skip paths (no DB)", () => {
+  let savedDatasourceUrl: string | undefined;
+  let savedDemoData: string | undefined;
+
+  beforeEach(() => {
+    savedDatasourceUrl = process.env.ATLAS_DATASOURCE_URL;
+    savedDemoData = process.env.ATLAS_DEMO_DATA;
+  });
+
+  afterEach(() => {
+    if (savedDatasourceUrl !== undefined) process.env.ATLAS_DATASOURCE_URL = savedDatasourceUrl;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    if (savedDemoData !== undefined) process.env.ATLAS_DEMO_DATA = savedDemoData;
+    else delete process.env.ATLAS_DEMO_DATA;
+    _resetPool();
+  });
+
+  it("skips (no INSERT, returns false) when no demo URL is resolvable", async () => {
+    // `resolveDatasourceUrl()` returns undefined: ATLAS_DATASOURCE_URL unset
+    // and ATLAS_DEMO_DATA not "true".
+    delete process.env.ATLAS_DATASOURCE_URL;
+    delete process.env.ATLAS_DEMO_DATA;
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    const installed = await _seedDemoDatasource("org_test");
+
+    expect(installed).toBe(false);
+    // Persisting a urless row is exactly #3847 — assert nothing was written.
+    expect(queries.length).toBe(0);
+  });
+
+  it("skips (no INSERT, returns false) when the demo URL has an unsupported scheme", async () => {
+    process.env.ATLAS_DATASOURCE_URL = "redis://localhost:6379";
+    delete process.env.ATLAS_DEMO_DATA;
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    const installed = await _seedDemoDatasource("org_test");
+
+    expect(installed).toBe(false);
+    expect(queries.length).toBe(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
 // 2. Real Postgres — full seed against Better Auth + Atlas schema.
 // ───────────────────────────────────────────────────────────────────
 
@@ -131,6 +185,7 @@ const ENV_KEYS = [
   "ATLAS_ENCRYPTION_KEY",
   "ATLAS_API_REGION",
   "ATLAS_ADMIN_EMAIL",
+  "ATLAS_DATASOURCE_URL",
   "STAGING_ADMIN_PASSWORD",
   "STAGING_TWENTY_API_KEY",
   "STAGING_TWENTY_BASE_URL",
@@ -170,6 +225,11 @@ describeIfPg("ensureStagingSeed — real Postgres", () => {
     process.env.BETTER_AUTH_URL = "http://localhost:3001";
     process.env.ATLAS_ENCRYPTION_KEY = "staging-seed-test-encryption-key-000001";
     process.env.ATLAS_API_REGION = "staging";
+    // The demo datasource install now persists an ENCRYPTED url resolved from
+    // ATLAS_DATASOURCE_URL (#3847 — empty `{}` config failed the boot resolver
+    // every boot). Point it at the scratch test DB so the seed has a real,
+    // pg-scheme url to encrypt and store.
+    process.env.ATLAS_DATASOURCE_URL = TEST_DB_URL;
     process.env.STAGING_ADMIN_PASSWORD = STAGING_ADMIN_PASSWORD;
     process.env.STAGING_TWENTY_API_KEY = "staging-twenty-api-key";
     process.env.STAGING_TWENTY_BASE_URL = "https://staging-crm.example.com";
@@ -274,6 +334,75 @@ describeIfPg("ensureStagingSeed — real Postgres", () => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
     expect(rows.some((r) => r.catalog_id.includes("demo-postgres"))).toBe(true);
     expect(rows.every((r) => r.status === "published")).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // Regression for #3847: the demo install must land at the canonical
+  // `__demo__` install id (NOT `default`, which collided with the real
+  // datasource install) and carry an encrypted, url-bearing config that the
+  // boot bridge can resolve — the previous empty-`{}` install failed the boot
+  // resolver every boot with `DatasourcePoolResolver(postgres): missing
+  // required field url`.
+  it("persists the demo install at the canonical __demo__ id with a resolvable url", async () => {
+    const { decryptSecretFields, parseConfigSchema } = await import(
+      "@atlas/api/lib/plugins/secrets"
+    );
+    const { resolveDatasourcePoolConfig } = await import(
+      "@atlas/api/lib/db/datasource-pool-resolver"
+    );
+    // `describeIfPg` only runs this block when TEST_DATABASE_URL is set, so
+    // the demo url the seed persisted is exactly this DSN.
+    const demoUrl = TEST_DB_URL as string;
+
+    const org = await pool.query<{ id: string }>(
+      `SELECT id FROM organization WHERE slug = $1`,
+      [STAGING_ORG_SLUG],
+    );
+    const orgId = org.rows[0]?.id as string;
+
+    const { rows } = await pool.query<{
+      install_id: string;
+      catalog_slug: string;
+      config: Record<string, unknown> | null;
+      config_schema: unknown;
+    }>(
+      `SELECT wp.install_id,
+              pc.slug AS catalog_slug,
+              wp.config,
+              pc.config_schema
+         FROM workspace_plugins wp
+         JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+        WHERE wp.workspace_id = $1
+          AND wp.pillar = 'datasource'
+          AND pc.slug = 'demo-postgres'`,
+      [orgId],
+    );
+
+    // Exactly one demo-postgres install, keyed by the canonical __demo__ id.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.install_id).toBe("__demo__");
+
+    // The persisted url is encrypted at rest, never the plaintext DSN.
+    const rawUrl = rows[0]?.config?.url;
+    expect(typeof rawUrl).toBe("string");
+    expect(rawUrl).not.toBe(demoUrl);
+    expect(rawUrl as string).toMatch(/^enc:/);
+
+    // The exact boot path (decrypt → resolve) must succeed without throwing —
+    // this is what emitted the recurring WARN before the fix.
+    const schema = parseConfigSchema(rows[0]?.config_schema);
+    const decrypted = decryptSecretFields(rows[0]?.config ?? {}, schema);
+    const poolConfig = resolveDatasourcePoolConfig(
+      {
+        workspaceId: orgId,
+        catalogId: "",
+        installId: rows[0]?.install_id as string,
+        pillar: "datasource",
+        catalogSlug: rows[0]?.catalog_slug as string,
+      },
+      decrypted,
+    );
+    expect(poolConfig.dbType).toBe("postgres");
+    expect((poolConfig as { url: string }).url).toBe(demoUrl);
   }, PG_TEST_TIMEOUT_MS);
 
   it("installs the staging Twenty integration for the staging org", async () => {

--- a/packages/api/src/lib/staging/seed.ts
+++ b/packages/api/src/lib/staging/seed.ts
@@ -51,6 +51,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createPlatformAdminUser } from "@atlas/api/lib/auth/admin-user-ops";
+import { detectDBType, resolveDatasourceUrl } from "@atlas/api/lib/db/connection";
+import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 
 const log = createLogger("staging-seed");
 
@@ -73,6 +75,18 @@ export const STAGING_ADMIN_EMAIL = "admin@staging.useatlas.dev";
  * staging org points that org at the shared demo data.
  */
 const STAGING_DEMO_DATASOURCE_SLUG = "demo-postgres";
+
+/**
+ * Canonical install_id for a workspace's demo-postgres datasource install.
+ * Every other surface keys the demo install on this exact id — migration
+ * 0096 step 3's backfill, `api/routes/mode.ts`'s `DEMO_ACTIVE_SQL` ("is demo
+ * active"), and `prompts/scoping.ts`. Mirrors `DEMO_CONNECTION_ID` in
+ * `semantic/entities.ts`; declared locally so this module keeps its narrow
+ * (auth-free) static graph. Using `default` here (as the seed previously did)
+ * collided with the real datasource install — which also lives at `default` —
+ * AND hid the demo from the `__demo__`-scoped "demo active" check (#3847).
+ */
+const STAGING_DEMO_INSTALL_ID = "__demo__";
 
 // ── Result + error types ───────────────────────────────────────────
 
@@ -173,7 +187,7 @@ export function ensureStagingSeed(): Effect.Effect<StagingSeedResult, StagingSee
     const userId = yield* step("admin", createAdminUser);
     yield* step("admin", () => verifyAdminEmail(userId));
     const orgId = yield* step("org", () => createStagingOrg(userId));
-    const datasource = yield* step("datasource", () => seedDemoDatasource(orgId));
+    const datasource = yield* step("datasource", () => _seedDemoDatasource(orgId));
     const twenty = yield* step("twenty", () => seedTwentyInstall(orgId));
 
     log.info(
@@ -285,17 +299,54 @@ async function createStagingOrg(userId: string): Promise<string> {
 /**
  * Install the shared `__demo__` NovaMart datasource (`demo-postgres`
  * catalog row) for the staging org. Mirrors the dev-seed workspace_plugins
- * upsert in `lib/auth/migrate.ts`. The demo dataset is operator/env-managed
- * (empty `config_schema`), so the install carries an empty config — the
- * connection URL resolves from `ATLAS_DATASOURCE_URL` at runtime.
+ * upsert in `lib/auth/migrate.ts` (`seedDemoData`): resolve the demo URL from
+ * `ATLAS_DATASOURCE_URL`, encrypt it under the catalog's `config_schema`
+ * (which marks `url` a required secret post-#2744), and persist it at the
+ * canonical `__demo__` install id.
  *
- * Returns `false` (non-fatal) if the catalog row is missing — that means
- * migration 0093 / the builtin datasource seeder has not run, which the
- * boot Layer's ordering dependency is meant to prevent.
+ * Why the url MUST be persisted (not env-resolved at runtime): post-#2744 the
+ * `ConnectionRegistry` boot bridge (`datasource-registry-bridge.ts`) builds
+ * the pool from `workspace_plugins.config`, whose resolver REQUIRES a `url`.
+ * The previous empty-config install (`'{}'`, install_id `'default'`) therefore
+ * failed that resolver on every boot with `DatasourcePoolResolver(postgres):
+ * missing required field url` — a recurring (benign) WARN — and collided with
+ * the real datasource install at `'default'` (#3847).
+ *
+ * Returns `false` (non-fatal) when:
+ *   - the catalog row is missing — migration 0093 / the builtin datasource
+ *     seeder has not run (the boot Layer's ordering dependency is meant to
+ *     prevent this), or
+ *   - `ATLAS_DATASOURCE_URL` is unset / has an unsupported scheme — there is no
+ *     demo dataset to point at, so we skip rather than persist an unqueryable
+ *     urless row (the exact state that produced the boot WARN).
+ *
+ * Exported (with the `_` prefix that marks the module's test-only surface, like
+ * `_resetPool` in `db/internal.ts`) so the skip branches — the exact #3847
+ * failure mode — can be unit-tested in isolation without standing up Better
+ * Auth for the admin/org steps `ensureStagingSeed` runs first.
  */
-async function seedDemoDatasource(orgId: string): Promise<boolean> {
-  const rows = await internalQuery<{ id: string }>(
-    `SELECT id FROM plugin_catalog WHERE slug = $1 AND pillar = 'datasource' LIMIT 1`,
+export async function _seedDemoDatasource(orgId: string): Promise<boolean> {
+  const url = resolveDatasourceUrl();
+  if (!url) {
+    log.warn(
+      "Staging seed: ATLAS_DATASOURCE_URL unset — skipping demo datasource install (no dataset to point at)",
+    );
+    return false;
+  }
+
+  let dbType: string;
+  try {
+    dbType = detectDBType(url);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Staging seed: demo datasource URL has an unsupported scheme — skipping datasource install",
+    );
+    return false;
+  }
+
+  const rows = await internalQuery<{ id: string; config_schema: unknown }>(
+    `SELECT id, config_schema FROM plugin_catalog WHERE slug = $1 AND pillar = 'datasource' LIMIT 1`,
     [STAGING_DEMO_DATASOURCE_SLUG],
   );
   if (rows.length === 0) {
@@ -305,13 +356,23 @@ async function seedDemoDatasource(orgId: string): Promise<boolean> {
     );
     return false;
   }
+
+  // Encrypt the url under the catalog `config_schema` (`url` is a `secret:true`
+  // field) so it lands encrypted-at-rest exactly like an admin / dev-seed
+  // install. The boot bridge's `decryptSecretFields` unwraps it symmetrically.
+  const schema = parseConfigSchema(rows[0].config_schema);
+  const config = encryptSecretFields(
+    { url, description: `Demo ${dbType} datasource`, db_type: dbType },
+    schema,
+  );
+
   await internalQuery(
     `INSERT INTO workspace_plugins
        (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at, status)
-     VALUES ($1, $2, $3, 'default', 'datasource', '{}'::jsonb, true, NOW(), 'published')
+     VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, true, NOW(), 'published')
      ON CONFLICT (workspace_id, catalog_id, install_id)
-       DO UPDATE SET status = 'published', updated_at = NOW()`,
-    [`cn_${orgId}_demo`, orgId, rows[0].id],
+       DO UPDATE SET config = EXCLUDED.config, status = 'published', updated_at = NOW()`,
+    [`cn_${orgId}_demo`, orgId, rows[0].id, STAGING_DEMO_INSTALL_ID, JSON.stringify(config)],
   );
   return true;
 }

--- a/packages/api/src/lib/staging/seed.ts
+++ b/packages/api/src/lib/staging/seed.ts
@@ -53,6 +53,7 @@ import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createPlatformAdminUser } from "@atlas/api/lib/auth/admin-user-ops";
 import { detectDBType, resolveDatasourceUrl } from "@atlas/api/lib/db/connection";
 import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import { hasVersionedPrefix } from "@atlas/api/lib/db/secret-encryption";
 
 const log = createLogger("staging-seed");
 
@@ -315,10 +316,13 @@ async function createStagingOrg(userId: string): Promise<string> {
  * Returns `false` (non-fatal) when:
  *   - the catalog row is missing — migration 0093 / the builtin datasource
  *     seeder has not run (the boot Layer's ordering dependency is meant to
- *     prevent this), or
+ *     prevent this),
  *   - `ATLAS_DATASOURCE_URL` is unset / has an unsupported scheme — there is no
  *     demo dataset to point at, so we skip rather than persist an unqueryable
- *     urless row (the exact state that produced the boot WARN).
+ *     urless row (the exact state that produced the boot WARN), or
+ *   - the resolved url is not Postgres — the `demo-postgres` slug is
+ *     postgres-only, so a non-pg url would persist a `db_type` that contradicts
+ *     the slug and fail the boot resolver; skip rather than write it.
  *
  * Exported (with the `_` prefix that marks the module's test-only surface, like
  * `_resetPool` in `db/internal.ts`) so the skip branches — the exact #3847
@@ -344,6 +348,18 @@ export async function _seedDemoDatasource(orgId: string): Promise<boolean> {
     );
     return false;
   }
+  // The `demo-postgres` catalog slug always resolves to a `postgres` pool
+  // (`catalogSlugToDbType`), so a non-postgres `ATLAS_DATASOURCE_URL` (e.g. a
+  // stray mysql:// value) would persist a `db_type` that contradicts the slug
+  // AND fail the boot bridge's postgres resolver. Warn-and-skip rather than
+  // write the contradictory row.
+  if (dbType !== "postgres") {
+    log.warn(
+      { dbType, slug: STAGING_DEMO_DATASOURCE_SLUG },
+      "Staging seed: ATLAS_DATASOURCE_URL is not a Postgres URL but the demo catalog is postgres-only — skipping datasource install",
+    );
+    return false;
+  }
 
   const rows = await internalQuery<{ id: string; config_schema: unknown }>(
     `SELECT id, config_schema FROM plugin_catalog WHERE slug = $1 AND pillar = 'datasource' LIMIT 1`,
@@ -365,6 +381,21 @@ export async function _seedDemoDatasource(orgId: string): Promise<boolean> {
     { url, description: `Demo ${dbType} datasource`, db_type: dbType },
     schema,
   );
+
+  // Defense-in-depth: `encryptSecretFields` passes values through as PLAINTEXT
+  // when the schema can't mark `url` secret — `state` is `absent`/`corrupt`, or
+  // `parsed` with no `url:{secret:true}` field. The post-0096 demo catalog
+  // declares `url` secret, so this only fires on a drifted / hand-patched
+  // catalog row. Warn loudly (don't block — a non-encrypted demo install still
+  // boots) rather than silently store the DSN unencrypted in
+  // `workspace_plugins.config`.
+  const persistedUrl = config.url;
+  if (typeof persistedUrl !== "string" || !hasVersionedPrefix(persistedUrl)) {
+    log.warn(
+      { schemaState: schema.state, slug: STAGING_DEMO_DATASOURCE_SLUG },
+      "Staging seed: demo datasource url is NOT encrypted at rest — the catalog config_schema does not mark `url` secret (drifted catalog row?). Storing anyway; re-run the builtin datasource catalog seeder to repair.",
+    );
+  }
 
   await internalQuery(
     `INSERT INTO workspace_plugins


### PR DESCRIPTION
## Summary
- The staging seed wrote the `demo-postgres` datasource install with an empty config (`'{}'`) at `install_id='default'`. Post-#2744 the `ConnectionRegistry` boot bridge (`datasource-registry-bridge.ts`) builds the pool from `workspace_plugins.config`, whose resolver **requires** a `url` — so the row failed every boot with a recurring (benign) WARN `DatasourcePoolResolver(postgres): missing required field url`, **and** collided with the real datasource install (also at `'default'`, different `catalog_id`) → ambiguous routing.
- The stale doc comment claimed the URL "resolves from `ATLAS_DATASOURCE_URL` at runtime" — false since the #2744 cutover (comment rot the fix removes).
- **Fix at the seed source**, mirroring the correct dev seed (`seedDemoData` in `lib/auth/migrate.ts`): resolve `ATLAS_DATASOURCE_URL`, encrypt it under the catalog `config_schema` (`url` is a `secret:true` field), and persist at the canonical `__demo__` install id — the id migration 0096 step 3, `api/routes/mode.ts`'s `DEMO_ACTIVE_SQL`, and `prompts/scoping.ts` all key the demo install on. Using `__demo__` also makes the staging demo visible to the "demo active" check (the old `default` install was invisible to it).
- When no demo URL is resolvable (env unset / unsupported scheme), skip non-fatally rather than persist an unqueryable urless row.

## Acceptance criteria
- [x] No recurring `missing required field url` WARN at boot for the demo-postgres install — the install now carries a resolvable url; the decrypt→resolve boot path no longer throws.
- [x] No two `workspace_plugins` rows collide on `install_id=default` — the demo install moves to the canonical `__demo__` id, leaving `default` for the real datasource.

## Test plan
- [x] Real-PG regression test (`describeIfPg`): install lands at `__demo__` (exactly one demo-postgres row, no `default` collision) with an encrypted (`enc:`-prefixed, not plaintext DSN) config; the exact boot path (`decryptSecretFields` → `resolveDatasourcePoolConfig`) succeeds and yields the demo url.
- [x] Confirmed RED on the unfixed code (install_id was `default`), GREEN with the fix.
- [x] Two no-DB unit tests cover the skip branches (no resolvable URL; unsupported scheme) — no INSERT, returns `false`.
- [x] `/ci`: lint, type, full test (`@atlas/api` + `test:others`), syncpack, and all drift/discipline gates pass. The 3 flakes seen in the local 708-file concurrent run (`discord`, `outbox-pg`, `chat-cap-pg` — unrelated files) all PASS in isolation.

Scope is confined to `packages/api/src/lib/staging/seed.ts` (+ its test) — no touch to `datasource-registry-bridge.ts`.

Closes #3847

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix staging demo-postgres install to persist encrypted URL at canonical `__demo__` install ID
> - `_seedDemoDatasource` in [`seed.ts`](https://github.com/AtlasDevHQ/atlas/pull/3850/files#diff-299751a0b6daddce18bb18e319e82df325d6b0e018ed494a407ecffa5db28716) now resolves the demo datasource URL, encrypts it with the catalog's config schema, and upserts into `workspace_plugins` at install ID `__demo__` (previously `default`) with the encrypted config (previously `{}`).
> - Adds early-exit guards: returns `false` without DB writes if the URL is unresolvable, uses an unsupported scheme, or resolves to a non-Postgres database type.
> - On conflict, the upsert now also updates `config` in addition to `status` and `updated_at`.
> - Behavioral Change: existing installs seeded under `default` are not migrated; new seeds land at `__demo__`. Any code keying on `default` for the demo datasource will no longer find it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b53021.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the staging seed's demo datasource install so it persists a resolvable encrypted URL at the canonical `__demo__` install ID rather than writing an empty config (`{}`) at `install_id='default'` — the state that caused a recurring boot WARN (`missing required field url`) and collided with the real datasource install post-#2744.

- `_seedDemoDatasource` now resolves `ATLAS_DATASOURCE_URL`, validates a Postgres scheme, encrypts the URL under the catalog `config_schema`, and upserts at `__demo__`; skip paths return `false` non-fatally and issue zero queries.
- Three no-DB unit tests cover every skip branch; a `describeIfPg` regression test walks the full decrypt → `resolveDatasourcePoolConfig` boot path and asserts the `enc:` prefix.
- Both concerns raised in prior review threads (silent plaintext URL on absent `config_schema`; `db_type` contradicting the `demo-postgres` slug) are resolved — a `hasVersionedPrefix` guard emits a loud `log.warn` when the URL isn't encrypted, and the non-postgres scheme check returns before any DB write.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to the staging seed, every skip branch is tested, and both prior review concerns are now explicitly guarded with warnings.

The change is confined to the staging bootstrap path; no production data or non-staging boot is affected. Both previously flagged issues (silent plaintext URL on absent schema, db_type/slug contradiction) are addressed with explicit guards. The ON CONFLICT clause correctly updates config so re-seeds refresh the encrypted value. The three skip-branch unit tests and the full PG regression test give strong coverage of the exact failure mode being fixed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/staging/seed.ts | Renames private seedDemoDatasource to exported _seedDemoDatasource; resolves ATLAS_DATASOURCE_URL, validates postgres scheme, encrypts under catalog config_schema, and persists at canonical __demo__ install_id instead of 'default'. Adds defense-in-depth warn when encryptSecretFields passes the URL through as plaintext. Logic is sound and well-guarded. |
| packages/api/src/lib/staging/__tests__/seed.test.ts | Adds three no-DB unit tests for skip branches (missing URL, unsupported scheme, non-postgres scheme) and a describeIfPg regression test that verifies install_id='__demo__', enc:-prefixed config, and the full decrypt→resolve boot path. Coverage is well-targeted to the exact failure mode. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_seedDemoDatasource(orgId)"] --> B["resolveDatasourceUrl()"]
    B -->|"undefined"| C["log.warn + return false"]
    B -->|"url"| D["detectDBType(url)"]
    D -->|"throws"| E["log.warn (unsupported scheme) + return false"]
    D -->|"dbType"| F{"dbType === 'postgres'?"}
    F -->|"no"| G["log.warn (non-pg) + return false"]
    F -->|"yes"| H["SELECT id, config_schema FROM plugin_catalog WHERE slug='demo-postgres'"]
    H -->|"no rows"| I["log.warn (missing catalog) + return false"]
    H -->|"rows[0]"| J["parseConfigSchema(rows[0].config_schema)"]
    J --> K["encryptSecretFields({url, db_type, description}, schema)"]
    K --> L{"hasVersionedPrefix(config.url)?"}
    L -->|"no"| M["log.warn (plaintext DSN!)"]
    L -->|"yes"| N["continue"]
    M --> N
    N --> O["INSERT INTO workspace_plugins\ninstall_id='__demo__'\nON CONFLICT DO UPDATE config"]
    O --> P["return true"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["_seedDemoDatasource(orgId)"] --> B["resolveDatasourceUrl()"]
    B -->|"undefined"| C["log.warn + return false"]
    B -->|"url"| D["detectDBType(url)"]
    D -->|"throws"| E["log.warn (unsupported scheme) + return false"]
    D -->|"dbType"| F{"dbType === 'postgres'?"}
    F -->|"no"| G["log.warn (non-pg) + return false"]
    F -->|"yes"| H["SELECT id, config_schema FROM plugin_catalog WHERE slug='demo-postgres'"]
    H -->|"no rows"| I["log.warn (missing catalog) + return false"]
    H -->|"rows[0]"| J["parseConfigSchema(rows[0].config_schema)"]
    J --> K["encryptSecretFields({url, db_type, description}, schema)"]
    K --> L{"hasVersionedPrefix(config.url)?"}
    L -->|"no"| M["log.warn (plaintext DSN!)"]
    L -->|"yes"| N["continue"]
    M --> N
    N --> O["INSERT INTO workspace_plugins\ninstall_id='__demo__'\nON CONFLICT DO UPDATE config"]
    O --> P["return true"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(staging-seed): harden demo install —..."](https://github.com/atlasdevhq/atlas/commit/7b53021a845a06279b307c36cca30f7dd0e9fe23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38924516)</sub>

<!-- /greptile_comment -->