### PR TITLE
fix(api): retry transient cold-connect failure on first datasource query (#3867)

### DIFF
--- a/packages/api/src/lib/db/__tests__/cold-connect-retry.test.ts
+++ b/packages/api/src/lib/db/__tests__/cold-connect-retry.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the cold-connect retry on core PostgreSQL / MySQL pools (#3867).
+ *
+ * The first analytical query after the API (re)deploys can transiently fail
+ * while the pool is cold: the first `pool.connect()` / `pool.getConnection()`
+ * rejects with a connection-establishment error, which previously surfaced as a
+ * bare "Query failed." even though an immediate retry succeeded. The acquire
+ * step now retries exactly ONCE on a transient connect failure — but never on a
+ * query-execution error, and a persistent connect failure still throws.
+ *
+ * These tests exercise the two policy primitives directly:
+ *   - `isTransientConnectError` — which acquire failures are retryable.
+ *   - `acquireWithColdConnectRetry` — the at-most-one-retry wrapper that
+ *     `createPostgresDB.query()` / `createMySQLDB.query()` apply to the acquire
+ *     step only.
+ *
+ * Testing the primitives (rather than mocking `pg`/`mysql2`) is deliberate: the
+ * cache-busting `import(...?t=)` needed to bypass the global
+ * `@atlas/api/lib/db/connection` mock registered by `sql.test.ts` also bypasses
+ * `mock.module("pg")`, so a real pg Pool would back any config-registered
+ * connection — the same cache-bust pattern as `tenant-pool.test.ts`, used here
+ * for a different end (its note explains the same mock-bypass). The primitives
+ * are pure/injectable, so they pin the actual retry semantics without that
+ * mock-interaction fragility.
+ */
+import { describe, it, expect } from "bun:test";
+import { resolve } from "path";
+
+// Cache-busting import bypasses sql.test.ts's global connection mock.
+const connModPath = resolve(__dirname, "../connection.ts");
+const connMod = await import(`${connModPath}?t=${Date.now()}`);
+const isTransientConnectError = connMod.isTransientConnectError as (err: unknown) => boolean;
+const acquireWithColdConnectRetry = connMod.acquireWithColdConnectRetry as <T>(
+  acquire: () => Promise<T>,
+  context: { dbType: string; targetHost?: string },
+) => Promise<T>;
+
+function makeError(message: string, code?: string): Error {
+  const err = new Error(message) as Error & { code?: string };
+  if (code) err.code = code;
+  return err;
+}
+
+const PG_CTX = { dbType: "postgres", targetHost: "db.example.com" };
+
+describe("isTransientConnectError (#3867)", () => {
+  it("matches transient Node socket error codes", () => {
+    for (const code of ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "EHOSTUNREACH", "ENETUNREACH", "EPIPE", "EAI_AGAIN"]) {
+      expect(isTransientConnectError(makeError("boom", code))).toBe(true);
+    }
+  });
+
+  it("matches transient mysql2 driver codes", () => {
+    expect(isTransientConnectError(makeError("Connection lost", "PROTOCOL_CONNECTION_LOST"))).toBe(true);
+    expect(isTransientConnectError(makeError("Too many connections", "ER_CON_COUNT_ERROR"))).toBe(true);
+  });
+
+  it("matches connect-timeout messages that carry no stable code", () => {
+    expect(isTransientConnectError(new Error("Connection terminated unexpectedly"))).toBe(true);
+    expect(isTransientConnectError(new Error("Connection terminated due to connection timeout"))).toBe(true);
+    expect(isTransientConnectError(new Error("timeout exceeded when trying to connect"))).toBe(true);
+    expect(isTransientConnectError(new Error("connect ETIMEDOUT"))).toBe(true);
+    expect(isTransientConnectError(new Error("The server closed the connection"))).toBe(true);
+  });
+
+  it("does NOT match query-execution / auth / permission errors", () => {
+    expect(isTransientConnectError(makeError("password authentication failed for user", "28P01"))).toBe(false);
+    expect(isTransientConnectError(makeError('relation "x" does not exist', "42P01"))).toBe(false);
+    expect(isTransientConnectError(makeError("Access denied for user", "ER_ACCESS_DENIED_ERROR"))).toBe(false);
+    expect(isTransientConnectError(makeError("canceling statement due to statement timeout", "57014"))).toBe(false);
+  });
+
+  it("does NOT match non-error / unknown shapes", () => {
+    expect(isTransientConnectError(undefined)).toBe(false);
+    expect(isTransientConnectError(null)).toBe(false);
+    expect(isTransientConnectError("ECONNREFUSED")).toBe(false); // a bare string has no .code and isn't an Error
+    expect(isTransientConnectError({ foo: "bar" })).toBe(false);
+  });
+});
+
+describe("acquireWithColdConnectRetry (#3867)", () => {
+  it("returns immediately when the first acquire succeeds (no retry)", async () => {
+    let calls = 0;
+    const result = await acquireWithColdConnectRetry(async () => {
+      calls++;
+      return "client";
+    }, PG_CTX);
+    expect(result).toBe("client");
+    expect(calls).toBe(1);
+  });
+
+  it("retries once and succeeds after a transient cold-connect failure", async () => {
+    let calls = 0;
+    const result = await acquireWithColdConnectRetry(async () => {
+      calls++;
+      if (calls === 1) throw makeError("connect ECONNREFUSED 10.0.0.1:5432", "ECONNREFUSED");
+      return "client";
+    }, PG_CTX);
+    expect(result).toBe("client");
+    expect(calls).toBe(2); // exactly one retry
+  });
+
+  it("retries on a connect-timeout message that has no code", async () => {
+    let calls = 0;
+    const result = await acquireWithColdConnectRetry(async () => {
+      calls++;
+      if (calls === 1) throw new Error("Connection terminated due to connection timeout");
+      return "client";
+    }, { dbType: "mysql" });
+    expect(result).toBe("client");
+    expect(calls).toBe(2);
+  });
+
+  it("does NOT retry a non-transient acquire failure — re-throws as-is", async () => {
+    let calls = 0;
+    await expect(
+      acquireWithColdConnectRetry(async () => {
+        calls++;
+        throw makeError("password authentication failed for user", "28P01");
+      }, PG_CTX),
+    ).rejects.toThrow("password authentication failed");
+    expect(calls).toBe(1); // no retry
+  });
+
+  it("re-throws when both attempts fail transiently (persistent outage)", async () => {
+    let calls = 0;
+    await expect(
+      acquireWithColdConnectRetry(async () => {
+        calls++;
+        throw makeError("connect ECONNREFUSED", "ECONNREFUSED");
+      }, PG_CTX),
+    ).rejects.toThrow("ECONNREFUSED");
+    expect(calls).toBe(2); // first + single retry, then give up
+  });
+
+  it("surfaces the SECOND failure when the retry fails with a different error", async () => {
+    let calls = 0;
+    await expect(
+      acquireWithColdConnectRetry(async () => {
+        calls++;
+        if (calls === 1) throw makeError("connect ETIMEDOUT", "ETIMEDOUT");
+        throw makeError("password authentication failed", "28P01");
+      }, PG_CTX),
+    ).rejects.toThrow("password authentication failed");
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -17,6 +17,7 @@
 
 import { matchError } from "@useatlas/types";
 import type { AtlasMode } from "@useatlas/types/auth";
+import type { PoolClient as PgPoolClient } from "pg";
 import { Data, Effect, Schedule, Duration, Fiber } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
@@ -212,6 +213,86 @@ export interface ConnectionConfig {
 /** Regex for valid SQL identifiers (used for schema name validation). */
 const VALID_SQL_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+// --- Cold-connect retry (#3867) ---
+//
+// The FIRST analytical query after the API (re)starts can transiently fail
+// while the pool is cold: the very first `pool.connect()` / `pool.getConnection()`
+// races a not-yet-ready socket and rejects with a connection-establishment
+// error (ECONNREFUSED / ETIMEDOUT / a dropped TLS handshake), which surfaced to
+// the user as a bare "Query failed." even though an immediate retry succeeded.
+//
+// We retry the ACQUIRE step exactly once, and ONLY when the failure is a
+// transient connection-establishment error — never a query-execution error
+// (bad SQL, timeout, permission), which must surface as-is. A persistent
+// connect failure is re-thrown after the single retry, so a genuinely
+// unreachable datasource still produces a real error, not a false success.
+
+/** One retry on a cold-connect failure; brief fixed backoff to let the socket settle. */
+const COLD_CONNECT_RETRY_DELAY_MS = 150;
+
+/** Node socket / driver error codes that indicate a transient connection-establishment failure. */
+const TRANSIENT_CONNECT_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EPIPE",
+  "EAI_AGAIN", // transient DNS failure
+  "PROTOCOL_CONNECTION_LOST", // mysql2
+  "ER_CON_COUNT_ERROR", // mysql2 — server momentarily out of connection slots
+]);
+
+/** Substrings of connection-establishment error messages drivers emit without a stable `code`. */
+const TRANSIENT_CONNECT_MESSAGES = [
+  "connection terminated unexpectedly", // pg: socket dropped mid-connect
+  "connection terminated due to connection timeout", // pg connect timeout
+  "timeout exceeded when trying to connect", // pg pool acquire timeout
+  "connect etimedout", // mysql2 connect timeout
+  "the server closed the connection", // generic
+];
+
+/**
+ * Whether an error thrown while ACQUIRING a pooled connection is a transient
+ * connection-establishment failure worth one retry. Matches on the Node error
+ * `code` first (most reliable), then on well-known message substrings for
+ * drivers that don't set a stable code on connect timeouts.
+ *
+ * Deliberately conservative: query-execution failures (syntax, permission,
+ * statement timeout) don't reach this path — it only wraps the acquire step —
+ * but even so we only treat the enumerated transient signals as retryable.
+ */
+export function isTransientConnectError(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  if (typeof code === "string" && TRANSIENT_CONNECT_CODES.has(code)) return true;
+  const message = err instanceof Error ? err.message.toLowerCase() : "";
+  return TRANSIENT_CONNECT_MESSAGES.some((m) => message.includes(m));
+}
+
+/**
+ * Acquire a pooled connection, retrying ONCE on a transient cold-connect
+ * failure. The acquire callback is the only thing retried — the caller runs
+ * the actual query on the returned connection, so a query-execution error is
+ * never retried here. A non-transient acquire failure, or a second transient
+ * failure, propagates unchanged.
+ */
+export async function acquireWithColdConnectRetry<T>(
+  acquire: () => Promise<T>,
+  context: { dbType: DBType; targetHost?: string },
+): Promise<T> {
+  try {
+    return await acquire();
+  } catch (err) {
+    if (!isTransientConnectError(err)) throw err;
+    log.warn(
+      { err: errorMessage(err), dbType: context.dbType, targetHost: context.targetHost },
+      "Transient cold-connect failure acquiring pooled connection — retrying once",
+    );
+    await new Promise((r) => setTimeout(r, COLD_CONNECT_RETRY_DELAY_MS));
+    return acquire();
+  }
+}
+
 function createPostgresDB(config: ConnectionConfig): DBConnection {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Pool } = require("pg");
@@ -254,9 +335,18 @@ function createPostgresDB(config: ConnectionConfig): DBConnection {
   // first queries don't all hit pg_namespace redundantly.
   let schemaCheckPromise: Promise<void> | null = null;
 
+  const pgTargetHost = extractTargetHost(config.url);
+
   return {
     async query(sql: string, timeoutMs = 30000, params?: readonly unknown[]) {
-      const client = await pool.connect();
+      // Acquire with a single cold-connect retry (#3867). Only the connect is
+      // retried — the query below runs once, so a query error never retries.
+      // `pool` is untyped (require("pg")), so annotate the acquire return so the
+      // generic infers the pg client shape instead of `unknown`.
+      const client = await acquireWithColdConnectRetry<PgPoolClient>(
+        () => pool.connect(),
+        { dbType: "postgres", targetHost: pgTargetHost },
+      );
       try {
         // Verify the schema exists (once, shared across concurrent callers).
         // Must run BEFORE setting search_path so no query executes against a
@@ -332,6 +422,17 @@ function createPostgresDB(config: ConnectionConfig): DBConnection {
   };
 }
 
+/**
+ * Minimal structural shape of a mysql2 pooled connection — only the members the
+ * query path uses. `pool.getConnection()` is untyped (require("mysql2/promise")),
+ * so this annotates the cold-connect-retry acquire so the generic infers this
+ * instead of `unknown` (the prior code relied on the require's implicit `any`).
+ */
+interface MySqlPoolConnection {
+  execute(sql: string, values?: unknown[]): Promise<[unknown, unknown]>;
+  release(): void;
+}
+
 function createMySQLDB(config: ConnectionConfig): DBConnection {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mysql = require("mysql2/promise");
@@ -343,9 +444,15 @@ function createMySQLDB(config: ConnectionConfig): DBConnection {
     bigNumberStrings: true,
   });
 
+  const mysqlTargetHost = extractTargetHost(config.url);
+
   return {
     async query(sql: string, timeoutMs = 30000, params?: readonly unknown[]) {
-      const conn = await pool.getConnection();
+      // Acquire with a single cold-connect retry (#3867).
+      const conn = await acquireWithColdConnectRetry<MySqlPoolConnection>(
+        () => pool.getConnection(),
+        { dbType: "mysql", targetHost: mysqlTargetHost },
+      );
       try {
         // Defense-in-depth: read-only session prevents DML even if validation has a bug
         await conn.execute('SET SESSION TRANSACTION READ ONLY');


### PR DESCRIPTION
## Summary

Surfaced by the #3253 multi-engine staging soak: with the env-picker routed to `mysql-staging`, the **first** analytical query after an `api-staging` redeploy returned a bare **"Query failed."** An immediate retry against the same connection succeeded. Root cause = a cold connection pool — the very first `pool.connect()` / `pool.getConnection()` after the API restarts races a not-yet-ready socket and rejects with a connection-establishment error, which surfaced to the user instead of being retried.

This PR ships **(a)** in full and documents **(b)** as a deliberate non-change (it's a product decision).

### (a) Cold-connect retry — implemented

- New `isTransientConnectError(err)` classifies an **acquire-time** failure as transiently retryable: enumerated Node socket / driver codes (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EHOSTUNREACH`, `ENETUNREACH`, `EPIPE`, `EAI_AGAIN`, mysql2 `PROTOCOL_CONNECTION_LOST` / `ER_CON_COUNT_ERROR`) plus a few codeless connect-timeout message substrings.
- New `acquireWithColdConnectRetry<T>(acquire, ctx)` retries the acquire **exactly once** (fixed 150ms backoff), then gives up.
- Wired into `createPostgresDB.query()` (wraps `pool.connect()`) and `createMySQLDB.query()` (wraps `pool.getConnection()`) — the **acquire only**. The query itself runs once, outside the wrapper.

Safety properties (all test-pinned):
- **Query-execution errors are never retried** — bad SQL, auth (`28P01` / `ER_ACCESS_DENIED_ERROR`), missing relation (`42P01`), statement timeout (`57014`) all surface unchanged.
- **A persistent connect failure re-throws** after the single retry — a genuinely unreachable datasource still produces a real error, never a false success.
- Hard-capped at one retry — a deterministic outage costs at most one extra round-trip + 150ms, never a retry storm.
- Error handling follows CLAUDE.md: the one new catch logs (type-narrowed via `errorMessage`, host-only via `extractTargetHost` — no credential/DSN leak) then either retries or re-throws; the re-thrown error flows through the existing `effect/sql.ts` → `runHandler` path to a normal 500-with-requestId.

This benefits every core-pool consumer of the cold path — including org-pool warmup and the periodic health probe — not just the chat query path.

### (b) Agent cross-env fallback when a specific env is selected — documented as a follow-up (product decision)

In the soak, after (a) failed on `mysql-staging` the agent autonomously queried the `clickhouse` connection instead. I traced the routing thoroughly:

- The agent picks the connection by passing `connectionId` directly to `executeSQL` (`sql.ts` `execute`: `connectionId ?? requestContextConnectionId ?? "default"`).
- The env-routing module (`env-routing/index.ts` `resolveRoutingPlan`) only governs **fanout within a single multi-member connection group** (`pin` / `all` / `auto`). It does **not** constrain which standalone connection the agent may target.
- `mysql-staging` and `clickhouse` were **separate connections** (separate groups-of-one), so the routing module's `pin` semantics never applied. The agent emitting `connectionId: "clickhouse"` is **working as the current code intends** — there is no concept of "selecting one connection hard-scopes the whole agent across all connections."

Whether selecting a non-`Auto` env *should* hard-block the agent from ever touching any other connection is a **genuine product/routing decision**, not a bug to fix here: a hard global scope would also block legitimate multi-source semantic-layer lookups/joins the agent is designed to do. Forcing a semantics change speculatively risks regressing that. Per the issue's own framing ("Needs a product/routing decision"), I'm scoping (b) out of this PR and leaving it as a tracked follow-up rather than guessing. No behavior or picker copy changed for (b).

## Test plan

- [x] New `cold-connect-retry.test.ts` (11 tests): success-first (no retry), retry-then-succeed, connect-timeout-message match, non-transient (no retry, re-throw), transient-twice (re-throw persistent outage), second-error-surfaced, query-error-not-retried, and the full transient/non-transient classification matrix incl. non-Error shapes.
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 99/99 pass (incl. the broad SQL/connection/tenant-pool suites).
- [x] `bun run lint` / `bun run type` — clean.
- [x] Full `bun run test` — only the 3 known WSL2 sandbox false-failures (`explore-backend` / `explore-workspace-override` / `python`, from `VERCEL_*`/`ATLAS_SANDBOX_URL` in the dev shell); verified they pass cleanly with those vars unset. Unrelated to this change.
- [x] Drift gates (schema, openapi, template, railway-watch, oauth-helper, settings-readers, saas-env, security-headers, published-symbols, twenty-resolver, test-discipline) — all pass.
- [x] Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy) — CLEAN, no must-fix.

Closes #3867

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient cold-connect failures once on first datasource query
> - Adds `isTransientConnectError` to classify transient connection errors by known Node/mysql2 error codes and message substrings (e.g. connect timeout, connection terminated).
> - Adds `acquireWithColdConnectRetry` that retries a connection acquire callback once after 150ms on transient errors, logging a warning with `dbType` and `targetHost`; non-transient errors are rethrown immediately.
> - Wraps `pool.connect()` (Postgres) and `pool.getConnection()` (MySQL) with this retry helper in [connection.ts](https://github.com/AtlasDevHQ/atlas/pull/3875/files#diff-5eaba92c5b51e2c4bc40c73644391e6c59c62320f39d189f9999981cb472be9f).
> - Behavioral Change: first datasource query now silently retries once on transient connect errors instead of failing immediately; query execution itself is not retried.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3a83c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->