### PR TITLE
feat(api,web): host-only per-region session cookies + cross-origin CORS foundation (#3970)

### DIFF
--- a/apps/docs/content/docs/deployment/authentication.mdx
+++ b/apps/docs/content/docs/deployment/authentication.mdx
@@ -174,7 +174,7 @@ BETTER_AUTH_URL=https://api.example.com
 
 > **Both variables are required together.** If you set `ATLAS_CORS_ORIGIN` but not `BETTER_AUTH_TRUSTED_ORIGINS`, CORS will pass but CSRF protection will reject auth requests. If you set `BETTER_AUTH_TRUSTED_ORIGINS` but not `ATLAS_CORS_ORIGIN`, the browser will block cross-origin requests entirely. Always set both for cross-origin managed auth.
 
-> **Cross-subdomain cookies:** When `ATLAS_CORS_ORIGIN` and `BETTER_AUTH_URL` are on different subdomains (e.g. `app.example.com` and `api.example.com`), the session cookie domain is automatically derived to the parent domain (`.example.com`). This allows cookies set by the API to be sent from the frontend subdomain. No manual cookie configuration is needed.
+> **Host-only session cookies:** The session cookie is **host-only** — scoped to the API host that issued it (`api.example.com`), with no parent-domain (`.example.com`) attribute. When the app and API are on different subdomains of the same registrable domain (e.g. `app.example.com` and `api.example.com`), the browser still sends the cookie on credentialed requests because they are *same-site* (cross-origin): the cookie rides `credentials: include` + the CORS allowlist with `SameSite=Lax` — no `SameSite=None` and no shared cookie domain are needed. Host-only scoping is deliberate: a session minted by one API host never transits another (the foundation for per-region data residency). No manual cookie configuration is needed.
 
 ### Frontend integration (All Deployments)
 

--- a/packages/api/src/lib/__tests__/web-origin.test.ts
+++ b/packages/api/src/lib/__tests__/web-origin.test.ts
@@ -2,12 +2,13 @@
  * `getWebOrigin()` resolution-order tests.
  *
  * The web origin anchors the passkey rpID, the `ATLAS_CORS_ORIGIN` default, and
- * the cross-subdomain cookie domain (`getAuthInstance` in `auth/server.ts`).
- * #3706 dropped the former `ATLAS_CORS_ORIGIN`-set gate on the cookie-domain
- * path, so `getWebOrigin()` is now consulted unconditionally — which means the
- * `BETTER_AUTH_TRUSTED_ORIGINS` fallback (the tier SaaS relies on once
- * `ATLAS_CORS_ORIGIN` is no longer stamped) and the region fallback must stay
- * pinned. Self-hosted single-origin deploys still resolve to `null`.
+ * Better Auth's `trustedOrigins` allowlist (`getAuthInstance` in
+ * `auth/server.ts`). (Session cookies are host-only, ADR-0024 §5, so there is no
+ * cross-subdomain cookie domain to anchor anymore.) `getWebOrigin()` is consulted
+ * unconditionally, so the `BETTER_AUTH_TRUSTED_ORIGINS` fallback (the tier SaaS
+ * relies on once `ATLAS_CORS_ORIGIN` is no longer stamped) and the region
+ * fallback must stay pinned. Self-hosted single-origin deploys still resolve to
+ * `null`.
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";

--- a/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
@@ -53,7 +53,6 @@ function authDeps(plugins: ReturnType<typeof buildPlugins>) {
     secret: parseAuthSecret("test-secret-at-least-32-characters-long"),
     baseURL: undefined,
     database: undefined,
-    cookieDomain: undefined,
     cookiePrefix: "atlas",
     socialProviders: undefined,
     plugins,

--- a/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
@@ -186,7 +186,6 @@ function authDeps(plugins: ReturnType<typeof buildPlugins>) {
     // undefined → Better Auth's in-memory adapter. `hasInternalDB()` is
     // driven at runtime by DATABASE_URL + the injected pool, not by this.
     database: undefined,
-    cookieDomain: undefined,
     cookiePrefix: "atlas",
     socialProviders: undefined,
     plugins,

--- a/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
+++ b/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
@@ -38,7 +38,6 @@ function makeDeps(overrides: Partial<BuildAuthOptionsDeps> = {}): BuildAuthOptio
     secret: SECRET,
     baseURL: "http://localhost:3000",
     database: undefined,
-    cookieDomain: undefined,
     cookiePrefix: "atlas",
     socialProviders: undefined,
     // Mirror the production wiring in `buildPlugins()` — passkey is loaded

--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -81,7 +81,6 @@ function makeDeps(overrides: Partial<BuildAuthOptionsDeps> = {}): BuildAuthOptio
     // `undefined` → Better Auth falls back to its built-in memory adapter;
     // the builder also derives `internalDbAvailable: false` from this.
     database: undefined,
-    cookieDomain: undefined,
     cookiePrefix: "atlas",
     socialProviders: undefined,
     plugins: [],
@@ -154,7 +153,7 @@ function sortKeys(value: unknown): unknown {
 /**
  * Build a POST /api/auth/<path> request with pinned IP headers.
  *
- * `x-atlas-client-ip` must match `buildAdvancedConfig(undefined).ipAddress.ipAddressHeaders`
+ * `x-atlas-client-ip` must match `buildAdvancedConfig(prefix).ipAddress.ipAddressHeaders`
  * — it's the single header Better Auth should read. `x-forwarded-for`
  * is supplied so the IP-spoof-resistance test can vary it without
  * affecting the rate-limit bucket; the default `forwardedFor === ip`
@@ -179,13 +178,19 @@ function authRequest(
 }
 
 describe("config wiring snapshot — buildAuthOptions", () => {
-  it("wires `advanced` to buildAdvancedConfig (F-06 IP header pin)", () => {
-    const options = buildAuthOptions(makeDeps({ cookieDomain: "useatlas.dev" }));
-    expect(options.advanced).toEqual(buildAdvancedConfig("useatlas.dev", "atlas"));
+  it("wires `advanced` to buildAdvancedConfig (F-06 IP header pin + host-only cookies)", () => {
+    const options = buildAuthOptions(makeDeps());
+    expect(options.advanced).toEqual(buildAdvancedConfig("atlas"));
     // The ipAddressHeaders list MUST be exactly [`x-atlas-client-ip`].
     // Adding `x-forwarded-for` here reopens F-06 — attackers spoof the
     // rate-limit bucket by sending the header themselves.
     expect(options.advanced?.ipAddress?.ipAddressHeaders).toEqual(["x-atlas-client-ip"]);
+    // ADR-0024 §5: the composed options must NOT pin a cookie domain — a
+    // parent-domain cookie would leak a regional session token to other
+    // regions' API hosts. Host-only is the residency invariant.
+    expect(
+      (options.advanced as Record<string, unknown> | undefined)?.defaultCookieAttributes,
+    ).toBeUndefined();
   });
 
   it("wires `rateLimit` to resolveAuthRateLimitConfig (F-06 /api/auth rules)", () => {
@@ -527,5 +532,23 @@ describe("session cookie name reflects cookiePrefix — prod↔staging isolation
     expect(prod).toContain("atlas.session_token");
     expect(prod).not.toContain("atlas-staging.session_token");
     expect(staging).toContain("atlas-staging.session_token");
+  });
+
+  it("mints a HOST-ONLY session cookie — no Domain attribute (ADR-0024 §5, criterion #3)", async () => {
+    // The actual residency invariant, asserted against the REAL minted cookie
+    // (not just the config): a regional session token must never carry a
+    // parent-domain (`Domain=.useatlas.dev`) attribute, or the browser would
+    // send it to every region's API host. Host-only = scoped to the issuing host
+    // only. A `Domain=` could be reintroduced via Better Auth's
+    // `crossSubDomainCookies`, a plugin, or a default change — none of which flow
+    // through `buildAdvancedConfig`, so this live check guards what the config
+    // tests can't.
+    const setCookie = await signUpSetCookie("atlas", "192.0.2.53");
+    expect(setCookie).toContain("atlas.session_token");
+    expect(setCookie).not.toContain("Domain=");
+    // Still SameSite=Lax, so the host-only cookie rides credentialed same-site
+    // cross-origin fetches from app.useatlas.dev. (Secure is verified at deploy —
+    // makeAuth uses an http baseURL, so Better Auth omits Secure in this env.)
+    expect(setCookie).toContain("SameSite=Lax");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
@@ -8,7 +8,8 @@ import {
   SESSION_COOKIE_CACHE_MAX_SEC,
   buildEmailAndPasswordConfig,
   buildAdvancedConfig,
-  deriveCookieDomain,
+  resolveAuthBaseURL,
+  resolveTrustedOrigins,
   _sendVerificationOTP,
 } from "../server";
 
@@ -243,7 +244,7 @@ describe("buildEmailAndPasswordConfig", () => {
 
 describe("buildAdvancedConfig", () => {
   it("pins ipAddressHeaders to exactly ['x-atlas-client-ip'] (F-06 invariant)", () => {
-    const config = buildAdvancedConfig(undefined, "atlas");
+    const config = buildAdvancedConfig("atlas");
     // Adding 'x-forwarded-for' here would make the IP bucket client-
     // spoofable and reopen F-06. Removing the list entirely would
     // fall back to Better Auth's default (x-forwarded-for) — same
@@ -251,106 +252,103 @@ describe("buildAdvancedConfig", () => {
     expect(config.ipAddress.ipAddressHeaders).toEqual(["x-atlas-client-ip"]);
   });
 
-  it("omits defaultCookieAttributes when cookieDomain is undefined", () => {
-    const config = buildAdvancedConfig(undefined, "atlas");
+  it("never sets a cookie domain — session cookies are HOST-ONLY (ADR-0024 §5)", () => {
+    // A parent-domain (`Domain=.useatlas.dev`) cookie would leak an EU session
+    // token to the US/APAC API hosts — the exact cross-region bleed residency
+    // forbids. Omitting `defaultCookieAttributes.domain` makes Better Auth scope
+    // the cookie to the issuing host only (host-only), and its defaults keep
+    // SameSite=Lax + Secure (on an https baseURL) + httpOnly. There is no
+    // `defaultCookieAttributes` key at all, for ANY deployment.
+    const config = buildAdvancedConfig("atlas") as Record<string, unknown>;
     expect(config.defaultCookieAttributes).toBeUndefined();
-  });
-
-  it("sets a subdomain cookie when cookieDomain is provided", () => {
-    const config = buildAdvancedConfig("useatlas.dev", "atlas");
-    expect(config.defaultCookieAttributes).toEqual({ domain: ".useatlas.dev" });
+    expect("defaultCookieAttributes" in config).toBe(false);
   });
 
   it("threads cookiePrefix through verbatim (env-isolation knob)", () => {
-    expect(buildAdvancedConfig(undefined, "atlas-staging").cookiePrefix).toBe("atlas-staging");
-    expect(buildAdvancedConfig("staging.useatlas.dev", "atlas-staging")).toEqual({
+    expect(buildAdvancedConfig("atlas-staging").cookiePrefix).toBe("atlas-staging");
+    expect(buildAdvancedConfig("atlas-staging")).toEqual({
       ipAddress: { ipAddressHeaders: ["x-atlas-client-ip"] },
       cookiePrefix: "atlas-staging",
-      defaultCookieAttributes: { domain: ".staging.useatlas.dev" },
     });
   });
 });
 
-describe("deriveCookieDomain", () => {
-  // Second arg is the single canonical app origin (getWebOrigin() — the first
-  // CORS entry), NOT the whole allowlist, so an unrelated allowlisted origin
-  // can't veto the shared domain. The call site resolves it via getWebOrigin().
-  it("returns undefined when either input is absent (host-only cookies / self-hosted single-origin)", () => {
-    expect(deriveCookieDomain(undefined, "https://app.useatlas.dev")).toBeUndefined();
-    expect(deriveCookieDomain("https://api.useatlas.dev", undefined)).toBeUndefined();
-    expect(deriveCookieDomain(undefined, undefined)).toBeUndefined();
-  });
+describe("resolveAuthBaseURL", () => {
+  // baseURL is "what host am I" for Better Auth — its links + cookie issuer.
+  // Per ADR-0024 §2 ("the process is the region"), each regional process needs
+  // its own regional baseURL. An explicit BETTER_AUTH_URL always wins; when
+  // unset, the region-derived API host (deriveRegionApiUrl, fed in by the
+  // caller) supplies it so SaaS need not stamp it per regional service.
+  const env = (e: Record<string, string | undefined>) => e as NodeJS.ProcessEnv;
 
-  it("prod: api + app under useatlas.dev → useatlas.dev (covers www + apex siblings)", () => {
+  it("prefers an explicit BETTER_AUTH_URL over everything", () => {
     expect(
-      deriveCookieDomain("https://api.useatlas.dev", "https://app.useatlas.dev"),
-    ).toBe("useatlas.dev");
+      resolveAuthBaseURL(
+        env({ BETTER_AUTH_URL: "https://api-eu.useatlas.dev" }),
+        "https://ignored.example.com",
+      ),
+    ).toBe("https://api-eu.useatlas.dev");
   });
 
-  it("staging: keeps the env-specific parent (regression for the slice(-2) bleed)", () => {
-    // The old `host.split('.').slice(-2)` collapsed this to `useatlas.dev`,
-    // the same slot as prod. The common-suffix derivation keeps it scoped.
+  it("falls back to the region-derived API host when BETTER_AUTH_URL is unset", () => {
+    expect(resolveAuthBaseURL(env({}), "https://api-eu.useatlas.dev")).toBe(
+      "https://api-eu.useatlas.dev",
+    );
+  });
+
+  it("falls back to Vercel's production URL when no region is configured", () => {
     expect(
-      deriveCookieDomain("https://api.staging.useatlas.dev", "https://app.staging.useatlas.dev"),
-    ).toBe("staging.useatlas.dev");
+      resolveAuthBaseURL(env({ VERCEL_PROJECT_PRODUCTION_URL: "my-app.vercel.app" }), null),
+    ).toBe("https://my-app.vercel.app");
   });
 
-  it("ignores the rest of the CORS allowlist — only the app origin is passed (P1)", () => {
-    // Codex P1: folding in an unrelated allowlisted origin would collapse the
-    // common suffix to nothing. The fix passes ONLY the app origin (getWebOrigin),
-    // so deriveCookieDomain literally never sees embed.partner.com and derives
-    // the correct app/API parent regardless of what else is allowlisted.
+  it("falls back to Vercel's preview URL (VERCEL_URL) when no production URL is set", () => {
+    expect(resolveAuthBaseURL(env({ VERCEL_URL: "preview-xyz.vercel.app" }), null)).toBe(
+      "https://preview-xyz.vercel.app",
+    );
+  });
+
+  it("prefers the region-derived host over Vercel auto-detection", () => {
     expect(
-      deriveCookieDomain("https://api.useatlas.dev", "https://app.useatlas.dev"),
-    ).toBe("useatlas.dev");
-    // A hypothetical "both args" different-site pair still yields undefined —
-    // proving the unrelated origin must never reach this function as arg 2.
+      resolveAuthBaseURL(
+        env({ VERCEL_PROJECT_PRODUCTION_URL: "my-app.vercel.app" }),
+        "https://api-apac.useatlas.dev",
+      ),
+    ).toBe("https://api-apac.useatlas.dev");
+  });
+
+  it("returns undefined when nothing resolves (self-hosted single-origin)", () => {
+    expect(resolveAuthBaseURL(env({}), null)).toBeUndefined();
+  });
+});
+
+describe("resolveTrustedOrigins", () => {
+  // trustedOrigins is the Better Auth allowlist for redirect/callback hosts —
+  // for SaaS it must be [app.useatlas.dev]. An explicit
+  // BETTER_AUTH_TRUSTED_ORIGINS wins; when unset, the region-derived web origin
+  // (getWebOrigin, fed in by the caller) supplies it.
+  const env = (e: Record<string, string | undefined>) => e as NodeJS.ProcessEnv;
+
+  it("parses an explicit comma-separated BETTER_AUTH_TRUSTED_ORIGINS", () => {
     expect(
-      deriveCookieDomain("https://api.useatlas.dev", "https://embed.partner.com"),
-    ).toBeUndefined();
+      resolveTrustedOrigins(
+        env({ BETTER_AUTH_TRUSTED_ORIGINS: "https://app.useatlas.dev, https://www.useatlas.dev" }),
+        "https://ignored.example.com",
+      ),
+    ).toEqual(["https://app.useatlas.dev", "https://www.useatlas.dev"]);
   });
 
-  it("self-hosted on a custom domain derives that domain (not hardcoded)", () => {
-    expect(
-      deriveCookieDomain("https://api.acme.example.com", "https://app.acme.example.com"),
-    ).toBe("acme.example.com");
+  it("falls back to the region-derived web origin when the env is unset", () => {
+    expect(resolveTrustedOrigins(env({}), "https://app.useatlas.dev")).toEqual([
+      "https://app.useatlas.dev",
+    ]);
   });
 
-  it("returns undefined when the hosts share no 2+ label suffix (different sites)", () => {
-    expect(
-      deriveCookieDomain("https://api.useatlas.dev", "https://app.example.org"),
-    ).toBeUndefined();
-  });
-
-  it("returns undefined for single-label hosts (localhost)", () => {
-    expect(deriveCookieDomain("http://localhost:3001", "http://localhost:3000")).toBeUndefined();
-  });
-
-  it("returns undefined for bare IPv4 (cookie domains can't be IPs)", () => {
-    expect(deriveCookieDomain("http://127.0.0.1:3001", "http://127.0.0.1:3000")).toBeUndefined();
-  });
-
-  it("returns undefined for IPv6 literals (host-only)", () => {
-    expect(deriveCookieDomain("http://[::1]:3001", "http://[::1]:3000")).toBeUndefined();
-  });
-
-  it("returns undefined when the app origin is malformed", () => {
-    expect(deriveCookieDomain("https://api.staging.useatlas.dev", "not-a-url")).toBeUndefined();
-    expect(deriveCookieDomain("not-a-url", "https://app.staging.useatlas.dev")).toBeUndefined();
-  });
-
-  it("documents the public-suffix limitation: no PSL, so same-2-label-suffix hosts collapse to it", () => {
-    // KNOWN LIMITATION (no public-suffix-list awareness). Two *different*
-    // registrable domains under a 2-label public suffix collapse to that
-    // suffix; browsers then reject `.co.uk` via the PSL so the cookie fails
-    // to set (no leak). Atlas's API + app are always one registrable domain.
-    expect(
-      deriveCookieDomain("https://api.acme.co.uk", "https://app.other.co.uk"),
-    ).toBe("co.uk");
-    // Same-tenant multi-label TLD works correctly (3-label common suffix).
-    expect(
-      deriveCookieDomain("https://api.acme.co.uk", "https://app.acme.co.uk"),
-    ).toBe("acme.co.uk");
+  it("returns an empty list when neither env nor a derived origin is available", () => {
+    expect(resolveTrustedOrigins(env({}), null)).toEqual([]);
+    // An env value that is only whitespace/commas collapses to empty, then
+    // falls through to the derived origin (here: none).
+    expect(resolveTrustedOrigins(env({ BETTER_AUTH_TRUSTED_ORIGINS: " , " }), null)).toEqual([]);
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/signup-origin-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/signup-origin-wiring.test.ts
@@ -96,7 +96,6 @@ function authDeps(plugins: ReturnType<typeof buildPlugins>) {
     secret: parseAuthSecret("test-secret-at-least-32-characters-long"),
     baseURL: undefined,
     database: undefined,
-    cookieDomain: undefined,
     cookiePrefix: "atlas",
     socialProviders: undefined,
     plugins,

--- a/packages/api/src/lib/auth/rpid.ts
+++ b/packages/api/src/lib/auth/rpid.ts
@@ -32,10 +32,11 @@ export const DEFAULT_RP_ID = "app.useatlas.dev";
  * but `app.useatlas.dev` is NOT (the exact footgun this module fixes: prod's
  * rpID silently inherited on a staging host).
  *
- * No public-suffix-list awareness (same caveat as `deriveCookieDomain`): a
- * plain dotted-label check. Atlas's app host and rpID are always the same
- * registrable domain, and the browser is the backstop for a pathological rpID
- * like a bare public suffix.
+ * No public-suffix-list awareness: a plain dotted-label check (the rpID is a
+ * registrable-domain suffix of the app host, never a cross-host cookie domain —
+ * session cookies are host-only, ADR-0024 §5). Atlas's app host and rpID are
+ * always the same registrable domain, and the browser is the backstop for a
+ * pathological rpID like a bare public suffix.
  */
 function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
   // Hostnames are case-insensitive (DNS), and browsers lowercase the rpID
@@ -138,10 +139,10 @@ function parseOriginHostForRpId(webOrigin: string): string | null {
  * domain` — fires only at ceremony time, in the user's browser, with no
  * boot-time signal. So whenever a web origin IS configured we assert the
  * effective rpID is valid for it and throw with an actionable message
- * otherwise. (This is stronger than the cross-origin cookie-domain check in
- * `getAuthInstance()`, which only `log.warn`s — a wrong rpID can't work at
- * all, so it warrants a hard fail.) A bogus *explicit* `ATLAS_RPID` is caught
- * here too; the derived path can never produce an invalid value, so unset
+ * otherwise. (Unlike most boot-time config, which we only `log.warn` on, a
+ * wrong rpID can't be repaired at runtime and fails silently in the browser
+ * ceremony — so it warrants a hard fail.) A bogus *explicit* `ATLAS_RPID` is
+ * caught here too; the derived path can never produce an invalid value, so unset
  * deploys never throw. Hostnames aren't secrets (CLAUDE.md), so they're safe
  * to log/surface.
  *

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -45,6 +45,7 @@ import {
   resolveCookiePrefix,
 } from "@atlas/api/lib/env-profile";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
+import { deriveRegionApiUrl } from "@atlas/api/lib/residency/origins";
 // rpID resolution lives in its own pure module so `startup.ts` can validate it
 // eagerly without importing better-auth (#3045). Re-exported here so the auth
 // surface (and its tests) keep a single import site.
@@ -862,95 +863,92 @@ export function buildEmailAndPasswordConfig(deps: BuildEmailAndPasswordConfigDep
  * reopens F-06. The tests assert this list is exactly the one custom
  * header we set in `withClientIpHeader`.
  *
- * `cookieDomain` is optional; when present the returned block also sets
- * the shared-subdomain cookie attribute for SaaS deployments.
+ * Session cookies are deliberately **host-only** (ADR-0024 §5): we set NO
+ * `defaultCookieAttributes.domain`, so Better Auth scopes the cookie to the
+ * issuing host (the resolved `baseURL` — `BETTER_AUTH_URL`, else the
+ * region-derived API host) only. Each region's API mints a cookie that
+ * is sent *only* back to that region's host — never to another region's
+ * (`api.useatlas.dev` ↔ `api-eu.useatlas.dev`), which is what makes a regional
+ * session non-portable across regions. `app.useatlas.dev` still authenticates
+ * because it shares the registrable domain `useatlas.dev` (same-site,
+ * cross-origin), so the host-only `SameSite=Lax` cookie rides credentialed
+ * fetches with the CORS allowlist. A parent-domain `.useatlas.dev` cookie would
+ * leak the token to every regional host and is rejected. Better Auth's cookie
+ * defaults (SameSite=Lax, Secure on an https baseURL, httpOnly) stand
+ * unmodified — we only withhold the domain.
  *
  * `cookiePrefix` names the session cookie (`${cookiePrefix}.session_token`)
  * and is resolved per deployment env (`resolveCookiePrefix`). It MUST match
  * the web proxy's `getSessionCookie({ cookiePrefix })` read — see
  * {@link import("@atlas/api/lib/env-profile").EnvProfile.cookiePrefix}.
  */
-export function buildAdvancedConfig(
-  cookieDomain: string | undefined,
-  cookiePrefix: string,
-): {
+export function buildAdvancedConfig(cookiePrefix: string): {
   ipAddress: { ipAddressHeaders: string[] };
   cookiePrefix: string;
-  defaultCookieAttributes?: { domain: string };
 } {
   return {
     ipAddress: {
       ipAddressHeaders: ["x-atlas-client-ip"],
     },
     cookiePrefix,
-    ...(cookieDomain
-      ? { defaultCookieAttributes: { domain: `.${cookieDomain}` } }
-      : {}),
   };
 }
 
 /**
- * Derive the parent domain for cross-subdomain session cookies, scoped as
- * tightly as the deployment allows.
+ * Resolve Better Auth's `baseURL` — the issuing host for the regional API.
  *
- * The cookie must be valid for both the API host (`BETTER_AUTH_URL`) and the
- * web app host (`webOrigin`), so the correct domain is the **longest dotted
- * suffix common to the two** — e.g.
- *   - prod:    `api.useatlas.dev` + `app.useatlas.dev` → `useatlas.dev`
- *   - staging: `api.staging.useatlas.dev` + `app.staging.useatlas.dev`
- *              → `staging.useatlas.dev` (NOT `useatlas.dev`)
+ * Per ADR-0024 §2 ("the process is the region"), each regional API process is
+ * bound to its own host, and the host-only session cookie it mints (see
+ * {@link buildAdvancedConfig}) is scoped to exactly this `baseURL`. Resolution
+ * order:
+ *   1. An explicit `BETTER_AUTH_URL` always wins (operator override / dev).
+ *   2. `regionApiUrl` — the region-derived API host (`deriveRegionApiUrl()`,
+ *      from `ATLAS_API_REGION` + the residency map). This is the "process is the
+ *      region" fallback, so SaaS need not stamp `BETTER_AUTH_URL` on each
+ *      regional service.
+ *   3. Vercel's auto-detected production/preview URL (standalone template).
+ *   4. `undefined` — Better Auth falls back to its own request-host auto-detect
+ *      (self-hosted single-origin), at the cost of a cold-start warning.
  *
- * `webOrigin` is the single canonical app origin (`getWebOrigin()` — the first
- * `ATLAS_CORS_ORIGIN` entry). We deliberately do NOT fold in the rest of the
- * CORS allowlist: an unrelated allowlisted origin (an embed/partner site on a
- * different registrable domain) would otherwise collapse the common suffix to
- * nothing, drop the cookie domain, and scope the session cookie to the API
- * host only — so the app host can't see it after login and users stick at
- * `/login`.
- *
- * The previous `host.split(".").slice(-2)` heuristic always collapsed to the
- * last two labels, so staging resolved to `useatlas.dev` — the same slot as
- * prod — which is exactly the cross-env cookie bleed this fixes.
- *
- * Returns `undefined` (host-only cookies) when either input is absent
- * (single-origin / self-hosted), when a URL is malformed, when the common
- * suffix is fewer than 2 labels (different sites), or when it looks like a
- * bare IPv4 (cookie domains can't be IPs).
- *
- * NOTE: there is no public-suffix-list awareness. Two *different* registrable
- * domains under a 2-label public suffix (`a.co.uk` + `b.co.uk`) resolve to
- * `co.uk`; browsers reject that via the PSL so the cookie simply fails to set
- * (no leak), and Atlas's API + app are always the same registrable domain.
- * Same-tenant multi-label TLDs (`api.acme.co.uk` + `app.acme.co.uk` →
- * `acme.co.uk`) work correctly.
+ * `regionApiUrl` is passed in (not read here) so this stays a pure resolver the
+ * unit tests can drive without standing up the config/residency map.
  */
-export function deriveCookieDomain(
-  authUrl: string | undefined,
-  webOrigin: string | undefined,
+export function resolveAuthBaseURL(
+  env: NodeJS.ProcessEnv,
+  regionApiUrl: string | null,
 ): string | undefined {
-  if (!authUrl || !webOrigin) return undefined;
+  return (
+    env.BETTER_AUTH_URL ||
+    regionApiUrl ||
+    (env.VERCEL_PROJECT_PRODUCTION_URL
+      ? `https://${env.VERCEL_PROJECT_PRODUCTION_URL}`
+      : env.VERCEL_URL
+        ? `https://${env.VERCEL_URL}`
+        : undefined)
+  );
+}
 
-  let authHost: string;
-  let webHost: string;
-  try {
-    authHost = new URL(authUrl).hostname;
-    webHost = new URL(webOrigin).hostname;
-  } catch {
-    return undefined;
-  }
-
-  // Longest common dotted suffix of the two hosts, compared from the right.
-  const a = authHost.split(".").reverse();
-  const b = webHost.split(".").reverse();
-  const common: string[] = [];
-  const len = Math.min(a.length, b.length);
-  for (let i = 0; i < len && a[i] === b[i]; i++) {
-    common.push(a[i]);
-  }
-  if (common.length < 2) return undefined;
-  if (common.every((label) => /^\d+$/.test(label))) return undefined; // bare IPv4
-
-  return common.reverse().join(".");
+/**
+ * Resolve Better Auth's `trustedOrigins` allowlist (redirect/callback hosts).
+ *
+ * For SaaS this must be `[app.useatlas.dev]`. An explicit
+ * `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) always wins; when it is
+ * unset/blank, the region-derived web origin (`getWebOrigin()`, passed in as
+ * `webOrigin`) supplies it — the same "process is the region" derivation used
+ * for the CORS default (#3706), so a regional service need not stamp the value.
+ * Returns `[]` only when neither source yields an origin (self-hosted
+ * single-origin, where Better Auth's own request-host check governs).
+ */
+export function resolveTrustedOrigins(
+  env: NodeJS.ProcessEnv,
+  webOrigin: string | null,
+): string[] {
+  const fromEnv =
+    env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  if (fromEnv.length > 0) return fromEnv;
+  return webOrigin ? [webOrigin] : [];
 }
 
 /**
@@ -2958,8 +2956,8 @@ export async function _autoProvisionSsoMember(user: { id: string; email: string 
 /**
  * Inputs to {@link buildAuthOptions}. Split out so `getAuthInstance()` can
  * resolve all boot-time concerns (env parsing, secret validation, plugin
- * assembly, cookie-domain derivation) and hand a pure struct to the options
- * builder — and so tests can drive the builder without standing up Better
+ * assembly, baseURL / trusted-origin derivation) and hand a pure struct to the
+ * options builder — and so tests can drive the builder without standing up Better
  * Auth's full plugin graph or an internal Postgres.
  *
  * Design notes:
@@ -2987,7 +2985,6 @@ export interface BuildAuthOptionsDeps {
    * lockstep.
    */
   database: InternalPool | undefined;
-  cookieDomain: string | undefined;
   /** Better Auth session-cookie prefix; see {@link buildAdvancedConfig}. */
   cookiePrefix: string;
   socialProviders: ReturnType<typeof buildSocialProviders>;
@@ -3186,7 +3183,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
     // F-06: the `advanced` block wires Better Auth's rate limiter to
     // read only the trusted `x-atlas-client-ip` header that our
     // middleware injects. See `buildAdvancedConfig` for the invariant.
-    advanced: buildAdvancedConfig(deps.cookieDomain, deps.cookiePrefix),
+    advanced: buildAdvancedConfig(deps.cookiePrefix),
     databaseHooks: {
       session: {
         create: {
@@ -3451,53 +3448,46 @@ export function getAuthInstance(): AuthInstance {
     );
   }
 
-  // Derive parent domain for cross-subdomain cookies — the longest dotted
-  // suffix common to the API host (BETTER_AUTH_URL) and the canonical app
-  // origin. Only for cross-origin deploys (a web origin is resolvable); without
-  // it, cookies are host-scoped and won't be sent from the frontend subdomain.
-  // Use getWebOrigin() (the FIRST CORS entry, else BETTER_AUTH_TRUSTED_ORIGINS,
-  // else the region-derived origin — #3706) rather than the whole allowlist, so
-  // an unrelated allowlisted origin can't veto the shared domain, and so the
-  // domain still derives once SaaS stops stamping ATLAS_CORS_ORIGIN per service
-  // (BETTER_AUTH_TRUSTED_ORIGINS stays env, so getWebOrigin() still resolves).
-  // NB: this dropped the former `ATLAS_CORS_ORIGIN`-set gate. A self-hosted
-  // deploy that sets BETTER_AUTH_TRUSTED_ORIGINS but NOT ATLAS_CORS_ORIGIN now
-  // also derives a parent cookie domain (previously host-scoped) — the intended
-  // cross-subdomain behavior, and a no-op for single-origin deploys where the
-  // API host and app origin share no 2+ label suffix (cookieDomain stays
-  // undefined). See `deriveCookieDomain` for why the env-specific suffix matters.
+  // The canonical app origin — `app.useatlas.dev` in SaaS — resolved from the
+  // first ATLAS_CORS_ORIGIN entry, else BETTER_AUTH_TRUSTED_ORIGINS, else the
+  // region-derived origin (#3706). Feeds `trustedOrigins` below (Better Auth's
+  // redirect/callback allowlist). Session cookies are HOST-ONLY (ADR-0024 §5 —
+  // see `buildAdvancedConfig`), so there is no parent-domain cookie to derive:
+  // `app.useatlas.dev` authenticates against the regional API as a same-site,
+  // cross-origin caller (credentials:include + the CORS allowlist), and the
+  // cookie stays scoped to the issuing region's host so it never transits
+  // another region.
   const webOrigin = getWebOrigin();
-  const cookieDomain = deriveCookieDomain(process.env.BETTER_AUTH_URL, webOrigin ?? undefined);
-  // Fail loud on the silent footgun: a cross-origin deploy that yields no
-  // shared domain — usually a malformed BETTER_AUTH_URL or an app origin that
-  // shares no 2+ label suffix with it — leaves session cookies host-only, so
-  // the app subdomain never receives them and auth breaks with no other
-  // signal. Hostnames aren't secrets (CLAUDE.md), so log them.
-  if (process.env.BETTER_AUTH_URL && webOrigin && !cookieDomain) {
-    log.warn(
-      { authUrl: process.env.BETTER_AUTH_URL, webOrigin },
-      "Cross-origin deploy (web origin resolved) but no shared cookie domain could be "
-        + "derived from the API host and the app origin — session cookies will be host-only "
-        + "and won't reach the app subdomain. Verify BETTER_AUTH_URL and the first "
-        + "ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry are valid URLs sharing a 2+ label suffix.",
-    );
-  }
 
-  // Session-cookie name prefix — distinct per deployment env so prod and
-  // staging (which share the `.useatlas.dev` cookie zone) don't collide on a
-  // single cookie slot. MUST match web's NEXT_PUBLIC_ATLAS_COOKIE_PREFIX.
+  // Session-cookie name prefix — distinct per deployment env. Host-only cookies
+  // already keep prod (`api.useatlas.dev`) and staging (`api.staging.useatlas.dev`)
+  // on separate hosts, but the prefix stays a defensive second guard and MUST
+  // match web's NEXT_PUBLIC_ATLAS_COOKIE_PREFIX.
   const cookiePrefix = resolveCookiePrefix(process.env);
 
-  // Resolve base URL: explicit env var > Vercel auto-detect > undefined (Better Auth auto-detect).
-  // On Vercel, VERCEL_PROJECT_PRODUCTION_URL or VERCEL_URL are always set.
-  // Without a baseURL, Better Auth logs a noisy warning on every cold start.
-  const baseURL =
-    process.env.BETTER_AUTH_URL ||
-    (process.env.VERCEL_PROJECT_PRODUCTION_URL
-      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-      : process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : undefined);
+  // Better Auth baseURL = this region's own API host (the cookie issuer). An
+  // explicit BETTER_AUTH_URL wins; otherwise the region-derived API host
+  // (`deriveRegionApiUrl()`) self-binds the process to its region (ADR-0024 §2),
+  // then Vercel auto-detect, then Better Auth's own request-host fallback.
+  const regionApiUrl = deriveRegionApiUrl();
+  const baseURL = resolveAuthBaseURL(process.env, regionApiUrl);
+
+  // Better Auth's redirect/callback + CSRF allowlist (`app.useatlas.dev` in
+  // SaaS). Env wins; else the region-derived web origin.
+  const trustedOrigins = resolveTrustedOrigins(process.env, webOrigin);
+  // Fail loud at boot on a residency misconfig: a regional (cross-origin) deploy
+  // that resolves an EMPTY allowlist will 403 every credentialed app→api auth
+  // request as an untrusted origin, with no other boot signal. This restores the
+  // fail-loud parity of the cross-subdomain cookie-domain guard that host-only
+  // cookies (ADR-0024 §5) retired. Hostnames aren't secrets (CLAUDE.md).
+  if (regionApiUrl && trustedOrigins.length === 0) {
+    log.warn(
+      { baseURL, regionApiUrl },
+      "Regional (cross-origin) deploy resolved an EMPTY trustedOrigins allowlist — "
+        + "credentialed app→api auth requests will be rejected as untrusted origins. Set "
+        + "BETTER_AUTH_TRUSTED_ORIGINS (or ATLAS_CORS_ORIGIN) to the app origin (e.g. https://app.useatlas.dev).",
+    );
+  }
 
   const socialProviders = buildSocialProviders();
   if (socialProviders) {
@@ -3535,14 +3525,10 @@ export function getAuthInstance(): AuthInstance {
     secret,
     baseURL,
     database: internalDbAvailable ? getInternalDB() : undefined,
-    cookieDomain,
     cookiePrefix,
     socialProviders,
     plugins: buildPlugins(),
-    trustedOrigins:
-      process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")
-        .map((s) => s.trim())
-        .filter(Boolean) || [],
+    trustedOrigins,
     bootstrapAdmin: resolveBootstrapAdminConfig(adminEmail, allowFirstSignupAdmin),
   });
 

--- a/packages/api/src/lib/env-profile.ts
+++ b/packages/api/src/lib/env-profile.ts
@@ -83,15 +83,14 @@ export interface EnvProfile {
 
   /**
    * Better Auth session-cookie name prefix (`advanced.cookiePrefix`). The
-   * session cookie is named `${cookiePrefix}.session_token`. A distinct
-   * prefix per deployment env is what isolates prod from staging: both live
-   * under the shared `.useatlas.dev` parent (staging is `*.staging.useatlas.dev`,
-   * a *subdomain* of the prod cookie domain), so prod's broadly-scoped
-   * `.useatlas.dev` cookie reaches staging hosts regardless of how staging's
-   * own cookie domain is scoped — the prefix, not the domain, is what isolates.
-   * A different name means each env's optimistic proxy gate
+   * session cookie is named `${cookiePrefix}.session_token`. Session cookies are
+   * host-only (ADR-0024 §5 — no `Domain=.useatlas.dev`), so prod's cookie is
+   * already scoped to `api.useatlas.dev` and never reaches a staging host. The
+   * distinct prefix per deployment env stays a defensive second guard: a
+   * different name means each env's optimistic proxy gate
    * (`packages/web/src/proxy.ts` → `getSessionCookie`) and Better Auth ignore
-   * the other env's cookie instead of being fooled by its mere presence.
+   * the other env's cookie even if one ever did reach the wrong host, instead of
+   * being fooled by its mere presence.
    *
    * MUST stay in lockstep with the web proxy's `getSessionCookie` read, which
    * CANNOT import this module (the frontend never imports `@atlas/api`). The

--- a/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
+++ b/packages/api/src/lib/residency/__tests__/region-origins-integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Region-derivation integration (#3706).
+ * Region-derivation integration (#3706, extended #3970).
  *
  * Walks the whole chain that used to require per-service env stamping —
  * `getWebOrigin()` → the `ATLAS_CORS_ORIGIN` default (`resolveCorsOrigin`) and
@@ -7,6 +7,12 @@
  * `ATLAS_API_REGION` + the residency map. Locks the derived CORS origin and
  * rpID for each SaaS region so a refactor can't silently shift the cookie CORS
  * allowlist or invalidate enrolled passkeys.
+ *
+ * #3970 extends the same "process is the region" derivation to Better Auth's
+ * own `baseURL`: `deriveRegionApiUrl()` returns the issuing regional API host
+ * (the value `resolveAuthBaseURL` falls back to when BETTER_AUTH_URL is unset),
+ * so each regional Better Auth instance is bound to its own host without per-
+ * service env stamping.
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
@@ -35,6 +41,7 @@ mock.module("@atlas/api/lib/settings", () => ({
 const { getWebOrigin } = await import("@atlas/api/lib/web-origin");
 const { resolveCorsOrigin } = await import("@atlas/api/lib/cors");
 const { resolvePasskeyRpId } = await import("@atlas/api/lib/auth/rpid");
+const { deriveRegionApiUrl } = await import("@atlas/api/lib/residency/origins");
 
 const PROD_RESIDENCY = {
   defaultRegion: "us",
@@ -65,19 +72,32 @@ describe("region-derived web origin → CORS default + passkey rpID", () => {
 
   // Every prod region collapses onto the single app.useatlas.dev web service;
   // staging keeps its own. rpID is the web origin's host (the value enrolled
-  // passkeys are bound to — must NOT drift).
+  // passkeys are bound to — must NOT drift). The Better Auth baseURL, by
+  // contrast, is the issuing region's OWN API host (#3970) — that is exactly
+  // what makes the minted cookie host-only to that region.
   it.each([
-    ["us", "https://app.useatlas.dev", "app.useatlas.dev"],
-    ["eu", "https://app.useatlas.dev", "app.useatlas.dev"],
-    ["apac", "https://app.useatlas.dev", "app.useatlas.dev"],
-    ["staging", "https://app.staging.useatlas.dev", "app.staging.useatlas.dev"],
-  ] as const)("region %s derives CORS origin %s and rpID %s", (region, expectedOrigin, expectedRpId) => {
-    process.env.ATLAS_API_REGION = region;
+    ["us", "https://app.useatlas.dev", "app.useatlas.dev", "https://api.useatlas.dev"],
+    ["eu", "https://app.useatlas.dev", "app.useatlas.dev", "https://api-eu.useatlas.dev"],
+    ["apac", "https://app.useatlas.dev", "app.useatlas.dev", "https://api-apac.useatlas.dev"],
+    [
+      "staging",
+      "https://app.staging.useatlas.dev",
+      "app.staging.useatlas.dev",
+      "https://api.staging.useatlas.dev",
+    ],
+  ] as const)(
+    "region %s derives CORS origin %s, rpID %s, auth baseURL %s",
+    (region, expectedOrigin, expectedRpId, expectedApiUrl) => {
+      process.env.ATLAS_API_REGION = region;
 
-    expect(getWebOrigin()).toBe(expectedOrigin);
-    expect(resolveCorsOrigin()).toBe(expectedOrigin);
-    expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe(expectedRpId);
-  });
+      expect(getWebOrigin()).toBe(expectedOrigin);
+      expect(resolveCorsOrigin()).toBe(expectedOrigin);
+      expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe(expectedRpId);
+      // The region's own API host — fed to resolveAuthBaseURL as the
+      // BETTER_AUTH_URL fallback so each regional process self-binds.
+      expect(deriveRegionApiUrl()).toBe(expectedApiUrl);
+    },
+  );
 
   it("explicit ATLAS_RPID overrides the region-derived value", () => {
     process.env.ATLAS_API_REGION = "us";
@@ -90,5 +110,8 @@ describe("region-derived web origin → CORS default + passkey rpID", () => {
     expect(getWebOrigin()).toBeNull();
     expect(resolveCorsOrigin()).toBe("*");
     expect(resolvePasskeyRpId(process.env, getWebOrigin())).toBe("app.useatlas.dev");
+    // No residency map → no derived API host; resolveAuthBaseURL then falls
+    // through to BETTER_AUTH_URL / Vercel / Better Auth's own auto-detect.
+    expect(deriveRegionApiUrl()).toBeNull();
   });
 });

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -7,7 +7,9 @@
  * browser sessions use cookies automatically.
  *
  * Base URL resolution priority:
- *   1. NEXT_PUBLIC_ATLAS_API_URL — cross-origin API (set when frontend and API are separate)
+ *   1. getApiUrl()               — the regional override if set, else the
+ *                                  build-time NEXT_PUBLIC_ATLAS_API_URL (the
+ *                                  cross-origin API host when frontend ≠ API)
  *   2. window.location.origin    — same-origin fallback (browser)
  *   3. http://localhost:3000      — SSR / prerender fallback
  *
@@ -53,11 +55,20 @@ function getBaseURL(): string {
   return "http://localhost:3000/api/auth";
 }
 
-// Auth always authenticates against the global API (not the regional endpoint).
-// The client is a module-level singleton created at import time, before
-// setRegionalApiUrl() is called. This is intentional: session cookies and
-// auth operations stay on the global endpoint; only data-plane calls (chat,
-// admin fetches) switch to the regional API after settings load.
+// Session cookies are HOST-ONLY per region (ADR-0024 §5): a session minted by a
+// regional API (`api-eu.useatlas.dev`) is scoped to that host and accepted by no
+// other region — there is no global cross-region session. `credentials:
+// "include"` (below) lets the browser store and send that host-only cookie on
+// same-site, cross-origin calls from `app.useatlas.dev`.
+//
+// The client is a module-level singleton built at import time against
+// `getBaseURL()` → `getApiUrl()`. At import that resolves to the BUILD-TIME
+// default (`NEXT_PUBLIC_ATLAS_API_URL`); the runtime regional override
+// (`setRegionalApiUrl`) lands after this singleton is constructed, so it does
+// not re-point it. Pointing the auth client at a non-default region's API before
+// the first auth call is the browser-region-awareness slice's job (#3971 — it
+// must resolve the region synchronously, e.g. from the `atlas_region` cookie,
+// before import); this slice lands the API-side host-only cookies it relies on.
 const _authClient = createAuthClient({
   baseURL: getBaseURL(),
   plugins: [

--- a/packages/web/src/lib/cross-origin-api.test.ts
+++ b/packages/web/src/lib/cross-origin-api.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { isCrossOriginApi } from "./cross-origin-api";
+
+const env = (v: string | undefined) =>
+  ({ NEXT_PUBLIC_ATLAS_API_URL: v }) as NodeJS.ProcessEnv;
+
+describe("isCrossOriginApi", () => {
+  it("is true when NEXT_PUBLIC_ATLAS_API_URL is a non-empty origin (SaaS app↔api split)", () => {
+    expect(isCrossOriginApi(env("https://api-eu.useatlas.dev"))).toBe(true);
+  });
+
+  it("is false when the var is unset (self-hosted same-origin via Next rewrites)", () => {
+    expect(isCrossOriginApi(env(undefined))).toBe(false);
+  });
+
+  it("treats a blank / whitespace value as same-origin (not cross-origin)", () => {
+    expect(isCrossOriginApi(env(""))).toBe(false);
+    expect(isCrossOriginApi(env("   "))).toBe(false);
+  });
+});

--- a/packages/web/src/lib/cross-origin-api.ts
+++ b/packages/web/src/lib/cross-origin-api.ts
@@ -1,0 +1,19 @@
+/**
+ * Whether the web app talks to its API on a SEPARATE origin — SaaS serves the
+ * app from `app.useatlas.dev` and the API from `api[-region].useatlas.dev`,
+ * signalled by a build-time `NEXT_PUBLIC_ATLAS_API_URL`.
+ *
+ * This reads ONLY the env (not `@/lib/api-url`'s mutable regional override), so
+ * a server-side caller — the proxy — gets a stable, request-independent answer.
+ * `@/lib/api-url.isCrossOrigin()` is the *client* counterpart: it folds in the
+ * runtime regional override and is the one components should use. The split
+ * matters for the proxy: in a cross-origin deploy the session cookie is
+ * host-only on the regional API host (ADR-0024 §5) and is never delivered to
+ * this app origin, so the proxy must NOT perform a server-side cookie-presence
+ * check (it would see no cookie for everyone and loop authenticated users to
+ * /login). Auth UX in that mode is the client-side `AuthGuard`'s job (a real
+ * `useSession()` validation), with the API as the enforcement boundary.
+ */
+export function isCrossOriginApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !!env.NEXT_PUBLIC_ATLAS_API_URL?.trim();
+}

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -13,7 +13,14 @@
  *    resolved mode without parsing cookies.
  *
  * Auth is an optimistic check — it reads the session cookie without hitting
- * the database. Actual auth enforcement happens at the API layer.
+ * the database. Actual auth enforcement happens at the API layer. It runs ONLY
+ * for same-origin deploys: when the API is a separate origin
+ * (`NEXT_PUBLIC_ATLAS_API_URL` set — SaaS app.useatlas.dev ↔ api[-region]),
+ * the session cookie is host-only on the regional API host (ADR-0024 §5) and is
+ * never delivered to this app origin, so a presence check here would see no
+ * cookie for *everyone* and loop signed-in users to /login. In that mode the
+ * redirect is skipped and the client-side `AuthGuard` (a real `useSession()`
+ * round-trip) owns the auth UX, with the API as the enforcement boundary.
  *
  * --- CSP: why the nonce posture lives in the proxy (#3899) ---
  *
@@ -54,6 +61,7 @@ import { ATLAS_MODES } from "@useatlas/types/auth";
 import { PUBLIC_ROUTE_PREFIXES } from "./lib/public-routes";
 import { resolveWebCookiePrefix } from "./lib/cookie-prefix";
 import { buildCsp, frameAncestorsFor } from "./lib/csp";
+import { isCrossOriginApi } from "./lib/cross-origin-api";
 
 const authMode = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 const VALID_MODES = new Set<string>(ATLAS_MODES);
@@ -66,9 +74,9 @@ const cspEnv = process.env.NODE_ENV === "development" ? "dev" : "prod";
 // to "atlas" to match the API's `production` profile, so unconfigured
 // self-hosted deploys agree without extra wiring. Atlas staging sets
 // NEXT_PUBLIC_ATLAS_COOKIE_PREFIX=atlas-staging; local dev sets atlas-dev.
-// Without this, prod's `.useatlas.dev` cookie (delivered to staging because
-// staging is a subdomain) would satisfy this optimistic presence check and
-// suppress the /login redirect on a different environment.
+// Host-only cookies (ADR-0024 §5) already keep each env's session token on its
+// own host, but a distinct prefix per env stays a defensive guard so this
+// same-origin presence check never mistakes another env's cookie for this one.
 // `process.env.NEXT_PUBLIC_*` is read here as a direct static reference so
 // Next inlines it at build time; `resolveWebCookiePrefix` only applies the
 // default/trim (mirrors the API's resolveCookiePrefix and is unit-tested).
@@ -138,6 +146,15 @@ export function proxy(request: NextRequest) {
 
   // Always allow public routes (demo, shared conversations, API, Next.js internals)
   if (isPublicRoute(pathname)) {
+    return withModeHeader(request, nonce, csp);
+  }
+
+  // Cross-origin deploy: the session cookie is host-only on the regional API
+  // host (ADR-0024 §5) and isn't delivered to this app origin, so the optimistic
+  // presence check below can't see it. Skip it (else every user looks logged-out
+  // and authenticated users loop to /login); the client-side AuthGuard enforces
+  // auth instead. Same-origin self-hosted deploys keep the optimistic redirect.
+  if (isCrossOriginApi()) {
     return withModeHeader(request, nonce, csp);
   }
 


### PR DESCRIPTION
## What & why

Implements **ADR-0024 §5** (host-only per-region session cookies) + §2 ("the process is the region") for the cross-origin auth foundation: a session minted by a regional API (`api-eu`) must be usable from `app.useatlas.dev` **and rejected everywhere else**. Non-portability is the feature, not a limitation.

Builds on #3982 (the shrunk `ResidencyResolver` / region→apiUrl map) and pairs with #3983 (browser region-awareness — already merged) for full end-to-end region routing. Part of the #3967 / v0.0.31 cluster.

Closes #3970

## Changes

### API — `packages/api/src/lib/auth/server.ts`
- **Host-only cookies.** Removed `deriveCookieDomain` + the `cookieDomain` dep + the `defaultCookieAttributes.domain` branch of `buildAdvancedConfig`. Better Auth now sets **no `Domain` attribute**, so a region's session cookie is scoped to its issuing host and never transits another region. BA defaults give `SameSite=Lax` + `Secure` (https baseURL) + `httpOnly`, unchanged — a parent-domain `.useatlas.dev` cookie (which would leak EU tokens to US/APAC) is structurally unrepresentable.
- **"The process is the region."** `resolveAuthBaseURL` falls back to the region-derived API host (`deriveRegionApiUrl`) and `resolveTrustedOrigins` to the region-derived web origin (`getWebOrigin`), so each regional Better Auth instance self-binds its `baseURL` + `trustedOrigins: [app.useatlas.dev]` without per-service env stamping. Explicit `BETTER_AUTH_URL` / `BETTER_AUTH_TRUSTED_ORIGINS` still win.
- **Fail loud at boot** when a regional deploy resolves an empty `trustedOrigins` allowlist (would 403 credentialed `app→api` auth), restoring the fail-loud parity of the retired cookie-domain guard.

### CORS (already in place, #3706)
`corsResponseHeaders` already allowlists `app.useatlas.dev` with `Access-Control-Allow-Credentials: true` and an explicit origin (never `*` for credentialed). Locked with tests.

### Web
- **`proxy.ts`** skips the optimistic server-side session-cookie redirect in cross-origin mode (`NEXT_PUBLIC_ATLAS_API_URL` set): the host-only cookie lives on the regional API host and isn't delivered to the app origin, so a presence check here would loop signed-in users to `/login`. Client-side `AuthGuard` (real `useSession()`) owns the auth UX; the API is the enforcement boundary. New env-only `isCrossOriginApi()` helper keeps the decision unit-testable.
- **`getCredentials()` / the data-plane + auth fetches already send `credentials: 'include'`** cross-origin (confirmed). `client.ts` comment reconciled with #3983's region-aware import-time base.

### Docs/comments
Reconciled stranded references to the removed cookie-domain derivation (`rpid.ts`, `env-profile.ts`, `web-origin.test.ts`, `authentication.mdx` — the latter was operator-facing and now describes host-only cookies).

## Acceptance criteria
- [x] Session cookie is **host-only**, `SameSite=Lax` (asserted against a **real minted `Set-Cookie`** in `rate-limit-integration.test.ts`), never `Domain=.useatlas.dev`.
- [x] No global SSO: no shared cross-region session (host-only ⇒ a session token only reaches its issuing region).
- [x] CORS allowlists `app.useatlas.dev` with credentials + explicit origin; rejects non-allowlisted origins.
- [x] `getCredentials()` sends `credentials: 'include'` on cross-origin data-plane + auth calls.
- [ ] EU session accepted by `api-eu` / 401s on `api.useatlas.dev` + `api-apac` — the runtime cross-region check; verifiable once the 3-region deploy carries this + #3983 (per-region `BETTER_AUTH_URL` / residency map).

## Testing
- TDD (red→green). New/updated unit + integration tests: host-only invariant at config **and** live-minted-cookie levels, `resolveAuthBaseURL` / `resolveTrustedOrigins` branch coverage, per-region `deriveRegionApiUrl` lock, `isCrossOriginApi`.
- Local gates green: lint, type, syncpack, template/schema/openapi/oauth-helper/railway/saas-env/security-header/settings/published-symbols drift, test-discipline. Affected suites: 42 API + 225 web isolated. Full `bun run test` running.

## Review panel
Two rounds, converged CLEAN: type-design CLEAN, silent-failure CLEAN (added the boot-warn it recommended), test-coverage CLEAN (added the real-`Set-Cookie` host-only assertion), comment-accuracy fixes applied (incl. the merge with #3983's authoritative `client.ts` comment).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch session cookies to host-only per-region model and add cross-origin CORS foundation
> - Removes `deriveCookieDomain` and the shared parent-domain `Domain` attribute from session cookies; cookies are now host-only (scoped to the issuing API host) and rely on `SameSite=Lax` with credentialed cross-origin requests.
> - Adds `resolveAuthBaseURL` and `resolveTrustedOrigins` helpers in [`server.ts`](https://github.com/AtlasDevHQ/atlas/pull/3985/files#diff-a90f21a4746a0b323fcdedf90f8bda584edc7618dff55cc26b921c1c32562526) to centralize Better Auth boot-time config, with fallbacks to region-derived API/web origins.
> - Adds [`cross-origin-api.ts`](https://github.com/AtlasDevHQ/atlas/pull/3985/files#diff-06271a73909ecdebfe27a92b1513cc307a8e3e9425630ac7c66681058f44dbcd) utility (`isCrossOriginApi`) that detects when `NEXT_PUBLIC_ATLAS_API_URL` is set, and uses it in [`proxy.ts`](https://github.com/AtlasDevHQ/atlas/pull/3985/files#diff-2e7739ce7a315ab9f6da0f07b2312f646916daf49b3d1e76f304babc5633b8c6) to skip the server-side session-cookie presence check in cross-origin deployments.
> - Behavioral Change: cross-origin deploys no longer perform server-side cookie-based redirects in the proxy; auth enforcement moves to the API boundary with client-side UX handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fcce83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->