### PR TITLE
feat(api,web): allow multiple datasources per plugin catalog (#3858)

### DIFF
--- a/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/datasource-form-handler.test.ts
@@ -118,10 +118,12 @@ type HandlerCtor = typeof import("../datasource-form-handler").DatasourceFormIns
 type FormErrCtor = typeof import("../email-form-handler").FormInstallValidationError;
 let DatasourceFormInstallHandler!: HandlerCtor;
 let FormInstallValidationError!: FormErrCtor;
+let DATASOURCE_INSTALL_ID_FIELD!: string;
 
 beforeAll(async () => {
-  DatasourceFormInstallHandler = (await import("../datasource-form-handler"))
-    .DatasourceFormInstallHandler;
+  const mod = await import("../datasource-form-handler");
+  DatasourceFormInstallHandler = mod.DatasourceFormInstallHandler;
+  DATASOURCE_INSTALL_ID_FIELD = mod.DATASOURCE_INSTALL_ID_FIELD;
   FormInstallValidationError = (await import("../email-form-handler")).FormInstallValidationError;
 });
 
@@ -143,12 +145,30 @@ function newHandler(
   return new DatasourceFormInstallHandler({ slug, installId, idGenerator });
 }
 
-/** The config blob written by the (single) upsert INSERT, parsed from JSON. */
-function upsertedConfig(): Record<string, unknown> {
+/** The single upsert INSERT capture (throws if none). */
+function upsertInsert(): CapturedQuery {
   const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
   if (!insert) throw new Error("no INSERT captured");
-  const json = insert.params[4] as string;
+  return insert;
+}
+
+/** The config blob written by the (single) upsert INSERT, parsed from JSON. */
+function upsertedConfig(): Record<string, unknown> {
+  const json = upsertInsert().params[4] as string;
   return JSON.parse(json) as Record<string, unknown>;
+}
+
+/** The `install_id` ($4) the upsert INSERT keyed the row on. */
+function upsertedInstallId(): string {
+  return upsertInsert().params[3] as string;
+}
+
+/** The `install_id` ($3) the existing-row restore lookup queried. */
+function restoreLookupInstallId(): string | undefined {
+  const lookup = captured.find(
+    (q) => q.sql.includes("FROM workspace_plugins") && q.sql.includes("SELECT config"),
+  );
+  return lookup?.params[2] as string | undefined;
 }
 
 beforeEach(() => {
@@ -272,6 +292,109 @@ describe("DatasourceFormInstallHandler — ClickHouse persistence + encryption",
     expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:pass@host:8443/analytics");
     // Non-secret description stays plaintext.
     expect(cfg.description).toBe("Prod ClickHouse");
+  });
+});
+
+// ── Multi-instance per catalog (#3858) ───────────────────────────────────────
+// A workspace must be able to hold more than one datasource of the same catalog
+// slug (e.g. an Elasticsearch AND an OpenSearch connection under the unified
+// `elasticsearch` slug). The reserved `__install_id__` meta-field selects/names
+// the connection; omitted → the default (slug) for the first install.
+describe("DatasourceFormInstallHandler — multi-instance install id (#3858)", () => {
+  it("defaults install_id to the slug when no custom id is supplied", async () => {
+    const handler = newHandler("clickhouse", "clickhouse", () => "ch-uuid-1");
+    await handler.validateConfig(WSID, { url: "clickhouse://h:8443/db" });
+    expect(upsertedInstallId()).toBe("clickhouse");
+  });
+
+  it("uses a custom install_id so a second connection of the same catalog coexists", async () => {
+    const handler = newHandler("elasticsearch", "elasticsearch", () => "es-uuid-2");
+    catalogSchemaOverride = {
+      value: [{ key: "url", type: "string", label: "URL", required: true, secret: true }],
+    };
+    const result = await handler.validateConfig(WSID, {
+      [DATASOURCE_INSTALL_ID_FIELD]: "opensearch-logs",
+      url: "https://opensearch:9200",
+    });
+    expect(upsertedInstallId()).toBe("opensearch-logs");
+    // The user-facing record's catalogId is the slug (unchanged); the row keys on
+    // the custom install id so it's a distinct connection from `elasticsearch`.
+    expect(result.installRecord.catalogId).toBe("elasticsearch");
+  });
+
+  it("treats a blank/whitespace custom id as 'not supplied' → defaults to the slug", async () => {
+    const handler = newHandler("clickhouse", "clickhouse", () => "ch-uuid-3");
+    await handler.validateConfig(WSID, {
+      [DATASOURCE_INSTALL_ID_FIELD]: "   ",
+      url: "clickhouse://h:8443/db",
+    });
+    expect(upsertedInstallId()).toBe("clickhouse");
+  });
+
+  it("strips the reserved id field from the persisted config (never a config value)", async () => {
+    const handler = newHandler("clickhouse", "clickhouse", () => "ch-uuid-4");
+    await handler.validateConfig(WSID, {
+      [DATASOURCE_INSTALL_ID_FIELD]: "ch-second",
+      url: "clickhouse://h:8443/db",
+      description: "desc",
+    });
+    const cfg = upsertedConfig();
+    expect(cfg[DATASOURCE_INSTALL_ID_FIELD]).toBeUndefined();
+    expect(cfg.description).toBe("desc");
+  });
+
+  it("restore-on-save keys the existing-row lookup on the resolved (custom) install id", async () => {
+    const storedCipher = encryptSecret("clickhouse://user:secret@old:8443/db");
+    existingInstallRows = [{ config: { url: storedCipher, description: "old" } }];
+    const handler = newHandler("clickhouse", "clickhouse", () => "ch-uuid-5");
+    await handler.validateConfig(WSID, {
+      [DATASOURCE_INSTALL_ID_FIELD]: "ch-cluster-b",
+      url: MASKED_PLACEHOLDER,
+      description: "renamed",
+    });
+    // The restore lookup must query the CUSTOM id — not the slug — so editing the
+    // second connection restores ITS secret, not the first connection's.
+    expect(restoreLookupInstallId()).toBe("ch-cluster-b");
+    const cfg = upsertedConfig();
+    expect(decryptSecret(cfg.url as string)).toBe("clickhouse://user:secret@old:8443/db");
+  });
+
+  it("rejects a non-string custom id with field-level detail (no INSERT)", async () => {
+    const handler = newHandler("clickhouse");
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, {
+        [DATASOURCE_INSTALL_ID_FIELD]: 123,
+        url: "clickhouse://h:8443/db",
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<FormErrCtor>).fieldErrors[DATASOURCE_INSTALL_ID_FIELD]).toBeDefined();
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+
+  it("rejects an id with illegal characters (no INSERT)", async () => {
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, {
+        [DATASOURCE_INSTALL_ID_FIELD]: "bad id/with spaces",
+        url: "clickhouse://h:8443/db",
+      }),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+
+  it("rejects an over-long id (no INSERT)", async () => {
+    const handler = newHandler("clickhouse");
+    await expect(
+      handler.validateConfig(WSID, {
+        [DATASOURCE_INSTALL_ID_FIELD]: "a".repeat(200),
+        url: "clickhouse://h:8443/db",
+      }),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/elasticsearch-form-handler.test.ts
@@ -96,10 +96,13 @@ type HandlerCtor = typeof import("../elasticsearch-form-handler").ElasticsearchF
 type FormErrCtor = typeof import("../email-form-handler").FormInstallValidationError;
 let ElasticsearchFormInstallHandler!: HandlerCtor;
 let FormInstallValidationError!: FormErrCtor;
+let DATASOURCE_INSTALL_ID_FIELD!: string;
 
 beforeAll(async () => {
   ElasticsearchFormInstallHandler = (await import("../elasticsearch-form-handler"))
     .ElasticsearchFormInstallHandler;
+  DATASOURCE_INSTALL_ID_FIELD = (await import("../datasource-form-handler"))
+    .DATASOURCE_INSTALL_ID_FIELD;
   FormInstallValidationError = (await import("../email-form-handler")).FormInstallValidationError;
 });
 
@@ -196,6 +199,10 @@ describe("ElasticsearchFormInstallHandler — persistence + encryption", () => {
     expect(insert).toBeDefined();
     expect(insert!.sql).toContain("'datasource'");
     expect(insert!.sql).toContain("ON CONFLICT (workspace_id, catalog_id, install_id)");
+    // The ES subclass defaults install_id ($4) to its slug for the first install
+    // (#3858) — pins that the production subclass wires `ELASTICSEARCH_INSTALL_ID`
+    // through, not just the generic handler.
+    expect(insert!.params[3]).toBe("elasticsearch");
 
     const cfg = upsertedConfig();
     // Non-secret url stays plaintext (DB ops grep-able).
@@ -204,6 +211,27 @@ describe("ElasticsearchFormInstallHandler — persistence + encryption", () => {
     expect(typeof cfg.apiKey).toBe("string");
     expect((cfg.apiKey as string).startsWith("enc:v1:")).toBe(true);
     expect(decryptSecret(cfg.apiKey as string)).toBe("base64-encoded-api-key");
+  });
+});
+
+// ── Multi-instance: ES + OpenSearch under one slug (#3858) ────────────────────
+// The unified `@useatlas/elasticsearch` plugin serves BOTH engines under slug
+// `elasticsearch`. A custom connection id on the ES form lets a second
+// connection (e.g. an OpenSearch cluster) coexist with the first.
+describe("ElasticsearchFormInstallHandler — multi-instance install id (#3858)", () => {
+  it("routes a custom connection id to the upsert so OpenSearch coexists with Elasticsearch", async () => {
+    const handler = newHandler(() => "es-uuid-2");
+    const result = await handler.validateConfig(
+      WSID,
+      validForm({ [DATASOURCE_INSTALL_ID_FIELD]: "opensearch-logs" }),
+    );
+    const insert = captured.find((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert!.params[3]).toBe("opensearch-logs");
+    // The user-facing record's catalogId stays the slug; the row keys on the
+    // custom install id, so it's a distinct connection from the first install.
+    expect(result.installRecord.catalogId).toBe("elasticsearch");
+    // The reserved meta-field is stripped — never a config value.
+    expect(upsertedConfig()[DATASOURCE_INSTALL_ID_FIELD]).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/integrations/install/datasource-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/datasource-form-handler.ts
@@ -39,11 +39,30 @@
  * misconfigured SaaS deploy fails closed at the credential boundary rather than
  * persisting a credential in plaintext.
  *
- * **Single-instance per workspace.** One install per (workspace, datasource) — a
- * fixed `installId`; re-submitting the form edits the same row. Query wiring for
- * admin-installed plugin datasources lives in the bridge boot path
- * (`loadSavedConnections` → `registerDatasourceInstall`, #3295) — this handler
- * owns install/edit/persist only.
+ * **Multi-instance per workspace (#3858).** A workspace may hold more than one
+ * datasource of the same catalog slug — e.g. an Elasticsearch *and* an OpenSearch
+ * connection (the unified `@useatlas/elasticsearch` plugin serves both under one
+ * slug), or two ClickHouse clusters. Each install gets its own `install_id`,
+ * which is the user-facing connection id keying the connection pool, group, and
+ * semantic scope — exactly how core (postgres/mysql) datasources already work,
+ * and how the OpenAPI datasource handler mints a fresh id per install.
+ *
+ * The form may carry a reserved `install_id` meta-field (see
+ * {@link DATASOURCE_INSTALL_ID_FIELD}) selecting which connection to write:
+ *   - **omitted** → the constructor's default id (conventionally the slug), so
+ *     the first install of a catalog reads `install_id = slug` and the legacy
+ *     single-instance path is unchanged (backward compatible);
+ *   - **present** → that id, letting a second connection of the same catalog
+ *     coexist (and re-submitting with the same id edits THAT connection in place,
+ *     so masked-secret restore-on-save stays keyed to the right row).
+ *
+ * The reserved meta-field is stripped from the config BEFORE the schema-driven
+ * encryption / validation / restore walkers run, so it is never a `config`
+ * column value and never confuses the secret walkers (it is a `workspace_plugins`
+ * column, not catalog config). Query wiring for admin-installed plugin
+ * datasources lives in the bridge boot path (`loadSavedConnections` →
+ * `registerDatasourceInstall`, #3295) — this handler owns install/edit/persist
+ * only.
  *
  * @see ./types.ts — {@link FormBasedInstallHandler}
  * @see ./elasticsearch-form-handler.ts — the #3270 ES specialization
@@ -67,14 +86,47 @@ import type { WorkspaceId } from "@useatlas/types";
 import { FormInstallValidationError } from "./email-form-handler";
 import type { CatalogId, FormBasedInstallHandler, InstallRecord } from "./types";
 
+/**
+ * Reserved form key carrying the per-install connection id (#3858). It is NOT a
+ * catalog `config_schema` field — it selects/names the `workspace_plugins` row,
+ * mirroring a core datasource's connection id. Stripped from the config before
+ * the secret walkers run. Underscore-bracketed so it can never collide with a
+ * real catalog field key (those are plain identifiers like `url` / `apiKey`).
+ *
+ * This is a wire-contract field name: the web install modal sends the same key
+ * (`CONNECTION_ID_FIELD` in `form-install-modal.tsx`). The two literals are
+ * jointly pinned by their drift tests — the API test imports THIS constant; the
+ * web test asserts its mirror equals `"__install_id__"`. Keep them in lockstep.
+ */
+export const DATASOURCE_INSTALL_ID_FIELD = "__install_id__";
+
+/**
+ * Max length for a custom `install_id`. Generous (connection ids are short
+ * labels), and bounded so a pathological paste can't bloat the row key.
+ */
+const INSTALL_ID_MAX = 128;
+
+/**
+ * A custom `install_id` is a connection-id label: non-empty after trimming,
+ * within {@link INSTALL_ID_MAX}, and restricted to URL-safe id characters
+ * (letters, digits, `-`, `_`, `.`). It flows into a connection-pool key, group
+ * name, and semantic scope, so keep it to the same alphabet a path/identifier
+ * would tolerate — rejecting whitespace, slashes, and other delimiters that
+ * would be ambiguous downstream. Mirrors the spirit of core connection ids.
+ */
+const INSTALL_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
 /** Construction parameters — the only per-datasource knobs. */
 export interface DatasourceFormInstallHandlerOptions {
   /** Catalog slug — the dispatch key in `registerFormHandler` + the `plugin_catalog` lookup. */
   readonly slug: CatalogId;
   /**
-   * Stable per-workspace install id. Datasource installs are single-instance for
-   * this slice, so a fixed id makes re-submits edit-in-place (and the
-   * restore-on-save lookup unambiguous). Conventionally the slug itself.
+   * Default per-workspace install id, used when the form omits a custom
+   * {@link DATASOURCE_INSTALL_ID_FIELD}. Conventionally the slug itself, so the
+   * first install of a catalog keeps the legacy `install_id = slug` row and
+   * re-submitting without a custom id edits it in place (#3858 backward compat).
+   * A form-supplied id overrides this per call, enabling multiple datasources of
+   * the same catalog in one workspace.
    */
   readonly installId: string;
   /** Test-only injection of the install-row id generator. */
@@ -94,13 +146,14 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
   readonly kind = "form" as const;
 
   protected readonly slug: CatalogId;
-  protected readonly installId: string;
+  /** Default install id (the slug) used when the form omits a custom one. */
+  protected readonly defaultInstallId: string;
   private readonly newId: () => string;
   private readonly log: ReturnType<typeof createLogger>;
 
   constructor(options: DatasourceFormInstallHandlerOptions) {
     this.slug = options.slug;
-    this.installId = options.installId;
+    this.defaultInstallId = options.installId;
     this.newId = options.idGenerator ?? (() => crypto.randomUUID());
     // Per-slug logger so install lines stay attributable per datasource type.
     this.log = createLogger(`integrations.install.${options.slug}`);
@@ -120,7 +173,16 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
         formErrors: ["Request body must be a JSON object of config fields."],
       });
     }
-    const incoming = formData as Record<string, unknown>;
+    const rawForm = formData as Record<string, unknown>;
+
+    // ── 1b. Resolve + strip the per-install connection id (#3858) ────
+    // The reserved `__install_id__` meta-field selects/names the connection
+    // (defaulting to the slug for the first install). It is NOT a catalog config
+    // field, so strip it before the schema-driven walkers run — leaving it in
+    // `incoming` would persist it as a `config` value and (under a corrupt
+    // schema) be encrypted as if it were a credential.
+    const installId = resolveInstallId(rawForm[DATASOURCE_INSTALL_ID_FIELD], this.defaultInstallId);
+    const { [DATASOURCE_INSTALL_ID_FIELD]: _droppedInstallId, ...incoming } = rawForm;
 
     // ── 2. Load the catalog row (id + live config_schema) ───────────
     // The schema is the source of truth for which fields are secret / required
@@ -191,6 +253,7 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
     const existingDecrypted = await this.loadExistingDecryptedConfig(
       workspaceId,
       catalogId,
+      installId,
       schema,
     );
     const restored = restoreMaskedSecrets(incoming, existingDecrypted, schema);
@@ -234,7 +297,7 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
                enabled = true,
                updated_at = NOW()
          RETURNING id`,
-        [candidateId, workspaceId, catalogId, this.installId, JSON.stringify(encryptedConfig)],
+        [candidateId, workspaceId, catalogId, installId, JSON.stringify(encryptedConfig)],
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
@@ -260,7 +323,7 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
     }
 
     this.log.info(
-      { workspaceId, installId: persistedId, credentialWritten },
+      { workspaceId, installId, rowId: persistedId, credentialWritten },
       "Datasource install completed",
     );
     return {
@@ -278,6 +341,7 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
   private async loadExistingDecryptedConfig(
     workspaceId: WorkspaceId,
     catalogId: string,
+    installId: string,
     schema: ConfigSchema,
   ): Promise<Record<string, unknown>> {
     const rows = await internalQuery<ExistingInstallRow>(
@@ -285,11 +349,51 @@ export class DatasourceFormInstallHandler implements FormBasedInstallHandler {
          FROM workspace_plugins
         WHERE workspace_id = $1 AND catalog_id = $2 AND install_id = $3
         LIMIT 1`,
-      [workspaceId, catalogId, this.installId],
+      [workspaceId, catalogId, installId],
     );
     if (rows.length === 0) return {};
     return decryptSecretFields(rows[0].config ?? {}, schema);
   }
+}
+
+/**
+ * Resolve the connection id for this install from the reserved form value,
+ * falling back to `defaultId` (the slug) when omitted. A supplied id is trimmed
+ * and validated against {@link INSTALL_ID_PATTERN} — an invalid one is a 400 with
+ * field-level detail (it becomes a connection-pool key / group / semantic scope,
+ * so it must be a clean identifier), never silently coerced.
+ */
+function resolveInstallId(raw: unknown, defaultId: string): string {
+  if (raw === undefined || raw === null) return defaultId;
+  if (typeof raw !== "string") {
+    throw new FormInstallValidationError({
+      fieldErrors: { [DATASOURCE_INSTALL_ID_FIELD]: ["Connection id must be a string."] },
+      formErrors: [],
+    });
+  }
+  const trimmed = raw.trim();
+  // An empty/whitespace-only value is treated as "not supplied" → default id, so
+  // a blank optional field in the form still installs the first connection.
+  if (trimmed.length === 0) return defaultId;
+  if (trimmed.length > INSTALL_ID_MAX) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [DATASOURCE_INSTALL_ID_FIELD]: [`Connection id must be ${INSTALL_ID_MAX} characters or fewer.`],
+      },
+      formErrors: [],
+    });
+  }
+  if (!INSTALL_ID_PATTERN.test(trimmed)) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [DATASOURCE_INSTALL_ID_FIELD]: [
+          "Connection id may contain only letters, digits, dots, dashes, and underscores.",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+  return trimmed;
 }
 
 /** Keys of every `secret: true` field in a parsed schema. */

--- a/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/elasticsearch-form-handler.ts
@@ -7,11 +7,18 @@
  * As of #3300 this is a thin specialization of the reusable
  * {@link DatasourceFormInstallHandler}: the generic handler carries the entire
  * behavior (config_schema-driven encryption, mask-on-read / restore-on-save,
- * SaaS keyset gate, corrupt-schema fail-close, single-instance upsert) and ES
- * supplies only its slug + install id. ClickHouse / Snowflake / BigQuery
+ * SaaS keyset gate, corrupt-schema fail-close, multi-instance upsert) and ES
+ * supplies only its slug + default install id. ClickHouse / Snowflake / BigQuery
  * register the same generic handler with their own slug — so a change to the
  * install behavior lands in one place, and ES's path stays identical (pinned by
  * `__tests__/elasticsearch-form-handler.test.ts`).
+ *
+ * Multi-instance (#3858): the unified `@useatlas/elasticsearch` plugin serves
+ * BOTH Elasticsearch and OpenSearch under this one slug, so a workspace must be
+ * able to install both at once. The form carries a reserved
+ * {@link DATASOURCE_INSTALL_ID_FIELD} connection id; when omitted, the first
+ * install reads `install_id = elasticsearch` ({@link ELASTICSEARCH_INSTALL_ID})
+ * and a second supplies its own (e.g. `opensearch-logs`).
  *
  * @see ./datasource-form-handler.ts — {@link DatasourceFormInstallHandler}
  * @see ./types.ts — {@link FormBasedInstallHandler}
@@ -26,10 +33,10 @@ export const ELASTICSEARCH_SLUG: CatalogId = "elasticsearch";
 /** Catalog FK — the canonical `catalog:<slug>` id seeded in `plugin_catalog`. */
 export const ELASTICSEARCH_CATALOG_ID = "catalog:elasticsearch";
 /**
- * Stable per-workspace install id — ES is single-instance for this slice, so a
- * fixed id makes re-submits edit-in-place (and the restore-on-save lookup
- * unambiguous). Multi-instance support rides along with the query-wiring slice
- * (#3295).
+ * Default per-workspace install id — used when the install form omits a custom
+ * connection id, so the FIRST Elasticsearch/OpenSearch connection reads
+ * `install_id = elasticsearch` and re-submits without a custom id edit it in
+ * place. A second connection of this catalog supplies its own id (#3858).
  */
 export const ELASTICSEARCH_INSTALL_ID = "elasticsearch";
 

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -177,9 +177,11 @@ export function registerBuiltinInstallHandlers(): void {
   // form-installable on SaaS now that the runtime connect path is uniform across
   // plugin datasources (#3297/#3299 adapter registration + the `createFromConfig`
   // bridge; #3295 query-path wiring). Each registers the generic
-  // `DatasourceFormInstallHandler` pinned to its slug — single-instance per
-  // workspace (install_id = slug), config_schema-driven (reads the catalog row
-  // live so the `secret: true` field(s) — ClickHouse/Snowflake `url`, BigQuery
+  // `DatasourceFormInstallHandler` pinned to its slug — multi-instance per
+  // workspace (#3858): the slug is the DEFAULT install_id (first connection), and
+  // a form-supplied connection id lets a second cluster of the same catalog
+  // coexist. The handler is config_schema-driven (reads the catalog row live so
+  // the `secret: true` field(s) — ClickHouse/Snowflake `url`, BigQuery
   // `service_account_json` — encrypt at rest with no per-type branch). No env
   // gate: the customer admin supplies credentials at install, same as every other
   // form handler. `loadSavedConnections` boot-registers the persisted

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -1446,6 +1446,10 @@ export default function ConnectionsPage() {
           name={formInstallCandidate.name}
           description={formInstallCandidate.description}
           configSchema={formInstallCandidate.configSchema}
+          // Surface the connection-name field so a workspace can install more
+          // than one datasource of the same catalog (#3858) — e.g. an
+          // Elasticsearch and an OpenSearch cluster under the unified slug.
+          showConnectionId
           onInstalled={handleFormInstallInstalled}
         />
       ) : null}

--- a/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
+++ b/packages/web/src/app/admin/integrations/__tests__/form-install-modal.test.ts
@@ -16,6 +16,8 @@ import {
   buildDefaultValues,
   buildSubmitPayload,
   isFieldVisible,
+  assembleInstallFields,
+  CONNECTION_ID_FIELD,
   type FormFieldDescriptor,
 } from "../form-install-modal";
 
@@ -126,6 +128,65 @@ describe("isFieldVisible", () => {
     expect(isFieldVisible(username, { authMode: "apiKey" })).toBe(false);
     expect(isFieldVisible(username, { authMode: "none" })).toBe(false);
     expect(isFieldVisible(username, {})).toBe(false);
+  });
+});
+
+// The connection-id field the datasource picker prepends (#3858). Mirrors the
+// `CONNECTION_ID_DESCRIPTOR` the modal injects when `showConnectionId` is set:
+// an optional, non-secret string riding the reserved key.
+const CONNECTION_ID_DESCRIPTOR: FormFieldDescriptor = {
+  key: CONNECTION_ID_FIELD,
+  type: "string",
+  label: "Connection name",
+  required: false,
+  secret: false,
+};
+
+describe("connection-id field (#3858 — multiple datasources per catalog)", () => {
+  test("the reserved key is underscore-bracketed so it can't collide with a catalog field", () => {
+    expect(CONNECTION_ID_FIELD).toBe("__install_id__");
+  });
+
+  test("is optional — a form with only a blank connection id passes validation", () => {
+    const schema = buildZodSchema([CONNECTION_ID_DESCRIPTOR, { key: "url", type: "string", required: true }]);
+    // Blank connection id + a filled url is valid (defaults to the slug server-side).
+    expect(schema.safeParse({ [CONNECTION_ID_FIELD]: "", url: "clickhouse://h:8443/db" }).success).toBe(true);
+  });
+
+  test("a blank connection id is dropped from the submit payload (server defaults to the slug)", () => {
+    const fields = [CONNECTION_ID_DESCRIPTOR, { key: "url", type: "string", required: true } as FormFieldDescriptor];
+    expect(buildSubmitPayload(fields, { [CONNECTION_ID_FIELD]: "", url: "clickhouse://h:8443/db" })).toEqual({
+      url: "clickhouse://h:8443/db",
+    });
+  });
+
+  test("a supplied connection id rides the reserved key into the submit payload", () => {
+    const fields = [CONNECTION_ID_DESCRIPTOR, { key: "url", type: "string", required: true } as FormFieldDescriptor];
+    expect(
+      buildSubmitPayload(fields, { [CONNECTION_ID_FIELD]: "opensearch-logs", url: "https://os:9200" }),
+    ).toEqual({ [CONNECTION_ID_FIELD]: "opensearch-logs", url: "https://os:9200" });
+  });
+});
+
+describe("assembleInstallFields — datasource vs chat/action gating (#3858)", () => {
+  const CATALOG = [
+    { key: "url", type: "string", required: true },
+    { key: "token", type: "string", secret: true },
+  ];
+
+  test("prepends the connection-id field for datasource installs (showConnectionId=true)", () => {
+    const fields = assembleInstallFields(CATALOG, true);
+    expect(fields[0].key).toBe(CONNECTION_ID_FIELD);
+    expect(fields.map((f) => f.key)).toEqual([CONNECTION_ID_FIELD, "url", "token"]);
+  });
+
+  test("chat/action installs (showConnectionId=false) never include the reserved field", () => {
+    const fields = assembleInstallFields(CATALOG, false);
+    expect(fields.map((f) => f.key)).toEqual(["url", "token"]);
+    // Non-regression: a single-instance chat/action submit can never emit the
+    // reserved key, so the server never sees a stray __install_id__ to validate.
+    const payload = buildSubmitPayload(fields, { url: "https://h", token: "t" });
+    expect(payload[CONNECTION_ID_FIELD]).toBeUndefined();
   });
 });
 

--- a/packages/web/src/app/admin/integrations/form-install-modal.tsx
+++ b/packages/web/src/app/admin/integrations/form-install-modal.tsx
@@ -305,6 +305,20 @@ export function buildSubmitPayload(
   return out;
 }
 
+/**
+ * Reserved form key carrying the per-install connection id (#3858). Mirrors the
+ * server-side `DATASOURCE_INSTALL_ID_FIELD`: it selects/names the
+ * `workspace_plugins` row rather than being a catalog `config_schema` field, so a
+ * workspace can hold more than one datasource of the same catalog (e.g. an
+ * Elasticsearch and an OpenSearch connection under the unified `elasticsearch`
+ * slug). Underscore-bracketed so it never collides with a real catalog field key.
+ *
+ * Wire contract: this literal must equal the API's `DATASOURCE_INSTALL_ID_FIELD`.
+ * The two are jointly pinned by drift tests (this side asserts the literal; the
+ * API side imports the real constant) — keep them in lockstep.
+ */
+export const CONNECTION_ID_FIELD = "__install_id__";
+
 export interface FormInstallModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -315,8 +329,55 @@ export interface FormInstallModalProps {
   description?: string | null;
   /** The catalog row's `configSchema` JSONB — drives the rendered fields. */
   configSchema: unknown;
+  /**
+   * When true, surface an optional "Connection name" field whose value is sent as
+   * {@link CONNECTION_ID_FIELD} — the per-install connection id (#3858). Set by
+   * the datasource picker (`/admin/connections`) so a workspace can install
+   * multiple datasources of the same catalog; omitted for chat/action installs
+   * (those are single-instance per workspace, so no id field). Leaving it blank
+   * installs the first connection under the catalog slug.
+   */
+  showConnectionId?: boolean;
   /** Fired after a successful install so the parent can refetch the catalog list. */
   onInstalled: () => void;
+}
+
+/**
+ * The synthetic "Connection name" descriptor prepended to a datasource install
+ * form (#3858). Optional + non-secret; its value rides the reserved
+ * {@link CONNECTION_ID_FIELD} key, which the server reads as the per-install
+ * connection id (default = catalog slug when blank).
+ */
+const CONNECTION_ID_DESCRIPTOR: FormFieldDescriptor = {
+  key: CONNECTION_ID_FIELD,
+  type: "string",
+  label: "Connection name",
+  description:
+    "A unique id for this connection (letters, digits, dots, dashes, underscores). " +
+    "Leave blank for your first connection of this type; set a distinct name to add another " +
+    "(e.g. an Elasticsearch and an OpenSearch cluster side by side).",
+  required: false,
+  secret: false,
+};
+
+/**
+ * Assemble the rendered field list: the parsed catalog `configSchema`, with the
+ * connection-id field prepended only for datasource installs (#3858) so a
+ * workspace can hold multiple datasources of the same catalog. The reserved
+ * field rides the same generic machinery (zod schema, defaults, submit payload)
+ * as every catalog field, so it reaches the server exactly like the others.
+ * Chat/action installs (`showConnectionId = false`) get the parsed fields
+ * unchanged — they stay single-instance and never emit the reserved key.
+ *
+ * Exported as a pure function so both branches are unit-testable without
+ * rendering the modal.
+ */
+export function assembleInstallFields(
+  configSchema: unknown,
+  showConnectionId: boolean,
+): FormFieldDescriptor[] {
+  const parsed = parseConfigSchema(configSchema);
+  return showConnectionId ? [CONNECTION_ID_DESCRIPTOR, ...parsed] : parsed;
 }
 
 /**
@@ -333,9 +394,13 @@ export function FormInstallModal({
   name,
   description,
   configSchema,
+  showConnectionId = false,
   onInstalled,
 }: FormInstallModalProps) {
-  const fields = useMemo(() => parseConfigSchema(configSchema), [configSchema]);
+  const fields = useMemo(
+    () => assembleInstallFields(configSchema, showConnectionId),
+    [configSchema, showConnectionId],
+  );
   const schema = useMemo(() => buildZodSchema(fields), [fields]);
   const defaultValues = useMemo(() => buildDefaultValues(fields), [fields]);
   const [saving, setSaving] = useState(false);


### PR DESCRIPTION
## Summary

A workspace could hold only **one** datasource per plugin catalog slug, because plugin datasource form-installs hardwired `install_id = slug`. The unified `@useatlas/elasticsearch` plugin serves **both** Elasticsearch and OpenSearch under slug `elasticsearch`, so the two could not coexist in one workspace (nor two ClickHouse clusters, etc.). Core (postgres/mysql) datasources already supported a custom connection id; this lifts the same capability to plugin datasources.

- **`DatasourceFormInstallHandler` → multi-instance.** A reserved `__install_id__` form meta-field selects/names the connection. Omitted/blank → the constructor's default (the slug), so the **first** install of a catalog keeps `install_id = slug` and the legacy single-instance path is unchanged. A custom id lets a second connection of the same catalog coexist; re-submitting with the same id edits that connection in place (restore-on-save stays keyed to the right row).
- **Fail-closed id validation.** `resolveInstallId()` validates a custom id (charset `[A-Za-z0-9._-]`, length ≤128, must be a string) — it becomes a connection-pool key / group name / semantic scope, so a bad value is a 400 with field-level detail, never silently coerced.
- **Meta-field stripped before the secret walkers** so it is never a `config` column value (and never encrypted as a phantom credential under a corrupt schema). The id flows only into the `(workspace_id, catalog_id, install_id)` upsert + the restore-on-save lookup.
- **Web:** the `/admin/connections` datasource picker's `FormInstallModal` surfaces an optional **"Connection name"** field (sent as `__install_id__`). Chat/action installs (`showConnectionId` unset) stay single-instance and never emit the reserved key.

Each instance gets its own connection + group + semantic scope and is independently queryable by the agent — keyed on its distinct `install_id`, exactly how the existing single-instance install already wires up at boot via `loadSavedConnections → registerDatasourceInstall` (#3295). No migration needed.

The reserved key is a small cross-package wire contract (`DATASOURCE_INSTALL_ID_FIELD` in API, `CONNECTION_ID_FIELD` in web) duplicated as twin literals jointly pinned by drift tests — deliberately not hoisted to `@useatlas/types` to avoid the value-export publish-ordering dance for one string.

## Review

- `/review-panel` (4 specialists): no must-fix. Addressed all actionable findings in-branch — bidirectional wire-contract cross-reference + joint-test note, ES-subclass default/custom-id assertions (the headline OpenSearch-under-`elasticsearch` case), a `showConnectionId=false` chat/action non-regression test, and three doc nits.
- `/ci`: lint, type, syncpack, all drift checks (template/schema/openapi/security-headers/railway-watch/oauth-helper/twenty-resolver/settings-readers/saas-env-doc), test-discipline, published-symbols — all pass. Full test suite green except the 5 documented WSL2/dev-shell environmental false-failures (explore/python under VERCEL_* + mcp smoke under DATABASE_URL), verified green with those env vars unset.

## Test plan

- [x] Custom `__install_id__` → row keyed on the custom id; second connection of the same catalog coexists
- [x] Omitted/blank id → defaults to the slug (backward compatible)
- [x] Reserved field stripped from the persisted `config`
- [x] Restore-on-save keys the existing-row lookup on the resolved id
- [x] Invalid id (non-string / illegal chars / over-long) → 400, no INSERT
- [x] ES subclass defaults to `elasticsearch` and routes a custom id (OpenSearch-under-`elasticsearch`)
- [x] Web: connection-id field prepended only for datasource installs; chat/action never emit the reserved key

## ⚠️ Staging cleanup (operational, post-deploy)

Per the issue, staging (`app.staging.useatlas.dev`, org `d0lhxGmKEfhqbCbd4N5NIuTO5JHHtCaP`) was hand-patched to complete the #3253 soak — `workspace_plugins.config.group_id` for `clickhouse` / `elasticsearch` was set **directly in Postgres** via psql to work around these bugs. Those manual psql edits should be removed once this lands and the real install path is exercised on a fresh datasource. (Not part of this code change — no staging files are touched here.)

Closes #3858

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow multiple datasource connections per plugin catalog entry
> - Adds a reserved `__install_id__` field to datasource form submissions so users can name additional connections for the same catalog plugin; when omitted or blank, the slug is used as the default.
> - The API's [`DatasourceFormInstallHandler`](https://github.com/AtlasDevHQ/atlas/pull/3876/files#diff-617add5fa1a47dae9f997661966549b7c163aeedcda21d2b2a21a7fc1beec078) resolves the connection id via a new `resolveInstallId()` function, keys both the existing-row lookup and the upsert on it, and strips the reserved field before persisting config.
> - The web [`FormInstallModal`](https://github.com/AtlasDevHQ/atlas/pull/3876/files#diff-71a274e58472a04fa107950e54515a3b81d21a5531b8e5c29ce2244db39d3d32) gains a `showConnectionId` prop; when true, a 'Connection name' input is prepended to the form via the new `assembleInstallFields` utility.
> - The [Connections page](https://github.com/AtlasDevHQ/atlas/pull/3876/files#diff-70a04c750aa8ff5d89851336c17ee36607804a9688a285c59f78d412ec788e78) passes `showConnectionId` to the modal for datasource form installs.
> - Risk: invalid connection ids (non-string, illegal characters, or over 128 chars) now return a 400 with field-level errors rather than falling through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cbcb62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->