### PR TITLE
fix(www): blog header headline "Writing" → "Field notes"

### DIFF
--- a/apps/www/src/app/blog/page.tsx
+++ b/apps/www/src/app/blog/page.tsx
@@ -137,7 +137,7 @@ export default function BlogIndex() {
           Blog
         </p>
         <h1 className="animate-fade-in-up delay-200 text-[clamp(2.25rem,1.8rem+2vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-balance text-fg">
-          Writing
+          Field notes
         </h1>
         <p className="animate-fade-in-up delay-300 mt-5 max-w-[52ch] text-[17px] leading-relaxed text-pretty text-fg-muted">
           Launch notes, technical deep dives, and the occasional founder note,


### PR DESCRIPTION
## What

Changes the blog index page's `<h1>` headline from **Writing** to **Field notes**.

## Why

The blog header uses a kicker + headline + dek stack:

```
Blog          ← kicker (mono eyebrow)
Writing       ← <h1> headline
Launch notes, technical deep dives…  ← subtitle
```

The kicker (`Blog`) and the headline (`Writing`) were near-synonyms, so the
large headline read as decorative rather than informative — it labelled the
section twice. `Field notes` gives the headline its own meaning and matches the
founder / how-I-build voice of the actual posts, while keeping the typographic
hierarchy intact.

## Scope

One-line copy change in `apps/www/src/app/blog/page.tsx`. No logic, no types.

https://claude.ai/code/session_01QDHH7Xt2Tp3zVYvNdLL6sY

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename blog index heading from 'Writing' to 'Field notes'
> Updates the `<h1>` text in the [BlogIndex](https://github.com/AtlasDevHQ/atlas/pull/3980/files#diff-63c13edb06ff40b638ec24e0ccfd6b8052f4d424d317ae26a88cd0afa09a6fdd) component to match the new section label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e57c37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->