### PR TITLE
fix(api): GET /admin/connections/:id resolves plugin datasources (#3866)

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -1395,6 +1395,43 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       expect(body.groupName).toBeNull();
     });
 
+    it("#3866 — get-by-id resolves a plugin datasource, not just native pools", async () => {
+      // A published plugin datasource (clickhouse-staging) registers ONLY in the
+      // per-workspace plugin map — present in describeForWorkspace, absent from
+      // the bare `has()`/`describe()`/`list()`. The detail route gated existence
+      // on `connections.has(id)` (core registry), so it 404'd every plugin
+      // datasource → the admin "Edit" dialog could never load its details
+      // ("Failed to load connection details: HTTP 404"). It must gate on the
+      // workspace-scoped describe, mirroring the list (#3844) and /test (#3853)
+      // endpoints; the `visible` set remains the authorization gate.
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "clickhouse-staging" }]);
+        if (sqlIs.detail(sql)) {
+          return Promise.resolve([
+            {
+              config: { url: "encrypted:clickhouse://user:pass@host:8123/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: "clickhouse",
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections/clickhouse-staging"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.id).toBe("clickhouse-staging");
+      // dbType comes from describeForWorkspace meta (the plugin pool), proving the
+      // route resolved the per-workspace registry rather than the bare describe().
+      expect(body.dbType).toBe("clickhouse");
+      expect(body.managed).toBe(true);
+      expect(body.groupId).toBe("clickhouse");
+      expect(body.groupName).toBe("clickhouse");
+    });
+
     it("get-by-id surfaces groupId + groupName when config carries group_id", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -1646,7 +1646,17 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
   const { id } = c.req.valid("param");
 
-  if (!connections.has(id)) {
+  // Existence is workspace-scoped: a published plugin datasource (clickhouse /
+  // elasticsearch / …) registers ONLY in the per-(workspace, install_id) plugin
+  // map, never in the bare `connections.has()` (`entries`). Gating on `has()`
+  // 404'd the detail load for every plugin datasource → the admin Edit dialog
+  // could never open its details ("Failed to load connection details: HTTP 404",
+  // #3866). `describeForWorkspace` unions the bare entries with this workspace's
+  // plugin pools — the correct registry-presence check, mirroring the list
+  // (#3844) and `/test` (#3853) endpoints. The `visible` set below is the
+  // content-mode / org-membership authorization gate.
+  const registeredForWorkspace = connections.describeForWorkspace(orgId);
+  if (!registeredForWorkspace.some((entry) => entry.id === id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
@@ -1656,7 +1666,7 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
-  const meta = connections.describe().find((m) => m.id === id);
+  const meta = registeredForWorkspace.find((entry) => entry.id === id);
 
   // If admin-managed, include masked URL and schema from DB. Post-#2744
   // the row lives in workspace_plugins with the URL inside `config`


### PR DESCRIPTION
## What

`GET /api/v1/admin/connections/:id` (the connection **detail** endpoint) gated existence on the **core** `ConnectionRegistry` (`connections.has(id)`), which never includes per-workspace plugin datasources. So it **404'd every ClickHouse / Elasticsearch / etc. connection** — while the list (#3844), health, and `/test` (#3853) endpoints already resolved them. Net effect: the admin **Connections → Edit** dialog failed to load for any plugin datasource ("Failed to load connection details: HTTP 404"), which also made #3852's PUT-metadata fix unreachable through the UI (the Edit flow can never reach the PUT because the prerequisite GET fails first).

## Fix

Mirror the #3853 fix exactly: gate existence on `connections.describeForWorkspace(orgId)` (the union of bare entries + this workspace's plugin pools) instead of `connections.has(id)`, and source `meta` from that same workspace-scoped describe so `dbType`/`description`/`health` populate for plugin rows. The `getVisibleConnectionIds` check below remains the content-mode / org-membership authorization gate; the `workspace_plugins` detail lookup was already correct — it was just gated out by the early 404.

```diff
- if (!connections.has(id)) { … 404 }
+ const registeredForWorkspace = connections.describeForWorkspace(orgId);
+ if (!registeredForWorkspace.some((e) => e.id === id)) { … 404 }
  …
- const meta = connections.describe().find((m) => m.id === id);
+ const meta = registeredForWorkspace.find((e) => e.id === id);
```

## Test

Regression test `#3866 — get-by-id resolves a plugin datasource, not just native pools` (uses the fixture's `clickhouse-staging` plugin pool — present in `describeForWorkspace`, absent from `has()`). Pre-fix it 404s; post-fix returns 200 with `dbType: "clickhouse"`, `managed: true`, group. 72/72 in the file pass; type + lint clean.

## Provenance

Surfaced by the #3253 clean-slate staging soak (2026-06-22) — verified the 404 live on `app.staging.useatlas.dev` for both `clickhouse` and `elasticsearch`. Same core-registry-vs-per-workspace-plugin family as #3844 / #3853 / #3852.

Closes #3866.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix GET /admin/connections/:id to resolve plugin datasources
> The `GET /:id` handler in [admin-connections.ts](https://github.com/AtlasDevHQ/atlas/pull/3869/files#diff-f6bfef41590fe265b86518b43c7543c707e1f44ae7a3fefd8dce760e01589f1d) previously checked only the core registry (`connections.has(id)` / `connections.describe()`), causing per-workspace plugin datasources to return 404. It now uses `connections.describeForWorkspace(orgId)` to build a workspace-scoped registry, matching the behavior of the list and `/test` routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c1f8e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->