### PR TITLE
docs(brand): ADR-0023 brand color system + net-zero spark/cream-ramp token groundwork

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -20,7 +20,7 @@
 
 ## Aesthetic Direction
 
-**Direction (set 2026-06-23):** the brand surface is moving from dark-teal-on-black to a **warm cream paper base with a deep forest green** as the committed brand color. The point is to sell the product's one thesis, *trust the answer*, harder: deep green reads as validation / correctness ("7 validators passed"), and going light deliberately breaks the saturated dark-dev-tool reflex (Vercel / Linear / Supabase) for real differentiation. Dialed-in prototype: `apps/www/src/app/proto-light/` (branch `www/proto-dark-ramp`). **The production landing migration is pending — until it lands, the live landing is still dark. Treat cream + forest as the target, not the current state.**
+**Direction (set 2026-06-23):** the brand surface is moving from dark-teal-on-black to a **warm cream paper base with a deep forest green** as the committed brand color. The point is to sell the product's one thesis, *trust the answer*, harder: deep green reads as validation / correctness ("7 validators passed"), and going light deliberately breaks the saturated dark-dev-tool reflex (Vercel / Linear / Supabase) for real differentiation. The landing shipped light on 2026-06-24 (#3913, #3917): cream + forest is now the **live** default — the prior dark theme and its `.theme-light` opt-in were retired once every landing page migrated. The remaining surfaces — **docs** (#3915) and the **product app + demo** (#3916) — adopt the same brand system next; Principle 5 defines how each one follows it.
 
 **Visual tone:** Clean, technical, considered. Warm and honest, not flashy or playful. Premium without being precious.
 
@@ -53,19 +53,28 @@ The agent's power comes from the semantic layer, and the UI should make that vis
 ### 4. One way to do things
 Standardize on single patterns: one font pair (Sora + JetBrains Mono), one icon set (Lucide), one component library (shadcn/ui), one state pattern per context (nuqs for URL state, useState for transient). Consistency reduces cognitive load for both users and the solo developer maintaining it.
 
-### 5. Light-first (cream + forest), code stays dark
-Build the brand surface light-first: warm cream paper, deep forest green. Code panes (YAML / SQL / agent replies) stay dark in every theme — they're terminal windows on paper, not themed surfaces. Drive all color through CSS-variable tokens (`--bg`, `--fg`, `--accent`, `--code-*`), never hardcoded values, so the theme is one edit. The product app (admin / dashboard) remains its own light-ready shadcn surface, separate from the brand surface.
+### 5. One brand, light-first — three surfaces, one forest accent
+There is **one** brand, expressed light-first as warm cream paper + deep forest green. The **light identity is the brand on every surface**, and the forest accent (`--atlas-brand`, `#1F5C45`) is the through-line in every surface *and mode*. Three surfaces express it (decided 2026-06-24, #3915 / #3916):
+
+- **Brand surface** — the landing, and **docs**: full marketing cream + forest. The landing is **light-only**; **docs** additionally keeps a dark mode (developers read it at night) that is *on-brand dark*, not a separate theme.
+- **Product surface** — the **app / admin** and the **demo** (which renders the product chat, so it inherits app theming): **light + dark**. Light mode *follows the brand* as a warm, desaturated **paper-lite** — the same cream family as the landing, pulled toward white and lower chroma so dense tables, charts, and long sessions stay calm and AA-legible. Dark mode is its own working surface — a faintly forest-tinted dark, not pure gray — still on-brand because the **primary stays forest (lightened for contrast), never teal**. A real dark mode the marketing surface doesn't need.
+- **Code surface** — the YAML / SQL / agent-reply panes: always-dark terminal windows (`--code-*`), identical on every surface and mode.
+
+**Teal (`--atlas-spark`, `#23CE9E`) is never a primary** — it is a rare spark on dark / green surfaces only (focus rings, active dots, the drenched-CTA accent, code highlights). Keeping forest as the primary even in dark mode is deliberate: it keeps the dark app a sibling of the cream landing instead of falling back into the neon-teal-on-black dev-tool lane we are leaving.
+
+Drive all color through CSS-variable tokens, never hardcoded values, so each surface is one edit. The shared **`brand.css`** (symlinked into all three apps) is the single source of truth for the brand color, the spark, and the cream ramp; each app's `globals.css` is a thin adapter onto its framework tokens (Tailwind utilities / Fumadocs `--fd-*` / shadcn `--primary`, sidebar-*). Full rationale + rejected alternatives: [ADR-0023](docs/adr/0023-brand-color-system.md).
 
 ## Design Tokens
 
 ### Colors
-- **Brand green (primary):** deep forest `#1F5C45` (oklch `0.40 0.115 158`) — headlines, CTAs, accents on the light brand surface
-- **Brand teal (spark):** `#23CE9E` (oklch `0.759 0.148 167.71`) — reserved for dark / green surfaces (code panes, the drenched CTA band)
-- **Paper base:** warm cream oklch `0.955 0.017 83` (raised sections `0.923 0.019 83`)
-- **Ink:** near-black, faint forest oklch `0.245 0.026 158`
-- **Code windows (fixed in every theme):** bg oklch `0.14 0.006 167`, chrome `0.185`, well `0.10`
-- **Color space:** oklch throughout — perceptually uniform, better for accessible contrast ratios
-- **Token source of truth:** `apps/www/src/app/proto-light/theme.css` (until migrated into the production landing)
+Token names live in the shared `brand.css`; the prose name and the token are the same word, so "brand" means one thing in the doc and in the code.
+- **`--atlas-brand` — deep forest `#1F5C45`** (oklch `0.40 0.115 158`): the committed brand color and the **primary accent on every surface and mode** (headlines, CTAs, links, buttons, active states). Lightened for contrast in dark mode, **never replaced by teal**.
+- **`--atlas-spark` — bright teal `#23CE9E`** (oklch `0.759 0.148 167.71`): a **spark**, never a primary. Dark / green surfaces only — focus rings, active dots, the drenched-CTA band, code-pane highlights.
+- **`--atlas-paper` — warm cream ramp:** oklch `0.955 0.017 83` (raised `0.923 0.019 83`, sunken `0.892 0.021 83`). The brand ground. Marketing surfaces (landing, docs) use it directly; the working app desaturates toward white (**paper-lite**) for dense data.
+- **`--atlas-ink` — near-black, faint forest:** oklch `0.245 0.026 158`.
+- **Code windows (fixed on every surface):** bg oklch `0.14 0.006 167`, chrome `0.185`, well `0.10`.
+- **Color space:** oklch throughout — perceptually uniform, better for accessible contrast ratios.
+- **Token source of truth:** the shared **`brand.css`** (symlinked into `apps/www`, `apps/docs`, `packages/web`); each app's `globals.css` adapts it onto framework tokens. Supersedes the `proto-light/theme.css` prototype now that the landing has shipped.
 
 ### Typography
 - **UI font:** Sora (Google Fonts) — clean geometric sans-serif

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -17,11 +17,11 @@
  * CTA's drenched-green band).
  */
 :root {
-  --bg: oklch(0.955 0.017 83); /* warm tan paper */
-  --bg-raised: oklch(0.923 0.019 83); /* sections / cards */
-  --bg-sunken: oklch(0.892 0.021 83);
-  --fg: oklch(0.245 0.026 158); /* near-black ink, faint forest */
-  --fg-muted: oklch(0.435 0.026 158);
+  --bg: var(--atlas-paper); /* warm tan paper */
+  --bg-raised: var(--atlas-paper-raised); /* sections / cards */
+  --bg-sunken: var(--atlas-paper-sunken);
+  --fg: var(--atlas-ink); /* near-black ink, faint forest */
+  --fg-muted: var(--atlas-ink-muted);
   --fg-faint: oklch(0.565 0.02 158);
   --border: oklch(0.245 0.03 158 / 0.16);
   --border-soft: oklch(0.245 0.03 158 / 0.09);
@@ -59,8 +59,13 @@
 }
 
 @theme inline {
-  --color-brand: var(--atlas-brand);
-  --color-brand-hover: var(--atlas-brand-hover);
+  /* The landing's `brand` utility is the teal *spark* on dark code panes
+   * (hero, deploy terminal, how-it-works) — not the forest brand accent, which
+   * is `--accent`. See ADR-0023. (`text-spark` is the preferred alias.) */
+  --color-brand: var(--atlas-spark);
+  --color-brand-hover: var(--atlas-spark-hover);
+  --color-spark: var(--atlas-spark);
+  --color-spark-hover: var(--atlas-spark-hover);
 
   --color-bg: var(--bg);
   --color-bg-raised: var(--bg-raised);

--- a/brand.css
+++ b/brand.css
@@ -1,13 +1,41 @@
-/* Atlas brand tokens — single source of truth.
- * Brand green: #23CE9E / oklch(0.759 0.148 167.71)
+/* Atlas brand tokens — the single source of truth (symlinked into each app:
+ * apps/www/brand.css · apps/docs/brand.css · packages/web/brand.css).
  *
- * Adapters per frontend:
- *   packages/web/globals.css  → shadcn/ui theme tokens (primary, ring, sidebar-*)
- *   apps/docs/globals.css     → Fumadocs theme tokens (fd-primary, fd-ring)
- *   apps/www/globals.css      → Tailwind utilities (brand, brand-hover)
+ * Vocabulary (see PRODUCT.md › Design Tokens, docs/adr/0023-brand-color-system.md):
+ *   --atlas-brand  the committed brand color, deep forest green #1F5C45 — the
+ *                  primary accent on every surface and mode. NOTE: still holds
+ *                  teal below, pending #3916: in the app this var is also the
+ *                  default for the white-label ATLAS_BRAND_COLOR setting, with a
+ *                  three-file lockstep (this file ↔ use-dark-mode.ts
+ *                  DEFAULT_BRAND_COLOR ↔ settings.ts ATLAS_BRAND_COLOR), so the
+ *                  teal→forest flip moves all three together — not in isolation.
+ *   --atlas-spark  bright teal #23CE9E — a spark on dark / green surfaces only
+ *                  (focus rings, active dots, code-pane highlights); never a
+ *                  primary.
+ *   --atlas-paper  warm cream ramp — the brand ground. Marketing surfaces use it
+ *                  directly; the working app desaturates toward white.
+ *
+ * Adapters per frontend map these onto framework tokens:
+ *   apps/www/globals.css     → Tailwind utilities + brand-surface vars
+ *   apps/docs/globals.css    → Fumadocs (--fd-primary, --fd-ring)
+ *   packages/web/globals.css → shadcn/ui (--primary, --ring, sidebar-*)
  */
 :root {
+  /* Committed brand color — deep forest #1F5C45 (oklch 0.40 0.115 158).
+   * Holds teal for now; the forest flip + white-label lockstep lands in #3916. */
   --atlas-brand: oklch(0.759 0.148 167.71);
   --atlas-brand-hover: oklch(0.82 0.148 167.71);
   --atlas-brand-foreground: oklch(0.145 0 0);
+
+  /* Spark — bright teal #23CE9E; dark / green surfaces only, never a primary. */
+  --atlas-spark: oklch(0.759 0.148 167.71);
+  --atlas-spark-hover: oklch(0.82 0.148 167.71);
+  --atlas-spark-foreground: oklch(0.145 0 0);
+
+  /* Warm cream ramp — the brand ground (forest ink on warm tan paper). */
+  --atlas-paper: oklch(0.955 0.017 83);
+  --atlas-paper-raised: oklch(0.923 0.019 83);
+  --atlas-paper-sunken: oklch(0.892 0.021 83);
+  --atlas-ink: oklch(0.245 0.026 158);
+  --atlas-ink-muted: oklch(0.435 0.026 158);
 }

--- a/docs/adr/0023-brand-color-system.md
+++ b/docs/adr/0023-brand-color-system.md
@@ -1,0 +1,64 @@
+# ADR-0023: Forest is the brand, teal is the spark — one brand expressed light-first, with on-brand dark for working surfaces
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Milestone:** — (brand direction set in PRODUCT.md 2026-06-23; landing migration #3913/#3917 shipped; remaining surfaces #3915/#3916)
+**Issues:** [#3913](https://github.com/AtlasDevHQ/atlas/issues/3913), [#3917](https://github.com/AtlasDevHQ/atlas/pull/3917) (landing, shipped), [#3915](https://github.com/AtlasDevHQ/atlas/issues/3915) (docs), [#3916](https://github.com/AtlasDevHQ/atlas/issues/3916) (app + demo)
+**See also:** [PRODUCT.md](../../PRODUCT.md) › Aesthetic Direction, Principle 5, Design Tokens
+
+## Context
+
+Atlas's brand surface moved off dark-teal-on-black to a **warm cream paper + deep forest green** direction (PRODUCT.md, 2026-06-23). The landing shipped light on 2026-06-24 (#3913, #3917): cream + forest is now the live default and the prior dark theme + `.theme-light` opt-in were retired.
+
+That left the brand system half-stated, in two ways a future reader would trip over:
+
+1. **The token vocabulary contradicted the design doc.** The shared `brand.css` (one real file, symlinked into all three frontends) declared `--atlas-brand` = **teal** `#23CE9E` and called it *"Brand green / single source of truth."* But PRODUCT.md had already named **forest** `#1F5C45` the committed brand color and demoted teal to a "spark." Worse, the landing's *actual* forest accent was hardcoded **locally** in `apps/www/globals.css` as `--accent` and never went into the shared token — so `brand.css` was neither the source of truth nor green, while `docs` (`--fd-primary`) and the `app` (sidebar tokens) both literally consumed the teal `--atlas-brand`.
+2. **The reach of cream + forest across the other surfaces was undecided.** #3915 (docs) and #3916 (app + demo) were both blocked `ready-for-human` on a single missing decision: does each surface follow the brand, and how far? Flipping the landing while docs/app diverge is split-brain.
+
+Resolved in a brand-system grilling session (2026-06-24). The crux: the token rename is **load-bearing, not cosmetic** — making `--atlas-brand` mean forest auto-shifts every consumer, so what the token *means* had to be settled before, and together with, the surface migrations.
+
+## Decision
+
+Five sub-decisions, all confirmed in the 2026-06-24 grill.
+
+### 1. Forest is the committed brand color; teal is a spark
+
+`--atlas-brand` is **deep forest green `#1F5C45`** (oklch `0.40 0.115 158`) — the committed brand color and the **primary accent on every surface and every mode**. Teal `#23CE9E` (oklch `0.759 0.148 167.71`) becomes `--atlas-spark`: a **rare highlight on dark / green surfaces only** (focus rings, active dots, the drenched-CTA band, code-pane highlights) and **never a primary**. The prose name and the token are now the same word, so "brand" means one thing in the design doc and in the code.
+
+### 2. One brand, expressed light-first — the light identity *is* the brand
+
+There is **one** brand, not a marketing palette plus an unrelated product palette. Its light expression (cream + forest) is the identity on every surface. The forest accent is the through-line in every surface *and mode*; the only thing that varies by surface is whether a surface additionally earns a *dark* mode.
+
+### 3. Three surfaces, distinguished by whether they get a working dark mode
+
+- **Brand surface** — the landing, and **docs**: full marketing cream + forest. The landing is **light-only** (a marketing page needs no dark mode). **Docs** additionally keeps a dark mode — developers read docs at night next to a dark IDE — rendered *on-brand dark*, not a separate theme; the toggle stays.
+- **Product surface** — the **app / admin** and the **demo**. The demo renders the product chat, so it **inherits app theming**; the two #3916 questions collapse into one surface. Keeps **light + dark** (people live in the app for hours).
+- **Code surface** — the YAML / SQL / agent-reply panes: always-dark terminal windows (`--code-*`), identical on every surface and mode.
+
+### 4. The product surface's light follows the brand as *paper-lite*; its dark keeps forest as primary
+
+- **Light mode** follows the brand as a warm, **desaturated paper-lite** — the same cream family as the landing, pulled toward white and lower chroma so dense tables, charts, and long sessions stay calm and AA-legible. **Not** the literal saturated marketing cream. `--primary` = forest.
+- **Dark mode** is its own working surface — a **faintly forest-tinted dark** (borrowing the code panes' hue), not pure gray — and **the primary stays forest, lightened for contrast, never teal**. This keeps the dark app a sibling of the cream landing rather than the neon-teal-on-black dev-tool look we are deliberately leaving.
+
+### 5. `brand.css` is the real single source of truth; apps are thin adapters
+
+The shared `brand.css` carries the **brand color (forest), the spark (teal), and the warm cream ramp** (`--atlas-paper*` / `--atlas-ink*`). Each app's `globals.css` is a thin adapter mapping those onto its framework tokens: Tailwind utilities + brand-surface vars (`apps/www`), Fumadocs `--fd-primary`/`--fd-ring` (`apps/docs`), shadcn `--primary`/`--ring`/`sidebar-*` (`packages/web`). "The theme is one edit" becomes literally true across all three.
+
+## Consequences
+
+- **The `--atlas-brand` flip ripples — and it is not a pure CSS edit.** `docs` (`--fd-primary`/`--fd-ring`) and the `app` (`--sidebar-primary`/`--sidebar-ring`) already consume `var(--atlas-brand)`, so flipping it teal→forest changes their rendering immediately. Crucially, **in the app `--atlas-brand` is also the default for the white-label `ATLAS_BRAND_COLOR` setting**: workspace admins override it at runtime (`use-dark-mode.ts` injects it via `style.setProperty("--atlas-brand", …)`, seeded from the `brandColor` API setting), and it carries a documented **three-file lockstep** — `brand.css` `:root --atlas-brand`, `use-dark-mode.ts` `DEFAULT_BRAND_COLOR`, and `settings.ts` `ATLAS_BRAND_COLOR.default`. Flipping the brand to forest therefore also **moves the app's default workspace brand** teal→forest and **must move all three together** (per-workspace white-label overrides keep flowing through `--atlas-brand`). That makes the flip part of **#3916** — a deliberate default change, with a thought for already-provisioned workspaces — not a net-zero precursor.
+- **Teal's spark role is already wired on the landing.** `text-brand` (`--color-brand` → `--atlas-brand`) is used on the landing's **dark code panes** (hero, deploy terminal, how-it-works) — i.e. as the teal spark, exactly `--atlas-spark`'s role. When the tokens split, the www adapter maps its `brand` utility to `--atlas-spark`, *not* the forest brand.
+- **Sequencing.** The shared `brand.css` restructure — add `--atlas-spark` + the cream ramp (purely additive, net-zero), then flip `--atlas-brand`→forest **with** the three-file white-label lockstep — is the first step, landed together with the first consuming surface while the others are pinned to explicit teal until their own migration: **brand.css + lockstep → #3915 docs → #3916 app/demo.** No surface ships half-forest/half-teal.
+- **`packages/react` is independent.** The embeddable `@useatlas/react` widget defines its own `--atlas-brand` (teal) in `styles.css` and does **not** import the shared `brand.css`; its default is a published-package change handled with the demo/app under #3916, not by this restructure.
+- **The landing adapter is net-zero.** `apps/www` stops hardcoding `--accent` and points it at `var(--atlas-brand)` — same forest value, no visual change; just makes the SSOT real.
+- **The app's hand-tuned teal `--primary` (`oklch(0.58 0.185 167.71)`) is replaced** by forest in light mode and lightened-forest in dark; teal survives only as `--atlas-spark` for sparks.
+- **No `.theme-light` / no dark wrappers on the brand surface.** The landing's light values are `:root` defaults (already shipped, #3914); docs and app express dark via their framework's `.dark` mechanism, not a brand-surface toggle.
+- **Two cream "weights" exist by design** — full marketing cream (landing, docs prose) and paper-lite (app/dense data). They are one family, not two palettes; the difference is saturation/lightness for ergonomics, not hue.
+
+## Alternatives considered
+
+- **One unified theme reaching every surface (no product/brand distinction).** Rejected: the app is dense (tables, charts, hours of use) and needs a real dark mode and calmer, lower-chroma grounds than a marketing page; forcing literal cream onto it muddies chart colors and fatigues. PRODUCT.md Principle 5's "the app is its own surface" intuition was right — we kept it as *its light mode follows the brand, its dark mode is its own on-brand dark* rather than collapsing the two.
+- **Two walled-off palettes (brand vs product) with no shared color.** Rejected: loses the through-line. The forest accent present in every surface and mode is exactly what makes the dark app read as a sibling of the cream landing.
+- **Keep teal as the brand, or make teal the dark-mode primary.** Rejected: the entire point of the rebrand is to leave the saturated neon-teal-on-black dev-tool lane (Vercel / Linear / Supabase). Teal-forward dark surfaces land right back in it. Forest-as-primary-even-in-dark keeps the accent identity constant; teal stays a rare spark, as PRODUCT.md states.
+- **Literal marketing cream in the app.** Rejected: saturated warm cream behind dense data is warm-heavy and reads muddy; shadcn's neutrals were tuned for near-white. Paper-lite keeps the brand family while staying a comfortable working ground.
+- **Docs light-only (pure brand surface).** Rejected: it would delete Fumadocs' dark mode, an affordance the core developer audience expects. Docs gets the brand in light mode (where marketing-driven first visits land) without taking dark mode from the developers who live in it.


### PR DESCRIPTION
## Summary
Records the **brand-system decision** settled in a grilling session, and lands the genuinely net-zero token groundwork. **No visual change** — every CSS edit is reference-only with identical oklch values; the www build is green.

The split-brain this fixes: `brand.css` declared `--atlas-brand` = **teal** and called it *"Brand green / single source of truth,"* while PRODUCT.md had committed to **forest** `#1F5C45` as the brand color and demoted teal to a "spark." The landing's real forest accent was hardcoded locally and never reached the shared token.

### The decided system (ADR-0023, PRODUCT.md Principle 5)
> One brand, expressed **light-first** as cream + forest. The light identity *is* the brand on every surface; the **forest accent is the through-line in every surface and mode**; **teal is a spark** on dark/green only, never a primary; code panes are always dark.

| Surface | Light | Dark |
|---|---|---|
| **Landing** | marketing cream + forest | — (light-only) |
| **Docs** (#3915) | cream + forest | Fumadocs dark, retinted on-brand |
| **App + demo** (#3916) | *paper-lite* (warm desaturated cousin), forest primary | forest-tinted dark; **forest primary lightened, never teal** |
| **Code panes** | always dark | always dark |

## What's in this PR
- **`docs/adr/0023-brand-color-system.md`** — the decision record + rejected alternatives (one-unified-theme, teal-primary-in-dark, literal-cream-in-app, docs-light-only), and the **white-label seam** finding (below).
- **`PRODUCT.md`** — Principle 5 rewritten to the three-surface model; Design Tokens vocabulary fixed (`--atlas-brand` = forest, `--atlas-spark` = teal, cream ramp); Aesthetic Direction updated now that the landing has shipped.
- **`brand.css`** (the symlinked SSOT) — add `--atlas-spark*` + the `--atlas-paper*`/`--atlas-ink*` cream ramp; rewrite the stale header comment.
- **`apps/www/globals.css`** — consume the shared cream ramp; map the landing's `brand` utility to `--atlas-spark` (it's the teal spark on the dark code panes, not the forest accent) + a `spark` alias.

## Deliberately **not** in this PR
The `--atlas-brand` teal→forest flip. In the app, `--atlas-brand` is the **default for the white-label `ATLAS_BRAND_COLOR` setting** (injected at runtime by `use-dark-mode.ts`), with a documented **three-file lockstep** (`brand.css` ↔ `DEFAULT_BRAND_COLOR` ↔ `settings.ts ATLAS_BRAND_COLOR.default`). Flipping it moves the app's default workspace brand and must move all three together — so it lands as part of **#3916**, not as a "net-zero precursor." `--atlas-brand` keeps its teal value here; docs/app adapters read it unchanged and are untouched.

## Sequencing
`brand.css` spark + ramp (this PR) → `--atlas-brand`→forest flip + white-label lockstep (head of #3916) → **#3915** docs → app/demo re-theme (rest of #3916). Decisions are recorded on both issues; both moved to `ready-for-agent`.

## Test plan
- [x] `bun run --filter '@atlas/www' build` — clean (15/15 static pages, exit 0)
- [x] CSS edits are reference-only with identical oklch values → rendered output unchanged
- [x] docs/app adapters consume only the unchanged `--atlas-brand` → not affected


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document brand color system in ADR-0023 and introduce shared `--atlas-spark`/`--atlas-paper` tokens
> - Adds [ADR-0023](https://github.com/AtlasDevHQ/atlas/pull/3918/files#diff-cd0e4b3437c1e772953822c6c1a677f4ed27417f801d27a619673a182a8243db) documenting the brand color system: forest as primary accent, teal as a rare spark, three surfaces (brand, product, code), and `brand.css` as the single source of truth.
> - Expands [brand.css](https://github.com/AtlasDevHQ/atlas/pull/3918/files#diff-2f4dc4d25e089e44696c019b7c858fe6599725fff09861e396ac46fb3e4e9743) with new shared tokens: `--atlas-spark` (teal), a warm cream ramp (`--atlas-paper*`), and ink tokens (`--atlas-ink*`).
> - Updates [apps/www/src/app/globals.css](https://github.com/AtlasDevHQ/atlas/pull/3918/files#diff-8c8aa23ab09ba3f9c1fd98ff8c0eaf86e9cc37d04561a50a4b959fa413b4588a) to wire surface variables (`--bg*`, `--fg*`) to the new shared tokens and remaps `--color-brand` to `--atlas-spark`.
> - Updates [PRODUCT.md](https://github.com/AtlasDevHQ/atlas/pull/3918/files#diff-211481d78d1a6589c26191397abaa961cf2f8d237ddcf9900b76e430c2ba2efc) to reflect the light theme landing shipped on 2026-06-24 and align design principles with the new token structure.
> - Behavioral Change: `--color-brand` in the www app now resolves to `--atlas-spark` (teal) instead of `--atlas-brand` (forest); forest flip is noted as pending #3916.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 587a7e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->