### PR TITLE
fix(api): demo-only signup suppresses 'connect your database' onboarding email

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -45158,6 +45158,19 @@
                               ]
                             }
                           },
+                          "suppressedSteps": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "welcome",
+                                "connect_database",
+                                "first_query",
+                                "invite_team",
+                                "explore_features"
+                              ]
+                            }
+                          },
                           "pendingSteps": {
                             "type": "array",
                             "items": {
@@ -45183,6 +45196,7 @@
                           "email",
                           "orgId",
                           "sentSteps",
+                          "suppressedSteps",
                           "pendingSteps",
                           "unsubscribed",
                           "createdAt"

--- a/packages/api/src/api/__tests__/admin-onboarding-emails.test.ts
+++ b/packages/api/src/api/__tests__/admin-onboarding-emails.test.ts
@@ -109,6 +109,7 @@ describe("GET /api/v1/admin/onboarding-emails", () => {
           email: "user@example.com",
           orgId: "org-1",
           sentSteps: ["welcome"],
+          suppressedSteps: [],
           pendingSteps: ["connect_database", "first_query", "invite_team", "explore_features"],
           unsubscribed: false,
           createdAt: "2026-03-20T00:00:00Z",

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -175,6 +175,24 @@ mock.module("@atlas/api/lib/plugins/hooks", () => ({
   dispatchHook: async () => {},
 }));
 
+// Onboarding-email milestone hooks. The route dynamically imports this module
+// post-commit; mock all exports so we can assert which hook fires on each
+// path (#3949: /use-demo must fire onDemoActivated, NOT onDatabaseConnected).
+const mockOnUserSignup = mock(() => {});
+const mockOnDatabaseConnected = mock(() => {});
+const mockOnDemoActivated = mock(() => {});
+const mockOnFirstQueryExecuted = mock(() => {});
+const mockOnTeamMemberInvited = mock(() => {});
+const mockOnFeatureExplored = mock(() => {});
+mock.module("@atlas/api/lib/email/hooks", () => ({
+  onUserSignup: mockOnUserSignup,
+  onDatabaseConnected: mockOnDatabaseConnected,
+  onDemoActivated: mockOnDemoActivated,
+  onFirstQueryExecuted: mockOnFirstQueryExecuted,
+  onTeamMemberInvited: mockOnTeamMemberInvited,
+  onFeatureExplored: mockOnFeatureExplored,
+}));
+
 const mockSetSetting: Mock<(key: string, value: string, userId?: string, orgId?: string) => Promise<void>> = mock(async () => {});
 
 mock.module("@atlas/api/lib/settings", () => ({
@@ -386,6 +404,8 @@ describe("POST /api/v1/onboarding/complete", () => {
     mockHasInternalDB.mockImplementation(() => true);
     mockInternalQuery.mockImplementation(async () => [{ id: "default" }]);
     mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
+    mockOnDatabaseConnected.mockClear();
+    mockOnDemoActivated.mockClear();
   });
 
   it("rejects when no active organization", async () => {
@@ -429,6 +449,21 @@ describe("POST /api/v1/onboarding/complete", () => {
     const data = await json(res);
     expect(data.connectionId).toBe("default");
     expect(data.dbType).toBe("postgres");
+  });
+
+  it("fires onDatabaseConnected (BYO milestone unchanged) and NOT onDemoActivated (#3949)", async () => {
+    const res = await request("/api/v1/onboarding/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "postgresql://user:pass@localhost:5432/mydb" }),
+    });
+    expect(res.status).toBe(201);
+    await new Promise((r) => setTimeout(r, 10));
+    // A real BYO connection still triggers the existing milestone unchanged.
+    expect(mockOnDatabaseConnected).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", email: "test@example.com", orgId: "org-1" }),
+    );
+    expect(mockOnDemoActivated).not.toHaveBeenCalled();
   });
 
   it("uses custom connectionId when provided", async () => {
@@ -687,6 +722,8 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     mockLogInfo.mockClear();
     mockLogWarn.mockClear();
     mockLogError.mockClear();
+    mockOnDemoActivated.mockClear();
+    mockOnDatabaseConnected.mockClear();
     // Reset filesystem stub to "all paths exist" — individual tests may
     // override `existsSyncImpl` to exercise the getDemoSemanticDir fallback.
     existsSyncImpl = () => true;
@@ -708,6 +745,59 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(data.connectionId).toBe("__demo__");
     expect(data.dbType).toBe("postgres");
     expect(data.entitiesImported).toBe(5);
+  });
+
+  it("fires onDemoActivated (suppresses connect_database) and NOT onDatabaseConnected (#3949)", async () => {
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    // Dynamic import + fire-and-forget hook resolves on a microtask.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Demo activation marks the connect_database step satisfied (no email)…
+    expect(mockOnDemoActivated).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", email: "test@example.com", orgId: "org-1" }),
+    );
+    // …and must NOT fire the BYO milestone that would send the misleading
+    // "Connect your database" email.
+    expect(mockOnDatabaseConnected).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onDemoActivated when the seed fails (no demo activated)", async () => {
+    // Import returns zero entities → DemoSeedFailure → 500, no hook.
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 0, skipped: 0, errors: [], total: 0, dbFailures: 0 }));
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockOnDemoActivated).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onDemoActivated when the user label is not an email (boundary, #3949)", async () => {
+    // Forces the `user.label?.includes("@")` guard's false branch with a
+    // non-email label (the shape a non-managed-auth label can take). The demo
+    // still seeds successfully (201) — only the email-drip decoration is skipped.
+    mockAuthenticate.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: { id: "user-1", mode: "managed", label: "no-email-label", role: "admin", activeOrganizationId: "org-1" },
+      }),
+    );
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockOnDemoActivated).not.toHaveBeenCalled();
   });
 
   it("saves connection with status='published' in workspace_plugins upsert SQL", async () => {

--- a/packages/api/src/api/routes/admin-onboarding-emails.ts
+++ b/packages/api/src/api/routes/admin-onboarding-emails.ts
@@ -31,6 +31,9 @@ const OnboardingEmailStatusSchema = z.object({
   email: z.string(),
   orgId: z.string(),
   sentSteps: z.array(stepEnum),
+  // Steps satisfied without a send (e.g. demo activation) — completed in the
+  // drip but no email dispatched (#3949). Distinct from sentSteps.
+  suppressedSteps: z.array(stepEnum),
   pendingSteps: z.array(stepEnum),
   unsubscribed: z.boolean(),
   createdAt: z.string(),

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -958,6 +958,31 @@ onboarding.openapi(
         "Demo onboarding complete",
       );
 
+      // Advance the onboarding drip past the `connect_database` step without
+      // sending the "Connect your database" email (#3949). A demo-only signup
+      // connected the bundled demo, not their *own* production DB — so firing
+      // the `database_connected` milestone (as the BYO `/complete` path does via
+      // `onDatabaseConnected`) would mislead them, and leaving the step
+      // unsatisfied would trip the 24h "connect your database" fallback nudge.
+      // Marking the step satisfied suppresses both. Fire-and-forget, mirroring
+      // the BYO hook. AtlasUser.label is the user's email in managed auth mode.
+      if (user?.id && user.label?.includes("@")) {
+        yield* Effect.tryPromise({
+          try: async () => {
+            const { onDemoActivated } = await import("@atlas/api/lib/email/hooks");
+            onDemoActivated({
+              userId: user.id,
+              email: user.label!,
+              orgId,
+            });
+          },
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll((err) => {
+          log.debug({ err: err.message, requestId, orgId, userId: user.id }, "Onboarding email hook not available");
+          return Effect.void;
+        }));
+      }
+
       return c.json({
         connectionId: id,
         dbType,

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -39,7 +39,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 // Now import the module under test
-const { sendOnboardingEmail, isOnboardingEmailEnabled, onMilestoneReached, markStepSatisfied, checkFallbackEmails } = await import("../engine");
+const { sendOnboardingEmail, isOnboardingEmailEnabled, onMilestoneReached, markStepSatisfied, checkFallbackEmails, getOnboardingStatuses } = await import("../engine");
 
 describe("isOnboardingEmailEnabled", () => {
   beforeEach(() => {
@@ -260,5 +260,49 @@ describe("checkFallbackEmails skips a connect_database step satisfied by demo (#
       (call: unknown[]) => (call[0] as { subject?: string }).subject ?? "",
     );
     expect(sentSteps.some((s: string) => s.includes("Connect your database"))).toBe(false);
+  });
+});
+
+describe("getOnboardingStatuses distinguishes suppressed (demo) steps from sent (#3949)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
+    mockHasDB = true;
+  });
+
+  it("reports a demo-satisfied connect_database in suppressedSteps, not sentSteps", async () => {
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    (internalQuery as ReturnType<typeof mock>).mockImplementation((sql: string) => {
+      if (typeof sql === "string" && sql.includes("COUNT(DISTINCT")) {
+        return Promise.resolve([{ count: "1" }]);
+      }
+      if (typeof sql === "string" && sql.includes('SELECT m."userId" as user_id')) {
+        return Promise.resolve([{ user_id: "u1", email: "demo@example.com", created_at: "2026-03-20T00:00:00Z" }]);
+      }
+      // getSuppressedSteps — the triggered_by-filtered query MUST be matched
+      // before the generic getSentSteps query (which is a prefix of it).
+      if (typeof sql === "string" && sql.includes("triggered_by = 'demo_activated'")) {
+        return Promise.resolve([{ step: "connect_database" }]);
+      }
+      // getSentSteps — every recorded step.
+      if (typeof sql === "string" && sql.includes("FROM onboarding_emails")) {
+        return Promise.resolve([{ step: "welcome" }, { step: "connect_database" }]);
+      }
+      if (typeof sql === "string" && sql.includes("email_preferences")) {
+        return Promise.resolve([]); // not unsubscribed
+      }
+      return Promise.resolve([]);
+    });
+
+    const { statuses, total } = await getOnboardingStatuses("org1");
+    expect(total).toBe(1);
+    expect(statuses).toHaveLength(1);
+    const s = statuses[0];
+    // welcome was genuinely sent; connect_database was demo-suppressed.
+    expect(s.sentSteps).toEqual(["welcome"]);
+    expect(s.suppressedSteps).toEqual(["connect_database"]);
+    // Both are "completed", so neither appears in pendingSteps.
+    expect(s.pendingSteps).not.toContain("welcome");
+    expect(s.pendingSteps).not.toContain("connect_database");
+    expect(s.pendingSteps).toContain("first_query");
   });
 });

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -39,7 +39,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 // Now import the module under test
-const { sendOnboardingEmail, isOnboardingEmailEnabled, onMilestoneReached } = await import("../engine");
+const { sendOnboardingEmail, isOnboardingEmailEnabled, onMilestoneReached, markStepSatisfied, checkFallbackEmails } = await import("../engine");
 
 describe("isOnboardingEmailEnabled", () => {
   beforeEach(() => {
@@ -147,5 +147,118 @@ describe("onMilestoneReached", () => {
     // @ts-expect-error testing invalid input
     await onMilestoneReached("unknown_milestone", "u1", "test@example.com", "org1");
     // Should not throw
+  });
+});
+
+describe("markStepSatisfied (#3949 — demo suppresses connect_database without sending)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
+    mockHasDB = true;
+    mockInternalQueryResult = [];
+    mockDeliveryResult = { success: true, provider: "log" };
+  });
+
+  it("records the step in onboarding_emails WITHOUT dispatching an email", async () => {
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    const { sendEmail } = await import("../delivery");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+    (sendEmail as ReturnType<typeof mock>).mockClear();
+    // Not unsubscribed.
+    (internalQuery as ReturnType<typeof mock>).mockImplementation(() => Promise.resolve([]));
+
+    const ok = await markStepSatisfied("u1", "org1", "connect_database", "demo_activated");
+    expect(ok).toBe(true);
+
+    // No email was ever rendered/dispatched.
+    expect(sendEmail as ReturnType<typeof mock>).not.toHaveBeenCalled();
+
+    // A row was recorded with the demo trigger and the connect_database step.
+    const insertCall = (internalQuery as ReturnType<typeof mock>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO onboarding_emails"),
+    );
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as unknown[];
+    // recordSentEmail params: [userId, orgId, step, triggeredBy]
+    expect(params[0]).toBe("u1");
+    expect(params[1]).toBe("org1");
+    expect(params[2]).toBe("connect_database");
+    expect(params[3]).toBe("demo_activated");
+  });
+
+  it("is a no-op when the feature is disabled", async () => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "false";
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+
+    const ok = await markStepSatisfied("u1", "org1", "connect_database", "demo_activated");
+    expect(ok).toBe(false);
+    const insertCall = (internalQuery as ReturnType<typeof mock>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO onboarding_emails"),
+    );
+    expect(insertCall).toBeUndefined();
+  });
+
+  it("does not write a row for an unsubscribed user", async () => {
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+    // First call is the unsubscribe check — return a row with onboarding_emails=false.
+    (internalQuery as ReturnType<typeof mock>).mockImplementation((sql: string) => {
+      if (typeof sql === "string" && sql.includes("email_preferences")) {
+        return Promise.resolve([{ onboarding_emails: false }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const ok = await markStepSatisfied("u1", "org1", "connect_database", "demo_activated");
+    expect(ok).toBe(false);
+    const insertCall = (internalQuery as ReturnType<typeof mock>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO onboarding_emails"),
+    );
+    expect(insertCall).toBeUndefined();
+  });
+});
+
+describe("checkFallbackEmails skips a connect_database step satisfied by demo (#3949)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
+    mockHasDB = true;
+    mockDeliveryResult = { success: true, provider: "log" };
+  });
+
+  it("does NOT send the 24h connect_database nudge once the step is recorded (demo_activated)", async () => {
+    // A user who signed up 48h ago (so the 24h connect_database fallback is due),
+    // whose connect_database step is ALREADY recorded — exactly the state
+    // markStepSatisfied("...", "demo_activated") leaves behind. The fallback
+    // scheduler must skip it and not send the misleading email.
+    const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    const { sendEmail } = await import("../delivery");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+    (sendEmail as ReturnType<typeof mock>).mockClear();
+    (internalQuery as ReturnType<typeof mock>).mockImplementation((sql: string) => {
+      if (typeof sql === "string" && sql.includes('FROM "user"')) {
+        return Promise.resolve([{ id: "u1", email: "demo@example.com", created_at: fortyEightHoursAgo }]);
+      }
+      if (typeof sql === "string" && sql.includes("FROM member")) {
+        return Promise.resolve([{ organizationId: "org1" }]);
+      }
+      if (typeof sql === "string" && sql.includes("FROM onboarding_emails")) {
+        // welcome (immediate) + connect_database (the demo-satisfied step).
+        return Promise.resolve([{ step: "welcome" }, { step: "connect_database" }]);
+      }
+      if (typeof sql === "string" && sql.includes("email_preferences")) {
+        return Promise.resolve([]); // not unsubscribed
+      }
+      return Promise.resolve([]);
+    });
+
+    const result = await checkFallbackEmails();
+    expect(result.checked).toBe(1);
+
+    // No connect_database email was dispatched — the recorded step suppressed it.
+    const sentSteps = (sendEmail as ReturnType<typeof mock>).mock.calls.map(
+      (call: unknown[]) => (call[0] as { subject?: string }).subject ?? "",
+    );
+    expect(sentSteps.some((s: string) => s.includes("Connect your database"))).toBe(false);
   });
 });

--- a/packages/api/src/lib/email/__tests__/hooks.test.ts
+++ b/packages/api/src/lib/email/__tests__/hooks.test.ts
@@ -9,19 +9,23 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 let mockEnabled = true;
 const mockSendOnboardingEmail = mock(() => Promise.resolve(true));
 const mockOnMilestoneReached = mock(() => Promise.resolve());
+const mockMarkStepSatisfied = mock(() => Promise.resolve(true));
 
 mock.module("../engine", () => ({
   isOnboardingEmailEnabled: () => mockEnabled,
   sendOnboardingEmail: mockSendOnboardingEmail,
   onMilestoneReached: mockOnMilestoneReached,
+  markStepSatisfied: mockMarkStepSatisfied,
 }));
 
 // --- Mock logger ---
 
+const mockLogWarn = mock(() => {});
+
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
-    warn: () => {},
+    warn: mockLogWarn,
     error: () => {},
     debug: () => {},
   }),
@@ -30,6 +34,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 const {
   onUserSignup,
   onDatabaseConnected,
+  onDemoActivated,
   onFirstQueryExecuted,
   onTeamMemberInvited,
   onFeatureExplored,
@@ -75,6 +80,46 @@ describe("onDatabaseConnected", () => {
     onDatabaseConnected(USER);
     await new Promise((r) => setTimeout(r, 10));
     expect(mockOnMilestoneReached).not.toHaveBeenCalled();
+  });
+});
+
+describe("onDemoActivated (#3949)", () => {
+  beforeEach(() => {
+    mockEnabled = true;
+    mockMarkStepSatisfied.mockClear();
+    mockOnMilestoneReached.mockClear();
+    mockSendOnboardingEmail.mockClear();
+  });
+
+  it("marks the connect_database step satisfied with the demo_activated trigger", async () => {
+    onDemoActivated(USER);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockMarkStepSatisfied).toHaveBeenCalledWith("u1", "org1", "connect_database", "demo_activated");
+  });
+
+  it("does NOT fire the database_connected milestone (no 'connect your database' email)", async () => {
+    onDemoActivated(USER);
+    await new Promise((r) => setTimeout(r, 10));
+    // The demo path must never send the BYO connect_database email.
+    expect(mockOnMilestoneReached).not.toHaveBeenCalled();
+    expect(mockSendOnboardingEmail).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when feature disabled", async () => {
+    mockEnabled = false;
+    onDemoActivated(USER);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockMarkStepSatisfied).not.toHaveBeenCalled();
+  });
+
+  it("catches errors and logs a warning (never silently swallows)", async () => {
+    mockLogWarn.mockClear();
+    mockMarkStepSatisfied.mockImplementation(() => Promise.reject(new Error("boom")));
+    onDemoActivated(USER);
+    await new Promise((r) => setTimeout(r, 10));
+    // The rejection was caught AND logged — not silently swallowed.
+    expect(mockLogWarn).toHaveBeenCalled();
+    mockMarkStepSatisfied.mockImplementation(() => Promise.resolve(true));
   });
 });
 

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -211,6 +211,56 @@ export async function onMilestoneReached(
   await sendOnboardingEmail(userId, email, orgId, step, milestone);
 }
 
+// ── Step satisfaction (no email) ────────────────────────────────────
+
+/**
+ * Mark an onboarding step as satisfied WITHOUT sending its email.
+ *
+ * Records the step in `onboarding_emails` (idempotent via the
+ * `(user_id, step)` unique index) so the drip advances past it and the
+ * time-based fallback nudge in {@link checkFallbackEmails} skips it — but
+ * never renders or dispatches a template.
+ *
+ * Used by the demo-activation path (#3949): a demo-only signup never
+ * connects their *own* database, so firing the `database_connected`
+ * milestone would send the misleading "Connect your database" email. Marking
+ * the `connect_database` step satisfied suppresses both that send and the 24h
+ * nudge while keeping the rest of the sequence on schedule.
+ *
+ * @returns true if a row was recorded (or already present), false if skipped
+ *   (feature disabled, unsubscribed).
+ */
+export async function markStepSatisfied(
+  userId: string,
+  orgId: string,
+  step: OnboardingEmailStep,
+  triggeredBy: OnboardingEmailTrigger,
+): Promise<boolean> {
+  if (!isOnboardingEmailEnabled()) {
+    log.debug({ userId, step }, "Onboarding emails disabled — skipping step-satisfy");
+    return false;
+  }
+
+  try {
+    // Respect unsubscribe for symmetry with sendOnboardingEmail: an
+    // unsubscribed user gets no drip rows written on their behalf.
+    if (await isUnsubscribed(userId)) {
+      log.debug({ userId, step }, "User unsubscribed — skipping step-satisfy");
+      return false;
+    }
+
+    await recordSentEmail(userId, orgId, step, triggeredBy);
+    log.info({ userId, step, triggeredBy }, "Onboarding step marked satisfied (no email sent)");
+    return true;
+  } catch (err) {
+    log.error(
+      { userId, step, err: err instanceof Error ? err.message : String(err) },
+      "Error marking onboarding step satisfied",
+    );
+    return false;
+  }
+}
+
 // ── Time-based fallback check ───────────────────────────────────────
 
 /**

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -80,6 +80,27 @@ async function getSentSteps(userId: string): Promise<OnboardingEmailStep[]> {
   return rows.map((r) => r.step).filter((s): s is OnboardingEmailStep => onboardingSteps.has(s));
 }
 
+/**
+ * Steps a user activated WITHOUT an email being dispatched — i.e. recorded via
+ * {@link markStepSatisfied} (trigger `demo_activated`), not a real send (#3949).
+ *
+ * A row in `onboarding_emails` historically meant "this email was sent", and the
+ * admin status view treats {@link getSentSteps} that way. Demo activation breaks
+ * that 1:1 — the `connect_database` step is *completed* in the drip but no email
+ * went out. This surfaces the suppressed subset so the admin view can label
+ * "satisfied (no email)" distinctly from "sent" instead of silently conflating
+ * the two. The completed-step partition (sent + suppressed → pending) is
+ * unchanged, so the drip-progression semantics `getSentSteps` drives are intact.
+ */
+async function getSuppressedSteps(userId: string): Promise<OnboardingEmailStep[]> {
+  const rows = await internalQuery<{ step: string }>(
+    `SELECT step FROM onboarding_emails WHERE user_id = $1 AND triggered_by = 'demo_activated'`,
+    [userId],
+  );
+  const onboardingSteps = new Set<string>(ONBOARDING_SEQUENCE.map((s) => s.step));
+  return rows.map((r) => r.step).filter((s): s is OnboardingEmailStep => onboardingSteps.has(s));
+}
+
 async function isUnsubscribed(userId: string): Promise<boolean> {
   const rows = await internalQuery<{ onboarding_emails: boolean }>(
     `SELECT onboarding_emails FROM email_preferences WHERE user_id = $1 LIMIT 1`,
@@ -410,16 +431,29 @@ export async function getOnboardingStatuses(
             try: () => isUnsubscribed(user.user_id),
             catch: normalizeError,
           }),
+          Effect.tryPromise({
+            try: () => getSuppressedSteps(user.user_id),
+            catch: normalizeError,
+          }),
         ], { concurrency: "unbounded" }).pipe(
-          Effect.map(([sentSteps, unsub]) => ({
-            userId: user.user_id,
-            email: user.email,
-            orgId,
-            sentSteps,
-            pendingSteps: ALL_STEPS.filter((s) => !sentSteps.includes(s)),
-            unsubscribed: unsub,
-            createdAt: user.created_at,
-          })),
+          // `sentSteps` from getSentSteps is every recorded step (the
+          // completed-vs-pending partition the drip relies on). `suppressedSteps`
+          // is the subset satisfied without a real send; subtract it so
+          // `sentSteps` reflects only truly-dispatched emails in the admin view
+          // (#3949), while the union of the two still complements `pendingSteps`.
+          Effect.map(([recordedSteps, unsub, suppressedSteps]) => {
+            const suppressed = new Set<OnboardingEmailStep>(suppressedSteps);
+            return {
+              userId: user.user_id,
+              email: user.email,
+              orgId,
+              sentSteps: recordedSteps.filter((s) => !suppressed.has(s)),
+              suppressedSteps,
+              pendingSteps: ALL_STEPS.filter((s) => !recordedSteps.includes(s)),
+              unsubscribed: unsub,
+              createdAt: user.created_at,
+            };
+          }),
           Effect.timeoutFail({
             duration: Duration.seconds(10),
             onTimeout: () => new Error("Onboarding status fetch timed out after 10s"),
@@ -431,6 +465,7 @@ export async function getOnboardingStatuses(
               email: user.email,
               orgId,
               sentSteps: [] as OnboardingEmailStep[],
+              suppressedSteps: [] as OnboardingEmailStep[],
               pendingSteps: ALL_STEPS,
               unsubscribed: false,
               createdAt: user.created_at,

--- a/packages/api/src/lib/email/hooks.ts
+++ b/packages/api/src/lib/email/hooks.ts
@@ -7,7 +7,12 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { isOnboardingEmailEnabled, onMilestoneReached, sendOnboardingEmail } from "./engine";
+import {
+  isOnboardingEmailEnabled,
+  markStepSatisfied,
+  onMilestoneReached,
+  sendOnboardingEmail,
+} from "./engine";
 
 const log = createLogger("onboarding-hooks");
 
@@ -50,6 +55,32 @@ export function onDatabaseConnected(user: UserContext): void {
       log.warn(
         { userId: user.userId, err: err instanceof Error ? err.message : String(err) },
         "Failed to trigger database_connected milestone email",
+      );
+    },
+  );
+}
+
+/**
+ * Called after a demo-only signup activates the bundled demo (`/use-demo`).
+ *
+ * A demo user never connects their *own* database, so the `connect_database`
+ * step has two bad outcomes if left to the normal flow: firing the
+ * `database_connected` milestone would *send* the misleading "Connect your
+ * database" email, and conversely leaving the step unrecorded would let the 24h
+ * fallback nudge fire later. Marking the step satisfied (no email) avoids both
+ * and advances the drip cleanly. The rest of the sequence (first_query,
+ * invite_team, …) is unaffected.
+ *
+ * Fire-and-forget — errors are logged, not thrown.
+ */
+export function onDemoActivated(user: UserContext): void {
+  if (!isOnboardingEmailEnabled()) return;
+
+  void markStepSatisfied(user.userId, user.orgId, "connect_database", "demo_activated").catch(
+    (err) => {
+      log.warn(
+        { userId: user.userId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to mark connect_database step satisfied for demo activation",
       );
     },
   );

--- a/packages/api/src/lib/email/index.ts
+++ b/packages/api/src/lib/email/index.ts
@@ -5,12 +5,12 @@
  * welcome → connect database → first query → invite team → explore features.
  */
 
-export { isOnboardingEmailEnabled, sendOnboardingEmail, onMilestoneReached, checkFallbackEmails, unsubscribeUser, resubscribeUser, getOnboardingStatuses } from "./engine";
+export { isOnboardingEmailEnabled, sendOnboardingEmail, onMilestoneReached, markStepSatisfied, checkFallbackEmails, unsubscribeUser, resubscribeUser, getOnboardingStatuses } from "./engine";
 export { ONBOARDING_SEQUENCE, MILESTONE_TO_STEP, getStepDef } from "./sequence";
 export { renderOnboardingEmail } from "./templates";
 export { sendEmail, getEmailTransport } from "./delivery";
 export type { EmailMessage, DeliveryResult } from "./delivery";
 export type { RenderedEmail } from "./templates";
 export type { SequenceStep } from "./sequence";
-export { onUserSignup, onDatabaseConnected, onFirstQueryExecuted, onTeamMemberInvited, onFeatureExplored } from "./hooks";
+export { onUserSignup, onDatabaseConnected, onDemoActivated, onFirstQueryExecuted, onTeamMemberInvited, onFeatureExplored } from "./hooks";
 export { runTick as emailSchedulerTick, isEmailSchedulerEnabled, DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS } from "./scheduler";

--- a/packages/types/src/onboarding-email.ts
+++ b/packages/types/src/onboarding-email.ts
@@ -62,9 +62,20 @@ export interface OnboardingEmailStatus {
   userId: string;
   email: string;
   orgId: string;
-  /** Steps that have been sent. Together with pendingSteps, partitions all OnboardingEmailStep values. */
+  /**
+   * Steps whose email was actually dispatched. Excludes steps satisfied without
+   * a send (see `suppressedSteps`). `sentSteps ∪ suppressedSteps` are the
+   * completed steps, and together with `pendingSteps` they partition the full
+   * sequence.
+   */
   sentSteps: OnboardingEmailStep[];
-  /** Steps remaining. Complement of sentSteps against the full sequence. */
+  /**
+   * Steps marked complete WITHOUT an email being sent — e.g. `connect_database`
+   * satisfied by activating the demo (#3949). Completed for drip-progression
+   * purposes (so they are not in `pendingSteps`) but no message went out.
+   */
+  suppressedSteps: OnboardingEmailStep[];
+  /** Steps remaining. Complement of the completed steps (sent + suppressed) against the full sequence. */
   pendingSteps: OnboardingEmailStep[];
   /** Whether the user has unsubscribed from onboarding emails. */
   unsubscribed: boolean;

--- a/packages/types/src/onboarding-email.ts
+++ b/packages/types/src/onboarding-email.ts
@@ -29,8 +29,20 @@ export const ONBOARDING_MILESTONES = [
 
 export type OnboardingMilestone = (typeof ONBOARDING_MILESTONES)[number];
 
-/** Trigger source for an onboarding email — either a milestone or a time-based fallback. */
-export type OnboardingEmailTrigger = OnboardingMilestone | "time_based";
+/**
+ * Trigger source for an onboarding email record.
+ *
+ * - a {@link OnboardingMilestone} — the milestone whose email actually sent;
+ * - `"time_based"` — a fallback nudge sent because the milestone wasn't hit in time;
+ * - `"demo_activated"` — a *satisfaction marker*, NOT an email send. Recorded when a
+ *   demo-only signup activates the bundled demo so the `connect_database` drip step
+ *   is marked done (drip advances, the 24h "connect your database" nudge is suppressed)
+ *   without ever sending the misleading "connect your *own* database" copy (#3949).
+ *   Unlike a milestone, it is never a key in the milestone→step map
+ *   (`MILESTONE_TO_STEP`, api/lib/email/sequence.ts) — it only ever appears in a
+ *   persisted record's `triggeredBy`.
+ */
+export type OnboardingEmailTrigger = OnboardingMilestone | "time_based" | "demo_activated";
 
 // ── Email record (persisted in onboarding_emails table) ─────────────
 


### PR DESCRIPTION
## Summary

A user who completes signup and chooses **"Explore demo data"** (the NovaMart demo, not their own database) was receiving a "Connect your database" onboarding drip nudge. The `/use-demo` handler never fired any onboarding milestone, so the `connect_database` step stayed unsatisfied and the **24h fallback nudge fired** — nagging the user to connect a database they intentionally skipped, with copy implying they'd connected their own production DB.

**Fix:** connecting the demo now marks the `connect_database` step *satisfied without sending an email*. The drip advances past it and the 24h nudge is suppressed, and the user never sees "connect your *own* database" copy. The bring-your-own-database (`/complete`) path is unchanged.

## Resolution of the open question in the issue

The issue asked whether to **suppress-with-demo-framing** or **skip**, and to confirm which template was actually landing.

- **Which template:** The "right away" email the reporter recalled is the **welcome** email (`onUserSignup` → `sendOnboardingEmail("welcome", …)`), which fires on signup for everyone and is correct/appropriate for demo users — it is *not* the bug. The misleading send the acceptance criteria target is the `connect_database` step's **24h fallback nudge** (subject "Connect your database to {{appName}}"), which a demo-only user trips because they never fire `database_connected`.
- **Decision:** **suppress with no email** (mark the step satisfied) rather than introduce a demo-specific milestone + template. It is the cleaner of the two options — no new copy to maintain, minimal surface area — and satisfies all four acceptance criteria directly.

## Changes

- **engine** (`lib/email/engine.ts`): new `markStepSatisfied()` records a step in `onboarding_emails` (idempotent via the `(user_id, step)` unique index) **without** rendering or dispatching a template; respects the feature-disabled and unsubscribe guards exactly like `sendOnboardingEmail`.
- **hooks** (`lib/email/hooks.ts`): new `onDemoActivated()` marks `connect_database` satisfied with trigger `demo_activated`; it does **not** fire the `database_connected` milestone (which would send the misleading email).
- **route** (`api/routes/onboarding.ts`): `/use-demo` fires `onDemoActivated` post-commit, mirroring the BYO `/complete` path's `onDatabaseConnected` wiring (same guard, fire-and-forget shape, error handling).
- **types** (`@useatlas/types`): widen `OnboardingEmailTrigger` with `"demo_activated"` — a *satisfaction marker*, structurally excluded from the milestone→step map (`MILESTONE_TO_STEP` is keyed on the narrow `OnboardingMilestone` union, so the compiler keeps it out of step resolution).

No migration: `onboarding_emails.triggered_by` is plain `TEXT` (no CHECK).

## Test plan

- [x] `markStepSatisfied` records the step **without** dispatching an email; no-ops when disabled; writes nothing for an unsubscribed user (`engine.test.ts`).
- [x] End-to-end: `checkFallbackEmails` does **not** send the 24h "Connect your database" nudge once the step is recorded (`engine.test.ts`).
- [x] `onDemoActivated` marks `connect_database`/`demo_activated`, never fires the milestone or sends, no-ops when disabled, catches+logs errors (`hooks.test.ts`).
- [x] `/use-demo` fires `onDemoActivated` and **not** `onDatabaseConnected`; `/complete` (BYO) still fires `onDatabaseConnected` and **not** `onDemoActivated` (AC #3 unchanged); seed-failure and non-email-label boundaries fire neither (`onboarding.test.ts`).
- [x] Local `/ci`: lint, type, full test (`@atlas/api` 729/729 + all 34 other packages), syncpack, all drift gates — green.

## Acceptance criteria

- [x] A demo-only signup does not receive a "connect your database" nudge or any email implying they connected their own database.
- [x] Connecting the demo advances the drip past `connect_database` (no spurious 24h nudge).
- [x] A real BYO-database connection still triggers the existing milestone/email unchanged.
- [x] Coverage asserts the demo path's email behavior.

Closes #3949

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress 'connect your database' onboarding email when user activates demo
> - Adds a `markStepSatisfied` function to [engine.ts](https://github.com/AtlasDevHQ/atlas/pull/3953/files#diff-e226505e1531869049d7f4fe9739b74e7d63551ee53f8a07f5deaa2618c43a7f) that records an onboarding step as complete in `onboarding_emails` without sending an email, respecting the feature flag and unsubscribe preferences.
> - Adds an `onDemoActivated` hook in [hooks.ts](https://github.com/AtlasDevHQ/atlas/pull/3953/files#diff-66b94fe3d65593fcdaded6c4857747bf509f5a5b9b6333df9e9b0e5bb6a21c06) that calls `markStepSatisfied` for the `connect_database` step with trigger `demo_activated`.
> - The `POST /api/v1/onboarding/use-demo` route in [onboarding.ts](https://github.com/AtlasDevHQ/atlas/pull/3953/files#diff-e16db7a68e91bfeeddbc09fda46a076dd110636e532211e2d2c61cf30865250b) fires `onDemoActivated` after successful demo provisioning for managed-auth users with an email-like label.
> - `getOnboardingStatuses` now returns a `suppressedSteps` array (steps satisfied without sending) alongside `sentSteps` and `pendingSteps`; the 24h `connect_database` fallback email is skipped when the step appears in suppressed steps.
> - `OnboardingEmailTrigger` and `OnboardingEmailStatus` types in [onboarding-email.ts](https://github.com/AtlasDevHQ/atlas/pull/3953/files#diff-4374e8613802606bc4aa953c709b55ab97991436de892f867c8aace27615e870) are extended to include `demo_activated` and `suppressedSteps`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a309355.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->