### PR TITLE
fix(web): gate dev-mode chat empty state on zero connections, not zero drafts (#3883)

### DIFF
--- a/packages/web/src/ui/__tests__/developer-chat-empty-state.test.tsx
+++ b/packages/web/src/ui/__tests__/developer-chat-empty-state.test.tsx
@@ -1,22 +1,24 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
-import { DeveloperChatEmptyState } from "../components/chat/developer-empty-state";
+import {
+  DeveloperChatEmptyState,
+  shouldShowDevChatEmpty,
+  type ShouldShowDevChatEmptyArgs,
+} from "../components/chat/developer-empty-state";
 
 describe("DeveloperChatEmptyState", () => {
   afterEach(() => {
     cleanup();
   });
 
-  test("renders the dev-mode message and admin connections CTA", () => {
+  test("renders the no-connections message and admin connections CTA", () => {
     const { getByText, getByRole, getByTestId } = render(
       <DeveloperChatEmptyState />,
     );
     expect(getByTestId("developer-chat-empty-state")).toBeTruthy();
+    expect(getByText("No connections configured.")).toBeTruthy();
     expect(
-      getByText("No connection configured in developer mode."),
-    ).toBeTruthy();
-    expect(
-      getByText("Connect a database in the admin panel to start testing."),
+      getByText("Connect a database in the admin panel to start querying."),
     ).toBeTruthy();
 
     const link = getByRole("link", { name: /Go to connections/ });
@@ -28,5 +30,70 @@ describe("DeveloperChatEmptyState", () => {
     // Restyles within the amber family are fine — we only care that the
     // developer-mode visual signal is present.
     expect(getByTestId("developer-chat-empty-state").innerHTML).toContain("amber");
+  });
+});
+
+describe("shouldShowDevChatEmpty", () => {
+  // A loaded env-groups query with one published SQL connection (the staging
+  // repro: 5 published connections, 0 drafts). The old draft-count gate fired
+  // here; the new gate must NOT. Group members are irrelevant to the gate (only
+  // list length matters), so a bare `{}` stands in for a connection group.
+  const loadedWithConnection: ShouldShowDevChatEmptyArgs = {
+    mode: "developer",
+    hasLoaded: true,
+    error: null,
+    reason: null,
+    groups: [{}],
+    restDatasources: [],
+  };
+
+  const loadedEmpty: ShouldShowDevChatEmptyArgs = {
+    ...loadedWithConnection,
+    groups: [],
+    restDatasources: [],
+  };
+
+  test("does NOT show the empty state when a published connection is visible (the #3883 bug)", () => {
+    expect(shouldShowDevChatEmpty(loadedWithConnection)).toBe(false);
+  });
+
+  test("does NOT show the empty state when only a REST datasource is visible", () => {
+    expect(
+      shouldShowDevChatEmpty({ ...loadedEmpty, restDatasources: [{}] }),
+    ).toBe(false);
+  });
+
+  test("shows the empty state in developer mode with zero connections", () => {
+    expect(shouldShowDevChatEmpty(loadedEmpty)).toBe(true);
+  });
+
+  test("never shows outside developer mode, even with zero connections", () => {
+    expect(shouldShowDevChatEmpty({ ...loadedEmpty, mode: "published" })).toBe(
+      false,
+    );
+  });
+
+  test("waits for the env-groups fetch to settle (no flash before load)", () => {
+    expect(shouldShowDevChatEmpty({ ...loadedEmpty, hasLoaded: false })).toBe(
+      false,
+    );
+  });
+
+  test("does not hard-block chat on a transport error", () => {
+    expect(shouldShowDevChatEmpty({ ...loadedEmpty, error: "HTTP 503" })).toBe(
+      false,
+    );
+  });
+
+  test("does not hard-block on a degraded reason (legacy no-internal-DB deploy is still queryable)", () => {
+    expect(
+      shouldShowDevChatEmpty({ ...loadedEmpty, reason: "no_internal_db" }),
+    ).toBe(false);
+  });
+
+  test("does not hard-block during an org-switch race (no_active_org)", () => {
+    expect(
+      shouldShowDevChatEmpty({ ...loadedEmpty, reason: "no_active_org" }),
+    ).toBe(false);
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -23,7 +23,10 @@ import { ToolPart } from "./chat/tool-part";
 import { Markdown } from "./chat/markdown";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
-import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
+import {
+  DeveloperChatEmptyState,
+  shouldShowDevChatEmpty,
+} from "./chat/developer-empty-state";
 import {
   ChatEnvPicker,
   shouldRenderEnvPicker,
@@ -33,7 +36,7 @@ import {
   type ConversationRoutingMode,
   type EnvSelectionProvenance,
 } from "./chat/env-picker";
-import { useDevModeNoDrafts } from "../hooks/use-dev-mode-no-drafts";
+import { useMode } from "@/ui/hooks/use-mode";
 import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
@@ -145,10 +148,7 @@ export function AtlasChat({
   emptyStateOverride,
 }: AtlasChatProps = {}) {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasConfig();
-  // In developer mode the chat talks to draft connections. If the admin
-  // hasn't drafted one yet, surface a dedicated empty state instead of
-  // letting the agent fail with a confusing "no datasource" error.
-  const showDevChatEmpty = useDevModeNoDrafts(["connections"]);
+  const { mode } = useMode();
   // #3081 — the host "connect data" gate engages only when BOTH a zero-table
   // workspace is signalled AND the host supplied a node to show. Without an
   // override we'd render `undefined` into the empty slot AND still hide the
@@ -360,6 +360,16 @@ export function AtlasChat({
     error: envGroupsQuery.error,
     restDatasources: envGroupsQuery.restDatasources,
   });
+
+  // #3883 — in developer mode, show the "no connections" empty state only when
+  // the workspace has *zero* connections the chat can reach (SQL groups + REST
+  // datasources), NOT when there are merely zero drafts. Dev mode resolves
+  // published + draft connections, and this env-groups query already reflects
+  // that superset — so keying off it (the same list `shouldRenderEnvPicker`
+  // above consumes) stops a fully-published workspace from being wrongly
+  // blocked. The previous `useDevModeNoDrafts(["connections"])` gate fired on
+  // draft-count and showed a misleading "No connection configured" prompt.
+  const showDevChatEmpty = shouldShowDevChatEmpty({ mode, ...envGroupsQuery });
 
   // Seed / restore the env-picker selection on a fresh chat. #3064 — the
   // decision is centralized in `resolveEnvSelection`: it waits until groups,

--- a/packages/web/src/ui/components/chat/developer-empty-state.tsx
+++ b/packages/web/src/ui/components/chat/developer-empty-state.tsx
@@ -3,12 +3,72 @@
 import Link from "next/link";
 import { Database, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { AtlasMode, MeConnectionGroupsEmptyReason } from "@/ui/lib/types";
 
 /**
- * Shown in the chat surface when an admin is in developer mode but has no
- * draft connections. Without this, sending a message would let the agent
- * run against nothing and surface a confusing error — instead we redirect
- * them to the admin connections page where they can draft one.
+ * Inputs to {@link shouldShowDevChatEmpty}. The connection fields are named to
+ * match `UseChatEnvGroupsResult` (env-picker) so the caller can forward its
+ * already-loaded env-groups query verbatim (`{ mode, ...envGroupsQuery }`) —
+ * the gate keys off the *same* connection list the env picker renders, with no
+ * hand-assembled remap to drift. Mirrors `ShouldRenderEnvPickerArgs`'s
+ * structural-slice convention (arrays typed as `ReadonlyArray<unknown>` — only
+ * their length matters here).
+ */
+export interface ShouldShowDevChatEmptyArgs {
+  /** Current content mode. The dev-chat empty state is developer-mode only. */
+  readonly mode: AtlasMode;
+  /** True once the env-groups fetch has settled at least once (#3078). */
+  readonly hasLoaded: boolean;
+  /** Transport error from the env-groups fetch, if any. */
+  readonly error: string | null;
+  /**
+   * Server-reported reason the env-groups list is empty (`no_internal_db` /
+   * `no_active_org`), or `null` when the list is genuinely (un)populated.
+   */
+  readonly reason: MeConnectionGroupsEmptyReason | null;
+  /** SQL connection groups visible to the user. */
+  readonly groups: ReadonlyArray<unknown>;
+  /** REST/OpenAPI datasources visible to the user. */
+  readonly restDatasources: ReadonlyArray<unknown>;
+}
+
+/**
+ * Whether the chat should show the "no connections" empty state.
+ *
+ * #3883 — gate on **zero connections visible in developer mode** (SQL groups +
+ * REST datasources), NOT draft-count. Developer mode resolves published + draft
+ * connections (`isConnectionVisibleInMode` → published + draft), and
+ * `/api/v1/me/connection-groups` already lists exactly that superset
+ * (`status != 'archived'`), so an empty list is the true "nothing to query"
+ * signal. The previous gate — `useDevModeNoDrafts(["connections"])` — fired on
+ * zero *drafts*, which wrongly blocked a workspace whose connections are all
+ * published-and-live (the soak-found bug). `useDevModeNoDrafts` stays correct
+ * for the admin *editing* surfaces (semantic / prompts), which preview drafts.
+ *
+ * Guards, in order:
+ * - Developer mode only (published mode is out of scope for this gate).
+ * - Wait for `hasLoaded` so the empty state never flashes before the list
+ *   settles.
+ * - Never on a transport error — a flaky `/me/connection-groups` fetch must not
+ *   hard-block chat; let the user try rather than stranding them.
+ * - Never on a degraded `reason` (`no_internal_db` / `no_active_org`) — a legacy
+ *   single-connection (no internal DB) deploy is still queryable and an
+ *   org-switch race resolves shortly; neither is "zero connections".
+ */
+export function shouldShowDevChatEmpty(args: ShouldShowDevChatEmptyArgs): boolean {
+  if (args.mode !== "developer") return false;
+  if (!args.hasLoaded) return false;
+  if (args.error) return false;
+  if (args.reason !== null) return false;
+  return args.groups.length === 0 && args.restDatasources.length === 0;
+}
+
+/**
+ * Shown in the chat surface when an admin is in developer mode and the
+ * workspace has *no connections at all* (neither published nor draft — see
+ * {@link shouldShowDevChatEmpty}). Without this, sending a message would let the
+ * agent run against nothing and surface a confusing error — instead we redirect
+ * them to the admin connections page where they can connect one.
  */
 export function DeveloperChatEmptyState() {
   return (
@@ -23,10 +83,10 @@ export function DeveloperChatEmptyState() {
           aria-hidden="true"
         />
         <p className="mt-3 text-sm font-medium text-foreground">
-          No connection configured in developer mode.
+          No connections configured.
         </p>
         <p className="mt-1 text-xs text-muted-foreground">
-          Connect a database in the admin panel to start testing.
+          Connect a database in the admin panel to start querying.
         </p>
         <div className="mt-4">
           <Button asChild size="sm" variant="default">


### PR DESCRIPTION
## Summary

In **developer mode**, the chat showed the **"No connection configured"** empty state (replacing the starter prompts) whenever there were **zero *draft* connections** — even when published connections were live and queryable. The resolver and the UI gate disagreed:

- **Resolver:** `isConnectionVisibleInMode(org, conn, "developer")` resolves **published + draft** (`packages/api/src/lib/db/connection.ts`), so the backend *would* answer a dev-mode chat against a published connection.
- **UI gate (the bug):** `showDevChatEmpty = useDevModeNoDrafts(["connections"])` fired on `draftCounts.connections === 0` — drafts-only. A fully-published workspace (e.g. all 5 staging connections published, 0 drafts) was blocked.

This implements the decision recorded on the issue (option **b**): gate dev-mode chat on **"zero connections visible in dev mode" (published + draft)**, not draft-count.

### Changes
- **New pure predicate `shouldShowDevChatEmpty()`** (`developer-empty-state.tsx`) keyed on the env-groups list being empty — the *same* list the env picker renders (`/api/v1/me/connection-groups`, which lists `status != 'archived'` = published + draft). Mirrors the sibling `shouldRenderEnvPicker` structural-slice convention, so the call site forwards the query verbatim: `shouldShowDevChatEmpty({ mode, ...envGroupsQuery })` — no hand-assembled remap to drift.
- **Guards degrade open:** never block on a transport error, nor on a degraded `reason` (`no_internal_db` legacy single-connection deploy / `no_active_org` org-switch race) — neither is "zero connections".
- **`useDevModeNoDrafts` left intact** for the admin *editing* surfaces (semantic / prompts), which correctly preview drafts.
- **Reworded the empty state** to "No connections configured." so the copy is accurate only when there are genuinely none.

### Note on the issue's "Send disabled" framing
On current `main` the composer (`Input` + `Send`) is **not** gated by `showDevChatEmpty` — only the empty-thread *placeholder* is (the composer is hidden solely by the separate `showDataSetupGate`). So the live regression this fixes is the **misleading "No connection configured" panel on the empty thread**, not a hard-disabled Send button (the staging screenshot in the issue was an older build). The end-to-end "send a query and get rows" path is a browser-e2e concern, not a unit one; the staging soak already exercised it manually.

## Test plan
- [x] New unit tests for `shouldShowDevChatEmpty` cover every guard branch: published-connection-visible → **no** empty state (the #3883 repro), REST-only → no empty state, zero connections → empty state, non-developer mode, not-yet-loaded, transport error, and both degraded reasons.
- [x] Reworded copy assertions updated.
- [x] `/ci`: lint, type, full test suite (exit 0, 0 fails — all 34 packages), syncpack, and all 13 drift checks green.
- [x] Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy): zero must-fix; adopted the type-design structural-slice simplification.

Closes #3883

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate developer-mode chat empty state on zero connections instead of zero drafts
> - Replaces the draft-count-based gate in [`AtlasChat`](https://github.com/AtlasDevHQ/atlas/pull/3888/files#diff-b6582432113490fa5122d8f7fbda273402df59cdb934dad37324ace1208b7413) with a new `shouldShowDevChatEmpty` function that checks whether the env-groups query has loaded, has no transport error or degraded reason, and has no SQL groups or REST datasources.
> - Updates copy in [`DeveloperChatEmptyState`](https://github.com/AtlasDevHQ/atlas/pull/3888/files#diff-0a85a7a9fc9feb7d6a4ea76eda2122293467fb4f1dee746acc8cf0d238cb4626): headline becomes 'No connections configured.' and subtext becomes 'Connect a database in the admin panel to start querying.'
> - Adds unit tests covering all gate conditions (visible SQL groups, REST datasources, non-developer mode, pre-load, transport error, degraded reasons).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 038f7d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->