### PR TITLE
fix(deploy): guard default datasource registration on ATLAS_DATASOURCE_URL — staging /api/health 503 fix

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -97,12 +97,21 @@ const proactiveAiRuntime = getProactiveAiRuntime();
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────
-  // The default analytics datasource — env var fallback handles this,
-  // but being explicit here for documentation.
+  // The default analytics datasource — registered only when
+  // ATLAS_DATASOURCE_URL is set. A region/env with no default analytics
+  // source (e.g. staging, which soaks via per-workspace connection groups
+  // rather than a shared default) must NOT register a `default` with an
+  // empty URL: `applyDatasources` registers every entry unconditionally,
+  // so a blank URL would either fail config validation at boot or leave a
+  // `default` whose health probe fails — flipping the region's /api/health
+  // to 503 (the primary-datasource gate, #3907) for a source it never
+  // needed. Omitting it lets the health probe report `degraded` (HTTP 200)
+  // instead. See #3896 (staging's default formerly reached prod's demo-data
+  // over a public TCP proxy that was deleted as a security fix).
   datasources: {
-    default: {
-      url: process.env.ATLAS_DATASOURCE_URL!,
-    },
+    ...(process.env.ATLAS_DATASOURCE_URL
+      ? { default: { url: process.env.ATLAS_DATASOURCE_URL } }
+      : {}),
   },
 
   // ── Tools ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`app.staging.useatlas.dev` shows **"Health check failed"** — `api.staging.useatlas.dev/api/health` returns **503**. Everything is healthy (internal DB, provider, scheduler, sandbox, plugins, Slack) **except** the default datasource:

```
"sources": { "default": { "status":"unhealthy", "latencyMs":11, "message":"Datasource query failed", "dbType":"postgres" } }
```

## Root cause

`api-staging`'s `ATLAS_DATASOURCE_URL` pointed at the **demo-data public TCP proxy** (`gondola.proxy.rlwy.net:22530`) — the exact proxy **#3896 deleted** as a security fix on 2026-06-23. The fatal assumption in #3896 ("the API connects to demo-data over private networking, not the public proxy", with the acceptance box *"Confirm nothing depended on the public demo-data proxy"* left unchecked) was wrong for staging:

- **demo-data lives only in the `production` Railway environment** (zero deployments in `staging`). Railway private networking is per-environment, so `api-staging` could **never** reach demo-data over `*.railway.internal` — the public proxy was its only path.
- With the proxy deleted, the shared Railway edge still **accepts the bare TCP handshake** but routes to no Postgres backend → connect succeeds in ~11ms, then the query fails → `"Datasource query failed"`.
- Since **v0.0.23 (#3907)**, a region's **primary datasource** gates `/api/health`. demo-data *is* staging's primary → its failure flips the region to 503 → the LB + web-staging report "Health check failed."

## Why this needs a code change (not just unsetting the var)

`deploy/api/atlas.config.ts` hardcoded `datasources.default = { url: process.env.ATLAS_DATASOURCE_URL! }`, and `applyDatasources` (`config.ts`) registers **every** config entry with no empty-URL guard. So simply unsetting `ATLAS_DATASOURCE_URL` would either fail config validation at boot or leave a `default` whose probe still fails (still 503).

## Fix

Spread `datasources.default` in **only when `ATLAS_DATASOURCE_URL` is set**. An env with no default analytics source (e.g. staging, which soaks via per-workspace connection groups) then registers no `default` → the health probe is skipped → status `degraded` → **HTTP 200** (the route returns 200 for ok *or* degraded). Also a general robustness win: a SaaS region with no analytics default shouldn't hard-503.

**Prod is unaffected** — its `ATLAS_DATASOURCE_URL` stays set, reaching demo-data over in-env private networking (`postgres-jzef.railway.internal`).

## Follow-up (manual, after this merges + staging deploys)

1. Unset `ATLAS_DATASOURCE_URL` on `api-staging` (only after the guard is live on staging — unsetting under the old code would break boot).
2. Verify `api.staging.useatlas.dev/api/health` → 200 (degraded).
3. Closes the staging half of #3896's acceptance criteria.

## Separately found (will file)

A real secondary bug in staging logs (unrelated to this 503): the plan-tier resolution query fails with `column s.createdAt does not exist` on the `subscription` table — internal-DB schema/column drift in the billing plan-cache query. Will file as its own issue.

Refs #3896.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard default datasource registration on `ATLAS_DATASOURCE_URL` to fix staging `/api/health` 503
> In [atlas.config.ts](https://github.com/AtlasDevHQ/atlas/pull/3921/files#diff-e6db0c3b52717e74ce220854d51820cab32a3a64d438da05dbcd246e316d0fa2), the `default` datasource was unconditionally registered using `process.env.ATLAS_DATASOURCE_URL!`, causing it to be registered with an undefined URL when the variable is absent. The entry is now conditionally spread so it is only added when `ATLAS_DATASOURCE_URL` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b467ea5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->