### PR TITLE
fix(web): send OTP explicitly on existing-email signup, end the dead-end (#4010)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -294,6 +294,11 @@ describe("config wiring snapshot — buildAuthOptions", () => {
     const options = buildAuthOptions(makeDeps());
     expect(options.emailVerification?.autoSignInAfterVerification).toBe(true);
     expect(options.emailVerification?.sendOnSignIn).toBe(true);
+    // #4010 — the signup auto-send must stay OFF so the client is the single
+    // source of the signup OTP (no double-send on fresh, no dead-end on
+    // existing-email's synthetic token:null). A refactor that drops this flag
+    // lets it default to `requireEmailVerification` (true) and reopens both.
+    expect(options.emailVerification?.sendOnSignUp).toBe(false);
   });
 
   it("wires `rewriteVerificationCallbackURL` into the password-reset dispatch path", async () => {

--- a/packages/api/src/lib/auth/__tests__/signup-otp-send.test.ts
+++ b/packages/api/src/lib/auth/__tests__/signup-otp-send.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { betterAuth } from "better-auth";
+import { emailOTP } from "better-auth/plugins/email-otp";
+import { buildAuthOptions, parseAuthSecret, type BuildAuthOptionsDeps } from "../server";
+
+/**
+ * Real-better-auth regression for #4010 — the existing-email OTP dead-end.
+ *
+ * The mock-based page test (`signup/account/page.test.tsx`) asserts the CLIENT
+ * now dispatches the OTP explicitly. This file owns the SERVER half: that
+ * better-auth's actual `requireEmailVerification: true` signup path behaves the
+ * way the fix assumes, exercised against a live instance with the built-in
+ * in-memory adapter (no DB) — the same wiring `getAuthInstance()` uses, plus the
+ * real `emailOTP` plugin (with a capturing `sendVerificationOTP` in place of the
+ * Resend dispatcher so we can observe sends).
+ *
+ * The three invariants the fix rests on:
+ *
+ *   1. A FRESH signup does NOT auto-send the OTP from the signup endpoint —
+ *      `emailVerification.sendOnSignUp: false` makes the client the single
+ *      source, so there's no double-send. (Before the fix this fired here.)
+ *   2. A SECOND signup with the SAME email returns the synthetic
+ *      `{ token: null }` success (enumeration protection) and likewise does not
+ *      send — byte-identical to the fresh case at the endpoint, which is exactly
+ *      why the client can't tell them apart and must own the send.
+ *   3. The client-driven `/email-otp/send-verification-otp` (what the page now
+ *      calls post-`signUp.email`) DOES dispatch a real OTP for the existing
+ *      user — proving the duplicate path reaches a truthful code screen rather
+ *      than dead-ending. This is the call the mock test can only assert was
+ *      issued; here we prove better-auth honors it.
+ *
+ * A pre-fix `sendOnSignUp: <default true>` would make invariant 1 red (the fresh
+ * signup would send once from the endpoint AND once from the client → two OTPs).
+ */
+
+const AUTH_ENV_VARS = ["ATLAS_REQUIRE_EMAIL_VERIFICATION"] as const;
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
+for (const key of AUTH_ENV_VARS) ORIGINAL_ENV[key] = process.env[key];
+
+beforeEach(() => {
+  for (const key of AUTH_ENV_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of AUTH_ENV_VARS) {
+    if (ORIGINAL_ENV[key] === undefined) delete process.env[key];
+    else process.env[key] = ORIGINAL_ENV[key];
+  }
+});
+
+// 32 chars — satisfies the BETTER_AUTH_SECRET length floor.
+const SECRET = parseAuthSecret("0123456789abcdef0123456789abcdef");
+
+/** Records every OTP the plugin asks Atlas to dispatch (plaintext code included
+ *  so a test can drive a real verify round-trip). */
+type SentOTP = { email: string; type: string; otp: string };
+
+/**
+ * Build a live better-auth instance wired through `buildAuthOptions` (the exact
+ * call path `getAuthInstance()` uses), with the real `emailOTP` plugin mirroring
+ * Atlas's server config — but its `sendVerificationOTP` captured into `sent`
+ * instead of hitting Resend, so we can assert exactly when (and how often) a
+ * send fires.
+ *
+ * `database: undefined` → better-auth falls back to its in-memory adapter, which
+ * starts empty per test-file subprocess under Atlas's isolated runner.
+ */
+function makeAuth(sent: SentOTP[]): ReturnType<typeof betterAuth> {
+  const deps: BuildAuthOptionsDeps = {
+    env: { ATLAS_REQUIRE_EMAIL_VERIFICATION: "true" } as NodeJS.ProcessEnv,
+    secret: SECRET,
+    baseURL: "http://localhost:3000",
+    database: undefined,
+    cookiePrefix: "atlas",
+    socialProviders: undefined,
+    // Mirror the production emailOTP config (server.ts buildPlugins) — same
+    // override + signup flags — with the dispatcher swapped for a recorder.
+    plugins: [
+      emailOTP({
+        otpLength: 8,
+        expiresIn: 600,
+        sendVerificationOnSignUp: false,
+        overrideDefaultEmailVerification: true,
+        storeOTP: "hashed",
+        sendVerificationOTP: async (data) => {
+          sent.push({ email: data.email, type: data.type, otp: data.otp });
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types vary by combination
+    ] as any,
+    trustedOrigins: ["http://localhost:3000"],
+    bootstrapAdmin: { mode: "none" },
+  };
+  const options = buildAuthOptions(deps);
+  return betterAuth(options as Parameters<typeof betterAuth>[0]);
+}
+
+// Each test passes its OWN `ip` so the auth rate-limit buckets (keyed on
+// x-atlas-client-ip; the OTP send endpoint inherits the global default
+// 100/60s, while /sign-up/email caps at 5/60s) never collide across tests
+// sharing this subprocess — mirroring rate-limit-integration.test.ts's
+// per-scenario IP isolation. A shared IP would let a sibling test's calls
+// exhaust the /sign-up bucket and turn a real dispatch into a silent 429.
+function authPost(path: string, body: unknown, ip: string): Request {
+  return new Request(`http://localhost:3000/api/auth${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-atlas-client-ip": ip, // TEST-NET-1 (192.0.2.0/24) — never a real client
+      "origin": "http://localhost:3000",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function signupRequest(email: string, ip: string): Request {
+  return authPost("/sign-up/email", { email, password: "hunter2hunter2", name: "Jane" }, ip);
+}
+
+function sendOtpRequest(email: string, ip: string): Request {
+  return authPost("/email-otp/send-verification-otp", { email, type: "email-verification" }, ip);
+}
+
+function verifyOtpRequest(email: string, otp: string, ip: string): Request {
+  return authPost("/email-otp/verify-email", { email, otp }, ip);
+}
+
+describe("signup OTP send wiring — real better-auth (#4010)", () => {
+  it("a FRESH signup returns token:null and does NOT auto-send from the signup endpoint (no double-send)", async () => {
+    const sent: SentOTP[] = [];
+    const auth = makeAuth(sent);
+    const email = `fresh-${Date.now()}@example.com`;
+    const ip = "192.0.2.11";
+
+    const res = await auth.handler(signupRequest(email, ip));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string | null };
+    // requireEmailVerification=true ⟹ no session token on signup.
+    expect(body.token).toBeNull();
+    // The single-source-of-send invariant: the signup endpoint must NOT fire
+    // the OTP. Before the fix (`sendOnSignUp` defaulting to true) this was 1,
+    // which — combined with the now-explicit client send — double-mailed.
+    expect(sent).toHaveLength(0);
+  });
+
+  it("a SECOND signup with the same email returns the synthetic token:null and still does not send", async () => {
+    const sent: SentOTP[] = [];
+    const auth = makeAuth(sent);
+    const email = `dup-${Date.now()}@example.com`;
+    const ip = "192.0.2.12";
+
+    const first = await auth.handler(signupRequest(email, ip));
+    expect(first.status).toBe(200);
+
+    const second = await auth.handler(signupRequest(email, ip));
+    // Enumeration protection: the existing-email branch returns a synthetic
+    // success indistinguishable from the fresh one — same 200, same token:null.
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as { token: string | null };
+    expect(body.token).toBeNull();
+    // Neither signup attempt sent — the endpoint is silent on both branches,
+    // which is precisely why the client (which can't tell them apart) owns it.
+    expect(sent).toHaveLength(0);
+  });
+
+  it("the client-driven resend endpoint DOES dispatch a real OTP for an already-registered email (the dead-end fix)", async () => {
+    const sent: SentOTP[] = [];
+    const auth = makeAuth(sent);
+    const email = `existing-${Date.now()}@example.com`;
+    const ip = "192.0.2.13";
+
+    // Register the email (first signup creates the real user row).
+    await auth.handler(signupRequest(email, ip));
+    // A second signup is the prod scenario; both signups are silent.
+    await auth.handler(signupRequest(email, ip));
+    expect(sent).toHaveLength(0);
+
+    // This is exactly what the fixed page does after `signUp.email` resolves
+    // with token:null — call the enumeration-safe resend endpoint. The user
+    // row exists, so better-auth dispatches a real OTP: no dead-end.
+    const res = await auth.handler(sendOtpRequest(email, ip));
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].email).toBe(email);
+    expect(sent[0].type).toBe("email-verification");
+  });
+
+  it("dispatches a real OTP for an already-VERIFIED existing email too (AC1 verified sub-case)", async () => {
+    // AC1 covers an already-registered email that is EITHER unverified OR
+    // verified. A verified user whose email is re-entered at signup still hits
+    // the synthetic `token: null` path and the page still drives the resend —
+    // so the resend must keep dispatching even after the user is verified, or
+    // the verified-existing-email signup would dead-end exactly like the bug.
+    const sent: SentOTP[] = [];
+    const auth = makeAuth(sent);
+    const email = `verified-${Date.now()}@example.com`;
+    const ip = "192.0.2.14";
+
+    // Register, then fully verify the user via a real OTP round-trip.
+    await auth.handler(signupRequest(email, ip));
+    const sendRes = await auth.handler(sendOtpRequest(email, ip));
+    expect(sendRes.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    const verifyRes = await auth.handler(verifyOtpRequest(email, sent[0].otp, ip));
+    expect(verifyRes.status).toBe(200); // email is now verified
+
+    // Re-entering the (now verified) email at signup returns the synthetic
+    // success again, and the client-driven resend must STILL dispatch a code.
+    const dupSignup = await auth.handler(signupRequest(email, ip));
+    expect(dupSignup.status).toBe(200);
+    const resend = await auth.handler(sendOtpRequest(email, ip));
+    expect(resend.status).toBe(200);
+    // A second OTP was dispatched for the verified user — no dead-end.
+    expect(sent).toHaveLength(2);
+    expect(sent[1].email).toBe(email);
+    expect(sent[1].type).toBe("email-verification");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2399,16 +2399,23 @@ export function buildPlugins() {
   // installs the OTP sender as `emailVerification.sendVerificationEmail`,
   // which is why our config above intentionally does NOT wire a
   // sendVerificationEmail callback — adding one would win the options
-  // merge and reintroduce a magic-link path. `sendVerificationOnSignUp:
-  // true` triggers the OTP send automatically as part of the signup
-  // pipeline. `storeOTP: "hashed"` keeps the plaintext code out of the
-  // verification table — only the hash is persisted, the user-supplied
-  // code is hashed and compared at verify time.
+  // merge and reintroduce a magic-link path. `storeOTP: "hashed"` keeps
+  // the plaintext code out of the verification table — only the hash is
+  // persisted, the user-supplied code is hashed and compared at verify
+  // time.
+  //
+  // `sendVerificationOnSignUp: false` (#4010): the plugin's auto-send-on-
+  // signup hook only fires when `overrideDefaultEmailVerification` is
+  // FALSE (see the plugin's `after` matcher) — with the override on it's
+  // already dead — but pinning it `false` makes the intent explicit:
+  // the signup OTP is sent by the client, not by the signup pipeline.
+  // Paired with `emailVerification.sendOnSignUp: false` above, this closes
+  // the existing-email dead-end (synthetic `{ token: null }` with no send).
   plugins.push(
     emailOTP({
       otpLength: 8,
       expiresIn: 600,
-      sendVerificationOnSignUp: true,
+      sendVerificationOnSignUp: false,
       overrideDefaultEmailVerification: true,
       storeOTP: "hashed",
       sendVerificationOTP: async (data) => {
@@ -3104,6 +3111,21 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       // tested helper for the rate-limit smoke tests; it has no live
       // call site now that OTP is the sole verification path.
       autoSignInAfterVerification: true,
+      // #4010 — the signup endpoint must NOT auto-send the verification OTP.
+      // better-auth's `requireEmailVerification: true` path returns a synthetic
+      // `{ token: null }` success for an already-registered email (enumeration
+      // protection) WITHOUT running its signup send block — so an implicit
+      // auto-send fires for fresh emails but silently skips duplicates, dead-
+      // ending the existing-email signup at the code screen with no OTP sent.
+      // We make the client own the send (via the enumeration-safe
+      // `/email-otp/send-verification-otp` resend endpoint, post-`signUp.email`)
+      // as the SINGLE source of the signup OTP — truthful "we sent a code" copy
+      // on every reachable path, no double-send on the fresh path. Without this
+      // `false`, the default is `requireEmailVerification` (true) and the fresh
+      // path would send twice. (This gates ONLY the signup auto-send; the
+      // `emailOTP` plugin's `init()` override still installs the OTP sender as
+      // `sendVerificationEmail` for `sendOnSignIn` re-issues below.)
+      sendOnSignUp: false,
       // Re-issue a verification code whenever an unverified user attempts
       // sign-in. The plugin's override turns this into an OTP send.
       sendOnSignIn: true,

--- a/packages/web/src/app/signup/account/page.test.tsx
+++ b/packages/web/src/app/signup/account/page.test.tsx
@@ -32,10 +32,15 @@ const signUpEmailMock = mock(async (_opts: { email: string; password: string; na
   error: null,
 }));
 const signInSocialMock = mock(async (_opts: { provider: string; callbackURL: string }) => ({}));
+type SendOtpResult = { data?: unknown; error?: { message?: string } | null };
+const sendVerificationOtpMock = mock(
+  async (_opts: { email: string; type: "email-verification" }): Promise<SendOtpResult> => ({ data: {}, error: null }),
+);
 mock.module("@/lib/auth/client", () => ({
   authClient: {
     signUp: { email: signUpEmailMock },
     signIn: { social: signInSocialMock },
+    emailOtp: { sendVerificationOtp: sendVerificationOtpMock },
   },
 }));
 
@@ -91,6 +96,8 @@ beforeEach(() => {
   signUpEmailMock.mockReset();
   signUpEmailMock.mockImplementation(async () => ({ data: { token: "tok" }, error: null }));
   signInSocialMock.mockReset();
+  sendVerificationOtpMock.mockReset();
+  sendVerificationOtpMock.mockImplementation(async () => ({ data: {}, error: null }));
   navigatePostAuthMock.mockReset();
   readDraftMock.mockReset();
   readDraftMock.mockImplementation(() => ({ email: "jane@example.com" }));
@@ -161,7 +168,13 @@ describe("AccountPage — create account on the regional client (#3972)", () => 
     expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/workspace");
   });
 
-  test("verification-required (no token) shows the OTP interstitial; verifying then navigates", async () => {
+  test("verification-required (no token) sends the OTP explicitly, then shows the interstitial; verifying navigates (#4010)", async () => {
+    // better-auth returns `token: null` for BOTH a fresh signup needing
+    // verification AND an already-registered email (enumeration protection's
+    // synthetic success). With `emailVerification.sendOnSignUp: false` on the
+    // server, the signup endpoint never auto-sends — so the client OWNS the
+    // send. Asserting the explicit `sendVerificationOtp` call makes the
+    // "we sent a code" copy truthful on every reachable path (no dead-end).
     signUpEmailMock.mockImplementation(async () => ({ data: { token: null }, error: null }));
     render(<AccountPage />);
     await screen.findByText("jane@example.com");
@@ -174,6 +187,11 @@ describe("AccountPage — create account on the regional client (#3972)", () => 
     await waitFor(() => {
       expect(screen.getByText(/enter your code/i)).toBeDefined();
     });
+    // The code screen is only truthful if a real OTP was dispatched.
+    expect(sendVerificationOtpMock).toHaveBeenCalledWith({
+      email: "jane@example.com",
+      type: "email-verification",
+    });
     // Not navigated yet — waiting on the code.
     expect(navigatePostAuthMock).not.toHaveBeenCalled();
 
@@ -181,6 +199,98 @@ describe("AccountPage — create account on the regional client (#3972)", () => 
       fireEvent.click(screen.getByRole("button", { name: /verify-code/i }));
     });
     expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/workspace");
+  });
+
+  test("an already-registered email still reaches a truthful code screen — the OTP is sent, no dead-end (#4010)", async () => {
+    // The prod symptom: signing up an existing email returned `token: null`
+    // (synthetic success) and the page rendered the code screen WITHOUT any
+    // send — a silent dead-end with lying copy. The duplicate case is
+    // byte-identical to a fresh signup at the client, so the explicit send
+    // must fire here too. (`sendVerificationOtp` is enumeration-safe and the
+    // user row exists post-signUp in both cases, so a real OTP is delivered.)
+    signUpEmailMock.mockImplementation(async () => ({ data: { token: null }, error: null }));
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(sendVerificationOtpMock).toHaveBeenCalledTimes(1);
+    });
+    expect(sendVerificationOtpMock.mock.calls[0][0]).toEqual({
+      email: "jane@example.com",
+      type: "email-verification",
+    });
+    expect(screen.getByText(/enter your code/i)).toBeDefined();
+  });
+
+  test("a token present (verification off) navigates straight on without sending an OTP", async () => {
+    // Self-hosted dev path: requireEmailVerification=false → signUp returns a
+    // session token and we skip the code screen entirely. No client-driven
+    // send should fire on this branch.
+    signUpEmailMock.mockImplementation(async () => ({ data: { token: "tok" }, error: null }));
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/signup/workspace");
+    });
+    expect(sendVerificationOtpMock).not.toHaveBeenCalled();
+  });
+
+  test("a THROWN OTP-send failure still lands the user on the code screen so Resend is reachable (#4010)", async () => {
+    // The send is awaited, but a thrown rejection (network failure) is caught
+    // and swallowed for navigation purposes — never block the UI on a send
+    // error. The code screen's "Resend code" control is the recovery path.
+    signUpEmailMock.mockImplementation(async () => ({ data: { token: null }, error: null }));
+    sendVerificationOtpMock.mockImplementation(async () => {
+      throw new Error("transient send failure");
+    });
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/enter your code/i)).toBeDefined();
+    });
+    expect(sendVerificationOtpMock).toHaveBeenCalled();
+  });
+
+  test("a RETURNED-error OTP send (e.g. rate-limit 429) still lands the code screen — better-auth returns, not throws (#4010)", async () => {
+    // The higher-probability production failure: better-auth client methods
+    // surface failures as a returned `{ error }` envelope (the OTP endpoint's
+    // rate limit returns 429 this way) rather than throwing. The page must NOT
+    // silently drop it — it logs — and must still reach the code screen so
+    // Resend is reachable.
+    signUpEmailMock.mockImplementation(async () => ({ data: { token: null }, error: null }));
+    sendVerificationOtpMock.mockImplementation(async () => ({
+      data: null,
+      error: { message: "rate limited" },
+    }));
+    render(<AccountPage />);
+    await screen.findByText("jane@example.com");
+
+    fillPassword("hunter2hunter2");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/enter your code/i)).toBeDefined();
+    });
+    expect(sendVerificationOtpMock).toHaveBeenCalled();
   });
 
   test("an invitee is routed to /accept-invitation after creating the account", async () => {

--- a/packages/web/src/app/signup/account/page.tsx
+++ b/packages/web/src/app/signup/account/page.tsx
@@ -61,9 +61,9 @@ export default function AccountPage() {
   const [loading, setLoading] = useState(false);
   const [socialLoading, setSocialLoading] = useState<string | null>(null);
   const [socialProviders, setSocialProviders] = useState<string[]>([]);
-  // Mirrors the prior single-page flow: when email verification is required,
-  // signUp returns no session token and the OTP has already been sent — hold
-  // the email to render the code-entry interstitial instead of navigating.
+  // When email verification is required, signUp returns no session token; we
+  // then dispatch the OTP ourselves (#4010) and hold the email to render the
+  // code-entry interstitial instead of navigating.
   const [pendingEmail, setPendingEmail] = useState<string | null>(null);
 
   // Hydrate the email/invitation from the signup draft. A missing draft means
@@ -125,13 +125,48 @@ export default function AccountPage() {
         setError(res.error.message ?? "Sign up failed");
         return;
       }
-      // Verification required → no token, OTP already dispatched: switch to the
-      // code-entry view. Verification off (self-hosted dev) → token present,
-      // navigate straight on. (See the prior single-page flow's rationale.)
+      // Verification off (self-hosted dev) → token present, navigate straight
+      // on. Verification required → no token: own the OTP send explicitly so
+      // the "we sent a code" copy is always true (#4010).
+      //
+      // better-auth returns `token: null` for a fresh-but-unverified signup AND
+      // for an already-registered email — its enumeration-protection synthetic
+      // success (`requireEmailVerification: true`). The synthetic path skips
+      // better-auth's signup send block entirely, so relying on an implicit
+      // auto-send dead-ended an existing-email signup at the code screen with no
+      // OTP ever sent. We dispatch via the enumeration-safe resend endpoint,
+      // which the server now treats as the SOLE source of the signup OTP
+      // (`emailVerification.sendOnSignUp: false`) — so there's no double-send on
+      // the fresh path either. The user row exists post-`signUp.email` in both
+      // cases, so a real OTP is delivered every time.
       const token = (res.data as { token?: string | null } | undefined)?.token;
       if (token) {
         completeAndNavigate();
       } else {
+        try {
+          // Better-auth client methods surface failures TWO ways: a returned
+          // `{ error }` envelope (e.g. the OTP endpoint's rate-limit 429 — the
+          // most likely real failure) AND a thrown rejection (network). Handle
+          // both so a failed send is never silent for operators.
+          const sendRes = await authClient.emailOtp?.sendVerificationOtp?.({
+            email,
+            type: "email-verification",
+          });
+          if (sendRes?.error) {
+            console.warn(
+              "Verification OTP send returned an error:",
+              sendRes.error.message ?? "unknown",
+            );
+          }
+        } catch (err) {
+          console.warn(
+            "Verification OTP send failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        // Reach the code screen regardless of send outcome — the screen's
+        // "Resend code" control is the recovery path, so a hiccup must not trap
+        // the user on the form.
         setPendingEmail(email);
       }
     } catch (err) {


### PR DESCRIPTION
## What

A brand-new signup whose email **already exists** dead-ended at the OTP screen: the funnel showed **"Enter your code"** with **"We sent an 8-character code to …"**, but **no OTP was ever sent**. "Resend code" worked (it sends unconditionally), so the default path was a silent dead-end with lying copy.

## Root cause

Better-auth's enumeration-protection path: with `requireEmailVerification: true`, `POST /api/auth/sign-up/email` for an **already-registered** email returns a *synthetic* success `{ token: null }` — no user created, no `sendVerificationEmail` fired — byte-identical in shape to a real first signup (the duplicate branch returns *before* better-auth's signup send block, verified against the vendored `sign-up.mjs`). The web funnel read `token == null` as "verification required ⟹ OTP already dispatched" and rendered the code screen. For an existing email that assumption is false → dead-end.

## Fix

Own the send explicitly on the client. After `signUp.email` resolves with `token == null`, dispatch via the enumeration-safe `/email-otp/send-verification-otp` resend endpoint — the user row exists post-signup in both the fresh and duplicate cases, so a real OTP is delivered every time:

- `packages/web/src/app/signup/account/page.tsx` — explicit `authClient.emailOtp.sendVerificationOtp({ email, type: "email-verification" })` on the no-token branch. Both better-auth failure surfaces are logged (returned `{ error }` envelope — the likely rate-limit case — AND a thrown rejection); a send hiccup still lands the user on the code screen so Resend stays reachable.
- `packages/api/src/lib/auth/server.ts` — `emailVerification.sendOnSignUp: false` so better-auth's implicit signup auto-send stops and the client-driven send is the **single source** (no double-mail on the fresh path). Also pins the now-dead `emailOTP.sendVerificationOnSignUp: false` for intent clarity (the plugin's auto-send hook is already disabled by `overrideDefaultEmailVerification: true`).

## Tests

- **New real-better-auth in-memory harness** (`signup-otp-send.test.ts`) — drives a live `betterAuth` instance through `buildAuthOptions` with a capturing `sendVerificationOTP`, proving: a fresh signup does **not** auto-send; a 2nd same-email signup returns synthetic `token:null` and is silent; the resend endpoint **does** dispatch for an existing user — for **both** the unverified and the already-**verified** sub-case (a real verify-OTP round-trip). Per-test IP isolation for rate-limit buckets.
- **Rewrote the page test that encoded the bug** to assert the explicit send on the fresh and duplicate paths, plus thrown- and returned-error send-failure recovery and the no-send token-present path.
- **Config-snapshot guard** in `rate-limit-integration.test.ts` pinning `sendOnSignUp: false` (a refactor that drops it re-defaults to `requireEmailVerification` (true) and reopens both bugs).

## Acceptance criteria

- [x] Already-registered (unverified OR verified) email delivers exactly one OTP, truthful code screen, no dead-end.
- [x] Fresh-email signup still delivers exactly one OTP (no double-send).
- [x] A test exercises **real** better-auth (in-memory harness) asserting a 2nd same-email signup + the client-driven send dispatches the OTP.
- [x] Code-screen copy is accurate for every reachable path.

## Verification

Re-run the `/verify-prod-signup` 3-region residency verification after this lands (surfaced by #4007).

Internal review panel: CLEAN after 2 rounds. Local gates: lint, type, syncpack, all drift/discipline checks pass; affected tests green. (One pre-existing, network-dependent flake in `admin-model-config.test.ts` — unrelated; reproduces on clean `main`.)

Closes #4010

https://claude.ai/code/session_011dBiMmwshzDRQa1uM6Lcv8

---
_Generated by [Claude Code](https://claude.ai/code/session_011dBiMmwshzDRQa1uM6Lcv8)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dead-end signup flow by explicitly sending OTP when signup returns no token
> - Disables auto-send of the email OTP on signup by setting `sendVerificationOnSignUp: false` and `sendOnSignUp: false` in [server.ts](https://github.com/AtlasDevHQ/atlas/pull/4015/files#diff-a90f21a4746a0b323fcdedf90f8bda584edc7618dff55cc26b921c1c32562526), preventing double-send on duplicate signups.
> - Updates [AccountPage](https://github.com/AtlasDevHQ/atlas/pull/4015/files#diff-092a69da43e6b0f6caa1cb007381ac2b427f0d217437a5187ce1f1566e1d4272) to explicitly call `authClient.emailOtp.sendVerificationOtp` after signup when no token is returned, then navigates to the OTP interstitial regardless of send outcome.
> - If signup returns a token (already-verified user), the page navigates directly without attempting an OTP send.
> - Behavioral Change: the OTP is now client-driven rather than server-driven on signup; send failures are logged but do not block the user from reaching the verification screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35240d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->