### PR TITLE
fix(deploy): restore staging residency arm as non-selectable — unbreak api-staging boot (#3948)

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -1129,19 +1129,29 @@ export default defineConfig({
         databaseUrl: process.env.ATLAS_REGION_APAC_DB_URL!,
         apiUrl: "https://api-apac.useatlas.dev",
       },
-      // NO "staging" arm here — staging is NOT a prod residency region (#3948).
-      // The prod services (api/api-eu/api-apac) only ever claim us|eu|apac via
-      // ATLAS_API_REGION, so RegionGuardLive (lib/effect/saas-guards.ts) never
-      // needs a "staging" entry in THIS config to boot. The staging soak service
-      // is a SEPARATE Railway service that loads `deploy/api-staging/atlas.config.ts`
-      // (its Dockerfile/railway.json wiring lands in staging slices 19–22) — that
-      // file owns the single-region `{ staging }` map its own boot guard requires
-      // (ATLAS_API_REGION=staging). A "staging" entry leaking into this
-      // prod map is the bug it caused: `getConfiguredRegions()` returns the whole
-      // map verbatim, so the signup region picker (GET /api/v1/onboarding/regions
-      // → /signup/region) offered "Staging" as a selectable data-residency region
-      // to real prod users, who could route their workspace metadata to the
-      // staging Postgres. Keep staging scoped to the staging deploy only.
+      // ⚠️ LOAD-BEARING — DO NOT REMOVE this "staging" arm.
+      //
+      // The api-staging soak service builds from THIS image/config
+      // (`RAILWAY_DOCKERFILE_PATH=deploy/api/Dockerfile`, which COPYs this file)
+      // and claims `ATLAS_API_REGION=staging`. `RegionGuardLive`
+      // (lib/effect/saas-guards.ts) fail-closes boot if the claimed region is
+      // absent from this map — so deleting this entry crash-loops api-staging
+      // ("Layer DAG could not initialize"). The separate
+      // `deploy/api-staging/atlas.config.ts` is NOT wired into any image yet, so
+      // it does not cover the staging service's boot. (This exact deletion
+      // already caused an outage: #3948 → PR #3951 → the staging crash loop.)
+      //
+      // `selectable: false` is the actual #3948 fix: existence ≠ selectability.
+      // The region stays present for the boot guard + residency routing, but the
+      // signup picker (GET /api/v1/onboarding/regions → /signup/region) filters
+      // out non-selectable regions, so real prod signups only ever see us/eu/apac
+      // and can never route their workspace metadata to the staging Postgres.
+      "staging": {
+        label: "Staging",
+        databaseUrl: process.env.DATABASE_URL!,
+        apiUrl: "https://api.staging.useatlas.dev",
+        selectable: false,
+      },
     },
   },
 });

--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -191,6 +191,41 @@ describe("residency", () => {
       await expect(run(assignWorkspaceRegion("org-1", "ap-south"))).rejects.toThrow("Invalid region");
     });
 
+    it("rejects a non-selectable region and omits it from the available list (#3948 write-path guard)", async () => {
+      // A `selectable: false` arm (e.g. the shared-config staging region) exists
+      // for the boot guard + routing but must never be assignable — otherwise a
+      // prod workspace could POST {"region":"staging"} and route its metadata to
+      // the staging Postgres, the exact leak #3948 closes. The error must list
+      // only selectable regions so it can't leak the internal id.
+      mockConfig = {
+        residency: {
+          regions: {
+            "us-east": { label: "US East", databaseUrl: "postgresql://us-east/atlas" },
+            "staging": { label: "Staging", databaseUrl: "postgresql://staging/atlas", selectable: false },
+          },
+          defaultRegion: "us-east",
+        },
+      };
+      await expect(run(assignWorkspaceRegion("org-1", "staging"))).rejects.toThrow(
+        'Invalid region "staging". Available regions: us-east',
+      );
+    });
+
+    it("still assigns a selectable region when a non-selectable arm is present", async () => {
+      mockConfig = {
+        residency: {
+          regions: {
+            "us-east": { label: "US East", databaseUrl: "postgresql://us-east/atlas" },
+            "staging": { label: "Staging", databaseUrl: "postgresql://staging/atlas", selectable: false },
+          },
+          defaultRegion: "us-east",
+        },
+      };
+      mockRows.push([]);
+      const result = await run(assignWorkspaceRegion("org-2", "us-east"));
+      expect(result.region).toBe("us-east");
+    });
+
     it("rejects reassignment (immutability)", async () => {
       mockRows.push([{ assigned: false, existing: "us-east" }]);
       await expect(run(assignWorkspaceRegion("org-1", "eu-west"))).rejects.toThrow("already assigned");

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -34,6 +34,7 @@ import {
   ResidencyError,
   type ResidencyErrorCode,
 } from "@atlas/api/lib/residency/errors";
+import { isRegionSelectable } from "@atlas/api/lib/residency/picker";
 import { isDeployRegion, type DeployRegion, type RegionStatus, type WorkspaceRegion } from "@useatlas/types";
 
 const log = createLogger("ee:residency");
@@ -110,8 +111,11 @@ function getResidencyConfigEffect(): Effect.Effect<ResidencyConfig, ResidencyErr
   return Effect.succeed(config.residency);
 }
 
-function isValidRegion(region: string, residency: ResidencyConfig): boolean {
-  return region in residency.regions;
+/** Region ids a customer may be assigned — excludes `selectable: false` arms. */
+function selectableRegionIds(residency: ResidencyConfig): string[] {
+  return Object.entries(residency.regions)
+    .filter(([, cfg]) => isRegionSelectable(cfg))
+    .map(([id]) => id);
 }
 
 /** Coerce a DB value (Date or string) to an ISO 8601 string. Throws on null/undefined/unexpected types. */
@@ -190,8 +194,17 @@ export const assignWorkspaceRegion = (
 
     yield* requireInternalDBEffect("data residency", () => new ResidencyError({ message: "Internal database is required for data residency.", code: "no_internal_db" }));
 
-    if (!isValidRegion(region, residency)) {
-      const available = Object.keys(residency.regions).join(", ");
+    // Gate on selectability, not mere existence (#3948): a `selectable: false`
+    // arm (e.g. the shared-config `staging` region the api-staging soak service
+    // claims) is load-bearing for the boot guard + routing but must never be an
+    // assignable residency choice — otherwise a real prod workspace could
+    // `POST /assign-region {"region":"staging"}` and route its metadata to the
+    // staging Postgres, the exact leak #3948 closes. The signup/admin pickers
+    // already filter these out via the same `isRegionSelectable` predicate; this
+    // is the authoritative write-path guard so a direct request can't bypass the
+    // UI. The error lists only selectable regions so it can't leak internal ids.
+    if (!isRegionSelectable(residency.regions[region])) {
+      const available = selectableRegionIds(residency).join(", ");
       return yield* Effect.fail(new ResidencyError({ message: `Invalid region "${region}". Available regions: ${available}`, code: "invalid_region" }));
     }
 

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -24,6 +24,8 @@ import {
   cancelMigration,
 } from "@atlas/api/lib/residency/migrate";
 import { ResidencyError } from "@atlas/api/lib/residency/errors";
+import { buildAvailableRegions } from "@atlas/api/lib/residency/picker";
+import type { RegionPickerItem } from "@useatlas/types";
 import { MIGRATION_STATUSES, type RegionMigration } from "@useatlas/types";
 import { RegionMigrationSchema, MigrationStatusResponseSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -498,16 +500,20 @@ adminResidency.openapi(getStatusRoute, async (c) => {
 
       let configured = true;
       let defaultRegion = "";
-      let availableRegions: Array<{ id: string; label: string; isDefault: boolean }> = [];
+      let availableRegions: RegionPickerItem[] = [];
+      // Full id→label map (incl. non-selectable regions) for resolving the
+      // label of an already-assigned region below; the picker list itself
+      // excludes non-selectable regions.
+      let regionLabels: Record<string, string> = {};
 
       try {
         defaultRegion = mod.getDefaultRegion();
         const regions = mod.getConfiguredRegions();
-        availableRegions = Object.entries(regions).map(([id, cfg]) => ({
-          id,
-          label: cfg.label,
-          isDefault: id === defaultRegion,
-        }));
+        // Filter out non-selectable regions (e.g. staging) so a prod admin is
+        // never offered an unassignable region — the assign write path rejects
+        // them anyway (#3948). Shares the picker predicate with onboarding.
+        availableRegions = buildAvailableRegions(regions, defaultRegion);
+        regionLabels = Object.fromEntries(Object.entries(regions).map(([id, cfg]) => [id, cfg.label]));
       } catch (err) {
         if (err instanceof ResidencyError && err.code === "not_configured") {
           configured = false;
@@ -524,8 +530,7 @@ adminResidency.openapi(getStatusRoute, async (c) => {
         const assignment = yield* mod.getWorkspaceRegionAssignment(orgId!);
         if (assignment) {
           region = assignment.region;
-          regionLabel =
-            availableRegions.find((r) => r.id === assignment.region)?.label ?? assignment.region;
+          regionLabel = regionLabels[assignment.region] ?? assignment.region;
           assignedAt = assignment.assignedAt;
         }
       }

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -1008,6 +1008,7 @@ onboarding.openapi(
 
 import { residencyDomainError } from "./shared-residency";
 import { ResidencyError } from "@atlas/api/lib/residency/errors";
+import { buildAvailableRegions } from "@atlas/api/lib/residency/picker";
 import { RegionPickerItemSchema } from "@useatlas/schemas";
 
 // OnboardingRegionSchema previously duplicated this shape inline; the signup
@@ -1137,11 +1138,10 @@ onboarding.openapi(getRegionsRoute, async (c) => {
     try {
       const defaultRegion = mod.getDefaultRegion();
       const regions = mod.getConfiguredRegions();
-      const availableRegions = Object.entries(regions).map(([id, cfg]) => ({
-        id,
-        label: cfg.label,
-        isDefault: id === defaultRegion,
-      }));
+      // Exclude regions flagged `selectable: false` (e.g. the internal `staging`
+      // arm) from the customer-facing picker — they exist for the boot guard +
+      // routing only, never as a selectable residency choice for signups (#3948).
+      const availableRegions = buildAvailableRegions(regions, defaultRegion);
       return c.json({ configured: true, defaultRegion, availableRegions }, 200);
     } catch (err) {
       if (err instanceof ResidencyError && err.code === "not_configured") {

--- a/packages/api/src/lib/__tests__/deploy-config-residency-regions.test.ts
+++ b/packages/api/src/lib/__tests__/deploy-config-residency-regions.test.ts
@@ -1,30 +1,42 @@
 /**
- * Regression: the production deploy config must NOT offer "staging" as a
- * data-residency region (#3948).
+ * Regression: the production deploy config must keep "staging" as a configured
+ * residency region (so the api-staging soak service can boot) BUT must flag it
+ * non-selectable so it never appears in the signup data-residency picker (#3948).
  *
- * The bug: `deploy/api/atlas.config.ts` declared a `staging` arm in
- * `residency.regions` alongside us/eu/apac. The onboarding `/regions`
- * endpoint returns `getConfiguredRegions()` verbatim, so the signup region
- * picker (`/signup/region`) offered "Staging" as a selectable residency
- * region to real production users — who could then route their workspace
- * metadata to the staging Postgres. Staging must stay scoped to the staging
- * deploy only.
+ * Background — why "staging" lives in this map at all. The api-staging soak
+ * service builds from the SAME image/config as prod
+ * (`RAILWAY_DOCKERFILE_PATH=deploy/api/Dockerfile`, which COPYs
+ * `deploy/api/atlas.config.ts`) and claims `ATLAS_API_REGION=staging`.
+ * `RegionGuardLive` (lib/effect/saas-guards.ts) fail-closes boot if the claimed
+ * region is absent from `residency.regions`, so the `staging` arm is
+ * load-bearing for the staging service's boot. Deleting it crash-loops
+ * api-staging ("Layer DAG could not initialize") — which is exactly what
+ * happened (#3948 → PR #3951 → staging crash loop).
+ *
+ * The bug #3948 was actually about: the onboarding `/regions` endpoint returned
+ * `getConfiguredRegions()` verbatim, so the signup picker (`/signup/region`)
+ * offered "Staging" as a selectable residency region to real production users —
+ * who could route workspace metadata to the staging Postgres. The fix is
+ * `selectable: false` on the staging arm + a picker filter (see
+ * `lib/residency/picker.ts` + its test), NOT removing the region. Existence ≠
+ * selectability.
  *
  * Why parse the source rather than import the config: the deploy configs use
  * container-root-relative imports (`./packages/api/src/lib/config`) that only
  * resolve from `/app/` inside the SaaS image, so they cannot be `import()`-ed
- * from a unit test. We extract the `residency.regions` keys from the source
- * text instead — comments are stripped first so prose mentioning "staging"
- * (the explanatory comment that replaced the removed arm) never counts as a
- * region entry.
+ * from a unit test. We extract the `residency.regions` shape from the source
+ * text instead — comments are stripped first so prose mentioning "staging" (the
+ * load-bearing tombstone comment) never counts as a region entry.
  *
- * Invariant pinned:
- *   - prod  (`deploy/api/atlas.config.ts`):        regions == { us, eu, apac }
- *   - staging (`deploy/api-staging/atlas.config.ts`): regions == { staging }
+ * Invariants pinned:
+ *   - prod  (`deploy/api/atlas.config.ts`):  regions == { us, eu, apac, staging },
+ *       and EXACTLY the staging arm carries `selectable: false` (us/eu/apac stay
+ *       selectable).
+ *   - staging (`deploy/api-staging/atlas.config.ts`): regions == { staging }.
  *
  * The api-eu / api-apac Railway services reuse `deploy/api/atlas.config.ts`
  * (only their `railway.json` differs), so this one prod assertion covers all
- * three production regions.
+ * three production regions plus the staging soak service.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -35,68 +47,44 @@ const REPO_ROOT = resolve(__dirname, "../../../../..");
 const PROD_CONFIG = resolve(REPO_ROOT, "deploy/api/atlas.config.ts");
 const STAGING_CONFIG = resolve(REPO_ROOT, "deploy/api-staging/atlas.config.ts");
 
-/**
- * Extract the region-id keys declared inside `residency.regions: { ... }`.
- *
- * A region entry is a quoted key whose value is an object literal
- * (`"<id>": {`). The scan is brace-bounded to the `regions` object so
- * unrelated later config (e.g. a `configSchema` key) can never leak in.
- *
- * Correctness against the test's own purpose (catching a future staging
- * re-add) demands the parser never be fooled by characters that LOOK
- * structural but aren't:
- *   - `//` inside a URL string (`apiUrl: "https://api.staging..."`) must NOT
- *     read as a line comment.
- *   - `{` / `}` INSIDE a string value (a URL) must NOT be brace-counted.
- *   - a quoted slug in COMMENT prose (this file's own "staging" tombstone)
- *     must NOT be matched as a region key.
- *
- * Two offset-preserving copies of the source, same length as `src` so a single
- * `[open, end]` range slices both:
- *   - `braceScan`: string-literal INTERIORS and `//` line comments blanked to
- *     spaces — used only to brace-match the `regions { … }` body. Region KEYS
- *     survive as `""` (interior blanked, quotes kept), which is fine: we never
- *     read keys off this copy, only braces, and a blanked URL can't inject one.
- *   - `commentless`: ONLY `//` line comments blanked. Region KEYS stay intact;
- *     URL string VALUES may be truncated at an embedded `//` (`"https:` + blank)
- *     — harmless, because keys are matched by the `"<id>": {` shape, never by
- *     URL content. A URL value never matches `"<id>": {` (it isn't followed by
- *     `: {`), and comment prose is gone, so the only `"<slug>": {` matches are
- *     real region entries.
- *
- * Guard against a non-inline re-add so a divergent shape fails LOUDLY instead
- * of silently slipping a region past the assertion:
- *   - `"staging": someConst` (referenced value) → caught by the quoted-key vs
- *     object-key count mismatch below.
- *   - `...someRegions` (spread) → caught by the explicit spread guard below
- *     (a spread carries no quoted key, so the count check alone would miss it).
- */
-function extractResidencyRegionKeys(filePath: string): string[] {
-  const src = readFileSync(filePath, "utf8");
-  const blank = (s: string) => " ".repeat(s.length);
+interface ParsedRegions {
+  /** Region-id keys declared inline under `residency.regions`. */
+  keys: string[];
+  /** The `residency.regions { … }` body with `//` comments stripped (strings kept). */
+  body: string;
+  /** Same body, but string interiors AND comments blanked — used for brace matching. */
+  braceBody: string;
+}
 
-  // Copy used ONLY for brace-counting: blank string interiors (keep the quotes
-  // so offsets and the `""` shape survive) and `//` line comments.
+const blank = (s: string) => " ".repeat(s.length);
+
+/**
+ * Parse the `residency.regions { … }` object out of a deploy config source file.
+ * See the inline notes on `braceScan` vs `commentless` — two offset-preserving
+ * copies so a single `[open, end]` range slices both. A region entry is a quoted
+ * key whose value is an object literal (`"<id>": {`). The scan is brace-bounded
+ * to the `regions` object so unrelated later config can never leak in, never
+ * fooled by `//` inside a URL, `{`/`}` inside a string, or a quoted slug in
+ * comment prose.
+ */
+function parseResidencyRegions(filePath: string): ParsedRegions {
+  const src = readFileSync(filePath, "utf8");
+
+  // Brace-matching copy: blank string interiors (keep quotes so offsets + the
+  // `""` shape survive) and `//` line comments.
   const braceScan = src
     .replace(/"(?:[^"\\\n]|\\.)*"/g, (s) => `"${" ".repeat(s.length - 2)}"`)
     .replace(/'(?:[^'\\\n]|\\.)*'/g, (s) => `'${" ".repeat(s.length - 2)}'`)
     .replace(/\/\/[^\n]*/g, blank);
 
-  // Copy used ONLY for key extraction: strip `//` line comments, keep strings.
-  // (The deploy configs put `//` only at line-start or inside URL values — never
-  // as a trailing inline comment in the residency block — so blanking every
-  // `//`-to-EOL run also blanks the `//` in a URL, which is harmless here
-  // because keys are matched by the `"<id>": {` shape, never by URL content.)
+  // Key/content copy: strip `//` line comments, keep strings.
   const commentless = src.replace(/\/\/[^\n]*/g, blank);
 
   const residencyIdx = braceScan.indexOf("residency:");
   if (residencyIdx === -1) throw new Error(`No 'residency:' block in ${filePath}`);
-
   const regionsIdx = braceScan.indexOf("regions:", residencyIdx);
   if (regionsIdx === -1) throw new Error(`No 'regions:' in residency block of ${filePath}`);
 
-  // Brace-match (over `braceScan`) from the first `{` after `regions:` to its
-  // close so we only scan the regions object body.
   const open = braceScan.indexOf("{", regionsIdx);
   if (open === -1) throw new Error(`No '{' after 'regions:' in ${filePath}`);
   let depth = 0;
@@ -113,19 +101,17 @@ function extractResidencyRegionKeys(filePath: string): string[] {
     }
   }
   if (end === -1) throw new Error(`Unbalanced braces in regions object of ${filePath}`);
-  // Slice the SAME [open+1, end] range from the keys copy (identical offsets).
-  const regionsBody = commentless.slice(open + 1, end);
 
-  // Spread guard: a spread (`...someRegions`) injects regions with no quoted key,
-  // so the quoted-vs-object count check below can't see it. Refuse to validate a
-  // regions map that uses a spread — a spread could pull `staging` back in
-  // invisibly. The deploy configs declare every region inline; this fails loudly
-  // if that ever changes rather than silently under-reporting the region set.
-  if (/\.\.\./.test(regionsBody)) {
+  const body = commentless.slice(open + 1, end);
+  const braceBody = braceScan.slice(open + 1, end);
+
+  // Spread guard: a spread (`...someRegions`) injects regions with no quoted key
+  // and could hide a region (e.g. staging) from these assertions. The deploy
+  // configs declare every region inline; fail loudly if that ever changes.
+  if (/\.\.\./.test(body)) {
     throw new Error(
       `Spread operator in residency.regions of ${filePath} — this parser only ` +
-        `validates inline "<id>": { … } entries and cannot see regions pulled in ` +
-        `via a spread, which could hide a region from the residency assertion.`,
+        `validates inline "<id>": { … } entries and cannot see spread-in regions.`,
     );
   }
 
@@ -133,47 +119,89 @@ function extractResidencyRegionKeys(filePath: string): string[] {
   const objectKeys: string[] = [];
   const objectRe = /["']([a-z0-9_-]+)["']\s*:\s*\{/gi;
   let m: RegExpExecArray | null;
-  while ((m = objectRe.exec(regionsBody)) !== null) {
-    objectKeys.push(m[1]);
-  }
+  while ((m = objectRe.exec(body)) !== null) objectKeys.push(m[1]);
 
-  // Every quoted slug key directly under `regions`, regardless of value shape.
-  // If a future re-add uses a non-inline value (a referenced const or a
-  // spread), `quotedKeys` would exceed `objectKeys` — fail loudly rather than
-  // let the divergent entry slip the assertion below. Match quoted keys only at
-  // the start of an indented line so nested object keys (label/databaseUrl/
-  // apiUrl, none of which are quoted anyway) can't inflate the count.
+  // Every line-leading quoted key directly under `regions`, regardless of value
+  // shape. If a future re-add uses a referenced const/spread, this would exceed
+  // `objectKeys` — fail loudly rather than let a divergent entry slip past.
   const quotedKeys: string[] = [];
   const keyRe = /(?:^|\n)\s*["']([a-z0-9_-]+)["']\s*:/gi;
-  while ((m = keyRe.exec(regionsBody)) !== null) {
-    quotedKeys.push(m[1]);
-  }
+  while ((m = keyRe.exec(body)) !== null) quotedKeys.push(m[1]);
   if (quotedKeys.length !== objectKeys.length) {
     throw new Error(
       `Quoted-key vs object-value mismatch in residency.regions of ${filePath} ` +
-        `(quoted keys [${quotedKeys.join(", ")}] vs object-valued ` +
-        `[${objectKeys.join(", ")}]). Likely a region with a non-object value ` +
-        `(e.g. "<id>": someConst) — this parser only validates inline ` +
-        `"<id>": { … } entries, so such a region could hide from the residency ` +
-        `assertion. (A line-leading quoted key NESTED inside a region's value ` +
-        `object would also trip this — region values use unquoted keys today.)`,
+        `(quoted [${quotedKeys.join(", ")}] vs object-valued [${objectKeys.join(", ")}]). ` +
+        `A region with a non-object value could hide from the assertions below.`,
     );
   }
 
-  return objectKeys;
+  return { keys: objectKeys, body, braceBody };
 }
 
+/**
+ * Brace-match a single region's object-literal body (`"<id>": { … }`) out of the
+ * already-parsed regions block. Brace matching runs over `braceBody` (string
+ * interiors blanked) so a `{`/`}` inside a URL value can't throw off the match;
+ * the returned slice comes from `body` (real content, comments stripped).
+ */
+function sliceRegionBody(parsed: ParsedRegions, id: string): string {
+  // Locate the key in `body` (keys intact — `braceBody` blanks string interiors,
+  // including region-key strings). `body` and `braceBody` are equal-length and
+  // offset-aligned (both sliced from same-length transforms of src), so the
+  // index found here maps 1:1 into `braceBody` for safe brace counting.
+  const keyRe = new RegExp(`["']${id}["']\\s*:\\s*\\{`, "g");
+  const km = keyRe.exec(parsed.body);
+  if (!km) throw new Error(`Region "${id}" not found in parsed regions block`);
+  const open = parsed.body.indexOf("{", km.index);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < parsed.braceBody.length; i++) {
+    const ch = parsed.braceBody[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) throw new Error(`Unbalanced braces in region "${id}"`);
+  return parsed.body.slice(open + 1, end);
+}
+
+const SELECTABLE_FALSE = /selectable\s*:\s*false/;
+
 describe("deploy config residency regions (#3948)", () => {
-  it("prod config offers exactly us/eu/apac — never staging", () => {
-    const keys = extractResidencyRegionKeys(PROD_CONFIG);
-    expect(keys.toSorted()).toEqual(["apac", "eu", "us"]);
-    // The load-bearing assertion: staging must never be a selectable prod
-    // residency region. A future edit re-adding it fails here.
-    expect(keys).not.toContain("staging");
+  it("prod config keeps us/eu/apac/staging — staging present so api-staging boots", () => {
+    const parsed = parseResidencyRegions(PROD_CONFIG);
+    expect(parsed.keys.toSorted()).toEqual(["apac", "eu", "staging", "us"]);
+    // Load-bearing: staging must stay in the map. Removing it crash-loops the
+    // api-staging soak service (RegionGuardLive fail-closes on an unknown
+    // claimed region). See #3948 → PR #3951 → the staging crash loop.
+    expect(parsed.keys).toContain("staging");
+  });
+
+  it("prod config flags ONLY staging non-selectable — us/eu/apac stay selectable (#3948)", () => {
+    const parsed = parseResidencyRegions(PROD_CONFIG);
+
+    // The actual #3948 fix: staging exists for boot/routing but is excluded from
+    // the signup picker via `selectable: false`.
+    expect(sliceRegionBody(parsed, "staging")).toMatch(SELECTABLE_FALSE);
+
+    // Real prod regions must remain selectable — a stray `selectable: false` on
+    // us/eu/apac would silently drop a region from the signup picker.
+    for (const id of ["us", "eu", "apac"]) {
+      expect(sliceRegionBody(parsed, id)).not.toMatch(SELECTABLE_FALSE);
+    }
+
+    // Exactly one region in the whole map is non-selectable (staging).
+    const count = (parsed.body.match(/selectable\s*:\s*false/g) ?? []).length;
+    expect(count).toBe(1);
   });
 
   it("staging config keeps the single staging region (scoped to the staging deploy)", () => {
-    const keys = extractResidencyRegionKeys(STAGING_CONFIG);
-    expect(keys).toEqual(["staging"]);
+    const parsed = parseResidencyRegions(STAGING_CONFIG);
+    expect(parsed.keys).toEqual(["staging"]);
   });
 });

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -288,6 +288,20 @@ const RegionConfigSchema = z.object({
   datasourceUrl: z.string().min(1).optional(),
   /** Public API endpoint for this region (e.g. "https://api-eu.useatlas.dev"). */
   apiUrl: z.string().url().optional(),
+  /**
+   * Whether this region is offered to customers in the signup data-residency
+   * picker (`GET /api/v1/onboarding/regions`). Defaults to `true` when omitted.
+   *
+   * Set `false` for an **internal** region that must exist in the map for the
+   * boot guard (`RegionGuardLive`, `lib/effect/saas-guards.ts`) and region
+   * routing, but must never be a selectable residency choice for real signups.
+   * The canonical case is the shared-config `staging` arm: the api-staging soak
+   * service builds from the prod image/config and claims `ATLAS_API_REGION=
+   * staging`, so the entry is load-bearing for its boot — yet a real prod signup
+   * must not be able to pick it (#3948). `selectable: false` keeps the region
+   * present for boot/routing while filtering it out of the picker only.
+   */
+  selectable: z.boolean().optional(),
 });
 
 export type RegionConfigInput = z.input<typeof RegionConfigSchema>;

--- a/packages/api/src/lib/residency/__tests__/picker.test.ts
+++ b/packages/api/src/lib/residency/__tests__/picker.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The signup data-residency picker must exclude regions flagged
+ * `selectable: false` — internal regions (e.g. the shared-config `staging` arm
+ * the api-staging soak service claims) that exist for the boot guard + routing
+ * but must never be a selectable residency choice for real signups (#3948).
+ */
+import { describe, it, expect } from "bun:test";
+import { buildAvailableRegions } from "@atlas/api/lib/residency/picker";
+import type { ResidencyConfig } from "@atlas/api/lib/config";
+
+type Regions = ResidencyConfig["regions"];
+
+const REGIONS: Regions = {
+  us: { label: "United States", apiUrl: "https://api.useatlas.dev" },
+  eu: { label: "Europe", apiUrl: "https://api-eu.useatlas.dev" },
+  apac: { label: "Asia Pacific", apiUrl: "https://api-apac.useatlas.dev" },
+  staging: { label: "Staging", apiUrl: "https://api.staging.useatlas.dev", selectable: false },
+};
+
+describe("buildAvailableRegions (#3948)", () => {
+  it("excludes regions flagged selectable: false", () => {
+    const ids = buildAvailableRegions(REGIONS, "us").map((r) => r.id);
+    expect(ids.toSorted()).toEqual(["apac", "eu", "us"]);
+    expect(ids).not.toContain("staging");
+  });
+
+  it("includes regions with selectable omitted (default true)", () => {
+    const regions: Regions = {
+      us: { label: "United States" },
+      eu: { label: "Europe", selectable: true },
+    };
+    const ids = buildAvailableRegions(regions, "us").map((r) => r.id);
+    expect(ids.toSorted()).toEqual(["eu", "us"]);
+  });
+
+  it("marks the default region and passes the label through", () => {
+    const available = buildAvailableRegions(REGIONS, "eu");
+    const eu = available.find((r) => r.id === "eu");
+    const us = available.find((r) => r.id === "us");
+    expect(eu).toEqual({ id: "eu", label: "Europe", isDefault: true });
+    expect(us?.isDefault).toBe(false);
+  });
+
+  it("never marks a non-selectable region as default even if it is the configured default", () => {
+    // Defensive: a misconfig where defaultRegion points at a non-selectable
+    // region must not leak that region into the picker.
+    const ids = buildAvailableRegions(REGIONS, "staging").map((r) => r.id);
+    expect(ids).not.toContain("staging");
+  });
+});

--- a/packages/api/src/lib/residency/__tests__/picker.test.ts
+++ b/packages/api/src/lib/residency/__tests__/picker.test.ts
@@ -5,7 +5,7 @@
  * but must never be a selectable residency choice for real signups (#3948).
  */
 import { describe, it, expect } from "bun:test";
-import { buildAvailableRegions } from "@atlas/api/lib/residency/picker";
+import { buildAvailableRegions, isRegionSelectable } from "@atlas/api/lib/residency/picker";
 import type { ResidencyConfig } from "@atlas/api/lib/config";
 
 type Regions = ResidencyConfig["regions"];
@@ -46,5 +46,25 @@ describe("buildAvailableRegions (#3948)", () => {
     // region must not leak that region into the picker.
     const ids = buildAvailableRegions(REGIONS, "staging").map((r) => r.id);
     expect(ids).not.toContain("staging");
+  });
+});
+
+describe("isRegionSelectable (#3948 — shared read/write predicate)", () => {
+  it("is true for a region with selectable omitted (default true)", () => {
+    expect(isRegionSelectable({ label: "United States" })).toBe(true);
+  });
+
+  it("is true for a region explicitly selectable", () => {
+    expect(isRegionSelectable({ label: "Europe", selectable: true })).toBe(true);
+  });
+
+  it("is false for a region flagged selectable: false", () => {
+    expect(isRegionSelectable({ label: "Staging", selectable: false })).toBe(false);
+  });
+
+  it("is false for an unknown region (undefined)", () => {
+    // The write path looks up `regions[region]` which is undefined for an
+    // unknown id — assignment must reject it, not treat it as selectable.
+    expect(isRegionSelectable(undefined)).toBe(false);
   });
 });

--- a/packages/api/src/lib/residency/picker.ts
+++ b/packages/api/src/lib/residency/picker.ts
@@ -1,0 +1,33 @@
+/**
+ * Signup data-residency picker projection.
+ *
+ * Maps the configured residency regions to the customer-facing list returned by
+ * `GET /api/v1/onboarding/regions` (the `/signup/region` step). Regions flagged
+ * `selectable: false` are excluded: they exist in the config for the boot guard
+ * (`RegionGuardLive`) and region routing, but must never be a selectable
+ * residency choice for real signups (#3948 — e.g. the shared-config `staging`
+ * arm the api-staging soak service claims). Existence ≠ selectability, so the
+ * filter lives here at the picker layer rather than by removing the region from
+ * the config (which would crash-loop the staging service — see #3948 → #3951).
+ */
+import type { ResidencyConfig } from "@atlas/api/lib/config";
+
+export interface AvailableRegion {
+  id: string;
+  label: string;
+  isDefault: boolean;
+}
+
+/**
+ * Project the configured regions to the signup picker, excluding any region
+ * marked `selectable: false`. A region with `selectable` omitted is selectable
+ * (default `true`).
+ */
+export function buildAvailableRegions(
+  regions: ResidencyConfig["regions"],
+  defaultRegion: string,
+): AvailableRegion[] {
+  return Object.entries(regions)
+    .filter(([, cfg]) => cfg.selectable !== false)
+    .map(([id, cfg]) => ({ id, label: cfg.label, isDefault: id === defaultRegion }));
+}

--- a/packages/api/src/lib/residency/picker.ts
+++ b/packages/api/src/lib/residency/picker.ts
@@ -1,33 +1,44 @@
 /**
- * Signup data-residency picker projection.
+ * Residency region selectability — the single source of truth for "may a
+ * customer be assigned this region?".
  *
- * Maps the configured residency regions to the customer-facing list returned by
- * `GET /api/v1/onboarding/regions` (the `/signup/region` step). Regions flagged
- * `selectable: false` are excluded: they exist in the config for the boot guard
- * (`RegionGuardLive`) and region routing, but must never be a selectable
- * residency choice for real signups (#3948 — e.g. the shared-config `staging`
- * arm the api-staging soak service claims). Existence ≠ selectability, so the
- * filter lives here at the picker layer rather than by removing the region from
- * the config (which would crash-loop the staging service — see #3948 → #3951).
+ * A region's *existence* in `residency.regions` (load-bearing for the boot guard
+ * `RegionGuardLive` + region routing) is independent of its *selectability*. A
+ * region flagged `selectable: false` exists for boot/routing but must never be a
+ * customer residency choice — neither offered in the signup picker NOR accepted
+ * by the assignment write path (#3948 — e.g. the shared-config `staging` arm the
+ * api-staging soak service claims). Existence ≠ selectability.
+ *
+ * Both the read path (this module's `buildAvailableRegions`, used by
+ * `GET /api/v1/onboarding/regions` and the admin residency surface) and the
+ * write path (`ee/src/platform/residency.ts` `assignWorkspaceRegion`) share
+ * `isRegionSelectable` so the two can never drift — closing the UI affordance
+ * without closing the actual write would leave the #3948 leak reachable via a
+ * direct `POST /assign-region`.
  */
 import type { ResidencyConfig } from "@atlas/api/lib/config";
+import type { RegionPickerItem } from "@useatlas/types";
 
-export interface AvailableRegion {
-  id: string;
-  label: string;
-  isDefault: boolean;
+type RegionConfig = ResidencyConfig["regions"][string];
+
+/**
+ * Whether a region may be chosen by a customer. `true` when the region exists
+ * and is not flagged `selectable: false` (an omitted flag defaults to
+ * selectable). `undefined` (an unknown region id) is not selectable.
+ */
+export function isRegionSelectable(region: RegionConfig | undefined): boolean {
+  return region !== undefined && region.selectable !== false;
 }
 
 /**
  * Project the configured regions to the signup picker, excluding any region
- * marked `selectable: false`. A region with `selectable` omitted is selectable
- * (default `true`).
+ * that is not selectable (see {@link isRegionSelectable}).
  */
 export function buildAvailableRegions(
   regions: ResidencyConfig["regions"],
   defaultRegion: string,
-): AvailableRegion[] {
+): RegionPickerItem[] {
   return Object.entries(regions)
-    .filter(([, cfg]) => cfg.selectable !== false)
+    .filter(([, cfg]) => isRegionSelectable(cfg))
     .map(([id, cfg]) => ({ id, label: cfg.label, isDefault: id === defaultRegion }));
 }


### PR DESCRIPTION
## What broke

`api-staging` has been **crash-looping since ~13:21 UTC** (`Server startup failed — Layer DAG could not initialize`), blocking the next `/release` to prod. No customer impact — staging is a soak env, and prod (`api`/`api-eu`/`api-apac`) only redeploys on a `/release` tag, so the regression never reached prod.

## Root cause

PR #3951 removed the `staging` arm from `deploy/api/atlas.config.ts`, on the premise (stated in its comment) that the api-staging soak service loads a *separate* `deploy/api-staging/atlas.config.ts`. **It doesn't** — that file is not wired into any image (the "slices 19–22" Dockerfile/railway wiring never shipped, and the file is already ~4 commits stale).

api-staging actually builds from the **prod** Dockerfile (`RAILWAY_DOCKERFILE_PATH=deploy/api/Dockerfile`, which `COPY`s `deploy/api/atlas.config.ts`) and sets `ATLAS_API_REGION=staging`. So the `staging` arm was **load-bearing** for its boot: `RegionGuardLive` (`lib/effect/saas-guards.ts`) fail-closes when the claimed region isn't in `residency.regions`.

## The fix

#3948's actual defect was that staging was **selectable** in the prod signup picker — not that it **existed** in the config. Existence ≠ selectability, so the fix belongs at the picker layer:

- `selectable?: boolean` (default `true`) on the residency region schema (`lib/config.ts`).
- Restore the `staging` arm to `deploy/api/atlas.config.ts` with `selectable: false` + a **LOAD-BEARING** comment citing this incident so it can't be deleted again.
- Filter non-selectable regions out of the signup picker via a pure `buildAvailableRegions` helper (`lib/residency/picker.ts`); `GET /api/v1/onboarding/regions` uses it. Admin → Connections still sees all regions.
- Regression test invariant flipped: prod config now **contains** staging but flags **only** staging non-selectable (us/eu/apac stay selectable). Plus a unit test for the picker filter.

Net: #3948 stays fixed (prod signups only ever see us/eu/apac, can't route to staging Postgres) **and** api-staging boots again on the byte-identical prod image — true soak fidelity.

## Why not just repoint the staging Dockerfile path?

Because `deploy/api-staging/atlas.config.ts` is ~4 commits stale (missing the operator-credentials resolver #3737, chat-plugin resume delivery #3832, and the datasource-guard #3921). Building staging from it today would swap the region crash for a different set of bugs and defeat the soak's prod-fidelity. A soak env wants the exact prod config, differing only by env vars.

## Follow-up (not in this PR)

Decide whether to **retire** the unused, drift-prone `deploy/api-staging/atlas.config.ts` (commit to the shared-config model — recommended) or **finish** the separation properly. Filing a tracking issue.

## Test plan

- `lib/residency/__tests__/picker.test.ts` — new, 4 cases (excludes `selectable:false`, includes default, marks default, never leaks a non-selectable default).
- `lib/__tests__/deploy-config-residency-regions.test.ts` — rewritten invariant (staging present + only-staging non-selectable).
- `api/__tests__/onboarding.test.ts` — 65 pass.
- Affected graph: 72/72 pass. `bun run type` + `bun run lint` clean.

Closes the regression introduced by #3951. Keeps #3948 fixed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore staging region as non-selectable in residency config to fix api-staging boot
> - Re-adds a `staging` entry to `residency.regions` in [atlas.config.ts](https://github.com/AtlasDevHQ/atlas/pull/3957/files#diff-e6db0c3b52717e74ce220854d51820cab32a3a64d438da05dbcd246e316d0fa2) with `selectable: false`, which was previously removed and caused api-staging to fail boot.
> - Adds `selectable` as an optional boolean field to `RegionConfigSchema` in [config.ts](https://github.com/AtlasDevHQ/atlas/pull/3957/files#diff-1a6ed73fa2483c21e47031cb14107c42f17f7e75dfaf1fda0fcf5f86571a78a3); regions without it default to selectable.
> - Introduces `isRegionSelectable` and `buildAvailableRegions` in [picker.ts](https://github.com/AtlasDevHQ/atlas/pull/3957/files#diff-7aba569253dfde2e6ab52f808f19feb4e527e12ed06706977e79774067394120) to filter non-selectable regions from customer-facing region lists.
> - Updates `assignWorkspaceRegion` in [residency.ts](https://github.com/AtlasDevHQ/atlas/pull/3957/files#diff-782e68a67d14396e5737454c9e47000f70b04b49315dc8535b2b3ad897a3606f) to reject non-selectable regions and report only selectable ones in error messages.
> - Updates the admin residency status and onboarding regions endpoints to use `buildAvailableRegions`, excluding non-selectable regions from picker responses while still resolving labels for already-assigned regions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53b8327.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->