### PR TITLE
fix(api): stop minting a user-level Stripe customer on signup (org-scoped billing)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/stripe-checkout.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-checkout.test.ts
@@ -128,9 +128,10 @@ async function signUp(auth: ReturnType<typeof makeAuth>): Promise<string> {
     }),
   );
   expect(res.status).toBe(200);
-  // createCustomerOnSignUp fires a USER customers.create during sign-up;
-  // clear it so assertions below isolate the ORG customer-creation path.
-  customersCreate.mockClear();
+  // createCustomerOnSignUp is OFF (org-scoped billing) — signup must NOT mint a
+  // user-level Stripe customer. Assert that here, so the ORG customer-creation
+  // assertions below also start from a clean call count.
+  expect(customersCreate).not.toHaveBeenCalled();
   return res.headers.get("set-cookie")!.split(";")[0];
 }
 

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -357,6 +357,21 @@ describe("buildStripePluginOptions — org-scoped configuration (#3416)", () => 
     }
   });
 
+  // Pin the org-scoped billing contract: NO user-level customer on signup.
+  // Atlas bills `organization.stripeCustomerId` exclusively; a per-signup user
+  // customer is never used for billing and required a plugin-managed
+  // `user.stripeCustomerId` column that drifted across region DBs (US had it,
+  // EU/APAC didn't → silent orphaned-customer leak on every EU/APAC signup). A
+  // revert to `true` would reintroduce that, and only this assertion would catch
+  // it (every other test exercises the org path). See residency cleanup (#4011).
+  it("does NOT create a user-level Stripe customer on signup (org-scoped only)", () => {
+    const options = buildStripePluginOptions({
+      stripeClient: makeStripeClient(),
+      webhookSecret: "whsec_test",
+    });
+    expect(options.createCustomerOnSignUp).toBe(false);
+  });
+
   // #3703 — pin the hot-reload contract: `plans` must be the resolver FUNCTION,
   // not an eager array snapshot. A revert to `plans: getStripePlans()` would
   // restore the redeploy-required footgun, and only this assertion would catch

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -361,9 +361,9 @@ describe("buildStripePluginOptions — org-scoped configuration (#3416)", () => 
   // Atlas bills `organization.stripeCustomerId` exclusively; a per-signup user
   // customer is never used for billing and required a plugin-managed
   // `user.stripeCustomerId` column that drifted across region DBs (US had it,
-  // EU/APAC didn't → silent orphaned-customer leak on every EU/APAC signup). A
-  // revert to `true` would reintroduce that, and only this assertion would catch
-  // it (every other test exercises the org path). See residency cleanup (#4011).
+  // EU/APAC didn't → an orphaned-customer leak on EU/APAC signup). A revert to
+  // `true` would reintroduce that. This is the config-shape guard; the behavioral
+  // counterpart (signup mints no customer) is in stripe-checkout.test.ts. See #4012.
   it("does NOT create a user-level Stripe customer on signup (org-scoped only)", () => {
     const options = buildStripePluginOptions({
       stripeClient: makeStripeClient(),

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2045,7 +2045,17 @@ export function buildStripePluginOptions(deps: {
   return {
     stripeClient,
     stripeWebhookSecret: webhookSecret,
-    createCustomerOnSignUp: true,
+    // OFF deliberately: Atlas subscriptions are ORG-scoped (org mode below), so
+    // billing always uses `organization.stripeCustomerId` (created lazily at the
+    // first /subscription/upgrade). A user-level customer minted on every signup
+    // is never used for billing — it only created Stripe clutter and required a
+    // plugin-managed `user.stripeCustomerId` column that drifted across region DBs
+    // (US had it; EU/APAC didn't), so every EU/APAC signup silently leaked an
+    // orphaned customer (the plugin's create-hook swallows the failed write). No
+    // Atlas code reads `user.stripeCustomerId` — the CRM conversion stamp uses the
+    // org/subscription customer. See residency cleanup (#4011); the now-unwritten
+    // column is dropped in the release-N+1 migration (two-phase discipline).
+    createCustomerOnSignUp: false,
     // #3416 — Atlas subscriptions are ORG-scoped, not user-scoped. With
     // org mode on, the plugin maintains `organization.stripeCustomerId`
     // (created lazily at first /subscription/upgrade), blocks org deletion

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2050,11 +2050,13 @@ export function buildStripePluginOptions(deps: {
     // first /subscription/upgrade). A user-level customer minted on every signup
     // is never used for billing — it only created Stripe clutter and required a
     // plugin-managed `user.stripeCustomerId` column that drifted across region DBs
-    // (US had it; EU/APAC didn't), so every EU/APAC signup silently leaked an
-    // orphaned customer (the plugin's create-hook swallows the failed write). No
-    // Atlas code reads `user.stripeCustomerId` — the CRM conversion stamp uses the
-    // org/subscription customer. See residency cleanup (#4011); the now-unwritten
-    // column is dropped in the release-N+1 migration (two-phase discipline).
+    // (US had it; EU/APAC didn't). On a column-less region the plugin's create-hook
+    // catches and error-logs its own failed write, so the first EU/APAC signup
+    // would leak an orphaned Stripe customer while still completing (latent — no
+    // EU/APAC signups have run post-residency-fix yet). No Atlas code reads
+    // `user.stripeCustomerId` (the CRM conversion stamp uses the org/subscription
+    // customer). Root cause #4012; the now-unwritten column is dropped in the
+    // release-N+1 migration #4013 (two-phase drop discipline).
     createCustomerOnSignUp: false,
     // #3416 — Atlas subscriptions are ORG-scoped, not user-scoped. With
     // org mode on, the plugin maintains `organization.stripeCustomerId`


### PR DESCRIPTION
Fixes #4012.

## What
Turns off `createCustomerOnSignUp` for the @better-auth/stripe plugin so Atlas no longer mints a **user-level** Stripe customer on every signup.

## Why
Atlas subscriptions are strictly **org-scoped** — billing uses `organization.stripeCustomerId` (created lazily at first `/subscription/upgrade`). With `createCustomerOnSignUp: true`, the plugin *also* created a user-level customer on every signup that billing never used, and required a plugin-managed `user.stripeCustomerId` column that **drifted across region DBs**: US had it, **EU/APAC didn't**. The plugin's create-hook catches + error-logs its own failed write, so the first EU/APAC signup would **leak an orphaned Stripe customer** while still completing (latent — no post-residency-fix EU/APAC signups have happened yet).

Surfaced during the v0.0.31 3-region residency verification (#4007) while tearing down the #3943 residue (the deleted verify accounts each carried an unused user-level customer).

## Safety
- **No Atlas code reads `user.stripeCustomerId`** — the SaaS-CRM conversion stamp uses the org/subscription customer; every other read is org/subscription-scoped.
- The plugin's webhook fallback `findReferenceByStripeCustomerId` queries `user` only when the **org lookup misses**, effectively dead in Atlas's org-scoped model.

## Two-phase removal
**Phase 1 (this PR):** stop the write. The `user.stripeCustomerId` column DROP is the **release-N+1** migration → #4013 (two-phase drop discipline — old instances still write the column during the rolling deploy).

## Tests
- `stripe-webhook-lifecycle.test.ts` pins `createCustomerOnSignUp === false` (config-shape guard).
- `stripe-checkout.test.ts` asserts signup mints no user-level customer (behavioral counterpart).
- All 3 stripe suites green (44 tests, 0 fail).

Also makes #4011 (teardown orphaning a user-level customer) moot for new accounts.

https://claude.ai/code/session_01Qu3NZLYPwp3Bs3J5qJmJzG


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop minting user-level Stripe customers on signup for org-scoped billing
> Sets `createCustomerOnSignUp` to `false` in `buildStripePluginOptions` in [server.ts](https://github.com/AtlasDevHQ/atlas/pull/4014/files#diff-a90f21a4746a0b323fcdedf90f8bda584edc7618dff55cc26b921c1c32562526), so the Stripe plugin no longer creates a per-user customer during signup. Stripe customer creation is now handled exclusively at the organization scope. Tests are updated to assert `customersCreate` is never called on signup and that the config option is explicitly `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a96ec9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->