### PR TITLE
fix(cli): union user.stripeCustomerId into verify teardown's Stripe purge

### DIFF
--- a/.claude/commands/verify-prod-signup.md
+++ b/.claude/commands/verify-prod-signup.md
@@ -141,7 +141,7 @@ for (const [r, host] of Object.entries(EDGES)) {
 
 ## Teardown (do this — surgically, via the CLI)
 
-The verify accounts are real prod identities (user + org + members; a Stripe customer if billing ran). Tear them down with the dedicated operator tool — **never by hand-rolled SQL or `ops wipe`**:
+The verify accounts are real prod identities (user + org + members; a Stripe customer — note that a trial signup's customer lands on the **user** row, not the org, see #4011). Tear them down with the dedicated operator tool — **never by hand-rolled SQL or `ops wipe`**:
 
 ```bash
 # DRY RUN first (default — lists exactly what would go, deletes nothing):

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -366,6 +366,29 @@ describe("purgeStripeBillingForWorkspace (GDPR purge path)", () => {
     ]);
   });
 
+  it("unions extraCustomerIds (e.g. a user-level customer) into the delete set", async () => {
+    // The org column is null (the #4011 shape: customer lives on user.stripeCustomerId,
+    // organization."stripeCustomerId" is null). The user-level id passed via
+    // extraCustomerIds must still be deleted so a verify teardown can't orphan it.
+    mockSubscriptionRows([]);
+
+    await purgeStripeBillingForWorkspace(ORG, null, ["cus_user"]);
+
+    expect(customersDel.mock.calls.map((c) => c[0])).toEqual(["cus_user"]);
+  });
+
+  it("de-dupes extraCustomerIds already present from the org column or subscriptions", async () => {
+    mockSubscriptionRows([subRow("sub_old", "canceled", "cus_acme")]);
+
+    // cus_acme appears on both the org column and extraCustomerIds — deleted once.
+    await purgeStripeBillingForWorkspace(ORG, "cus_acme", ["cus_acme", "cus_user"]);
+
+    expect(customersDel.mock.calls.map((c) => c[0]).toSorted()).toEqual([
+      "cus_acme",
+      "cus_user",
+    ]);
+  });
+
   it("makes no customer call when there is no Stripe customer linkage", async () => {
     mockSubscriptionRows([]);
 

--- a/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
+++ b/packages/api/src/lib/billing/__tests__/workspace-teardown.test.ts
@@ -389,6 +389,33 @@ describe("purgeStripeBillingForWorkspace (GDPR purge path)", () => {
     ]);
   });
 
+  it("deletes BOTH a distinct org customer and a distinct user customer (true union)", async () => {
+    // Org acquired its own customer while the signup user-level one persisted —
+    // both distinct ids must be deleted, not just one.
+    mockSubscriptionRows([]);
+
+    await purgeStripeBillingForWorkspace(ORG, "cus_org", ["cus_user"]);
+
+    expect(customersDel.mock.calls.map((c) => c[0]).toSorted()).toEqual([
+      "cus_org",
+      "cus_user",
+    ]);
+  });
+
+  it("treats a resource_missing on an extraCustomerIds id as already-gone (multi-org re-pass is safe)", async () => {
+    // The multi-org fan-out re-passes the same user customer to each owned org's
+    // purge; the 2nd+ delete hits resource_missing and must be an action, not a warning.
+    mockSubscriptionRows([]);
+    customersDel.mockImplementation(async () => {
+      throw new FakeStripeError("No such customer", "resource_missing");
+    });
+
+    const outcome = await purgeStripeBillingForWorkspace(ORG, null, ["cus_user"]);
+
+    expect(outcome.warnings).toEqual([]);
+    expect(outcome.actions.some((a) => a.includes("already absent"))).toBe(true);
+  });
+
   it("makes no customer call when there is no Stripe customer linkage", async () => {
     mockSubscriptionRows([]);
 

--- a/packages/api/src/lib/billing/workspace-teardown.ts
+++ b/packages/api/src/lib/billing/workspace-teardown.ts
@@ -452,11 +452,19 @@ export async function cancelStripeSubscriptionsForWorkspace(
  * organization row. Customer ids found on subscription rows are unioned in
  * defensively, so a drifted org column can't leave a customer behind.
  *
+ * `extraCustomerIds` lets a caller union in customer ids that live OUTSIDE the
+ * org row — notably `user.stripeCustomerId`, where the @better-auth/stripe
+ * plugin's `createCustomerOnSignUp` parks a customer at signup before any org
+ * subscription exists (#4011). Without this the org-only id would tear down the
+ * workspace but orphan a live `cus_…` on the user row. The set is de-duped and
+ * `resource_missing` counts as success, so passing an already-known id is safe.
+ *
  * Total — never throws; failures land in `warnings`.
  */
 export async function purgeStripeBillingForWorkspace(
   orgId: string,
   stripeCustomerId: string | null,
+  extraCustomerIds: readonly string[] = [],
 ): Promise<StripeTeardownOutcome> {
   if (!hasInternalDB()) return noopOutcome();
   const stripe = getStripeClient();
@@ -494,6 +502,11 @@ export async function purgeStripeBillingForWorkspace(
   if (stripeCustomerId) customerIds.add(stripeCustomerId);
   for (const row of rows) {
     if (row.stripeCustomerId) customerIds.add(row.stripeCustomerId);
+  }
+  // Customer ids carried outside the org row (e.g. user.stripeCustomerId from
+  // createCustomerOnSignUp) — the Set de-dupes any already collected above.
+  for (const id of extraCustomerIds) {
+    if (id) customerIds.add(id);
   }
 
   for (const customerId of customerIds) {

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -391,10 +391,17 @@ describe("teardownTargets", () => {
       softDelete: async () => { calls.push("soft"); return true; },
       hardDelete: async () => { calls.push("hard"); return 0; },
     };
-    const report = await teardownTargets([target({ orgs: [ownedOrg()] })], deps, true);
+    const report = await teardownTargets(
+      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg()] })],
+      deps,
+      true,
+    );
     expect(calls).toEqual([]);
     expect(report.dryRun).toBe(true);
     expect(report.targets[0]!.orgs[0]!.status).toBe("would-tear-down");
+    // Preview must still report the user-level customer that the live run will
+    // delete — a dropped carry-through here would make the dry run lie (#4011).
+    expect(report.targets[0]!.userStripeCustomerId).toBe("cus_user");
     expect(report.totals).toMatchObject({ orgsWouldTearDown: 1, orgsTornDown: 0 });
   });
 
@@ -467,6 +474,9 @@ describe("teardownTargets", () => {
     );
     expect(report.targets[0]!.warnings.some((w) => w.includes("cus_orphan"))).toBe(true);
     expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
+    // Counted so the handler exits non-zero — a surviving billable customer
+    // must not be reported as a clean teardown.
+    expect(report.totals.orphanedUserCustomers).toBe(1);
   });
 
   it("warns when a user owns NO workspace (only non-owner memberships) but carries a customer", async () => {
@@ -490,6 +500,7 @@ describe("teardownTargets", () => {
     expect(calls).toEqual([]); // no purge ran — every membership is non-owner
     expect(report.targets[0]!.warnings.some((w) => w.includes("cus_nonowner"))).toBe(true);
     expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
+    expect(report.totals.orphanedUserCustomers).toBe(1);
   });
 
   it("does NOT warn (customer is reached) when the user owns at least one workspace", async () => {
@@ -505,6 +516,7 @@ describe("teardownTargets", () => {
     );
     // An owned org's purge unions the customer in, so no manual-cleanup warning fires.
     expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(false);
+    expect(report.totals.orphanedUserCustomers).toBe(0);
   });
 
   it("unions the user customer into EVERY owned org's purge (multi-org fan-out)", async () => {

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -220,6 +220,7 @@ interface FakeRow extends Record<string, unknown> {
   userId: string;
   email: string;
   userName: string | null;
+  userStripeCustomerId: string | null;
   memberRole: string | null;
   orgId: string | null;
   orgName: string | null;
@@ -242,6 +243,7 @@ function row(over: Partial<FakeRow>): FakeRow {
     userId: "user_1",
     email: "matt+us@useatlas.dev",
     userName: "Matt US",
+    userStripeCustomerId: null,
     memberRole: "owner",
     orgId: "org_1",
     orgName: "Atlas us Verify",
@@ -265,7 +267,23 @@ describe("resolveVerifyTargets", () => {
   it("marks an email with no user row as not found", async () => {
     const q = fakeQuery({});
     const [t] = await resolveVerifyTargets(q, ["ghost+us@useatlas.dev"]);
-    expect(t).toEqual({ email: "ghost+us@useatlas.dev", userId: null, found: false, orgs: [] });
+    expect(t).toEqual({
+      email: "ghost+us@useatlas.dev",
+      userId: null,
+      found: false,
+      userStripeCustomerId: null,
+      orgs: [],
+    });
+  });
+
+  it("carries user.stripeCustomerId onto the target (the #4011 user-level customer)", async () => {
+    const q = fakeQuery({
+      "matt+us@useatlas.dev": [row({ userStripeCustomerId: "cus_user", stripeCustomerId: null })],
+    });
+    const [t] = await resolveVerifyTargets(q, ["matt+us@useatlas.dev"]);
+    expect(t!.userStripeCustomerId).toBe("cus_user");
+    // The org column is null in the #4011 shape — the customer lives only on the user.
+    expect(t!.orgs[0]!.stripeCustomerId).toBeNull();
   });
 
   it("treats a user with no membership (LEFT JOIN null org) as found with zero orgs", async () => {
@@ -317,14 +335,14 @@ describe("resolveVerifyTargets", () => {
 describe("countOwnedOrgs", () => {
   it("counts only owned orgs across targets, ignoring non-owner memberships", () => {
     const targets: VerifyTarget[] = [
-      { email: "a", userId: "u1", found: true, orgs: [
+      { email: "a", userId: "u1", found: true, userStripeCustomerId: null, orgs: [
         { orgId: "o1", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
         { orgId: "o2", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: false },
       ] },
-      { email: "b", userId: "u2", found: true, orgs: [
+      { email: "b", userId: "u2", found: true, userStripeCustomerId: null, orgs: [
         { orgId: "o3", orgName: null, orgSlug: null, region: "eu", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
       ] },
-      { email: "c", userId: null, found: false, orgs: [] },
+      { email: "c", userId: null, found: false, userStripeCustomerId: null, orgs: [] },
     ];
     expect(countOwnedOrgs(targets)).toBe(2);
     expect(countOwnedOrgs(targets)).toBeLessThanOrEqual(MAX_TEARDOWN_TARGETS);
@@ -346,6 +364,7 @@ function target(over: Partial<VerifyTarget> & { orgs?: VerifyTarget["orgs"] }): 
     email: "matt+us@useatlas.dev",
     userId: "user_1",
     found: true,
+    userStripeCustomerId: null,
     orgs: [],
     ...over,
   };
@@ -397,6 +416,57 @@ describe("teardownTargets", () => {
     expect(org.rowsPurged).toBe(42);
     expect(org.stripeActions).toContain("deleted Stripe customer cus_1");
     expect(report.totals).toMatchObject({ orgsTornDown: 1, rowsPurged: 42, errors: 0 });
+  });
+
+  it("unions the user-level customer into the purge call (#4011 — org column null)", async () => {
+    // The #4011 shape: customer parked on user.stripeCustomerId, org column null.
+    const purgeCalls: Array<[string, string | null, readonly string[]]> = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async (orgId, stripeCustomerId, extraCustomerIds) => {
+        purgeCalls.push([orgId, stripeCustomerId, extraCustomerIds]);
+        return okStripe({ actions: ["deleted Stripe customer cus_user"] });
+      },
+      softDelete: async () => true,
+      hardDelete: async () => 1,
+    };
+    const report = await teardownTargets(
+      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg({ stripeCustomerId: null })] })],
+      deps,
+      false,
+    );
+    expect(purgeCalls).toEqual([["org_1", null, ["cus_user"]]]);
+    expect(report.targets[0]!.userStripeCustomerId).toBe("cus_user");
+    expect(report.targets[0]!.orgs[0]!.stripeActions).toContain("deleted Stripe customer cus_user");
+  });
+
+  it("passes an empty extra-ids array when the user has no user-level customer", async () => {
+    const purgeCalls: Array<readonly string[]> = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async (_o, _c, extraCustomerIds) => { purgeCalls.push(extraCustomerIds); return okStripe(); },
+      softDelete: async () => true,
+      hardDelete: async () => 1,
+    };
+    await teardownTargets(
+      [target({ userStripeCustomerId: null, orgs: [ownedOrg({ stripeCustomerId: "cus_org" })] })],
+      deps,
+      false,
+    );
+    expect(purgeCalls).toEqual([[]]);
+  });
+
+  it("warns when an orphan user (no owned org) carries a user-level customer the purge can't reach", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe(),
+      softDelete: async () => true,
+      hardDelete: async () => 0,
+    };
+    const report = await teardownTargets(
+      [target({ email: "orphan+us@useatlas.dev", userStripeCustomerId: "cus_orphan", orgs: [] })],
+      deps,
+      false,
+    );
+    expect(report.targets[0]!.warnings.some((w) => w.includes("cus_orphan"))).toBe(true);
+    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
   });
 
   it("skips a non-owner membership without calling any dep", async () => {

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -469,6 +469,65 @@ describe("teardownTargets", () => {
     expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
   });
 
+  it("warns when a user owns NO workspace (only non-owner memberships) but carries a customer", async () => {
+    // The org-loop skips every non-owner membership, so the user-level customer
+    // is never unioned into a purge — it must still be surfaced loudly (#4011),
+    // not just in the zero-membership case.
+    const calls: string[] = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async () => { calls.push("purge"); return okStripe(); },
+      softDelete: async () => true,
+      hardDelete: async () => 0,
+    };
+    const report = await teardownTargets(
+      [target({
+        userStripeCustomerId: "cus_nonowner",
+        orgs: [ownedOrg({ orgId: "org_shared", isOwner: false })],
+      })],
+      deps,
+      false,
+    );
+    expect(calls).toEqual([]); // no purge ran — every membership is non-owner
+    expect(report.targets[0]!.warnings.some((w) => w.includes("cus_nonowner"))).toBe(true);
+    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
+  });
+
+  it("does NOT warn (customer is reached) when the user owns at least one workspace", async () => {
+    const deps: TeardownDeps = {
+      purgeStripe: async () => okStripe({ actions: ["deleted Stripe customer cus_user"] }),
+      softDelete: async () => true,
+      hardDelete: async () => 1,
+    };
+    const report = await teardownTargets(
+      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg()] })],
+      deps,
+      false,
+    );
+    // An owned org's purge unions the customer in, so no manual-cleanup warning fires.
+    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(false);
+  });
+
+  it("unions the user customer into EVERY owned org's purge (multi-org fan-out)", async () => {
+    // A user owning 2 workspaces: the same user-level customer is passed to each
+    // owned org's purge. The first deletes it, the rest hit resource_missing (a
+    // no-op success) — proven safe, never orphaned, never double-counted.
+    const extraArgs: Array<readonly string[]> = [];
+    const deps: TeardownDeps = {
+      purgeStripe: async (_o, _c, extraCustomerIds) => { extraArgs.push(extraCustomerIds); return okStripe(); },
+      softDelete: async () => true,
+      hardDelete: async () => 1,
+    };
+    await teardownTargets(
+      [target({
+        userStripeCustomerId: "cus_user",
+        orgs: [ownedOrg({ orgId: "org_a" }), ownedOrg({ orgId: "org_b" })],
+      })],
+      deps,
+      false,
+    );
+    expect(extraArgs).toEqual([["cus_user"], ["cus_user"]]);
+  });
+
   it("skips a non-owner membership without calling any dep", async () => {
     const calls: string[] = [];
     const deps: TeardownDeps = {

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -16,6 +16,12 @@
  * three SSOT functions the platform-admin purge uses:
  *   1. `purgeStripeBillingForWorkspace` — cancel subs + delete the Stripe
  *      customer (a torn-down account must leave no billable Stripe linkage).
+ *      The org's `organization."stripeCustomerId"` AND the user's
+ *      `user.stripeCustomerId` are both unioned into the delete set: the
+ *      @better-auth/stripe plugin's `createCustomerOnSignUp` parks a customer
+ *      on the USER row at signup, so a trial verify account's only `cus_…`
+ *      lives there while the org column is null — passing only the org id would
+ *      tear the workspace down but orphan that customer (#4011).
  *   2. `updateWorkspaceStatus(orgId, "deleted")` — the soft-delete precondition
  *      `hardDeleteWorkspace` enforces (it aborts unless the org is "deleted").
  *   3. `hardDeleteWorkspace` — the exhaustive GDPR-grade row purge, which also
@@ -217,6 +223,14 @@ export interface VerifyTarget {
   email: string;
   userId: string | null;
   found: boolean;
+  /**
+   * The customer id on the USER row (`user.stripeCustomerId`). The
+   * @better-auth/stripe plugin's `createCustomerOnSignUp` parks a customer here
+   * at signup before any org subscription exists, so for a trial verify account
+   * this is populated while every owned org's `stripeCustomerId` is null (#4011).
+   * Unioned into each owned org's Stripe purge so a verify teardown can't orphan it.
+   */
+  userStripeCustomerId: string | null;
   orgs: VerifyOrg[];
 }
 
@@ -256,6 +270,7 @@ interface TargetRow extends Record<string, unknown> {
   userId: string;
   email: string;
   userName: string | null;
+  userStripeCustomerId: string | null;
   memberRole: string | null;
   orgId: string | null;
   orgName: string | null;
@@ -283,6 +298,7 @@ export async function resolveVerifyTargets(
          u.id                  AS "userId",
          u.email               AS "email",
          u.name                AS "userName",
+         u."stripeCustomerId"  AS "userStripeCustomerId",
          m.role                AS "memberRole",
          o.id                  AS "orgId",
          o.name                AS "orgName",
@@ -298,11 +314,12 @@ export async function resolveVerifyTargets(
     );
 
     if (rows.length === 0) {
-      targets.push({ email, userId: null, found: false, orgs: [] });
+      targets.push({ email, userId: null, found: false, userStripeCustomerId: null, orgs: [] });
       continue;
     }
 
     const userId = rows[0]!.userId;
+    const userStripeCustomerId = rows[0]!.userStripeCustomerId;
     const orgs: VerifyOrg[] = [];
     for (const r of rows) {
       if (!r.orgId) continue; // user with no membership (LEFT JOIN null row)
@@ -316,7 +333,7 @@ export async function resolveVerifyTargets(
         isOwner: r.memberRole === "owner",
       });
     }
-    targets.push({ email, userId, found: true, orgs });
+    targets.push({ email, userId, found: true, userStripeCustomerId, orgs });
   }
   return targets;
 }
@@ -338,6 +355,9 @@ export interface TargetTeardownResult {
   email: string;
   userId: string | null;
   found: boolean;
+  /** The user-row Stripe customer unioned into the org purges (#4011) — surfaced
+   *  so a dry-run preview shows it will be deleted, not just the org-level id. */
+  userStripeCustomerId: string | null;
   orgs: OrgTeardownResult[];
   warnings: string[];
 }
@@ -361,7 +381,11 @@ export interface TeardownReport {
  *  `hardDelete` returns the total rows purged; the handler sums the SSOT's
  *  per-table `HardDeleteResult` so the orchestration stays shape-agnostic. */
 export interface TeardownDeps {
-  purgeStripe: (orgId: string, stripeCustomerId: string | null) => Promise<StripeTeardownOutcome>;
+  purgeStripe: (
+    orgId: string,
+    stripeCustomerId: string | null,
+    extraCustomerIds: readonly string[],
+  ) => Promise<StripeTeardownOutcome>;
   softDelete: (orgId: string) => Promise<boolean>;
   hardDelete: (orgId: string) => Promise<number>;
 }
@@ -375,6 +399,14 @@ export interface TeardownDeps {
  * `hardDelete` enforces), then hard-delete the rows. A single org's failure is
  * recorded and the run continues — one stuck account never strands the rest.
  * Non-owner memberships and orphan users become warnings, never deletions.
+ *
+ * The user's `user.stripeCustomerId` is unioned into each owned org's Stripe
+ * purge (#4011): the @better-auth/stripe plugin's `createCustomerOnSignUp`
+ * parks a customer on the user row at signup, so a trial verify account carries
+ * a live `cus_…` there while every org column is null — passing only the org id
+ * would tear the workspace down but orphan that customer. The purge de-dupes
+ * and treats `resource_missing` as success, so attaching it to each owned org
+ * (rather than guessing one) can't double-delete or strand it.
  */
 export async function teardownTargets(
   targets: VerifyTarget[],
@@ -401,6 +433,15 @@ export async function teardownTargets(
         `User ${target.email} (${target.userId}) has no workspace membership — ` +
           "orphan user row left untouched; remove it manually if it is a verification artifact.",
       );
+      // An orphan user with NO owned org never reaches the org-loop purge below,
+      // so its user-level customer can't be unioned in anywhere — call it out
+      // explicitly rather than silently leaving a live `cus_…` behind (#4011).
+      if (target.userStripeCustomerId) {
+        targetWarnings.push(
+          `User ${target.email} carries a Stripe customer ${target.userStripeCustomerId} but owns no ` +
+            "workspace to purge — delete it manually in the Stripe dashboard so it isn't orphaned.",
+        );
+      }
     }
 
     for (const org of target.orgs) {
@@ -436,7 +477,11 @@ export async function teardownTargets(
       }
 
       try {
-        const stripe = await deps.purgeStripe(org.orgId, org.stripeCustomerId);
+        const stripe = await deps.purgeStripe(
+          org.orgId,
+          org.stripeCustomerId,
+          target.userStripeCustomerId ? [target.userStripeCustomerId] : [],
+        );
         // softDelete returns false when no row matched (e.g. the org was
         // concurrently reactivated/removed between resolve and execute). Surface
         // that as the cause rather than letting hardDelete throw the downstream
@@ -483,6 +528,7 @@ export async function teardownTargets(
       email: target.email,
       userId: target.userId,
       found: target.found,
+      userStripeCustomerId: target.userStripeCustomerId,
       orgs: orgResults,
       warnings: targetWarnings,
     });
@@ -500,6 +546,9 @@ export function printTeardownReport(report: TeardownReport): void {
 
   for (const target of report.targets) {
     console.log(`\n• ${target.email}${target.userId ? ` (user ${target.userId})` : ""}`);
+    if (target.userStripeCustomerId) {
+      console.log(`  user stripe customer: ${target.userStripeCustomerId} (unioned into owned-org purge)`);
+    }
     for (const w of target.warnings) console.log(`  ⚠ ${w}`);
     for (const org of target.orgs) {
       const tag = {

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -228,7 +228,9 @@ export interface VerifyTarget {
    * @better-auth/stripe plugin's `createCustomerOnSignUp` parks a customer here
    * at signup before any org subscription exists, so for a trial verify account
    * this is populated while every owned org's `stripeCustomerId` is null (#4011).
-   * Unioned into each owned org's Stripe purge so a verify teardown can't orphan it.
+   * Unioned into each *owned* org's Stripe purge; a user who owns no workspace
+   * (zero or only non-owner memberships) is surfaced as a manual-cleanup warning
+   * instead, since no purge can reach it.
    */
   userStripeCustomerId: string | null;
   orgs: VerifyOrg[];
@@ -433,15 +435,19 @@ export async function teardownTargets(
         `User ${target.email} (${target.userId}) has no workspace membership — ` +
           "orphan user row left untouched; remove it manually if it is a verification artifact.",
       );
-      // An orphan user with NO owned org never reaches the org-loop purge below,
-      // so its user-level customer can't be unioned in anywhere — call it out
-      // explicitly rather than silently leaving a live `cus_…` behind (#4011).
-      if (target.userStripeCustomerId) {
-        targetWarnings.push(
-          `User ${target.email} carries a Stripe customer ${target.userStripeCustomerId} but owns no ` +
-            "workspace to purge — delete it manually in the Stripe dashboard so it isn't orphaned.",
-        );
-      }
+    }
+
+    // The user-level customer is unioned into the purge of every OWNED org (see
+    // the loop below). When the user owns NO workspace — whether they have zero
+    // memberships or only non-owner ones — no purge reaches it, so a live `cus_…`
+    // would be silently left behind (the exact #4011 orphaning, via a different
+    // topology). Warn loudly in that case rather than reporting a clean teardown.
+    const ownsAnyWorkspace = target.orgs.some((o) => o.isOwner);
+    if (target.found && target.userStripeCustomerId && !ownsAnyWorkspace) {
+      targetWarnings.push(
+        `User ${target.email} carries a Stripe customer ${target.userStripeCustomerId} but owns no ` +
+          "workspace to purge — delete it manually in the Stripe dashboard so it isn't orphaned.",
+      );
     }
 
     for (const org of target.orgs) {

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -376,6 +376,12 @@ export interface TeardownReport {
      *  warning (e.g. a customer that couldn't be deleted) — a non-clean
      *  outcome the handler exits non-zero on, even though the row purge ran. */
     stripeWarnings: number;
+    /** Users carrying a `user.stripeCustomerId` who own no workspace, so no
+     *  purge could reach it (#4011) — a live billable customer the run can't
+     *  delete. Counted so the handler exits non-zero rather than reporting a
+     *  clean teardown while an orphan `cus_…` survives (a scripted/CI cleanup
+     *  must fail loudly). The customer id is in the per-target warning. */
+    orphanedUserCustomers: number;
   };
 }
 
@@ -422,6 +428,7 @@ export async function teardownTargets(
     rowsPurged: 0,
     errors: 0,
     stripeWarnings: 0,
+    orphanedUserCustomers: 0,
   };
 
   for (const target of targets) {
@@ -448,6 +455,9 @@ export async function teardownTargets(
         `User ${target.email} carries a Stripe customer ${target.userStripeCustomerId} but owns no ` +
           "workspace to purge — delete it manually in the Stripe dashboard so it isn't orphaned.",
       );
+      // Counted into totals so the handler exits non-zero: a surviving billable
+      // customer is a non-clean outcome a scripted/CI cleanup must not pass over.
+      totals.orphanedUserCustomers += 1;
     }
 
     for (const org of target.orgs) {
@@ -553,7 +563,15 @@ export function printTeardownReport(report: TeardownReport): void {
   for (const target of report.targets) {
     console.log(`\n• ${target.email}${target.userId ? ` (user ${target.userId})` : ""}`);
     if (target.userStripeCustomerId) {
-      console.log(`  user stripe customer: ${target.userStripeCustomerId} (unioned into owned-org purge)`);
+      // The customer is unioned into a purge only when the user owns a workspace;
+      // an owner-less user gets the manual-cleanup warning below instead, so the
+      // parenthetical must reflect which case this is (a "skipped-not-owner" or
+      // empty org list means no purge reached it).
+      const reached = target.orgs.some((o) => o.status !== "skipped-not-owner");
+      const note = reached
+        ? "(unioned into owned-org purge)"
+        : "(NOT reached by any purge — see warning below)";
+      console.log(`  user stripe customer: ${target.userStripeCustomerId} ${note}`);
     }
     for (const w of target.warnings) console.log(`  ⚠ ${w}`);
     for (const org of target.orgs) {
@@ -578,6 +596,9 @@ export function printTeardownReport(report: TeardownReport): void {
       `${report.dryRun ? t.orgsWouldTearDown : t.orgsTornDown} workspace(s)` +
       (report.dryRun ? "" : `, ${t.rowsPurged} rows purged`) +
       (t.stripeWarnings > 0 ? `, ${t.stripeWarnings} workspace(s) with Stripe warnings` : "") +
+      (t.orphanedUserCustomers > 0
+        ? `, ${t.orphanedUserCustomers} orphaned user-level Stripe customer(s) needing manual deletion`
+        : "") +
       (t.errors > 0 ? `, ${t.errors} error(s)` : ""),
   );
 }
@@ -651,14 +672,21 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
     }, dryRun);
 
     printTeardownReport(report);
-    // Exit non-zero on a row-purge error OR a left-behind Stripe linkage — a
-    // scripted cleanup must fail loudly rather than report a clean "success"
-    // while a billable Stripe customer survives. A failed customer-delete /
+    // Exit non-zero on a row-purge error, a left-behind Stripe linkage, OR an
+    // orphaned user-level customer that no purge could reach — a scripted
+    // cleanup must fail loudly rather than report a clean "success" while a
+    // billable Stripe customer survives. A failed customer-delete /
     // subscription-cancel is enqueued in `stripe_teardown_pending` for durable
-    // retry; some warnings (a subscription-read or outbox-write failure) are
-    // manual-follow-up only — either way the operator/CI should know it didn't
-    // fully complete.
-    if (report.totals.errors > 0 || report.totals.stripeWarnings > 0) process.exitCode = 1;
+    // retry; some warnings (a subscription-read or outbox-write failure, or an
+    // owner-less user-level customer) are manual-follow-up only — either way the
+    // operator/CI should know it didn't fully complete.
+    if (
+      report.totals.errors > 0 ||
+      report.totals.stripeWarnings > 0 ||
+      report.totals.orphanedUserCustomers > 0
+    ) {
+      process.exitCode = 1;
+    }
   } catch (err) {
     console.error(
       `[ops:teardown-verify-accounts] failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

`atlas ops teardown-verify-accounts` only passed the org-level `organization."stripeCustomerId"` into `purgeStripeBillingForWorkspace`, but a trial verify account's Stripe customer is parked on **`user.stripeCustomerId`** (via the `@better-auth/stripe` plugin's `createCustomerOnSignUp`) with the org column null. So a teardown tore down the org + user but **orphaned a live `cus_…`** (#4011).

- `resolveVerifyTargets` now reads `u."stripeCustomerId"` onto the target.
- `teardownTargets` unions the user-level id into **each owned org's** purge (de-duped, `resource_missing`-as-success → safe to re-pass across orgs).
- `purgeStripeBillingForWorkspace` gains an optional `extraCustomerIds` arg (backward-compatible; the platform-admin caller is unchanged), unioned into its customer-delete `Set`.
- A user who owns **no** workspace (zero or only non-owner memberships) carries a customer no purge can reach — surfaced as an explicit manual-cleanup warning, counted into totals, and the handler **exits non-zero** so a scripted/CI cleanup fails loudly rather than reporting a clean teardown while a billable customer survives.

## Investigation: (a) legacy vs (b) current bug → **(b)**

The acceptance criterion asked whether user-level Stripe customers are a legacy artifact or a current billing-attribution bug. **Determined (b):** `buildStripePluginOptions` (`packages/api/src/lib/auth/server.ts`) sets `createCustomerOnSignUp: true` **alongside** `organization: { enabled: true }`; the plugin's signup hook writes a `customerType: "user"` customer to the user row at *every* signup, while the org-level id is created only lazily at first `/subscription/upgrade`. Both flags landed together in #3925/#3928 — there was no user-mode→org-mode cutover, so user-level customers are produced by the *current* config. Full evidence in the [#4011 determination comment](https://github.com/AtlasDevHQ/atlas/issues/4011#issuecomment-4814466240).

Root-cause follow-up filed as **#4012** (set `createCustomerOnSignUp: false`; consider a prod orphan-customer backfill-cleanup). This PR is the tool-completeness half.

## Test plan

- [x] `purgeStripeBillingForWorkspace` unions `extraCustomerIds` (org-null), de-dupes, true-unions distinct org+user ids, and treats a re-passed `resource_missing` user id as already-gone.
- [x] `resolveVerifyTargets` carries `userStripeCustomerId`; `teardownTargets` passes it to each owned org's purge (multi-org fan-out), passes `[]` when absent, and warns + counts an owner-less customer.
- [x] Dry-run preview reports the user-level customer.
- [x] `bun run lint` / `bun run type` / full `bun run test` (the one failure, `admin-model-config.test.ts`, is a pre-existing environmental network timeout outside this diff's graph) + relevant drift gates green.

Closes #4011

---
_Generated by [Claude Code](https://claude.ai/code/session_011dBiMmwshzDRQa1uM6Lcv8)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Union user-level `stripeCustomerId` into Stripe purge during verify teardown
> - Extends `purgeStripeBillingForWorkspace` in [workspace-teardown.ts](https://github.com/AtlasDevHQ/atlas/pull/4016/files#diff-32c6a49c57e055b1f28b6c9beec7ed2d4aceaee29fa948c2fc714fd2115e22b7) to accept an `extraCustomerIds` parameter, de-duplicating and deleting all supplied IDs alongside org and subscription-derived ones.
> - Updates `resolveVerifyTargets` in [ops-teardown-verify.ts](https://github.com/AtlasDevHQ/atlas/pull/4016/files#diff-dd41568c6ead7f1f84f56bf9704379da252d8545033b68cc8e369a2b690dad66) to SELECT `u.stripeCustomerId AS userStripeCustomerId` and propagate it through `VerifyTarget`.
> - In `teardownTargets`, passes the user's `stripeCustomerId` to each owned org's purge call; if the user has a Stripe customer but owns no workspaces, emits a warning and increments `totals.orphanedUserCustomers`.
> - `handleTeardownVerifyAccounts` now exits non-zero when `orphanedUserCustomers > 0`, signaling manual Stripe cleanup is needed.
> - Risk: trials that created a Stripe customer on the user row (not the org) will now trigger deletion during teardown where they previously were silently skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1491f10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->