### PR TITLE
fix(api): demo-onboard composer dead-end — seed demo semantic layer as published (#3932)

### DIFF
--- a/docs/development/cold-start-activation-audit.md
+++ b/docs/development/cold-start-activation-audit.md
@@ -33,7 +33,7 @@ tag to confirm the flagged items are resolved.
 | 4c. Signup · region | `/signup/region` | ⚠️ dead-end on error | Auto-skips when no regions configured (200 `[]`); **traps the user when the regions API errors** (disabled Continue, only Back). |
 | 4d. Signup · connect | `/signup/connect` | ✅ clear | "Connect your database" + "Explore demo data" + "Skip for now". ![connect](./assets/cold-start-activation/funnel-04-signup-connect.png) |
 | 5. Success / trial | `/signup/success` | ✅ polished | Trial clearly communicated ("14-day free trial… no charges until you pick a plan"), starter prompts, secondary actions. ![success](./assets/cold-start-activation/funnel-05-signup-success.png) |
-| 6. Authed first-run | `/` (`(workspace)/page.tsx`) | ⛔ **composer dead-end** | After connecting the demo dataset, the chat shows "Connect data to get started" and **hides the composer** — see flagged finding F1. |
+| 6. Authed first-run | `/` (`(workspace)/page.tsx`) | ✅ fixed (#3932) | Was a composer dead-end after connecting the demo dataset; `/use-demo` now seeds the demo layer as `published` so the gate + agent see it — see F1. |
 
 The demo funnel reaches a real, high-quality first answer with zero signup. The
 authed funnel is polished step-to-step but has one blocking dead-end (F1) at the
@@ -135,6 +135,18 @@ publish status (its job is "is data connected?", not "what's published"); (b) th
 published-mode entity list includes entities backed by a published install;
 (c) `/use-demo` publishes the imported entities. Touches the content-mode system
 (ADRs / `docs/development/content-mode.md`) — not a safe polish change.
+
+**Resolution (#3932 → chose (c)).** Diagnosis corrected the "by design" framing
+above: a published *install* does **not** make draft entities visible in
+published mode — `listEntityRows(…, "published")` requires the **entity's own**
+`status='published'`, so the bug also hit the **agent's** whitelist (empty), not
+just the gate. (a) alone would therefore ship a worse dead-end (composer shows →
+agent has no tables); (b) leaks every workspace's WIP drafts into published mode.
+(c) wins: `/use-demo` now seeds the curated, read-only demo layer as `published`
+(`importFromDisk({ status: "published" })`), fixing the gate **and** the agent
+with zero blast radius elsewhere. Invariant recorded in
+[content-mode.md](content-mode.md) § *System-seeded content may be
+published-at-seed*; live-PG regression in `demo-publish-visibility-pg.test.ts`.
 
 ### F2 — P1: stale/expired-session cookie trap
 

--- a/docs/development/content-mode.md
+++ b/docs/development/content-mode.md
@@ -32,3 +32,19 @@ Partial failure rolls every table back — **never** stamp a content table's dra
 ## Carve-outs must be explicit and justified
 
 A table that bypasses mode (e.g. `user_favorite_prompts`, where pins are per-user and must never be a shared-workspace draft) needs a comment explaining why in the schema file. If in doubt, opt in: retrofitting mode after launch is painful.
+
+### System-seeded content may be published-at-seed (the `/use-demo` carve-out, #3932)
+
+The "promote only via the atomic publish endpoint" rule governs **human-authored drafts** (admin edits, profiler/wizard output) that need a review step before going live. **System-curated, read-only content with no review step** is a justified carve-out: it may be written directly at `status='published'` at seed time.
+
+The canonical case is the `/use-demo` onboarding seed. It imports the bundled demo semantic layer via `importFromDisk(orgId, { …, status: "published" })` (which threads `status` into `bulkUpsertEntities`), inside the same `withDemoSeedLock` transaction that flips the workspace's `__demo__` install to `published`.
+
+**Why published, not draft (the invariant decision behind #3932):** a fresh signup runs in `published` atlas-mode by default (no developer cookie). The published-mode entity read (`listEntityRows(…, "published")` — the source for **both** the chat data-setup gate **and** the agent's whitelist) requires the **entity's own** `status='published'`. A published *install* alone does **not** surface a draft entity. Seeded as drafts, the demo entities were invisible to the gate (→ "Connect data" prompt, composer hidden) **and** the agent (→ empty whitelist), dead-ending the brand-new user at the activation moment.
+
+Three fixes were weighed:
+
+- **(a)** Gate on install-presence instead of entity count — *rejected*: fixes only the gate, leaving the agent with an empty whitelist (a worse dead-end: composer shows, then the agent says it has no tables).
+- **(b)** Make published-mode reads surface any entity backed by a published install — *rejected*: widest blast radius; every workspace's in-progress draft entities would leak into published mode, weakening the core published-only invariant globally.
+- **(c) — chosen**: seed the demo entities as `published`. The demo layer *is* the customer's queryable layer for the demo datasource; it's read-only (`use-demo-readonly`) with no review step, so there is no draft to "promote later". This fixes the gate and the agent with **zero** change to any other workspace's draft/published semantics, and it removes the phantom "drafts pending publish" backlog the old behavior left in every demo org's `draftCounts`.
+
+The carve-out is bounded: only the `/use-demo` route passes `status: "published"`; `bulkUpsertEntities` / `importFromDisk` still default to `draft`, so the admin-import, wizard, profiler, and auth-migrate paths keep their review-then-publish workflow. The published upsert's `ON CONFLICT … WHERE status='published'` keeps re-seeding idempotent. Regression coverage: `lib/semantic/__tests__/demo-publish-visibility-pg.test.ts` (live-PG, pins published-visible / draft-invisible) plus the unit chain in `bulk-upsert-atomicity`, `semantic-sync`, and `onboarding` tests.

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -737,16 +737,21 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(params[3]).toBe("__demo__");   // install_id
   });
 
-  it("imports semantic entities with connectionId='__demo__'", async () => {
+  it("imports semantic entities with connectionId='__demo__' as PUBLISHED (#3932)", async () => {
     await request("/api/v1/onboarding/use-demo", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ demoType: "cybersec" }),
     });
 
+    // The demo layer is curated + read-only with no human-review step, so it
+    // seeds as `published` (not the import default `draft`). A fresh signup runs
+    // in published atlas-mode by default; draft entities would be invisible to
+    // both the chat data-setup gate AND the agent's published-mode whitelist,
+    // dead-ending the user at the activation moment (#3932).
     expect(mockImportFromDisk).toHaveBeenCalledWith(
       "org-1",
-      expect.objectContaining({ connectionId: "__demo__" }),
+      expect.objectContaining({ connectionId: "__demo__", status: "published" }),
     );
   });
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -800,10 +800,28 @@ onboarding.openapi(
         try: () => withDemoSeedLock(orgId, async (tx) => {
           // Phase 2 — import demo semantic entities on the transaction
           // connection so they commit (or roll back) with phase 3.
+          //
+          // Seed as `published`, not the import default `draft` (#3932). A fresh
+          // signup runs in `published` atlas-mode by default (no developer
+          // cookie), and the published-mode entity read requires the ENTITY's
+          // own `status='published'` — a published install alone does NOT surface
+          // draft entities. Left as drafts, the curated demo layer is invisible
+          // to BOTH the chat data-setup gate (`/semantic/entities` → 0 →
+          // composer hidden) AND the agent's published-mode whitelist (empty →
+          // "I have no tables"), dead-ending the user at the activation moment.
+          //
+          // CONTENT-MODE CARVE-OUT: this is the one place demo entities go live
+          // outside the atomic publish endpoint. Justified because the demo layer
+          // is system-curated and read-only (`use-demo-readonly`) with no
+          // human-review step — it is published-at-seed by design, the same way
+          // on-disk YAML entities are always treated as published. The published
+          // upsert's `ON CONFLICT ... WHERE status='published'` keeps the re-seed
+          // idempotent. See docs/development/content-mode.md.
           const importResult = await importFromDisk(orgId, {
             sourceDir: semanticDir,
             connectionId: DEMO_CONNECTION_ID,
             exec: tx.query,
+            status: "published",
           });
 
           if (importResult.total === 0) {

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -28,8 +28,9 @@ import * as path from "path";
 import type { SemanticEntityRow } from "../semantic/entities";
 
 const mockListEntities = mock((): Promise<SemanticEntityRow[]> => Promise.resolve([]));
-const mockBulkUpsertEntities = mock((_orgId: string, entities: unknown[]): Promise<number> =>
-  Promise.resolve(Array.isArray(entities) ? entities.length : 0),
+const mockBulkUpsertEntities = mock(
+  (_orgId: string, entities: unknown[], _exec?: unknown, _status?: "draft" | "published"): Promise<number> =>
+    Promise.resolve(Array.isArray(entities) ? entities.length : 0),
 );
 const mockHasInternalDB = mock((): boolean => true);
 const mockInternalQuery = mock((): Promise<Array<{ org_id: string }>> => Promise.resolve([]));
@@ -773,6 +774,31 @@ describe("importFromDisk", () => {
     expect(result.imported).toBe(1);
     // The mock bulkUpsertEntities doesn't check connectionId,
     // but we verify it doesn't error
+  });
+
+  it("threads status:'published' through to bulkUpsertEntities (#3932 demo seed)", async () => {
+    const orgId = testOrgId();
+    await syncEntityToDisk(orgId, "test", "entity", "table: test\n");
+
+    await importFromDisk(orgId, { connectionId: "__demo__", status: "published" });
+
+    // bulkUpsertEntities receives the status as its 4th positional arg, after
+    // (orgId, entities, exec). The demo seed relies on this to land the curated
+    // layer queryable in published mode (#3932).
+    const call = mockBulkUpsertEntities.mock.calls.at(-1);
+    expect(call?.[3]).toBe("published");
+  });
+
+  it("defaults bulkUpsertEntities to draft status when status is omitted", async () => {
+    const orgId = testOrgId();
+    await syncEntityToDisk(orgId, "test", "entity", "table: test\n");
+
+    await importFromDisk(orgId, { connectionId: "warehouse" });
+
+    // Omitting status preserves the review-then-publish default for the admin
+    // import / auth-migrate callers — they must keep landing drafts.
+    const call = mockBulkUpsertEntities.mock.calls.at(-1);
+    expect(call?.[3] ?? "draft").toBe("draft");
   });
 
   it("surfaces dbFailures when bulkUpsertEntities persists fewer rows than scanned (#3683)", async () => {

--- a/packages/api/src/lib/semantic/__tests__/bulk-upsert-atomicity.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/bulk-upsert-atomicity.test.ts
@@ -63,3 +63,83 @@ describe("bulkUpsertEntities — transactional atomicity (#3683)", () => {
     expect(calls).toBe(3);
   });
 });
+
+/**
+ * Status dispatch (#3932). `bulkUpsertEntities` writes `draft` rows by default
+ * (the admin import / wizard / profiler "review-then-publish" workflow), but the
+ * /use-demo seed threads `status: 'published'` so the curated, read-only demo
+ * layer lands queryable in published mode (the default mode for a fresh signup).
+ * Without this, the curated demo entities are stranded as drafts — invisible to
+ * both the chat data-setup gate AND the agent's published-mode whitelist,
+ * dead-ending the user at the activation moment.
+ *
+ * The injected `exec` records the INSERT so we can assert the inlined status
+ * literal without a real DB.
+ */
+describe("bulkUpsertEntities — status dispatch (#3932)", () => {
+  let savedDbUrl: string | undefined;
+
+  beforeEach(() => {
+    savedDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://fake:fake@localhost:5432/fake";
+  });
+
+  afterEach(() => {
+    if (savedDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedDbUrl;
+  });
+
+  function recordingExec(): { exec: <T extends Record<string, unknown>>(sql: string) => Promise<T[]>; sqls: string[] } {
+    const sqls: string[] = [];
+    const exec = async <T extends Record<string, unknown>>(sql: string): Promise<T[]> => {
+      sqls.push(sql);
+      return [] as T[];
+    };
+    return { exec, sqls };
+  }
+
+  it("defaults to draft rows when status is omitted", async () => {
+    const { exec, sqls } = recordingExec();
+    const n = await bulkUpsertEntities("org-1", rows, exec);
+
+    expect(n).toBe(3);
+    expect(sqls).toHaveLength(3);
+    for (const sql of sqls) {
+      expect(sql).toContain("'draft'");
+      expect(sql).not.toContain("'published'");
+    }
+  });
+
+  it("writes published rows when status='published' (demo seed)", async () => {
+    const { exec, sqls } = recordingExec();
+    const n = await bulkUpsertEntities("org-1", rows, exec, "published");
+
+    expect(n).toBe(3);
+    expect(sqls).toHaveLength(3);
+    for (const sql of sqls) {
+      expect(sql).toContain("'published'");
+      expect(sql).not.toContain("'draft'");
+    }
+  });
+
+  it("dispatches a group-scoped row to the PUBLISHED group helper (direct connection_group_id)", async () => {
+    const { exec, sqls } = recordingExec();
+    // A row carrying `connectionGroupId` directly (canonical groups/<group>/ or
+    // legacy <source>/ layout) must route to `upsertEntityForGroup`, not the
+    // flat `upsertEntity` install-resolution path.
+    const n = await bulkUpsertEntities(
+      "org-1",
+      [{ entityType: "entity", name: "orders", yamlContent: "table: orders\n", connectionGroupId: "eu_prod" }],
+      exec,
+      "published",
+    );
+
+    expect(n).toBe(1);
+    expect(sqls).toHaveLength(1);
+    expect(sqls[0]).toContain("'published'");
+    // Group-direct INSERT writes `connection_group_id` from $5 verbatim — it must
+    // NOT route through the install-resolving subquery the flat connectionId path
+    // uses, which is how we know the published *group* branch was selected.
+    expect(sqls[0]).not.toContain("COALESCE(config->>'group_id'");
+  });
+});

--- a/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
@@ -1,0 +1,192 @@
+/**
+ * LIVE-Postgres regression for the demo composer dead-end (#3932, F1).
+ *
+ * The bug: `/use-demo` imported the curated demo layer as `status='draft'` and
+ * relied on the published `__demo__` install to make it "visible". But the
+ * published-mode entity read (`listEntityRows(..., 'published')` — the source for
+ * BOTH the chat data-setup gate and the agent's whitelist) requires the ENTITY's
+ * OWN `status='published'`; a published install alone does NOT surface a draft
+ * entity. A fresh signup runs in `published` mode by default, so the curated demo
+ * tables were invisible to the gate (→ composer hidden) AND the agent (→ empty
+ * whitelist), dead-ending the user at the activation moment.
+ *
+ * The fix: seed the demo entities as `published` (this file's `seedDemo(...,
+ * "published")`). This test pins the exact SQL-level invariant the fix depends
+ * on — with the SAME published `__demo__` install, the ENTITY status is the
+ * lever:
+ *   • published entity → visible in published mode (gate count > 0 AND agent
+ *     whitelist non-empty);
+ *   • draft entity     → invisible in published mode (the original dead-end),
+ * which also proves the install-resolution chain: demo entities resolve
+ * `connection_group_id = COALESCE(config->>'group_id', install_id) = '__demo__'`
+ * (group-of-one), so published-mode visibility flows through the published-install
+ * branch of the `listEntityRows` visibility clause.
+ *
+ * Skips cleanly when `TEST_DATABASE_URL` is unset (CI sets it; opt in locally
+ * with `bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas`).
+ */
+
+import { afterAll, beforeAll, afterEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  internalQuery,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import { bulkUpsertEntities, listEntityRows } from "@atlas/api/lib/semantic/entities";
+import {
+  loadOrgWhitelist,
+  invalidateOrgWhitelist,
+  _resetOrgWhitelists,
+  _resetWhitelists,
+  _resetPluginEntities,
+} from "@atlas/api/lib/semantic/whitelist";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+if (!TEST_DB_URL) {
+  console.warn(
+    "demo-publish-visibility-pg: TEST_DATABASE_URL unset — skipping live demo published-mode visibility test (set it to opt in).",
+  );
+}
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+const DEMO_INSTALL = "__demo__";
+
+describeIfPg("demo seed → published-mode visibility (#3932)", () => {
+  let pool: Pool;
+  const schemaName = `demo_pub_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let prevDatabaseUrl: string | undefined;
+
+  /** Flatten the whitelist Map<connId, Set<table>> into one set of table names. */
+  const flatTables = (wl: Map<string, Set<string>>): Set<string> =>
+    new Set([...wl.values()].flatMap((s) => [...s]));
+
+  /**
+   * Reproduce the /use-demo seed for one org: a PUBLISHED `__demo__` datasource
+   * install (no `group_id` → group-of-one keyed under the install id) plus the
+   * curated entity imported at `status`. Returns the table name the entity
+   * declares (what the whitelist keys on).
+   */
+  async function seedDemo(orgId: string, status: "draft" | "published"): Promise<string> {
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at)
+       VALUES ($1, $2, 'catalog:demo-pg-3932', $3, 'datasource', $4::jsonb, true, 'published', NOW())
+       ON CONFLICT (workspace_id, catalog_id, install_id)
+         DO UPDATE SET status = 'published', config = EXCLUDED.config`,
+      [`${orgId}-${DEMO_INSTALL}`, orgId, DEMO_INSTALL, JSON.stringify({ db_type: "postgres" })],
+    );
+    const table = "demo_orders";
+    await bulkUpsertEntities(
+      orgId,
+      [{ entityType: "entity", name: table, yamlContent: `table: ${table}\ndescription: Demo orders\n`, connectionId: DEMO_INSTALL }],
+      internalQuery,
+      status,
+    );
+    return table;
+  }
+
+  beforeAll(async () => {
+    prevDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`demo-publish-visibility-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+
+    // Catalog FK target for the demo install rows.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:demo-pg-3932', 'Demo Postgres', 'demo-pg-3932', 'datasource', 'datasource', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterEach(() => {
+    _resetWhitelists();
+    _resetOrgWhitelists();
+    _resetPluginEntities();
+  });
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (prevDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDatabaseUrl;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`demo-publish-visibility-pg: schema cleanup failed: ${message}`);
+    });
+    await pool.end();
+  });
+
+  it("a PUBLISHED demo entity is visible in published mode — gate sees it AND the agent whitelists it", async () => {
+    const orgId = `org-pub-3932-${Math.floor(Math.random() * 1e6)}`;
+    const table = await seedDemo(orgId, "published");
+
+    // Sanity: the row landed as published, keyed under the group-of-one install.
+    const raw = await pool.query<{ status: string; cg: string | null }>(
+      `SELECT status, connection_group_id AS cg FROM semantic_entities WHERE org_id = $1 AND name = $2`,
+      [orgId, table],
+    );
+    expect(raw.rows[0]?.status).toBe("published");
+    expect(raw.rows[0]?.cg).toBe(DEMO_INSTALL);
+
+    // Gate: the published-mode entity list (what `use-datasource-summary` counts)
+    // includes the demo table → tableCount > 0 → composer shown.
+    const gateRows = await listEntityRows(orgId, "entity", "published");
+    expect(gateRows.map((r) => r.name)).toContain(table);
+
+    // Agent: the published-mode whitelist contains the demo table → the agent can
+    // answer the first question instead of "I have no tables".
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(flatTables(wl).has(table)).toBe(true);
+  });
+
+  it("a DRAFT demo entity stays invisible in published mode despite the published install (the original #3932 dead-end)", async () => {
+    const orgId = `org-draft-3932-${Math.floor(Math.random() * 1e6)}`;
+    const table = await seedDemo(orgId, "draft");
+
+    // The published install is present and published — but the ENTITY is a draft,
+    // so the published-mode read filters it out. This is exactly the state the
+    // fix moves away from: gate sees 0 (composer hidden) and the agent's
+    // whitelist is empty (dead-end).
+    const gateRows = await listEntityRows(orgId, "entity", "published");
+    expect(gateRows.map((r) => r.name)).not.toContain(table);
+
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(flatTables(wl).has(table)).toBe(false);
+
+    // ...and it IS reachable in developer mode (drafts overlay), proving the row
+    // persisted and the invisibility is purely the published-mode status gate.
+    invalidateOrgWhitelist(orgId);
+    const devWl = await loadOrgWhitelist(orgId, "developer");
+    expect(flatTables(devWl).has(table)).toBe(true);
+  });
+
+  it("re-seeding published is idempotent — ON CONFLICT upserts in place, no duplicate rows", async () => {
+    const orgId = `org-reseed-3932-${Math.floor(Math.random() * 1e6)}`;
+    const table = await seedDemo(orgId, "published");
+    // Second seed must not throw on the published partial unique index, and must
+    // not leave a second row — the idempotency the /use-demo comment relies on.
+    await seedDemo(orgId, "published");
+
+    const rows = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+         FROM semantic_entities
+        WHERE org_id = $1 AND name = $2 AND status = 'published'`,
+      [orgId, table],
+    );
+    expect(rows.rows[0]?.count).toBe("1");
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -238,11 +238,16 @@ export async function upsertEntity(
   name: string,
   yamlContent: string,
   connectionId?: string,
+  // Optional transaction-bound executor so a multi-entity import can commit
+  // atomically with its caller — the published sibling of the `exec` param on
+  // {@link upsertDraftEntity}, used by the /use-demo seed to land the curated
+  // demo layer published-and-queryable inside `withDemoSeedLock` (#3932).
+  exec: InternalQueryExecutor = internalQuery,
 ): Promise<void> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
-  await internalQuery(
+  await exec(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
      VALUES ($1, $2, $3, $4, ${inlineConnectionGroupSql("$5", "$1")}, 'published')
      ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'published'
@@ -273,11 +278,14 @@ export async function upsertEntityForGroup(
   name: string,
   yamlContent: string,
   connectionGroupId?: string | null,
+  // See {@link upsertEntity} — optional transaction-bound executor so a grouped
+  // published import commits atomically with its caller (#3932).
+  exec: InternalQueryExecutor = internalQuery,
 ): Promise<void> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
-  await internalQuery(
+  await exec(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
      VALUES ($1, $2, $3, $4, $5, 'published')
      ON CONFLICT (org_id, entity_type, name, ${coalescedScopeColumn(GROUP_COLUMN)}) WHERE status = 'published'
@@ -1624,6 +1632,14 @@ export async function bulkUpsertEntities(
   orgId: string,
   entities: Array<{ entityType: SemanticEntityType; name: string; yamlContent: string; connectionId?: string; connectionGroupId?: string | null }>,
   exec: InternalQueryExecutor = internalQuery,
+  // Content-mode status for the written rows. Defaults to `draft` — the
+  // review-then-publish workflow the wizard `/save`, admin import, profiler, and
+  // auth-migrate all rely on. The /use-demo seed passes `published` so its
+  // curated, read-only layer is queryable in published mode (the default mode
+  // for a fresh signup) without a manual publish step (#3932). Promoting drafts
+  // to live still flows only through the atomic publish endpoint; this is a
+  // documented carve-out for system-seeded content (see content-mode.md).
+  status: "draft" | "published" = "draft",
 ): Promise<number> {
   if (!hasInternalDB()) {
     throw new Error("Internal DB required for org-scoped semantic entities");
@@ -1634,17 +1650,25 @@ export async function bulkUpsertEntities(
   // transaction — partial commits are not on the table, so a row failure must
   // propagate rather than be counted as a skip.
   const atomic = exec !== internalQuery;
+  const published = status === "published";
 
   let upserted = 0;
   for (const e of entities) {
     try {
       // A group-scoped row (canonical `groups/<group>/` or legacy `<source>/`)
       // carries its group directly; the flat default dir keeps resolving the
-      // connection/install id through `inlineConnectionGroupSql` (#3245).
+      // connection/install id through `inlineConnectionGroupSql` (#3245). The
+      // status branch picks the published vs draft sibling — both keyed on their
+      // own partial unique index, so a re-run upserts the same-status row in
+      // place (idempotent demo re-seed).
       if (e.connectionGroupId !== undefined) {
-        await upsertDraftEntityForGroup(orgId, e.entityType, e.name, e.yamlContent, e.connectionGroupId, exec);
+        await (published ? upsertEntityForGroup : upsertDraftEntityForGroup)(
+          orgId, e.entityType, e.name, e.yamlContent, e.connectionGroupId, exec,
+        );
       } else {
-        await upsertDraftEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId, exec);
+        await (published ? upsertEntity : upsertDraftEntity)(
+          orgId, e.entityType, e.name, e.yamlContent, e.connectionId, exec,
+        );
       }
       upserted++;
     } catch (err) {

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -635,6 +635,13 @@ export async function importFromDisk(
      * where partial imports are tolerated and counted via `dbFailures`.
      */
     exec?: import("@atlas/api/lib/db/internal").InternalQueryExecutor;
+    /**
+     * Content-mode status for the imported rows. Defaults to `draft` (the
+     * admin-import / auth-migrate "review-then-publish" workflow). The /use-demo
+     * seed passes `published` so the curated, read-only demo layer is queryable
+     * in published mode for a fresh signup (#3932).
+     */
+    status?: "draft" | "published";
   },
 ): Promise<ImportResult> {
   const { bulkUpsertEntities } = await import("@atlas/api/lib/semantic/entities");
@@ -694,7 +701,7 @@ export async function importFromDisk(
     // On the transactional path (`options.exec` set) this throws on the first
     // row failure so the enclosing transaction rolls back — `dbFailures` below
     // is then unreachable and always 0 on the value that does return (#3683).
-    imported = await bulkUpsertEntities(orgId, entities, options?.exec);
+    imported = await bulkUpsertEntities(orgId, entities, options?.exec, options?.status ?? "draft");
   } finally {
     // Always invalidate — partial writes may have occurred
     invalidateOrgWhitelist(orgId);


### PR DESCRIPTION
## What & why

Closes #3932 — **P0 v0.1.0 launch blocker** (F1 from the #3925 cold-start audit).

After signup → **"Explore demo data"**, the authed home chat showed "Connect data to get started" and **hid the composer** — a dead-end at the exact activation moment, for a user who did everything right.

### Root cause (deeper than the issue framed it)

`/use-demo` imported the bundled demo semantic layer as `status='draft'` and flipped the `__demo__` install to `published`, on the belief that the published *install* makes draft entities visible. **It doesn't.** The published-mode entity read — `listEntityRows(…, "published")`, the source for **both** the chat data-setup gate **and** the agent's whitelist — requires the **entity's own** `status='published'`. A fresh signup runs in `published` atlas-mode by default (no developer cookie), so the draft demo entities were invisible to:

- the **gate** (`/api/v1/semantic/entities` → 0 → `tableCount===0` → `<ConnectDataPrompt>`, composer hidden), **and**
- the **agent** (`loadOrgWhitelist(…, "published")` → empty whitelist).

The agent failure was **latent** — masked by the gate hiding the composer first. So the issue's recommended fix (a) (gate-only) would have shipped a *worse* dead-end: composer shows → user asks → agent says it has no tables. Verified end-to-end against a live Postgres (see the regression test).

### Content-mode invariant decision: (c)

Picked **(c) — seed the demo entities as `published`** over (a)/(b), and recorded the rationale in [`docs/development/content-mode.md`](../blob/fix/3932-demo-composer-dead-end/docs/development/content-mode.md) § *System-seeded content may be published-at-seed* and in the audit doc's F1 resolution note:

- **(a)** gate-only → leaves the agent with an empty whitelist (worse dead-end). Rejected.
- **(b)** make published-mode reads surface any install-backed draft → widest blast radius; every workspace's WIP drafts would leak into published mode. Rejected.
- **(c)** the demo layer *is* the customer's queryable layer; it's read-only (`use-demo-readonly`) with no review step, so there's no draft to "promote later". Fixes gate **and** agent with **zero** change to any other workspace's draft/published semantics, and clears the phantom "drafts pending publish" the old behavior left in every demo org's `draftCounts`.

It's a **documented content-mode carve-out**: only `/use-demo` passes `status: "published"`; `bulkUpsertEntities` / `importFromDisk` still default to `draft`, so admin-import, wizard, profiler, and auth-migrate keep their review-then-publish workflow. The published upsert's `ON CONFLICT … WHERE status='published'` keeps the re-seed idempotent.

## Changes

- `entities.ts`: `bulkUpsertEntities` gains a trailing `status: "draft" | "published" = "draft"` and dispatches to the published vs draft upsert helpers; `upsertEntity` / `upsertEntityForGroup` gain the transaction `exec` param (mirroring the draft variants) so the published path commits inside `withDemoSeedLock`.
- `sync.ts`: `importFromDisk` options gain `status?: "draft" | "published"`, threaded to `bulkUpsertEntities`.
- `onboarding.ts`: `/use-demo` phase-2 import passes `status: "published"` with the carve-out comment.
- Docs: `content-mode.md` (invariant + carve-out), `cold-start-activation-audit.md` (F1 resolution; corrected the "published install makes drafts visible" framing).

## Tests

- **`demo-publish-visibility-pg.test.ts`** (new, live-PG, gated on `TEST_DATABASE_URL`) — pins the SQL-level invariant: with the **same published `__demo__` install**, a `published` demo entity is visible in published mode (gate `listEntityRows` **and** agent `loadOrgWhitelist`); a `draft` one is **not** (the original dead-end), and is reachable in developer mode (proving the row persisted). Plus an executed idempotent-re-seed assertion.
- `bulk-upsert-atomicity.test.ts` — status dispatch across all four quadrants {draft,published}×{flat,group}, via recorded SQL.
- `semantic-sync.test.ts` — `importFromDisk` threads `status` (both directions); default stays `draft`.
- `onboarding.test.ts` — `/use-demo` imports with `status: "published"`.

## Verification

- Internal `/review-panel` (4 specialists) converged CLEAN in 2 rounds.
- `bun run lint`, `bun run type`, OpenAPI-drift: green. Affected test graph + full api suite green (one unrelated dev-shell `VERCEL_*` sandbox false-failure, confirmed green with the var unset and in CI).

## AC status (#3932)

- [x] Composer shown + first question accepted after signup → explore-demo (gate + agent both see the layer; live-PG proof)
- [x] Content-mode fix (c) + rationale recorded; invariant documented
- [x] No regression to non-demo published/draft behavior (default stays `draft`; carve-out is `/use-demo`-only)
- [x] Test covers "connected published install with draft-only entities" — pinned in the live-PG test as the *negative* case (the dead-end), with (c) moving the demo onto the published path
- [ ] Playwright re-walk of signup→explore-demo→first-answer — covered at the SQL/whitelist level by the live-PG test; recommend a staging soak walk (main = staging) since the local SaaS funnel bring-up is heavy


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed demo semantic layer as published in `/use-demo` to fix composer dead-end
> - The `/api/v1/onboarding/use-demo` route previously seeded demo entities as drafts, making them invisible in published mode and causing the gate and agent to see an empty semantic layer.
> - `importFromDisk` and `bulkUpsertEntities` now accept a `status` parameter (`'draft'` | `'published'`), defaulting to `'draft'`; the demo onboarding path passes `status: 'published'`.
> - `upsertEntity` and `upsertEntityForGroup` accept an optional `exec` parameter to support running published upserts within a transaction.
> - A live-Postgres regression test in [`demo-publish-visibility-pg.test.ts`](https://github.com/AtlasDevHQ/atlas/pull/3940/files#diff-9ea3c24ed0ef14c8c7f66aa3a00eeba1d093ce4dec277875c5e7521771a0d3ab) verifies published-mode visibility and idempotent re-seeding.
> - Behavioral Change: only the `/use-demo` seed path writes `status='published'`; `bulkUpsertEntities` and `importFromDisk` still default to draft for all other callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9498beb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->