### PR TITLE
fix(api): tenant/non-default datasource health no longer 503s the shared region (/health isolation)

### DIFF
--- a/apps/docs/content/docs/deployment/multi-datasource.mdx
+++ b/apps/docs/content/docs/deployment/multi-datasource.mdx
@@ -370,10 +370,15 @@ curl http://localhost:3001/api/health
 }
 ```
 
-The aggregate `status` (and the 503-on-unhealthy contract) always reflects
-**every** registered source regardless of who is asking — a degraded or
-unhealthy non-`default` source still degrades or fails the overall status for
-anonymous callers; it just isn't enumerated in their `sources` breakdown.
+The aggregate `status` (and the 503 load-balancer contract) reflects only
+**platform-critical infrastructure** — the region's own primary datasource
+(`default`) and, in SaaS, the internal database. A degraded or unhealthy
+**non-`default`** source (a secondary connection group, a tenant's
+connection-group datasource, a cross-region fleet member) is advisory: it shows
+up in the per-source `sources` breakdown (and the workspace's Admin → Connections
+view) but does **not** change the aggregate `status` or trip a 503. This keeps one
+workspace's misconfigured connection from pulling the whole shared region out of
+the load balancer.
 
 ---
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -54,8 +54,13 @@ let connMetadata: ConnectionMetadata[] = [];
 // `sources` section unions them in via `describeAllWorkspacePlugins()` (#3844).
 let pluginMetadata: ConnectionMetadata[] = [];
 
+// Datasource live-probe impl — mutable so a test can simulate the `default`
+// datasource's SELECT 1 failing mid-life (the "pod connected, DB died" path the
+// base status turns into a 503). Defaults to success; reset per-scenario.
+let dsQueryImpl: () => Promise<unknown> = () =>
+  Promise.resolve({ columns: ["?column?"], rows: [{ "?column?": 1 }] });
 const mockDBConnection = {
-  query: async () => ({ columns: ["?column?"], rows: [{ "?column?": 1 }] }),
+  query: () => dsQueryImpl(),
   close: async () => {},
 };
 
@@ -258,6 +263,8 @@ describe("GET /api/health — sources section", () => {
     delete process.env.DATABASE_URL;
     connMetadata = [];
     pluginMetadata = [];
+    dsQueryImpl = () =>
+      Promise.resolve({ columns: ["?column?"], rows: [{ "?column?": 1 }] });
     mockValidateEnvironment.mockReset();
     mockValidateEnvironment.mockResolvedValue([]);
     mockGetStartupWarnings.mockReset();
@@ -269,6 +276,8 @@ describe("GET /api/health — sources section", () => {
     else delete process.env.ATLAS_DATASOURCE_URL;
     if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
     else delete process.env.DATABASE_URL;
+    dsQueryImpl = () =>
+      Promise.resolve({ columns: ["?column?"], rows: [{ "?column?": 1 }] });
   });
 
   it("returns sources section omitted when no connections are registered", async () => {
@@ -366,6 +375,47 @@ describe("GET /api/health — sources section", () => {
     // Still surfaced in the breakdown.
     const sources = body.sources as Record<string, unknown>;
     expect((sources.warehouse as Record<string, unknown>).status).toBe("degraded");
+  });
+
+  // The #1981 contract via the LIVE probe path (not just the boot diagnostic): the
+  // default datasource's SELECT 1 failing mid-life ("pod connected, DB died") must
+  // still 503 — and an otherwise-healthy non-default source must not mask it.
+  it("still 503s when the default datasource live probe fails, even with a healthy non-default source", async () => {
+    dsQueryImpl = () => Promise.reject(new Error("connection refused"));
+    connMetadata = [
+      { id: "default", dbType: "postgres" },
+      { id: "warehouse", dbType: "postgres", health: { status: "healthy", latencyMs: 4, checkedAt: new Date() } },
+    ];
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+  });
+
+  // Realistic shared-region shape: several tenant/secondary sources impaired at
+  // once. None may move the platform status — guards against a future
+  // "promote if N unhealthy" regression.
+  it("a healthy default with MULTIPLE unhealthy non-default sources stays ok", async () => {
+    const down = (msg: string): HealthCheckResult => ({
+      status: "unhealthy",
+      latencyMs: 5000,
+      message: msg,
+      checkedAt: new Date(),
+    });
+    connMetadata = [
+      { id: "default", dbType: "postgres", health: { status: "healthy", latencyMs: 3, checkedAt: new Date() } },
+      { id: "us-prod", dbType: "postgres", health: down("dns") },
+      { id: "eu-prod", dbType: "postgres", health: down("timeout") },
+    ];
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    const sources = body.sources as Record<string, unknown>;
+    expect((sources["us-prod"] as Record<string, unknown>).status).toBe("unhealthy");
+    expect((sources["eu-prod"] as Record<string, unknown>).status).toBe("unhealthy");
   });
 
   it("includes multiple sources in the sources section", async () => {

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -304,7 +304,12 @@ describe("GET /api/health — sources section", () => {
     expect(defaultSource.checkedAt).toBe("2026-01-15T12:00:00.000Z");
   });
 
-  it("promotes top-level status to 'error' when a non-default source is unhealthy", async () => {
+  // Multi-tenant health isolation: a NON-default source (a tenant's connection-group
+  // datasource, a secondary env group) being unhealthy must NOT affect the shared
+  // region's platform status — no 503, not even `degraded`. It stays visible in the
+  // `sources` breakdown so operators/admins can see and fix it. Only the region's own
+  // `default` datasource gates platform status / 503 (#1981).
+  it("a non-default unhealthy source does NOT change platform status (stays ok, still visible)", async () => {
     const unhealthy: HealthCheckResult = {
       status: "unhealthy",
       latencyMs: 5000,
@@ -312,19 +317,36 @@ describe("GET /api/health — sources section", () => {
       checkedAt: new Date(),
     };
     connMetadata = [
+      { id: "default", dbType: "postgres", health: { status: "healthy", latencyMs: 3, checkedAt: new Date() } },
       { id: "warehouse", dbType: "postgres", health: unhealthy },
     ];
 
     const response = await app.fetch(healthRequest());
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(200);
 
     const body = (await response.json()) as Record<string, unknown>;
-    expect(body.status).toBe("error");
+    expect(body.status).toBe("ok");
+    // The unhealthy source is still surfaced — operators must see it to fix it.
     const sources = body.sources as Record<string, unknown>;
     expect((sources.warehouse as Record<string, unknown>).status).toBe("unhealthy");
   });
 
-  it("promotes top-level status to 'degraded' when a non-default source is degraded and no other errors", async () => {
+  // Guard against over-correction: the region's OWN primary datasource (`default`)
+  // being unreachable MUST still 503 — that's the #1981 LB contract. Only NON-default
+  // sources are advisory.
+  it("still 503s when the region's own default datasource is unreachable (#1981)", async () => {
+    mockValidateEnvironment.mockResolvedValue([
+      { code: "DB_UNREACHABLE", message: "datasource down" },
+    ]);
+    connMetadata = [{ id: "default", dbType: "postgres" }];
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+  });
+
+  it("a non-default degraded source does NOT change platform status (stays ok)", async () => {
     const degraded: HealthCheckResult = {
       status: "degraded",
       latencyMs: 2000,
@@ -332,6 +354,7 @@ describe("GET /api/health — sources section", () => {
       checkedAt: new Date(),
     };
     connMetadata = [
+      { id: "default", dbType: "postgres", health: { status: "healthy", latencyMs: 3, checkedAt: new Date() } },
       { id: "warehouse", dbType: "postgres", health: degraded },
     ];
 
@@ -339,7 +362,10 @@ describe("GET /api/health — sources section", () => {
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as Record<string, unknown>;
-    expect(body.status).toBe("degraded");
+    expect(body.status).toBe("ok");
+    // Still surfaced in the breakdown.
+    const sources = body.sources as Record<string, unknown>;
+    expect((sources.warehouse as Record<string, unknown>).status).toBe("degraded");
   });
 
   it("includes multiple sources in the sources section", async () => {
@@ -805,9 +831,13 @@ describe("GET /api/health — plugin component", () => {
 // anonymous callers; EU/APAC exposed only `default`. The full per-source
 // breakdown is recon surface, so it's now gated behind an operator signal
 // (admin session / API key / local-dev no-auth). Anonymous callers see only the
-// aggregate `status` + the region's own datasource (`default`). The overall
-// status-promotion aggregation (and the 503-on-unhealthy contract) is unchanged
-// — it still considers every source regardless of who's asking.
+// aggregate `status` + the region's own datasource (`default`).
+//
+// Multi-tenant health isolation: a NON-default source being unhealthy/degraded no
+// longer moves the platform `status` for ANY caller — only the region's own
+// `default` datasource (+ the SaaS internal DB) gates 503. So a tenant's bad
+// connection can't pull the shared region from the LB. The tests below assert the
+// new contract.
 describe("GET /api/health — per-source fleet visibility gating (#3685)", () => {
   const origDatasource = process.env.ATLAS_DATASOURCE_URL;
   const origDatabaseUrl = process.env.DATABASE_URL;
@@ -916,7 +946,7 @@ describe("GET /api/health — per-source fleet visibility gating (#3685)", () =>
     expect(Object.keys(sources)).toEqual(["default"]);
   });
 
-  it("overall status promotion stays intact for anonymous callers — a degraded non-default source still degrades the aggregate without being enumerated", async () => {
+  it("a degraded non-default source no longer degrades the aggregate for anonymous callers — stays ok, fleet not enumerated", async () => {
     connMetadata = fleet({
       "eu-prod": {
         status: "degraded",
@@ -930,14 +960,15 @@ describe("GET /api/health — per-source fleet visibility gating (#3685)", () =>
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
-    // Aggregate reflects the fleet (eu-prod degraded) ...
-    expect(body.status).toBe("degraded");
-    // ... but the breakdown does not enumerate the degraded region.
+    // Multi-tenant isolation: a non-default (cross-region / tenant) source being
+    // impaired does not move the platform status.
+    expect(body.status).toBe("ok");
+    // ... and the breakdown still does not enumerate the cross-region fleet.
     const sources = body.sources as Record<string, unknown>;
     expect(Object.keys(sources)).toEqual(["default"]);
   });
 
-  it("503-on-unhealthy-source contract holds for anonymous callers without enumerating the fleet", async () => {
+  it("a non-default unhealthy source no longer 503s anonymous callers — stays ok, fleet not enumerated", async () => {
     connMetadata = fleet({
       "eu-prod": {
         status: "unhealthy",
@@ -949,9 +980,11 @@ describe("GET /api/health — per-source fleet visibility gating (#3685)", () =>
     authenticateRequestImpl = () => Promise.resolve(ANON_AUTH);
 
     const response = await app.fetch(healthRequest());
-    expect(response.status).toBe(503);
+    // Multi-tenant isolation: a non-default (cross-region / tenant) source being
+    // unhealthy must NOT take the shared region out of the LB.
+    expect(response.status).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
-    expect(body.status).toBe("error");
+    expect(body.status).toBe("ok");
     const sources = body.sources as Record<string, unknown>;
     expect(Object.keys(sources)).toEqual(["default"]);
   });

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -409,8 +409,7 @@ health.openapi(healthRoute, async (c) => {
         // breakdown below and in the per-workspace Admin → Connections view, but it
         // MUST NOT move the shared region's top-level status. Letting it would either
         // 503 the whole region (LB removal for every tenant) or trip every operator's
-        // platform alert because one workspace fat-fingered a connection host. The
-        // platform probe reflects platform infrastructure, not tenant data sources.
+        // platform alert because one workspace fat-fingered a connection host.
         // Multi-tenant health isolation — no promotion off non-`default` sources.
       }
     } catch (err) {

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -399,12 +399,19 @@ health.openapi(healthRoute, async (c) => {
           };
         }
 
-        // Promote overall status based on effective source health (includes live probe overrides)
-        const sourceStatuses = Object.values(sourcesSection).map((s) => s.status);
-        const hasUnhealthy = sourceStatuses.includes("unhealthy");
-        const hasDegraded = sourceStatuses.includes("degraded");
-        if (hasUnhealthy && status !== "error") status = "error";
-        else if (hasDegraded && status === "ok") status = "degraded";
+        // Per-source health is ADVISORY for every source EXCEPT the region's own
+        // primary datasource (`default`). `default` is the only platform-critical
+        // source, and it already gates the 503 LB contract (#1981) via the live
+        // SELECT 1 probe folded into the base `status` computation above. A
+        // NON-default source — a tenant's connection-group datasource, a secondary
+        // env group, a cross-region fleet member — being unhealthy or degraded is a
+        // tenant-/fleet-scoped condition: it stays visible in the operator `sources`
+        // breakdown below and in the per-workspace Admin → Connections view, but it
+        // MUST NOT move the shared region's top-level status. Letting it would either
+        // 503 the whole region (LB removal for every tenant) or trip every operator's
+        // platform alert because one workspace fat-fingered a connection host. The
+        // platform probe reflects platform infrastructure, not tenant data sources.
+        // Multi-tenant health isolation — no promotion off non-`default` sources.
       }
     } catch (err) {
       log.warn(
@@ -569,9 +576,10 @@ health.openapi(healthRoute, async (c) => {
     // per-DB latencies. That breakdown is reconnaissance surface for an
     // unauthenticated caller, so only operators receive it. Anonymous callers
     // get the aggregate `status` plus the region's own datasource (`default`) —
-    // the shape EU/APAC already return. The status-promotion aggregation above
-    // (lines computing sourceStatuses) still considers every source regardless
-    // of who's asking, so the 503-on-unhealthy-source contract is unchanged.
+    // the shape EU/APAC already return. The aggregate `status` itself reflects
+    // only platform-critical infra (the `default` datasource + SaaS internal DB),
+    // not non-`default` sources (see the multi-tenant-isolation note above), so a
+    // tenant's unhealthy connection never changes it for any caller.
     const isOperator = await isOperatorHealthRequest(c.req.raw);
     const visibleSources = sourcesSection
       ? isOperator


### PR DESCRIPTION
## Problem

The platform health endpoint (`GET /api/health`) promoted its top-level `status` — and therefore the **503 load-balancer contract** — off the health of **every** registered datasource. The `ConnectionRegistry` holds all sources, including a workspace's connection-group datasources (`us-prod` / `eu-prod` / `apac-prod`). So a **single tenant's** misconfigured connection — e.g. a hostname that fails DNS (`getaddrinfo ENOTFOUND`) — flipped the **shared region's** `/api/health` to `error` → **HTTP 503**, with every platform component otherwise healthy.

On a SaaS region that's an availability hazard: one workspace fat-fingering a connection host could pull the whole region out of the load balancer **for every tenant**.

### How it was found
Surfaced while verifying the **v0.0.22** prod deploy. US `/api/health` returned 503 while `datasource`/`internalDb`/`provider`/`scheduler`/`sandbox`/`plugins` were all `healthy`. Railway logs traced it to a workspace `us-prod` connection failing `SELECT 1` with `DNSException` every 60s. Pre-existing — the health code is byte-identical across `v0.0.21..v0.0.22`, so this is **not** a release regression.

## Fix

Make **non-`default`** source health **advisory**. Only the region's own primary datasource (`default`) — plus, in SaaS, the internal DB — gates the top-level `status`/503 (the [#1981](https://github.com/AtlasDevHQ/atlas/issues/1981) LB contract, already enforced via the live `SELECT 1` probe in the base status computation).

A non-`default` source being unhealthy or degraded:
- ✅ stays fully visible in the operator `sources` breakdown and the per-workspace **Admin → Connections** view,
- ❌ no longer moves the platform `status` for any caller (no 503, not even `degraded`).

## Changes
- **`health.ts`** — drop the per-source status promotion off non-`default` sources; refresh the #3685 gating comment.
- **`health.test.ts`** — flip the two tests that encoded the old "non-default unhealthy → 503 / degraded → degraded" contract; **add a #1981 guard** (the region's own `default` datasource unreachable still 503s).
- **`docs/deployment/multi-datasource.mdx`** — document the platform-critical-only aggregate contract.

## Test plan
- TDD: updated tests fail against the old code (4 red), pass after the fix (32/32 green).
- `--affected` suite green (9/9, incl. both health tests + admin); `bun run type` + `bun run lint` clean; OpenAPI drift in sync.

## Operational note
This explains the US-region 503 observed during the v0.0.22 release verification. The underlying `us-prod` workspace connection still has a bad host and should be repaired/removed separately in Admin → Connections; once it resolves, the per-source view goes healthy. This PR ensures that tenant condition can never again degrade the shared platform probe.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/health` aggregate status to ignore non-default datasource failures
> - Previously, any unhealthy or degraded non-default datasource would promote the aggregate `/health` status to `error`/`degraded` and return a 503, potentially removing a healthy region from the load balancer due to a single workspace's misconfiguration.
> - Removes the status-promotion logic in [health.ts](https://github.com/AtlasDevHQ/atlas/pull/3907/files#diff-b66b14bcec9a4dedaf769953071256234d031205e3f290457c996e7f1cd29546) so only the region's `default` datasource (and the SaaS internal DB) can cause a 503 or a degraded/error aggregate status.
> - Non-default sources remain visible in the per-source breakdown for operators but are now advisory-only.
> - Updates [multi-datasource.mdx](https://github.com/AtlasDevHQ/atlas/pull/3907/files#diff-08600eac74c0aa41cdb0be544fd0461ae6ee5fa9ea7e47374f96be2fb9897a22) to document the new aggregate health semantics.
> - Behavioral Change: non-default datasource failures that previously returned 503 now return 200 with an `ok` top-level status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f80b4e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->