### PR TITLE
fix(api): demo first-answer dead-end — union unpinned whitelist for the real conversation connection id (#3961)

### DIFF
--- a/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/demo-publish-visibility-pg.test.ts
@@ -44,6 +44,9 @@ import {
   _resetWhitelists,
   _resetPluginEntities,
 } from "@atlas/api/lib/semantic/whitelist";
+import { connections } from "@atlas/api/lib/db/connection";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { validateSQL } from "@atlas/api/lib/tools/sql";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -397,5 +400,273 @@ describeIfPg("demo first-answer: executeSQL whitelist resolves the demo tables (
     await loadOrgWhitelist(orgId, "published");
     const allowed = getOrgWhitelistedTables(orgId, "default", "published");
     expect(allowed.size).toBe(0);
+  });
+});
+
+/**
+ * LIVE-Postgres regression for the demo first-answer dead-end STILL not fixed in
+ * prod after #3947 (#3961).
+ *
+ * #3947 broadened the union fallback in `getOrgWhitelistedTables`, but ONLY for
+ * the literal `connectionId === "default"` sentinel. The real prod path never
+ * passes `"default"`: an unpinned chat conversation (reach = "All sources", no
+ * agent-named group) collapses `executeSQL`'s `currentMember` to the
+ * conversation's own `requestContextConnectionId` — a REAL, non-`"default"`
+ * connection id stamped by the chat route — which matches NO entity bucket
+ * (entities key under `connection_group_id`). So the direct lookup missed AND the
+ * literal-`"default"` union was bypassed → every demo table rejected on the first
+ * answer, while `GET /api/v1/tables` (the web page fetches it with no
+ * `connectionId` → resolves `"default"` → unions) still listed the full demo set.
+ * That asymmetry is exactly what `/verify-prod-signup` caught post-v0.0.28.
+ *
+ * The fix threads an explicit `unpinned` signal from `validateSQL` (derived from
+ * the RequestContext: All-sources reach AND the lookup id IS the conversation's
+ * own connection) into `getOrgWhitelistedTables`, so the union fires for the
+ * real-id unpinned case too — not only the literal sentinel.
+ *
+ * These tests feed the lookup the ACTUAL `requestContextConnectionId` a demo
+ * conversation carries (a real id, NOT `"default"`), so a fix that only satisfies
+ * the literal-`"default"` unit test (the #3947 gap) fails here. The final test
+ * drives the full `validateSQL` boundary inside a `withRequestContext`, pinning
+ * the RequestContext → `unpinned` derivation end-to-end.
+ */
+describeIfPg("demo first-answer: real requestContextConnectionId resolves the demo tables (#3961)", () => {
+  let pool: Pool;
+  const schemaName = `demo_3961_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let prevDatabaseUrl: string | undefined;
+
+  /** The real, non-`"default"` connection id an unpinned demo conversation carries. */
+  const CONV_CONN_ID = "demo-conn-7f3a";
+
+  async function install(orgId: string, installId: string, config: Record<string, unknown>): Promise<void> {
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at)
+       VALUES ($1, $2, 'catalog:demo-3961', $3, 'datasource', $4::jsonb, true, 'published', NOW())
+       ON CONFLICT (workspace_id, catalog_id, install_id)
+         DO UPDATE SET status = 'published', config = EXCLUDED.config`,
+      [`${orgId}-${installId}`, orgId, installId, JSON.stringify(config)],
+    );
+  }
+
+  async function seedEntities(orgId: string, installId: string, tables: string[]): Promise<void> {
+    await bulkUpsertEntities(
+      orgId,
+      tables.map((t) => ({
+        entityType: "entity" as const,
+        name: t,
+        yamlContent: `table: ${t}\ndescription: ${t}\n`,
+        connectionId: installId,
+      })),
+      internalQuery,
+      "published",
+    );
+  }
+
+  beforeAll(async () => {
+    prevDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`demo-3961: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:demo-3961', 'Demo Postgres', 'demo-3961', 'datasource', 'datasource', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  /** The conversation's own connection id, a sibling WITH a bucket, and an empty sibling. */
+  const SIBLING_CONN_ID = "warehouse";
+  const EMPTY_SIBLING_CONN_ID = "warehouse-empty";
+
+  afterEach(() => {
+    _resetWhitelists();
+    _resetOrgWhitelists();
+    _resetPluginEntities();
+    connections.unregister(CONV_CONN_ID);
+    connections.unregister(SIBLING_CONN_ID);
+    connections.unregister(EMPTY_SIBLING_CONN_ID);
+  });
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (prevDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDatabaseUrl;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`demo-3961: schema cleanup failed: ${message}`);
+    });
+    await pool.end();
+  });
+
+  const DEMO_TABLES = ["order_items", "products", "categories", "orders"];
+
+  it("the REAL conversation connection id (not `default`) dead-ends WITHOUT the unpinned flag — reproduces the #3961 prod bug", async () => {
+    // Entities key under the demo install bucket (`__demo__`); the conversation
+    // carries a different real connection id. This is the prod shape: the
+    // pre-#3961 lookup (`getOrgWhitelistedTables(orgId, <real id>)`, no union)
+    // returns EMPTY — the exact dead-end `/verify-prod-signup` hit, and exactly
+    // what the literal-`"default"` #3947 test could never catch.
+    const orgId = `org-3961-repro-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+
+    const deadEnd = getOrgWhitelistedTables(orgId, CONV_CONN_ID, "published");
+    expect(deadEnd.size).toBe(0); // every demo table rejected — the bug
+
+    const fixed = getOrgWhitelistedTables(orgId, CONV_CONN_ID, "published", { unpinned: true });
+    for (const t of DEMO_TABLES) expect(fixed.has(t)).toBe(true); // the fix
+  });
+
+  it("unpinned union across multiple buckets resolves the demo tables for the real conversation id (config.group_id shape)", async () => {
+    // The realistic multi-bucket shape: the demo install carries an explicit
+    // `config.group_id`, so entities key under BOTH the group AND its member.
+    // The conversation still carries its own distinct connection id → direct miss
+    // → without the union, empty. The unpinned union must resolve the full set.
+    const orgId = `org-3961-groupid-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres", group_id: "grp_demo" });
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+
+    invalidateOrgWhitelist(orgId);
+    const wl = await loadOrgWhitelist(orgId, "published");
+    expect(wl.size).toBeGreaterThan(1); // multi-bucket — the shape #3947 missed
+    expect(wl.has(CONV_CONN_ID)).toBe(false); // the conversation id is NOT a bucket key
+
+    const fixed = getOrgWhitelistedTables(orgId, CONV_CONN_ID, "published", { unpinned: true });
+    for (const t of DEMO_TABLES) expect(fixed.has(t)).toBe(true);
+  });
+
+  it("a PINNED real connection id is NOT widened by the absence of the unpinned flag (isolation preserved)", async () => {
+    // The unpinned union fires ONLY when the caller passes `unpinned: true`. A
+    // query the agent pinned to a real connection/group id is resolved WITHOUT
+    // the flag, so it sees its own bucket alone — a connection with no bucket
+    // gets the empty set, never the union of its siblings.
+    const orgId = `org-3961-pinned-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await install(orgId, "warehouse", { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, ["order_items", "products"]);
+    await seedEntities(orgId, "warehouse", ["widgets"]);
+
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+
+    // Pinned to a real bucket → that bucket alone (direct hit), no union.
+    const warehouseOnly = getOrgWhitelistedTables(orgId, "warehouse", "published");
+    expect(warehouseOnly.has("widgets")).toBe(true);
+    expect(warehouseOnly.has("order_items")).toBe(false);
+
+    // Pinned to a real id with NO bucket, WITHOUT the unpinned flag → empty, not
+    // the union (the leak the flag-gating prevents).
+    const pinnedMiss = getOrgWhitelistedTables(orgId, CONV_CONN_ID, "published");
+    expect(pinnedMiss.size).toBe(0);
+  });
+
+  it("validateSQL accepts a demo table for an UNPINNED conversation carrying the real connection id (full boundary)", async () => {
+    // The end-to-end #3961 boundary: drive `validateSQL` exactly as `executeSQL`
+    // does on a demo first answer — a RequestContext with All-sources reach
+    // (`groupReach` absent) and `connectionId` = the conversation's own real id,
+    // and the SAME id as the lookup `connId`. `validateSQL` must derive
+    // `unpinned: true` and accept the demo table, instead of rejecting it as "not
+    // in the allowed list".
+    const orgId = `org-3961-validate-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+
+    // Register the conversation's connection so `getDBType` resolves (postgres);
+    // no pool is opened — `validateSQL` only parses + whitelist-checks.
+    connections.register(CONV_CONN_ID, { url: TEST_DB_URL! });
+
+    // Unpinned conversation: groupReach omitted (All sources), connectionId = the
+    // real conversation id. `executeSQL`'s `currentMember` collapses to this same
+    // id, so we pass it as the validateSQL `connId`.
+    const accepted = await withRequestContext(
+      { requestId: "test-3961-unpinned", atlasMode: "published", connectionId: CONV_CONN_ID },
+      () => validateSQL("SELECT order_total FROM orders LIMIT 10", CONV_CONN_ID, orgId),
+    );
+    expect(accepted.valid).toBe(true);
+
+    // Contrast: a FOCUSED conversation (groupReach set to a different group) is
+    // not All-sources → `unpinned` stays false → the demo bucket is not unioned
+    // in → the same query is rejected. Locks the derivation's isolation side.
+    const rejected = await withRequestContext(
+      {
+        requestId: "test-3961-focused",
+        atlasMode: "published",
+        connectionId: CONV_CONN_ID,
+        groupReach: "grp_other",
+      },
+      () => validateSQL("SELECT order_total FROM orders LIMIT 10", CONV_CONN_ID, orgId),
+    );
+    expect(rejected.valid).toBe(false);
+  });
+
+  it("validateSQL does NOT widen an agent pin to a SIBLING connection under All-sources reach (isolation — locks the equality clause)", async () => {
+    // The load-bearing half of the derivation: `unpinned` requires the lookup id
+    // to BE the conversation's own connection. When the agent pins a different
+    // (sibling) connection while reach is still All-sources, `currentMember` is
+    // the sibling id ≠ `reqCtx.connectionId`, so `unpinned` MUST stay false and
+    // the sibling resolves its own bucket alone — never the org-wide union.
+    //
+    // The EMPTY-bucket sibling is what actually locks the equality clause: a
+    // sibling WITH a bucket is isolated by the `tables.size === 0` direct-hit
+    // short-circuit regardless of the flag, so dropping the clause would still
+    // pass. Only an empty-bucket pin reaches the union, so the empty-sibling
+    // assertion below FLIPS (reject → accept, demo tables leak) if a future edit
+    // drops `connectionId === sqlReqCtx?.connectionId`.
+    const orgId = `org-3961-sibling-${Math.floor(Math.random() * 1e6)}`;
+    await install(orgId, DEMO_INSTALL, { db_type: "postgres" });
+    await install(orgId, SIBLING_CONN_ID, { db_type: "postgres" });
+    await install(orgId, EMPTY_SIBLING_CONN_ID, { db_type: "postgres" });
+    await seedEntities(orgId, DEMO_INSTALL, DEMO_TABLES);
+    await seedEntities(orgId, SIBLING_CONN_ID, ["widgets"]);
+    // EMPTY_SIBLING_CONN_ID intentionally gets NO entities — an empty bucket.
+    invalidateOrgWhitelist(orgId);
+    await loadOrgWhitelist(orgId, "published");
+
+    // Registered so `getDBType` resolves (postgres); no pool is opened.
+    connections.register(CONV_CONN_ID, { url: TEST_DB_URL! });
+    connections.register(SIBLING_CONN_ID, { url: TEST_DB_URL! });
+    connections.register(EMPTY_SIBLING_CONN_ID, { url: TEST_DB_URL! });
+
+    // Conversation is unpinned (All sources), but the agent pins a SIBLING for
+    // this query → lookup connId = sibling ≠ the conversation id.
+    const ctx = {
+      requestId: "test-3961-sibling",
+      atlasMode: "published" as const,
+      connectionId: CONV_CONN_ID,
+    };
+
+    // THE LOCK: an EMPTY-bucket sibling pin would reach the union if `unpinned`
+    // wrongly flipped true (dropped equality clause) → demo `orders` would leak.
+    // With the clause, `unpinned` stays false → empty set → demo `orders` rejected.
+    const emptySiblingLeak = await withRequestContext(ctx, () =>
+      validateSQL("SELECT order_total FROM orders LIMIT 10", EMPTY_SIBLING_CONN_ID, orgId),
+    );
+    expect(emptySiblingLeak.valid).toBe(false);
+
+    // A non-empty sibling pin is also not widened (here the direct-hit
+    // short-circuit does the isolating) — demo `orders` still rejected.
+    const fullSiblingLeak = await withRequestContext(ctx, () =>
+      validateSQL("SELECT order_total FROM orders LIMIT 10", SIBLING_CONN_ID, orgId),
+    );
+    expect(fullSiblingLeak.valid).toBe(false);
+
+    // The sibling's OWN table still validates — isolation, not a blanket deny.
+    const ownBucket = await withRequestContext(ctx, () =>
+      validateSQL("SELECT id FROM widgets LIMIT 10", SIBLING_CONN_ID, orgId),
+    );
+    expect(ownBucket.valid).toBe(true);
   });
 });

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -797,23 +797,29 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
  * so a published-mode load won't satisfy a developer-mode lookup. Returns an
  * empty set if the requested cache has not been loaded.
  *
- * When `connectionId` is the unpinned sentinel `"default"`, the direct lookup
- * yields no tables, and the org has no bucket literally keyed `"default"` (the
- * usual case — entities key under their `connection_group_id`: `"__demo__"`, a
- * wizard id, an explicit group), the lookup falls back to the UNION of every
- * connection bucket the org has — the "All sources" reach an unpinned query
- * carries. This is what keeps the agent's query-time whitelist in lockstep with
- * `/api/v1/tables` for a demo / multi-connection workspace (#2142, broadened in
- * #3947). A real `"default"` bucket short-circuits the fallback (direct hit
- * wins), and a query pinned to a real connection id resolves that connection's
- * bucket alone (no widening).
+ * When the query is UNPINNED ("All sources" reach, no agent-named group), the
+ * direct lookup yields no tables (entities key under their `connection_group_id`:
+ * `"__demo__"`, a wizard id, an explicit group — never `"default"`), so the
+ * lookup falls back to the UNION of every connection bucket the org has. This is
+ * what keeps the agent's query-time whitelist in lockstep with `/api/v1/tables`
+ * for a demo / multi-connection workspace (#2142, broadened in #3947). The
+ * unpinned signal is either the literal `"default"` sentinel (no-context callers)
+ * or `opts.unpinned` (the chat path, whose `currentMember` is the conversation's
+ * own real `requestContextConnectionId` — #3961). A non-empty direct hit
+ * short-circuits the fallback (direct hit wins), and a query pinned to a real
+ * connection id resolves that connection's bucket alone (no widening).
  *
  * @param mode - `"published"` → published-only cache; `"developer"` → overlay
  *   cache (drafts on published, tombstones hidden, archived-connection entities
  *   excluded); omitted → legacy cache built from `listEntityRows` with no status
  *   filter (includes tombstones and archived rows).
  */
-export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default", mode?: "published" | "developer"): Set<string> {
+export function getOrgWhitelistedTables(
+  orgId: string,
+  connectionId: string = "default",
+  mode?: "published" | "developer",
+  opts?: { readonly unpinned?: boolean },
+): Set<string> {
   const cacheKey = whitelistCacheKey(orgId, mode);
   const cached = _orgWhitelists.get(cacheKey);
   if (!cached) {
@@ -822,34 +828,40 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
   }
   const byConnection = cached.tables;
 
-  // Unpinned-`default` fallback (#2142, broadened for #3947).
+  // Unpinned "All sources" fallback (#2142, broadened for #3947, fixed for #3961).
   //
-  // `executeSQL` collapses an unpinned conversation to the literal sentinel
-  // `connectionId = "default"` (tools/sql.ts: `currentMember = … ?? "default"`),
-  // but org entities are keyed under their `connection_group_id` — `"__demo__"` for
-  // a group-of-one demo install, a user-chosen id for a wizard datasource, or an
-  // explicit `config.group_id`. None of those is `"default"`, so the direct
-  // lookup misses and the agent rejects every table on the user's first query
-  // ("not in the allowed list") even though `/api/v1/tables` — which resolves the
-  // demo connection id explicitly — lists them.
+  // Org entities are keyed under their `connection_group_id` — `"__demo__"` for a
+  // group-of-one demo install, a user-chosen id for a wizard datasource, or an
+  // explicit `config.group_id`. An UNPINNED conversation (reach = "All sources",
+  // no agent-named group) has no single bucket to point at — its correct answer
+  // is the UNION of every bucket the org has, exactly the set `/api/v1/tables`
+  // advertises. Without this, the direct lookup misses and the agent rejects
+  // every table on the user's first query ("not in the allowed list").
   //
-  // The original fallback only rescued the SINGLE-bucket org (exactly one
-  // connection group, not named "default"). That broke the moment a second
-  // bucket existed — the demo install carrying an explicit `config.group_id`
-  // (which keys entities under both the group AND its member id), or a second
-  // datasource connected alongside the demo (#3947). An unpinned `default` query
-  // has reach = "All sources" (no group focus), so the correct resolution is the
-  // UNION of every bucket the org has — exactly the set the workspace advertises.
-  // This fires ONLY for the unpinned `"default"` sentinel with no own bucket; a
-  // query pinned to a real connection id still resolves that connection's bucket
-  // alone, so cross-connection isolation is preserved.
+  // The "is this query unpinned?" signal arrives two ways, because `executeSQL`'s
+  // `currentMember` resolves differently per caller:
+  //   • Literal `"default"` sentinel — callers with no RequestContext (MCP /
+  //     scheduler / direct tool calls) collapse to `… ?? "default"`.
+  //   • `opts.unpinned` — the chat path's `currentMember` collapses to the
+  //     conversation's own `requestContextConnectionId` (a REAL, non-`"default"`
+  //     id), so the literal check alone missed it and dead-ended the demo first
+  //     answer in prod even after #3947. `validateSQL` derives the flag from the
+  //     RequestContext (All-sources reach + the lookup id IS the conversation's
+  //     own connection) and threads it here (#3961).
+  //
+  // Fires ONLY for the unpinned case; a query the agent pinned to a real
+  // connection/group id resolves that bucket alone (direct hit), so
+  // cross-connection isolation is preserved. The `tables.size === 0` guard means
+  // a non-empty direct hit always wins over the union, and `byConnection.size >= 1`
+  // keeps a loaded-but-empty org fail-closed (no phantom union).
   let tables = new Set(byConnection.get(connectionId) ?? []);
-  if (
-    tables.size === 0 &&
-    connectionId === "default" &&
-    byConnection.size >= 1 &&
-    !byConnection.has("default")
-  ) {
+  const unionUnpinned =
+    // Literal sentinel with no own `"default"` bucket (a real default bucket
+    // would have been a non-empty direct hit, short-circuiting via tables.size).
+    (connectionId === "default" && !byConnection.has("default")) ||
+    // Real `requestContextConnectionId` carried by an unpinned chat conversation.
+    opts?.unpinned === true;
+  if (tables.size === 0 && unionUnpinned && byConnection.size >= 1) {
     tables = new Set<string>();
     for (const bucket of byConnection.values()) {
       for (const t of bucket) tables.add(t);
@@ -859,9 +871,10 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
         orgId,
         requestedConnectionId: connectionId,
         resolvedConnectionIds: Array.from(byConnection.keys()),
+        unpinned: opts?.unpinned === true,
         mode: mode ?? "developer",
       },
-      "getOrgWhitelistedTables: unpinned-default fallback resolved the union of all connection buckets",
+      "getOrgWhitelistedTables: unpinned All-sources fallback resolved the union of all connection buckets",
     );
   }
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -635,8 +635,36 @@ export async function validateSQL(sql: string, connectionId?: string, workspaceI
       if (orgId) {
         await loadOrgWhitelist(orgId, sqlReqCtx?.atlasMode);
       }
+      // #3961 — an UNPINNED chat conversation ("All sources" reach, no
+      // agent-named group) carries the conversation's own connection id as
+      // `currentMember` (`requestContextConnectionId`), NOT the literal
+      // `"default"` sentinel the #3947 union fallback keyed on. That real id
+      // matches no entity bucket (entities key under `connection_group_id`), so
+      // the direct lookup missed AND the literal-`"default"` union was bypassed →
+      // every demo table rejected on the first answer, while `/api/v1/tables`
+      // (fetched with no connectionId → resolves "default" → unions) still listed
+      // the full demo set. Detect the unpinned case here — All-sources reach AND
+      // the lookup id IS the conversation's own connection — and tell the
+      // whitelist to union every bucket, matching `/api/v1/tables`.
+      //
+      // The `connectionId === sqlReqCtx?.connectionId` clause is load-bearing: it
+      // keeps `unpinned = false` for an agent pin to a SIBLING connection
+      // (`currentMember` ≠ the conversation's own id), so an explicit pin is never
+      // widened to the union. A user-pinned or fanout self-leg CAN still derive
+      // `unpinned = true`, but its own bucket is non-empty, so isolation there is
+      // preserved by the `tables.size === 0` direct-hit short-circuit in
+      // `getOrgWhitelistedTables` — not by this flag. Reach is decoded via the
+      // canonical `reachStateFromColumn` SSOT so this notion of "All sources"
+      // can't drift from `executeSQL`'s reach gate (a falsy-but-non-null
+      // `groupReach` is "all", which a bare `?? null` check would miss).
+      const unpinnedAllSources =
+        reachStateFromColumn(sqlReqCtx?.groupReach).kind === "all" &&
+        connectionId !== undefined &&
+        connectionId === sqlReqCtx?.connectionId;
       const allowed = orgId
-        ? getOrgWhitelistedTables(orgId, connectionId, sqlReqCtx?.atlasMode)
+        ? getOrgWhitelistedTables(orgId, connectionId, sqlReqCtx?.atlasMode, {
+            unpinned: unpinnedAllSources,
+          })
         : getWhitelistedTables(connectionId);
 
       // Self-hosted reads its whitelist from on-disk `catalog.yml` / entity


### PR DESCRIPTION
## Problem

`/verify-prod-signup` re-ran against prod immediately after the **v0.0.28** deploy and the demo first-answer dead-end (#3947) was **still live**: a fresh demo signup's first `executeSQL` is rejected with `Table "orders" is not in the allowed list`, even though `/api/v1/tables` and `/api/v1/semantic/entities` both list the 13 NovaMart demo tables.

## Root cause

#3947 broadened the union fallback in `getOrgWhitelistedTables`, but keyed it on the literal `connectionId === "default"` sentinel **only**. The real prod path never passes `"default"`:

- An **unpinned** chat conversation ("All sources" reach, no agent-named group) collapses `executeSQL`'s `currentMember` to the conversation's own `requestContextConnectionId` — a real, non-`"default"` connection id stamped by the chat route.
- That real id matches **no entity bucket** (entities key under `connection_group_id` — `__demo__`, a group id, member ids — never `"default"`), so the direct lookup misses **and** the literal-`"default"` union is bypassed → empty set → every demo table rejected.
- Meanwhile `GET /api/v1/tables` is fetched by the web page **with no `connectionId`** → `groupKey = "default"` → unions → still lists all 13 tables. That advertise/enforce asymmetry is the exact #3947 condition, on the path #3947's test never exercised (it pinned the literal `"default"`).

## Fix

`validateSQL` derives an `unpinned` signal from the `RequestContext` and threads it to `getOrgWhitelistedTables`:

```ts
const unpinnedAllSources =
  reachStateFromColumn(sqlReqCtx?.groupReach).kind === "all" && // All-sources reach (canonical SSOT decoder)
  connectionId !== undefined &&
  connectionId === sqlReqCtx?.connectionId;                     // the lookup id IS the conversation's own connection
```

The union now fires for the real-id unpinned case, not only the literal sentinel.

- **Isolation preserved.** The `connectionId === reqCtx.connectionId` clause keeps `unpinned = false` for an agent pin to a *sibling* connection, so an explicit pin is never widened. A non-empty pinned bucket is isolated by the existing `tables.size === 0` direct-hit short-circuit; a loaded-but-empty org stays fail-closed (`byConnection.size >= 1`).
- **No-context callers unchanged.** MCP / scheduler / direct tool calls (no `RequestContext`) fall back to the literal-`"default"` path exactly as before.

## Tests

New live-PG `#3961` block in `demo-publish-visibility-pg.test.ts`:
- feeds the lookup the **actual real conversation connection id** a demo first answer carries (not `"default"`), asserting dead-end without the flag and resolution with it — so a fix satisfying only the literal-`"default"` unit test fails here (AC3);
- a full `validateSQL`-boundary test inside `withRequestContext` (accept unpinned / reject focused / **reject sibling-pin with an empty-bucket sibling that genuinely locks the isolation clause** — verified red→green by dropping the clause).

The existing #3947 / #3932 blocks still pass.

## Acceptance criteria

- [x] The query-time whitelist resolves the same demo tables `/api/v1/tables` advertises, for the `currentMember` value a real demo conversation carries — not only the literal `"default"` sentinel.
- [x] Regression test at the `executeSQL`/`validateSQL` boundary (feeds the real `requestContextConnectionId`).
- [ ] Re-run `/verify-prod-signup` (all 3 regions) green on the first answer — **post-merge/release verification** (this PR deploys to staging; prod is `/release`-gated).

## Reviewer note (acknowledged, not blocking)

The `unpinned` signal is threaded into the **enforcement** seam (`validateSQL`) only, not the **advertise** seam (`resolveAllowedTables` / `/api/v1/tables`). On equivalent inputs the two stay in lockstep (no-`connectionId` → both union via `"default"`; explicit pin → both that bucket), and the demo path — which fetches `/tables` with no `connectionId` — is unaffected. The only divergence is a hypothetical `/tables?connectionId=<conversation's own id>`, where enforce(union) ≥ advertise(bucket) — the **safe** direction (never advertises a table it won't enforce). `resolveAllowedTables` is a stateless per-connection resolver with no conversation context, so it can't know a given id is "the conversation's own"; reconciling would require giving it a RequestContext-derived unpinned concept — a separate design question, not needed for this fix.

Internal review panel (silent-failure-hunter / type-design-analyzer / pr-test-analyzer / comment-analyzer): no CRITICAL/HIGH; all MEDIUM/LOW addressed inline (reach SSOT, isolation-clause test lock, comment accuracy) or acknowledged above.

Closes #3961

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix demo first-answer dead-end by unioning whitelist buckets for unpinned conversation connections
> - In demo chat flows, a real `requestContextConnectionId` (not `'default'`) was passed to `getOrgWhitelistedTables`, causing an empty direct lookup and blocking query validation against demo tables.
> - [`whitelist.ts`](https://github.com/AtlasDevHQ/atlas/pull/3963/files#diff-e3bdaac61983f441334f9a76c457b832047f6c8579e3bdac4ff2db4f6a429969) extends `getOrgWhitelistedTables` with an `opts.unpinned` flag that triggers the union-of-all-buckets fallback when the direct hit is empty, independent of the `'default'` sentinel.
> - [`sql.ts`](https://github.com/AtlasDevHQ/atlas/pull/3963/files#diff-aff638412280e753f8b324c261136e133472c2e24d24882f34736d3700920e17) derives `unpinned` in `validateSQL` when the conversation has All-sources reach and the `connectionId` matches the request context connection — passing it through to `getOrgWhitelistedTables`.
> - Agent-pinned sibling connections are explicitly excluded from widening, preserving their isolation.
> - Risk: any org where the direct bucket lookup is empty and reach is `'all'` will now receive the full union whitelist instead of an empty set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2b8c904. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->