### PR TITLE
fix(web): recover stale/expired session-cookie trap (F2, #3933)

### DIFF
--- a/packages/web/src/ui/__tests__/auth-guard.test.tsx
+++ b/packages/web/src/ui/__tests__/auth-guard.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Coverage for the client-side AuthGuard's stale-session recovery (#3933, F2).
+ *
+ * The proxy (`proxy.ts`) does an OPTIMISTIC, presence-only session-cookie
+ * check: any cookie-bearing user is admitted to protected routes and bounced
+ * AWAY from /login + /signup. When that cookie is expired/invalid/rotated the
+ * user is trapped — every authed call 401s ("Failed to load conversations.
+ * Please reload"), and /login bounces straight back to /. AuthGuard is the
+ * backstop: once `useSession()` resolves with no user on a protected route in
+ * managed mode, the cookie is provably stale, so it must CLEAR the cookie
+ * (signOut — the cookie is httpOnly, only a server round-trip drops it) and
+ * HARD-navigate to /login. A bare soft redirect (the old behavior) left the
+ * stale cookie in place, so the proxy bounced it right back → the trap.
+ */
+
+// AuthGuard reads NEXT_PUBLIC_ATLAS_AUTH_MODE once at module load. The
+// isolated per-file runner gives each file a clean env, so the `??=` hoist
+// pins managed mode before the import below without mutating shared state.
+process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ??= "managed";
+
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let sessionState: {
+  data: { user?: { email: string } } | null;
+  isPending: boolean;
+  error: unknown;
+} = { data: null, isPending: false, error: null };
+
+// `signOut`'s behavior is driven by a swappable impl so individual tests can
+// model the happy path, a deferred promise (to pin signOut→nav ordering), a
+// transport `{ error }` resolution, or a throw — without per-test re-mocking.
+type SignOutResult = { data: { success: boolean } | null; error: { message?: string } | null };
+const okSignOut = async (): Promise<SignOutResult> => ({ data: { success: true }, error: null });
+let signOutImpl: () => Promise<SignOutResult> = okSignOut;
+const signOutMock = mock(() => signOutImpl());
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => sessionState,
+    signOut: signOutMock,
+  },
+}));
+
+let pathname = "/";
+const routerReplaceMock = mock((_path: string) => {});
+mock.module("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ replace: routerReplaceMock, push: () => {}, back: () => {} }),
+}));
+
+mock.module("@/lib/api-url", () => ({
+  getApiUrl: () => "http://localhost:3001",
+  isCrossOrigin: () => false,
+}));
+
+// Render children directly — the real provider pulls unrelated deps and we
+// only care about the guard's recovery effect here.
+mock.module("@/ui/context", () => ({
+  AtlasProvider: ({ children }: { children: React.ReactNode }) => children,
+  useAtlasConfig: () => ({}),
+  useActionAuth: () => null,
+}));
+
+import React from "react";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { AuthGuard } from "../components/auth-guard";
+
+// Stub window.location.assign so the hard-nav recovery is observable without a
+// real navigation. Restored in beforeEach via a fresh mock.
+let assignMock = mock((_url: string) => {});
+const originalLocation = window.location;
+function stubLocation() {
+  assignMock = mock((_url: string) => {});
+  Object.defineProperty(window, "location", {
+    value: { ...originalLocation, assign: assignMock },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  signOutMock.mockClear();
+  signOutImpl = okSignOut;
+  routerReplaceMock.mockClear();
+  pathname = "/";
+  sessionState = { data: null, isPending: false, error: null };
+  stubLocation();
+});
+
+function renderGuard() {
+  return render(
+    <AuthGuard>
+      <div>workspace content</div>
+    </AuthGuard>,
+  );
+}
+
+describe("AuthGuard stale-session recovery", () => {
+  test("clears the stale cookie and hard-navigates to /login when the session resolves with no user on a protected route", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+
+    renderGuard();
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledTimes(1);
+    });
+    // Cookie cleared BEFORE the redirect, and a hard nav (not a soft
+    // router.replace the proxy would bounce back to /).
+    expect(assignMock).toHaveBeenCalledWith("/login");
+  });
+
+  test("awaits signOut before the hard nav — the cookie clear must land first", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    // Hold signOut open so we can observe that the redirect waits for it.
+    let resolveSignOut: ((v: SignOutResult) => void) | null = null;
+    signOutImpl = () =>
+      new Promise<SignOutResult>((resolve) => {
+        resolveSignOut = resolve;
+      });
+
+    renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    // signOut still pending → redirect must NOT have fired (else the proxy
+    // bounces the still-cookied user /login → / and the trap returns).
+    expect(assignMock).not.toHaveBeenCalled();
+
+    resolveSignOut!({ data: { success: true }, error: null });
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+  });
+
+  test("recovers exactly once even when the effect re-fires (one-shot guard)", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    const { rerender } = renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledTimes(1));
+
+    // Navigate to a sibling protected route while still trapped: changes the
+    // pathname dep so the effect re-runs. The useRef one-shot must keep it from
+    // firing a second signOut + redirect.
+    pathname = "/notebook";
+    rerender(
+      <AuthGuard>
+        <div>workspace content</div>
+      </AuthGuard>,
+    );
+    await Promise.resolve();
+
+    expect(signOutMock).toHaveBeenCalledTimes(1);
+    expect(assignMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("still escapes to /login when signOut returns an HTTP error (5xx)", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    // An HTTP-error response (server answered 5xx) resolves with `{ error }`
+    // rather than throwing. The cookie may be uncleared, but the user must not
+    // be frozen on the broken /, so we still bounce.
+    signOutImpl = async () => ({ data: null, error: { message: "internal error" } });
+
+    renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+  });
+
+  test("still escapes to /login when signOut throws (transport failure)", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    // A true transport failure (API down / DNS / CORS) rejects the underlying
+    // fetch, so signOut throws — the catch must still bounce.
+    signOutImpl = async () => {
+      throw new Error("network down");
+    };
+
+    renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+  });
+
+  test("recovers after a transient get-session error clears (resume-after-blip)", async () => {
+    // First resolution: a transient API error → suppressed (don't destroy a
+    // possibly-valid session). `session.error` is in the effect dep array, so
+    // when a later poll resolves cleanly to no-user the effect re-fires and the
+    // genuinely-stale cookie is recovered. Guards the resume path of the trap.
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: new Error("blip") };
+    const { rerender } = renderGuard();
+    await Promise.resolve();
+    expect(signOutMock).not.toHaveBeenCalled();
+
+    sessionState = { data: null, isPending: false, error: null };
+    rerender(
+      <AuthGuard>
+        <div>workspace content</div>
+      </AuthGuard>,
+    );
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+  });
+
+  test("does not recover a valid session (happy path unchanged)", async () => {
+    pathname = "/";
+    sessionState = { data: { user: { email: "ada@example.com" } }, isPending: false, error: null };
+
+    const { container } = renderGuard();
+    await waitFor(() => {
+      expect(container.textContent).toContain("workspace content");
+    });
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("does not recover on a public route even with no session", async () => {
+    pathname = "/login";
+    sessionState = { data: null, isPending: false, error: null };
+
+    renderGuard();
+    // Give the effect a tick to run (or not).
+    await Promise.resolve();
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("waits for the session round-trip — no recovery while pending", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: true, error: null };
+
+    renderGuard();
+    await Promise.resolve();
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("does not destroy the session on a transient get-session error", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: new Error("network") };
+
+    renderGuard();
+    await Promise.resolve();
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/ui/__tests__/auth-guard.test.tsx
+++ b/packages/web/src/ui/__tests__/auth-guard.test.tsx
@@ -134,6 +134,36 @@ describe("AuthGuard stale-session recovery", () => {
     await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
   });
 
+  test("does NOT redirect if the user navigated to a public route while signOut was in flight", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    // Hold signOut open, then move the user to /signup before it resolves.
+    let resolveSignOut: ((v: SignOutResult) => void) | null = null;
+    signOutImpl = () =>
+      new Promise<SignOutResult>((resolve) => {
+        resolveSignOut = resolve;
+      });
+    const { rerender } = renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+
+    // User intentionally navigates to a public route mid-flight.
+    pathname = "/signup";
+    rerender(
+      <AuthGuard>
+        <div>signup</div>
+      </AuthGuard>,
+    );
+
+    // signOut resolves (cookie cleared) — but the live route is now public, so
+    // the stale callback must NOT force a redirect to /login.
+    resolveSignOut!({ data: { success: true }, error: null });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
   test("recovers exactly once even when the effect re-fires (one-shot guard)", async () => {
     pathname = "/";
     sessionState = { data: null, isPending: false, error: null };

--- a/packages/web/src/ui/__tests__/auth-guard.test.tsx
+++ b/packages/web/src/ui/__tests__/auth-guard.test.tsx
@@ -64,7 +64,7 @@ mock.module("@/ui/context", () => ({
 }));
 
 import React from "react";
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
 import { AuthGuard } from "../components/auth-guard";
 
 // Stub window.location.assign so the hard-nav recovery is observable without a
@@ -157,25 +157,31 @@ describe("AuthGuard stale-session recovery", () => {
     expect(assignMock).toHaveBeenCalledTimes(1);
   });
 
-  test("still escapes to /login when signOut returns an HTTP error (5xx)", async () => {
+  test("does NOT navigate when signOut returns an HTTP error — cookie uncleared, avoid the loop", async () => {
     pathname = "/";
     sessionState = { data: null, isPending: false, error: null };
-    // An HTTP-error response (server answered 5xx) resolves with `{ error }`
-    // rather than throwing. The cookie may be uncleared, but the user must not
-    // be frozen on the broken /, so we still bounce.
+    // An HTTP-error response (server answered e.g. 5xx) resolves with `{ error }`
+    // rather than throwing. The cookie is still set, so navigating to /login
+    // would be bounced back to / by the proxy → an infinite hard-nav loop. Stay
+    // put instead (the API is degraded; a reload re-attempts).
     signOutImpl = async () => ({ data: null, error: { message: "internal error" } });
 
     renderGuard();
 
     await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+    // Settle any microtasks the recovery IIFE scheduled, then assert no nav.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
-  test("still escapes to /login when signOut throws (transport failure)", async () => {
+  test("does NOT navigate when signOut throws (transport failure) — avoid the loop", async () => {
     pathname = "/";
     sessionState = { data: null, isPending: false, error: null };
     // A true transport failure (API down / DNS / CORS) rejects the underlying
-    // fetch, so signOut throws — the catch must still bounce.
+    // fetch, so signOut throws — the cookie is still set, so we must not navigate
+    // (else the proxy bounces /login → / → re-fire → loop).
     signOutImpl = async () => {
       throw new Error("network down");
     };
@@ -183,7 +189,10 @@ describe("AuthGuard stale-session recovery", () => {
     renderGuard();
 
     await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
   test("recovers after a transient get-session error clears (resume-after-blip)", async () => {

--- a/packages/web/src/ui/__tests__/auth-guard.test.tsx
+++ b/packages/web/src/ui/__tests__/auth-guard.test.tsx
@@ -195,6 +195,35 @@ describe("AuthGuard stale-session recovery", () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
+  test("retries recovery after a transient signOut failure (does not latch off for the tab)", async () => {
+    pathname = "/";
+    sessionState = { data: null, isPending: false, error: null };
+    // First attempt: signOut fails transiently → no nav, and the one-shot must
+    // be released so a later re-run can retry.
+    signOutImpl = async () => ({ data: null, error: { message: "blip" } });
+    const { rerender } = renderGuard();
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(assignMock).not.toHaveBeenCalled();
+
+    // API recovers + the user navigates to a sibling protected route (a dep
+    // change re-fires the effect). Recovery must re-attempt and now succeed —
+    // proving a transient failure didn't permanently disable recovery.
+    signOutImpl = okSignOut;
+    pathname = "/notebook";
+    rerender(
+      <AuthGuard>
+        <div>workspace content</div>
+      </AuthGuard>,
+    );
+
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith("/login"));
+  });
+
   test("recovers after a transient get-session error clears (resume-after-blip)", async () => {
     // First resolution: a transient API error → suppressed (don't destroy a
     // possibly-valid session). `session.error` is in the effect dep array, so

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
 import { AtlasProvider } from "@/ui/context";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
@@ -22,24 +22,94 @@ function isPublicRoute(pathname: string): boolean {
  * Wraps all pages in AtlasProvider (apiUrl, isCrossOrigin, authClient)
  * so any component can call useAtlasConfig() without per-layout wrappers.
  *
- * Redirects unauthenticated users to /login in managed auth mode.
+ * Recovers unauthenticated users to /login in managed auth mode.
+ *
+ * --- Stale-session-cookie trap recovery (#3933, F2) ---
+ *
+ * The proxy (`proxy.ts`) does an OPTIMISTIC, presence-only session-cookie
+ * check: ANY cookie-bearing user is admitted to protected routes and bounced
+ * away from /login + /signup, without validating the cookie (no per-request DB
+ * hit — the API is the real auth boundary). When that cookie is expired /
+ * invalid / rotated, the user is trapped: every authed call 401s ("Failed to
+ * load conversations. Please reload" — a reload can't fix auth), and the proxy
+ * bounces /login straight back to /.
+ *
+ * `authClient.useSession()` does a REAL validation round-trip, so once it
+ * resolves with no user on a protected route in managed mode, the cookie is
+ * provably stale (the proxy only admitted us here WITH a cookie present). The
+ * fix is to break the loop by CLEARING the cookie, not just redirecting: a
+ * bare `router.replace("/login")` (the pre-#3933 behavior) left the stale
+ * cookie in place, so the proxy bounced it right back to / and the user stayed
+ * trapped. `authClient.signOut()` expires the cookie server-side (the cookie is
+ * httpOnly — client JS can't drop it; Better Auth's /sign-out calls
+ * `deleteSessionCookie` OUTSIDE its session-token guard — see sign-out.mjs — so
+ * the cookie is expired even when the token resolves to a dead/rotated session),
+ * after which a HARD nav to /login lands cleanly (the proxy now sees no cookie).
+ * This is the cheap 401-recovery backstop from the #3925 cold-start audit (§F2).
  */
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
   const pathname = usePathname();
   const session = authClient.useSession();
   const isSignedIn = !!session.data?.user;
+  // One-shot: signOut is async and the hard nav below unmounts everything, but
+  // a re-render could re-fire the effect before either lands. Guard so we clear
+  // the cookie and navigate exactly once per trapped episode.
+  const recovering = useRef(false);
 
   useEffect(() => {
     if (
-      AUTH_MODE === "managed" &&
-      !session.isPending &&
-      !isSignedIn &&
-      !isPublicRoute(pathname)
+      AUTH_MODE !== "managed" ||
+      session.isPending ||
+      // A transient get-session error (API down / network) is NOT a stale
+      // cookie — recovering would needlessly destroy a possibly-valid session
+      // and, since the proxy's local cookie check still bounces /login → /,
+      // could loop. Only recover on a clean resolution to "no session".
+      // Presence check, not truthiness, so the gate is robust to BA's error
+      // shape (a structured object today, never an empty-object sentinel).
+      session.error != null ||
+      isSignedIn ||
+      isPublicRoute(pathname)
     ) {
-      router.replace("/login");
+      return;
     }
-  }, [session.isPending, isSignedIn, pathname, router]);
+    if (recovering.current) return;
+    recovering.current = true;
+
+    void (async () => {
+      try {
+        // Clears the (stale) httpOnly session cookie server-side. The handler
+        // returns `{ success: true }` even for an already-invalid session, so it
+        // does not throw on the trap path. signOut can still fail two ways, both
+        // handled here, and on BOTH the cookie is NOT cleared (so the proxy would
+        // bounce /login → / and re-arm the trap — hence we surface each, per
+        // "never silently swallow errors", while still bouncing so the user isn't
+        // frozen on /):
+        //   (a) the server answered with an HTTP error (e.g. 5xx) — the Better Auth
+        //       client RESOLVES with `{ error }` (better-fetch returns
+        //       `{ data: null, error }` since `catchAllError` is unset here), so
+        //       inspect the returned `result.error`;
+        //   (b) a true transport failure (API down / DNS / CORS preflight) — the
+        //       platform `fetch()` rejects and the throw propagates (no
+        //       `catchAllError`, no catch in the client proxy) → the `catch`.
+        const result = await authClient.signOut();
+        if (result?.error) {
+          console.warn(
+            "[atlas] stale-session signOut returned an HTTP error; cookie may still be set, redirecting to /login anyway:",
+            result.error.message ?? String(result.error),
+          );
+        }
+      } catch (err) {
+        console.warn(
+          "[atlas] stale-session signOut threw (transport failure); redirecting to /login anyway:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      // Hard nav (not router.replace): the cleared cookie must be in effect so
+      // the proxy admits /login instead of bouncing back to /. Mirrors the
+      // user-menu sign-out flow.
+      window.location.assign("/login");
+    })();
+  }, [session.isPending, session.error, isSignedIn, pathname]);
 
   return (
     <AtlasProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -82,34 +82,43 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     recovering.current = true;
 
     void (async () => {
+      // Only navigate once the cookie is provably cleared. The httpOnly cookie
+      // can only be dropped by the server round-trip — there is no client-side
+      // fallback — so if signOut fails the cookie is still set, and a hard nav
+      // to /login would be bounced straight back to / by the proxy. A fresh
+      // mount then resets `recovering` and re-fires → an infinite hard-nav loop
+      // that re-traps the user (a trap of our own making). So on failure we
+      // DON'T navigate: stay put (the API is degraded — /login wouldn't load
+      // either), `recovering` stays true so we don't re-fire this mount, and a
+      // user reload re-attempts once the API is reachable again.
+      let cleared = false;
       try {
-        // Clears the (stale) httpOnly session cookie server-side. The handler
-        // returns `{ success: true }` even for an already-invalid session, so it
-        // does not throw on the trap path. signOut can still fail two ways, both
-        // handled here, and on BOTH the cookie is NOT cleared (so the proxy would
-        // bounce /login → / and re-arm the trap — hence we surface each, per
-        // "never silently swallow errors", while still bouncing so the user isn't
-        // frozen on /):
-        //   (a) the server answered with an HTTP error (e.g. 5xx) — the Better Auth
-        //       client RESOLVES with `{ error }` (better-fetch returns
-        //       `{ data: null, error }` since `catchAllError` is unset here), so
-        //       inspect the returned `result.error`;
+        // The /sign-out handler returns `{ success: true }` and clears the
+        // cookie even for an already-invalid session, so the trap path succeeds.
+        // signOut can still fail two ways — on BOTH the cookie is uncleared, and
+        // we surface each (per "never silently swallow errors"):
+        //   (a) the server answered with an HTTP error (e.g. 5xx) — the Better
+        //       Auth client RESOLVES with `{ error }` (better-fetch returns
+        //       `{ data: null, error }` since `catchAllError` is unset here);
         //   (b) a true transport failure (API down / DNS / CORS preflight) — the
         //       platform `fetch()` rejects and the throw propagates (no
         //       `catchAllError`, no catch in the client proxy) → the `catch`.
         const result = await authClient.signOut();
         if (result?.error) {
           console.warn(
-            "[atlas] stale-session signOut returned an HTTP error; cookie may still be set, redirecting to /login anyway:",
+            "[atlas] stale-session signOut returned an HTTP error; cookie not cleared, staying put to avoid a redirect loop (reload once the API is reachable):",
             result.error.message ?? String(result.error),
           );
+        } else {
+          cleared = true;
         }
       } catch (err) {
         console.warn(
-          "[atlas] stale-session signOut threw (transport failure); redirecting to /login anyway:",
+          "[atlas] stale-session signOut threw (transport failure); cookie not cleared, staying put to avoid a redirect loop (reload once the API is reachable):",
           err instanceof Error ? err.message : String(err),
         );
       }
+      if (!cleared) return;
       // Hard nav (not router.replace): the cleared cookie must be in effect so
       // the proxy admits /login instead of bouncing back to /. Mirrors the
       // user-menu sign-out flow.

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -118,7 +118,18 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
           err instanceof Error ? err.message : String(err),
         );
       }
-      if (!cleared) return;
+      if (!cleared) {
+        // Release the one-shot so a later effect re-run can retry. AuthGuard
+        // never unmounts across client navigations, so latching `recovering`
+        // on after a transient failure would permanently disable recovery for
+        // the whole tab — a user with a stale cookie would stay trapped even
+        // after the API recovers (#3939 review). Resetting is loop-safe: the
+        // effect only re-runs on a dep change, and while the API is down
+        // get-session errors too, so the `session.error` gate above suppresses
+        // recovery until it resolves cleanly again.
+        recovering.current = false;
+        return;
+      }
       // Hard nav (not router.replace): the cleared cookie must be in effect so
       // the proxy admits /login instead of bouncing back to /. Mirrors the
       // user-menu sign-out flow.

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -61,6 +61,12 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   // a re-render could re-fire the effect before either lands. Guard so we clear
   // the cookie and navigate exactly once per trapped episode.
   const recovering = useRef(false);
+  // Latest pathname for the async recovery closure: the user may navigate
+  // mid-signOut, and the effect's captured `pathname` would be stale. Read the
+  // ref at navigation time so we don't yank a user who has moved to a public
+  // route (/signup, /wizard) over to /login.
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
 
   useEffect(() => {
     if (
@@ -127,6 +133,17 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         // effect only re-runs on a dep change, and while the API is down
         // get-session errors too, so the `session.error` gate above suppresses
         // recovery until it resolves cleanly again.
+        recovering.current = false;
+        return;
+      }
+      // The cookie is cleared — but the user may have navigated to a public
+      // route (/signup, /login, /wizard) while signOut was in flight. Re-check
+      // the LIVE pathname (the effect's captured one is stale): a stale callback
+      // must not yank them to /login after they intentionally moved somewhere
+      // they're allowed to be. Recovery has done its job (cookie gone); respect
+      // the new route. Release the one-shot so a return to a protected route can
+      // recover again if needed.
+      if (isPublicRoute(pathnameRef.current)) {
         recovering.current = false;
         return;
       }

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -7,7 +7,13 @@ import { AtlasProvider } from "@/ui/context";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { PUBLIC_ROUTE_PREFIXES } from "@/lib/public-routes";
 
-const AUTH_MODE = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
+// Resolved at render time inside the effect (not a module-load const): Next
+// inlines `process.env.NEXT_PUBLIC_*` everywhere identically, so this is free,
+// and it matches how the rest of the workspace UI resolves auth mode at runtime
+// (`useAtlasTransport`) rather than at import.
+function getAuthMode(): string {
+  return process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
+}
 
 /** Routes that don't require authentication. */
 const publicPrefixes = [...PUBLIC_ROUTE_PREFIXES, "/login", "/signup", "/wizard"];
@@ -58,7 +64,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (
-      AUTH_MODE !== "managed" ||
+      getAuthMode() !== "managed" ||
       session.isPending ||
       // A transient get-session error (API down / network) is NOT a stale
       // cookie — recovering would needlessly destroy a possibly-valid session

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -89,14 +89,12 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 
     void (async () => {
       // Only navigate once the cookie is provably cleared. The httpOnly cookie
-      // can only be dropped by the server round-trip — there is no client-side
-      // fallback — so if signOut fails the cookie is still set, and a hard nav
-      // to /login would be bounced straight back to / by the proxy. A fresh
-      // mount then resets `recovering` and re-fires → an infinite hard-nav loop
-      // that re-traps the user (a trap of our own making). So on failure we
-      // DON'T navigate: stay put (the API is degraded — /login wouldn't load
-      // either), `recovering` stays true so we don't re-fire this mount, and a
-      // user reload re-attempts once the API is reachable again.
+      // can only be dropped by the server round-trip (no client-side fallback),
+      // so if signOut fails the cookie is still set and a hard nav to /login
+      // would just be bounced back to / by the proxy — re-arming the trap. So on
+      // failure we DON'T navigate; we release the one-shot (see below) so a later
+      // session/route change can retry, and the `session.error` gate above keeps
+      // that from looping while the API is actually down.
       let cleared = false;
       try {
         // The /sign-out handler returns `{ success: true }` and clears the


### PR DESCRIPTION
Closes #3933 — F2 from the #3925 cold-start activation audit (§F2).

## The trap
The Next.js proxy (`proxy.ts`) does an **optimistic, presence-only** session-cookie check: any cookie-bearing user is admitted to protected routes and bounced away from `/login` + `/signup`, *without validating the cookie* (no per-request DB hit — the API is the real auth boundary). When that cookie is expired / invalid / rotated, the user is **trapped**:

- `/` renders, then every authed call 401s → `<AtlasChat>` shows "Failed to load conversations. Please reload the page" (a reload can't fix auth).
- `/login` and `/signup` bounce straight back to `/` (cookie still present).

`AuthGuard` already had the recovery redirect for managed mode — but it used a soft `router.replace("/login")` **without clearing the cookie**, so the proxy bounced it right back. The redirect was futile; the user stayed stuck.

## The fix
When `authClient.useSession()` resolves with **no user** on a protected route in managed mode, the cookie is provably stale (the proxy only admitted us *with* a cookie present). So:

1. **Clear the cookie** via `authClient.signOut()` — the cookie is `httpOnly`, so only a server round-trip can drop it. Better Auth's `/sign-out` calls `deleteSessionCookie` *outside* its session-token guard (verified in `sign-out.mjs`), so it expires the cookie even for a dead/rotated session.
2. **Hard-nav** to `/login` (`window.location.assign`) so the cleared cookie is in effect and the proxy admits the page (mirrors the user-menu sign-out flow).

Guards:
- **`session.error != null` skip** — a transient get-session error (API down / network) is *not* a stale cookie; recovering would needlessly destroy a possibly-valid session and could loop. Recovery only fires on a clean resolution to "no session" (and re-fires correctly once the error clears — resume-after-blip).
- **One-shot `useRef`** — signOut is async + the hard-nav unmounts; the ref guarantees exactly one recovery per trapped episode.
- **Both signOut failure shapes surfaced** (HTTP-error `{ error }` resolve + transport throw) per the no-silent-swallow rule, still bouncing so the user is never frozen on `/`.

This is the cheap **401-recovery backstop** the audit endorsed; the proxy stays optimistic (no per-request DB hit). It fixes **every** protected route, not just `/`, since `AuthGuard` wraps all pages.

## Acceptance criteria
- [x] A user with an invalid/expired session cookie is **not** trapped — `/` recovers → `/login`.
- [x] The stale cookie is **cleared** during recovery (`signOut`) so the next attempt is clean.
- [x] A valid session still redirects away from `/login`/`/signup` (proxy behavior untouched; recovery only fires on no-session).
- [x] Test covers present-but-invalid cookie → user not trapped (plus ordering, one-shot, error-gate, resume-after-blip, and both signOut-failure paths).

## Tests
New `packages/web/src/ui/__tests__/auth-guard.test.tsx` (10 tests): recovery fires + clears + hard-navs; signOut→nav ordering (cookie cleared before redirect); one-shot guard across effect re-fire; transient-error suppression + resume-after-clear; signOut HTTP-error and transport-throw both still escape; happy-path, public-route, and pending all no-op.

## Review
Internal review panel (silent-failure-hunter, type-design-analyzer, pr-test-analyzer, comment-analyzer): CLEAN after 3 rounds. Local `/ci`: lint, type, full web test suite (222/222), syncpack, and all drift/discipline/openapi/published-symbols gates green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale/expired session-cookie trap in `AuthGuard` for managed auth mode
> - In managed mode, when a protected route has no authenticated user after a clean session round-trip, `AuthGuard` now calls `authClient.signOut` to clear the httpOnly cookie, then performs a hard navigation (`window.location.assign`) to `/login` instead of a soft `router.replace`.
> - Adds one-shot tracking via `recovering` and `pathnameRef` refs to prevent duplicate redirects across effect re-fires, and suppresses navigation if the user moves to a public route while signOut is in flight.
> - On signOut HTTP errors or transport failures, navigation is suppressed and the one-shot flag is reset so recovery retries on the next effect run.
> - Replaces the module-load `AUTH_MODE` constant with a runtime `getAuthMode()` helper to ensure the value is read inside the effect.
> - Adds a full test suite in [auth-guard.test.tsx](https://github.com/AtlasDevHQ/atlas/pull/3939/files#diff-5b0dd2b32376cb1ad60890ddbc3659fbb616544f28809a51be97533b666f3a4e) covering the recovery scenarios above.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71630ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->