### PR TITLE
test(api): /verify-prod-signup residency regression gate + verify-account teardown (#3974)

### DIFF
--- a/.claude/commands/verify-prod-signup.md
+++ b/.claude/commands/verify-prod-signup.md
@@ -32,12 +32,15 @@ Start each region from a clean session: if already signed in, open the user menu
 5. **Connect** — choose **Explore demo data** → "Use NovaMart (E-commerce) demo dataset". (The funnel won't advance unless `assign-region` returned 200.) Screenshot.
 6. **Success** — screenshot. Confirm the dataset-derived starter prompts render (#3935) and the 14-day trial banner shows.
 7. **First answer** — click a starter prompt → app opens with it pre-filled (dismiss the guided tour if it appears) → Send. Wait ~25s, snapshot. **A correct answer with a result table is the pass.** A "Table X is not in the allowed list" error is a fail (see #3947).
+8. **Residency invariants** — before signing out, run primitives 4 & 7 (cross-region edge matrix + raw probe) from the authed app; then sign out and run primitive 5 (login routing). Screenshot each result.
+
+**After all three regions** — for the multi-region chooser (primitive 6), sign up the **same** email (`matt+multi@useatlas.dev`) in **two** regions (e.g. us then eu), then run `resolve-region` once and confirm `outcome: "multiple"`. Tear `matt+multi@` down in **both** regions during teardown.
 
 ---
 
 ## Verification primitives (run in the authed browser via `browser_evaluate`)
 
-All are credentialed `fetch`es from `app.useatlas.dev` (the `.useatlas.dev` session cookie rides cross-subdomain) to the region API — substitute the per-region host below, don't hard-code `api.useatlas.dev`:
+All are credentialed `fetch`es from `app.useatlas.dev` to the region API — substitute the per-region host below, don't hard-code `api.useatlas.dev`. Under ADR-0024 §5 the session cookie is **host-only** (not a parent-`.useatlas.dev` cookie), so it is sent **only** to the workspace's own region host: a credentialed fetch to `api-<region>` carries it (→ `200`), and a fetch to any other region edge carries no cookie (→ `401`). That non-portability is exactly what primitive 4 below asserts.
 
 ```js
 // Region API base — pick the host for the region under test. eu/apac MUST use their own
@@ -63,29 +66,106 @@ await fetch(`${API}/api/v1/tables`, { credentials: 'include' }).then(r => r.json
 
 ---
 
+## ADR-0024 residency-invariant assertions (the #3967 regression gate)
+
+The primitives above prove the picker *recorded* the region and the demo seed *landed in-region*. They do **not** prove the deeper [ADR-0024](../../docs/adr/0024-regional-identity-isolation.md) invariant that #3967 was filed for: **the identity itself is regional** — an EU/APAC workspace has *no row in the US DB*, and `api.useatlas.dev` genuinely `401`s it. Run these per region; an unexpected `200` from a foreign region's edge is the residency violation returning.
+
+```js
+// The full region→edge map. Under ADR-0024 §5 the session cookie is HOST-ONLY:
+// an eu session token is sent ONLY to api-eu, never to api.useatlas.dev or api-apac.
+const EDGES = { us: 'https://api.useatlas.dev', eu: 'https://api-eu.useatlas.dev', apac: 'https://api-apac.useatlas.dev' };
+
+// 4. CROSS-REGION EDGE MATRIX (the core #3967 invariant). From the authed app
+//    after the signup, hit every region edge. EXACTLY the workspace's own region
+//    must 200; the OTHER two must 401 (no identity row there + host-only cookie
+//    never transits them). A 200 from a foreign edge = the residency violation.
+for (const [r, host] of Object.entries(EDGES)) {
+  const status = (await fetch(`${host}/api/v1/tables`, { credentials: 'include' })).status;
+  // r === region → 200 (13 tables) ;  r !== region → 401   (200 on a foreign edge = FAIL, #3967)
+}
+
+// 5. RETURNING-USER LOGIN ROUTING (ADR-0024 §3, #3973). Sign out first (zero
+//    session). The login front-door lives on the WEB app (app.useatlas.dev),
+//    NOT a regional API, and resolves email→region before any session exists.
+await fetch('https://app.useatlas.dev/api/login/resolve-region', {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ email: `matt+${region}@useatlas.dev` }),
+}).then(r => r.json())
+// → { outcome: "single", region: "<region>", apiUrl: "https://api-<region>.useatlas.dev" }
+
+// 6. MULTI-REGION CHOOSER (ADR-0024 §6 — same email = two accounts). Requires a
+//    SHARED email signed up in ≥2 regions: do an extra signup of matt+multi@useatlas.dev
+//    in BOTH us and eu, then resolve it. Two hits → the chooser, not a silent pick.
+await fetch('https://app.useatlas.dev/api/login/resolve-region', {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ email: 'matt+multi@useatlas.dev' }),
+}).then(r => r.json())
+// → { outcome: "multiple", regions: [ { region: "us", apiUrl, label }, { region: "eu", … } ] }
+
+// 7. RAW REGION PROBE (the front-door's per-region oracle, ADR-0024 §3). Deterministic
+//    existence check that doesn't depend on a session — hash the email (sha256 of the
+//    lower-cased address, 64-hex) and POST it to each region's probe. `exists` is true
+//    in EXACTLY the region(s) the email is registered in. Proves identity locality directly.
+const emailHash = [...new Uint8Array(await crypto.subtle.digest('SHA-256',
+  new TextEncoder().encode(`matt+${region}@useatlas.dev`.toLowerCase())))]
+  .map(b => b.toString(16).padStart(2, '0')).join('');
+for (const [r, host] of Object.entries(EDGES)) {
+  const { exists } = await fetch(`${host}/api/v1/auth/region-probe`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ emailHash }),
+  }).then(res => res.json());
+  // exists === (r === region)   — true only in the home region, false everywhere else
+}
+```
+
+**Residency assertion (gates #3967):** for a workspace in region `R`, edge `api-R` `200`s and BOTH other edges `401` (primitive 4); `resolve-region` routes the returning login to `R` (5); the raw probe reports `exists` in `R` only (7); and an email present in two regions surfaces `outcome: "multiple"` (6). Any foreign-edge `200`, or `resolve-region` pointing at the wrong region, is the residency regression.
+
+---
+
 ## Per-region acceptance criteria
 
 - [ ] Signup completes end-to-end through the real OTP gate, no dead-end at any step
 - [ ] `/signup/region` shows all configured regions, default `us` pre-selected; picking the target → `assign-region` 200
 - [ ] `assign-region.region` == picked region; `/api/v1/tables` resolves the 13 demo tables in-region (routing proof)
+- [ ] **Cross-region edge matrix (ADR-0024 / #3967):** the workspace's own region edge `200`s; **both** other region edges `401` (identity row lives only in-region; a foreign-edge `200` is the residency violation)
+- [ ] **Returning-user login routes to the home region:** after sign-out, `resolve-region` for the workspace's email → `{ outcome: "single", region: <home> }`
+- [ ] **Raw probe is region-local:** the per-region `region-probe` reports `exists: true` only in the home region
+- [ ] **Multi-region chooser:** an email signed up in two regions → `resolve-region` → `{ outcome: "multiple", regions: [...] }`
 - [ ] Post-signup app loads and a **demo query returns an answer** in that region
 - [ ] Screenshot captured at each funnel step
 - [ ] Any defect filed as a follow-up issue (don't fix inline)
 
 ---
 
-## Teardown (do this — surgically)
+## Teardown (do this — surgically, via the CLI)
 
-The 3 accounts are plain signups: **no Stripe customer**, a 14-day auto-expiring trial row, empty demo-only workspaces.
+The verify accounts are real prod identities (user + org + members; a Stripe customer if billing ran). Tear them down with the dedicated operator tool — **never by hand-rolled SQL or `ops wipe`**:
 
-- **Default (safe): leave them to auto-expire.** Harmless; no billing artifacts.
-- **Surgical delete (only if needed):** delete just the test org + user rows in each region DB (`ATLAS_REGION_US/EU/APAC_DB_URL`).
+```bash
+# DRY RUN first (default — lists exactly what would go, deletes nothing):
+bun run atlas -- ops teardown-verify-accounts --region eu --email matt+eu@useatlas.dev
+# EXECUTE (double-gated, like ops wipe): cancels Stripe + soft-deletes + hard-deletes
+#   the org and its now-orphaned user, reusing the platform-admin purge SSOT:
+ATLAS_TEARDOWN_OK=1 bun run atlas -- ops teardown-verify-accounts \
+  --region eu --email matt+eu@useatlas.dev --confirm
+# Repeat per region (--region us/eu/apac selects ATLAS_REGION_<R>_DB_URL). The shared
+# matt+multi@ chooser account exists in two regions — tear it down in EACH.
+```
+
+- **DRY RUN by default; EXECUTE needs `ATLAS_TEARDOWN_OK=1` + `--confirm`** (the same double-gate as `ops wipe`). Non-plus-addressed emails are refused unless `--force` — a guard against fat-fingering a real customer's address into a prod teardown.
+- **One region DB per invocation.** `--region` resolves `ATLAS_REGION_<R>_DB_URL`; there is **no `DATABASE_URL` fallback** (the wrong-DB footgun).
+- **Mislocated-account residue check (ADR-0024 / #3967):** the pre-fix verify runs created EU/APAC accounts *in the US DB*. Prove they're gone — a DRY RUN of the US DB against the EU/APAC emails must resolve **zero** orgs:
+  ```bash
+  bun run atlas -- ops teardown-verify-accounts --region us \
+    --email matt+eu@useatlas.dev,matt+apac@useatlas.dev   # expect: 0 workspace(s)
+  ```
 - **NEVER `bun run atlas -- ops wipe`** against a prod region DB — it TRUNCATEs every public table and would destroy real tenants.
 
 ---
 
 ## Known issues this flow surfaces (check whether still open before re-filing)
 
+- **#3967** — EU/APAC residency selection ignored (workspace + identity provisioned/served from US). **Fixed by the #3969–#3974 cluster (ADR-0024); the residency-invariant assertions above are its regression gate** — a foreign-edge `200` or a mis-routed login means the regression is back. File a re-open, not a new issue.
 - **#3947** — demo first-answer dead-ends: `executeSQL` rejects whitelisted tables despite `/api/v1/tables` listing them (region-agnostic; **fails criterion 4**).
 - **#3948** — `staging` region leaks into the prod region picker.
 - **#3949** — demo-only signup gets a "connect your database" onboarding email (no demo-aware branch in the email sequence).
@@ -97,9 +177,9 @@ The 3 accounts are plain signups: **no Stripe customer**, a 14-day auto-expiring
 The only thing keeping this HITL is the **email OTP** — everything else is already scriptable (the Playwright drive + the three `fetch` assertions above). To run it in CI:
 
 1. **Programmatic OTP read.** Give the test inbox an API (a Resend *inbound* route → webhook/store, or an IMAP/mailbox API for `useatlas.dev`) so the runner can poll for the 8-char code instead of a human. This is the single blocker.
-2. **Dedicated test identities.** Pre-provisioned `ci+us@ / ci+eu@ / ci+apac@useatlas.dev` (business-domain) with automatic surgical teardown after each run.
+2. **Dedicated test identities.** Pre-provisioned `ci+us@ / ci+eu@ / ci+apac@useatlas.dev` (business-domain) with automatic surgical teardown after each run via `atlas ops teardown-verify-accounts --region <R> --email <ci+R@…> --confirm` (`ATLAS_TEARDOWN_OK=1`).
 3. **Cadence, not per-PR.** Run post-`/release` (a `staging-smoke`-style job gated on the prod promote) or nightly — not on every PR. It exercises live prod signup + Resend + residency routing, which is a soak check, not a unit gate.
-4. **Assert, don't screenshot.** In CI the three primitives above are the pass/fail signal; keep screenshots as artifacts for triage only.
+4. **Assert, don't screenshot.** In CI the routing + residency primitives above (1–7) are the pass/fail signal; the cross-region edge matrix (4), `resolve-region` (5), and raw probe (7) are session-light and deterministic. Keep screenshots as artifacts for triage only.
 5. **No `executeSQL` LLM dependence in the gate.** Criterion 4 (demo answer) needs the agent; keep that as a separate `@llm`-tagged check so the routing assertions (1–3) stay deterministic and cheap.
 
 Until (1) lands, this stays a human-in-the-loop ops command — run it by hand after each prod release.

--- a/.claude/commands/verify-prod-signup.md
+++ b/.claude/commands/verify-prod-signup.md
@@ -91,7 +91,9 @@ await fetch('https://app.useatlas.dev/api/login/resolve-region', {
   method: 'POST', headers: { 'content-type': 'application/json' },
   body: JSON.stringify({ email: `matt+${region}@useatlas.dev` }),
 }).then(r => r.json())
-// → { outcome: "single", region: "<region>", apiUrl: "https://api-<region>.useatlas.dev" }
+// → { outcome: "single", region: "<region>", apiUrl: EDGES[region] }
+//   (apiUrl is the region's edge: api-eu/api-apac for eu/apac, but the bare
+//    api.useatlas.dev for us — it has no `-us` suffix.)
 
 // 6. MULTI-REGION CHOOSER (ADR-0024 §6 — same email = two accounts). Requires a
 //    SHARED email signed up in ≥2 regions: do an extra signup of matt+multi@useatlas.dev

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -18,6 +18,8 @@ import {
   MAX_TEARDOWN_TARGETS,
   REGION_DB_ENV,
   checkTeardownGate,
+  isDryRun,
+  checkBlastRadius,
   resolveRegionDbUrl,
   parseTargetEmails,
   isThrowawayVerifyEmail,
@@ -62,39 +64,77 @@ describe("checkTeardownGate", () => {
 // --- resolveRegionDbUrl ---
 
 describe("resolveRegionDbUrl", () => {
-  it("returns --database-url when set, regardless of --region", () => {
+  it("returns --database-url when set (region null), regardless of --region", () => {
     const r = resolveRegionDbUrl(
       ["--database-url", "postgresql://x/y", "--region", "eu"],
       { ATLAS_REGION_EU_DB_URL: "postgresql://eu" } as NodeJS.ProcessEnv,
     );
-    expect(r).toEqual({ url: "postgresql://x/y", source: "--database-url" });
+    expect(r).toEqual({ ok: true, url: "postgresql://x/y", source: "--database-url", region: null });
   });
 
-  it("maps --region us|eu|apac to the matching ATLAS_REGION_*_DB_URL", () => {
+  it("maps --region us|eu|apac to the matching ATLAS_REGION_*_DB_URL with the region key", () => {
     const env = {
       ATLAS_REGION_US_DB_URL: "postgresql://us",
       ATLAS_REGION_EU_DB_URL: "postgresql://eu",
       ATLAS_REGION_APAC_DB_URL: "postgresql://apac",
     } as NodeJS.ProcessEnv;
-    expect(resolveRegionDbUrl(["--region", "us"], env)).toMatchObject({ url: "postgresql://us" });
-    expect(resolveRegionDbUrl(["--region", "eu"], env)).toMatchObject({ url: "postgresql://eu" });
-    expect(resolveRegionDbUrl(["--region", "apac"], env)).toMatchObject({ url: "postgresql://apac" });
+    expect(resolveRegionDbUrl(["--region", "us"], env)).toMatchObject({ ok: true, url: "postgresql://us", region: "us" });
+    expect(resolveRegionDbUrl(["--region", "eu"], env)).toMatchObject({ ok: true, url: "postgresql://eu", region: "eu" });
+    expect(resolveRegionDbUrl(["--region", "apac"], env)).toMatchObject({ ok: true, url: "postgresql://apac", region: "apac" });
   });
 
   it("errors on an unknown region", () => {
     const r = resolveRegionDbUrl(["--region", "moon"], {} as NodeJS.ProcessEnv);
-    expect(r).toHaveProperty("error");
-    expect((r as { error: string }).error).toContain("--region must be one of");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("--region must be one of");
+  });
+
+  it("rejects a prototype-chain key (constructor) — own-key check, not `in`", () => {
+    const r = resolveRegionDbUrl(["--region", "constructor"], {} as NodeJS.ProcessEnv);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("--region must be one of");
   });
 
   it("errors when the region's env var is unset", () => {
     const r = resolveRegionDbUrl(["--region", "eu"], {} as NodeJS.ProcessEnv);
-    expect((r as { error: string }).error).toContain(REGION_DB_ENV.eu);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain(REGION_DB_ENV.eu);
   });
 
   it("errors with no DATABASE_URL fallback when neither flag is given", () => {
     const r = resolveRegionDbUrl([], { DATABASE_URL: "postgresql://wrong" } as NodeJS.ProcessEnv);
-    expect((r as { error: string }).error).toContain("no DATABASE_URL fallback");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("no DATABASE_URL fallback");
+  });
+});
+
+// --- isDryRun / checkBlastRadius (the two execute safety gates) ---
+
+describe("isDryRun", () => {
+  const exec = { [TEARDOWN_OK_ENV]: "1" } as NodeJS.ProcessEnv;
+  it("is true when the gate is not satisfied (preview by default)", () => {
+    expect(isDryRun(["--confirm"], {} as NodeJS.ProcessEnv)).toBe(true);
+    expect(isDryRun([], exec)).toBe(true);
+  });
+  it("is false only when both gate halves are present", () => {
+    expect(isDryRun(["--confirm"], exec)).toBe(false);
+  });
+  it("--dry-run forces preview even when the gate is fully open", () => {
+    expect(isDryRun(["--confirm", "--dry-run"], exec)).toBe(true);
+  });
+});
+
+describe("checkBlastRadius", () => {
+  it("allows any count on dry-run (preview uncapped)", () => {
+    expect(checkBlastRadius(MAX_TEARDOWN_TARGETS + 50, true)).toBeNull();
+  });
+  it("allows up to the cap on execute (boundary)", () => {
+    expect(checkBlastRadius(MAX_TEARDOWN_TARGETS, false)).toBeNull();
+  });
+  it("refuses above the cap on execute (boundary + 1)", () => {
+    const r = checkBlastRadius(MAX_TEARDOWN_TARGETS + 1, false);
+    expect(r).toContain("Refusing to execute");
+    expect(r).toContain(String(MAX_TEARDOWN_TARGETS));
   });
 });
 
@@ -128,6 +168,10 @@ describe("parseTargetEmails", () => {
     expect(() => parseTargetEmails(["--email"])).toThrow(/requires a value/);
     expect(() => parseTargetEmails(["--email", "--confirm"])).toThrow(/requires a value/);
   });
+
+  it("trims whitespace and drops empty parts (trailing comma, spaces)", () => {
+    expect(parseTargetEmails(["--email", "a@x.com, ,b@x.com,"])).toEqual(["a@x.com", "b@x.com"]);
+  });
 });
 
 // --- isThrowawayVerifyEmail / assertTargetsAllowed ---
@@ -141,6 +185,14 @@ describe("isThrowawayVerifyEmail", () => {
     expect(isThrowawayVerifyEmail("ceo@bigcustomer.com")).toBe(false);
     expect(isThrowawayVerifyEmail("not-an-email")).toBe(false);
     expect(isThrowawayVerifyEmail("+leadingplus@x.com")).toBe(true);
+  });
+
+  it("only the local part counts — a `+` in the domain is not a throwaway signal", () => {
+    expect(isThrowawayVerifyEmail("matt@x+.com")).toBe(false);
+  });
+
+  it("rejects an address with an empty local part (at index 0)", () => {
+    expect(isThrowawayVerifyEmail("@x.com")).toBe(false);
   });
 });
 
@@ -239,6 +291,24 @@ describe("resolveVerifyTargets", () => {
       ["org_owned", true],
       ["org_shared", false],
     ]);
+  });
+
+  it("resolves each email independently across a multi-email list", async () => {
+    const q = fakeQuery({
+      "matt+us@useatlas.dev": [row({ userId: "u_us", orgId: "org_us", region: "us" })],
+      "matt+eu@useatlas.dev": [row({ userId: "u_eu", orgId: "org_eu", region: "eu" })],
+    });
+    const targets = await resolveVerifyTargets(q, [
+      "matt+us@useatlas.dev",
+      "matt+eu@useatlas.dev",
+      "ghost+apac@useatlas.dev",
+    ]);
+    expect(targets).toHaveLength(3);
+    expect(targets[0]).toMatchObject({ email: "matt+us@useatlas.dev", found: true });
+    expect(targets[0]!.orgs[0]!.orgId).toBe("org_us");
+    expect(targets[1]).toMatchObject({ email: "matt+eu@useatlas.dev", found: true });
+    expect(targets[1]!.orgs[0]!.orgId).toBe("org_eu");
+    expect(targets[2]).toMatchObject({ email: "ghost+apac@useatlas.dev", found: false, orgs: [] });
   });
 });
 
@@ -345,7 +415,7 @@ describe("teardownTargets", () => {
     expect(report.targets[0]!.orgs[0]!.status).toBe("skipped-not-owner");
   });
 
-  it("surfaces Stripe teardown warnings on the org result", async () => {
+  it("surfaces Stripe teardown warnings on the org result and counts them in totals", async () => {
     const deps: TeardownDeps = {
       purgeStripe: async () => okStripe({ warnings: ["Failed to delete Stripe customer cus_1: boom"] }),
       softDelete: async () => true,
@@ -353,6 +423,20 @@ describe("teardownTargets", () => {
     };
     const report = await teardownTargets([target({ orgs: [ownedOrg({ stripeCustomerId: "cus_1" })] })], deps, false);
     expect(report.targets[0]!.orgs[0]!.warnings).toContain("Failed to delete Stripe customer cus_1: boom");
+    // A left-behind billable customer is a non-clean outcome — counted so the
+    // handler can exit non-zero even though the row purge (status "torn-down") ran.
+    expect(report.targets[0]!.orgs[0]!.status).toBe("torn-down");
+    expect(report.totals.stripeWarnings).toBe(1);
+  });
+
+  it("warns (not silently) when soft-delete affects 0 rows", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe(),
+      softDelete: async () => false, // org concurrently reactivated/removed
+      hardDelete: async () => 3,
+    };
+    const report = await teardownTargets([target({ orgs: [ownedOrg()] })], deps, false);
+    expect(report.targets[0]!.orgs[0]!.warnings.some((w) => w.includes("Soft-delete affected 0 rows"))).toBe(true);
   });
 
   it("records a per-org failure and continues to the next org", async () => {

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for `atlas ops teardown-verify-accounts` (#3974). The command tears
+ * down throwaway `/verify-prod-signup` accounts from a region's internal DB, so
+ * the surface that matters is:
+ *   1. The execute double-gate (ATLAS_TEARDOWN_OK=1 + --confirm) — missing
+ *      either falls back to DRY RUN, never an accidental delete.
+ *   2. Region-DB resolution refuses to run without an explicit region/url (no
+ *      DATABASE_URL fallback — the wrong-DB footgun).
+ *   3. The throwaway-email guard blocks a non-plus-addressed address on execute.
+ *   4. Target resolution maps email → user → owned orgs against a fake query.
+ *   5. The orchestration: dry-run lists, execute calls purge→softDelete→
+ *      hardDelete in order, skips non-owners, surfaces Stripe warnings, and
+ *      keeps going after one org errors.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  TEARDOWN_OK_ENV,
+  MAX_TEARDOWN_TARGETS,
+  REGION_DB_ENV,
+  checkTeardownGate,
+  resolveRegionDbUrl,
+  parseTargetEmails,
+  isThrowawayVerifyEmail,
+  assertTargetsAllowed,
+  resolveVerifyTargets,
+  countOwnedOrgs,
+  teardownTargets,
+  handleTeardownVerifyAccounts,
+  type RowQuery,
+  type TeardownDeps,
+  type VerifyTarget,
+} from "../commands/ops-teardown-verify";
+import { handleOps } from "../commands/ops";
+import type { StripeTeardownOutcome } from "@atlas/api/lib/billing/workspace-teardown";
+
+// --- checkTeardownGate (mirrors checkWipeGate's double-gate contract) ---
+
+describe("checkTeardownGate", () => {
+  it("returns a reason when ATLAS_TEARDOWN_OK is missing", () => {
+    expect(checkTeardownGate(["--confirm"], {} as NodeJS.ProcessEnv)).toContain(TEARDOWN_OK_ENV);
+  });
+
+  it("returns a reason when --confirm is missing", () => {
+    expect(
+      checkTeardownGate([], { [TEARDOWN_OK_ENV]: "1" } as NodeJS.ProcessEnv),
+    ).toContain("--confirm");
+  });
+
+  it("rejects a truthy-but-not-1 value (e.g. ATLAS_TEARDOWN_OK=true)", () => {
+    expect(
+      checkTeardownGate(["--confirm"], { [TEARDOWN_OK_ENV]: "true" } as NodeJS.ProcessEnv),
+    ).toContain(TEARDOWN_OK_ENV);
+  });
+
+  it("returns null (cleared to execute) when both gates are present", () => {
+    expect(
+      checkTeardownGate(["--confirm"], { [TEARDOWN_OK_ENV]: "1" } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+});
+
+// --- resolveRegionDbUrl ---
+
+describe("resolveRegionDbUrl", () => {
+  it("returns --database-url when set, regardless of --region", () => {
+    const r = resolveRegionDbUrl(
+      ["--database-url", "postgresql://x/y", "--region", "eu"],
+      { ATLAS_REGION_EU_DB_URL: "postgresql://eu" } as NodeJS.ProcessEnv,
+    );
+    expect(r).toEqual({ url: "postgresql://x/y", source: "--database-url" });
+  });
+
+  it("maps --region us|eu|apac to the matching ATLAS_REGION_*_DB_URL", () => {
+    const env = {
+      ATLAS_REGION_US_DB_URL: "postgresql://us",
+      ATLAS_REGION_EU_DB_URL: "postgresql://eu",
+      ATLAS_REGION_APAC_DB_URL: "postgresql://apac",
+    } as NodeJS.ProcessEnv;
+    expect(resolveRegionDbUrl(["--region", "us"], env)).toMatchObject({ url: "postgresql://us" });
+    expect(resolveRegionDbUrl(["--region", "eu"], env)).toMatchObject({ url: "postgresql://eu" });
+    expect(resolveRegionDbUrl(["--region", "apac"], env)).toMatchObject({ url: "postgresql://apac" });
+  });
+
+  it("errors on an unknown region", () => {
+    const r = resolveRegionDbUrl(["--region", "moon"], {} as NodeJS.ProcessEnv);
+    expect(r).toHaveProperty("error");
+    expect((r as { error: string }).error).toContain("--region must be one of");
+  });
+
+  it("errors when the region's env var is unset", () => {
+    const r = resolveRegionDbUrl(["--region", "eu"], {} as NodeJS.ProcessEnv);
+    expect((r as { error: string }).error).toContain(REGION_DB_ENV.eu);
+  });
+
+  it("errors with no DATABASE_URL fallback when neither flag is given", () => {
+    const r = resolveRegionDbUrl([], { DATABASE_URL: "postgresql://wrong" } as NodeJS.ProcessEnv);
+    expect((r as { error: string }).error).toContain("no DATABASE_URL fallback");
+  });
+});
+
+// --- parseTargetEmails ---
+
+describe("parseTargetEmails", () => {
+  it("parses a single --email", () => {
+    expect(parseTargetEmails(["--email", "matt+us@useatlas.dev"])).toEqual([
+      "matt+us@useatlas.dev",
+    ]);
+  });
+
+  it("splits comma-separated and merges repeated --email flags, deduped + lowercased", () => {
+    expect(
+      parseTargetEmails([
+        "--email",
+        "matt+us@useatlas.dev,Matt+EU@useatlas.dev",
+        "--email",
+        "matt+apac@useatlas.dev",
+        "--email",
+        "matt+us@useatlas.dev",
+      ]),
+    ).toEqual(["matt+us@useatlas.dev", "matt+eu@useatlas.dev", "matt+apac@useatlas.dev"]);
+  });
+
+  it("throws when no --email is given (never an implicit delete-all)", () => {
+    expect(() => parseTargetEmails(["--region", "us"])).toThrow(/At least one --email/);
+  });
+
+  it("throws when --email has no value", () => {
+    expect(() => parseTargetEmails(["--email"])).toThrow(/requires a value/);
+    expect(() => parseTargetEmails(["--email", "--confirm"])).toThrow(/requires a value/);
+  });
+});
+
+// --- isThrowawayVerifyEmail / assertTargetsAllowed ---
+
+describe("isThrowawayVerifyEmail", () => {
+  it("accepts plus-addressed business emails", () => {
+    expect(isThrowawayVerifyEmail("matt+us@useatlas.dev")).toBe(true);
+  });
+
+  it("rejects a plain address and a malformed one", () => {
+    expect(isThrowawayVerifyEmail("ceo@bigcustomer.com")).toBe(false);
+    expect(isThrowawayVerifyEmail("not-an-email")).toBe(false);
+    expect(isThrowawayVerifyEmail("+leadingplus@x.com")).toBe(true);
+  });
+});
+
+describe("assertTargetsAllowed", () => {
+  it("passes when every email is plus-addressed", () => {
+    expect(() =>
+      assertTargetsAllowed(["matt+us@useatlas.dev", "matt+eu@useatlas.dev"], false),
+    ).not.toThrow();
+  });
+
+  it("throws listing the non-throwaway addresses when not forced", () => {
+    expect(() =>
+      assertTargetsAllowed(["matt+us@useatlas.dev", "ceo@bigcustomer.com"], false),
+    ).toThrow(/ceo@bigcustomer.com/);
+  });
+
+  it("passes any address when --force is set", () => {
+    expect(() => assertTargetsAllowed(["ceo@bigcustomer.com"], true)).not.toThrow();
+  });
+});
+
+// --- resolveVerifyTargets (against a fake RowQuery) ---
+
+interface FakeRow extends Record<string, unknown> {
+  userId: string;
+  email: string;
+  userName: string | null;
+  memberRole: string | null;
+  orgId: string | null;
+  orgName: string | null;
+  orgSlug: string | null;
+  region: string | null;
+  workspaceStatus: string | null;
+  stripeCustomerId: string | null;
+}
+
+/** Build a fake query that returns the given rows per lower-cased email param. */
+function fakeQuery(byEmail: Record<string, FakeRow[]>): RowQuery {
+  return (async <T extends Record<string, unknown>>(_sql: string, params?: unknown[]) => {
+    const email = String(params?.[0] ?? "");
+    return (byEmail[email] ?? []) as unknown as T[];
+  }) as RowQuery;
+}
+
+function row(over: Partial<FakeRow>): FakeRow {
+  return {
+    userId: "user_1",
+    email: "matt+us@useatlas.dev",
+    userName: "Matt US",
+    memberRole: "owner",
+    orgId: "org_1",
+    orgName: "Atlas us Verify",
+    orgSlug: "atlas-us-verify",
+    region: "us",
+    workspaceStatus: "active",
+    stripeCustomerId: null,
+    ...over,
+  };
+}
+
+describe("resolveVerifyTargets", () => {
+  it("resolves a found user with one owned org", async () => {
+    const q = fakeQuery({ "matt+us@useatlas.dev": [row({})] });
+    const [t] = await resolveVerifyTargets(q, ["matt+us@useatlas.dev"]);
+    expect(t).toMatchObject({ email: "matt+us@useatlas.dev", userId: "user_1", found: true });
+    expect(t!.orgs).toHaveLength(1);
+    expect(t!.orgs[0]).toMatchObject({ orgId: "org_1", region: "us", isOwner: true });
+  });
+
+  it("marks an email with no user row as not found", async () => {
+    const q = fakeQuery({});
+    const [t] = await resolveVerifyTargets(q, ["ghost+us@useatlas.dev"]);
+    expect(t).toEqual({ email: "ghost+us@useatlas.dev", userId: null, found: false, orgs: [] });
+  });
+
+  it("treats a user with no membership (LEFT JOIN null org) as found with zero orgs", async () => {
+    const q = fakeQuery({
+      "matt+us@useatlas.dev": [
+        row({ memberRole: null, orgId: null, orgName: null, orgSlug: null, region: null, workspaceStatus: null }),
+      ],
+    });
+    const [t] = await resolveVerifyTargets(q, ["matt+us@useatlas.dev"]);
+    expect(t).toMatchObject({ found: true, userId: "user_1" });
+    expect(t!.orgs).toEqual([]);
+  });
+
+  it("records owner vs non-owner across multiple memberships", async () => {
+    const q = fakeQuery({
+      "matt+us@useatlas.dev": [
+        row({ orgId: "org_owned", memberRole: "owner" }),
+        row({ orgId: "org_shared", memberRole: "member", stripeCustomerId: "cus_x" }),
+      ],
+    });
+    const [t] = await resolveVerifyTargets(q, ["matt+us@useatlas.dev"]);
+    expect(t!.orgs.map((o) => [o.orgId, o.isOwner])).toEqual([
+      ["org_owned", true],
+      ["org_shared", false],
+    ]);
+  });
+});
+
+// --- countOwnedOrgs (blast-radius the execute guard caps) ---
+
+describe("countOwnedOrgs", () => {
+  it("counts only owned orgs across targets, ignoring non-owner memberships", () => {
+    const targets: VerifyTarget[] = [
+      { email: "a", userId: "u1", found: true, orgs: [
+        { orgId: "o1", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
+        { orgId: "o2", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: false },
+      ] },
+      { email: "b", userId: "u2", found: true, orgs: [
+        { orgId: "o3", orgName: null, orgSlug: null, region: "eu", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
+      ] },
+      { email: "c", userId: null, found: false, orgs: [] },
+    ];
+    expect(countOwnedOrgs(targets)).toBe(2);
+    expect(countOwnedOrgs(targets)).toBeLessThanOrEqual(MAX_TEARDOWN_TARGETS);
+  });
+
+  it("is 0 when nothing resolved", () => {
+    expect(countOwnedOrgs([])).toBe(0);
+  });
+});
+
+// --- teardownTargets (orchestration, with injected fakes) ---
+
+function okStripe(over: Partial<StripeTeardownOutcome> = {}): StripeTeardownOutcome {
+  return { attempted: true, actions: [], warnings: [], ...over };
+}
+
+function target(over: Partial<VerifyTarget> & { orgs?: VerifyTarget["orgs"] }): VerifyTarget {
+  return {
+    email: "matt+us@useatlas.dev",
+    userId: "user_1",
+    found: true,
+    orgs: [],
+    ...over,
+  };
+}
+
+function ownedOrg(over: Partial<VerifyTarget["orgs"][number]> = {}): VerifyTarget["orgs"][number] {
+  return {
+    orgId: "org_1",
+    orgName: "Atlas us Verify",
+    orgSlug: "atlas-us-verify",
+    region: "us",
+    workspaceStatus: "active",
+    stripeCustomerId: null,
+    isOwner: true,
+    ...over,
+  };
+}
+
+describe("teardownTargets", () => {
+  it("dry-run lists owned orgs as would-tear-down and calls no deps", async () => {
+    const calls: string[] = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async () => { calls.push("purge"); return okStripe(); },
+      softDelete: async () => { calls.push("soft"); return true; },
+      hardDelete: async () => { calls.push("hard"); return 0; },
+    };
+    const report = await teardownTargets([target({ orgs: [ownedOrg()] })], deps, true);
+    expect(calls).toEqual([]);
+    expect(report.dryRun).toBe(true);
+    expect(report.targets[0]!.orgs[0]!.status).toBe("would-tear-down");
+    expect(report.totals).toMatchObject({ orgsWouldTearDown: 1, orgsTornDown: 0 });
+  });
+
+  it("execute calls purge → softDelete → hardDelete in order and sums rows", async () => {
+    const order: string[] = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async () => { order.push("purge"); return okStripe({ actions: ["deleted Stripe customer cus_1"] }); },
+      softDelete: async () => { order.push("soft"); return true; },
+      hardDelete: async () => { order.push("hard"); return 42; },
+    };
+    const report = await teardownTargets(
+      [target({ orgs: [ownedOrg({ stripeCustomerId: "cus_1" })] })],
+      deps,
+      false,
+    );
+    expect(order).toEqual(["purge", "soft", "hard"]);
+    const org = report.targets[0]!.orgs[0]!;
+    expect(org.status).toBe("torn-down");
+    expect(org.rowsPurged).toBe(42);
+    expect(org.stripeActions).toContain("deleted Stripe customer cus_1");
+    expect(report.totals).toMatchObject({ orgsTornDown: 1, rowsPurged: 42, errors: 0 });
+  });
+
+  it("skips a non-owner membership without calling any dep", async () => {
+    const calls: string[] = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async () => { calls.push("purge"); return okStripe(); },
+      softDelete: async () => { calls.push("soft"); return true; },
+      hardDelete: async () => { calls.push("hard"); return 0; },
+    };
+    const report = await teardownTargets(
+      [target({ orgs: [ownedOrg({ orgId: "org_shared", isOwner: false })] })],
+      deps,
+      false,
+    );
+    expect(calls).toEqual([]);
+    expect(report.targets[0]!.orgs[0]!.status).toBe("skipped-not-owner");
+  });
+
+  it("surfaces Stripe teardown warnings on the org result", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe({ warnings: ["Failed to delete Stripe customer cus_1: boom"] }),
+      softDelete: async () => true,
+      hardDelete: async () => 1,
+    };
+    const report = await teardownTargets([target({ orgs: [ownedOrg({ stripeCustomerId: "cus_1" })] })], deps, false);
+    expect(report.targets[0]!.orgs[0]!.warnings).toContain("Failed to delete Stripe customer cus_1: boom");
+  });
+
+  it("records a per-org failure and continues to the next org", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe(),
+      softDelete: async () => true,
+      hardDelete: async (orgId) => {
+        if (orgId === "org_bad") throw new Error("status check failed");
+        return 5;
+      },
+    };
+    const report = await teardownTargets(
+      [target({ orgs: [ownedOrg({ orgId: "org_bad" }), ownedOrg({ orgId: "org_good" })] })],
+      deps,
+      false,
+    );
+    const [bad, good] = report.targets[0]!.orgs;
+    expect(bad!.status).toBe("error");
+    expect(bad!.warnings[0]).toContain("status check failed");
+    expect(good!.status).toBe("torn-down");
+    expect(report.totals).toMatchObject({ orgsTornDown: 1, errors: 1 });
+  });
+
+  it("warns for a not-found email and an orphan user with no workspace", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe(),
+      softDelete: async () => true,
+      hardDelete: async () => 0,
+    };
+    const report = await teardownTargets(
+      [
+        target({ email: "ghost+us@useatlas.dev", userId: null, found: false, orgs: [] }),
+        target({ email: "orphan+us@useatlas.dev", orgs: [] }),
+      ],
+      deps,
+      false,
+    );
+    expect(report.targets[0]!.warnings[0]).toContain("No user row found");
+    expect(report.targets[1]!.warnings[0]).toContain("no workspace membership");
+  });
+});
+
+// --- handler arg-boundary (early exits, before any DB binding) ---
+
+const errors: string[] = [];
+const origConsoleError = console.error;
+const origExit = process.exit;
+let exitCode: number | null = null;
+
+beforeEach(() => {
+  errors.length = 0;
+  exitCode = null;
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map((a) => String(a)).join(" "));
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__process_exit__:${exitCode}`);
+  }) as unknown as typeof process.exit;
+});
+
+afterEach(() => {
+  console.error = origConsoleError;
+  process.exit = origExit;
+});
+
+async function expectExit1(args: string[]): Promise<void> {
+  let caught: Error | null = null;
+  try {
+    await handleTeardownVerifyAccounts(args);
+  } catch (err) {
+    caught = err instanceof Error ? err : new Error(String(err));
+  }
+  expect(caught?.message).toBe("__process_exit__:1");
+}
+
+describe("handleTeardownVerifyAccounts arg boundary", () => {
+  it("exits 1 when no --email is given", async () => {
+    await expectExit1(["ops", "teardown-verify-accounts", "--region", "us"]);
+    expect(errors.some((l) => l.includes("--email"))).toBe(true);
+  });
+
+  it("exits 1 when no region/url is resolvable (no DATABASE_URL fallback)", async () => {
+    const origUs = process.env.ATLAS_REGION_US_DB_URL;
+    delete process.env.ATLAS_REGION_US_DB_URL;
+    try {
+      await expectExit1(["ops", "teardown-verify-accounts", "--email", "matt+us@useatlas.dev"]);
+      expect(errors.some((l) => l.includes("No region DB selected"))).toBe(true);
+    } finally {
+      if (origUs !== undefined) process.env.ATLAS_REGION_US_DB_URL = origUs;
+    }
+  });
+
+  it("exits 1 on a non-throwaway email under the execute gate (no --force)", async () => {
+    const origOk = process.env[TEARDOWN_OK_ENV];
+    process.env[TEARDOWN_OK_ENV] = "1";
+    try {
+      await expectExit1([
+        "ops",
+        "teardown-verify-accounts",
+        "--confirm",
+        "--region",
+        "us",
+        "--email",
+        "ceo@bigcustomer.com",
+      ]);
+      expect(errors.some((l) => l.includes("non-throwaway"))).toBe(true);
+    } finally {
+      if (origOk === undefined) delete process.env[TEARDOWN_OK_ENV];
+      else process.env[TEARDOWN_OK_ENV] = origOk;
+    }
+  });
+});
+
+// --- dispatch wiring through handleOps ---
+
+describe("handleOps teardown-verify-accounts wiring", () => {
+  it("routes `ops teardown-verify-accounts` to the handler (exits 1 on missing --email)", async () => {
+    let caught: Error | null = null;
+    try {
+      await handleOps(["ops", "teardown-verify-accounts", "--region", "us"]);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught?.message).toBe("__process_exit__:1");
+    expect(errors.some((l) => l.includes("--email"))).toBe(true);
+  });
+
+  it("usage text lists teardown-verify-accounts", async () => {
+    let caught: Error | null = null;
+    try {
+      await handleOps(["ops", "unknown-subcommand"]);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught?.message).toBe("__process_exit__:1");
+    expect(errors.some((l) => l.includes("teardown-verify-accounts"))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -522,7 +522,7 @@ export function printTeardownReport(report: TeardownReport): void {
     `\n[ops:teardown-verify-accounts] ${report.dryRun ? "would tear down" : "tore down"} ` +
       `${report.dryRun ? t.orgsWouldTearDown : t.orgsTornDown} workspace(s)` +
       (report.dryRun ? "" : `, ${t.rowsPurged} rows purged`) +
-      (t.stripeWarnings > 0 ? `, ${t.stripeWarnings} Stripe warning(s)` : "") +
+      (t.stripeWarnings > 0 ? `, ${t.stripeWarnings} workspace(s) with Stripe warnings` : "") +
       (t.errors > 0 ? `, ${t.errors} error(s)` : ""),
   );
 }
@@ -588,15 +588,21 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
       softDelete: (orgId) => updateWorkspaceStatus(orgId, "deleted"),
       hardDelete: async (orgId) => {
         const purged = await hardDeleteWorkspace(orgId);
-        return Object.values(purged).reduce((sum, n) => sum + n, 0);
+        // HardDeleteResult is an all-number per-table count map; assert that so
+        // the sum can't silently become NaN/string-concat if a non-number field
+        // is ever added (Object.values on an index-signature-less type widens to any).
+        return (Object.values(purged) as number[]).reduce((sum, n) => sum + n, 0);
       },
     }, dryRun);
 
     printTeardownReport(report);
-    // Exit non-zero on a row-purge error OR a left-behind Stripe customer — a
+    // Exit non-zero on a row-purge error OR a left-behind Stripe linkage — a
     // scripted cleanup must fail loudly rather than report a clean "success"
-    // while a billable Stripe linkage survives (it's enqueued for durable retry,
-    // but the operator/CI should still know it didn't fully complete).
+    // while a billable Stripe customer survives. A failed customer-delete /
+    // subscription-cancel is enqueued in `stripe_teardown_pending` for durable
+    // retry; some warnings (a subscription-read or outbox-write failure) are
+    // manual-follow-up only — either way the operator/CI should know it didn't
+    // fully complete.
     if (report.totals.errors > 0 || report.totals.stripeWarnings > 0) process.exitCode = 1;
   } catch (err) {
     console.error(

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -1,0 +1,544 @@
+/**
+ * `atlas ops teardown-verify-accounts` — surgically tear down the throwaway
+ * `/verify-prod-signup` test accounts (user + org + Stripe customer) left in a
+ * region's internal DB after a 3-region residency verification (ADR-0024,
+ * #3974). This is the operator-side cleanup half of the residency regression
+ * gate: the verifier creates real prod accounts (`matt+<region>@useatlas.dev`,
+ * workspace "Atlas <REGION> Verify") to exercise the signup funnel, and they
+ * must be removed afterwards — including the EU/APAC accounts that the #3967
+ * defect mislocated into the US DB.
+ *
+ * Why reuse, not re-implement: the per-org row set is large and grows (see
+ * `hardDeleteWorkspace` in db/internal.ts — ~40 tables). Re-implementing that
+ * cascade here would silently drift the moment a new org-scoped table lands,
+ * leaving secrets/rows behind on a "torn-down" account. So this command binds
+ * the internal-DB pool to the chosen region's DB and delegates to the same
+ * three SSOT functions the platform-admin purge uses:
+ *   1. `purgeStripeBillingForWorkspace` — cancel subs + delete the Stripe
+ *      customer (a torn-down account must leave no billable Stripe linkage).
+ *   2. `updateWorkspaceStatus(orgId, "deleted")` — the soft-delete precondition
+ *      `hardDeleteWorkspace` enforces (it aborts unless the org is "deleted").
+ *   3. `hardDeleteWorkspace` — the exhaustive GDPR-grade row purge, which also
+ *      deletes the org's members and any now-orphaned user rows.
+ *
+ * Safety (this targets a PROD region DB):
+ *   - One region DB per invocation (`--region` or `--database-url`); no silent
+ *     DATABASE_URL fallback (the wrong-DB footgun the skill warns about).
+ *   - DRY RUN by default. Executing requires BOTH `ATLAS_TEARDOWN_OK=1` and
+ *     `--confirm` (the same double-gate as `ops wipe`).
+ *   - Targets are explicit `--email` addresses — never a blind "delete every
+ *     test-looking account". On execute, each must look like a throwaway
+ *     plus-addressed verify account unless `--force` is passed, and the run
+ *     refuses to execute against more than MAX_TEARDOWN_TARGETS orgs.
+ *   - Non-owner memberships and orphan users are surfaced as warnings for
+ *     manual follow-up, never silently mutated.
+ */
+import {
+  internalQuery,
+  closeInternalDB,
+  updateWorkspaceStatus,
+  hardDeleteWorkspace,
+} from "@atlas/api/lib/db/internal";
+import {
+  purgeStripeBillingForWorkspace,
+  type StripeTeardownOutcome,
+} from "@atlas/api/lib/billing/workspace-teardown";
+import { getFlag } from "../../lib/cli-utils";
+
+/** Env var that, set to exactly "1", is one half of the execute double-gate. */
+export const TEARDOWN_OK_ENV = "ATLAS_TEARDOWN_OK";
+
+/**
+ * Blast-radius cap. A throwaway verification run creates one account per
+ * region (3), so a target set larger than this on EXECUTE is almost certainly
+ * an operator mistake (a too-broad `--email` list) and is refused. Dry-run is
+ * uncapped so an operator can preview any set.
+ */
+export const MAX_TEARDOWN_TARGETS = 12;
+
+/** The real prod residency regions whose DB URL `--region` can resolve. */
+export const REGION_DB_ENV = {
+  us: "ATLAS_REGION_US_DB_URL",
+  eu: "ATLAS_REGION_EU_DB_URL",
+  apac: "ATLAS_REGION_APAC_DB_URL",
+} as const;
+
+export type TeardownRegion = keyof typeof REGION_DB_ENV;
+
+/**
+ * The execute double-gate, mirroring `checkWipeGate`. Returns null when the
+ * run is cleared to EXECUTE (both gates present), or a human-readable reason
+ * when it is not — in which case the caller falls back to a DRY RUN rather
+ * than erroring, so a gate-less invocation safely previews instead of deleting.
+ */
+export function checkTeardownGate(args: string[], env: NodeJS.ProcessEnv): string | null {
+  if (env[TEARDOWN_OK_ENV] !== "1") {
+    return `${TEARDOWN_OK_ENV} is not set to 1`;
+  }
+  if (!args.includes("--confirm")) {
+    return "--confirm was not passed";
+  }
+  return null;
+}
+
+/** Resolved region DB target — the URL plus a label for log lines. */
+export interface ResolvedRegionDb {
+  url: string;
+  /** e.g. "--database-url" or "region eu (ATLAS_REGION_EU_DB_URL)". */
+  source: string;
+}
+
+/**
+ * Resolve which region DB to operate on. Precedence: an explicit
+ * `--database-url` wins (escape hatch for a non-standard URL); otherwise
+ * `--region <us|eu|apac>` maps to that region's `ATLAS_REGION_*_DB_URL`.
+ * Returns an error string (never throws) when neither is usable — there is
+ * deliberately NO fallback to a bare DATABASE_URL, so an operator can never
+ * tear down the wrong DB by forgetting the flag.
+ */
+export function resolveRegionDbUrl(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): ResolvedRegionDb | { error: string } {
+  const explicit = getFlag(args, "--database-url");
+  if (explicit) return { url: explicit, source: "--database-url" };
+
+  const region = getFlag(args, "--region");
+  if (region) {
+    if (!(region in REGION_DB_ENV)) {
+      return {
+        error: `--region must be one of: ${Object.keys(REGION_DB_ENV).join(", ")} (got "${region}")`,
+      };
+    }
+    const envVar = REGION_DB_ENV[region as TeardownRegion];
+    const url = env[envVar];
+    if (!url) {
+      return { error: `--region ${region} requires ${envVar} to be set in the environment.` };
+    }
+    return { url, source: `region ${region} (${envVar})` };
+  }
+
+  return {
+    error:
+      "No region DB selected. Pass --region <us|eu|apac> (resolves ATLAS_REGION_<R>_DB_URL) " +
+      "or --database-url <url>. There is no DATABASE_URL fallback — pick the region explicitly.",
+  };
+}
+
+/**
+ * Parse `--email` targets. Accepts the flag repeated and/or comma-separated
+ * (`--email a@x.com,b@x.com --email c@x.com`), lower-cases and de-dupes.
+ * Throws when no address is given — a teardown with no explicit target is
+ * always operator error, never "delete everything".
+ */
+export function parseTargetEmails(args: string[]): string[] {
+  const collected: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "--email") continue;
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error("--email requires a value (e.g. --email matt+us@useatlas.dev)");
+    }
+    for (const part of value.split(",")) {
+      const trimmed = part.trim().toLowerCase();
+      if (trimmed) collected.push(trimmed);
+    }
+  }
+  const deduped = [...new Set(collected)];
+  if (deduped.length === 0) {
+    throw new Error("At least one --email <addr> is required (the account(s) to tear down).");
+  }
+  return deduped;
+}
+
+/**
+ * Whether an email looks like a throwaway `/verify-prod-signup` account. The
+ * verifier always uses plus-addressing on a business domain
+ * (`matt+us@useatlas.dev`), so a plus-tag is the cheap signature that
+ * distinguishes a verification account from a real customer's primary address.
+ * Used only to gate EXECUTE (overridable with `--force`); previews are
+ * unrestricted.
+ */
+export function isThrowawayVerifyEmail(email: string): boolean {
+  const at = email.indexOf("@");
+  if (at <= 0) return false;
+  const local = email.slice(0, at);
+  return local.includes("+");
+}
+
+/**
+ * Throw when EXECUTE is requested against an address that doesn't look like a
+ * throwaway verify account and `--force` was not passed — the guard against
+ * fat-fingering a real customer's email into a prod teardown.
+ */
+export function assertTargetsAllowed(emails: string[], force: boolean): void {
+  if (force) return;
+  const suspicious = emails.filter((e) => !isThrowawayVerifyEmail(e));
+  if (suspicious.length > 0) {
+    throw new Error(
+      `Refusing to tear down non-throwaway-looking address(es): ${suspicious.join(", ")}. ` +
+        "Verification accounts are plus-addressed (e.g. matt+us@useatlas.dev). " +
+        "Pass --force to override if you are certain.",
+    );
+  }
+}
+
+/** One org a target user belongs to, with the fields teardown needs. */
+export interface VerifyOrg {
+  orgId: string;
+  orgName: string | null;
+  orgSlug: string | null;
+  region: string | null;
+  workspaceStatus: string | null;
+  stripeCustomerId: string | null;
+  isOwner: boolean;
+}
+
+/** A resolved target: the user row (if any) for an email plus its orgs. */
+export interface VerifyTarget {
+  email: string;
+  userId: string | null;
+  found: boolean;
+  orgs: VerifyOrg[];
+}
+
+/**
+ * Total owned workspaces across resolved targets — the blast radius the
+ * execute guard caps at {@link MAX_TEARDOWN_TARGETS}. Non-owner memberships
+ * don't count (they're never torn down).
+ */
+export function countOwnedOrgs(targets: VerifyTarget[]): number {
+  return targets.reduce((n, t) => n + t.orgs.filter((o) => o.isOwner).length, 0);
+}
+
+/** Minimal row-returning query surface — `internalQuery` or a test fake. */
+export type RowQuery = <T extends Record<string, unknown>>(
+  sql: string,
+  params?: unknown[],
+) => Promise<T[]>;
+
+interface TargetRow extends Record<string, unknown> {
+  userId: string;
+  email: string;
+  userName: string | null;
+  memberRole: string | null;
+  orgId: string | null;
+  orgName: string | null;
+  orgSlug: string | null;
+  region: string | null;
+  workspaceStatus: string | null;
+  stripeCustomerId: string | null;
+}
+
+/**
+ * Resolve each email to its user row and the orgs that user is a member of, in
+ * the bound region DB. A LEFT JOIN so a user with no membership still resolves
+ * (surfaced as `found: true, orgs: []`). `isOwner` is recorded so the
+ * orchestration only purges workspaces the verify user owns — a shared
+ * membership is reported, never deleted.
+ */
+export async function resolveVerifyTargets(
+  query: RowQuery,
+  emails: string[],
+): Promise<VerifyTarget[]> {
+  const targets: VerifyTarget[] = [];
+  for (const email of emails) {
+    const rows = await query<TargetRow>(
+      `SELECT
+         u.id                  AS "userId",
+         u.email               AS "email",
+         u.name                AS "userName",
+         m.role                AS "memberRole",
+         o.id                  AS "orgId",
+         o.name                AS "orgName",
+         o.slug                AS "orgSlug",
+         o.region              AS "region",
+         o.workspace_status    AS "workspaceStatus",
+         o."stripeCustomerId"  AS "stripeCustomerId"
+       FROM "user" u
+       LEFT JOIN member m       ON m."userId" = u.id
+       LEFT JOIN organization o ON o.id = m."organizationId"
+       WHERE lower(u.email) = $1`,
+      [email],
+    );
+
+    if (rows.length === 0) {
+      targets.push({ email, userId: null, found: false, orgs: [] });
+      continue;
+    }
+
+    const userId = rows[0]!.userId;
+    const orgs: VerifyOrg[] = [];
+    for (const r of rows) {
+      if (!r.orgId) continue; // user with no membership (LEFT JOIN null row)
+      orgs.push({
+        orgId: r.orgId,
+        orgName: r.orgName,
+        orgSlug: r.orgSlug,
+        region: r.region,
+        workspaceStatus: r.workspaceStatus,
+        stripeCustomerId: r.stripeCustomerId,
+        isOwner: r.memberRole === "owner",
+      });
+    }
+    targets.push({ email, userId, found: true, orgs });
+  }
+  return targets;
+}
+
+/** Per-org teardown outcome (one entry per owned org, plus reported skips). */
+export interface OrgTeardownResult {
+  orgId: string;
+  orgName: string | null;
+  region: string | null;
+  stripeCustomerId: string | null;
+  status: "torn-down" | "would-tear-down" | "skipped-not-owner" | "error";
+  rowsPurged: number;
+  stripeActions: string[];
+  warnings: string[];
+}
+
+/** Per-email rollup. `warnings` covers the user-level cases (not found, no org). */
+export interface TargetTeardownResult {
+  email: string;
+  userId: string | null;
+  found: boolean;
+  orgs: OrgTeardownResult[];
+  warnings: string[];
+}
+
+export interface TeardownReport {
+  dryRun: boolean;
+  targets: TargetTeardownResult[];
+  totals: {
+    orgsTornDown: number;
+    orgsWouldTearDown: number;
+    rowsPurged: number;
+    errors: number;
+  };
+}
+
+/** Injected SSOT operations — real in the handler, fakes in unit tests.
+ *  `hardDelete` returns the total rows purged; the handler sums the SSOT's
+ *  per-table `HardDeleteResult` so the orchestration stays shape-agnostic. */
+export interface TeardownDeps {
+  purgeStripe: (orgId: string, stripeCustomerId: string | null) => Promise<StripeTeardownOutcome>;
+  softDelete: (orgId: string) => Promise<boolean>;
+  hardDelete: (orgId: string) => Promise<number>;
+}
+
+/**
+ * Orchestrate the teardown across resolved targets. Pure of I/O wiring — every
+ * side effect is an injected `deps` call, so unit tests drive it with fakes.
+ *
+ * For each owned org: cancel/delete Stripe FIRST (before the cascade destroys
+ * the org row carrying `stripeCustomerId`), then soft-delete (the precondition
+ * `hardDelete` enforces), then hard-delete the rows. A single org's failure is
+ * recorded and the run continues — one stuck account never strands the rest.
+ * Non-owner memberships and orphan users become warnings, never deletions.
+ */
+export async function teardownTargets(
+  targets: VerifyTarget[],
+  deps: TeardownDeps,
+  dryRun: boolean,
+): Promise<TeardownReport> {
+  const results: TargetTeardownResult[] = [];
+  const totals = { orgsTornDown: 0, orgsWouldTearDown: 0, rowsPurged: 0, errors: 0 };
+
+  for (const target of targets) {
+    const targetWarnings: string[] = [];
+    const orgResults: OrgTeardownResult[] = [];
+
+    if (!target.found) {
+      targetWarnings.push(`No user row found for ${target.email} — nothing to tear down.`);
+    } else if (target.orgs.length === 0) {
+      targetWarnings.push(
+        `User ${target.email} (${target.userId}) has no workspace membership — ` +
+          "orphan user row left untouched; remove it manually if it is a verification artifact.",
+      );
+    }
+
+    for (const org of target.orgs) {
+      if (!org.isOwner) {
+        orgResults.push({
+          orgId: org.orgId,
+          orgName: org.orgName,
+          region: org.region,
+          stripeCustomerId: org.stripeCustomerId,
+          status: "skipped-not-owner",
+          rowsPurged: 0,
+          stripeActions: [],
+          warnings: [
+            `${target.email} is a non-owner member of workspace ${org.orgName ?? org.orgId} — left untouched.`,
+          ],
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        orgResults.push({
+          orgId: org.orgId,
+          orgName: org.orgName,
+          region: org.region,
+          stripeCustomerId: org.stripeCustomerId,
+          status: "would-tear-down",
+          rowsPurged: 0,
+          stripeActions: [],
+          warnings: [],
+        });
+        totals.orgsWouldTearDown += 1;
+        continue;
+      }
+
+      try {
+        const stripe = await deps.purgeStripe(org.orgId, org.stripeCustomerId);
+        await deps.softDelete(org.orgId);
+        const rowsPurged = await deps.hardDelete(org.orgId);
+        orgResults.push({
+          orgId: org.orgId,
+          orgName: org.orgName,
+          region: org.region,
+          stripeCustomerId: org.stripeCustomerId,
+          status: "torn-down",
+          rowsPurged,
+          stripeActions: stripe.actions,
+          warnings: stripe.warnings,
+        });
+        totals.orgsTornDown += 1;
+        totals.rowsPurged += rowsPurged;
+      } catch (err) {
+        totals.errors += 1;
+        orgResults.push({
+          orgId: org.orgId,
+          orgName: org.orgName,
+          region: org.region,
+          stripeCustomerId: org.stripeCustomerId,
+          status: "error",
+          rowsPurged: 0,
+          stripeActions: [],
+          warnings: [
+            `Teardown failed for workspace ${org.orgName ?? org.orgId}: ${err instanceof Error ? err.message : String(err)}`,
+          ],
+        });
+      }
+    }
+
+    results.push({
+      email: target.email,
+      userId: target.userId,
+      found: target.found,
+      orgs: orgResults,
+      warnings: targetWarnings,
+    });
+  }
+
+  return { dryRun, targets: results, totals };
+}
+
+/** Render the report as operator-facing console lines. */
+export function printTeardownReport(report: TeardownReport): void {
+  const banner = report.dryRun
+    ? `DRY RUN — set ${TEARDOWN_OK_ENV}=1 and pass --confirm to execute`
+    : "EXECUTE";
+  console.log(`[ops:teardown-verify-accounts] ${banner}`);
+
+  for (const target of report.targets) {
+    console.log(`\n• ${target.email}${target.userId ? ` (user ${target.userId})` : ""}`);
+    for (const w of target.warnings) console.log(`  ⚠ ${w}`);
+    for (const org of target.orgs) {
+      const tag = {
+        "torn-down": "✓ torn down",
+        "would-tear-down": "→ would tear down",
+        "skipped-not-owner": "– skipped (not owner)",
+        error: "✗ error",
+      }[org.status];
+      const region = org.region ? ` region=${org.region}` : "";
+      const rows = org.status === "torn-down" ? ` (${org.rowsPurged} rows)` : "";
+      console.log(`  ${tag}: ${org.orgName ?? org.orgId} [${org.orgId}]${region}${rows}`);
+      if (org.stripeCustomerId) console.log(`     stripe customer: ${org.stripeCustomerId}`);
+      for (const a of org.stripeActions) console.log(`     stripe: ${a}`);
+      for (const w of org.warnings) console.log(`     ⚠ ${w}`);
+    }
+  }
+
+  const t = report.totals;
+  console.log(
+    `\n[ops:teardown-verify-accounts] ${report.dryRun ? "would tear down" : "tore down"} ` +
+      `${report.dryRun ? t.orgsWouldTearDown : t.orgsTornDown} workspace(s)` +
+      (report.dryRun ? "" : `, ${t.rowsPurged} rows purged`) +
+      (t.errors > 0 ? `, ${t.errors} error(s)` : ""),
+  );
+}
+
+/** Wire the command: resolve gate/region/targets, bind the pool, run, report. */
+export async function handleTeardownVerifyAccounts(args: string[]): Promise<void> {
+  // DRY RUN unless the double-gate is satisfied AND --dry-run was not forced.
+  const gateReason = checkTeardownGate(args, process.env);
+  const dryRun = gateReason !== null || args.includes("--dry-run");
+  const force = args.includes("--force");
+
+  let emails: string[];
+  try {
+    emails = parseTargetEmails(args);
+    if (!dryRun) assertTargetsAllowed(emails, force);
+  } catch (err) {
+    console.error(
+      `[ops:teardown-verify-accounts] ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+
+  const resolved = resolveRegionDbUrl(args, process.env);
+  if ("error" in resolved) {
+    console.error(`[ops:teardown-verify-accounts] ${resolved.error}`);
+    process.exit(1);
+  }
+
+  // Bind the internal-DB pool to the chosen region DB. The reused SSOT
+  // teardown functions all operate on the pool that getInternalDB() lazily
+  // initializes from DATABASE_URL; nothing in this code path touches the pool
+  // before this assignment, so it binds to the region we resolved (one-shot
+  // CLI process). Set after resolution so a bad target never rebinds it.
+  process.env.DATABASE_URL = resolved.url;
+  console.log(
+    `[ops:teardown-verify-accounts] target DB: ${resolved.source} · ${dryRun ? "DRY RUN" : "EXECUTE"} · ${emails.length} email(s)`,
+  );
+
+  try {
+    const targets = await resolveVerifyTargets(internalQuery, emails);
+
+    // Blast-radius guard — only on EXECUTE. A preview can list any number.
+    const ownedOrgCount = countOwnedOrgs(targets);
+    if (!dryRun && ownedOrgCount > MAX_TEARDOWN_TARGETS) {
+      console.error(
+        `[ops:teardown-verify-accounts] Refusing to execute: ${ownedOrgCount} owned workspaces resolved ` +
+          `(> ${MAX_TEARDOWN_TARGETS}). This looks too broad for a verification cleanup — narrow --email or re-check the target DB.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const report = await teardownTargets(targets, {
+      purgeStripe: purgeStripeBillingForWorkspace,
+      softDelete: (orgId) => updateWorkspaceStatus(orgId, "deleted"),
+      hardDelete: async (orgId) => {
+        const purged = await hardDeleteWorkspace(orgId);
+        return Object.values(purged).reduce((sum, n) => sum + n, 0);
+      },
+    }, dryRun);
+
+    printTeardownReport(report);
+    if (report.totals.errors > 0) process.exitCode = 1;
+  } catch (err) {
+    console.error(
+      `[ops:teardown-verify-accounts] failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exitCode = 1;
+  } finally {
+    await closeInternalDB().catch((closeErr) => {
+      console.warn(
+        `[ops:teardown-verify-accounts] connection close failed: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+      );
+    });
+  }
+}

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -9,7 +9,7 @@
  * defect mislocated into the US DB.
  *
  * Why reuse, not re-implement: the per-org row set is large and grows (see
- * `hardDeleteWorkspace` in db/internal.ts — ~40 tables). Re-implementing that
+ * `hardDeleteWorkspace` in db/internal.ts — 50+ tables). Re-implementing that
  * cascade here would silently drift the moment a new org-scoped table lands,
  * leaving secrets/rows behind on a "torn-down" account. So this command binds
  * the internal-DB pool to the chosen region's DB and delegates to the same
@@ -81,44 +81,62 @@ export function checkTeardownGate(args: string[], env: NodeJS.ProcessEnv): strin
   return null;
 }
 
-/** Resolved region DB target — the URL plus a label for log lines. */
-export interface ResolvedRegionDb {
-  url: string;
-  /** e.g. "--database-url" or "region eu (ATLAS_REGION_EU_DB_URL)". */
-  source: string;
+/**
+ * Whether this invocation is a DRY RUN (preview, no deletes). True unless the
+ * execute double-gate is satisfied — and `--dry-run` always forces preview
+ * even when the gate is open, so an operator can belt-and-braces a gated run.
+ */
+export function isDryRun(args: string[], env: NodeJS.ProcessEnv): boolean {
+  return checkTeardownGate(args, env) !== null || args.includes("--dry-run");
 }
+
+/**
+ * Resolved region DB target. Tagged union so the handler narrows on `ok`
+ * rather than probing for an `error` key. `region` is the selected region key
+ * when `--region` was used, or `null` for a raw `--database-url` (whose region
+ * we can't know — see the note on the region label in `handleTeardownVerifyAccounts`).
+ */
+export type RegionDbResolution =
+  | { ok: true; url: string; source: string; region: TeardownRegion | null }
+  | { ok: false; error: string };
 
 /**
  * Resolve which region DB to operate on. Precedence: an explicit
  * `--database-url` wins (escape hatch for a non-standard URL); otherwise
  * `--region <us|eu|apac>` maps to that region's `ATLAS_REGION_*_DB_URL`.
- * Returns an error string (never throws) when neither is usable — there is
- * deliberately NO fallback to a bare DATABASE_URL, so an operator can never
+ * Returns `{ ok: false, error }` (never throws) when neither is usable — there
+ * is deliberately NO fallback to a bare DATABASE_URL, so an operator can never
  * tear down the wrong DB by forgetting the flag.
  */
 export function resolveRegionDbUrl(
   args: string[],
   env: NodeJS.ProcessEnv,
-): ResolvedRegionDb | { error: string } {
+): RegionDbResolution {
   const explicit = getFlag(args, "--database-url");
-  if (explicit) return { url: explicit, source: "--database-url" };
+  if (explicit) return { ok: true, url: explicit, source: "--database-url", region: null };
 
   const region = getFlag(args, "--region");
   if (region) {
-    if (!(region in REGION_DB_ENV)) {
+    // Own-key check (not `in`, which walks the prototype chain and would let
+    // `--region constructor` slip past) — keeps the runtime whitelist locked
+    // to the `TeardownRegion` keyof so the cast below is provably sound.
+    if (!Object.hasOwn(REGION_DB_ENV, region)) {
       return {
+        ok: false,
         error: `--region must be one of: ${Object.keys(REGION_DB_ENV).join(", ")} (got "${region}")`,
       };
     }
-    const envVar = REGION_DB_ENV[region as TeardownRegion];
+    const regionKey = region as TeardownRegion;
+    const envVar = REGION_DB_ENV[regionKey];
     const url = env[envVar];
     if (!url) {
-      return { error: `--region ${region} requires ${envVar} to be set in the environment.` };
+      return { ok: false, error: `--region ${region} requires ${envVar} to be set in the environment.` };
     }
-    return { url, source: `region ${region} (${envVar})` };
+    return { ok: true, url, source: `region ${region} (${envVar})`, region: regionKey };
   }
 
   return {
+    ok: false,
     error:
       "No region DB selected. Pass --region <us|eu|apac> (resolves ATLAS_REGION_<R>_DB_URL) " +
       "or --database-url <url>. There is no DATABASE_URL fallback — pick the region explicitly.",
@@ -209,6 +227,23 @@ export interface VerifyTarget {
  */
 export function countOwnedOrgs(targets: VerifyTarget[]): number {
   return targets.reduce((n, t) => n + t.orgs.filter((o) => o.isOwner).length, 0);
+}
+
+/**
+ * The blast-radius guard: refuse to EXECUTE against more owned workspaces than
+ * {@link MAX_TEARDOWN_TARGETS} — a verification run creates one account per
+ * region, so a larger set is almost certainly a too-broad `--email` list or a
+ * wrong DB where one address matches many orgs. Returns a refusal reason, or
+ * null when the run may proceed. Dry-run is always uncapped (preview anything).
+ */
+export function checkBlastRadius(ownedOrgCount: number, dryRun: boolean): string | null {
+  if (!dryRun && ownedOrgCount > MAX_TEARDOWN_TARGETS) {
+    return (
+      `Refusing to execute: ${ownedOrgCount} owned workspaces resolved (> ${MAX_TEARDOWN_TARGETS}). ` +
+      "This looks too broad for a verification cleanup — narrow --email or re-check the target DB."
+    );
+  }
+  return null;
 }
 
 /** Minimal row-returning query surface — `internalQuery` or a test fake. */
@@ -315,6 +350,10 @@ export interface TeardownReport {
     orgsWouldTearDown: number;
     rowsPurged: number;
     errors: number;
+    /** Orgs whose DB cascade succeeded but whose Stripe teardown left a
+     *  warning (e.g. a customer that couldn't be deleted) — a non-clean
+     *  outcome the handler exits non-zero on, even though the row purge ran. */
+    stripeWarnings: number;
   };
 }
 
@@ -343,7 +382,13 @@ export async function teardownTargets(
   dryRun: boolean,
 ): Promise<TeardownReport> {
   const results: TargetTeardownResult[] = [];
-  const totals = { orgsTornDown: 0, orgsWouldTearDown: 0, rowsPurged: 0, errors: 0 };
+  const totals = {
+    orgsTornDown: 0,
+    orgsWouldTearDown: 0,
+    rowsPurged: 0,
+    errors: 0,
+    stripeWarnings: 0,
+  };
 
   for (const target of targets) {
     const targetWarnings: string[] = [];
@@ -392,7 +437,17 @@ export async function teardownTargets(
 
       try {
         const stripe = await deps.purgeStripe(org.orgId, org.stripeCustomerId);
-        await deps.softDelete(org.orgId);
+        // softDelete returns false when no row matched (e.g. the org was
+        // concurrently reactivated/removed between resolve and execute). Surface
+        // that as the cause rather than letting hardDelete throw the downstream
+        // "not in deleted status" error with a misattributed message.
+        const softDeleted = await deps.softDelete(org.orgId);
+        const warnings = [...stripe.warnings];
+        if (!softDeleted) {
+          warnings.push(
+            "Soft-delete affected 0 rows (org concurrently reactivated or removed?) — hard-delete may abort.",
+          );
+        }
         const rowsPurged = await deps.hardDelete(org.orgId);
         orgResults.push({
           orgId: org.orgId,
@@ -402,10 +457,11 @@ export async function teardownTargets(
           status: "torn-down",
           rowsPurged,
           stripeActions: stripe.actions,
-          warnings: stripe.warnings,
+          warnings,
         });
         totals.orgsTornDown += 1;
         totals.rowsPurged += rowsPurged;
+        if (stripe.warnings.length > 0) totals.stripeWarnings += 1;
       } catch (err) {
         totals.errors += 1;
         orgResults.push({
@@ -466,15 +522,15 @@ export function printTeardownReport(report: TeardownReport): void {
     `\n[ops:teardown-verify-accounts] ${report.dryRun ? "would tear down" : "tore down"} ` +
       `${report.dryRun ? t.orgsWouldTearDown : t.orgsTornDown} workspace(s)` +
       (report.dryRun ? "" : `, ${t.rowsPurged} rows purged`) +
+      (t.stripeWarnings > 0 ? `, ${t.stripeWarnings} Stripe warning(s)` : "") +
       (t.errors > 0 ? `, ${t.errors} error(s)` : ""),
   );
 }
 
 /** Wire the command: resolve gate/region/targets, bind the pool, run, report. */
 export async function handleTeardownVerifyAccounts(args: string[]): Promise<void> {
-  // DRY RUN unless the double-gate is satisfied AND --dry-run was not forced.
-  const gateReason = checkTeardownGate(args, process.env);
-  const dryRun = gateReason !== null || args.includes("--dry-run");
+  // DRY RUN unless the execute double-gate is satisfied AND --dry-run wasn't forced.
+  const dryRun = isDryRun(args, process.env);
   const force = args.includes("--force");
 
   let emails: string[];
@@ -489,16 +545,22 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
   }
 
   const resolved = resolveRegionDbUrl(args, process.env);
-  if ("error" in resolved) {
+  if (!resolved.ok) {
     console.error(`[ops:teardown-verify-accounts] ${resolved.error}`);
     process.exit(1);
   }
 
-  // Bind the internal-DB pool to the chosen region DB. The reused SSOT
-  // teardown functions all operate on the pool that getInternalDB() lazily
-  // initializes from DATABASE_URL; nothing in this code path touches the pool
-  // before this assignment, so it binds to the region we resolved (one-shot
-  // CLI process). Set after resolution so a bad target never rebinds it.
+  // Bind the internal-DB pool to the chosen region DB. The reused SSOT teardown
+  // functions all operate on the pool getInternalDB() lazily initializes from
+  // DATABASE_URL. Close any pre-bound pool FIRST so this rebind is authoritative
+  // rather than a silent no-op against a previously-bound DB — the wrong-DB
+  // footgun would otherwise delete from the wrong region. (In the normal
+  // one-shot CLI path no pool exists yet, so this is a cheap no-op.)
+  await closeInternalDB().catch(() => {
+    // intentionally ignored: best-effort discard of any pre-bound pool before
+    // rebinding; a close failure here doesn't change which URL the next
+    // getInternalDB() binds to.
+  });
   process.env.DATABASE_URL = resolved.url;
   console.log(
     `[ops:teardown-verify-accounts] target DB: ${resolved.source} · ${dryRun ? "DRY RUN" : "EXECUTE"} · ${emails.length} email(s)`,
@@ -507,13 +569,16 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
   try {
     const targets = await resolveVerifyTargets(internalQuery, emails);
 
+    // Deliberately NO "org.region must equal --region" guard: the stamped
+    // organization.region label is exactly the untrustworthy #3967 artifact this
+    // tool cleans up (an EU/APAC label on a row mislocated in the US DB). The
+    // physical DB selected by --region/--database-url is the ground truth; the
+    // label is surfaced in the report as mislocation evidence, never gated on.
+
     // Blast-radius guard — only on EXECUTE. A preview can list any number.
-    const ownedOrgCount = countOwnedOrgs(targets);
-    if (!dryRun && ownedOrgCount > MAX_TEARDOWN_TARGETS) {
-      console.error(
-        `[ops:teardown-verify-accounts] Refusing to execute: ${ownedOrgCount} owned workspaces resolved ` +
-          `(> ${MAX_TEARDOWN_TARGETS}). This looks too broad for a verification cleanup — narrow --email or re-check the target DB.`,
-      );
+    const blastRefusal = checkBlastRadius(countOwnedOrgs(targets), dryRun);
+    if (blastRefusal) {
+      console.error(`[ops:teardown-verify-accounts] ${blastRefusal}`);
       process.exitCode = 1;
       return;
     }
@@ -528,7 +593,11 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
     }, dryRun);
 
     printTeardownReport(report);
-    if (report.totals.errors > 0) process.exitCode = 1;
+    // Exit non-zero on a row-purge error OR a left-behind Stripe customer — a
+    // scripted cleanup must fail loudly rather than report a clean "success"
+    // while a billable Stripe linkage survives (it's enqueued for durable retry,
+    // but the operator/CI should still know it didn't fully complete).
+    if (report.totals.errors > 0 || report.totals.stripeWarnings > 0) process.exitCode = 1;
   } catch (err) {
     console.error(
       `[ops:teardown-verify-accounts] failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -18,6 +18,13 @@
  *                          staging-smoke gate, not per-PR CI. Optional
  *                          `--wipe-twenty` is double-gated by
  *                          `ATLAS_SMOKE_WIPE_OK=1`. See ./ops-smoke-crm.ts.
+ *   teardown-verify-accounts  Surgically tear down the throwaway
+ *                          `/verify-prod-signup` test accounts (user + org +
+ *                          Stripe customer) left in a region's internal DB after
+ *                          a 3-region residency verification (ADR-0024, #3974).
+ *                          DRY RUN by default; EXECUTE is double-gated by
+ *                          `ATLAS_TEARDOWN_OK=1` + `--confirm`. One region DB per
+ *                          invocation. See ./ops-teardown-verify.ts.
  *
  * Wipe replaces internal/wipe-prod.sh's per-DB logic; the script's
  * Railway-credential fetching and 3-region orchestration are operator concerns
@@ -269,9 +276,13 @@ export async function handleOps(args: string[]): Promise<void> {
     const { handleOpsSmokeCrm } = await import("./ops-smoke-crm");
     return handleOpsSmokeCrm(args);
   }
+  if (subcommand === "teardown-verify-accounts") {
+    const { handleTeardownVerifyAccounts } = await import("./ops-teardown-verify");
+    return handleTeardownVerifyAccounts(args);
+  }
 
   console.error(
-    "Usage: atlas ops <wipe|backfill-crm-leads|smoke-crm> [options]\n\n" +
+    "Usage: atlas ops <wipe|backfill-crm-leads|smoke-crm|teardown-verify-accounts> [options]\n\n" +
       "Subcommands:\n" +
       "  wipe                 TRUNCATE every public table in the tenant DB. DESTRUCTIVE — requires ATLAS_WIPE_OK=1 + --confirm.\n" +
       "  backfill-crm-leads   Enqueue every demo_leads row into crm_outbox for dispatch to Twenty.\n" +
@@ -279,7 +290,11 @@ export async function handleOps(args: string[]): Promise<void> {
       "  smoke-crm            End-to-end CRM lead-capture verification (below Turnstile).\n" +
       "                       Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1),\n" +
       "                              --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60),\n" +
-      "                              --database-url <url>\n",
+      "                              --database-url <url>\n" +
+      "  teardown-verify-accounts  Surgically delete throwaway /verify-prod-signup accounts (user + org + Stripe customer)\n" +
+      "                       from one region's internal DB. DRY RUN by default; EXECUTE requires ATLAS_TEARDOWN_OK=1 + --confirm.\n" +
+      "                       Flags: --email <addr[,addr]> (required, repeatable), --region <us|eu|apac> OR --database-url <url>,\n" +
+      "                              --dry-run, --force (allow non-plus-addressed emails)\n",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Hardens `/verify-prod-signup` into the **ADR-0024 residency regression gate** for the #3967 cluster, and adds the operator tooling to tear down the throwaway `verify-*` accounts the original prod verification left behind. Closeout gate for #3967 (all deps #3969–#3973 merged).

**Skill (`.claude/commands/verify-prod-signup.md`)** — new per-region ADR-0024 residency-invariant assertions:
- **Cross-region edge matrix** — the workspace's own region edge `200`s; both other region edges `401` (identity row lives only in-region; the host-only session cookie never transits a foreign edge). A foreign-edge `200` is the #3967 violation returning.
- **Returning-user login routing** via the `app.useatlas.dev` front-door (`POST /api/login/resolve-region` → `{ outcome:"single", region, apiUrl }`).
- **Multi-region chooser** (same email in two regions → `outcome:"multiple"`).
- **Raw per-region existence probe** (`POST /api/v1/auth/region-probe` with `sha256(lower(email))`) — region-local, session-free.
- Corrected the now-wrong "cookie rides cross-subdomain" note (host-only per ADR-0024 §5); rewrote teardown around the new CLI tool + a US-DB residue dry-run check.

**CLI (`atlas ops teardown-verify-accounts`)** — surgically tears down throwaway verify accounts (user + org + Stripe customer) from **one** region's internal DB:
- **Reuses the platform-admin purge SSOT** (`purgeStripeBillingForWorkspace` → `updateWorkspaceStatus(deleted)` → `hardDeleteWorkspace`) instead of re-implementing the 50+-table cascade — no schema drift.
- **DRY RUN by default**; EXECUTE double-gated (`ATLAS_TEARDOWN_OK=1` + `--confirm`), like `ops wipe`. `--region <us|eu|apac>` resolves `ATLAS_REGION_<R>_DB_URL` with **no `DATABASE_URL` fallback**; non-plus-addressed emails refused unless `--force`; blast-radius cap on executes; binds the internal pool authoritatively (closes any pre-bound pool first).
- Pure helpers + injected-deps orchestration, unit-tested with fakes (47 tests, no real DB).

## Deferred to post-`/release` (operator step)

Prod-green verification across all 3 regions **and** prod teardown execution are deferred to **after** `/release` advances prod to v0.0.31 — that is the operator step, out of scope here. `main` = staging; prod stays on the prior tag until release. This PR lands the **verifier extensions + teardown tooling**, validated against unit tests and (where the fix is deployed) staging. The "gate passes green on prod across all 3 regions" acceptance criterion is the deferred operator action.

## Test plan
- [x] `bun run lint` / `bun run type` clean
- [x] `@atlas/cli` full isolated suite 31/31 (incl. 47 new teardown tests)
- [x] `--affected` confirms the CLI-only change touches zero `@atlas/api` tests (the 4 local `@atlas/api` fails are the documented WSL2 sandbox/agent flakes; cli→api dependency direction only)
- [x] All `/ci` drift gates pass (template, schema, openapi, railway-watch, settings-readers, saas-env-doc, published-symbols, …)
- [x] Internal review-panel: 2 rounds → CLEAN (silent-failure, type-design, test-coverage, comments)

Closes #3974

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `atlas ops teardown-verify-accounts` CLI command with dry-run and residency regression tests
> - Adds a new [`ops-teardown-verify.ts`](https://github.com/AtlasDevHQ/atlas/pull/4008/files#diff-dd41568c6ead7f1f84f56bf9704379da252d8545033b68cc8e369a2b690dad66) CLI command that tears down verification accounts by email, performing Stripe purge → soft-delete → hard-delete in sequence against a chosen region DB.
> - Requires a double-gate (`ATLAS_TEARDOWN_OK=1` env var + `--confirm` flag) to execute; defaults to dry-run preview mode.
> - Enforces safety checks: plus-addressed email validation, a blast-radius cap of 12 owned workspaces, explicit `--region` or `--database-url` selection with no implicit `DATABASE_URL` fallback.
> - Routes the new subcommand through the existing [`ops.ts`](https://github.com/AtlasDevHQ/atlas/pull/4008/files#diff-c2df7f0c16fef1764df4a6b8e58453161aba0a6fcf13f09d4a601606f98def69) dispatcher and adds a full unit test suite in [`ops-teardown-verify.test.ts`](https://github.com/AtlasDevHQ/atlas/pull/4008/files#diff-ffcd05650f8eb914b4d59cfd50ebe95bf894bd6e9459d0196c9256586edf60e2).
> - Expands the `/verify-prod-signup` runbook with ADR-0024 residency-invariant checks and teardown guidance referencing the new command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7801450.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->