### PR TITLE
refactor(email): one sender seam so per-workspace BYO email resolves consistently (#3889)

### DIFF
--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -211,6 +211,14 @@ const mockSendEmailWithTransport: Mock<(...args: unknown[]) => Promise<DeliveryR
 mock.module("@atlas/api/lib/email/delivery", () => ({
   sendEmail: mockSendEmail,
   sendEmailWithTransport: mockSendEmailWithTransport,
+  // The baseline brand sender reuses this seam constant (#3889) — keep the
+  // mock's value in lockstep with the real default so the baseline assertion
+  // holds.
+  DEFAULT_FROM_ADDRESS: "Atlas <noreply@ship.useatlas.dev>",
+  // The smtp/ses save-time gate reads the bridge URL through this seam (#3889);
+  // model the real resolver's env tier so the gate tests that toggle
+  // process.env.ATLAS_SMTP_URL still drive it.
+  resolveSmtpBridgeUrl: () => process.env.ATLAS_SMTP_URL,
   // Pulled transitively via the agent tool registry (email-tool imports
   // resolveOutboundClampRegion from this module). null → no staging clamp;
   // this route test exercises provider config, not the outbound clamp.

--- a/packages/api/src/api/__tests__/admin-integrations-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-audit.test.ts
@@ -425,6 +425,107 @@ describe("POST /api/v1/admin/integrations/email/test — audit emission (F-29 re
     if (prevSmtpUrl !== undefined) process.env.ATLAS_SMTP_URL = prevSmtpUrl;
   });
 
+  it("routes the test-send through the canonical delivery seam — sends from the install sender_address (#3889)", async () => {
+    // The admin test-send builds the SAME EmailTransport prod resolves and sends
+    // via deliverViaTransport, so the From on the wire is the install's own
+    // sender_address (test path == prod path), not a parallel test-only sender.
+    // A distinctive sender_address (not the default-install value) ensures the
+    // assertion can't be satisfied by a coincidental fallback.
+    mockGetEmailInstallationByOrg.mockImplementationOnce(async () => ({
+      org_id: "org-alpha",
+      installed_at: new Date().toISOString(),
+      config_id: "cfg-byo",
+      provider: "resend" as const,
+      sender_address: "Acme BYO <byo@acme.test>",
+      config: { provider: "resend" as const, apiKey: "re_byo" },
+    }));
+    let capturedFrom: unknown;
+    mockFetch.mockImplementation((_url, init) => {
+      const body = init?.body ? (JSON.parse(String(init.body)) as { from?: unknown }) : {};
+      capturedFrom = body.from;
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/integrations/email/test", {
+        recipientEmail: "dest@test.com",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedFrom).toBe("Acme BYO <byo@acme.test>");
+  });
+
+  it("test-send for a non-resend provider hits the canonical per-provider sender (#3889)", async () => {
+    // The consolidation's payoff: sendgrid/postmark/smtp/ses test-sends now route
+    // through deliverViaTransport's single per-provider senders too, not a
+    // parallel copy. A sendgrid install must hit api.sendgrid.com with its own
+    // sender_address.
+    mockGetEmailInstallationByOrg.mockImplementationOnce(async () => ({
+      org_id: "org-alpha",
+      installed_at: new Date().toISOString(),
+      config_id: "cfg-sg",
+      provider: "sendgrid" as const,
+      sender_address: "sg@acme.test",
+      config: { provider: "sendgrid" as const, apiKey: "SG.byo_key" },
+    }));
+    let capturedUrl: string | undefined;
+    let capturedFrom: unknown;
+    mockFetch.mockImplementation((url, init) => {
+      capturedUrl = String(url);
+      const body = init?.body ? (JSON.parse(String(init.body)) as { from?: { email?: unknown } }) : {};
+      capturedFrom = body.from?.email;
+      return Promise.resolve(
+        new Response(JSON.stringify({}), { status: 202, headers: { "Content-Type": "application/json" } }),
+      );
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/integrations/email/test", {
+        recipientEmail: "dest@test.com",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedUrl).toContain("api.sendgrid.com");
+    expect(capturedFrom).toBe("sg@acme.test");
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ platform: "email", provider: "sendgrid", success: true });
+  });
+
+  it("test-send retries a transient 503 — proves it uses the canonical deliverResend, not a parallel sender (#3889)", async () => {
+    // The removed parallel sender used a plain `fetch` with no retry; the
+    // canonical `deliverResend` retries 5xx via `fetchWithRetry`. A 503-then-200
+    // sequence that ultimately succeeds can only happen on the canonical path.
+    let calls = 0;
+    mockFetch.mockImplementation(() => {
+      calls++;
+      const status = calls === 1 ? 503 : 200;
+      return Promise.resolve(
+        new Response(JSON.stringify(status === 200 ? { id: "ok" } : "busy"), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/integrations/email/test", {
+        recipientEmail: "dest@test.com",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(calls).toBe(2);
+  });
+
   it("does not emit when no email configuration is saved (400)", async () => {
     mockGetEmailInstallationByOrg.mockImplementationOnce(async () => null);
 

--- a/packages/api/src/api/routes/admin-email-provider.ts
+++ b/packages/api/src/api/routes/admin-email-provider.ts
@@ -20,7 +20,7 @@ import {
   saveEmailInstallation,
   deleteEmailInstallationByOrg,
 } from "@atlas/api/lib/email/store";
-import { sendEmail, sendEmailWithTransport } from "@atlas/api/lib/email/delivery";
+import { sendEmail, sendEmailWithTransport, DEFAULT_FROM_ADDRESS, resolveSmtpBridgeUrl } from "@atlas/api/lib/email/delivery";
 import {
   EMAIL_PROVIDERS,
   type EmailProvider,
@@ -37,17 +37,20 @@ const log = createLogger("admin-email-provider");
 // ---------------------------------------------------------------------------
 
 /**
- * Baseline is deliberately hardcoded to Resend + the atlas.dev sender — it is
- * NOT derived from `ATLAS_EMAIL_PROVIDER` / `ATLAS_EMAIL_FROM` platform
- * settings. The baseline represents "Atlas owns delivery" — the shared SaaS
- * identity rendered as a locked row in the UI so orgs know what falls back
- * when they have no override. The actual runtime fallback resolved by
- * `lib/email/delivery.ts` may differ on self-hosted deployments (platform
- * settings / env vars can change the transport) — this baseline is a brand
- * statement, not a live status readout.
+ * Baseline is deliberately Resend + the atlas.dev sender — it is NOT derived
+ * from `ATLAS_EMAIL_PROVIDER` / `ATLAS_EMAIL_FROM` platform settings. The
+ * baseline represents "Atlas owns delivery" — the shared SaaS identity rendered
+ * as a locked row in the UI so orgs know what falls back when they have no
+ * override. The actual runtime fallback resolved by `lib/email/delivery.ts` may
+ * differ on self-hosted deployments (platform settings / env vars can change the
+ * transport) — this baseline is a brand statement, not a live status readout.
+ *
+ * The sender literal reuses the single {@link DEFAULT_FROM_ADDRESS} seam
+ * constant (#3889) so the displayed brand sender and the send-path default can
+ * never drift apart; it is still a static brand statement, not a settings read.
  */
 const BASELINE_PROVIDER: EmailProvider = "resend";
-const BASELINE_FROM_ADDRESS = "Atlas <noreply@ship.useatlas.dev>";
+const BASELINE_FROM_ADDRESS = DEFAULT_FROM_ADDRESS;
 
 // Provider-specific secret config shapes. Each carries the `provider`
 // discriminator (#1542) — the wire contract now requires it on the
@@ -355,8 +358,11 @@ adminEmailProvider.openapi(setConfigRoute, async (c) => {
     }
 
     // SMTP/SES require the webhook bridge at delivery time; warn early so admins
-    // don't save credentials that can't be used on this deployment.
-    if ((body.provider === "smtp" || body.provider === "ses") && !process.env.ATLAS_SMTP_URL) {
+    // don't save credentials that can't be used on this deployment. Read through
+    // the same `resolveSmtpBridgeUrl()` seam the send path uses (#3889) so a
+    // registry-set ATLAS_SMTP_URL satisfies this gate exactly as it satisfies
+    // delivery — the save-time check can't disagree with the actual transport.
+    if ((body.provider === "smtp" || body.provider === "ses") && !resolveSmtpBridgeUrl()) {
       return c.json({
         error: "validation",
         message: `${body.provider.toUpperCase()} delivery requires ATLAS_SMTP_URL to be configured as an HTTP bridge on the server.`,

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -44,7 +44,8 @@ import {
   deleteEmailInstallationByOrg,
 } from "@atlas/api/lib/email/store";
 import { EMAIL_PROVIDERS } from "@atlas/api/lib/email/store";
-import type { EmailProvider, ProviderConfig } from "@atlas/api/lib/email/store";
+import type { EmailProvider } from "@atlas/api/lib/email/store";
+import { sendEmailWithTransport } from "@atlas/api/lib/email/delivery";
 import { getConfig } from "@atlas/api/lib/config";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -1694,8 +1695,27 @@ adminIntegrations.openapi(testEmailRoute, async (c) => {
         );
       }
 
+      // Route the test-send through the canonical delivery seam (#3889): build
+      // the SAME EmailTransport `resolveEmailSender(orgId)` would for this org
+      // (org-transport) from the install we just validated, and send it via
+      // `sendEmailWithTransport` → `deliverViaTransport` — the exact per-provider
+      // senders production uses, with the staging outbound clamp. This replaces
+      // the removed parallel raw test-senders, so the test path's provider + from
+      // are byte-for-byte what the real send uses. `result.success`/`result.error`
+      // drive the response; the audited `provider` stays the installed one below.
       const result = yield* Effect.tryPromise({
-        try: () => sendTestEmail(install, recipientEmail),
+        try: () => sendEmailWithTransport(
+          {
+            to: recipientEmail,
+            subject: "Atlas Email Test",
+            html: "<h1>Atlas Email Test</h1><p>This is a test email from Atlas to verify your email configuration is working correctly.</p>",
+          },
+          {
+            provider: install.provider,
+            senderAddress: install.sender_address,
+            config: install.config,
+          },
+        ),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(
         Effect.tapError((err) =>
@@ -1835,201 +1855,13 @@ adminIntegrations.openapi(disconnectEmailRoute, async (c) => {
 // `validateProviderConfig` was removed in #1542 — the route's
 // `ProviderConfigSchema` (z.discriminatedUnion) plus the sibling-match
 // check in the handler cover the same ground without double-validation.
-
-interface TestEmailResult {
-  success: boolean;
-  error?: string;
-}
-
-async function sendTestEmail(
-  install: { sender_address: string; config: ProviderConfig },
-  recipientEmail: string,
-): Promise<TestEmailResult> {
-  const subject = "Atlas Email Test";
-  const html = "<h1>Atlas Email Test</h1><p>This is a test email from Atlas to verify your email configuration is working correctly.</p>";
-
-  // `install.config` is a tagged union (#1542); the switch narrows each
-  // case to the matching variant so the helpers can accept their exact
-  // config shape rather than `Record<string, unknown>`.
-  switch (install.config.provider) {
-    case "smtp":
-      return sendSmtpTestEmail(install.sender_address, recipientEmail, subject, html);
-    case "sendgrid":
-      return sendSendGridTestEmail(install.config.apiKey, install.sender_address, recipientEmail, subject, html);
-    case "postmark":
-      return sendPostmarkTestEmail(install.config.serverToken, install.sender_address, recipientEmail, subject, html);
-    case "ses":
-      return sendSesTestEmail(install.sender_address, recipientEmail, subject, html);
-    case "resend":
-      return sendResendTestEmail(install.config.apiKey, install.sender_address, recipientEmail, subject, html);
-  }
-}
-
-async function sendSendGridTestEmail(
-  apiKey: string,
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-): Promise<TestEmailResult> {
-  try {
-    const res = await fetch("https://api.sendgrid.com/v3/mail/send", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        personalizations: [{ to: [{ email: to }] }],
-        from: { email: from },
-        subject,
-        content: [{ type: "text/html", value: html }],
-      }),
-      signal: AbortSignal.timeout(15_000),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { success: false, error: `SendGrid API error (${res.status}): ${text.slice(0, 200)}` };
-    }
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: errorMessage(err) };
-  }
-}
-
-async function sendPostmarkTestEmail(
-  serverToken: string,
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-): Promise<TestEmailResult> {
-  try {
-    const res = await fetch("https://api.postmarkapp.com/email", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Postmark-Server-Token": serverToken,
-      },
-      body: JSON.stringify({
-        From: from,
-        To: to,
-        Subject: subject,
-        HtmlBody: html,
-      }),
-      signal: AbortSignal.timeout(15_000),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { success: false, error: `Postmark API error (${res.status}): ${text.slice(0, 200)}` };
-    }
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: errorMessage(err) };
-  }
-}
-
-async function sendSmtpTestEmail(
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-): Promise<TestEmailResult> {
-  // SMTP delivery delegates to the ATLAS_SMTP_URL webhook bridge.
-  // The bridge endpoint is responsible for connecting to the SMTP server
-  // using the config stored in the database — we do not send credentials
-  // over the wire in this payload.
-  const smtpUrl = process.env.ATLAS_SMTP_URL;
-  if (!smtpUrl) {
-    return {
-      success: false,
-      error: "SMTP test requires ATLAS_SMTP_URL to be configured as an SMTP-to-HTTP bridge endpoint. " +
-        "Configuration has been saved and will be used when ATLAS_SMTP_URL is available.",
-    };
-  }
-
-  try {
-    const res = await fetch(smtpUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ from, to, subject, html }),
-      signal: AbortSignal.timeout(15_000),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { success: false, error: `SMTP webhook error (${res.status}): ${text.slice(0, 200)}` };
-    }
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: errorMessage(err) };
-  }
-}
-
-async function sendSesTestEmail(
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-): Promise<TestEmailResult> {
-  // AWS Signature V4 is complex — for the test email we delegate to the
-  // ATLAS_SMTP_URL webhook bridge if available. We do not send AWS credentials
-  // over the wire; the bridge reads them from its own config or the database.
-  const smtpUrl = process.env.ATLAS_SMTP_URL;
-  if (!smtpUrl) {
-    return {
-      success: false,
-      error: "SES test email requires ATLAS_SMTP_URL configured as an SES-compatible bridge. " +
-        "Configuration has been saved.",
-    };
-  }
-
-  try {
-    const res = await fetch(smtpUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ from, to, subject, html }),
-      signal: AbortSignal.timeout(15_000),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { success: false, error: `SES webhook error (${res.status}): ${text.slice(0, 200)}` };
-    }
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: errorMessage(err) };
-  }
-}
-
-async function sendResendTestEmail(
-  apiKey: string,
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-): Promise<TestEmailResult> {
-  try {
-    const res = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({ from, to: [to], subject, html }),
-      signal: AbortSignal.timeout(15_000),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { success: false, error: `Resend API error (${res.status}): ${text.slice(0, 200)}` };
-    }
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: errorMessage(err) };
-  }
-}
+//
+// The per-provider test-send helpers (sendResendTestEmail / sendSendGridTestEmail
+// / sendPostmarkTestEmail / sendSmtpTestEmail / sendSesTestEmail) were removed in
+// #3889. They were a parallel copy of the canonical senders in
+// `lib/email/delivery.ts`, so the Admin "test email" could pass through a
+// different provider/from than production actually uses. The test-send handler
+// now builds the install's `EmailTransport` and calls `sendEmailWithTransport(..)`
+// → `deliverViaTransport` — one sender per provider, test path == prod path.
 
 export { adminIntegrations };

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -157,10 +157,16 @@ describe("indirect-read drift guard", () => {
     return new Set([...matches].map((m) => m[1] as string));
   }
 
-  test("every process.env.X in lib/email/dpa-guard.ts is in SAAS_ENV_KEYS", async () => {
-    const reads = await readProcessEnvKeys("lib/email/dpa-guard.ts");
-    expect(reads.size).toBeGreaterThan(0); // sanity: file did read at least one env var
-    for (const key of reads) {
+  // #3889 — the DPA guard no longer reads `process.env` directly. Its transport
+  // keys now flow through the lib/email/delivery seam (`resolveResendApiKey` /
+  // `resolveSmtpBridgeUrl` → `getSetting`), so a static `process.env.X` grep of
+  // dpa-guard.ts finds nothing. The boot-contract requirement is unchanged: the
+  // keys the DPA guard resolves at SaaS boot must stay in SAAS_ENV_KEYS so the
+  // boot-smoke fixture populates them and the guard can resolve Resend. Assert
+  // that membership directly (a drift in either the resolver keys or the SaaS
+  // contract trips here before CI's boot smoke).
+  test("the DPA guard's resolved transport keys are in SAAS_ENV_KEYS (#3889 indirection)", () => {
+    for (const key of ["RESEND_API_KEY", "ATLAS_SMTP_URL"] as const) {
       expect(SAAS_ENV_KEYS).toContain(key as (typeof SAAS_ENV_KEYS)[number]);
     }
   });

--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -10,8 +10,14 @@ import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 
 let settingsStore: Record<string, string> = {};
 
+// Faithfully model the real `getSetting` precedence (#3889): DB/registry
+// override (here `settingsStore`) → env var → undefined. The send path now
+// reads RESEND_API_KEY / ATLAS_SMTP_URL / ATLAS_EMAIL_FROM through `getSetting`
+// rather than `process.env` directly, so the mock must honor the env tier or
+// the existing env-var fallback tests would break. Registry default (tier 4)
+// is omitted — the email resolvers supply their own default constant.
 mock.module("@atlas/api/lib/settings", () => ({
-  getSetting: (key: string) => settingsStore[key],
+  getSetting: (key: string) => settingsStore[key] ?? process.env[key],
 }));
 
 // Controllable per-org email install (default: none). Mirrors the store's
@@ -49,6 +55,9 @@ const {
   shouldEnqueueFailedSend,
   enqueueFailedTransactionalEmail,
   computeExpiresAt,
+  DEFAULT_FROM_ADDRESS,
+  resolveResendApiKey,
+  resolveSmtpBridgeUrl,
 } = await import("../delivery");
 type DeliveryResult = import("../delivery").DeliveryResult;
 type EmailMessage = import("../delivery").EmailMessage;
@@ -67,6 +76,26 @@ function installFetchMock(response: { status: number; body: unknown }) {
       status: response.status,
       headers: { "Content-Type": "application/json" },
     })) as unknown as typeof globalThis.fetch;
+}
+
+/**
+ * Fetch mock that records every request's parsed JSON body so a test can
+ * assert the `from` address actually put on the wire (#3889). Returns the
+ * mutable call log.
+ */
+function installCapturingFetchMock(
+  response: { status: number; body: unknown } = { status: 200, body: { id: "e1" } },
+): Array<{ url: string; body: Record<string, unknown> }> {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    calls.push({ url: String(url), body });
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return calls;
 }
 
 beforeEach(() => {
@@ -373,6 +402,108 @@ describe("isAuthEmailDeliveryConfigured", () => {
     // sends email into a black hole.
     settingsStore["ATLAS_EMAIL_PROVIDER"] = "resend";
     expect(isAuthEmailDeliveryConfigured()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One sender seam — consolidated from-address + key resolution (#3889)
+// ---------------------------------------------------------------------------
+
+describe("one sender seam — from-address + key consolidation (#3889)", () => {
+  it("(a) honors a registry ATLAS_EMAIL_FROM on the resend-env fallback branch", async () => {
+    // resend-env branch (no org transport, no platform provider). Before #3889
+    // this branch read process.env.ATLAS_EMAIL_FROM directly and ignored the
+    // registry, so an Admin-set From address was silently dropped here.
+    process.env.RESEND_API_KEY = "re_env_key";
+    settingsStore["ATLAS_EMAIL_FROM"] = "Workspace <ws@acme.test>";
+    const calls = installCapturingFetchMock();
+
+    const result = await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" });
+    expect(result.provider).toBe("resend");
+    expect(calls[0]!.body.from).toBe("Workspace <ws@acme.test>");
+  });
+
+  it("(a) honors a registry ATLAS_EMAIL_FROM on the smtp-webhook fallback branch", async () => {
+    process.env.ATLAS_SMTP_URL = "http://bridge.test";
+    settingsStore["ATLAS_EMAIL_FROM"] = "Workspace <ws@acme.test>";
+    const calls = installCapturingFetchMock();
+
+    const result = await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" });
+    expect(result.provider).toBe("webhook");
+    expect(calls[0]!.body.from).toBe("Workspace <ws@acme.test>");
+  });
+
+  it("(a) falls back to the single DEFAULT_FROM_ADDRESS constant when nothing sets the From", async () => {
+    process.env.RESEND_API_KEY = "re_env_key";
+    const calls = installCapturingFetchMock();
+
+    await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" });
+    expect(calls[0]!.body.from).toBe(DEFAULT_FROM_ADDRESS);
+  });
+
+  it("(b) sends from the org BYO sender_address on the org-transport branch", async () => {
+    mockOrgInstall = {
+      provider: "resend",
+      sender_address: "Acme <reports@acme.test>",
+      config: { provider: "resend", apiKey: "re_org" },
+    };
+    const calls = installCapturingFetchMock();
+
+    const result = await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" }, "org-1");
+    expect(result.provider).toBe("resend");
+    expect(calls[0]!.body.from).toBe("Acme <reports@acme.test>");
+  });
+
+  it("(b) the org BYO sender_address wins over a registry ATLAS_EMAIL_FROM regardless of branch", async () => {
+    settingsStore["ATLAS_EMAIL_FROM"] = "Global <global@atlas.test>";
+    mockOrgInstall = {
+      provider: "resend",
+      sender_address: "Acme <reports@acme.test>",
+      config: { provider: "resend", apiKey: "re_org" },
+    };
+    const calls = installCapturingFetchMock();
+
+    await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" }, "org-1");
+    // No fallthrough to the global From — the org sender_address is honored.
+    expect(calls[0]!.body.from).toBe("Acme <reports@acme.test>");
+  });
+
+  it("(criterion 3) a registry-only RESEND_API_KEY is visible to BOTH resolveEmailSender and isAuthEmailDeliveryConfigured", async () => {
+    // Registry-set RESEND_API_KEY without ATLAS_EMAIL_PROVIDER. Before #3889
+    // the env-fallback branch + isAuthEmailDeliveryConfigured read process.env
+    // directly, so a registry-only key was invisible to both — they disagreed
+    // with the platform-config branch (which already read via getSetting).
+    settingsStore["RESEND_API_KEY"] = "re_registry_only";
+
+    const resolved = await resolveEmailSender();
+    expect(resolved.kind).toBe("resend-env");
+    expect(isAuthEmailDeliveryConfigured()).toBe(true);
+  });
+
+  it("(criterion 3) the shared key resolvers read a registry-only value — the source the DPA guard + auth probe consume", async () => {
+    // resolveResendApiKey / resolveSmtpBridgeUrl are the single source the DPA
+    // guard's productionDeps now read (was process.env directly). A registry-only
+    // value (no env) must be visible, or boot would fail-closed a correctly
+    // configured SaaS deploy.
+    settingsStore["RESEND_API_KEY"] = "re_registry_only";
+    settingsStore["ATLAS_SMTP_URL"] = "http://registry-bridge.test";
+
+    expect(resolveResendApiKey()).toBe("re_registry_only");
+    expect(resolveSmtpBridgeUrl()).toBe("http://registry-bridge.test");
+  });
+
+  it("(criterion 2) the platform-transport branch resolves its From through the registry too", async () => {
+    // getPlatformEmailConfig now uses resolvePlatformFromAddress(); a registry
+    // ATLAS_EMAIL_FROM must reach the From on the wire for the platform branch,
+    // not just the fallback branches.
+    settingsStore["ATLAS_EMAIL_PROVIDER"] = "resend";
+    settingsStore["RESEND_API_KEY"] = "re_platform_key";
+    settingsStore["ATLAS_EMAIL_FROM"] = "Platform <platform@acme.test>";
+    const calls = installCapturingFetchMock();
+
+    const result = await sendEmail({ to: "u@x.com", subject: "S", html: "<p>x</p>" });
+    expect(result.provider).toBe("resend");
+    expect(calls[0]!.body.from).toBe("Platform <platform@acme.test>");
   });
 });
 

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -7,8 +7,15 @@
  *    SMTP and SES require ATLAS_SMTP_URL as an HTTP bridge.
  * 2. Platform email provider (from settings registry).
  * 3. Webhook via ATLAS_SMTP_URL (POST JSON to any email API endpoint)
- * 4. Resend API via RESEND_API_KEY (existing env-var fallback)
+ * 4. Resend API via RESEND_API_KEY (registry/env fallback)
  * 5. Logging fallback when nothing is configured (dev mode).
+ *
+ * Provider keys (RESEND_API_KEY, ATLAS_SMTP_URL) and the fallback from-address
+ * (ATLAS_EMAIL_FROM) resolve through the single resolvers in this module
+ * (`resolveResendApiKey` / `resolveSmtpBridgeUrl` / `resolvePlatformFromAddress`,
+ * #3889) so every branch — and every consumer (the admin test-sends, the DPA
+ * guard, the scheduler preflight, the auth-config probe) — reads the same
+ * source and can never disagree about provider, key, or sender.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -235,6 +242,67 @@ function isEmailProvider(s: string): s is EmailProvider {
   return (EMAIL_PROVIDERS as readonly string[]).includes(s);
 }
 
+// ---------------------------------------------------------------------------
+// Single-source provider/key + from-address resolution (#3889)
+// ---------------------------------------------------------------------------
+
+/**
+ * The one default sender used when no per-org / platform / registry
+ * from-address is configured. Exported so the send path's fallback branches and
+ * the admin email-provider baseline brand row both reference the SAME literal.
+ * The `ATLAS_EMAIL_FROM` settings-registry `default` (settings.ts) is a separate
+ * copy of this string kept in sync by a comment there — settings.ts can't import
+ * this (it's a dependency of this module, importing back would cycle). Changing
+ * Atlas's default sender is a two-line edit: here + that registry default (#3889).
+ */
+export const DEFAULT_FROM_ADDRESS = "Atlas <noreply@ship.useatlas.dev>";
+
+/**
+ * Resolve the platform Resend API key (platform-scoped: platform DB override →
+ * env; `undefined` when unset — the key has no registry default). The single
+ * source for the key across the whole send path — `resolveEmailSender`'s
+ * env-fallback branch, `deliverResend`'s default key, `isAuthEmailDeliveryConfigured`,
+ * and the DPA guard all read it here. Before #3889 the fallback branch and the
+ * auth probe read `process.env.RESEND_API_KEY` directly, so a registry-only key
+ * (set in Admin without `ATLAS_EMAIL_PROVIDER`) was invisible to them while the
+ * platform-config branch already honored it — the same deploy disagreed with
+ * itself about whether email was configured.
+ */
+export function resolveResendApiKey(): string | undefined {
+  return getSetting("RESEND_API_KEY");
+}
+
+/**
+ * Resolve the `ATLAS_SMTP_URL` HTTP-bridge endpoint through the same single
+ * accessor. `ATLAS_SMTP_URL` is currently env-only (unregistered), so this is
+ * equivalent to `process.env.ATLAS_SMTP_URL` today — routing it through
+ * `getSetting` keeps every bridge read in one place so the resolution can never
+ * fork, and a future registry registration would apply uniformly (#3889).
+ */
+export function resolveSmtpBridgeUrl(): string | undefined {
+  return getSetting("ATLAS_SMTP_URL");
+}
+
+/**
+ * The ONE from-address resolver for sends that have no transport object — the
+ * `resend-env` and `smtp-webhook` fallback branches, and the platform
+ * transport's sender. Reads `ATLAS_EMAIL_FROM` through the settings registry
+ * (platform DB override → env → registry default) and falls back to
+ * {@link DEFAULT_FROM_ADDRESS}. NEVER reads `process.env.ATLAS_EMAIL_FROM`
+ * directly — that bypassed the registry, so the From address depended on which
+ * provider branch was active rather than on config (#3889).
+ *
+ * `orgId` is threaded through for forward-compatibility but is currently inert:
+ * `ATLAS_EMAIL_FROM` is platform-scoped, so `getSetting` ignores the orgId.
+ * Per-workspace BYO senders are NOT resolved here — they live on the
+ * `org-transport` {@link EmailTransport} (`email_installations.sender_address`)
+ * and are sent verbatim by {@link deliverViaTransport}. This resolver only
+ * governs the branches with no transport object.
+ */
+export function resolvePlatformFromAddress(orgId?: string): string {
+  return getSetting("ATLAS_EMAIL_FROM", orgId) ?? DEFAULT_FROM_ADDRESS;
+}
+
 /**
  * Whether the deployment can deliver auth emails (password reset, etc.)
  * without per-org config. Used by the public `/api/v1/onboarding/password-reset-status`
@@ -252,8 +320,11 @@ function isEmailProvider(s: string): s is EmailProvider {
  */
 export function isAuthEmailDeliveryConfigured(): boolean {
   if (getPlatformEmailConfig() !== null) return true;
-  if (process.env.ATLAS_SMTP_URL) return true;
-  if (process.env.RESEND_API_KEY) return true;
+  // Read through the SAME resolvers the send path uses (#3889) so this probe
+  // can never disagree with the actual transport — e.g. a registry-only
+  // RESEND_API_KEY is now seen here exactly as `resolveEmailSender` sees it.
+  if (resolveSmtpBridgeUrl()) return true;
+  if (resolveResendApiKey()) return true;
   return false;
 }
 
@@ -298,7 +369,7 @@ function getPlatformEmailConfig(): EmailTransport | null {
   }
   const provider = raw;
 
-  const fromAddress = getSetting("ATLAS_EMAIL_FROM") ?? "Atlas <noreply@ship.useatlas.dev>";
+  const fromAddress = resolvePlatformFromAddress();
 
   switch (provider) {
     case "resend": {
@@ -332,7 +403,7 @@ function getPlatformEmailConfig(): EmailTransport | null {
       // minimal config tagged with the provider; deliverViaTransport only
       // reads it for the `provider` discriminator before delegating to
       // the webhook.
-      if (!process.env.ATLAS_SMTP_URL) {
+      if (!resolveSmtpBridgeUrl()) {
         log.warn({ provider }, "Platform email provider requires ATLAS_SMTP_URL bridge — falling through");
         return null;
       }
@@ -391,7 +462,7 @@ export async function resolveEmailSender(orgId?: string): Promise<ResolvedEmailS
     if (transport) {
       const bridgeMissing =
         (transport.config.provider === "smtp" || transport.config.provider === "ses") &&
-        !process.env.ATLAS_SMTP_URL;
+        !resolveSmtpBridgeUrl();
       return bridgeMissing
         ? { kind: "org-transport", transport, bridgeMissing }
         : { kind: "org-transport", transport };
@@ -404,13 +475,15 @@ export async function resolveEmailSender(orgId?: string): Promise<ResolvedEmailS
     return { kind: "platform-transport", transport: platformConfig };
   }
 
-  // 3. Webhook delivery (generic email API)
-  if (process.env.ATLAS_SMTP_URL) {
+  // 3. Webhook delivery (generic email API) — single accessor (#3889)
+  if (resolveSmtpBridgeUrl()) {
     return { kind: "smtp-webhook" };
   }
 
-  // 4. Resend API delivery (env-var fallback for backward compat)
-  if (process.env.RESEND_API_KEY) {
+  // 4. Resend API delivery (registry/env fallback for backward compat) — read
+  //    through the single key resolver so a registry-only RESEND_API_KEY is
+  //    honored here, not just on the platform-config branch (#3889).
+  if (resolveResendApiKey()) {
     return { kind: "resend-env" };
   }
 
@@ -436,18 +509,20 @@ export async function sendEmail(message: EmailMessage, orgId?: string): Promise<
   const outbound = clampForOutbound(message);
 
   const resolved = await resolveEmailSender(orgId);
-  const fromAddress = process.env.ATLAS_EMAIL_FROM ?? "Atlas <noreply@ship.useatlas.dev>";
 
   switch (resolved.kind) {
     case "org-transport":
     case "platform-transport":
+      // The org / platform transport carries its own sender_address.
       return deliverViaTransport(outbound, resolved.transport);
 
     case "smtp-webhook":
-      return deliverWebhook(outbound, fromAddress);
+      // No transport object — resolve the From through the single
+      // registry+org-aware resolver (#3889), never process.env directly.
+      return deliverWebhook(outbound, resolvePlatformFromAddress(orgId));
 
     case "resend-env":
-      return deliverResend(outbound, fromAddress);
+      return deliverResend(outbound, resolvePlatformFromAddress(orgId));
 
     case "log":
       // Dev fallback — log instead of sending. Returns success: false so the email
@@ -705,11 +780,20 @@ async function deliverViaTransport(
 
     case "smtp":
     case "ses":
-      if (process.env.ATLAS_SMTP_URL) {
+      if (resolveSmtpBridgeUrl()) {
         return deliverWebhook(message, from);
       }
       log.warn({ to: message.to, provider: transport.provider }, "DB email config found but provider requires ATLAS_SMTP_URL bridge");
-      return { success: false, provider: "log", error: `${transport.provider} provider requires ATLAS_SMTP_URL bridge` };
+      return {
+        success: false,
+        provider: "log",
+        // Actionable for every caller of this shared path (real send + both
+        // admin test-sends, #3889) without asserting the config was persisted —
+        // the fresh-creds test-send sends WITHOUT saving, so "config saved"
+        // would be false there.
+        error: `${transport.provider.toUpperCase()} delivery requires the ATLAS_SMTP_URL HTTP bridge, which is not configured on this server. ` +
+          `Set ATLAS_SMTP_URL, or switch to an API-based provider (Resend, SendGrid, Postmark).`,
+      };
 
     default: {
       // `never` at the type layer — if this arm fires, the store/wire
@@ -784,7 +868,14 @@ async function fetchWithRetry(
  * Compatible with any email service that accepts JSON webhooks.
  */
 async function deliverWebhook(message: EmailMessage, from: string): Promise<DeliveryResult> {
-  const url = process.env.ATLAS_SMTP_URL!;
+  // Resolved through the single bridge accessor (#3889). Callers only reach
+  // this once `resolveSmtpBridgeUrl()` was truthy, but guard defensively so a
+  // future caller can't dereference an undefined URL.
+  const url = resolveSmtpBridgeUrl();
+  if (!url) {
+    log.error({ to: message.to }, "Webhook email delivery attempted with ATLAS_SMTP_URL unset");
+    return { success: false, provider: "webhook", error: "ATLAS_SMTP_URL bridge is not configured" };
+  }
   try {
     const resp = await fetchWithRetry(url, {
       method: "POST",
@@ -814,7 +905,7 @@ async function deliverWebhook(message: EmailMessage, from: string): Promise<Deli
 }
 
 async function deliverResend(message: EmailMessage, from: string, apiKey?: string): Promise<DeliveryResult> {
-  const key = apiKey ?? process.env.RESEND_API_KEY;
+  const key = apiKey ?? resolveResendApiKey();
   try {
     const resp = await fetchWithRetry("https://api.resend.com/emails", {
       method: "POST",

--- a/packages/api/src/lib/email/dpa-guard.ts
+++ b/packages/api/src/lib/email/dpa-guard.ts
@@ -30,11 +30,12 @@
  *   2. **Resolved transport**. `sendEmail`'s fallback order is platform-config
  *      → `ATLAS_SMTP_URL` → `RESEND_API_KEY` → log. The DPA-safe outcomes are
  *      "platform-resend with key" and "RESEND_API_KEY fallback" — both are
- *      recognised by `hasResendKey()` (the platform Resend config reads its
- *      key via `getSetting("RESEND_API_KEY")`, which itself falls through to
- *      env). If no Resend key exists, `ATLAS_SMTP_URL` would route through
- *      an arbitrary bridge → FAIL. If nothing is configured at all, mail is
- *      silently dropped → FAIL.
+ *      recognised by `hasResendKey()`, which since #3889 reads the key directly
+ *      through the shared `resolveResendApiKey()` seam (`getSetting("RESEND_API_KEY")`,
+ *      registry override → env), the SAME source the actual send path reads. If
+ *      no Resend key exists, `ATLAS_SMTP_URL` would route through an arbitrary
+ *      bridge → FAIL. If nothing is configured at all, mail is silently dropped
+ *      → FAIL.
  *
  * The guard is wired into `buildAppLayer` via the `Layer.effectDiscard`
  * built from `assertSaasPlatformEmailIsResendEffect`; throwing here fails
@@ -44,6 +45,7 @@
 
 import { Data } from "effect";
 import { getSetting } from "@atlas/api/lib/settings";
+import { resolveResendApiKey, resolveSmtpBridgeUrl } from "@atlas/api/lib/email/delivery";
 import { EMAIL_PROVIDERS, type EmailProvider } from "@atlas/api/lib/integrations/types";
 
 /** Resolved-transport discriminator carried by `DpaInconsistencyError`. */
@@ -82,8 +84,13 @@ const productionDeps: Omit<DpaGuardDeps, "isSaas"> = {
     if (!PROVIDER_SET.has(raw)) return null;
     return raw as EmailProvider;
   },
-  hasSmtpUrl: () => Boolean(process.env.ATLAS_SMTP_URL),
-  hasResendKey: () => Boolean(process.env.RESEND_API_KEY),
+  // Read transport keys through the SAME resolvers the actual send path uses
+  // (#3889) — `getSetting`-backed, so a registry-only RESEND_API_KEY (env or
+  // Admin) is recognized here exactly as `sendEmail` would resolve it. Reading
+  // `process.env` directly here would have failed boot on a registry-only key
+  // even though Resend was correctly configured.
+  hasSmtpUrl: () => Boolean(resolveSmtpBridgeUrl()),
+  hasResendKey: () => Boolean(resolveResendApiKey()),
 };
 
 const ISSUE_REF = "#1969";

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -712,6 +712,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     label: "From Address",
     description: "Default sender address for platform emails",
     type: "string",
+    // Keep in sync with DEFAULT_FROM_ADDRESS in lib/email/delivery.ts (#3889).
+    // It can't be imported here — delivery.ts depends on this module, so the
+    // back-import would cycle — hence a synced literal rather than a shared ref.
     default: "Atlas <noreply@ship.useatlas.dev>",
     envVar: "ATLAS_EMAIL_FROM",
     scope: "platform",


### PR DESCRIPTION
Closes #3889.

## What & why
The BYO per-workspace email sender mechanism existed, but resolution was split across env / registry / org and there were **parallel per-provider send implementations**, so the same deploy could send from different addresses — and an Admin "test email" could pass through a different path than production actually uses. This consolidates the entire send chain behind one seam in `lib/email/delivery.ts`.

## Changes
- **One from-address resolver.** `resolvePlatformFromAddress()` resolves `ATLAS_EMAIL_FROM` through the settings registry; the `resend-env` and `smtp-webhook` fallback branches (and the platform transport) use it instead of reading `process.env.ATLAS_EMAIL_FROM` directly. One exported default: `DEFAULT_FROM_ADDRESS` (reused by the admin baseline brand row; the settings-registry default is a synced literal — a back-import would cycle).
- **One key resolver.** `resolveResendApiKey()` / `resolveSmtpBridgeUrl()` are the single source for `RESEND_API_KEY` / `ATLAS_SMTP_URL`. `resolveEmailSender`, `deliverResend`, `isAuthEmailDeliveryConfigured`, and the **DPA guard** all read through them — so a registry-only `RESEND_API_KEY` (set in Admin without `ATLAS_EMAIL_PROVIDER`) is now visible everywhere, not just on the platform-config branch.
- **Exactly one impl per provider.** Deleted the 5 parallel raw test-senders in `admin-integrations.ts`. The admin test-send now builds the install's `EmailTransport` and routes through `sendEmailWithTransport → deliverViaTransport` — the same per-provider senders + the staging outbound clamp prod uses, so **test path == prod path**.
- **Consistency cleanups.** `deliverWebhook` replaces a `process.env.ATLAS_SMTP_URL!` non-null assertion with a checked failure; the smtp/ses save-gate in `admin-email-provider.ts` reads `resolveSmtpBridgeUrl()` so save-time can't disagree with delivery.

## Acceptance criteria
- [x] org BYO `sender_address` honored on every branch (no fallthrough to global default when an org sender exists)
- [x] from-address resolved in exactly one registry-aware function; `process.env.ATLAS_EMAIL_FROM` removed from the send path; one exported default constant
- [x] `RESEND_API_KEY`/provider resolution through one resolver; `isAuthEmailDeliveryConfigured` agrees for a registry-only key
- [x] exactly one impl per provider; both Admin test-sends route through the production delivery seam
- [x] regression tests (a) registry `ATLAS_EMAIL_FROM` honored on resend-env/smtp-webhook; (b) org BYO sender wins regardless of branch; (c) admin test-send uses same provider+from as real send (sender_address on the wire + 503-retry proving the canonical path)
- [x] existing email-delivery, dpa-guard, sender-preflight, staging-clamp tests pass

## Testing
Pure refactor, no migration. Internal review panel (silent-failure / type-design / pr-test / comment) → CLEAN after 2 rounds. Local CI: lint, type, syncpack, full `bun run test` (api + others), and all drift/discipline gates pass. The saas-env indirect-read drift guard for dpa-guard.ts was updated — the guard no longer reads `process.env` directly (now via the seam), so the test asserts SAAS_ENV_KEYS membership of the resolved keys directly.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate email sender resolution to a single seam in `delivery.ts` for per-workspace BYO email
> - Introduces `DEFAULT_FROM_ADDRESS`, `resolveResendApiKey`, `resolveSmtpBridgeUrl`, and `resolvePlatformFromAddress` in [delivery.ts](https://github.com/AtlasDevHQ/atlas/pull/3890/files#diff-d8e793d8e99f11d281fb61f586eaf9ca02c053fe08bdd334f200fe0e28c4465c) so all reads of `RESEND_API_KEY`, `ATLAS_SMTP_URL`, and the fallback From address go through a single settings-registry-aware accessor.
> - Replaces direct `process.env` reads throughout `sendEmail`, `deliverViaTransport`, `deliverWebhook`, `deliverResend`, `isAuthEmailDeliveryConfigured`, and `getPlatformEmailConfig` with the new resolvers, so registry overrides (e.g. per-workspace DB settings) are honored consistently.
> - Consolidates the admin test-send path in [admin-integrations.ts](https://github.com/AtlasDevHQ/atlas/pull/3890/files#diff-6d6bcf4e092b120c1dbf4ace82339130f9c83400a62cb04ba8ed3e09c91f7a56) to use `sendEmailWithTransport` instead of per-provider helpers, routing test emails through `deliverViaTransport` with staging clamp and shared retry logic.
> - Updates the SaaS boot guard in [dpa-guard.ts](https://github.com/AtlasDevHQ/atlas/pull/3890/files#diff-ebf220afa4785d8abc234fa43a07531b65e9e8ab811940d129594740b5b78d60) to use the same resolvers, so it agrees with the send path on whether a key or bridge URL is configured.
> - Behavioral Change: `deliverWebhook` now returns a structured error instead of crashing when `ATLAS_SMTP_URL` is absent; SMTP/SES save-time validation in the admin route uses `resolveSmtpBridgeUrl()` instead of a raw env read.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01b4955.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->