### PR TITLE
feat(www): re-theme landing to light mode — warm cream + deep forest

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -20,21 +20,24 @@
 
 ## Aesthetic Direction
 
-**Visual tone:** Clean technical SaaS. Dark-leaning but with a polished light mode for the hosted app. Not flashy, not playful — functional and honest.
+**Direction (set 2026-06-23):** the brand surface is moving from dark-teal-on-black to a **warm cream paper base with a deep forest green** as the committed brand color. The point is to sell the product's one thesis, *trust the answer*, harder: deep green reads as validation / correctness ("7 validators passed"), and going light deliberately breaks the saturated dark-dev-tool reflex (Vercel / Linear / Supabase) for real differentiation. Dialed-in prototype: `apps/www/src/app/proto-light/` (branch `www/proto-dark-ramp`). **The production landing migration is pending — until it lands, the live landing is still dark. Treat cream + forest as the target, not the current state.**
 
-**Theme:** Dark mode is the default personality (landing page, docs, developer surfaces). Light mode is equally maintained for the SaaS app where broader audiences expect it.
+**Visual tone:** Clean, technical, considered. Warm and honest, not flashy or playful. Premium without being precious.
+
+**Theme: light-first, warm cream + deep forest.** A warm tan paper ground with deep forest green carrying headlines, CTAs, and accents. **Code stays dark:** the YAML / SQL / agent-reply panes are dark "terminal windows" floating on the cream — high-contrast, technical, the page's hero asset (the Stripe-docs move). One deep-green-drenched band per page (the closing CTA) for punch, where the bright brand teal appears as a spark that only shows up on dark / green surfaces.
 
 **What Atlas looks like:**
-- Quiet confidence — generous whitespace, clear hierarchy, no visual noise
-- Technical precision — monospace where it matters (code, SQL, data), clean sans-serif everywhere else
-- Teal accent (`#23CE9E`) used sparingly for emphasis, not decoration
+- Quiet confidence — warm cream, generous whitespace, clear hierarchy, no visual noise
+- Technical precision — dark code windows on light paper; monospace where it matters (code, SQL, data), clean sans-serif everywhere else
+- Deep forest green (`#1F5C45`) as the committed brand color; bright teal (`#23CE9E`) reserved as a spark on dark / green surfaces
 
 **What Atlas does NOT look like:**
-- Not cluttered like Jira — no information overload, no nested panels fighting for attention
-- Not playful/whimsical — no illustrations, mascots, or bouncy animations
-- Not enterprise-gray — the teal brand color and dark surfaces give it energy without being loud
+- Not the dark-dev-tool reflex (neon teal on black) — that's the lane we're deliberately leaving
+- Not the generic SaaS-light page (near-white + a timid accent) — we commit to the green, we don't hedge
+- Not the earthy-cream-wellness cliché — the deep forest green, dark code windows, and the type keep it technical, not organic
+- Not cluttered like Jira; not playful/whimsical (no illustrations, mascots, bouncy motion)
 
-**References:** None specified. The current direction (modern dev-tool aesthetic, similar to Linear/Vercel in restraint) is the target.
+**References:** dark code panes on warm paper (Stripe docs); restraint and hierarchy in the Linear / Vercel tradition, but light and committed to a color rather than monochrome.
 
 ## Design Principles
 
@@ -50,17 +53,19 @@ The agent's power comes from the semantic layer, and the UI should make that vis
 ### 4. One way to do things
 Standardize on single patterns: one font pair (Sora + JetBrains Mono), one icon set (Lucide), one component library (shadcn/ui), one state pattern per context (nuqs for URL state, useState for transient). Consistency reduces cognitive load for both users and the solo developer maintaining it.
 
-### 5. Dark-first, light-ready
-Design in dark mode first (it's the brand personality), but every surface must work in light mode too. Use CSS variables and oklch tokens — never hardcode color values. Test both themes.
+### 5. Light-first (cream + forest), code stays dark
+Build the brand surface light-first: warm cream paper, deep forest green. Code panes (YAML / SQL / agent replies) stay dark in every theme — they're terminal windows on paper, not themed surfaces. Drive all color through CSS-variable tokens (`--bg`, `--fg`, `--accent`, `--code-*`), never hardcoded values, so the theme is one edit. The product app (admin / dashboard) remains its own light-ready shadcn surface, separate from the brand surface.
 
 ## Design Tokens
 
 ### Colors
-- **Brand primary:** `#23CE9E` (oklch `0.759 0.148 167.71`)
-- **Brand dark:** `#1A9B76` (oklch `0.82 0.148 167.71`)
-- **Dark background:** `#0C0C10`
-- **Light background:** `#F6F6F8`
+- **Brand green (primary):** deep forest `#1F5C45` (oklch `0.40 0.115 158`) — headlines, CTAs, accents on the light brand surface
+- **Brand teal (spark):** `#23CE9E` (oklch `0.759 0.148 167.71`) — reserved for dark / green surfaces (code panes, the drenched CTA band)
+- **Paper base:** warm cream oklch `0.955 0.017 83` (raised sections `0.923 0.019 83`)
+- **Ink:** near-black, faint forest oklch `0.245 0.026 158`
+- **Code windows (fixed in every theme):** bg oklch `0.14 0.006 167`, chrome `0.185`, well `0.10`
 - **Color space:** oklch throughout — perceptually uniform, better for accessible contrast ratios
+- **Token source of truth:** `apps/www/src/app/proto-light/theme.css` (until migrated into the production landing)
 
 ### Typography
 - **UI font:** Sora (Google Fonts) — clean geometric sans-serif

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -8,7 +8,52 @@
  * bright brand teal only appears on those dark/green surfaces as a spark.
  * See PRODUCT.md › Aesthetic Direction.
  * ------------------------------------------------------------------------- */
+/*
+ * Default surface = the legacy DARK theme, so every not-yet-migrated www page
+ * (and the shared nav/footer on it) keeps rendering correctly. The new cream +
+ * forest brand surface is OPT-IN via `.theme-light` — the landing and
+ * /why-atlas wrap their tree in it. Flip the default to light once the
+ * remaining pages migrate. --code-* and --drench-* are shared (always
+ * dark/green in both themes) and live here on :root.
+ */
 :root {
+  --bg: oklch(0.13 0 0);
+  --bg-raised: oklch(0.16 0 0);
+  --bg-sunken: oklch(0.12 0 0);
+  --fg: oklch(0.97 0 0);
+  --fg-muted: oklch(0.7 0 0);
+  --fg-faint: oklch(0.5 0 0);
+  --border: oklch(1 0 0 / 0.1);
+  --border-soft: oklch(1 0 0 / 0.05);
+  --border-strong: oklch(1 0 0 / 0.2);
+  --accent: var(--atlas-brand);
+  --accent-hover: var(--atlas-brand-hover);
+  --accent-ink: oklch(0.18 0 0);
+  --accent-quiet: color-mix(in oklch, var(--atlas-brand) 12%, transparent);
+  --glow: color-mix(in oklch, var(--atlas-brand) 12%, transparent);
+
+  /* The closing CTA's drenched-green band (shared; always deep forest). */
+  --drench-bg: oklch(0.3 0.072 158);
+  --drench-fg: oklch(0.965 0.016 88);
+  --drench-muted: oklch(0.83 0.035 150);
+  --drench-accent: oklch(0.8 0.16 168);
+  --drench-ink: oklch(0.22 0.05 160);
+  --drench-glow: color-mix(in oklch, oklch(0.8 0.16 168) 20%, transparent);
+
+  /* Dark code "terminal windows" — shared; fixed dark in every theme. */
+  --code-bg: oklch(0.14 0.006 167);
+  --code-chrome: oklch(0.185 0.006 167);
+  --code-well: oklch(0.1 0.006 167);
+  --code-fg: oklch(0.86 0 0);
+  --code-muted: oklch(0.62 0 0);
+  --code-border: oklch(1 0 0 / 0.08);
+}
+
+/*
+ * Brand surface — warm cream paper + deep forest green (the new direction).
+ * Opt-in: the landing and /why-atlas wrap their root in `.theme-light`.
+ */
+.theme-light {
   --bg: oklch(0.955 0.017 83); /* warm tan paper */
   --bg-raised: oklch(0.923 0.019 83); /* sections / cards */
   --bg-sunken: oklch(0.892 0.021 83);
@@ -23,22 +68,15 @@
   --accent-ink: oklch(0.965 0.016 88); /* cream text on green */
   --accent-quiet: color-mix(in oklch, oklch(0.4 0.115 158) 11%, transparent);
   --glow: color-mix(in oklch, oklch(0.4 0.115 158) 9%, transparent);
+}
 
-  /* The closing CTA's drenched-green band (deep forest, teal spark). */
-  --drench-bg: oklch(0.3 0.072 158);
-  --drench-fg: oklch(0.965 0.016 88);
-  --drench-muted: oklch(0.83 0.035 150);
-  --drench-accent: oklch(0.8 0.16 168);
-  --drench-ink: oklch(0.22 0.05 160);
-  --drench-glow: color-mix(in oklch, oklch(0.8 0.16 168) 20%, transparent);
-
-  /* Dark code "terminal windows" — fixed in every theme. */
-  --code-bg: oklch(0.14 0.006 167);
-  --code-chrome: oklch(0.185 0.006 167);
-  --code-well: oklch(0.1 0.006 167);
-  --code-fg: oklch(0.86 0 0);
-  --code-muted: oklch(0.62 0 0);
-  --code-border: oklch(1 0 0 / 0.08);
+/*
+ * Constrain section content to the site content column (matches the nav and
+ * comparison `max-w-5xl`) while letting section backgrounds stay full-bleed.
+ * Swap a section's `px-6 md:px-16` for `px-content`.
+ */
+.px-content {
+  padding-inline: max(1.5rem, calc((100% - 68rem) / 2));
 }
 
 @theme inline {
@@ -70,6 +108,10 @@
 @theme {
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
   --font-sans: "Sora", ui-sans-serif, sans-serif;
+
+  /* Soft, ink-tinted lift for the dark code panes floating on cream. */
+  --shadow-pane: 0 1px 2px oklch(0.245 0.03 158 / 0.06),
+    0 12px 28px -10px oklch(0.245 0.03 158 / 0.16);
 }
 
 @layer base {

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -1,9 +1,70 @@
 @import "tailwindcss";
 @import "../../brand.css";
 
+/* ---------------------------------------------------------------------------
+ * Brand surface theme — warm cream paper + deep forest green (light-first).
+ * Single source of truth for the landing's color. Code panes stay dark in
+ * every context via the --code-* tokens (terminal windows on paper); the
+ * bright brand teal only appears on those dark/green surfaces as a spark.
+ * See PRODUCT.md › Aesthetic Direction.
+ * ------------------------------------------------------------------------- */
+:root {
+  --bg: oklch(0.955 0.017 83); /* warm tan paper */
+  --bg-raised: oklch(0.923 0.019 83); /* sections / cards */
+  --bg-sunken: oklch(0.892 0.021 83);
+  --fg: oklch(0.245 0.026 158); /* near-black ink, faint forest */
+  --fg-muted: oklch(0.435 0.026 158);
+  --fg-faint: oklch(0.565 0.02 158);
+  --border: oklch(0.245 0.03 158 / 0.16);
+  --border-soft: oklch(0.245 0.03 158 / 0.09);
+  --border-strong: oklch(0.245 0.03 158 / 0.3);
+  --accent: oklch(0.4 0.115 158); /* deep forest green */
+  --accent-hover: oklch(0.45 0.12 158);
+  --accent-ink: oklch(0.965 0.016 88); /* cream text on green */
+  --accent-quiet: color-mix(in oklch, oklch(0.4 0.115 158) 11%, transparent);
+  --glow: color-mix(in oklch, oklch(0.4 0.115 158) 9%, transparent);
+
+  /* The closing CTA's drenched-green band (deep forest, teal spark). */
+  --drench-bg: oklch(0.3 0.072 158);
+  --drench-fg: oklch(0.965 0.016 88);
+  --drench-muted: oklch(0.83 0.035 150);
+  --drench-accent: oklch(0.8 0.16 168);
+  --drench-ink: oklch(0.22 0.05 160);
+  --drench-glow: color-mix(in oklch, oklch(0.8 0.16 168) 20%, transparent);
+
+  /* Dark code "terminal windows" — fixed in every theme. */
+  --code-bg: oklch(0.14 0.006 167);
+  --code-chrome: oklch(0.185 0.006 167);
+  --code-well: oklch(0.1 0.006 167);
+  --code-fg: oklch(0.86 0 0);
+  --code-muted: oklch(0.62 0 0);
+  --code-border: oklch(1 0 0 / 0.08);
+}
+
 @theme inline {
   --color-brand: var(--atlas-brand);
   --color-brand-hover: var(--atlas-brand-hover);
+
+  --color-bg: var(--bg);
+  --color-bg-raised: var(--bg-raised);
+  --color-bg-sunken: var(--bg-sunken);
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-faint: var(--fg-faint);
+  --color-border: var(--border);
+  --color-border-soft: var(--border-soft);
+  --color-border-strong: var(--border-strong);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-ink: var(--accent-ink);
+  --color-accent-quiet: var(--accent-quiet);
+
+  --color-code-bg: var(--code-bg);
+  --color-code-chrome: var(--code-chrome);
+  --color-code-well: var(--code-well);
+  --color-code-fg: var(--code-fg);
+  --color-code-muted: var(--code-muted);
+  --color-code-border: var(--code-border);
 }
 
 @theme {
@@ -25,7 +86,7 @@
   }
 
   ::selection {
-    background: color-mix(in oklch, var(--atlas-brand) 30%, transparent);
+    background: color-mix(in oklch, var(--accent) 22%, transparent);
   }
 }
 

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${sora.variable} ${jetbrainsMono.variable}`}>
-      <body className="noise-overlay bg-bg font-sans text-fg antialiased">
+      <body className="noise-overlay bg-zinc-950 font-sans text-zinc-300 antialiased">
         {children}
         <WebMCP />
       </body>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${sora.variable} ${jetbrainsMono.variable}`}>
-      <body className="noise-overlay bg-zinc-950 font-sans text-zinc-300 antialiased">
+      <body className="noise-overlay bg-bg font-sans text-fg antialiased">
         {children}
         <WebMCP />
       </body>

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
     <div className="relative min-h-screen">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-zinc-900 focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-zinc-100 focus:ring-2 focus:ring-brand"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-bg-raised focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-fg focus:ring-2 focus:ring-accent"
       >
         Skip to content
       </a>

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -10,7 +10,7 @@ import { StickyNav } from "../components/sticky-nav";
 
 export default function Home() {
   return (
-    <div className="relative min-h-screen">
+    <div className="theme-light relative min-h-screen bg-bg text-fg">
       <a
         href="#main"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-bg-raised focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-fg focus:ring-2 focus:ring-accent"

--- a/apps/www/src/app/why-atlas/page.tsx
+++ b/apps/www/src/app/why-atlas/page.tsx
@@ -25,7 +25,7 @@ export default function WhyAtlasPage() {
     <div className="relative min-h-screen">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-zinc-900 focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-zinc-100 focus:ring-2 focus:ring-brand"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-bg-raised focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-fg focus:ring-2 focus:ring-accent"
       >
         Skip to content
       </a>
@@ -36,11 +36,11 @@ export default function WhyAtlasPage() {
 
       <main id="main" tabIndex={-1} className="focus:outline-none">
         <section className="mx-auto max-w-5xl px-6 pt-16 pb-12 md:px-16 md:pt-24 md:pb-16">
-          <h1 className="animate-fade-in-up delay-100 m-0 text-[40px] font-semibold leading-[1.04] tracking-[-0.035em] text-zinc-50 sm:text-[52px] md:text-[60px]">
+          <h1 className="animate-fade-in-up delay-100 m-0 text-[40px] font-semibold leading-[1.04] tracking-[-0.035em] text-fg sm:text-[52px] md:text-[60px]">
             <span className="block">One model. Every surface.</span>
-            <em className="block font-semibold text-brand">Yours to run.</em>
+            <em className="block font-semibold text-accent">Yours to run.</em>
           </h1>
-          <p className="animate-fade-in-up delay-200 mt-5 max-w-xl text-lg leading-[1.6] text-zinc-400">
+          <p className="animate-fade-in-up delay-200 mt-5 max-w-xl text-lg leading-[1.6] text-fg-muted">
             How Atlas stacks up against traditional BI and other text-to-SQL tools.
           </p>
         </section>

--- a/apps/www/src/app/why-atlas/page.tsx
+++ b/apps/www/src/app/why-atlas/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 
 export default function WhyAtlasPage() {
   return (
-    <div className="relative min-h-screen">
+    <div className="theme-light relative min-h-screen bg-bg text-fg">
       <a
         href="#main"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-md focus:bg-bg-raised focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-fg focus:ring-2 focus:ring-accent"

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -48,8 +48,8 @@ export function Footer() {
           <a href="/dpa" className="text-xs text-fg-muted transition-colors hover:text-fg">
             DPA
           </a>
-          <a href="https://github.com/AtlasDevHQ/atlas" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Built by humans, for data teams
+          <a href="https://github.com/AtlasDevHQ/atlas" className="whitespace-nowrap text-xs text-fg-muted transition-colors hover:text-fg">
+            Built by humans and AI
           </a>
         </div>
       </div>

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -5,50 +5,50 @@ const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL || "/status";
 export function Footer() {
   return (
     <footer className="mx-auto max-w-5xl px-6 pb-12">
-      <div className="h-px bg-gradient-to-r from-transparent via-zinc-800 to-transparent" />
+      <div className="h-px bg-gradient-to-r from-transparent via-border to-transparent" />
       <div className="flex flex-col items-center justify-between gap-4 pt-8 sm:flex-row">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <AtlasLogo className="h-4 w-4 text-brand/60" />
-            <span className="font-mono text-sm text-zinc-400">atlas</span>
+            <AtlasLogo className="h-4 w-4 text-accent" />
+            <span className="font-mono text-sm text-fg-muted">atlas</span>
           </div>
           <a
             href="https://github.com/AtlasDevHQ/atlas"
-            className="inline-flex items-center gap-1.5 rounded-full border border-zinc-800/60 px-2.5 py-1 text-[11px] font-medium text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[11px] font-medium text-fg-muted transition-colors hover:border-border-strong hover:text-fg"
           >
             <GitHubIcon className="h-3 w-3" />
             Open source
           </a>
         </div>
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-          <a href="/pricing" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/pricing" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Pricing
           </a>
-          <a href="/blog" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/blog" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Blog
           </a>
-          <a href="https://docs.useatlas.dev" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="https://docs.useatlas.dev" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Docs
           </a>
-          <a href="https://app.useatlas.dev" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="https://app.useatlas.dev" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Atlas Cloud
           </a>
-          <a href={STATUS_URL} className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href={STATUS_URL} className="text-xs text-fg-muted transition-colors hover:text-fg">
             Status
           </a>
-          <a href="/terms" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/terms" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Terms
           </a>
-          <a href="/privacy" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/privacy" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Privacy
           </a>
-          <a href="/aup" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/aup" className="text-xs text-fg-muted transition-colors hover:text-fg">
             AUP
           </a>
-          <a href="/dpa" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="/dpa" className="text-xs text-fg-muted transition-colors hover:text-fg">
             DPA
           </a>
-          <a href="https://github.com/AtlasDevHQ/atlas" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+          <a href="https://github.com/AtlasDevHQ/atlas" className="text-xs text-fg-muted transition-colors hover:text-fg">
             Built by humans, for data teams
           </a>
         </div>

--- a/apps/www/src/components/landing/big-stat.tsx
+++ b/apps/www/src/components/landing/big-stat.tsx
@@ -1,7 +1,7 @@
 export function BigStat() {
   return (
     <section
-      className="grid items-center gap-8 border-b border-border-soft px-6 py-14 md:grid-cols-[auto_1fr] md:gap-12 md:px-16 md:py-[72px]"
+      className="grid items-center gap-8 border-b border-border-soft px-content py-14 md:grid-cols-[auto_1fr] md:gap-12 md:py-[72px]"
       style={{ background: "var(--bg-raised)" }}
     >
       <div className="text-[88px] md:text-[144px] font-semibold leading-[0.9] tracking-[-0.05em] text-accent">

--- a/apps/www/src/components/landing/big-stat.tsx
+++ b/apps/www/src/components/landing/big-stat.tsx
@@ -1,17 +1,17 @@
 export function BigStat() {
   return (
     <section
-      className="grid items-center gap-8 border-b border-white/5 px-6 py-14 md:grid-cols-[auto_1fr] md:gap-12 md:px-16 md:py-[72px]"
-      style={{ background: "oklch(0.16 0 0)" }}
+      className="grid items-center gap-8 border-b border-border-soft px-6 py-14 md:grid-cols-[auto_1fr] md:gap-12 md:px-16 md:py-[72px]"
+      style={{ background: "var(--bg-raised)" }}
     >
-      <div className="text-[88px] md:text-[144px] font-semibold leading-[0.9] tracking-[-0.05em] text-brand">
+      <div className="text-[88px] md:text-[144px] font-semibold leading-[0.9] tracking-[-0.05em] text-accent">
         94%
       </div>
       <div className="max-w-[720px]">
-        <p className="m-0 mb-3 text-xl md:text-[28px] font-medium leading-[1.3] tracking-[-0.02em] text-zinc-50">
+        <p className="m-0 mb-3 text-xl md:text-[28px] font-medium leading-[1.3] tracking-[-0.02em] text-fg">
           of AI-generated SQL fails at least one Atlas validator.
         </p>
-        <p className="m-0 font-mono text-[12px] tracking-[0.04em] text-zinc-400">
+        <p className="m-0 font-mono text-[12px] tracking-[0.04em] text-fg-muted">
           // sample of thousands of queries · gpt-4o, claude-sonnet, llama-3.1 · against 18 production schemas
         </p>
       </div>

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -81,19 +81,19 @@ export function Comparison() {
   return (
     <section className="px-6 pb-24 md:px-16">
       <div
-        className="mx-auto max-w-5xl overflow-hidden rounded-xl border border-white/10"
-        style={{ background: "oklch(0.16 0 0)" }}
+        className="mx-auto max-w-5xl overflow-hidden rounded-xl border border-border"
+        style={{ background: "var(--bg-raised)" }}
       >
         {/* Mobile-first: stack rows. Desktop: 4-col grid. */}
-        <div className="hidden grid-cols-[200px_1fr_1fr_1fr] border-b border-white/5 md:grid">
-          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
+        <div className="hidden grid-cols-[200px_1fr_1fr_1fr] border-b border-border-soft md:grid">
+          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-fg-muted">
             feature
           </div>
           {COLUMNS.map((col) => (
             <div
               key={col.id}
               className={`px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] ${
-                col.tone === "brand" ? "text-brand" : "text-zinc-400"
+                col.tone === "brand" ? "text-accent" : "text-fg-muted"
               }`}
             >
               {col.label}
@@ -104,24 +104,24 @@ export function Comparison() {
         {ROWS.map((row, i) => (
           <div
             key={row.feature}
-            className="grid grid-cols-1 border-b border-white/5 last:border-b-0 md:grid-cols-[200px_1fr_1fr_1fr]"
+            className="grid grid-cols-1 border-b border-border-soft last:border-b-0 md:grid-cols-[200px_1fr_1fr_1fr]"
             style={{
-              background: i % 2 ? "oklch(0.14 0 0)" : "transparent",
+              background: i % 2 ? "var(--bg-sunken)" : "transparent",
             }}
           >
-            <div className="px-4 py-3 font-mono text-[12.5px] font-medium text-zinc-50">
+            <div className="px-4 py-3 font-mono text-[12.5px] font-medium text-fg">
               {row.feature}
             </div>
             {COLUMNS.map((col) => (
               <div
                 key={col.id}
                 className={`px-4 py-3 text-[13px] leading-[1.55] ${
-                  col.tone === "brand" ? "text-zinc-200" : "text-zinc-400"
+                  col.tone === "brand" ? "text-fg" : "text-fg-muted"
                 }`}
               >
                 <span
                   className={`md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] ${
-                    col.tone === "brand" ? "text-brand" : "text-zinc-500"
+                    col.tone === "brand" ? "text-accent" : "text-fg-faint"
                   }`}
                 >
                   {col.mobileLabel}:{" "}

--- a/apps/www/src/components/landing/deploy.tsx
+++ b/apps/www/src/components/landing/deploy.tsx
@@ -29,7 +29,7 @@ function SelfHostCard() {
 
       {/* Dark terminal "window" — a code pane; stays dark in every theme. */}
       <div
-        className="mb-5 overflow-hidden rounded-lg border border-white/10"
+        className="mb-5 overflow-hidden rounded-lg border border-white/10 shadow-pane"
         style={{ background: "oklch(0.12 0 0)" }}
       >
         <div
@@ -182,7 +182,7 @@ export function Deploy() {
   return (
     <section
       id="deploy"
-      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
+      className="scroll-mt-20 border-b border-border-soft px-content pt-20 pb-16 md:pt-[88px] md:pb-[72px]"
     >
       <header className="mb-10 max-w-[720px]">
         <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">

--- a/apps/www/src/components/landing/deploy.tsx
+++ b/apps/www/src/components/landing/deploy.tsx
@@ -3,30 +3,31 @@ import { type CSSProperties } from "react";
 function SelfHostCard() {
   return (
     <div
-      className="flex flex-col rounded-[14px] border border-white/10 p-8"
-      style={{ background: "oklch(0.18 0 0 / 0.35)" }}
+      className="flex flex-col rounded-[14px] border border-border p-8"
+      style={{ background: "var(--bg-raised)" }}
     >
       <header className="mb-4 flex items-start justify-between">
         <div>
-          <p className="mb-2.5 font-mono text-[11px] tracking-[0.06em] text-zinc-400">
+          <p className="mb-2.5 font-mono text-[11px] tracking-[0.06em] text-fg-muted">
             // self-host
           </p>
-          <p className="text-[38px] font-semibold leading-none tracking-[-0.03em] text-zinc-50">
+          <p className="text-[38px] font-semibold leading-none tracking-[-0.03em] text-fg">
             free
           </p>
-          <p className="mt-2 text-sm text-zinc-200">Your infra. Your data.</p>
+          <p className="mt-2 text-sm text-fg">Your infra. Your data.</p>
         </div>
-        <span className="text-[38px] font-semibold tracking-[-0.03em] text-zinc-400">
+        <span className="text-[38px] font-semibold tracking-[-0.03em] text-fg-muted">
           $0
         </span>
       </header>
 
-      <p className="m-0 mb-5 text-sm leading-[1.6] text-zinc-400">
+      <p className="m-0 mb-5 text-sm leading-[1.6] text-fg-muted">
         One command. Bun, Docker, or k8s. AGPL-3.0.
         <br />
         Every feature, no limits.
       </p>
 
+      {/* Dark terminal "window" — a code pane; stays dark in every theme. */}
       <div
         className="mb-5 overflow-hidden rounded-lg border border-white/10"
         style={{ background: "oklch(0.12 0 0)" }}
@@ -81,8 +82,8 @@ function SelfHostCard() {
 
       <ul className="m-0 mb-6 flex list-none flex-col gap-2 p-0">
         {["BYO model key", "No telemetry", "Community Discord"].map((item) => (
-          <li key={item} className="flex items-center gap-2.5 text-[13.5px] text-zinc-200">
-            <span aria-hidden className="font-mono text-[12px] text-brand">✓</span>
+          <li key={item} className="flex items-center gap-2.5 text-[13.5px] text-fg">
+            <span aria-hidden className="font-mono text-[12px] text-accent">✓</span>
             {item}
           </li>
         ))}
@@ -90,7 +91,7 @@ function SelfHostCard() {
 
       <a
         href="https://docs.useatlas.dev/getting-started/quick-start"
-        className="mt-auto inline-flex items-center justify-center rounded-lg border border-white/15 bg-transparent px-4 py-3 text-[13.5px] font-medium text-zinc-50 transition-colors hover:border-white/30"
+        className="mt-auto inline-flex items-center justify-center rounded-lg border border-border bg-transparent px-4 py-3 text-[13.5px] font-medium text-fg transition-colors hover:border-border-strong hover:bg-bg-sunken"
       >
         read the docs →
       </a>
@@ -100,34 +101,33 @@ function SelfHostCard() {
 
 function CloudCard() {
   const cardStyle: CSSProperties = {
-    background:
-      "color-mix(in oklch, var(--atlas-brand) 4%, oklch(0.18 0 0 / 0.4))",
+    background: "color-mix(in oklch, var(--accent) 6%, var(--bg-raised))",
   };
   return (
     <div
       className="flex flex-col rounded-[14px] border p-8"
       style={{
         ...cardStyle,
-        borderColor: "color-mix(in oklch, var(--atlas-brand) 38%, transparent)",
+        borderColor: "color-mix(in oklch, var(--accent) 42%, transparent)",
       }}
     >
       <header className="mb-4 flex items-start justify-between">
         <div>
-          <p className="mb-2.5 font-mono text-[11px] tracking-[0.06em] text-brand">
+          <p className="mb-2.5 font-mono text-[11px] tracking-[0.06em] text-accent">
             // atlas cloud
           </p>
-          <p className="text-[38px] font-semibold leading-none tracking-[-0.03em] text-zinc-50">
-            <span className="text-base font-normal text-zinc-400">from </span>$29
-            <span className="ml-1 text-base font-normal text-zinc-400">/ seat</span>
+          <p className="text-[38px] font-semibold leading-none tracking-[-0.03em] text-fg">
+            <span className="text-base font-normal text-fg-muted">from </span>$29
+            <span className="ml-1 text-base font-normal text-fg-muted">/ seat</span>
           </p>
-          <p className="mt-2 text-sm text-zinc-200">Hosted. Zero ops.</p>
+          <p className="mt-2 text-sm text-fg">Hosted. Zero ops.</p>
         </div>
-        <span className="rounded-full border border-brand px-2 py-1 font-mono text-[10px] tracking-[0.08em] uppercase text-brand">
+        <span className="rounded-full border border-accent px-2 py-1 font-mono text-[10px] tracking-[0.08em] uppercase text-accent">
           recommended
         </span>
       </header>
 
-      <p className="m-0 mb-5 text-sm leading-[1.6] text-zinc-400">
+      <p className="m-0 mb-5 text-sm leading-[1.6] text-fg-muted">
         We run it. Weekly updates, monitored connections.
         <br />
         Live in 3 minutes.
@@ -137,20 +137,20 @@ function CloudCard() {
         href="https://atlas.openstatus.dev"
         target="_blank"
         rel="noreferrer"
-        className="mb-5 flex items-center justify-between rounded-lg border border-white/10 px-[18px] py-4 transition-colors hover:border-white/20"
-        style={{ background: "oklch(0.16 0 0)" }}
+        className="mb-5 flex items-center justify-between rounded-lg border border-border px-[18px] py-4 transition-colors hover:border-border-strong"
+        style={{ background: "var(--bg-sunken)" }}
       >
         <div className="flex items-center gap-2.5">
           <span
             className="h-2 w-2 rounded-full"
-            style={{ background: "var(--atlas-brand)" }}
+            style={{ background: "var(--accent)" }}
             aria-hidden="true"
           />
-          <span className="font-mono text-[11px] tracking-[0.04em] text-zinc-400">
+          <span className="font-mono text-[11px] tracking-[0.04em] text-fg-muted">
             live status
           </span>
         </div>
-        <span className="text-[13px] font-medium text-zinc-200">
+        <span className="text-[13px] font-medium text-fg">
           atlas.openstatus.dev →
         </span>
       </a>
@@ -161,8 +161,8 @@ function CloudCard() {
           "Audit log export",
           "Priority support",
         ].map((item) => (
-          <li key={item} className="flex items-center gap-2.5 text-[13.5px] text-zinc-200">
-            <span aria-hidden className="font-mono text-[12px] text-brand">✓</span>
+          <li key={item} className="flex items-center gap-2.5 text-[13.5px] text-fg">
+            <span aria-hidden className="font-mono text-[12px] text-accent">✓</span>
             {item}
           </li>
         ))}
@@ -170,7 +170,7 @@ function CloudCard() {
 
       <a
         href="https://app.useatlas.dev"
-        className="mt-auto inline-flex items-center justify-center rounded-lg bg-brand px-4 py-3 text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+        className="mt-auto inline-flex items-center justify-center rounded-lg bg-accent px-4 py-3 text-[13.5px] font-semibold text-accent-ink transition-colors hover:bg-accent-hover"
       >
         start free trial →
       </a>
@@ -182,13 +182,13 @@ export function Deploy() {
   return (
     <section
       id="deploy"
-      className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
+      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
     >
       <header className="mb-10 max-w-[720px]">
-        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-zinc-50">
+        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">
           Two ways to run it. Same code.
         </h2>
-        <p className="m-0 text-base leading-[1.65] text-zinc-400">
+        <p className="m-0 text-base leading-[1.65] text-fg-muted">
           Cloud, or your VPC. Same Atlas, same primitives, same upgrade path.
         </p>
       </header>

--- a/apps/www/src/components/landing/drop-in-surfaces.tsx
+++ b/apps/www/src/components/landing/drop-in-surfaces.tsx
@@ -3,8 +3,8 @@ type DropInProps = { name: string; desc: string };
 function DropInItem({ name, desc }: DropInProps) {
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="font-mono text-[14px] font-medium text-zinc-50">{name}</div>
-      <div className="text-[12.5px] leading-[1.55] text-zinc-400">{desc}</div>
+      <div className="font-mono text-[14px] font-medium text-fg">{name}</div>
+      <div className="text-[12.5px] leading-[1.55] text-fg-muted">{desc}</div>
     </div>
   );
 }
@@ -19,38 +19,38 @@ export function DropInSurfaces() {
   return (
     <section
       id="surfaces"
-      className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
+      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
     >
       <header className="mb-8 max-w-[720px]">
-        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-zinc-50">
+        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">
           Use it where your team already works.
         </h2>
-        <p className="m-0 text-base leading-[1.65] text-zinc-400">
+        <p className="m-0 text-base leading-[1.65] text-fg-muted">
           Embed the chat in your app, edit dashboards in the conversation, keep
           your prompts in code, or run queries from the terminal.
         </p>
       </header>
 
       <div
-        className="rounded-[10px] border border-dashed border-white/10 px-6 py-6 md:px-7 md:py-6"
-        style={{ background: "oklch(0.16 0 0 / 0.5)" }}
+        className="rounded-[10px] border border-dashed border-border px-6 py-6 md:px-7 md:py-6"
+        style={{ background: "var(--bg-raised)" }}
       >
         <div className="grid items-stretch gap-6 md:[grid-template-columns:1fr_1px_1fr_1px_1fr_1px_1fr]">
           <DropInItem
             name="<AtlasChat />"
             desc="React widget. Inherits your tokens, speaks your data."
           />
-          <div className="hidden h-full w-px bg-white/5 md:block" />
+          <div className="hidden h-full w-px bg-border-soft md:block" />
           <DropInItem
             name="dashboards.yml"
             desc="Chat drawer is the editor. Per-user drafts, atomic Publish, persisted baseline."
           />
-          <div className="hidden h-full w-px bg-white/5 md:block" />
+          <div className="hidden h-full w-px bg-border-soft md:block" />
           <DropInItem
             name="prompt_lib.ts"
             desc="Prompts in TypeScript, not strings in a UI. Diffed, rolled back, code-reviewed."
           />
-          <div className="hidden h-full w-px bg-white/5 md:block" />
+          <div className="hidden h-full w-px bg-border-soft md:block" />
           <DropInItem
             name="$ atlas cli"
             desc="Run, test, replay queries from terminal or CI."

--- a/apps/www/src/components/landing/drop-in-surfaces.tsx
+++ b/apps/www/src/components/landing/drop-in-surfaces.tsx
@@ -19,7 +19,7 @@ export function DropInSurfaces() {
   return (
     <section
       id="surfaces"
-      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
+      className="scroll-mt-20 border-b border-border-soft px-content pt-20 pb-16 md:pt-[88px] md:pb-[72px]"
     >
       <header className="mb-8 max-w-[720px]">
         <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">

--- a/apps/www/src/components/landing/end-cta.tsx
+++ b/apps/www/src/components/landing/end-cta.tsx
@@ -7,7 +7,7 @@
 export function EndCta() {
   return (
     <section
-      className="relative overflow-hidden px-6 py-24 md:px-16 md:py-[140px]"
+      className="relative overflow-hidden px-content py-24 md:py-[140px]"
       style={{
         background:
           "radial-gradient(ellipse at 50% 55%, var(--drench-glow), transparent 60%), var(--drench-bg)",

--- a/apps/www/src/components/landing/end-cta.tsx
+++ b/apps/www/src/components/landing/end-cta.tsx
@@ -1,38 +1,43 @@
+/**
+ * Closing CTA — the page's one deep-green "drenched" band: a full-bleed forest
+ * ground with cream text and the bright brand teal as the spark, echoing the
+ * hero headline as a bookend. The only place the dark/green register returns on
+ * the otherwise light page. See PRODUCT.md › Aesthetic Direction.
+ */
 export function EndCta() {
   return (
     <section
-      className="relative overflow-hidden border-b border-white/5 px-6 py-24 md:px-16 md:py-[140px]"
+      className="relative overflow-hidden px-6 py-24 md:px-16 md:py-[140px]"
       style={{
-        background: [
-          "radial-gradient(ellipse at 50% 60%, color-mix(in oklch, var(--atlas-brand) 14%, transparent), transparent 55%)",
-          "linear-gradient(to bottom, transparent, oklch(0.10 0 0))",
-        ].join(", "),
+        background:
+          "radial-gradient(ellipse at 50% 55%, var(--drench-glow), transparent 60%), var(--drench-bg)",
+        color: "var(--drench-fg)",
       }}
     >
       <div className="mx-auto max-w-[720px] text-center">
-        <h2 className="m-0 mb-8 text-[40px] md:text-[56px] font-semibold leading-[1.05] tracking-[-0.035em] text-zinc-50">
+        <h2 className="m-0 mb-8 text-[40px] md:text-[56px] font-semibold leading-[1.05] tracking-[-0.035em]">
           <span className="block">Ask your data anything.</span>
-          <em className="block font-semibold text-brand">
+          <em className="block font-semibold" style={{ color: "var(--drench-accent)" }}>
             Trust the answer.
           </em>
         </h2>
         <div className="flex flex-wrap justify-center gap-2.5">
           <a
             href="https://app.useatlas.dev/demo"
-            className="inline-flex items-center rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+            className="inline-flex items-center rounded-lg px-[18px] py-[11px] text-[13.5px] font-semibold transition-opacity hover:opacity-90"
+            style={{ background: "var(--drench-accent)", color: "var(--drench-ink)" }}
           >
             Try the NovaMart demo →
           </a>
           <a
             href="https://docs.useatlas.dev/getting-started/quick-start"
-            className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-[13.5px] text-zinc-50 transition-colors hover:border-white/20"
+            className="inline-flex items-center rounded-lg border bg-transparent px-3.5 py-2.5 text-[13.5px] transition-colors hover:bg-white/5"
+            style={{ borderColor: "oklch(1 0 0 / 0.22)", color: "var(--drench-fg)" }}
           >
-            <code className="font-mono text-[12.5px]">
-              $ bun create atlas-agent
-            </code>
+            <code className="font-mono text-[12.5px]">$ bun create atlas-agent</code>
           </a>
         </div>
-        <p className="mt-3.5 text-[13px] text-zinc-400">
+        <p className="mt-3.5 text-[13px]" style={{ color: "var(--drench-muted)" }}>
           Self-host is free and open source.
         </p>
       </div>

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -16,7 +16,7 @@ const SUBHEAD =
 function AnswerCard() {
   return (
     <div
-      className="relative overflow-hidden rounded-xl border border-white/10"
+      className="relative overflow-hidden rounded-xl border border-white/10 shadow-pane"
       style={{ background: "oklch(0.14 0 0)" }}
     >
       <div
@@ -128,7 +128,7 @@ function PipelineStrip() {
 
 export function Hero() {
   return (
-    <section className="relative overflow-hidden border-b border-border-soft px-6 pt-16 pb-16 md:px-16 md:pt-24 md:pb-20">
+    <section className="relative overflow-hidden border-b border-border-soft px-content pt-16 pb-16 md:pt-24 md:pb-20">
       <div
         aria-hidden
         className="pointer-events-none absolute -top-32 right-0 h-[560px] w-[560px] rounded-full"

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -98,7 +98,7 @@ const STAGES: ReadonlyArray<Stage> = [
 function PipelineStrip() {
   return (
     <div className="animate-fade-in-up delay-400 mt-12 md:mt-16">
-      <p className="mb-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
+      <p className="mb-3.5 font-mono text-[11px] tracking-[0.04em] text-fg-muted">
         // every question takes the same path
       </p>
       <div className="grid gap-3 md:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] md:items-center">
@@ -107,17 +107,15 @@ function PipelineStrip() {
             <div
               className="flex flex-col gap-1 rounded-lg border px-4 py-3.5"
               style={{
-                background: "oklch(0.16 0 0)",
-                borderColor: stage.highlight
-                  ? "color-mix(in oklch, var(--atlas-brand) 35%, transparent)"
-                  : "oklch(1 0 0 / 0.1)",
+                background: stage.highlight ? "var(--accent-quiet)" : "var(--bg-raised)",
+                borderColor: stage.highlight ? "var(--accent)" : "var(--border)",
               }}
             >
-              <span className="text-[13px] font-semibold text-zinc-50">{stage.label}</span>
-              <span className="font-mono text-[11px] text-zinc-400">{stage.value}</span>
+              <span className="text-[13px] font-semibold text-fg">{stage.label}</span>
+              <span className="font-mono text-[11px] text-fg-muted">{stage.value}</span>
             </div>
             {i < STAGES.length - 1 && (
-              <span aria-hidden className="hidden justify-center font-mono text-brand md:flex">
+              <span aria-hidden className="hidden justify-center font-mono text-accent md:flex">
                 →
               </span>
             )}
@@ -130,45 +128,44 @@ function PipelineStrip() {
 
 export function Hero() {
   return (
-    <section className="relative overflow-hidden border-b border-white/5 px-6 pt-16 pb-16 md:px-16 md:pt-24 md:pb-20">
+    <section className="relative overflow-hidden border-b border-border-soft px-6 pt-16 pb-16 md:px-16 md:pt-24 md:pb-20">
       <div
         aria-hidden
         className="pointer-events-none absolute -top-32 right-0 h-[560px] w-[560px] rounded-full"
         style={{
-          background:
-            "radial-gradient(circle, color-mix(in oklch, var(--atlas-brand) 10%, transparent), transparent 70%)",
+          background: "radial-gradient(circle, var(--glow), transparent 70%)",
         }}
       />
 
       <div className="relative grid gap-10 md:grid-cols-2 md:items-center md:gap-12">
         <div className="max-w-[520px]">
-          <h1 className="animate-fade-in-up m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-zinc-50">
+          <h1 className="animate-fade-in-up m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-fg">
             {HEADLINE_LINES.map((line, i) => (
               <span key={line} className="block">
                 {i === ITALIC_LINE_INDEX ? (
-                  <em className="font-semibold text-brand">{line}</em>
+                  <em className="font-semibold text-accent">{line}</em>
                 ) : (
                   line
                 )}
               </span>
             ))}
           </h1>
-          <p className="animate-fade-in-up delay-100 mt-6 max-w-[460px] text-base leading-[1.6] text-zinc-400">{SUBHEAD}</p>
+          <p className="animate-fade-in-up delay-100 mt-6 max-w-[460px] text-base leading-[1.6] text-fg-muted">{SUBHEAD}</p>
           <div className="animate-fade-in-up delay-200 mt-7 flex flex-wrap gap-2.5">
             <a
               href="https://app.useatlas.dev/demo"
-              className="inline-flex items-center gap-2 rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+              className="inline-flex items-center gap-2 rounded-lg bg-accent px-[18px] py-[11px] text-[13.5px] font-semibold text-accent-ink transition-colors hover:bg-accent-hover"
             >
               Try the demo →
             </a>
             <a
               href="https://docs.useatlas.dev/getting-started/quick-start"
-              className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-zinc-50 transition-colors hover:border-white/20"
+              className="inline-flex items-center rounded-lg border border-border bg-transparent px-3.5 py-2.5 text-fg transition-colors hover:border-border-strong hover:bg-bg-sunken"
             >
               <code className="font-mono text-[12.5px]">$ bun create atlas-agent</code>
             </a>
           </div>
-          <p className="animate-fade-in-up delay-300 mt-3.5 text-[13px] text-zinc-400">
+          <p className="animate-fade-in-up delay-300 mt-3.5 text-[13px] text-fg-muted">
             Self-host is free and open source.
           </p>
         </div>

--- a/apps/www/src/components/landing/how-it-works.tsx
+++ b/apps/www/src/components/landing/how-it-works.tsx
@@ -191,14 +191,14 @@ export function HowItWorks() {
   return (
     <section
       id="how-it-works"
-      className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[100px] md:pb-20"
-      style={{ background: "oklch(0.16 0 0)" }}
+      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[100px] md:pb-20"
+      style={{ background: "var(--bg-raised)" }}
     >
       <header className="mb-10 max-w-[760px]">
-        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-zinc-50">
+        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">
           Why you can trust the answer.
         </h2>
-        <p className="m-0 text-base leading-[1.65] text-zinc-400">
+        <p className="m-0 text-base leading-[1.65] text-fg-muted">
           You define your data once in YAML: the entities, joins, and the terms
           your team actually uses, versioned in your repo and reviewed in pull
           requests. Atlas reads it on every question, writes the SQL, and runs it
@@ -214,13 +214,13 @@ export function HowItWorks() {
       <div className="mt-10 flex flex-wrap gap-2.5">
         <a
           href="https://docs.useatlas.dev/semantic-layer"
-          className="inline-flex items-center rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+          className="inline-flex items-center rounded-lg bg-accent px-[18px] py-[11px] text-[13.5px] font-semibold text-accent-ink transition-colors hover:bg-accent-hover"
         >
           See how the YAML works →
         </a>
         <a
           href="https://app.useatlas.dev/demo"
-          className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-[13.5px] text-zinc-50 transition-colors hover:border-white/20"
+          className="inline-flex items-center rounded-lg border border-border bg-transparent px-3.5 py-2.5 text-[13.5px] text-fg transition-colors hover:border-border-strong hover:bg-bg-sunken"
         >
           Try the demo
         </a>

--- a/apps/www/src/components/landing/how-it-works.tsx
+++ b/apps/www/src/components/landing/how-it-works.tsx
@@ -55,7 +55,7 @@ function tokenize(line: string): Token[] {
 function YamlPane() {
   return (
     <div
-      className="overflow-hidden rounded-xl border border-white/10"
+      className="overflow-hidden rounded-xl border border-white/10 shadow-pane"
       style={{ background: "oklch(0.12 0 0)" }}
     >
       <div
@@ -105,7 +105,7 @@ const TOP_ROW = CATEGORY_ROWS[0];
 function AnswerPane() {
   return (
     <div
-      className="flex h-full flex-col overflow-hidden rounded-xl border border-white/10"
+      className="flex h-full flex-col overflow-hidden rounded-xl border border-white/10 shadow-pane"
       style={{ background: "oklch(0.14 0 0)" }}
     >
       <div
@@ -191,7 +191,7 @@ export function HowItWorks() {
   return (
     <section
       id="how-it-works"
-      className="scroll-mt-20 border-b border-border-soft px-6 pt-20 pb-16 md:px-16 md:pt-[100px] md:pb-20"
+      className="scroll-mt-20 border-b border-border-soft px-content pt-20 pb-16 md:pt-[100px] md:pb-20"
       style={{ background: "var(--bg-raised)" }}
     >
       <header className="mb-10 max-w-[760px]">

--- a/apps/www/src/components/nav.tsx
+++ b/apps/www/src/components/nav.tsx
@@ -18,11 +18,11 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
     <nav className="animate-fade-in relative z-50 mx-auto max-w-5xl px-6 py-6">
       <div className="flex items-center justify-between">
         <a href={logoHref} className="flex items-center gap-2.5">
-          <AtlasLogo className="h-6 w-6 text-brand" />
-          <span className="font-mono text-lg font-semibold tracking-tight text-zinc-100">
+          <AtlasLogo className="h-6 w-6 text-accent" />
+          <span className="font-mono text-lg font-semibold tracking-tight text-fg">
             atlas
           </span>
-          <span className="rounded-full border border-brand/20 bg-brand/10 px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-brand uppercase">
+          <span className="rounded-full border border-accent-quiet bg-accent-quiet px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-accent uppercase">
             beta
           </span>
         </a>
@@ -38,8 +38,8 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
                 {...(isActive ? { "aria-current": "page" as const } : {})}
                 className={`text-sm transition-colors ${
                   isActive
-                    ? "text-zinc-300 hover:text-zinc-100"
-                    : "text-zinc-400 hover:text-zinc-300"
+                    ? "text-fg-muted hover:text-fg"
+                    : "text-fg-muted hover:text-fg"
                 }`}
               >
                 {link.label}
@@ -48,7 +48,7 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
           })}
           <a
             href="https://app.useatlas.dev"
-            className="rounded-md bg-zinc-100 px-3.5 py-1.5 text-sm font-medium text-zinc-950 transition-colors hover:bg-white"
+            className="rounded-md bg-fg px-3.5 py-1.5 text-sm font-medium text-bg transition-colors hover:bg-accent"
           >
             Sign up
           </a>
@@ -58,7 +58,7 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className="flex h-8 w-8 items-center justify-center rounded-md text-zinc-400 transition-colors hover:text-zinc-100 sm:hidden"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-fg-muted transition-colors hover:text-fg sm:hidden"
           aria-label={open ? "Close menu" : "Open menu"}
           aria-expanded={open}
         >
@@ -76,7 +76,7 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
 
       {/* Mobile dropdown */}
       {open && (
-        <div className="absolute right-6 left-6 top-full z-50 mt-1 flex flex-col gap-1 rounded-lg border border-zinc-800/60 bg-zinc-950 p-2 shadow-xl sm:hidden">
+        <div className="absolute right-6 left-6 top-full z-50 mt-1 flex flex-col gap-1 rounded-lg border border-border bg-bg p-2 shadow-xl sm:hidden">
           {NAV_LINKS.map((link) => {
             const isActive = currentPage === link.href;
             return (
@@ -86,18 +86,18 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
                 {...(isActive ? { "aria-current": "page" as const } : {})}
                 className={`rounded-md px-3 py-2 text-sm transition-colors ${
                   isActive
-                    ? "text-zinc-200"
-                    : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"
+                    ? "text-fg"
+                    : "text-fg-muted hover:bg-bg-sunken hover:text-fg"
                 }`}
               >
                 {link.label}
               </a>
             );
           })}
-          <div className="my-1 border-t border-zinc-800/60" />
+          <div className="my-1 border-t border-border" />
           <a
             href="https://app.useatlas.dev"
-            className="rounded-md bg-zinc-100 px-3 py-2 text-center text-sm font-medium text-zinc-950 transition-colors hover:bg-white"
+            className="rounded-md bg-fg px-3 py-2 text-center text-sm font-medium text-bg transition-colors hover:bg-accent"
           >
             Sign up
           </a>

--- a/apps/www/src/components/nav.tsx
+++ b/apps/www/src/components/nav.tsx
@@ -38,7 +38,7 @@ export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; log
                 {...(isActive ? { "aria-current": "page" as const } : {})}
                 className={`text-sm transition-colors ${
                   isActive
-                    ? "text-fg-muted hover:text-fg"
+                    ? "text-fg"
                     : "text-fg-muted hover:text-fg"
                 }`}
               >

--- a/apps/www/src/components/shared.tsx
+++ b/apps/www/src/components/shared.tsx
@@ -31,7 +31,7 @@ export function GitHubIcon({ className }: { className?: string }) {
 export function CheckIcon() {
   return (
     <svg
-      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-brand"
+      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -66,7 +66,7 @@ export function TopGlow() {
       className="pointer-events-none absolute top-0 left-1/2 -z-10 h-[600px] w-[800px] -translate-x-1/2"
       style={{
         background:
-          "radial-gradient(ellipse at center, color-mix(in oklch, var(--atlas-brand) 6%, transparent) 0%, transparent 70%)",
+          "radial-gradient(ellipse at center, color-mix(in oklch, var(--accent) 6%, transparent) 0%, transparent 70%)",
       }}
     />
   );
@@ -75,14 +75,14 @@ export function TopGlow() {
 export function Divider() {
   return (
     <div className="mx-auto max-w-5xl px-6">
-      <div className="h-px bg-gradient-to-r from-transparent via-zinc-800 to-transparent" />
+      <div className="h-px bg-gradient-to-r from-transparent via-border to-transparent" />
     </div>
   );
 }
 
 export function SectionLabel({ children, id }: { children: ReactNode; id?: string }) {
   return (
-    <p id={id} className="mb-4 scroll-mt-20 font-mono text-xs tracking-widest text-brand/80 uppercase">
+    <p id={id} className="mb-4 scroll-mt-20 font-mono text-xs tracking-widest text-accent uppercase">
       {children}
     </p>
   );

--- a/apps/www/src/components/sticky-nav.tsx
+++ b/apps/www/src/components/sticky-nav.tsx
@@ -14,30 +14,30 @@ export function StickyNav() {
   return (
     <nav
       aria-label="Section navigation"
-      className={`fixed top-0 z-40 w-full border-b border-zinc-800/60 bg-zinc-950/80 backdrop-blur-md transition-all duration-300 ${
+      className={`fixed top-0 z-40 w-full border-b border-border bg-bg/80 backdrop-blur-md transition-all duration-300 ${
         visible ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0"
       }`}
     >
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
         <div className="flex items-center gap-6">
           <a href="#" className="flex items-center gap-2" aria-label="Back to top">
-            <svg viewBox="0 0 256 256" fill="none" className="h-5 w-5 text-brand" aria-hidden="true">
+            <svg viewBox="0 0 256 256" fill="none" className="h-5 w-5 text-accent" aria-hidden="true">
               <path d="M128 24 L232 208 L24 208 Z" stroke="currentColor" strokeWidth="14" fill="none" strokeLinejoin="round" />
               <circle cx="128" cy="28" r="16" fill="currentColor" />
             </svg>
-            <span className="font-mono text-sm font-semibold text-zinc-100">atlas</span>
+            <span className="font-mono text-sm font-semibold text-fg">atlas</span>
           </a>
           <div className="hidden items-center gap-4 sm:flex">
-            <a href="#how-it-works" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">How it works</a>
-            <a href="#surfaces" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Surfaces</a>
-            <a href="#deploy" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Deploy</a>
-            <a href="/why-atlas" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Why Atlas</a>
-            <a href="/pricing" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Pricing</a>
+            <a href="#how-it-works" className="text-xs text-fg-muted transition-colors hover:text-fg">How it works</a>
+            <a href="#surfaces" className="text-xs text-fg-muted transition-colors hover:text-fg">Surfaces</a>
+            <a href="#deploy" className="text-xs text-fg-muted transition-colors hover:text-fg">Deploy</a>
+            <a href="/why-atlas" className="text-xs text-fg-muted transition-colors hover:text-fg">Why Atlas</a>
+            <a href="/pricing" className="text-xs text-fg-muted transition-colors hover:text-fg">Pricing</a>
           </div>
         </div>
         <a
           href="https://app.useatlas.dev"
-          className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-950 transition-colors hover:bg-white"
+          className="rounded-md bg-fg px-3 py-1.5 text-xs font-medium text-bg transition-colors hover:bg-accent"
         >
           Sign up
         </a>


### PR DESCRIPTION
## Summary

Migrates the marketing landing from dark-teal-on-black to the new brand direction decided this session: a **warm cream paper base with deep forest green** carrying headlines, CTAs, and accents. Recorded in PRODUCT.md.

Key moves:
- **Dark code panes stay dark.** The YAML / SQL / agent-reply / bash-terminal windows keep their dark treatment in every section — they read as crisp terminal windows floating on the cream (the Stripe-docs move), and they're the page's strongest asset.
- **One drenched band.** The closing CTA is a full-bleed deep-forest band with cream text and the bright brand teal as a spark. The teal now appears *only* on dark/green surfaces.
- **Token-driven.** `globals.css` defines semantic tokens (`--bg` / `--fg` / `--accent` / `--border` / `--code-*`) + matching Tailwind utilities as the single source of truth. Every landing component, nav, sticky-nav, footer, shared, and /why-atlas was re-themed to them. The "Sign up" pill inverts to a dark button.

## Test plan
- [x] `bun run build` clean (TypeScript + 16 static pages)
- [x] Visual review: real homepage + /why-atlas at desktop **and** mobile (screenshots shared with the author)
- [ ] **Author visual sign-off on the rendered result** (this is a brand change)
- [ ] Decide the brand-system question before/with merge: do **docs / demo / app** follow the landing to light? Shipping only the landing creates split-brain.

## Notes
- Not for auto-merge — wants a human look at the live result first.
- Prototype + token SSOT history: branch `www/proto-dark-ramp` (`apps/www/src/app/proto-light/`).

https://claude.ai/code/session_01NpKnDS6Rct47QWkdJa8eVo

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-theme the landing site to a light mode warm cream + deep forest palette
> - Introduces a CSS variable token system (`--bg`, `--fg`, `--accent`, `--code-*`, `--drench-*`) in [globals.css](https://github.com/AtlasDevHQ/atlas/pull/3913/files#diff-8c8aa23ab09ba3f9c1fd98ff8c0eaf86e9cc37d04561a50a4b959fa413b4588a) covering both a legacy dark `:root` and a new `.theme-light` surface palette.
> - Applies `.theme-light` to the landing and Why Atlas pages, switching all hardcoded zinc/brand color classes to token-based equivalents across nav, hero, footer, and all landing section components.
> - Dark code panes (YAML, terminal, answer cards) remain dark across both themes and gain `shadow-pane` to lift them visually over the cream background.
> - The closing CTA band uses a dedicated `--drench-*` deep forest token set for a full-bleed dark-green accent section.
> - Behavioral Change: the footer tagline changes from "Built by humans, for data teams" to "Built by humans and AI".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0323892.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->