### PR TITLE
fix(api): demo-aware onboarding drip + non-eager first_query milestone (#3962)

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -21,7 +21,7 @@ import { corsResponseHeaders } from "@atlas/api/lib/cors";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
-import { logFirstAnswerLatency, isFirstTurn } from "@atlas/api/lib/activation-metrics";
+import { logFirstAnswerLatency, isFirstTurn, turnAnsweredQuery } from "@atlas/api/lib/activation-metrics";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import {
   authenticateRequest,
@@ -1699,18 +1699,31 @@ chat.openapi(chatRoute, async (c) => {
             },
           });
   
-          // Fire-and-forget: trigger onboarding "first query" milestone.
-          // AtlasUser.label is the user's email in managed auth mode.
+          // Fire-and-forget: trigger the onboarding "first query executed"
+          // milestone — but ONLY once the turn actually answered a question, i.e.
+          // a successful executeSQL result is present in the resolved steps. The
+          // previous code fired here at stream-creation on EVERY chat turn, gated
+          // only on "user has an email", so it marked the milestone even for a
+          // turn whose SQL was rejected by the whitelist (#3961) or that never ran
+          // SQL — misrepresenting activation. Resolving `agentResult.steps` also
+          // naturally defers the fire to after the agent loop completes (and skips
+          // it when the stream errors → the promise rejects). The milestone itself
+          // now records the step satisfied to suppress the 72h fallback nudge
+          // WITHOUT sending an in-turn "ask your first question" email (#3962 —
+          // see lib/email/hooks.ts). AtlasUser.label is the user's email in
+          // managed auth mode.
           if (authResult.user?.id && authResult.user.label?.includes("@")) {
             const uid = authResult.user.id;
             const uemail = authResult.user.label;
             const uorg = authResult.user.activeOrganizationId ?? "default";
-            void import("@atlas/api/lib/email/hooks")
-              .then(({ onFirstQueryExecuted }) => {
+            void Promise.resolve(agentResult.steps)
+              .then(async (steps) => {
+                if (!turnAnsweredQuery(steps)) return;
+                const { onFirstQueryExecuted } = await import("@atlas/api/lib/email/hooks");
                 onFirstQueryExecuted({ userId: uid, email: uemail, orgId: uorg });
               })
               .catch((err: unknown) => {
-                log.debug({ err: err instanceof Error ? err.message : String(err) }, "Onboarding email hook not available — non-blocking");
+                log.debug({ err: err instanceof Error ? err.message : String(err) }, "Onboarding first-query milestone skipped — non-blocking");
               });
           }
   

--- a/packages/api/src/lib/__tests__/activation-metrics.test.ts
+++ b/packages/api/src/lib/__tests__/activation-metrics.test.ts
@@ -3,6 +3,7 @@ import {
   buildFirstAnswerLatencyEvent,
   logFirstAnswerLatency,
   isFirstTurn,
+  turnAnsweredQuery,
 } from "@atlas/api/lib/activation-metrics";
 
 describe("buildFirstAnswerLatencyEvent", () => {
@@ -92,6 +93,44 @@ describe("isFirstTurn", () => {
         { role: "assistant" },
       ]),
     ).toBe(true);
+  });
+});
+
+describe("turnAnsweredQuery (#3962 — gates first_query milestone on a real answer)", () => {
+  test("true when an executeSQL result came back successful", () => {
+    expect(
+      turnAnsweredQuery([
+        { toolResults: [{ toolName: "executeSQL", output: { success: true, columns: ["n"], rows: [{ n: 1 }] } }] },
+      ]),
+    ).toBe(true);
+  });
+
+  test("false when the only executeSQL result was rejected (#3961 whitelist case)", () => {
+    expect(
+      turnAnsweredQuery([
+        { toolResults: [{ toolName: "executeSQL", output: { success: false, error: "Table not in allowed list" } }] },
+      ]),
+    ).toBe(false);
+  });
+
+  test("false when the turn ran no SQL at all", () => {
+    expect(turnAnsweredQuery([{ toolResults: [{ toolName: "explore", output: { ok: true } }] }])).toBe(false);
+    expect(turnAnsweredQuery([{}])).toBe(false);
+    expect(turnAnsweredQuery([])).toBe(false);
+  });
+
+  test("true if any step has a successful query, even alongside a rejected one", () => {
+    expect(
+      turnAnsweredQuery([
+        { toolResults: [{ toolName: "executeSQL", output: { success: false, error: "bad" } }] },
+        { toolResults: [{ toolName: "executeSQL", output: { success: true, rows: [] } }] },
+      ]),
+    ).toBe(true);
+  });
+
+  test("ignores a non-object / null output defensively", () => {
+    expect(turnAnsweredQuery([{ toolResults: [{ toolName: "executeSQL", output: null }] }])).toBe(false);
+    expect(turnAnsweredQuery([{ toolResults: [{ toolName: "executeSQL", output: "done" }] }])).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/activation-metrics.ts
+++ b/packages/api/src/lib/activation-metrics.ts
@@ -78,6 +78,36 @@ export function isFirstTurn(
 }
 
 /**
+ * Whether an agent turn actually *answered* a data question — i.e. `executeSQL`
+ * ran a query that came back successfully. Gates the onboarding
+ * `first_query_executed` milestone (#3962): the milestone must reflect a query
+ * the user got a real answer to, not merely "a chat turn happened". Firing it at
+ * stream-creation on any turn (the prior behavior) marked the milestone even for
+ * a turn whose SQL was rejected by the table whitelist (#3961), errored, or
+ * never touched the database — none of which is a first answer.
+ *
+ * Reads the success-discriminated `executeSQL` tool output (`{ success: true, … }`
+ * for an answered query; `{ success: false, error }` for a rejected/failed one —
+ * see `lib/tools/sql.ts`). Pure over the resolved agent steps, so it is unit
+ * testable without driving the route.
+ */
+export function turnAnsweredQuery(
+  steps: ReadonlyArray<{
+    readonly toolResults?: ReadonlyArray<{ readonly toolName: string; readonly output: unknown }>;
+  }>,
+): boolean {
+  return steps.some((step) =>
+    (step.toolResults ?? []).some(
+      (tr) =>
+        tr.toolName === "executeSQL" &&
+        typeof tr.output === "object" &&
+        tr.output !== null &&
+        (tr.output as { success?: unknown }).success === true,
+    ),
+  );
+}
+
+/**
  * Shape the structured first-answer-latency event. Pure: clamps to a
  * non-negative integer (a backwards clock or a finish reading taken before the
  * start must never emit a negative latency) and omits correlation ids that

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -137,8 +137,8 @@ describe("sendOnboardingEmail demo-awareness (#3962 — reads datasource state, 
     mockDeliveryResult = { success: true, provider: "log" };
   });
 
-  // workspace_plugins state → (has_demo, has_real) the isDemoOnlyWorkspace probe returns.
-  async function sendFirstQueryWith(pluginRow: { has_demo: boolean | null; has_real: boolean | null }) {
+  // workspace_plugins state → (has_demo, has_real_sql) the isDemoOnlyWorkspace probe returns.
+  async function sendFirstQueryWith(pluginRow: { has_demo: boolean | null; has_real_sql: boolean | null }) {
     const { internalQuery } = await import("@atlas/api/lib/db/internal");
     const { sendEmail } = await import("../delivery");
     (internalQuery as ReturnType<typeof mock>).mockClear();
@@ -153,22 +153,31 @@ describe("sendOnboardingEmail demo-awareness (#3962 — reads datasource state, 
     return (call?.[0] as { html?: string } | undefined)?.html ?? "";
   }
 
-  it("uses demo copy for a demo-only workspace (demo datasource, no real one)", async () => {
-    const html = await sendFirstQueryWith({ has_demo: true, has_real: false });
+  it("uses demo copy for a demo-only workspace (demo datasource, no real SQL one)", async () => {
+    const html = await sendFirstQueryWith({ has_demo: true, has_real_sql: false });
     expect(html).toContain("Your demo dataset is loaded");
     expect(html).not.toContain("Your database is connected");
   });
 
-  it("uses BYO copy once the workspace graduates to a real datasource (demo + real)", async () => {
+  it("uses BYO copy once the workspace graduates to a real SQL datasource (demo + real SQL)", async () => {
     // The graduation case the marker-based check missed: a demo workspace that
     // later connects its own DB must NOT keep getting demo copy.
-    const html = await sendFirstQueryWith({ has_demo: true, has_real: true });
+    const html = await sendFirstQueryWith({ has_demo: true, has_real_sql: true });
     expect(html).toContain("Your database is connected");
     expect(html).not.toContain("Your demo dataset is loaded");
   });
 
+  it("keeps demo copy for demo + a REST datasource (no SQL pool → has_real_sql false)", async () => {
+    // A REST/OpenAPI datasource is pillar='datasource' but not a SQL pool, so it
+    // must NOT flip the workspace to the SQL-centric "your database is connected"
+    // copy. The query's allowlist join yields has_real_sql=false for demo+REST.
+    const html = await sendFirstQueryWith({ has_demo: true, has_real_sql: false });
+    expect(html).toContain("Your demo dataset is loaded");
+    expect(html).not.toContain("Your database is connected");
+  });
+
   it("uses BYO copy for a workspace with no datasource at all (bool_or → null)", async () => {
-    const html = await sendFirstQueryWith({ has_demo: null, has_real: null });
+    const html = await sendFirstQueryWith({ has_demo: null, has_real_sql: null });
     expect(html).toContain("Your database is connected");
   });
 });

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -130,6 +130,49 @@ describe("sendOnboardingEmail", () => {
   });
 });
 
+describe("sendOnboardingEmail demo-awareness (#3962 — reads datasource state, not the drip marker)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
+    mockHasDB = true;
+    mockDeliveryResult = { success: true, provider: "log" };
+  });
+
+  // workspace_plugins state → (has_demo, has_real) the isDemoOnlyWorkspace probe returns.
+  async function sendFirstQueryWith(pluginRow: { has_demo: boolean | null; has_real: boolean | null }) {
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    const { sendEmail } = await import("../delivery");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+    (sendEmail as ReturnType<typeof mock>).mockClear();
+    (internalQuery as ReturnType<typeof mock>).mockImplementation((sql: string) => {
+      if (typeof sql === "string" && sql.includes("workspace_plugins")) return Promise.resolve([pluginRow]);
+      // not unsubscribed / nothing sent yet / no branding
+      return Promise.resolve([]);
+    });
+    await sendOnboardingEmail("u1", "demo@example.com", "org1", "first_query", "time_based");
+    const call = (sendEmail as ReturnType<typeof mock>).mock.calls[0];
+    return (call?.[0] as { html?: string } | undefined)?.html ?? "";
+  }
+
+  it("uses demo copy for a demo-only workspace (demo datasource, no real one)", async () => {
+    const html = await sendFirstQueryWith({ has_demo: true, has_real: false });
+    expect(html).toContain("Your demo dataset is loaded");
+    expect(html).not.toContain("Your database is connected");
+  });
+
+  it("uses BYO copy once the workspace graduates to a real datasource (demo + real)", async () => {
+    // The graduation case the marker-based check missed: a demo workspace that
+    // later connects its own DB must NOT keep getting demo copy.
+    const html = await sendFirstQueryWith({ has_demo: true, has_real: true });
+    expect(html).toContain("Your database is connected");
+    expect(html).not.toContain("Your demo dataset is loaded");
+  });
+
+  it("uses BYO copy for a workspace with no datasource at all (bool_or → null)", async () => {
+    const html = await sendFirstQueryWith({ has_demo: null, has_real: null });
+    expect(html).toContain("Your database is connected");
+  });
+});
+
 describe("onMilestoneReached (#3962 — action milestones suppress the nudge, no in-turn email)", () => {
   beforeEach(() => {
     process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
@@ -296,10 +339,6 @@ describe("getOnboardingStatuses distinguishes suppressed steps from sent (#3949,
       }
       if (typeof sql === "string" && sql.includes('SELECT m."userId" as user_id')) {
         return Promise.resolve([{ user_id: "u1", email: "demo@example.com", created_at: "2026-03-20T00:00:00Z" }]);
-      }
-      // isDemoOnlySignup probe (LIMIT 1) — only matters for send-time copy, harmless here.
-      if (typeof sql === "string" && sql.includes("LIMIT 1") && sql.includes("'demo_activated'")) {
-        return Promise.resolve([{ one: 1 }]);
       }
       // getSentSteps + getSuppressedSteps now both read `SELECT step, triggered_by …`
       // (no triggered_by filter); the suppressed/sent split is computed in JS from

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -130,7 +130,7 @@ describe("sendOnboardingEmail", () => {
   });
 });
 
-describe("onMilestoneReached", () => {
+describe("onMilestoneReached (#3962 — action milestones suppress the nudge, no in-turn email)", () => {
   beforeEach(() => {
     process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
     mockHasDB = true;
@@ -138,14 +138,33 @@ describe("onMilestoneReached", () => {
     mockDeliveryResult = { success: true, provider: "log" };
   });
 
-  it("sends email for mapped milestone", async () => {
-    await onMilestoneReached("database_connected", "u1", "test@example.com", "org1");
-    // No assertion needed beyond not throwing — delivery is mocked
+  it("records the step satisfied WITHOUT dispatching the nudge email", async () => {
+    const { internalQuery } = await import("@atlas/api/lib/db/internal");
+    const { sendEmail } = await import("../delivery");
+    (internalQuery as ReturnType<typeof mock>).mockClear();
+    (sendEmail as ReturnType<typeof mock>).mockClear();
+    // Not unsubscribed.
+    (internalQuery as ReturnType<typeof mock>).mockImplementation(() => Promise.resolve([]));
+
+    await onMilestoneReached("first_query_executed", "u1", "org1");
+
+    // The "ask your first question" nudge is NOT mailed back in the same turn.
+    expect(sendEmail as ReturnType<typeof mock>).not.toHaveBeenCalled();
+
+    // The first_query step was recorded with the milestone as its trigger so the
+    // 72h fallback nudge is suppressed.
+    const insertCall = (internalQuery as ReturnType<typeof mock>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO onboarding_emails"),
+    );
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as unknown[];
+    expect(params[2]).toBe("first_query");
+    expect(params[3]).toBe("first_query_executed");
   });
 
   it("handles unknown milestone gracefully", async () => {
     // @ts-expect-error testing invalid input
-    await onMilestoneReached("unknown_milestone", "u1", "test@example.com", "org1");
+    await onMilestoneReached("unknown_milestone", "u1", "org1");
     // Should not throw
   });
 });
@@ -263,13 +282,13 @@ describe("checkFallbackEmails skips a connect_database step satisfied by demo (#
   });
 });
 
-describe("getOnboardingStatuses distinguishes suppressed (demo) steps from sent (#3949)", () => {
+describe("getOnboardingStatuses distinguishes suppressed steps from sent (#3949, #3962)", () => {
   beforeEach(() => {
     process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "true";
     mockHasDB = true;
   });
 
-  it("reports a demo-satisfied connect_database in suppressedSteps, not sentSteps", async () => {
+  it("classifies by trigger: welcome/time_based = sent; demo + action milestones = suppressed", async () => {
     const { internalQuery } = await import("@atlas/api/lib/db/internal");
     (internalQuery as ReturnType<typeof mock>).mockImplementation((sql: string) => {
       if (typeof sql === "string" && sql.includes("COUNT(DISTINCT")) {
@@ -278,14 +297,22 @@ describe("getOnboardingStatuses distinguishes suppressed (demo) steps from sent 
       if (typeof sql === "string" && sql.includes('SELECT m."userId" as user_id')) {
         return Promise.resolve([{ user_id: "u1", email: "demo@example.com", created_at: "2026-03-20T00:00:00Z" }]);
       }
-      // getSuppressedSteps — the triggered_by-filtered query MUST be matched
-      // before the generic getSentSteps query (which is a prefix of it).
-      if (typeof sql === "string" && sql.includes("triggered_by = 'demo_activated'")) {
-        return Promise.resolve([{ step: "connect_database" }]);
+      // isDemoOnlySignup probe (LIMIT 1) — only matters for send-time copy, harmless here.
+      if (typeof sql === "string" && sql.includes("LIMIT 1") && sql.includes("'demo_activated'")) {
+        return Promise.resolve([{ one: 1 }]);
       }
-      // getSentSteps — every recorded step.
+      // getSentSteps + getSuppressedSteps now both read `SELECT step, triggered_by …`
+      // (no triggered_by filter); the suppressed/sent split is computed in JS from
+      // the trigger. welcome (signup_completed) + an invite_team fallback nudge
+      // (time_based) are sent; connect_database (demo_activated) + first_query
+      // (the action milestone) are suppressed.
       if (typeof sql === "string" && sql.includes("FROM onboarding_emails")) {
-        return Promise.resolve([{ step: "welcome" }, { step: "connect_database" }]);
+        return Promise.resolve([
+          { step: "welcome", triggered_by: "signup_completed" },
+          { step: "connect_database", triggered_by: "demo_activated" },
+          { step: "first_query", triggered_by: "first_query_executed" },
+          { step: "invite_team", triggered_by: "time_based" },
+        ]);
       }
       if (typeof sql === "string" && sql.includes("email_preferences")) {
         return Promise.resolve([]); // not unsubscribed
@@ -297,12 +324,14 @@ describe("getOnboardingStatuses distinguishes suppressed (demo) steps from sent 
     expect(total).toBe(1);
     expect(statuses).toHaveLength(1);
     const s = statuses[0];
-    // welcome was genuinely sent; connect_database was demo-suppressed.
-    expect(s.sentSteps).toEqual(["welcome"]);
-    expect(s.suppressedSteps).toEqual(["connect_database"]);
-    // Both are "completed", so neither appears in pendingSteps.
-    expect(s.pendingSteps).not.toContain("welcome");
-    expect(s.pendingSteps).not.toContain("connect_database");
-    expect(s.pendingSteps).toContain("first_query");
+    // welcome + invite_team had emails dispatched; connect_database (demo) and
+    // first_query (action milestone) were satisfied without a send.
+    expect(s.sentSteps.toSorted()).toEqual(["invite_team", "welcome"]);
+    expect(s.suppressedSteps.toSorted()).toEqual(["connect_database", "first_query"]);
+    // All four are "completed", so none appear in pendingSteps.
+    for (const completed of ["welcome", "connect_database", "first_query", "invite_team"]) {
+      expect(s.pendingSteps).not.toContain(completed);
+    }
+    expect(s.pendingSteps).toContain("explore_features");
   });
 });

--- a/packages/api/src/lib/email/__tests__/hooks.test.ts
+++ b/packages/api/src/lib/email/__tests__/hooks.test.ts
@@ -72,7 +72,7 @@ describe("onDatabaseConnected", () => {
   it("calls onMilestoneReached with database_connected", async () => {
     onDatabaseConnected(USER);
     await new Promise((r) => setTimeout(r, 10));
-    expect(mockOnMilestoneReached).toHaveBeenCalledWith("database_connected", "u1", "test@example.com", "org1");
+    expect(mockOnMilestoneReached).toHaveBeenCalledWith("database_connected", "u1", "org1");
   });
 
   it("is a no-op when feature disabled", async () => {
@@ -132,7 +132,7 @@ describe("onFirstQueryExecuted", () => {
   it("calls onMilestoneReached with first_query_executed", async () => {
     onFirstQueryExecuted(USER);
     await new Promise((r) => setTimeout(r, 10));
-    expect(mockOnMilestoneReached).toHaveBeenCalledWith("first_query_executed", "u1", "test@example.com", "org1");
+    expect(mockOnMilestoneReached).toHaveBeenCalledWith("first_query_executed", "u1", "org1");
   });
 });
 
@@ -145,7 +145,7 @@ describe("onTeamMemberInvited", () => {
   it("calls onMilestoneReached with team_member_invited", async () => {
     onTeamMemberInvited(USER);
     await new Promise((r) => setTimeout(r, 10));
-    expect(mockOnMilestoneReached).toHaveBeenCalledWith("team_member_invited", "u1", "test@example.com", "org1");
+    expect(mockOnMilestoneReached).toHaveBeenCalledWith("team_member_invited", "u1", "org1");
   });
 });
 
@@ -158,7 +158,7 @@ describe("onFeatureExplored", () => {
   it("calls onMilestoneReached with feature_explored", async () => {
     onFeatureExplored(USER);
     await new Promise((r) => setTimeout(r, 10));
-    expect(mockOnMilestoneReached).toHaveBeenCalledWith("feature_explored", "u1", "test@example.com", "org1");
+    expect(mockOnMilestoneReached).toHaveBeenCalledWith("feature_explored", "u1", "org1");
   });
 });
 

--- a/packages/api/src/lib/email/__tests__/templates.test.ts
+++ b/packages/api/src/lib/email/__tests__/templates.test.ts
@@ -62,6 +62,25 @@ describe("renderOnboardingEmail", () => {
     expect(result.html).toContain(`${BASE_URL}/admin/connections`);
   });
 
+  it("first_query asserts the connected DB for a BYO signup (default)", () => {
+    const result = renderOnboardingEmail("first_query", BASE_URL, UNSUB_URL);
+    expect(result.html).toContain("Your database is connected");
+    expect(result.html).not.toContain("Your demo dataset is loaded");
+  });
+
+  it("first_query uses demo copy for a demo-only signup (#3962)", () => {
+    const result = renderOnboardingEmail("first_query", BASE_URL, UNSUB_URL, null, { demoMode: true });
+    // A demo-only signup never connected their own production DB, so the nudge
+    // must not assert it (the #3962 bug).
+    expect(result.html).not.toContain("Your database is connected");
+    expect(result.html).toContain("Your demo dataset is loaded");
+  });
+
+  it("explicit demoMode:false keeps BYO copy", () => {
+    const result = renderOnboardingEmail("first_query", BASE_URL, UNSUB_URL, null, { demoMode: false });
+    expect(result.html).toContain("Your database is connected");
+  });
+
   it("escapes HTML in branding text", () => {
     const result = renderOnboardingEmail("welcome", BASE_URL, UNSUB_URL, {
       logoUrl: null,

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -10,6 +10,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { resolveOnboardingEmailsEnabled } from "@atlas/api/lib/env-profile";
 import type { OnboardingEmailStep, OnboardingMilestone, OnboardingEmailTrigger, OnboardingEmailStatus } from "@useatlas/types";
+import { BUILTIN_DATASOURCE_CATALOG_SLUGS } from "@atlas/api/lib/db/datasource-pool-resolver";
 import { ONBOARDING_SEQUENCE, MILESTONE_TO_STEP } from "./sequence";
 import { renderOnboardingEmail } from "./templates";
 import { sendEmail } from "./delivery";
@@ -129,10 +130,21 @@ async function getSuppressedSteps(userId: string): Promise<OnboardingEmailStep[]
 
 /**
  * Whether this workspace is on the bundled demo and has NOT connected its own
- * production datasource — true when a published `__demo__` datasource install
- * exists and no non-demo one does. Drives demo-aware email copy (#3962): a
- * demo-only workspace must never receive a nudge asserting "your database is
- * connected".
+ * production SQL database — true when a published `__demo__` datasource install
+ * exists and no non-demo *SQL* one does. Drives demo-aware email copy (#3962):
+ * a demo-only workspace must never receive the `first_query` nudge asserting
+ * "your database is connected" (and "Atlas will translate it to SQL").
+ *
+ * "Real" is the positive SQL allowlist `BUILTIN_DATASOURCE_CATALOG_SLUGS` (the
+ * catalog slugs ConnectionRegistry resolves into a SQL pool — postgres, mysql,
+ * snowflake, …, INCLUDING `demo-postgres`, which the `install_id <> '__demo__'`
+ * filter then excludes), NOT merely "any non-demo datasource". A REST/OpenAPI
+ * datasource (`openapi-generic`) is `pillar = 'datasource'` too but is
+ * deliberately OUT of that allowlist — it has no SQL pool — so a demo + REST
+ * workspace stays demo-only and keeps demo copy rather than getting the
+ * SQL-centric "your database is connected" claim (which would be false: no SQL
+ * DB is connected). Any future non-SQL query layer is excluded for free by the
+ * same allowlist. `bool_or` over zero rows is NULL → false.
  *
  * This reads the live datasource install state (`workspace_plugins`), NOT the
  * onboarding drip's `demo_activated` marker, deliberately. The marker is a
@@ -143,22 +155,23 @@ async function getSuppressedSteps(userId: string): Promise<OnboardingEmailStep[]
  * marker forever. The install state is org-scoped ground truth that flips
  * correctly however the real datasource was added, and a workspace with no
  * datasource at all reads false (BYO default) rather than a false "demo loaded"
- * claim. `bool_or` over zero rows is NULL → false.
+ * claim.
  *
  * Defaults to false (BYO copy) on any read error — the same safe default the
  * BYO drip already assumes.
  */
 async function isDemoOnlyWorkspace(orgId: string): Promise<boolean> {
   try {
-    const rows = await internalQuery<{ has_demo: boolean | null; has_real: boolean | null }>(
-      `SELECT bool_or(install_id = '__demo__')  AS has_demo,
-              bool_or(install_id <> '__demo__') AS has_real
-         FROM workspace_plugins
-        WHERE workspace_id = $1 AND pillar = 'datasource' AND status = 'published'`,
-      [orgId],
+    const rows = await internalQuery<{ has_demo: boolean | null; has_real_sql: boolean | null }>(
+      `SELECT bool_or(wp.install_id = '__demo__') AS has_demo,
+              bool_or(wp.install_id <> '__demo__' AND pc.slug = ANY($2)) AS has_real_sql
+         FROM workspace_plugins wp
+         JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+        WHERE wp.workspace_id = $1 AND wp.pillar = 'datasource' AND wp.status = 'published'`,
+      [orgId, BUILTIN_DATASOURCE_CATALOG_SLUGS as readonly string[]],
     );
     const row = rows[0];
-    return Boolean(row?.has_demo) && !row?.has_real;
+    return Boolean(row?.has_demo) && !row?.has_real_sql;
   } catch (err) {
     log.warn(
       { orgId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -128,26 +128,40 @@ async function getSuppressedSteps(userId: string): Promise<OnboardingEmailStep[]
 }
 
 /**
- * Whether this signup activated the bundled demo rather than connecting their
- * own production database — true when the `connect_database` step was satisfied
- * by demo activation (#3949). Drives demo-aware email copy (#3962): a demo-only
- * user must never receive a nudge asserting "your database is connected".
+ * Whether this workspace is on the bundled demo and has NOT connected its own
+ * production datasource — true when a published `__demo__` datasource install
+ * exists and no non-demo one does. Drives demo-aware email copy (#3962): a
+ * demo-only workspace must never receive a nudge asserting "your database is
+ * connected".
  *
- * Defaults to false (BYO copy) on any read error or when the marker is absent —
- * the same safe default the BYO drip already assumes.
+ * This reads the live datasource install state (`workspace_plugins`), NOT the
+ * onboarding drip's `demo_activated` marker, deliberately. The marker is a
+ * per-user, write-once record: the `(user_id, step)` unique index means a later
+ * real `database_connected` can never overwrite it, and the admin-console
+ * connect path doesn't fire that milestone at all — so a workspace that
+ * *graduates* from the demo to its own DB would keep looking "demo-only" by the
+ * marker forever. The install state is org-scoped ground truth that flips
+ * correctly however the real datasource was added, and a workspace with no
+ * datasource at all reads false (BYO default) rather than a false "demo loaded"
+ * claim. `bool_or` over zero rows is NULL → false.
+ *
+ * Defaults to false (BYO copy) on any read error — the same safe default the
+ * BYO drip already assumes.
  */
-async function isDemoOnlySignup(userId: string): Promise<boolean> {
+async function isDemoOnlyWorkspace(orgId: string): Promise<boolean> {
   try {
-    const rows = await internalQuery<{ one: number }>(
-      `SELECT 1 AS one FROM onboarding_emails
-       WHERE user_id = $1 AND step = 'connect_database' AND triggered_by = 'demo_activated'
-       LIMIT 1`,
-      [userId],
+    const rows = await internalQuery<{ has_demo: boolean | null; has_real: boolean | null }>(
+      `SELECT bool_or(install_id = '__demo__')  AS has_demo,
+              bool_or(install_id <> '__demo__') AS has_real
+         FROM workspace_plugins
+        WHERE workspace_id = $1 AND pillar = 'datasource' AND status = 'published'`,
+      [orgId],
     );
-    return rows.length > 0;
+    const row = rows[0];
+    return Boolean(row?.has_demo) && !row?.has_real;
   } catch (err) {
     log.warn(
-      { userId, err: err instanceof Error ? err.message : String(err) },
+      { orgId, err: err instanceof Error ? err.message : String(err) },
       "Failed to resolve demo-only status — defaulting to BYO email copy",
     );
     return false;
@@ -239,7 +253,7 @@ export async function sendOnboardingEmail(
     // "your database is connected" (#3962). Independent reads — run together.
     const [branding, demoMode] = await Promise.all([
       getBrandingForOrg(orgId),
-      isDemoOnlySignup(userId),
+      isDemoOnlyWorkspace(orgId),
     ]);
     const baseUrl = getBaseUrl();
     const unsubscribeUrl = buildUnsubscribeUrl(userId);

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -81,24 +81,77 @@ async function getSentSteps(userId: string): Promise<OnboardingEmailStep[]> {
 }
 
 /**
- * Steps a user activated WITHOUT an email being dispatched — i.e. recorded via
- * {@link markStepSatisfied} (trigger `demo_activated`), not a real send (#3949).
+ * Triggers under which a recorded `onboarding_emails` row means an email was
+ * actually dispatched — the welcome send (`signup_completed`) and time-based
+ * fallback nudges (`time_based`). Every *other* trigger is a satisfaction
+ * marker: the step is complete for drip-progression purposes but no message
+ * went out. See {@link getSuppressedSteps}.
+ */
+const EMAIL_SENT_TRIGGERS = new Set<OnboardingEmailTrigger>(["signup_completed", "time_based"]);
+
+/**
+ * Steps a user completed WITHOUT an email being dispatched — recorded via
+ * {@link markStepSatisfied}, not a real send.
  *
  * A row in `onboarding_emails` historically meant "this email was sent", and the
- * admin status view treats {@link getSentSteps} that way. Demo activation breaks
- * that 1:1 — the `connect_database` step is *completed* in the drip but no email
- * went out. This surfaces the suppressed subset so the admin view can label
- * "satisfied (no email)" distinctly from "sent" instead of silently conflating
- * the two. The completed-step partition (sent + suppressed → pending) is
- * unchanged, so the drip-progression semantics `getSentSteps` drives are intact.
+ * admin status view treats {@link getSentSteps} that way. Two paths break that
+ * 1:1, and both record a satisfaction marker instead of sending:
+ *   - demo activation (#3949) — `connect_database` satisfied by the bundled demo
+ *     (trigger `demo_activated`);
+ *   - reaching any action milestone (#3962) — e.g. answering a first query
+ *     satisfies `first_query`, inviting a teammate satisfies `invite_team`, etc.
+ *     {@link onMilestoneReached} suppresses the now-moot "go do X" nudge rather
+ *     than mailing it back to a user who just did X (trigger = the milestone).
+ *
+ * Both are "completed, no email", so the suppressed subset is everything
+ * recorded whose trigger is NOT an {@link EMAIL_SENT_TRIGGERS} member. The
+ * admin view can then label "satisfied (no email)" distinctly from "sent". The
+ * completed-step partition (sent + suppressed → pending) is unchanged, so the
+ * drip-progression semantics `getSentSteps` drives are intact.
+ *
+ * (Rows written before #3962 by the old send-on-milestone behavior carry a
+ * milestone trigger yet did dispatch an email; this reclassifies them as
+ * suppressed in the admin view. Cosmetic only — no live drip decision reads
+ * the suppressed/sent split — and the onboarding-email feature is recent, so
+ * the affected history is small. No backfill.)
  */
 async function getSuppressedSteps(userId: string): Promise<OnboardingEmailStep[]> {
-  const rows = await internalQuery<{ step: string }>(
-    `SELECT step FROM onboarding_emails WHERE user_id = $1 AND triggered_by = 'demo_activated'`,
+  const rows = await internalQuery<{ step: string; triggered_by: string }>(
+    `SELECT step, triggered_by FROM onboarding_emails WHERE user_id = $1`,
     [userId],
   );
   const onboardingSteps = new Set<string>(ONBOARDING_SEQUENCE.map((s) => s.step));
-  return rows.map((r) => r.step).filter((s): s is OnboardingEmailStep => onboardingSteps.has(s));
+  return rows
+    .filter((r) => !EMAIL_SENT_TRIGGERS.has(r.triggered_by as OnboardingEmailTrigger))
+    .map((r) => r.step)
+    .filter((s): s is OnboardingEmailStep => onboardingSteps.has(s));
+}
+
+/**
+ * Whether this signup activated the bundled demo rather than connecting their
+ * own production database — true when the `connect_database` step was satisfied
+ * by demo activation (#3949). Drives demo-aware email copy (#3962): a demo-only
+ * user must never receive a nudge asserting "your database is connected".
+ *
+ * Defaults to false (BYO copy) on any read error or when the marker is absent —
+ * the same safe default the BYO drip already assumes.
+ */
+async function isDemoOnlySignup(userId: string): Promise<boolean> {
+  try {
+    const rows = await internalQuery<{ one: number }>(
+      `SELECT 1 AS one FROM onboarding_emails
+       WHERE user_id = $1 AND step = 'connect_database' AND triggered_by = 'demo_activated'
+       LIMIT 1`,
+      [userId],
+    );
+    return rows.length > 0;
+  } catch (err) {
+    log.warn(
+      { userId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to resolve demo-only status — defaulting to BYO email copy",
+    );
+    return false;
+  }
 }
 
 async function isUnsubscribed(userId: string): Promise<boolean> {
@@ -181,13 +234,18 @@ export async function sendOnboardingEmail(
       return false;
     }
 
-    // Resolve branding
-    const branding = await getBrandingForOrg(orgId);
+    // Resolve branding + demo-awareness. A demo-only signup connected the
+    // bundled demo, not their own production DB, so the copy must not assert
+    // "your database is connected" (#3962). Independent reads — run together.
+    const [branding, demoMode] = await Promise.all([
+      getBrandingForOrg(orgId),
+      isDemoOnlySignup(userId),
+    ]);
     const baseUrl = getBaseUrl();
     const unsubscribeUrl = buildUnsubscribeUrl(userId);
 
     // Render and send
-    const rendered = renderOnboardingEmail(step, baseUrl, unsubscribeUrl, branding);
+    const rendered = renderOnboardingEmail(step, baseUrl, unsubscribeUrl, branding, { demoMode });
     const result = await sendEmail({
       to: email,
       subject: rendered.subject,
@@ -214,13 +272,26 @@ export async function sendOnboardingEmail(
 // ── Milestone trigger ───────────────────────────────────────────────
 
 /**
- * Called when a user hits an onboarding milestone.
- * Sends the corresponding email if not already sent.
+ * Called when a user hits an action onboarding milestone (connected a DB, ran
+ * their first query, invited a teammate, explored a feature).
+ *
+ * Marks the corresponding step satisfied WITHOUT sending its email — it does
+ * NOT dispatch the step's nudge. Every non-welcome step in the sequence is a
+ * "go do X" prompt; reaching its milestone means the user already did X, so
+ * mailing the nudge in the same breath is backwards (it surfaced live as a
+ * demo-only signup getting "ask your first question" the instant they asked —
+ * #3962). The nudge therefore exists ONLY as the time-based fallback in
+ * {@link checkFallbackEmails}, fired when the milestone is NOT reached in time;
+ * recording the step here suppresses that fallback. This generalizes the
+ * demo-activation suppression from #3949 to every action milestone.
+ *
+ * The sole proactive send is `welcome` (the `signup_completed` milestone),
+ * which {@link onUserSignup} dispatches directly via {@link sendOnboardingEmail}
+ * and never routes through here.
  */
 export async function onMilestoneReached(
   milestone: OnboardingMilestone,
   userId: string,
-  email: string,
   orgId: string,
 ): Promise<void> {
   const step = MILESTONE_TO_STEP.get(milestone);
@@ -229,7 +300,7 @@ export async function onMilestoneReached(
     return;
   }
 
-  await sendOnboardingEmail(userId, email, orgId, step, milestone);
+  await markStepSatisfied(userId, orgId, step, milestone);
 }
 
 // ── Step satisfaction (no email) ────────────────────────────────────

--- a/packages/api/src/lib/email/hooks.ts
+++ b/packages/api/src/lib/email/hooks.ts
@@ -45,12 +45,15 @@ export function onUserSignup(user: UserContext): void {
 
 /**
  * Called after a database connection is created or completed via onboarding.
- * Fire-and-forget.
+ *
+ * Marks the `connect_database` step satisfied (the user just connected, so the
+ * "connect your database" nudge is moot) without sending an email — see
+ * {@link onMilestoneReached}. Fire-and-forget.
  */
 export function onDatabaseConnected(user: UserContext): void {
   if (!isOnboardingEmailEnabled()) return;
 
-  void onMilestoneReached("database_connected", user.userId, user.email, user.orgId).catch(
+  void onMilestoneReached("database_connected", user.userId, user.orgId).catch(
     (err) => {
       log.warn(
         { userId: user.userId, err: err instanceof Error ? err.message : String(err) },
@@ -87,13 +90,18 @@ export function onDemoActivated(user: UserContext): void {
 }
 
 /**
- * Called after a user's first successful chat query.
+ * Called after a user's first successful chat query (the caller gates on an
+ * actually-answered query — see `turnAnsweredQuery` in activation-metrics.ts).
+ *
+ * Marks the `first_query` step satisfied so the 72h fallback nudge is
+ * suppressed, WITHOUT mailing the "ask your first question" prompt back in the
+ * same turn the user asked it (#3962) — see {@link onMilestoneReached}.
  * Fire-and-forget.
  */
 export function onFirstQueryExecuted(user: UserContext): void {
   if (!isOnboardingEmailEnabled()) return;
 
-  void onMilestoneReached("first_query_executed", user.userId, user.email, user.orgId).catch(
+  void onMilestoneReached("first_query_executed", user.userId, user.orgId).catch(
     (err) => {
       log.warn(
         { userId: user.userId, err: err instanceof Error ? err.message : String(err) },
@@ -105,12 +113,14 @@ export function onFirstQueryExecuted(user: UserContext): void {
 
 /**
  * Called after a team member is invited to the workspace.
- * Fire-and-forget.
+ *
+ * Marks the `invite_team` step satisfied (no email) — see
+ * {@link onMilestoneReached}. Fire-and-forget.
  */
 export function onTeamMemberInvited(user: UserContext): void {
   if (!isOnboardingEmailEnabled()) return;
 
-  void onMilestoneReached("team_member_invited", user.userId, user.email, user.orgId).catch(
+  void onMilestoneReached("team_member_invited", user.userId, user.orgId).catch(
     (err) => {
       log.warn(
         { userId: user.userId, err: err instanceof Error ? err.message : String(err) },
@@ -122,12 +132,14 @@ export function onTeamMemberInvited(user: UserContext): void {
 
 /**
  * Called when a user explores a feature (notebook, admin console, etc.).
- * Fire-and-forget.
+ *
+ * Marks the `explore_features` step satisfied (no email) — see
+ * {@link onMilestoneReached}. Fire-and-forget.
  */
 export function onFeatureExplored(user: UserContext): void {
   if (!isOnboardingEmailEnabled()) return;
 
-  void onMilestoneReached("feature_explored", user.userId, user.email, user.orgId).catch(
+  void onMilestoneReached("feature_explored", user.userId, user.orgId).catch(
     (err) => {
       log.warn(
         { userId: user.userId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/email/templates.ts
+++ b/packages/api/src/lib/email/templates.ts
@@ -124,11 +124,18 @@ function connectDatabaseContent(ctx: BrandingContext, baseUrl: string): string {
     </div>`;
 }
 
-function firstQueryContent(ctx: BrandingContext, baseUrl: string): string {
+function firstQueryContent(ctx: BrandingContext, baseUrl: string, demoMode: boolean): string {
+  // A demo-only signup activated the bundled demo, not their own production DB
+  // (#3962). Asserting "your database is connected" to them is the same
+  // demo-blindness #3949 fixed for connect_database, one step further down the
+  // drip — so the demo variant points at the loaded demo dataset instead.
+  const lede = demoMode
+    ? `Your demo dataset is loaded — try asking a question in plain English. ${escapeHtml(ctx.appName)} will translate it to SQL and return the results.`
+    : `Your database is connected — now try asking a question in plain English. ${escapeHtml(ctx.appName)} will translate it to SQL and return the results.`;
   return `
     <h1 style="margin:0 0 16px;font-size:24px;color:${ctx.primaryColor};">Ask your first question</h1>
     <p style="margin:0 0 16px;font-size:15px;color:#404040;line-height:1.6;">
-      Your database is connected — now try asking a question in plain English. ${escapeHtml(ctx.appName)} will translate it to SQL and return the results.
+      ${lede}
     </p>
     <p style="margin:0 0 8px;font-size:14px;font-weight:600;color:${ctx.primaryColor};">Try something like:</p>
     <ul style="margin:0 0 24px;padding-left:20px;font-size:14px;color:#404040;line-height:1.8;">
@@ -141,6 +148,11 @@ function firstQueryContent(ctx: BrandingContext, baseUrl: string): string {
     </div>`;
 }
 
+// invite_team / explore_features audited for the #3962 BYO assumption: neither
+// asserts "your database is connected" nor implies a connected production DB.
+// "your data" reads as the loaded demo dataset for a demo-only signup, and the
+// feature tour is datasource-agnostic — so both are demo-appropriate as-is and
+// take no demoMode branch.
 function inviteTeamContent(ctx: BrandingContext, baseUrl: string): string {
   return `
     <h1 style="margin:0 0 16px;font-size:24px;color:${ctx.primaryColor};">Invite your team</h1>
@@ -172,7 +184,12 @@ function exploreFeaturesContent(ctx: BrandingContext, baseUrl: string): string {
     </div>`;
 }
 
-const STEP_CONTENT: Record<OnboardingEmailStep, (ctx: BrandingContext, baseUrl: string) => string> = {
+// All step renderers take `demoMode` for a uniform signature; only first_query
+// branches on it today (#3962). The rest ignore the extra arg.
+const STEP_CONTENT: Record<
+  OnboardingEmailStep,
+  (ctx: BrandingContext, baseUrl: string, demoMode: boolean) => string
+> = {
   welcome: welcomeContent,
   connect_database: connectDatabaseContent,
   first_query: firstQueryContent,
@@ -194,16 +211,19 @@ export interface RenderedEmail {
  * @param baseUrl - The app base URL (e.g. https://app.useatlas.dev)
  * @param unsubscribeUrl - Full URL to unsubscribe endpoint
  * @param branding - Optional workspace branding to apply
+ * @param opts.demoMode - The recipient activated the bundled demo rather than
+ *   connecting their own database (#3962); selects demo-appropriate copy.
  */
 export function renderOnboardingEmail(
   step: OnboardingEmailStep,
   baseUrl: string,
   unsubscribeUrl: string,
   branding?: WorkspaceBrandingPublic | null,
+  opts?: { demoMode?: boolean },
 ): RenderedEmail {
   const ctx = buildBrandingContext(branding);
   const contentFn = STEP_CONTENT[step];
-  const content = contentFn(ctx, baseUrl);
+  const content = contentFn(ctx, baseUrl, opts?.demoMode ?? false);
   const html = wrap(ctx, content, unsubscribeUrl);
 
   // Resolve subject template

--- a/packages/types/src/onboarding-email.ts
+++ b/packages/types/src/onboarding-email.ts
@@ -30,17 +30,29 @@ export const ONBOARDING_MILESTONES = [
 export type OnboardingMilestone = (typeof ONBOARDING_MILESTONES)[number];
 
 /**
- * Trigger source for an onboarding email record.
+ * Trigger source for an onboarding email record. Splits into two classes —
+ * triggers under which an email was *dispatched*, and *satisfaction markers*
+ * under which the step is recorded complete but no message was sent:
  *
- * - a {@link OnboardingMilestone} — the milestone whose email actually sent;
- * - `"time_based"` — a fallback nudge sent because the milestone wasn't hit in time;
- * - `"demo_activated"` — a *satisfaction marker*, NOT an email send. Recorded when a
- *   demo-only signup activates the bundled demo so the `connect_database` drip step
- *   is marked done (drip advances, the 24h "connect your database" nudge is suppressed)
- *   without ever sending the misleading "connect your *own* database" copy (#3949).
- *   Unlike a milestone, it is never a key in the milestone→step map
- *   (`MILESTONE_TO_STEP`, api/lib/email/sequence.ts) — it only ever appears in a
- *   persisted record's `triggeredBy`.
+ * Dispatched:
+ * - `"signup_completed"` — the welcome email (sent immediately on signup). The
+ *   only milestone that mails proactively.
+ * - `"time_based"` — a fallback nudge sent because the step's milestone wasn't
+ *   hit within its `fallbackHours` window.
+ *
+ * Satisfaction markers (NO email — see api/lib/email/engine.ts `getSuppressedSteps`):
+ * - an *action* {@link OnboardingMilestone} (`database_connected`,
+ *   `first_query_executed`, `team_member_invited`, `feature_explored`) — recorded
+ *   when the user does the thing the step nudges toward. Mailing the nudge in the
+ *   same breath is backwards (a demo-only signup got "ask your first question" the
+ *   instant they asked — #3962), so reaching the milestone *suppresses* the nudge
+ *   instead: it marks the step done (the time-based fallback then skips it) without
+ *   sending. Recorded via `onMilestoneReached`.
+ * - `"demo_activated"` — the demo-only analogue for `connect_database`: a demo
+ *   signup activates the bundled demo, satisfying the step without the misleading
+ *   "connect your *own* database" copy (#3949). Never a key in the milestone→step
+ *   map (`MILESTONE_TO_STEP`, api/lib/email/sequence.ts) — it only ever appears in
+ *   a persisted record's `triggeredBy`.
  */
 export type OnboardingEmailTrigger = OnboardingMilestone | "time_based" | "demo_activated";
 


### PR DESCRIPTION
## Summary

Follow-up to #3949/#3953 (which made only `connect_database` demo-aware). Surfaced live by `/verify-prod-signup` on v0.0.28. Closes the two adjacent gaps the issue documents:

- **Demo-blind copy** — the `first_query` email hardcoded "Your database is connected", false for a demo-only signup. `firstQueryContent` now takes a `demoMode` flag ("Your demo dataset is loaded" variant); the engine resolves it at send time from the `connect_database` `demo_activated` marker. Audited `invite_team`/`explore_features` — neither asserts a connected DB, so both are demo-appropriate as-is (documented in `templates.ts`).
- **Eager milestone fire** — `chat.ts` fired `first_query_executed` at stream-creation on *any* turn, even when the SQL was whitelist-rejected (#3961). It now fires only once the turn actually answered a query (a `success: true` `executeSQL` result), via the new pure `turnAnsweredQuery(steps)` predicate.
- **Backwards nudge** — reaching an action milestone now *suppresses* the now-moot nudge instead of mailing it back in the same turn: `onMilestoneReached` marks the step satisfied (no email), generalizing #3949's demo suppression to every action milestone. The nudge survives only as the time-based fallback. `getSuppressedSteps` is generalized to classify by trigger (sent = `signup_completed`/`time_based`; everything else = satisfied-no-email) so the admin sent-vs-suppressed view stays accurate.

## Test plan

- [x] `bun run type` + `bun run lint` clean
- [x] New/updated unit tests: `turnAnsweredQuery` gating, demo-aware `first_query` copy, milestone suppression (no in-turn email), trigger-based admin classification
- [x] Full `/ci`: 729 test files pass (3 failures are the documented `VERCEL_*`/`ATLAS_SANDBOX_URL` dev-shell sandbox flakes — untouched by this diff, green in CI), all drift/check gates pass
- [ ] **Post-deploy:** re-run `/verify-prod-signup` against a demo-only account to confirm the onboarding email set is demo-appropriate (AC #4 — can only run after this lands on prod)

Closes #3962

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding drip to record milestones without sending emails and gate `first_query` on successful SQL execution
> - `onMilestoneReached` in [`engine.ts`](https://github.com/AtlasDevHQ/atlas/pull/3964/files#diff-e226505e1531869049d7f4fe9739b74e7d63551ee53f8a07f5deaa2618c43a7f) now records a step as satisfied via `markStepSatisfied` without dispatching an email, so action milestones suppress future nudge emails rather than triggering immediate sends.
> - The chat route in [`chat.ts`](https://github.com/AtlasDevHQ/atlas/pull/3964/files#diff-72ac19602beee2bcc30ea80ba99adaf1c9d25b0494e4217baca470a34aa187ba) defers the `first_query_executed` milestone until agent steps resolve and only fires if `turnAnsweredQuery` detects a successful `executeSQL` result.
> - A new `isDemoOnlyWorkspace` helper detects whether an org uses only a demo datasource, and `sendOnboardingEmail` passes a `demoMode` flag to `renderOnboardingEmail` so the `first_query` email shows demo-appropriate copy.
> - `getSuppressedSteps` now classifies suppressed steps in code (any `triggered_by` not in `EMAIL_SENT_TRIGGERS`) rather than filtering by `demo_activated` in SQL.
> - Behavioral Change: milestone hooks (`onDatabaseConnected`, `onFirstQueryExecuted`, `onTeamMemberInvited`, `onFeatureExplored`) no longer send emails immediately on trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d694bdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->