### PR TITLE
fix(api): standalone group-less datasource is its own group-of-one (#3855)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-org.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-org.test.ts
@@ -114,6 +114,32 @@ describe("loadOrgWhitelist", () => {
     expect(result.get("default")?.has("events")).toBeFalsy();
   });
 
+  it("routes two same-named tables on group-of-one connections to distinct scopes (#3855)", async () => {
+    // #3855 regression at the whitelist layer: a standalone (group-less)
+    // datasource is keyed under its OWN connectionId (group-of-one). Two
+    // `test_orders` entities saved from two different connections
+    // (`mysql-staging`, `clickhouse`) carry distinct `connection_group_id`
+    // values, so `recordTables` keys each under its own group — each queryable
+    // on its own connection, neither leaking into the flat default bucket where
+    // the pre-fix last-write-wins collision happened.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        { ...makeEntityRow("test_orders", "test_orders"), connection_group_id: "mysql-staging" },
+        { ...makeEntityRow("test_orders", "test_orders"), connection_group_id: "clickhouse" },
+      ]),
+    );
+
+    const result = await loadOrgWhitelist("org-1");
+    expect(result.get("mysql-staging")?.has("test_orders")).toBe(true);
+    expect(result.get("clickhouse")?.has("test_orders")).toBe(true);
+    // Never leaks into the flat default bucket where it would collide.
+    expect(result.get("default")?.has("test_orders")).toBeFalsy();
+
+    // executeSQL(connectionId=...) resolves each on its own connection.
+    expect(getOrgWhitelistedTables("org-1", "clickhouse").has("test_orders")).toBe(true);
+    expect(getOrgWhitelistedTables("org-1", "mysql-staging").has("test_orders")).toBe(true);
+  });
+
   it("honors the canonical `group:` field in stored YAML (ADR-0012)", async () => {
     // The DB-backed path resolves the group via readGroupField, so a stored
     // entity that declares `group:` keys the whitelist under that group.

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -22,7 +22,7 @@ import {
   _resetPool,
   hasInternalDB as _hasInternalDB,
 } from "@atlas/api/lib/db/internal";
-import { listEntitiesWithOverlay } from "@atlas/api/lib/semantic/entities";
+import { listEntitiesWithOverlay, listEntityRows } from "@atlas/api/lib/semantic/entities";
 
 // ---------------------------------------------------------------------------
 // In-memory Postgres wired into the internal DB pool singleton
@@ -296,6 +296,134 @@ describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", 
     seedEntity({ id: "demo-ent", name: "novamart_orders", status: "published", connectionId: "__demo__" });
 
     const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rows).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Group-of-one — standalone group-less datasources (#3855)
+  // -------------------------------------------------------------------------
+
+  /**
+   * A group-LESS datasource install: `config` carries no `group_id`, so its
+   * entities key under the bare `install_id` (a group-of-one) rather than the
+   * shared NULL/default bucket. Distinct from {@link seedConnection}, which
+   * always stamps `config.group_id = g_<id>`.
+   */
+  function seedGrouplessConnection(
+    id: string,
+    status: "published" | "draft" | "archived" = "published",
+    workspaceId = "org-1",
+  ): void {
+    db.public.none(
+      `INSERT INTO workspace_plugins (install_id, workspace_id, pillar, status, config)
+       VALUES ('${id}', '${workspaceId}', 'datasource', '${status}', '{}'::jsonb)`,
+    );
+  }
+
+  /** Seed an entity keyed directly under a group-of-one's bare `install_id`. */
+  function seedGroupOfOneEntity(opts: {
+    id: string;
+    name: string;
+    status: "published" | "draft" | "draft_delete" | "archived";
+    installId: string;
+    yaml?: string;
+  }): void {
+    const yaml = (opts.yaml ?? `table: ${opts.name}`).replace(/'/g, "''");
+    db.public.none(
+      `INSERT INTO semantic_entities (id, org_id, entity_type, name, yaml_content, connection_group_id, status)
+       VALUES ('${opts.id}', 'org-1', 'entity', '${opts.name}', '${yaml}', '${opts.installId}', '${opts.status}')`,
+    );
+  }
+
+  it("two same-named tables on distinct group-less connections both survive — no last-write-wins (#3855)", async () => {
+    // The bug: `test_orders` generated+saved from `mysql-staging` then from
+    // `clickhouse` (both group-less → pre-fix resolved to NULL) shared the
+    // `coalesce(connection_group_id,'default')` upsert key and the second
+    // clobbered the first. The fix keys each under its own install_id, so the
+    // two rows are distinct AND each is surfaced by the install_id visibility
+    // branch.
+    seedGrouplessConnection("mysql-staging");
+    seedGrouplessConnection("clickhouse");
+    seedGroupOfOneEntity({
+      id: "e-mysql",
+      name: "test_orders",
+      status: "published",
+      installId: "mysql-staging",
+      yaml: "table: test_orders\nengine: mysql",
+    });
+    seedGroupOfOneEntity({
+      id: "e-ch",
+      name: "test_orders",
+      status: "published",
+      installId: "clickhouse",
+      yaml: "table: test_orders\nengine: clickhouse",
+    });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    // Two distinct rows — one per connection group-of-one. `DISTINCT ON`
+    // keys on connection_group_id, so the same name no longer collapses.
+    expect(rows).toHaveLength(2);
+    const scopes = rows.map((r) => r.connection_group_id).toSorted();
+    expect(scopes).toEqual(["clickhouse", "mysql-staging"]);
+    // Each row kept its own dialect-specific YAML — neither overwrote the other.
+    const byScope = new Map(rows.map((r) => [r.connection_group_id, r.yaml_content]));
+    expect(byScope.get("mysql-staging")).toContain("engine: mysql");
+    expect(byScope.get("clickhouse")).toContain("engine: clickhouse");
+  });
+
+  it("a group-of-one entity is invisible once its standalone install is shadowed/archived (#3855)", async () => {
+    // Sanity that the install_id visibility branch is gated on a LIVE install,
+    // not a blanket pass — archiving the standalone datasource hides its
+    // group-of-one entities just like a grouped connection.
+    seedGrouplessConnection("clickhouse", "archived");
+    seedGroupOfOneEntity({ id: "e-ch", name: "test_orders", status: "published", installId: "clickhouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("a per-org install shadows a `__global__` group-of-one install with the same id (#3855)", async () => {
+    // The group-less mirror of the #2304 shadow-precedence check: a `__global__`
+    // group-of-one install is surfaced via the global install_id branch UNLESS
+    // the org has its own row at the same install_id, in which case the NOT-IN
+    // shadow guard drops it (and its entities) from the developer-mode overlay.
+    seedGrouplessConnection("clickhouse", "published", "__global__");
+    seedGroupOfOneEntity({ id: "e-ch", name: "test_orders", status: "published", installId: "clickhouse" });
+    expect(rowsByName(await listEntitiesWithOverlay("org-1", "entity"))).toEqual({ test_orders: "published" });
+
+    // Org-local install of the same id arrives — shadows the global group-of-one.
+    seedGrouplessConnection("clickhouse", "archived", "org-1");
+    expect(await listEntitiesWithOverlay("org-1", "entity")).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // listEntityRows (PUBLISHED read path) — the path real end-user queries take.
+  // It carries the same group-of-one visibility branches as the developer
+  // overlay above but with a `status = 'published'` install filter, so it
+  // needs its own coverage: a copy-paste slip in the published variant would
+  // pass every developer-mode test yet make a standalone datasource's tables
+  // un-queryable in production (#3855, pr-test-analyzer gap #1).
+  // -------------------------------------------------------------------------
+
+  it("listEntityRows(published) surfaces two same-named group-of-one tables on distinct connections (#3855)", async () => {
+    seedGrouplessConnection("mysql-staging");
+    seedGrouplessConnection("clickhouse");
+    seedGroupOfOneEntity({ id: "e-mysql", name: "test_orders", status: "published", installId: "mysql-staging" });
+    seedGroupOfOneEntity({ id: "e-ch", name: "test_orders", status: "published", installId: "clickhouse" });
+
+    const rows = await listEntityRows("org-1", "entity", "published");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.connection_group_id).toSorted()).toEqual(["clickhouse", "mysql-staging"]);
+  });
+
+  it("listEntityRows(published) hides a group-of-one entity whose standalone install is archived (#3855)", async () => {
+    // Only `status = 'published'` installs count in the published read — an
+    // archived (or draft-only) standalone datasource must not surface its
+    // group-of-one entities here.
+    seedGrouplessConnection("clickhouse", "archived");
+    seedGroupOfOneEntity({ id: "e-ch", name: "test_orders", status: "published", installId: "clickhouse" });
+
+    const rows = await listEntityRows("org-1", "entity", "published");
     expect(rows).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/semantic/__tests__/resolve-group-of-one.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/resolve-group-of-one.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the standalone-datasource group-of-one resolution (#3855).
+ *
+ * The onboarding wizard's `generate` → `save` flow scopes every saved entity
+ * by `resolveGroupIdForConnection(orgId, connectionId)`. A standalone
+ * datasource with no `config.group_id` resolved to `null`, so two saves of a
+ * same-named table from two DIFFERENT connections (e.g. `mysql-staging` and
+ * `clickhouse`) shared the conflict key
+ * `(org_id, entity_type, name, coalesce(connection_group_id,'default'))` and
+ * the second silently clobbered the first (last-write-wins).
+ *
+ * Fix: a group-less install resolves to its own `connectionId` (a
+ * group-of-one) rather than `null`, so:
+ *   - two same-named tables on different connections get distinct
+ *     `connection_group_id` values → no collision, and
+ *   - `executeSQL(connectionId=...)` finds the entity under its own id.
+ *
+ * This suite pins the TS-resolver contract (`internalQuery` stubbed); the
+ * pg-mem integration in `overlay-queries-integration.test.ts` proves the
+ * two-connection same-name case produces two correctly-scoped, visible rows
+ * end to end (exercising the inline-SQL mirror + the visibility join).
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { resolve } from "path";
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+// ---------------------------------------------------------------------------
+// Stage the workspace_plugins lookup per scenario. We spread the REAL module
+// and override only the two functions `resolveGroupIdForConnection` touches —
+// `mock.module` mocks all exports (the rest pass through unchanged).
+// ---------------------------------------------------------------------------
+
+let queuedRows: Record<string, unknown>[][] = [];
+const capturedCalls: Array<{ sql: string; params: unknown[] | undefined }> = [];
+
+const mockInternalQuery = mock(async (sql: string, params?: unknown[]) => {
+  capturedCalls.push({ sql, params });
+  return queuedRows.shift() ?? [];
+});
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+}));
+
+const entitiesPath = resolve(__dirname, "../entities.ts");
+const entitiesMod = await import(`${entitiesPath}?t=${Date.now()}`);
+const resolveGroupIdForConnection =
+  entitiesMod.resolveGroupIdForConnection as typeof import("../entities").resolveGroupIdForConnection;
+const DEMO_CONNECTION_ID = entitiesMod.DEMO_CONNECTION_ID as string;
+
+describe("resolveGroupIdForConnection — group-of-one for standalone datasources (#3855)", () => {
+  beforeEach(() => {
+    queuedRows = [];
+    capturedCalls.length = 0;
+  });
+
+  it("returns the explicit group when the install carries one", async () => {
+    queuedRows.push([{ group_id: "g_prod" }]);
+
+    expect(await resolveGroupIdForConnection("org-1", "mysql-staging")).toBe("g_prod");
+  });
+
+  it("returns the connectionId itself when a group-less install exists (group-of-one)", async () => {
+    // The install row exists (pillar='datasource') but config->>'group_id' is
+    // NULL — the standalone, never-grouped datasource. Pre-#3855 this returned
+    // null and collided with every other group-less connection in the org.
+    queuedRows.push([{ group_id: null }]);
+
+    expect(await resolveGroupIdForConnection("org-1", "clickhouse")).toBe("clickhouse");
+  });
+
+  it("scopes two group-less connections to two DISTINCT groups (no shared key)", async () => {
+    queuedRows.push([{ group_id: null }]);
+    const a = await resolveGroupIdForConnection("org-1", "mysql-staging");
+    queuedRows.push([{ group_id: null }]);
+    const b = await resolveGroupIdForConnection("org-1", "clickhouse");
+
+    expect(a).toBe("mysql-staging");
+    expect(b).toBe("clickhouse");
+    expect(a).not.toBe(b);
+  });
+
+  it("returns null for an unknown connection (no install row)", async () => {
+    // No row → the connection isn't a real datasource install (default/unknown)
+    // → flat default group, preserving legacy NULL-scope behavior.
+    queuedRows.push([]);
+
+    expect(await resolveGroupIdForConnection("org-1", "does-not-exist")).toBeNull();
+  });
+
+  it("returns null for a null/undefined connectionId without a DB call", async () => {
+    expect(await resolveGroupIdForConnection("org-1", null)).toBeNull();
+    expect(await resolveGroupIdForConnection("org-1", undefined)).toBeNull();
+    expect(capturedCalls.length).toBe(0);
+  });
+
+  it("treats the demo connection as its own group-of-one when group-less", async () => {
+    // The per-workspace demo install is a real datasource install with no
+    // `config.group_id` post-0096, so it resolves to its own id rather than
+    // NULL — its entities key under `__demo__` and stay distinct from any
+    // other group-less datasource in the org.
+    queuedRows.push([{ group_id: null }]);
+
+    expect(await resolveGroupIdForConnection("org-1", DEMO_CONNECTION_ID)).toBe(DEMO_CONNECTION_ID);
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -139,6 +139,20 @@ export async function listConnectionGroupMembers(
  * connection belongs to — group-of-one for a standalone datasource, NULL for
  * the default/unknown connection — so adding a member to a populated group
  * updates the shared group rows rather than duplicating them.
+ *
+ * Group-of-one (#3855): a real datasource install that carries NO explicit
+ * `config.group_id` resolves to its OWN `connectionId` (install_id), not NULL.
+ * NULL is the single flat "default" bucket every group-less connection would
+ * otherwise share, so saving a same-named table (e.g. `test_orders`) from two
+ * different connections collided on the
+ * `(org_id, entity_type, name, coalesce(connection_group_id,'default'))` upsert
+ * key and the second silently clobbered the first (last-write-wins). Keying a
+ * standalone datasource under its own connectionId makes two same-named tables
+ * on different engines distinct rows AND keeps each queryable via
+ * `executeSQL(connectionId=...)` (the whitelist fans an entity's tables out
+ * under its `connection_group_id`). A missing install row (unknown / `default`
+ * connection) still resolves to NULL — the flat default group — preserving
+ * single-DB back-compat.
  */
 export async function resolveGroupIdForConnection(
   orgId: string,
@@ -160,7 +174,11 @@ export async function resolveGroupIdForConnection(
       LIMIT 1`,
     [connectionId, orgId],
   );
-  return rows[0]?.group_id ?? null;
+  // No install row → unknown / `default` connection → flat default group (NULL).
+  if (rows.length === 0) return null;
+  // A real install with an explicit group uses it; one with no group is its own
+  // group-of-one, keyed under its connectionId (#3855).
+  return rows[0].group_id ?? connectionId;
 }
 
 /**
@@ -172,22 +190,26 @@ export async function resolveGroupIdForConnection(
  *
  * `$connParam` is the placeholder for the connection id; `$orgParam`
  * is the placeholder for the org id (already in the outer query's
- * parameter list). If onboarding has pre-created the deterministic
- * single-member group but has not committed the connection row yet, the
- * query falls back to `connection_groups.id = 'g_' || connection_id`.
- * That preserves demo import scope while the connection-visibility join
- * continues to hide the imported rows until the connection commit lands.
- * The subquery returns NULL when neither row is present, which keeps
- * legacy NULL-scope semantics.
+ * parameter list). The subquery returns NULL when no install row is
+ * present (unknown / `default` connection), which keeps legacy NULL-scope
+ * semantics.
+ *
+ * Group-of-one (#3855): when an install row exists but carries no explicit
+ * `config.group_id`, the subquery resolves to the connection's OWN id
+ * (`COALESCE(config->>'group_id', install_id)`) so a standalone datasource is
+ * keyed under its own connectionId rather than the shared NULL/default bucket —
+ * the same resolution {@link resolveGroupIdForConnection} performs, kept in
+ * lockstep so the inline-INSERT write paths and the TS resolver can't disagree.
  */
 function inlineConnectionGroupSql(connParam: string, orgParam: string): string {
   // Post-0096 cutover (#2744 / ADR-0007): the install's group_id lives
   // in `workspace_plugins.config->>'group_id'`. The pre-cutover
   // singleton-group fallback (`connection_groups.id = 'g_' || conn_id`)
   // is gone post pure-collapse — own-workspace beats __global__ via the
-  // ORDER BY priority.
+  // ORDER BY priority. `COALESCE(..., install_id)` is the inline mirror of
+  // the group-of-one resolution: a group-less install keys under its own id.
   return `(
-    SELECT config->>'group_id' AS group_id
+    SELECT COALESCE(config->>'group_id', install_id) AS group_id
       FROM workspace_plugins
      WHERE install_id = ${connParam}
        AND pillar = 'datasource'
@@ -472,6 +494,11 @@ export async function listEntityRows(
   // Post-0096 cutover (#2744 / ADR-0007): connections live in
   // workspace_plugins (pillar='datasource'), group_id is JSONB.
   // OWN_OR_GLOBAL shadow rule preserved — install_id is the new key.
+  // Group-of-one (#3855): a group-less standalone datasource keys its entities
+  // under its OWN `install_id`. The two `install_id` branches surface those
+  // rows (mirroring the `config.group_id` branches but matching group-less
+  // installs); without them a standalone datasource's published entities would
+  // be invisible — neither NULL nor a `config.group_id`.
   const visibilityClause = statusFilter === "published"
     ? `AND (org_id = $1 OR org_id = '__global__')
        AND (
@@ -482,11 +509,27 @@ export async function listEntityRows(
               AND config->>'group_id' IS NOT NULL
          )
          OR connection_group_id IN (
+           SELECT install_id FROM workspace_plugins
+            WHERE workspace_id = $1 AND pillar = 'datasource' AND status = 'published'
+              AND config->>'group_id' IS NULL
+         )
+         OR connection_group_id IN (
            SELECT config->>'group_id' FROM workspace_plugins
             WHERE workspace_id = '__global__'
               AND pillar = 'datasource'
               AND status = 'published'
               AND config->>'group_id' IS NOT NULL
+              AND install_id NOT IN (
+                SELECT install_id FROM workspace_plugins
+                 WHERE workspace_id = $1 AND pillar = 'datasource'
+              )
+         )
+         OR connection_group_id IN (
+           SELECT install_id FROM workspace_plugins
+            WHERE workspace_id = '__global__'
+              AND pillar = 'datasource'
+              AND status = 'published'
+              AND config->>'group_id' IS NULL
               AND install_id NOT IN (
                 SELECT install_id FROM workspace_plugins
                  WHERE workspace_id = $1 AND pillar = 'datasource'
@@ -737,6 +780,15 @@ export async function listEntitiesWithOverlay(
   // Post-0096 cutover (#2744 / ADR-0007): same OWN_OR_GLOBAL shadow
   // rule, pivoted to workspace_plugins (pillar='datasource') with
   // group_id in JSONB.
+  //
+  // Group-of-one (#3855): a group-less standalone datasource keys its entities
+  // under its OWN `install_id` (not `config.group_id`, which is NULL). Those
+  // rows are surfaced by the two `install_id` branches below — mirroring the
+  // `config.group_id` branches but matching `connection_group_id = install_id`
+  // for installs WITHOUT an explicit group. Without these branches the
+  // group-of-one rows would be invisible (they are neither NULL nor a
+  // `config.group_id`), so a standalone datasource's saved entities would
+  // vanish from the whitelist.
   const connectionVisibilitySql = `
     connection_group_id IS NULL
     OR connection_group_id IN (
@@ -746,11 +798,28 @@ export async function listEntitiesWithOverlay(
          AND config->>'group_id' IS NOT NULL
     )
     OR connection_group_id IN (
+      SELECT install_id FROM workspace_plugins
+       WHERE workspace_id = $1 AND pillar = 'datasource'
+         AND status IN ('published', 'draft')
+         AND config->>'group_id' IS NULL
+    )
+    OR connection_group_id IN (
       SELECT config->>'group_id' FROM workspace_plugins
        WHERE workspace_id = '__global__'
          AND pillar = 'datasource'
          AND status IN ('published', 'draft')
          AND config->>'group_id' IS NOT NULL
+         AND install_id NOT IN (
+           SELECT install_id FROM workspace_plugins
+            WHERE workspace_id = $1 AND pillar = 'datasource'
+         )
+    )
+    OR connection_group_id IN (
+      SELECT install_id FROM workspace_plugins
+       WHERE workspace_id = '__global__'
+         AND pillar = 'datasource'
+         AND status IN ('published', 'draft')
+         AND config->>'group_id' IS NULL
          AND install_id NOT IN (
            SELECT install_id FROM workspace_plugins
             WHERE workspace_id = $1 AND pillar = 'datasource'


### PR DESCRIPTION
## Summary

The onboarding wizard's `generate` → `save` flow silently collided when two different connections exposed a same-named table. `resolveGroupIdForConnection` returned `NULL` for any group-less standalone datasource, so two `test_orders` saves from different connections shared the `coalesce(connection_group_id,'default')` upsert key and the second clobbered the first (last-write-wins).

- **A real datasource install with no `config.group_id` now resolves to its own `connectionId`** (a group-of-one), keyed under that id rather than the shared `NULL`/default bucket. `NULL` scope is now reserved strictly for the no-install (unknown/`default`) case, preserving single-DB back-compat.
- **The inline-INSERT mirror** (`COALESCE(config->>'group_id', install_id)`) stays in lockstep with the TS resolver so the write paths and the resolver can't disagree.
- **Both visibility joins gain `install_id` branches** — `listEntityRows` (published-mode, the path real end-user queries traverse) and `listEntitiesWithOverlay` (developer-mode) — so a group-of-one's rows are surfaced when its install is live. Without them the saved entities would be invisible (they are neither `NULL` nor a `config.group_id`).

Result: saving the same table name from two distinct connections produces two correctly-scoped rows, one per connection, each queryable on its own `connectionId` — no silent overwrite.

## Acceptance criteria
- [x] Same table name saved from two distinct connections → two correctly-scoped rows, each queryable on its own connection, no silent overwrite
- [x] A standalone group-less datasource's saved entities are whitelisted + routed under its own `connectionId`
- [x] Regression test for the two-connection same-name case

## Test plan
- [x] `resolve-group-of-one.test.ts` — pins the resolver contract (explicit group / group-less→own-id / unknown→null / no-DB-call / demo)
- [x] `semantic-org.test.ts` — whitelist routes two same-named group-of-one tables to distinct scopes, neither leaking to `default`
- [x] `overlay-queries-integration.test.ts` (pg-mem) — end-to-end against real SQL: two same-named tables survive with distinct scopes + preserved per-engine YAML; archived/`__global__`-shadowed group-of-one hidden; both developer-mode (`listEntitiesWithOverlay`) and published-mode (`listEntityRows`) paths
- [x] `/ci`: lint, type, full `@atlas/api` (709 files) + all 34 other packages, syncpack, schema-drift, test-discipline — all green
- [x] Rebased onto latest `main` (includes #3852 / #3861)

## Notes
- Diff kept minimal and localized to `entities.ts` (+ tests) per the #3856 umbrella overlap; touches `wizard.ts` not at all (the wizard `/save` already passes the resolved `connectionGroupId` through).
- The staging "manual unblock" note in the issue is operator-only and out of scope for this PR.

Closes #3855

https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix standalone group-less datasource installs to resolve as their own group-of-one
> - `resolveGroupIdForConnection` in [entities.ts](https://github.com/AtlasDevHQ/atlas/pull/3863/files#diff-f4d91adbcb6c7f8453befbee5445d0fd99d23bfaeefe99fb4bd9de0f60dce08f) now returns the `connectionId` itself (instead of `null`) when an install exists but has no `group_id`, making it its own group-of-one.
> - `inlineConnectionGroupSql` is updated to emit `COALESCE(config->>'group_id', install_id)` so writes also set `connection_group_id` to `install_id` for group-less installs.
> - `listEntityRows` and `listEntitiesWithOverlay` are extended with additional OR branches to include entities whose `connection_group_id` matches `install_id` for group-less installs, covering both own-org and unshadowed global cases.
> - Behavioral Change: group-less installs that previously returned `null` from `resolveGroupIdForConnection` (and were invisible in overlay/published queries) now resolve and surface correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24ab5ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->