### PR TITLE
fix(api): honor connectionGroupId on structured entity write (#3854)

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -379,6 +379,7 @@ const mockGetEntityAdmin: Mock<(orgId: string, type: string, name: string) => Pr
 const mockUpsertEntityAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
 const mockDeleteEntityAdmin: Mock<(orgId: string, type: string, name: string) => Promise<boolean>> = mock(() => Promise.resolve(false));
 const mockUpsertDraftEntityAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
+const mockUpsertDraftEntityForGroupAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
 const mockUpsertTombstoneAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
 const mockDeleteDraftEntityAdmin: Mock<(...args: unknown[]) => Promise<boolean>> = mock(() => Promise.resolve(true));
 const mockCreateVersion: Mock<(...args: unknown[]) => Promise<string>> = mock(() => Promise.resolve("version-1"));
@@ -406,6 +407,7 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   upsertEntity: mockUpsertEntityAdmin,
   deleteEntity: mockDeleteEntityAdmin,
   upsertDraftEntity: mockUpsertDraftEntityAdmin,
+  upsertDraftEntityForGroup: mockUpsertDraftEntityForGroupAdmin,
   upsertTombstone: mockUpsertTombstoneAdmin,
   deleteDraftEntity: mockDeleteDraftEntityAdmin,
   upsertTombstoneForGroup: mockUpsertTombstoneAdmin,
@@ -3312,6 +3314,8 @@ describe("PUT /api/v1/admin/semantic/entities/edit/:name", () => {
     mockUpsertEntityAdmin.mockResolvedValue(undefined);
     mockUpsertDraftEntityAdmin.mockReset();
     mockUpsertDraftEntityAdmin.mockResolvedValue(undefined);
+    mockUpsertDraftEntityForGroupAdmin.mockReset();
+    mockUpsertDraftEntityForGroupAdmin.mockResolvedValue(undefined);
     mockSyncEntityToDisk.mockReset();
     mockSyncEntityToDisk.mockResolvedValue(undefined);
   });
@@ -3412,6 +3416,80 @@ describe("PUT /api/v1/admin/semantic/entities/edit/:name", () => {
     expect(res.status).toBe(200);
     const call = (mockUpsertDraftEntityAdmin.mock.calls as unknown[][])[0];
     expect(call?.[4]).toBe("warehouse");
+    // connectionGroupId path must NOT be taken when only connectionId is given.
+    expect(mockUpsertDraftEntityForGroupAdmin).not.toHaveBeenCalled();
+  });
+
+  it("writes via upsertDraftEntityForGroup when connectionGroupId is provided (#3854)", async () => {
+    setOrgAdmin("org-1");
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/edit/test_orders", "PUT", {
+      table: "test_orders",
+      connectionGroupId: "mysql-staging",
+    }));
+    expect(res.status).toBe(200);
+    // The row must land in the requested group scope, NOT the default null scope.
+    expect(mockUpsertDraftEntityForGroupAdmin).toHaveBeenCalledTimes(1);
+    const call = (mockUpsertDraftEntityForGroupAdmin.mock.calls as unknown[][])[0];
+    expect(call?.[0]).toBe("org-1");
+    expect(call?.[1]).toBe("entity");
+    expect(call?.[2]).toBe("test_orders");
+    expect(call?.[4]).toBe("mysql-staging");
+    // The connectionId-resolving path must NOT be taken.
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("treats empty-string connectionGroupId as the explicit null/legacy scope (#3854)", async () => {
+    setOrgAdmin("org-1");
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/edit/demo_users", "PUT", {
+      table: "demo_users",
+      connectionGroupId: "",
+    }));
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityForGroupAdmin).toHaveBeenCalledTimes(1);
+    // "" → null (legacy/unscoped), addressed directly via the group write.
+    const call = (mockUpsertDraftEntityForGroupAdmin.mock.calls as unknown[][])[0];
+    expect(call?.[4]).toBeNull();
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("rejects a conflicting connectionId + connectionGroupId pair with 400 (#3854)", async () => {
+    setOrgAdmin("org-1");
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/edit/orders", "PUT", {
+      table: "orders",
+      connectionId: "warehouse",
+      connectionGroupId: "mysql-staging",
+    }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("conflicting_scope");
+    // Neither write path runs — the request is rejected, not silently resolved.
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+    expect(mockUpsertDraftEntityForGroupAdmin).not.toHaveBeenCalled();
+  });
+
+  it("treats empty-string connectionId as absent — not a conflict, normalized to undefined (#3854)", async () => {
+    setOrgAdmin("org-1");
+    // `connectionId: ""` is meaningless (asymmetric with connectionGroupId);
+    // it must NOT trip the conflict guard alongside a real group, and on the
+    // legacy path it must be normalized to undefined, never passed as "".
+    const conflictRes = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/edit/orders", "PUT", {
+      table: "orders",
+      connectionId: "",
+      connectionGroupId: "mysql-staging",
+    }));
+    expect(conflictRes.status).toBe(200);
+    expect(mockUpsertDraftEntityForGroupAdmin).toHaveBeenCalledTimes(1);
+    expect((mockUpsertDraftEntityForGroupAdmin.mock.calls as unknown[][])[0]?.[4]).toBe("mysql-staging");
+
+    mockUpsertDraftEntityAdmin.mockClear();
+    const legacyRes = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/edit/orders", "PUT", {
+      table: "orders",
+      connectionId: "",
+    }));
+    expect(legacyRes.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    // "" normalized to undefined → default/null scope, not the literal "".
+    expect((mockUpsertDraftEntityAdmin.mock.calls as unknown[][])[0]?.[4]).toBeUndefined();
   });
 
   it("returns 500 when upsertDraftEntity throws", async () => {

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -77,12 +77,23 @@ const EntityBodySchema = z.object({
   measures: z.array(MeasureSchema).optional().default([]),
   joins: z.array(JoinSchema).optional().default([]),
   query_patterns: z.array(QueryPatternSchema).optional().default([]),
+  // Connection-id scope: the write resolves this id → its group_id via
+  // `inlineConnectionGroupSql`. Mutually exclusive with `connectionGroupId`
+  // (see below) — sending both is a 400, never a silent resolution (#3854).
+  // `""` is treated as absent (an empty id resolves to no connection),
+  // unlike `connectionGroupId` where `""` is the explicit legacy-null group.
   connectionId: z.string().optional(),
   // Group scope for multi-environment orgs (#2412). When the entity name
   // exists in more than one group, the FE must pick one or the backend
   // will 409. Empty string deliberately encodes "legacy null-group" so
   // a workspace mixing `__global__` demo rows with named-group rows can
   // still address the demo row explicitly.
+  //
+  // Precedence vs `connectionId` (#3854): the two are MUTUALLY EXCLUSIVE.
+  // Providing `connectionGroupId` writes the row under that group DIRECTLY
+  // (via `upsertDraftEntityForGroup`); providing `connectionId` resolves the
+  // group from the connection. Sending BOTH is rejected with 400 rather than
+  // silently picking one — they can disagree, and guessing hides bugs.
   connectionGroupId: z.string().optional(),
 });
 
@@ -581,9 +592,39 @@ export function registerSemanticEditorRoutes(
       // Convert structured data to YAML
       const yamlContent = await entityToYaml(body);
 
+      // Precedence (#3854): `connectionId` and `connectionGroupId` are
+      // mutually exclusive scoping inputs. They can disagree (a connection's
+      // resolved group ≠ the named group), so rather than silently pick one
+      // we reject the conflicting pair. `connectionGroupId` provided →
+      // write the group DIRECTLY; `connectionId` provided → resolve the
+      // group from the connection.
+      //
+      // The two fields treat the empty string ASYMMETRICALLY, on purpose:
+      //   • `connectionGroupId: ""` is a real, explicit value — the legacy
+      //     null/unscoped group — so it counts as "present" (a direct group
+      //     write targeting the null scope).
+      //   • `connectionId: ""` is meaningless (no connection resolves from an
+      //     empty id), so it counts as "absent" — it neither triggers the
+      //     conflict guard nor a group-resolving write.
+      const hasConnectionId =
+        body.connectionId !== undefined && body.connectionId !== "";
+      const hasConnectionGroupId = body.connectionGroupId !== undefined;
+      if (hasConnectionId && hasConnectionGroupId) {
+        return c.json(
+          {
+            error: "conflicting_scope",
+            message:
+              "Provide either connectionId or connectionGroupId, not both — they scope the entity differently and may disagree.",
+            requestId,
+          },
+          400,
+        );
+      }
+
       // Store in DB
       const {
         upsertDraftEntity,
+        upsertDraftEntityForGroup,
         getEntity,
         createVersion,
         generateChangeSummary,
@@ -604,7 +645,19 @@ export function registerSemanticEditorRoutes(
       // published row is preserved until the admin publishes via
       // `/api/v1/admin/publish`. The pending-changes pill in the top bar
       // surfaces the draft count.
-      await upsertDraftEntity(orgId, "entity", name, yamlContent, body.connectionId);
+      //
+      // When `connectionGroupId` is provided, write the group DIRECTLY (the
+      // `scope` resolved above) so the row lands in the requested environment
+      // instead of the default null scope (#3854). Otherwise resolve the
+      // group from `connectionId` (or null when neither is given).
+      if (hasConnectionGroupId) {
+        await upsertDraftEntityForGroup(orgId, "entity", name, yamlContent, scope);
+      } else {
+        // `hasConnectionId` already collapsed `""` → absent, so pass the
+        // normalized id (undefined when empty) — never the raw `""`, which
+        // would resolve to no group via `inlineConnectionGroupSql`.
+        await upsertDraftEntity(orgId, "entity", name, yamlContent, hasConnectionId ? body.connectionId : undefined);
+      }
 
       // Create version snapshot — non-fatal. Narrow the catch so tagged
       // errors (e.g. AmbiguousEntityError) re-throw and surface their

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -589,9 +589,6 @@ export function registerSemanticEditorRoutes(
         return c.json({ error: "not_available", message: "Semantic entity editor requires an internal database (DATABASE_URL).", requestId }, 501);
       }
 
-      // Convert structured data to YAML
-      const yamlContent = await entityToYaml(body);
-
       // Precedence (#3854): `connectionId` and `connectionGroupId` are
       // mutually exclusive scoping inputs. They can disagree (a connection's
       // resolved group ≠ the named group), so rather than silently pick one
@@ -606,6 +603,9 @@ export function registerSemanticEditorRoutes(
       //   • `connectionId: ""` is meaningless (no connection resolves from an
       //     empty id), so it counts as "absent" — it neither triggers the
       //     conflict guard nor a group-resolving write.
+      //
+      // Checked BEFORE `entityToYaml` so a conflicting request fails fast
+      // without doing the YAML serialization work (Greptile, #3854).
       const hasConnectionId =
         body.connectionId !== undefined && body.connectionId !== "";
       const hasConnectionGroupId = body.connectionGroupId !== undefined;
@@ -620,6 +620,9 @@ export function registerSemanticEditorRoutes(
           400,
         );
       }
+
+      // Convert structured data to YAML
+      const yamlContent = await entityToYaml(body);
 
       // Store in DB
       const {


### PR DESCRIPTION
## What

`PUT /api/v1/admin/semantic/entities/edit/{name}` accepted a `connectionGroupId` body field (per `EntityBodySchema`) but **ignored it on write**. The handler fed `connectionGroupId` only to the READ scope (`getEntity`); the WRITE always went through `upsertDraftEntity(... body.connectionId)`, which resolves the group from a *connection id*. So passing `connectionGroupId` silently no-op'd — the row landed under the default null/`__global__` scope instead of the requested group.

## Fix

- When `connectionGroupId` is provided, write via `upsertDraftEntityForGroup` (sets `connection_group_id` directly) so the row lands in the requested environment.
- **Precedence is now defined and documented**: `connectionId` and `connectionGroupId` are **mutually exclusive**. A conflicting pair is **rejected with `400 conflicting_scope`**, not silently resolved (they can disagree — a connection's resolved group ≠ a named group — and guessing hides bugs).
- Empty-string handling is asymmetric **on purpose**:
  - `connectionGroupId: ""` → the explicit legacy/null group → counts as *present* (direct group write to null scope).
  - `connectionId: ""` → meaningless (no connection resolves from an empty id) → counts as *absent* (no conflict, normalized to `undefined` on the legacy path, never passed as `""`).

The diff is kept localized to the route write-path scoping — `lib/semantic/entities.ts` is **untouched** (the sibling `upsertDraftEntityForGroup` already exists) to ease rebasing against sibling issues touching that module.

## Tests (regression)

In `admin.test.ts` (`PUT …/entities/edit/:name`):
- `connectionGroupId` provided → row lands in that group via `upsertDraftEntityForGroup` (not default); legacy path NOT taken.
- `connectionGroupId: ""` → null/legacy scope, still via the group write.
- conflicting `connectionId` + `connectionGroupId` → `400 conflicting_scope`, **neither** write path runs.
- `connectionId: ""` → treated as absent (no conflict with a real group; normalized to `undefined` on the legacy path).
- existing `connectionId`-only path unchanged, group path NOT taken.

## Out of scope

The issue's "staging manual unblock" note is operator-only (psql `group_id` cleanup on staging) — not addressed here.

## Internal review

Specialist panel (silent-failure, type-design, test-coverage, comments) ran clean after addressing one LOW–MEDIUM `connectionId: ""` asymmetry finding (now fixed + tested + re-reviewed clean).

Closes #3854

https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PUT /api/v1/admin/semantic/entities/edit/:name` to honor `connectionGroupId` on structured entity write
> - When `connectionGroupId` is provided, the handler now writes drafts via `upsertDraftEntityForGroup` instead of the legacy `upsertDraftEntity` path; an empty-string `connectionGroupId` is treated as an explicit null group.
> - Requests supplying both `connectionId` and `connectionGroupId` (non-empty) are rejected with HTTP 400 and error code `conflicting_scope`.
> - An empty-string `connectionId` is normalized to `undefined` so it is not passed downstream on the legacy path.
> - Behavioral Change: clients that previously sent both `connectionId` and `connectionGroupId` will now receive a 400 error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf71e92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent-ignore bug where the `connectionGroupId` body field on `PUT /api/v1/admin/semantic/entities/edit/{name}` was used only for the READ scope but never honored on WRITE — the row always landed in the default null scope. The fix branches the write path on the presence of `connectionGroupId`, calling `upsertDraftEntityForGroup` directly for the group-scoped case.

- When `connectionGroupId` is provided, the handler now calls `upsertDraftEntityForGroup` with the resolved scope; `connectionId` continues to reach `upsertDraftEntity` as before.
- Providing both a non-empty `connectionId` and any `connectionGroupId` is now rejected with `400 conflicting_scope`; the conflict check is placed before `entityToYaml` to fail fast.
- The asymmetric empty-string treatment (`connectionGroupId: ""` → explicit null scope, `connectionId: ""` → treated as absent) is intentional, documented in inline comments, and fully regression-tested with five new cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is localized to the write path of a single route, the pre-existing read and version-snapshot paths are unaffected, and all five new regression tests exercise the branching logic directly.

The write-path branching is straightforward: a pre-guard conflict check, then a single if/else on a boolean computed from validated body fields. The underlying upsertDraftEntityForGroup function already existed and is well-tested in the entities module. The asymmetric empty-string behavior is intentional, documented, and covered by tests.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/api/routes/admin-semantic.ts | Adds conflict guard (before entityToYaml), branches write path on hasConnectionGroupId, and normalizes empty connectionId to undefined — logic is correct and well-commented. |
| packages/api/src/api/__tests__/admin.test.ts | Five new regression tests added covering group write, empty-string group (null scope), conflict rejection, and asymmetric empty connectionId handling; mocks correctly reset in beforeEach and extended for upsertDraftEntityForGroup. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(api): fail-fast the connectionG..."](https://github.com/atlasdevhq/atlas/commit/bf71e92068c1f136688b05312aa6402b9acebeb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38941288)</sub>

<!-- /greptile_comment -->