### PR TITLE
fix(api): demo first-answer dead-end — union unpinned-default whitelist (#3947)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-org.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-org.test.ts
@@ -283,10 +283,13 @@ describe("getOrgWhitelistedTables", () => {
     expect(tables.size).toBe(0);
   });
 
-  it("does NOT fall back when the org has multiple connections", async () => {
-    // Multi-source orgs require explicit connectionId; a "default" lookup
-    // with no matching key returns empty rather than picking one
-    // arbitrarily.
+  it("unpinned 'default' resolves the UNION of all buckets on a multi-connection org (#3947)", async () => {
+    // An unpinned conversation collapses to connectionId="default" (reach = All
+    // sources). When the org has several connection buckets and none is literally
+    // "default", the lookup must return EVERY reachable table — not the empty set.
+    // The pre-#3947 behavior returned empty here, dead-ending the demo first
+    // answer the moment a second connection bucket existed (an explicit
+    // config.group_id, or a second datasource alongside the demo).
     mockListEntities.mockImplementation(() =>
       Promise.resolve([
         makeEntityRow("customers", "customers", "warehouse"),
@@ -296,7 +299,25 @@ describe("getOrgWhitelistedTables", () => {
 
     await loadOrgWhitelist("org-multi");
     const tables = getOrgWhitelistedTables("org-multi", "default");
-    expect(tables.size).toBe(0);
+    expect(tables.has("customers")).toBe(true);
+    expect(tables.has("events")).toBe(true);
+  });
+
+  it("a PINNED connectionId is never widened to the union — isolation holds on multi-connection orgs", async () => {
+    // The union fallback fires ONLY for the unpinned "default" sentinel. A query
+    // pinned to a specific connection must see exactly that connection's bucket,
+    // so multi-source orgs can't cross-route a pinned query.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow("customers", "customers", "warehouse"),
+        makeEntityRow("events", "events", "ops"),
+      ]),
+    );
+
+    await loadOrgWhitelist("org-multi");
+    const warehouse = getOrgWhitelistedTables("org-multi", "warehouse");
+    expect(warehouse.has("customers")).toBe(true);
+    expect(warehouse.has("events")).toBe(false);
   });
 
   it("prefers a real 'default' entry over the fallback path", async () => {

--- a/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
@@ -38,6 +38,7 @@ import {
 import { bulkUpsertEntities, listEntityRows } from "@atlas/api/lib/semantic/entities";
 import {
   loadOrgWhitelist,
+  getOrgWhitelistedTables,
   invalidateOrgWhitelist,
   _resetOrgWhitelists,
   _resetWhitelists,
@@ -188,5 +189,213 @@ describeIfPg("demo seed → published-mode visibility (#3932)", () => {
       [orgId, table],
     );
     expect(rows.rows[0]?.count).toBe("1");
+  });
+});
+
+/**
+ * LIVE-Postgres regression for the demo first-answer dead-end (#3947).
+ *
+ * The agent loop's `executeSQL` validates against `getOrgWhitelistedTables(orgId,
+ * connectionId, mode)` where, for a fresh conversation with no pinned connection,
+ * `connectionId` collapses to the literal `"default"` (sql.ts: `currentMember =
+ * groupTargetMember ?? connectionId ?? requestContextConnectionId ?? "default"`).
+ * Demo entities, however, are keyed under their `connection_group_id` (`__demo__`
+ * for a group-of-one demo install), NOT `"default"`. The single-connection
+ * fallback that bridged this (#2142) only fires when the org has EXACTLY ONE
+ * connection bucket — so the moment a second bucket exists (the demo install
+ * carries an explicit `config.group_id`, or a second datasource is connected),
+ * the `"default"` lookup returns the empty set and the agent rejects every demo
+ * table as "not in the allowed list" — while `GET /api/v1/tables`, which resolves
+ * through `resolveAllowedTables` with the demo connection id, still lists them.
+ *
+ * The fix broadens the unpinned-`"default"` fallback in `getOrgWhitelistedTables`
+ * to the UNION of every org bucket (the "All sources" reach an unpinned default
+ * query has), so the query-time whitelist resolves the SAME table set the demo
+ * workspace advertises — for one OR many connection buckets.
+ *
+ * These tests pin the exact lookup `executeSQL` performs (`connectionId =
+ * "default"`) against the realistic multi-bucket shapes, so a regression that
+ * re-narrows the fallback fails here.
+ */
+describeIfPg("demo first-answer: executeSQL whitelist resolves the demo tables (#3947)", () => {
+  let pool: Pool;
+  const schemaName = `demo_3947_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let prevDatabaseUrl: string | undefined;
+
+  /** Insert a published datasource install for one org. */
+  async function install(orgId: string, installId: string, config: Record<string, unknown>): Promise<void> {
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at)
+       VALUES ($1, $2, 'catalog:demo-3947', $3, 'datasource', $4::jsonb, true, 'published', NOW())
+       ON CONFLICT (workspace_id, catalog_id, install_id)
+         DO UPDATE SET status = 'published', config = EXCLUDED.config`,
+      [`${orgId}-${installId}`, orgId, installId, JSON.stringify(config)],
+    );
+  }
+
+  /** Import published entities scoped to one connection install. */
+  async function seedEntities(orgId: string, installId: string, tables: string[]): Promise<void> {
+    await bulkUpsertEntities(
+      orgId,
+      tables.map((t) => ({
+        entityType: "entity" as const,
+        name: t,
+        yamlContent: `table: ${t}\ndescription: ${t}\n`,
+        connectionId: installId,
+      })),
+      internalQuery,
+      "published",
+    );
+  }
+
+  beforeAll(async () => {
+    prevDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`demo-3947: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:demo-3947', 'Demo Postgres', 'demo-3947', 'datasource', 'datasource', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterEach(() => {
+    _resetWhitelists();
+    _resetOrgWhitelists();
+    _resetPluginEntities();
+  });
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (prevDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDatabaseUrl;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`demo-3947: schema cleanup failed: ${message}`);
+    });
+    await pool.end();
+  });
+
+  const DEMO_TABLES = ["order_items", "products", "categories", "orders"];
+
+  it("single demo connection: the unpinned `default` lookup resolves the demo tables (baseline #2142)", async () => {
+    const orgId = `org-3947-single-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" }); // group-of-one, no group_id
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+    // What executeSQL asks for on a fresh conversation: connectionId === "default".
+    const allowed = getOrgWhitelistedTables(orgId, "default", "published");
+    for (const t of DEMO_TABLES) expect(allowed.has(t)).toBe(true);
+  });
+
+  it("demo install with an explicit config.group_id: unpinned `default` STILL resolves the demo tables (the #3947 dead-end)", async () => {
+    // Two whitelist buckets land for this org: the entity's resolved
+    // `connection_group_id` (the explicit group) AND that group's member
+    // install id. `byConnection.size > 1`, so the old single-connection
+    // fallback could not fire and `getOrgWhitelistedTables(orgId, "default")`
+    // returned EMPTY — every demo table rejected on the user's first query.
+    const orgId = `org-3947-groupid-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres", group_id: "grp_demo" });
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(wl.size).toBeGreaterThan(1); // pin the multi-bucket shape that broke the old fallback
+
+    const allowed = getOrgWhitelistedTables(orgId, "default", "published");
+    for (const t of DEMO_TABLES) {
+      expect(allowed.has(t)).toBe(true);
+    }
+  });
+
+  it("demo + a second datasource: unpinned `default` resolves the UNION of both (no more empty set)", async () => {
+    // A fresh workspace that connected the demo AND a real datasource has two
+    // buckets. The unpinned `default` agent query (reach = All sources) must
+    // see every reachable table, not nothing.
+    const orgId = `org-3947-multi-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await install(orgId, "warehouse", { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, ["order_items", "products"]);
+    await seedEntities(orgId, "warehouse", ["widgets"]);
+
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(wl.size).toBeGreaterThan(1);
+
+    const allowed = getOrgWhitelistedTables(orgId, "default", "published");
+    expect(allowed.has("order_items")).toBe(true);
+    expect(allowed.has("products")).toBe(true);
+    expect(allowed.has("widgets")).toBe(true);
+  });
+
+  it("a PINNED connection id is NOT widened — it still sees only its own bucket (isolation preserved)", async () => {
+    // The broadened fallback fires only for the unpinned `default` sentinel.
+    // A query pinned to a specific connection must keep seeing exactly that
+    // connection's tables — never the union — or cross-connection isolation
+    // would regress.
+    const orgId = `org-3947-pinned-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await install(orgId, "warehouse", { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, ["order_items", "products"]);
+    await seedEntities(orgId, "warehouse", ["widgets"]);
+
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+
+    const demoOnly = getOrgWhitelistedTables(orgId, DEMO_INSTALL, "published");
+    expect(demoOnly.has("order_items")).toBe(true);
+    expect(demoOnly.has("widgets")).toBe(false); // the warehouse table must NOT leak into the demo connection
+
+    const warehouseOnly = getOrgWhitelistedTables(orgId, "warehouse", "published");
+    expect(warehouseOnly.has("widgets")).toBe(true);
+    expect(warehouseOnly.has("order_items")).toBe(false);
+  });
+
+  it("a real `default` bucket short-circuits the union — direct hit wins even with a second bucket", async () => {
+    // An org that genuinely has a `default`-keyed bucket (an entity scoped to a
+    // connection with no `workspace_plugins` install row → resolves to the flat
+    // NULL/`default` group) alongside the demo bucket must, on a `default`
+    // lookup, return ONLY the `default` bucket — never the union. Guards against
+    // a future "simplification" of the `!byConnection.has("default")` guard that
+    // would let the union fire and silently widen a non-demo org's first query.
+    const orgId = `org-3947-realdefault-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    // No install row for "default" → entity keys under the flat `default` bucket.
+    await seedEntities(orgId, "default", ["base_users"]);
+    await seedEntities(orgId, DEMO_INSTALL, ["order_items"]);
+
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(wl.has("default")).toBe(true);
+    expect(wl.size).toBeGreaterThan(1);
+
+    const allowed = getOrgWhitelistedTables(orgId, "default", "published");
+    expect(allowed.has("base_users")).toBe(true);
+    expect(allowed.has("order_items")).toBe(false); // the demo bucket must NOT be unioned in when a real default exists
+  });
+
+  it("an org with no entities resolves the unpinned `default` to an empty set (fail-closed)", async () => {
+    // The `byConnection.size >= 1` guard means a loaded-but-empty org never
+    // accidentally unions a non-existent bucket. With no entities, the `default`
+    // lookup must be empty — every query rejected, fail-closed.
+    const orgId = `org-3947-empty-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    // Intentionally seed NO entities.
+
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+    const allowed = getOrgWhitelistedTables(orgId, "default", "published");
+    expect(allowed.size).toBe(0);
   });
 });

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -795,6 +795,17 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
  * so a published-mode load won't satisfy a developer-mode lookup. Returns an
  * empty set if the requested cache has not been loaded.
  *
+ * When `connectionId` is the unpinned sentinel `"default"`, the direct lookup
+ * yields no tables, and the org has no bucket literally keyed `"default"` (the
+ * usual case — entities key under their `connection_group_id`: `"__demo__"`, a
+ * wizard id, an explicit group), the lookup falls back to the UNION of every
+ * connection bucket the org has — the "All sources" reach an unpinned query
+ * carries. This is what keeps the agent's query-time whitelist in lockstep with
+ * `/api/v1/tables` for a demo / multi-connection workspace (#2142, broadened in
+ * #3947). A real `"default"` bucket short-circuits the fallback (direct hit
+ * wins), and a query pinned to a real connection id resolves that connection's
+ * bucket alone (no widening).
+ *
  * @param mode - `"published"` → published-only cache; `"developer"` → overlay
  *   cache (drafts on published, tombstones hidden, archived-connection entities
  *   excluded); omitted → legacy cache built from `listEntityRows` with no status
@@ -809,21 +820,46 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
   }
   const byConnection = cached.tables;
 
-  // Single-connection orgs: callers default to "default", but demo stores
-  // under "__demo__" and wizard orgs under user-chosen ids (#2142).
+  // Unpinned-`default` fallback (#2142, broadened for #3947).
+  //
+  // `executeSQL` collapses an unpinned conversation to the literal sentinel
+  // `connectionId = "default"` (tools/sql.ts: `currentMember = … ?? "default"`),
+  // but org entities are keyed under their `connection_group_id` — `"__demo__"` for
+  // a group-of-one demo install, a user-chosen id for a wizard datasource, or an
+  // explicit `config.group_id`. None of those is `"default"`, so the direct
+  // lookup misses and the agent rejects every table on the user's first query
+  // ("not in the allowed list") even though `/api/v1/tables` — which resolves the
+  // demo connection id explicitly — lists them.
+  //
+  // The original fallback only rescued the SINGLE-bucket org (exactly one
+  // connection group, not named "default"). That broke the moment a second
+  // bucket existed — the demo install carrying an explicit `config.group_id`
+  // (which keys entities under both the group AND its member id), or a second
+  // datasource connected alongside the demo (#3947). An unpinned `default` query
+  // has reach = "All sources" (no group focus), so the correct resolution is the
+  // UNION of every bucket the org has — exactly the set the workspace advertises.
+  // This fires ONLY for the unpinned `"default"` sentinel with no own bucket; a
+  // query pinned to a real connection id still resolves that connection's bucket
+  // alone, so cross-connection isolation is preserved.
   let tables = new Set(byConnection.get(connectionId) ?? []);
   if (
     tables.size === 0 &&
     connectionId === "default" &&
-    byConnection.size === 1 &&
+    byConnection.size >= 1 &&
     !byConnection.has("default")
   ) {
-    const [storedKey] = byConnection.keys();
-    const [onlyTables] = byConnection.values();
-    tables = new Set(onlyTables);
+    tables = new Set<string>();
+    for (const bucket of byConnection.values()) {
+      for (const t of bucket) tables.add(t);
+    }
     log.debug(
-      { orgId, requestedConnectionId: connectionId, resolvedConnectionId: storedKey, mode: mode ?? "developer" },
-      "getOrgWhitelistedTables: single-connection fallback",
+      {
+        orgId,
+        requestedConnectionId: connectionId,
+        resolvedConnectionIds: Array.from(byConnection.keys()),
+        mode: mode ?? "developer",
+      },
+      "getOrgWhitelistedTables: unpinned-default fallback resolved the union of all connection buckets",
     );
   }
 


### PR DESCRIPTION
## Summary

A freshly-signed-up demo user's **first `executeSQL` was rejected** with `Table "X" is not in the allowed list` even though `GET /api/v1/tables` and `GET /api/v1/semantic/entities` both listed the 13 NovaMart demo tables for the same workspace — dead-ending the entire cold-start "explore demo → first answer" flow that v0.0.27 shipped.

**Root cause.** The agent loop collapses an unpinned conversation to the literal `connectionId = "default"` sentinel (`tools/sql.ts`: `currentMember = … ?? "default"`), but org entities key under their `connection_group_id` — `"__demo__"` for a group-of-one demo install, a wizard id, or an explicit `config.group_id` — never `"default"`. The single-connection fallback in `getOrgWhitelistedTables` (#2142) only rescued this when the org had **exactly one** connection bucket. The moment a second bucket existed — the demo install carrying an explicit `config.group_id` (which keys entities under both the group **and** its member id), or a second datasource connected alongside the demo — the `"default"` lookup returned the **empty set** and every demo table was rejected, while `/api/v1/tables` (which resolves the demo connection id explicitly) still listed them. That is the exact "executeSQL whitelist disagrees with /api/v1/tables for the same workspace" divergence in the issue.

**Fix.** Broaden the unpinned-`"default"` fallback to the **UNION of every org connection bucket** — the "All sources" reach an unpinned query carries — so the query-time whitelist resolves the same set the workspace advertises, for one **or** many buckets. Scoped tightly:
- Fires **only** for the unpinned `"default"` sentinel with no own bucket.
- A real `"default"` bucket short-circuits it (direct hit wins).
- A query pinned to a real connection id resolves that connection's bucket alone — **no cross-connection widening**, no cross-tenant reach (the union iterates one org's cache entry only).

## Test plan

Live-Postgres regression (`demo-publish-visibility-pg.test.ts`) pinning the exact lookup `executeSQL` performs (`connectionId="default"`):
- [x] single demo connection — baseline #2142 (still resolves)
- [x] demo install with an explicit `config.group_id` — **the #3947 dead-end** (multi-bucket, now resolves)
- [x] demo + a second datasource — unpinned `default` resolves the union
- [x] a **pinned** connection id is NOT widened — isolation preserved (bidirectional)
- [x] a real `default` bucket short-circuits the union — direct hit wins
- [x] empty org → unpinned `default` is empty (fail-closed)
- [x] unit: `semantic-org.test.ts` updated to the union semantics + pinned-isolation guard (covers published/developer mode parity + plugin-entity merge)
- [x] `/ci`: lint, type, full test, syncpack, all drift gates — green (7 full-suite failures are documented WSL2 env flakes; all pass in isolation)

Closes #3947

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getOrgWhitelistedTables` to return union of all connection buckets for unpinned 'default' lookups
> - Previously, `getOrgWhitelistedTables(orgId, 'default')` only fell back to a single bucket when exactly one bucket existed; multi-connection orgs with no `'default'` bucket returned an empty set, causing demo first-answer dead-ends.
> - Now, when there is no `'default'` bucket, the function returns the union of all connection buckets' tables regardless of bucket count.
> - A real `'default'` bucket still short-circuits the union, and pinned `connectionId` values remain isolated to their own bucket.
> - Adds unit tests in [`semantic-org.test.ts`](https://github.com/AtlasDevHQ/atlas/pull/3954/files#diff-220e87da66976aba506e88faa40ec10f780af23ae2a4550c6ecb8cd9d58fe4e0) and a Postgres-backed regression suite in [`demo-publish-visibility-pg.test.ts`](https://github.com/AtlasDevHQ/atlas/pull/3954/files#diff-9ea3c24ed0ef14c8c7f66aa3a00eeba1d093ce4dec277875c5e7521771a0d3ab) covering six org shapes.
> - Behavioral Change: multi-connection orgs with no `'default'` bucket now receive a wider table set on `'default'` lookups instead of an empty set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ade0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->