### PR TITLE
fix(api): hot-register datasources on publish + group-of-one env picker (#3856)

### DIFF
--- a/apps/docs/content/docs/guides/developer-mode.mdx
+++ b/apps/docs/content/docs/guides/developer-mode.mdx
@@ -83,8 +83,14 @@ The endpoint executes four phases inside a single PostgreSQL transaction. Any fa
 
 After a successful response, **no `draft` or `draft_delete` rows remain for the org**.
 
+After the transaction commits, the endpoint **reconciles the org's datasources into the live connection registry** (best-effort, outside the transaction): every non-archived datasource install is (re)registered and every archived one is deregistered. This is what makes a freshly-published standalone datasource **agent-queryable immediately — with no API restart**. A transient registry hiccup here does not fail an already-committed publish; the next API boot reconciles regardless.
+
 <Callout title="Atomicity">
-  Every mutation above runs through a single `BEGIN ... COMMIT` block. If any statement throws — a constraint violation, a lost connection, anything — the endpoint issues `ROLLBACK`, releases the client, and returns `500 publish_failed` with the original error detail. The internal DB state is left untouched.
+  The four phases above run through a single `BEGIN ... COMMIT` block. If any statement throws — a constraint violation, a lost connection, anything — the endpoint issues `ROLLBACK`, releases the client, and returns `500 publish_failed` with the original error detail. The internal DB state is left untouched. The post-commit registry reconcile runs only on the success path.
+</Callout>
+
+<Callout title="Standalone datasource happy path">
+  The end-to-end path for a single self-installed datasource (one ClickHouse, one Elasticsearch, …) is: **install** via Admin → Connections → **auto-profile / generate entities** → **publish**. After the publish you can `executeSQL` against it right away — no API restart, and **no manual `group_id` SQL**. A standalone connection with no explicit Connection group behaves as its own *group-of-one* keyed by its install id, so its generated entities are whitelisted and routed under that connection out of the box, and it appears in the chat env picker automatically.
 </Callout>
 
 ### Responses

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -169,6 +169,10 @@ export function buildInternalDbMockDefaults(deps: {
     closeInternalDB: mock(async () => {}),
     migrateInternalDB: mock(async () => {}),
     loadSavedConnections: mock(async () => 0),
+    // #3856 — post-publish datasource hot-register/deregister reconcile. Default
+    // no-op (zero counts) so routes that call it on the success path don't trip
+    // on an undefined export under partial mocks.
+    reconcileWorkspaceDatasources: mock(async () => ({ registered: 0, deregistered: 0 })),
     _resetPool: mock(() => {}),
     _resetCircuitBreaker: mock(() => {}),
     isInternalCircuitOpen: () => false,

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -64,6 +64,27 @@ const mockGetInternalDB = mock(() => ({
   connect: async () => makeMockClient(),
 }));
 
+// #3856 — drives the post-commit `reconcileWorkspaceDatasources` hot-register.
+// Default: zero counts (the common case). Tests reassign it to assert the
+// orgId it's invoked with, or to reject (best-effort: must not 500 a
+// committed publish).
+let reconcileHandler: (
+  orgId: string,
+) => Promise<{ registered: number; deregistered: number }> = async () => ({
+  registered: 0,
+  deregistered: 0,
+});
+const reconcileCalls: string[] = [];
+// Snapshot of the client query log AT THE MOMENT reconcile was invoked — lets
+// a test assert the COMMIT had already landed (reconcile runs post-commit, not
+// before), pinning the ordering the "AFTER commit" test name claims.
+let clientQueriesAtReconcile: string[] = [];
+const mockReconcileWorkspaceDatasources = mock(async (orgId: string) => {
+  reconcileCalls.push(orgId);
+  clientQueriesAtReconcile = clientQueries.map((q) => q.sql.trim().toUpperCase());
+  return reconcileHandler(orgId);
+});
+
 // ── Mocks ──────────────────────────────────────────────────────────────
 
 const mocks = createApiTestMocks({
@@ -77,6 +98,7 @@ const mocks = createApiTestMocks({
   authMode: "managed",
   internal: {
     getInternalDB: mockGetInternalDB,
+    reconcileWorkspaceDatasources: mockReconcileWorkspaceDatasources,
   },
 });
 
@@ -213,6 +235,9 @@ function resetClient(): void {
   demoIndustryFixture = null;
   throwOnGet = null;
   incompleteLayersHandler = async () => [];
+  reconcileCalls.length = 0;
+  clientQueriesAtReconcile = [];
+  reconcileHandler = async () => ({ registered: 0, deregistered: 0 });
 }
 
 afterAll(() => {
@@ -781,6 +806,49 @@ describe("POST /api/v1/admin/publish — atomicity", () => {
     // release() called with no arg means "return to pool" — the client is
     // clean because ROLLBACK succeeded.
     expect(clientReleaseArg).toBeUndefined();
+  });
+});
+
+describe("POST /api/v1/admin/publish — datasource hot-register (#3856)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.mockInternalQuery.mockResolvedValue([]);
+    resetClient();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("reconciles the org's datasources into the live registry AFTER a successful commit", async () => {
+    reconcileHandler = async () => ({ registered: 1, deregistered: 0 });
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(200);
+    // Reconcile fired once, scoped to the publishing org.
+    expect(reconcileCalls).toEqual(["org-alpha"]);
+    // ...and the COMMIT had ALREADY landed when reconcile was invoked — proving
+    // the registry reflects the persisted truth, not an in-flight transaction.
+    expect(clientQueriesAtReconcile.includes("COMMIT")).toBe(true);
+  });
+
+  it("does NOT reconcile when the transaction rolled back (500)", async () => {
+    queryHandler = async (sql) => {
+      if (/^\s*UPDATE/i.test(sql)) throw new Error("simulated UPDATE failure");
+      return { rows: [] };
+    };
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(500);
+    // The reconcile runs only on the post-commit success path.
+    expect(reconcileCalls).toEqual([]);
+  });
+
+  it("still returns 200 when the post-commit reconcile throws (best-effort)", async () => {
+    // The publish already committed; a transient registry failure must not
+    // turn it into a 500 — the next boot's loadSavedConnections reconciles.
+    reconcileHandler = async () => {
+      throw new Error("registry blip");
+    };
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(200);
+    expect(reconcileCalls).toEqual(["org-alpha"]);
   });
 });
 

--- a/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
+++ b/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
@@ -109,6 +109,7 @@ mock.module("@atlas/api/lib/db/internal", () => {
     createInternalDBTestLayer: notUsed,
     migrateInternalDB: async () => {},
     loadSavedConnections: async () => 0,
+    reconcileWorkspaceDatasources: async () => ({ registered: 0, deregistered: 0 }),
     findPatternBySQL: async () => null,
     insertLearnedPattern: () => {},
     insertSemanticAmendment: async () => {},
@@ -308,13 +309,10 @@ describe("GET /api/v1/me/connection-groups — primaryConnectionId surfacing (po
     expect(ids).toEqual(["prod", "staging"]);
   });
 
-  it("does NOT surface a group when every member is archived (config->>'group_id' IS NOT NULL filter)", async () => {
-    // The post-cutover query filters `config->>'group_id' IS NOT NULL`
-    // AND `status != 'archived'`, so the legacy LEFT JOIN behavior of
-    // returning a one-row-with-NULL-connection_id for an empty group is
-    // gone. Archived-only groups disappear from the picker entirely —
-    // which is the right UX (an empty group with no live members can't
-    // route a query anywhere).
+  it("does NOT surface a group when every member is archived (status != 'archived' filter)", async () => {
+    // The query filters `status != 'archived'`, so archived-only groups
+    // disappear from the picker entirely — which is the right UX (an empty
+    // group with no live members can't route a query anywhere).
     fakeAuth = userAuth();
     rowsForOrg["org-1"] = [];
     const res = await meConnectionGroups.request("/", { method: "GET" });
@@ -354,6 +352,55 @@ describe("GET /api/v1/me/connection-groups — primaryConnectionId surfacing (po
     const res = await meConnectionGroups.request("/", { method: "GET" });
     const body = await getJson(res);
     expect(body.groups[0]?.members[0]?.dbType).toBe("unknown");
+  });
+});
+
+describe("GET /api/v1/me/connection-groups — group-of-one standalone datasource (#3856)", () => {
+  it("the SQL-member query no longer filters out group-less installs (uses COALESCE for group-of-one)", async () => {
+    // #3856: a standalone datasource with no explicit config.group_id must
+    // still surface in the picker — keyed under its own install_id (group-of-one,
+    // mirroring resolveGroupIdForConnection's COALESCE(group_id, install_id)).
+    // The prior `config->>'group_id' IS NOT NULL` filter hid such connections.
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [];
+    await meConnectionGroups.request("/", { method: "GET" });
+
+    const memberQuery = capturedQueries.find((q) =>
+      q.includes("install_id           AS connection_id"),
+    );
+    expect(memberQuery).toBeDefined();
+    const normalized = memberQuery!.replace(/\s+/g, " ");
+    // The group key resolves group-of-one via COALESCE — not a NULL filter.
+    expect(normalized).toContain("COALESCE(config->>'group_id', install_id) AS group_id");
+    expect(normalized).not.toContain("config->>'group_id' IS NOT NULL");
+  });
+
+  it("surfaces a group-less standalone datasource as a group-of-one keyed by its install_id", async () => {
+    // Postgres resolves `COALESCE(config->>'group_id', install_id)` to the
+    // install_id for a group-less row; the mock returns the post-COALESCE shape
+    // the real SQL would produce.
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [
+      {
+        group_id: "clickhouse", // = install_id (group-of-one)
+        connection_id: "clickhouse",
+        db_type: "clickhouse",
+        description: "Standalone ClickHouse",
+      },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.groups).toHaveLength(1);
+    expect(body.groups[0]).toMatchObject({ id: "clickhouse", name: "clickhouse" });
+    expect(body.groups[0]?.members).toEqual([
+      {
+        connectionId: "clickhouse",
+        dbType: "clickhouse",
+        description: "Standalone ClickHouse",
+      },
+    ]);
+    expect(body.reason).toBeNull();
   });
 });
 

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -399,6 +399,59 @@ adminPublish.openapi(publishRoute, async (c) =>
       "Publish succeeded",
     );
 
+    // #3856 — hot-register newly-published datasources (and deregister archived
+    // ones) into the live `ConnectionRegistry`, so a standalone datasource is
+    // agent-queryable immediately after publish with NO api restart and no
+    // manual `group_id` SQL. Boot-time `loadSavedConnections` registered the
+    // process's installs once; publish (a pure status flip + archive cascade
+    // above) never touched the registry, so without this the just-published
+    // connection relied on its install-time registration surviving and a
+    // just-archived one kept serving from a stale pool until the next boot.
+    // Run AFTER commit so the registry reflects the persisted truth, and
+    // best-effort: the publish has already committed, so a transient registry
+    // failure must not turn it into a 500 — log and move on (the next boot's
+    // `loadSavedConnections` reconciles). Reconcile is idempotent + symmetric:
+    // the bridge's `has()` guards make a NATIVE re-register a no-op and a
+    // deregister of a never-live row a no-op (a PLUGIN pool — clickhouse /
+    // snowflake / … — is rebuilt in place via `createFromConfig`, still safe in
+    // effect: the live connection is swapped for an equivalent one).
+    //
+    // Lazy-`import` (not a top-level import) so this route's static module
+    // graph doesn't require the export at load time — several admin-route tests
+    // partial-`mock.module("@atlas/api/lib/db/internal")` with a subset of
+    // exports, and a top-level import would break the admin router's load on
+    // any fixture that omits this one symbol. Same posture `loadSavedConnections`
+    // and `workspace-installer.ts` use for the registry bridge.
+    try {
+      const { reconcileWorkspaceDatasources } = await import(
+        "@atlas/api/lib/db/internal"
+      );
+      const reconcile = await reconcileWorkspaceDatasources(orgId);
+      if (reconcile.registered > 0 || reconcile.deregistered > 0) {
+        log.info(
+          {
+            requestId,
+            orgId,
+            registered: reconcile.registered,
+            deregistered: reconcile.deregistered,
+          },
+          "Publish hot-registered datasources into the live ConnectionRegistry",
+        );
+      }
+    } catch (reconcileErr) {
+      log.warn(
+        {
+          requestId,
+          orgId,
+          err:
+            reconcileErr instanceof Error
+              ? reconcileErr.message
+              : String(reconcileErr),
+        },
+        "Publish committed, but reconciling datasources into the ConnectionRegistry failed — newly-published connections may need an api restart until the next boot",
+      );
+    }
+
     // #3682 — surface any DURABLE partial-profile markers for the org. The
     // publish just promoted these layers to `published`; if one was profiled
     // incompletely (tables failed introspection below the abort threshold), it

--- a/packages/api/src/api/routes/me-connection-groups.ts
+++ b/packages/api/src/api/routes/me-connection-groups.ts
@@ -167,7 +167,17 @@ meConnectionGroups.openapi(listRoute, async (c) => {
         db_type: string | null;
         description: string | null;
       }>(
-        `SELECT config->>'group_id' AS group_id,
+        // Group-of-one (#3855 / #3856): a standalone datasource with no explicit
+        // `config.group_id` is its OWN group, keyed by its `install_id` — the
+        // same `COALESCE(config->>'group_id', install_id)` resolution
+        // `resolveGroupIdForConnection` performs on the write side. Before this,
+        // the `config->>'group_id' IS NOT NULL` filter hid every group-less
+        // standalone connection from the env picker, so a freshly-installed
+        // datasource never appeared until the admin manually assigned a group.
+        // Keying the group-less install under its own id makes it a visible
+        // group-of-one with itself as the sole member, so the picker + agent
+        // "just work" with no extra steps.
+        `SELECT COALESCE(config->>'group_id', install_id) AS group_id,
                 install_id           AS connection_id,
                 config->>'db_type'   AS db_type,
                 config->>'description' AS description
@@ -176,8 +186,7 @@ meConnectionGroups.openapi(listRoute, async (c) => {
             AND pillar = 'datasource'
             AND catalog_id <> ALL($2)
             AND status != 'archived'
-            AND config->>'group_id' IS NOT NULL
-          ORDER BY config->>'group_id' ASC, install_id ASC`,
+          ORDER BY COALESCE(config->>'group_id', install_id) ASC, install_id ASC`,
         [orgId, restCatalogIds],
       ),
       // REST datasources — group_id may be NULL (workspace-global) or set

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -15,6 +15,7 @@ import {
   queryEffect,
   migrateInternalDB,
   loadSavedConnections,
+  reconcileWorkspaceDatasources,
   cascadeWorkspaceDelete,
   hardDeleteWorkspace,
   updateWorkspacePlanTier,
@@ -509,6 +510,178 @@ describe("internal DB module", () => {
 
       const count = await loadSavedConnections();
       expect(count).toBe(0);
+    });
+  });
+
+  describe("reconcileWorkspaceDatasources() — hot-register on publish (#3856)", () => {
+    afterEach(() => {
+      connections._reset();
+    });
+
+    it("returns zero counts when DATABASE_URL is not set", async () => {
+      delete process.env.DATABASE_URL;
+      expect(await reconcileWorkspaceDatasources("org-1")).toEqual({
+        registered: 0,
+        deregistered: 0,
+      });
+    });
+
+    it("registers the org's non-archived datasource installs into the live registry", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setResult({
+        rows: [
+          {
+            workspace_id: "org-1",
+            install_id: "warehouse",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://host/wh" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "published",
+          },
+          {
+            workspace_id: "org-1",
+            install_id: "reporting",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://host/rp" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "draft",
+          },
+        ],
+      });
+      _resetPool(pool);
+
+      const result = await reconcileWorkspaceDatasources("org-1");
+      // Both fresh registrations — a draft install registers too (developer
+      // mode previews queries against it before publish).
+      expect(result.registered).toBe(2);
+      expect(result.deregistered).toBe(0);
+      expect(connections.has("warehouse")).toBe(true);
+      expect(connections.has("reporting")).toBe(true);
+    });
+
+    it("deregisters an archived install so it stops serving without a restart", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      // Pre-register the pool as if it went live at install time, then archive
+      // it. The reconcile must evict it — not merely skip it like the boot
+      // loader does.
+      connections.register("legacy", { url: "postgresql://host/legacy" });
+      connections.registerForWorkspace("org-1", "legacy", {
+        url: "postgresql://host/legacy",
+      });
+      expect(connections.has("legacy")).toBe(true);
+
+      pool._setResult({
+        rows: [
+          {
+            workspace_id: "org-1",
+            install_id: "legacy",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://host/legacy" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "archived",
+          },
+        ],
+      });
+      _resetPool(pool);
+
+      const result = await reconcileWorkspaceDatasources("org-1");
+      expect(result.registered).toBe(0);
+      expect(result.deregistered).toBe(1);
+      expect(connections.has("legacy")).toBe(false);
+      expect(connections.hasForWorkspace("org-1", "legacy")).toBe(false);
+    });
+
+    it("is idempotent — re-registering an already-live install reports zero fresh", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setResult({
+        rows: [
+          {
+            workspace_id: "org-1",
+            install_id: "warehouse",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://host/wh" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "published",
+          },
+        ],
+      });
+      _resetPool(pool);
+
+      const first = await reconcileWorkspaceDatasources("org-1");
+      expect(first.registered).toBe(1);
+      // Second pass over the same persisted state: the bridge's has()-guards
+      // make this a no-op (no double-register).
+      const second = await reconcileWorkspaceDatasources("org-1");
+      expect(second.registered).toBe(0);
+      expect(second.deregistered).toBe(0);
+      expect(connections.has("warehouse")).toBe(true);
+    });
+
+    it("skips a single bad install without aborting the reconcile", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setResult({
+        rows: [
+          {
+            workspace_id: "org-1",
+            install_id: "good",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://host/db" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "published",
+          },
+          {
+            workspace_id: "org-1",
+            install_id: "bad",
+            catalog_slug: "postgres",
+            config: { url: "badscheme://host/db" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+            status: "published",
+          },
+        ],
+      });
+      _resetPool(pool);
+
+      const result = await reconcileWorkspaceDatasources("org-1");
+      expect(result.registered).toBe(1);
+      expect(connections.has("good")).toBe(true);
+      expect(connections.has("bad")).toBe(false);
+    });
+
+    it("returns zero counts on the 42P01 table-missing branch (fresh DB, no plugin tables)", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      // Attach the Postgres SQLSTATE so `isPgError` recognizes the
+      // undefined_table case and takes the dedicated warn branch — not the
+      // generic error branch. Both return zero counts, but this pins the
+      // 42P01-specific path the comment promises.
+      const tableMissing = Object.assign(
+        new Error('relation "workspace_plugins" does not exist'),
+        { code: "42P01" },
+      );
+      pool._setError(tableMissing);
+      _resetPool(pool);
+
+      expect(await reconcileWorkspaceDatasources("org-1")).toEqual({
+        registered: 0,
+        deregistered: 0,
+      });
+    });
+
+    it("returns zero counts on a generic query failure (not 42P01)", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      // No `.code` → falls through to the generic error branch.
+      pool._setError(new Error("connection reset by peer"));
+      _resetPool(pool);
+
+      expect(await reconcileWorkspaceDatasources("org-1")).toEqual({
+        registered: 0,
+        deregistered: 0,
+      });
     });
   });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1182,6 +1182,168 @@ export async function loadSavedConnections(): Promise<number> {
   }
 }
 
+/**
+ * Counts of the fresh registry mutations a {@link reconcileWorkspaceDatasources}
+ * pass performed — best-effort observability, not an accounting guarantee
+ * (per-row failures are logged + skipped, so this may undercount the rows seen).
+ */
+export interface ReconcileResult {
+  readonly registered: number;
+  readonly deregistered: number;
+}
+
+/**
+ * Reconcile the live `ConnectionRegistry` against the CURRENTLY-PERSISTED
+ * datasource installs for a single workspace/org — the hot path that retires
+ * the "publish, then restart the API" dance (#3856).
+ *
+ * Boot-time `loadSavedConnections` registers every non-archived install once,
+ * process-wide. But the atomic publish endpoint (`admin-publish.ts`) only flips
+ * `workspace_plugins.status` in SQL — it never touches the in-memory registry.
+ * So a datasource that an admin newly published (draft → published) is live in
+ * the registry ONLY because its install-time registration happened to survive;
+ * and a datasource the publish flow ARCHIVED keeps serving from a stale pool
+ * until the next boot. This function closes both ends: after a publish commits,
+ * the caller reconciles this org's installs so newly-published datasources go
+ * queryable immediately and archived ones stop serving — with no API restart
+ * and no manual `group_id` SQL.
+ *
+ * Symmetric and idempotent:
+ *   - every non-archived install → `registerDatasourceInstall` (idempotent —
+ *     the bridge's `has()` guards make a re-register a no-op; a plugin pool is
+ *     rebuilt in place);
+ *   - every archived install → `unregisterDatasourceInstall` (returns `false`
+ *     when nothing was registered — a no-op for a row that never went live).
+ *
+ * Per-row failures are caught + logged (never abort the loop) so one
+ * misconfigured install can't strand the rest — exactly the boot-loader
+ * posture. Best-effort by contract: the publish has already COMMITTED before
+ * this runs, so a transient registry failure must not fail the publish (the
+ * next boot's `loadSavedConnections` still reconciles).
+ *
+ * @param orgId - Workspace/org whose datasource installs to reconcile.
+ * @returns Counts of fresh registrations + deregistrations performed.
+ */
+export async function reconcileWorkspaceDatasources(
+  orgId: string,
+): Promise<ReconcileResult> {
+  if (!hasInternalDB()) return { registered: 0, deregistered: 0 };
+
+  const { BUILTIN_DATASOURCE_CATALOG_SLUGS } = await import(
+    "@atlas/api/lib/db/datasource-pool-resolver"
+  );
+  const { registerDatasourceInstall, unregisterDatasourceInstall } = await import(
+    "@atlas/api/lib/db/datasource-registry-bridge"
+  );
+  const { decryptSecretFields, parseConfigSchema } =
+    await import("@atlas/api/lib/plugins/secrets");
+
+  try {
+    type WpRow = {
+      workspace_id: string;
+      install_id: string;
+      catalog_slug: string;
+      config: Record<string, unknown> | null;
+      config_schema: unknown;
+      // The content-mode column (enum + CHECK per migration). Only `archived`
+      // is semantically load-bearing here (drives the deregister branch); any
+      // non-archived value (`draft`/`published`) is treated as "should be live".
+      // The union annotation documents the closed domain and guards the
+      // `=== "archived"` literal at compile time — the `internalQuery<T>` cast
+      // is unchecked, so an out-of-domain value falls into the (idempotent)
+      // re-register branch, which fails safe.
+      status: "draft" | "published" | "archived";
+    };
+    // Unlike `loadSavedConnections`, this scopes to ONE workspace and reads
+    // ALL statuses (incl. `archived`) so the archived rows drive the
+    // deregister branch — the reconcile must be able to evict a pool the
+    // publish just archived, not merely skip it.
+    const rows = await internalQuery<WpRow>(
+      `SELECT wp.workspace_id,
+              wp.install_id,
+              pc.slug AS catalog_slug,
+              wp.config,
+              pc.config_schema,
+              wp.status
+         FROM workspace_plugins wp
+         JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+        WHERE wp.workspace_id = $1
+          AND wp.pillar = 'datasource'
+          AND pc.slug = ANY($2::text[])
+        ORDER BY wp.install_id ASC`,
+      [orgId, BUILTIN_DATASOURCE_CATALOG_SLUGS as readonly string[]],
+    );
+
+    let registered = 0;
+    let deregistered = 0;
+    for (const row of rows) {
+      let stage: "parse" | "decrypt" | "bridge" = "parse";
+      try {
+        if (row.status === "archived") {
+          stage = "bridge";
+          // Deregister is config-free — evict the live pool for this
+          // (workspace, install_id) so an archived datasource fails closed
+          // on the next query instead of at boot/TTL.
+          if (unregisterDatasourceInstall(row.workspace_id, row.install_id)) {
+            deregistered++;
+          }
+          continue;
+        }
+        const schema = parseConfigSchema(row.config_schema);
+        stage = "decrypt";
+        const decryptedConfig = decryptSecretFields(row.config ?? {}, schema);
+        stage = "bridge";
+        const didRegister = await registerDatasourceInstall(
+          {
+            workspaceId: row.workspace_id,
+            catalogId: "",
+            installId: row.install_id,
+            pillar: "datasource",
+            catalogSlug: row.catalog_slug,
+          },
+          decryptedConfig,
+        );
+        if (didRegister) registered++;
+      } catch (err) {
+        log.warn(
+          {
+            stage,
+            orgId,
+            workspaceId: row.workspace_id,
+            installId: row.install_id,
+            catalogSlug: row.catalog_slug,
+            status: row.status,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to reconcile datasource install after publish — skipping (next boot will retry)",
+        );
+      }
+    }
+
+    if (registered > 0 || deregistered > 0) {
+      log.info(
+        { orgId, registered, deregistered },
+        "Reconciled workspace datasources into the live ConnectionRegistry after publish",
+      );
+    }
+    return { registered, deregistered };
+  } catch (err) {
+    const sqlstate = isPgError(err) ? err.code : undefined;
+    if (sqlstate === "42P01") {
+      log.warn(
+        { orgId, sqlstate, err: err instanceof Error ? err.message : String(err) },
+        "workspace_plugins / plugin_catalog not present — skipping post-publish datasource reconcile",
+      );
+      return { registered: 0, deregistered: 0 };
+    }
+    log.error(
+      { orgId, sqlstate, err: err instanceof Error ? err.message : String(err) },
+      "Failed to reconcile workspace datasources after publish — registry unchanged until next boot",
+    );
+    return { registered: 0, deregistered: 0 };
+  }
+}
+
 /** Postgres SQLSTATE error shape. `pg` driver attaches `.code` to thrown errors. */
 function isPgError(err: unknown): err is Error & { code: string } {
   return (


### PR DESCRIPTION
## Summary

A standalone datasource is now **agent-queryable immediately after install + publish** — no API restart, no manual `group_id` SQL. This is the umbrella/capstone for the milestone; it closes the two gaps that remained after #3852 / #3854 / #3855 landed.

- **(a) Hot-register on publish.** New `reconcileWorkspaceDatasources(orgId)` in `db/internal.ts` registers every non-archived datasource install for the org and deregisters every archived one (symmetric + idempotent; per-row best-effort, mirrors the boot-loader posture). The atomic publish endpoint (`admin-publish.ts`) calls it **post-commit** (lazy `import` so partial-mock admin-route fixtures don't break module load). Before this, publish only flipped `workspace_plugins.status` in SQL and never touched the live `ConnectionRegistry` — so a just-published datasource relied on its install-time registration surviving and a just-archived one kept serving from a stale pool until the next boot.
- **(b) Group-of-one env picker.** `GET /api/v1/me/connection-groups` now surfaces a group-less standalone datasource as its own group-of-one keyed by `install_id` via `COALESCE(config->>'group_id', install_id)` — mirroring #3855's `resolveGroupIdForConnection`. The previous `config->>'group_id' IS NOT NULL` filter hid every group-less connection from the chat picker until an admin manually assigned a group.
- **(c) Docs.** Developer-mode happy path (install → auto-profile/generate → publish → query) + a note that the manual psql group edits used to unblock staging are no longer needed.

This builds on the now-merged sub-dependencies (#3852 install/update hot-register via the createFromConfig bridge, #3854 `connectionGroupId` honored on write, #3855 group-of-one resolver + whitelist default) and adds only the genuinely-missing publish-time and env-picker pieces.

## Test plan
- [x] `reconcileWorkspaceDatasources` unit tests (`internal.test.ts`): registers non-archived (incl. draft), deregisters archived, idempotent re-pass, skip-bad-row-without-aborting, 42P01 vs generic failure, no-internal-DB short-circuit — asserted against the real `connections` registry.
- [x] `admin-publish.test.ts`: reconcile fires once post-commit (asserts COMMIT had already landed when reconcile ran), does NOT fire on rollback (500), and a reconcile throw still returns 200 (best-effort).
- [x] `me-connection-groups.test.ts`: SQL uses `COALESCE(...)` and no longer filters `IS NOT NULL`; a group-less standalone datasource surfaces as a group-of-one keyed by its install_id.
- [x] `/ci` — lint, type, full `bun run test` (api + 34 other packages), syncpack, and all drift/discipline scripts green.

Closes #3856

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwnKSu16foaTfuaKGRhhc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hot-register datasources on publish and surface standalone datasources as group-of-one
> - Adds `reconcileWorkspaceDatasources` in [`internal.ts`](https://github.com/AtlasDevHQ/atlas/pull/3865/files#diff-529cda9356c35645b01b8c05f4e2bac08aba6126b0369625803abe23644e8034) that syncs a workspace's datasource installs with the live `ConnectionRegistry` after a successful publish, handling both registration of non-archived installs and deregistration of archived ones.
> - The [`adminPublish`](https://github.com/AtlasDevHQ/atlas/pull/3865/files#diff-8729828d2cb91186322d085c5b8f79a3d2b09e94212b23f910795d9925648ba3) route invokes this reconcile in a best-effort `try/catch` after a successful transaction commit; failures are logged at warn level and do not affect the 200 response.
> - The [`meConnectionGroups.list`](https://github.com/AtlasDevHQ/atlas/pull/3865/files#diff-e2369832c8c726ffd111e351e2660250b64879cebeaaa4655a1fcaac16d3da8e) route now uses `COALESCE(config->>'group_id', install_id)` instead of filtering out rows where `group_id IS NULL`, so standalone datasources surface as a group-of-one keyed by `install_id`.
> - Behavioral Change: datasources with no explicit `group_id` that were previously excluded from connection group listings now appear as individual groups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c01735.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->