### PR TITLE
feat(api): executeSQL per-query group target + reach-bounded GroupReachResolver (#3893)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,8 @@
     "./lib/email-outbox": "./src/lib/email-outbox/index.ts",
     "./lib/env-routing": "./src/lib/env-routing/index.ts",
     "./lib/env-routing/*": "./src/lib/env-routing/*.ts",
+    "./lib/group-reach": "./src/lib/group-reach/index.ts",
+    "./lib/group-reach/*": "./src/lib/group-reach/*.ts",
     "./lib/multi-env-merger": "./src/lib/multi-env-merger/index.ts",
     "./lib/sub-processor-publisher": "./src/lib/sub-processor-publisher/index.ts",
     "./lib/semantic": "./src/lib/semantic/index.ts",

--- a/packages/api/src/lib/group-reach/__tests__/index.test.ts
+++ b/packages/api/src/lib/group-reach/__tests__/index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Behavioral unit tests for the pure cross-group reach resolver
+ * (ADR-0022, slice (a) #3893). Pure — no DB, no IO. The named `describe`
+ * blocks line up with the issue's acceptance criteria: default-all,
+ * visibility filtering, and the no-substitution invariant.
+ *
+ * `GroupReachResolver` is the new axis *above* the `env-routing/` Member
+ * planner: it decides *which Connection groups* are reachable, never
+ * *which Member within a group* (that stays env-routing's job). These
+ * tests pin the reach policy so the executeSQL group-target bound and
+ * the slice-(c) picker inherit a verified resolver.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveReach,
+  isReachable,
+  type VisibleGroup,
+  type ReachReason,
+} from "../index";
+
+/** Build a `VisibleGroup` with a sane single-member default. */
+function g(id: string, members?: string[]): VisibleGroup {
+  const m = members ?? [id];
+  return { id, members: m, primary: m[0] ?? id };
+}
+
+const VISIBLE: readonly VisibleGroup[] = [
+  g("postgres", ["pg-us", "pg-eu"]),
+  g("clickhouse"),
+  g("stripe-rest"),
+];
+
+describe("resolveReach — All (default)", () => {
+  it("kind 'all' → every visible group is reachable, order preserved", () => {
+    const result = resolveReach({ kind: "all" }, VISIBLE);
+    expect(result.reachableGroups.map((x) => x.id)).toEqual([
+      "postgres",
+      "clickhouse",
+      "stripe-rest",
+    ]);
+    expect(result.reason).toBe("all-visible");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("kind 'all' over an empty workspace → empty reach, no warning", () => {
+    const result = resolveReach({ kind: "all" }, []);
+    expect(result.reachableGroups).toEqual([]);
+    expect(result.reason).toBe("all-visible");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("returns the visible group objects intact (members + primary preserved)", () => {
+    const result = resolveReach({ kind: "all" }, VISIBLE);
+    const pg = result.reachableGroups.find((x) => x.id === "postgres");
+    expect(pg?.members).toEqual(["pg-us", "pg-eu"]);
+    expect(pg?.primary).toBe("pg-us");
+  });
+});
+
+describe("resolveReach — visibility filtering", () => {
+  it("never includes a group absent from the visible set (content-mode/whitelist-invisible excluded)", () => {
+    // `draft-group` is NOT in the visible set (caller filtered it by
+    // content-mode/whitelist), so it can never be reachable.
+    const result = resolveReach({ kind: "all" }, VISIBLE);
+    expect(result.reachableGroups.map((x) => x.id)).not.toContain("draft-group");
+  });
+
+  it("Focus on a visible group → exactly that group", () => {
+    const result = resolveReach({ kind: "focus", groupId: "clickhouse" }, VISIBLE);
+    expect(result.reachableGroups.map((x) => x.id)).toEqual(["clickhouse"]);
+    expect(result.reason).toBe("focus-resolved");
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("resolveReach — no silent substitution", () => {
+  it("Focus on an INVISIBLE/unknown group → empty reach, never another group", () => {
+    const result = resolveReach({ kind: "focus", groupId: "draft-group" }, VISIBLE);
+    // The keystone invariant: an out-of-reach focus resolves to *nothing*,
+    // it does NOT fall back to the first visible group or any substitute.
+    expect(result.reachableGroups).toEqual([]);
+    expect(result.reason).toBe("focus-invisible");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("draft-group");
+  });
+
+  it("Focus on an empty workspace → empty reach (no substitution possible)", () => {
+    const result = resolveReach({ kind: "focus", groupId: "postgres" }, []);
+    expect(result.reachableGroups).toEqual([]);
+    expect(result.reason).toBe("focus-invisible");
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe("isReachable", () => {
+  it("true for a group in the resolved reach, false otherwise", () => {
+    const all = resolveReach({ kind: "all" }, VISIBLE);
+    expect(isReachable(all, "postgres")).toBe(true);
+    expect(isReachable(all, "clickhouse")).toBe(true);
+    expect(isReachable(all, "draft-group")).toBe(false);
+  });
+
+  it("false for every group but the focused one under Focus", () => {
+    const focus = resolveReach({ kind: "focus", groupId: "stripe-rest" }, VISIBLE);
+    expect(isReachable(focus, "stripe-rest")).toBe(true);
+    expect(isReachable(focus, "postgres")).toBe(false);
+  });
+
+  it("matches by canonical group id, not by member connection id", () => {
+    // A query naming a *member* id ("pg-us") is not naming the *group*
+    // ("postgres"). Reach is a group axis; member selection is env-routing's
+    // job. `isReachable` must not accept a member id as the group.
+    const all = resolveReach({ kind: "all" }, VISIBLE);
+    expect(isReachable(all, "postgres")).toBe(true);
+    expect(isReachable(all, "pg-us")).toBe(false);
+  });
+});
+
+describe("ReachReason — stable identifiers", () => {
+  it("emits one of the documented reason strings", () => {
+    const cases: Array<{ state: Parameters<typeof resolveReach>[0]; reason: ReachReason }> = [
+      { state: { kind: "all" }, reason: "all-visible" },
+      { state: { kind: "focus", groupId: "postgres" }, reason: "focus-resolved" },
+      { state: { kind: "focus", groupId: "nope" }, reason: "focus-invisible" },
+    ];
+    for (const { state, reason } of cases) {
+      expect(resolveReach(state, VISIBLE).reason).toBe(reason);
+    }
+  });
+});

--- a/packages/api/src/lib/group-reach/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/group-reach/__tests__/lookup.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Behavioral tests for the impure visible-groups lookup
+ * (ADR-0022, slice (a) #3893). Mocks the two data inputs — the content-mode
+ * filtered whitelist map (`loadOrgWhitelist`) and group membership
+ * (`listConnectionGroupMembers`) — and asserts the derived `VisibleGroup[]`:
+ * member connections fold into their canonical group, group-of-one
+ * standalone datasources stand alone, empty (content-mode invisible)
+ * whitelists are excluded, and ordering is deterministic.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// Mutable fixtures the mocks read each call.
+let whitelistMap: Map<string, Set<string>>;
+let memberRows: ReadonlyArray<{ group_id: string; id: string }>;
+let whitelistThrows = false;
+let membersThrow = false;
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  loadOrgWhitelist: async () => {
+    if (whitelistThrows) throw new Error("whitelist load failed");
+    return whitelistMap;
+  },
+  getOrgWhitelistedTables: () => new Set<string>(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set<string>(),
+  _resetWhitelists: () => {},
+}));
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  listConnectionGroupMembers: async () => {
+    if (membersThrow) throw new Error("members load failed");
+    return memberRows;
+  },
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { loadVisibleGroups } = await import("../lookup");
+
+describe("loadVisibleGroups", () => {
+  beforeEach(() => {
+    whitelistThrows = false;
+    membersThrow = false;
+    whitelistMap = new Map();
+    memberRows = [];
+  });
+
+  it("returns [] when no orgId (self-hosted / no workspace)", async () => {
+    const groups = await loadVisibleGroups(undefined, "published");
+    expect(groups).toEqual([]);
+  });
+
+  it("folds member connections into their canonical group, group-of-one stands alone", async () => {
+    whitelistMap = new Map([
+      ["postgres", new Set(["orders", "customers"])], // explicit group key
+      ["pg-us", new Set(["orders", "customers"])], // member
+      ["pg-eu", new Set(["orders", "customers"])], // member
+      ["clickhouse", new Set(["events"])], // group-of-one
+    ]);
+    memberRows = [
+      { group_id: "postgres", id: "pg-us" },
+      { group_id: "postgres", id: "pg-eu" },
+    ];
+
+    const groups = await loadVisibleGroups("org-1", "published");
+
+    // Deterministic ascending id order; members folded; no duplicate groups.
+    expect(groups.map((g) => g.id)).toEqual(["clickhouse", "postgres"]);
+
+    const pg = groups.find((g) => g.id === "postgres");
+    expect(pg?.members).toEqual(["pg-eu", "pg-us"]); // sorted, members not separate groups
+    expect(pg?.primary).toBe("pg-eu");
+
+    const ch = groups.find((g) => g.id === "clickhouse");
+    expect(ch?.members).toEqual(["clickhouse"]);
+    expect(ch?.primary).toBe("clickhouse");
+  });
+
+  it("excludes groups with an empty whitelist (content-mode / draft invisible)", async () => {
+    whitelistMap = new Map([
+      ["live", new Set(["orders"])],
+      ["draft", new Set<string>()], // no published entities in this mode → invisible
+    ]);
+    memberRows = [];
+
+    const groups = await loadVisibleGroups("org-1", "published");
+    expect(groups.map((g) => g.id)).toEqual(["live"]);
+  });
+
+  it("returns [] when the whitelist load fails (degrades, never throws)", async () => {
+    whitelistThrows = true;
+    const groups = await loadVisibleGroups("org-1", "published");
+    expect(groups).toEqual([]);
+  });
+
+  it("still resolves groups when membership lookup fails (each visible key its own group)", async () => {
+    whitelistMap = new Map([
+      ["postgres", new Set(["orders"])],
+      ["pg-us", new Set(["orders"])],
+    ]);
+    memberRows = [{ group_id: "postgres", id: "pg-us" }];
+    membersThrow = true; // membership unavailable → no folding
+
+    const groups = await loadVisibleGroups("org-1", "published");
+    // Without membership we cannot fold pg-us into postgres; both surface as
+    // their own group rather than the whole workspace going dark.
+    expect(groups.map((g) => g.id)).toEqual(["pg-us", "postgres"]);
+  });
+});

--- a/packages/api/src/lib/group-reach/index.ts
+++ b/packages/api/src/lib/group-reach/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure cross-group **reach** resolver (ADR-0022, keystone slice (a) #3893).
+ *
+ * Reach is a new axis *above* the `env-routing/` Member planner: it decides
+ * **which Connection groups** a conversation may query, where the Member
+ * planner decides **which Member within a group** a query hits. The two are
+ * deliberately separate modules — reach (cross-group) and routing
+ * (intra-group) are distinct axes and must not be folded together (ADR-0022
+ * §1; PRD #3892 "Implementation Decisions").
+ *
+ * Given the conversation's reach state and the workspace's **visible** groups
+ * (already filtered by content-mode / RLS / whitelist by the caller — see
+ * `./lookup.ts`), this resolves the set of **reachable** groups:
+ *
+ *   - `all`  → every visible group (the default; the agent ranges cross-group
+ *              and the picker that narrows to Focus lands in slice (c)).
+ *   - `focus`→ exactly the named group **iff it is visible**, else **empty**.
+ *              An out-of-reach focus resolves to *nothing* — it is **never**
+ *              silently substituted with another group. That no-substitution
+ *              invariant is the security property the whole feature rests on
+ *              (the #3867(b) fix): the agent must not be able to reach a
+ *              source the conversation's scope excludes.
+ *
+ * **Pure.** No DB, no IO. The caller resolves `visibleGroups` (impure, see
+ * `loadVisibleGroups` in `./lookup.ts`) and hands them in, making the reach
+ * policy exhaustively unit-testable and decoupled from the executeSQL
+ * plumbing — exactly the shape `resolveRoutingPlan` already uses.
+ *
+ * @see ADR-0022 — cross-group reach + cross-source composition
+ * @see issue #3893 — slice (a) acceptance criteria
+ */
+
+/**
+ * Per-conversation Group-reach value.
+ *
+ * Slice (a) always passes `{ kind: "all" }` — the picker / conversation-scope
+ * persistence that produces a `focus` state lands in slice (c). The `focus`
+ * branch is built and tested now so the bound is enforced from day one and
+ * slice (c) inherits a verified resolver.
+ */
+export type ReachState =
+  | { readonly kind: "all" }
+  | { readonly kind: "focus"; readonly groupId: string };
+
+/**
+ * A Connection group the workspace can see, as resolved by the impure
+ * `loadVisibleGroups` lookup. `id` is the canonical `connection_group_id`
+ * (a group-of-one standalone datasource uses its own connection id as its
+ * group id — #3855). `members` / `primary` carry the connection(s) the
+ * caller routes execution to; the resolver itself reads only `id`.
+ */
+export interface VisibleGroup {
+  /** Canonical group id (group-of-one: equal to the connection id). */
+  readonly id: string;
+  /** Member connection ids of this group (always ≥ 1). */
+  readonly members: readonly string[];
+  /** Representative connection id execution routes to by default. */
+  readonly primary: string;
+}
+
+/** Why the resolver returned the reach set it did. Surfaced to logs / audit. */
+export type ReachReason = "all-visible" | "focus-resolved" | "focus-invisible";
+
+export interface ReachResult {
+  /** The reachable groups, intact (members + primary preserved). */
+  readonly reachableGroups: readonly VisibleGroup[];
+  /** Discriminator for why this reach set was chosen. */
+  readonly reason: ReachReason;
+  /**
+   * Warnings to surface in logs / audit. Empty for a clean resolution; a
+   * Focus that names an invisible/unknown group emits one so the divergence
+   * is observable rather than silently collapsing to empty reach.
+   */
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Resolve the reachable Connection groups from a reach state + the visible
+ * groups. Pure; total — every input shape produces a result, never throws.
+ *
+ * Critically, a `focus` on a group that is not in `visibleGroups` resolves
+ * to an **empty** reach set with a warning — it does **not** fall back to any
+ * other group. Callers must treat empty reach as "nothing reachable," never
+ * as "use the default."
+ */
+export function resolveReach(
+  state: ReachState,
+  visibleGroups: readonly VisibleGroup[],
+): ReachResult {
+  if (state.kind === "all") {
+    return {
+      reachableGroups: visibleGroups,
+      reason: "all-visible",
+      warnings: [],
+    };
+  }
+
+  // Focus: exactly the named group, iff visible. No substitution.
+  const match = visibleGroups.find((grp) => grp.id === state.groupId);
+  if (match) {
+    return {
+      reachableGroups: [match],
+      reason: "focus-resolved",
+      warnings: [],
+    };
+  }
+
+  return {
+    reachableGroups: [],
+    reason: "focus-invisible",
+    warnings: [
+      `focus group "${state.groupId}" is not visible to this workspace ` +
+        `(visible: ${visibleGroups.map((grp) => grp.id).join(", ") || "none"}) ` +
+        `— reach is empty; not substituting another source`,
+    ],
+  };
+}
+
+/**
+ * Whether `groupId` is within a resolved reach set. Matches by **canonical
+ * group id** only — a member connection id is not its group, so naming a
+ * Member where a Group is expected is (correctly) not reachable.
+ */
+export function isReachable(result: ReachResult, groupId: string): boolean {
+  return result.reachableGroups.some((grp) => grp.id === groupId);
+}

--- a/packages/api/src/lib/group-reach/lookup.ts
+++ b/packages/api/src/lib/group-reach/lookup.ts
@@ -1,0 +1,97 @@
+/**
+ * Impure helper that enumerates the **visible** Connection groups a workspace
+ * can query, for the pure {@link resolveReach} module to bound against
+ * (ADR-0022, slice (a) #3893).
+ *
+ * Lives alongside the pure resolver but in its own file so the reach policy
+ * stays testable without a DB — exactly the `env-routing/` split
+ * ({@link resolveRoutingPlan} ↔ {@link loadGroupRoutingContext}).
+ *
+ * "Visible" is sourced from the **content-mode-filtered whitelist map**
+ * (`loadOrgWhitelist`), which is the workspace's authoritative analytical
+ * surface: a group with no whitelisted tables in the active mode (a
+ * draft/unpublished datasource, or one outside the workspace) is invisible
+ * and never surfaces here. Member connection ids fold into their canonical
+ * `connection_group_id` (via `listConnectionGroupMembers`); a group-of-one
+ * standalone datasource (#3855) keys under its own connection id and stands
+ * alone. The result is the set of groups the agent may target with
+ * `executeSQL`'s per-query group bound.
+ *
+ * Scope note: this enumerates **SQL** Connection groups only — the whitelist
+ * is SQL-entity-derived. REST datasources are reached via their own tool
+ * (`executeRestOperation`) and bounded by REST scope (ADR-0011), a separate
+ * axis; the slice-(b) Source catalog is what unifies both into one menu.
+ *
+ * Never throws — every failure mode degrades (logged, per CLAUDE.md "never
+ * silently swallow errors") rather than hard-failing the agent's turn.
+ *
+ * @see ADR-0022 — cross-group reach
+ * @see issue #3893 — slice (a) acceptance criteria
+ */
+
+import { loadOrgWhitelist } from "@atlas/api/lib/semantic";
+import { listConnectionGroupMembers } from "@atlas/api/lib/semantic/entities";
+import { createLogger } from "@atlas/api/lib/logger";
+import type { VisibleGroup } from "./index";
+
+const log = createLogger("group-reach:lookup");
+
+/**
+ * Resolve the workspace's visible Connection groups for the given content
+ * mode. Returns `[]` when there is no workspace (`orgId` undefined — the
+ * self-hosted / single-flat-connection case) or when the whitelist can't be
+ * loaded; both mean "no enumerable cross-group surface," and the caller
+ * treats an absent target as the degenerate single-connection case.
+ */
+export async function loadVisibleGroups(
+  orgId: string | undefined,
+  mode?: "published" | "developer",
+): Promise<readonly VisibleGroup[]> {
+  if (!orgId) return [];
+
+  let whitelist: Map<string, Set<string>>;
+  try {
+    whitelist = await loadOrgWhitelist(orgId, mode);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to load whitelist for visible-groups lookup — reporting no reachable groups",
+    );
+    return [];
+  }
+
+  // Group membership: member connection id → canonical group id, plus the
+  // member roster per group. Best-effort — a failure means we cannot fold
+  // members into groups, so each visible key surfaces as its own group
+  // rather than the whole workspace going dark (logged, not swallowed).
+  const memberToGroup = new Map<string, string>();
+  const groupToMembers = new Map<string, string[]>();
+  try {
+    const rows = await listConnectionGroupMembers(orgId);
+    for (const { group_id, id } of rows) {
+      memberToGroup.set(id, group_id);
+      const roster = groupToMembers.get(group_id) ?? [];
+      roster.push(id);
+      groupToMembers.set(group_id, roster);
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to load group membership — visible groups will not fold env replicas",
+    );
+  }
+
+  // Canonical group ids = the non-empty whitelist keys, with member ids
+  // collapsed into their group. An empty table set means content-mode
+  // filtered this key out (invisible) — skip it.
+  const canonical = new Set<string>();
+  for (const [key, tables] of whitelist) {
+    if (tables.size === 0) continue;
+    canonical.add(memberToGroup.get(key) ?? key);
+  }
+
+  return [...canonical].sort().map((id) => {
+    const members = (groupToMembers.get(id) ?? [id]).slice().sort();
+    return { id, members, primary: members[0] ?? id } satisfies VisibleGroup;
+  });
+}

--- a/packages/api/src/lib/group-reach/lookup.ts
+++ b/packages/api/src/lib/group-reach/lookup.ts
@@ -30,7 +30,6 @@
  */
 
 import { loadOrgWhitelist } from "@atlas/api/lib/semantic";
-import { listConnectionGroupMembers } from "@atlas/api/lib/semantic/entities";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { VisibleGroup } from "./index";
 
@@ -67,6 +66,14 @@ export async function loadVisibleGroups(
   const memberToGroup = new Map<string, string>();
   const groupToMembers = new Map<string, string[]>();
   try {
+    // Dynamic import (mirrors `whitelist.ts`): `entities.ts` is frequently
+    // partial-mocked by test fixtures, so a STATIC import here would pull it
+    // into the broadly-imported `sql.ts` graph and break those fixtures with a
+    // module-load "export not found" SyntaxError. Resolving at call-time keeps
+    // the dependency out of the load graph.
+    const { listConnectionGroupMembers } = await import(
+      "@atlas/api/lib/semantic/entities"
+    );
     const rows = await listConnectionGroupMembers(orgId);
     for (const { group_id, id } of rows) {
       memberToGroup.set(id, group_id);

--- a/packages/api/src/lib/tools/__tests__/sql-group-target.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-group-target.test.ts
@@ -1,0 +1,263 @@
+/**
+ * executeSQL per-query GROUP target + reach bounding (ADR-0022, slice (a)
+ * #3893). The keystone security change: the agent names which Connection
+ * group a query runs against, validation uses THAT group's whitelist, and a
+ * group outside the conversation's reach is rejected — a hard error, never a
+ * silent re-route to another source (the #3867(b) fix at the execution
+ * layer).
+ *
+ * The pure reach resolver (`resolveReach`/`isReachable`) runs for real here;
+ * only the impure visible-groups lookup is mocked, so these assert real
+ * end-to-end reach behavior. Prior art: `sql-org-routing.test.ts` harness +
+ * `createConnectionMock`.
+ */
+
+import { describe, expect, it, beforeEach, mock, type Mock } from "bun:test";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// --- Per-group whitelist: keyed by the resolved connection id so a query
+// validated against group A's connection only sees group A's tables. ---
+const GROUP_TABLES: Record<string, Set<string>> = {
+  postgres: new Set(["companies"]),
+  clickhouse: new Set(["events"]),
+  // Members of the multi-member `postgres` group register the group's tables
+  // under their own connection id too (the dual-key whitelist model).
+  "pg-us": new Set(["companies"]),
+  "pg-eu": new Set(["companies"]),
+};
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: (_orgId: string, connId: string) =>
+    GROUP_TABLES[connId] ?? new Set<string>(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: (connId: string) => GROUP_TABLES[connId] ?? new Set<string>(),
+  _resetWhitelists: () => {},
+}));
+
+// --- Visible groups for reach. Two reachable group-of-one datasources;
+// "secret-db" is deliberately absent (out of reach). ---
+let visibleGroups: Array<{ id: string; members: string[]; primary: string }>;
+const mockLoadVisibleGroups: Mock<() => Promise<unknown>> = mock(async () => visibleGroups);
+mock.module("@atlas/api/lib/group-reach/lookup", () => ({
+  loadVisibleGroups: mockLoadVisibleGroups,
+}));
+
+// --- Connection registry: spy on getForWorkspace to assert the resolved
+// member; query records calls so we can prove a rejected group never ran. ---
+const mockQuery: Mock<() => Promise<unknown>> = mock(async () => ({
+  columns: ["id"],
+  rows: [{ id: 1 }],
+}));
+const mockDBConnection = { query: mockQuery, close: async () => {} };
+const mockGetForWorkspace: Mock<(workspaceId: string, installId: string) => unknown> = mock(
+  () => mockDBConnection,
+);
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockDBConnection,
+    connections: {
+      get: () => mockDBConnection,
+      getDefault: () => mockDBConnection,
+      getDBType: () => "postgres" as const,
+      isOrgPoolingEnabled: () => false,
+      getForWorkspace: mockGetForWorkspace,
+      // A per-workspace config backs the read → getForWorkspace(org, connId)
+      // routes by the resolved member, letting us assert which one was used.
+      hasForWorkspace: () => true,
+      recordQuery: () => {},
+      recordSuccess: () => {},
+      recordError: () => {},
+    },
+  }),
+);
+
+let mockRequestContext: Record<string, unknown> | undefined;
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  getRequestContext: () => mockRequestContext,
+}));
+
+mock.module("@atlas/api/lib/auth/audit", () => ({ logQueryAudit: () => {} }));
+mock.module("@atlas/api/lib/security", () => ({
+  SENSITIVE_PATTERNS: /password|secret/i,
+  maskConnectionUrl: (url: string) => url,
+}));
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (_n: string, _a: unknown, fn: () => Promise<unknown>) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+mock.module("@atlas/api/lib/db/source-rate-limit", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withSourceSlot: (_sourceId: string, effect: any) => effect,
+}));
+mock.module("@atlas/api/lib/config", () => ({ getConfig: () => ({}) }));
+mock.module("@atlas/api/lib/rls", () => ({
+  resolveRLSFilters: () => ({ groups: [] }),
+  injectRLSConditions: (sql: string) => sql,
+}));
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: (k: string) => (k === "ATLAS_ROW_LIMIT" ? "1000" : k === "ATLAS_QUERY_TIMEOUT" ? "30000" : undefined),
+  getSettingAuto: (k: string) => (k === "ATLAS_ROW_LIMIT" ? "1000" : k === "ATLAS_QUERY_TIMEOUT" ? "30000" : undefined),
+  getSettingLive: async (k: string) => (k === "ATLAS_ROW_LIMIT" ? "1000" : k === "ATLAS_QUERY_TIMEOUT" ? "30000" : undefined),
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
+mock.module("@atlas/api/lib/cache/index", () => ({
+  cacheEnabled: () => false,
+  getCache: () => ({ get: () => null, set: () => {} }),
+  buildCacheKey: () => "",
+  getDefaultTtl: () => 60000,
+}));
+mock.module("@atlas/api/lib/plugins/hooks", () => ({
+  dispatchHook: async () => {},
+  dispatchMutableHook: async (_n: string, ctx: { sql: string }) => ctx.sql,
+}));
+
+const { executeSQL } = await import("@atlas/api/lib/tools/sql");
+
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+type ToolResult = { success: boolean; error?: string; [key: string]: unknown };
+const executeTool = executeSQL.execute as unknown as (
+  args: { sql: string; explanation: string; group?: string; connectionId?: string; scope?: string },
+  ctx: { toolCallId: string; messages: unknown[]; abortSignal: AbortSignal },
+) => Promise<ToolResult>;
+
+const run = (args: { sql: string; explanation?: string; group?: string; connectionId?: string }) =>
+  executeTool(
+    { explanation: "test", ...args },
+    { toolCallId: "tc", messages: [], abortSignal: undefined as unknown as AbortSignal },
+  );
+
+describe("executeSQL — per-query group target + reach bounding", () => {
+  beforeEach(() => {
+    mockRequestContext = { user: { id: "u1", activeOrganizationId: "org-1" } };
+    visibleGroups = [
+      { id: "postgres", members: ["postgres"], primary: "postgres" },
+      { id: "clickhouse", members: ["clickhouse"], primary: "clickhouse" },
+    ];
+    mockQuery.mockClear();
+    mockGetForWorkspace.mockClear();
+    mockLoadVisibleGroups.mockClear();
+  });
+
+  it("runs a query against the agent-named reachable group's connection", async () => {
+    const result = await run({ sql: "SELECT id FROM events", group: "clickhouse" });
+    expect(result.success).toBe(true);
+    // Resolved to clickhouse's connection — proven by the routed member id.
+    expect(mockGetForWorkspace.mock.calls.length).toBe(1);
+    expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("clickhouse");
+    expect(mockQuery.mock.calls.length).toBe(1);
+  });
+
+  it("validates against THAT group's whitelist — a table from another group is rejected (unknown_entity)", async () => {
+    // `companies` lives in the postgres group, not clickhouse. Targeting
+    // clickhouse must validate against clickhouse's whitelist and reject it.
+    const result = await run({ sql: "SELECT id FROM companies", group: "clickhouse" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not in the allowed list");
+    // The wrong-group table is caught at validation — no query is executed.
+    expect(mockQuery.mock.calls.length).toBe(0);
+  });
+
+  it("accepts the same table when the correct group is targeted", async () => {
+    const result = await run({ sql: "SELECT id FROM companies", group: "postgres" });
+    expect(result.success).toBe(true);
+    expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("postgres");
+  });
+
+  it("REJECTS an out-of-reach group — hard error, never re-routed to another source", async () => {
+    const result = await run({ sql: "SELECT id FROM events", group: "secret-db" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not within this conversation's reach");
+    expect(result.error).toContain("secret-db");
+    // The crux of #3867(b): no connection was resolved, NO query ran. The
+    // out-of-reach group is not silently swapped for a reachable one.
+    expect(mockGetForWorkspace.mock.calls.length).toBe(0);
+    expect(mockQuery.mock.calls.length).toBe(0);
+  });
+
+  it("rejected error names the reachable groups so the agent can self-correct", async () => {
+    const result = await run({ sql: "SELECT id FROM events", group: "secret-db" });
+    expect(result.error).toContain("postgres");
+    expect(result.error).toContain("clickhouse");
+  });
+
+  it("rejects a `group` when the workspace has no reachable groups", async () => {
+    // No activeOrganizationId → loadVisibleGroups returns []; reach is empty,
+    // so any named group is rejected (degenerate workspace rejects, never
+    // silently falls through to the default connection).
+    mockRequestContext = { user: { id: "u1" } };
+    visibleGroups = [];
+    const result = await run({ sql: "SELECT id FROM events", group: "postgres" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not within this conversation's reach");
+    expect(result.error).toContain("none");
+    expect(mockQuery.mock.calls.length).toBe(0);
+  });
+
+  describe("multi-member group — member pinning via connectionId", () => {
+    beforeEach(() => {
+      // A real multi-member group (env replicas) plus a separate group.
+      visibleGroups = [
+        { id: "postgres", members: ["pg-eu", "pg-us"], primary: "pg-eu" },
+        { id: "clickhouse", members: ["clickhouse"], primary: "clickhouse" },
+      ];
+    });
+
+    it("targets the group's primary member when only `group` is given", async () => {
+      const result = await run({ sql: "SELECT id FROM companies", group: "postgres" });
+      expect(result.success).toBe(true);
+      expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("pg-eu");
+    });
+
+    it("honors a `connectionId` that is a member of the targeted group (member pin)", async () => {
+      const result = await run({ sql: "SELECT id FROM companies", group: "postgres", connectionId: "pg-us" });
+      expect(result.success).toBe(true);
+      expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("pg-us");
+    });
+
+    it("IGNORES a foreign `connectionId` (member of another group) — falls back to primary, no cross-group escape", async () => {
+      // `clickhouse` is a member of a DIFFERENT group; pairing it with
+      // group=postgres must NOT execute against clickhouse — it falls back to
+      // postgres's primary. This is the cross-group-escape guard.
+      const result = await run({ sql: "SELECT id FROM companies", group: "postgres", connectionId: "clickhouse" });
+      expect(result.success).toBe(true);
+      const routedTo = (mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1];
+      expect(routedTo).toBe("pg-eu");
+      expect(routedTo).not.toBe("clickhouse");
+    });
+
+    it("rejects a `group` that names a MEMBER id, not the canonical group", async () => {
+      // `pg-us` is a member of `postgres`, not a group of its own. Naming it
+      // as `group` is out of reach (reach is a group axis) → hard reject.
+      const result = await run({ sql: "SELECT id FROM companies", group: "pg-us" });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not within this conversation's reach");
+      expect(mockQuery.mock.calls.length).toBe(0);
+    });
+  });
+
+  it("omitting `group` keeps legacy single-connection behavior — no reach lookup", async () => {
+    // The chat route stamps the conversation's connection into RequestContext;
+    // omitting `group` binds to it exactly as before this slice.
+    mockRequestContext = { user: { id: "u1", activeOrganizationId: "org-1" }, connectionId: "postgres" };
+    const result = await run({ sql: "SELECT id FROM companies" });
+    expect(result.success).toBe(true);
+    // The degenerate single-reachable-group case stays on the fast path:
+    // no visible-groups enumeration, runs against the stamped connection.
+    expect(mockLoadVisibleGroups.mock.calls.length).toBe(0);
+    expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("postgres");
+  });
+});

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -45,6 +45,8 @@ import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { appendRowLimit, hasLimitClause } from "./auto-limit";
 import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
+import { resolveReach, isReachable } from "@atlas/api/lib/group-reach";
+import { loadVisibleGroups } from "@atlas/api/lib/group-reach/lookup";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
 import {
   ApprovalGate,
@@ -2338,11 +2340,17 @@ export const executeSQL = tool({
     explanation: z
       .string()
       .describe("Brief explanation of what this query does and why"),
+    group: z
+      .string()
+      .optional()
+      .describe(
+        "Target Connection group (cross-group reach, ADR-0022). Names which datasource group this query runs against — its connection AND its table whitelist resolve to THIS group. Use the group/source name from the semantic tree (`explore`). Omit to use the conversation's current group. A group outside your reach is rejected — the query is NOT silently re-routed to another source; pick a reachable group or omit this. To answer a cross-source question, run one query per relevant group and correlate the results yourself; always report which source(s) you used.",
+      ),
     connectionId: z
       .string()
       .optional()
       .describe(
-        "Target connection ID. Check the entity YAML's `connection` field to determine which source a table belongs to. Omit for the default connection.",
+        "Target connection ID — a specific member WITHIN the targeted group. Check the entity YAML's `connection` field to determine which source a table belongs to. Omit for the group's default connection. For cross-group targeting use `group`, not this.",
       ),
     scope: z
       .string()
@@ -2352,14 +2360,63 @@ export const executeSQL = tool({
       ),
   }),
 
-  execute: async ({ sql, explanation, connectionId, scope }) => {
+  execute: async ({ sql, explanation, group, connectionId, scope }) => {
     // Chat routes stamp the user-selected per-turn connection into
     // RequestContext. The model normally omits `connectionId`, so fall back to
     // that routed context before the legacy default to avoid executing against
     // the wrong environment while conversation metadata says otherwise.
     const reqCtx = getRequestContext();
     const requestContextConnectionId = reqCtx?.connectionId;
-    const currentMember = connectionId ?? requestContextConnectionId ?? "default";
+
+    // Cross-group reach (ADR-0022, slice (a) #3893). When the agent names a
+    // `group`, that is a per-query GROUP target — an axis ABOVE member routing.
+    // The named group must be within the conversation's reach (slice (a): reach
+    // defaults to ALL visible groups; the Focus picker that narrows it lands in
+    // slice (c)). A group outside the reachable set is REJECTED here — a hard
+    // error, never a silent re-route to a different source (the #3867(b) fix at
+    // the execution layer). When `group` is omitted, today's implicit
+    // single-connection binding is the degenerate single-reachable-group case.
+    let groupTargetMember: string | undefined;
+    if (group !== undefined) {
+      const reachOrgId = reqCtx?.user?.activeOrganizationId;
+      const visibleGroups = await loadVisibleGroups(reachOrgId, reqCtx?.atlasMode);
+      // Slice (a): no conversation-scope reach state yet, so reach is always
+      // "all visible". Slice (c) sources this from the conversation's persisted
+      // Group-reach value (`all` | focus-group-id) — and must then surface
+      // `reach.warnings` (a `focus`-on-invisible resolution explains why reach
+      // is empty rather than substituting); under `all` it's always [].
+      const reach = resolveReach({ kind: "all" }, visibleGroups);
+      if (!isReachable(reach, group)) {
+        const reachable = reach.reachableGroups.map((g) => g.id);
+        log.warn(
+          { group, orgId: reachOrgId, reachable },
+          "executeSQL rejected an out-of-reach group target — not re-routing",
+        );
+        return {
+          success: false,
+          explanation,
+          error:
+            `Connection group "${group}" is not within this conversation's reach ` +
+            `(reachable groups: ${reachable.join(", ") || "none"}). ` +
+            `I will not query a different source instead — re-run against a reachable ` +
+            `group, or omit \`group\` to use the conversation's current source.`,
+          executionMs: 0,
+        };
+      }
+      // Resolve the group to a connection to execute against: the group's
+      // primary member (a group-of-one resolves to its own connection id).
+      // `connectionId`, if also supplied, may pin a specific member of THIS
+      // group; otherwise the group's primary is used. The per-group whitelist
+      // resolves via this connection id (members register their group's tables).
+      const target = reach.reachableGroups.find((g) => g.id === group);
+      groupTargetMember =
+        connectionId && target?.members.includes(connectionId)
+          ? connectionId
+          : target?.primary;
+    }
+
+    const currentMember =
+      groupTargetMember ?? connectionId ?? requestContextConnectionId ?? "default";
 
     // #2518 — three-state picker. `routingMode` reaches us via
     // `RequestContext` (stamped by the chat route from the conversation


### PR DESCRIPTION
## What

The **keystone** of [ADR-0022 cross-group reach](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0022-cross-group-reach-llm-composition.md) — slice (a) of PRD #3892. Gives the agent the ability to query across **all reachable Connection groups in one conversation** and correlate per-source result sets, proven end-to-end before any picker UI exists.

- **New pure module `lib/group-reach/`** (sibling to `env-routing/`, a distinct axis *above* member routing): `resolveReach(reachState, visibleGroups) → reachableGroups`. Default reach = **all visible groups**; a Focus on an invisible/unknown group resolves to **empty** reach — **never** a silent substitution. The `focus` branch is built + tested now so the bound is enforced from day one (the Focus picker lands in slice c).
- **Impure `lib/group-reach/lookup.ts` `loadVisibleGroups`** enumerates the workspace's visible groups from the content-mode-filtered whitelist + group membership (member connections fold into their canonical group; group-of-one datasources stand alone). Never throws — degrades + logs.
- **`executeSQL` gains a per-query `group` target**, bounded by the reachable set. A query naming an **out-of-reach group is hard-rejected at the execution layer** — never silently re-routed to another source (the #3867(b) fix). Validation uses **that group's** whitelist (already group-keyed); per-source SQL safety (dialect + whitelist + 4-layer AST) is unchanged. Omitting `group` is the degenerate single-reachable-group case — legacy behavior, no reach lookup on the hot path.
- **Agent guidance** on the `group` param: report which source(s) were used; never silently fall back to an unrelated source when the relevant one is empty or errors.
- Explicit `@atlas/api/lib/group-reach` package `exports` mirror `env-routing` (directory module resolution).

## Acceptance criteria

- [x] `GroupReachResolver` resolves reach: default = all visible; content-mode/whitelist-invisible excluded; never substitutes a different group.
- [x] `executeSQL` runs against the agent-named reachable group, validated against **that** group's whitelist.
- [x] An out-of-reach (or invisible) group is **rejected** with a clear error — no cross-route.
- [x] Per-source SQL safety unchanged (dialect + per-group whitelist + AST validation per query).
- [x] Agent guidance: report source(s) used; no silent fallback (tool-param contract).
- [x] Behavioral tests for `GroupReachResolver` (default-all / visibility filtering / no-substitution) and `executeSQL` group-targeting (reachable runs; out-of-reach rejected; wrong-group table → `unknown_entity`; member-pin honored; foreign `connectionId` → primary, the cross-group-escape guard).

The 2-group end-to-end correlation criterion is an agent-behavioral property: this slice ships the **mechanism** (per-query group target + reach bound + report-sources/no-fallback guidance); the deeper system-prompt narrative is slice (d).

## Scope

This is slice (a) only. Out of scope (later slices): Source catalog + group `description` (b); Group-reach picker + `conversations` reach persistence + migration (c); full agent-prompt cross-source composition guidance (d). No federation engine; residency untouched (ADR-0022).

## Testing

- `lib/group-reach/__tests__/index.test.ts` — pure resolver (11)
- `lib/group-reach/__tests__/lookup.test.ts` — impure lookup (5)
- `lib/tools/__tests__/sql-group-target.test.ts` — executeSQL group-targeting (11)
- Internal review panel (code / silent-failure / type-design / test-coverage): **clean**; reach bound is fail-closed at two layers (reach + per-group whitelist).
- `bun run lint`, full `bun run type`, and the affected isolated suite all green.

Closes #3893

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-query group targeting and reach-bounded resolution to `executeSQL`
> - Adds an optional `group` field to the `executeSQL` tool input schema. When provided, the tool loads visible Connection groups for the workspace, checks if the requested group is reachable, and routes the query to the group's primary member (or a pinned in-group `connectionId`).
> - Introduces a new `group-reach` module ([index.ts](https://github.com/AtlasDevHQ/atlas/pull/3897/files#diff-a337b1502b640cc1303043ffe3c8c3a79f239a33d77c2ba47d8cfcf29da85c9b)) with a pure `resolveReach` resolver and `isReachable` helper, plus an impure `loadVisibleGroups` function ([lookup.ts](https://github.com/AtlasDevHQ/atlas/pull/3897/files#diff-0f9abd55b3ce85bc0ce95213d004548fcb7e0757290caa81d99ff86d9b1e6d96)) that folds connection group memberships into canonical visible groups.
> - Out-of-reach group requests are rejected without executing any query; the error includes a list of reachable group names.
> - When `group` is omitted, prior single-connection behavior is fully preserved.
> - Risk: every `executeSQL` call with a `group` parameter now incurs two additional async lookups (whitelist + group membership).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ee1461.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->