### PR TITLE
chore(security): nonce-based script-src CSP for web; drop 'unsafe-inline'/'unsafe-eval' (#3899)

### DIFF
--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -3,10 +3,25 @@ import { join } from "path";
 const OUT_DIR = join(import.meta.dir, "out");
 const port = parseInt(process.env.PORT || "8080");
 
-// `script-src 'unsafe-inline'` is required by Next.js's `__NEXT_DATA__` and
-// hydration runtime. `style-src 'unsafe-inline'` is required by Next.js's
-// inlined critical CSS. `https://challenges.cloudflare.com` is required for
-// the Cloudflare Turnstile widget on the talk-to-sales form (script + iframe).
+// `script-src 'unsafe-inline'` is REQUIRED here and — unlike packages/web —
+// cannot be replaced with a nonce. www is a Next.js **static export**
+// (`output: "export"`, served by this Bun static server with no per-request
+// runtime). Each built HTML page bakes in Next.js's own inline hydration
+// scripts (`self.__next_f.push(...)`, dozens per page, content differing per
+// page), and a CSP nonce can only be minted per request by a live server —
+// which a static file server is not. The doc-cited alternative (experimental
+// `experimental.sri` hash-based CSP) only covers external chunk files, not
+// these inline RSC-payload scripts, so it wouldn't let us drop `'unsafe-inline'`
+// either. Dropping it without abandoning the static-export architecture would
+// break hydration. So www keeps `'unsafe-inline'` for scripts as a documented,
+// named-reason exception; the nonce hardening in #3899 applies to packages/web
+// (which has a server runtime / proxy) only. `frame-ancestors 'none'` below
+// still gives www full clickjacking protection regardless.
+//
+// `style-src 'unsafe-inline'` is required by Next.js's inlined critical CSS.
+// `https://challenges.cloudflare.com` is required for the Cloudflare Turnstile
+// widget on the talk-to-sales form (script + iframe); it loads as an external
+// `src=` script, so it does NOT depend on `'unsafe-inline'`.
 // `https://static.cloudflareinsights.com` is the Cloudflare Web Analytics
 // beacon auto-injected when the site is proxied through Cloudflare (its
 // reports POST to `cloudflareinsights.com`, already covered by `connect-src

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -62,6 +62,18 @@ const nextConfig: NextConfig = {
   //   data; `'unsafe-eval'` is included for libraries like Recharts that JIT
   //   chart paths. Operators on a strict-CSP build can fork this list.
   //
+  //   NOTE (this package only): the CSP below is the *self-hosted fallback*.
+  //   At runtime `src/proxy.ts` mints a per-request nonce and OVERWRITES the
+  //   `Content-Security-Policy` response header with a stronger nonce-based
+  //   `script-src 'self' 'nonce-…' 'strict-dynamic'` (no `'unsafe-inline'`;
+  //   `'unsafe-eval'` dev-only). In the standalone router-server, proxy
+  //   response headers are merged into config `headers()` by key, so the
+  //   proxy's CSP replaces this one (a single header — not two). This static
+  //   block stays here so the scaffold mirrors keep a working CSP (they ship
+  //   no proxy) and so a CSP survives even if the proxy is bypassed. The
+  //   block is drift-locked to the scaffolds, so the nonce posture is added
+  //   in the proxy, NOT by editing the directives below. See #3899.
+  //
   // The `/shared/:token/embed` route inherits everything except frame-ancestors,
   // which it overrides to `*` so customers can embed shared conversations.
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { buildThemeInitScript } from "@/ui/hooks/theme-init-script";
 import { AuthGuard } from "@/ui/components/auth-guard";
@@ -13,15 +14,34 @@ export const metadata: Metadata = {
   description: "Ask your data anything",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // The proxy mints a per-request CSP nonce and forwards it on `x-nonce`. The
+  // hand-written theme-init <script> below is inline, so under the nonce-based
+  // `script-src` (no `'unsafe-inline'`) it only executes if it carries the
+  // matching nonce. Next.js stamps the nonce onto its own framework scripts
+  // automatically; this one is ours, so we stamp it explicitly. Reading
+  // headers() opts the layout into dynamic rendering, which the nonce posture
+  // requires anyway (a baked-at-build nonce would never match the request's).
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+  if (!nonce && process.env.NODE_ENV !== "production") {
+    // No x-nonce means the proxy didn't run for this render. If the response
+    // CSP is nonce-based (no 'unsafe-inline'), this inline script is then
+    // silently CSP-blocked → a dark-mode flash with no other breadcrumb.
+    // Surface it loudly in dev so the wiring break is caught before deploy;
+    // prod stays resilient (undefined → React omits the nonce attribute, and
+    // the static next.config.ts CSP still permits the inline script).
+    console.warn(
+      "[atlas] RootLayout: no x-nonce header — the CSP proxy may not have run for this request; the inline theme script may be CSP-blocked.",
+    );
+  }
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: buildThemeInitScript() }} />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: buildThemeInitScript() }} />
       </head>
       <body className="flex h-dvh flex-col bg-white text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100">
         <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground">Skip to content</a>

--- a/packages/web/src/lib/csp.test.ts
+++ b/packages/web/src/lib/csp.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "bun:test";
+import { buildCsp, isEmbedRoute, frameAncestorsFor } from "./csp";
+
+/** Pull a single directive's value out of a built CSP string. */
+function directive(csp: string, name: string): string | undefined {
+  return csp
+    .split("; ")
+    .find((d) => d === name || d.startsWith(`${name} `))
+    ?.slice(name.length)
+    .trim();
+}
+
+describe("buildCsp", () => {
+  const NONCE = "dGVzdC1ub25jZQ=="; // base64("test-nonce")
+
+  it("script-src is nonce + strict-dynamic and NEVER contains 'unsafe-inline' (the #3899 acceptance criterion)", () => {
+    const script = directive(buildCsp(NONCE, "'self'", "prod"), "script-src")!;
+    expect(script).toContain(`'nonce-${NONCE}'`);
+    expect(script).toContain("'strict-dynamic'");
+    // The whole point: an injected inline <script> must not execute.
+    expect(script).not.toContain("'unsafe-inline'");
+  });
+
+  it("'unsafe-eval' is dev-only — present in dev, absent in prod", () => {
+    expect(directive(buildCsp(NONCE, "'self'", "dev"), "script-src")).toContain(
+      "'unsafe-eval'",
+    );
+    // Production build needs no eval (Recharts draws via d3-shape, no codegen).
+    expect(
+      directive(buildCsp(NONCE, "'self'", "prod"), "script-src"),
+    ).not.toContain("'unsafe-eval'");
+  });
+
+  it("frame-ancestors threads through: 'self' for the app shell, '*' for embeds", () => {
+    expect(directive(buildCsp(NONCE, "'self'", "prod"), "frame-ancestors")).toBe(
+      "'self'",
+    );
+    expect(directive(buildCsp(NONCE, "*", "prod"), "frame-ancestors")).toBe("*");
+  });
+
+  it("preserves the rest of the hardened directive set unchanged", () => {
+    const csp = buildCsp(NONCE, "'self'", "prod");
+    expect(directive(csp, "default-src")).toBe("'self'");
+    expect(directive(csp, "object-src")).toBe("'none'");
+    expect(directive(csp, "base-uri")).toBe("'self'");
+    expect(directive(csp, "form-action")).toBe("'self'");
+    // style-src intentionally keeps 'unsafe-inline' (Tailwind/Next critical CSS).
+    expect(directive(csp, "style-src")).toBe("'self' 'unsafe-inline'");
+  });
+
+  it("style-src is unaffected by env (only script-src gains unsafe-eval)", () => {
+    expect(directive(buildCsp(NONCE, "'self'", "dev"), "style-src")).toBe(
+      "'self' 'unsafe-inline'",
+    );
+  });
+});
+
+describe("frameAncestorsFor", () => {
+  it("widens to '*' ONLY on the embed sub-route (so customers can frame shared conversations)", () => {
+    expect(frameAncestorsFor("/shared/abc123/embed")).toBe("*");
+    expect(frameAncestorsFor("/shared/abc123/embed/")).toBe("*");
+  });
+
+  it("keeps 'self' for the app/admin shell — guards the clickjacking boundary (the security decision under test)", () => {
+    // A regression returning "*" here would make every admin page embeddable
+    // from any origin. This is the assertion that catches an inverted ternary.
+    expect(frameAncestorsFor("/admin")).toBe("'self'");
+    expect(frameAncestorsFor("/")).toBe("'self'");
+    expect(frameAncestorsFor("/shared/abc123")).toBe("'self'");
+    expect(frameAncestorsFor("/report/abc123/embed")).toBe("'self'");
+  });
+});
+
+describe("isEmbedRoute", () => {
+  it("matches the embed view with and without a trailing slash", () => {
+    expect(isEmbedRoute("/shared/abc123/embed")).toBe(true);
+    expect(isEmbedRoute("/shared/abc123/embed/")).toBe(true);
+  });
+
+  it("does NOT match the shared conversation page itself (only the embed sub-route widens frame-ancestors)", () => {
+    expect(isEmbedRoute("/shared/abc123")).toBe(false);
+    expect(isEmbedRoute("/shared/abc123/")).toBe(false);
+  });
+
+  it("does not match deeper paths or token segments containing slashes", () => {
+    expect(isEmbedRoute("/shared/abc123/embed/extra")).toBe(false);
+    expect(isEmbedRoute("/shared/a/b/embed")).toBe(false);
+  });
+
+  it("does not match unrelated or look-alike routes (no frame-ancestors widening leak)", () => {
+    expect(isEmbedRoute("/embed")).toBe(false);
+    expect(isEmbedRoute("/admin")).toBe(false);
+    expect(isEmbedRoute("/shared")).toBe(false);
+    expect(isEmbedRoute("/report/abc123/embed")).toBe(false);
+  });
+});

--- a/packages/web/src/lib/csp.ts
+++ b/packages/web/src/lib/csp.ts
@@ -1,0 +1,83 @@
+/**
+ * Content-Security-Policy construction for the per-request nonce posture (#3899).
+ *
+ * Pure functions, kept out of `proxy.ts` so they're unit-testable without
+ * pulling in better-auth/cookies and the proxy's env reads (mirrors how
+ * `cookie-prefix.ts` factors out the proxy's other pure helper). `proxy.ts`
+ * mints the nonce per request and calls `buildCsp` to assemble the header.
+ */
+
+/** `frame-ancestors` is the only directive that varies by route. */
+export type FrameAncestors = "'self'" | "*";
+
+/**
+ * `'unsafe-eval'` belongs in `script-src` only in dev. Encoded as a named
+ * union (not a bare boolean) so the call site reads `"prod"` instead of an
+ * opaque `false`, symmetric with `FrameAncestors`.
+ */
+export type CspEnv = "dev" | "prod";
+
+/**
+ * Build the CSP header value for a request.
+ *
+ * `script-src` is `'self' 'nonce-…' 'strict-dynamic'` — the nonce admits this
+ * request's inline/framework scripts, `'strict-dynamic'` lets that nonce'd
+ * bootstrap script transitively trust the hashed `/_next/static/*` chunks it
+ * loads. Crucially there is NO `'unsafe-inline'`: that token is what an
+ * injected inline <script> would otherwise ride to execution, so dropping it
+ * is the whole point. `'unsafe-eval'` is added ONLY when `env === "dev"`, where
+ * `next dev`/React Refresh use `eval` for HMR and server-error stacks; a
+ * production build needs no eval (Recharts draws via d3-shape path math
+ * — bundled through victory-vendor — not runtime codegen), so prod omits it
+ * and closes the eval/new-Function vector.
+ *
+ * `style-src` keeps `'unsafe-inline'` (Tailwind + Next inline critical CSS);
+ * nonce'ing styles is deliberately out of scope for this change.
+ *
+ * `frameAncestors` is `*` for the `/shared/:token/embed` view (must frame from
+ * any origin so customers can embed shared conversations) and `'self'`
+ * everywhere else (clickjacking protection for the app/admin shell). Browsers
+ * honor CSP `frame-ancestors` over the `X-Frame-Options: DENY` set in
+ * next.config.ts, so the embed path frames while every other path stays denied.
+ */
+export function buildCsp(
+  nonce: string,
+  frameAncestors: FrameAncestors,
+  env: CspEnv,
+): string {
+  const allowEval = env === "dev";
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${allowEval ? " 'unsafe-eval'" : ""}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    "connect-src 'self' https: wss:",
+    "frame-src 'self'",
+    `frame-ancestors ${frameAncestors}`,
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "worker-src 'self' blob:",
+  ].join("; ");
+}
+
+/**
+ * The embed view (`/shared/<token>/embed`, optional trailing slash) inherits
+ * the global CSP but widens `frame-ancestors` to `*`. Matched on the resolved
+ * pathname only — query/hash are not part of `nextUrl.pathname`.
+ */
+export function isEmbedRoute(pathname: string): boolean {
+  return /^\/shared\/[^/]+\/embed\/?$/.test(pathname);
+}
+
+/**
+ * The per-route `frame-ancestors` decision — the single gate that widens the
+ * clickjacking boundary to `*`. Extracted from the proxy so the security
+ * decision (not just the regex and the header builder in isolation) is unit
+ * tested: a regression that returned `*` for the app/admin shell would make
+ * every admin page embeddable from any origin, and this is what guards it.
+ */
+export function frameAncestorsFor(pathname: string): FrameAncestors {
+  return isEmbedRoute(pathname) ? "*" : "'self'";
+}

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -1,16 +1,50 @@
 /**
  * Next.js 16 proxy (replaces the middleware.ts convention from Next.js 15).
  *
- * Two responsibilities:
- * 1. Auth redirects — redirects unauthenticated users to /login and
+ * Three responsibilities:
+ * 1. Content-Security-Policy — mints a per-request nonce and emits a
+ *    nonce-based CSP so `script-src` uses `'nonce-…' 'strict-dynamic'` instead
+ *    of `'unsafe-inline'`. See the CSP section below.
+ * 2. Auth redirects — redirects unauthenticated users to /login and
  *    authenticated users away from auth pages. Only active when
  *    NEXT_PUBLIC_ATLAS_AUTH_MODE is "managed" (Better Auth).
- * 2. Mode forwarding — reads the `atlas-mode` cookie and forwards it as
+ * 3. Mode forwarding — reads the `atlas-mode` cookie and forwards it as
  *    an `x-atlas-mode` request header so server components can access the
  *    resolved mode without parsing cookies.
  *
  * Auth is an optimistic check — it reads the session cookie without hitting
  * the database. Actual auth enforcement happens at the API layer.
+ *
+ * --- CSP: why the nonce posture lives in the proxy (#3899) ---
+ *
+ * A nonce-based `script-src` needs a *fresh, per-request* nonce, which the
+ * static `headers()` config in next.config.ts cannot mint. So the proxy mints
+ * the nonce, surfaces it on the `x-nonce` request header, and sets the CSP on
+ * BOTH the forwarded request (so Next, seeing a `'nonce-…'` token in the
+ * request's `Content-Security-Policy`, stamps that nonce onto its own
+ * framework/hydration <script> tags during SSR) and the response (so the
+ * browser enforces it). The root layout reads `x-nonce` to stamp the one
+ * hand-written inline script (theme init). Dropping `'unsafe-inline'` from
+ * `script-src` is the point: it's the directive that otherwise neuters CSP's
+ * XSS protection (an injected inline <script> would execute).
+ *
+ * next.config.ts `headers()` STILL declares a static `'unsafe-inline'` CSP.
+ * That is deliberate and not a duplicate: in the standalone router-server
+ * (how this package deploys — `output: "standalone"`, set whenever not on
+ * Vercel; the canonical deploy is Railway) the proxy's response headers are
+ * merged into the config headers BY KEY, so this proxy's later
+ * `set("Content-Security-Policy", …)` OVERWRITES the config's static CSP — the
+ * browser sees exactly one CSP header, the nonce one. (If a future Next.js
+ * upgrade ever *appended* a same-key response header instead of replacing it,
+ * two CSP headers would ship and the browser would enforce their intersection,
+ * silently re-admitting the static `'unsafe-inline'`. The live header is
+ * spot-checkable with `curl -sI <url> | grep -ci content-security-policy` →
+ * must be 1.) The static block is kept because (a) it is drift-locked
+ * byte-for-byte to the scaffold next.config.ts mirrors, which ship NO proxy
+ * and so rely on it for a working CSP, and (b) it is a safe fallback if a
+ * deploy ever bypasses the proxy. The non-CSP security headers (HSTS,
+ * X-Frame-Options, nosniff, Referrer-Policy) and Cache-Control are owned
+ * solely by next.config.ts.
  */
 
 import { NextResponse } from "next/server";
@@ -19,9 +53,12 @@ import { getSessionCookie } from "better-auth/cookies";
 import { ATLAS_MODES } from "@useatlas/types/auth";
 import { PUBLIC_ROUTE_PREFIXES } from "./lib/public-routes";
 import { resolveWebCookiePrefix } from "./lib/cookie-prefix";
+import { buildCsp, frameAncestorsFor } from "./lib/csp";
 
 const authMode = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 const VALID_MODES = new Set<string>(ATLAS_MODES);
+
+const cspEnv = process.env.NODE_ENV === "development" ? "dev" : "prod";
 
 // Session-cookie name prefix — MUST match the API's `advanced.cookiePrefix`
 // (resolved per deploy env in `@atlas/api/lib/env-profile`). The frontend
@@ -57,26 +94,51 @@ function isAuthRoute(pathname: string): boolean {
  * Forward the `atlas-mode` cookie as an `x-atlas-mode` request header so
  * server components can read the resolved mode without parsing cookies.
  * Invalid or missing cookie values default to `published`.
+ *
+ * Also stamps the per-request `x-nonce` request header and the CSP on both the
+ * forwarded request (so Next sees `'nonce-…'` and propagates it to its own
+ * <script> tags during SSR) and the response (so the browser enforces it).
  */
-function withModeHeader(request: NextRequest): NextResponse {
+function withModeHeader(request: NextRequest, nonce: string, csp: string): NextResponse {
   const raw = request.cookies.get("atlas-mode")?.value;
   const mode = raw && VALID_MODES.has(raw) ? raw : "published";
   const headers = new Headers(request.headers);
   headers.set("x-atlas-mode", mode);
-  return NextResponse.next({ request: { headers } });
+  headers.set("x-nonce", nonce);
+  headers.set("Content-Security-Policy", csp);
+  const response = NextResponse.next({ request: { headers } });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}
+
+/**
+ * A redirect (307) has no HTML/script body, so a missing CSP on it can't be
+ * exploited — and the redirect target re-enters the proxy and gets its own
+ * fresh nonce CSP. We still stamp the response CSP here so enforcement is
+ * uniform across every exit point (no "why does this one response lack a CSP?"
+ * surprise for a future reader) rather than relying on the target's re-entry.
+ */
+function redirectWithCsp(url: URL, csp: string): NextResponse {
+  const response = NextResponse.redirect(url);
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
 }
 
 export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  // Per-request nonce: random and unguessable, so an injected inline <script>
+  // can't carry a matching nonce. Encoded base64 per the Next.js CSP guide.
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = buildCsp(nonce, frameAncestorsFor(pathname), cspEnv);
+
   // Only enforce redirects for managed (Better Auth) mode
   if (authMode !== "managed") {
-    return withModeHeader(request);
+    return withModeHeader(request, nonce, csp);
   }
-
-  const { pathname } = request.nextUrl;
 
   // Always allow public routes (demo, shared conversations, API, Next.js internals)
   if (isPublicRoute(pathname)) {
-    return withModeHeader(request);
+    return withModeHeader(request, nonce, csp);
   }
 
   try {
@@ -84,13 +146,13 @@ export function proxy(request: NextRequest) {
 
     // Authenticated user on an auth page → redirect to home
     if (sessionToken && isAuthRoute(pathname)) {
-      return NextResponse.redirect(new URL("/", request.url));
+      return redirectWithCsp(new URL("/", request.url), csp);
     }
 
     // Unauthenticated user on any non-public, non-auth route → redirect to login.
     // Default-deny: new pages are protected without needing to update a list.
     if (!sessionToken && !isAuthRoute(pathname)) {
-      return NextResponse.redirect(new URL("/login", request.url));
+      return redirectWithCsp(new URL("/login", request.url), csp);
     }
   } catch (err) {
     // Fail open: the API layer is the real auth boundary. A crash here
@@ -101,7 +163,7 @@ export function proxy(request: NextRequest) {
     );
   }
 
-  return withModeHeader(request);
+  return withModeHeader(request, nonce, csp);
 }
 
 // Next.js 16 requires the export to be named `config`, not `proxyConfig`.


### PR DESCRIPTION
## Summary

Hardens the **web app** CSP `script-src` to a per-request **nonce** posture (`'self' 'nonce-…' 'strict-dynamic'`), dropping `'unsafe-inline'` and — in production — `'unsafe-eval'`. The directive that otherwise neuters CSP's XSS protection (`'unsafe-inline'`, which lets an injected inline `<script>` execute) is gone.

- **`packages/web/src/proxy.ts`** (the existing Next.js 16 proxy) mints a random per-request nonce, sets `x-nonce` + the CSP on the forwarded **request** (so Next.js auto-stamps its framework/hydration `<script>` tags) and the **response** (so the browser enforces it). Pure CSP logic (`buildCsp`, `isEmbedRoute`, `frameAncestorsFor`) is extracted to **`lib/csp.ts`** and unit-tested.
- **`packages/web/src/app/layout.tsx`** reads `x-nonce` and stamps the one hand-written inline script (theme init); a dev-only warn fires if the nonce is absent (a proxy-bypass breadcrumb).
- **Clickjacking posture preserved:** `/shared/:token/embed` → `frame-ancestors *` (embed must frame from any origin); every other route → `frame-ancestors 'self'` (admin/app shell). Now decided per-route in the proxy.
- **`packages/web/next.config.ts`** keeps the static `'unsafe-inline'` CSP as the **drift-locked scaffold + fallback** policy (scaffolds ship no proxy). In the standalone router-server the proxy's CSP **overwrites** this by key, so exactly **one** CSP header ships — comment-only change here, so `check-security-headers-drift.sh` stays green with no script edits.
- **`apps/www/serve.ts`**: `www` is a Next.js **static export** (`output: "export"`) served by a plain Bun file server — there is no per-request runtime to mint a nonce, and each built page bakes in dozens of Next inline RSC-hydration scripts (`experimental.sri` covers external chunks, not these). A nonce is therefore impossible without abandoning static export. Its `'unsafe-inline'` is now documented as a **named-reason exception** (Cloudflare Turnstile/insights allowances kept; `frame-ancestors 'none'` still gives full clickjacking protection).

### `'unsafe-eval'`

**Dropped in production** (kept dev-only via `CspEnv`): Next.js 16 needs `eval` only in `next dev`/React Refresh (HMR + server-error stacks); a production build uses none. Verified Recharts draws via d3-shape path math (bundled through victory-vendor) — no runtime `new Function`/`eval` (greppped the dist).

## Test plan

- [x] `lib/csp.test.ts` — 11 tests: `script-src` never contains `'unsafe-inline'`; `'unsafe-eval'` dev-only; `frame-ancestors` `*`-only-on-embed (locks the clickjacking boundary against an inverted ternary); directive set preserved.
- [x] Production standalone build + live `curl`: `/login` → nonce `script-src` (no `'unsafe-inline'`/`'unsafe-eval'`) + `frame-ancestors 'self'`; `/shared/x/embed` → `frame-ancestors *`; **exactly one** CSP header; every emitted `<script>` (24, incl. the theme-init one) carries the matching nonce → **hydration intact**.
- [x] `bun run build` shows `ƒ Proxy (Middleware)` recognized; all routes dynamically rendered (the nonce posture requires it).
- [x] `/ci`: lint, type, web tests (220/220), syncpack, template-drift, security-headers-drift, + all other drift/parity gates pass. (The 4 full-suite failures are the documented WSL2 `VERCEL_*`/`ATLAS_SANDBOX_URL` dev-shell sandbox false-failures — 75/75 pass in a clean env; unrelated to this web/www change.)

## Notes
- Reading `headers()` in the root layout opts the web app into dynamic rendering app-wide (doc-required for nonces; the app is auth-gated/dynamic already).
- `style-src 'unsafe-inline'` intentionally retained (Tailwind/Next critical CSS) — out of scope per the issue.

Closes #3899

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace 'unsafe-inline'/'unsafe-eval' with nonce-based script-src CSP in the web app
> - [proxy.ts](https://github.com/AtlasDevHQ/atlas/pull/3903/files#diff-2e7739ce7a315ab9f6da0f07b2312f646916daf49b3d1e76f304babc5633b8c6) mints a per-request nonce (`base64(crypto.randomUUID())`) and builds a CSP via the new `buildCsp` util, setting `Content-Security-Policy` on every response (including auth redirects) with `script-src 'nonce-…' 'strict-dynamic'`; `'unsafe-eval'` is included only in dev.
> - [RootLayout](https://github.com/AtlasDevHQ/atlas/pull/3903/files#diff-b9e7df6154a381274a045523d51f0bf1d27fb0beb1bdcf12bbbf900464db1270) reads the `x-nonce` header forwarded by the proxy and stamps it onto the inline theme-init `<script>`, making the component render dynamically.
> - [csp.ts](https://github.com/AtlasDevHQ/atlas/pull/3903/files#diff-d6a837063e325709746a3aeffe446bdeb979371c4146f3a31d7f485c7bb7c844) introduces `buildCsp`, `isEmbedRoute`, and `frameAncestorsFor` utilities; embed routes (`/shared/:token/embed`) get `frame-ancestors '*'` while all other routes use `frame-ancestors 'self'`.
> - [serve.ts](https://github.com/AtlasDevHQ/atlas/pull/3903/files#diff-e7e2495060c11caf612f11082c08dcf970c0d8d3e80bbb4fe1e7ba8db012d47b) and [next.config.ts](https://github.com/AtlasDevHQ/atlas/pull/3903/files#diff-50694935396357b5d23f5f64b4d1cda2a0b304bc005566266ed040040e6cf0f9) receive updated comments noting that the static `www` site still requires `'unsafe-inline'` due to Next.js static export constraints.
> - Behavioral Change: the web app's CSP now omits `'unsafe-inline'` from `script-src` in production; any inline scripts without a matching nonce will be blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 592cebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->