### PR TITLE
feat(api,web): Group-reach picker + conversation reach persistence + clean-break migration (#3895)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -112,6 +112,13 @@
                     ],
                     "minLength": 1
                   },
+                  "groupReach": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
                   "boundDashboardId": {
                     "type": "string",
                     "format": "uuid"
@@ -2361,6 +2368,12 @@
                               "null"
                             ]
                           },
+                          "groupReach": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "starred": {
                             "type": "boolean"
                           },
@@ -2648,6 +2661,12 @@
                       }
                     },
                     "restFocusDatasourceId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "groupReach": {
                       "type": [
                         "string",
                         "null"

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -726,6 +726,11 @@ export function createApiTestMocks(
     // they override locally when they do.
     updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
     updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+    // #3895 — per-conversation Group reach write path. Same no-op success
+    // default; chat.ts statically imports it, so the shared mock MUST export it
+    // (a partial mock omitting it breaks every route test's module load with a
+    // "Export named 'updateConversationGroupReach' not found" SyntaxError).
+    updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
     // NULL → "pin" back-compat default helper used by the chat route to
     // resolve a conversation's persisted `routing_mode`. Mocked as a pure
     // pass-through so tests can simulate either an explicit mode or the

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -140,6 +140,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -339,6 +339,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -351,6 +351,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -307,6 +307,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -245,6 +245,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -604,6 +604,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -136,6 +136,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -134,6 +134,13 @@ const mockUpdateConversationRestExcluded = mock(() =>
 const mockUpdateConversationRestFocus = mock(() =>
   Promise.resolve({ ok: true as const }),
 );
+// #3895 — captured so tests can assert the Group-reach persist path, incl. the
+// widen-via-null case (the #3073 transport-omits-null bug class). The chat route
+// imports + CALLS this synchronously (before .catch), so it MUST be mocked or
+// the persist-reach branch throws a TypeError the moment the picker is touched.
+const mockUpdateConversationGroupReach = mock(() =>
+  Promise.resolve({ ok: true as const }),
+);
 type ReservationResult =
   | { status: "ok"; totalStepsBefore: number }
   | { status: "exceeded"; totalSteps: number }
@@ -176,6 +183,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mockUpdateConversationRestExcluded,
   updateConversationRestFocus: mockUpdateConversationRestFocus,
+  updateConversationGroupReach: mockUpdateConversationGroupReach,
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
@@ -266,6 +274,8 @@ describe("POST /api/v1/chat", () => {
     mockUpdateConversationRestExcluded.mockResolvedValue({ ok: true as const });
     mockUpdateConversationRestFocus.mockReset();
     mockUpdateConversationRestFocus.mockResolvedValue({ ok: true as const });
+    mockUpdateConversationGroupReach.mockReset();
+    mockUpdateConversationGroupReach.mockResolvedValue({ ok: true as const });
     mockReserveConversationBudget.mockReset();
     mockReserveConversationBudget.mockResolvedValue({ status: "ok", totalStepsBefore: 0 });
     mockSettleConversationSteps.mockReset();
@@ -699,6 +709,131 @@ describe("POST /api/v1/chat", () => {
     expect(capturedContext?.restFocusDatasourceId).toBe("ds-stripe");
     // …and did NOT burn an UPDATE (body absent → inherit, no change).
     expect(mockUpdateConversationRestFocus).not.toHaveBeenCalled();
+  });
+
+  // #3895 — the conversation's Group reach (a Focus group id) must reach the
+  // agent via the ALS frame so executeSQL's reach resolver bounds queries to it.
+  it("propagates groupReach into the ALS frame the agent sees (#3895)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "focus prod" }] }],
+        groupReach: "g_prod",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.groupReach).toBe("g_prod");
+  });
+
+  // #3895 — a null/All-sources reach must NOT be stamped on the ALS frame, so the
+  // default "every visible group reachable" shape is byte-identical for the
+  // common non-focused conversation.
+  it("does not stamp a null groupReach on the ALS frame (All sources) (#3895)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        groupReach: null,
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.groupReach).toBeUndefined();
+  });
+
+  // #3895 / #3073 — the widen path. An existing conversation is Focused on
+  // g_prod; the user widens to All sources, so the body carries `null`. The route
+  // distinguishes "field present as null" (persist the widen) from "field absent"
+  // (inherit the row) — without it a widen silently keeps the stale Focus.
+  it("persists a widen (null widens a prior Focus to All sources) (#3895/#3073)", async () => {
+    const convId = "a1b2c3d4-e5f6-4708-9a0b-1c2d3e4f5061";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+        groupReach: "g_prod",
+        messages: [],
+      },
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "widen" }] }],
+        conversationId: convId,
+        groupReach: null,
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockUpdateConversationGroupReach).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationGroupReach.mock.calls as unknown as unknown[][];
+    // Second arg is the new (null) reach persisted to the row.
+    expect(calls[0]![1]).toBeNull();
+  });
+
+  // #3895 — when the body OMITS groupReach (the common follow-up turn), the
+  // stored Focus is inherited into the ALS frame and NO redundant UPDATE fires.
+  it("inherits the stored Group reach and skips the UPDATE when the body omits it (#3895)", async () => {
+    const convId = "b2c3d4e5-f6a7-4819-8b0c-2d3e4f506172";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+        groupReach: "g_prod",
+        messages: [],
+      },
+    });
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "follow up" }] }],
+        conversationId: convId,
+        // groupReach intentionally omitted
+      }),
+    );
+    expect(response.status).toBe(200);
+    // Inherited the stored Focus into the ALS frame…
+    expect(capturedContext?.groupReach).toBe("g_prod");
+    // …and did NOT burn an UPDATE (body absent → inherit, no change).
+    expect(mockUpdateConversationGroupReach).not.toHaveBeenCalled();
   });
 
   // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -150,6 +150,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -356,6 +356,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -132,6 +132,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -164,6 +164,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -161,6 +161,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -133,6 +133,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -352,6 +352,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -290,6 +290,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -982,6 +982,49 @@ chat.openapi(chatRoute, async (c) => {
           // internal DB has no group concept to begin with.
         }
 
+        // #3895 — a body-supplied Focus `groupReach` is a group id we persist
+        // onto the row, so it gets the SAME org-ownership gate as
+        // `connectionGroupId` (#2424): a cross-org pointer must not survive on
+        // the row even though the runtime reach bound (org-scoped
+        // `loadVisibleGroups`) already refuses to reach another org's data — this
+        // keeps the persisted-pointer integrity story consistent across both
+        // cross-group fields. Skip when null (a widen to All sources names no
+        // group) or when it equals `connectionGroupId` (already verified above —
+        // the picker sends both equal on a Focus, so the common path adds no
+        // second lookup).
+        if (
+          parsed.data.groupReach &&
+          parsed.data.groupReach !== parsed.data.connectionGroupId
+        ) {
+          const verdict = await verifyGroupBelongsToOrg(
+            parsed.data.groupReach,
+            authResult.user?.activeOrganizationId,
+          );
+          if (verdict === "not_found") {
+            return c.json(
+              {
+                error: "invalid_connection_group",
+                message: "The requested environment is not available in this workspace.",
+                retryable: false,
+                requestId,
+              },
+              400,
+            );
+          }
+          if (verdict === "error") {
+            return c.json(
+              {
+                error: "internal_error",
+                message: "Could not verify environment ownership. Please retry.",
+                retryable: true,
+                requestId,
+              },
+              500,
+            );
+          }
+          // `no_db` falls through, exactly as the connectionGroupId gate above.
+        }
+
         // Conversation persistence — Ownership verification blocks here (can 404); message writes are fire-and-forget via internalExecute.
         if (hasInternalDB()) {
           if (conversationId) {

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -45,6 +45,7 @@ import {
   updateConversationRoutingMode,
   updateConversationRestExcluded,
   updateConversationRestFocus,
+  updateConversationGroupReach,
   resolveRoutingMode,
 } from "@atlas/api/lib/conversations";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
@@ -435,6 +436,29 @@ export const ChatRequestSchema = z.object({
   restFocusDatasourceId: z
     .string()
     .min(1, "restFocusDatasourceId must be a non-empty install_id or null.")
+    .nullable()
+    .optional(),
+  /**
+   * #3895 (ADR-0022) — per-conversation Group reach. The scope picker sends the
+   * focused `connection_group_id` (to Focus → that group, a hard/exclusive
+   * narrowing) or `null` (All sources — every visible group reachable). The
+   * route persists it onto the conversation row AND stamps it into the request
+   * context so the reach resolver bounds `executeSQL` for this turn.
+   *
+   * Presence is meaningful, like the REST-scope fields: an explicit `null`
+   * widens back to All sources, whereas an OMITTED field inherits the
+   * conversation's stored reach. The web transport must therefore send the
+   * field (including `null`) whenever the picker was touched, or a widen
+   * silently keeps the stale Focus (the #3073 transport-omits-null bug class).
+   *
+   * An empty string is rejected (`.min(1)`): the only valid values are a
+   * non-empty group id (Focus) or `null` (All sources). `""` would persist as
+   * Focus yet read back as All at the runtime truthy gate — invalid stored state
+   * with the UI and agent disagreeing (mirrors restFocusDatasourceId).
+   */
+  groupReach: z
+    .string()
+    .min(1, "groupReach must be a non-empty connection_group_id or null.")
     .nullable()
     .optional(),
   /**
@@ -906,6 +930,14 @@ chat.openapi(chatRoute, async (c) => {
         // row (the transport-omits-null bug class, #3073).
         let effectiveRestFocus: string | null | undefined =
           parsed.data.restFocusDatasourceId;
+        // #3895 — per-conversation Group reach (ADR-0022). Body value (this
+        // turn, from the scope picker) > stored value on the row. PRESENCE is
+        // meaningful: an explicit `null` widens to All sources, an OMITTED field
+        // inherits the row's reach. We keep `undefined` (omitted) vs `null`
+        // (widen) distinct all the way through so a widen actually nulls the row
+        // (the transport-omits-null bug class, #3073).
+        let effectiveGroupReach: string | null | undefined =
+          parsed.data.groupReach;
 
         // #2424 — when the body supplies `connectionGroupId`, verify it
         // belongs to the caller's active org BEFORE persisting it onto the
@@ -995,6 +1027,13 @@ chat.openapi(chatRoute, async (c) => {
             if (effectiveRestFocus === undefined) {
               effectiveRestFocus = existing.data.restFocusDatasourceId ?? null;
             }
+            // #3895 — inherit Group reach from the row when the body omits it.
+            // An explicit `null` from the body is NOT omitted (it widens to All
+            // sources), so the `=== undefined` guard keeps "widen" distinct from
+            // "field absent → use the row".
+            if (effectiveGroupReach === undefined) {
+              effectiveGroupReach = existing.data.groupReach ?? null;
+            }
             // Persist the picker mode if the body explicitly set one for
             // this turn. We compare against the stored value to avoid
             // burning an UPDATE on every chat turn when nothing changed.
@@ -1076,6 +1115,33 @@ chat.openapi(chatRoute, async (c) => {
                     conversationId,
                   },
                   "updateConversationRestFocus rejected",
+                );
+              });
+            }
+            // #3895 — persist Group reach when the body explicitly set one this
+            // turn AND it differs from the stored value. An explicit `null` that
+            // widens a prior Focus back to All sources DOES persist (the widen
+            // path the transport must support); normalize the row's value with
+            // `?? null` so a string→null or null→string change is detected.
+            if (
+              parsed.data.groupReach !== undefined &&
+              parsed.data.groupReach !== (existing.data.groupReach ?? null)
+            ) {
+              // Fire-and-forget, same contract as routing-mode / REST scope
+              // above: the runtime honours the body's reach for this turn even
+              // if the persist fails; the helper logs its own failures.
+              updateConversationGroupReach(
+                conversationId,
+                parsed.data.groupReach,
+                authResult.user?.id,
+                authResult.user?.activeOrganizationId,
+              ).catch((err: unknown) => {
+                log.warn(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    conversationId,
+                  },
+                  "updateConversationGroupReach rejected",
                 );
               });
             }
@@ -1195,6 +1261,11 @@ chat.openapi(chatRoute, async (c) => {
                 // null when the picker is in default mode, so `?? null` keeps a
                 // newly-created default-mode conversation un-focused.
                 restFocusDatasourceId: effectiveRestFocus ?? null,
+                // #3895 — persist Group reach the user picked at creation.
+                // Undefined / null ⇒ NULL (All sources — the new default). The
+                // transport sends null when the picker is at All sources, so
+                // `?? null` keeps a newly-created conversation ranging all groups.
+                groupReach: effectiveGroupReach ?? null,
                 orgId: authResult.user?.activeOrganizationId,
               });
               if (created) {
@@ -1449,6 +1520,14 @@ chat.openapi(chatRoute, async (c) => {
               // not-focused shape so default-scope turns are unchanged.
               ...(effectiveRestFocus
                 ? { restFocusDatasourceId: effectiveRestFocus }
+                : {}),
+              // #3895 — the resolved Group reach reaches `executeSQL`'s reach
+              // resolver + the Source-catalog builder via the request context.
+              // Stamped only when truthy (a Focus group id); a null/All-sources
+              // reach keeps the legacy "all visible groups" shape so the default
+              // is byte-identical for non-focused conversations.
+              ...(effectiveGroupReach
+                ? { groupReach: effectiveGroupReach }
                 : {}),
             },
             () =>

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -112,6 +112,16 @@ const ConversationSchema = z.object({
    * Mirrors the `Conversation` wire type.
    */
   restFocusDatasourceId: z.string().nullable().optional(),
+  /**
+   * Per-conversation Group reach (#3895, ADR-0022). `null` = All sources
+   * (every visible Connection group reachable); a `connectionGroupId` value =
+   * Focus → that group (hard/exclusive — only it is reachable). The cross-group
+   * axis ABOVE member routing (`routingMode`); independent of the REST-scope
+   * fields. Genuinely nullable; optional so pre-#3895 rows / SDK consumers need
+   * not supply it. Mirrors the `Conversation` wire type — `GET /conversations/:id`
+   * carries it so the picker restores the persisted reach on open.
+   */
+  groupReach: z.string().nullable().optional(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -26,6 +26,7 @@ import {
   convertToNotebook,
   updateConversationRestExcluded,
   updateConversationRestFocus,
+  updateConversationGroupReach,
 } from "../conversations";
 
 // ---------------------------------------------------------------------------
@@ -1464,6 +1465,44 @@ describe("conversations module", () => {
 
     it("updateConversationRestFocus short-circuits to no_db when the internal DB is off", async () => {
       const result = await updateConversationRestFocus("c1", "ds-stripe");
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    // #3895 — Group reach persistence. Same org-scoped / fail-open contract as
+    // updateConversationRestFocus; uses scopeClause(3, …) so the org param lands
+    // at $4 (an off-by-one in the SQL would surface in the param assertion).
+    it("updateConversationGroupReach writes the Focus group id, scoped + parameterized", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "c1" }] });
+
+      const result = await updateConversationGroupReach("c1", "g_prod", "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      expect(queryCalls[0].sql).toContain("UPDATE conversations SET group_reach = $1");
+      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["g_prod", "c1", "u1", "org-B"]);
+    });
+
+    it("updateConversationGroupReach persists null to WIDEN back to All sources", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "c1" }] });
+
+      const result = await updateConversationGroupReach("c1", null, "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      // $1 is null — the widen path the transport must support (#3073).
+      expect(queryCalls[0].params).toEqual([null, "c1", "u1", "org-B"]);
+    });
+
+    it("updateConversationGroupReach returns not_found when no row matches (cross-org)", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await updateConversationGroupReach("c1", "g_prod", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("updateConversationGroupReach short-circuits to no_db when the internal DB is off", async () => {
+      const result = await updateConversationGroupReach("c1", "g_prod");
       expect(result).toEqual({ ok: false, reason: "no_db" });
       expect(queryCalls).toHaveLength(0);
     });

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -134,8 +134,8 @@ describe("conversations module", () => {
       const result = await createConversation({ userId: "u1", title: "Test" });
       expect(result).toEqual({ id: "conv-123" });
       expect(queryCalls[0].sql).toContain("INSERT INTO conversations");
-      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id]
-      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null, null]);
+      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id]
+      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null, null, null]);
     });
 
     it("returns null when no DB", async () => {
@@ -156,7 +156,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-456" }] });
 
       await createConversation({});
-      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, [], null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, [], null, null, null]);
     });
 
     it("accepts custom surface and connectionId", async () => {
@@ -164,7 +164,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-789" }] });
 
       await createConversation({ surface: "api", connectionId: "wh" });
-      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, [], null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, [], null, null, null]);
     });
 
     it("includes orgId when provided", async () => {
@@ -173,7 +173,7 @@ describe("conversations module", () => {
 
       const result = await createConversation({ userId: "u1", orgId: "org-123" });
       expect(result).toEqual({ id: "conv-org" });
-      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, [], null, "org-123"]);
+      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, [], null, null, "org-123"]);
     });
 
     // #2345 — group-aware routing. Both columns are independent;
@@ -197,6 +197,7 @@ describe("conversations module", () => {
         "g_prod",
         null,
         [],
+        null,
         null,
         "org-1",
       ]);
@@ -224,6 +225,7 @@ describe("conversations module", () => {
         null,
         [],
         null,
+        null,
         "org-1",
       ]);
     });
@@ -249,6 +251,7 @@ describe("conversations module", () => {
         null,
         [],
         "ds-stripe",
+        null,
         "org-1",
       ]);
     });
@@ -1559,7 +1562,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });
@@ -1574,7 +1577,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -32,6 +32,7 @@ import { resolveWorkspaceRestDatasources, resolveWorkspaceRestDatasourcesOrThrow
 import type { RestDatasource } from "./openapi/datasource";
 import { buildAgentRepresentation } from "./openapi/representation";
 import { loadSourceCatalog, type RestCatalogSource } from "./source-catalog/lookup";
+import { reachStateFromColumn } from "./group-reach";
 import { REST_OPERATION_DESCRIPTION, createExecuteRestOperationTool } from "./tools/rest-operation";
 import { getStreamWriter } from "./tools/python-stream";
 import { getContextFragments, getDialectHints } from "./plugins/tools";
@@ -1449,7 +1450,18 @@ export async function runAgent({
   // in with `explore`. Built once per turn after REST resolution (it lists the
   // same conversation-scoped REST set). Fail-soft: an assembly hiccup yields ""
   // (no block), never a failed turn.
-  const sourceCatalog = await loadSourceCatalog(orgId, atlasMode, restCatalogSources);
+  //
+  // #3895 — narrow the SQL half to the conversation's Group reach: under Focus
+  // the menu lists only the focused group, matching what `executeSQL` will allow
+  // (so the agent isn't told about groups every query to which would be
+  // rejected). Sourced from the same RequestContext value that bounds executeSQL.
+  const sourceCatalog = await loadSourceCatalog(
+    orgId,
+    atlasMode,
+    restCatalogSources,
+    {},
+    reachStateFromColumn(reqCtx?.groupReach),
+  );
 
   // System prompt is built once and pinned: it carries the semantic index +
   // glossary AND the durable memory block (#3755), and is passed to the model

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -407,6 +407,9 @@ describe("migrateAuthTables", () => {
             // 0148 creates connection_group_descriptions (Atlas-internal
             // Source-catalog metadata, #3894) — runs in every auth mode.
             { name: "0148_connection_group_descriptions.sql" },
+            // 0149 adds conversations.group_reach (Atlas-internal per-conversation
+            // Group reach, ADR-0022 §5, #3895) — runs in every auth mode.
+            { name: "0149_conversation_group_reach.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -150,6 +150,13 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     // getSharedConversation, which doesn't surface scope to anon viewers)
     // reads as null, matching the column's "not focused" default.
     restFocusDatasourceId: (r.rest_focus_datasource_id as string) ?? null,
+    // #3895 — per-conversation Group reach (ADR-0022). Plain nullable text
+    // column: NULL → null = All sources (every visible group reachable); a
+    // `connection_group_id` value = Focus → that group. The SELECTs feeding
+    // this mapper include the column; a caller that omits it (e.g.
+    // getSharedConversation, which doesn't surface scope to anon viewers) reads
+    // as null, matching the column's "All sources" default.
+    groupReach: (r.group_reach as string) ?? null,
     starred: r.starred === true,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -213,6 +220,13 @@ export async function createConversation(opts: {
    * suspends `executeSQL` for the conversation.
    */
   restFocusDatasourceId?: string | null;
+  /**
+   * #3895 — per-conversation Group reach (ADR-0022). `null` / undefined ⇒
+   * persist NULL = All sources (every visible group reachable). A
+   * `connection_group_id` value Focuses the conversation on that group
+   * (hard/exclusive). Legacy callers are unaffected — omitting it keeps All.
+   */
+  groupReach?: string | null;
   orgId?: string | null;
 }): Promise<{ id: string } | null> {
   if (!hasInternalDB()) return null;
@@ -222,11 +236,13 @@ export async function createConversation(opts: {
   const restExcluded = opts.restExcludedDatasourceIds ?? [];
   // #3067 — null/undefined ⇒ persist NULL ("not focused").
   const restFocus = opts.restFocusDatasourceId ?? null;
+  // #3895 — null/undefined ⇒ persist NULL ("All sources").
+  const groupReach = opts.groupReach ?? null;
   try {
     const rows = opts.id
       ? await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
            RETURNING id`,
           [
             opts.id,
@@ -238,12 +254,13 @@ export async function createConversation(opts: {
             opts.routingMode ?? null,
             restExcluded,
             restFocus,
+            groupReach,
             opts.orgId ?? null,
           ],
         )
       : await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
            RETURNING id`,
           [
             opts.userId ?? null,
@@ -254,6 +271,7 @@ export async function createConversation(opts: {
             opts.routingMode ?? null,
             restExcluded,
             restFocus,
+            groupReach,
             opts.orgId ?? null,
           ],
         );
@@ -346,6 +364,36 @@ export async function updateConversationRestFocus(
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: errorMessage(err) }, "updateConversationRestFocus failed");
+    return { ok: false, reason: "error" };
+  }
+}
+
+/**
+ * #3895 (ADR-0022) — update the conversation's `group_reach`. Same fail-open /
+ * org-scoped contract as {@link updateConversationRestFocus}: a no-DB / error
+ * result is logged but the chat turn still proceeds (the runtime honours the
+ * body's reach for this turn even if the persist fails). Pass a
+ * `connection_group_id` to Focus that group (hard/exclusive — only it is
+ * reachable), or `null` to widen back to All sources (every visible group
+ * reachable). pg binds the string|null directly to the nullable text column.
+ */
+export async function updateConversationGroupReach(
+  id: string,
+  groupReach: string | null,
+  userId?: string | null,
+  orgId?: string | null,
+): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET group_reach = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [groupReach, id, ...scope.params],
+    );
+    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
+  } catch (err) {
+    log.error({ err: errorMessage(err) }, "updateConversationGroupReach failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -730,7 +778,7 @@ export async function getConversation(
   try {
     const scope = scopeClause(2, userId, orgId);
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, starred, notebook_state, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, starred, notebook_state, created_at, updated_at
        FROM conversations WHERE id = $1${scope.sql}`,
       [id, ...scope.params],
     );
@@ -802,7 +850,7 @@ export async function listConversations(opts?: {
       params,
     );
     const dataRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, starred, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, starred, created_at, updated_at
        FROM conversations ${where}
        ORDER BY updated_at DESC LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
       [...params, limit, offset],
@@ -879,7 +927,7 @@ export async function forkConversation(opts: {
     // source row's org_id; scopeClause rejects mismatches (NULL-safe for legacy rows).
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -915,8 +963,8 @@ export async function forkConversation(opts: {
     // the user keeps the same env context after branching.
     const orgId = opts.orgId ?? (source.org_id as string) ?? null;
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (fork)`,
@@ -929,6 +977,9 @@ export async function forkConversation(opts: {
         (source.rest_excluded_datasource_ids as string[]) ?? [],
         // #3067 — inherit the source's REST-only focus too.
         (source.rest_focus_datasource_id as string) ?? null,
+        // #3895 — inherit the source's Group reach (All / Focus → group) so the
+        // fork/notebook keeps the same cross-group scope after branching.
+        (source.group_reach as string) ?? null,
         orgId,
       ],
     );
@@ -1072,7 +1123,7 @@ export async function convertToNotebook(opts: {
     // Verify source exists and caller has access in both the user + org dimensions.
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -1085,8 +1136,8 @@ export async function convertToNotebook(opts: {
     // both routing columns + the picker mode so the notebook preserves
     // the source's env context end-to-end.
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (notebook)`,
@@ -1099,6 +1150,9 @@ export async function convertToNotebook(opts: {
         (source.rest_excluded_datasource_ids as string[]) ?? [],
         // #3067 — inherit the source's REST-only focus too.
         (source.rest_focus_datasource_id as string) ?? null,
+        // #3895 — inherit the source's Group reach (All / Focus → group) so the
+        // fork/notebook keeps the same cross-group scope after branching.
+        (source.group_reach as string) ?? null,
         orgId,
       ],
     );

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -281,6 +281,70 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(after.rows[0]?.bound_dashboard_id).toBeNull();
   }, PG_TEST_TIMEOUT_MS);
 
+  // ─────────────────────────────────────────────────────────────────────
+  // 0149 — conversations.group_reach + behavior-preserving backfill (#3895)
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("0149: conversations.group_reach is a nullable text column with no default (#3895)", async () => {
+    const { rows } = await pool.query<{
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>(
+      `SELECT data_type, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_name = 'conversations'
+          AND column_name = 'group_reach'
+          AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    expect(rows[0]?.is_nullable).toBe("YES");
+    // NULL = All sources is the default state — no column default needed.
+    expect(rows[0]?.column_default).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0149: the behavior-preserving backfill maps a group-bound row to Focus, leaves a null-group row at All (#3895)", async () => {
+    // A clean forward run has no pre-existing rows, so exercise the exact
+    // backfill statement against real Postgres: a conversation already bound to
+    // a group (connection_group_id) must become Focus → that group, while a
+    // null-group conversation stays NULL (All sources). The WHERE guard
+    // (group_reach IS NULL) is what makes the backfill safe to re-run.
+    const stamp = Date.now();
+    const orgId = `org-3895-${stamp}`;
+    const bound = await pool.query<{ id: string }>(
+      `INSERT INTO conversations (user_id, org_id, connection_group_id, group_reach)
+       VALUES ('u-3895', $1, 'g_prod', NULL) RETURNING id`,
+      [orgId],
+    );
+    const noGroup = await pool.query<{ id: string }>(
+      `INSERT INTO conversations (user_id, org_id, connection_group_id, group_reach)
+       VALUES ('u-3895', $1, NULL, NULL) RETURNING id`,
+      [orgId],
+    );
+
+    // The exact backfill from 0149.
+    await pool.query(
+      `UPDATE conversations
+          SET group_reach = connection_group_id
+        WHERE connection_group_id IS NOT NULL AND group_reach IS NULL
+          AND org_id = $1`,
+      [orgId],
+    );
+
+    const boundRow = await pool.query<{ group_reach: string | null }>(
+      `SELECT group_reach FROM conversations WHERE id = $1`,
+      [bound.rows[0]?.id],
+    );
+    const noGroupRow = await pool.query<{ group_reach: string | null }>(
+      `SELECT group_reach FROM conversations WHERE id = $1`,
+      [noGroup.rows[0]?.id],
+    );
+    // Group-bound → Focus → that group (behavior-preserving).
+    expect(boundRow.rows[0]?.group_reach).toBe("g_prod");
+    // Null-group → All sources (unchanged).
+    expect(noGroupRow.rows[0]?.group_reach).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
   // ---------------------------------------------------------------------------
   // proactive_pauses (#2295)
   // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -172,7 +172,9 @@ describe("runMigrations", () => {
     //   progressive-disclosure pass, milestone v0.0.13) = 148.
     //   Plus 0148 (connection_group_descriptions Source-catalog routing
     //   metadata, ADR-0022 §4, #3894) = 149.
-    expect(count).toBe(149);
+    //   Plus 0149 (conversations.group_reach per-conversation Group reach,
+    //   ADR-0022 §5, #3895) = 150.
+    expect(count).toBe(150);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -350,6 +352,7 @@ describe("runMigrations", () => {
         "0146_agent_runs_parked_reason_check.sql",
         "0147_elasticsearch_auth_mode_selector_config_schema.sql",
         "0148_connection_group_descriptions.sql",
+        "0149_conversation_group_reach.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0149_conversation_group_reach.sql
+++ b/packages/api/src/lib/db/migrations/0149_conversation_group_reach.sql
@@ -1,0 +1,39 @@
+-- Migration 0149: per-conversation Group reach (#3895, ADR-0022 slice (c)).
+--
+-- Cross-group reach: the agent ranges across every visible Connection group by
+-- default (All sources); a conversation may instead FOCUS on exactly one group
+-- — a hard, exclusive narrowing where only that group is reachable. This column
+-- persists that reach axis per-conversation:
+--   - NULL (the default)    → All sources: every visible group is reachable and
+--                             the agent routes per question via the Source
+--                             catalog (ADR-0022 §4).
+--   - <connection_group_id> → Focus → that group: only it is reachable;
+--                             executeSQL REJECTS any other group target — never
+--                             a silent re-route to a different source (#3867(b)).
+--
+-- Reach is the axis ABOVE member routing (`routing_mode` Auto/Pin/All), which
+-- stays an intra-group concern. REST scope (`rest_*_datasource_id`) is a
+-- separate axis and is unchanged. This column is what feeds the slice-(a) reach
+-- resolver (#3893) so Focus actually bounds executeSQL. See ADR-0022 §5.
+--
+-- Clean break (pre-customer posture, CONTEXT.md §Deployment posture): a
+-- conversation already bound to a single group (`connection_group_id`) was,
+-- pre-ADR-0022, reachable only within that group — which IS Focus → that group.
+-- Backfill it so the migration preserves behavior. New conversations default to
+-- All sources (NULL). No deprecation shim — the two internal workspaces absorb
+-- the break.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS is a no-op on re-run; the backfill is
+-- guarded on `group_reach IS NULL` so a re-run never re-stamps a row an operator
+-- has since changed.
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS group_reach text;
+
+-- Behavior-preserving backfill: existing group-bound conversations → Focus.
+UPDATE conversations
+  SET group_reach = connection_group_id
+  WHERE connection_group_id IS NOT NULL AND group_reach IS NULL;
+
+COMMENT ON COLUMN conversations.group_reach IS
+  'Per-conversation Group reach (#3895, ADR-0022). NULL = All sources (every visible Connection group reachable; the agent routes per question). A connection_group_id value = Focus → that group (hard/exclusive: only it is reachable, executeSQL rejects any other group — no substitution). Above member routing (routing_mode); REST scope is a separate axis. Existing group-bound rows backfilled to Focus (behavior-preserving).';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -141,6 +141,16 @@ export const conversations = pgTable(
     // as normal, and they stay RETAINED-but-inert while focused so
     // clearing focus returns to the prior scope. See ADR-0011.
     restFocusDatasourceId: text("rest_focus_datasource_id"),
+    // 0149 — per-conversation Group reach (#3895, ADR-0022 slice (c)). NULL
+    // (the default) = All sources: every visible Connection group is reachable
+    // and the agent routes per question via the Source catalog. A
+    // `connection_group_id` value = Focus → that group: only it is reachable;
+    // executeSQL REJECTS any other group target (no silent re-route — the
+    // #3867(b) fix). Reach is the axis ABOVE member routing (`routing_mode`);
+    // REST scope is a separate axis. This column feeds the slice-(a) reach
+    // resolver (#3893) so Focus actually bounds executeSQL. Existing group-bound
+    // rows were backfilled to Focus (behavior-preserving).
+    groupReach: text("group_reach"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     // Saved/starred

--- a/packages/api/src/lib/group-reach/__tests__/index.test.ts
+++ b/packages/api/src/lib/group-reach/__tests__/index.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect } from "bun:test";
 import {
   resolveReach,
   isReachable,
+  reachStateFromColumn,
   type VisibleGroup,
   type ReachReason,
 } from "../index";
@@ -127,5 +128,31 @@ describe("ReachReason — stable identifiers", () => {
     for (const { state, reason } of cases) {
       expect(resolveReach(state, VISIBLE).reason).toBe(reason);
     }
+  });
+});
+
+describe("reachStateFromColumn — column ↔ state encoding (#3895)", () => {
+  it("maps null / undefined / empty string to All sources", () => {
+    // NULL is the column default; undefined is an absent read; "" is never a
+    // valid group id (the chat-route Zod rejects it) but coalesces to All for
+    // safety rather than producing a focus on the empty string.
+    expect(reachStateFromColumn(null)).toEqual({ kind: "all" });
+    expect(reachStateFromColumn(undefined)).toEqual({ kind: "all" });
+    expect(reachStateFromColumn("")).toEqual({ kind: "all" });
+  });
+
+  it("maps a connection_group_id to Focus → that group", () => {
+    expect(reachStateFromColumn("postgres")).toEqual({
+      kind: "focus",
+      groupId: "postgres",
+    });
+  });
+
+  it("round-trips through resolveReach: a focus column resolves to exactly that group", () => {
+    const reach = resolveReach(reachStateFromColumn("postgres"), VISIBLE);
+    expect(reach.reachableGroups.map((g) => g.id)).toEqual(["postgres"]);
+    // …and a null column (All sources) resolves to every visible group.
+    const all = resolveReach(reachStateFromColumn(null), VISIBLE);
+    expect(all.reachableGroups.length).toBe(VISIBLE.length);
   });
 });

--- a/packages/api/src/lib/group-reach/index.ts
+++ b/packages/api/src/lib/group-reach/index.ts
@@ -43,6 +43,20 @@ export type ReachState =
   | { readonly kind: "focus"; readonly groupId: string };
 
 /**
+ * Map a persisted `conversations.group_reach` column value to a {@link ReachState}
+ * (slice (c) #3895). `null` / `undefined` (the column default) → `all`; a
+ * non-empty `connection_group_id` → `focus` on that group.
+ *
+ * Pure + total. Centralises the column ↔ state encoding so the chat route, the
+ * `executeSQL` reach bound, and the Source-catalog narrowing all read the
+ * conversation's reach the same way — the column is the single wire/DB
+ * representation and this is the single decoder.
+ */
+export function reachStateFromColumn(value: string | null | undefined): ReachState {
+  return value ? { kind: "focus", groupId: value } : { kind: "all" };
+}
+
+/**
  * A Connection group the workspace can see, as resolved by the impure
  * `loadVisibleGroups` lookup. `id` is the canonical `connection_group_id`
  * (a group-of-one standalone datasource uses its own connection id as its

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -125,6 +125,18 @@ interface RequestContext {
    * truthy, so the legacy shape is unchanged for non-focused conversations.
    */
   restFocusDatasourceId?: string | null;
+  /**
+   * #3895 (ADR-0022) — per-conversation Group reach. The chat route stamps this
+   * from the resolved conversation row (or the per-turn body override) so the
+   * reach resolver in `executeSQL` (and the Source-catalog builder) bounds which
+   * Connection groups the agent may query. `null` / undefined here = All sources
+   * (every visible group reachable, the default); a `connection_group_id` value
+   * = Focus → that group (hard/exclusive — only it is reachable, any other group
+   * target is rejected). Stamped only when truthy, so the legacy "all" shape is
+   * unchanged for non-focused conversations. Independent of `routingMode`
+   * (intra-group) and the REST-scope fields (a separate axis).
+   */
+  groupReach?: string | null;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/source-catalog/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/source-catalog/__tests__/lookup.test.ts
@@ -72,6 +72,36 @@ describe("loadSourceCatalog", () => {
     expect(out).toContain("Key entities: customers, orders.");
   });
 
+  it("#3895 — Focus reach narrows the SQL half to the focused group only", async () => {
+    visibleGroups = [g("orders"), g("analytics")];
+    entityEntries = [
+      { name: "orders", source: "orders" },
+      { name: "events", source: "analytics" },
+    ];
+    // All sources (default) lists every visible group.
+    const all = await loadSourceCatalog("org", "published", []);
+    expect(all).toContain("[id: `orders`]");
+    expect(all).toContain("[id: `analytics`]");
+    // Focus → orders lists only orders (matching what executeSQL will allow).
+    const focused = await loadSourceCatalog("org", "published", [], {}, {
+      kind: "focus",
+      groupId: "orders",
+    });
+    expect(focused).toContain("[id: `orders`]");
+    expect(focused).not.toContain("[id: `analytics`]");
+  });
+
+  it("#3895 — Focus on an invisible group drops the SQL half entirely (no substitution)", async () => {
+    visibleGroups = [g("orders")];
+    entityEntries = [{ name: "orders", source: "orders" }];
+    const out = await loadSourceCatalog("org", "published", [
+      { id: "stripe_1", displayName: "Stripe", operationNames: ["ListCharges"] },
+    ], {}, { kind: "focus", groupId: "gone" });
+    // The focused group isn't visible → no SQL section; REST (separate axis) stays.
+    expect(out).not.toContain("### SQL connection groups");
+    expect(out).toContain("**Stripe** [id: `stripe_1`]");
+  });
+
   it("falls back to an entity-name summary when a group has no description", async () => {
     visibleGroups = [g("analytics")];
     entityEntries = [{ name: "events", source: "analytics" }];

--- a/packages/api/src/lib/source-catalog/lookup.ts
+++ b/packages/api/src/lib/source-catalog/lookup.ts
@@ -28,6 +28,7 @@
 import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
 import { loadVisibleGroups } from "@atlas/api/lib/group-reach/lookup";
+import { resolveReach, type ReachState } from "@atlas/api/lib/group-reach";
 import {
   getGroupDescriptionMap,
   upsertAutoGroupDescription,
@@ -58,12 +59,20 @@ export interface RestCatalogSource {
 /**
  * Render the Source-catalog block for a workspace, or `""` when there is nothing
  * to route between (no workspace, no visible SQL groups, and no REST datasources).
+ *
+ * `reach` (#3895, ADR-0022) narrows the SQL half to the conversation's reachable
+ * groups: under `all` (the default) every visible group is listed; under `focus`
+ * only the focused group is — so the menu the agent reads matches what
+ * `executeSQL` will actually allow, instead of advertising groups every query to
+ * which would be rejected. REST datasources are a separate axis (REST scope,
+ * ADR-0011) and are never narrowed by SQL reach.
  */
 export async function loadSourceCatalog(
   orgId: string | undefined,
   mode: "published" | "developer" | undefined,
   restDatasources: readonly RestCatalogSource[] = [],
   options: SourceCatalogOptions = {},
+  reach: ReachState = { kind: "all" },
 ): Promise<string> {
   const restSources: CatalogSource[] = restDatasources.map((ds) => ({
     kind: "rest",
@@ -86,7 +95,13 @@ export async function loadSourceCatalog(
       loadEntityNamesByGroup(orgId, mode),
     ]);
 
-    sqlSources = visibleGroups.map((grp) => ({
+    // #3895 — narrow to the reachable groups: under Focus the catalog lists only
+    // the focused group (a `focus`-on-invisible reach resolves to none, so the
+    // catalog drops the SQL half entirely rather than listing an unreachable
+    // group). Under `all` this is every visible group, unchanged.
+    const reachableGroups = resolveReach(reach, visibleGroups).reachableGroups;
+
+    sqlSources = reachableGroups.map((grp) => ({
       kind: "sql",
       id: grp.id,
       // Groups have no separate display name post-0096 — the id IS the name.

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -144,6 +144,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/lib/tools/__tests__/sql-group-target.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-group-target.test.ts
@@ -255,9 +255,60 @@ describe("executeSQL — per-query group target + reach bounding", () => {
     mockRequestContext = { user: { id: "u1", activeOrganizationId: "org-1" }, connectionId: "postgres" };
     const result = await run({ sql: "SELECT id FROM companies" });
     expect(result.success).toBe(true);
-    // The degenerate single-reachable-group case stays on the fast path:
-    // no visible-groups enumeration, runs against the stamped connection.
+    // Under All-sources reach with no named group, the degenerate
+    // single-reachable case stays on the fast path: no visible-groups
+    // enumeration, runs against the stamped connection.
     expect(mockLoadVisibleGroups.mock.calls.length).toBe(0);
     expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("postgres");
+  });
+
+  // #3895 (ADR-0022 slice (c)) — the conversation's persisted Group reach
+  // (stamped into RequestContext.groupReach by the chat route) now bounds
+  // executeSQL. Under Focus → X, only X is reachable even though other groups
+  // are visible; the omitted-group default binds to X (never a stale member
+  // outside it). Rejection-path assertions (no query runs) exercise the bound.
+  describe("Focus reach — conversation groupReach bounds executeSQL (#3895)", () => {
+    it("REJECTS a query to a different VISIBLE group when the conversation is Focused — only the focused group is reachable", async () => {
+      // postgres + clickhouse are both visible workspace groups, but the
+      // conversation is Focused on postgres → clickhouse is out of reach. Hard
+      // reject, never a silent re-route (the #3867(b) fix, now Focus-driven).
+      mockRequestContext = {
+        user: { id: "u1", activeOrganizationId: "org-1" },
+        groupReach: "postgres",
+      };
+      const result = await run({ sql: "SELECT id FROM events", group: "clickhouse" });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not within this conversation's reach");
+      expect(mockQuery.mock.calls.length).toBe(0);
+    });
+
+    it("rejects an omitted-group query when Focused on a group that is no longer visible — no substitution", async () => {
+      // group_reach points at a group content-mode has since hidden / removed.
+      // Reach resolves to empty; the agent omits `group` → we must NOT fall back
+      // to a default connection outside the (now-invisible) focus.
+      mockRequestContext = {
+        user: { id: "u1", activeOrganizationId: "org-1" },
+        connectionId: "postgres",
+        groupReach: "gone",
+      };
+      const result = await run({ sql: "SELECT id FROM companies" });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("focused on group");
+      expect(mockGetForWorkspace.mock.calls.length).toBe(0);
+      expect(mockQuery.mock.calls.length).toBe(0);
+    });
+
+    it("binds an omitted-group query to the focused group's member (no `group` arg needed under Focus)", async () => {
+      // Focused on clickhouse, agent omits `group` → execution binds to
+      // clickhouse's member, not the stamped/default connection.
+      mockRequestContext = {
+        user: { id: "u1", activeOrganizationId: "org-1" },
+        connectionId: "postgres",
+        groupReach: "clickhouse",
+      };
+      const result = await run({ sql: "SELECT id FROM events" });
+      expect(result.success).toBe(true);
+      expect((mockGetForWorkspace.mock.calls as unknown[][])[0]?.[1]).toBe("clickhouse");
+    });
   });
 });

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -45,7 +45,7 @@ import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { appendRowLimit, hasLimitClause } from "./auto-limit";
 import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
-import { resolveReach, isReachable } from "@atlas/api/lib/group-reach";
+import { resolveReach, isReachable, reachStateFromColumn } from "@atlas/api/lib/group-reach";
 import { loadVisibleGroups } from "@atlas/api/lib/group-reach/lookup";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
 import {
@@ -2368,47 +2368,65 @@ export const executeSQL = tool({
     const reqCtx = getRequestContext();
     const requestContextConnectionId = reqCtx?.connectionId;
 
-    // Cross-group reach (ADR-0022, slice (a) #3893). When the agent names a
-    // `group`, that is a per-query GROUP target — an axis ABOVE member routing.
-    // The named group must be within the conversation's reach (slice (a): reach
-    // defaults to ALL visible groups; the Focus picker that narrows it lands in
-    // slice (c)). A group outside the reachable set is REJECTED here — a hard
-    // error, never a silent re-route to a different source (the #3867(b) fix at
-    // the execution layer). When `group` is omitted, today's implicit
-    // single-connection binding is the degenerate single-reachable-group case.
+    // Cross-group reach (ADR-0022). The conversation's persisted Group-reach
+    // state (slice (c) #3895, stamped into RequestContext by the chat route)
+    // bounds which Connection groups this query may reach — the axis ABOVE
+    // member routing. `all` (the default) → every visible group reachable;
+    // `focus` → exactly one. A target outside the reachable set is REJECTED
+    // here — a hard error, never a silent re-route to a different source (the
+    // #3867(b) fix at the execution layer).
+    //
+    // Resolve reach when the agent names a `group` (validate the named target)
+    // OR the conversation is Focused (bound the implicit default to the focused
+    // group, never a stale `connectionId` outside it). Under `all` with no
+    // named group we skip the lookup entirely — every group is reachable, so
+    // there is nothing to bound and the legacy single-connection path stands
+    // (no per-query DB cost added to the common default case).
+    const reachState = reachStateFromColumn(reqCtx?.groupReach);
     let groupTargetMember: string | undefined;
-    if (group !== undefined) {
+    if (group !== undefined || reachState.kind === "focus") {
       const reachOrgId = reqCtx?.user?.activeOrganizationId;
       const visibleGroups = await loadVisibleGroups(reachOrgId, reqCtx?.atlasMode);
-      // Slice (a): no conversation-scope reach state yet, so reach is always
-      // "all visible". Slice (c) sources this from the conversation's persisted
-      // Group-reach value (`all` | focus-group-id) — and must then surface
-      // `reach.warnings` (a `focus`-on-invisible resolution explains why reach
-      // is empty rather than substituting); under `all` it's always [].
-      const reach = resolveReach({ kind: "all" }, visibleGroups);
-      if (!isReachable(reach, group)) {
+      const reach = resolveReach(reachState, visibleGroups);
+      // A `focus`-on-invisible resolution explains (via a warning) why reach is
+      // empty rather than substituting another source; surface it so the
+      // divergence is observable. Under `all` warnings is always [].
+      for (const w of reach.warnings) {
+        log.warn({ group, groupReach: reqCtx?.groupReach, orgId: reachOrgId }, w);
+      }
+      // The group this query targets: the agent's explicit `group`, else — under
+      // Focus — the single focused group. (Under `all` with no explicit group we
+      // don't enter this branch.)
+      const targetGroupId =
+        group ?? (reachState.kind === "focus" ? reach.reachableGroups[0]?.id : undefined);
+      if (targetGroupId === undefined || !isReachable(reach, targetGroupId)) {
         const reachable = reach.reachableGroups.map((g) => g.id);
         log.warn(
-          { group, orgId: reachOrgId, reachable },
+          { group, groupReach: reqCtx?.groupReach, orgId: reachOrgId, reachable },
           "executeSQL rejected an out-of-reach group target — not re-routing",
         );
-        return {
-          success: false,
-          explanation,
-          error:
-            `Connection group "${group}" is not within this conversation's reach ` +
-            `(reachable groups: ${reachable.join(", ") || "none"}). ` +
-            `I will not query a different source instead — re-run against a reachable ` +
-            `group, or omit \`group\` to use the conversation's current source.`,
-          executionMs: 0,
-        };
+        // Two shapes: the agent named an out-of-reach group, OR the conversation
+        // is Focused on a group that isn't currently reachable (content-mode hid
+        // it, or it was removed). Either way we refuse to substitute another
+        // source — the no-substitution invariant the whole feature rests on.
+        const error =
+          group === undefined && reachState.kind === "focus"
+            ? `This conversation is focused on group "${reachState.groupId}", which is not ` +
+              `currently reachable (visible groups: ${reachable.join(", ") || "none"}). ` +
+              `The focused source may be unpublished or removed — I will not query a ` +
+              `different source instead. Widen the conversation's scope to All sources to query elsewhere.`
+            : `Connection group "${group}" is not within this conversation's reach ` +
+              `(reachable groups: ${reachable.join(", ") || "none"}). ` +
+              `I will not query a different source instead — re-run against a reachable ` +
+              `group, or omit \`group\` to use the conversation's current source.`;
+        return { success: false, explanation, error, executionMs: 0 };
       }
       // Resolve the group to a connection to execute against: the group's
       // primary member (a group-of-one resolves to its own connection id).
       // `connectionId`, if also supplied, may pin a specific member of THIS
       // group; otherwise the group's primary is used. The per-group whitelist
       // resolves via this connection id (members register their group's tables).
-      const target = reach.reachableGroups.find((g) => g.id === group);
+      const target = reach.reachableGroups.find((g) => g.id === targetGroupId);
       groupTargetMember =
         connectionId && target?.members.includes(connectionId)
           ? connectionId

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -84,6 +84,26 @@ export interface Conversation {
    * can omit it; the runtime treats missing the same as `null`.
    */
   restFocusDatasourceId?: string | null;
+  /**
+   * Per-conversation Group reach (#3895, ADR-0022). The cross-group axis ABOVE
+   * member routing (`routingMode`):
+   *
+   *   - `null` / absent — **All sources** (the default): every visible
+   *     Connection group is reachable and the agent routes per question via the
+   *     Source catalog.
+   *   - a `connectionGroupId` value — **Focus → that group**: a hard, exclusive
+   *     narrowing where only that group is reachable for the conversation.
+   *     `executeSQL` rejects any other group target — never a silent re-route to
+   *     a different source.
+   *
+   * Authoritative per-conversation; the web sticky preference only seeds NEW
+   * chats (mirrors `restFocusDatasourceId`). Independent of `routingMode`
+   * (intra-group) and the REST scope fields (a separate axis). Genuinely
+   * nullable: the column is plain nullable `text` and `null` is the meaningful
+   * "All sources" state. Optional so pre-#3895 fixtures / SDK consumers can omit
+   * it; the runtime treats missing the same as `null`.
+   */
+  groupReach?: string | null;
   starred: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -92,6 +92,53 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
   });
 });
 
+describe("useChatRoutingPreferenceStore Group reach (#3895)", () => {
+  it("setPreference records the Group reach (null = All sources, a group id = Focus)", () => {
+    useChatRoutingPreferenceStore.getState().setPreference({
+      workspaceId: "org-1",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: "g_prod",
+    });
+    expect(useChatRoutingPreferenceStore.getState().groupReach).toBe("g_prod");
+  });
+
+  it("clean-break migration (v0 → v1) clears the single-group preference, keeps REST scope", async () => {
+    // A pre-#3895 persisted blob: a single-group seed (groupId/connectionId/
+    // routingMode) that would re-focus the last group on every new chat. The
+    // cross-group default is All sources, so the migration must DROP that SQL
+    // seed (start at All sources) while carrying the workspace + REST scope.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        state: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: ["billing-api"],
+          restFocusDatasourceId: "stripe",
+        },
+      }),
+    );
+    await useChatRoutingPreferenceStore.persist.rehydrate();
+    const s = useChatRoutingPreferenceStore.getState();
+    // SQL single-group seed cleared → new chats start at All sources.
+    expect(s.groupId).toBeNull();
+    expect(s.connectionId).toBeNull();
+    expect(s.routingMode).toBeNull();
+    expect(s.groupReach).toBeNull();
+    // Workspace + REST scope (a separate axis) carry forward.
+    expect(s.workspaceId).toBe("org-1");
+    expect(s.restExcludedDatasourceIds).toEqual(["billing-api"]);
+    expect(s.restFocusDatasourceId).toBe("stripe");
+  });
+});
+
 describe("useChatRoutingPreferenceStore hydration gate (#3064)", () => {
   // The reset-on-reload fix gates atlas-chat's seed/restore effect on the
   // persist store having finished rehydrating localStorage. Without that

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -51,6 +51,16 @@ export interface ChatRoutingPreference {
    * targets only that datasource and SQL is suspended.
    */
   readonly restFocusDatasourceId: string | null;
+  /**
+   * #3895 (ADR-0022) — Group reach the user last chose. `null` = **All sources**
+   * (every visible Connection group reachable — the new default); a
+   * `connection_group_id` value = **Focus → that group** (hard/exclusive). Seeds
+   * NEW chats only (mirrors `restFocusDatasourceId`); the per-conversation row is
+   * authoritative once a conversation exists. The clean-break migration (persist
+   * `version: 1`) clears any legacy single-group preference so existing browsers
+   * start fresh at All sources (ADR-0022 migration).
+   */
+  readonly groupReach: string | null;
 }
 
 interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
@@ -78,6 +88,7 @@ const EMPTY: ChatRoutingPreference = {
   routingMode: null,
   restExcludedDatasourceIds: [],
   restFocusDatasourceId: null,
+  groupReach: null,
 };
 
 export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>()(
@@ -94,6 +105,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
           routingMode: next.routingMode,
           restExcludedDatasourceIds: next.restExcludedDatasourceIds,
           restFocusDatasourceId: next.restFocusDatasourceId,
+          groupReach: next.groupReach,
         }),
       // Partial set — zustand shallow-merges, so `_hasHydrated` (absent from
       // EMPTY) is preserved. A clear must not re-close the hydration gate.
@@ -102,6 +114,28 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
     {
       name: "atlas:chat:routing-preference",
       storage: createJSONStorage(() => localStorage),
+      // #3895 (ADR-0022) — clean-break migration. v0 stored a single-group
+      // preference (groupId/connectionId/routingMode) that seeded each new chat
+      // onto that one group. Cross-group reach flips the default to All sources,
+      // so a persisted v0 single-group seed must be CLEARED: drop the SQL pin and
+      // start at All sources (groupReach null), exactly as the conversation-row
+      // migration clears the sticky single-group preference. REST scope carries
+      // forward (a separate axis, unchanged). New browsers persist v1 directly.
+      version: 1,
+      migrate: (persisted, version) => {
+        const prev = (persisted ?? {}) as Partial<ChatRoutingPreference>;
+        if (version < 1) {
+          return {
+            ...EMPTY,
+            // Keep the workspace + REST scope; clear the SQL single-group seed so
+            // new chats default to All sources rather than re-focusing the last group.
+            workspaceId: prev.workspaceId ?? null,
+            restExcludedDatasourceIds: prev.restExcludedDatasourceIds ?? [],
+            restFocusDatasourceId: prev.restFocusDatasourceId ?? null,
+          } satisfies ChatRoutingPreference;
+        }
+        return prev as ChatRoutingPreference;
+      },
       // Persist ONLY the preference fields. `_hasHydrated` + setters are
       // transient: persisting them is meaningless, and a stored
       // `_hasHydrated: true` would — under any async-storage swap — report
@@ -113,6 +147,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
         routingMode: s.routingMode,
         restExcludedDatasourceIds: s.restExcludedDatasourceIds,
         restFocusDatasourceId: s.restFocusDatasourceId,
+        groupReach: s.groupReach,
       }),
       // Fires after rehydration (synchronously for localStorage, even when
       // storage was empty), so the consumer's gate opens exactly once the

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -3033,23 +3033,29 @@ describe("resolveEnvSelection / resolveConversationScope — Group reach (#3895)
   });
 
   test("a sticky preference's Focus on a NO-LONGER-VISIBLE group falls back to All sources (never lies)", () => {
-    // The pref remembers Focus → g_archived, but it's no longer in `groups`
-    // (content-mode hid it / it was removed). Seeding Focus on a gone group
-    // would lie; the resolver coalesces prefReach to null = All sources.
+    // The pref's member routing points at a VISIBLE group (g_a/a) so the restore
+    // branch fires and actually computes nextGroupReach = prefReach — but the
+    // pref's *reach* is g_archived, which is no longer in `groups`. Seeding Focus
+    // on a gone group would lie, so prefReach coalesces to null = All sources.
+    // (Member routing for g_a still restores — reach is the independent axis.)
     const decision = resolveEnvSelection(
       baseInput({
         activeWorkspaceId: "org-1",
         preference: {
           ...emptyPref,
           workspaceId: "org-1",
-          groupId: "g_archived", // also gone → no member-routing restore
-          connectionId: "x",
-          groupReach: "g_archived",
+          groupId: "g_a",
+          connectionId: "a",
+          routingMode: "pin",
+          groupReach: "g_archived", // gone → must fall back to All, not restore Focus
         },
       }),
     );
-    // No member-routing restore (group gone) AND reach falls back to All.
-    if (decision.kind === "restore" || decision.kind === "seed") {
+    expect(decision.kind).toBe("restore");
+    if (decision.kind === "restore") {
+      expect(decision.groupId).toBe("g_a");
+      // The reach falls back to All sources rather than restoring a Focus on a
+      // group the workspace can no longer see.
       expect(decision.groupReach).toBeNull();
     }
   });

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -3032,6 +3032,28 @@ describe("resolveEnvSelection / resolveConversationScope — Group reach (#3895)
     }
   });
 
+  test("a sticky preference's Focus on a NO-LONGER-VISIBLE group falls back to All sources (never lies)", () => {
+    // The pref remembers Focus → g_archived, but it's no longer in `groups`
+    // (content-mode hid it / it was removed). Seeding Focus on a gone group
+    // would lie; the resolver coalesces prefReach to null = All sources.
+    const decision = resolveEnvSelection(
+      baseInput({
+        activeWorkspaceId: "org-1",
+        preference: {
+          ...emptyPref,
+          workspaceId: "org-1",
+          groupId: "g_archived", // also gone → no member-routing restore
+          connectionId: "x",
+          groupReach: "g_archived",
+        },
+      }),
+    );
+    // No member-routing restore (group gone) AND reach falls back to All.
+    if (decision.kind === "restore" || decision.kind === "seed") {
+      expect(decision.groupReach).toBeNull();
+    }
+  });
+
   test("passes an explicit reach through a SQL seed instead of clobbering it (reach provenance decoupled)", () => {
     // A conversation-open restore set the reach authoritative ("explicit") while
     // the SQL member routing must still seed → the reach must survive.

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -96,6 +96,7 @@ import {
   shouldRenderEnvPicker,
   useChatEnvGroups,
   type ChatEnvGroup,
+  type ChatEnvSelection,
   type ResolveEnvSelectionInput,
 } from "../components/chat/env-picker";
 
@@ -411,6 +412,10 @@ describe("ChatEnvPicker chip label collapse (#2408)", () => {
         groups={groups}
         activeGroupId="g_warehouse"
         activeConnectionId="warehouse"
+        // #3895 — the Pin chip collapse applies to a focused group (or a
+        // single-group workspace); under multi-group All sources the chip reads
+        // "All sources". Focus → g_warehouse exercises the collapse here.
+        activeGroupReach="g_warehouse"
         onSelect={noop}
       />,
     );
@@ -448,6 +453,7 @@ describe("ChatEnvPicker chip label collapse (#2408)", () => {
         groups={groups}
         activeGroupId="g_warehouse"
         activeConnectionId="warehouse"
+        activeGroupReach="g_warehouse"
         onSelect={noop}
       />,
     );
@@ -1677,11 +1683,14 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
         routingMode: null,
         restExcludedDatasourceIds: [],
         restFocusDatasourceId: null,
+        groupReach: null,
       },
       provenance: "unset",
       // #3078 — REST scope provenance defaults to "unset" (follows the SQL
       // seed/restore). Tests that exercise the decoupled lifecycle override it.
       restProvenance: "unset",
+      // #3895 — Group reach provenance, same default (follows the seed/restore).
+      groupReachProvenance: "unset",
       preference: {
         workspaceId: null,
         groupId: null,
@@ -1689,6 +1698,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
         routingMode: null,
         restExcludedDatasourceIds: [],
         restFocusDatasourceId: null,
+        groupReach: null,
       },
       activeWorkspaceId: null,
       preferenceHydrated: true,
@@ -1764,6 +1774,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1792,6 +1803,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1819,6 +1831,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "auto",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1878,6 +1891,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1899,6 +1913,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1920,6 +1935,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1942,6 +1958,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "auto",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1958,6 +1975,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "only",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -1973,6 +1991,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1984,6 +2003,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -1998,6 +2018,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         provenance: "default",
         preference: {
@@ -2007,6 +2028,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2018,6 +2040,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2038,6 +2061,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: ["stripe"],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         provenance: "unset",
         restProvenance: "explicit",
@@ -2051,6 +2075,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "us-prod",
       restExcludedDatasourceIds: ["stripe"],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2063,6 +2088,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         provenance: "unset",
         restProvenance: "explicit",
@@ -2074,6 +2100,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2089,6 +2116,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: ["stripe"],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         provenance: "unset",
         restProvenance: "explicit",
@@ -2099,6 +2127,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2110,6 +2139,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: ["stripe"],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2125,6 +2155,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: ["stripe"],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         provenance: "explicit",
         restProvenance: "explicit",
@@ -2135,6 +2166,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2160,6 +2192,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: ["stripe"],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         provenance: "default",
         restProvenance: "explicit",
@@ -2170,6 +2203,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2189,6 +2223,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         provenance: "unset",
         restProvenance: "explicit",
@@ -2199,6 +2234,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: "pin",
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "github",
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2210,6 +2246,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2233,6 +2270,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["stripe"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
         }),
       ).kind,
@@ -2251,6 +2289,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: ["stripe"],
           restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2263,6 +2302,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: null,
       restExcludedDatasourceIds: ["stripe"],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2278,6 +2318,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           routingMode: null,
           restExcludedDatasourceIds: [],
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -2289,6 +2330,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       routingMode: null,
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2305,6 +2347,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["stripe"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
           activeWorkspaceId: "org-A",
         }),
@@ -2324,6 +2367,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["stripe"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
           preference: {
             workspaceId: "org-1",
@@ -2332,6 +2376,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["stripe"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
           activeWorkspaceId: "org-1",
         }),
@@ -2353,6 +2398,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["github"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
           restProvenance: "explicit",
           preference: {
@@ -2362,6 +2408,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
             routingMode: null,
             restExcludedDatasourceIds: ["stripe"],
             restFocusDatasourceId: null,
+            groupReach: null,
           },
           activeWorkspaceId: "org-1",
         }),
@@ -2410,7 +2457,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
@@ -2421,7 +2468,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("preserves an 'all' routing mode", () => {
@@ -2430,7 +2477,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "all" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("two different conversations resolve to two different scopes (switching updates the picker each time)", () => {
@@ -2456,7 +2503,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: null },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("legacy conversation with an omitted routing mode defaults to null", () => {
@@ -2467,7 +2514,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("seeds (defers) for a fully-null row — never makes nulls authoritative", () => {
@@ -2478,7 +2525,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: null, routingMode: null },
         groups,
       ),
-    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("seeds when the row's group has been archived / is no longer visible", () => {
@@ -2489,7 +2536,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_archived", connectionId: "old-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("repairs an archived member to the group primary when the group still resolves", () => {
@@ -2500,7 +2547,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "ap-prod-archived", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("repairs a group-only row (null member, e.g. Auto) to the group primary", () => {
@@ -2511,7 +2558,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: null, routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("falls back to members[0] when repairing under a group with no primary", () => {
@@ -2520,7 +2567,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_staging", connectionId: "gone", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("trusts the row optimistically when groups have not loaded yet (cold-start open)", () => {
@@ -2532,7 +2579,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "all" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("still seeds a fully-null row even when groups have not loaded", () => {
@@ -2543,7 +2590,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: null, routingMode: null },
         [],
       ),
-    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("restores a legacy group-less row by locating the group that owns its connection", () => {
@@ -2558,7 +2605,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("seeds a legacy group-less row only when its connection no longer exists in any group", () => {
@@ -2568,7 +2615,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "deleted-conn", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("optimistically restores a legacy group-less row (null group) on cold-start", () => {
@@ -2581,7 +2628,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   test("seeds when a resolved group has no live members (fully archived group)", () => {
@@ -2596,7 +2643,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_empty", connectionId: "anything", routingMode: "pin" },
         [emptyGroup],
       ),
-    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null });
   });
 
   // #3067 — the row's REST-only focus is restored alongside the SQL scope, the
@@ -2609,6 +2656,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
           connectionId: "eu-prod",
           routingMode: "pin",
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         groups,
       ),
@@ -2619,6 +2667,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2636,6 +2685,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       routingMode: "pin",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2663,6 +2713,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       kind: "seed",
       restExcludedDatasourceIds: ["stripe"],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2673,6 +2724,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
           connectionGroupId: null,
           connectionId: null,
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         groups,
       ),
@@ -2680,6 +2732,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       kind: "seed",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
   });
 
@@ -2700,6 +2753,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       kind: "seed",
       restExcludedDatasourceIds: ["stripe", "github"],
       restFocusDatasourceId: null,
+      groupReach: null,
     });
   });
 
@@ -2713,6 +2767,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
           connectionId: "old-prod",
           routingMode: "pin",
           restFocusDatasourceId: "stripe",
+          groupReach: null,
         },
         groups,
       ),
@@ -2720,7 +2775,316 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       kind: "seed",
       restExcludedDatasourceIds: [],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3895 (ADR-0022 §5) — Group reach axis: All sources (default) | Focus → group,
+// with member routing nested under a focused multi-member group.
+// ---------------------------------------------------------------------------
+describe("ChatEnvPicker — Group reach axis (#3895)", () => {
+  afterEach(() => cleanup());
+
+  const twoGroups: ChatEnvGroup[] = [
+    {
+      id: "g_prod",
+      name: "prod",
+      primaryConnectionId: "us-prod",
+      members: [
+        { connectionId: "eu-prod", dbType: "postgres", description: null },
+        { connectionId: "us-prod", dbType: "postgres", description: null },
+      ],
+    },
+    {
+      id: "g_analytics",
+      name: "analytics",
+      primaryConnectionId: null,
+      members: [{ connectionId: "warehouse", dbType: "clickhouse", description: null }],
+    },
+  ];
+
+  test("multi-group default (no reach) shows the 'All sources' chip + reach chooser, no member routing", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId={null}
+        activeConnectionId={null}
+        activeGroupReach={null}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent,
+    ).toBe("All sources");
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]')?.getAttribute("data-reach"),
+    ).toBe("all");
+    // The reach chooser is present and "All sources" is active.
+    const all = container.querySelector('[data-testid="chat-env-picker-reach-all"]');
+    expect(all?.getAttribute("data-active")).toBe("true");
+    // Both groups are offered as Focus targets.
+    expect(container.querySelector('[data-testid="chat-env-picker-reach-focus-g_prod"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="chat-env-picker-reach-focus-g_analytics"]')).not.toBeNull();
+    // Member routing is NOT shown under All sources (no single group).
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).toBeNull();
+  });
+
+  test("Focus on a multi-member group reveals nested member routing + marks the focus active", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="auto"
+        activeGroupReach="g_prod"
+        onSelect={noop}
+      />,
+    );
+    // Reach focus marked active.
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-reach-focus-g_prod"]')?.getAttribute("data-active"),
+    ).toBe("true");
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-reach-all"]')?.getAttribute("data-active"),
+    ).toBe("false");
+    // Member routing IS shown (focused group has >1 member).
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="chat-env-picker-member-eu-prod"]')).not.toBeNull();
+  });
+
+  test("Focus on a single-member group hides member routing (nothing to route)", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId="g_analytics"
+        activeConnectionId="warehouse"
+        activeGroupReach="g_analytics"
+        onSelect={noop}
+      />,
+    );
+    expect(container.querySelector('[data-testid="chat-env-picker-reach-focus-g_analytics"]')?.getAttribute("data-active")).toBe("true");
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).toBeNull();
+  });
+
+  test("selecting 'All sources' emits a cleared selection (reach + member binding both null)", () => {
+    let captured: ChatEnvSelection | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-prod"
+        activeGroupReach="g_prod"
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    container
+      .querySelector<HTMLElement>('[data-testid="chat-env-picker-reach-all"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured).toEqual({
+      groupReach: null,
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+    });
+  });
+
+  test("selecting 'Focus → group' emits a focus selection with the group's primary member + Auto", () => {
+    let captured: ChatEnvSelection | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId={null}
+        activeConnectionId={null}
+        activeGroupReach={null}
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    container
+      .querySelector<HTMLElement>('[data-testid="chat-env-picker-reach-focus-g_prod"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured).toEqual({
+      groupReach: "g_prod",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+      routingMode: "auto",
+    });
+  });
+
+  test("changing member routing under Focus preserves the reach (does not widen to All)", () => {
+    let captured: ChatEnvSelection | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={twoGroups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="auto"
+        activeGroupReach="g_prod"
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    container
+      .querySelector<HTMLElement>('[data-testid="chat-env-picker-member-eu-prod"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured!.groupReach).toBe("g_prod");
+    expect(captured!.connectionId).toBe("eu-prod");
+    expect(captured!.routingMode).toBe("pin");
+  });
+
+  test("a single-group workspace shows no reach chooser (reach is trivial)", () => {
+    const oneGroup: ChatEnvGroup[] = [twoGroups[0]];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={oneGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        activeGroupReach={null}
+        onSelect={noop}
+      />,
+    );
+    // No reach chooser for a single-group workspace…
+    expect(container.querySelector('[data-testid="chat-env-picker-reach-all"]')).toBeNull();
+    // …but member routing for the sole multi-member group is still available.
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3895 — reach threading through the pure seed/restore resolvers.
+// ---------------------------------------------------------------------------
+describe("resolveEnvSelection / resolveConversationScope — Group reach (#3895)", () => {
+  const g = (id: string, members: string[]): ChatEnvGroup => ({
+    id,
+    name: id,
+    primaryConnectionId: members[0] ?? null,
+    members: members.map((c) => ({ connectionId: c, dbType: "postgres", description: null })),
+  });
+  const emptyPref = {
+    workspaceId: null,
+    groupId: null,
+    connectionId: null,
+    routingMode: null,
+    restExcludedDatasourceIds: [],
+    restFocusDatasourceId: null,
+    groupReach: null,
+  };
+  const baseInput = (overrides: Partial<ResolveEnvSelectionInput>): ResolveEnvSelectionInput => ({
+    groups: [g("g_a", ["a"]), g("g_b", ["b"])],
+    current: {
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
+    },
+    provenance: "unset",
+    restProvenance: "unset",
+    groupReachProvenance: "unset",
+    preference: emptyPref,
+    activeWorkspaceId: null,
+    preferenceHydrated: true,
+    sessionResolved: true,
+    groupsLoaded: true,
+    ...overrides,
+  });
+
+  test("a MULTI-group fresh chat with no preference defaults to All sources — no group is bound", () => {
+    // The ADR-0022 flip: a multi-group workspace no longer focus-seeds the first
+    // group; it starts at All sources (the agent ranges every group).
+    const decision = resolveEnvSelection(baseInput({}));
+    // Either noop (already at the All-sources default) or a seed that binds no
+    // group — never a focus-first-group seed.
+    if (decision.kind === "seed") {
+      expect(decision.groupId).toBeNull();
+      expect(decision.groupReach).toBeNull();
+    } else {
+      expect(decision.kind).toBe("noop");
+    }
+  });
+
+  test("seeds the Group reach from a workspace-matching sticky preference (Focus restored on a fresh chat)", () => {
+    const decision = resolveEnvSelection(
+      baseInput({
+        activeWorkspaceId: "org-1",
+        preference: {
+          ...emptyPref,
+          workspaceId: "org-1",
+          groupId: "g_a",
+          connectionId: "a",
+          routingMode: "pin",
+          groupReach: "g_a",
+        },
+      }),
+    );
+    expect(decision.kind).toBe("restore");
+    if (decision.kind === "restore") {
+      expect(decision.groupReach).toBe("g_a");
+      expect(decision.groupId).toBe("g_a");
+    }
+  });
+
+  test("passes an explicit reach through a SQL seed instead of clobbering it (reach provenance decoupled)", () => {
+    // A conversation-open restore set the reach authoritative ("explicit") while
+    // the SQL member routing must still seed → the reach must survive.
+    const decision = resolveEnvSelection(
+      baseInput({
+        current: {
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: "g_b",
+        },
+        groupReachProvenance: "explicit",
+      }),
+    );
+    // Whatever the SQL decision, the explicit reach passes through unchanged.
+    if (decision.kind === "restore" || decision.kind === "seed") {
+      expect(decision.groupReach).toBe("g_b");
+    }
+  });
+
+  test("resolveConversationScope restores the row's Group reach on a restore", () => {
+    const decision = resolveConversationScope(
+      {
+        connectionGroupId: "g_a",
+        connectionId: "a",
+        routingMode: "pin",
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+        groupReach: "g_a",
+      },
+      [g("g_a", ["a"])],
+    );
+    expect(decision.kind).toBe("restore");
+    expect(decision.groupReach).toBe("g_a");
+  });
+
+  test("resolveConversationScope carries the row's Group reach even when the SQL scope defers to seed", () => {
+    // All-null SQL scope → SQL seed, but the row's reach (independent axis) is
+    // still restored verbatim (like the REST scope, #3078).
+    const decision = resolveConversationScope(
+      {
+        connectionGroupId: null,
+        connectionId: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+        groupReach: "g_a",
+      },
+      [g("g_a", ["a"])],
+    );
+    expect(decision.kind).toBe("seed");
+    expect(decision.groupReach).toBe("g_a");
   });
 });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -230,6 +230,11 @@ export function AtlasChat({
   // SQL is suspended. Seeded from the sticky preference on a fresh chat,
   // restored from the row when a conversation is opened.
   const [selectedRestFocus, setSelectedRestFocus] = useState<string | null>(null);
+  // #3895 (ADR-0022) — per-conversation Group reach. `null` = All sources (every
+  // visible group reachable — the new default); a group id = Focus → that group.
+  // The cross-group axis ABOVE member routing. Seeded from the sticky preference
+  // on a fresh chat, restored from the row when a conversation is opened.
+  const [selectedGroupReach, setSelectedGroupReach] = useState<string | null>(null);
   // #3044 — persisted env-picker preference so a reload restores the user's
   // last selection instead of re-seeding from the first group. Select fields
   // individually so the store object identity doesn't churn effect deps.
@@ -239,6 +244,7 @@ export function AtlasChat({
   const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
   const prefRestExcluded = useChatRoutingPreferenceStore((s) => s.restExcludedDatasourceIds);
   const prefRestFocus = useChatRoutingPreferenceStore((s) => s.restFocusDatasourceId);
+  const prefGroupReach = useChatRoutingPreferenceStore((s) => s.groupReach);
   const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
   const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
   // #3064 — how the current picker SQL scope (group / member / mode) was set, so
@@ -254,6 +260,14 @@ export function AtlasChat({
   // through any SQL seed/restore instead of clobbering it — the seam that fixes
   // the all-null-SQL exclude-set data loss. `handleNewChat` resets it to "unset".
   const restScopeProvenanceRef = useRef<EnvSelectionProvenance>("unset");
+  // #3895 — the Group reach has its OWN provenance, decoupled from the SQL
+  // member-routing (`selectionProvenanceRef`) and REST (`restScopeProvenanceRef`)
+  // provenances (the #3078 decoupling, applied to the reach axis). Opening a
+  // conversation makes the row's reach authoritative ("explicit") regardless of
+  // the SQL decision; a reach pick marks it explicit too. While explicit,
+  // `resolveEnvSelection` passes the current reach through any SQL seed/restore
+  // instead of clobbering it. `handleNewChat` resets it to "unset".
+  const groupReachProvenanceRef = useRef<EnvSelectionProvenance>("unset");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -305,6 +319,9 @@ export function AtlasChat({
     // #3067 — forward the REST-only focus on every turn (always, even null) so
     // a clear actually nulls the row instead of inheriting the stale focus.
     getRestFocusDatasourceId: () => selectedRestFocus,
+    // #3895 — forward the Group reach on every turn (always, even null) so a
+    // widen back to All sources nulls the row instead of inheriting stale Focus.
+    getGroupReach: () => selectedGroupReach,
     // #3749 — onRunId: capture the active run id for correlation/telemetry only
     // (not used to target a resume). getResumeConversationId: a resume targets the
     // bound CONVERSATION (not the run id); the affordance only shows once a
@@ -387,6 +404,7 @@ export function AtlasChat({
         routingMode: selectedRoutingMode,
         restExcludedDatasourceIds: selectedRestExcluded,
         restFocusDatasourceId: selectedRestFocus,
+        groupReach: selectedGroupReach,
       },
       provenance: selectionProvenanceRef.current,
       // #3078 — REST scope provenance is independent of the SQL provenance. When
@@ -394,6 +412,8 @@ export function AtlasChat({
       // resolver passes the current REST scope through instead of clobbering it
       // with the default seed / sticky preference while SQL seeds or restores.
       restProvenance: restScopeProvenanceRef.current,
+      // #3895 — Group reach provenance, independent of both (same seam as REST).
+      groupReachProvenance: groupReachProvenanceRef.current,
       preference: {
         workspaceId: prefWorkspaceId,
         groupId: prefGroupId,
@@ -401,6 +421,7 @@ export function AtlasChat({
         routingMode: prefRoutingMode,
         restExcludedDatasourceIds: prefRestExcluded,
         restFocusDatasourceId: prefRestFocus,
+        groupReach: prefGroupReach,
       },
       activeWorkspaceId,
       preferenceHydrated: prefHasHydrated,
@@ -422,9 +443,13 @@ export function AtlasChat({
         setSelectedRestExcluded(decision.restExcludedDatasourceIds);
         // #3067 — seed the sticky preference's REST-only focus too.
         setSelectedRestFocus(decision.restFocusDatasourceId);
+        // #3895 — seed the sticky preference's Group reach too.
+        setSelectedGroupReach(decision.groupReach);
         // A restored sticky preference is the user's deliberate prior choice —
-        // mark it explicit so a later effect run can't seed over it.
+        // mark it explicit so a later effect run can't seed over it. The reach
+        // has its own provenance but settles together with the SQL scope here.
         selectionProvenanceRef.current = "explicit";
+        groupReachProvenanceRef.current = "explicit";
         break;
       case "seed":
         setSelectedGroupId(decision.groupId);
@@ -433,10 +458,14 @@ export function AtlasChat({
         setSelectedRestExcluded(decision.restExcludedDatasourceIds);
         // #3067 — a default seed is not focused (SQL active).
         setSelectedRestFocus(decision.restFocusDatasourceId);
+        // #3895 — a default seed is All sources (null), unless the reach was
+        // explicit and passed through.
+        setSelectedGroupReach(decision.groupReach);
         // Record that this was auto-seeded: a workspace-matching preference
         // arriving later is still restored over it (the resolver re-runs), but
         // a second default seed is suppressed.
         selectionProvenanceRef.current = "default";
+        groupReachProvenanceRef.current = "default";
         break;
       case "wait":
       case "noop":
@@ -465,12 +494,16 @@ export function AtlasChat({
     selectedRestExcluded,
     // #3067 — focus is part of `current` too; keep it in deps for the same reason.
     selectedRestFocus,
+    // #3895 — reach is part of `current` too; keep it in deps so a pref-only reach
+    // change re-evaluates restore-vs-noop rather than going stale.
+    selectedGroupReach,
     prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
     prefRoutingMode,
     prefRestExcluded,
     prefRestFocus,
+    prefGroupReach,
     prefHasHydrated,
     activeWorkspaceId,
     sessionResolved,
@@ -879,6 +912,11 @@ export function AtlasChat({
       restScopeProvenanceRef.current = "explicit";
       setSelectedRestExcluded(decision.restExcludedDatasourceIds);
       setSelectedRestFocus(decision.restFocusDatasourceId);
+      // #3895 — Group reach — restored on BOTH decision kinds (read straight from
+      // the row's `group_reach`, independent of the SQL member-routing decision),
+      // made authoritative so the seed/restore effect can't clobber it.
+      groupReachProvenanceRef.current = "explicit";
+      setSelectedGroupReach(decision.groupReach);
       // SQL scope — restore vs defer-to-seed.
       if (decision.kind === "restore") {
         selectionProvenanceRef.current = "explicit";
@@ -945,6 +983,11 @@ export function AtlasChat({
     // conversation's `explicit` REST scope doesn't carry into the new chat and
     // block the seed/restore effect from seeding the sticky preference / default.
     restScopeProvenanceRef.current = "unset";
+    // #3895 — reset the Group reach provenance + value too, so a just-opened
+    // conversation's `explicit` reach doesn't carry into the new chat. The new
+    // chat re-seeds reach from the sticky preference (or the All-sources default).
+    groupReachProvenanceRef.current = "unset";
+    setSelectedGroupReach(null);
     setSelectedGroupId(null);
     setSelectedConnectionId(null);
     setSelectedRoutingMode(null);
@@ -1113,6 +1156,7 @@ export function AtlasChat({
                     activeGroupId={selectedGroupId}
                     activeConnectionId={selectedConnectionId}
                     activeRoutingMode={selectedRoutingMode}
+                    activeGroupReach={selectedGroupReach}
                     restDatasources={envGroupsQuery.restDatasources}
                     restExcludedDatasourceIds={selectedRestExcluded}
                     onRestExcludedChange={(next) => {
@@ -1134,6 +1178,9 @@ export function AtlasChat({
                         routingMode: selectedRoutingMode,
                         restExcludedDatasourceIds: next,
                         restFocusDatasourceId: selectedRestFocus,
+                        // #3895 — carry the current reach so a REST toggle doesn't
+                        // drop it from the sticky preference.
+                        groupReach: selectedGroupReach,
                       });
                     }}
                     restFocusDatasourceId={selectedRestFocus}
@@ -1152,12 +1199,19 @@ export function AtlasChat({
                         routingMode: selectedRoutingMode,
                         restExcludedDatasourceIds: selectedRestExcluded,
                         restFocusDatasourceId: next,
+                        // #3895 — carry the current reach so a focus toggle doesn't
+                        // drop it from the sticky preference.
+                        groupReach: selectedGroupReach,
                       });
                     }}
-                    onSelect={({ groupId, connectionId, routingMode }) => {
+                    onSelect={({ groupReach, groupId, connectionId, routingMode }) => {
                       // #3064 — a user pick is authoritative; mark it explicit
-                      // so the seed/restore effect never replaces it.
+                      // so the seed/restore effect never replaces it. #3895 — a
+                      // reach pick (All sources / Focus → group) sets the reach +
+                      // member routing together, so mark BOTH provenances explicit.
                       selectionProvenanceRef.current = "explicit";
+                      groupReachProvenanceRef.current = "explicit";
+                      setSelectedGroupReach(groupReach);
                       setSelectedGroupId(groupId);
                       setSelectedConnectionId(connectionId);
                       setSelectedRoutingMode(routingMode);
@@ -1173,6 +1227,9 @@ export function AtlasChat({
                         // #3067 — carry the current focus so an env change
                         // doesn't drop it from the sticky preference.
                         restFocusDatasourceId: selectedRestFocus,
+                        // #3895 — persist the picked Group reach so new chats
+                        // inherit it (mirrors the REST scope's sticky seeding).
+                        groupReach,
                       });
                     }}
                   />

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -80,9 +80,18 @@ export interface ChatEnvGroup {
  *
  * #3895 (ADR-0022) — `groupReach` is the cross-group axis ABOVE member routing:
  * `null` = **All sources** (every visible group reachable); a group id = **Focus
- * → that group** (hard/exclusive). When `groupReach` is `null` the member-routing
- * fields are `null` too (there is no single group to route within); when it names
- * a group they carry that group's member routing (`groupId === groupReach`).
+ * → that group** (hard/exclusive). The reach/member-routing coupling is enforced
+ * by this component's four `onSelect` producers (not the type), and depends on
+ * the workspace shape:
+ *
+ *   - **Multi-group:** `null` groupReach ⇒ member-routing fields are `null` too
+ *     (no single group to route within); a named group ⇒ `groupId === groupReach`.
+ *   - **Single-group:** the reach chooser is hidden (reach is trivially All), so
+ *     `groupReach` stays `null` while `groupId`/`connectionId`/`routingMode` bind
+ *     the sole group for member-routing context (`groupId !== groupReach` here).
+ *
+ * The producer behaviour is pinned by the picker's onSelect tests (#3895), so the
+ * flat (vs. discriminated-union) shape can't drift into an illegal combination.
  */
 export interface ChatEnvSelection {
   readonly groupReach: string | null;

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -73,15 +73,22 @@ export interface ChatEnvGroup {
 }
 
 /**
- * Payload for {@link ChatEnvPickerProps.onSelect}. The parent receives
- * the full triple every time so it can persist any subset onto the
- * conversation row without the picker having to know which fields the
- * server treats as content-scope vs. per-turn execution-target.
+ * Payload for {@link ChatEnvPickerProps.onSelect}. The parent receives the full
+ * reach + member-routing selection every time so it can persist any subset onto
+ * the conversation row without the picker having to know which fields the server
+ * treats as reach vs. content-scope vs. per-turn execution-target.
+ *
+ * #3895 (ADR-0022) — `groupReach` is the cross-group axis ABOVE member routing:
+ * `null` = **All sources** (every visible group reachable); a group id = **Focus
+ * → that group** (hard/exclusive). When `groupReach` is `null` the member-routing
+ * fields are `null` too (there is no single group to route within); when it names
+ * a group they carry that group's member routing (`groupId === groupReach`).
  */
 export interface ChatEnvSelection {
-  readonly groupId: string;
-  readonly connectionId: string;
-  readonly routingMode: ConversationRoutingMode;
+  readonly groupReach: string | null;
+  readonly groupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode: ConversationRoutingMode | null;
 }
 
 export interface ChatEnvPickerProps {
@@ -114,6 +121,16 @@ export interface ChatEnvPickerProps {
    * pinned to that member".
    */
   readonly activeRoutingMode?: ConversationRoutingMode | null;
+  /**
+   * #3895 (ADR-0022) — the conversation's Group reach. `null` = **All sources**
+   * (every visible Connection group reachable — the default); a group id =
+   * **Focus → that group** (hard/exclusive narrowing). Drives the picker's reach
+   * UI (the "All sources" vs "Focus: <group>" choice) and gates member routing:
+   * Auto/Pin/All surface only when a multi-member group is the single reachable
+   * group (Focus → it, or the sole group under All sources). Optional / defaults
+   * to `null` (All sources) for back-compat with callers that don't pass it.
+   */
+  readonly activeGroupReach?: string | null;
   /**
    * #3044 — the workspace's REST datasources + their env scope. Rendered in the
    * dropdown so the user can see (and, #3066, toggle) what the conversation
@@ -291,6 +308,8 @@ export interface ResolveEnvSelectionInput {
     readonly restExcludedDatasourceIds: ReadonlyArray<string>;
     /** #3067 — current REST-only focus, so a pref-only focus change still restores. */
     readonly restFocusDatasourceId: string | null;
+    /** #3895 — current Group reach (null = All sources), so a pref-only reach change still restores. */
+    readonly groupReach: string | null;
   };
   /** How {@link current}'s SQL scope (group / member / mode) was set. */
   readonly provenance: EnvSelectionProvenance;
@@ -306,6 +325,18 @@ export interface ResolveEnvSelectionInput {
    * silent default in a precedence resolver is how the clobber bug returns.
    */
   readonly restProvenance: EnvSelectionProvenance;
+  /**
+   * #3895 — how {@link current}'s Group reach was set, independent of the SQL
+   * member-routing {@link provenance} and the {@link restProvenance} (mirrors the
+   * decoupling that fixed #3078). When `"explicit"` the reach is authoritative —
+   * a conversation-open restore made the row's reach the source of truth, or the
+   * user picked All sources / Focus — so the resolver passes the *current* reach
+   * through any seed/restore instead of clobbering it with the default (All) /
+   * the sticky preference. `"unset"` / `"default"` mean "reach follows the
+   * seed/restore." Required, like {@link provenance}: a silent default in a
+   * precedence resolver is how a clobber bug returns.
+   */
+  readonly groupReachProvenance: EnvSelectionProvenance;
   /** The persisted sticky preference for this browser. */
   readonly preference: EnvSelectionPreference;
   /** Active workspace id (`null` = self-hosted / no active org). */
@@ -347,15 +378,26 @@ export type EnvSelectionDecision =
       readonly restExcludedDatasourceIds: string[];
       /** #3067 — the sticky preference's REST-only focus to seed onto this fresh chat. */
       readonly restFocusDatasourceId: string | null;
+      /** #3895 — the Group reach to apply (sticky preference's reach, or null = All sources). */
+      readonly groupReach: string | null;
     }
   | {
       readonly kind: "seed";
-      readonly groupId: string;
-      readonly connectionId: string;
+      /**
+       * #3895 — the SQL member binding to seed. Non-null for a SINGLE-group
+       * workspace (bind that group for member-routing context). `null` for a
+       * MULTI-group workspace, where the new default is All sources (the agent
+       * ranges every group, so no single group is bound) — `groupReach` carries
+       * the reach and the SQL scope stays null.
+       */
+      readonly groupId: string | null;
+      readonly connectionId: string | null;
       /** #3066 — a default seed excludes nothing (every in-scope datasource queryable). */
       readonly restExcludedDatasourceIds: string[];
       /** #3067 — a default seed is not focused (SQL active). */
       readonly restFocusDatasourceId: string | null;
+      /** #3895 — the Group reach to apply (null = All sources, the default). */
+      readonly groupReach: string | null;
     };
 
 /**
@@ -392,6 +434,7 @@ export function resolveEnvSelection(
     current,
     provenance,
     restProvenance,
+    groupReachProvenance,
     preference,
     activeWorkspaceId,
     preferenceHydrated,
@@ -405,6 +448,24 @@ export function resolveEnvSelection(
   // scope free to seed/restore while the REST scope stays put — the seam that
   // fixes the all-null-SQL exclude-set data loss.
   const restExplicit = restProvenance === "explicit";
+  // #3895 — same seam for Group reach: when the reach is authoritative (a
+  // conversation-open restore made the row's reach the source of truth, or the
+  // user picked All sources / Focus), pass the CURRENT reach through any
+  // seed/restore instead of clobbering it with the default (All) / the sticky
+  // preference. Its OWN provenance, decoupled from the SQL + REST provenances.
+  const reachExplicit = groupReachProvenance === "explicit";
+
+  // The sticky preference's reach to seed a fresh chat: only when it belongs to
+  // the active workspace AND still names a visible group (else fall back to All
+  // sources — a Focus on a gone group would lie). When reach is explicit the
+  // current reach passes through untouched (computed per-branch below).
+  const prefMatchesWorkspaceForReach = preference.workspaceId === activeWorkspaceId;
+  const prefReach =
+    prefMatchesWorkspaceForReach &&
+    preference.groupReach &&
+    groups.some((g) => g.id === preference.groupReach)
+      ? preference.groupReach
+      : null;
 
   // 1. Gate — wait until the inputs we need to choose correctly are ready.
   // (Group readiness is handled per-branch below: a *loaded-empty* group list is
@@ -419,10 +480,11 @@ export function resolveEnvSelection(
   if (groups.length === 0) {
     if (!groupsLoaded) return { kind: "wait" };
     // An explicit selection (user pick / conversation restore) is authoritative,
-    // and an explicit REST scope must not be clobbered — leave both alone.
-    if (provenance === "explicit" || restExplicit) return { kind: "noop" };
+    // and an explicit REST/reach scope must not be clobbered — leave all alone.
+    if (provenance === "explicit" || restExplicit || reachExplicit) return { kind: "noop" };
     // Restore the workspace-matching preference's REST scope; another workspace's
-    // preference is ignored (ids can collide). SQL scope stays null (no groups).
+    // preference is ignored (ids can collide). SQL scope stays null (no groups);
+    // reach is All (no groups to Focus → prefReach resolves to null here).
     const prefMatchesWorkspace = preference.workspaceId === activeWorkspaceId;
     const nextRestExcluded = prefMatchesWorkspace
       ? [...(preference.restExcludedDatasourceIds ?? [])]
@@ -430,10 +492,11 @@ export function resolveEnvSelection(
     const nextRestFocus = prefMatchesWorkspace
       ? preference.restFocusDatasourceId ?? null
       : null;
-    // Already on the target REST scope — don't churn (and don't loop).
+    // Already on the target REST + reach scope — don't churn (and don't loop).
     if (
       sameExcludeSet(current.restExcludedDatasourceIds ?? [], nextRestExcluded) &&
-      (current.restFocusDatasourceId ?? null) === nextRestFocus
+      (current.restFocusDatasourceId ?? null) === nextRestFocus &&
+      (current.groupReach ?? null) === prefReach
     ) {
       return { kind: "noop" };
     }
@@ -444,12 +507,13 @@ export function resolveEnvSelection(
       routingMode: null,
       restExcludedDatasourceIds: nextRestExcluded,
       restFocusDatasourceId: nextRestFocus,
+      groupReach: prefReach,
     };
   }
 
   // 2. An explicit pick (or conversation-restored value) is authoritative.
-  // (When SQL is explicit the REST scope is already settled too, so there is no
-  // divergent REST action to take here — the early noop is safe.)
+  // (When SQL is explicit the REST + reach scopes are settled too — a user pick /
+  // conversation open marks all three at once — so the early noop is safe.)
   if (provenance === "explicit") return { kind: "noop" };
 
   // 3. Restore a workspace-matching, still-resolvable preference.
@@ -462,27 +526,28 @@ export function resolveEnvSelection(
     (m) => m.connectionId === preference.connectionId,
   );
   if (prefGroup && prefMember) {
-    // The REST scope this restore would apply: the preference's, UNLESS the REST
-    // scope is explicit (#3078) — then the current exclude-set / focus is
-    // authoritative and passes through untouched. Computed once so the no-churn
-    // guard and the returned decision agree (a mismatch would loop forever).
+    // The REST + reach scope this restore would apply: the preference's, UNLESS
+    // explicit (#3078 / #3895) — then the current value is authoritative and
+    // passes through untouched. Computed once so the no-churn guard and the
+    // returned decision agree (a mismatch would loop forever).
     const nextRestExcluded = restExplicit
       ? [...(current.restExcludedDatasourceIds ?? [])]
       : [...(preference.restExcludedDatasourceIds ?? [])];
     const nextRestFocus = restExplicit
       ? current.restFocusDatasourceId ?? null
       : preference.restFocusDatasourceId ?? null;
+    const nextGroupReach = reachExplicit ? current.groupReach ?? null : prefReach;
 
-    // Already on the preferred selection — don't churn React state. The
-    // routing mode AND the REST scope (#3066/#3067) are part of the selection,
-    // so a mode-only or REST-only difference (e.g. a default seed landed on the
-    // preferred member but with no mode / empty exclude-set) must still restore.
+    // Already on the preferred selection — don't churn React state. The routing
+    // mode, REST scope (#3066/#3067), AND Group reach (#3895) are all part of the
+    // selection, so a mode-only / REST-only / reach-only difference must restore.
     if (
       current.groupId === prefGroup.id &&
       current.connectionId === prefMember.connectionId &&
       current.routingMode === preference.routingMode &&
       sameExcludeSet(current.restExcludedDatasourceIds ?? [], nextRestExcluded) &&
-      (current.restFocusDatasourceId ?? null) === nextRestFocus
+      (current.restFocusDatasourceId ?? null) === nextRestFocus &&
+      (current.groupReach ?? null) === nextGroupReach
     ) {
       return { kind: "noop" };
     }
@@ -493,30 +558,54 @@ export function resolveEnvSelection(
       routingMode: preference.routingMode,
       restExcludedDatasourceIds: nextRestExcluded,
       restFocusDatasourceId: nextRestFocus,
+      groupReach: nextGroupReach,
     };
   }
 
-  // No restorable preference. Seed the group-primary default only on a fresh
-  // chat (provenance "unset"); once a default has been seeded — or anything
-  // is already selected — leave it in place rather than re-seeding.
+  // No restorable preference. Seed the default. #3895 — the new default is All
+  // sources (ADR-0022): a MULTI-group workspace binds NO group (the agent ranges
+  // every group; reach = All), while a SINGLE-group workspace binds that one
+  // group for member-routing context (All sources ≡ the one group; the reach
+  // chooser is hidden, so `groupReach` stays null = All). Seed only on a fresh
+  // chat (provenance "unset"); once a default has been seeded — or a member is
+  // already selected — leave it in place rather than re-seeding.
   if (provenance === "default" || current.connectionId !== null) {
     return { kind: "noop" };
   }
-  const seed = pickDefaultEnvSeed(groups, current.connectionId);
-  if (!seed) return { kind: "noop" };
-  // A default seed carries no exclusions — every in-scope REST datasource stays
-  // queryable until the user opts one out — and is not focused (SQL active).
-  // #3078 — UNLESS the REST scope is explicit (e.g. an all-null-SQL conversation
-  // whose exclude-set / focus was just restored): pass it through so seeding the
-  // SQL default doesn't wipe it.
+  // A default seed carries no exclusions and is not focused, UNLESS the REST /
+  // reach scope is explicit (#3078/#3895) — then it passes through so seeding the
+  // SQL default doesn't wipe a just-restored REST scope / reach.
+  const seedRestExcluded = restExplicit ? [...(current.restExcludedDatasourceIds ?? [])] : [];
+  const seedRestFocus = restExplicit ? current.restFocusDatasourceId ?? null : null;
+  const seedGroupReach = reachExplicit ? current.groupReach ?? null : null;
+  const seed = groups.length === 1 ? pickDefaultEnvSeed(groups, current.connectionId) : null;
+  if (!seed) {
+    // Multi-group All-sources default: no SQL binding. Seed only if the reach (or
+    // a passed-through REST scope) actually differs from current — else noop so
+    // the effect doesn't churn. `current.connectionId` is already null here.
+    if (
+      (current.groupReach ?? null) === seedGroupReach &&
+      sameExcludeSet(current.restExcludedDatasourceIds ?? [], seedRestExcluded) &&
+      (current.restFocusDatasourceId ?? null) === seedRestFocus
+    ) {
+      return { kind: "noop" };
+    }
+    return {
+      kind: "seed",
+      groupId: null,
+      connectionId: null,
+      restExcludedDatasourceIds: seedRestExcluded,
+      restFocusDatasourceId: seedRestFocus,
+      groupReach: seedGroupReach,
+    };
+  }
   return {
     kind: "seed",
     groupId: seed.groupId,
     connectionId: seed.connectionId,
-    restExcludedDatasourceIds: restExplicit
-      ? [...(current.restExcludedDatasourceIds ?? [])]
-      : [],
-    restFocusDatasourceId: restExplicit ? current.restFocusDatasourceId ?? null : null,
+    restExcludedDatasourceIds: seedRestExcluded,
+    restFocusDatasourceId: seedRestFocus,
+    groupReach: seedGroupReach,
   };
 }
 
@@ -535,6 +624,8 @@ export interface ConversationScopeSource {
   readonly restExcludedDatasourceIds?: ReadonlyArray<string> | null;
   /** #3067 — the row's REST-only focus (`install_id`, or null = not focused). */
   readonly restFocusDatasourceId?: string | null;
+  /** #3895 — the row's Group reach (`connection_group_id` = Focus, or null = All sources). Absent ⇒ All. */
+  readonly groupReach?: string | null;
 }
 
 /**
@@ -557,6 +648,15 @@ export interface RestoredRestScope {
    * focused). Carried the same way as the exclude-set.
    */
   readonly restFocusDatasourceId: string | null;
+  /**
+   * #3895 — the conversation's Group reach (`connection_group_id` = Focus → that
+   * group, or null = All sources). Carried on EVERY decision the same way as the
+   * REST scope: reach is the authoritative cross-group axis read straight from the
+   * row's `group_reach` column, independent of the SQL member-routing
+   * (group/member) restore-vs-seed validation. The caller restores it and marks
+   * its own provenance `explicit` regardless of the SQL `kind`.
+   */
+  readonly groupReach: string | null;
 }
 
 /** The picker selection restored from a conversation row — SQL scope + REST scope. */
@@ -636,18 +736,26 @@ export function resolveConversationScope(
   // #3067 — the row's REST-only focus (null = not focused). Carried on every
   // decision the same way as the exclude-set (#3078).
   const restFocusDatasourceId = source.restFocusDatasourceId ?? null;
+  // #3895 — the row's Group reach (null = All sources). The authoritative
+  // cross-group axis, read straight from the row's `group_reach` column and
+  // carried on EVERY decision below (restore AND seed), independent of the SQL
+  // member-routing validation: reach is not derived from `connection_group_id`.
+  // executeSQL re-validates a Focus on a now-invisible group at query time, so a
+  // verbatim restore here is safe (the picker shows the persisted reach; the
+  // agent refuses to query an unreachable focused group rather than substitute).
+  const groupReach = source.groupReach ?? null;
 
   // A row that persisted no SQL scope is never authoritative for routing — defer
   // to the seed/restore effect (decided before the load gate so it holds either
   // way). The REST scope still rides along, so an all-null-SQL conversation with
   // an exclude-set keeps it (#3078).
-  if (groupId === null && connectionId === null) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
+  if (groupId === null && connectionId === null) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
 
   // Groups not loaded yet (cold-start open): we can't validate, so trust the
   // row optimistically. Losing the restore here would be a worse, more common
   // regression than the rare archived-env + cold-start intersection.
   if (groups.length === 0) {
-    return { kind: "restore", groupId, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
+    return { kind: "restore", groupId, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
   }
 
   // Groups loaded — validate the row against the visible environments.
@@ -655,20 +763,20 @@ export function resolveConversationScope(
     // The row named a content group: it must still resolve, else a stale group
     // id reaches the chat route and is rejected (invalid_connection_group).
     const group = groups.find((g) => g.id === groupId);
-    if (!group) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
+    if (!group) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
 
     // Group resolves. Keep the pinned member if it's still present; otherwise
     // repair the execution target to the group primary (never send a stale id),
     // preserving the still-valid group rather than discarding it.
     const member = group.members.find((m) => m.connectionId === connectionId);
     if (member) {
-      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
+      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
     }
     const repaired =
       group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
       group.members[0];
-    if (!repaired) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId }; // group exists but has no live members
-    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
+    if (!repaired) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId, groupReach }; // group exists but has no live members
+    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
   }
 
   // Legacy group-less row (connectionGroupId null, connectionId set, e.g. a
@@ -681,8 +789,8 @@ export function resolveConversationScope(
   const owningGroup = groups.find((g) =>
     g.members.some((m) => m.connectionId === connectionId),
   );
-  if (!owningGroup) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
-  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
+  if (!owningGroup) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
+  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId, groupReach };
 }
 
 /**
@@ -705,6 +813,7 @@ export function ChatEnvPicker({
   activeGroupId,
   activeConnectionId,
   activeRoutingMode = null,
+  activeGroupReach = null,
   restDatasources = [],
   restExcludedDatasourceIds = [],
   onRestExcludedChange,
@@ -749,20 +858,40 @@ export function ChatEnvPicker({
     return null;
   }
 
+  // #3895 (ADR-0022) — Group reach. `activeGroupReach` null = All sources (every
+  // visible group reachable — the default); a group id = Focus → that group. The
+  // reach chooser (All sources / Focus list) shows only for a MULTI-group
+  // workspace; a single-group workspace keeps the member-routing-only picker (its
+  // reach is trivial — All sources ≡ the one group).
+  const multiGroup = groups.length > 1;
+  const isAllSources = activeGroupReach === null;
+  // The single SQL group whose member routing applies: the FOCUSED group (Focus
+  // → X), or — for a single-group workspace — the sole group (its reach is
+  // trivially All). Undefined for a multi-group All-sources workspace (no single
+  // group; the agent ranges all) and a zero-group (REST-only) workspace. Member
+  // routing (Auto/Pin/All) surfaces only when this group has >1 member (AC2).
+  const focusedGroup =
+    activeGroupReach !== null ? groups.find((g) => g.id === activeGroupReach) : undefined;
+  // For a single-group workspace the active group is the sole group (preferring
+  // the one `activeGroupId` names — the member-routing binding — else the only
+  // group). A multi-group All-sources workspace has no single active group.
   const activeGroup =
-    groups.find((g) => g.id === activeGroupId) ??
-    groups.find((g) => g.members.some((m) => m.connectionId === activeConnectionId)) ??
-    groups[0];
+    focusedGroup ??
+    (multiGroup
+      ? undefined
+      : groups.find((g) => g.id === activeGroupId) ?? groups[0]);
   const activeMember =
     activeGroup?.members.find((m) => m.connectionId === activeConnectionId) ??
     activeGroup?.members.find((m) => m.connectionId === activeGroup.primaryConnectionId) ??
     activeGroup?.members[0];
 
-  // #3078 — a zero-group (REST-only) workspace has no SQL routing to display.
-  // `activeGroup` is undefined there, so the chip / dropdown drop the SQL
-  // routing modes, member list, and singleton hint and show only the REST
-  // scope. `hasSqlScope` gates every SQL affordance below.
+  // `hasSqlScope` = there is a single active SQL group to route WITHIN (Focus →
+  // it, or the sole group). Drives the REST-scope partition (by `activeGroup`)
+  // and the member-routing affordances. False for a multi-group All-sources
+  // workspace (no single group — REST is all-reachable, member routing hidden)
+  // and a zero-group (REST-only) workspace (#3078).
   const hasSqlScope = activeGroup != null;
+  const hasGroups = groups.length > 0;
   const mode = effectiveMode(activeRoutingMode);
   const groupLabel = activeGroup ? stripGroupPrefix(activeGroup.name) : "—";
   const memberLabel = activeMember?.connectionId ?? "—";
@@ -787,37 +916,52 @@ export function ChatEnvPicker({
     : undefined;
   const isFocused = restFocusDatasourceId !== null;
 
-  // Chip label. Precedence: REST-only focus (SQL suspended) > SQL routing chip
-  // (with the REST count appended) > SQL-less REST count (zero-group workspace).
+  // #3066 — append the REST count (e.g. `· 2/3 REST`) to the chip only when the
+  // workspace has a reachable REST datasource, so SQL-only workspaces keep their
+  // byte-identical chip. Shared by the SQL-routing + reach chip branches.
+  const withRestCount = (label: string): string =>
+    reachableRest.length > 0
+      ? `${label} · ${restInScopeCount}/${reachableRest.length} REST`
+      : label;
+
+  // Chip label. Precedence: REST-only focus (SQL suspended) > All sources
+  // (multi-group, agent ranges every group) > SQL routing chip (focused or
+  // single group) > Focus-on-invisible-group > SQL-less REST count (zero-group).
   let chipLabel: string;
   let ChipIcon: typeof Layers;
   if (isFocused) {
-    // #3067 — focus overrides the chip entirely: SQL routing is suspended, so the
+    // #3067 — REST focus overrides the chip entirely: SQL is suspended, so the
     // chip reads "<name> only" for the datasource the agent targets.
     chipLabel = `${focusedDatasource?.displayName ?? "REST"} only`;
     ChipIcon = Crosshair;
+  } else if (multiGroup && isAllSources) {
+    // #3895 — All sources: the agent ranges every visible Connection group.
+    chipLabel = withRestCount("All sources");
+    ChipIcon = Layers;
   } else if (hasSqlScope) {
-    // SQL routing chip — tracks the mode so the trigger reflects the next turn's
+    // Focused group (multi-group Focus) OR single-group workspace: the
+    // member-routing chip tracks the mode so the trigger reflects the next turn's
     // routing. The compact forms keep the chip readable for long names.
     if (mode === "auto") {
-      chipLabel = `Auto · ${groupLabel}`;
+      chipLabel = withRestCount(`Auto · ${groupLabel}`);
       ChipIcon = Sparkles;
     } else if (mode === "all") {
-      chipLabel = `All · ${groupLabel}`;
+      chipLabel = withRestCount(`All · ${groupLabel}`);
       ChipIcon = Globe2;
     } else {
       // Pin — show the member name. Collapse "warehouse / warehouse" →
       // "warehouse" when the stripped group name and the member id match (the
       // common 0062 backfill shape: g_<connId> + one member named <connId>).
-      chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+      const pin = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+      chipLabel = withRestCount(pin);
       ChipIcon = Pin;
     }
-    // #3066 — append the REST count (e.g. `Pin · apac-prod · 2/3 REST`) only when
-    // the workspace has a reachable REST datasource, so SQL-only workspaces keep
-    // their byte-identical chip.
-    if (reachableRest.length > 0) {
-      chipLabel = `${chipLabel} · ${restInScopeCount}/${reachableRest.length} REST`;
-    }
+  } else if (activeGroupReach !== null) {
+    // #3895 — Focus on a group that isn't currently visible (content-mode hid it,
+    // or it was removed). Show the persisted focus so the user can change it;
+    // executeSQL refuses to query it rather than substitute another source.
+    chipLabel = withRestCount(`Focus: ${stripGroupPrefix(activeGroupReach)}`);
+    ChipIcon = Crosshair;
   } else {
     // #3078 — zero-group (REST-only) workspace: no SQL group/member to show, so
     // the chip is just the REST count.
@@ -825,36 +969,56 @@ export function ChatEnvPicker({
     ChipIcon = Network;
   }
 
-  // When every group has at most one member (the 0062 backfill shape,
-  // or a defensive-empty group), the dropdown has no actual
-  // multi-member choice to offer. Surface a hint so admins discover
-  // that merging connections into a shared environment is possible.
+  // Member routing surfaces only when the single active group has >1 member
+  // (AC2): the focused group (multi-group Focus), or the sole group (single-group
+  // workspace). `activeGroup.members.length > 1` is the gate.
+  const showMemberRouting = hasSqlScope && (activeGroup?.members.length ?? 0) > 1;
+
+  // When every group has at most one member, there's no member routing to offer
+  // anywhere — surface the #2408 discoverability hint that admins can merge
+  // connections into shared environments. Gated on `hasGroups` so a zero-group
+  // (REST-only) workspace, where `allSingletons` is vacuously true, never shows it.
   const allSingletons = groups.every((g) => g.members.length <= 1);
+  const showSingletonHint = hasGroups && allSingletons;
 
-  // The active group's member list is the source the Pin/Member rows
-  // render from. We re-resolve here (vs. consuming `activeGroup` directly)
-  // so a defensive-empty group renders an "empty" affordance rather than
-  // a silent zero-length list.
-  const activeMembers = activeGroup?.members ?? [];
-
-  // Mode dispatch — every selection produces the full triple so the
-  // parent can persist whichever subset matters. Implicit rules:
-  //   - Switching mode keeps the current member as the execution
-  //     target (pinned mode targets it; auto/all also need a sensible
-  //     `currentMember` for the server-side routing lookup).
-  //   - Selecting a member from the member list implies `pin` mode —
-  //     you can't "select a member" in fanout, and the most natural
-  //     interpretation is "pin to that one".
+  // Mode dispatch — a member-routing change keeps the CURRENT reach (a focused
+  // group stays focused; a single-group workspace stays at All sources): changing
+  // Auto/Pin/All must never flip the Group-reach axis. `groupId` carries the
+  // active group as member-routing context; selecting a member implies `pin`.
   const handleModeSelect = (nextMode: ConversationRoutingMode) => {
     if (!activeGroup || !activeMember) return;
     onSelect({
+      groupReach: activeGroupReach,
       groupId: activeGroup.id,
       connectionId: activeMember.connectionId,
       routingMode: nextMode,
     });
   };
-  const handleMemberSelect = (groupId: string, connectionId: string) => {
-    onSelect({ groupId, connectionId, routingMode: "pin" });
+  const handleMemberSelect = (connectionId: string) => {
+    if (!activeGroup) return;
+    onSelect({
+      groupReach: activeGroupReach,
+      groupId: activeGroup.id,
+      connectionId,
+      routingMode: "pin",
+    });
+  };
+  // #3895 — Group-reach chooser dispatch. "All sources" clears the focus (reach +
+  // member binding both null); "Focus → X" narrows reach to X with its primary
+  // member and Auto routing (the agent picks the member; the user can then Pin).
+  const handleAllSources = () => {
+    onSelect({ groupReach: null, groupId: null, connectionId: null, routingMode: null });
+  };
+  const handleFocusGroup = (group: ChatEnvGroup) => {
+    const member =
+      group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
+      group.members[0];
+    onSelect({
+      groupReach: group.id,
+      groupId: group.id,
+      connectionId: member?.connectionId ?? null,
+      routingMode: "auto",
+    });
   };
 
   return (
@@ -868,12 +1032,15 @@ export function ChatEnvPicker({
           data-mode={mode}
           data-focused={isFocused}
           data-sql-scope={hasSqlScope}
+          data-reach={activeGroupReach ?? "all"}
           aria-label={
             isFocused
               ? `Conversation scope: focused on ${chipLabel} — SQL suspended. Change.`
-              : hasSqlScope
-                ? `Cross-environment routing: ${chipLabel}. Change.`
-                : `Conversation scope: ${chipLabel}. Change.`
+              : multiGroup && isAllSources
+                ? `Group reach: all sources — the agent ranges every group. Change.`
+                : hasSqlScope
+                  ? `Cross-environment routing: ${chipLabel}. Change.`
+                  : `Conversation scope: ${chipLabel}. Change.`
           }
         >
           <ChipIcon className="size-3.5 text-zinc-500" aria-hidden />
@@ -885,13 +1052,73 @@ export function ChatEnvPicker({
         className="w-72"
         data-testid="chat-env-picker-menu"
       >
-        {/* Mode section — three SQL-routing states with the current mode marked.
-            #3078 — hidden for a zero-group (REST-only) workspace: there is no SQL
-            to route, so the dropdown shows only the REST scope section below. */}
-        {hasSqlScope && (
+        {/* #3895 — Group reach chooser (ADR-0022 §5). Multi-group only: All
+            sources (default — every group reachable) or Focus → one group (a hard,
+            exclusive narrowing). A single-group workspace's reach is trivial, so
+            it shows the member-routing picker directly (below). */}
+        {multiGroup && (
           <>
             <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-              Routing
+              Group reach
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              onSelect={handleAllSources}
+              className="flex items-start gap-2 text-xs"
+              data-testid="chat-env-picker-reach-all"
+              data-active={isAllSources}
+            >
+              <Layers
+                className={`mt-0.5 size-3.5 ${isAllSources ? "text-primary" : "text-zinc-500"}`}
+                aria-hidden
+              />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className={`truncate ${isAllSources ? "font-medium" : ""}`}>
+                  All sources
+                </span>
+                <span className="truncate text-[10px] text-zinc-500 dark:text-zinc-400">
+                  Agent ranges every group
+                </span>
+              </div>
+              {isAllSources && <Check className="size-3.5 shrink-0 text-primary" aria-hidden />}
+            </DropdownMenuItem>
+            {groups.map((group) => {
+              const focused = group.id === activeGroupReach;
+              return (
+                <DropdownMenuItem
+                  key={group.id}
+                  onSelect={() => handleFocusGroup(group)}
+                  className="flex items-center justify-between gap-2 text-xs"
+                  data-testid={`chat-env-picker-reach-focus-${group.id}`}
+                  data-active={focused}
+                >
+                  <span className="flex min-w-0 items-center gap-1.5 truncate">
+                    {focused ? (
+                      <Check className="size-3 shrink-0 text-primary" aria-hidden />
+                    ) : (
+                      <Crosshair className="size-3 shrink-0 text-zinc-400" aria-hidden />
+                    )}
+                    <span className="truncate">Focus: {stripGroupPrefix(group.name)}</span>
+                  </span>
+                  <span className="text-[10px] uppercase tracking-wider text-zinc-400">
+                    {group.members.length > 1
+                      ? `${group.members.length} envs`
+                      : group.members[0]?.dbType ?? ""}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </>
+        )}
+
+        {/* Member routing — Auto/Pin/All within the single active group, plus its
+            member list. Surfaces only when that group has >1 member (#3895 AC2):
+            the focused group for multi-group, or the sole group for single-group.
+            #3078 — never for a zero-group (REST-only) workspace. */}
+        {showMemberRouting && activeGroup && (
+          <>
+            {multiGroup && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+              Routing · {stripGroupPrefix(activeGroup.name)}
             </DropdownMenuLabel>
             <ChatEnvModeItem
               mode="auto"
@@ -917,28 +1144,20 @@ export function ChatEnvPicker({
               subtitle="Fan out to every member"
               onSelect={() => handleModeSelect("all")}
             />
-          </>
-        )}
-
-        {activeGroup && activeMembers.length > 0 && (
-          <>
-            <DropdownMenuSeparator />
             <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
               {stripGroupPrefix(activeGroup.name)} members
             </DropdownMenuLabel>
-            {activeMembers.map((member) => {
-              // Pin highlight only when the current mode is pin AND we're
-              // on the member it pins to — otherwise highlighting the
-              // member would falsely suggest "this is the active target"
-              // while routing is in Auto/All.
+            {activeGroup.members.map((member) => {
+              // Pin highlight only when the current mode is pin AND we're on the
+              // member it pins to — otherwise highlighting the member would
+              // falsely suggest "this is the active target" while routing is
+              // Auto/All.
               const isActive =
                 mode === "pin" && member.connectionId === activeMember?.connectionId;
               return (
                 <DropdownMenuItem
                   key={member.connectionId}
-                  onSelect={() =>
-                    handleMemberSelect(activeGroup.id, member.connectionId)
-                  }
+                  onSelect={() => handleMemberSelect(member.connectionId)}
                   className="flex items-center justify-between gap-2 text-xs"
                   data-testid={`chat-env-picker-member-${member.connectionId}`}
                   data-active={isActive}
@@ -956,30 +1175,9 @@ export function ChatEnvPicker({
           </>
         )}
 
-        {groups.length > 1 && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-              Other environments
-            </DropdownMenuLabel>
-            {groups
-              .filter((g) => g.id !== activeGroup?.id)
-              .map((group) => (
-                <ChatEnvOtherGroupItem
-                  key={group.id}
-                  group={group}
-                  onSelect={(connectionId) =>
-                    handleMemberSelect(group.id, connectionId)
-                  }
-                />
-              ))}
-          </>
-        )}
-
-        {/* #3078 — the singleton hint is an SQL-connections affordance; suppress
-            it on a zero-group (REST-only) workspace, where `allSingletons` would
-            be vacuously true for the empty group list. */}
-        {hasSqlScope && allSingletons && (
+        {/* #2408 — discoverability hint when no group has multiple members, so
+            member routing is unavailable everywhere. */}
+        {showSingletonHint && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel
@@ -1253,52 +1451,6 @@ function ChatEnvModeItem({
       </div>
       {active && <Check className="size-3.5 shrink-0 text-primary" aria-hidden />}
     </DropdownMenuItem>
-  );
-}
-
-/**
- * Row for a member of a *different* group. Selecting it switches both
- * the active group and pins to that member — the natural "I want to
- * work in a different environment" gesture.
- */
-function ChatEnvOtherGroupItem({
-  group,
-  onSelect,
-}: {
-  group: ChatEnvGroup;
-  onSelect: (connectionId: string) => void;
-}): React.ReactElement {
-  const label = stripGroupPrefix(group.name);
-  return (
-    <>
-      {group.members.length === 0 ? (
-        <DropdownMenuItem
-          disabled
-          className="text-xs italic text-zinc-400"
-          data-testid={`chat-env-picker-empty-${group.id}`}
-        >
-          {label} — no members
-        </DropdownMenuItem>
-      ) : (
-        group.members.map((member) => (
-          <DropdownMenuItem
-            key={`${group.id}:${member.connectionId}`}
-            onSelect={() => onSelect(member.connectionId)}
-            className="flex items-center justify-between gap-2 text-xs"
-            data-testid={`chat-env-picker-other-${group.id}-${member.connectionId}`}
-          >
-            <span className="flex min-w-0 items-center gap-1.5 truncate">
-              <span className="truncate text-zinc-500">{label}</span>
-              <span className="text-zinc-300">/</span>
-              <span className="truncate">{member.connectionId}</span>
-            </span>
-            <span className="text-[10px] uppercase tracking-wider text-zinc-400">
-              {member.dbType}
-            </span>
-          </DropdownMenuItem>
-        ))
-      )}
-    </>
   );
 }
 

--- a/packages/web/src/ui/hooks/__tests__/use-atlas-transport.test.ts
+++ b/packages/web/src/ui/hooks/__tests__/use-atlas-transport.test.ts
@@ -108,6 +108,20 @@ describe("buildChatRequestBody (#3749)", () => {
     expect(body.restExcludedDatasourceIds).toEqual(["a", "b"]);
     expect(body.restExcludedDatasourceIds).not.toBe(src);
   });
+
+  test("#3895 — ALWAYS sends groupReach when present, even null (widen to All sources)", () => {
+    // A focus → its group id reaches the server; a widen → an explicit null
+    // reaches it too, so the row's stale Focus is cleared (the #3073 bug class).
+    expect(buildChatRequestBody(MSGS, { groupReach: "g_prod" }).groupReach).toBe("g_prod");
+    const widened = buildChatRequestBody(MSGS, { groupReach: null });
+    expect("groupReach" in widened).toBe(true);
+    expect(widened.groupReach).toBeNull();
+  });
+
+  test("#3895 — omits groupReach when the getter is absent (SDK/API callers inherit the row)", () => {
+    const body = buildChatRequestBody(MSGS, { groupReach: undefined });
+    expect("groupReach" in body).toBe(false);
+  });
 });
 
 describe("nextCapturedId (#3749)", () => {

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -64,6 +64,13 @@ export interface ChatRoutingInputs {
   restExcludedDatasourceIds?: readonly string[] | undefined;
   /** Always sent when present (even `null`) so a clear nulls the row (#3067). */
   restFocusDatasourceId?: string | null | undefined;
+  /**
+   * #3895 (ADR-0022) — Group reach. Always sent when the getter is wired (even
+   * `null`) so a widen back to All sources nulls the row instead of inheriting
+   * the stale Focus (the #3073 transport-omits-null bug class). `null` = All
+   * sources; a `connection_group_id` value = Focus → that group.
+   */
+  groupReach?: string | null | undefined;
 }
 
 /**
@@ -89,6 +96,11 @@ export function buildChatRequestBody(
   }
   if (inputs.restFocusDatasourceId !== undefined) {
     body.restFocusDatasourceId = inputs.restFocusDatasourceId;
+  }
+  // #3895 — Group reach: always sent when the getter is wired (even `null`), like
+  // the REST-scope fields, so a widen to All sources resets the row.
+  if (inputs.groupReach !== undefined) {
+    body.groupReach = inputs.groupReach;
   }
   return body;
 }
@@ -151,6 +163,14 @@ export interface UseAtlasTransportOptions {
   getRestExcludedDatasourceIds?: () => readonly string[];
   /** #3067 — REST-only focus (`install_id`, or null = not focused). */
   getRestFocusDatasourceId?: () => string | null;
+  /**
+   * #3895 (ADR-0022) — Group reach (`connection_group_id` = Focus, or null = All
+   * sources). When provided, the transport ALWAYS sends it (even `null`), because
+   * the chat route distinguishes "field present as null" (widen to All sources —
+   * clear the row's Focus) from "field absent" (inherit the row). Omitting it on
+   * a widen would silently keep a stale Focus — the #3073 bug class.
+   */
+  getGroupReach?: () => string | null;
 }
 
 export interface UseAtlasTransportReturn {
@@ -214,6 +234,11 @@ export function useAtlasTransport(
   getRestExcludedDatasourceIdsRef.current = opts.getRestExcludedDatasourceIds;
   const getRestFocusDatasourceIdRef = useRef(opts.getRestFocusDatasourceId);
   getRestFocusDatasourceIdRef.current = opts.getRestFocusDatasourceId;
+  // #3895 — Group reach getter. Ref for the same reason as the routing getters:
+  // a reach change between turns reaches the next request without rebuilding the
+  // transport.
+  const getGroupReachRef = useRef(opts.getGroupReach);
+  getGroupReachRef.current = opts.getGroupReach;
 
   // --- Auth state (seed from module cache to avoid flash on client-side nav) ---
   const [authMode, setAuthModeState] = useState<AuthMode | null>(_cachedAuthMode);
@@ -405,6 +430,7 @@ export function useAtlasTransport(
             routingMode: getRoutingModeRef.current?.(),
             restExcludedDatasourceIds: getRestExcludedDatasourceIdsRef.current?.(),
             restFocusDatasourceId: getRestFocusDatasourceIdRef.current?.(),
+            groupReach: getGroupReachRef.current?.(),
           }),
         };
       },


### PR DESCRIPTION
Closes #3895 · ADR-0022 §5 (the last slice of cross-group reach, PRD #3892)

## What

Surfaces the **Group reach** axis in the scope picker and persists it per-conversation, wiring it into the slice-(a) reach resolver (#3893) so **Focus actually bounds `executeSQL`** — the load-bearing detail the issue called out (today `executeSQL` hardcoded `resolveReach({ kind: "all" })`).

## How

- **Migration 0149 + schema mirror** — `conversations.group_reach text` (NULL = All sources, a `connection_group_id` = Focus → that group). Clean-break backfill maps existing group-bound conversations to Focus (behavior-preserving); new conversations default to All sources. Drizzle mirror in the same change.
- **Wire/persistence** — `@useatlas/types` `Conversation` + `ChatRequestSchema` + `ConversationSchema` (`GET /conversations/:id`) carry `groupReach`; `RequestContext` stamps it; the chat route resolves (body > row), persists on change (`updateConversationGroupReach`), and org-verifies a Focus group id before persist (mirrors the #2424 `connectionGroupId` gate). Carried through fork/notebook duplication.
- **executeSQL reach bound** — `reachStateFromColumn(reqCtx.groupReach)` replaces the hardcoded `{ kind: "all" }`. Focus rejects an out-of-reach group target **and** bounds the implicit (no-`group`) default to the focused group — never a silent substitution (the #3867(b) invariant). A Focus on a now-invisible group (content-mode) is rejected. The Source catalog narrows to the reachable set under Focus.
- **Picker reshape** — **All sources** (default) | **Focus → one group**; **Member routing** (Auto/Pin/All) is nested, surfaced only under a focused multi-member group (or the sole group of a single-group workspace). Chip distinguishes states (`All sources` vs `Pin · us-prod · …`). Sticky preference gains `groupReach` + a v1 clean-break migration clearing the legacy single-group seed. Transport always-sends `groupReach` (even null) so a widen clears the row.

## Acceptance criteria

- [x] Picker exposes All sources (default) + Focus → one group; Focus is hard/exclusive (enforced via slice-1's reach bound at `executeSQL`).
- [x] Member routing (Auto/Pin/All) surfaces only under a focused multi-member group; Pin and Focus are distinct controls.
- [x] New conversation defaults to All sources; an opened conversation restores its persisted reach; the chip reflects the state.
- [x] Reach persists on `conversations` (schema mirror + wire types); a newly-added datasource is reachable by default (All sources reaches every visible group; not auto-excluded).
- [x] Content-mode respected — a draft/unpublished focused group resolves to empty reach → rejected (`loadVisibleGroups` is mode-filtered).
- [x] Residency untouched — the picker never surfaces or considers the control-plane region.
- [x] Migration: existing group-bound conversations read back as Focus → that group; real-Postgres backfill asserted in `migrate-pg.test.ts`.

## Notes for review

- **Resume path** stamps a minimal context (it already carries none of `connectionId`/`routingMode`/`restFocus`); `groupReach` follows that existing pattern rather than being added unilaterally — a pre-existing parity characteristic, not introduced here.
- Internal **review panel** (silent-failure / type-design / test-coverage / comment) ran in 2 rounds. Caught + fixed: a latent `TypeError` (route tests' shared conversations mock omitted `updateConversationGroupReach`), the #2424 org-verify asymmetry, a `ChatEnvSelection` docstring inaccuracy for single-group, and a vacuous fallback test. Final verdict CLEAN.
- The 2 local API test fails (`python` / `explore-workspace-override`) are the documented WSL2 sandbox flakes — identical on clean `main`, green in CI.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-conversation group reach axis with UI picker, persistence, and enforcement in chat
> - Adds a `groupReach` field to conversations (via DB migration `0149_conversation_group_reach.sql`) that stores either `null` (All sources) or a `connection_group_id` (Focus on that group), backfilled from `connection_group_id` for existing rows.
> - Adds a "Group reach" section to the `ChatEnvPicker` UI in multi-group workspaces, letting users toggle between All sources and Focus on a specific group; the chip label and member-routing section update accordingly.
> - The `/api/v1/chat` endpoint accepts an optional `groupReach` field per turn, validates org ownership, inherits stored reach when omitted, and persists changes asynchronously via `updateConversationGroupReach`.
> - `executeSQL` and `loadSourceCatalog` now enforce the conversation's focus reach, rejecting queries targeting connections outside the focused group and narrowing the SQL catalog to the focused group.
> - The routing preference store is migrated to v1, clearing legacy single-group SQL pins so new chats default to All sources while preserving REST scope.
> - Risk: Existing focused conversations will have `group_reach` backfilled from `connection_group_id`; agents in focused conversations will now see a narrowed source catalog and receive reach-enforcement errors if they target outside the focus group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ba4638.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->