### PR TITLE
fix(connections): enable Test button when Connection URL is filled

### DIFF
--- a/packages/web/src/app/admin/connections/__tests__/connection-form-fields.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/connection-form-fields.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Component tests for the watch-driven slivers of the Add/Edit Connection
+ * dialog (#3846).
+ *
+ * The bug: on Admin → Connections → Add database, the footer **Test** button
+ * stayed disabled even with a valid Connection URL filled, so you couldn't
+ * pre-flight a connection before persisting. Root cause was that the button's
+ * `disabled` gate read `form.watch("url")` from inside `FormDialog`'s
+ * `extraFooter` render-prop, and React Compiler memoized that stable
+ * `extraFooter?.(form)` call — `watch` never re-ran, so the gate was frozen at
+ * its empty initial value. The conditional Environment-name and Postgres-schema
+ * fields shared the same latent staleness.
+ *
+ * The fix moves each watched read into its own component that owns a `useWatch`
+ * subscription, so it re-renders on field changes independent of the parent.
+ *
+ * NOTE: bun:test does NOT run the React Compiler transform, so these tests
+ * can't reproduce the compiler-specific staleness directly (the old inline
+ * code would pass here too). They lock the intended reactive contract — the
+ * button tracks the URL field, the conditional fields mount on their trigger —
+ * and guard against a refactor that drops the `useWatch` subscription. The
+ * compiler-safety itself comes from the structural extraction.
+ */
+
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import React, { type ReactNode } from "react";
+import { useForm, type UseFormReturn } from "react-hook-form";
+import { render, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import { Form } from "@/components/ui/form";
+import { ENV_SENTINEL_NONE, ENV_SENTINEL_CREATE } from "../generate-prompt";
+import {
+  type ConnectionFormValues,
+  TestConnectionButton,
+  NewEnvNameField,
+  PostgresSchemaField,
+} from "../connection-form-fields";
+
+function baseValues(
+  overrides: Partial<ConnectionFormValues> = {},
+): ConnectionFormValues {
+  return {
+    id: "",
+    dbType: "postgres",
+    url: "",
+    schema: "",
+    description: "",
+    envSelection: ENV_SENTINEL_NONE,
+    newGroupName: "",
+    ...overrides,
+  };
+}
+
+/**
+ * Renders a real react-hook-form around the field under test and exposes the
+ * `form` instance to the test body via a ref-style callback, mirroring how
+ * `ConnectionFormDialog` hands `form` to its render props.
+ */
+function Harness({
+  defaults,
+  onForm,
+  children,
+}: {
+  defaults?: Partial<ConnectionFormValues>;
+  onForm: (form: UseFormReturn<ConnectionFormValues>) => void;
+  children: (form: UseFormReturn<ConnectionFormValues>) => ReactNode;
+}) {
+  const form = useForm<ConnectionFormValues>({
+    defaultValues: baseValues(defaults),
+  });
+  onForm(form);
+  return (
+    <Form {...form}>
+      <input data-testid="url-input" {...form.register("url")} />
+      {children(form)}
+    </Form>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TestConnectionButton (#3846)", () => {
+  test("is disabled with an empty URL and enables once a URL is present", async () => {
+    const onTest = mock(() => {});
+
+    const { getByText, getByTestId } = render(
+      <Harness onForm={() => {}}>
+        {(form) => (
+          <TestConnectionButton form={form} saving={false} onTest={onTest} />
+        )}
+      </Harness>,
+    );
+
+    const button = getByText("Test").closest("button");
+    if (!button) throw new Error("Test button not found");
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(getByTestId("url-input"), {
+      target: { value: "mysql://user:pass@host:3306/db" },
+    });
+
+    await waitFor(() => {
+      expect(button.disabled).toBe(false);
+    });
+  });
+
+  test("clicking reads the latest url + schema at click time, not a stale snapshot", async () => {
+    const onTest = mock((_url: string, _schema: string) => {});
+    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+
+    const { getByText, getByTestId } = render(
+      <Harness onForm={(f) => (captured = f)}>
+        {(form) => (
+          <TestConnectionButton form={form} saving={false} onTest={onTest} />
+        )}
+      </Harness>,
+    );
+
+    fireEvent.change(getByTestId("url-input"), {
+      target: { value: "postgresql://u:p@h:5432/db" },
+    });
+
+    // Mutate schema AFTER mount: the button reads it via `getValues` at click
+    // time, so a regression that snapshots schema into a prop/closure at mount
+    // would surface the old (empty) value here.
+    const form = captured;
+    if (!form) throw new Error("form not captured");
+    act(() => form.setValue("schema", "analytics"));
+
+    const button = getByText("Test").closest("button");
+    if (!button) throw new Error("Test button not found");
+    await waitFor(() => expect(button.disabled).toBe(false));
+
+    fireEvent.click(button);
+    expect(onTest).toHaveBeenCalledTimes(1);
+    expect(onTest).toHaveBeenCalledWith("postgresql://u:p@h:5432/db", "analytics");
+  });
+
+  test("stays disabled while a test is in flight even with a URL present", () => {
+    const onTest = mock(() => {});
+
+    const { getByText } = render(
+      <Harness
+        defaults={{ url: "mysql://u:p@h:3306/db" }}
+        onForm={() => {}}
+      >
+        {(form) => (
+          <TestConnectionButton form={form} saving={true} onTest={onTest} />
+        )}
+      </Harness>,
+    );
+
+    const button = getByText("Test").closest("button");
+    if (!button) throw new Error("Test button not found");
+    expect(button.disabled).toBe(true);
+  });
+});
+
+describe("NewEnvNameField (#3846)", () => {
+  test("hidden until envSelection becomes the create-sentinel, then mounts", async () => {
+    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+
+    const { queryByTestId } = render(
+      <Harness onForm={(f) => (captured = f)}>
+        {(form) => <NewEnvNameField form={form} />}
+      </Harness>,
+    );
+
+    expect(queryByTestId("env-new-name-input")).toBeNull();
+
+    const form = captured;
+    if (!form) throw new Error("form not captured");
+    act(() => form.setValue("envSelection", ENV_SENTINEL_CREATE));
+
+    await waitFor(() => {
+      expect(queryByTestId("env-new-name-input")).not.toBeNull();
+    });
+  });
+});
+
+describe("PostgresSchemaField (#3846)", () => {
+  test("shown for postgres and hidden once dbType changes away", async () => {
+    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+
+    const { queryByText } = render(
+      <Harness defaults={{ dbType: "postgres" }} onForm={(f) => (captured = f)}>
+        {(form) => <PostgresSchemaField form={form} />}
+      </Harness>,
+    );
+
+    expect(queryByText("Schema")).not.toBeNull();
+
+    const form = captured;
+    if (!form) throw new Error("form not captured");
+    act(() => form.setValue("dbType", "mysql"));
+
+    await waitFor(() => {
+      expect(queryByText("Schema")).toBeNull();
+    });
+  });
+});

--- a/packages/web/src/app/admin/connections/connection-form-fields.tsx
+++ b/packages/web/src/app/admin/connections/connection-form-fields.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { z } from "zod";
+import { type UseFormReturn, useWatch } from "react-hook-form";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  FormDescription as FormDesc,
+} from "@/components/form-dialog";
+import { ENV_SENTINEL_CREATE } from "./generate-prompt";
+
+// Mirrors the backend GROUP_NAME_PATTERN in `lib/db/connection-groups-helpers.ts`.
+// Inlined (rather than imported) so the web bundle doesn't pull from
+// `@atlas/api` — see "Frontend is a pure HTTP client" in CLAUDE.md. A drift here
+// surfaces in tests because the API returns a 400 with the same message.
+const ENV_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$/;
+
+// `ENV_SENTINEL_NONE` / `ENV_SENTINEL_CREATE` (the Environment combobox
+// sentinels) live in ./generate-prompt — shared with the new-group detection
+// for the inline "Generate semantic layer" prompt (#3237) so there's one
+// source of truth.
+
+const envSelectionSchema = z.string();
+
+export const connectionCreateSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1, "Connection ID is required")
+      .regex(/^[a-z][a-z0-9_-]*$/, "Lowercase letters, numbers, hyphens, underscores. Must start with a letter."),
+    dbType: z.string().min(1, "Database type is required"),
+    url: z.string().min(1, "Connection URL is required"),
+    schema: z.string(),
+    description: z.string(),
+    envSelection: envSelectionSchema,
+    newGroupName: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.envSelection === ENV_SENTINEL_CREATE) {
+      const trimmed = data.newGroupName.trim();
+      if (!trimmed) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["newGroupName"],
+          message: "Environment name is required.",
+        });
+      } else if (!ENV_NAME_PATTERN.test(trimmed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["newGroupName"],
+          message: "Letters, digits, spaces, hyphens, or underscores (max 64 chars). Must start with a letter or digit.",
+        });
+      }
+    }
+  });
+
+export const connectionEditSchema = z
+  .object({
+    id: z.string(),
+    dbType: z.string(),
+    url: z.string(), // empty string is valid on edit — empty means keep current URL
+    schema: z.string(),
+    description: z.string(),
+    envSelection: envSelectionSchema,
+    newGroupName: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.envSelection === ENV_SENTINEL_CREATE) {
+      const trimmed = data.newGroupName.trim();
+      if (!trimmed) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["newGroupName"],
+          message: "Environment name is required.",
+        });
+      } else if (!ENV_NAME_PATTERN.test(trimmed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["newGroupName"],
+          message: "Letters, digits, spaces, hyphens, or underscores (max 64 chars). Must start with a letter or digit.",
+        });
+      }
+    }
+  });
+
+/**
+ * Form value shape for the Add/Edit Connection dialog, derived from the create
+ * schema so the schema stays the single source of truth — there's no
+ * hand-maintained mirror that can silently drift. `connectionEditSchema` infers
+ * the same shape; `ConnectionFormDialog` pins both to this type (page.tsx) so
+ * the form carries one value type rather than a `Create | Edit` union.
+ */
+export type ConnectionFormValues = z.infer<typeof connectionCreateSchema>;
+
+/**
+ * Why these three slivers live in their own components instead of inline in
+ * `ConnectionFormDialog`'s render props (#3846):
+ *
+ * `FormDialog` invokes the caller's `children(form)` / `extraFooter?.(form)`
+ * render-prop callbacks. Under React Compiler (`reactCompiler: true`) those
+ * calls are memoized on their stable inputs — the `form` object and the
+ * callback identity are both referentially stable across the re-renders that
+ * `form.watch(...)` triggers — so the compiler never re-invokes the render prop
+ * and the `form.watch(...)` read inside that memoized subtree never re-runs.
+ * (`watch` itself isn't broken — its subscription fires, but the value can't
+ * reach a render of the memoized output that never happens.) The Test button
+ * stayed disabled even with a filled URL because `!form.watch("url")` was frozen
+ * at its empty initial value; the conditional Environment-name and
+ * Postgres-schema fields had the same latent staleness.
+ *
+ * `useWatch` fixes it structurally: each component owns its own field
+ * subscription via its own hook, so it re-renders on field changes regardless
+ * of whether the parent re-invokes the render prop. This mirrors the
+ * established pattern in `branding/page.tsx` and `integrations/config-schema-fields.tsx`.
+ */
+
+export function TestConnectionButton({
+  form,
+  saving,
+  onTest,
+}: {
+  form: UseFormReturn<ConnectionFormValues>;
+  saving: boolean;
+  onTest: (url: string, schema: string) => void;
+}) {
+  const url = useWatch({ control: form.control, name: "url" });
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={() => onTest(form.getValues("url"), form.getValues("schema"))}
+      disabled={saving || !url}
+    >
+      {saving ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+      Test
+    </Button>
+  );
+}
+
+export function NewEnvNameField({
+  form,
+}: {
+  form: UseFormReturn<ConnectionFormValues>;
+}) {
+  const envSelection = useWatch({ control: form.control, name: "envSelection" });
+  if (envSelection !== ENV_SENTINEL_CREATE) return null;
+  return (
+    <FormField
+      control={form.control}
+      name="newGroupName"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>New Environment Name</FormLabel>
+          <FormControl>
+            <Input
+              placeholder="e.g. Production"
+              {...field}
+              autoFocus
+              data-testid="env-new-name-input"
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+export function PostgresSchemaField({
+  form,
+}: {
+  form: UseFormReturn<ConnectionFormValues>;
+}) {
+  const dbType = useWatch({ control: form.control, name: "dbType" });
+  if (dbType !== "postgres") return null;
+  return (
+    <FormField
+      control={form.control}
+      name="schema"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Schema</FormLabel>
+          <FormControl>
+            <Input placeholder="public" {...field} />
+          </FormControl>
+          <FormDesc>
+            PostgreSQL schema (sets search_path). Leave empty for &quot;public&quot;.
+          </FormDesc>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -89,6 +89,14 @@ import {
 } from "@/ui/components/admin/compact";
 import { CollapsibleRow } from "@/ui/components/admin/collapsible-row";
 import {
+  type ConnectionFormValues,
+  connectionCreateSchema,
+  connectionEditSchema,
+  TestConnectionButton,
+  NewEnvNameField,
+  PostgresSchemaField,
+} from "./connection-form-fields";
+import {
   AddConnectionPicker,
   type DatasourceFormCandidate,
 } from "./add-connection-picker";
@@ -122,79 +130,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 // ── Connection Form Dialog ───────────────────────────────────────
 
-// Mirrors the backend GROUP_NAME_PATTERN in `lib/db/connection-groups-helpers.ts`.
-// Inlined (rather than imported) so the web bundle doesn't pull from
-// `@atlas/api` — see "Frontend is a pure HTTP client" in CLAUDE.md. A drift here
-// surfaces in tests because the API returns a 400 with the same message.
-const ENV_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$/;
-
-// `ENV_SENTINEL_NONE` / `ENV_SENTINEL_CREATE` (the Environment combobox
-// sentinels) live in ./generate-prompt — shared with the new-group detection
-// for the inline "Generate semantic layer" prompt (#3237) so there's one
-// source of truth.
-
-const envSelectionSchema = z.string();
-
-const connectionCreateSchema = z
-  .object({
-    id: z
-      .string()
-      .min(1, "Connection ID is required")
-      .regex(/^[a-z][a-z0-9_-]*$/, "Lowercase letters, numbers, hyphens, underscores. Must start with a letter."),
-    dbType: z.string().min(1, "Database type is required"),
-    url: z.string().min(1, "Connection URL is required"),
-    schema: z.string(),
-    description: z.string(),
-    envSelection: envSelectionSchema,
-    newGroupName: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.envSelection === ENV_SENTINEL_CREATE) {
-      const trimmed = data.newGroupName.trim();
-      if (!trimmed) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["newGroupName"],
-          message: "Environment name is required.",
-        });
-      } else if (!ENV_NAME_PATTERN.test(trimmed)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["newGroupName"],
-          message: "Letters, digits, spaces, hyphens, or underscores (max 64 chars). Must start with a letter or digit.",
-        });
-      }
-    }
-  });
-
-const connectionEditSchema = z
-  .object({
-    id: z.string(),
-    dbType: z.string(),
-    url: z.string(), // empty string is valid on edit — empty means keep current URL
-    schema: z.string(),
-    description: z.string(),
-    envSelection: envSelectionSchema,
-    newGroupName: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.envSelection === ENV_SENTINEL_CREATE) {
-      const trimmed = data.newGroupName.trim();
-      if (!trimmed) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["newGroupName"],
-          message: "Environment name is required.",
-        });
-      } else if (!ENV_NAME_PATTERN.test(trimmed)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["newGroupName"],
-          message: "Letters, digits, spaces, hyphens, or underscores (max 64 chars). Must start with a letter or digit.",
-        });
-      }
-    }
-  });
+// `connectionCreateSchema` / `connectionEditSchema` and the derived
+// `ConnectionFormValues` type live in ./connection-form-fields alongside the
+// field components that consume them — the schema is the single source of
+// truth for the form's value shape.
 
 /** Wire shape for `/api/v1/admin/connection-groups` — subset of the
  * `ConnectionGroup` shape the dialog uses. Post-0096 cutover (#2744)
@@ -269,7 +208,15 @@ function ConnectionFormDialog({
     invalidates: onSuccess,
   });
 
-  const schema = isEdit ? connectionEditSchema : connectionCreateSchema;
+  // Pin both branches to one value type so the form (and the extracted
+  // watch-driven field components) carry a single `ConnectionFormValues`
+  // rather than a `Create | Edit` union. `ConnectionFormValues` is
+  // `z.infer<typeof connectionCreateSchema>`, so the create schema is the
+  // source of truth; this annotation additionally fails the build if
+  // `connectionEditSchema` drops a field the create schema declares.
+  const schema: z.ZodType<ConnectionFormValues, ConnectionFormValues> = isEdit
+    ? connectionEditSchema
+    : connectionCreateSchema;
 
   // Env dropdown only surfaces user-named envs. Auto-`g_<id>` singletons
   // are hidden so the dropdown doesn't leak migration-0062's
@@ -417,15 +364,11 @@ function ConnectionFormDialog({
       }
       className="sm:max-w-md"
       extraFooter={(form) => (
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => handleTest(form.getValues("url"), form.getValues("schema"))}
-          disabled={testMutation.saving || !form.watch("url")}
-        >
-          {testMutation.saving ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-          Test
-        </Button>
+        <TestConnectionButton
+          form={form}
+          saving={testMutation.saving}
+          onTest={handleTest}
+        />
       )}
     >
       {(form) => (
@@ -486,26 +429,7 @@ function ConnectionFormDialog({
             )}
           />
 
-          {form.watch("envSelection") === ENV_SENTINEL_CREATE && (
-            <FormField
-              control={form.control}
-              name="newGroupName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>New Environment Name</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="e.g. Production"
-                      {...field}
-                      autoFocus
-                      data-testid="env-new-name-input"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
+          <NewEnvNameField form={form} />
 
           <FormField
             control={form.control}
@@ -585,24 +509,7 @@ function ConnectionFormDialog({
             )}
           />
 
-          {form.watch("dbType") === "postgres" && (
-            <FormField
-              control={form.control}
-              name="schema"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Schema</FormLabel>
-                  <FormControl>
-                    <Input placeholder="public" {...field} />
-                  </FormControl>
-                  <FormDesc>
-                    PostgreSQL schema (sets search_path). Leave empty for &quot;public&quot;.
-                  </FormDesc>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
+          <PostgresSchemaField form={form} />
 
           <FormField
             control={form.control}


### PR DESCRIPTION
## Summary
- **Bug:** On Admin → Connections → Add database, the footer **Test** button stayed disabled even with a valid Connection URL filled, so you couldn't pre-flight a connection before persisting. (Adding the connection with the *same* value succeeded → `201`, proving the URL was in form state.)
- **Root cause (React Compiler):** the button's `disabled` gate read `form.watch("url")` inside `FormDialog`'s `extraFooter` render-prop. With `reactCompiler: true`, the `extraFooter?.(form)` call is memoized on its referentially-stable `form`/callback inputs, so the compiler never re-invokes it and the `watch` read freezes at its empty initial value. (`watch` itself works — the value just can't reach a render of the memoized output that never happens.) The conditional **Environment-name** and **Postgres-schema** fields read via the same memoized `children(form)` render-prop and had the identical latent staleness.
- **Fix:** extract the three watched reads into their own components (`TestConnectionButton`, `NewEnvNameField`, `PostgresSchemaField`), each owning a `useWatch` subscription — the established `branding/page.tsx` / `integrations/config-schema-fields.tsx` pattern — so they re-render on field changes regardless of parent memoization. The form schemas + the derived `ConnectionFormValues` type (`z.infer<typeof connectionCreateSchema>`) move into the new module so the schema is the single source of truth.

A real keystroke fails the same way as the Playwright `fill` (the gate is frozen, not input-event-dependent), so this is a genuine enable-gate bug, not a not-repro.

## Test plan
- [x] New `connection-form-fields.test.tsx` (5 tests): Test button disabled→enabled on URL entry; click reads latest url+schema at click time; stays disabled while `saving`; Environment-name field mounts on the create-sentinel; Postgres-schema field shows for postgres and unmounts on dbType change.
- [x] `bun run type`, `bun run lint`, full `bun run test` (api + 34 others) — all green.
- [x] Existing `salesforce-block.test.tsx` (imports `page.tsx`) green in isolation.

> Note: `bun:test` does not run the React Compiler transform, so the tests lock the intended reactive contract (and guard against dropping the `useWatch` subscription) rather than reproducing the compiler-specific staleness — the structural extraction is what fixes the compiler path. Documented in the test header.

Surfaced by the #3253 staging soak.

Closes #3846

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Test button disabled state when Connection URL is filled
> - Extracts `TestConnectionButton`, `NewEnvNameField`, and `PostgresSchemaField` into standalone components in [connection-form-fields.tsx](https://github.com/AtlasDevHQ/atlas/pull/3851/files#diff-b9506077684ac14cc415f5e4cc24c9ca9f32d494911007cb235d9defd6e05c6e), each managing its own `useWatch` subscription.
> - Fixes the Test button remaining disabled despite a URL being present, caused by stale values under memoized render-prop execution in [page.tsx](https://github.com/AtlasDevHQ/atlas/pull/3851/files#diff-70a04c750aa8ff5d89851336c17ee36607804a9688a285c59f78d412ec788e78).
> - Moves Zod schemas (`connectionCreateSchema`, `connectionEditSchema`) and the `ConnectionFormValues` type to the shared fields file, adding client-side validation for environment names when the create sentinel is selected.
> - Adds tests covering the enabled/disabled states of `TestConnectionButton` and conditional rendering of `NewEnvNameField` and `PostgresSchemaField`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4748787.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a React Compiler memoization bug where the Test button on the Add/Edit Connection dialog remained disabled even after a valid Connection URL was entered. The root cause was `form.watch()` calls frozen inside a memoized `extraFooter` render-prop callback.

- **New `connection-form-fields.tsx` module**: extracts `TestConnectionButton`, `NewEnvNameField`, and `PostgresSchemaField` into standalone components, each owning a `useWatch` subscription so they re-render on field changes independently of any parent memoization. Connection schemas (`connectionCreateSchema`, `connectionEditSchema`) and the `ConnectionFormValues` type are co-located here as the single source of truth.
- **`page.tsx` cleanup**: removes ~70 lines of inline schema definitions and replaces three render-prop widget blocks with the new component calls.
- **New `connection-form-fields.test.tsx`**: 5 tests covering the disabled→enabled gate, click-time value freshness, in-flight save guard, env-name field sentinel mount, and dbType-conditional schema field.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted structural extraction with no behavior changes outside the React Compiler memoization fix it addresses.

The three extracted components correctly own their own `useWatch` subscriptions, the click handler correctly uses `getValues` for at-click-time freshness, the Zod v4 type annotation on `schema` is correct for the two-parameter `ZodType<Output, Input>` signature, and the test suite validates the reactive contract for all three components including the subtle schema-at-click-time case.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/admin/connections/connection-form-fields.tsx | New module housing the two Zod schemas, the derived ConnectionFormValues type, and three extracted useWatch-driven components. Logic is clean; superRefine validation is intentionally duplicated between create/edit schemas (pre-existing pattern, not introduced here). |
| packages/web/src/app/admin/connections/page.tsx | Removes the inline schema declarations and replaces inline render-prop widgets with the extracted components. The z.ZodType<ConnectionFormValues, ConnectionFormValues> annotation is correct for Zod v4's two-parameter signature (Output, Input). |
| packages/web/src/app/admin/connections/__tests__/connection-form-fields.test.tsx | Comprehensive test suite with a well-designed Harness component. Covers all three extracted components, including the click-time freshness test for getValues vs stale closures. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant ConnectionFormDialog
    participant TestConnectionButton
    participant NewEnvNameField
    participant PostgresSchemaField
    participant RHF as React Hook Form

    User->>ConnectionFormDialog: opens Add/Edit dialog
    ConnectionFormDialog->>RHF: useForm(defaultValues)

    note over TestConnectionButton: useWatch("url")
    note over NewEnvNameField: useWatch("envSelection")
    note over PostgresSchemaField: useWatch("dbType")

    User->>RHF: types URL
    RHF-->>TestConnectionButton: url updated
    TestConnectionButton-->>User: Test button enabled

    User->>RHF: selects Create new env
    RHF-->>NewEnvNameField: mounts input

    User->>RHF: selects postgres
    RHF-->>PostgresSchemaField: mounts Schema field

    User->>TestConnectionButton: clicks Test
    TestConnectionButton->>RHF: getValues(url, schema)
    TestConnectionButton->>ConnectionFormDialog: onTest(url, schema)
    ConnectionFormDialog->>User: fires /api/v1/admin/connections/test
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant ConnectionFormDialog
    participant TestConnectionButton
    participant NewEnvNameField
    participant PostgresSchemaField
    participant RHF as React Hook Form

    User->>ConnectionFormDialog: opens Add/Edit dialog
    ConnectionFormDialog->>RHF: useForm(defaultValues)

    note over TestConnectionButton: useWatch("url")
    note over NewEnvNameField: useWatch("envSelection")
    note over PostgresSchemaField: useWatch("dbType")

    User->>RHF: types URL
    RHF-->>TestConnectionButton: url updated
    TestConnectionButton-->>User: Test button enabled

    User->>RHF: selects Create new env
    RHF-->>NewEnvNameField: mounts input

    User->>RHF: selects postgres
    RHF-->>PostgresSchemaField: mounts Schema field

    User->>TestConnectionButton: clicks Test
    TestConnectionButton->>RHF: getValues(url, schema)
    TestConnectionButton->>ConnectionFormDialog: onTest(url, schema)
    ConnectionFormDialog->>User: fires /api/v1/admin/connections/test
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connections): enable Test button whe..."](https://github.com/atlasdevhq/atlas/commit/47487873c9208f67f55bf563d5c0c68612ce2d46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38928137)</sub>

<!-- /greptile_comment -->