### PR TITLE
fix(www): split footer into product + legal tiers

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -5,11 +5,32 @@ import { AtlasLogo, GitHubIcon } from "./shared";
 const STATUS_URL =
   process.env.NEXT_PUBLIC_STATUS_URL || "https://atlas.openstatus.dev";
 
+// Primary footer links: product + resources. Legal links live in the dimmer
+// baseline row below so the two readings stay distinct and neither crowds out
+// the other as the legal set grows.
+const PRIMARY_LINKS = [
+  { href: "/pricing", label: "Pricing" },
+  { href: "/blog", label: "Blog" },
+  { href: "https://docs.useatlas.dev", label: "Docs" },
+  { href: "https://app.useatlas.dev", label: "Atlas Cloud" },
+  { href: STATUS_URL, label: "Status" },
+];
+
+const LEGAL_LINKS = [
+  { href: "/security", label: "Security" },
+  { href: "/terms", label: "Terms" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/aup", label: "AUP" },
+  { href: "/dpa", label: "DPA" },
+];
+
 export function Footer() {
   return (
     <footer className="mx-auto max-w-5xl px-6 pb-12">
       <div className="h-px bg-gradient-to-r from-transparent via-border to-transparent" />
-      <div className="flex flex-col items-center justify-between gap-4 pt-8 sm:flex-row">
+
+      {/* Primary row: brand cluster + product/resource nav */}
+      <div className="flex flex-col items-center justify-between gap-6 pt-8 sm:flex-row">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
             <AtlasLogo className="h-4 w-4 text-accent" />
@@ -23,41 +44,40 @@ export function Footer() {
             Open source
           </a>
         </div>
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-          <a href="/pricing" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Pricing
-          </a>
-          <a href="/blog" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Blog
-          </a>
-          <a href="https://docs.useatlas.dev" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Docs
-          </a>
-          <a href="https://app.useatlas.dev" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Atlas Cloud
-          </a>
-          <a href={STATUS_URL} className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Status
-          </a>
-          <a href="/security" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Security
-          </a>
-          <a href="/terms" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Terms
-          </a>
-          <a href="/privacy" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            Privacy
-          </a>
-          <a href="/aup" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            AUP
-          </a>
-          <a href="/dpa" className="text-xs text-fg-muted transition-colors hover:text-fg">
-            DPA
-          </a>
-          <a href="https://github.com/AtlasDevHQ/atlas" className="whitespace-nowrap text-xs text-fg-muted transition-colors hover:text-fg">
-            Built by humans and AI
-          </a>
-        </div>
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2"
+        >
+          {PRIMARY_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="text-sm text-fg-muted transition-colors hover:text-fg"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+
+      {/* Baseline row: credit + legal — dimmer and smaller so it reads as a
+          sub-tier, not a second primary nav. */}
+      <div className="mt-6 flex flex-col-reverse items-center justify-between gap-3 border-t border-border-soft pt-6 sm:flex-row">
+        <p className="text-xs text-fg-faint">Built by humans and AI</p>
+        <nav
+          aria-label="Legal"
+          className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2"
+        >
+          {LEGAL_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="text-xs text-fg-faint transition-colors hover:text-fg-muted"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

The new public `/security` page (#3923, #3926) tipped the www landing footer over a rendering edge: it was a single `flex-wrap` row of 10 links with the "Built by humans and AI" tagline jammed in as an 11th pseudo-link (which redundantly linked to GitHub, the same destination as the adjacent **Open source** pill). Adding `/security` overflowed the row, wrapping the tagline down into a visual collision with the brand cluster.

This restructures the footer into the restrained two-tier pattern (Stripe/Linear style), not a heavy multi-column mega-footer that would fight the brand's quiet-confidence voice:

- **Primary row** — brand cluster (logo + Open source pill) left; product/resource links right (Pricing, Blog, Docs, Atlas Cloud, Status) at `text-sm`.
- **Dimmer legal baseline row** — "Built by humans and AI" as plain credit text (no more duplicate GitHub link) left; legal links right (Security, Terms, Privacy, AUP, DPA) at `text-xs` in `fg-faint`, a real two-step hierarchy so legal reads as a sub-tier.

Links moved into `PRIMARY_LINKS` / `LEGAL_LINKS` arrays (matching `nav.tsx`'s pattern); each `<nav>` is `aria-label`led. Each row caps at 5 links, so the next legal page slots into the baseline instead of crowding the line.

## Key files
- `apps/www/src/components/footer.tsx` — footer restructure

## Verification
- ESLint clean on the changed file.
- Rendered headless at 1024px and 390px: two clean tiers, no collision, links wrap gracefully on mobile with the credit anchored at the bottom.

## Notes
- `apps/www/src/app/sub-processors/` is a live legal page not currently linked in the footer. Now that there's a dedicated legal row it'd be natural to add it alongside DPA — left out here to keep the change scoped to the layout fix.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split footer into product and legal tiers in `Footer` component
> - Refactors [footer.tsx](https://github.com/AtlasDevHQ/atlas/pull/3929/files#diff-57f2fdd0d117eb32a4f7f280d223e3300b80c0b1b8ebc03bb3cd9033e0f82db5) to render two rows: a primary row with product/resource links and a baseline row with legal links, each in its own `<nav>` with an `aria-label`.
> - Replaces hardcoded anchor lists with mapped arrays (`PRIMARY_LINKS` and `LEGAL_LINKS`) covering Pricing, Blog, Docs, Atlas Cloud, Status, Security, Terms, Privacy, AUP, and DPA.
> - Removes the "Built by humans and AI" GitHub link, replacing it with a plain `<p>` element.
> - Behavioral Change: link layout, text sizes, and hover states differ from the previous single-row footer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 983229f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->