### PR TITLE
feat(web): demo empty-state loading skeleton + cold-start fallback prompts (F5)

### DIFF
--- a/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Widget empty-state loading + cold-start fallback behavior (#3936 §F5).
+ *
+ * The adaptive starter-prompt list (`/api/v1/starter-prompts`) is generated
+ * server-side and can take ~15s on a cold semantic index. A first-time
+ * visitor must never face a bare "ask anything" empty state with no
+ * suggestions while that resolves — nor when it comes back empty (the
+ * server's cold-start signal). This file pins three guarantees:
+ *
+ *  1. While the fetch is in flight → skeleton chips render (no bare empty
+ *     state, no "ask your first question" dead-end).
+ *  2. Adaptive prompts replace the skeleton once they resolve.
+ *  3. An empty adaptive response (cold-start) falls back to the shared
+ *     static prompt set rather than rendering nothing.
+ *
+ * The `starterPrompts` override path already short-circuits the fetch (see
+ * atlas-chat.starter-prompts.test.tsx); it never sees the skeleton/fallback,
+ * which this file leaves to that suite.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { AtlasChat } from "../atlas-chat";
+import { DEFAULT_STARTER_PROMPT_TEXTS } from "../../lib/fallback-starter-prompts";
+
+let resolveStarter: ((res: Response) => void) | null = null;
+
+function makeFetch(starterBody: unknown | "pending") {
+  return function fetchImpl(input: string | URL | Request): Promise<Response> {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url.includes("/api/health")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ checks: { auth: { mode: "simple-key" } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("/api/v1/starter-prompts")) {
+      if (starterBody === "pending") {
+        // Never resolves on its own — the test drives it via resolveStarter.
+        return new Promise<Response>((resolve) => {
+          resolveStarter = resolve;
+        });
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(starterBody), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("/api/v1/branding")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ branding: { hideAtlasBranding: false } }), { status: 200 }),
+      );
+    }
+    return Promise.resolve(new Response(JSON.stringify({ error: "not_found" }), { status: 404 }));
+  };
+}
+
+const fetchMock = mock(makeFetch("pending"));
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  resolveStarter = null;
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("AtlasChat empty state — loading skeleton + cold-start fallback", () => {
+  it("renders skeleton chips while the adaptive list is in flight (no bare empty state)", async () => {
+    fetchMock.mockImplementation(makeFetch("pending"));
+    const { findAllByTestId, queryByText } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    const chips = await findAllByTestId("starter-prompt-skeleton", undefined, { timeout: 5_000 });
+    expect(chips.length).toBeGreaterThan(0);
+    // The dead-end copy must NOT show while we're still loading.
+    expect(queryByText("Ask your first question below to get started.")).toBeNull();
+  });
+
+  it("replaces the skeleton with adaptive prompts once they resolve", async () => {
+    fetchMock.mockImplementation(
+      makeFetch({
+        prompts: [{ id: "popular:1", text: "Top accounts by revenue", provenance: "popular" }],
+        total: 1,
+      }),
+    );
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    await findByText("Top accounts by revenue", undefined, { timeout: 5_000 });
+    // Skeleton is gone once real prompts land.
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+  });
+
+  it("falls back to the shared static prompts when the adaptive list resolves empty (cold-start)", async () => {
+    fetchMock.mockImplementation(makeFetch({ prompts: [], total: 0 }));
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    // Every shared fallback prompt renders rather than a bare dead-end.
+    await findByText(DEFAULT_STARTER_PROMPT_TEXTS[0], undefined, { timeout: 5_000 });
+    for (const text of DEFAULT_STARTER_PROMPT_TEXTS.slice(1)) {
+      await findByText(text);
+    }
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+  });
+
+  it("swaps skeleton → adaptive without ever showing the dead-end copy", async () => {
+    fetchMock.mockImplementation(makeFetch("pending"));
+    const { findAllByTestId, findByText, queryByText } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    await findAllByTestId("starter-prompt-skeleton", undefined, { timeout: 5_000 });
+    expect(queryByText("Ask your first question below to get started.")).toBeNull();
+
+    // Now let the in-flight request resolve with adaptive prompts.
+    await waitFor(() => expect(resolveStarter).not.toBeNull());
+    resolveStarter!(
+      new Response(
+        JSON.stringify({
+          prompts: [{ id: "library:1", text: "Cybersecurity threat trends", provenance: "library" }],
+          total: 1,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await findByText("Cybersecurity threat trends");
+    expect(queryByText("Ask your first question below to get started.")).toBeNull();
+  });
+});

--- a/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
@@ -5,7 +5,8 @@
  * server-side and can take ~15s on a cold semantic index. A first-time
  * visitor must never face a bare "ask anything" empty state with no
  * suggestions while that resolves — nor when it comes back empty (the
- * server's cold-start signal). This file pins three guarantees:
+ * server's cold-start signal). This file pins three guarantees (the final
+ * test exercises 1→2 end-to-end):
  *
  *  1. While the fetch is in flight → skeleton chips render (no bare empty
  *     state, no "ask your first question" dead-end).
@@ -24,7 +25,7 @@ import { DEFAULT_STARTER_PROMPT_TEXTS } from "../../lib/fallback-starter-prompts
 
 let resolveStarter: ((res: Response) => void) | null = null;
 
-function makeFetch(starterBody: unknown | "pending") {
+function makeFetch(starterBody: unknown | "pending", starterStatus = 200) {
   return function fetchImpl(input: string | URL | Request): Promise<Response> {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 
@@ -45,7 +46,7 @@ function makeFetch(starterBody: unknown | "pending") {
       }
       return Promise.resolve(
         new Response(JSON.stringify(starterBody), {
-          status: 200,
+          status: starterStatus,
           headers: { "Content-Type": "application/json" },
         }),
       );
@@ -138,5 +139,65 @@ describe("AtlasChat empty state — loading skeleton + cold-start fallback", () 
 
     await findByText("Cybersecurity threat trends");
     expect(queryByText("Ask your first question below to get started.")).toBeNull();
+  });
+
+  it("falls back to static prompts when the adaptive fetch 5xx-soft-fails (transient backend fault)", async () => {
+    // The SDK soft-fails a 5xx to an empty list, so the empty-state gate sees
+    // the same resolved-empty signal as a cold-start 200 — and must still
+    // render the fallback, not a bare dead-end. This is the most common way a
+    // real cold-start visitor hits an empty list (a backend hiccup), so it's
+    // the load-bearing regression guard for the PR's stated reason to exist.
+    fetchMock.mockImplementation(makeFetch({ error: "internal" }, 500));
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    await findByText(DEFAULT_STARTER_PROMPT_TEXTS[0], undefined, { timeout: 5_000 });
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+  });
+
+  it("falls back to static prompts when the adaptive fetch 4xx-throws (auth / rate limit)", async () => {
+    // A 4xx throws in the SDK → React Query error state, data: undefined →
+    // empty list once it settles (after the retry: 1 backoff, ~1s+). The
+    // empty state must degrade to the fallback rather than a dead-end, so a
+    // first-time visitor with an expired key / rate limit still gets prompts.
+    fetchMock.mockImplementation(makeFetch({ error: "unauthorized" }, 401));
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    // Longer timeout: the query only settles after the retry backoff.
+    await findByText(DEFAULT_STARTER_PROMPT_TEXTS[0], undefined, { timeout: 10_000 });
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+  });
+
+  it("override path never shows the skeleton, even on first paint", async () => {
+    // The override prop disables the fetch; the empty-state gate must short-
+    // circuit BOTH the skeleton and the fallback so the host owns its empty
+    // state. Guards against a future change that gates the skeleton on the
+    // disabled query's isPending (true) instead of isLoading.
+    fetchMock.mockImplementation(makeFetch("pending"));
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" starterPrompts={["Custom host prompt"]} />,
+    );
+
+    await findByText("Custom host prompt", undefined, { timeout: 5_000 });
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+  });
+
+  it("empty override array renders the dead-end copy (host opted out of suggestions)", async () => {
+    // `starterPrompts={[]}` is the ONLY path to the dead-end copy after this
+    // change — the adaptive path substitutes the static fallback instead. The
+    // host explicitly chose no suggestions, so we honor it rather than
+    // injecting the fallback.
+    fetchMock.mockImplementation(makeFetch("pending"));
+    const { findByText, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" starterPrompts={[]} />,
+    );
+
+    await findByText("Ask your first question below to get started.", undefined, { timeout: 5_000 });
+    expect(queryByTestId("starter-prompt-skeleton")).toBeNull();
+    // No fallback chips leaked in despite the empty list.
+    expect(queryByTestId("starter-prompt-cold-start")).toBeNull();
   });
 });

--- a/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
@@ -5,14 +5,19 @@
  * server-side and can take ~15s on a cold semantic index. A first-time
  * visitor must never face a bare "ask anything" empty state with no
  * suggestions while that resolves — nor when it comes back empty (the
- * server's cold-start signal). This file pins three guarantees (the final
- * test exercises 1→2 end-to-end):
+ * server's cold-start signal). This file pins the empty-state contract
+ * across every path. The three core guarantees:
  *
  *  1. While the fetch is in flight → skeleton chips render (no bare empty
  *     state, no "ask your first question" dead-end).
  *  2. Adaptive prompts replace the skeleton once they resolve.
  *  3. An empty adaptive response (cold-start) falls back to the shared
  *     static prompt set rather than rendering nothing.
+ *
+ * Plus the resolution-via-error and override paths: a 5xx soft-fail and a
+ * 4xx throw both degrade to the static fallback; the override prop owns its
+ * own empty state (no skeleton, no fallback, and an explicit `[]` keeps the
+ * dead-end copy rather than injecting suggestions).
  *
  * The `starterPrompts` override path already short-circuits the fetch (see
  * atlas-chat.starter-prompts.test.tsx); it never sees the skeleton/fallback,
@@ -174,8 +179,9 @@ describe("AtlasChat empty state — loading skeleton + cold-start fallback", () 
   it("override path never shows the skeleton, even on first paint", async () => {
     // The override prop disables the fetch; the empty-state gate must short-
     // circuit BOTH the skeleton and the fallback so the host owns its empty
-    // state. Guards against a future change that gates the skeleton on the
-    // disabled query's isPending (true) instead of isLoading.
+    // state. Guards the `!isOverridePath` short-circuit on the loading gate —
+    // a disabled React Query reports isPending: true, so dropping that guard
+    // (or gating on isPending) would leak the skeleton onto the override path.
     fetchMock.mockImplementation(makeFetch("pending"));
     const { findByText, queryByTestId } = render(
       <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" starterPrompts={["Custom host prompt"]} />,

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -675,8 +675,10 @@ function AtlasChatInner({
                       </div>
                       {starterPromptsLoading ? (
                         // Skeleton chips while the ~15s adaptive list loads.
-                        // Same grid + chip dimensions as the real prompts so
-                        // the swap is layout-shift-free (#3936 §F5).
+                        // Identical grid container + matching single-line chip
+                        // height (42px) as the real prompts, so the swap is
+                        // layout-shift-free for single-line prompts (a wrapping
+                        // adaptive prompt can still grow its row) (#3936 §F5).
                         <div
                           className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2"
                           aria-hidden="true"

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -21,6 +21,7 @@ import { ConversationSidebar } from "./conversations/conversation-sidebar";
 import { ChangePasswordDialog } from "./admin/change-password-dialog";
 import { useHealthQuery } from "../hooks/use-health-query";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
+import { DEFAULT_STARTER_PROMPTS } from "../lib/fallback-starter-prompts";
 import { Sun, Moon, Monitor, Star, TableProperties, Pin, Send } from "lucide-react";
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import {
@@ -480,7 +481,26 @@ function AtlasChatInner({
       provenance: "library" as const,
     }));
   }, [starterPromptsOverride]);
-  const starterPromptsList: StarterPrompt[] = overrideStarterPrompts ?? fetchedStarterPrompts;
+  // Empty-state prompt resolution (#3936 §F5). Two paths:
+  //
+  //  • Override path — the host passed a static `starterPrompts` prop. Render
+  //    exactly what they gave us (including `[]` → no suggestions); no fetch,
+  //    so no skeleton and no fallback. The host owns their empty state.
+  //
+  //  • Adaptive path — we fetch `/api/v1/starter-prompts`, which can take ~15s
+  //    on a cold semantic index. While in flight we render skeleton chips so a
+  //    first-time visitor never faces a bare "ask anything". When it resolves
+  //    empty (the server's cold-start signal), we substitute the shared static
+  //    fallback rather than a dead-end — adaptive rows replace it once present.
+  const isOverridePath = overrideStarterPrompts !== null;
+  const starterPromptsLoading = !isOverridePath && starterPromptsQuery.isLoading;
+  const starterPromptsList: StarterPrompt[] = isOverridePath
+    ? overrideStarterPrompts
+    : fetchedStarterPrompts.length > 0
+      ? fetchedStarterPrompts
+      : starterPromptsLoading
+        ? []
+        : [...DEFAULT_STARTER_PROMPTS];
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -653,7 +673,23 @@ function AtlasChatInner({
                           Ask a question about your data to get started
                         </p>
                       </div>
-                      {starterPromptsList.length > 0 ? (
+                      {starterPromptsLoading ? (
+                        // Skeleton chips while the ~15s adaptive list loads.
+                        // Same grid + chip dimensions as the real prompts so
+                        // the swap is layout-shift-free (#3936 §F5).
+                        <div
+                          className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2"
+                          aria-hidden="true"
+                        >
+                          {DEFAULT_STARTER_PROMPTS.map((prompt) => (
+                            <div
+                              key={prompt.id}
+                              data-testid="starter-prompt-skeleton"
+                              className="h-[42px] animate-pulse rounded-lg border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-800/50"
+                            />
+                          ))}
+                        </div>
+                      ) : starterPromptsList.length > 0 ? (
                         <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
                           {starterPromptsList.map((prompt) => {
                             const isFavorite = prompt.provenance === "favorite";
@@ -677,11 +713,13 @@ function AtlasChatInner({
                           })}
                         </div>
                       ) : (
-                        !starterPromptsQuery.isLoading && (
-                          <p className="max-w-sm text-center text-sm text-zinc-500 dark:text-zinc-500">
-                            Ask your first question below to get started.
-                          </p>
-                        )
+                        // Reached only on the override path with an explicit
+                        // empty list (`starterPrompts={[]}`) — the adaptive path
+                        // substitutes the static fallback above, so it never
+                        // lands here with nothing to show.
+                        <p className="max-w-sm text-center text-sm text-zinc-500 dark:text-zinc-500">
+                          Ask your first question below to get started.
+                        </p>
                       )}
                     </div>
                   )}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -61,10 +61,11 @@ export type {
   FavoriteStarterPrompt,
 } from "@useatlas/types/starter-prompt";
 
-// Shared cold-start fallback prompts — the static set the widget empty state
-// shows while the adaptive list loads / when it resolves empty (#3936 §F5).
-// Exported so the post-signup success page (#3935 §F4, not yet landed) can
-// adopt the same texts instead of its current divergent hardcoded copy.
+// Shared cold-start fallback prompts — the static NovaMart set the widget
+// empty state shows while the adaptive list loads / when it resolves empty
+// (#3936 §F5). Exported so the post-signup success page (#3935 §F4) draws
+// from this one source rather than re-hardcoding a divergent set; this
+// package is the only one both the widget and @atlas/web can import.
 export {
   DEFAULT_STARTER_PROMPTS,
   DEFAULT_STARTER_PROMPT_TEXTS,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -61,6 +61,15 @@ export type {
   FavoriteStarterPrompt,
 } from "@useatlas/types/starter-prompt";
 
+// Shared cold-start fallback prompts — the static set the widget empty state
+// shows while the adaptive list loads / when it resolves empty (#3936 §F5).
+// Exported so the post-signup success page (#3935 §F4) reuses the same texts
+// instead of maintaining a divergent copy.
+export {
+  DEFAULT_STARTER_PROMPTS,
+  DEFAULT_STARTER_PROMPT_TEXTS,
+} from "./lib/fallback-starter-prompts";
+
 // Cross-environment routing wire types — re-exported from @useatlas/types
 // so embedders writing a custom `executeSQL` tool renderer can read
 // `envContributions[]` (per-env row count + error + durationMs) from

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -63,8 +63,8 @@ export type {
 
 // Shared cold-start fallback prompts — the static set the widget empty state
 // shows while the adaptive list loads / when it resolves empty (#3936 §F5).
-// Exported so the post-signup success page (#3935 §F4) reuses the same texts
-// instead of maintaining a divergent copy.
+// Exported so the post-signup success page (#3935 §F4, not yet landed) can
+// adopt the same texts instead of its current divergent hardcoded copy.
 export {
   DEFAULT_STARTER_PROMPTS,
   DEFAULT_STARTER_PROMPT_TEXTS,

--- a/packages/react/src/lib/fallback-starter-prompts.ts
+++ b/packages/react/src/lib/fallback-starter-prompts.ts
@@ -12,9 +12,10 @@ import type { StarterPrompt } from "@useatlas/types/starter-prompt";
  *
  * Deliberately generic so they read sensibly against any business schema
  * (the success page after signup, the public demo, a fresh embed) without
- * promising a column that may not exist. Shared with the post-signup success
- * page (#3935 §F4) via `DEFAULT_STARTER_PROMPT_TEXTS` so the two cold-start
- * surfaces never drift apart.
+ * promising a column that may not exist. Exported as
+ * `DEFAULT_STARTER_PROMPT_TEXTS` so the post-signup success page (#3935 §F4,
+ * not yet landed — it currently hardcodes its own divergent copy) can adopt
+ * this set and keep the two cold-start surfaces from drifting apart.
  */
 export const DEFAULT_STARTER_PROMPT_TEXTS: readonly string[] = [
   "What are our top 10 customers by revenue?",

--- a/packages/react/src/lib/fallback-starter-prompts.ts
+++ b/packages/react/src/lib/fallback-starter-prompts.ts
@@ -1,0 +1,37 @@
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
+
+/**
+ * Static, schema-agnostic starter prompts shown when the adaptive set hasn't
+ * resolved (or comes back empty in a cold-start state).
+ *
+ * The adaptive list (`GET /api/v1/starter-prompts`) is generated server-side
+ * and can take ~15s on a cold semantic index. Until it lands — and whenever
+ * it lands empty — a first-time visitor must never face a bare "ask anything"
+ * with no suggestions (#3936, cold-start audit §F5). These prompts give the
+ * empty state something actionable to render immediately.
+ *
+ * Deliberately generic so they read sensibly against any business schema
+ * (the success page after signup, the public demo, a fresh embed) without
+ * promising a column that may not exist. Shared with the post-signup success
+ * page (#3935 §F4) via `DEFAULT_STARTER_PROMPT_TEXTS` so the two cold-start
+ * surfaces never drift apart.
+ */
+export const DEFAULT_STARTER_PROMPT_TEXTS: readonly string[] = [
+  "What are our top 10 customers by revenue?",
+  "Show me revenue trends over the last 12 months",
+  "Which products are selling the most this quarter?",
+  "How many new customers did we acquire last month?",
+] as const;
+
+/**
+ * The shared fallback set as `StarterPrompt` objects, ready to render in the
+ * widget empty state. Tagged `cold-start` provenance — these are the
+ * client-side stand-in for the server's (empty) cold-start tier, not a
+ * personalized list, so they render without the favorite pin marker.
+ */
+export const DEFAULT_STARTER_PROMPTS: readonly StarterPrompt[] =
+  DEFAULT_STARTER_PROMPT_TEXTS.map((text, idx) => ({
+    id: `fallback:${idx}`,
+    text,
+    provenance: "cold-start" as const,
+  }));

--- a/packages/react/src/lib/fallback-starter-prompts.ts
+++ b/packages/react/src/lib/fallback-starter-prompts.ts
@@ -1,8 +1,8 @@
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 
 /**
- * Static, schema-agnostic starter prompts shown when the adaptive set hasn't
- * resolved (or comes back empty in a cold-start state).
+ * Static fallback starter prompts shown when the adaptive set hasn't resolved
+ * (or comes back empty in a cold-start state).
  *
  * The adaptive list (`GET /api/v1/starter-prompts`) is generated server-side
  * and can take ~15s on a cold semantic index. Until it lands — and whenever
@@ -10,18 +10,25 @@ import type { StarterPrompt } from "@useatlas/types/starter-prompt";
  * with no suggestions (#3936, cold-start audit §F5). These prompts give the
  * empty state something actionable to render immediately.
  *
- * Deliberately generic so they read sensibly against any business schema
- * (the success page after signup, the public demo, a fresh embed) without
- * promising a column that may not exist. Exported as
- * `DEFAULT_STARTER_PROMPT_TEXTS` so the post-signup success page (#3935 §F4,
- * not yet landed — it currently hardcodes its own divergent copy) can adopt
- * this set and keep the two cold-start surfaces from drifting apart.
+ * Drawn from the canonical NovaMart e-commerce question set
+ * (`eval/canonical-questions/questions.yml`, locked in #2021) — the same
+ * dataset the public demo renders, so the fallback matches the connected
+ * schema rather than reading as a generic SaaS placeholder.
+ *
+ * Lives in `@useatlas/react` because it is the only package both consumers can
+ * import: the demo empty state renders through `<AtlasChat>` here, and the
+ * post-signup success page (`@atlas/web`, #3935 §F4) depends on this package.
+ * Putting it in `@atlas/web` would be unreachable from the widget. Exported as
+ * `DEFAULT_STARTER_PROMPT_TEXTS` so both cold-start surfaces draw from this one
+ * source instead of re-hardcoding divergent sets.
  */
 export const DEFAULT_STARTER_PROMPT_TEXTS: readonly string[] = [
-  "What are our top 10 customers by revenue?",
-  "Show me revenue trends over the last 12 months",
-  "Which products are selling the most this quarter?",
-  "How many new customers did we acquire last month?",
+  "What is our total GMV?",
+  "Who are our top customers by spend?",
+  "What is our revenue broken down by category?",
+  "How has our GMV changed by month?",
+  "What is our average order value?",
+  "How are our shipping carriers performing?",
 ] as const;
 
 /**


### PR DESCRIPTION
Closes #3936 (F5 from the #3925 cold-start activation audit, §F5).

## Problem
The demo chat empty state fetches adaptive starter prompts server-side (~15s on a cold semantic index). While that resolved — and whenever it resolved empty (the server's cold-start signal) — a first-time visitor briefly faced a bare "What would you like to know?" with no suggestions. That's the worst moment for a cold visitor to see nothing.

## Change
`<AtlasChat>` (in `@useatlas/react`, what `/demo` renders) now drives a three-state empty surface on the adaptive path:

- **in-flight** → skeleton chips (identical grid container + matching single-line chip height → layout-shift-free for single-line prompts)
- **resolved non-empty** → adaptive prompts replace the skeleton
- **resolved empty (cold-start) / 5xx soft-fail / 4xx throw** → shared static fallback prompts, never a bare dead-end

The **override path** (`starterPrompts` prop) is unchanged: no fetch, no skeleton, no fallback. An explicit `starterPrompts={[]}` still renders the "ask your first question" copy — the host opted out of suggestions, so we honor it.

### Shared fallback (coupling with #3935 / F4)
New module `packages/react/src/lib/fallback-starter-prompts.ts` exports `DEFAULT_STARTER_PROMPTS` / `DEFAULT_STARTER_PROMPT_TEXTS` (generic, schema-agnostic; tagged `cold-start` provenance so they render without the favorite pin). Re-exported from `@useatlas/react` so the post-signup success page (#3935 §F4, **not yet landed** — it currently hardcodes its own divergent copy) can adopt the same set and keep the two cold-start surfaces from drifting. If #3935 lands first with its own shared module, this can rebase onto theirs.

## Tests
New `atlas-chat.empty-state-fallback.test.tsx` (8 cases) pins the full matrix: skeleton-in-flight, adaptive-replaces-skeleton, cold-start-200-fallback, 5xx-soft-fail-fallback, 4xx-throw-fallback, skeleton→adaptive swap (no dead-end flash), override-skips-skeleton, empty-override-dead-end (no fallback leak). Sibling `atlas-chat.starter-prompts.test.tsx` (override-no-fetch + provenance) still green.

## Gates
Internal review panel: CLEAN (2 rounds — silent-failure + type-design clean throughout; round 1 closed comment-accuracy + test-coverage findings). Local CI: lint, type, syncpack, all drift checks, published-symbols, react isolated suite (12/12) — all green.

## Notes
- No scaffold-bound source value-imports the new export, so `check-published-symbols` passes. Per the version-bump-ordering rule, any `@atlas/web`/scaffold consumer of `DEFAULT_STARTER_PROMPT_TEXTS` should be sequenced after a `@useatlas/react` publish.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skeleton loading state and cold-start fallback prompts to `AtlasChat` empty state
> - While adaptive starter prompts are in-flight, the empty state renders skeleton chips (`data-testid="starter-prompt-skeleton"`) using the same layout as real chips to minimize layout shift.
> - When the adaptive fetch resolves empty or errors (5xx soft-fail or 4xx after retry), the empty state falls back to `DEFAULT_STARTER_PROMPTS`, a new static set of NovaMart prompts tagged with `provenance: cold-start`.
> - The override path (caller-provided prompts) bypasses the skeleton entirely; an explicit empty override array renders the dead-end copy with no fallback chips.
> - `DEFAULT_STARTER_PROMPTS` and `DEFAULT_STARTER_PROMPT_TEXTS` are now exported from the package public API for use by embedders (e.g. post-signup success page).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47f6a0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

## Update — convergence with #3937 (F4)
The sibling #3937 (F4) curated the same shared fallback from the canonical NovaMart question set (#2021) but placed it in `@atlas/web` (`packages/web/src/ui/lib/starter-prompt-fallback.ts`) — which the `@useatlas/react` widget that renders the demo empty state **cannot import** (web depends on react). This PR keeps the shared SSOT in `@useatlas/react` (the only package both consumers can import) and adopts the dataset-matched NovaMart prompt wording so the two cold-start surfaces don't drift. When #3937 lands, its success page can import `DEFAULT_STARTER_PROMPT_TEXTS` from `@useatlas/react` and drop its web-local copy (sequenced after a `@useatlas/react` publish per the version-bump rule).
