### PR TITLE
fix(api): probe + test plugin datasources via per-workspace pools (#3853)

### DIFF
--- a/packages/api/src/__mocks__/connection.ts
+++ b/packages/api/src/__mocks__/connection.ts
@@ -37,6 +37,8 @@ export interface ConnectionsOverrides {
   has?: AnyFn;
   _reset?: AnyFn;
   healthCheck?: AnyFn;
+  healthCheckForWorkspace?: AnyFn;
+  hasDirectForWorkspace?: AnyFn;
   register?: AnyFn;
   unregister?: AnyFn;
   recordQuery?: AnyFn;
@@ -101,12 +103,20 @@ export function createConnectionMock(overrides?: ConnectionMockOverrides) {
     describeForWorkspace: (_workspaceId: string) => connections.describe(),
     describeAllWorkspacePlugins: () => [],
     has: () => true,
+    healthCheck: async () => ({ status: "healthy" as const, latencyMs: 1, checkedAt: new Date() }),
     isOrgPoolingEnabled: () => false,
     getForOrg: () => dbConn,
     getForWorkspace: () => dbConn,
     // Default: no per-workspace config registered in the mock, so the
     // org-pooling-OFF read path keeps pool metrics on the bare entry (#3109).
     hasForWorkspace: () => false,
+    // #3853 — default: no per-workspace PLUGIN pool registered, so the admin
+    // list / `/:id/test` route's plugin-pool branch is skipped and
+    // healthCheckForWorkspace falls back to the native healthCheck. Tests that
+    // exercise a plugin datasource override both.
+    hasDirectForWorkspace: () => false,
+    healthCheckForWorkspace: (_workspaceId: string, installId: string) =>
+      connections.healthCheck(installId),
     drainWorkspacePool: () => 0,
     recordQuery: () => {},
     recordSuccess: () => {},

--- a/packages/api/src/api/__tests__/admin-connections-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-audit.test.ts
@@ -65,6 +65,15 @@ const mocks = createApiTestMocks({
       list: mockConnectionList,
       has: mockConnectionHas,
       describe: mockConnectionDescribe,
+      // #3853 — the `/:id/test` route now resolves presence via the
+      // workspace-scoped describe and probes via healthCheckForWorkspace.
+      // Derive describeForWorkspace from `mockConnectionList` so the existing
+      // "not registered (404)" test (which sets list → []) still 404s; warehouse
+      // is a native id, so hasDirectForWorkspace is false and
+      // healthCheckForWorkspace delegates to the native healthCheck mock.
+      describeForWorkspace: () => mockConnectionList().map((id) => ({ id, dbType: "postgres" })),
+      hasDirectForWorkspace: () => false,
+      healthCheckForWorkspace: (_orgId: string, id: string) => mockConnectionHealthCheck(id),
       register: mockConnectionRegister,
       unregister: mockConnectionUnregister,
       healthCheck: mockConnectionHealthCheck,

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -527,6 +527,44 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       // health comes from the cached fiber, not this active probe).
       expect(mockHealthCheckForWorkspace).toHaveBeenCalledWith("org-alpha", "clickhouse-staging");
     });
+
+    it("#3860 — one throwing plugin probe degrades its row, never 500s the whole list", async () => {
+      // TOCTOU defense-in-depth: `healthCheckForWorkspace` is contractually
+      // "never throws", but the list route still wraps each probe so that even
+      // an unexpected rejection (e.g. a race-removed pool reaching the native
+      // fallback's `ConnectionNotRegisteredError`) is contained to a single
+      // `degraded` row rather than rejecting the route's `Promise.allSettled`
+      // and failing the entire connections list with a 500.
+      mockHealthCheckForWorkspace.mockClear();
+      mockHealthCheckForWorkspace.mockImplementationOnce(() =>
+        Promise.reject(new Error('Connection "clickhouse-staging" is not registered.')),
+      );
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) {
+          return Promise.resolve([{ install_id: "warehouse" }, { install_id: "clickhouse-staging" }]);
+        }
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([
+            { install_id: "warehouse", group_id: null },
+            { install_id: "clickhouse-staging", group_id: null },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      // The list survives — no 500 — despite the throwing probe.
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const clickhouse = body.connections.find((c: { id: string }) => c.id === "clickhouse-staging");
+      // The bad row is degraded, not absent or fatal.
+      expect(clickhouse).toBeDefined();
+      expect(clickhouse.health.status).toBe("degraded");
+      // Native rows are unaffected.
+      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
+      expect(warehouse).toBeDefined();
+    });
   });
 
   // ─── 3. PUT 404s for wrong workspace ──────────────────────────────────

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -47,6 +47,13 @@ const mockHealthCheck = mock(() =>
   Promise.resolve({ status: "healthy", latencyMs: 3, checkedAt: new Date() }),
 );
 
+// #3853 — workspace-scoped probe used by the list route's plugin-pool health
+// enrichment and the `POST /:id/test` route. Returns a distinct latency so
+// tests can assert the route used THIS path (not the bare `healthCheck`).
+const mockHealthCheckForWorkspace = mock(() =>
+  Promise.resolve({ status: "healthy" as const, latencyMs: 7, checkedAt: new Date() }),
+);
+
 // Captured so tests can assert on register-call sequences (e.g. the
 // registry-rollback contract on PUT). Without a captured reference,
 // inline `mock(() => {})` is unobservable from `.mock.calls`.
@@ -82,6 +89,13 @@ const mocks = createApiTestMocks({
         { id: "clickhouse-staging", dbType: "clickhouse", description: "ClickHouse" },
       ],
       healthCheck: mockHealthCheck,
+      // #3853 — the `/test` route and list health-enrichment resolve plugin
+      // pools through the workspace-scoped probe / presence check, not the bare
+      // `entries`. `clickhouse-staging` is a plugin pool (present in
+      // describeForWorkspace, absent from `list()`), so the fixture wires the
+      // workspace-scoped helpers to recognise it.
+      healthCheckForWorkspace: mockHealthCheckForWorkspace,
+      hasDirectForWorkspace: (_orgId: string, id: string) => id === "clickhouse-staging",
       register: mockRegister,
       unregister: mock(() => false),
       has: (id: string) => ["default", "warehouse", "other-org-conn"].includes(id),
@@ -480,6 +494,39 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       // It owns a workspace_plugins row, so it counts toward the plan/billing.
       expect(clickhouse.billable).toBe(true);
     });
+
+    it("#3853 — list actively probes a plugin pool so it carries a health object", async () => {
+      // The plugin pool (clickhouse-staging) arrives from describeForWorkspace
+      // with no cached `health` (the periodic fiber probes only bare entries).
+      // The list route must probe it via healthCheckForWorkspace so the row
+      // shows latency instead of "Status unknown" and the aggregate reaches
+      // full count.
+      mockHealthCheckForWorkspace.mockClear();
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) {
+          return Promise.resolve([{ install_id: "warehouse" }, { install_id: "clickhouse-staging" }]);
+        }
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([
+            { install_id: "warehouse", group_id: null },
+            { install_id: "clickhouse-staging", group_id: null },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const clickhouse = body.connections.find((c: { id: string }) => c.id === "clickhouse-staging");
+      expect(clickhouse.health).toBeDefined();
+      expect(clickhouse.health.status).toBe("healthy");
+      expect(clickhouse.health.latencyMs).toBe(7);
+      // The plugin pool was the only one probed (warehouse is a native id whose
+      // health comes from the cached fiber, not this active probe).
+      expect(mockHealthCheckForWorkspace).toHaveBeenCalledWith("org-alpha", "clickhouse-staging");
+    });
   });
 
   // ─── 3. PUT 404s for wrong workspace ──────────────────────────────────
@@ -643,6 +690,30 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       );
 
       expect(res.status).toBe(200);
+    });
+
+    it("#3853 — health-checks a plugin datasource (no 404) via the workspace-scoped probe", async () => {
+      // clickhouse-staging is a plugin pool: present in describeForWorkspace,
+      // absent from the bare `list()`. Pre-fix the route gated on `list()` →
+      // 404; now it gates on describeForWorkspace and probes via
+      // healthCheckForWorkspace, returning a real reachability result.
+      setOrgAdmin("org-alpha");
+      mockHealthCheckForWorkspace.mockClear();
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "clickhouse-staging" }]);
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/clickhouse-staging/test", "POST"),
+      );
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.status).toBe("healthy");
+      expect(body.latencyMs).toBe(7);
+      expect(mockHealthCheckForWorkspace).toHaveBeenCalledWith("org-alpha", "clickhouse-staging");
     });
 
     it("platform admin health-checking an install not in their active workspace gets 404", async () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -504,23 +504,58 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   // per-workspace direct-plugin map the fiber never visits, so they arrived
   // with no `health` field — the row rendered "Status unknown" and the
   // aggregate stuck at N-1/N (#3853). Actively probe any plugin pool here so
-  // every connection in the list carries a real reachability result. Probes
-  // run concurrently and a failure is captured as a `degraded`/`unhealthy`
-  // health object by `healthCheckForWorkspace`, never thrown.
+  // every connection in the list carries a real reachability result.
+  //
+  // `healthCheckForWorkspace` is contractually "never throws" — it converts
+  // connection-level failures AND the TOCTOU race (a pool unregistered between
+  // the `hasDirectForWorkspace` filter and the probe, which would otherwise
+  // throw `ConnectionNotRegisteredError` from the native fallback) into a
+  // `degraded` result. We still use `Promise.allSettled` here as defense in
+  // depth so that even an unexpected throw from a single probe degrades that
+  // one row instead of rejecting the whole list with a 500 (#3860).
+  //
+  // TODO(#3853-followup): the `conn.health === undefined` guard means we only
+  // probe plugin pools that have never been checked; once `lastHealth` is
+  // cached (first list call or explicit `/test`) we serve the cached value and
+  // never re-probe. The periodic health-check fiber visits only bare `entries`,
+  // not plugin pools, so plugin-pool health is never background-refreshed and
+  // its age is unbounded (native pools refresh every 60s). Extending the
+  // periodic fiber to plugin pools is tracked as the next iteration and is
+  // intentionally out of scope for this PR.
   const healthByConnection = new Map<string, HealthCheckResult>();
   const pluginPoolsToProbe = filtered.filter(
     (conn) => conn.health === undefined && connections.hasDirectForWorkspace(orgId, conn.id),
   );
   if (pluginPoolsToProbe.length > 0) {
-    const probed = await Promise.all(
+    const probed = await Promise.allSettled(
       pluginPoolsToProbe.map(async (conn) => {
         const health = await connections.healthCheckForWorkspace(orgId, conn.id);
         return [conn.id, health] as const;
       }),
     );
-    for (const [id, health] of probed) {
-      healthByConnection.set(id, health);
-    }
+    probed.forEach((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        const [id, health] = outcome.value;
+        healthByConnection.set(id, health);
+        return;
+      }
+      // Defensive: `healthCheckForWorkspace` should never reject, but if it
+      // somehow does, contain the blast radius to this single row rather than
+      // failing the entire connections list. Surface a synthetic `degraded`.
+      // The log line keeps the raw `reason` (pino preserves the stack, central
+      // scrubbing handles the log side); the response `message` runs through
+      // `errorMessage` so a driver-echoed DSN can't leak to the admin UI —
+      // mirrors the scrub in `healthCheckForWorkspace`'s own arms.
+      const conn = pluginPoolsToProbe[i];
+      const reason = outcome.reason;
+      log.warn({ connectionId: conn.id, orgId, err: reason }, "Plugin pool health probe rejected unexpectedly");
+      healthByConnection.set(conn.id, {
+        status: "degraded",
+        latencyMs: 0,
+        message: errorMessage(reason),
+        checkedAt: new Date(),
+      });
+    });
   }
 
   // Decorate with `group_id` from `workspace_plugins.config`. Per

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -14,7 +14,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getConfig } from "@atlas/api/lib/config";
-import { connections, detectDBType } from "@atlas/api/lib/db/connection";
+import { connections, detectDBType, type HealthCheckResult } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
@@ -498,6 +498,31 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   const filtered = visible ? connList.filter((conn) => visible.has(conn.id)) : connList;
 
+  // Health enrichment for plugin datasources. Native pools carry a cached
+  // `health` from the periodic health-check fiber (which probes only the bare
+  // `entries`); plugin pools (clickhouse / elasticsearch / …) live in the
+  // per-workspace direct-plugin map the fiber never visits, so they arrived
+  // with no `health` field — the row rendered "Status unknown" and the
+  // aggregate stuck at N-1/N (#3853). Actively probe any plugin pool here so
+  // every connection in the list carries a real reachability result. Probes
+  // run concurrently and a failure is captured as a `degraded`/`unhealthy`
+  // health object by `healthCheckForWorkspace`, never thrown.
+  const healthByConnection = new Map<string, HealthCheckResult>();
+  const pluginPoolsToProbe = filtered.filter(
+    (conn) => conn.health === undefined && connections.hasDirectForWorkspace(orgId, conn.id),
+  );
+  if (pluginPoolsToProbe.length > 0) {
+    const probed = await Promise.all(
+      pluginPoolsToProbe.map(async (conn) => {
+        const health = await connections.healthCheckForWorkspace(orgId, conn.id);
+        return [conn.id, health] as const;
+      }),
+    );
+    for (const [id, health] of probed) {
+      healthByConnection.set(id, health);
+    }
+  }
+
   // Decorate with `group_id` from `workspace_plugins.config`. Per
   // ADR-0007 the `connection_groups` table is gone; named groups
   // collapse into the per-row JSONB key `config->>'group_id'`. The
@@ -540,8 +565,10 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
 
   const decorated = filtered.map((c) => {
     const info = groupInfoByConnection.get(c.id);
+    const probedHealth = healthByConnection.get(c.id);
     return {
       ...c,
+      ...(probedHealth ? { health: probedHealth } : {}),
       groupId: info?.groupId ?? null,
       groupName: info?.groupName ?? null,
       billable: groupInfoByConnection.has(c.id),
@@ -740,8 +767,15 @@ adminConnections.openapi(testExistingConnectionRoute, async (c) => runHandler(c,
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
   const { id } = c.req.valid("param");
 
-  const registered = connections.list();
-  if (!registered.includes(id)) {
+  // Existence is workspace-scoped: a published plugin datasource (clickhouse /
+  // elasticsearch / …) registers ONLY in the per-(workspace, install_id) plugin
+  // map, never in the bare `connections.list()` (`entries`). Gating on
+  // `list()` 404'd every plugin pool here (#3853). `describeForWorkspace`
+  // unions the bare entries with this workspace's plugin pools, so it's the
+  // correct registry-presence check; the `visible` set below is the
+  // content-mode / org-membership authorization gate.
+  const registeredForWorkspace = connections.describeForWorkspace(orgId);
+  if (!registeredForWorkspace.some((entry) => entry.id === id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
@@ -750,7 +784,12 @@ adminConnections.openapi(testExistingConnectionRoute, async (c) => runHandler(c,
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
-  const result = await connections.healthCheck(id);
+  // Workspace-scoped probe: resolves the plugin pool first, falling back to the
+  // native health check for bare ids. Plugin datasources have no entry in the
+  // bare `entries` map: the old `connections.list()` gate above 404'd them
+  // first, and even past that gate the prior `connections.healthCheck(id)`
+  // would have thrown ConnectionNotRegisteredError → 500 (#3853).
+  const result = await connections.healthCheckForWorkspace(orgId, id);
 
   // `connection.health_check` is distinct from `connection.probe` (the
   // ephemeral `POST /test` surface) so forensic queries can separately
@@ -758,7 +797,7 @@ adminConnections.openapi(testExistingConnectionRoute, async (c) => runHandler(c,
   // a persisted datasource. Metadata shape matches probe: same success
   // / dbType / latencyMs fields so downstream dashboards can union the
   // two when appropriate. See F-29 / F-34.
-  const registryEntry = connections.describe().find((entry) => entry.id === id);
+  const registryEntry = registeredForWorkspace.find((entry) => entry.id === id);
   logAdminAction({
     actionType: ADMIN_ACTIONS.connection.healthCheck,
     targetType: "connection",

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -390,4 +390,99 @@ describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () 
     expect(all.every((m) => m.id === "clickhouse")).toBe(true);
     registry._reset();
   });
+
+  // #3853 — health/test half of the native-vs-plugin registry split. The bare
+  // `healthCheck(id)` only probes `entries`, so plugin pools threw
+  // ConnectionNotRegisteredError; `healthCheckForWorkspace` resolves the plugin
+  // pool first and caches the result so `describeForWorkspace` carries `health`.
+  it("healthCheckForWorkspace probes a plugin pool and caches health onto its describe", async () => {
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-1", "ch", fakeConn("ch"), "clickhouse", "ClickHouse");
+
+    // Bare healthCheck can't see the plugin pool — this is the bug.
+    await expect(registry.healthCheck("ch")).rejects.toThrow(/not registered/i);
+
+    const result = await registry.healthCheckForWorkspace("ws-1", "ch");
+    expect(result.status).toBe("healthy");
+    expect(typeof result.latencyMs).toBe("number");
+
+    // The probe result is cached on the entry so the admin list (which reads
+    // through describeForWorkspace) surfaces a `health` object.
+    const meta = registry.describeForWorkspace("ws-1").find((m) => m.id === "ch");
+    expect(meta?.health?.status).toBe("healthy");
+    registry._reset();
+  });
+
+  it("healthCheckForWorkspace reports degraded (never throws) when the plugin probe fails", async () => {
+    const failingConn = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+      close: async () => {},
+    };
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-1", "ch", failingConn, "clickhouse");
+
+    const result = await registry.healthCheckForWorkspace("ws-1", "ch");
+    expect(result.status).toBe("degraded");
+    expect(result.message).toBeDefined();
+    registry._reset();
+  });
+
+  it("healthCheckForWorkspace stays degraded on repeated plugin failures (never escalates to unhealthy)", async () => {
+    // The documented contract: plugin pools don't track the consecutive-failure
+    // span the native path uses to escalate to `unhealthy`, so repeated probe
+    // failures must report `degraded` every time. Guards a future refactor that
+    // might unify the two paths and silently change plugin behaviour (#3853).
+    const failingConn = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+      close: async () => {},
+    };
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-1", "ch", failingConn, "clickhouse");
+
+    for (let i = 0; i < 4; i++) {
+      const result = await registry.healthCheckForWorkspace("ws-1", "ch");
+      expect(result.status).toBe("degraded");
+    }
+    registry._reset();
+  });
+
+  it("healthCheckForWorkspace scrubs DSN userinfo from a failed plugin probe message", async () => {
+    // "No secrets in responses": when no curated matchError pattern fires, the
+    // plugin failure path surfaces the raw driver error via `errorMessage`,
+    // which scrubs `scheme://user:pass@host` userinfo. A DSN echoed in such an
+    // error must not reach HealthCheckResult.message — this result renders in
+    // the admin UI (#3853). (matchError's own ECONNREFUSED/ENOTFOUND messages
+    // only ever carry a `host:port` token, never the DSN, so the fallback is
+    // the path that needs the scrub guarantee.)
+    const failingConn = {
+      query: async () => {
+        throw new Error(
+          "authentication failed for clickhouse://admin:sup3rsecret@db.internal:8443/main",
+        );
+      },
+      close: async () => {},
+    };
+    const registry = new ConnectionRegistry();
+    registry.registerDirectForWorkspace("ws-1", "ch", failingConn, "clickhouse");
+
+    const result = await registry.healthCheckForWorkspace("ws-1", "ch");
+    expect(result.status).toBe("degraded");
+    expect(result.message).toBeDefined();
+    expect(result.message).not.toContain("sup3rsecret");
+    expect(result.message).not.toContain("admin:");
+    registry._reset();
+  });
+
+  it("healthCheckForWorkspace falls back to the native healthCheck for a bare id", async () => {
+    const registry = new ConnectionRegistry();
+    registry.registerDirect("warehouse", fakeConn("pg"), "postgres", "PG");
+    // No plugin pool registered for (ws-1, warehouse) → native path.
+    const result = await registry.healthCheckForWorkspace("ws-1", "warehouse");
+    expect(result.status).toBe("healthy");
+    registry._reset();
+  });
 });

--- a/packages/api/src/lib/db/__tests__/connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/connection.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { resolve } from "path";
+import type { HealthCheckResult } from "../connection";
 
 const modulePath = resolve(__dirname, "../connection.ts");
 const mod = await import(`${modulePath}?t=${Date.now()}`);
@@ -483,6 +484,39 @@ describe("ConnectionRegistry — DB-stored plugin datasources (#3253 seam)", () 
     // No plugin pool registered for (ws-1, warehouse) → native path.
     const result = await registry.healthCheckForWorkspace("ws-1", "warehouse");
     expect(result.status).toBe("healthy");
+    registry._reset();
+  });
+
+  // #3860 — TOCTOU: a caller (e.g. the admin list route) sees a plugin pool via
+  // `hasDirectForWorkspace`, but the pool is unregistered before the probe runs.
+  // `healthCheckForWorkspace` then finds no entry in `workspacePluginEntries`,
+  // falls through to the native `healthCheck(installId)`, which throws
+  // `ConnectionNotRegisteredError` because the id is absent from `entries` too.
+  // The method's JSDoc promises it "never throws". The admin list route
+  // additionally wraps each probe in `Promise.allSettled` as defense in depth,
+  // but this test pins the method's OWN contract directly — the native-fallback
+  // arm must catch the throw and convert it to a synthetic `degraded` result.
+  it("healthCheckForWorkspace returns degraded (never throws) for an id absent from BOTH maps", async () => {
+    const registry = new ConnectionRegistry();
+    // Nothing registered at all — neither a plugin pool nor a bare entry.
+    expect(registry.hasDirectForWorkspace("ws-1", "gone")).toBe(false);
+    // Bare healthCheck throws for the missing id — the underlying failure mode.
+    await expect(registry.healthCheck("gone")).rejects.toThrow(/not registered/i);
+
+    // healthCheckForWorkspace must absorb it into a degraded result.
+    let result: HealthCheckResult | undefined;
+    await expect(
+      (async () => {
+        result = await registry.healthCheckForWorkspace("ws-1", "gone");
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result?.status).toBe("degraded");
+    // No live probe ran (entry gone from both maps) → synthetic zero latency.
+    expect(result?.latencyMs).toBe(0);
+    // The surfaced message carries the underlying failure but never leaks
+    // credentials (the synthetic-degraded arm scrubs via `errorMessage`).
+    expect(result?.message).toMatch(/not registered/i);
+    expect(result?.message).not.toContain("@");
     registry._reset();
   });
 });

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -473,6 +473,18 @@ interface WorkspacePluginEntry {
   targetHost: string;
   validate?: (query: string) => { valid: boolean; reason?: string } | Promise<{ valid: boolean; reason?: string }>;
   pluginMeta?: ConnectionPluginMeta;
+  /**
+   * Last health probe result for this plugin pool. Set by
+   * {@link ConnectionRegistry.healthCheckForWorkspace}; surfaced through
+   * {@link ConnectionRegistry.describeForWorkspace} (and
+   * {@link ConnectionRegistry.describeAllWorkspacePlugins}) via `_pluginMeta` so
+   * the admin Connections list carries a `health` object for plugin datasources
+   * (#3853). Unlike the
+   * native {@link RegistryEntry}, plugin pools don't track a consecutive-failure
+   * span (the periodic fiber probes only bare `entries`), so a failed probe is
+   * reported as `degraded` rather than escalating to `unhealthy`.
+   */
+  lastHealth?: HealthCheckResult;
 }
 
 /** Configuration for per-org pool isolation. */
@@ -1378,12 +1390,17 @@ export class ConnectionRegistry {
     }));
   }
 
-  /** {@link ConnectionMetadata} for a per-workspace plugin pool (no `lastHealth` tracked on these entries). */
+  /**
+   * {@link ConnectionMetadata} for a per-workspace plugin pool. Carries a
+   * `health` object once {@link healthCheckForWorkspace} has probed the pool and
+   * cached `lastHealth` on the entry (#3853); omitted until the first probe.
+   */
   private _pluginMeta(entry: WorkspacePluginEntry): ConnectionMetadata {
     return {
       id: entry.installId,
       dbType: entry.dbType,
       ...(entry.description !== undefined ? { description: entry.description } : {}),
+      ...(entry.lastHealth ? { health: entry.lastHealth } : {}),
     };
   }
 
@@ -1476,6 +1493,60 @@ export class ConnectionRegistry {
       const matched = matchError(err);
       const result: HealthCheckResult = {
         status,
+        latencyMs,
+        message: matched?.message ?? scrubbedMessage,
+        checkedAt: new Date(),
+      };
+      entry.lastHealth = result;
+      return result;
+    }
+  }
+
+  /**
+   * Run a health check for a connection visible to a specific workspace,
+   * resolving a per-(workspace, install_id) PLUGIN pool first and falling back
+   * to the native {@link healthCheck} for bare/native ids.
+   *
+   * Plugin datasources (clickhouse / elasticsearch / snowflake / …) register a
+   * pre-built live connection ONLY in {@link workspacePluginEntries} — never in
+   * the bare `entries` map that {@link healthCheck} probes — so a bare
+   * `healthCheck(installId)` threw `ConnectionNotRegisteredError` and the admin
+   * `/test` route 404'd for them (#3853). This probes the plugin pool directly
+   * (`SELECT 1`, 5s budget) and caches the result on the entry so a subsequent
+   * {@link describeForWorkspace} carries the `health` object.
+   *
+   * On a probe failure the plugin path reports `degraded` (plugin entries don't
+   * track the consecutive-failure span the native path uses to escalate to
+   * `unhealthy`); the native fallback keeps its own escalation behaviour.
+   */
+  async healthCheckForWorkspace(workspaceId: string, installId: string): Promise<HealthCheckResult> {
+    const entry = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, installId));
+    if (!entry) {
+      // Native/bare id (e.g. self-hosted `default`, a postgres/mysql pool):
+      // defer to the native probe, which owns failure-span escalation.
+      return this.healthCheck(installId);
+    }
+
+    const start = performance.now();
+    try {
+      await entry.conn.query("SELECT 1", 5000);
+      const result: HealthCheckResult = {
+        status: "healthy",
+        latencyMs: Math.round(performance.now() - start),
+        checkedAt: new Date(),
+      };
+      entry.lastHealth = result;
+      return result;
+    } catch (err) {
+      const latencyMs = Math.round(performance.now() - start);
+      // Scrub driver-echoed DSN userinfo from the surfaced message (the log
+      // line keeps the raw `err` so pino's serializer preserves the stack;
+      // central scrubbing handles the log side). Mirrors {@link healthCheck}.
+      const scrubbedMessage = errorMessage(err);
+      log.warn({ err, workspaceId, installId, latencyMs }, "Plugin connection health check failed");
+      const matched = matchError(err);
+      const result: HealthCheckResult = {
+        status: "degraded",
         latencyMs,
         message: matched?.message ?? scrubbedMessage,
         checkedAt: new Date(),

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1518,13 +1518,47 @@ export class ConnectionRegistry {
    * On a probe failure the plugin path reports `degraded` (plugin entries don't
    * track the consecutive-failure span the native path uses to escalate to
    * `unhealthy`); the native fallback keeps its own escalation behaviour.
+   *
+   * **Never throws** — unconditionally. The plugin-pool probe arm catches
+   * connection-level failures (timeout, refused) → `degraded`. The native
+   * fallback arm is also wrapped: if `installId` is absent from BOTH
+   * {@link workspacePluginEntries} AND the bare `entries` map (the TOCTOU race
+   * where a pool is unregistered between a caller's presence check and this
+   * probe, #3860), {@link healthCheck} would throw `ConnectionNotRegisteredError`.
+   * We catch that (and any unexpected throw) and convert it to a synthetic
+   * `degraded` result so callers like the admin list route's concurrent probe
+   * can never be rejected by a single race-removed connection.
    */
   async healthCheckForWorkspace(workspaceId: string, installId: string): Promise<HealthCheckResult> {
     const entry = this.workspacePluginEntries.get(this._workspaceKey(workspaceId, installId));
     if (!entry) {
       // Native/bare id (e.g. self-hosted `default`, a postgres/mysql pool):
-      // defer to the native probe, which owns failure-span escalation.
-      return this.healthCheck(installId);
+      // defer to the native probe, which owns failure-span escalation. Wrap it
+      // so a TOCTOU unregistration (id absent from both maps) surfaces as a
+      // synthetic `degraded` rather than a thrown `ConnectionNotRegisteredError`
+      // — keeping the "never throws" contract above unconditionally true.
+      try {
+        return await this.healthCheck(installId);
+      } catch (err) {
+        // Scrub any driver-echoed DSN userinfo from the surfaced message; the
+        // log line keeps the raw `err` (pino's serializer preserves the stack,
+        // central scrubbing handles the log side). Mirrors the probe-failure
+        // arm below.
+        const scrubbedMessage = errorMessage(err);
+        log.warn(
+          { err, workspaceId, installId },
+          "Plugin connection health check fell back to native probe and threw (race-removed pool?)",
+        );
+        const matched = matchError(err);
+        return {
+          status: "degraded",
+          // No live probe ran (the entry was gone from both maps), so there is
+          // no meaningful round-trip latency to report.
+          latencyMs: 0,
+          message: matched?.message ?? scrubbedMessage,
+          checkedAt: new Date(),
+        };
+      }
     }
 
     const start = performance.now();


### PR DESCRIPTION
Closes #3853

## Problem

A published plugin datasource (ClickHouse, Elasticsearch, …) appears in the admin Connections list (the #3844 visibility fix works) but shows **no health status**, its per-connection **Test action 404s**, and the aggregate sticks at `N-1 / N live`.

## Root cause

This is the health/test half of the native-vs-plugin registry split. Plugin datasources register only in the per-`(workspace, install_id)` plugin map (`workspacePluginEntries`), never in the bare `entries`. The list-level health probe and `POST /api/v1/admin/connections/{id}/test` resolved connections only from `entries`:

- the periodic health-check fiber + list route only read `entries`, so plugin pools were never probed (`health` absent → "Status unknown");
- `/{id}/test` gated on `connections.list()` (= `entries` keys) → 404, and even past that gate `healthCheck(id)` would have thrown `ConnectionNotRegisteredError` → 500.

## Fix

- **`ConnectionRegistry.healthCheckForWorkspace(workspaceId, installId)`** — resolves the per-workspace plugin pool first (probe `SELECT 1`, 5s budget, caches `lastHealth` on the entry), falling back to the native `healthCheck` for bare ids. Probe failures report `degraded` (plugin pools don't track the consecutive-failure span the native path uses to escalate to `unhealthy`) and never throw; DSN userinfo is scrubbed from the surfaced message.
- **`WorkspacePluginEntry.lastHealth` + `_pluginMeta`** — surface a `health` object so `describeForWorkspace` / `describeAllWorkspacePlugins` (and thus the admin list and `/api/health` sources) carry health for plugin pools.
- **admin-connections list route** — actively probes plugin pools lacking cached health (concurrently), so every row carries a real reachability result and the aggregate reaches full count.
- **`POST /{id}/test`** — resolves presence via `describeForWorkspace` and probes via `healthCheckForWorkspace` (no 404, no latent 500 for plugin datasources).

Diff is deliberately localized to the health-probe + `/test` resolution to ease rebasing against the related keystone #3852 (which touches the update/re-register path). The operator-only staging "manual unblock" note in the issue is out of scope.

## Acceptance criteria

- [x] `GET /api/v1/admin/connections` returns a `health` object for plugin datasources, probed via the plugin pool.
- [x] `POST /api/v1/admin/connections/{id}/test` works for plugin datasources (no 404) and returns a real reachability result.
- [x] Aggregate reaches full count when every connection is healthy; rows show latency, not "Status unknown".
- [x] Regression tests for list-health + `/test` on a per-workspace plugin pool.

## Tests

- `connection.test.ts`: registry probe + cache onto describe; degraded-never-escalates on repeated failure; DSN credential scrub on the failure path; native fallback for bare ids; pre-fix bug pinned (`healthCheck("ch")` rejects).
- `admin-connections.test.ts`: list actively probes a plugin pool → carries `health`; `/{id}/test` works for a plugin pool (no 404), both asserting workspace-scoped dispatch.
- Central `createConnectionMock` gains `healthCheckForWorkspace` + `hasDirectForWorkspace` defaults.

## Review

Internal review panel (4 specialists) run pre-PR; converged in 1 round. All must-fix items addressed (stale `_pluginMeta` JSDoc, inline import-type, comment-accuracy wording, plus the two suggested regression tests). Local gates: lint, type, syncpack, template/schema/openapi/test-discipline drift, affected tests — all green. The only full-suite "failures" were 3 unrelated chat-platform tests (discord/teams) that pass in isolation (full-run ordering flake; CI shards run them isolated).

https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix probing and testing of plugin datasources via per-workspace connection pools
> - `GET /` connection list now actively probes plugin datasource pools using `connections.healthCheckForWorkspace(orgId, id)` and merges health results into each row; probe failures degrade only the affected row instead of failing the entire request.
> - `POST /:id/test` now uses `connections.describeForWorkspace(orgId)` for existence checks and `connections.healthCheckForWorkspace(orgId, id)` for probing, fixing 404/500 errors for plugin datasources.
> - `ConnectionRegistry.healthCheckForWorkspace` is a new method that probes per-(workspace, install_id) plugin pools, caches results in `lastHealth`, falls back to native `healthCheck` for bare ids, and never throws — degraded results are returned on any failure with sanitized error messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64ace0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the health/test half of the native-vs-plugin registry split: plugin datasource connections (ClickHouse, Elasticsearch, etc.) now carry a real health status on the admin Connections list, and `POST /:id/test` no longer 404s for them.

- **`ConnectionRegistry.healthCheckForWorkspace`** — new method that resolves the per-`(workspace, install_id)` plugin pool first, probes it with a 5 s `SELECT 1`, caches `lastHealth` on the entry for subsequent `describeForWorkspace` reads, and falls back to the native `healthCheck` for bare ids; the entire method is "never throws" (probe failures → `degraded`, TOCTOU unregistration → synthetic `degraded`).
- **List route health enrichment** — after building the filtered connection list, the route concurrently probes any plugin pool without cached health via `Promise.allSettled`; a rejected probe (defense-in-depth) degrades only that row instead of 500-ing the whole list.
- **`POST /:id/test` fix** — presence check now uses `describeForWorkspace` (which unions bare entries with the workspace's plugin pools) instead of `connections.list()`, and the probe uses `healthCheckForWorkspace` instead of `healthCheck`; regression tests added for both the list and test paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped to the health-probe and /test resolution paths, all failure modes are explicitly handled, and the existing test suite is extended with targeted regression tests.

Both changed routes now correctly route plugin pools through healthCheckForWorkspace, the never-throws contract is enforced both in the method itself and by Promise.allSettled in the list route, DSN credential scrubbing is consistent across all code paths, and the TOCTOU race is tested end-to-end. No correctness issues were found.

No files require special attention. The core logic in connection.ts and the route changes in admin-connections.ts are well-tested and the failure paths are fully covered.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/lib/db/connection.ts | Core change: adds `lastHealth` to `WorkspacePluginEntry`, surfaces it through `_pluginMeta`, and introduces `healthCheckForWorkspace` with correct plugin-first/native-fallback logic, "never throws" contract, DSN scrubbing, and TOCTOU handling. |
| packages/api/src/api/routes/admin-connections.ts | List route adds a concurrent plugin-pool probe block using `Promise.allSettled`; test route replaces `list()`+`healthCheck` with `describeForWorkspace`+`healthCheckForWorkspace`. Both changes are well-scoped and correctly handle failure paths. |
| packages/api/src/lib/db/__tests__/connection.test.ts | Six new tests cover: successful probe + caching, degraded-on-failure, never-escalates-to-unhealthy, DSN credential scrub, native fallback, and TOCTOU/absent-from-both-maps — good contract coverage. |
| packages/api/src/api/__tests__/admin-connections.test.ts | Adds tests for list active-probe of plugin pool, TOCTOU rejection containment (one row degraded, list survives), and `/test` workspace-scoped dispatch. The `hasDirectForWorkspace` predicate change from `() => true` to a per-id check correctly narrows the mock scope. |
| packages/api/src/api/__tests__/admin-connections-audit.test.ts | Minimal update: derives `describeForWorkspace` from `mockConnectionList` so existing "not registered → 404" audit test still works; `hasDirectForWorkspace: false` correctly routes warehouses through the native path. |
| packages/api/src/__mocks__/connection.ts | Adds `healthCheckForWorkspace` and `hasDirectForWorkspace` defaults and overrides to the central mock; defaults correctly model the "no plugin pool registered" case so unrelated tests are unaffected. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant ListRoute as GET /admin/connections
    participant TestRoute as POST /admin/connections/:id/test
    participant Registry as ConnectionRegistry
    participant PluginMap as workspacePluginEntries
    participant NativeMap as entries (bare)

    Note over ListRoute: Health enrichment (#3853)
    Client->>ListRoute: GET /api/v1/admin/connections
    ListRoute->>Registry: describeForWorkspace(orgId)
    Registry->>PluginMap: filter by workspaceId
    Registry->>NativeMap: describe()
    Registry-->>ListRoute: unified ConnectionMetadata[]

    ListRoute->>Registry: hasDirectForWorkspace(orgId, id) per conn
    Note over ListRoute: filter: health===undefined AND isPlugin
    ListRoute->>Registry: Promise.allSettled([healthCheckForWorkspace(orgId, id)...])

    alt Plugin pool found
        Registry->>PluginMap: lookup (workspaceId, installId)
        PluginMap-->>Registry: entry
        Registry->>Registry: entry.conn.query(SELECT 1, 5000ms)
        Registry->>PluginMap: cache lastHealth on entry
        Registry-->>ListRoute: "{status, latencyMs, checkedAt}"
    else Native fallback (bare id)
        Registry->>NativeMap: healthCheck(installId)
        NativeMap-->>Registry: "{status, latencyMs, checkedAt}"
        Registry-->>ListRoute: native result
    else TOCTOU / absent from both maps
        Registry->>NativeMap: healthCheck(installId) throws
        Registry-->>ListRoute: synthetic degraded (latencyMs:0)
    end

    Note over ListRoute: Promise.allSettled: rejection => synthetic degraded row
    ListRoute-->>Client: connections[] with health per row

    Note over TestRoute: Plugin /test fix (#3853)
    Client->>TestRoute: POST /admin/connections/clickhouse-staging/test
    TestRoute->>Registry: describeForWorkspace(orgId)
    Registry-->>TestRoute: "[..., {id: clickhouse-staging}]"
    TestRoute->>Registry: getVisibleConnectionIds (auth gate)
    TestRoute->>Registry: healthCheckForWorkspace(orgId, clickhouse-staging)
    Registry->>PluginMap: lookup entry
    PluginMap-->>Registry: entry
    Registry->>Registry: probe SELECT 1
    Registry-->>TestRoute: "{status: healthy, latencyMs, checkedAt}"
    TestRoute-->>Client: "200 {status, latencyMs, checkedAt}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant ListRoute as GET /admin/connections
    participant TestRoute as POST /admin/connections/:id/test
    participant Registry as ConnectionRegistry
    participant PluginMap as workspacePluginEntries
    participant NativeMap as entries (bare)

    Note over ListRoute: Health enrichment (#3853)
    Client->>ListRoute: GET /api/v1/admin/connections
    ListRoute->>Registry: describeForWorkspace(orgId)
    Registry->>PluginMap: filter by workspaceId
    Registry->>NativeMap: describe()
    Registry-->>ListRoute: unified ConnectionMetadata[]

    ListRoute->>Registry: hasDirectForWorkspace(orgId, id) per conn
    Note over ListRoute: filter: health===undefined AND isPlugin
    ListRoute->>Registry: Promise.allSettled([healthCheckForWorkspace(orgId, id)...])

    alt Plugin pool found
        Registry->>PluginMap: lookup (workspaceId, installId)
        PluginMap-->>Registry: entry
        Registry->>Registry: entry.conn.query(SELECT 1, 5000ms)
        Registry->>PluginMap: cache lastHealth on entry
        Registry-->>ListRoute: "{status, latencyMs, checkedAt}"
    else Native fallback (bare id)
        Registry->>NativeMap: healthCheck(installId)
        NativeMap-->>Registry: "{status, latencyMs, checkedAt}"
        Registry-->>ListRoute: native result
    else TOCTOU / absent from both maps
        Registry->>NativeMap: healthCheck(installId) throws
        Registry-->>ListRoute: synthetic degraded (latencyMs:0)
    end

    Note over ListRoute: Promise.allSettled: rejection => synthetic degraded row
    ListRoute-->>Client: connections[] with health per row

    Note over TestRoute: Plugin /test fix (#3853)
    Client->>TestRoute: POST /admin/connections/clickhouse-staging/test
    TestRoute->>Registry: describeForWorkspace(orgId)
    Registry-->>TestRoute: "[..., {id: clickhouse-staging}]"
    TestRoute->>Registry: getVisibleConnectionIds (auth gate)
    TestRoute->>Registry: healthCheckForWorkspace(orgId, clickhouse-staging)
    Registry->>PluginMap: lookup entry
    PluginMap-->>Registry: entry
    Registry->>Registry: probe SELECT 1
    Registry-->>TestRoute: "{status: healthy, latencyMs, checkedAt}"
    TestRoute-->>Client: "200 {status, latencyMs, checkedAt}"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/atlasdevhq/atlas/commit/64ace0dfa0729b7955d1ebaab9b3af73aab73947) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38940908)</sub>

<!-- /greptile_comment -->