### PR TITLE
fix(api): deploy-mode-gate global action-credential health check (#3905)

### DIFF
--- a/packages/api/src/lib/__tests__/startup-actions.test.ts
+++ b/packages/api/src/lib/__tests__/startup-actions.test.ts
@@ -305,6 +305,62 @@ describe("action diagnostics — missing credentials", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #3905 — global action-credential check is deploy-mode-gated.
+// Per the #3766 config model, action targets are per-workspace-only on SaaS —
+// there is no platform/global default env credential. Warning on a missing
+// *global* JIRA_* on SaaS reported a credential model SaaS doesn't use and
+// surfaced as a spurious /api/health warning. Self-host is unchanged.
+// ---------------------------------------------------------------------------
+
+describe("action diagnostics — deploy-mode gate (#3905)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_ACTIONS_ENABLED = "true";
+    process.env.ATLAS_API_KEY = "test-key-123"; // satisfy auth requirement
+    mockValidateActionCredentials = () => [
+      { action: "createJiraTicket", missing: ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"] },
+    ];
+  });
+
+  it("suppresses missing global action-credential warnings on SaaS", async () => {
+    mockConfig = { deployMode: "saas" };
+
+    await validateEnvironment();
+    const warnings = getStartupWarnings();
+    expect(warnings.filter((w) => w.includes("missing credentials"))).toHaveLength(0);
+    // The skip is narrow: unrelated, non-action startup warnings still fire on
+    // SaaS (proves we suppressed only the global action-cred check — DATABASE_URL
+    // is unset in this suite's beforeEach, so its warning must still appear).
+    expect(
+      warnings.some((w) => w.includes("Action framework requires DATABASE_URL")),
+    ).toBe(true);
+  });
+
+  it("still warns on self-hosted when a registered action lacks its global creds", async () => {
+    mockConfig = { deployMode: "self-hosted" };
+
+    await validateEnvironment();
+    const warnings = getStartupWarnings();
+    const credWarnings = warnings.filter((w) => w.includes("missing credentials"));
+    expect(credWarnings).toHaveLength(1);
+    expect(credWarnings[0]).toContain("createJiraTicket");
+    expect(credWarnings[0]).toContain("JIRA_BASE_URL");
+  });
+
+  it("validates (warns) when the resolved config has no deploy mode set", async () => {
+    // checkConfigFile() runs loadConfig() before checkActionFramework(), so by
+    // the gate getConfig() returns a resolved config (the mock's loadConfig
+    // sets `{ source: "env" }`, deployMode unset). A config without a deployMode
+    // (`undefined !== "saas"`) must fail open to validating — the self-host
+    // default — never silently suppress a real self-host misconfiguration.
+    mockConfig = { source: "env" };
+
+    await validateEnvironment();
+    const warnings = getStartupWarnings();
+    expect(warnings.filter((w) => w.includes("missing credentials"))).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ATLAS_ACTIONS_ENABLED=true without DATABASE_URL — persistent tracking warning
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -721,15 +721,32 @@ async function checkActionFramework(errors: DiagnosticError[], authMode: string)
   }
 
   // Check required credentials for registered actions (warnings only —
-  // missing optional action credentials should not block chat queries)
+  // missing optional action credentials should not block chat queries).
+  //
+  // SaaS skips this check: per the #3766 config model, action targets
+  // (Jira, Linear, GitHub, Salesforce, …) are per-workspace-only on SaaS —
+  // there is no platform/global default env credential.
+  // `validateActionCredentials()` checks each *registered* action's required
+  // keys against the global env, so on SaaS it would report those globals
+  // (e.g. a registered Jira action's JIRA_*) missing and surface them as
+  // spurious /api/health warnings for a credential model SaaS isn't supposed
+  // to use (#3905). Read the *resolved* deploy mode (not raw env): a `saas`
+  // request that downgraded to self-hosted because enterprise wasn't enabled
+  // resolves to `self-hosted` here and is still validated. Core/platform
+  // globals (AI gateway, sandbox) are unaffected — they aren't action
+  // credentials. Self-host behavior is unchanged. Out of scope: per-workspace
+  // resolution and dropping global-env registration on SaaS (#3766).
   try {
-    const { buildRegistry } = await import("@atlas/api/lib/tools/registry");
-    const { registry: actionRegistry } = await buildRegistry({ includeActions: true });
-    const missingCreds = actionRegistry.validateActionCredentials();
-    for (const { action, missing } of missingCreds) {
-      const msg = `Action "${action}" missing credentials: ${missing.join(", ")}`;
-      if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
-      log.warn(msg);
+    const { getConfig } = await import("@atlas/api/lib/config");
+    if (getConfig()?.deployMode !== "saas") {
+      const { buildRegistry } = await import("@atlas/api/lib/tools/registry");
+      const { registry: actionRegistry } = await buildRegistry({ includeActions: true });
+      const missingCreds = actionRegistry.validateActionCredentials();
+      for (const { action, missing } of missingCreds) {
+        const msg = `Action "${action}" missing credentials: ${missing.join(", ")}`;
+        if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
+        log.warn(msg);
+      }
     }
   } catch (err) {
     log.warn(


### PR DESCRIPTION
## Summary
- On **SaaS**, `checkActionFramework()` validated each registered action's required credentials against the global `process.env` and pushed a startup warning for any missing ones (e.g. `Action "createJiraTicket" missing credentials: JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN`). That warning surfaced in `/api/health`'s `warnings[]` for a credential model SaaS isn't supposed to use — per the #3766 config model, action targets are **per-workspace-only** on SaaS; there is no platform/global default env credential.
- **Fix:** gate the global action-credential check on the **resolved** deploy mode at the `checkActionFramework` caller — skip the `validateActionCredentials()` warning loop when `getConfig()?.deployMode === "saas"`. Reading the *resolved* mode (not raw `ATLAS_DEPLOY_MODE`) means a requested `saas` that downgraded to self-hosted (enterprise off) is **still validated**.
- Self-host behavior is unchanged. Core/platform globals (AI gateway, sandbox) are unaffected — they aren't action credentials and never flow through this check.

## Scope note
This is the isolated **health-correctness** fix. Per-workspace action-credential **resolution** and dropping global-env registration on SaaS remain tracked by **#3766** (out of scope here).

A precision note for reviewers: on current `main`, startup `warnings` populate `/api/health`'s `warnings[]` array but do **not** themselves flip the overall `status` field to `degraded` (that's driven by component errors). This fix removes the spurious warning at its source, so it no longer appears for SaaS and can't drive `degraded` in any monitor or older code path.

## Test plan
- [x] New `describe("action diagnostics — deploy-mode gate (#3905)")` block in `startup-actions.test.ts` covers both deploy modes:
  - `deployMode: "saas"` → **no** "missing credentials" warning, **and** an unrelated non-action warning (DATABASE_URL) still fires (proves the skip is narrow).
  - `deployMode: "self-hosted"` → still warns with the action name + missing keys.
  - resolved config with deployMode unset → fails open to validating (self-host default).
- [x] Self-contained tests (no top-level `process.env` mutation); 25/25 pass.
- [x] `/ci` green: lint, type, full test, syncpack, all drift/discipline gates.

Closes #3905

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip global action-credential health checks in `checkActionFramework` when deploy mode is 'saas'
> - In `saas` deploy mode, `checkActionFramework` now skips `validateActionCredentials()` and suppresses any 'missing credentials' startup warnings, since global env-based credentials are not expected in that environment.
> - For `self-hosted` mode or when `deployMode` is unset, credential validation continues as before.
> - Tests added in [startup-actions.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3906/files#diff-573b92bc55490cec58e1359c81caafa2b50f71e345c534c9d4d68de084ea51d2) cover all three cases.
> - Behavioral Change: SaaS deployments will no longer emit missing-credential startup warnings for registered actions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77964b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->