### PR TITLE
feat(api): configurable demo model — default Haiku on gateway (#3931)

### DIFF
--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -49,6 +49,10 @@ mock.module("@atlas/api/lib/db/connection", () => {
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // demo.ts (mounted via the app) statically imports getModelForConfig — it
+  // must be present so the mock links, even though the anthropic default
+  // resolves no demo override and never calls it. (#3931)
+  getModelForConfig: () => ({ model: {}, providerType: "anthropic", modelId: "claude-test" }),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -81,6 +81,10 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 mock.module("@atlas/api/lib/providers", () => ({
   getDefaultProvider: () => "anthropic",
+  // demo.ts (mounted via the app) statically imports getModelForConfig — it
+  // must be present so the mock links, even though the anthropic default
+  // resolves no demo override and never calls it. (#3931)
+  getModelForConfig: () => ({ model: {}, providerType: "anthropic", modelId: "claude-test" }),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -43,6 +43,7 @@ import {
   demoUserId,
   checkDemoRateLimit,
   getDemoMaxSteps,
+  demoRunAgentModelParams,
   captureDemoLead,
   countDemoConversations,
 } from "@atlas/api/lib/demo";
@@ -638,11 +639,17 @@ demo.openapi(demoChatRoute, async (c) => {
       }
 
       try {
+        // #3931 — demo turns run on the configured demo model (Haiku on the
+        // gateway by default); `demoRunAgentModelParams()` yields `{}` on a
+        // non-gateway deploy so runAgent resolves the platform default.
+        // Passing `aiModel` makes the demo model authoritative, so
+        // `token_usage.model`/`provider` reflect it.
         // Demo uses default tools only — no actions, no plugin tools
         const agentResult = await runAgent({
           messages,
           conversationId,
           maxSteps: getDemoMaxSteps(),
+          ...demoRunAgentModelParams(),
         });
 
         const stream = createUIMessageStream({

--- a/packages/api/src/lib/__tests__/demo-model.test.ts
+++ b/packages/api/src/lib/__tests__/demo-model.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, afterEach } from "bun:test";
+
+// #3931 — configurable demo model. getDemoModelId / resolveDemoAiModel read
+// process.env + the settings registry at call time, so no module-level mocking
+// is needed — set/restore the vars each test touches.
+const { getDemoModelId, demoRunAgentModelParams } = await import("@atlas/api/lib/demo");
+
+// ---------------------------------------------------------------------------
+// Env snapshot — capture/restore only the vars these tests touch
+// ---------------------------------------------------------------------------
+
+const origDemoModel = process.env.ATLAS_DEMO_MODEL;
+const origProvider = process.env.ATLAS_PROVIDER;
+const origModel = process.env.ATLAS_MODEL;
+const origVercel = process.env.VERCEL;
+const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
+const origGatewayKey = process.env.AI_GATEWAY_API_KEY;
+
+function restore(key: string, orig: string | undefined): void {
+  if (orig !== undefined) process.env[key] = orig;
+  else delete process.env[key];
+}
+
+afterEach(() => {
+  restore("ATLAS_DEMO_MODEL", origDemoModel);
+  restore("ATLAS_PROVIDER", origProvider);
+  restore("ATLAS_MODEL", origModel);
+  restore("VERCEL", origVercel);
+  restore("ATLAS_DEPLOY_MODE", origDeployMode);
+  restore("AI_GATEWAY_API_KEY", origGatewayKey);
+});
+
+// ---------------------------------------------------------------------------
+// getDemoModelId — pure model-id resolution (no SDK client built)
+// ---------------------------------------------------------------------------
+
+describe("getDemoModelId", () => {
+  test("unset + gateway provider → Haiku gateway model", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    process.env.ATLAS_PROVIDER = "gateway";
+    expect(getDemoModelId()).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("unset + gateway via SaaS deploy mode (no explicit provider) → Haiku", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    delete process.env.ATLAS_PROVIDER;
+    delete process.env.VERCEL;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    expect(getDemoModelId()).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("unset + non-gateway provider → null (platform default, no self-hosted regression)", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    process.env.ATLAS_PROVIDER = "anthropic";
+    expect(getDemoModelId()).toBeNull();
+  });
+
+  test("unset + no provider, no SaaS markers → null (self-hosted default is anthropic)", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    delete process.env.ATLAS_PROVIDER;
+    delete process.env.VERCEL;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    expect(getDemoModelId()).toBeNull();
+  });
+
+  test("ATLAS_DEMO_MODEL set → returned verbatim, overriding the provider default", () => {
+    process.env.ATLAS_DEMO_MODEL = "anthropic/claude-sonnet-4.6";
+    process.env.ATLAS_PROVIDER = "gateway";
+    expect(getDemoModelId()).toBe("anthropic/claude-sonnet-4.6");
+  });
+
+  test("ATLAS_DEMO_MODEL set → honored even on a non-gateway provider", () => {
+    process.env.ATLAS_DEMO_MODEL = "claude-haiku-4-5";
+    process.env.ATLAS_PROVIDER = "anthropic";
+    expect(getDemoModelId()).toBe("claude-haiku-4-5");
+  });
+
+  test("blank / whitespace-only ATLAS_DEMO_MODEL is treated as unset", () => {
+    process.env.ATLAS_DEMO_MODEL = "   ";
+    process.env.ATLAS_PROVIDER = "anthropic";
+    expect(getDemoModelId()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// demoRunAgentModelParams — the runAgent({ aiModel? }) fragment the demo route
+// spreads. Directly covers the inject-or-omit wiring (acceptance: demo turns
+// use the configured model via runAgent({ aiModel }); token_usage reflects it).
+// ---------------------------------------------------------------------------
+
+describe("demoRunAgentModelParams", () => {
+  test("gateway default → { aiModel } with the Haiku gateway model + gateway providerType", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    process.env.ATLAS_PROVIDER = "gateway";
+    process.env.AI_GATEWAY_API_KEY = "test-key"; // buildModel asserts presence, not validity
+
+    const params = demoRunAgentModelParams();
+    expect(params.aiModel).toBeDefined();
+    expect(params.aiModel?.modelId).toBe("anthropic/claude-haiku-4.5");
+    expect(params.aiModel?.providerType).toBe("gateway");
+  });
+
+  test("explicit ATLAS_DEMO_MODEL on gateway → { aiModel } with that model id", () => {
+    process.env.ATLAS_DEMO_MODEL = "anthropic/claude-sonnet-4.6";
+    process.env.ATLAS_PROVIDER = "gateway";
+    process.env.AI_GATEWAY_API_KEY = "test-key";
+
+    const params = demoRunAgentModelParams();
+    expect(params.aiModel?.modelId).toBe("anthropic/claude-sonnet-4.6");
+    expect(params.aiModel?.providerType).toBe("gateway");
+  });
+
+  test("non-gateway + unset → {} (no aiModel key; runAgent resolves the platform default)", () => {
+    delete process.env.ATLAS_DEMO_MODEL;
+    process.env.ATLAS_PROVIDER = "anthropic";
+
+    const params = demoRunAgentModelParams();
+    // Key genuinely absent (not present-as-undefined) so runAgent falls
+    // through to its own platform-default resolution.
+    expect("aiModel" in params).toBe(false);
+  });
+});

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -13,6 +13,8 @@ import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { getSettingAuto } from "@atlas/api/lib/settings";
+import { getDefaultProvider, getModelForConfig } from "@atlas/api/lib/providers";
+import type { AtlasAiModelShape } from "@atlas/api/lib/effect/ai";
 
 const log = createLogger("demo");
 
@@ -61,6 +63,55 @@ export function getDemoRpmLimit(): number {
     return DEMO_DEFAULT_RPM;
   }
   return Math.floor(n);
+}
+
+/**
+ * Default demo model on the gateway (SaaS) — Haiku, the cheapest tier. The
+ * curated NovaMart demo dataset de-risks a cheaper model on the top-of-funnel
+ * path. Keep in lockstep with the starter plan's `defaultModel`
+ * (`billing/plans.ts`) — both are the cheap gateway-Haiku default.
+ */
+const DEMO_DEFAULT_GATEWAY_MODEL = "anthropic/claude-haiku-4.5";
+
+/**
+ * Resolve the model id demo turns should run on, or `null` to use the platform
+ * default. (#3931)
+ *
+ * - `ATLAS_DEMO_MODEL` set (non-blank) → that model id, verbatim.
+ * - Unset + resolved provider is the gateway (SaaS) → the cheap Haiku gateway
+ *   model {@link DEMO_DEFAULT_GATEWAY_MODEL}.
+ * - Unset + non-gateway (self-hosted / BYO) → `null`: fall back to the platform
+ *   default, so a gateway-only model id can never break a non-gateway deploy.
+ *
+ * Provider resolution mirrors `providers.ts:resolveSelection`
+ * (`ATLAS_PROVIDER ?? getDefaultProvider()`) so the demo default tracks the
+ * same provider the platform would pick. Hot-reloadable: read per demo turn.
+ */
+export function getDemoModelId(): string | null {
+  // Platform-scoped settings registry (#3705): DB override > env > default ("").
+  const configured = getSettingAuto("ATLAS_DEMO_MODEL")?.trim();
+  if (configured) return configured;
+
+  const provider = process.env.ATLAS_PROVIDER ?? getDefaultProvider();
+  return provider === "gateway" ? DEMO_DEFAULT_GATEWAY_MODEL : null;
+}
+
+/**
+ * The `runAgent` params fragment that injects the demo model: `{ aiModel }`
+ * when a demo model resolves, else `{}` so `runAgent` resolves the platform
+ * default. Spread into the `runAgent({ ... })` call so the inject-or-omit
+ * decision is one testable unit rather than an inline ternary. (#3931)
+ *
+ * Passing `aiModel` makes the demo model authoritative, so `token_usage.model`
+ * / `provider` reflect it. Resolution failures propagate to the caller (the
+ * demo route's `classifyDemoError` maps a missing gateway key / unknown model
+ * to the same structured provider error the platform path raises) rather than
+ * silently falling back to a different — billed — model.
+ */
+export function demoRunAgentModelParams(): { aiModel?: AtlasAiModelShape } {
+  const modelId = getDemoModelId();
+  if (!modelId) return {};
+  return { aiModel: getModelForConfig(undefined, modelId) };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1032,6 +1032,24 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+  {
+    // #3931 — demo LLM override. The anonymous /demo path is top-of-funnel and
+    // an unbounded, unattributed cost center; this lets an operator pick a
+    // cheaper demo model without a redeploy. Blank ⇒ Haiku on the gateway
+    // (SaaS — the curated NovaMart dataset de-risks the cheaper model), else
+    // the platform default so a non-gateway deploy can never break. Resolved
+    // per demo turn via `getDemoModelId()`.
+    key: "ATLAS_DEMO_MODEL",
+    section: "Demo",
+    label: "Demo Model",
+    description:
+      "Model the public /demo path runs on — a gateway model id (e.g. anthropic/claude-haiku-4.5) or a direct model id matching the configured provider. Leave blank to default to Haiku on the gateway (SaaS) or the platform default on a non-gateway deploy.",
+    type: "string",
+    default: "",
+    envVar: "ATLAS_DEMO_MODEL",
+    scope: "platform",
+    saasVisible: false,
+  },
 
   // Abuse Prevention — anomaly-detection thresholds (lib/security/abuse.ts).
   // Hot-reloadable: `getAbuseConfig()` reads per query-event. Platform-only and


### PR DESCRIPTION
## Summary

PR1 of #3931 — makes the anonymous `/demo` LLM operator-configurable and cheap by default.

- The `/demo` path is our top-of-funnel activation surface and an **unbounded, unattributed cost center** — today it runs the full platform model (Sonnet 4.6 via gateway) with no demo-specific override. This wires in a configurable demo model, defaulting to **Haiku on the gateway** (the curated NovaMart dataset de-risks the cheaper model).
- **`ATLAS_DEMO_MODEL`** — new platform-scoped settings-registry knob (hot-reloadable, `saasVisible: false`), mirroring `ATLAS_DEMO_MAX_STEPS` / `ATLAS_DEMO_RATE_LIMIT_RPM`. Editable in `/platform/settings` immediately (~30s hot-reload, no redeploy).
- **`getDemoModelId()`** — configured `ATLAS_DEMO_MODEL` → else Haiku on the gateway (SaaS) → else `null` (platform default). Non-gateway deploys can never break on a gateway-only model id (no self-hosted regression). Provider resolution mirrors `providers.ts:resolveSelection`.
- **`demoRunAgentModelParams()`** — builds the `runAgent({ aiModel })` fragment via `getModelForConfig`, so `token_usage.model`/`provider` reflect the demo model. Resolution failures propagate to the route's `classifyDemoError` (structured provider error) rather than silently falling back to a different — billed — model.

Scoped to **model setting + demo-route wiring**. The `/platform/demo` tracking page + `latency_ms` persistence (which carries a schema migration) are deferred to **PR2**.

### Note on the health-test mock change
`demo.ts` (mounted via the app) now statically imports `getModelForConfig` from `providers`, so the app-mounting `health.test.ts` / `health-plugin.test.ts` providers mocks must export it too (the mock-all-exports rule). `--affected` misses these (the app→demo-route→demo.ts edge is too indirect); the full suite caught them.

## Test plan
- [x] `bun run lint` / `bun run type` / `bun x syncpack lint` — green
- [x] Full api suite green (the only 3 failures are the documented WSL2 sandbox-env false-failures — explore/python — verified green with `VERCEL_*` unset; green in CI)
- [x] All CI drift/discipline scripts pass (incl. `check-settings-readers` — `ATLAS_DEMO_MODEL` has a runtime reader)
- [x] New unit tests: `getDemoModelId` (gateway→Haiku, SaaS deploy-mode inference, non-gateway→null, explicit override, blank/whitespace) + `demoRunAgentModelParams` (gateway builds Haiku w/ gateway providerType, explicit override, non-gateway→`{}`)
- [ ] CI green on real Postgres

Part of #3931 (PR1 of 2 — model config). The issue stays open until PR2 (the /platform/demo tracking page + latency_ms migration) lands.

https://claude.ai/code/session_01UkyhLyy5uuE55ML3kBtBzx


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default demo chat to Claude Haiku on gateway provider
> - Adds `getDemoModelId` in [`demo.ts`](https://github.com/AtlasDevHQ/atlas/pull/3942/files#diff-0a4f8466d70a979d538aa3080eaed0a6d39d3e78e2903933cfa67e134f53e90d) to resolve a demo-specific model: returns `ATLAS_DEMO_MODEL` if set, `anthropic/claude-haiku-4.5` when the provider is `gateway`, or `null` to fall back to the platform default.
> - Adds `demoRunAgentModelParams` which spreads an `aiModel` into `runAgent` calls when a demo model resolves, wiring this into the [`demo` route handler](https://github.com/AtlasDevHQ/atlas/pull/3942/files#diff-8329061d476087ee84928405e812080e44a3e0e9319cbe36ed8069f4cd9e6556).
> - Registers `ATLAS_DEMO_MODEL` in the settings registry so it can be configured via environment or settings system.
> - Behavioral Change: demo chat runs on gateway deployments now use Haiku by default instead of the platform default model; `token_usage.model`/`provider` in responses will reflect this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5913aae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->