### PR TITLE
fix(api): drop "staging" from prod data-residency region picker (#3948)

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -1129,16 +1129,19 @@ export default defineConfig({
         databaseUrl: process.env.ATLAS_REGION_APAC_DB_URL!,
         apiUrl: "https://api-apac.useatlas.dev",
       },
-      // Staging arm — single-region soak environment. Per PRD #2894 it shares
-      // the prod NovaMart datasource but its own Postgres (DATABASE_URL). No
-      // real cross-region traffic ever claims residency="staging"; this arm
-      // exists so the SaaS region guard at saas-guards.ts:570 accepts
-      // ATLAS_API_REGION=staging without a hard-fail boot.
-      "staging": {
-        label: "Staging",
-        databaseUrl: process.env.DATABASE_URL!,
-        apiUrl: "https://api.staging.useatlas.dev",
-      },
+      // NO "staging" arm here — staging is NOT a prod residency region (#3948).
+      // The prod services (api/api-eu/api-apac) only ever claim us|eu|apac via
+      // ATLAS_API_REGION, so RegionGuardLive (lib/effect/saas-guards.ts) never
+      // needs a "staging" entry in THIS config to boot. The staging soak service
+      // is a SEPARATE Railway service that loads `deploy/api-staging/atlas.config.ts`
+      // (its Dockerfile/railway.json wiring lands in staging slices 19–22) — that
+      // file owns the single-region `{ staging }` map its own boot guard requires
+      // (ATLAS_API_REGION=staging). A "staging" entry leaking into this
+      // prod map is the bug it caused: `getConfiguredRegions()` returns the whole
+      // map verbatim, so the signup region picker (GET /api/v1/onboarding/regions
+      // → /signup/region) offered "Staging" as a selectable data-residency region
+      // to real prod users, who could route their workspace metadata to the
+      // staging Postgres. Keep staging scoped to the staging deploy only.
     },
   },
 });

--- a/packages/api/src/lib/__tests__/deploy-config-residency-regions.test.ts
+++ b/packages/api/src/lib/__tests__/deploy-config-residency-regions.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression: the production deploy config must NOT offer "staging" as a
+ * data-residency region (#3948).
+ *
+ * The bug: `deploy/api/atlas.config.ts` declared a `staging` arm in
+ * `residency.regions` alongside us/eu/apac. The onboarding `/regions`
+ * endpoint returns `getConfiguredRegions()` verbatim, so the signup region
+ * picker (`/signup/region`) offered "Staging" as a selectable residency
+ * region to real production users — who could then route their workspace
+ * metadata to the staging Postgres. Staging must stay scoped to the staging
+ * deploy only.
+ *
+ * Why parse the source rather than import the config: the deploy configs use
+ * container-root-relative imports (`./packages/api/src/lib/config`) that only
+ * resolve from `/app/` inside the SaaS image, so they cannot be `import()`-ed
+ * from a unit test. We extract the `residency.regions` keys from the source
+ * text instead — comments are stripped first so prose mentioning "staging"
+ * (the explanatory comment that replaced the removed arm) never counts as a
+ * region entry.
+ *
+ * Invariant pinned:
+ *   - prod  (`deploy/api/atlas.config.ts`):        regions == { us, eu, apac }
+ *   - staging (`deploy/api-staging/atlas.config.ts`): regions == { staging }
+ *
+ * The api-eu / api-apac Railway services reuse `deploy/api/atlas.config.ts`
+ * (only their `railway.json` differs), so this one prod assertion covers all
+ * three production regions.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const PROD_CONFIG = resolve(REPO_ROOT, "deploy/api/atlas.config.ts");
+const STAGING_CONFIG = resolve(REPO_ROOT, "deploy/api-staging/atlas.config.ts");
+
+/**
+ * Extract the region-id keys declared inside `residency.regions: { ... }`.
+ *
+ * A region entry is a quoted key whose value is an object literal
+ * (`"<id>": {`). The scan is brace-bounded to the `regions` object so
+ * unrelated later config (e.g. a `configSchema` key) can never leak in.
+ *
+ * Correctness against the test's own purpose (catching a future staging
+ * re-add) demands the parser never be fooled by characters that LOOK
+ * structural but aren't:
+ *   - `//` inside a URL string (`apiUrl: "https://api.staging..."`) must NOT
+ *     read as a line comment.
+ *   - `{` / `}` INSIDE a string value (a URL) must NOT be brace-counted.
+ *   - a quoted slug in COMMENT prose (this file's own "staging" tombstone)
+ *     must NOT be matched as a region key.
+ *
+ * Two offset-preserving copies of the source, same length as `src` so a single
+ * `[open, end]` range slices both:
+ *   - `braceScan`: string-literal INTERIORS and `//` line comments blanked to
+ *     spaces — used only to brace-match the `regions { … }` body. Region KEYS
+ *     survive as `""` (interior blanked, quotes kept), which is fine: we never
+ *     read keys off this copy, only braces, and a blanked URL can't inject one.
+ *   - `commentless`: ONLY `//` line comments blanked. Region KEYS stay intact;
+ *     URL string VALUES may be truncated at an embedded `//` (`"https:` + blank)
+ *     — harmless, because keys are matched by the `"<id>": {` shape, never by
+ *     URL content. A URL value never matches `"<id>": {` (it isn't followed by
+ *     `: {`), and comment prose is gone, so the only `"<slug>": {` matches are
+ *     real region entries.
+ *
+ * Guard against a non-inline re-add so a divergent shape fails LOUDLY instead
+ * of silently slipping a region past the assertion:
+ *   - `"staging": someConst` (referenced value) → caught by the quoted-key vs
+ *     object-key count mismatch below.
+ *   - `...someRegions` (spread) → caught by the explicit spread guard below
+ *     (a spread carries no quoted key, so the count check alone would miss it).
+ */
+function extractResidencyRegionKeys(filePath: string): string[] {
+  const src = readFileSync(filePath, "utf8");
+  const blank = (s: string) => " ".repeat(s.length);
+
+  // Copy used ONLY for brace-counting: blank string interiors (keep the quotes
+  // so offsets and the `""` shape survive) and `//` line comments.
+  const braceScan = src
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, (s) => `"${" ".repeat(s.length - 2)}"`)
+    .replace(/'(?:[^'\\\n]|\\.)*'/g, (s) => `'${" ".repeat(s.length - 2)}'`)
+    .replace(/\/\/[^\n]*/g, blank);
+
+  // Copy used ONLY for key extraction: strip `//` line comments, keep strings.
+  // (The deploy configs put `//` only at line-start or inside URL values — never
+  // as a trailing inline comment in the residency block — so blanking every
+  // `//`-to-EOL run also blanks the `//` in a URL, which is harmless here
+  // because keys are matched by the `"<id>": {` shape, never by URL content.)
+  const commentless = src.replace(/\/\/[^\n]*/g, blank);
+
+  const residencyIdx = braceScan.indexOf("residency:");
+  if (residencyIdx === -1) throw new Error(`No 'residency:' block in ${filePath}`);
+
+  const regionsIdx = braceScan.indexOf("regions:", residencyIdx);
+  if (regionsIdx === -1) throw new Error(`No 'regions:' in residency block of ${filePath}`);
+
+  // Brace-match (over `braceScan`) from the first `{` after `regions:` to its
+  // close so we only scan the regions object body.
+  const open = braceScan.indexOf("{", regionsIdx);
+  if (open === -1) throw new Error(`No '{' after 'regions:' in ${filePath}`);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < braceScan.length; i++) {
+    const ch = braceScan[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) throw new Error(`Unbalanced braces in regions object of ${filePath}`);
+  // Slice the SAME [open+1, end] range from the keys copy (identical offsets).
+  const regionsBody = commentless.slice(open + 1, end);
+
+  // Spread guard: a spread (`...someRegions`) injects regions with no quoted key,
+  // so the quoted-vs-object count check below can't see it. Refuse to validate a
+  // regions map that uses a spread — a spread could pull `staging` back in
+  // invisibly. The deploy configs declare every region inline; this fails loudly
+  // if that ever changes rather than silently under-reporting the region set.
+  if (/\.\.\./.test(regionsBody)) {
+    throw new Error(
+      `Spread operator in residency.regions of ${filePath} — this parser only ` +
+        `validates inline "<id>": { … } entries and cannot see regions pulled in ` +
+        `via a spread, which could hide a region from the residency assertion.`,
+    );
+  }
+
+  // Object-valued region entries: a quoted slug key immediately followed by `{`.
+  const objectKeys: string[] = [];
+  const objectRe = /["']([a-z0-9_-]+)["']\s*:\s*\{/gi;
+  let m: RegExpExecArray | null;
+  while ((m = objectRe.exec(regionsBody)) !== null) {
+    objectKeys.push(m[1]);
+  }
+
+  // Every quoted slug key directly under `regions`, regardless of value shape.
+  // If a future re-add uses a non-inline value (a referenced const or a
+  // spread), `quotedKeys` would exceed `objectKeys` — fail loudly rather than
+  // let the divergent entry slip the assertion below. Match quoted keys only at
+  // the start of an indented line so nested object keys (label/databaseUrl/
+  // apiUrl, none of which are quoted anyway) can't inflate the count.
+  const quotedKeys: string[] = [];
+  const keyRe = /(?:^|\n)\s*["']([a-z0-9_-]+)["']\s*:/gi;
+  while ((m = keyRe.exec(regionsBody)) !== null) {
+    quotedKeys.push(m[1]);
+  }
+  if (quotedKeys.length !== objectKeys.length) {
+    throw new Error(
+      `Quoted-key vs object-value mismatch in residency.regions of ${filePath} ` +
+        `(quoted keys [${quotedKeys.join(", ")}] vs object-valued ` +
+        `[${objectKeys.join(", ")}]). Likely a region with a non-object value ` +
+        `(e.g. "<id>": someConst) — this parser only validates inline ` +
+        `"<id>": { … } entries, so such a region could hide from the residency ` +
+        `assertion. (A line-leading quoted key NESTED inside a region's value ` +
+        `object would also trip this — region values use unquoted keys today.)`,
+    );
+  }
+
+  return objectKeys;
+}
+
+describe("deploy config residency regions (#3948)", () => {
+  it("prod config offers exactly us/eu/apac — never staging", () => {
+    const keys = extractResidencyRegionKeys(PROD_CONFIG);
+    expect(keys.toSorted()).toEqual(["apac", "eu", "us"]);
+    // The load-bearing assertion: staging must never be a selectable prod
+    // residency region. A future edit re-adding it fails here.
+    expect(keys).not.toContain("staging");
+  });
+
+  it("staging config keeps the single staging region (scoped to the staging deploy)", () => {
+    const keys = extractResidencyRegionKeys(STAGING_CONFIG);
+    expect(keys).toEqual(["staging"]);
+  });
+});


### PR DESCRIPTION
## Summary

On **production**, the signup data-region step and `GET /api/v1/onboarding/regions` exposed a **Staging** region alongside us/eu/apac, so a real prod signup could select "Staging" as their data-residency region — routing their workspace metadata to the staging Postgres.

Root cause: the prod `deploy/api/atlas.config.ts` declared a `staging` arm in `residency.regions`. `getConfiguredRegions()` returns that map verbatim, and the onboarding `/regions` handler maps every entry into `availableRegions`, so the `/signup/region` picker rendered "Staging" as selectable.

- **Remove the dead `staging` entry** from the prod `residency.regions` map. Prod services (api / api-eu / api-apac — all share this config) only ever claim `us` / `eu` / `apac` via `ATLAS_API_REGION`, so `RegionGuardLive` never needs a `staging` entry to boot. The staging soak service loads a **separate** config (`deploy/api-staging/atlas.config.ts`) that owns the single-region `{ staging }` map its own boot guard requires — staging stays scoped to the staging deploy.
- **Verified safe:** `resolveRegionDatabaseUrl`'s `DEPLOY_REGION_ROUTING` short-circuit returns `null` for staging-keyed workspaces *before* the `regionConfig` lookup, and the misrouting middleware reads the regions map via optional chaining — neither needs a prod `staging` entry. No existing test asserted the prod map contained staging.
- Replaced the (incorrect) "needed for the boot guard" comment with a tombstone documenting why staging is intentionally absent from the prod config.
- **Regression test** (`deploy-config-residency-regions.test.ts`) parses both deploy configs and pins: prod `== {us, eu, apac}` (never `staging`), staging `== {staging}`. The source-text parser is hardened against same-line-brace / trailing-comment / referenced-const / spread re-adds (each fails loudly).

## Acceptance criteria (#3948)

- [x] `GET /api/v1/onboarding/regions` on prod returns only `us` / `eu` / `apac` (no `staging`) — the endpoint maps `getConfiguredRegions()`, which no longer contains staging.
- [x] `/signup/region` on prod shows only `us` / `eu` / `apac` — the picker renders `availableRegions` verbatim.
- [x] Staging region scoped to the staging environment only — it remains solely in `deploy/api-staging/atlas.config.ts`.

## Test plan

- [x] Regression test red on the pre-fix config (catches `staging`), green on the fixed config.
- [x] `bun run lint`, `bun run type`, `bun run test`, syncpack, and all drift/parity gates pass locally. (4 sandbox/explore test files fail only in the WSL2 dev shell due to `VERCEL_*`/`ATLAS_SANDBOX_URL` env — green when those are unset and in CI; none touched by this diff.)

Closes #3948

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop 'staging' from production data-residency region picker
> - Removes the `staging` entry from `residency.regions` in [deploy/api/atlas.config.ts](https://github.com/AtlasDevHQ/atlas/pull/3951/files#diff-e6db0c3b52717e74ce220854d51820cab32a3a64d438da05dbcd246e316d0fa2), leaving only `us`, `eu`, and `apac`.
> - Adds a test suite in [deploy-config-residency-regions.test.ts](https://github.com/AtlasDevHQ/atlas/pull/3951/files#diff-9f829a0578effa67873748c4febbc4b5f064bfe7ae49c00f927832e8fb316397) that parses both the prod and staging deploy configs and asserts the correct region sets, preventing regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e830932.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->