### PR TITLE
fix(billing): reconcile sweep ordered by non-existent subscription.createdAt

### DIFF
--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers-pg.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Real-Postgres coverage for the plan-tier reconciliation sweep (#3423).
+ * Mirrors the `chat-cap-pg.test.ts` harness: skips cleanly when
+ * `TEST_DATABASE_URL` is unset, runs every migration into a unique per-test
+ * schema, and exercises the sweep's ACTUAL query against the real schema.
+ *
+ * What this catches that the mock-based `reconcile-plan-tiers.test.ts` can't:
+ *   - The sweep's main SELECT is never executed by the unit test (it scripts
+ *     the result rows via a mocked `internalQuery`). A column that doesn't
+ *     exist on Better Auth's `subscription` table — e.g. ordering by a
+ *     non-existent `s."createdAt"` (PG: `column s.createdAt does not exist`,
+ *     which silently broke EVERY reconcile pass and 503'd staging's health
+ *     when surfaced through the datasource probe) — passes every unit test but
+ *     throws here against the real table. The `subscription` table has no
+ *     creation timestamp; `periodStart` is the newest-subscription proxy.
+ *
+ * `organization` and `subscription` are owned by Better Auth in production, so
+ * they are not in our migration set — the fixture creates the minimal columns
+ * the sweep's query and heal-write read (mirrors chat-cap-pg's `organization`
+ * fixture). `stripe_webhook_events` (0128) + `stripe_purged_subscriptions`
+ * (0129) ARE regular migrations, so `runMigrations` creates them.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import { reconcilePlanTiers } from "@atlas/api/lib/billing/reconcile-plan-tiers";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+// The full migration set can take several seconds on shared CI runners
+// (matches migrate-pg.test.ts's 30s budget).
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("reconcilePlanTiers (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `reconcile_pt_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`reconcile-plan-tiers-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // Minimal Better-Auth-owned `organization` — only the columns the sweep's
+    // SELECT (`plan_tier`, `plan_override_until`) and `updateWorkspacePlanTier`
+    // write read. Nullable `plan_override_until` mirrors migration 0132.
+    await pool.query(
+      `CREATE TABLE organization (
+         id text PRIMARY KEY,
+         name text,
+         slug text,
+         plan_tier text NOT NULL DEFAULT 'free',
+         plan_override_until timestamptz
+       )`,
+    );
+    // Minimal Better-Auth-stripe `subscription` — only the columns the sweep's
+    // LATERAL subquery reads. Crucially there is NO `createdAt` column (the bug):
+    // the real table's newest-period proxy is `periodStart`.
+    await pool.query(
+      `CREATE TABLE subscription (
+         id text PRIMARY KEY,
+         plan text,
+         "referenceId" text,
+         "stripeSubscriptionId" text,
+         status text,
+         "periodStart" timestamptz
+       )`,
+    );
+
+    // Point the sweep's module pool (`internalQuery`/`updateWorkspacePlanTier`)
+    // at this scratch-schema pool, and make `hasInternalDB()` true.
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query(`DELETE FROM subscription`);
+    await pool.query(`DELETE FROM organization`);
+  });
+
+  async function seedOrg(id: string, planTier: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1, $1, $1, $2)`,
+      [id, planTier],
+    );
+  }
+
+  async function seedSubscription(opts: {
+    id: string;
+    org: string;
+    plan: string;
+    stripeSubscriptionId: string;
+    status?: string;
+    periodStart: string; // SQL expression, e.g. "now()" or "now() - interval '30 days'"
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO subscription (id, plan, "referenceId", "stripeSubscriptionId", status, "periodStart")
+       VALUES ($1, $2, $3, $4, $5, ${opts.periodStart})`,
+      [opts.id, opts.plan, opts.org, opts.stripeSubscriptionId, opts.status ?? "active"],
+    );
+  }
+
+  it(
+    "heals an org whose plan_tier drifted below its active subscription (runs the real SELECT against the real schema)",
+    async () => {
+      const org = `org-heal-${Date.now()}`;
+      await seedOrg(org, "free"); // drifted: org says free
+      await seedSubscription({
+        id: `s-${org}`,
+        org,
+        plan: "pro", // subscription says pro
+        stripeSubscriptionId: "sub_heal_1",
+        periodStart: "now()",
+      });
+
+      const result = await reconcilePlanTiers();
+      expect(result.healed).toBe(1);
+
+      const { rows } = await pool.query<{ plan_tier: string }>(
+        `SELECT plan_tier FROM organization WHERE id = $1`,
+        [org],
+      );
+      expect(rows[0]?.plan_tier).toBe("pro");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "orders by periodStart — among multiple active subscriptions the newest period's plan wins (guards the fixed ORDER BY)",
+    async () => {
+      const org = `org-multi-${Date.now()}`;
+      await seedOrg(org, "free");
+      // Older period — starter — must LOSE the LIMIT 1 ordering.
+      await seedSubscription({
+        id: `s-old-${org}`,
+        org,
+        plan: "starter",
+        stripeSubscriptionId: "sub_old",
+        periodStart: "now() - interval '30 days'",
+      });
+      // Newer period — pro — must WIN (ORDER BY periodStart DESC).
+      await seedSubscription({
+        id: `s-new-${org}`,
+        org,
+        plan: "pro",
+        stripeSubscriptionId: "sub_new",
+        periodStart: "now()",
+      });
+
+      const result = await reconcilePlanTiers();
+      expect(result.healed).toBe(1);
+
+      const { rows } = await pool.query<{ plan_tier: string }>(
+        `SELECT plan_tier FROM organization WHERE id = $1`,
+        [org],
+      );
+      // The newest-period subscription (pro) drives the heal, not the older starter.
+      expect(rows[0]?.plan_tier).toBe("pro");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "leaves a paid-tier org with no active subscription untouched (flag-don't-heal)",
+    async () => {
+      const org = `org-flag-${Date.now()}`;
+      await seedOrg(org, "pro"); // paid tier, but no subscription row
+
+      const result = await reconcilePlanTiers();
+      expect(result.healed).toBe(0);
+      expect(result.flagged).toBe(1);
+
+      const { rows } = await pool.query<{ plan_tier: string }>(
+        `SELECT plan_tier FROM organization WHERE id = $1`,
+        [org],
+      );
+      expect(rows[0]?.plan_tier).toBe("pro"); // unchanged
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/billing/reconcile-plan-tiers.ts
+++ b/packages/api/src/lib/billing/reconcile-plan-tiers.ts
@@ -119,7 +119,12 @@ export async function reconcilePlanTiers(): Promise<PlanTierReconcileResult> {
               SELECT 1 FROM stripe_webhook_events w
                WHERE w.stripe_subscription_id = s."stripeSubscriptionId"
                  AND w.event_type = 'customer.subscription.deleted')
-          ORDER BY s."createdAt" DESC
+          -- Better Auth's subscription table has NO createdAt column; periodStart
+          -- (newest current-period start) is the right "most recent subscription"
+          -- proxy when an org has more than one active/trialing row. Ordering by a
+          -- non-existent createdAt threw "column s.createdAt does not exist",
+          -- silently breaking every reconcile pass. Covered by reconcile-plan-tiers-pg.
+          ORDER BY s."periodStart" DESC NULLS LAST
           LIMIT 1
        ) sub ON true
        LEFT JOIN LATERAL (


### PR DESCRIPTION
## Problem

The plan-tier reconciliation sweep (`reconcilePlanTiers`, #3423 — the safety net that heals `organization.plan_tier` drift from the Stripe subscription table) ordered the per-org active subscription by:

```sql
ORDER BY s."createdAt" DESC
```

But Better Auth's `subscription` table **has no `createdAt` column** (its timestamps are `periodStart`/`periodEnd`/`trialStart`/`cancelAt`/`canceledAt`/`endedAt`). So Postgres rejected **every** reconcile pass:

```
ERROR: column s.createdAt does not exist
HINT:  Perhaps you meant to reference the column "o.createdAt".
```

Plan-tier drift was therefore never healed in any environment (prod included). It surfaced while investigating staging's `/api/health` 503 — the error logs at INFO from the scheduler fiber.

**Why it shipped:** `reconcile-plan-tiers.test.ts` mocks `internalQuery`, scripting the result rows — so the real SELECT never executes and the bad column passed every unit test.

## Fix

Order by `"periodStart" DESC NULLS LAST` — the newest current-period start is the right "most recent subscription" proxy when an org has more than one active/trialing row (the BA subscription table has no creation timestamp). Validated against the real staging DB: the corrected query runs cleanly; the old one reproduces the error.

## Regression test

New **`reconcile-plan-tiers-pg.test.ts`** (mirrors `chat-cap-pg.test.ts`): runs the **actual sweep** against a migrated scratch schema + minimal BA `organization`/`subscription` fixtures (BA owns those tables, so they're not in our migration set; `stripe_webhook_events`/`stripe_purged_subscriptions` are regular migrations). Covers:
- heals an org whose `plan_tier` drifted below its active subscription (runs the real SELECT against the real schema — this is what catches the `createdAt` class of bug),
- the `periodStart` ordering (newest period's plan wins among multiple active subs),
- flag-don't-heal for a paid-tier org with no subscription.

Passes via the isolated runner with `TEST_DATABASE_URL` set; skips cleanly without it (CI's `api-tests` shards run it against real Postgres).

Found during the staging health-check incident (sibling to #3921).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix reconcile sweep to order subscriptions by `periodStart` instead of non-existent `createdAt`
> - Fixes a broken SQL query in `reconcilePlanTiers` ([reconcile-plan-tiers.ts](https://github.com/AtlasDevHQ/atlas/pull/3922/files#diff-5854c10f8b1800484bd4ef688918aae2f49b9e63b0c08053924541d3d4313d9f)) where the LATERAL subquery ordered by `s."createdAt"`, a column that does not exist on the subscription table.
> - Changes the order to `s."periodStart" DESC NULLS LAST` so the sweep correctly picks the newest active/trialing subscription per org.
> - Adds a real-Postgres integration test suite ([reconcile-plan-tiers-pg.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3922/files#diff-0a6966450c2124c1f3627662d8d6156681b1f439436013c9c39554525323a74b)) that runs when `TEST_DATABASE_URL` is set, covering healing, `periodStart`-based ordering, and flagging behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f71422b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->