### PR TITLE
chore(plugins): drop baseUrl + ignoreDeprecations from 9 plugin tsconfigs

### DIFF
--- a/plugins/bigquery/tsconfig.json
+++ b/plugins/bigquery/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/clickhouse/tsconfig.json
+++ b/plugins/clickhouse/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/duckdb/tsconfig.json
+++ b/plugins/duckdb/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/elasticsearch/tsconfig.json
+++ b/plugins/elasticsearch/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/mysql/tsconfig.json
+++ b/plugins/mysql/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/obsidian/tsconfig.json
+++ b/plugins/obsidian/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
@@ -9,7 +7,7 @@
     "allowJs": true,
     "strict": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*.ts"]

--- a/plugins/salesforce/tsconfig.json
+++ b/plugins/salesforce/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/snowflake/tsconfig.json
+++ b/plugins/snowflake/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/yaml-context/tsconfig.json
+++ b/plugins/yaml-context/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "baseUrl": "."
+    "rootDir": "."
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary

TypeScript 7.0 (RC) **removes `baseUrl`** (hard error TS5102) and turns the TS6.0 deprecations into hard build errors. Nine plugin tsconfigs leaned on `baseUrl: "."` + `ignoreDeprecations: "6.0"` to stay quiet — both become build breakers under TS7.

- **`baseUrl: "."` removed** from all 9. None of these configs declare `paths`, so `baseUrl` was inert dead config (verified: no `paths` in any plugin tsconfig, nor the root).
- **`ignoreDeprecations: "6.0"` removed** from all 9. For the 8 root-extending plugins (snowflake, clickhouse, yaml-context, bigquery, duckdb, elasticsearch, salesforce, mysql) it was only suppressing the `baseUrl` deprecation, so it goes with `baseUrl`.
- **obsidian** (standalone config) additionally set `moduleResolution: "node"` — the real TS6.0 deprecation its `ignoreDeprecations` was silencing (TS5107). Switched to `bundler`, which matches its `module: ESNext` + esbuild bundle and the root tsconfig's resolution mode. The `obsidian` package has no `exports` map, so `node` and `bundler` resolve it identically — no type-surface change.

Per-plugin so each plugin's build + the root `bun run type` (tsgo) stays green.

## Test plan

- [x] No `baseUrl` / `ignoreDeprecations` remaining in any `plugins/*/tsconfig.json`
- [x] Root `bun run type` (tsgo `--noEmit`) — green
- [x] obsidian `tsc -noEmit -skipLibCheck` build — green
- [x] All 8 root-extending plugin configs free of config-level deprecation errors (TS5102/TS5107) under `tsgo -p`
- [x] Full `/ci` — lint, type, syncpack, all drift/discipline gates green; full test suite green (3 explore/python failures are the known WSL2-local vercel-sandbox false-failures, verified passing with sandbox env unset)

Closes #3871

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `baseUrl` and `ignoreDeprecations` from 9 plugin tsconfigs
> Removes deprecated `baseUrl: "."` and `ignoreDeprecations: "6.0"` compiler options from the `tsconfig.json` of 9 plugins (bigquery, clickhouse, duckdb, elasticsearch, mysql, obsidian, salesforce, snowflake, yaml-context). The obsidian plugin also updates `moduleResolution` from `node` to `bundler`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0722318.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->