### PR TITLE
chore(www): advertise shipped-but-unlisted capabilities (#3994)

### DIFF
--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -19,20 +19,35 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Agent-native",
     atlas:
-      "MCP server first: Claude Desktop, Cursor, Continue with bunx @useatlas/mcp init; read tools open, datasource writes gated by OAuth scope + RBAC",
+      "MCP server first (stdio + SSE): Claude Desktop, Cursor, Continue with bunx @useatlas/mcp init; read tools open, datasource writes gated by OAuth scope + RBAC",
     bi: "Bolted-on AI feature",
     textToSql: "Standalone chat UI",
   },
   {
     feature: "Embeddable",
-    atlas: "Script tag, React component, headless API, MCP, 6 chat platforms",
+    atlas:
+      "Script-tag widget, <AtlasChat /> React component, typed @useatlas/sdk, MCP, 6 chat platforms",
     bi: "Standalone app",
     textToSql: "Standalone app",
   },
   {
+    feature: "Long-running turns",
+    atlas:
+      "Durable agent loop: a turn interrupted by a deploy, crash, or serverless timeout resumes from its last checkpoint — security re-verified on resume",
+    bi: "N/A",
+    textToSql: "Restarts from scratch",
+  },
+  {
+    feature: "Semantic layer editing",
+    atlas:
+      "Author entities, dimensions, measures, joins and query patterns in the in-product admin editor — or as YAML in your repo, versioned in PRs",
+    bi: "GUI-only, proprietary store",
+    textToSql: "None",
+  },
+  {
     feature: "Dashboards as conversations",
     atlas:
-      "Chat drawer is the editor: per-user drafts + atomic three-way-merge Publish over a persisted baseline",
+      "Chat drawer is the editor: per-user drafts + atomic three-way-merge Publish over a versioned baseline; bound-mode editing keeps the agent on the dashboard you opened",
     bi: "Static dashboards with separate edit mode",
     textToSql: "No dashboards",
   },
@@ -51,7 +66,8 @@ const ROWS: ReadonlyArray<Row> = [
   },
   {
     feature: "Plugin ecosystem",
-    atlas: "21 plugins across 5 types, extend anything",
+    atlas:
+      "24 plugins across 5 types (datasource, context, interaction, action, sandbox); author your own with @useatlas/plugin-sdk and install from the in-product registry",
     bi: "Closed",
     textToSql: "Limited",
   },
@@ -64,7 +80,7 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Multi-database",
     atlas:
-      "PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, Salesforce",
+      "PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch / OpenSearch, Salesforce",
     bi: "Usually one",
     textToSql: "Usually one",
   },
@@ -76,6 +92,28 @@ const ROWS: ReadonlyArray<Row> = [
     textToSql: "None",
   },
 ];
+
+// ---------------------------------------------------------------------------
+// CLAIM-ACCURACY NOTE (#3994). Every cell above is verified against shipped
+// code. Specifically:
+//   - "Multi-database" lists only queryable read datasources. Elasticsearch
+//     and OpenSearch are one unified plugin (engine flag), so both are named.
+//     Twenty (CRM) and Obsidian are deliberately NOT here — Twenty is an
+//     action/write target and Obsidian is a surface + vault-reader action,
+//     not analytics datasources.
+//   - "24 plugins across 5 types" = directories under plugins/ whose
+//     definePlugin() declares a PluginType (the `obsidian` client app extends
+//     Obsidian's own Plugin class and declares none, so it's excluded). This
+//     is a hand-counted figure — recount it whenever plugins/ changes.
+//   - The REST/OpenAPI datasources named on the landing page (Stripe, Notion,
+//     GitHub, any OpenAPI spec) are OpenAPI presets in
+//     packages/api/src/lib/openapi/data-candidates.ts, NOT plugins/ entries —
+//     the absence of a plugins/github dir is expected, not drift.
+//   - "Long-running turns", "Semantic layer editing", MCP stdio+SSE, and the
+//     @useatlas/sdk / <AtlasChat /> embed claims are each backed by shipped
+//     packages — see #3994 for the verification trail.
+// Do not add a capability row without the same verification.
+// ---------------------------------------------------------------------------
 
 export function Comparison() {
   return (

--- a/apps/www/src/components/landing/drop-in-surfaces.tsx
+++ b/apps/www/src/components/landing/drop-in-surfaces.tsx
@@ -10,6 +10,35 @@ function DropInItem({ name, desc }: DropInProps) {
 }
 
 /**
+ * Queryable read datasources Atlas ships today (#3994). Verified against the
+ * shipped connection/plugin code — every entry is a datasource you can connect
+ * and query, not an action or write target. Elasticsearch and OpenSearch are
+ * one unified engine, so they share a chip. Twenty (CRM action) and Obsidian
+ * (a surface + vault-reader action) are intentionally absent — they aren't
+ * analytics datasources.
+ *
+ * Postgres/MySQL are native (packages/api/src/lib/db/connection.ts); the
+ * warehouses/search engines are `datasource`-typed plugins under plugins/;
+ * Stripe/Notion/GitHub and arbitrary OpenAPI specs are REST/OpenAPI presets in
+ * packages/api/src/lib/openapi/data-candidates.ts — so there is no plugins/
+ * directory for them, and that's expected, not stale.
+ */
+const DATASOURCES: ReadonlyArray<string> = [
+  "PostgreSQL",
+  "MySQL",
+  "ClickHouse",
+  "Snowflake",
+  "BigQuery",
+  "DuckDB",
+  "Elasticsearch / OpenSearch",
+  "Salesforce",
+  "Stripe",
+  "Notion",
+  "GitHub",
+  "any OpenAPI 3.x spec",
+];
+
+/**
  * The "drop-in surfaces" band. Carried over from the old Primitives section —
  * the four architecture cards were cut as too internal for a plain-language
  * page, but "use it wherever your team already works" is a real outcome, so the
@@ -26,8 +55,9 @@ export function DropInSurfaces() {
           Use it where your team already works.
         </h2>
         <p className="m-0 text-base leading-[1.65] text-fg-muted">
-          Embed the chat in your app, edit dashboards in the conversation, keep
-          your prompts in code, or run queries from the terminal.
+          Embed the chat in your app, hand it to any MCP client, edit
+          dashboards in the conversation, keep your prompts in code, or run
+          queries from the terminal.
         </p>
       </header>
 
@@ -38,24 +68,46 @@ export function DropInSurfaces() {
         <div className="grid items-stretch gap-6 md:[grid-template-columns:1fr_1px_1fr_1px_1fr_1px_1fr]">
           <DropInItem
             name="<AtlasChat />"
-            desc="React widget. Inherits your tokens, speaks your data."
+            desc="React component, typed @useatlas/sdk, or a one-line script-tag widget. Inherits your tokens, speaks your data."
+          />
+          <div className="hidden h-full w-px bg-border-soft md:block" />
+          <DropInItem
+            name="bunx @useatlas/mcp"
+            desc="MCP server (stdio + SSE). One init wires Atlas into Claude Desktop, Cursor, or Continue."
           />
           <div className="hidden h-full w-px bg-border-soft md:block" />
           <DropInItem
             name="dashboards.yml"
-            desc="Chat drawer is the editor. Per-user drafts, atomic Publish, persisted baseline."
-          />
-          <div className="hidden h-full w-px bg-border-soft md:block" />
-          <DropInItem
-            name="prompt_lib.ts"
-            desc="Prompts in TypeScript, not strings in a UI. Diffed, rolled back, code-reviewed."
+            desc="Chat drawer is the editor. Per-user drafts, versioned baseline, atomic Publish, bound-mode editing."
           />
           <div className="hidden h-full w-px bg-border-soft md:block" />
           <DropInItem
             name="$ atlas cli"
-            desc="Run, test, replay queries from terminal or CI."
+            desc="Prompts in code, run/test/replay queries from terminal or CI."
           />
         </div>
+      </div>
+
+      <div className="mt-8">
+        <p className="mb-3.5 font-mono text-[11px] tracking-[0.04em] text-fg-muted">
+          // connect anything — read-only, behind the same validators
+        </p>
+        <ul className="flex flex-wrap gap-2 p-0">
+          {DATASOURCES.map((name) => (
+            <li
+              key={name}
+              className="rounded-md border border-border px-2.5 py-1 font-mono text-[12px] text-fg-muted"
+              style={{ background: "var(--bg-raised)" }}
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-[12.5px] leading-[1.55] text-fg-muted">
+          SQL warehouses, search engines, and REST APIs all become datasources
+          you can ask in plain English. Bring any OpenAPI spec and Atlas reads
+          it like a table.
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Surface capabilities that ship today but weren't advertised on the marketing site (WS4 of #3984). Every claim was verified against the codebase before writing it — no overclaiming.

**why-atlas comparison table** (`apps/www/src/components/landing/comparison.tsx`):
- New rows: **Long-running turns** (durable agent loop resumes from last checkpoint, security re-verified on resume), **Semantic layer editing** (in-product admin editor + YAML-in-repo).
- Enriched: **Agent-native** now notes MCP stdio + SSE; **Embeddable** now names the script-tag widget, `<AtlasChat/>` React component, and typed `@useatlas/sdk`; **Dashboards as conversations** now mentions the versioned baseline + bound-mode editing; **Plugin ecosystem** bumped to the verified **24 plugins across 5 types** with `@useatlas/plugin-sdk` + in-product registry; **Multi-database** corrected to **Elasticsearch / OpenSearch**.

**landing drop-in surfaces** (`apps/www/src/components/landing/drop-in-surfaces.tsx`):
- New MCP `bunx @useatlas/mcp` tile; folded SDK + script-tag widget into the `<AtlasChat/>` tile; dashboard tile now notes versioned baseline + bound-mode.
- Added a queryable-datasource chip strip: PostgreSQL, MySQL, ClickHouse, Snowflake, BigQuery, DuckDB, Elasticsearch / OpenSearch, Salesforce, Stripe, Notion, GitHub, any OpenAPI 3.x spec.

**Accuracy guardrails:** Twenty (CRM action target) and Obsidian (a surface + vault-reader action) are deliberately **NOT** listed as datasources — they aren't analytics datasources. `CLAIM-ACCURACY` notes in both files record the verification trail and re-derivation rules (e.g. how the "24 plugins" count is derived, why GitHub/Stripe/Notion are OpenAPI presets and not `plugins/` entries).

**Out of scope:** does not touch per-tier feature-ladder counts (that is #3995, human-gated).

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] `apps/www` `bun run build` — static export succeeds
- [x] Internal review panel (4 specialists) — CLEAN; comment-analyzer verified every factual claim against the source tree

Closes #3994

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise shipped capabilities in the landing page comparison and drop-in surfaces sections
> - Updates copy in [comparison.tsx](https://github.com/AtlasDevHQ/atlas/pull/4017/files#diff-d8dec0881324cb7fecafa0c5a495abfd6f0e30ed10c2449abb76fdf38e91816d) to reflect current Atlas capabilities: adds 'Long-running turns' and 'Semantic layer editing' rows, expands plugin count to 24 across 5 types, and clarifies datasource entries (e.g. Elasticsearch / OpenSearch).
> - Rewrites [drop-in-surfaces.tsx](https://github.com/AtlasDevHQ/atlas/pull/4017/files#diff-3591fcd1266a2c00270461453da0d23a6394ea20280db8005a4047c33cc61ca8) to surface the MCP server (`bunx @useatlas/mcp`, stdio + SSE), the `@useatlas/sdk` typed package, and the one-line script-tag widget.
> - Adds a datasource chips list rendering 12 queryable sources (PostgreSQL, Snowflake, Salesforce, OpenAPI 3.x, etc.) with explanatory text about SQL warehouses, search engines, and REST APIs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84767e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->