### PR TITLE
fix(api): resolve group-of-one datasource in chat env-ownership gate (#3879)

### DIFF
--- a/packages/api/src/lib/__tests__/conversations-group-routing.test.ts
+++ b/packages/api/src/lib/__tests__/conversations-group-routing.test.ts
@@ -23,7 +23,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
 import { withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
-import { resolveGroupForConnection } from "@atlas/api/lib/conversations";
+import { resolveGroupForConnection, verifyGroupBelongsToOrg } from "@atlas/api/lib/conversations";
 
 // ── Mock internal pool ────────────────────────────────────────────────
 
@@ -277,5 +277,72 @@ describe("missing group falls back to legacy behavior", () => {
     // The caller's null orgId is forwarded as a SQL NULL so the
     // null-safe operator can match against workspace_plugins.workspace_id IS NULL.
     expect(params).toEqual(["conn-1", null]);
+  });
+});
+
+// ── 4. #3879 — group-of-one verify gate ───────────────────────────────
+
+describe("verifyGroupBelongsToOrg resolves a group-of-one by install_id (#3879)", () => {
+  it("returns no_db when the internal DB is not configured", async () => {
+    const result = await verifyGroupBelongsToOrg("opensearch", "org-1");
+    expect(result).toBe("no_db");
+    // Short-circuits before any query.
+    expect(queryCalls.length).toBe(0);
+  });
+
+  it("uses COALESCE(config->>'group_id', install_id) so a group-less install verifies by its own id", async () => {
+    // The bug: the picker (`/me/connection-groups`) and the write-side
+    // resolvers surface a standalone, group-less datasource as a
+    // group-of-one keyed by its `install_id` via
+    // `COALESCE(config->>'group_id', install_id)` (#3855). This gate
+    // matched only the bare `config->>'group_id' = $1`, so pinning a
+    // freshly-installed group-less datasource 400'd with "environment
+    // not available" — the row had a NULL `config.group_id`, so no row
+    // matched its install_id.
+    //
+    // Mock-theater caveat (see the #2415 test above): the mock returns
+    // whatever rows we hand it regardless of WHERE semantics, so the
+    // behavioral "ok" only proves the caller maps a non-empty result to
+    // "ok". The real regression signal is the SQL string — the COALESCE
+    // form is what makes an install_id-keyed group-of-one resolvable, and
+    // it must stay in lockstep with the picker's identical resolution
+    // (locked by `me-connection-groups.test.ts`). Real-Postgres COALESCE
+    // semantics are standard SQL and exercised by the picker path.
+    enableInternalDB();
+    setResults({ rows: [{ install_id: "opensearch" }] });
+
+    const result = await verifyGroupBelongsToOrg("opensearch", "org-1");
+    expect(result).toBe("ok");
+
+    expect(queryCalls.length).toBe(1);
+    const { sql, params } = queryCalls[0];
+    // Must resolve the group id the same way the picker does.
+    expect(sql).toContain("COALESCE(config->>'group_id', install_id) = $1");
+    // The pre-#3879 bare-equality form is forbidden — it can't match a
+    // group-less install keyed by its install_id.
+    expect(sql).not.toMatch(/WHERE\s+config->>'group_id'\s*=\s*\$1/);
+    // Still scoped to datasource installs in the caller's workspace (or
+    // the shared `__global__` bucket), null-safe on the workspace id.
+    expect(sql).toContain("pillar = 'datasource'");
+    expect(sql).toContain("IS NOT DISTINCT FROM");
+    expect(params).toEqual(["opensearch", "org-1"]);
+  });
+
+  it("returns not_found when no install resolves to the pinned group id", async () => {
+    enableInternalDB();
+    setResults({ rows: [] });
+
+    const result = await verifyGroupBelongsToOrg("ghost-env", "org-1");
+    expect(result).toBe("not_found");
+  });
+
+  it("returns error (caller fails closed → 500) when the query throws", async () => {
+    enableInternalDB();
+    queryThrow = new Error("connection refused");
+
+    const result = await verifyGroupBelongsToOrg("opensearch", "org-1");
+    // Fails closed: the chat route maps "error" to a retryable 500 rather
+    // than silently treating an unverifiable group as owned.
+    expect(result).toBe("error");
   });
 });

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -438,12 +438,25 @@ export async function verifyGroupBelongsToOrg(
   try {
     // Post-0096 cutover (#2744 / ADR-0007 pure-collapse): there is no
     // `connection_groups` row — a group is implicit, defined by any
-    // datasource install whose `config->>'group_id'` matches. The group
-    // "belongs to" the caller's org if at least one such install lives
-    // in the caller's workspace (or `__global__`).
+    // datasource install whose group id matches. The group "belongs to"
+    // the caller's org if at least one such install lives in the caller's
+    // workspace (or `__global__`).
+    //
+    // #3879 — the group id is resolved as `COALESCE(config->>'group_id',
+    // install_id)`, NOT the bare `config->>'group_id'`. A standalone
+    // datasource with no explicit `config.group_id` is its OWN group-of-one
+    // keyed by its `install_id` (#3855), which is exactly how the env-picker
+    // (`/me/connection-groups`) and the write-side resolvers
+    // (`resolveGroupIdForConnection` / `inlineConnectionGroupSql`) surface it.
+    // Matching only the bare `config->>'group_id'` here made this gate
+    // disagree with the picker: a freshly-installed group-less datasource
+    // appeared in the picker keyed by its install_id, but pinning it 400'd
+    // with "environment not available" because no row had
+    // `config->>'group_id' = <install_id>`. The COALESCE keeps the gate in
+    // lockstep with the canonical group-of-one resolution.
     const rows = await internalQuery<{ install_id: string }>(
       `SELECT install_id FROM workspace_plugins
-        WHERE config->>'group_id' = $1
+        WHERE COALESCE(config->>'group_id', install_id) = $1
           AND pillar = 'datasource'
           AND (workspace_id IS NOT DISTINCT FROM $2 OR workspace_id = '__global__')
         LIMIT 1`,


### PR DESCRIPTION
## Problem

During the 2026-06-22 soak (#3253), a freshly-installed `opensearch` plugin datasource was offered by the chat env-picker and listed in `GET /me/connection-groups`, but pinning it and asking a question returned **"The requested environment is not available in this workspace."** (#3879). The pre-existing `elasticsearch` datasource (same `@useatlas/elasticsearch` plugin) routed fine in the same session.

## Root cause

A group-id resolution mismatch between the env-picker and the chat pre-flight gate — **not** the hot-registration gap suspected in the issue, and **not** the degraded-health confound (health does not gate routability at any layer).

- The picker (`/me/connection-groups`) and the write-side resolvers (`resolveGroupIdForConnection`, `inlineConnectionGroupSql`) surface a standalone datasource with no explicit `config.group_id` as a **group-of-one keyed by its `install_id`**, via `COALESCE(config->>'group_id', install_id)` (#3855).
- `verifyGroupBelongsToOrg` (the gate at `chat.ts` that 400s a pinned `connectionGroupId` before the agent runs) matched only the **bare** `config->>'group_id' = $1`, with no `install_id` fallback.

So a freshly-installed group-less datasource showed up in the picker keyed by its install_id (`opensearch`), but pinning it found no row with `config.group_id = 'opensearch'` → `not_found` → "environment not available". A datasource installed with an explicit group (or seeded that way at boot, like the working `elasticsearch`) was unaffected.

The agent-time routing path (`loadGroupRoutingContext` / `resolveGroupForConnection`) already keys off `install_id` and handles group-of-one correctly, so the gate was the only gap. `#3844` (now closed) only touched read surfaces (admin list, `/health`, probe) — it never touched this gate.

## Fix

Wrap the gate's predicate in `COALESCE(config->>'group_id', install_id) = $1` so it resolves a group id exactly the way the picker and the write-side resolvers do. One-line predicate change, keeping the existing `pillar = 'datasource'` + null-safe workspace scope.

## Tests

Adds a `verifyGroupBelongsToOrg` regression block to `conversations-group-routing.test.ts`:
- **locks the `COALESCE(config->>'group_id', install_id) = $1` invariant** and forbids the pre-#3879 bare-equality form (the real signal — the mock pool returns rows regardless of WHERE semantics, so this is what keeps the gate in lockstep with the picker, whose identical COALESCE is locked by `me-connection-groups.test.ts`);
- `ok` / `not_found` / `no_db` / `error` behavior.

`bun run scripts/test-isolated.ts --affected` → 27 files pass. Type-check + lint clean.

## Verification (staging)

Full end-to-end re-verification (install a plugin datasource at runtime → publish → pin → query, no api restart) is gated on this landing + api-staging redeploying. The related staging-infra blockers from the same soak — #3878 (OpenSearch resource starvation) and #3880 (idle serverless DBs) — have been fixed on the staging Railway env so the e2e check runs against a healthy, awake cluster.

Closes #3879


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `verifyGroupBelongsToOrg` to resolve group-of-one datasources by `install_id`
> A datasource install with a `NULL` `config.group_id` represents a group-of-one, but the previous SQL predicate (`config->>'group_id' = $1`) would never match, causing the chat env-ownership gate to return `not_found`. The fix changes the predicate in [conversations.ts](https://github.com/AtlasDevHQ/atlas/pull/3881/files#diff-f3cbd5076fa7c219178637bc610bac045e1d9fc9c213a3d31c70bed7ac75673b) to `COALESCE(config->>'group_id', install_id) = $1`, so installs without an explicit group ID fall back to matching on `install_id`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a7328c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->