### PR TITLE
feat(web,api): signup reorder — region before the first identity write (#3972)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -13791,6 +13791,10 @@
                           },
                           "isDefault": {
                             "type": "boolean"
+                          },
+                          "apiUrl": {
+                            "type": "string",
+                            "format": "uri"
                           }
                         },
                         "required": [

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -278,6 +278,37 @@ describe("GET /api/v1/onboarding/social-providers", () => {
   });
 });
 
+describe("GET /api/v1/onboarding/regions (public — pre-auth, ADR-0024 §4)", () => {
+  it("returns 200 without a session — the picker renders before any identity write", async () => {
+    // Under the signup reorder the region step precedes account creation, so
+    // there is NO session yet. `standardAuth` would 401 this; the route is now
+    // public. Force an unauthenticated `authenticate` to prove the route never
+    // consults it (withRequestId runs no auth).
+    mockAuthMode = "managed";
+    mockAuthenticate.mockImplementation(() =>
+      Promise.resolve({ authenticated: false, mode: "managed", status: 401, error: "No session" }),
+    );
+    const res = await request("/api/v1/onboarding/regions");
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    // Residency resolver is unavailable in the test runtime → configured:false
+    // (still a 200; the frontend reads `configured` to skip the region step).
+    expect(data.configured).toBe(false);
+    expect(data.availableRegions).toEqual([]);
+  });
+
+  it("404s when auth mode is not managed", async () => {
+    mockAuthMode = "none";
+    try {
+      const res = await request("/api/v1/onboarding/regions");
+      expect(res.status).toBe(404);
+    } finally {
+      // Restore even if the assertion throws, so the mode can't leak forward.
+      mockAuthMode = "managed";
+    }
+  });
+});
+
 describe("POST /api/v1/onboarding/test-connection", () => {
   beforeEach(() => {
     mockAuthMode = "managed";

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -29,7 +29,7 @@ import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { importFromDisk } from "@atlas/api/lib/semantic/sync";
 import { setSetting } from "@atlas/api/lib/settings";
 import { ErrorSchema } from "./shared-schemas";
-import { standardAuth, requestContext, type AuthEnv } from "./middleware";
+import { standardAuth, requestContext, withRequestId, type AuthEnv } from "./middleware";
 import {
   DEMO_CONNECTION_ID,
   DEMO_INDUSTRY,
@@ -1116,8 +1116,14 @@ const assignRegionRoute = createRoute({
   },
 });
 
-onboarding.use("/regions", standardAuth);
-onboarding.use("/regions", requestContext);
+// `/regions` is PUBLIC (pre-auth). Under ADR-0024 §4 the signup order is
+// email → region → create-account, so the region picker is rendered *before*
+// any Better Auth session exists — gating this behind `standardAuth` would 401
+// the picker and dead-end every regional signup. The payload is static deploy
+// config (region id/label/apiUrl), carries no PII, and mirrors the already-public
+// `/social-providers`. `withRequestId` still stamps a requestId for log
+// correlation; the handler reads only `RequestContext` (no `orgId`/session).
+onboarding.use("/regions", withRequestId);
 onboarding.use("/assign-region", standardAuth);
 onboarding.use("/assign-region", requestContext);
 

--- a/packages/api/src/lib/residency/__tests__/picker.test.ts
+++ b/packages/api/src/lib/residency/__tests__/picker.test.ts
@@ -33,12 +33,23 @@ describe("buildAvailableRegions (#3948)", () => {
     expect(ids.toSorted()).toEqual(["eu", "us"]);
   });
 
-  it("marks the default region and passes the label through", () => {
+  it("marks the default region and passes the label + apiUrl through", () => {
     const available = buildAvailableRegions(REGIONS, "eu");
     const eu = available.find((r) => r.id === "eu");
     const us = available.find((r) => r.id === "us");
-    expect(eu).toEqual({ id: "eu", label: "Europe", isDefault: true });
+    // apiUrl rides along so the signup picker can repoint the browser at the
+    // chosen region before the first identity write (ADR-0024 §4).
+    expect(eu).toEqual({ id: "eu", label: "Europe", isDefault: true, apiUrl: "https://api-eu.useatlas.dev" });
     expect(us?.isDefault).toBe(false);
+    expect(us?.apiUrl).toBe("https://api.useatlas.dev");
+  });
+
+  it("passes apiUrl through as undefined when the region config omits it", () => {
+    // Single-region / local-dev configs omit apiUrl; the browser then stays on
+    // its same-origin base (no repoint possible) rather than getting a bad URL.
+    const regions: Regions = { us: { label: "United States" } };
+    const us = buildAvailableRegions(regions, "us").find((r) => r.id === "us");
+    expect(us).toEqual({ id: "us", label: "United States", isDefault: true, apiUrl: undefined });
   });
 
   it("never marks a non-selectable region as default even if it is the configured default", () => {

--- a/packages/api/src/lib/residency/picker.ts
+++ b/packages/api/src/lib/residency/picker.ts
@@ -40,5 +40,9 @@ export function buildAvailableRegions(
 ): RegionPickerItem[] {
   return Object.entries(regions)
     .filter(([, cfg]) => isRegionSelectable(cfg))
-    .map(([id, cfg]) => ({ id, label: cfg.label, isDefault: id === defaultRegion }));
+    // `apiUrl` carries the region→base map to the signup picker so the browser
+    // can point its API base at the chosen region before the first identity
+    // write (ADR-0024 §4). Passed through verbatim — `undefined` when the region
+    // config omits it (single-region / local dev), where no repoint is possible.
+    .map(([id, cfg]) => ({ id, label: cfg.label, isDefault: id === defaultRegion, apiUrl: cfg.apiUrl }));
 }

--- a/packages/schemas/src/__tests__/residency.test.ts
+++ b/packages/schemas/src/__tests__/residency.test.ts
@@ -254,6 +254,16 @@ describe("structural rejection", () => {
     expect(RegionPickerItemSchema.safeParse(missing).success).toBe(false);
   });
 
+  test("RegionPickerItemSchema parses the optional apiUrl (ADR-0024 §4)", () => {
+    const withApiUrl = { ...validPicker, apiUrl: "https://api-eu.useatlas.dev" };
+    expect(RegionPickerItemSchema.parse(withApiUrl)).toEqual(withApiUrl);
+  });
+
+  test("RegionPickerItemSchema rejects a malformed apiUrl", () => {
+    const bad = { ...validPicker, apiUrl: "not-a-url" };
+    expect(RegionPickerItemSchema.safeParse(bad).success).toBe(false);
+  });
+
   test("RegionMigrationSchema rejects undefined on nullable field", () => {
     // Zod's `.nullable()` accepts null but not undefined. This guards the
     // route-serialization / web-parse contract — the API emits explicit

--- a/packages/schemas/src/residency.ts
+++ b/packages/schemas/src/residency.ts
@@ -43,6 +43,11 @@ export const RegionPickerItemSchema = z.object({
   id: z.string(),
   label: z.string(),
   isDefault: z.boolean(),
+  // Region's public API base — lets the signup picker repoint the browser at
+  // the chosen region before the first identity write (ADR-0024 §4). Optional:
+  // single-region / local-dev configs omit it. `.url()` rejects a malformed
+  // base before it ever reaches `applyRegionSignal`'s own credential-safe check.
+  apiUrl: z.string().url().optional(),
 }) satisfies z.ZodType<RegionPickerItem>;
 
 export const RegionStatusSchema = z.object({

--- a/packages/types/src/residency.ts
+++ b/packages/types/src/residency.ts
@@ -69,6 +69,16 @@ export interface RegionPickerItem {
   label: string;
   /** Whether this region is the deployment's default. */
   isDefault: boolean;
+  /**
+   * Public API base for this region (e.g. "https://api-eu.useatlas.dev").
+   *
+   * Carries the region→apiUrl map to the browser so the signup region step can
+   * point the API base at the chosen region *before* the first identity write
+   * (ADR-0024 §4 — `applyRegionSignal` in `@/lib/api-url`). Omitted when the
+   * region config declares no `apiUrl` (single-region / local dev), where the
+   * browser stays on its same-origin base and no repoint is possible.
+   */
+  apiUrl?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/__tests__/proxy.test.ts
+++ b/packages/web/src/__tests__/proxy.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Coverage for the proxy pre-auth route allowlist (ADR-0024 §4, #3972).
+ *
+ * The signup reorder moves region selection and account creation BEFORE any
+ * session exists, so `/signup/region` and `/signup/account` must be reachable
+ * while signed out on a same-origin managed deploy — otherwise the proxy's
+ * `!sessionToken && !isAuthRoute` branch 307s every regional signup to /login
+ * mid-flow. This pins that membership directly via the exported `isAuthRoute`
+ * predicate (env-independent, so it can't diverge local↔CI like a full
+ * `proxy()` test would via the module-level NEXT_PUBLIC_* reads — #3939).
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+
+// proxy.ts pulls in next/server + better-auth/cookies at import; stub them so
+// the import has no heavy side effects (the predicate under test needs neither).
+mock.module("next/server", () => ({
+  NextResponse: { next: () => ({}), redirect: () => ({}) },
+}));
+mock.module("better-auth/cookies", () => ({
+  getSessionCookie: () => null,
+}));
+
+import { isAuthRoute } from "../proxy";
+
+describe("proxy isAuthRoute — pre-auth signup steps (#3972)", () => {
+  test("the pre-auth signup steps are reachable while signed out", () => {
+    expect(isAuthRoute("/signup")).toBe(true);
+    expect(isAuthRoute("/signup/region")).toBe(true);
+    expect(isAuthRoute("/signup/account")).toBe(true);
+  });
+
+  test("the post-account signup steps stay session-gated (NOT auth routes)", () => {
+    expect(isAuthRoute("/signup/workspace")).toBe(false);
+    expect(isAuthRoute("/signup/connect")).toBe(false);
+    expect(isAuthRoute("/signup/success")).toBe(false);
+  });
+
+  test("the other auth-only routes are unchanged", () => {
+    expect(isAuthRoute("/login")).toBe(true);
+    expect(isAuthRoute("/forgot-password")).toBe(true);
+    expect(isAuthRoute("/reset-password")).toBe(true);
+    // A real app route is not an auth route.
+    expect(isAuthRoute("/")).toBe(false);
+  });
+});

--- a/packages/web/src/app/signup/account/page.test.tsx
+++ b/packages/web/src/app/signup/account/page.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Coverage for the signup account step (ADR-0024 §4, #3972).
+ *
+ * This is the FIRST identity write. On the regional path it is reached after
+ * the region step (hard-nav rebuilds the auth client against the regional base);
+ * invitees reach it directly from /signup (region skipped) and single-region
+ * deploys via the region step's auto-skip. The email comes from the signup
+ * draft (it survives the region step's hard reload); a missing draft means a
+ * deep link, which bounces back to /signup. These tests pin the draft
+ * hydration, the create→navigate path, the OTP interstitial, and the invite
+ * routing — the auth client itself is mocked, so they assert orchestration, not
+ * which region the network call physically hit (that's the e2e/prod concern).
+ *
+ * `mock.module(...)` stubs every named export of the modules it touches (repo
+ * rule). Shell + OTP form are passthrough/stub so the test exercises this page.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const routerReplaceMock = mock((_path: string) => {});
+const routerMock = { push: () => {}, replace: routerReplaceMock, back: () => {} };
+mock.module("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+type SignUpResult = { data?: { token?: string | null } | null; error?: { message?: string } | null };
+const signUpEmailMock = mock(async (_opts: { email: string; password: string; name: string }): Promise<SignUpResult> => ({
+  data: { token: "tok" },
+  error: null,
+}));
+const signInSocialMock = mock(async (_opts: { provider: string; callbackURL: string }) => ({}));
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    signUp: { email: signUpEmailMock },
+    signIn: { social: signInSocialMock },
+  },
+}));
+
+const navigatePostAuthMock = mock((_path: string) => {});
+mock.module("@/lib/auth/post-auth-nav", () => ({
+  navigatePostAuth: navigatePostAuthMock,
+}));
+
+const readDraftMock = mock((): { email: string; invitationId?: string } | null => ({ email: "jane@example.com" }));
+const clearDraftMock = mock(() => {});
+mock.module("@/lib/signup-draft", () => ({
+  readSignupDraft: readDraftMock,
+  clearSignupDraft: clearDraftMock,
+  saveSignupDraft: () => {},
+}));
+
+mock.module("@/ui/components/signup/signup-context-provider", () => ({
+  SignupContextProvider: ({ children }: { children: unknown }) => <>{children as never}</>,
+  useSignupContext: () => ({ status: "ready", showRegion: true }),
+}));
+
+mock.module("@/ui/components/signup/signup-shell", () => ({
+  SignupShell: ({ children, back }: { children: unknown; back?: { href: string } }) => (
+    <div>
+      {back ? <a href={back.href}>Back</a> : null}
+      {children as never}
+    </div>
+  ),
+}));
+
+mock.module("@/ui/components/auth/verify-email-otp-form", () => ({
+  VerifyEmailOTPForm: ({ onVerified }: { onVerified: () => void }) => (
+    <button type="button" onClick={onVerified}>verify-code</button>
+  ),
+}));
+
+// social-providers probe — configurable per test (default none → no buttons).
+let socialProviders: string[] = [];
+const fetchMock = mock(async (): Promise<Response> =>
+  new Response(JSON.stringify({ providers: socialProviders }), { status: 200, headers: { "content-type": "application/json" } }),
+);
+const originalFetch = globalThis.fetch;
+globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+import AccountPage from "./page";
+
+function fillPassword(value: string) {
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value } });
+}
+
+beforeEach(() => {
+  routerReplaceMock.mockReset();
+  signUpEmailMock.mockReset();
+  signUpEmailMock.mockImplementation(async () => ({ data: { token: "tok" }, error: null }));
+  signInSocialMock.mockReset();
+  navigatePostAuthMock.mockReset();
+  readDraftMock.mockReset();
+  readDraftMock.mockImplementation(() => ({ email: "jane@example.com" }));
+  clearDraftMock.mockReset();
+  fetchMock.mockClear();
+  socialProviders = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("AccountPage — draft hydration (#3972)", () => {
+  test("a missing signup draft bounces back to /signup (no deep-linking past email)", async () => {
+    readDraftMock.mockImplementation(() => null);
+    render(<AccountPage />);
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith("/signup");
+    });
+  });
+
+  test("renders the draft email so the user knows which account they're creating", async () => {
+    render(<AccountPage />);
+    await waitFor(() => {
+      expect(screen.getByText("jane@example.com")).toBeDefined();
+    });
+  });
+
+  test("Back goes to the region step for a fresh signup (residency configured)", async () => {
+    // useSignupContext mock reports showRegion: true; a non-invitee passed
+    // through the region step, so Back returns there.
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+    const back = screen.getByRole("link", { name: /back/i }) as HTMLAnchorElement;
+    expect(back.getAttribute("href")).toBe("/signup/region");
+  });
+
+  test("Back goes to /signup for an invitee even on a multi-region deploy (region skipped)", async () => {
+    readDraftMock.mockImplementation(() => ({ email: "teammate@acme.com", invitationId: "inv-9" }));
+    render(<AccountPage />);
+    await screen.findByText("teammate@acme.com");
+    const back = screen.getByRole("link", { name: /back/i }) as HTMLAnchorElement;
+    expect(back.getAttribute("href")).toBe("/signup");
+  });
+});
+
+describe("AccountPage — create account on the regional client (#3972)", () => {
+  test("submitting creates the account for the draft email, clears the draft, and hard-navigates to workspace", async () => {
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(signUpEmailMock).toHaveBeenCalledTimes(1);
+    });
+    const arg = signUpEmailMock.mock.calls[0][0];
+    expect(arg.email).toBe("jane@example.com");
+    expect(arg.password).toBe("hunter2hunter2");
+    expect(clearDraftMock).toHaveBeenCalled();
+    expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/workspace");
+  });
+
+  test("verification-required (no token) shows the OTP interstitial; verifying then navigates", async () => {
+    signUpEmailMock.mockImplementation(async () => ({ data: { token: null }, error: null }));
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/enter your code/i)).toBeDefined();
+    });
+    // Not navigated yet — waiting on the code.
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /verify-code/i }));
+    });
+    expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/workspace");
+  });
+
+  test("an invitee is routed to /accept-invitation after creating the account", async () => {
+    readDraftMock.mockImplementation(() => ({ email: "teammate@acme.com", invitationId: "inv-9" }));
+    render(<AccountPage />);
+    await screen.findByText("teammate@acme.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/accept-invitation/inv-9");
+    });
+  });
+
+  test("a signup error is surfaced and does NOT navigate or clear the draft", async () => {
+    signUpEmailMock.mockImplementation(async () => ({ data: null, error: { message: "Email already in use" } }));
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("Email already in use");
+    });
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
+    expect(clearDraftMock).not.toHaveBeenCalled();
+  });
+
+  test("a network failure shows the connection-specific message", async () => {
+    signUpEmailMock.mockImplementation(async () => {
+      throw new TypeError("fetch failed");
+    });
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/unable to reach the server/i);
+    });
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("AccountPage — social sign-in runs post-region (#3972)", () => {
+  test("clicking a social provider clears the draft and signs in with the workspace callback", async () => {
+    socialProviders = ["google"];
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    const googleBtn = await screen.findByRole("button", { name: /continue with google/i });
+    await act(async () => {
+      fireEvent.click(googleBtn);
+    });
+
+    await waitFor(() => {
+      expect(signInSocialMock).toHaveBeenCalledTimes(1);
+    });
+    expect(signInSocialMock.mock.calls[0][0]).toEqual({ provider: "google", callbackURL: "/signup/workspace" });
+    // Draft cleared before handing off to the provider redirect.
+    expect(clearDraftMock).toHaveBeenCalled();
+  });
+
+  test("an invitee's social sign-in carries the accept-invitation callback", async () => {
+    socialProviders = ["google"];
+    readDraftMock.mockImplementation(() => ({ email: "teammate@acme.com", invitationId: "inv-9" }));
+    render(<AccountPage />);
+    await screen.findByText("teammate@acme.com");
+
+    const googleBtn = await screen.findByRole("button", { name: /continue with google/i });
+    await act(async () => {
+      fireEvent.click(googleBtn);
+    });
+
+    await waitFor(() => {
+      expect(signInSocialMock.mock.calls[0][0]).toEqual({ provider: "google", callbackURL: "/accept-invitation/inv-9" });
+    });
+  });
+});

--- a/packages/web/src/app/signup/account/page.tsx
+++ b/packages/web/src/app/signup/account/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth/client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
+import { getApiBase, getCredentials } from "@/lib/fetch-json";
+import { readSignupDraft, clearSignupDraft } from "@/lib/signup-draft";
+import { useSignupContext } from "@/ui/components/signup/signup-context-provider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { GoogleIcon, GitHubIcon, MicrosoftIcon } from "@/ui/components/social-icons";
+import { SignupShell } from "@/ui/components/signup/signup-shell";
+import { VerifyEmailOTPForm } from "@/ui/components/auth/verify-email-otp-form";
+import { Loader2, MailCheck } from "lucide-react";
+
+/**
+ * Account-creation step (ADR-0024 §4) — the FIRST identity write in the flow.
+ *
+ * On the **regional path** (residency configured, fresh signup) this page is
+ * hard-navigated to from the region step (`navigatePostAuth`) with the
+ * `atlas_region` cookie set, so `@/lib/auth/client`'s Better-Auth singleton has
+ * rebuilt against the chosen region's API base — every call here (`signUp.email`,
+ * OTP verify, social sign-in) lands on the regional API and the user /
+ * organization / member / session rows are created in-region.
+ *
+ * Two other paths reach this page WITHOUT a region signal, and that's correct:
+ *   - **Invitee** (`/signup` soft-pushes here, region skipped): joins an org
+ *     whose region is already fixed by the invitation; account lands on the
+ *     default base, matching the pre-reorder invite behavior.
+ *   - **Single-region / no residency** (region step soft-replaces here): there
+ *     is only one API base, so same-origin IS the region.
+ *
+ * The email was collected on `/signup` and carried in the signup draft (it
+ * survives the region step's hard reload, which wipes React state). No draft
+ * means the user deep-linked here — bounce them back to the email step.
+ */
+export default function AccountPage() {
+  const router = useRouter();
+  const ctx = useSignupContext();
+  // `showRegion` reflects only whether residency is configured (the store keys
+  // on config, not on this user's path). It drives the Back affordance together
+  // with `invitationId` below: an invitee skips the region step, so their Back
+  // must go to /signup even on a multi-region deploy.
+  const showRegion = ctx.status === "ready" ? ctx.showRegion : false;
+
+  const [email, setEmail] = useState<string | null>(null);
+  const [invitationId, setInvitationId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [socialLoading, setSocialLoading] = useState<string | null>(null);
+  const [socialProviders, setSocialProviders] = useState<string[]>([]);
+  // Mirrors the prior single-page flow: when email verification is required,
+  // signUp returns no session token and the OTP has already been sent — hold
+  // the email to render the code-entry interstitial instead of navigating.
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+
+  // Hydrate the email/invitation from the signup draft. A missing draft means
+  // the user landed here directly (no email step) — send them back to start.
+  useEffect(() => {
+    const draft = readSignupDraft();
+    if (!draft) {
+      router.replace("/signup");
+      return;
+    }
+    setEmail(draft.email);
+    setInvitationId(draft.invitationId ?? null);
+  }, [router]);
+
+  useEffect(() => {
+    const base = getApiBase();
+    fetch(`${base}/api/v1/onboarding/social-providers`, { credentials: getCredentials() })
+      .then((r) => {
+        if (!r.ok) throw new Error(`Social providers returned ${r.status}`);
+        return r.json();
+      })
+      .then((data: { providers?: string[] }) => {
+        if (Array.isArray(data.providers)) setSocialProviders(data.providers);
+      })
+      .catch((err: unknown) => {
+        // Graceful degradation: email/password form still works.
+        console.warn("Social providers unavailable:", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
+  const postSignupPath = invitationId
+    ? `/accept-invitation/${encodeURIComponent(invitationId)}`
+    : "/signup/workspace";
+  // Invitees skipped the region step (routed straight from /signup), so Back
+  // returns them to the email step — never the region picker they never saw.
+  const backHref = !invitationId && showRegion ? "/signup/region" : "/signup";
+
+  function completeAndNavigate() {
+    // The draft has served its purpose once the account exists; clear it so a
+    // later visit to /signup starts clean.
+    clearSignupDraft();
+    navigatePostAuth(postSignupPath);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email || !password) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await authClient.signUp.email({
+        email,
+        password,
+        name: name || email.split("@")[0],
+      });
+      if (res.error) {
+        setError(res.error.message ?? "Sign up failed");
+        return;
+      }
+      // Verification required → no token, OTP already dispatched: switch to the
+      // code-entry view. Verification off (self-hosted dev) → token present,
+      // navigate straight on. (See the prior single-page flow's rationale.)
+      const token = (res.data as { token?: string | null } | undefined)?.token;
+      if (token) {
+        completeAndNavigate();
+      } else {
+        setPendingEmail(email);
+      }
+    } catch (err) {
+      console.warn("Signup failed:", err instanceof Error ? err.message : String(err));
+      setError(
+        err instanceof TypeError
+          ? "Unable to reach the server. Check your connection and try again."
+          : err instanceof Error
+            ? err.message
+            : "Sign up failed. Please try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSocialLogin(provider: string) {
+    setError(null);
+    setSocialLoading(provider);
+    try {
+      // Social sign-in is also an identity write; it runs here (post-region) so
+      // the OAuth callback lands on the regional API. Clear the draft before the
+      // provider redirect — its only job was to carry the email/invitationId to
+      // this page; the callback target (postSignupPath) doesn't read it, and the
+      // email/invitationId already live in component state for this render.
+      clearSignupDraft();
+      await authClient.signIn.social({
+        provider: provider as "google" | "github" | "microsoft",
+        callbackURL: postSignupPath,
+      });
+    } catch (err) {
+      console.warn("Social login failed:", err instanceof Error ? err.message : String(err));
+      setError(err instanceof Error ? err.message : "Social login failed");
+    } finally {
+      setSocialLoading(null);
+    }
+  }
+
+  // Pre-hydration (or mid-redirect when no draft): render the stepped shell
+  // with a spinner so there's no flash of an empty form.
+  if (!email) {
+    return (
+      <SignupShell step="account" back={{ href: backHref }}>
+        <Card>
+          <CardContent className="flex items-center justify-center p-12">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </SignupShell>
+    );
+  }
+
+  if (pendingEmail) {
+    return (
+      <SignupShell step="account">
+        <Card>
+          <CardHeader className="space-y-3 text-center">
+            <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <MailCheck className="size-6" aria-hidden="true" />
+            </div>
+            <CardTitle className="text-2xl tracking-tight">Enter your code</CardTitle>
+            <CardDescription>
+              We sent an 8-character code to{" "}
+              <span className="font-medium text-foreground">{pendingEmail}</span>.
+              It&apos;s good for the next 10 minutes.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <VerifyEmailOTPForm email={pendingEmail} onVerified={completeAndNavigate} />
+            <p className="text-center text-xs text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => router.replace("/signup")}
+                className="font-medium text-primary hover:underline"
+              >
+                Use a different email
+              </button>
+            </p>
+          </CardContent>
+        </Card>
+      </SignupShell>
+    );
+  }
+
+  return (
+    <SignupShell step="account" back={{ href: backHref }}>
+      <Card>
+        <CardHeader className="space-y-1.5 text-center">
+          <CardTitle className="text-2xl tracking-tight">Create your account</CardTitle>
+          <CardDescription>
+            Signing up as <span className="font-medium text-foreground">{email}</span>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {socialProviders.length > 0 && (
+            <>
+              <div className="grid gap-2">
+                {socialProviders.includes("google") && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    disabled={socialLoading !== null}
+                    onClick={() => handleSocialLogin("google")}
+                  >
+                    <GoogleIcon />
+                    {socialLoading === "google" ? "Redirecting..." : "Continue with Google"}
+                  </Button>
+                )}
+                {socialProviders.includes("github") && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    disabled={socialLoading !== null}
+                    onClick={() => handleSocialLogin("github")}
+                  >
+                    <GitHubIcon />
+                    {socialLoading === "github" ? "Redirecting..." : "Continue with GitHub"}
+                  </Button>
+                )}
+                {socialProviders.includes("microsoft") && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    disabled={socialLoading !== null}
+                    onClick={() => handleSocialLogin("microsoft")}
+                  >
+                    <MicrosoftIcon />
+                    {socialLoading === "microsoft" ? "Redirecting..." : "Continue with Microsoft"}
+                  </Button>
+                )}
+              </div>
+              <div className="relative">
+                <Separator />
+                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+                  or
+                </span>
+              </div>
+            </>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="signup-name">Name</Label>
+              <Input
+                id="signup-name"
+                placeholder="Jane Doe"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup-password">Password</Label>
+              <Input
+                id="signup-password"
+                type="password"
+                placeholder="At least 8 characters"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </div>
+            {error && (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            )}
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={loading || !password}
+            >
+              {loading ? "Creating account..." : "Create account"}
+            </Button>
+          </form>
+
+          <p className="text-center text-xs text-muted-foreground">
+            By signing up, you agree to our{" "}
+            <a href="https://www.useatlas.dev/terms" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+              Terms of Service
+            </a>{" "}
+            and{" "}
+            <a href="https://www.useatlas.dev/privacy" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+              Privacy Policy
+            </a>
+            .
+          </p>
+        </CardContent>
+      </Card>
+    </SignupShell>
+  );
+}

--- a/packages/web/src/app/signup/page.test.tsx
+++ b/packages/web/src/app/signup/page.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Coverage for the signup email step (ADR-0024 §4, #3972).
+ *
+ * The first signup step collects an email (NOT an identity write), stashes it
+ * in the signup draft, and routes forward: invitees skip the region picker and
+ * go straight to /signup/account; everyone else goes to /signup/region. These
+ * tests pin that routing fork plus the draft persistence and pre-fill.
+ *
+ * `mock.module(...)` stubs every named export of the modules it touches (repo
+ * rule). The signup shell is a passthrough so the test exercises the page's
+ * own logic, not the residency-probe dep tree.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, cleanup, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const routerPushMock = mock((_path: string) => {});
+const routerReplaceMock = mock((_path: string) => {});
+const routerMock = { push: routerPushMock, replace: routerReplaceMock, back: () => {} };
+let searchString = "";
+mock.module("next/navigation", () => ({
+  useRouter: () => routerMock,
+  useSearchParams: () => new URLSearchParams(searchString),
+}));
+
+const savePlanIntentMock = mock((_plan: string | null) => {});
+// Mock EVERY value export (repo rule: partial mocks SyntaxError other files).
+mock.module("@/lib/billing/plan-intent", () => ({
+  savePlanIntent: savePlanIntentMock,
+  PAID_TIERS: ["starter", "pro", "business"] as const,
+  isPlanIntent: () => false,
+  consumePlanIntent: () => null,
+}));
+
+const saveDraftMock = mock((_draft: { email: string; invitationId?: string }) => {});
+const readDraftMock = mock((): { email: string; invitationId?: string } | null => null);
+mock.module("@/lib/signup-draft", () => ({
+  saveSignupDraft: saveDraftMock,
+  readSignupDraft: readDraftMock,
+  clearSignupDraft: () => {},
+}));
+
+mock.module("@/ui/components/signup/signup-shell", () => ({
+  SignupShell: ({ children }: { children: unknown }) => <div>{children as never}</div>,
+}));
+
+import SignupPage from "./page";
+
+function typeEmail(value: string) {
+  const input = screen.getByLabelText(/work email/i) as HTMLInputElement;
+  fireEvent.change(input, { target: { value } });
+}
+
+beforeEach(() => {
+  routerPushMock.mockReset();
+  routerReplaceMock.mockReset();
+  savePlanIntentMock.mockReset();
+  saveDraftMock.mockReset();
+  readDraftMock.mockReset();
+  readDraftMock.mockImplementation(() => null);
+  searchString = "";
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SignupPage — email step routing (#3972)", () => {
+  test("a non-invite Continue saves the draft and routes to the region step", () => {
+    render(<SignupPage />);
+    typeEmail("jane@example.com");
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(saveDraftMock).toHaveBeenCalledWith({ email: "jane@example.com", invitationId: undefined });
+    expect(routerPushMock).toHaveBeenCalledWith("/signup/region");
+  });
+
+  test("an invitee skips the region picker and goes to the account step", () => {
+    searchString = "invitationId=inv-123";
+    render(<SignupPage />);
+    typeEmail("teammate@acme.com");
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(saveDraftMock).toHaveBeenCalledWith({ email: "teammate@acme.com", invitationId: "inv-123" });
+    expect(routerPushMock).toHaveBeenCalledWith("/signup/account");
+  });
+
+  test("an empty email shows an error and does not navigate", () => {
+    render(<SignupPage />);
+    // The button is disabled while empty; submit the form directly to prove the
+    // handler guards too (defense in depth).
+    const form = screen.getByLabelText(/work email/i).closest("form")!;
+    fireEvent.submit(form);
+
+    expect(screen.getByRole("alert")).toBeDefined();
+    expect(saveDraftMock).not.toHaveBeenCalled();
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  test("pre-fills the email from an existing draft (Back keeps what was typed)", () => {
+    readDraftMock.mockImplementation(() => ({ email: "returning@example.com" }));
+    render(<SignupPage />);
+    const input = screen.getByLabelText(/work email/i) as HTMLInputElement;
+    expect(input.value).toBe("returning@example.com");
+  });
+});

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
-import { authClient } from "@/lib/auth/client";
+import { useRouter, useSearchParams } from "next/navigation";
 import { savePlanIntent } from "@/lib/billing/plan-intent";
-import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
-import { getApiUrl } from "@/lib/api-url";
+import { saveSignupDraft, readSignupDraft } from "@/lib/signup-draft";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,169 +14,64 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { GoogleIcon, GitHubIcon, MicrosoftIcon } from "@/ui/components/social-icons";
 import { SignupShell } from "@/ui/components/signup/signup-shell";
-import { VerifyEmailOTPForm } from "@/ui/components/auth/verify-email-otp-form";
-import { MailCheck } from "lucide-react";
 
-function getApiBase(): string {
-  const url = getApiUrl();
-  if (url) return url;
-  if (typeof window !== "undefined") return window.location.origin;
-  return "http://localhost:3000";
-}
-
+/**
+ * Email-entry step — the start of the ADR-0024 §4 signup order
+ * (**email → region → create-account**).
+ *
+ * Collecting the email here is NOT an identity write, so picking a region on
+ * the next step still precedes the first Better-Auth write. The email is
+ * stashed in the signup draft (sessionStorage) so it survives the region step's
+ * hard reload, then consumed by `/signup/account`. Region selection points the
+ * browser at the regional API; account creation, OTP, workspace, and connect
+ * then all run in-region.
+ */
 export default function SignupPage() {
-  // `?invitationId=…` is set when the user clicks an org-invitation
-  // email link while signed out and picks "Create account". Threading it
-  // through the signup + OTP flow lets us route to /accept-invitation
-  // post-verify instead of /signup/workspace (joining an existing org
-  // rather than creating their own).
+  const router = useRouter();
+  // `?invitationId=…` is set when the user clicks an org-invitation email link
+  // while signed out and picks "Create account". It rides in the draft so the
+  // account step routes to /accept-invitation post-verify (joining an existing
+  // org) rather than /signup/workspace. An invitee joins an org that already
+  // has a region, so they skip the region picker.
   const searchParams = useSearchParams();
   const invitationId = searchParams.get("invitationId");
-  // `?plan=…` is the pricing-page CTA intent (#3418). The signup flow
-  // spans five hard-navigated steps plus optional OAuth redirects, so the
-  // param can't survive as URL state — stash it; the billing plan picker
-  // consumes it for preselection. Saved in an effect (not render) so
-  // React strict-mode double-render doesn't double-write.
+  // `?plan=…` is the pricing-page CTA intent (#3418). Stashed (not URL state)
+  // because the multi-step flow + OAuth redirects drop the param; the billing
+  // plan picker consumes it later. Saved in an effect so strict-mode's double
+  // render doesn't double-write.
   const planParam = searchParams.get("plan");
   useEffect(() => {
     savePlanIntent(planParam);
   }, [planParam]);
-  const postSignupPath = invitationId
-    ? `/accept-invitation/${encodeURIComponent(invitationId)}`
-    : "/signup/workspace";
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [socialLoading, setSocialLoading] = useState<string | null>(null);
-  const [socialProviders, setSocialProviders] = useState<string[]>([]);
-  // When email verification is required server-side, signup does not create
-  // a session — we can't push to /signup/workspace because the proxy will
-  // bounce the unauthenticated user to /login. Hold the email here to
-  // render the "check your inbox" interstitial instead. The verification
-  // link's callbackURL bounces the user back to /signup/workspace post-verify
-  // (Better Auth auto-signs them in via `autoSignInAfterVerification`).
-  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
 
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Pre-fill from an existing draft so Back from the region/account step keeps
+  // the email the user already typed.
   useEffect(() => {
-    const base = getApiBase();
-    fetch(`${base}/api/v1/onboarding/social-providers`)
-      .then((r) => {
-        if (!r.ok) throw new Error(`Social providers returned ${r.status}`);
-        return r.json();
-      })
-      .then((data: { providers?: string[] }) => {
-        if (Array.isArray(data.providers)) setSocialProviders(data.providers);
-      })
-      .catch((err: unknown) => {
-        // Graceful degradation: email/password form still works
-        console.warn("Social providers unavailable:", err instanceof Error ? err.message : String(err));
-      });
+    const draft = readSignupDraft();
+    if (draft?.email) setEmail(draft.email);
   }, []);
 
-  async function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!email || !password) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await authClient.signUp.email({
-        email,
-        password,
-        name: name || email.split("@")[0],
-      });
-      if (res.error) {
-        setError(res.error.message ?? "Sign up failed");
-        return;
-      }
-      // When verification is required server-side, Better Auth omits the
-      // session token from the signup response and the emailOTP plugin's
-      // `sendVerificationOnSignUp: true` has already dispatched the OTP.
-      // Switch to the OTP entry view; the form will land the user back on
-      // /signup/workspace once the code is verified (session is established
-      // as part of the verify call). When verification is off (self-hosted
-      // dev), the response carries a token and we can push directly.
-      const token = (res.data as { token?: string | null } | undefined)?.token;
-      if (token) {
-        // Hard nav after auth — see post-auth-nav for the rationale. Same
-        // applies on the OTP-verified branch below.
-        navigatePostAuth(postSignupPath);
-      } else {
-        setPendingEmail(email);
-      }
-    } catch (err) {
-      console.warn("Signup failed:", err instanceof Error ? err.message : String(err));
-      setError(
-        err instanceof TypeError
-          ? "Unable to reach the server. Check your connection and try again."
-          : err instanceof Error
-            ? err.message
-            : "Sign up failed. Please try again.",
-      );
-    } finally {
-      setLoading(false);
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setError("Enter your work email to continue.");
+      return;
     }
-  }
-
-  async function handleSocialLogin(provider: string) {
     setError(null);
-    setSocialLoading(provider);
-    try {
-      await authClient.signIn.social({
-        provider: provider as "google" | "github" | "microsoft",
-        callbackURL: postSignupPath,
-      });
-    } catch (err) {
-      console.warn("Social login failed:", err instanceof Error ? err.message : String(err));
-      setError(err instanceof Error ? err.message : "Social login failed");
-    } finally {
-      setSocialLoading(null);
-    }
-  }
-
-  if (pendingEmail) {
-    return (
-      <SignupShell step="account">
-        <Card>
-          <CardHeader className="space-y-3 text-center">
-            <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-              <MailCheck className="size-6" aria-hidden="true" />
-            </div>
-            <CardTitle className="text-2xl tracking-tight">Enter your code</CardTitle>
-            <CardDescription>
-              We sent an 8-character code to{" "}
-              <span className="font-medium text-foreground">{pendingEmail}</span>.
-              It&apos;s good for the next 10 minutes.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <VerifyEmailOTPForm
-              email={pendingEmail}
-              onVerified={() => navigatePostAuth(postSignupPath)}
-            />
-            <p className="text-center text-xs text-muted-foreground">
-              <button
-                type="button"
-                onClick={() => setPendingEmail(null)}
-                className="font-medium text-primary hover:underline"
-              >
-                Use a different email
-              </button>
-            </p>
-          </CardContent>
-        </Card>
-      </SignupShell>
-    );
+    saveSignupDraft({ email: trimmed, invitationId: invitationId ?? undefined });
+    // Invitees join an existing org (fixed region) — skip the picker. Everyone
+    // else goes to the region step; it auto-skips to /signup/account when no
+    // residency is configured (self-hosted / single-region).
+    router.push(invitationId ? "/signup/account" : "/signup/region");
   }
 
   return (
-    <SignupShell step="account">
+    <SignupShell step="email">
       <Card>
         <CardHeader className="space-y-1.5 text-center">
           <CardTitle className="text-2xl tracking-tight">Create your account</CardTitle>
@@ -187,63 +80,7 @@ export default function SignupPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {socialProviders.length > 0 && (
-            <>
-              <div className="grid gap-2">
-                {socialProviders.includes("google") && (
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    disabled={socialLoading !== null}
-                    onClick={() => handleSocialLogin("google")}
-                  >
-                    <GoogleIcon />
-                    {socialLoading === "google" ? "Redirecting..." : "Continue with Google"}
-                  </Button>
-                )}
-                {socialProviders.includes("github") && (
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    disabled={socialLoading !== null}
-                    onClick={() => handleSocialLogin("github")}
-                  >
-                    <GitHubIcon />
-                    {socialLoading === "github" ? "Redirecting..." : "Continue with GitHub"}
-                  </Button>
-                )}
-                {socialProviders.includes("microsoft") && (
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    disabled={socialLoading !== null}
-                    onClick={() => handleSocialLogin("microsoft")}
-                  >
-                    <MicrosoftIcon />
-                    {socialLoading === "microsoft" ? "Redirecting..." : "Continue with Microsoft"}
-                  </Button>
-                )}
-              </div>
-              <div className="relative">
-                <Separator />
-                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-[11px] uppercase tracking-wider text-muted-foreground">
-                  or
-                </span>
-              </div>
-            </>
-          )}
-
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="signup-name">Name</Label>
-              <Input
-                id="signup-name"
-                placeholder="Jane Doe"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                autoFocus
-              />
-            </div>
             <div className="space-y-2">
               <Label htmlFor="signup-email">Work email</Label>
               <Input
@@ -253,18 +90,7 @@ export default function SignupPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="signup-password">Password</Label>
-              <Input
-                id="signup-password"
-                type="password"
-                placeholder="At least 8 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                minLength={8}
+                autoFocus
               />
             </div>
             {error && (
@@ -272,17 +98,13 @@ export default function SignupPage() {
                 {error}
               </p>
             )}
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={loading || !email || !password}
-            >
-              {loading ? "Creating account..." : "Create account"}
+            <Button type="submit" className="w-full" disabled={!email.trim()}>
+              Continue
             </Button>
           </form>
 
           <p className="text-center text-xs text-muted-foreground">
-            By signing up, you agree to our{" "}
+            By continuing, you agree to our{" "}
             <a href="https://www.useatlas.dev/terms" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
               Terms of Service
             </a>{" "}

--- a/packages/web/src/app/signup/region/page.test.tsx
+++ b/packages/web/src/app/signup/region/page.test.tsx
@@ -1,15 +1,20 @@
 /**
- * Coverage for the signup region step (#3925).
+ * Coverage for the signup region step (#3925, #3972).
  *
- * The step auto-skips to /signup/connect when no residency is configured, and
- * — the change under test — pairs a region-load *failure* with an in-place
- * Retry instead of dead-ending the user on a disabled Continue with only the
- * Back link. There is no e2e coverage for this page, so these unit tests pin
- * both the no-dead-end paths (auto-skip on empty, Retry on error).
+ * Under ADR-0024 §4 the region is chosen BEFORE account creation: selecting a
+ * region repoints the browser at the regional API (`applyRegionSignal`) and
+ * hard-navigates to /signup/account (so the Better-Auth client rebuilds against
+ * the regional base) — it no longer POSTs the auth-gated /assign-region. When
+ * no residency is configured it auto-skips straight to /signup/account.
+ *
+ * The earlier #3925/#3934 change pairs a region-load *failure* with an in-place
+ * Retry instead of dead-ending the user. There is no e2e coverage for this
+ * page, so these unit tests pin both the no-dead-end paths and the new pre-auth
+ * region-selection contract.
  *
  * `mock.module(...)` stubs every named export of the modules it touches (per
  * repo rule). The signup shell + region grid are mocked to passthroughs so the
- * test exercises the page's load/retry logic, not their dep trees.
+ * test exercises the page's load/retry/select logic, not their dep trees.
  */
 
 import { describe, expect, test, mock, beforeEach, afterEach, afterAll } from "bun:test";
@@ -27,10 +32,30 @@ mock.module("next/navigation", () => ({
   useRouter: () => routerMock,
 }));
 
-// `@/lib/api-url` is used unmocked: with NEXT_PUBLIC_ATLAS_API_URL empty in the
-// test env, getApiUrl() → "" and isCrossOrigin() → false (so getApiBase() falls
-// back to window.location.origin). No atlas_region cookie is set here, so the
-// module's import-time restore is a no-op.
+// `@/lib/api-url` — getApiUrl()/isCrossOrigin() keep getApiBase() on the
+// same-origin fallback; applyRegionSignal is spied so we can assert the region
+// step repoints the browser (and can simulate a rejected base). Mock EVERY
+// named value export (repo rule: partial mocks SyntaxError other files).
+const applyRegionSignalMock = mock((_region: string, _apiUrl: string) => true);
+mock.module("@/lib/api-url", () => ({
+  getApiUrl: () => "",
+  isCrossOrigin: () => false,
+  applyRegionSignal: applyRegionSignalMock,
+  getActiveRegion: () => null,
+  clearRegionSignal: () => {},
+  initRegionFromCookie: () => null,
+  secureCookieAttr: () => "",
+  REGION_COOKIE: "atlas_region",
+  _resetApiUrl: () => {},
+}));
+
+// The region→account transition is a HARD nav (rebuilds the regional auth
+// client). Mock the one centralized hard-nav helper so we can assert the target.
+const navigatePostAuthMock = mock((_path: string) => {});
+mock.module("@/lib/auth/post-auth-nav", () => ({
+  navigatePostAuth: navigatePostAuthMock,
+}));
+
 mock.module("@/ui/components/signup/signup-shell", () => ({
   SignupShell: ({ children, back }: { children: unknown; back?: { href: string } }) => (
     <div>
@@ -41,7 +66,23 @@ mock.module("@/ui/components/signup/signup-shell", () => ({
 }));
 
 mock.module("@/ui/components/region-picker", () => ({
-  RegionCardGrid: () => <div data-testid="region-grid" />,
+  // Interactive passthrough: render a select button per region so a test can
+  // pick a NON-default region (the page preselects only the default).
+  RegionCardGrid: ({
+    regions,
+    onSelect,
+  }: {
+    regions: { id: string }[];
+    onSelect: (id: string) => void;
+  }) => (
+    <div data-testid="region-grid">
+      {regions.map((r) => (
+        <button key={r.id} type="button" onClick={() => onSelect(r.id)}>
+          {`select-${r.id}`}
+        </button>
+      ))}
+    </div>
+  ),
   ComplianceBadge: () => null,
 }));
 
@@ -69,7 +110,8 @@ function regionsConfigured(): Response {
     JSON.stringify({
       configured: true,
       defaultRegion: "us",
-      availableRegions: [{ id: "us", label: "United States", isDefault: true }],
+      // apiUrl rides along (ADR-0024 §4) so the page can repoint the browser.
+      availableRegions: [{ id: "us", label: "United States", isDefault: true, apiUrl: "https://api.useatlas.dev" }],
     }),
     { status: 200, headers: { "content-type": "application/json" } },
   );
@@ -79,6 +121,9 @@ beforeEach(() => {
   routerReplaceMock.mockReset();
   routerPushMock.mockReset();
   fetchMock.mockReset();
+  applyRegionSignalMock.mockReset();
+  applyRegionSignalMock.mockImplementation(() => true);
+  navigatePostAuthMock.mockReset();
 });
 
 afterEach(() => {
@@ -177,15 +222,132 @@ describe("RegionPage — load failure recovery (#3925)", () => {
 });
 
 describe("RegionPage — auto-skip when no residency configured", () => {
-  test("an unconfigured/empty response advances to /signup/connect (not a dead end)", async () => {
+  test("an unconfigured/empty response advances to /signup/account (not a dead end)", async () => {
     fetchMock.mockImplementation(async () => regionsUnconfigured());
     render(<RegionPage />);
 
     await waitFor(() => {
-      expect(routerReplaceMock).toHaveBeenCalledWith("/signup/connect");
+      // ADR-0024 §4: with no residency there's one API base, so skip straight to
+      // account creation on it (was /signup/connect in the pre-reorder flow).
+      expect(routerReplaceMock).toHaveBeenCalledWith("/signup/account");
     });
     // Auto-skip is the deliberate no-dead-end path for the empty case — no
     // error, no Retry button.
     expect(screen.queryByRole("button", { name: /^retry$/i })).toBeNull();
+  });
+});
+
+describe("RegionPage — region selection repoints pre-auth (ADR-0024 §4, #3972)", () => {
+  test("Continue applies the region signal then hard-navigates to /signup/account", async () => {
+    fetchMock.mockImplementation(async () => regionsConfigured());
+    render(<RegionPage />);
+
+    // The default region ("us") is preselected on load, enabling Continue.
+    const cont = await screen.findByRole("button", { name: /continue with default region/i });
+    await act(async () => {
+      fireEvent.click(cont);
+    });
+
+    await waitFor(() => {
+      expect(applyRegionSignalMock).toHaveBeenCalledWith("us", "https://api.useatlas.dev");
+    });
+    // Hard nav (rebuilds the regional auth client) to the account step.
+    expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/account");
+  });
+
+  test("Continue does NOT POST the auth-gated /assign-region (region is pre-auth now)", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/onboarding/regions")) return regionsConfigured();
+      return regionsFailure();
+    });
+    render(<RegionPage />);
+
+    const cont = await screen.findByRole("button", { name: /continue with default region/i });
+    await act(async () => {
+      fireEvent.click(cont);
+    });
+    await waitFor(() => expect(navigatePostAuthMock).toHaveBeenCalled());
+
+    const assignCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("assign-region"),
+    );
+    expect(assignCalls.length).toBe(0);
+  });
+
+  test("a configured region with no apiUrl proceeds without repointing (single-region deploy)", async () => {
+    // A region config without apiUrl means one API base — nothing to repoint —
+    // so the page must NOT call applyRegionSignal but still advance to account.
+    fetchMock.mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          configured: true,
+          defaultRegion: "local",
+          availableRegions: [{ id: "local", label: "Local", isDefault: true }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    render(<RegionPage />);
+
+    const cont = await screen.findByRole("button", { name: /continue with default region/i });
+    await act(async () => {
+      fireEvent.click(cont);
+    });
+
+    await waitFor(() => expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/account"));
+    expect(applyRegionSignalMock).not.toHaveBeenCalled();
+  });
+
+  test("refuses a NON-default region missing apiUrl instead of silently using the default base", async () => {
+    // A selectable non-default region with no apiUrl is a misconfig; proceeding
+    // would create the account in the default (US) region — the silent dead-end
+    // #3967/#3971 kill. The page must error and not navigate.
+    fetchMock.mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          configured: true,
+          defaultRegion: "us",
+          availableRegions: [
+            { id: "us", label: "United States", isDefault: true, apiUrl: "https://api.useatlas.dev" },
+            { id: "eu", label: "Europe", isDefault: false }, // misconfig: no apiUrl
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    render(<RegionPage />);
+
+    // Pick the misconfigured non-default region, then Continue.
+    const euBtn = await screen.findByRole("button", { name: /select-eu/i });
+    await act(async () => {
+      fireEvent.click(euBtn);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/isn.t fully configured for signup/i)).toBeDefined();
+    });
+    expect(applyRegionSignalMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
+  });
+
+  test("a rejected region signal surfaces an error and does not navigate", async () => {
+    // applyRegionSignal returns false for a non-credential-safe base — the page
+    // must not hard-navigate (which would create the account in the US region).
+    applyRegionSignalMock.mockImplementation(() => false);
+    fetchMock.mockImplementation(async () => regionsConfigured());
+    render(<RegionPage />);
+
+    const cont = await screen.findByRole("button", { name: /continue with default region/i });
+    await act(async () => {
+      fireEvent.click(cont);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn.t route you to the selected region/i)).toBeDefined();
+    });
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/app/signup/region/page.tsx
+++ b/packages/web/src/app/signup/region/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
-import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { getApiUrl, isCrossOrigin, applyRegionSignal } from "@/lib/api-url";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -61,9 +62,11 @@ export default function RegionPage() {
       .then((raw) => RegionsResponseSchema.parse(raw))
       .then((data) => {
         if (!data.configured || data.availableRegions.length === 0) {
-          // No residency configured — skip to connect
+          // No residency configured (self-hosted / single-region) — there's
+          // nothing to pick and only one API base, so skip straight to account
+          // creation on it. `replace` keeps this transient step out of history.
           setSkipping(true);
-          router.replace("/signup/connect");
+          router.replace("/signup/account");
           return;
         }
         setRegions(data.availableRegions);
@@ -93,47 +96,52 @@ export default function RegionPage() {
     loadRegions();
   }, [loadRegions]);
 
-  async function handleContinue() {
+  function handleContinue() {
     if (!selected) return;
 
     setSaving(true);
     setError(null);
 
-    try {
-      const base = getApiBase();
-      const res = await fetch(`${base}/api/v1/onboarding/assign-region`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: getCredentials(),
-        body: JSON.stringify({ region: selected }),
-      });
+    // Under ADR-0024 §4 the region is chosen BEFORE the first identity write,
+    // so there is no session yet and nothing to POST to a server. Instead, the
+    // selection repoints the browser at the region's API base and persists the
+    // `atlas_region` cookie (`applyRegionSignal`, #3971). The org's region is
+    // then stamped from the ambient `ATLAS_API_REGION` when the workspace is
+    // created on that regional API (#3969) — no post-hoc `assign-region`.
+    const region = regions.find((r) => r.id === selected);
+    const apiUrl = region?.apiUrl;
 
-      let data: Record<string, unknown>;
-      try {
-        data = await res.json() as Record<string, unknown>;
-      } catch (parseErr) {
-        console.warn("Failed to parse assign-region response:", parseErr instanceof Error ? parseErr.message : String(parseErr));
-        setError("Server returned an unexpected response. Please try again.");
+    if (apiUrl) {
+      if (!applyRegionSignal(selected, apiUrl)) {
+        // applyRegionSignal logged the rejected base; surface it rather than
+        // hard-navigate to a region we couldn't actually point the browser at,
+        // which would silently create the account in the default (US) region.
+        setError("We couldn't route you to the selected region. Please try again or contact support.");
+        setSaving(false);
         return;
       }
-
-      if (!res.ok) {
-        setError(typeof data.message === "string" ? data.message : "Failed to assign region");
-        return;
-      }
-
-      router.push("/signup/connect");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn("Region assignment failed:", message);
-      setError(
-        err instanceof TypeError
-          ? "Unable to reach the server. Check your connection and try again."
-          : `Failed to assign region: ${message}`,
-      );
-    } finally {
+    } else if (!region?.isDefault) {
+      // A *non-default* selectable region with no apiUrl is a deploy
+      // misconfiguration: there's nothing to repoint to, so falling through
+      // would create the account on the default (US) base — the exact silent
+      // wrong-region dead-end this flow exists to kill (#3967/#3971). Refuse,
+      // the same as a rejected signal, instead of proceeding on a warning.
+      console.error(`Region "${selected}" is selectable but has no apiUrl; refusing to fall back to the default region.`);
+      setError("This region isn't fully configured for signup yet. Please contact support.");
       setSaving(false);
+      return;
     }
+    // Only path left without a repoint: the DEFAULT region on a single-region /
+    // local deploy (its own apiUrl omitted) — the same-origin base IS that one
+    // region, so creating the account on it is correct, not a fallback.
+
+    // HARD navigation (full reload via navigatePostAuth), not router.push:
+    // `@/lib/auth/client`'s Better-Auth singleton captured its baseURL at module
+    // import, so only a fresh page load re-reads the `atlas_region` cookie and
+    // rebuilds the client against the regional base. A soft nav would create the
+    // account on the pre-region (default) API. The account step then runs
+    // entirely in-region.
+    navigatePostAuth("/signup/account");
   }
 
   if (loading || skipping) {
@@ -149,7 +157,7 @@ export default function RegionPage() {
   }
 
   return (
-    <SignupShell step="region" width="wide" back={{ href: "/signup/workspace" }}>
+    <SignupShell step="region" width="wide" back={{ href: "/signup" }}>
       <Card>
         <CardHeader className="space-y-1.5 text-center">
           <CardTitle className="text-2xl tracking-tight">Choose your data region</CardTitle>

--- a/packages/web/src/app/signup/workspace/page.test.tsx
+++ b/packages/web/src/app/signup/workspace/page.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Coverage for the signup workspace step nav target (ADR-0024 §4, #3972).
+ *
+ * Region now precedes account creation, so after the workspace is created
+ * (its region already stamped from the ambient ATLAS_API_REGION at creation,
+ * #3969) the flow proceeds to /signup/connect — NOT back to /signup/region as
+ * in the pre-reorder flow. This pins that redirect target so a regression can't
+ * silently loop a just-created workspace back to the region picker.
+ *
+ * `mock.module(...)` stubs every named export of the modules it touches (repo
+ * rule). The signup shell is a passthrough so the test exercises this page.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const routerPushMock = mock((_path: string) => {});
+const routerMock = { push: routerPushMock, replace: () => {}, back: () => {} };
+mock.module("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+const orgCreateMock = mock(async (_opts: { name: string; slug: string }) => ({
+  data: { id: "org-1" },
+  error: null as { message?: string } | null,
+}));
+const setActiveMock = mock(async (_opts: { organizationId: string }) => ({ data: {}, error: null }));
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    organization: { create: orgCreateMock, setActive: setActiveMock },
+  },
+}));
+
+mock.module("@/ui/components/signup/signup-shell", () => ({
+  SignupShell: ({ children }: { children: unknown }) => <div>{children as never}</div>,
+}));
+
+import WorkspacePage from "./page";
+
+beforeEach(() => {
+  routerPushMock.mockReset();
+  orgCreateMock.mockReset();
+  orgCreateMock.mockImplementation(async () => ({ data: { id: "org-1" }, error: null }));
+  setActiveMock.mockReset();
+  setActiveMock.mockImplementation(async () => ({ data: {}, error: null }));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WorkspacePage — proceeds to connect, not region (#3972)", () => {
+  test("creating a workspace routes forward to /signup/connect", async () => {
+    render(<WorkspacePage />);
+
+    fireEvent.change(screen.getByLabelText(/workspace name/i), { target: { value: "Acme Corp" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    });
+
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(routerPushMock).toHaveBeenCalledWith("/signup/connect");
+    // Must not loop back to the (now-upstream) region step.
+    expect(routerPushMock).not.toHaveBeenCalledWith("/signup/region");
+  });
+});

--- a/packages/web/src/app/signup/workspace/page.tsx
+++ b/packages/web/src/app/signup/workspace/page.tsx
@@ -100,7 +100,10 @@ export default function WorkspacePage() {
         }
       }
 
-      router.push("/signup/region");
+      // Region was chosen before account creation (ADR-0024 §4) and the org was
+      // stamped with the ambient region at creation (#3969) — workspace setup
+      // flows straight to connecting a datasource, not a post-hoc region pick.
+      router.push("/signup/connect");
     } catch (err) {
       setSubmitError(
         err instanceof TypeError

--- a/packages/web/src/lib/__tests__/signup-draft.test.ts
+++ b/packages/web/src/lib/__tests__/signup-draft.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Coverage for the signup draft (ADR-0024 §4, #3972).
+ *
+ * The draft carries the collected email (+ optional invitationId) across the
+ * region step's hard reload via sessionStorage. These tests pin the round-trip,
+ * the invitation passthrough, and the defensive reads (missing / malformed /
+ * email-less values resolve to null rather than throwing).
+ */
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { saveSignupDraft, readSignupDraft, clearSignupDraft } from "../signup-draft";
+
+const KEY = "atlas:signup:draft";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("signup-draft", () => {
+  test("round-trips the email", () => {
+    saveSignupDraft({ email: "jane@example.com" });
+    expect(readSignupDraft()).toEqual({ email: "jane@example.com", invitationId: undefined });
+  });
+
+  test("carries the invitationId when present", () => {
+    saveSignupDraft({ email: "teammate@acme.com", invitationId: "inv-9" });
+    expect(readSignupDraft()).toEqual({ email: "teammate@acme.com", invitationId: "inv-9" });
+  });
+
+  test("returns null when no draft is stored", () => {
+    expect(readSignupDraft()).toBeNull();
+  });
+
+  test("ignores a malformed (unparseable) draft instead of throwing", () => {
+    sessionStorage.setItem(KEY, "{not json");
+    expect(readSignupDraft()).toBeNull();
+  });
+
+  test("ignores a draft with no email (an incomplete write)", () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ invitationId: "inv-9" }));
+    expect(readSignupDraft()).toBeNull();
+  });
+
+  test("clearSignupDraft removes the stored draft", () => {
+    saveSignupDraft({ email: "jane@example.com" });
+    clearSignupDraft();
+    expect(readSignupDraft()).toBeNull();
+  });
+});

--- a/packages/web/src/lib/auth/post-auth-nav.ts
+++ b/packages/web/src/lib/auth/post-auth-nav.ts
@@ -14,6 +14,13 @@
  * we centralize it here so tests have one mock point and the rationale
  * lives next to the call sites that need it.
  *
+ * Also used for the signup region→account boundary (ADR-0024 §4): selecting a
+ * region repoints the API base via the `atlas_region` cookie, but the
+ * `@/lib/auth/client` Better-Auth singleton fixed its baseURL at module import.
+ * Only a full reload re-reads the cookie and rebuilds that client against the
+ * regional base, so account creation lands in-region — a `router.push` would
+ * keep the stale (default) client and write to the wrong region.
+ *
  * Don't use this for in-app navigation between two pages that share an
  * authenticated session — `router.push` keeps the SPA experience.
  */

--- a/packages/web/src/lib/signup-draft.ts
+++ b/packages/web/src/lib/signup-draft.ts
@@ -1,0 +1,79 @@
+/**
+ * Transient signup draft carried across the email → region → account steps.
+ *
+ * Under ADR-0024 §4 the signup order is **email → region → create-account**.
+ * Selecting a region repoints the browser at that region's API and forces a
+ * hard reload (so the Better-Auth client singleton rebuilds against the
+ * regional base — see `@/lib/api-url` + `@/lib/auth/client`). A hard reload
+ * wipes React state, so the email collected on `/signup` can't survive to
+ * `/signup/account` in memory — it rides in `sessionStorage` instead.
+ *
+ * Email is deliberately NOT threaded as a URL query param: it's PII and would
+ * leak into history, server logs, and the Referer header. `invitationId` (an
+ * opaque token already present in the inbound `/signup?invitationId=…` URL)
+ * rides along so the account step can route a verified invitee to
+ * `/accept-invitation/<id>` instead of the workspace step.
+ *
+ * Scoped to `sessionStorage` (per-tab, cleared on tab close) and wiped by
+ * `clearSignupDraft()` once the account is created.
+ */
+
+const DRAFT_KEY = "atlas:signup:draft";
+
+export interface SignupDraft {
+  /** The email the user entered on the first signup step. */
+  email: string;
+  /**
+   * Org-invitation token from `/signup?invitationId=…`, when the user is
+   * creating an account to accept an invitation rather than starting fresh.
+   */
+  invitationId?: string;
+}
+
+export function saveSignupDraft(draft: SignupDraft): void {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    sessionStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  } catch (err) {
+    // A full/blocked sessionStorage is non-fatal — the account step falls back
+    // to redirecting to /signup. Surface it rather than swallow (CLAUDE.md).
+    console.warn(
+      "signup-draft: failed to persist signup draft:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export function readSignupDraft(): SignupDraft | null {
+  if (typeof sessionStorage === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(DRAFT_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { email, invitationId } = parsed as Record<string, unknown>;
+    if (typeof email !== "string" || !email) return null;
+    return {
+      email,
+      invitationId: typeof invitationId === "string" && invitationId ? invitationId : undefined,
+    };
+  } catch (err) {
+    console.warn(
+      "signup-draft: ignoring an unreadable signup draft:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+}
+
+export function clearSignupDraft(): void {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    sessionStorage.removeItem(DRAFT_KEY);
+  } catch (err) {
+    console.warn(
+      "signup-draft: failed to clear signup draft:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -82,8 +82,25 @@ const cspEnv = process.env.NODE_ENV === "development" ? "dev" : "prod";
 // default/trim (mirrors the API's resolveCookiePrefix and is unit-tested).
 const cookiePrefix = resolveWebCookiePrefix(process.env.NEXT_PUBLIC_ATLAS_COOKIE_PREFIX);
 
-/** Routes that only unauthenticated users should see (exact match). */
-const authRoutes = ["/signup", "/login", "/forgot-password", "/reset-password"];
+/**
+ * Routes that only unauthenticated users should see (exact match).
+ *
+ * `/signup/region` and `/signup/account` are the pre-auth signup steps under
+ * ADR-0024 §4 (email → region → create-account): the region is picked and the
+ * account is created BEFORE any session exists, so on a same-origin managed
+ * deploy they must be reachable while signed out — otherwise the redirect below
+ * bounces every regional signup to /login mid-flow. The remaining sub-steps
+ * (/signup/workspace, /signup/connect, /signup/success) run post-account and
+ * stay session-gated (absent from this list).
+ */
+const authRoutes = [
+  "/signup",
+  "/signup/region",
+  "/signup/account",
+  "/login",
+  "/forgot-password",
+  "/reset-password",
+];
 
 /** Routes that are always accessible regardless of auth state. */
 const publicPrefixes = [...PUBLIC_ROUTE_PREFIXES, "/api", "/_next"];
@@ -92,9 +109,14 @@ function isPublicRoute(pathname: string): boolean {
   return publicPrefixes.some((prefix) => pathname.startsWith(prefix));
 }
 
-function isAuthRoute(pathname: string): boolean {
-  // Exact match only — sub-routes like /signup/workspace are onboarding
-  // steps that require an active session and must not redirect away.
+// Exported for unit testing the pre-auth-route membership (ADR-0024 §4) without
+// standing up a NextRequest + the module-level NEXT_PUBLIC_* env reads, which
+// the `??=` import-hoist gotcha (#3939) makes brittle across local vs CI.
+export function isAuthRoute(pathname: string): boolean {
+  // Exact match only — the post-account sub-steps (/signup/workspace,
+  // /signup/connect, /signup/success) are NOT listed and so require an active
+  // session and must not redirect away. The pre-auth steps (/signup/region,
+  // /signup/account) ARE listed (ADR-0024 §4) so signed-out users can reach them.
   return authRoutes.some((route) => pathname === route);
 }
 

--- a/packages/web/src/ui/components/signup/signup-steps.ts
+++ b/packages/web/src/ui/components/signup/signup-steps.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Building2, CheckCircle2, Database, MapPin, UserPlus } from "lucide-react";
+import { Building2, CheckCircle2, Database, Mail, MapPin, UserPlus } from "lucide-react";
 
 export interface SignupStepDef {
   readonly id: string;
@@ -11,10 +11,18 @@ export interface SignupStepDef {
 // is derived from a single source of truth. Adding, removing, or renaming an
 // entry here is the only thing needed — every consumer picks it up at compile
 // time.
+//
+// Order encodes ADR-0024 §4's signup reorder: **email → region → account** →
+// workspace → connect. Region is chosen *before* the first identity write
+// (account creation), so the workspace is provisioned in the selected region's
+// DB rather than US. "Email" (identifier entry, not a write) leads so the
+// region picker can repoint the browser at the regional API before account
+// creation. The order is strictly forward — each page maps to exactly one step.
 export const FULL_STEPS = [
+  { id: "email", label: "Email", icon: Mail },
+  { id: "region", label: "Region", icon: MapPin },
   { id: "account", label: "Account", icon: UserPlus },
   { id: "workspace", label: "Workspace", icon: Building2 },
-  { id: "region", label: "Region", icon: MapPin },
   { id: "connect", label: "Connect", icon: Database },
   { id: "done", label: "Done", icon: CheckCircle2 },
 ] as const satisfies readonly SignupStepDef[];


### PR DESCRIPTION
## Summary

Reorders the SaaS signup flow to **email → region → create-account** (ADR-0024 §4) so a workspace's identity rows (`user`/`organization`/`member`/`session`) are provisioned in the **selected region's** internal DB rather than always US. Builds directly on the sibling slices' plumbing: #3971 (`applyRegionSignal` + `atlas_region` cookie + pre-auth regional base), #3970 (host-only per-region cookies + CORS), #3969 (org region stamped from ambient `ATLAS_API_REGION` at creation).

**Frontend (the reorder):**
- New `/signup` email step (no identity write) → `/signup/region` → new `/signup/account` (account creation). A `signup-draft` (sessionStorage) carries the email across the region step's hard reload.
- `/signup/region` now calls `applyRegionSignal(region, apiUrl)` (persists `atlas_region`) and **hard-navigates** to `/signup/account` so the Better-Auth client singleton rebuilds against the regional base — it no longer POSTs the (auth-gated) `/assign-region`. A non-default selectable region missing `apiUrl` is **refused** rather than silently falling back to US.
- `/signup/workspace` now flows forward to `/signup/connect` (region is upstream); step model reordered to email → region → account → workspace → connect.
- `proxy.ts`: `/signup/region` + `/signup/account` are pre-auth steps, reachable while signed out on a same-origin managed deploy.

**Backend:**
- `GET /api/v1/onboarding/regions` is now **public** (pre-auth) — the picker renders before any session exists; payload is static config, no PII.
- `RegionPickerItem` carries each region's `apiUrl` (types + schema + picker + regenerated `openapi.json`) so the browser can repoint before the first identity write.

## Test plan
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] Full `bun run test` — 729 pass; 3 failures are the documented WSL2/vercel-sandbox false-failures in `src/lib/tools/` (untouched here, green in CI)
- [x] New unit tests: email-step routing fork, region selection (applies signal + hard-nav, refuses non-default-no-apiUrl, no assign-region), account create/OTP/invite/social/error paths, signup-draft round-trip, `/regions` public, picker/schema `apiUrl`, proxy pre-auth route membership, workspace→connect nav
- [x] All drift gates (openapi, schema, template, railway-watch, …) pass
- [ ] Post-deploy: verify an EU-selected signup lands identity rows in EU (api-eu serves; api.useatlas.dev 401s) via `/verify-prod-signup`

Closes #3972

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reorder signup flow to collect region before the first identity write
> - `/signup` is now an email-only entry step that persists the email (and optional `invitationId`) to a sessionStorage draft via a new [`signup-draft`](https://github.com/AtlasDevHQ/atlas/pull/4004/files#diff-592fcceed0f700d79906710e56aecbc86e7c96036c3f5ffe67bb0fe8d62d413b) utility, then routes to `/signup/region` (or `/signup/account` for invitees).
> - `/signup/region` now runs pre-auth: it applies the region API base via `applyRegionSignal` without calling the authenticated `/onboarding/assign-region` endpoint, then hard-navigates to `/signup/account`.
> - A new [`/signup/account`](https://github.com/AtlasDevHQ/atlas/pull/4004/files#diff-092a69da43e6b0f6caa1cb007381ac2b427f0d217437a5187ce1f1566e1d4272) page handles the actual account creation step, supporting email+password with OTP interstitial and social sign-in.
> - The `/api/v1/onboarding/regions` endpoint is made public (pre-auth), removing the session/org auth requirement so it can be called before identity creation.
> - `RegionPickerItem` gains an optional `apiUrl` field used by the region step to repoint the API base before signup.
> - Behavioral Change: the step order is now `email → region → account → workspace → connect → done`; post-workspace navigation goes to `/signup/connect` instead of `/signup/region`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cb935a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->