### PR TITLE
fix(api): scope validate-sql connection lookups to the request workspace (#3857)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -10813,6 +10813,31 @@
               }
             }
           },
+          "404": {
+            "description": "Connection not found for the request's workspace scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation error (invalid request body)",
             "content": {

--- a/packages/api/src/api/__tests__/validate-sql.test.ts
+++ b/packages/api/src/api/__tests__/validate-sql.test.ts
@@ -43,6 +43,8 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
   getClientIP: mockGetClientIP,
 }));
 
+const mockGetRequestContext: Mock<() => unknown> = mock(() => null);
+
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
@@ -51,14 +53,14 @@ mock.module("@atlas/api/lib/logger", () => ({
     debug: () => {},
   }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
-  getRequestContext: () => null,
+  getRequestContext: mockGetRequestContext,
 }));
 
 const mockValidateSQL: Mock<
-  (sql: string, connectionId?: string) => { valid: boolean; error?: string }
+  (sql: string, connectionId?: string, workspaceId?: string) => { valid: boolean; error?: string }
 > = mock(() => ({ valid: true }));
 
-const mockParserDatabase: Mock<(dbType: string, connectionId?: string) => string> = mock(
+const mockParserDatabase: Mock<(dbType: string, connectionId?: string, workspaceId?: string) => string> = mock(
   () => "PostgresQL",
 );
 
@@ -80,7 +82,9 @@ mock.module("node-sql-parser", () => ({
 }));
 
 const mockDetectDBType: Mock<() => string> = mock(() => "postgres");
-const mockGetDBType: Mock<(id: string) => string> = mock(() => "postgres");
+const mockGetDBType: Mock<(id: string, workspaceId?: string) => string> = mock(
+  () => "postgres",
+);
 
 mock.module("@atlas/api/lib/db/connection", () =>
   createConnectionMock({
@@ -109,6 +113,9 @@ mock.module("@atlas/api/lib/auth/detect", () => ({
 // Import after mocks
 const { Hono } = await import("hono");
 const { validateSqlRoute } = await import("../routes/validate-sql");
+const { ConnectionNotRegisteredError } = await import(
+  "@atlas/api/lib/db/connection"
+);
 
 const app = new Hono();
 app.route("/api/v1/validate-sql", validateSqlRoute);
@@ -145,6 +152,8 @@ describe("POST /api/v1/validate-sql", () => {
     mockGetDBType.mockReturnValue("postgres");
     mockParserDatabase.mockReset();
     mockParserDatabase.mockReturnValue("PostgresQL");
+    mockGetRequestContext.mockReset();
+    mockGetRequestContext.mockReturnValue(null);
   });
 
   it("returns valid=true with tables for a valid SELECT", async () => {
@@ -237,7 +246,8 @@ describe("POST /api/v1/validate-sql", () => {
       makeRequest({ sql: "SELECT 1", connectionId: "my-conn" }),
     );
     expect(response.status).toBe(200);
-    expect(mockValidateSQL).toHaveBeenCalledWith("SELECT 1", "my-conn");
+    // workspaceId is resolved from the request context (null in this mock → undefined).
+    expect(mockValidateSQL).toHaveBeenCalledWith("SELECT 1", "my-conn", undefined);
   });
 
   it("deduplicates extracted tables", async () => {
@@ -389,7 +399,8 @@ describe("POST /api/v1/validate-sql", () => {
       makeRequest({ sql: "SELECT 1 FROM t", connectionId: "my-conn" }),
     );
     expect(response.status).toBe(200);
-    expect(mockGetDBType).toHaveBeenCalledWith("my-conn");
+    // workspaceId is resolved from the request context (null in this mock → undefined).
+    expect(mockGetDBType).toHaveBeenCalledWith("my-conn", undefined);
     expect(mockDetectDBType).not.toHaveBeenCalled();
   });
 
@@ -407,5 +418,81 @@ describe("POST /api/v1/validate-sql", () => {
 
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.error).toBe("auth_error");
+  });
+
+  // --- #3857: per-workspace plugin connections ---
+
+  it("passes the request's workspaceId to validateSQL and getDBType", async () => {
+    // A per-workspace plugin connection (ClickHouse, Elasticsearch) only resolves
+    // when getDBType is called WITH the workspace scope. Simulate it: getDBType
+    // throws unless the second arg (workspaceId) is present.
+    mockGetRequestContext.mockReturnValue({
+      user: { activeOrganizationId: "ws-123" },
+    });
+    mockGetDBType.mockImplementation((_id: string, workspaceId?: string) => {
+      if (!workspaceId) {
+        throw new ConnectionNotRegisteredError({
+          message: `Connection "${_id}" is not registered.`,
+          id: _id,
+        });
+      }
+      return "clickhouse";
+    });
+
+    const response = await app.fetch(
+      makeRequest({ sql: "SELECT id FROM test_orders", connectionId: "clickhouse" }),
+    );
+
+    // No 500 — the workspace-scoped lookup succeeds and tables are extracted.
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.valid).toBe(true);
+    expect(body.tables).toEqual(["users", "orders"]);
+    expect(mockValidateSQL).toHaveBeenCalledWith(
+      "SELECT id FROM test_orders",
+      "clickhouse",
+      "ws-123",
+    );
+    expect(mockGetDBType).toHaveBeenCalledWith("clickhouse", "ws-123");
+    // parserDatabase must also be workspace-scoped so the dialect lookup resolves
+    // the per-workspace plugin's parser (args: resolved dbType, connectionId, workspaceId).
+    expect(mockParserDatabase).toHaveBeenCalledWith("clickhouse", "clickhouse", "ws-123");
+  });
+
+  it("rethrows non-ConnectionNotRegisteredError from getDBType (does not mask as 404)", async () => {
+    // The catch is deliberately narrow: only ConnectionNotRegisteredError → 404.
+    // Any other failure must propagate (→ 500), never be swallowed as a 404
+    // ("prefer errors over silent fallbacks").
+    mockGetDBType.mockImplementation(() => {
+      throw new Error("registry pool exploded");
+    });
+
+    const response = await app.fetch(
+      makeRequest({ sql: "SELECT 1 FROM t", connectionId: "my-conn" }),
+    );
+
+    // The error propagates (500), and crucially is NOT swallowed as the 404
+    // connection_not_found path.
+    expect(response.status).toBe(500);
+    expect(response.status).not.toBe(404);
+  });
+
+  it("returns 404 (not 500) when getDBType throws ConnectionNotRegisteredError", async () => {
+    // Even with the fix, a genuinely-unregistered connection must surface as a
+    // clean 404, never an unhandled 500 (#3857).
+    mockGetDBType.mockImplementation((id: string) => {
+      throw new ConnectionNotRegisteredError({
+        message: `Connection "${id}" is not registered.`,
+        id,
+      });
+    });
+
+    const response = await app.fetch(
+      makeRequest({ sql: "SELECT 1 FROM t", connectionId: "ghost-conn" }),
+    );
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("connection_not_found");
   });
 });

--- a/packages/api/src/api/routes/validate-sql.ts
+++ b/packages/api/src/api/routes/validate-sql.ts
@@ -14,9 +14,9 @@ import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { Parser } from "node-sql-parser";
-import { createLogger } from "@atlas/api/lib/logger";
+import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { validateSQL, parserDatabase } from "@atlas/api/lib/tools/sql";
-import { connections, detectDBType } from "@atlas/api/lib/db/connection";
+import { connections, detectDBType, ConnectionNotRegisteredError } from "@atlas/api/lib/db/connection";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -91,6 +91,10 @@ const validateRoute = createRoute({
       description: "Forbidden — insufficient permissions",
       content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
     },
+    404: {
+      description: "Connection not found for the request's workspace scope",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
     422: {
       description: "Validation error (invalid request body)",
       content: {
@@ -129,7 +133,17 @@ validateSqlRoute.openapi(
   async (c) => {
     const { sql, connectionId } = c.req.valid("json");
 
-    const result = await validateSQL(sql, connectionId);
+    // Resolve the request's workspace scope. A per-workspace plugin datasource
+    // (ClickHouse, Elasticsearch via `registerDirectForWorkspace`) lives in a
+    // per-(workspace, install_id) pool, so every connection lookup below must be
+    // workspace-scoped or it falls back to the bare registry and throws
+    // ConnectionNotRegisteredError (#3857). This mirrors the agent path
+    // (`lib/tools/sql.ts`), which passes `workspaceId` to validateSQL/getDBType.
+    // validateSQL defaults to the same value internally, but getDBType/parserDatabase
+    // here are called directly and need the scope passed explicitly.
+    const workspaceId = getRequestContext()?.user?.activeOrganizationId;
+
+    const result = await validateSQL(sql, connectionId, workspaceId);
 
     if (!result.valid) {
       return c.json({
@@ -140,19 +154,35 @@ validateSqlRoute.openapi(
     }
 
     // Extract referenced tables from the valid query.
-    // getDBType/detectDBType are outside the catch — operational errors
-    // (missing connection, bad config) should propagate, not be swallowed.
     let tables: string[] = [];
     let dbType: string;
     if (connectionId) {
-      dbType = connections.getDBType(connectionId);
+      // Workspace-scoped lookup so per-workspace plugin connections resolve.
+      // A genuinely-unregistered connection surfaces as a clean 404 rather than
+      // an unhandled 500 (#3857) — validateSQL already passed for this same
+      // (connectionId, workspaceId) above, so reaching here with a missing
+      // connection is an unexpected registry race, not a routine miss.
+      try {
+        dbType = connections.getDBType(connectionId, workspaceId);
+      } catch (err) {
+        if (err instanceof ConnectionNotRegisteredError) {
+          return c.json(
+            {
+              error: "connection_not_found",
+              message: `Connection "${connectionId}" is not registered.`,
+            },
+            404,
+          );
+        }
+        throw err;
+      }
     } else {
       dbType = detectDBType();
     }
     const trimmed = sql.trim().replace(/;\s*$/, "");
     try {
       const tableRefs = parser.tableList(trimmed, {
-        database: parserDatabase(dbType, connectionId),
+        database: parserDatabase(dbType, connectionId, workspaceId),
       });
       tables = [
         ...new Set(


### PR DESCRIPTION
## Problem

`POST /api/v1/validate-sql` returned an unhandled **500 `internal_error`** for a per-workspace **plugin** datasource (ClickHouse, Elasticsearch) once its table was whitelisted. After `validateSQL` returned `valid:true`, the table-extraction step called `connections.getDBType(connectionId)` **without** `workspaceId`. A plugin datasource lives in a per-(workspace, install_id) pool (`registerDirectForWorkspace`), so the workspace-unscoped lookup missed it and `ConnectionNotRegisteredError` propagated past the route's catch as a 500.

(It only 500'd *after* whitelisting because, before that, `validateSQL` returned `valid:false` and the handler returned 200 early — never reaching the `getDBType` call.)

## Fix

- Resolve `workspaceId` from the request context (`getRequestContext()?.user?.activeOrganizationId`), mirroring the agent path in `lib/tools/sql.ts`, and pass it to `validateSQL`, `connections.getDBType`, and `parserDatabase`. (`validateSQL` already defaults to the same value internally; the load-bearing fix is the direct `getDBType`/`parserDatabase` calls.)
- Catch `ConnectionNotRegisteredError` from `getDBType` and return a clean **404** (`connection_not_found`) instead of an unhandled 500. Non-matching errors still propagate (no swallow).
- Declare the 404 on the OpenAPI route + regenerate `apps/docs/openapi.json`.

## Tests

- Per-workspace plugin connection (whitelisted table) → **200** with extracted tables (the `getDBType` mock throws unless workspace-scoped, reproducing the bug).
- `workspaceId` threaded to `validateSQL`, `getDBType`, **and** `parserDatabase`.
- `ConnectionNotRegisteredError` → **404 `connection_not_found`** (never 500).
- A non-tagged error from `getDBType` still propagates as **500** (not masked as 404).

## Notes

- `connection.ts` (`getDBType`) is **not** modified — the fix is entirely in the caller, as the issue anticipated. No overlap with #3853 / PR #3860 (`healthCheckForWorkspace`).
- The staging "manual unblock" note in the issue is operator-only and out of scope here.

Closes #3857

https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `validate-sql` connection lookups to the request workspace and return 404 on missing connections
> - The `POST /api/v1/validate-sql` handler now resolves `workspaceId` from the request context and passes it to `validateSQL`, `getDBType`, and `parserDatabase` so that connection lookups are scoped to the active workspace.
> - When a `connectionId` is provided but not registered for the workspace, the handler catches `ConnectionNotRegisteredError` and returns a structured 404 (`connection_not_found`) instead of propagating an internal error.
> - The OpenAPI schema is updated to document the new 404 response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afc6c7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->