### PR TITLE
fix(plugins): force Accept-Encoding: identity on Elasticsearch/OpenSearch client (#3878)

### DIFF
--- a/plugins/elasticsearch/__tests__/elasticsearch.test.ts
+++ b/plugins/elasticsearch/__tests__/elasticsearch.test.ts
@@ -416,6 +416,9 @@ describe("createElasticsearchClient", () => {
     const headers = capturedInit?.headers as Record<string, string>;
     expect(headers?.Authorization).toBe(`ApiKey ${API_KEY}`);
     expect(headers?.Accept).toBe("application/json");
+    // #3878: force uncompressed responses so the cluster never negotiates zstd,
+    // which a low-heap OpenSearch (NoDirectBuffers allocator) cannot encode.
+    expect(headers?.["Accept-Encoding"]).toBe("identity");
   });
 
   test("ping issues NO Authorization header for an explicit no-auth (authMode:'none') config", async () => {

--- a/plugins/elasticsearch/src/connection.ts
+++ b/plugins/elasticsearch/src/connection.ts
@@ -979,7 +979,20 @@ export function createElasticsearchClient(
    * is added only for a non-empty body so GETs stay unsigned-content clean.
    */
   function buildHeaders(method: string, url: string, body: string): Record<string, string> {
-    const headers: Record<string, string> = { Accept: "application/json" };
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      // Force an uncompressed response. The runtime (undici / bun `fetch`)
+      // otherwise advertises `Accept-Encoding: gzip, deflate, br, zstd`.
+      // OpenSearch 2.19 honors zstd, but a memory-constrained cluster runs
+      // Netty's `NoDirectBuffers` allocator, whose `ZstdEncoder` cannot
+      // allocate a direct buffer — the response encode throws, the channel is
+      // closed, and the request hangs until the client times out (#3878).
+      // `identity` sidesteps the whole compression path (and the gzip/br
+      // encoders, which can hit the same allocator) and avoids the
+      // manual-`Accept-Encoding` auto-decompression pitfall. Query results are
+      // small, so the uncompressed-wire cost is negligible.
+      "Accept-Encoding": "identity",
+    };
     if (body.length > 0) headers["Content-Type"] = "application/json";
     switch (auth.mode) {
       case "none":


### PR DESCRIPTION
## What

Force `Accept-Encoding: identity` on every request the `@useatlas/elasticsearch` connection client makes, so the cluster never negotiates compressed HTTP responses.

Closes #3878.

## Why

On the staging soak, the `opensearch` datasource was persistently **Degraded @ 5001ms** (the health-check timeout ceiling) while Elasticsearch was fine at 224ms. Railway deploy logs showed the OpenSearch process was healthy (JobSweeper + hourly cron succeeding) — the failure was on the HTTP **response** path:

```
Caused by: java.lang.UnsupportedOperationException: Direct buffers not supported
    at org.opensearch.transport.NettyAllocator$NoDirectBuffers.directBuffer(...)
    at io.netty.handler.codec.compression.ZstdEncoder.handlerAdded(...)
→ io.netty.handler.codec.EncoderException: java.nio.channels.ClosedChannelException
```

Mechanism:
1. The runtime (undici / bun `fetch`) advertises `Accept-Encoding: gzip, deflate, br, zstd` by default.
2. OpenSearch 2.19 **honors zstd** and installs a `ZstdEncoder` for the response.
3. A memory-constrained cluster (no `OPENSEARCH_JAVA_OPTS` heap override → small default heap) runs Netty's **`NoDirectBuffers`** allocator.
4. `ZstdEncoder` needs a direct buffer → throws → the channel is closed → no response is ever sent → the client hangs to its timeout → **Degraded**.

Elasticsearch was unaffected because it didn't serve zstd here.

## Fix

`buildHeaders` is the single chokepoint every request (`ping`, `sqlQuery`, cursor close, DSL) routes through. Adding `Accept-Encoding: identity` there sidesteps the entire compression path — not just zstd, but the gzip/br encoders that can hit the same allocator — and avoids the undici manual-`Accept-Encoding` auto-decompression pitfall. Query results are small, so the uncompressed-wire cost is negligible. The header is added before SigV4 signing and is not in the signed header set, so AWS OpenSearch Service auth is unaffected.

This is a **portable** fix: it also protects self-hosted OpenSearch users on constrained instances, not just staging.

## Test

Extended the existing `ping` header-assertion test to assert `Accept-Encoding: identity`. `bun test plugins/elasticsearch/__tests__/elasticsearch.test.ts` → 172 pass.

## Notes

- A complementary infra mitigation (give staging OpenSearch a real heap, or `http.compression: false`) is optional belt-and-suspenders; this client fix is the root cause for any consumer.
- Found during the 2026-06-22 post-fix datasource re-soak (#3253). The other two soak findings split off: #3884 closed (correct SaaS isolation, not a bug), #3883 (dev-mode chat empty-state gating) parked pending a customer-tenant re-soak.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force `Accept-Encoding: identity` on Elasticsearch/OpenSearch client requests
> Adds `Accept-Encoding: identity` as a default header in [`buildHeaders`](https://github.com/AtlasDevHQ/atlas/pull/3885/files#diff-07e117a44212996626572c41b57fe76dc7b358401f195eb28e82a29eda729a3a) so the Elasticsearch/OpenSearch client always requests uncompressed responses. This prevents servers from negotiating compressed encodings (e.g. zstd) that the client may not handle correctly. A corresponding test assertion is added in [`elasticsearch.test.ts`](https://github.com/AtlasDevHQ/atlas/pull/3885/files#diff-8feff706c825dde8c76bd9520adadc361ee6d9508444e88b8b10ec13477c5203).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db63d3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->