### PR TITLE
feat(web): browser region-awareness — pre-auth regional API base + atlas_region persistence

### DIFF
--- a/packages/web/src/app/signup/region/page.test.tsx
+++ b/packages/web/src/app/signup/region/page.test.tsx
@@ -27,13 +27,10 @@ mock.module("next/navigation", () => ({
   useRouter: () => routerMock,
 }));
 
-mock.module("@/lib/api-url", () => ({
-  // getApiBase() falls back to window.location.origin when getApiUrl() is empty.
-  getApiUrl: () => "",
-  isCrossOrigin: () => false,
-  _resetApiUrl: () => {},
-}));
-
+// `@/lib/api-url` is used unmocked: with NEXT_PUBLIC_ATLAS_API_URL empty in the
+// test env, getApiUrl() → "" and isCrossOrigin() → false (so getApiBase() falls
+// back to window.location.origin). No atlas_region cookie is set here, so the
+// module's import-time restore is a no-op.
 mock.module("@/ui/components/signup/signup-shell", () => ({
   SignupShell: ({ children, back }: { children: unknown; back?: { href: string } }) => (
     <div>

--- a/packages/web/src/app/signup/region/page.test.tsx
+++ b/packages/web/src/app/signup/region/page.test.tsx
@@ -31,7 +31,6 @@ mock.module("@/lib/api-url", () => ({
   // getApiBase() falls back to window.location.origin when getApiUrl() is empty.
   getApiUrl: () => "",
   isCrossOrigin: () => false,
-  setRegionalApiUrl: () => {},
   _resetApiUrl: () => {},
 }));
 

--- a/packages/web/src/lib/api-url.ts
+++ b/packages/web/src/lib/api-url.ts
@@ -3,22 +3,30 @@
  *
  * The browser must target its workspace's regional API *before* any
  * authenticated call. Region is therefore a signal the browser knows up
- * front — a region selection during signup, or the `atlas_region` cookie on
- * a returning visit — never something it learns by first calling the US API.
- * (The retired path did exactly that: it discovered the regional host from
- * the US admin-settings response, which only worked while data was wrongly
- * readable from US. ADR-0024 deletes that circular dependency.)
+ * front — never something it learns by first calling the US API. (The retired
+ * path did exactly that: it discovered the regional host from the US
+ * admin-settings response, which only worked while data was wrongly readable
+ * from US. ADR-0024 deletes that circular dependency.)
+ *
+ * What this module implements:
+ *   - applyRegionSignal(region, apiUrl): point the API base at a region and
+ *     persist `{ region, apiUrl }` in the `atlas_region` cookie.
+ *   - restore-on-import + initRegionFromCookie(): a returning visit resolves
+ *     the regional base straight from that cookie, with no network round-trip.
  *
  * Resolution order for getApiUrl():
- *   1. An active region signal — a selection this session, or the
- *      `atlas_region` cookie restored on load → that region's apiUrl.
- *   2. Otherwise the build-time default (NEXT_PUBLIC_ATLAS_API_URL), which is
- *      empty on self-hosted → same-origin, unaffected by any of this.
+ *   1. An active region signal — applied this session, or restored from the
+ *      `atlas_region` cookie on load → that region's apiUrl.
+ *   2. Otherwise the build-time default (NEXT_PUBLIC_ATLAS_API_URL), empty on
+ *      self-hosted → same-origin, unaffected by any of this.
  *
- * The `atlas_region` cookie persists `{ region, apiUrl }` so the regional
- * base survives reloads with no network round-trip, and the region key seeds
- * the login fast-path (it short-circuits the front-door region fan-out).
+ * Intended consumers (separate slices): the signup region step calls
+ * applyRegionSignal so the choice is made before the first identity write, and
+ * a login fast-path reads getActiveRegion() to short-circuit the front-door
+ * region fan-out. Neither is wired here — this is the primitive they build on.
  */
+
+import type { Region } from "@useatlas/types";
 
 const DEFAULT_API_URL = (process.env.NEXT_PUBLIC_ATLAS_API_URL ?? "").replace(/\/+$/, "");
 
@@ -28,12 +36,15 @@ export const REGION_COOKIE = "atlas_region";
 /** 1 year — region rarely changes; a returning user keeps the fast-path. */
 const REGION_COOKIE_MAX_AGE = 31_536_000;
 
+/** Hosts allowed to serve a regional base over plain http (local dev only). */
+const LOCAL_HOSTS = /^(localhost|127\.0\.0\.1|\[::1\])$/;
+
 /** A region selection projected onto the API base it resolves to. */
 export interface RegionSignal {
   /** Region identifier (e.g. "eu") — seeds the login fast-path. */
-  region: string;
+  readonly region: Region;
   /** Resolved regional API base (e.g. "https://api-eu.useatlas.dev"). */
-  apiUrl: string;
+  readonly apiUrl: string;
 }
 
 /**
@@ -42,16 +53,28 @@ export interface RegionSignal {
  */
 let activeSignal: RegionSignal | null = null;
 
-/** Trim + strip trailing slashes; return null unless it parses as a URL. */
+/**
+ * Trim + strip trailing slashes; return null unless the value parses as a URL
+ * on a credential-safe scheme. Requires https (the regional bases are https),
+ * allowing http only for localhost so local dev still works. The regional base
+ * is fed to credentialed fetches and the `atlas_region` cookie is
+ * client-writable, so rejecting arbitrary http/`javascript:` origins here keeps
+ * a tampered cookie from repointing authenticated traffic at an attacker host.
+ */
 function normalizeUrl(url: string): string | null {
   const cleaned = url.trim().replace(/\/+$/, "");
   if (!cleaned) return null;
+  let parsed: URL;
   try {
-    new URL(cleaned);
-    return cleaned;
+    parsed = new URL(cleaned);
   } catch {
+    // intentionally ignored: a parse failure IS the "invalid URL" signal; the
+    // caller (applyRegionSignal / readRegionCookie) surfaces the rejection.
     return null;
   }
+  if (parsed.protocol === "https:") return cleaned;
+  if (parsed.protocol === "http:" && LOCAL_HOSTS.test(parsed.hostname)) return cleaned;
+  return null;
 }
 
 /** Validate a raw `{ region, apiUrl }` shape into a RegionSignal, or null. */
@@ -71,43 +94,62 @@ function readRegionCookie(): RegionSignal | null {
     .split("; ")
     .find((c) => c.startsWith(`${REGION_COOKIE}=`));
   const raw = match?.slice(REGION_COOKIE.length + 1);
-  if (!raw) return null;
+  if (!raw) return null; // no cookie — the normal, default-base path; stay quiet
+
+  let parsed: unknown;
   try {
-    return toSignal(JSON.parse(decodeURIComponent(raw)));
+    parsed = JSON.parse(decodeURIComponent(raw));
   } catch (err) {
-    // A tampered or stale-format cookie must not strand the browser — fall
-    // back to the default base rather than throwing on every call.
     console.warn(
-      "api-url: ignoring malformed atlas_region cookie:",
+      "api-url: ignoring atlas_region cookie with an unparseable value:",
       err instanceof Error ? err.message : String(err),
     );
     return null;
   }
+
+  const signal = toSignal(parsed);
+  if (!signal) {
+    // Present but shape-invalid — a tampered value, or a cookie left by an
+    // older format after a RegionSignal change. Surface it: silently demoting
+    // a regional user to the US build-time default is the residency failure
+    // #3971 exists to kill, so it must be observable, not swallowed.
+    console.warn("api-url: ignoring atlas_region cookie with an invalid shape.");
+  }
+  return signal;
 }
 
 /**
- * `Secure` on https (prod regional hosts) but omitted on http so the cookie
- * is actually stored during local development (and in the test DOM, which
- * runs on http://localhost).
+ * `; Secure` on https (prod regional hosts), omitted on http so the cookie is
+ * actually stored during local development (and in the test DOM, which runs on
+ * http://localhost). Pure on `protocol` so the https branch is unit-testable —
+ * the test DOM can't exercise it via a real document.cookie write.
  */
-function cookieSecureAttr(): string {
-  if (typeof window !== "undefined" && window.location?.protocol === "http:") return "";
-  return "; Secure";
+export function secureCookieAttr(protocol: string | undefined): string {
+  return protocol === "http:" ? "" : "; Secure";
+}
+
+function currentProtocol(): string | undefined {
+  return typeof window !== "undefined" ? window.location?.protocol : undefined;
 }
 
 function writeRegionCookie(signal: RegionSignal | null): void {
   if (typeof document === "undefined") return;
+  const secure = secureCookieAttr(currentProtocol());
   if (signal === null) {
-    document.cookie = `${REGION_COOKIE}=; path=/; max-age=0; SameSite=Lax${cookieSecureAttr()}`;
+    document.cookie = `${REGION_COOKIE}=; path=/; max-age=0; SameSite=Lax${secure}`;
     return;
   }
   const value = encodeURIComponent(JSON.stringify(signal));
   document.cookie =
-    `${REGION_COOKIE}=${value}; path=/; max-age=${REGION_COOKIE_MAX_AGE}; SameSite=Lax${cookieSecureAttr()}`;
+    `${REGION_COOKIE}=${value}; path=/; max-age=${REGION_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
 }
 
 // Restore synchronously at module load (browser only) so getApiUrl() is
-// already regional on the very first call, before any component renders.
+// already regional on the very first call, before any component renders. SSR
+// resolves to the default base (no `document`) while the client resolves
+// regional after this restore — an intentional divergence that is safe because
+// `apiUrl` is only ever used to address fetches, never rendered as hydrated
+// text.
 if (typeof document !== "undefined") {
   activeSignal = readRegionCookie();
 }
@@ -126,7 +168,7 @@ export function isCrossOrigin(): boolean {
 }
 
 /** The active region key, if any — seeds the login fast-path. */
-export function getActiveRegion(): string | null {
+export function getActiveRegion(): Region | null {
   return activeSignal?.region ?? null;
 }
 
@@ -134,8 +176,8 @@ export function getActiveRegion(): string | null {
  * Apply a region selection: point the API base at the region's `apiUrl` and
  * persist `{ region, apiUrl }` in the `atlas_region` cookie so it survives
  * reloads. Returns `false` (base unchanged, cookie untouched) when the region
- * is empty or the `apiUrl` doesn't parse — a bad signal must never strand the
- * browser on an unreachable host.
+ * is empty or the `apiUrl` is not a credential-safe URL — a bad signal must
+ * never strand the browser on an unreachable host.
  */
 export function applyRegionSignal(region: string, apiUrl: string): boolean {
   const signal = toSignal({ region, apiUrl });

--- a/packages/web/src/lib/api-url.ts
+++ b/packages/web/src/lib/api-url.ts
@@ -1,57 +1,172 @@
 /**
- * Dynamic API URL resolution for regional data residency.
+ * Pre-auth regional API base resolution (ADR-0024 §3–§4).
  *
- * Bootstrap flow:
- *   1. Page loads → getApiUrl() returns the default (build-time) URL
- *   2. User authenticates against the global API
- *   3. Settings load → regionApiUrl discovered → setRegionalApiUrl()
- *   4. All subsequent fetches use the regional URL
+ * The browser must target its workspace's regional API *before* any
+ * authenticated call. Region is therefore a signal the browser knows up
+ * front — a region selection during signup, or the `atlas_region` cookie on
+ * a returning visit — never something it learns by first calling the US API.
+ * (The retired path did exactly that: it discovered the regional host from
+ * the US admin-settings response, which only worked while data was wrongly
+ * readable from US. ADR-0024 deletes that circular dependency.)
  *
- * Self-hosted deployments (no region config) are unaffected — getApiUrl()
- * always returns the build-time value when no regional override is set.
+ * Resolution order for getApiUrl():
+ *   1. An active region signal — a selection this session, or the
+ *      `atlas_region` cookie restored on load → that region's apiUrl.
+ *   2. Otherwise the build-time default (NEXT_PUBLIC_ATLAS_API_URL), which is
+ *      empty on self-hosted → same-origin, unaffected by any of this.
+ *
+ * The `atlas_region` cookie persists `{ region, apiUrl }` so the regional
+ * base survives reloads with no network round-trip, and the region key seeds
+ * the login fast-path (it short-circuits the front-door region fan-out).
  */
 
 const DEFAULT_API_URL = (process.env.NEXT_PUBLIC_ATLAS_API_URL ?? "").replace(/\/+$/, "");
 
-/** Module-level regional override — set after settings fetch. */
-let regionalApiUrl: string | null = null;
+/** Cookie persisting the selected region + its resolved API base. */
+export const REGION_COOKIE = "atlas_region";
 
-/** Returns the current API URL, preferring the regional override if set. */
-export function getApiUrl(): string {
-  return regionalApiUrl ?? DEFAULT_API_URL;
+/** 1 year — region rarely changes; a returning user keeps the fast-path. */
+const REGION_COOKIE_MAX_AGE = 31_536_000;
+
+/** A region selection projected onto the API base it resolves to. */
+export interface RegionSignal {
+  /** Region identifier (e.g. "eu") — seeds the login fast-path. */
+  region: string;
+  /** Resolved regional API base (e.g. "https://api-eu.useatlas.dev"). */
+  apiUrl: string;
 }
 
-/** Whether an explicit API URL is configured (implying cross-origin deployment). */
+/**
+ * Active region signal — a selection made this session, or the cookie
+ * restored on load. `null` means "no signal → build-time default".
+ */
+let activeSignal: RegionSignal | null = null;
+
+/** Trim + strip trailing slashes; return null unless it parses as a URL. */
+function normalizeUrl(url: string): string | null {
+  const cleaned = url.trim().replace(/\/+$/, "");
+  if (!cleaned) return null;
+  try {
+    new URL(cleaned);
+    return cleaned;
+  } catch {
+    return null;
+  }
+}
+
+/** Validate a raw `{ region, apiUrl }` shape into a RegionSignal, or null. */
+function toSignal(raw: unknown): RegionSignal | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const { region, apiUrl } = raw as Record<string, unknown>;
+  if (typeof region !== "string" || typeof apiUrl !== "string") return null;
+  const trimmedRegion = region.trim();
+  const normalized = normalizeUrl(apiUrl);
+  if (!trimmedRegion || !normalized) return null;
+  return { region: trimmedRegion, apiUrl: normalized };
+}
+
+function readRegionCookie(): RegionSignal | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${REGION_COOKIE}=`));
+  const raw = match?.slice(REGION_COOKIE.length + 1);
+  if (!raw) return null;
+  try {
+    return toSignal(JSON.parse(decodeURIComponent(raw)));
+  } catch (err) {
+    // A tampered or stale-format cookie must not strand the browser — fall
+    // back to the default base rather than throwing on every call.
+    console.warn(
+      "api-url: ignoring malformed atlas_region cookie:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+}
+
+/**
+ * `Secure` on https (prod regional hosts) but omitted on http so the cookie
+ * is actually stored during local development (and in the test DOM, which
+ * runs on http://localhost).
+ */
+function cookieSecureAttr(): string {
+  if (typeof window !== "undefined" && window.location?.protocol === "http:") return "";
+  return "; Secure";
+}
+
+function writeRegionCookie(signal: RegionSignal | null): void {
+  if (typeof document === "undefined") return;
+  if (signal === null) {
+    document.cookie = `${REGION_COOKIE}=; path=/; max-age=0; SameSite=Lax${cookieSecureAttr()}`;
+    return;
+  }
+  const value = encodeURIComponent(JSON.stringify(signal));
+  document.cookie =
+    `${REGION_COOKIE}=${value}; path=/; max-age=${REGION_COOKIE_MAX_AGE}; SameSite=Lax${cookieSecureAttr()}`;
+}
+
+// Restore synchronously at module load (browser only) so getApiUrl() is
+// already regional on the very first call, before any component renders.
+if (typeof document !== "undefined") {
+  activeSignal = readRegionCookie();
+}
+
+/** Returns the current API URL, preferring the active regional base. */
+export function getApiUrl(): string {
+  return activeSignal?.apiUrl ?? DEFAULT_API_URL;
+}
+
+/**
+ * Whether requests cross an origin (an explicit/regional API base is set),
+ * so consumers send `credentials: "include"` on credentialed fetches.
+ */
 export function isCrossOrigin(): boolean {
   return !!getApiUrl();
 }
 
-/**
- * Set the regional API URL override. Called after the settings response
- * includes a `regionApiUrl` that differs from the default.
- * Pass `null` to clear the override.
- */
-export function setRegionalApiUrl(url: string | null): void {
-  if (url === null) {
-    regionalApiUrl = null;
-    return;
-  }
-  const cleaned = url.replace(/\/+$/, "").trim();
-  if (!cleaned) {
-    regionalApiUrl = null;
-    return;
-  }
-  try {
-    new URL(cleaned);
-    regionalApiUrl = cleaned;
-  } catch {
-    console.error(
-      `setRegionalApiUrl: rejected invalid URL "${url}". Continuing with default API URL.`,
-    );
-  }
+/** The active region key, if any — seeds the login fast-path. */
+export function getActiveRegion(): string | null {
+  return activeSignal?.region ?? null;
 }
 
-/** Reset to default (for testing). */
+/**
+ * Apply a region selection: point the API base at the region's `apiUrl` and
+ * persist `{ region, apiUrl }` in the `atlas_region` cookie so it survives
+ * reloads. Returns `false` (base unchanged, cookie untouched) when the region
+ * is empty or the `apiUrl` doesn't parse — a bad signal must never strand the
+ * browser on an unreachable host.
+ */
+export function applyRegionSignal(region: string, apiUrl: string): boolean {
+  const signal = toSignal({ region, apiUrl });
+  if (!signal) {
+    console.error(
+      `applyRegionSignal: rejected region="${region}" apiUrl="${apiUrl}". Keeping current API URL.`,
+    );
+    return false;
+  }
+  activeSignal = signal;
+  writeRegionCookie(signal);
+  return true;
+}
+
+/** Clear the region signal + cookie, reverting to the build-time default. */
+export function clearRegionSignal(): void {
+  activeSignal = null;
+  writeRegionCookie(null);
+}
+
+/**
+ * Restore the active region signal from the `atlas_region` cookie. Idempotent;
+ * call on app load (the module also does this once on import) or after a
+ * cookie change in another tab. A missing/malformed cookie clears the signal.
+ */
+export function initRegionFromCookie(): RegionSignal | null {
+  activeSignal = readRegionCookie();
+  return activeSignal;
+}
+
+/** Reset in-memory state (testing). Does not touch the cookie. */
 export function _resetApiUrl(): void {
-  regionalApiUrl = null;
+  activeSignal = null;
 }

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -53,11 +53,15 @@ function getBaseURL(): string {
   return "http://localhost:3000/api/auth";
 }
 
-// Auth always authenticates against the global API (not the regional endpoint).
-// The client is a module-level singleton created at import time, before
-// setRegionalApiUrl() is called. This is intentional: session cookies and
-// auth operations stay on the global endpoint; only data-plane calls (chat,
-// admin fetches) switch to the regional API after settings load.
+// The auth client targets whatever `getApiUrl()` resolves at import. Under
+// ADR-0024 identity is regional, so when the `atlas_region` cookie is already
+// set — a returning user, or a fresh user after a region selection + the
+// signup flow's hard navigation — this is the workspace's own regional API,
+// and session cookies are minted host-only there (§5). With no region signal
+// it's the build-time default. The client is a module-level singleton built
+// after api-url.ts restores the cookie on import, so a returning user's
+// regional base is already in effect. Region is never discovered post-auth by
+// calling the US API — that circular path is retired (#3971).
 const _authClient = createAuthClient({
   baseURL: getBaseURL(),
   plugins: [

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -54,14 +54,15 @@ function getBaseURL(): string {
 }
 
 // The auth client targets whatever `getApiUrl()` resolves at import. Under
-// ADR-0024 identity is regional, so when the `atlas_region` cookie is already
-// set — a returning user, or a fresh user after a region selection + the
-// signup flow's hard navigation — this is the workspace's own regional API,
-// and session cookies are minted host-only there (§5). With no region signal
-// it's the build-time default. The client is a module-level singleton built
-// after api-url.ts restores the cookie on import, so a returning user's
-// regional base is already in effect. Region is never discovered post-auth by
-// calling the US API — that circular path is retired (#3971).
+// ADR-0024 identity is regional, so for a returning user whose `atlas_region`
+// cookie is already set, api-url.ts restores it on import (before this
+// module-level singleton is built) and the client targets that workspace's own
+// regional API — where its session cookie was minted host-only (§5). With no
+// region signal it's the build-time default. Persisting the selection during
+// signup and consuming the region key on login land in follow-up slices; until
+// then only a cookie left by a prior session takes effect. Region is never
+// discovered post-auth by calling the US API — that circular path is retired
+// (#3971).
 const _authClient = createAuthClient({
   baseURL: getBaseURL(),
   plugins: [

--- a/packages/web/src/ui/__tests__/api-url-module-load.test.ts
+++ b/packages/web/src/ui/__tests__/api-url-module-load.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterAll } from "bun:test";
+
+/**
+ * The module-load restore is the *only* production path that makes a returning
+ * user's very first getApiUrl() call regional — the top-level
+ * `if (typeof document !== "undefined") activeSignal = readRegionCookie()` in
+ * api-url.ts. The sibling api-url.test.ts simulates it via an explicit
+ * initRegionFromCookie() call, but that branch never runs with a cookie present
+ * because the static import there resolves before any test seeds a cookie.
+ *
+ * The isolated per-file runner gives this file fresh module state, so seeding
+ * the cookie *before* the dynamic import exercises the real import-time branch.
+ * This is also what transitively points the auth client's baseURL at the
+ * regional host on import (auth/client.ts).
+ */
+
+// Seed BEFORE importing api-url so its top-level restore runs with the cookie
+// present — the dynamic import is what executes that branch.
+document.cookie = `atlas_region=${encodeURIComponent(
+  JSON.stringify({ region: "eu", apiUrl: "https://api-eu.useatlas.dev" }),
+)}; path=/`;
+
+const mod = await import("../../lib/api-url");
+
+// Tidy up so the seeded cookie + restored singleton don't leak into any file
+// co-run in the same process (CI runs each file isolated, but stay a good
+// citizen).
+afterAll(() => {
+  document.cookie = "atlas_region=; path=/; max-age=0";
+  mod._resetApiUrl();
+});
+
+describe("api-url module-load cookie restore", () => {
+  it("resolves the regional base at import when the atlas_region cookie is present", () => {
+    expect(mod.getApiUrl()).toBe("https://api-eu.useatlas.dev");
+    expect(mod.getActiveRegion()).toBe("eu");
+    expect(mod.isCrossOrigin()).toBe(true);
+  });
+});

--- a/packages/web/src/ui/__tests__/api-url.test.ts
+++ b/packages/web/src/ui/__tests__/api-url.test.ts
@@ -6,6 +6,7 @@ import {
   applyRegionSignal,
   clearRegionSignal,
   initRegionFromCookie,
+  secureCookieAttr,
   _resetApiUrl,
   REGION_COOKIE,
 } from "../../lib/api-url";
@@ -177,6 +178,50 @@ describe("api-url", () => {
 
     it("returns true on a successful apply", () => {
       expect(applyRegionSignal("eu", EU)).toBe(true);
+    });
+  });
+
+  describe("apiUrl scheme policy (client-writable cookie → credentialed fetch)", () => {
+    it("accepts an https regional base", () => {
+      expect(applyRegionSignal("eu", "https://api-eu.useatlas.dev")).toBe(true);
+    });
+
+    it("accepts http only for localhost (local dev)", () => {
+      expect(applyRegionSignal("dev", "http://localhost:3001")).toBe(true);
+      expect(getApiUrl()).toBe("http://localhost:3001");
+    });
+
+    it("rejects http on a non-localhost host", () => {
+      expect(applyRegionSignal("eu", "http://api-eu.useatlas.dev")).toBe(false);
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+
+    it("rejects a javascript: scheme even though it parses", () => {
+      expect(applyRegionSignal("eu", "javascript:alert(1)")).toBe(false);
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+
+    it("ignores a cookie whose apiUrl uses a disallowed scheme", () => {
+      seedRegionCookie(
+        encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "http://evil.example.com" })),
+      );
+      initRegionFromCookie();
+      expect(getActiveRegion()).toBeNull();
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+  });
+
+  describe("secureCookieAttr", () => {
+    it("omits Secure on http so the cookie stores in local dev / the test DOM", () => {
+      expect(secureCookieAttr("http:")).toBe("");
+    });
+
+    it("adds Secure on https (prod regional hosts)", () => {
+      expect(secureCookieAttr("https:")).toBe("; Secure");
+    });
+
+    it("defaults to Secure when the protocol is unknown (SSR)", () => {
+      expect(secureCookieAttr(undefined)).toBe("; Secure");
     });
   });
 });

--- a/packages/web/src/ui/__tests__/api-url.test.ts
+++ b/packages/web/src/ui/__tests__/api-url.test.ts
@@ -1,100 +1,182 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import { getApiUrl, isCrossOrigin, setRegionalApiUrl, _resetApiUrl } from "../../lib/api-url";
+import {
+  getApiUrl,
+  isCrossOrigin,
+  getActiveRegion,
+  applyRegionSignal,
+  clearRegionSignal,
+  initRegionFromCookie,
+  _resetApiUrl,
+  REGION_COOKIE,
+} from "../../lib/api-url";
 
 // The default API URL comes from NEXT_PUBLIC_ATLAS_API_URL, which is
 // typically empty in the test environment.
 const DEFAULT_URL = (process.env.NEXT_PUBLIC_ATLAS_API_URL ?? "").replace(/\/+$/, "");
+const EU = "https://api-eu.useatlas.dev";
+
+/** Read the raw `atlas_region` cookie value (decoded), or null. */
+function readRegionCookie(): { region?: string; apiUrl?: string } | null {
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${REGION_COOKIE}=`));
+  const raw = match?.slice(REGION_COOKIE.length + 1);
+  if (!raw) return null;
+  return JSON.parse(decodeURIComponent(raw)) as { region?: string; apiUrl?: string };
+}
+
+/** Write the cookie directly, simulating what a previous session/load left. */
+function seedRegionCookie(value: string): void {
+  document.cookie = `${REGION_COOKIE}=${value}; path=/`;
+}
+
+function deleteRegionCookie(): void {
+  document.cookie = `${REGION_COOKIE}=; path=/; max-age=0`;
+}
 
 describe("api-url", () => {
   beforeEach(() => {
+    deleteRegionCookie();
     _resetApiUrl();
   });
 
-  describe("getApiUrl", () => {
-    it("returns default (env-based) URL initially", () => {
+  describe("getApiUrl / default fallback", () => {
+    it("returns the build-time default URL with no region signal", () => {
       expect(getApiUrl()).toBe(DEFAULT_URL);
+      expect(getActiveRegion()).toBeNull();
     });
 
-    it("returns regional URL after setRegionalApiUrl", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev");
-      expect(getApiUrl()).toBe("https://api-eu.useatlas.dev");
+    it("returns the regional URL after applyRegionSignal", () => {
+      applyRegionSignal("eu", EU);
+      expect(getApiUrl()).toBe(EU);
+      expect(getActiveRegion()).toBe("eu");
     });
 
-    it("strips trailing slashes from regional URL", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev///");
-      expect(getApiUrl()).toBe("https://api-eu.useatlas.dev");
+    it("strips trailing slashes from the regional URL", () => {
+      applyRegionSignal("eu", `${EU}///`);
+      expect(getApiUrl()).toBe(EU);
     });
 
-    it("reverts to default after setRegionalApiUrl(null)", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev");
-      expect(getApiUrl()).toBe("https://api-eu.useatlas.dev");
-
-      setRegionalApiUrl(null);
+    it("reverts to the default after clearRegionSignal", () => {
+      applyRegionSignal("eu", EU);
+      expect(getApiUrl()).toBe(EU);
+      clearRegionSignal();
       expect(getApiUrl()).toBe(DEFAULT_URL);
+      expect(getActiveRegion()).toBeNull();
     });
 
-    it("reverts to default after _resetApiUrl", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev");
+    it("reverts to the default after _resetApiUrl (in-memory only)", () => {
+      applyRegionSignal("eu", EU);
       _resetApiUrl();
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+  });
+
+  describe("atlas_region cookie persistence", () => {
+    it("persists {region, apiUrl} in the atlas_region cookie on apply", () => {
+      applyRegionSignal("eu", EU);
+      const cookie = readRegionCookie();
+      expect(cookie?.region).toBe("eu");
+      expect(cookie?.apiUrl).toBe(EU);
+    });
+
+    it("survives a reload: a fresh init reads the cookie and resolves the regional base", () => {
+      // Simulate selection in one page lifetime…
+      applyRegionSignal("eu", EU);
+      // …then a reload: in-memory state is gone but the cookie remains.
+      _resetApiUrl();
+      expect(getApiUrl()).toBe(DEFAULT_URL); // not yet restored
+      initRegionFromCookie();
+      expect(getApiUrl()).toBe(EU);
+      expect(getActiveRegion()).toBe("eu");
+    });
+
+    it("initRegionFromCookie restores from a cookie written by a prior session", () => {
+      seedRegionCookie(
+        encodeURIComponent(JSON.stringify({ region: "apac", apiUrl: "https://api-apac.useatlas.dev" })),
+      );
+      initRegionFromCookie();
+      expect(getActiveRegion()).toBe("apac");
+      expect(getApiUrl()).toBe("https://api-apac.useatlas.dev");
+    });
+
+    it("clearRegionSignal removes the atlas_region cookie", () => {
+      applyRegionSignal("eu", EU);
+      expect(readRegionCookie()).not.toBeNull();
+      clearRegionSignal();
+      expect(readRegionCookie()).toBeNull();
+    });
+
+    it("ignores a malformed cookie and falls back to the default", () => {
+      seedRegionCookie("not-json");
+      initRegionFromCookie();
+      expect(getActiveRegion()).toBeNull();
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+
+    it("ignores a cookie missing region or apiUrl", () => {
+      seedRegionCookie(encodeURIComponent(JSON.stringify({ region: "eu" })));
+      initRegionFromCookie();
+      expect(getActiveRegion()).toBeNull();
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+    });
+
+    it("ignores a cookie whose apiUrl is not a valid URL", () => {
+      seedRegionCookie(encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "not-a-url" })));
+      initRegionFromCookie();
+      expect(getActiveRegion()).toBeNull();
       expect(getApiUrl()).toBe(DEFAULT_URL);
     });
   });
 
   describe("isCrossOrigin", () => {
-    it("returns false when no API URL is configured", () => {
-      _resetApiUrl();
-      // When default is empty and no regional override, not cross-origin
+    it("returns false with no region signal when the default is empty", () => {
       if (DEFAULT_URL === "") {
         expect(isCrossOrigin()).toBe(false);
       } else {
-        // If env var is set in this environment, cross-origin is true
         expect(isCrossOrigin()).toBe(true);
       }
     });
 
-    it("returns true when regional URL is set", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev");
+    it("returns true when a regional base is active", () => {
+      applyRegionSignal("eu", EU);
       expect(isCrossOrigin()).toBe(true);
     });
 
-    it("returns false after clearing regional URL when default is empty", () => {
-      setRegionalApiUrl("https://api-eu.useatlas.dev");
+    it("returns to the default-derived value after clearing the regional base", () => {
+      applyRegionSignal("eu", EU);
       expect(isCrossOrigin()).toBe(true);
-      setRegionalApiUrl(null);
+      clearRegionSignal();
       expect(isCrossOrigin()).toBe(!!DEFAULT_URL);
     });
   });
 
-  describe("setRegionalApiUrl", () => {
-    it("overrides the default URL", () => {
-      setRegionalApiUrl("https://regional.example.com");
-      expect(getApiUrl()).toBe("https://regional.example.com");
+  describe("applyRegionSignal validation", () => {
+    it("rejects an invalid apiUrl and keeps the current base", () => {
+      expect(applyRegionSignal("eu", "not-a-url")).toBe(false);
+      expect(getApiUrl()).toBe(DEFAULT_URL);
+      expect(getActiveRegion()).toBeNull();
+      expect(readRegionCookie()).toBeNull();
     });
 
-    it("accepts null to clear override", () => {
-      setRegionalApiUrl("https://regional.example.com");
-      setRegionalApiUrl(null);
+    it("rejects a whitespace-only apiUrl and keeps the current base", () => {
+      expect(applyRegionSignal("eu", "   ")).toBe(false);
       expect(getApiUrl()).toBe(DEFAULT_URL);
     });
 
-    it("rejects invalid URL and keeps default", () => {
-      setRegionalApiUrl("not-a-url");
+    it("rejects an empty region and keeps the current base", () => {
+      expect(applyRegionSignal("  ", EU)).toBe(false);
       expect(getApiUrl()).toBe(DEFAULT_URL);
+      expect(readRegionCookie()).toBeNull();
     });
 
-    it("rejects whitespace-only string and keeps default", () => {
-      setRegionalApiUrl("   ");
-      expect(getApiUrl()).toBe(DEFAULT_URL);
+    it("trims whitespace from a valid apiUrl", () => {
+      applyRegionSignal("eu", `  ${EU}  `);
+      expect(getApiUrl()).toBe(EU);
     });
 
-    it("rejects empty string and keeps default", () => {
-      setRegionalApiUrl("");
-      expect(getApiUrl()).toBe(DEFAULT_URL);
-    });
-
-    it("trims whitespace from valid URL", () => {
-      setRegionalApiUrl("  https://api-eu.useatlas.dev  ");
-      expect(getApiUrl()).toBe("https://api-eu.useatlas.dev");
+    it("returns true on a successful apply", () => {
+      expect(applyRegionSignal("eu", EU)).toBe(true);
     });
   });
 });

--- a/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
@@ -28,11 +28,6 @@ mock.module("@/ui/hooks/use-admin-fetch", () => ({
   friendlyError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
 }));
 
-mock.module("@/lib/api-url", () => ({
-  setRegionalApiUrl: () => {},
-  getApiUrl: () => "http://localhost:3001",
-}));
-
 const { useDeployMode } = await import("../use-deploy-mode");
 
 function staged(overrides: Partial<typeof fetchReturn>) {

--- a/packages/web/src/ui/hooks/use-deploy-mode.ts
+++ b/packages/web/src/ui/hooks/use-deploy-mode.ts
@@ -2,14 +2,12 @@
 
 import { useEffect } from "react";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
-import { setRegionalApiUrl, getApiUrl } from "@/lib/api-url";
 import type { DeployMode } from "@/ui/lib/types";
 
 interface SettingsResponse {
   settings: unknown[];
   manageable: boolean;
   deployMode: DeployMode;
-  regionApiUrl?: string;
 }
 
 /**
@@ -35,8 +33,10 @@ interface SettingsResponse {
  *   is `true` or `error` is non-null — a guessed mode never decides what
  *   gets persisted.
  *
- * Also applies the regional API URL override when the settings response
- * includes a `regionApiUrl` (tier-2 data residency).
+ * This hook does **not** resolve the regional API base. Under ADR-0024 the
+ * region is known pre-auth (a signup selection or the `atlas_region` cookie,
+ * see `@/lib/api-url`); it is never discovered by reading `regionApiUrl` off
+ * the US admin-settings response — that circular path is retired (#3971).
  */
 function guessDeployModeFromHost(): DeployMode {
   if (typeof window === "undefined") return "self-hosted";
@@ -74,18 +74,6 @@ export function useDeployMode(opts?: { enabled?: boolean }): {
       console.warn("useDeployMode: settings fetch failed — using hostname-based deploy mode guess:", error);
     }
   }, [error]);
-
-  // Apply or clear regional API URL override based on settings response
-  useEffect(() => {
-    if (!data) return;
-    if (data.regionApiUrl) {
-      if (data.regionApiUrl !== getApiUrl()) {
-        setRegionalApiUrl(data.regionApiUrl);
-      }
-    } else {
-      setRegionalApiUrl(null);
-    }
-  }, [data?.regionApiUrl]);
 
   return {
     deployMode: data?.deployMode ?? guessDeployModeFromHost(),

--- a/packages/web/src/ui/hooks/use-deploy-mode.ts
+++ b/packages/web/src/ui/hooks/use-deploy-mode.ts
@@ -35,8 +35,9 @@ interface SettingsResponse {
  *
  * This hook does **not** resolve the regional API base. Under ADR-0024 the
  * region is known pre-auth (a signup selection or the `atlas_region` cookie,
- * see `@/lib/api-url`); it is never discovered by reading `regionApiUrl` off
- * the US admin-settings response — that circular path is retired (#3971).
+ * see `@/lib/api-url`); the web client no longer reads `regionApiUrl` off the
+ * US admin-settings response to discover its regional host (#3971). (The server
+ * still returns that field for now — vestigial, pending a follow-up removal.)
  */
 function guessDeployModeFromHost(): DeployMode {
   if (typeof window === "undefined") return "self-hosted";


### PR DESCRIPTION
## What & why

Browser-side **region-awareness plumbing** for ADR-0024 §3–§4 (milestone v0.0.31, parent #3967). Today the only thing that flips the API origin to a regional host runs lazily inside an admin-page effect that calls the **US** admin-settings endpoint — a circular dependency that only worked while data was wrongly readable from US. Backend dependency #3969 ("the process is the region", squash `1939c34a`) is merged; this builds the browser half.

Makes the API base settable **pre-auth** from a region signal (a region selection, or the `atlas_region` cookie) and retires the US-admin-settings discovery path.

Closes #3971

## Changes

- **`packages/web/src/lib/api-url.ts`** — resolve the API base from an active region signal: `applyRegionSignal(region, apiUrl)` points the base at a region and persists `{ region, apiUrl }` in the `atlas_region` cookie; a returning visit restores it on import (and via `initRegionFromCookie()`) with **no network round-trip**. `getApiUrl()` prefers the signal, else the build-time default (empty on self-hosted → same-origin). `isCrossOrigin()` stays `true` when a regional base is active, so consumers already send `credentials: "include"`. `getActiveRegion()` exposes the region key to seed the login fast-path. Replaces `setRegionalApiUrl`.
- **`packages/web/src/ui/hooks/use-deploy-mode.ts`** — drop the `regionApiUrl` → `setRegionalApiUrl` effect. The web client no longer learns its regional host by reading the US admin-settings response.
- **`packages/web/src/lib/auth/client.ts`** — comment-only: the auth client already targets `getApiUrl()`; refresh the stale "auth always global" comment (which referenced the deleted function) to the ADR-0024 regional-identity model. With the import-time cookie restore, a returning regional user's auth client is built against its own regional API.

## Acceptance criteria

- [x] Selecting region `eu` makes subsequent calls target `api-eu.useatlas.dev` and survives reload via `atlas_region` — `applyRegionSignal` + import-time/`initRegionFromCookie` restore (unit + dedicated module-load test).
- [x] No region signal → build-time default (self-hosted unaffected).
- [x] Cross-origin requests send credentials — `isCrossOrigin()` true when a regional base is active.
- [x] The admin-settings-driven `setRegionalApiUrl` discovery path is removed.
- [x] Unit/integration tests cover region-signal → base resolution → persistence.

## Scope boundary

This is the **plumbing**. The signup-flow reorder (write the cookie via the region step) and the login front-door (consume `getActiveRegion()` to short-circuit the region fan-out) are **separate slices** in this milestone — so `applyRegionSignal`/`getActiveRegion` have no production caller yet; they are the primitive those slices build on. The server still returns `regionApiUrl` from admin-settings (now vestigial; a follow-up two-phase removal). Pairs with the host-only-cookies + CORS slice (#3970) for end-to-end verification.

## Review panel

Ran the internal 4-reviewer panel; addressed all must-fix findings in `03d84e4`:
- **readRegionCookie** now logs *shape-invalid* cookies (not just unparseable JSON) — silently demoting a regional user to the US default is the residency failure this fixes, so it's observable.
- **normalizeUrl** requires `https` (http only for localhost): the `atlas_region` cookie is client-writable and feeds credentialed fetches, so a tampered cookie can't repoint auth traffic at an arbitrary host. Parse-failure catch annotated per the no-silent-catch rule.
- **RegionSignal** fields are `readonly`; `region` typed as the `@useatlas/types` `Region` SSOT.
- Added a dedicated import-time restore test (the real returning-user path) and a pure `secureCookieAttr` test for the https branch the test DOM can't write; dropped the now-partial `@/lib/api-url` mock in the signup-region test.

## Testing

Local gates green: lint, type, web suite (225/225), syncpack, template/security-headers/railway-watch/schema/openapi/oauth-helper/test-discipline/saas-env/settings-readers/published-symbols drift. (Web-only change; the 3 failing api tests locally are the known WSL2 explore/python sandbox flakes, unrelated.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cookie-backed regional API base persistence to pre-auth browser flows
> - Replaces `setRegionalApiUrl` in [`api-url.ts`](https://github.com/AtlasDevHQ/atlas/pull/3983/files#diff-aeb6cff44d37bfbe189c9bff9ba3c7609efa371a6d40fc5cd4e610571574321d) with `applyRegionSignal`/`clearRegionSignal`/`initRegionFromCookie`, which persist the selected region and resolved API base to an `atlas_region` cookie.
> - At module load, if `document` is defined, the cookie is read synchronously so `getApiUrl()` returns the regional base without an explicit init call.
> - Adds URL normalization that accepts `https` everywhere and `http` only for localhost/loopback, rejecting other schemes.
> - Removes the `useEffect` in [`use-deploy-mode.ts`](https://github.com/AtlasDevHQ/atlas/pull/3983/files#diff-b5b377a70ccfc1b732e8c697b347c66021861803f85060e877afbfa4d3ff5b08) that mutated the API base as a side effect of fetching admin settings; the hook now only reports `deployMode`.
> - Behavioral Change: `getApiUrl()` may now resolve to a cookie-restored regional base on first call after import, before any explicit region selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03d84e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->