### PR TITLE
feat(web): success-page starter prompts derive from connected dataset (F4)

### DIFF
--- a/packages/web/src/app/signup/success/page.test.tsx
+++ b/packages/web/src/app/signup/success/page.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Coverage for the signup success step (#3935 §F4).
+ *
+ * The change under test swaps the page's hardcoded `STARTER_PROMPTS` constant
+ * for the adaptive `useSuccessStarterPrompts` hook (semantic-layer-derived
+ * prompts with a shared static fallback). There is no e2e coverage for this
+ * page, so this unit test pins the page-owned glue the hook test can't see:
+ * the prompts render as clickable rows, and a click navigates to the chat with
+ * the `?prompt=<text>` payload that is the whole point of the section.
+ *
+ * `mock.module(...)` stubs every named export of the modules it touches (per
+ * repo rule). The signup shell + trial-status are passthrough/no-op stubs so
+ * the test exercises the prompt section, not their dep trees.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const routerPushMock = mock((_path: string) => {});
+const routerMock = { push: routerPushMock, replace: () => {}, back: () => {} };
+mock.module("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+const getSessionMock = mock(async () => ({ data: null }));
+mock.module("@/lib/auth/client", () => ({
+  authClient: { getSession: getSessionMock },
+}));
+
+mock.module("@/ui/hooks/use-trial-status", () => ({
+  // Off-trial / self-hosted → TrialNotice renders nothing. Keeps the test
+  // focused on the prompt section.
+  useTrialStatus: () => ({ trial: null, loading: false }),
+}));
+
+const PROMPTS = [
+  "What is our total GMV?",
+  "Who are our top customers by spend?",
+] as const;
+mock.module("@/ui/hooks/use-success-starter-prompts", () => ({
+  useSuccessStarterPrompts: () => ({
+    prompts: PROMPTS,
+    loading: false,
+    isFallback: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+mock.module("@/ui/components/signup/signup-shell", () => ({
+  SignupShell: ({ children }: { children: unknown }) => <div>{children as never}</div>,
+}));
+
+import SuccessPage from "./page";
+
+beforeEach(() => {
+  routerPushMock.mockReset();
+  getSessionMock.mockReset();
+  getSessionMock.mockImplementation(async () => ({ data: null }));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("SuccessPage — starter prompts (#3935)", () => {
+  test("renders the hook's prompts as clickable rows", () => {
+    render(<SuccessPage />);
+
+    for (const prompt of PROMPTS) {
+      expect(screen.getByRole("button", { name: new RegExp(prompt, "i") })).toBeDefined();
+    }
+  });
+
+  test("clicking a prompt navigates to the chat with the ?prompt= payload", async () => {
+    render(<SuccessPage />);
+
+    const target = PROMPTS[0];
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: new RegExp(target, "i") }));
+    });
+
+    // openAtlas hydrates the session first, then pushes the encoded prompt.
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith(
+        `/?prompt=${encodeURIComponent(target)}`,
+      );
+    });
+    expect(getSessionMock).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/signup/success/page.tsx
+++ b/packages/web/src/app/signup/success/page.tsx
@@ -13,6 +13,7 @@ import {
 import { ArrowRight, BookOpen, Clock, MessageSquare, Settings, Users } from "lucide-react";
 import { SignupShell } from "@/ui/components/signup/signup-shell";
 import { useTrialStatus } from "@/ui/hooks/use-trial-status";
+import { useSuccessStarterPrompts } from "@/ui/hooks/use-success-starter-prompts";
 import { formatDate } from "@/lib/format";
 
 interface NextStepDef {
@@ -45,14 +46,12 @@ const NEXT_STEPS: NextStepDef[] = [
   },
 ];
 
-const STARTER_PROMPTS = [
-  "What are our top 10 customers by revenue this quarter?",
-  "Which products had the biggest week-over-week drop?",
-  "Show me churn risk by plan tier.",
-];
-
 export default function SuccessPage() {
   const router = useRouter();
+  // Starter prompts derive from the connected workspace's semantic layer via
+  // the same adaptive resolver the in-chat empty state uses (#3935 §F4), with
+  // a shared static fallback for a cold-start / not-yet-ready semantic layer.
+  const { prompts: starterPrompts } = useSuccessStarterPrompts();
 
   // #2487: hydrate the Better Auth session store before navigating to a
   // guarded route. Without this, AuthGuard can read the pre-signup `null`
@@ -90,7 +89,7 @@ export default function SuccessPage() {
               </h2>
             </div>
             <ul className="space-y-2">
-              {STARTER_PROMPTS.map((prompt) => (
+              {starterPrompts.map((prompt) => (
                 <li key={prompt}>
                   <button
                     type="button"

--- a/packages/web/src/ui/hooks/__tests__/use-success-starter-prompts.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-success-starter-prompts.test.tsx
@@ -1,0 +1,247 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  afterEach,
+  mock,
+} from "bun:test";
+import { renderHook, cleanup, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  notifyManager,
+} from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useSuccessStarterPrompts } from "../use-success-starter-prompts";
+import { STATIC_STARTER_PROMPTS } from "@/ui/lib/starter-prompt-fallback";
+
+/**
+ * Success-page starter-prompt resolution (#3935 §F4).
+ *
+ * The hook reuses the adaptive resolver (`/api/v1/starter-prompts`) and falls
+ * back to the shared static set whenever that resolver yields no prompts —
+ * cold-start (empty 200), a 5xx soft-fail (SDK returns `[]`), or a 4xx throw.
+ *
+ * Determinism note (#3455): force synchronous observer notification so the
+ * query result propagates inside `waitFor` independent of event-loop load.
+ */
+
+function buildWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function stubFetch(handler: () => Response) {
+  const calls: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    calls.push(typeof input === "string" ? input : input.toString());
+    return handler();
+  }) as typeof fetch;
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe("useSuccessStarterPrompts", () => {
+  beforeAll(() => {
+    notifyManager.setScheduler((cb) => cb());
+  });
+  afterAll(() => {
+    notifyManager.setScheduler((cb) => setTimeout(cb, 0));
+  });
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+  });
+
+  test("uses adaptive prompt texts when the resolver returns prompts", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            prompts: [
+              { id: "library:a", text: "What is our total GMV?", provenance: "library" },
+              { id: "favorite:b", text: "My pinned question", provenance: "favorite" },
+            ],
+            total: 2,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.prompts).toEqual([
+        "What is our total GMV?",
+        "My pinned question",
+      ]);
+      expect(result.current.isFallback).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(fetchStub.calls.length).toBe(1);
+      expect(fetchStub.calls[0]).toContain("/api/v1/starter-prompts");
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  test("drops empty-text adaptive entries and keeps the usable ones", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            prompts: [
+              { id: "library:a", text: "Usable one", provenance: "library" },
+              { id: "library:b", text: "", provenance: "library" },
+              { id: "library:c", text: "Usable two", provenance: "library" },
+            ],
+            total: 3,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.prompts).toEqual(["Usable one", "Usable two"]);
+      expect(result.current.isFallback).toBe(false);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  test("falls back to the static set when every adaptive entry has empty text", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            prompts: [
+              { id: "library:a", text: "", provenance: "library" },
+              { id: "library:b", text: "", provenance: "library" },
+            ],
+            total: 2,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // The fallback decision keys off the POST-filter length, not the raw
+      // response length — an all-blank response collapses to the static set.
+      expect(result.current.prompts).toEqual([...STATIC_STARTER_PROMPTS]);
+      expect(result.current.isFallback).toBe(true);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  test("falls back to the static set on cold-start (empty 200)", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(JSON.stringify({ prompts: [], total: 0 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.prompts).toEqual([...STATIC_STARTER_PROMPTS]);
+      expect(result.current.isFallback).toBe(true);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  test("falls back to the static set when the backend 5xx soft-fails to []", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(JSON.stringify({ error: "boom", requestId: "r-1" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.prompts).toEqual([...STATIC_STARTER_PROMPTS]);
+      expect(result.current.isFallback).toBe(true);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  test("falls back to the static set when the request 4xx throws", async () => {
+    const fetchStub = stubFetch(
+      () =>
+        new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    try {
+      const { result } = renderHook(() => useSuccessStarterPrompts(), {
+        wrapper: buildWrapper(newClient()),
+      });
+
+      // 4xx rejects the query; the hook still surfaces the static fallback
+      // (a red banner on a celebratory success page is worse than offering
+      // sensible defaults). The hook retries once on failure, so wait for the
+      // query to fully settle (`loading` false) before asserting the final
+      // fallback — `isFallback` is true throughout (it's also the loading-state
+      // value), so it can't witness the settle on its own.
+      await waitFor(() => expect(result.current.loading).toBe(false), {
+        timeout: 3000,
+      });
+
+      expect(result.current.prompts).toEqual([...STATIC_STARTER_PROMPTS]);
+      expect(result.current.isFallback).toBe(true);
+      // The 4xx stays distinguishable from a benign cold-start via isError —
+      // it is not collapsed into isFallback.
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).toBeInstanceOf(Error);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+});

--- a/packages/web/src/ui/hooks/use-success-starter-prompts.ts
+++ b/packages/web/src/ui/hooks/use-success-starter-prompts.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { fetchStarterPrompts } from "@useatlas/sdk";
+import { useQuery } from "@tanstack/react-query";
+import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { STATIC_STARTER_PROMPTS } from "@/ui/lib/starter-prompt-fallback";
+
+const SUCCESS_STARTER_PROMPTS_LIMIT = 6;
+
+export interface UseSuccessStarterPromptsResult {
+  /** Prompt texts to offer — adaptive when available, static fallback otherwise. */
+  readonly prompts: readonly string[];
+  /** True while the adaptive list is still resolving (the static set is shown meanwhile). */
+  readonly loading: boolean;
+  /** True when `prompts` is the static fallback rather than the adaptive list. */
+  readonly isFallback: boolean;
+  /**
+   * True when the adaptive fetch rejected (a 4xx from the SDK — auth / rate
+   * limit / bad request). The page still shows the static fallback (a red
+   * banner on a celebratory surface is worse), but this keeps the failure
+   * distinguishable from a benign cold-start for any consumer that wants to
+   * react to it, rather than collapsing both into `isFallback`.
+   */
+  readonly isError: boolean;
+  /** The rejection reason when `isError`, else null. */
+  readonly error: Error | null;
+}
+
+/**
+ * Resolve the starter prompts to offer on the post-signup success page.
+ *
+ * The page lives in the main app's authenticated tree, so the adaptive
+ * resolver (`/api/v1/starter-prompts`) runs against the freshly-created
+ * workspace via the session cookie — the same source the in-chat empty state
+ * uses (#3935 §F4). When that resolver yields an empty list — a brand-new
+ * workspace whose semantic-layer library hasn't produced prompts yet, or a
+ * transient backend fault that soft-fails to `[]` (5xx) — we fall back to the
+ * shared static set so the page never shows an empty "try one of these"
+ * section.
+ *
+ * Returns plain prompt texts (not the provenance-tagged wire shape) because
+ * the success page only navigates with `?prompt=<text>` — it has no pin /
+ * unpin affordance, so the badges and namespaced ids are irrelevant here.
+ */
+export function useSuccessStarterPrompts(): UseSuccessStarterPromptsResult {
+  const apiUrl = getApiUrl();
+  const crossOrigin = isCrossOrigin();
+
+  const query = useQuery({
+    // Distinct from the in-chat `useStarterPromptsQuery` key
+    // (`["atlas", "starter-prompts", apiUrl]`): this hook authenticates via the
+    // session cookie with no Authorization header, so it must not share a cache
+    // entry with the header-driven chat query — same `apiUrl`, different request
+    // inputs. The extra `"success"` segment isolates the two.
+    queryKey: ["atlas", "starter-prompts", "success", apiUrl],
+    queryFn: ({ signal }) =>
+      fetchStarterPrompts({
+        apiUrl,
+        credentials: crossOrigin ? "include" : "same-origin",
+        // Cookie-authenticated session — no Authorization header to attach.
+        headers: {},
+        signal,
+        limit: SUCCESS_STARTER_PROMPTS_LIMIT,
+      }),
+    retry: 1,
+    staleTime: 60_000,
+  });
+
+  const adaptive = (query.data ?? [])
+    .map((p) => p.text)
+    // Guard the SDK trust boundary: `fetchStarterPrompts` casts the wire body
+    // without per-element validation, so a malformed entry could carry a
+    // non-string `text`. Drop anything that isn't a usable string rather than
+    // rendering a blank, zero-text prompt chip.
+    .filter((t): t is string => typeof t === "string" && t.length > 0);
+  const useAdaptive = adaptive.length > 0;
+
+  return {
+    prompts: useAdaptive ? adaptive : STATIC_STARTER_PROMPTS,
+    loading: query.isLoading,
+    isFallback: !useAdaptive,
+    isError: query.isError,
+    error: query.error,
+  };
+}

--- a/packages/web/src/ui/lib/starter-prompt-fallback.ts
+++ b/packages/web/src/ui/lib/starter-prompt-fallback.ts
@@ -1,0 +1,29 @@
+/**
+ * Static fallback starter prompts.
+ *
+ * The adaptive starter surface (`/api/v1/starter-prompts`) derives prompts
+ * from the connected workspace's semantic layer (the demo-industry library
+ * tier, favorites, and approved popular suggestions). When that resolver
+ * returns an empty list — a brand-new workspace whose semantic layer hasn't
+ * produced library prompts yet, or a transient backend fault that soft-fails
+ * to `[]` — surfaces that want a non-empty "try one of these" affordance fall
+ * back to this static set instead of showing nothing.
+ *
+ * The questions are drawn from the canonical NovaMart e-commerce question set
+ * (`eval/canonical-questions/questions.yml`, locked in #2021) — the same
+ * dataset the demo path and the cold-start audit (#3925 §F4) walk through, so
+ * the fallback matches the connected schema rather than the generic SaaS
+ * placeholders ("churn risk by plan tier") it replaces. They read sensibly as
+ * a first-question set for any commerce-shaped dataset.
+ *
+ * Shared so the success page (#3935) and the demo empty-state (#3936 / §F5)
+ * draw from one source rather than re-hardcoding divergent sets.
+ */
+export const STATIC_STARTER_PROMPTS = [
+  "What is our total GMV?",
+  "Who are our top customers by spend?",
+  "What is our revenue broken down by category?",
+  "How has our GMV changed by month?",
+  "What is our average order value?",
+  "How are our shipping carriers performing?",
+] as const;


### PR DESCRIPTION
## Summary

The post-signup `/signup/success` page hardcoded generic SaaS starter prompts (e.g. "Show me churn risk by plan tier") that don't fit the connected NovaMart e-commerce schema. This reuses the **same adaptive resolver the in-chat empty state uses** (`/api/v1/starter-prompts`, session-cookie auth) so the prompts derive from the connected workspace's semantic layer, with a **shared static fallback** for cold-start / not-yet-ready / transient-fault cases.

- **New `ui/lib/starter-prompt-fallback.ts`** — `STATIC_STARTER_PROMPTS`, drawn from the canonical NovaMart question set (`eval/canonical-questions/questions.yml`, #2021). Placed in a **reusable shared module** so #3936 (F5, demo empty-state) can share it rather than re-hardcoding a divergent set.
- **New `useSuccessStarterPrompts` hook** — adaptive fetch via the shared `fetchStarterPrompts` SDK helper + fallback. Uses a **distinct query key** (`["atlas","starter-prompts","success",apiUrl]`) since it authenticates via the session cookie with no `Authorization` header, and **surfaces `isError`** so a 4xx (auth/rate-limit) stays distinguishable from a benign cold-start rather than silently collapsing into the fallback.
- **`page.tsx`** swaps the hardcoded constant for the hook.

The static fallback prompts and the adaptive (library-tier) path both match the connected NovaMart e-commerce schema, per the audit walkthrough (`docs/development/cold-start-activation-audit.md` §F4).

## Coupling note (F5 / #3936)

Per the #3925 audit, F4 (this) and F5 (#3936) share the adaptive starter source and a static fallback set. The fallback lives in a standalone shared module (`STATIC_STARTER_PROMPTS`) so #3936 can import it directly. If #3936 lands first with its own shared fallback, that one should win and this can re-point.

## Test plan

- [x] `useSuccessStarterPrompts` hook tests — adaptive prompts present, cold-start (empty 200), 5xx soft-fail to `[]`, 4xx throw (asserts `isError`), empty-text filtering, all-empty collapse-to-fallback
- [x] `success/page.tsx` render test — prompts render as clickable rows; click navigates to `/?prompt=<encoded>` (precedent: `signup/region/page.test.tsx`)
- [x] Internal review panel (silent-failure, type-design, test-coverage, comment) — CLEAN; MEDIUM/LOW suggestions applied
- [x] `bun run lint` / `bun run type` clean; full test suite green (3 unrelated WSL2 sandbox-env false-failures, verified green under CI conditions)

Closes #3935

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive signup success page starter prompts from connected dataset via `useSuccessStarterPrompts`
> - Replaces the hardcoded `STARTER_PROMPTS` constant in [page.tsx](https://github.com/AtlasDevHQ/atlas/pull/3937/files#diff-412b473f977cc5278426c81070c3a061dfc9b9366a8aaf6ed65f39a694f328ec) with a new [`useSuccessStarterPrompts`](https://github.com/AtlasDevHQ/atlas/pull/3937/files#diff-3744d551c3e56338bdc960459378ba5ab076308146ef8e8fe29b87d1559f72bc) hook that fetches from `/api/v1/starter-prompts` using react-query.
> - The hook maps API responses to prompt texts, filtering empty entries, and falls back to [`STATIC_STARTER_PROMPTS`](https://github.com/AtlasDevHQ/atlas/pull/3937/files#diff-c6813857d0f5ca1b21b95358c1fc14db7f5bbc1add995b8ae49a3751f42b1b29) (six NovaMart commerce questions) when the adaptive list is empty or the request fails.
> - Exposes `loading`, `isFallback`, `isError`, and `error` state for consumers; uses a distinct query key to avoid sharing cache with the chat surface.
> - Behavioral Change: starter prompts on the success page are now dynamic and dataset-driven; users may see different prompts depending on their connected dataset and backend availability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1616dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->