### PR TITLE
fix(connections): plugin-datasource metadata update via createFromConfig bridge (#3852)

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -52,6 +52,32 @@ const mockHealthCheck = mock(() =>
 // inline `mock(() => {})` is unobservable from `.mock.calls`.
 const mockRegister = mock(() => {});
 
+// Plugin-datasource re-registration bridge (#3852). The PUT handler routes
+// plugin dbTypes (clickhouse / elasticsearch / …) through
+// `registerDatasourceInstall` (ADR-0013 `createFromConfig` seam) instead of the
+// core `connections.register`, which only understands postgresql:// / mysql://.
+// Captured + mocked so the regression test asserts the bridge is used and the
+// real `findDatasourcePluginConnection` (which would throw "no plugin
+// registered" in a unit test) is never reached.
+// Default `false` mirrors the dominant real-world plugin-update case: the
+// bridge ALWAYS rebuilds the live connection but returns `!already`, so an
+// in-place rebuild of an existing (workspace, install_id) returns `false`. The
+// probe must NOT be gated on this boolean (#3852 round-2 fix) — it's gated on
+// `hasDirectForWorkspace` instead.
+const mockRegisterDatasourceInstall = mock(() => Promise.resolve(false));
+
+// The post-update plugin-adapter liveness probe (#3852) runs
+// `connections.getForWorkspace(orgId, id).query("SELECT 1", …)` (or `ping()`).
+// Capture the query so a test can (a) assert the probe fired and (b) make it
+// reject to drive the rollback path.
+const mockProbeQuery = mock(() =>
+  Promise.resolve({ columns: [] as string[], rows: [] as Record<string, unknown>[] }),
+);
+const mockGetForWorkspace = mock(() => ({
+  query: mockProbeQuery,
+  close: () => Promise.resolve(),
+}));
+
 const mocks = createApiTestMocks({
   authUser: {
     id: "admin-1",
@@ -83,6 +109,13 @@ const mocks = createApiTestMocks({
       ],
       healthCheck: mockHealthCheck,
       register: mockRegister,
+      // #3852 — plugin pools live in the per-workspace direct map, not the bare
+      // `entries`. The PUT handler probes the freshly-built plugin connection
+      // via `getForWorkspace(orgId, id)` (default mock returns a working query
+      // stub) gated on `hasDirectForWorkspace`.
+      hasDirectForWorkspace: () => true,
+      getForWorkspace: mockGetForWorkspace,
+      unregisterDirectForWorkspace: mock(() => true),
       unregister: mock(() => false),
       has: (id: string) => ["default", "warehouse", "other-org-conn"].includes(id),
       list: () => ["default", "warehouse", "other-org-conn"],
@@ -110,6 +143,19 @@ let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
 mock.module("@atlas/api/lib/config", () => ({
   getConfig: () => mockConfigOverride,
   defineConfig: (c: unknown) => c,
+}));
+
+// Mock the datasource-registry bridge (#3852) — the PUT handler's plugin
+// re-registration seam. All value exports are mocked (mock-all-exports
+// discipline); the route only calls `registerDatasourceInstall`, the rest are
+// inert stubs so a partial mock can't leave a real export wired.
+mock.module("@atlas/api/lib/db/datasource-registry-bridge", () => ({
+  registerDatasourceInstall: mockRegisterDatasourceInstall,
+  unregisterDatasourceInstall: mock(() => true),
+  findDatasourcePluginConnection: mock(() => Promise.resolve(undefined)),
+  probePluginDatasourceConnection: mock(() => Promise.resolve({ kind: "ok" })),
+  probeNativeDatasourceConnection: mock(() => Promise.resolve({ kind: "ok" })),
+  isHandlerManagedDatasourceDbType: () => false,
 }));
 
 // --- Import app after mocks ---
@@ -257,6 +303,13 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
     mocks.mockInternalQuery.mockResolvedValue([]);
     mockHealthCheck.mockClear();
     mockRegister.mockClear();
+    mockRegisterDatasourceInstall.mockClear();
+    mockRegisterDatasourceInstall.mockImplementation(() => Promise.resolve(false));
+    mockGetForWorkspace.mockClear();
+    mockProbeQuery.mockClear();
+    mockProbeQuery.mockImplementation(() =>
+      Promise.resolve({ columns: [] as string[], rows: [] as Record<string, unknown>[] }),
+    );
     mockConfigOverride = null;
     setOrgAdmin("org-alpha");
   });
@@ -548,6 +601,199 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       expect(body.id).toBe("warehouse");
+    });
+
+    // ─── #3852 — plugin datasource metadata update ────────────────────
+    // The keystone bug: setting a Connection group (or any metadata) on a
+    // plugin datasource (clickhouse:// / elasticsearch://) 500'd because the
+    // handler re-registered via the core `connections.register`, which only
+    // accepts postgresql:// / mysql://. The fix routes plugin re-registration
+    // through the `createFromConfig` bridge (`registerDatasourceInstall`).
+    describe("PUT /connections/:id — plugin datasource (#3852)", () => {
+      // Plugin catalog row — `url` is the lone secret field, mirroring the
+      // seeded built-in datasource catalog shape. `decryptSecretFields` uses the
+      // REAL (unmocked) `decryptSecret` from `db/secret-encryption`, which leaves
+      // a non-`enc:v1:` value verbatim, so the fixture stores PLAINTEXT URLs —
+      // no `encrypted:` sentinel needed (and none to confuse the assertion).
+      function pluginCatalogRow(slug: string) {
+        return {
+          id: `cat_${slug}`,
+          slug,
+          install_model: "form",
+          pillar: "datasource",
+          config_schema: [
+            { key: "url", type: "string", required: true, secret: true },
+            { key: "description", type: "string" },
+          ],
+          enabled: true,
+        };
+      }
+
+      function mockPluginPut(slug: string, storedUrl: string): void {
+        const row = pluginCatalogRow(slug);
+        mocks.mockInternalQuery.mockImplementation((sql: string) => {
+          if (sqlIs.putLoad(sql)) {
+            return Promise.resolve([
+              {
+                catalog_slug: slug,
+                config: { url: storedUrl },
+                config_schema: row.config_schema,
+                group_id: null,
+              },
+            ]);
+          }
+          if (sqlIs.groupExists(sql)) {
+            // newGroupName creates inline — no cross-org existence check fires,
+            // but a defensive stub keeps the dispatch total.
+            return Promise.resolve([{ install_id: slug }]);
+          }
+          if (sqlIs.catalogLookup(sql)) return Promise.resolve([row]);
+          if (sqlIs.installerLoadForUpdate(sql)) {
+            return Promise.resolve([
+              {
+                id: `cn_org-alpha_${slug}`,
+                install_id: slug,
+                config: { url: storedUrl },
+                status: "published",
+              },
+            ]);
+          }
+          if (sqlIs.installerUpdate(sql)) return Promise.resolve([]);
+          return Promise.resolve([]);
+        });
+      }
+
+      it("setting a Connection group on a clickhouse datasource succeeds (no core-scheme 500)", async () => {
+        setOrgAdmin("org-alpha");
+        mockPluginPut("clickhouse", "clickhouse://user:pass@host:8443/db");
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/clickhouse", "PUT", {
+            newGroupName: "clickhouse",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+        const body = (await res.json()) as any;
+        expect(body.id).toBe("clickhouse");
+        // dbType is the plugin slug, not a core-detected scheme.
+        expect(body.dbType).toBe("clickhouse");
+        expect(body.groupId).toBe("clickhouse");
+
+        // Re-registration went through the createFromConfig bridge…
+        expect(mockRegisterDatasourceInstall).toHaveBeenCalled();
+        const [row, config] = mockRegisterDatasourceInstall.mock.calls[0] as unknown as [
+          { workspaceId: string; catalogSlug: string; installId: string },
+          Record<string, unknown>,
+        ];
+        expect(row.workspaceId).toBe("org-alpha");
+        expect(row.catalogSlug).toBe("clickhouse");
+        expect(row.installId).toBe("clickhouse");
+        // The plaintext clickhouse:// URL reaches `createFromConfig` — proving
+        // the plugin scheme survives to the bridge, not the core adapter.
+        expect(config.url).toBe("clickhouse://user:pass@host:8443/db");
+
+        // …and NOT through the core adapter, which would have thrown on the
+        // clickhouse:// scheme (the 500 this fixes).
+        expect(mockRegister).not.toHaveBeenCalled();
+
+        // The probe ran against the live per-workspace plugin connection
+        // (criterion #2 — post-update health check uses the plugin adapter).
+        // NOTE: `mockRegisterDatasourceInstall` returns `false` here (in-place
+        // rebuild), so this also guards the round-2 fix: the probe is gated on
+        // `hasDirectForWorkspace`, NOT the bridge's boolean return.
+        expect(mockGetForWorkspace).toHaveBeenCalledWith("org-alpha", "clickhouse");
+        expect(mockProbeQuery).toHaveBeenCalled();
+
+        // group_id is persisted into config (criterion #3): the installer's
+        // UPDATE writes the merged config JSON with the group_id key.
+        const installerUpdateCall = mocks.mockInternalQuery.mock.calls.find(
+          ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
+        );
+        expect(installerUpdateCall).toBeDefined();
+        const configJson = (installerUpdateCall![1] as unknown[])[0] as string;
+        expect(configJson).toContain("group_id");
+        expect(configJson).toContain("clickhouse");
+      });
+
+      it("changing the clickhouse URL re-registers via the bridge and probes the plugin adapter", async () => {
+        setOrgAdmin("org-alpha");
+        mockPluginPut("clickhouse", "clickhouse://user:pass@host:8443/db");
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/clickhouse", "PUT", {
+            url: "clickhouse://user:pass@newhost:8443/db",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(mockRegisterDatasourceInstall).toHaveBeenCalled();
+        const [, config] = mockRegisterDatasourceInstall.mock.calls[0] as unknown as [
+          unknown,
+          Record<string, unknown>,
+        ];
+        expect(config.url).toBe("clickhouse://user:pass@newhost:8443/db");
+        expect(mockProbeQuery).toHaveBeenCalled();
+        expect(mockRegister).not.toHaveBeenCalled();
+      });
+
+      it("setting a group on an elasticsearch datasource also succeeds (not clickhouse-special-cased)", async () => {
+        setOrgAdmin("org-alpha");
+        mockPluginPut("elasticsearch", "elasticsearch://user:pass@host:9200");
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/elasticsearch", "PUT", {
+            newGroupName: "elasticsearch",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+        const body = (await res.json()) as any;
+        expect(body.dbType).toBe("elasticsearch");
+        expect(body.groupId).toBe("elasticsearch");
+        expect(mockRegisterDatasourceInstall).toHaveBeenCalled();
+        expect(mockRegister).not.toHaveBeenCalled();
+      });
+
+      it("a URL change whose probe fails rolls back to the pre-update config and 400s", async () => {
+        setOrgAdmin("org-alpha");
+        mockPluginPut("clickhouse", "clickhouse://user:pass@host:8443/db");
+        // The freshly-built connection is registered, then the liveness probe
+        // rejects (unreachable host) — the handler must roll back and 400.
+        mockProbeQuery.mockImplementation(() =>
+          Promise.reject(new Error("ECONNREFUSED 10.0.0.1:8443")),
+        );
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/clickhouse", "PUT", {
+            url: "clickhouse://user:pass@unreachable:8443/db",
+          }),
+        );
+
+        expect(res.status).toBe(400);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+        const body = (await res.json()) as any;
+        expect(body.error).toBe("connection_failed");
+        expect(body.requestId).toBeDefined();
+
+        // The bridge was called twice: once for the attempted new URL, once for
+        // the rollback to the pre-update URL.
+        expect(mockRegisterDatasourceInstall.mock.calls.length).toBe(2);
+        const [, attemptedConfig] = mockRegisterDatasourceInstall.mock.calls[0] as unknown as [
+          unknown,
+          Record<string, unknown>,
+        ];
+        const [, rolledBackConfig] = mockRegisterDatasourceInstall.mock.calls[1] as unknown as [
+          unknown,
+          Record<string, unknown>,
+        ];
+        expect(attemptedConfig.url).toBe("clickhouse://user:pass@unreachable:8443/db");
+        // Rollback re-registers the ORIGINAL stored URL, not the rejected one.
+        expect(rolledBackConfig.url).toBe("clickhouse://user:pass@host:8443/db");
+        expect(mockRegister).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -698,13 +698,13 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
         // clickhouse:// scheme (the 500 this fixes).
         expect(mockRegister).not.toHaveBeenCalled();
 
-        // The probe ran against the live per-workspace plugin connection
-        // (criterion #2 — post-update health check uses the plugin adapter).
-        // NOTE: `mockRegisterDatasourceInstall` returns `false` here (in-place
-        // rebuild), so this also guards the round-2 fix: the probe is gated on
-        // `hasDirectForWorkspace`, NOT the bridge's boolean return.
-        expect(mockGetForWorkspace).toHaveBeenCalledWith("org-alpha", "clickhouse");
-        expect(mockProbeQuery).toHaveBeenCalled();
+        // This is a metadata-only change (group rename, no URL) — the live
+        // connection is rebuilt but the liveness PROBE must NOT fire, matching
+        // the core path's `urlChanged` gate and ADR-0007. A transiently
+        // unreachable datasource must not 500 a valid rename (#3852, round-2
+        // review). The rebuild still happened (bridge called above) so the live
+        // pool reflects the new config.
+        expect(mockProbeQuery).not.toHaveBeenCalled();
 
         // group_id is persisted into config (criterion #3): the installer's
         // UPDATE writes the merged config JSON with the group_id key.
@@ -755,6 +755,72 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
         expect(body.groupId).toBe("elasticsearch");
         expect(mockRegisterDatasourceInstall).toHaveBeenCalled();
         expect(mockRegister).not.toHaveBeenCalled();
+        // Metadata-only change: no URL ⇒ no probe (URL-change-gated, ADR-0007).
+        expect(mockProbeQuery).not.toHaveBeenCalled();
+      });
+
+      it("a metadata-only group rename succeeds even when the datasource is unreachable (no probe)", async () => {
+        // Round-2 review regression (#3852): a group rename with NO URL change
+        // must not run the liveness probe, so a transiently-unreachable plugin
+        // datasource (maintenance window) can still be renamed. If the probe
+        // fired here it would reject and 500 the rename — the bug this guards.
+        setOrgAdmin("org-alpha");
+        mockPluginPut("clickhouse", "clickhouse://user:pass@host:8443/db");
+        mockProbeQuery.mockImplementation(() =>
+          Promise.reject(new Error("ECONNREFUSED 10.0.0.1:8443")),
+        );
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/clickhouse", "PUT", {
+            newGroupName: "clickhouse",
+          }),
+        );
+
+        // Succeeds despite the unreachable host — the probe was never invoked.
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+        const body = (await res.json()) as any;
+        expect(body.groupId).toBe("clickhouse");
+        // The liveness probe was never invoked — that is what lets the rename
+        // succeed against an unreachable host.
+        expect(mockProbeQuery).not.toHaveBeenCalled();
+        // The live pool was still rebuilt via the bridge (not the core adapter).
+        expect(mockRegisterDatasourceInstall).toHaveBeenCalled();
+        expect(mockRegister).not.toHaveBeenCalled();
+      });
+
+      it("a metadata-only rebuild failure (bridge throws, not the probe) 500s internal_error", async () => {
+        // The companion to the no-probe success case: on a metadata-only change
+        // the probe is skipped, but the in-place REBUILD still runs — if the
+        // bridge itself throws, that is a genuine server-side failure and must
+        // map to 500 internal_error (not the 400 connection_failed reserved for
+        // a URL-change probe rejection). Guards the asymmetric error mapping.
+        setOrgAdmin("org-alpha");
+        mockPluginPut("clickhouse", "clickhouse://user:pass@host:8443/db");
+        // First call (the rebuild) throws; the rollback re-register succeeds.
+        let call = 0;
+        mockRegisterDatasourceInstall.mockImplementation(() => {
+          call += 1;
+          return call === 1
+            ? Promise.reject(new Error("createFromConfig blew up"))
+            : Promise.resolve(false);
+        });
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/connections/clickhouse", "PUT", {
+            newGroupName: "clickhouse",
+          }),
+        );
+
+        expect(res.status).toBe(500);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+        const body = (await res.json()) as any;
+        expect(body.error).toBe("internal_error");
+        expect(body.requestId).toBeDefined();
+        // Probe never fires on a metadata-only change, even on the failure path.
+        expect(mockProbeQuery).not.toHaveBeenCalled();
+        // Rollback re-registered the pre-update config via the bridge.
+        expect(mockRegisterDatasourceInstall.mock.calls.length).toBe(2);
       });
 
       it("a URL change whose probe fails rolls back to the pre-update config and 400s", async () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -15,6 +15,9 @@ import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getConfig } from "@atlas/api/lib/config";
 import { connections, detectDBType } from "@atlas/api/lib/db/connection";
+import type { DBConnection, DBType } from "@atlas/api/lib/db/connection";
+import { catalogSlugToDbType } from "@atlas/api/lib/db/datasource-pool-resolver";
+import { registerDatasourceInstall } from "@atlas/api/lib/db/datasource-registry-bridge";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
@@ -50,6 +53,33 @@ const log = createLogger("admin-connections");
 /** Read atlasMode from the Hono context. Defaults to "published" (most restrictive) when not set. */
 function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types/auth").AtlasMode {
   return (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
+}
+
+/**
+ * Liveness window for the post-update plugin-datasource probe — matches the
+ * `PLUGIN_PROBE_TIMEOUT_MS` the datasource bridge uses for its own pre-flight
+ * probe (10s) so a cold-start warehouse (ClickHouse / Snowflake / BigQuery can
+ * take several seconds to open the first session) isn't spuriously failed (#3852).
+ */
+const PLUGIN_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Probe an already-registered plugin-datasource connection for liveness. Prefers
+ * the adapter's native `ping()` (Elasticsearch / OpenSearch — whose `query()`
+ * routes to the cluster SQL API `/_sql`, optional on OpenSearch, so `SELECT 1`
+ * would test the wrong surface) and falls back to `SELECT 1` for SQL-only
+ * adapters (ClickHouse / Snowflake / BigQuery). Mirrors the bridge's
+ * `probePluginDatasourceConnection` surface choice, but probes the LIVE
+ * registered connection rather than building a throwaway one. Throws on failure;
+ * the caller maps it to a rollback + HTTP error.
+ */
+async function probeLivePluginConnection(conn: DBConnection): Promise<void> {
+  const maybePing = (conn as { ping?: (timeoutMs?: number) => Promise<unknown> }).ping;
+  if (typeof maybePing === "function") {
+    await maybePing.call(conn, PLUGIN_PROBE_TIMEOUT_MS);
+    return;
+  }
+  await conn.query("SELECT 1", PLUGIN_PROBE_TIMEOUT_MS);
 }
 
 // ---------------------------------------------------------------------------
@@ -1170,9 +1200,16 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
   let currentUrl: string;
   let currentDescription: string | null;
   let currentSchema: string | null;
+  // Full decrypted config — the plugin re-registration bridge
+  // (`registerDatasourceInstall` → `createFromConfig`) needs every field a
+  // plugin connection carries (not just url/description/schema), so capture
+  // the whole object here and merge patched fields onto it below (#3852).
+  // Definitely assigned before any read: the catch returns early.
+  let currentDecryptedConfig: Readonly<Record<string, unknown>>;
   try {
     const schemaSpec = parseConfigSchema(current.config_schema);
     const decrypted = decryptSecretFields(current.config ?? {}, schemaSpec);
+    currentDecryptedConfig = decrypted;
     currentUrl = typeof decrypted.url === "string" ? decrypted.url : "";
     currentDescription =
       typeof decrypted.description === "string" && decrypted.description.length > 0
@@ -1196,10 +1233,29 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
   const urlChanged = typeof url === "string" && url !== currentUrl;
 
   // dbType for the response — derived from the catalog slug since that's
-  // the source of truth post-cutover. For URL changes we re-detect to
-  // validate the new URL's shape before the test-connect dance.
-  let dbType = current.catalog_slug;
-  if (urlChanged) {
+  // the source of truth post-cutover. `catalogSlugToDbType` collapses the
+  // `demo-postgres` alias onto `postgres`; throws on an unknown slug.
+  let dbType: DBType;
+  try {
+    dbType = catalogSlugToDbType(current.catalog_slug);
+  } catch (err) {
+    log.error({ connectionId: id, requestId, catalogSlug: current.catalog_slug, err: errorMessage(err) }, "Unknown catalog slug on connection update");
+    return c.json({ error: "internal_error", message: "Connection has an unrecognized datasource type and cannot be updated.", requestId }, 500);
+  }
+
+  // Plugin datasources — everything except core postgres/mysql (clickhouse,
+  // snowflake, bigquery, duckdb, elasticsearch, salesforce) — re-register
+  // through the `createFromConfig` bridge (ADR-0013), NOT the core
+  // `connections.register`, which only understands postgresql:// / mysql:// and
+  // would 500 on a plugin URL scheme (#3852). The core re-detect-and-validate
+  // dance below is postgres/mysql-only for the same reason:
+  // `detectDBType("clickhouse://…")` throws.
+  const isPluginDbType = dbType !== "postgres" && dbType !== "mysql";
+
+  // For a core URL change, re-detect to validate the new URL's shape before the
+  // test-connect dance. Plugin URLs keep the catalog-slug dbType (their schemes
+  // are unknown to the core detector).
+  if (urlChanged && !isPluginDbType) {
     try {
       dbType = detectDBType(newUrl);
     } catch (err) {
@@ -1207,9 +1263,77 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
     }
   }
 
-  // Re-test if URL changed. Test-connect dance is route-owned per
-  // ADR-0007 — the installer trusts the caller's reachability check.
-  if (urlChanged) {
+  // Re-register the live pool to reflect the metadata change. Plugin
+  // datasources route through the `createFromConfig` bridge (ADR-0013);
+  // core (postgres/mysql) keep the native `connections.register` path. Both
+  // re-test only when the URL changed — the test-connect dance is route-owned
+  // per ADR-0007. (#3852)
+  if (isPluginDbType) {
+    // Merge the patched url/description/schema onto the full decrypted config
+    // so plugin-specific fields the caller didn't touch survive the rebuild.
+    const mergedConfig: Record<string, unknown> = { ...currentDecryptedConfig, url: newUrl };
+    if (newDescription !== null) mergedConfig.description = newDescription;
+    else delete mergedConfig.description;
+    if (newSchema !== null) mergedConfig.schema = newSchema;
+    else delete mergedConfig.schema;
+
+    try {
+      // `registerDatasourceInstall` builds the connection via the plugin's
+      // `createFromConfig` and registers it via `registerDirectForWorkspace`
+      // (which closes + replaces any prior live connection). For a plugin
+      // dbType it ALWAYS rebuilds the live connection from the merged config —
+      // its boolean return is "was this a fresh (workspace, install_id)
+      // registration" (`false` on an in-place rebuild of an existing one, which
+      // is the common URL-change case), NOT "did anything get built". It returns
+      // `false` without building only for handler-managed (OAuth) types like
+      // salesforce, which keep their LazyPluginLoader connection.
+      await registerDatasourceInstall(
+        { workspaceId: orgId, catalogId: "", installId: id, pillar: "datasource", catalogSlug: current.catalog_slug },
+        mergedConfig,
+      );
+      // Probe the (re)built plugin connection through the plugin adapter. Gate
+      // on `hasDirectForWorkspace`, NOT the boolean return: an in-place rebuild
+      // returns `false` yet a fresh connection — possibly to a new URL — is now
+      // live and MUST be probed. Salesforce registers no direct connection, so
+      // the guard correctly skips it. (The core `connections.healthCheck` reads
+      // the bare `entries` map, which plugin pools never populate — they live in
+      // `workspacePluginEntries`.)
+      if (connections.hasDirectForWorkspace(orgId, id)) {
+        await probeLivePluginConnection(connections.getForWorkspace(orgId, id));
+      }
+    } catch (err) {
+      // Rebuild the previous connection from the pre-update config so the live
+      // pool isn't left pointing at the rejected URL.
+      let rollbackFailed = false;
+      try {
+        await registerDatasourceInstall(
+          { workspaceId: orgId, catalogId: "", installId: id, pillar: "datasource", catalogSlug: current.catalog_slug },
+          currentDecryptedConfig,
+        );
+      } catch (restoreErr) {
+        rollbackFailed = true;
+        log.error({ connectionId: id, requestId, err: errorMessage(restoreErr) }, "Failed to restore previous plugin connection after update failure — connection unregistered");
+        connections.unregisterDirectForWorkspace(orgId, id);
+      }
+      const baseMsg = urlChanged
+        ? `Connection test failed: ${errorMessage(err)}. Fix the URL and try again.`
+        : `Failed to update connection: ${errorMessage(err)}.`;
+      if (rollbackFailed) {
+        return c.json({ error: "internal_error", message: `${baseMsg} The connection may need a server restart to restore.`, requestId }, 500);
+      }
+      // A URL-change failure is the caller's input problem (400, connection_failed);
+      // a metadata-only failure means the rebuild itself broke (500,
+      // internal_error). Both surface the scrubbed cause (`errorMessage` strips
+      // DSN userinfo) so the admin gets an actionable message, not a bare
+      // "Failed to update connection."
+      return c.json(
+        urlChanged
+          ? { error: "connection_failed", message: baseMsg, requestId }
+          : { error: "internal_error", message: baseMsg, requestId },
+        urlChanged ? 400 : 500,
+      );
+    }
+  } else if (urlChanged) {
     try {
       connections.register(id, { url: newUrl, description: newDescription ?? undefined, schema: newSchema ?? undefined });
       await connections.healthCheck(id);
@@ -1273,15 +1397,24 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
       ),
   );
   if (result.kind === "error") {
-    // Rollback the registry to the pre-update URL — the DB write didn't
-    // land so the live pool shouldn't reflect the attempted change.
+    // Rollback the registry to the pre-update config — the DB write didn't
+    // land so the live pool shouldn't reflect the attempted change. Plugin
+    // datasources rebuild via the bridge; core via `connections.register`.
     let rollbackFailed = false;
     try {
-      connections.register(id, { url: currentUrl, description: currentDescription ?? undefined, schema: currentSchema ?? undefined });
+      if (isPluginDbType) {
+        await registerDatasourceInstall(
+          { workspaceId: orgId, catalogId: "", installId: id, pillar: "datasource", catalogSlug: current.catalog_slug },
+          currentDecryptedConfig,
+        );
+      } else {
+        connections.register(id, { url: currentUrl, description: currentDescription ?? undefined, schema: currentSchema ?? undefined });
+      }
     } catch (restoreErr) {
       rollbackFailed = true;
       log.error({ connectionId: id, requestId, err: errorMessage(restoreErr) }, "Failed to restore previous connection after installer error — connection unregistered");
-      connections.unregister(id);
+      if (isPluginDbType) connections.unregisterDirectForWorkspace(orgId, id);
+      else connections.unregister(id);
     }
     if (rollbackFailed) {
       // Rollback failed AND the installer rejected the change: the in-memory

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -1291,14 +1291,21 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
         { workspaceId: orgId, catalogId: "", installId: id, pillar: "datasource", catalogSlug: current.catalog_slug },
         mergedConfig,
       );
-      // Probe the (re)built plugin connection through the plugin adapter. Gate
-      // on `hasDirectForWorkspace`, NOT the boolean return: an in-place rebuild
-      // returns `false` yet a fresh connection — possibly to a new URL — is now
-      // live and MUST be probed. Salesforce registers no direct connection, so
-      // the guard correctly skips it. (The core `connections.healthCheck` reads
-      // the bare `entries` map, which plugin pools never populate — they live in
-      // `workspacePluginEntries`.)
-      if (connections.hasDirectForWorkspace(orgId, id)) {
+      // Probe the (re)built plugin connection through the plugin adapter —
+      // but ONLY when the URL changed, matching the core path's `else if
+      // (urlChanged)` gate and the comment above (test-connect is route-owned
+      // per ADR-0007). A metadata-only change (e.g. a group rename) must not
+      // probe: a transiently-unreachable datasource would otherwise 500 a valid
+      // rename (#3852). The rebuild itself always runs so the live pool reflects
+      // the new config; only the liveness PROBE is URL-change-gated.
+      //
+      // The probe is further gated on `hasDirectForWorkspace`, NOT the boolean
+      // return: an in-place rebuild returns `false` yet a fresh connection — to
+      // a new URL — is now live and MUST be probed. Salesforce registers no
+      // direct connection, so the guard correctly skips it. (The core
+      // `connections.healthCheck` reads the bare `entries` map, which plugin
+      // pools never populate — they live in `workspacePluginEntries`.)
+      if (urlChanged && connections.hasDirectForWorkspace(orgId, id)) {
         await probeLivePluginConnection(connections.getForWorkspace(orgId, id));
       }
     } catch (err) {

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -466,19 +466,29 @@ async function registerPluginDatasourceInstall(
  * Resolve `(row, decryptedConfig)` and register the resulting native pool
  * with the `ConnectionRegistry`.
  *
+ * The boolean return reports whether a FRESH (workspace, install_id)
+ * registration happened — it is NOT "did anything get built". For a plugin
+ * dbType the live connection is ALWAYS (re)built via `createFromConfig`
+ * regardless of the return value (see `registerPluginDatasourceInstall`).
+ *
  * Returns:
- *   - `true`  — a fresh registration was performed (the per-(workspace,
- *               install_id) config and/or the bare install_id row was new)
+ *   - `true`  — a fresh registration was performed: for native types the
+ *               per-(workspace, install_id) config and/or the bare install_id
+ *               row was new; for plugin types no direct connection existed for
+ *               this (workspace, install_id) before this call
  *   - `false` — the dbType is handler-managed (Salesforce / OAuth — skipped
- *               entirely, see `HANDLER_MANAGED_DATASOURCE_DBTYPES`), OR the
- *               dbType is plugin-managed (filter short-circuit), OR BOTH the
- *               per-(workspace, install_id) config and the bare install_id were
- *               already registered (full idempotent re-register)
+ *               entirely, NOTHING built, see `HANDLER_MANAGED_DATASOURCE_DBTYPES`),
+ *               OR a plugin connection for this (workspace, install_id) already
+ *               existed and was REBUILT in place (a new connection IS live), OR
+ *               for native types BOTH the per-(workspace, install_id) config and
+ *               the bare install_id were already registered (idempotent re-register).
+ *               Callers that must probe the live connection should NOT gate on
+ *               this — gate on `connections.hasDirectForWorkspace` instead.
  *
  * Throws on any resolver violation (missing required field, invalid
  * schema identifier, unknown catalog slug). Resolver runs before the
- * native filter — a plugin-managed row with malformed config throws
- * here, never reaching the short-circuit branch.
+ * native filter — a malformed-config row throws here, never reaching the
+ * registration branch.
  *
  * The native-only filter matches the prior in-line check in
  * `loadSavedConnections` — without it, `connections.register` would


### PR DESCRIPTION
## Summary

`PUT /api/v1/admin/connections/{id}` returned **500 `internal_error`** for any metadata change (group, description, URL) on a **plugin** datasource (ClickHouse, Elasticsearch, Snowflake, BigQuery). The update handler re-registered the live pool through the **core** adapter (`connections.register`), which only understands `postgresql://` / `mysql://` and throws `Unsupported database URL scheme "clickhouse://"` on a plugin URL — so the whole update failed and the group binding never persisted. This blocked group-scoped semantic routing (ADR-0012) for every plugin datasource — the keystone of the *Real-World Testing Fixes* milestone.

- Route plugin-dbType re-registration through `registerDatasourceInstall` (the ADR-0013 `createFromConfig` seam) instead of the core `connections.register`. The live plugin connection is rebuilt in place (closing the prior one) from the merged decrypted config.
- Post-update health check now uses the **plugin adapter**: a new `probeLivePluginConnection` helper prefers the adapter's native `ping()` (Elasticsearch/OpenSearch route `query()` to the cluster `/_sql` API, so `SELECT 1` would test the wrong surface) and falls back to `SELECT 1` for SQL-only adapters, at the bridge's 10s timeout.
- Skip the core `detectDBType` re-validation for plugin URL schemes (it throws on `clickhouse://` too).
- Rollback paths (update-probe failure and installer error) now rebuild from the pre-update config via the bridge for plugin types, with the matching `unregisterDirectForWorkspace` teardown on a failed restore.
- The probe is gated on `hasDirectForWorkspace`, **not** the bridge's boolean return — an in-place rebuild returns `false` yet a fresh connection (possibly to a new URL) is now live and must be probed. Also corrected the stale `registerDatasourceInstall` return-value JSDoc that mis-described the plugin case.
- Setting a Connection group now persists `config.group_id` and is reflected in `GET /api/v1/admin/connections` (`groupId`).

## Acceptance criteria

- [x] PUT succeeds for plugin datasources (clickhouse / elasticsearch / snowflake / bigquery) when changing group, description, or URL — no 500.
- [x] Re-registration routes through `createFromConfig` (ADR-0013), not core `connections.register`; live pool cleanly rebuilt; post-update health check uses the plugin adapter.
- [x] Setting a group persists `config.group_id`, reflected in `GET` `groupId`.
- [x] Regression test covering a metadata update on a plugin-dbType connection (no core-scheme throw).

## Test plan

- [x] `bun run lint`, `bun run type` — clean
- [x] All drift gates (syncpack, template, schema, openapi, oauth-helper, test-discipline, settings-readers, saas-env-doc, published-symbols, railway-watch, security-headers, twenty-resolver) — pass
- [x] Affected test graph — 8/8 files pass (`admin-connections`, `datasource-registry-bridge`, `workspace-installer`, mcp-lifecycle/profile, datasource-form-install-roundtrip, …)
- [x] New regression tests in `admin-connections.test.ts`: clickhouse group-set, clickhouse URL change + probe, elasticsearch group-set, URL-change-probe-failure rollback (4 tests)
- [ ] `-pg` real-Postgres tests run in CI shards (Docker unavailable locally); this change alters no SELECT shape or migration, so `-pg` fixtures are unaffected.

## Operator follow-up (out of scope for this code fix)

Per the issue, staging (`app.staging.useatlas.dev`, workspace `d0lhxGmKEfhqbCbd4N5NIuTO5JHHtCaP`) was hand-patched during the #3253 soak: `clickhouse` + `elasticsearch` had `workspace_plugins.config.group_id` set **directly via psql** because this endpoint 500'd. Now that the real fix lands, an operator should remove those manual psql edits and re-apply the groups through the now-working `PUT …/connections/{id}` path (verifying on a fresh plugin datasource, or after clearing the manual `group_id`). No staging DB changes are made by this PR.

Closes #3852

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route plugin datasource metadata updates through `registerDatasourceInstall` bridge in `PUT /connections/:id`
> - Plugin (non-postgres/mysql) connection updates now rebuild the live connection via `registerDatasourceInstall` with the full decrypted config, preserving untouched fields during partial updates.
> - Liveness probing via `probeLivePluginConnection` (prefers `ping()`, falls back to `SELECT 1`) is gated on URL changes only, and only when a direct workspace connection exists.
> - URL-change probe failures return 400 `connection_failed` and trigger bridge-based rollback; metadata-only rebuild failures return 500 `internal_error`; rollback failure unregisters the direct workspace connection.
> - Core postgres/mysql URL-change behavior (re-detect dbType, healthCheck, rollback) is unchanged.
> - Risk: the response `dbType` field now reflects `catalogSlugToDbType` output (e.g. `demo-postgres` collapses to `postgres`), which is a behavioral change for callers inspecting that field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2826c83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 500 `internal_error` on `PUT /api/v1/admin/connections/{id}` for plugin datasources (ClickHouse, Elasticsearch, Snowflake, BigQuery) by routing re-registration through `registerDatasourceInstall` (`createFromConfig` bridge, ADR-0013) instead of the core `connections.register`, which only understands `postgresql://`/`mysql://`. The previous reviewer's concern about an unconditional liveness probe has been addressed: the probe is now correctly gated on `urlChanged`, matching ADR-0007 and core-path behavior.

- Adds `probeLivePluginConnection` in `admin-connections.ts` that prefers an adapter's native `ping()` and falls back to `SELECT 1`, with a 10 s timeout matching the bridge's own probe.
- Rollback paths for both probe failure and installer DB-write failure now call `registerDatasourceInstall` with `currentDecryptedConfig` for plugin types, with a matching `unregisterDirectForWorkspace` on double failure.
- Six new regression tests cover: group-set on ClickHouse/Elasticsearch, URL-change probe, probe-skipped-on-metadata-only, metadata-only rebuild failure (500), and URL-change probe failure rollback (400).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the plugin re-registration path is correct, probe gating matches core-path semantics, and rollback logic is symmetric and tested end-to-end.

The fix is well-scoped: it replaces a single bad call site (`connections.register` for plugin URLs) with the right bridge function, adds a targeted liveness probe gated on URL changes only, and provides symmetric rollback at both the pre-DB and post-DB failure points. The previous reviewer's concern about the unconditional probe has been addressed — `urlChanged` now gates the probe, matching the core path. Six new regression tests cover the happy paths, the metadata-only no-probe invariant, and both rollback scenarios. No changes to SELECT shapes or migrations, so unrelated call sites are unaffected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/api/routes/admin-connections.ts | Core fix: new `isPluginDbType` branch routes plugin re-registration through `registerDatasourceInstall`; probe correctly gated on `urlChanged`; rollback paths updated for both early (probe) and late (installer) failure; JSDoc matches actual behavior. |
| packages/api/src/lib/db/datasource-registry-bridge.ts | JSDoc-only change: corrects the `registerDatasourceInstall` return-value description to clarify that `false` on an in-place rebuild still means a new connection is live; callers should gate on `hasDirectForWorkspace`, not this boolean. |
| packages/api/src/api/__tests__/admin-connections.test.ts | Adds mocks for `registerDatasourceInstall`, `getForWorkspace`, and `probeQuery`; six new tests cover the group-set, URL-change probe, unreachable-host metadata-only, rebuild failure, and rollback paths for plugin datasources. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PUT /admin/connections/:id] --> B{isPluginDbType?}
    B -- No postgres/mysql --> C{urlChanged?}
    C -- Yes --> D[connections.register + healthCheck]
    C -- No --> E[connections.register metadata only]
    D --> F{success?}
    F -- No --> G[rollback: connections.register prev URL]
    F -- Yes --> I[runInstaller.updateDatasourceConfig]
    E --> I
    B -- Yes clickhouse/ES/snowflake/etc --> H[registerDatasourceInstall mergedConfig]
    H --> J{threw?}
    J -- No --> K{urlChanged AND hasDirectForWorkspace?}
    K -- Yes --> L[probeLivePluginConnection]
    K -- No --> I
    L --> M{probe OK?}
    M -- No --> N[rollback: registerDatasourceInstall currentDecryptedConfig]
    N --> O[400 connection_failed]
    M -- Yes --> I
    J -- Yes --> P[rollback: registerDatasourceInstall currentDecryptedConfig]
    P --> Q[500 internal_error]
    I --> R{installer success?}
    R -- No --> S[rollback via bridge or register]
    R -- Yes --> T[200 OK + groupId]
    S --> U[return installer error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PUT /admin/connections/:id] --> B{isPluginDbType?}
    B -- No postgres/mysql --> C{urlChanged?}
    C -- Yes --> D[connections.register + healthCheck]
    C -- No --> E[connections.register metadata only]
    D --> F{success?}
    F -- No --> G[rollback: connections.register prev URL]
    F -- Yes --> I[runInstaller.updateDatasourceConfig]
    E --> I
    B -- Yes clickhouse/ES/snowflake/etc --> H[registerDatasourceInstall mergedConfig]
    H --> J{threw?}
    J -- No --> K{urlChanged AND hasDirectForWorkspace?}
    K -- Yes --> L[probeLivePluginConnection]
    K -- No --> I
    L --> M{probe OK?}
    M -- No --> N[rollback: registerDatasourceInstall currentDecryptedConfig]
    N --> O[400 connection_failed]
    M -- Yes --> I
    J -- Yes --> P[rollback: registerDatasourceInstall currentDecryptedConfig]
    P --> Q[500 internal_error]
    I --> R{installer success?}
    R -- No --> S[rollback via bridge or register]
    R -- Yes --> T[200 OK + groupId]
    S --> U[return installer error]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(connections): gate plugin probe on u..."](https://github.com/atlasdevhq/atlas/commit/2826c8387421f5711cd4d565c9b2d9b5ccd8e663) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38941680)</sub>

<!-- /greptile_comment -->