### PR TITLE
feat(api): cross-source composition prompt guidance (slice d, #3909)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-cross-source-composition.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-source-composition.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #3909 — Cross-source composition prompt guidance (ADR-0022 §2, slice (d)).
+ *
+ * Pins the contract that `buildSystemParam` carries explicit cross-source
+ * composition guidance whenever a Source catalog is in reach (≥1 reachable
+ * source), and nothing when there is no catalog (single-source / no-internal-DB
+ * workspaces unchanged). The guidance teaches the agent to query each relevant
+ * source and correlate the result sets by reasoning — never a cross-engine JOIN
+ * or federated query engine — to report provenance, and to refuse a silent
+ * fallback to an unrelated source.
+ *
+ * The guidance lives in the SYSTEM prompt (not the message transcript), riding
+ * on the catalog block, and sits ahead of the durable working-memory block so
+ * the memory-LAST invariant (#3755) still holds.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { buildSystemParam } from "@atlas/api/lib/agent";
+
+function promptText(result: ReturnType<typeof buildSystemParam>): string {
+  if (typeof result === "string") return result;
+  return typeof result.content === "string" ? result.content : "";
+}
+
+const CATALOG = "## Source catalog\n\nPick the data source...";
+const MEMORY = "## Working memory\n\n- foo: bar";
+
+const COMPOSITION_HEADING = "## Cross-source composition";
+
+/** Build with the catalog at its positional slot, leaving the rest defaulted. */
+function withCatalog(sourceCatalog: string | undefined, memoryBlock?: string) {
+  return promptText(
+    buildSystemParam(
+      "openai",
+      undefined, // registry
+      undefined, // warnings
+      undefined, // orgSemanticIndex
+      undefined, // learnedPatternsSection
+      undefined, // routingContext
+      undefined, // boundDashboardContext
+      "developer",
+      undefined, // restRepresentation
+      undefined, // modelId
+      memoryBlock,
+      sourceCatalog,
+    ),
+  );
+}
+
+describe("buildSystemParam — cross-source composition guidance (#3909)", () => {
+  it("emits composition guidance when a Source catalog is supplied", () => {
+    const prompt = withCatalog(CATALOG);
+    expect(prompt).toContain(COMPOSITION_HEADING);
+  });
+
+  it("teaches per-source querying + reasoning correlation, never a cross-engine join", () => {
+    const prompt = withCatalog(CATALOG);
+    // Query each source on its own…
+    expect(prompt).toContain("executeSQL");
+    expect(prompt).toContain("executeRestOperation");
+    // …then correlate the result sets in reasoning.
+    expect(prompt.toLowerCase()).toContain("correlate");
+    // Assert the PROHIBITION, not just the token — a polarity flip ("you may
+    // JOIN across sources") must fail this. ADR-0022 §2: no federation / no
+    // single cross-engine JOIN.
+    expect(prompt).toMatch(/never[^.]*JOIN/i);
+  });
+
+  it("lives in the SYSTEM message content on the cache (object) provider branch", () => {
+    // anthropic/bedrock providers return a SystemModelMessage rather than a bare
+    // string; the guidance must live in that message's `content` (the SYSTEM
+    // prompt), never in the message transcript (ADR-0020 / memory-LAST #3755).
+    const result = buildSystemParam(
+      "anthropic",
+      undefined, undefined, undefined, undefined, undefined,
+      undefined, "developer", undefined, undefined, undefined, CATALOG,
+    );
+    expect(typeof result).not.toBe("string");
+    // Narrow off the string branch — the cache providers return an object.
+    if (typeof result === "string") {
+      throw new Error("expected a SystemModelMessage on the anthropic cache branch");
+    }
+    expect(result.role).toBe("system");
+    expect(promptText(result)).toContain(COMPOSITION_HEADING);
+  });
+
+  it("directs the agent to report provenance (which source[s] it drew from)", () => {
+    const prompt = withCatalog(CATALOG);
+    expect(prompt.toLowerCase()).toContain("provenance");
+  });
+
+  it("forbids a silent fallback to an unrelated source", () => {
+    const prompt = withCatalog(CATALOG);
+    expect(prompt.toLowerCase()).toContain("fall back");
+  });
+
+  it("omits the guidance when there is no catalog (no behavior change vs. today)", () => {
+    const withEmpty = withCatalog("");
+    const without = withCatalog(undefined);
+    expect(withEmpty).not.toContain(COMPOSITION_HEADING);
+    expect(without).not.toContain(COMPOSITION_HEADING);
+    // The whole prompt is byte-identical to today's no-catalog output.
+    expect(withEmpty).toBe(without);
+  });
+
+  it("keeps the durable memory block AFTER the composition guidance (memory-LAST invariant)", () => {
+    const prompt = withCatalog(CATALOG, MEMORY);
+    expect(prompt).toContain(COMPOSITION_HEADING);
+    expect(prompt).toContain("## Working memory");
+    expect(prompt.indexOf(COMPOSITION_HEADING)).toBeLessThan(
+      prompt.indexOf("## Working memory"),
+    );
+  });
+
+  it("places the guidance right after the Source catalog block", () => {
+    const prompt = withCatalog(CATALOG);
+    expect(prompt.indexOf("## Source catalog")).toBeLessThan(
+      prompt.indexOf(COMPOSITION_HEADING),
+    );
+  });
+
+  it("places the guidance ahead of the per-datasource REST representation", () => {
+    // The composition guidance (how to compose across the menu) belongs before
+    // the deep per-REST-datasource detail it routes into.
+    const REST = "## REST datasource: acme\n\noperations...";
+    const prompt = promptText(
+      buildSystemParam(
+        "openai",
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, "developer", REST, undefined, undefined, CATALOG,
+      ),
+    );
+    expect(prompt).toContain(COMPOSITION_HEADING);
+    expect(prompt).toContain("## REST datasource: acme");
+    expect(prompt.indexOf(COMPOSITION_HEADING)).toBeLessThan(
+      prompt.indexOf("## REST datasource: acme"),
+    );
+  });
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -566,6 +566,39 @@ You are answering inside a chat platform (Slack/Teams/etc.) where the audience i
 - End with a single short line offering the analyst view: "Want the SQL or full breakdown? Tap the button below." Do NOT use markdown formatting on this closing line.
 `;
 
+/**
+ * #3909 — Cross-source composition guidance (ADR-0022 §2, slice (d)).
+ *
+ * Teaches the agent how to *compose* an answer across the sources it can now
+ * route to. It rides on the Source catalog (#3894): appended only when a catalog
+ * is in reach (≥1 source), so single-source / no-internal-DB workspaces — which
+ * never get a catalog — are unchanged. Cross-source answers are **LLM
+ * composition, not federation** (ADR-0022): query each source on its own engine
+ * (each query keeps its dialect + whitelist + 4-layer AST validation), then
+ * stitch the result sets together in reasoning. Atlas runs no cross-engine query
+ * engine, so a single SQL `JOIN` across sources is never an option.
+ *
+ * Two behavioral rules the catalog's routing blurb does not cover:
+ *   - **Provenance** — name which source(s) the answer drew from, so the user can
+ *     sanity-check it.
+ *   - **No silent fallback** — if the source that actually holds the answer is
+ *     empty or errors, state the gap; never answer from an unrelated source and
+ *     imply it is equivalent.
+ *
+ * Lives in the SYSTEM prompt (out-of-band of the message transcript), placed
+ * right after the catalog and ahead of the durable memory block so the
+ * memory-LAST invariant (#3755) still holds; like the rest of the system prompt
+ * it is itself compaction-immune by construction (compaction only rewrites the
+ * message array — ADR-0020). Exported so unit tests can pin the contract.
+ */
+export const CROSS_SOURCE_COMPOSITION_GUIDANCE = `## Cross-source composition
+
+When a question spans more than one source in the catalog above — several SQL Connection groups, or a group plus a REST datasource — answer by **composition, not federation**:
+
+- **Query each relevant source on its own**, then correlate the result sets in your own reasoning: \`executeSQL\` per Connection group, \`executeRestOperation\` per REST datasource. The "join" is you stitching the returned rows together in context — Atlas runs **no** cross-engine query engine, so never attempt a single SQL \`JOIN\` across sources or assume a federated query layer exists. (Example: "how many of last month's signups converted to paid?" → count signups in the Postgres group, list paid customers from the Stripe datasource, then correlate the two sets yourself.)
+- **Report which source(s) you drew from** so the user can check provenance — e.g. "1,240 signups (Postgres), 180 of them paid (Stripe)".
+- **Never silently fall back to an unrelated source.** If the source that actually holds the answer is empty or errors, say so plainly and state the gap — do not answer from a different source and imply it is equivalent.`;
+
 export function buildSystemParam(
   providerType: ProviderType,
   registry: ToolRegistry = defaultRegistry,
@@ -601,10 +634,11 @@ export function buildSystemParam(
   /**
    * #3894 — the Source catalog (ADR-0022 §4): the compact routing menu of SQL
    * Connection groups + REST datasources the agent reads to pick a source before
-   * drilling in with `explore`. Injected right before the REST representation
-   * (the menu sits just ahead of the per-datasource detail), and before the
-   * durable memory block so the memory-LAST invariant (#3755) holds. Empty
-   * string / omitted ⇒ nothing appended (single-source / no-internal-DB
+   * drilling in with `explore`. Injected ahead of the cross-source composition
+   * guidance (#3909) and the REST representation — the menu sits just ahead of
+   * the compose-across-the-menu guidance and the per-datasource detail — and
+   * before the durable memory block so the memory-LAST invariant (#3755) holds.
+   * Empty string / omitted ⇒ nothing appended (single-source / no-internal-DB
    * workspaces are unchanged).
    */
   sourceCatalog?: string,
@@ -613,6 +647,11 @@ export function buildSystemParam(
 
   if (sourceCatalog) {
     content += "\n\n" + sourceCatalog;
+    // #3909 — composition guidance rides on the catalog: appended only when a
+    // non-empty catalog is supplied (≥1 source in reach), a no-op for single-
+    // source / no-catalog workspaces. Sits right after the menu (how to compose
+    // across what it lists) and ahead of memory.
+    content += "\n\n" + CROSS_SOURCE_COMPOSITION_GUIDANCE;
   }
 
   if (restRepresentation) {


### PR DESCRIPTION
## Summary

Slice **(d)** of PRD #3892 (cross-group reach) — the last unbuilt slice. Now that the agent can route to multiple datasources (Source catalog #3894) and target a Connection group per query (#3893), this teaches it how to **compose** an answer across them.

- Adds `CROSS_SOURCE_COMPOSITION_GUIDANCE` to the agent system prompt, appended in `buildSystemParam` right after the Source catalog block. Cross-source answers are **LLM composition, not federation** (ADR-0022 §2): query each relevant source on its own engine (each query keeps its dialect + whitelist + 4-layer AST validation), then correlate the result sets by reasoning — never a single cross-engine `JOIN`.
- Three behavioral rules the catalog's routing blurb doesn't cover: **report provenance** (which source[s] the answer drew from) and **never silently fall back** to an unrelated source when the relevant one is empty/errored.
- Rides on the catalog: present **iff** a non-empty catalog is in reach (≥1 source). No-op for single-source / no-internal-DB workspaces (byte-identical prompt vs. today). Lives in the SYSTEM prompt, ahead of the durable memory block so the memory-LAST invariant (#3755) and compaction-safe placement (ADR-0020) hold.
- **No schema, API, or UI change.**

Covers User Stories 3, 4, 11, 12, 22 from #3892.

## Test plan

- [x] New `agent-cross-source-composition.test.ts` (9 tests): guidance present when a catalog is supplied; absent + byte-identical no-op when empty/omitted; per-source query + reasoning-correlation + JOIN-prohibition content; provenance + no-silent-fallback rules; lives in the SYSTEM message content on the cache (object) provider branch; memory-LAST ordering; placement after the catalog and ahead of the REST representation.
- [x] `--affected` suite (70 files) + full `bun run test` green (3 unrelated failures are the known dev-shell vercel-sandbox false-positives — explore/python).
- [x] Internal review panel (silent-failure, type-design, test-coverage, comment-accuracy) — CLEAN after 2 rounds.
- [x] lint, type, syncpack, schema-drift, test-discipline, openapi-drift — all pass.

Closes #3909

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-source composition guidance to agent system prompt
> - Introduces `CROSS_SOURCE_COMPOSITION_GUIDANCE`, a new exported constant containing a `## Cross-source composition` system prompt section in [agent.ts](https://github.com/AtlasDevHQ/atlas/pull/3910/files#diff-3e03d12ba1cff0d76d15506a217b68932d6fe7f701dc8048816a1095cd0f5c98).
> - When `sourceCatalog` is a non-empty string, `buildSystemParam` appends this guidance immediately after the catalog and before the REST representation and memory blocks.
> - The guidance instructs agents to query each source independently via `executeSQL`/`executeRestOperation`, correlate results in reasoning, report provenance, and prohibits cross-engine SQL JOINs.
> - New tests in [agent-cross-source-composition.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3910/files#diff-9976ffe2ce59c391e9bfdd31448507c3093cd03c1704dc22897ae620f604af99) pin the ordering and content contract, and assert no guidance is emitted when the catalog is empty or omitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 928450b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->