### PR TITLE
feat(www): road-to-launch + founder-note blog posts, redesigned blog

### DIFF
--- a/apps/www/src/app/blog/announcing-atlas/page.tsx
+++ b/apps/www/src/app/blog/announcing-atlas/page.tsx
@@ -2,75 +2,42 @@ import type { Metadata } from "next";
 
 import { Footer } from "../../../components/footer";
 import { Nav } from "../../../components/nav";
-import { ArrowIcon, Divider, TopGlow } from "../../../components/shared";
+import {
+  Article,
+  BackToBlog,
+  CodeBlock,
+  DefItem,
+  DefList,
+  H2,
+  InlineCode,
+  Lead,
+  P,
+  PostActions,
+  PostHeader,
+  PullQuote,
+  Signoff,
+  StatStrip,
+  Step,
+  Steps,
+} from "../../../components/prose";
+import { Divider, TopGlow } from "../../../components/shared";
 import { StickyNav } from "../../../components/sticky-nav";
 
 export const metadata: Metadata = {
-  title: "Announcing Atlas: Open-Source Text-to-SQL with a Semantic Layer",
+  title: "The Road to Launch: Everything I Shipped in Atlas's Beta",
   description:
-    "Atlas is in open beta. Connect your database, auto-generate a semantic layer, and let an AI agent query your data. Self-hosted or on Atlas Cloud.",
+    "Atlas goes GA in July 2026. A recap of the first half of the year — SQL safety, new datasources, a smarter agent, a grown-up MCP server, dashboards, and Atlas Cloud, across nearly 4,000 issues and pull requests.",
+  authors: [{ name: "Matt Sywulak" }],
   openGraph: {
-    title: "Announcing Atlas: Open-Source Text-to-SQL with a Semantic Layer",
+    title: "The Road to Launch: Everything I Shipped in Atlas's Beta",
     description:
-      "Atlas is in open beta. Connect your database, auto-generate a semantic layer, and let an AI agent query your data.",
+      "Atlas goes GA in July 2026. A recap of the first half of 2026 — a run of internal milestones from 0.1 through 1.6, then twenty-nine public releases in under a month. By Matt Sywulak.",
     url: "https://www.useatlas.dev/blog/announcing-atlas",
     siteName: "Atlas",
     type: "article",
+    authors: ["Matt Sywulak"],
   },
 };
-
-// ---------------------------------------------------------------------------
-// Inline components
-// ---------------------------------------------------------------------------
-
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <h2 className="mt-16 mb-6 text-xl font-semibold tracking-tight text-fg md:text-2xl">
-      {children}
-    </h2>
-  );
-}
-
-function Paragraph({ children }: { children: React.ReactNode }) {
-  return <p className="mb-5 text-[15px] leading-relaxed text-fg-muted">{children}</p>;
-}
-
-function InlineCode({ children }: { children: React.ReactNode }) {
-  return (
-    <code className="rounded bg-bg-sunken px-1.5 py-0.5 font-mono text-[13px] text-fg">
-      {children}
-    </code>
-  );
-}
-
-function BlockCode({ title, children }: { title: string; children: string }) {
-  return (
-    <div className="my-6 overflow-hidden rounded-xl border border-code-border bg-code-bg shadow-pane">
-      <div className="flex items-center gap-2 border-b border-code-border px-4 py-3">
-        <span className="h-2.5 w-2.5 rounded-full bg-code-muted" />
-        <span className="h-2.5 w-2.5 rounded-full bg-code-muted" />
-        <span className="h-2.5 w-2.5 rounded-full bg-code-muted" />
-        <span className="ml-3 font-mono text-xs text-code-muted">{title}</span>
-      </div>
-      <pre className="overflow-x-auto p-5 font-mono text-sm leading-relaxed text-code-fg">
-        <code>{children}</code>
-      </pre>
-    </div>
-  );
-}
-
-function FeatureBullet({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <li className="mb-4">
-      <span className="font-medium text-fg">{title}</span>
-      <span className="text-fg-muted">: {children}</span>
-    </li>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
 
 export default function AnnouncingAtlas() {
   return (
@@ -79,269 +46,303 @@ export default function AnnouncingAtlas() {
       <TopGlow />
       <Nav currentPage="/blog" />
 
-      <article className="mx-auto max-w-2xl px-6 pt-24 pb-20 md:pt-36 md:pb-28">
-        {/* Header */}
-        <header className="mb-12">
-          <div className="mb-5 flex items-center gap-3">
-            <span className="rounded-full border border-accent/20 bg-accent-quiet px-2.5 py-0.5 font-mono text-[10px] font-medium tracking-wider text-accent uppercase">
-              Launch
-            </span>
-            <time dateTime="2026-03-25" className="font-mono text-xs text-fg-faint">2026-03-25</time>
-          </div>
-          <h1 className="animate-fade-in-up delay-100 text-2xl font-semibold leading-tight tracking-tight text-fg md:text-4xl">
-            Announcing Atlas: open-source text-to-SQL with a semantic layer
-          </h1>
-          <p className="animate-fade-in-up delay-200 mt-5 text-lg leading-relaxed text-fg-muted">
-            You&apos;re already using AI to query your data. Atlas makes it
-            safe, accurate, and deployable.
-          </p>
-        </header>
+      <Article>
+        <PostHeader
+          tag="Road to launch"
+          isoDate="2026-06-25"
+          dateLabel="June 25, 2026"
+          readingTime="6 min read"
+          title="The road to launch: everything I shipped in beta"
+          dek="Atlas goes GA in July. Here's the recap of the first half of 2026, from a single commit to a hosted cloud, and a product you can trust in production."
+        />
 
-        {/* ── The problem ── */}
-        <SectionHeading>The problem: everyone is already doing this</SectionHeading>
-        <Paragraph>
-          Every data team we talk to is using ChatGPT or Copilot to write SQL.
-          Paste your schema, describe the question, copy the query back into
-          your database client, and hope it works.
-        </Paragraph>
-        <Paragraph>
-          It works surprisingly often. But it fails in ways that are hard to
-          catch: silently wrong column references, missing WHERE clauses that
-          filter soft-deletes, metrics calculated before discounts instead of
-          after. The AI doesn&apos;t know your business rules. It guesses from
-          column names like <InlineCode>fact_txn_amt</InlineCode> and{" "}
-          <InlineCode>is_del_flg</InlineCode>, and it gets the semantics wrong
-          often enough that you can&apos;t trust the output without reading
-          every query line by line.
-        </Paragraph>
-        <Paragraph>
-          The other problem is operational. ChatGPT can&apos;t run the query.
-          It doesn&apos;t validate that the SQL is read-only. It doesn&apos;t
-          enforce row-level access. There&apos;s no audit trail. You can&apos;t
-          embed it in a product. It&apos;s a parlor trick, not
-          infrastructure.
-        </Paragraph>
+        <H2>Where I started</H2>
+        <Lead>
+          A few months ago I announced Atlas with a simple argument: text-to-SQL
+          should be safe, accurate, and deployable infrastructure. A data
+          analyst you embed in your own product, not another standalone BI tool
+          you send people to, and not a chatbot parlor trick that hands you SQL
+          it can&apos;t run, validate, or audit.
+        </Lead>
+        <P>
+          Since then, I&apos;ve shipped without letting up. Atlas began as a
+          single commit in February; by the time I cut the first public release
+          tag in late May, it had already grown a semantic layer, multi-tenancy,
+          and a hosted SaaS platform across a run of internal milestones from{" "}
+          <InlineCode>0.1</InlineCode> through <InlineCode>1.6</InlineCode>. The
+          public train that followed sits on top of all of it.
+        </P>
 
-        {/* ── What Atlas is ── */}
-        <SectionHeading>What Atlas is</SectionHeading>
-        <Paragraph>
-          Atlas is a text-to-SQL agent that connects to your database,
-          understands your schema through a semantic layer, validates every
-          query, and runs it. All in one place. Self-host it with Docker,
-          Railway, or Vercel, or use Atlas Cloud at{" "}
-          <a
-            href="https://app.useatlas.dev"
-            className="text-accent hover:underline"
-          >
-            app.useatlas.dev
-          </a>{" "}
-          and skip infrastructure entirely.
-        </Paragraph>
-        <Paragraph>
-          The core idea: give the AI the context it needs to write correct SQL,
-          then validate the output before it touches your database. No training
-          data, no vector databases, no fine-tuning. Just a YAML semantic layer
-          that describes what your tables and columns actually mean.
-        </Paragraph>
+        <StatStrip
+          items={[
+            { value: "29", label: "releases in 27 days" },
+            { value: "~4,000", label: "issues & pull requests" },
+            { value: "1,300+", label: "commits" },
+          ]}
+        />
 
-        <BlockCode title="terminal">{`$ bun create atlas-agent my-app --demo
-$ cd my-app && bun run dev
+        <P>
+          But the count isn&apos;t the point; what shipped is. The agent got
+          smarter, the datasource list grew, the MCP server grew up, and Atlas
+          Cloud became a real hosted product with billing, trials, and
+          enterprise controls.
+        </P>
+        <P>
+          A note on that pace, since I keep writing &ldquo;I&rdquo; and not
+          &ldquo;we&rdquo;: it&apos;s been me and an AI coding agent the whole
+          way, no team hiding behind the usual corporate plural. That&apos;s
+          also, quietly, the thesis. Atlas is a data analyst you run as an agent
+          against your database; it was built by one person running an agent
+          against a codebase.
+        </P>
 
-> Ready on http://localhost:3000
-> Connected to PostgreSQL - 42 tables profiled
-> Semantic layer generated at ./semantic/`}</BlockCode>
+        <PullQuote>Same wager, both ends.</PullQuote>
 
-        <Paragraph>
-          Run <InlineCode>atlas init</InlineCode> against your database and it
-          profiles every table (column types, sample values, cardinality,
-          nullability) and generates YAML entity files that the agent reads
-          before writing SQL. You can enrich these with descriptions, business
-          terms, and known query patterns. Changes go through pull requests.
-          The semantic layer lives in your repo, versioned like code.
-        </Paragraph>
-
-        {/* ── How it works ── */}
-        <SectionHeading>How it works under the hood</SectionHeading>
-        <Paragraph>
-          When a user asks a question, the agent reads the semantic layer to
-          understand what tables exist, what columns mean, how tables join, and
-          what metrics are defined. Then it writes SQL. Before the query
-          reaches your database, it passes through a 7-layer validation
-          pipeline:
-        </Paragraph>
-        <ol className="mb-6 list-inside list-decimal space-y-2 text-[15px] text-fg-muted">
-          <li><span className="text-fg">Empty check</span>: rejects blank input</li>
-          <li><span className="text-fg">Regex mutation guard</span>: blocks INSERT, UPDATE, DELETE, DROP</li>
-          <li><span className="text-fg">AST parse</span>: confirms a single SELECT statement</li>
-          <li><span className="text-fg">Table whitelist</span>: only tables in the semantic layer are queryable</li>
-          <li><span className="text-fg">RLS injection</span>: appends WHERE clauses for tenant isolation</li>
-          <li><span className="text-fg">Auto LIMIT</span>: prevents unbounded result sets</li>
-          <li><span className="text-fg">Statement timeout</span>: kills runaway queries</li>
-        </ol>
-        <Paragraph>
-          This is defense-in-depth. Any single layer can fail, but the pipeline
-          makes it so all of them would have to fail simultaneously for a
-          dangerous query to execute.
-        </Paragraph>
-
-        {/* ── What ships today ── */}
-        <SectionHeading>What ships today</SectionHeading>
-        <ul className="mb-6 list-none space-y-1 text-[15px]">
-          <FeatureBullet title="7 databases">
-            PostgreSQL, MySQL, BigQuery, ClickHouse, DuckDB, Snowflake, and
-            Salesforce via datasource plugins
-          </FeatureBullet>
-          <FeatureBullet title="6 LLM providers">
-            Anthropic, OpenAI, Bedrock, Ollama, OpenAI-compatible (vLLM, TGI,
-            LiteLLM), and AI Gateway. Bring your own keys or use Atlas
-            Cloud&apos;s managed tokens
-          </FeatureBullet>
-          <FeatureBullet title="21+ plugins">
-            Datasource adapters, sandbox backends, interaction channels (Slack,
-            Teams, MCP), action triggers (email, JIRA, webhooks). Build your
-            own with the Plugin SDK
-          </FeatureBullet>
-          <FeatureBullet title="Embeddable everywhere">
-            Script tag widget, React component, TypeScript SDK, headless API.
-            Works with Next.js, Nuxt, SvelteKit, or any HTTP client
-          </FeatureBullet>
-          <FeatureBullet title="Chat SDK">
-            8 platform adapters: Slack, Teams, Discord, Telegram, Google Chat,
-            GitHub, Linear, and WhatsApp
-          </FeatureBullet>
-          <FeatureBullet title="Enterprise features">
-            SSO (SAML/OIDC), SCIM provisioning, custom roles, IP allowlists,
-            approval workflows, audit log retention and export, data residency
-          </FeatureBullet>
-          <FeatureBullet title="Effect.ts architecture">
-            The entire backend uses Effect.ts for structured concurrency,
-            typed errors, composable Layers, and graceful shutdown. The agent
-            loop runs on @effect/ai, database connections on @effect/sql
-          </FeatureBullet>
-          <FeatureBullet title="Admin console">
-            Connections, users, plugin marketplace, semantic layer editor
-            with autocomplete, query analytics, learned patterns, billing,
-            and settings. All in one place
-          </FeatureBullet>
-        </ul>
-
-        {/* ── How Atlas compares ── */}
-        <SectionHeading>How Atlas compares</SectionHeading>
-        <Paragraph>
-          There are good tools in this space. Atlas is different in a few
-          specific ways.
-        </Paragraph>
-        <Paragraph>
-          <span className="text-fg">vs Vanna AI:</span> Vanna is a Python
-          library that learns from historical queries via RAG. Atlas uses an
-          explicit YAML semantic layer. You know exactly what context the agent
-          sees, and changes go through code review. Vanna is great for Python
-          shops that want a library. Atlas is a deployable product with auth,
-          admin, and embedding built in.
-        </Paragraph>
-        <Paragraph>
-          <span className="text-fg">vs WrenAI:</span> WrenAI is a GenBI
-          platform with a UI-based semantic modeling layer. It&apos;s closer to
-          &ldquo;replace Looker&rdquo; than &ldquo;embed an analyst.&rdquo;
-          Atlas is designed to be a component in your application, not a
-          standalone BI tool. WrenAI is also AGPL-3.0 end-to-end. Atlas&apos;s
-          client libraries are MIT.
-        </Paragraph>
-        <Paragraph>
-          <span className="text-fg">vs raw MCP:</span> Connecting Claude
-          Desktop directly to your database via a MCP server gives the AI raw
-          schema with no business context, no validation, and no audit trail.
-          Atlas has its own MCP server that provides the same semantic layer and
-          validation pipeline. Context + safety, not just connectivity.
-        </Paragraph>
-        <Paragraph>
-          <span className="text-fg">vs enterprise platforms:</span>{" "}
-          ThoughtSpot, Databricks AI/BI, and Looker AI are powerful but
-          proprietary and locked to their ecosystems. Atlas is open-source,
-          deploy-anywhere, and designed for embedding, not for replacing your
-          entire BI stack.
-        </Paragraph>
-        <Paragraph>
-          Detailed comparisons:{" "}
-          <a href="https://docs.useatlas.dev/comparisons" className="text-accent hover:underline">
-            docs.useatlas.dev/comparisons
+        <P>
+          It&apos;s also the first thing I&apos;ve ever actually finished. My
+          GitHub is a graveyard of half-built repos, including one security
+          product I rebuilt a dozen times and never shipped. I wrote about why
+          this one made it over the line, and the rest didn&apos;t, in{" "}
+          <a href="/blog/the-first-thing-i-finished" className="link-accent">
+            The first thing I ever finished
           </a>
-        </Paragraph>
+          .
+        </P>
+        <P>
+          Here&apos;s the recap of the changes that matter, ahead of the{" "}
+          <InlineCode>v0.1.0</InlineCode> public launch in July.
+        </P>
 
-        {/* ── Pricing ── */}
-        <SectionHeading>Self-hosted is free. Cloud is for teams.</SectionHeading>
-        <Paragraph>
-          Atlas is AGPL-3.0 licensed. You can self-host the full product,
-          every feature, no artificial limits, for free. Run{" "}
-          <InlineCode>bun create atlas-agent</InlineCode>, connect your
-          database, and you&apos;re done.
-        </Paragraph>
-        <Paragraph>
-          <a href="https://app.useatlas.dev" className="text-accent hover:underline">
+        <H2>The safety core, deeper</H2>
+        <P>
+          The thing that made Atlas worth trusting on day one is still the thing
+          I hardened most. Every query the agent writes passes through a 7-layer
+          validation pipeline before it reaches your database:
+        </P>
+        <Steps>
+          <Step n={1} title="Empty check">rejects blank input</Step>
+          <Step n={2} title="Regex mutation guard">
+            blocks INSERT, UPDATE, DELETE, DROP
+          </Step>
+          <Step n={3} title="AST parse">confirms a single SELECT statement</Step>
+          <Step n={4} title="Table whitelist">
+            only tables in your semantic layer are queryable
+          </Step>
+          <Step n={5} title="RLS injection">
+            optional WHERE clauses for tenant isolation
+          </Step>
+          <Step n={6} title="Auto LIMIT">caps unbounded result sets</Step>
+          <Step n={7} title="Statement timeout">kills runaway queries</Step>
+        </Steps>
+        <P>
+          Reads only. No writes, no shell escapes, no surprises. I also made
+          that story legible to anyone evaluating Atlas: there&apos;s now a
+          public{" "}
+          <a href="https://www.useatlas.dev/security" className="link-accent">
+            security page
+          </a>{" "}
+          that lays out the read-only, SELECT-only model in plain language, and
+          a production-observability pass means request traces and metrics now
+          export to a collector so operators can actually see what the agent is
+          doing.
+        </P>
+
+        <H2>From two databases to a dozen sources</H2>
+        <P>
+          Atlas launched with PostgreSQL and MySQL. It now connects to BigQuery,
+          ClickHouse, Snowflake, DuckDB, Salesforce, and Elasticsearch/OpenSearch
+          through datasource plugins, and to{" "}
+          <span className="text-fg">any REST service</span> that publishes an
+          OpenAPI 3.x spec, as a first-class datasource the agent queries right
+          alongside your SQL connections. Twenty, Stripe, GitHub, and Notion
+          ship as ready-made connectors on that same primitive.
+        </P>
+        <P>
+          Just as important, onboarding a datasource no longer means a trip to
+          the terminal. Add a connection and Atlas profiles its schema into a
+          queryable semantic layer in-product, through the install wizard, the
+          CLI, or the MCP server alike. The rule underneath is now simply:{" "}
+          <span className="text-fg">if Atlas can connect to it, it can profile it.</span>
+        </P>
+
+        <H2>A semantic layer that builds itself</H2>
+        <P>
+          The semantic layer is what lets Atlas write correct SQL instead of
+          guessing from column names. Generating one used to be a manual step;
+          now it&apos;s two phases. First, an instant, free, no-AI mechanical
+          baseline you can query immediately. Then optional per-table
+          enrichment, AI-written descriptions, business terms, and known query
+          patterns, that never runs by accident and always shows the cost first.
+        </P>
+        <P>
+          The layer also learned about performance. The profiler now harvests
+          index metadata and column cardinality, so the agent knows which
+          predicates are sargable and which columns are selective before it
+          writes a query. Generated SQL that&apos;s more likely to be fast, not
+          just correct.
+        </P>
+
+        <H2>A smarter agent</H2>
+        <DefList>
+          <DefItem term="Cross-source reach">
+            Ask one question and Atlas composes the answer across every
+            connected datasource in a single turn, correlating the separate
+            result sets and telling you which source each part came from. If it
+            can&apos;t reach a source, the answer is reported as partial, never
+            silently narrowed to one.
+          </DefItem>
+          <DefItem term="Performance-aware patterns">
+            Learned query patterns now carry a rolling latency average, scoring
+            favors the patterns that actually run fast, and a nightly job
+            auto-promotes the winners and decays stale ones.
+          </DefItem>
+          <DefItem term="Durable long-running turns">
+            The long, multi-step turns that real analysis sometimes needs now
+            checkpoint per step and resume after a crash, and a turn that hits
+            an approval gate parks instead of failing, then auto-resumes once
+            approved. Context compaction keeps long turns inside the
+            model&apos;s window. All opt-in, all degrading cleanly to
+            today&apos;s behavior.
+          </DefItem>
+        </DefList>
+
+        <H2>The MCP server grew up</H2>
+        <P>
+          Atlas&apos;s MCP server went from a read-only data analyst to a
+          complete, production-grade surface AI assistants can safely act
+          through. It speaks the latest MCP spec, tool annotations, structured
+          results, progress and cancellation, pagination, resource
+          subscriptions, and sits on a real security spine: roles resolved
+          against the live database, an explicit <InlineCode>mcp:write</InlineCode>{" "}
+          scope for mutations, an approval gate on sensitive actions, and a
+          per-workspace action policy that can only be tightened, never
+          loosened. You can even provision, profile, and manage datasources
+          end-to-end from an MCP client, with credentials gathered through
+          masked forms so secrets never pass through the model.
+        </P>
+        <P>
+          And the front door opens straight from an AI client: a{" "}
+          <InlineCode>start_trial</InlineCode> tool at{" "}
+          <a href="https://mcp.useatlas.dev" className="link-accent">
+            mcp.useatlas.dev
+          </a>{" "}
+          provisions a trial workspace on the spot and hands back a connect URL,
+          business-email-only, abuse-protected, and claimed on the web with a
+          one-time passcode.
+        </P>
+
+        <H2>Dashboards became a BI surface</H2>
+        <P>
+          The dashboard surface grew from a saved-query gallery toward a real BI
+          tool. KPI cards gained period-over-period deltas, value formatting,
+          and inline sparklines; charts carry goal lines, thresholds, and event
+          annotations to mark releases or incidents on the timeline. Dashboards
+          became explorable too: click a data point to drill down, filter every
+          card from one with cross-filtering, and export a single card to CSV or
+          a whole dashboard to PDF. You can even edit a dashboard from chat, with
+          every change landing in your personal draft until you publish.
+        </P>
+
+        <H2>Atlas Cloud became a real product</H2>
+        <P>
+          Self-hosting Atlas was always free and complete. What landed during
+          beta is the hosted option for teams that don&apos;t want to run
+          infrastructure:{" "}
+          <a href="https://app.useatlas.dev" className="link-accent">
             Atlas Cloud
-          </a>{" "}
-          is the managed option for teams that don&apos;t want to run
-          infrastructure. It starts with a 14-day free trial (no credit card),
-          then Starter, Pro, and Business tiers.{" "}
-          <a href="/pricing" className="text-accent hover:underline">
-            See pricing
-          </a>.
-        </Paragraph>
-
-        {/* ── CTA ── */}
-        <SectionHeading>Try it</SectionHeading>
-        <Paragraph>
-          The fastest way to see Atlas is the live demo. No signup, no
-          installation. It&apos;s connected to NovaMart — an e-commerce DTC brand
-          with 52 tables and ~480K rows of realistic, messy data.
-        </Paragraph>
-
-        <div className="mt-8 flex flex-wrap items-center gap-4">
-          <a
-            href="https://app.useatlas.dev/demo"
-            className="group inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-ink transition-all hover:bg-accent-hover"
-          >
-            Try the live demo
-            <ArrowIcon />
           </a>
-          <a
-            href="https://github.com/AtlasDevHQ/atlas"
-            className="group inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-fg-muted transition-all hover:border-border-strong hover:text-fg"
-          >
-            GitHub
-            <ArrowIcon />
-          </a>
+          . Pick a plan and pay from the billing page, subscriptions scope to
+          your organization rather than the admin who clicked, a failed payment
+          starts a recovery sequence instead of an abrupt lockout, and usage
+          accounting lines up exactly across the usage page, the billing page,
+          and live enforcement. Here&apos;s the snapshot of what ships today:
+        </P>
+        <DefList>
+          <DefItem term="Eight databases & warehouses">
+            PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB,
+            Salesforce, and Elasticsearch/OpenSearch, plus any REST/OpenAPI
+            service
+          </DefItem>
+          <DefItem term="Six LLM providers">
+            Anthropic, OpenAI, Bedrock, Ollama, OpenAI-compatible endpoints, and
+            the Vercel AI Gateway. Bring your own keys or use Atlas Cloud&apos;s
+            managed tokens
+          </DefItem>
+          <DefItem term="20+ plugins">
+            Datasource adapters, sandbox backends, chat-platform channels, and
+            action triggers. Build your own with the Plugin SDK
+          </DefItem>
+          <DefItem term="Embeddable everywhere">
+            A script-tag widget, a React component, a TypeScript SDK, the
+            headless API, and the MCP server
+          </DefItem>
+          <DefItem term="Eight chat platforms">
+            Slack live today; Teams, Discord, Telegram, WhatsApp, Linear,
+            GitHub, and Google Chat wired
+          </DefItem>
+          <DefItem term="Enterprise controls">
+            SSO (SAML/OIDC), SCIM provisioning, custom roles, IP allowlists,
+            approval workflows, audit-log retention and export, and data
+            residency
+          </DefItem>
+        </DefList>
+
+        <H2>A new look</H2>
+        <P>
+          Atlas also got a new brand, warm cream and deep forest green,
+          light-first, across every surface: the landing site, the docs, and
+          the product. It steps away from the saturated dark dev-tool default
+          toward something calmer and more legible for the dense work of reading
+          data.
+        </P>
+
+        <H2>What&apos;s next: July</H2>
+        <P>
+          <InlineCode>v0.1.0</InlineCode> is the public launch, and it lands in
+          July. A short list is still in flight, a final live security pass and
+          finishing multi-region data-residency routing, and then I cut it. The
+          fastest way to see where things are right now is the live demo: no
+          signup, no installation, connected to a realistic e-commerce dataset
+          with dozens of tables and hundreds of thousands of messy rows.
+        </P>
+
+        <PostActions />
+
+        <div className="mt-12">
+          <P>
+            Or run it yourself. Self-hosting is free and complete under
+            AGPL-3.0, no artificial limits:
+          </P>
         </div>
 
-        <BlockCode title="terminal">{`$ bun create atlas-agent my-app
+        <CodeBlock title="terminal">{`$ bun create atlas-agent my-app
 $ cd my-app
 $ cp .env.example .env   # add your ANTHROPIC_API_KEY + ATLAS_DATASOURCE_URL
-$ bun run dev`}</BlockCode>
+$ bun run dev`}</CodeBlock>
 
-        <Paragraph>
+        <P>
           Read the{" "}
-          <a href="https://docs.useatlas.dev/getting-started/quick-start" className="text-accent hover:underline">
+          <a href="https://docs.useatlas.dev/getting-started/quick-start" className="link-accent">
             quick start guide
           </a>{" "}
           for the full walkthrough, or jump straight to{" "}
-          <a href="https://docs.useatlas.dev/getting-started/connect-your-data" className="text-accent hover:underline">
+          <a href="https://docs.useatlas.dev/getting-started/connect-your-data" className="link-accent">
             connecting your database
-          </a>.
-        </Paragraph>
-
-        {/* Back to blog */}
-        <div className="mt-16 border-t border-border pt-8">
-          <a
-            href="/blog"
-            className="inline-flex items-center gap-1.5 font-mono text-xs text-fg-faint transition-colors hover:text-fg-muted"
-          >
-            <svg className="h-3 w-3 rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
-            </svg>
-            Back to blog
           </a>
-        </div>
-      </article>
+          .
+        </P>
+        <P>
+          If you try it, I&apos;d genuinely like to hear what breaks. Open an
+          issue on{" "}
+          <a href="https://github.com/AtlasDevHQ/atlas" className="link-accent">
+            GitHub
+          </a>{" "}
+          and it reaches me directly. See you at the launch.
+        </P>
+        <Signoff />
+
+        <BackToBlog />
+      </Article>
 
       <Divider />
       <Footer />

--- a/apps/www/src/app/blog/page.tsx
+++ b/apps/www/src/app/blog/page.tsx
@@ -8,11 +8,11 @@ import { StickyNav } from "../../components/sticky-nav";
 export const metadata: Metadata = {
   title: "Blog — Atlas",
   description:
-    "Updates, announcements, and technical deep dives from the Atlas team.",
+    "Launch notes, technical deep dives, and the occasional founder note, on building a text-to-SQL agent.",
   openGraph: {
     title: "Blog — Atlas",
     description:
-      "Updates, announcements, and technical deep dives from the Atlas team.",
+      "Launch notes, technical deep dives, and the occasional founder note, on building a text-to-SQL agent.",
     url: "https://www.useatlas.dev/blog",
     siteName: "Atlas",
     type: "website",
@@ -20,25 +20,39 @@ export const metadata: Metadata = {
 };
 
 // ---------------------------------------------------------------------------
-// Data
+// Data — newest first. The first entry renders as the featured lead.
 // ---------------------------------------------------------------------------
 
 interface Post {
   slug: string;
   title: string;
   description: string;
-  date: string;
+  isoDate: string;
+  dateLabel: string;
+  readingTime: string;
   tag: string;
 }
 
 const POSTS: Post[] = [
   {
     slug: "announcing-atlas",
-    title: "Announcing Atlas: open-source text-to-SQL with a semantic layer",
+    title: "The road to launch: everything I shipped in beta",
     description:
-      "Atlas is in open beta. Connect your database, auto-generate a semantic layer, and let an AI agent query your data — self-hosted or on Atlas Cloud.",
-    date: "2026-03-25",
-    tag: "Launch",
+      "A recap of the first half of 2026 — a run of internal milestones from 0.1 through 1.6, then twenty-nine public releases in under a month: SQL safety, new datasources, a smarter agent, MCP, dashboards, and Atlas Cloud.",
+    isoDate: "2026-06-25",
+    dateLabel: "June 25, 2026",
+    readingTime: "6 min read",
+    tag: "Road to launch",
+  },
+  {
+    slug: "the-first-thing-i-finished",
+    title: "The first thing I ever finished",
+    description:
+      "Thirty-two repositories since 2023, most dead within two weeks. Why Atlas is the first one I got over the line, and the first I built start-to-finish with an AI agent.",
+    isoDate: "2026-06-25",
+    dateLabel: "June 25, 2026",
+    readingTime: "3 min read",
+    tag: "Founder note",
   },
 ];
 
@@ -46,29 +60,52 @@ const POSTS: Post[] = [
 // Components
 // ---------------------------------------------------------------------------
 
-function PostCard({ post }: { post: Post }) {
+function PostMeta({ post }: { post: Post }) {
   return (
-    <a
-      href={`/blog/${post.slug}`}
-      className="group block rounded-xl border border-border bg-bg-raised p-8 transition-colors hover:border-border-strong hover:bg-bg-sunken"
-    >
-      <div className="mb-4 flex items-center gap-3">
-        <span className="rounded-full border border-accent/20 bg-accent-quiet px-2.5 py-0.5 font-mono text-[10px] font-medium tracking-wider text-accent uppercase">
-          {post.tag}
-        </span>
-        <time dateTime={post.date} className="font-mono text-xs text-fg-faint">{post.date}</time>
-      </div>
-      <h2 className="mb-3 text-lg font-semibold tracking-tight text-fg group-hover:text-accent">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[11px]">
+      <span className="rounded-full border border-accent/25 bg-accent-quiet px-2.5 py-0.5 font-medium tracking-[0.12em] text-accent uppercase">
+        {post.tag}
+      </span>
+      <time dateTime={post.isoDate} className="tracking-[0.04em] text-fg-faint">
+        {post.dateLabel}
+      </time>
+      <span aria-hidden className="text-border-strong">·</span>
+      <span className="tracking-[0.04em] text-fg-faint">{post.readingTime}</span>
+    </div>
+  );
+}
+
+function FeaturedPost({ post }: { post: Post }) {
+  return (
+    <a href={`/blog/${post.slug}`} className="group block">
+      <PostMeta post={post} />
+      <h2 className="mt-4 text-[clamp(1.75rem,1.3rem+1.8vw,2.5rem)] font-semibold leading-[1.08] tracking-[-0.025em] text-balance text-fg transition-colors group-hover:text-accent">
         {post.title}
       </h2>
-      <p className="mb-6 text-sm leading-relaxed text-fg-muted">
+      <p className="mt-4 max-w-[60ch] text-[17px] leading-relaxed text-pretty text-fg-muted">
         {post.description}
       </p>
-      <span className="inline-flex items-center gap-1.5 font-mono text-xs text-accent">
+      <span className="mt-5 inline-flex items-center gap-1.5 font-mono text-xs text-accent">
         Read post
         <ArrowIcon className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
       </span>
     </a>
+  );
+}
+
+function PostRow({ post }: { post: Post }) {
+  return (
+    <li className="border-t border-border-soft">
+      <a href={`/blog/${post.slug}`} className="group flex flex-col gap-2.5 py-7">
+        <PostMeta post={post} />
+        <h3 className="text-xl font-semibold tracking-[-0.015em] text-balance text-fg transition-colors group-hover:text-accent md:text-[1.375rem]">
+          {post.title}
+        </h3>
+        <p className="max-w-[62ch] text-[15px] leading-relaxed text-pretty text-fg-muted">
+          {post.description}
+        </p>
+      </a>
+    </li>
   );
 }
 
@@ -77,29 +114,37 @@ function PostCard({ post }: { post: Post }) {
 // ---------------------------------------------------------------------------
 
 export default function BlogIndex() {
+  const [featured, ...rest] = POSTS;
+
   return (
     <div className="relative min-h-screen">
       <StickyNav />
       <TopGlow />
       <Nav currentPage="/blog" />
 
-      <section className="mx-auto max-w-3xl px-6 pt-24 pb-20 md:pt-36 md:pb-28">
-        <p className="animate-fade-in-up delay-100 mb-4 font-mono text-sm tracking-wide text-accent">
+      <section className="mx-auto max-w-3xl px-6 pt-24 pb-20 md:pt-32 md:pb-28">
+        <p className="animate-fade-in-up delay-100 mb-4 font-mono text-xs tracking-[0.12em] text-accent uppercase">
           Blog
         </p>
-        <h1 className="animate-fade-in-up delay-200 mb-6 text-3xl font-semibold tracking-tight text-fg md:text-4xl">
-          Updates & announcements
+        <h1 className="animate-fade-in-up delay-200 text-[clamp(2.25rem,1.8rem+2vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-balance text-fg">
+          Writing
         </h1>
-        <p className="animate-fade-in-up delay-300 mb-16 max-w-xl text-fg-muted">
-          Product launches, technical deep dives, and the occasional opinion
-          about text-to-SQL.
+        <p className="animate-fade-in-up delay-300 mt-5 max-w-[52ch] text-[17px] leading-relaxed text-pretty text-fg-muted">
+          Launch notes, technical deep dives, and the occasional founder note,
+          from building Atlas.
         </p>
 
-        <div className="animate-fade-in-up delay-400 flex flex-col gap-6">
-          {POSTS.map((post) => (
-            <PostCard key={post.slug} post={post} />
-          ))}
+        <div className="animate-fade-in-up delay-400 mt-16">
+          <FeaturedPost post={featured} />
         </div>
+
+        {rest.length > 0 && (
+          <ul className="animate-fade-in-up delay-500 mt-14 border-b border-border-soft">
+            {rest.map((post) => (
+              <PostRow key={post.slug} post={post} />
+            ))}
+          </ul>
+        )}
       </section>
 
       <Divider />

--- a/apps/www/src/app/blog/the-first-thing-i-finished/page.tsx
+++ b/apps/www/src/app/blog/the-first-thing-i-finished/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+
+import { Footer } from "../../../components/footer";
+import { Nav } from "../../../components/nav";
+import {
+  Article,
+  BackToBlog,
+  H2,
+  InlineCode,
+  Lead,
+  P,
+  PostActions,
+  PostHeader,
+  PullQuote,
+  Signoff,
+  StatStrip,
+} from "../../../components/prose";
+import { Divider, TopGlow } from "../../../components/shared";
+import { StickyNav } from "../../../components/sticky-nav";
+
+export const metadata: Metadata = {
+  title: "The First Thing I Ever Finished",
+  description:
+    "Thirty-two repositories since 2023, most dead within two weeks. Why Atlas is the first one I got over the line — and the first I built start-to-finish with an AI agent.",
+  authors: [{ name: "Matt Sywulak" }],
+  openGraph: {
+    title: "The First Thing I Ever Finished",
+    description:
+      "Thirty-two repositories since 2023, most dead within two weeks. Why Atlas is the first one I got over the line — and the first I built with an AI agent. By Matt Sywulak.",
+    url: "https://www.useatlas.dev/blog/the-first-thing-i-finished",
+    siteName: "Atlas",
+    type: "article",
+    authors: ["Matt Sywulak"],
+  },
+};
+
+export default function FirstThingIFinished() {
+  return (
+    <div className="relative min-h-screen">
+      <StickyNav />
+      <TopGlow />
+      <Nav currentPage="/blog" />
+
+      <Article>
+        <PostHeader
+          tag="Founder note"
+          isoDate="2026-06-25"
+          dateLabel="June 25, 2026"
+          readingTime="3 min read"
+          title="The first thing I ever finished"
+          dek="Thirty-two repositories since 2023. Most died within two weeks. Atlas is the first one I got over the line, and the first I built start-to-finish with an AI agent."
+        />
+
+        <Lead>
+          I want to tell you something about Atlas that isn&apos;t in the
+          changelog. It&apos;s the first thing I&apos;ve ever actually finished.
+        </Lead>
+        <P>
+          If you scroll back through my GitHub, it reads like a graveyard. A
+          burst of energy, a README, a half-built prototype, and then silence,
+          over and over. Only a handful of projects ever made it past two
+          months.
+        </P>
+
+        <StatStrip
+          items={[
+            { value: "32", label: "repos since 2023" },
+            { value: "22", label: "died in < 2 weeks" },
+            { value: "1", label: "finished" },
+          ]}
+        />
+
+        <H2>The same idea, a dozen times</H2>
+        <P>
+          The clearest tell is a security product I kept calling Tide. I started
+          it, scrapped it, and rebuilt it from scratch more times than I&apos;d
+          like to admit: <InlineCode>easy-casb</InlineCode>, then{" "}
+          <InlineCode>securitytides</InlineCode>, then{" "}
+          <InlineCode>tidesecurity</InlineCode>, then{" "}
+          <InlineCode>tide-appdir</InlineCode>, then{" "}
+          <InlineCode>tide-security</InlineCode>, then{" "}
+          <InlineCode>tide-ai</InlineCode>, then just{" "}
+          <InlineCode>tide</InlineCode>, then{" "}
+          <InlineCode>tide-monorepo</InlineCode>. A dozen repositories, the same
+          idea, across three years.
+        </P>
+        <P>
+          Some of them got real. One got genuinely big before I walked away.
+          I&apos;d get close, close enough to see the finish line, and then
+          I&apos;d lose the thread. A refactor I couldn&apos;t finish. A rewrite
+          that felt cleaner. A week away that turned into a month. The momentum
+          would go cold, and starting over always felt easier than picking back
+          up.
+        </P>
+
+        <PullQuote>So I&apos;d start over. Again.</PullQuote>
+
+        <H2>What was actually broken</H2>
+        <P>
+          It was never the ideas. Some of them were good. It was the messy
+          middle, the unglamorous stretch between a working prototype and a
+          finished product, where every project I&apos;ve ever started went to
+          die. Solo, that middle is brutal. You lose context, you lose nerve,
+          and there&apos;s no one to keep the thing moving while you sleep. The
+          rewrite is always right there, promising a clean slate, and a clean
+          slate is so much more fun than finishing.
+        </P>
+
+        <H2>What changed</H2>
+        <P>
+          Atlas is the first project I built start-to-finish alongside an AI
+          agent. Not as a fancy autocomplete, but as a collaborator that held
+          the whole codebase in its head, never lost the thread, and kept the
+          work moving through exactly the stretch where I always used to quit. I
+          directed; it did the heavy lifting. The project never went cold long
+          enough for me to talk myself into a rewrite. For the first time, the
+          messy middle had someone else in it.
+        </P>
+        <P>
+          There&apos;s a symmetry to that I didn&apos;t plan. Atlas is a data
+          analyst you run as an AI agent against your database. It was built by
+          one person running an AI agent against a codebase. The same bet, both
+          ends, and the first one of mine that ever paid off.
+        </P>
+
+        <H2>Over the line</H2>
+        <P>
+          Atlas goes GA in July. After thirty-one false starts, that sentence
+          still feels strange to write. If you want the product side of the
+          story, everything that shipped on the road here, it&apos;s in the{" "}
+          <a href="/blog/announcing-atlas" className="link-accent">
+            launch recap
+          </a>
+          . If you just want to see it work, the demo is live: no signup, no
+          installation.
+        </P>
+
+        <PostActions />
+        <Signoff />
+
+        <BackToBlog />
+      </Article>
+
+      <Divider />
+      <Footer />
+    </div>
+  );
+}

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -225,6 +225,22 @@
   background-size: 256px 256px;
 }
 
+/* Blog body links — refined underline (forest, offset) shared across /blog
+ * posts. Matches the legal-prose link treatment with a touch more offset for
+ * the larger reading size. */
+.link-accent {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--accent) 32%, transparent);
+  text-underline-offset: 3px;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
+}
+
+.link-accent:hover {
+  color: var(--accent-hover);
+  text-decoration-color: var(--accent-hover);
+}
+
 /* Legal prose — used by app/terms/, app/privacy/, app/dpa/ pages */
 .legal-prose ul {
   list-style-type: disc;

--- a/apps/www/src/app/sitemap.ts
+++ b/apps/www/src/app/sitemap.ts
@@ -18,6 +18,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/blog/the-first-thing-i-finished`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
     { url: `${baseUrl}/security`, lastModified, changeFrequency: "monthly", priority: 0.7 },
     { url: `${baseUrl}/privacy`, lastModified, changeFrequency: "monthly", priority: 0.5 },
     { url: `${baseUrl}/terms`, lastModified, changeFrequency: "monthly", priority: 0.5 },

--- a/apps/www/src/components/prose.tsx
+++ b/apps/www/src/components/prose.tsx
@@ -1,0 +1,274 @@
+import { type ReactNode } from "react";
+
+import { ArrowIcon, AtlasLogo } from "./shared";
+
+/* ---------------------------------------------------------------------------
+ * Blog prose system — shared long-form primitives for /blog posts.
+ *
+ * One reading column, one type ramp, one set of editorial beats (lead, pull
+ * quote, stat strip, definition list, numbered steps). Both posts import from
+ * here so the typography stays identical and tuned in one place. Drives all
+ * color through brand tokens (text-fg / text-accent / --code-*); no hardcoded
+ * values. See PRODUCT.md › Aesthetic Direction + the landing's BigStat / EndCta
+ * for the shared display-number and mono-caption language this echoes.
+ * ------------------------------------------------------------------------- */
+
+// ── Shell ──────────────────────────────────────────────────────────────────
+
+/** The reading column. ~70ch at the body size — within the 65–75ch target. */
+export function Article({ children }: { children: ReactNode }) {
+  return (
+    <article className="mx-auto max-w-[680px] px-6 pt-24 pb-20 md:pt-32 md:pb-28">
+      {children}
+    </article>
+  );
+}
+
+// ── Header ───────────────────────────────────────────────────────────────────
+
+export interface PostHeaderProps {
+  tag: string;
+  /** ISO date for the <time> machine attribute. */
+  isoDate: string;
+  /** Human label, e.g. "June 25, 2026". */
+  dateLabel: string;
+  readingTime: string;
+  title: ReactNode;
+  dek: ReactNode;
+}
+
+export function PostHeader({
+  tag,
+  isoDate,
+  dateLabel,
+  readingTime,
+  title,
+  dek,
+}: PostHeaderProps) {
+  return (
+    <header className="mb-14">
+      <div className="mb-6 flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[11px]">
+        <span className="rounded-full border border-accent/25 bg-accent-quiet px-2.5 py-0.5 font-medium tracking-[0.12em] text-accent uppercase">
+          {tag}
+        </span>
+        <time dateTime={isoDate} className="tracking-[0.04em] text-fg-faint">
+          {dateLabel}
+        </time>
+        <span aria-hidden className="text-border-strong">·</span>
+        <span className="tracking-[0.04em] text-fg-faint">{readingTime}</span>
+      </div>
+      <h1 className="animate-fade-in-up delay-100 text-[clamp(2rem,1.4rem+2.6vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-balance text-fg">
+        {title}
+      </h1>
+      <p className="animate-fade-in-up delay-200 mt-6 text-[clamp(1.125rem,1.04rem+0.5vw,1.375rem)] leading-[1.5] tracking-[-0.01em] text-pretty text-fg-muted">
+        {dek}
+      </p>
+      <Byline />
+    </header>
+  );
+}
+
+/** Author block — the Atlas mark in a forest chip + name and role. */
+export function Byline() {
+  return (
+    <div className="animate-fade-in-up delay-300 mt-8 flex items-center gap-3">
+      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-accent-quiet ring-1 ring-accent/20">
+        <AtlasLogo className="h-4 w-4 text-accent" />
+      </span>
+      <span className="leading-tight">
+        <span className="block text-sm font-medium text-fg">Matt Sywulak</span>
+        <span className="block font-mono text-[11px] tracking-[0.04em] text-fg-faint">
+          Founder, Atlas
+        </span>
+      </span>
+    </div>
+  );
+}
+
+// ── Body ─────────────────────────────────────────────────────────────────────
+
+/** Opening paragraph — a touch larger and in full ink to drop the reader in. */
+export function Lead({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-6 text-[19px] leading-[1.6] tracking-[-0.01em] text-pretty text-fg">
+      {children}
+    </p>
+  );
+}
+
+export function P({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-6 text-[17px] leading-[1.72] tracking-[-0.005em] text-pretty text-fg-muted">
+      {children}
+    </p>
+  );
+}
+
+export function H2({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="mt-16 mb-5 scroll-mt-24 text-[1.5rem] font-semibold leading-[1.15] tracking-[-0.02em] text-balance text-fg md:text-[1.75rem]">
+      {children}
+    </h2>
+  );
+}
+
+export function InlineCode({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded bg-bg-sunken px-1.5 py-0.5 font-mono text-[0.85em] text-fg">
+      {children}
+    </code>
+  );
+}
+
+/** Dark "terminal window" floating on the cream — the page's technical hero
+ *  asset. Graduated chrome dots read as a real window without skeuomorphism. */
+export function CodeBlock({
+  title,
+  children,
+}: {
+  title: string;
+  children: string;
+}) {
+  return (
+    <div className="my-8 overflow-hidden rounded-xl border border-code-border bg-code-bg shadow-pane">
+      <div className="flex items-center gap-2 border-b border-code-border px-4 py-3">
+        <span className="h-2.5 w-2.5 rounded-full bg-code-muted/70" />
+        <span className="h-2.5 w-2.5 rounded-full bg-code-muted/45" />
+        <span className="h-2.5 w-2.5 rounded-full bg-code-muted/30" />
+        <span className="ml-3 font-mono text-xs text-code-muted">{title}</span>
+      </div>
+      <pre className="overflow-x-auto p-5 font-mono text-sm leading-relaxed text-code-fg">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+/** A forest-accent display quote that breaks the text column for rhythm. */
+export function PullQuote({ children }: { children: ReactNode }) {
+  return (
+    <figure className="my-12">
+      <blockquote className="text-[clamp(1.375rem,1.1rem+1.2vw,1.875rem)] font-semibold leading-[1.22] tracking-[-0.02em] text-balance text-accent">
+        {children}
+      </blockquote>
+    </figure>
+  );
+}
+
+// ── Editorial beats ──────────────────────────────────────────────────────────
+
+export interface Stat {
+  value: string;
+  label: string;
+}
+
+/** Stat strip echoing the landing's BigStat language: big forest numerals,
+ *  mono caption. A visual anchor between prose, not a hero metric. */
+export function StatStrip({ items }: { items: Stat[] }) {
+  return (
+    <dl className="my-12 grid grid-cols-1 gap-x-8 gap-y-7 border-y border-border-soft py-8 sm:grid-cols-3">
+      {items.map((it) => (
+        <div key={it.label}>
+          <dt className="font-mono text-[11px] uppercase tracking-[0.08em] text-fg-faint">
+            {it.label}
+          </dt>
+          <dd className="mt-2 text-[2.75rem] font-semibold leading-[0.95] tracking-[-0.04em] text-accent md:text-[3.25rem]">
+            {it.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/** Two-column definition list: term rail + description. Replaces inline
+ *  bold-title bullets with a scannable, aligned structure. */
+export function DefList({ children }: { children: ReactNode }) {
+  return <dl className="my-8 space-y-6">{children}</dl>;
+}
+
+export function DefItem({
+  term,
+  children,
+}: {
+  term: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid gap-1.5 sm:grid-cols-[170px_1fr] sm:gap-7">
+      <dt className="text-[15px] font-semibold leading-snug text-fg">{term}</dt>
+      <dd className="text-[15px] leading-[1.6] text-fg-muted">{children}</dd>
+    </div>
+  );
+}
+
+export function Steps({ children }: { children: ReactNode }) {
+  return <ol className="my-8 space-y-3.5">{children}</ol>;
+}
+
+export function Step({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <li className="grid grid-cols-[1.875rem_1fr] items-baseline gap-3 text-[15px]">
+      <span className="font-mono text-[13px] font-medium tabular-nums text-accent">
+        {String(n).padStart(2, "0")}
+      </span>
+      <span className="leading-[1.55] text-fg-muted">
+        <span className="font-medium text-fg">{title}</span>: {children}
+      </span>
+    </li>
+  );
+}
+
+// ── Footer pieces ────────────────────────────────────────────────────────────
+
+/** Primary demo + GitHub actions, shared by both posts. */
+export function PostActions() {
+  return (
+    <div className="mt-8 flex flex-wrap items-center gap-3">
+      <a
+        href="https://app.useatlas.dev/demo"
+        className="group inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-ink transition-colors hover:bg-accent-hover"
+      >
+        Try the live demo
+        <ArrowIcon />
+      </a>
+      <a
+        href="https://github.com/AtlasDevHQ/atlas"
+        className="group inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-fg-muted transition-colors hover:border-border-strong hover:text-fg"
+      >
+        Star on GitHub
+        <ArrowIcon />
+      </a>
+    </div>
+  );
+}
+
+export function Signoff() {
+  return (
+    <p className="mt-10 text-[17px] leading-relaxed text-fg">
+      <span aria-hidden>— </span>Matt
+    </p>
+  );
+}
+
+export function BackToBlog() {
+  return (
+    <div className="mt-16 border-t border-border pt-8">
+      <a
+        href="/blog"
+        className="group inline-flex items-center gap-1.5 font-mono text-xs text-fg-faint transition-colors hover:text-fg-muted"
+      >
+        <ArrowIcon className="h-3 w-3 rotate-180 transition-transform group-hover:-translate-x-0.5" />
+        Back to blog
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Refreshes the blog for the July launch run-up: replaces the stale March "Announcing Atlas" post, adds a personal founder note, and rebuilds the index. Content + an `/impeccable` design pass + a copywriting pass.

The old post (dated 2026-03-25) predated the entire `v0.0.1`→`v0.0.29` train. It's **rewritten in place at the same `/blog/announcing-atlas` URL** so no inbound link or sitemap entry breaks.

## Posts

- **`/blog/announcing-atlas` — "The road to launch: everything I shipped in beta."** First-person beta recap (Matt Sywulak), grouped thematically (safety, datasources, semantic layer, agent, MCP, dashboards, Cloud, brand). Scale grounded in git + changelog: Feb origin, internal `0.1`→`1.6` milestones, **29 releases in 27 days**, ~4,000 issues/PRs.
- **`/blog/the-first-thing-i-finished` — "The first thing I ever finished."** Founder note: 32 repos since 2023, the recurring "Tide" rebuild saga (named deliberately), Atlas as the first project finished start-to-finish with an AI agent.

## Design (`/impeccable`, cream + forest brand)

- Twin-card index → **featured-lead + hairline list** (kills the identical-card grid).
- Shared **`components/prose.tsx`**: tuned long-form type (17px/1.72), stat strips (reusing the `BigStat` display-number language), pull quotes, numbered `Steps`, two-column definition lists, `.link-accent` underlines, byline with the Atlas mark.
- Removes the duplicated prose primitives that were copy-pasted across both posts.

## Accuracy guardrails

- **Anchors only publicly-verifiable claims** (Feb origin, 1,300+ commits in the public repo, the ~4,000 tracker). Internal repo mechanics kept out of the copy.
- **Data residency** framed as *in-progress*, not a working 3-region promise, per the known launch blocker #3967.
- License is **AGPL-3.0** (not the stale MIT in the old `blog-intro.md` draft).
- Sensitive private repo names omitted; only the "Tide" saga named, by intent.

## Scope / checks

- **www-only.** No API / template / dependency / `package.json` impact.
- `tsgo --noEmit` and `eslint` pass on `apps/www`; verified rendered in the browser (light cream+forest, all three routes 200).

https://claude.ai/code/session_019Y5bZRXCgde5nctbXzaKRp


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add two founder blog posts and redesign the blog index page
> - Adds a new blog post at `/blog/the-first-thing-i-finished` and rewrites `/blog/announcing-atlas` as "The Road to Launch: Everything I Shipped in Atlas's Beta", both using shared prose layout components.
> - Redesigns the `/blog` index to feature the most recent post prominently at the top, with remaining posts displayed in a bordered list including tag, date, and reading time metadata.
> - Introduces a shared [prose.tsx](https://github.com/AtlasDevHQ/atlas/pull/3976/files#diff-8d2268600e586ae5d607653bea045e750fafb851118500429a5c395fb9863563) component library (`Article`, `PostHeader`, `Byline`, `Lead`, `P`, `H2`, `PullQuote`, `StatStrip`, `DefList`, `Steps`, `PostActions`, `Signoff`, `BackToBlog`) replacing ad-hoc per-page components.
> - Adds a `.link-accent` CSS class in [globals.css](https://github.com/AtlasDevHQ/atlas/pull/3976/files#diff-8c8aa23ab09ba3f9c1fd98ff8c0eaf86e9cc37d04561a50a4b959fa413b4588a) for consistent link styling across blog body content.
> - Updates the sitemap to include the new blog post URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdb6dea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->