### PR TITLE
fix(web,api): F3 region-step resolution — retry copy + regions-error alert

### DIFF
--- a/docs/development/cold-start-activation-audit.md
+++ b/docs/development/cold-start-activation-audit.md
@@ -167,13 +167,58 @@ are skipped, and a failed clear releases the one-shot so a later route/session
 change retries (no loop, no permanent latch-off). Auth mode is resolved at
 render time.
 
-### F3 — P1: region auto-skip policy on API error
+### F3 — ✅ P1: region step policy on API error (#3934)
 
 The region step intentionally does **not** auto-skip when the regions API errors
 (only on an explicit "not configured" 200), to avoid pushing a user past a
-required residency pick during a transient failure. This PR adds a Retry button
-(safe). Whether a persistent error should eventually allow "continue without a
-region" is a residency-policy decision left for review.
+required residency pick during a transient failure. #3928 added a Retry button
+(safe). The open question was whether a *persistent* error should eventually
+allow "continue without a region."
+
+**Decision: block + Retry is correct — no "continue without a region" escape
+hatch.** The reasoning, grounded in how residency actually works:
+
+- **Skipping gains nothing on residency.** By the region step the workspace
+  already physically exists (created at `/signup/workspace`) on whatever
+  regional instance the user was routed to. While `organization.region` is NULL,
+  `resolveRegionDatabaseUrl` returns null and routing falls through to that same
+  home region — so an unassigned workspace already lives exactly where a "skip"
+  would leave it. The escape hatch would not move data anywhere safer.
+- **The only realistic error is transient and client-side.** The handler reads
+  residency config synchronously; the `not_configured` case returns a 200 (and
+  auto-skips). A genuine failure is a network/CORS/edge blip on the cross-origin
+  `app → api` fetch — which **Retry already resolves**.
+- **A *persistent* failure is a bug or a full-API outage, not a user state.** If
+  only `/regions` is broken while the rest of the API is healthy, that is a
+  defect to fix and alert on — not to route users around. If the whole API host
+  is down, the next steps (`assign-region`, `/connect`) are down too, so a skip
+  doesn't rescue the funnel; it defers the failure one step.
+- **Region is recoverable anyway.** Self-serve assignment is one-way (rejects
+  re-assignment), but region can be changed via the admin **cross-region
+  migration** flow (`POST /admin/residency/migrate`, rate-limited 1/30 days).
+  So nothing here is a one-way door — which argues *against* over-engineering a
+  signup escape, and against auto-guessing a region during an outage (we can't
+  even fetch the default region — it's the same failing endpoint).
+
+**Implemented (this PR).** Two small, launch-defensible changes instead of an
+escape hatch:
+
+1. **Honest persistent-error copy.** After ≥2 consecutive failed loads, the
+   region step swaps the generic "Unable to load region options" for a message
+   that names the likely cause and surfaces a **Contact support** path
+   (`mailto:support@useatlas.dev`) alongside Retry — no silent dead-end, no
+   blind skip. (`packages/web/src/app/signup/region/page.tsx`)
+2. **Alertable server event.** `GET /api/v1/onboarding/regions` now emits a
+   named `onboarding.regions_error` log event on any non-`not_configured`
+   failure, so a real prod occurrence is caught by monitoring rather than
+   discovered through a quietly-stuck signup. The realistic client-network mode
+   never reaches the server — it's covered by the retry copy and API uptime
+   monitoring. (`packages/api/src/api/routes/onboarding.ts`)
+
+Also corrected in passing: several stale "region is immutable once set" comments
+(`services.ts`, `ee/platform/residency.ts`, `db/internal.ts`, `admin-residency.ts`)
+that predated the cross-region migration flow — they now say "one-way via the
+assign path; changeable via admin migration."
 
 ### F4 — ✅ P2: success-page starter prompts don't match the dataset (#3935 → PR #3937)
 
@@ -213,5 +258,5 @@ skeleton, no fallback.
 - [x] Cold visitor reaches a real answer without a dead end — demo path verified;
       the authed-onboard path's blocking dead-end (F1) is now fixed (#3932)
 - [x] Judgment-heavy changes implemented conventionally + flagged (F1–F5).
-      Shipped since: F1 (#3932), F2 (#3933), F4 (#3935), F5 (#3936). Remaining:
-      F3 (#3934, region residency-policy decision) — still flagged for human review.
+      Shipped since: F1 (#3932), F2 (#3933), F4 (#3935), F5 (#3936),
+      F3 (#3934, region policy decided — block + Retry + alerting, no skip).

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -5,8 +5,11 @@
  * database URLs for connection routing. Access-gated via platformAdminAuth
  * middleware (platform_admin role required).
  *
- * Region assignment is immutable after creation — changing a workspace's
- * region requires data migration (separate future work).
+ * Region assignment is one-way via the self-serve/assign path: once a
+ * workspace has a region, re-assignment is rejected. Changing a region is a
+ * deliberate, operator-driven cross-region migration (`POST /admin/residency/
+ * migrate`, rate-limited to one per 30 days) that relocates the workspace's
+ * data — not a casual re-pick.
  *
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
@@ -174,7 +177,9 @@ export function getConfiguredRegions(): ResidencyConfig["regions"] {
 }
 
 /**
- * Assign a region to a workspace. Region is immutable once set.
+ * Assign a region to a workspace. One-way: rejects with `already_assigned`
+ * once a region is set — changing it goes through the admin cross-region
+ * migration flow (`POST /admin/residency/migrate`), not this path.
  */
 export const assignWorkspaceRegion = (
   workspaceId: string,

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -588,9 +588,10 @@ adminResidency.openapi(assignRegionRoute, async (c) => {
         }),
       );
       log.info({ orgId, region }, "Workspace region assigned via self-serve");
-      // Permanent decision — `permanent: true` surfaces the irreversibility
-      // on the audit row so triage flags it at read time rather than
-      // requiring reviewers to remember that residency is immutable.
+      // Irreversible via self-serve — `permanent: true` surfaces on the audit
+      // row that this assignment can't be undone through the assign path, so
+      // triage flags it at read time. (Changing it later is possible, but only
+      // via the deliberate operator cross-region migration flow below.)
       logAdminAction({
         actionType: ADMIN_ACTIONS.residency.workspaceAssign,
         targetType: "residency",

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -1122,6 +1122,18 @@ onboarding.openapi(getRegionsRoute, async (c) => {
       if (err instanceof ResidencyError && err.code === "not_configured") {
         return c.json({ configured: false, defaultRegion: "none", availableRegions: [] }, 200);
       }
+      // Alertable: in a configured managed deploy the regions lookup reads
+      // config synchronously and should never throw anything but
+      // `not_configured` (handled above). A non-`not_configured` failure here
+      // is the *only* server-side cause of the F3 signup dead-end, so emit a
+      // named event monitoring can key on instead of letting it blend into
+      // generic 500 noise. (The realistic client-network failure mode never
+      // reaches the server — it's covered by the region step's retry copy and
+      // API uptime monitoring.) (#3934)
+      log.error(
+        { event: "onboarding.regions_error", requestId, err: err instanceof Error ? err.message : String(err) },
+        "Onboarding regions lookup failed unexpectedly",
+      );
       throw err;
     }
   }), { label: "get onboarding regions" });

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2456,16 +2456,19 @@ export async function getWorkspaceRegion(orgId: string): Promise<string | null> 
 }
 
 /**
- * Assign a region to a workspace. Region is immutable — once set, returns
- * `{ assigned: false, existing: <current region> }` without updating.
- * On first assignment, returns `{ assigned: true }`. If the workspace
- * does not exist, returns `{ assigned: false }` without an `existing` field.
+ * Assign a region to a workspace. One-way: once set, returns
+ * `{ assigned: false, existing: <current region> }` without updating — this
+ * path never changes an existing region (that goes through the admin
+ * cross-region migration flow). On first assignment, returns
+ * `{ assigned: true }`. If the workspace does not exist, returns
+ * `{ assigned: false }` without an `existing` field.
  */
 export async function setWorkspaceRegion(
   orgId: string,
   region: string,
 ): Promise<{ assigned: boolean; existing?: string }> {
-  // Only assign if region is currently NULL (immutable after first assignment)
+  // Only assign if region is currently NULL — this path is one-way; an
+  // existing region is changed only via the admin cross-region migration flow.
   const rows = await internalQuery<{ id: string }>(
     `UPDATE organization SET region = $1, region_assigned_at = now()
      WHERE id = $2 AND region IS NULL RETURNING id`,

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1261,7 +1261,8 @@ export interface ResidencyResolverShape {
   readonly getDefaultRegion: () => string;
   /** Region-id → config map. Throws `ResidencyError("not_configured")` synchronously when no-op. */
   readonly getConfiguredRegions: () => ResidencyConfigRegions;
-  /** Assign a region to a workspace. Region is immutable once set. */
+  /** Assign a region to a workspace. One-way: rejects re-assignment once set —
+   * changing a region goes through the admin cross-region migration flow. */
   readonly assignWorkspaceRegion: (
     workspaceId: string,
     region: string,

--- a/packages/web/src/app/signup/region/page.test.tsx
+++ b/packages/web/src/app/signup/region/page.test.tsx
@@ -113,6 +113,26 @@ describe("RegionPage — load failure recovery (#3925)", () => {
       expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
     });
   });
+
+  test("a persistent load failure swaps in support copy + a Contact support link (#3934)", async () => {
+    fetchMock.mockImplementation(async () => regionsFailure());
+    render(<RegionPage />);
+
+    // First failure: generic copy, Retry only, no support escape yet.
+    const retry = await screen.findByRole("button", { name: /^retry$/i });
+    expect(screen.queryByRole("link", { name: /contact support/i })).toBeNull();
+
+    // Second failure (retry also fails) => persistent: copy + support path.
+    await act(async () => {
+      fireEvent.click(retry);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/still unable to load region options/i)).toBeDefined();
+    });
+    const support = screen.getByRole("link", { name: /contact support/i });
+    expect((support as HTMLAnchorElement).href).toContain("mailto:support@useatlas.dev");
+  });
 });
 
 describe("RegionPage — auto-skip when no residency configured", () => {

--- a/packages/web/src/app/signup/region/page.test.tsx
+++ b/packages/web/src/app/signup/region/page.test.tsx
@@ -68,6 +68,17 @@ function regionsUnconfigured(): Response {
   );
 }
 
+function regionsConfigured(): Response {
+  return new Response(
+    JSON.stringify({
+      configured: true,
+      defaultRegion: "us",
+      availableRegions: [{ id: "us", label: "United States", isDefault: true }],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
 beforeEach(() => {
   routerReplaceMock.mockReset();
   routerPushMock.mockReset();
@@ -132,6 +143,40 @@ describe("RegionPage — load failure recovery (#3925)", () => {
     });
     const support = screen.getByRole("link", { name: /contact support/i });
     expect((support as HTMLAnchorElement).href).toContain("mailto:support@useatlas.dev");
+  });
+
+  test("a successful load after failures clears the persistent copy — no leak into later errors (#3945)", async () => {
+    // Two failed /regions loads, then success — the persistent-outage copy must
+    // not survive the successful load (loadAttempts resets), so a later
+    // assign-region failure can't inherit the wrong message.
+    let regionsCalls = 0;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/onboarding/regions")) {
+        regionsCalls += 1;
+        return regionsCalls <= 2 ? regionsFailure() : regionsConfigured();
+      }
+      return regionsFailure();
+    });
+    render(<RegionPage />);
+
+    // Drive into the persistent state (initial load + one retry both fail).
+    const retry = await screen.findByRole("button", { name: /^retry$/i });
+    await act(async () => {
+      fireEvent.click(retry);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/still unable to load region options/i)).toBeDefined();
+    });
+
+    // Retry once more — this load succeeds; persistent copy + support link clear.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue with default region/i })).toBeDefined();
+    });
+    expect(screen.queryByText(/still unable to load region options/i)).toBeNull();
+    expect(screen.queryByRole("link", { name: /contact support/i })).toBeNull();
   });
 });
 

--- a/packages/web/src/app/signup/region/page.tsx
+++ b/packages/web/src/app/signup/region/page.tsx
@@ -70,6 +70,10 @@ export default function RegionPage() {
         setDefaultRegion(data.defaultRegion);
         // Pre-select the default region
         setSelected(data.defaultRegion);
+        // Reset on success so a later, unrelated failure (e.g. assign-region
+        // in handleContinue) doesn't inherit the "persistent load outage" copy
+        // — the count tracks region-*load* failures only.
+        setLoadAttempts(0);
         setLoading(false);
       })
       .catch((err: unknown) => {

--- a/packages/web/src/app/signup/region/page.tsx
+++ b/packages/web/src/app/signup/region/page.tsx
@@ -44,6 +44,10 @@ export default function RegionPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [skipping, setSkipping] = useState(false);
+  // Count consecutive load failures so a persistent outage swaps the generic
+  // "retry" copy for an honest support path instead of a silent dead-end
+  // (#3934). The initial load + one failed retry both failing => persistent.
+  const [loadAttempts, setLoadAttempts] = useState(0);
 
   const loadRegions = useCallback(() => {
     setLoading(true);
@@ -75,6 +79,7 @@ export default function RegionPage() {
         // transient failure can't push someone past a deploy's required region
         // pick. #3925 — pair the error with an in-place Retry so the user isn't
         // dead-ended on a disabled Continue with only the Back link.
+        setLoadAttempts((n) => n + 1);
         setError("Unable to load region options.");
         setLoading(false);
       });
@@ -168,20 +173,35 @@ export default function RegionPage() {
 
           {error && (
             <div role="alert" className="space-y-3 text-sm text-destructive">
-              <p>{error}</p>
+              <p>
+                {loadAttempts >= 2
+                  ? "We're still unable to load region options. This is usually a temporary network issue — retry, or contact support if it keeps happening."
+                  : error}
+              </p>
               {/* Load failure leaves no region to select, so Continue stays
                   disabled — offer an in-place retry instead of a dead end whose
-                  only escape is the Back link. (#3925) */}
+                  only escape is the Back link. After repeated failures the copy
+                  swaps to a support path so a persistent outage isn't a silent
+                  dead-end (#3934). (#3925) */}
               {regions.length === 0 && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={loadRegions}
-                  disabled={saving}
-                  className="w-full"
-                >
-                  Retry
-                </Button>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={loadRegions}
+                    disabled={saving}
+                    className="w-full"
+                  >
+                    Retry
+                  </Button>
+                  {loadAttempts >= 2 && (
+                    <Button asChild type="button" variant="ghost" className="w-full">
+                      <a href="mailto:support@useatlas.dev?subject=Trouble%20loading%20signup%20regions">
+                        Contact support
+                      </a>
+                    </Button>
+                  )}
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary

Resolves **F3** (#3934) from the cold-start activation audit (#3925) as part of v0.1.0 launch readiness.

**Decision: block + Retry is correct — no "continue without a region" escape hatch.** Grounded in how residency actually works: by the region step the workspace already physically lives in its home region (`organization.region` NULL → `resolveRegionDatabaseUrl` falls through to that same region), the only realistic error is a transient client-side fetch (which Retry handles), and a *persistent* failure is a bug to fix/alert on — not to route users around (if the API is down, the next steps are too).

- **web** — the region step swaps to honest copy + a **Contact support** path after ≥2 consecutive failed loads, instead of a generic disabled-Continue dead-end.
- **api** — `GET /onboarding/regions` emits a named `onboarding.regions_error` log event on any non-`not_configured` failure, so a real prod occurrence is caught by monitoring rather than discovered through a quietly-stuck signup.
- **comments** — corrected stale "region is immutable once set" comments (`services.ts`, `ee/platform/residency.ts`, `db/internal.ts`, `admin-residency.ts`) that predated the admin **cross-region migration** flow; they now say "one-way via the assign path; changeable via migration." Left the 409-response descriptions, which are contract-accurate.
- **docs** — decision + full rationale recorded in `docs/development/cold-start-activation-audit.md` §F3.

The end-to-end prod verification of all three regions is tracked separately in **#3943** (needs a prod release first + human-in-the-loop OTP).

## Test plan

- [x] `bun run lint` / `bun run type` — clean
- [x] Region-page tests pass incl. new persistent-failure coverage (4/4)
- [x] Onboarding route tests pass (61/61)
- [x] Affected-graph suite 312/312 (the 3 full-suite fails are the documented WSL2 sandbox-priority false-failures, unrelated to this diff)
- [x] All `/ci` drift + discipline gates pass

Closes #3934

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show persistent support link in signup region step after repeated load failures
> - The signup [region page](https://github.com/AtlasDevHQ/atlas/pull/3945/files#diff-78c4ffafdda5b3fd69fc9de0964ea74f34911fa6b3a23db7cf00221750e68243) now tracks consecutive load failures; after two failures it swaps generic error copy for a persistent-outage message with a 'Contact support' mailto link alongside the existing Retry button. The counter resets on a successful fetch.
> - The `getRegionsRoute` handler in [onboarding.ts](https://github.com/AtlasDevHQ/atlas/pull/3945/files#diff-e16db7a68e91bfeeddbc09fda46a076dd110636e532211e2d2c61cf30865250b) now emits a structured `onboarding.regions_error` log event (with `requestId` and error message) on unexpected region fetch failures before rethrowing; HTTP semantics are unchanged.
> - Audit docs and comments across the residency stack are updated to clarify that self-serve region assignment is one-way and re-assignment requires an operator-driven admin migration flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfbe2ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->