### PR TITLE
feat(api): TokenWeighting + output-equivalent token accounting (WS2)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -77163,6 +77163,9 @@
                         "tokenCount": {
                           "type": "number"
                         },
+                        "weightedTokenCount": {
+                          "type": "number"
+                        },
                         "seatCount": {
                           "type": "number"
                         },

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -374,8 +374,13 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     const totalTokenBudget = computeTokenBudget(workspace.plan_tier, seatCount);
     const tokenLimit = isUnlimited(totalTokenBudget) ? null : totalTokenBudget;
 
+    // The budget gauge denominates in output-equivalent (model-weighted)
+    // tokens (#3989) — the SAME denominator enforcement uses — so the page's
+    // usage percent can never diverge from the 429 the workspace actually hits.
+    // `?? tokenCount` mirrors the enforcement consumer: if the weighted field is
+    // ever absent, the gauge degrades to raw rather than showing a false 0%.
     const tokenOverage = tokenLimit !== null
-      ? buildMetricStatus("tokens", usage.tokenCount, tokenLimit)
+      ? buildMetricStatus("tokens", usage.weightedTokenCount ?? usage.tokenCount, tokenLimit)
       : { usagePercent: 0, status: "ok" as const };
 
     return c.json({
@@ -408,6 +413,7 @@ billing.openapi(getBillingStatusRoute, async (c) => {
       usage: {
         queryCount: usage.queryCount,
         tokenCount: usage.tokenCount,
+        weightedTokenCount: usage.weightedTokenCount,
         seatCount,
         tokenUsagePercent: tokenOverage.usagePercent,
         tokenOverageStatus: tokenOverage.status,

--- a/packages/api/src/lib/__tests__/metering.test.ts
+++ b/packages/api/src/lib/__tests__/metering.test.ts
@@ -129,6 +129,7 @@ describe("metering", () => {
         "user-1",
         "query",
         1,
+        null, // weighted_quantity — omitted for a non-token event
         JSON.stringify({ model: "gpt-4" }),
       ]);
     });
@@ -142,7 +143,29 @@ describe("metering", () => {
       });
 
       expect(queryCalls).toHaveLength(1);
-      expect(queryCalls[0].params).toEqual([null, null, "token", 500, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "token", 500, null, null]);
+    });
+
+    it("persists the weighted (output-equivalent) quantity for a token event (#3989)", () => {
+      logUsageEvent({
+        workspaceId: "org-1",
+        userId: "user-1",
+        eventType: "token",
+        quantity: 1500,
+        weightedQuantity: 4200,
+        metadata: { input: 500, output: 1000, weighted: 4200 },
+      });
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].sql).toContain("weighted_quantity");
+      expect(queryCalls[0].params).toEqual([
+        "org-1",
+        "user-1",
+        "token",
+        1500,
+        4200,
+        JSON.stringify({ input: 500, output: 1000, weighted: 4200 }),
+      ]);
     });
 
     it("is a no-op when internal DB is not configured", () => {
@@ -217,17 +240,24 @@ describe("metering", () => {
     it("returns current period aggregates (UTC-month fallback, no subscription)", async () => {
       queryResults = [
         [], // no active subscription row → UTC month
-        [{ query_count: 42, token_count: 10000, active_users: 3 }],
+        [{ query_count: 42, token_count: 10000, weighted_token_count: 23000, active_users: 3 }],
       ];
 
       const result = await getCurrentPeriodUsage("org-1");
 
       expect(result.queryCount).toBe(42);
       expect(result.tokenCount).toBe(10000);
+      // Output-equivalent (model-weighted) token spend — the budget denominator (#3989).
+      expect(result.weightedTokenCount).toBe(23000);
       expect(result.activeUsers).toBe(3);
       expect(result.periodStart).toBeTruthy();
       expect(result.periodEnd).toBeTruthy();
       expect(result.periodSource).toBe("utc-month");
+
+      // The aggregate sums the weighted column with a COALESCE fallback to raw
+      // so token rows predating migration 0152 still contribute.
+      const usageCall = queryCalls.find((c) => c.sql.includes("usage_events"));
+      expect(usageCall?.sql).toContain("COALESCE(weighted_quantity, quantity)");
     });
 
     it("anchors on the Stripe period when an active subscription exists", async () => {
@@ -254,13 +284,14 @@ describe("metering", () => {
     it("returns zeros when no data", async () => {
       queryResults = [
         [], // no active subscription
-        [{ query_count: 0, token_count: 0, active_users: 0 }],
+        [{ query_count: 0, token_count: 0, weighted_token_count: 0, active_users: 0 }],
       ];
 
       const result = await getCurrentPeriodUsage("org-empty");
 
       expect(result.queryCount).toBe(0);
       expect(result.tokenCount).toBe(0);
+      expect(result.weightedTokenCount).toBe(0);
       expect(result.activeUsers).toBe(0);
     });
 
@@ -268,6 +299,7 @@ describe("metering", () => {
       mockHasInternalDB = false;
       const result = await getCurrentPeriodUsage("org-1");
       expect(result.queryCount).toBe(0);
+      expect(result.weightedTokenCount).toBe(0);
       expect(result.periodSource).toBe("utc-month");
       expect(queryCalls).toHaveLength(0);
     });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -62,6 +62,7 @@ import {
 } from "./durable-state";
 import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
+import { toOutputEquivalentTokens } from "./billing/token-weighting";
 import { buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
 import { resolveOrgKnowledgeSection } from "./learn/org-knowledge-section";
 import { dispatchMutableHook } from "./plugins/hooks";
@@ -2008,7 +2009,17 @@ export async function runAgent({
           // Wrapped in its own try/catch to ensure a metering failure
           // never disrupts the onFinish callback or stream finalization.
           try {
-            const totalTokens = (totalUsage.inputTokens ?? 0) + (totalUsage.outputTokens ?? 0);
+            const inputTokens = totalUsage.inputTokens ?? 0;
+            const outputTokens = totalUsage.outputTokens ?? 0;
+            const totalTokens = inputTokens + outputTokens;
+            // Output-equivalent (model-weighted) tokens (#3989): normalize the
+            // turn's raw tokens by the per-model weight so budget math can
+            // denominate in output-equivalent tokens. Recorded alongside the raw
+            // `quantity` on the same agent-step accounting event.
+            const weightedTokens = toOutputEquivalentTokens(
+              { inputTokens, outputTokens },
+              resolvedModelId,
+            );
             logUsageEvent({
               workspaceId: orgId ?? null,
               userId: userId ?? null,
@@ -2022,7 +2033,8 @@ export async function runAgent({
                 userId: userId ?? null,
                 eventType: "token",
                 quantity: totalTokens,
-                metadata: { input: totalUsage.inputTokens ?? 0, output: totalUsage.outputTokens ?? 0 },
+                weightedQuantity: weightedTokens,
+                metadata: { input: inputTokens, output: outputTokens, weighted: weightedTokens },
               });
             }
           } catch (err) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -413,6 +413,12 @@ describe("migrateAuthTables", () => {
             // 0150 adds token_usage.latency_ms (Atlas-internal per-turn latency,
             // demo tracking, #3931) — runs in every auth mode.
             { name: "0150_token_usage_latency.sql" },
+            // 0151 is a managed-auth migration (user email-hash index) — skipped
+            // in this non-managed test mode, so it is intentionally absent here.
+            // 0152 adds usage_events.weighted_quantity (Atlas-internal
+            // output-equivalent token accounting, TokenWeighting WS2, #3989) —
+            // runs in every auth mode, so it must be pre-applied here.
+            { name: "0152_usage_events_weighted_quantity.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -18,13 +18,29 @@ import {
 
 let mockHasInternalDB = true;
 let mockWorkspace: Record<string, unknown> | null = null;
-let mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
+let mockUsage: {
+  queryCount: number;
+  tokenCount: number;
+  /** When set, the budget denominator (#3989); otherwise mirrors `tokenCount`. */
+  weightedTokenCount?: number;
+  activeUsers: number;
+  periodStart: string;
+  periodEnd: string;
+} = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
 let mockWorkspaceDetailsShouldThrow = false;
 /** Count of `getWorkspaceDetails` invocations — i.e. internal-DB plan reads
  *  that the per-replica planCache did NOT absorb. Used by the #3432
  *  per-replica staleness-contract test. */
 let mockWorkspaceReadCount = 0;
 let mockUsageShouldThrow = false;
+/**
+ * When true, the metering mock returns `mockUsage` VERBATIM (no auto-mirrored
+ * `weightedTokenCount`), so enforcement sees the field genuinely absent — used
+ * to exercise the `?? tokenCount` defensive fallback (#3989). Default false:
+ * the legacy threshold cases drive the budget via `tokenCount` and rely on the
+ * mirror so they don't each have to set `weightedTokenCount`.
+ */
+let mockOmitWeighted = false;
 /** Rows returned by the `internalQuery` mock (chat-integration count query). */
 let mockInternalQueryResult: unknown[] = [];
 /** When true, the `internalQuery` mock throws (count-query failure path). */
@@ -79,7 +95,18 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 mock.module("@atlas/api/lib/metering", () => ({
   getCurrentPeriodUsage: async () => {
     if (mockUsageShouldThrow) throw new Error("metering error");
-    return mockUsage;
+    // Budget enforcement denominates in output-equivalent tokens (#3989). The
+    // threshold cases below set the budget-driving figure via `tokenCount`; the
+    // weighted denominator mirrors it unless a case sets `weightedTokenCount`
+    // explicitly (the spread is last, so it wins), so existing threshold
+    // assertions stay meaningful while the weighting wire-through is exercised.
+    // `mockOmitWeighted` returns the shape verbatim to exercise the absent-field
+    // fallback path.
+    if (mockOmitWeighted) return mockUsage;
+    return {
+      weightedTokenCount: mockUsage.tokenCount,
+      ...mockUsage,
+    };
   },
   logUsageEvent: () => {},
   aggregateUsageSummary: async () => {},
@@ -263,6 +290,7 @@ describe("billing/enforcement", () => {
     mockHasInternalDB = true;
     mockWorkspaceDetailsShouldThrow = false;
     mockUsageShouldThrow = false;
+    mockOmitWeighted = false;
     mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
     mockWorkspace = null;
     mockWorkspaceReadCount = 0;
@@ -463,6 +491,61 @@ describe("billing/enforcement", () => {
     const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
     expect(exceeded.httpStatus).toBe(429);
     expect(exceeded.usage.metric).toBe("tokens");
+  });
+
+  // ── Output-equivalent (model-weighted) denomination (#3989) ───────
+  // The budget is denominated in OUTPUT-EQUIVALENT tokens, not raw. These
+  // cases pin that the decision keys off `weightedTokenCount`, NOT
+  // `tokenCount` — so reverting enforcement.ts back to `usage.tokenCount`
+  // would flip every assertion here. Starter budget = 2M (1 seat).
+
+  it("blocks when WEIGHTED usage exceeds the hard limit even though RAW usage is under budget", async () => {
+    mockWorkspace = makeWorkspace(); // starter: 2M/seat, hard limit 110% = 2.2M
+    // Raw usage 1.5M (75%, well under budget) but a pricier model weighted it
+    // up to 2.3M (115%, over the hard limit). Enforcement must block on the
+    // weighted figure — if it read raw, this would be allowed with no warning.
+    mockUsage = {
+      queryCount: 0,
+      tokenCount: 1_500_000,
+      weightedTokenCount: 2_300_000,
+      activeUsers: 0,
+      periodStart: "",
+      periodEnd: "",
+    };
+    const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
+    expect(exceeded.httpStatus).toBe(429);
+    // The reported usage is the WEIGHTED count, not the raw 1.5M.
+    expect(exceeded.usage.currentUsage).toBe(2_300_000);
+    expect(exceeded.usage.limit).toBe(2_000_000);
+  });
+
+  it("allows when WEIGHTED usage is under budget even though RAW usage is over the hard limit", async () => {
+    mockWorkspace = makeWorkspace(); // starter: 2M/seat
+    // Raw usage 2.4M (120%, would hard-block on raw) but a cheap model (e.g.
+    // Haiku) weighted it down to 800k (40%). Enforcement must allow on the
+    // weighted figure with no warning — proving it does not read raw.
+    mockUsage = {
+      queryCount: 0,
+      tokenCount: 2_400_000,
+      weightedTokenCount: 800_000,
+      activeUsers: 0,
+      periodStart: "",
+      periodEnd: "",
+    };
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("falls back to raw tokenCount when weightedTokenCount is absent (defensive)", async () => {
+    mockWorkspace = makeWorkspace();
+    // No `weightedTokenCount` on the usage shape (e.g. an older code path). The
+    // `?? tokenCount` fallback denominates on raw rather than treating usage as
+    // an unenforced zero. 2.2M raw = 110% → hard block.
+    mockOmitWeighted = true;
+    mockUsage = { queryCount: 0, tokenCount: 2_200_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
+    expect(exceeded.httpStatus).toBe(429);
+    expect(exceeded.usage.currentUsage).toBe(2_200_000);
   });
 
   // ── Per-seat scaling ──────────────────────────────────────────────

--- a/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
@@ -57,7 +57,13 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 mock.module("@atlas/api/lib/metering", () => ({
-  getCurrentPeriodUsage: async () => mockUsage,
+  // Budget enforcement denominates in output-equivalent tokens (#3989); this
+  // parity test drives the budget via `tokenCount`, so mirror it onto
+  // `weightedTokenCount` (the denominator enforcement actually reads).
+  getCurrentPeriodUsage: async () => ({
+    weightedTokenCount: mockUsage.tokenCount,
+    ...mockUsage,
+  }),
   logUsageEvent: () => {},
   aggregateUsageSummary: async () => {},
   getUsageHistory: async () => [],

--- a/packages/api/src/lib/billing/__tests__/token-weighting.test.ts
+++ b/packages/api/src/lib/billing/__tests__/token-weighting.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "bun:test";
+import {
+  resolveModelWeight,
+  toOutputEquivalentTokens,
+  MODEL_WEIGHTS,
+  DEFAULT_WEIGHT,
+  REFERENCE_MODEL_FAMILY,
+  INPUT_WEIGHT,
+  type WeightedModelFamily,
+} from "@atlas/api/lib/billing/token-weighting";
+
+describe("token-weighting: invariants", () => {
+  it("the reference family weighs exactly 1.0", () => {
+    expect(MODEL_WEIGHTS[REFERENCE_MODEL_FAMILY]).toBe(1.0);
+  });
+
+  it("the unknown-model default equals the reference weight (never free, never punitive)", () => {
+    expect(DEFAULT_WEIGHT).toBe(MODEL_WEIGHTS[REFERENCE_MODEL_FAMILY]);
+    expect(DEFAULT_WEIGHT).toBe(1.0);
+  });
+});
+
+describe("resolveModelWeight", () => {
+  // [modelId, expectedFamily, expectedWeight, known]
+  const cases: ReadonlyArray<
+    [string | null | undefined, WeightedModelFamily | null, number, boolean]
+  > = [
+    ["anthropic/claude-haiku-4.5", "haiku", MODEL_WEIGHTS.haiku, true],
+    ["anthropic/claude-sonnet-4.6", "sonnet", MODEL_WEIGHTS.sonnet, true],
+    ["anthropic/claude-opus-4.8", "opus", MODEL_WEIGHTS.opus, true],
+    // Direct / versioned ids (no gateway prefix).
+    ["claude-haiku-4-5-20251001", "haiku", MODEL_WEIGHTS.haiku, true],
+    ["claude-opus-4-8-20251101", "opus", MODEL_WEIGHTS.opus, true],
+    // Case-insensitive.
+    ["Anthropic/Claude-SONNET", "sonnet", MODEL_WEIGHTS.sonnet, true],
+    // Unknown / empty → default weight, known:false, family:null.
+    ["gpt-4o", null, DEFAULT_WEIGHT, false],
+    ["mistral-large", null, DEFAULT_WEIGHT, false],
+    ["", null, DEFAULT_WEIGHT, false],
+    [null, null, DEFAULT_WEIGHT, false],
+    [undefined, null, DEFAULT_WEIGHT, false],
+  ];
+
+  it.each(cases)(
+    "resolves %p → family %p, weight %p, known %p",
+    (model, family, weight, known) => {
+      const r = resolveModelWeight(model);
+      expect(r.family).toBe(family);
+      expect(r.weight).toBe(weight);
+      expect(r.known).toBe(known);
+    },
+  );
+});
+
+describe("toOutputEquivalentTokens", () => {
+  // [model, inputTokens, outputTokens, expectedOutputEquivalent]
+  const cases: ReadonlyArray<[string | null | undefined, number, number, number]> = [
+    // Reference model (sonnet, weight 1.0): output passes through 1:1, input at
+    // INPUT_WEIGHT (1/5). 1000 in + 1000 out = round(1000*0.2 + 1000) = 1200.
+    ["anthropic/claude-sonnet-4.6", 1000, 1000, 1200],
+    // Pure output on the reference model passes through unchanged.
+    ["anthropic/claude-sonnet-4.6", 0, 1000, 1000],
+    // Pure input on the reference model is discounted to INPUT_WEIGHT.
+    ["anthropic/claude-sonnet-4.6", 1000, 0, 200],
+    // Haiku weighs LESS than the reference: same tokens → fewer equivalents.
+    // round((0*0.2 + 1000) * 1/3) = round(333.33) = 333.
+    ["anthropic/claude-haiku-4.5", 0, 1000, 333],
+    // Opus weighs MORE: round((0*0.2 + 1000) * 5) = 5000.
+    ["anthropic/claude-opus-4.8", 0, 1000, 5000],
+    // Unknown model uses the default (reference) weight: same as sonnet.
+    ["gpt-4o", 1000, 1000, 1200],
+    ["mistral-large", 0, 1000, 1000],
+    [null, 0, 1000, 1000],
+    // Zero tokens → 0.
+    ["anthropic/claude-opus-4.8", 0, 0, 0],
+    // Large counts don't overflow / stay integer.
+    ["anthropic/claude-sonnet-4.6", 10_000_000, 10_000_000, 12_000_000],
+    // Negative inputs clamp to 0 (defensive).
+    ["anthropic/claude-sonnet-4.6", -500, -500, 0],
+    ["anthropic/claude-sonnet-4.6", -500, 1000, 1000],
+  ];
+
+  it.each(cases)(
+    "model %p, in %p, out %p → %p output-equivalent tokens",
+    (model, input, output, expected) => {
+      expect(
+        toOutputEquivalentTokens({ inputTokens: input, outputTokens: output }, model),
+      ).toBe(expected);
+    },
+  );
+
+  it("always returns a non-negative finite integer", () => {
+    for (const model of ["anthropic/claude-opus-4.8", "unknown", null]) {
+      for (const [i, o] of [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [123_456, 789_012],
+        [-1, -1],
+      ] as const) {
+        const v = toOutputEquivalentTokens({ inputTokens: i, outputTokens: o }, model);
+        expect(Number.isInteger(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("opus weighs strictly more than haiku for identical raw tokens", () => {
+    const counts = { inputTokens: 5000, outputTokens: 5000 };
+    const haiku = toOutputEquivalentTokens(counts, "anthropic/claude-haiku-4.5");
+    const sonnet = toOutputEquivalentTokens(counts, "anthropic/claude-sonnet-4.6");
+    const opus = toOutputEquivalentTokens(counts, "anthropic/claude-opus-4.8");
+    expect(haiku).toBeLessThan(sonnet);
+    expect(sonnet).toBeLessThan(opus);
+  });
+
+  it("INPUT_WEIGHT discounts input relative to output on the reference model", () => {
+    const pureOutput = toOutputEquivalentTokens(
+      { inputTokens: 0, outputTokens: 1000 },
+      "anthropic/claude-sonnet-4.6",
+    );
+    const pureInput = toOutputEquivalentTokens(
+      { inputTokens: 1000, outputTokens: 0 },
+      "anthropic/claude-sonnet-4.6",
+    );
+    expect(pureInput).toBe(Math.round(pureOutput * INPUT_WEIGHT));
+  });
+});

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -278,7 +278,16 @@ export async function checkPlanLimits(
   if (!isUnlimited(totalBudget)) {
     try {
       const usage = await getCurrentPeriodUsage(orgId);
-      return evaluateUsage(orgId, usage.tokenCount, totalBudget);
+      // Denominate the budget in output-equivalent tokens (#3989): a turn on a
+      // pricier model consumes more of the budget per raw token, making the
+      // advertised "model-aware budget" literally true. `weightedTokenCount`
+      // already falls back to the raw count for token rows predating migration
+      // 0152 (COALESCE in the aggregate), so un-backfilled history is never
+      // over- or under-counted relative to raw. The `?? tokenCount` here is a
+      // second belt: if a future shape change ever made the weighted field
+      // arrive undefined, we denominate on raw rather than silently treating
+      // usage as zero and never enforcing (a false-negative on the budget path).
+      return evaluateUsage(orgId, usage.weightedTokenCount ?? usage.tokenCount, totalBudget);
     } catch (err) {
       // DELIBERATE FAIL-OPEN (#3428): if we can't read usage, ALLOW the request
       // — metering is best-effort and we prioritise availability over revenue

--- a/packages/api/src/lib/billing/token-weighting.ts
+++ b/packages/api/src/lib/billing/token-weighting.ts
@@ -1,0 +1,161 @@
+/**
+ * TokenWeighting — output-equivalent token accounting (#3989, WS2).
+ *
+ * A pure module that normalizes a turn's raw input/output tokens to
+ * "output-equivalent tokens" via a per-model weight table. This is what makes
+ * the advertised "model-aware budget" framing literally true: a turn on a more
+ * capable (pricier) model consumes more of the budget per raw token than a turn
+ * on a cheaper model, in proportion to how much more it costs to serve.
+ *
+ * ## The model
+ *
+ * Output tokens are the reference unit — they cost the most and are the natural
+ * denominator for a usage-priced product. Each model is assigned a single
+ * `weight` relative to a REFERENCE model (whose weight is exactly 1.0):
+ *
+ *   output_equivalent = round((inputTokens * INPUT_WEIGHT + outputTokens) * weight)
+ *
+ * `INPUT_WEIGHT` captures that an input token is cheaper than an output token
+ * for the SAME model. We use a single ratio across the Anthropic family
+ * (input ≈ 1/5 of output, matching the published 1:5 input:output list-price
+ * ratio for Haiku/Sonnet/Opus), so a turn that is mostly cached/cheap input
+ * doesn't denominate as if every input token were an output token.
+ *
+ * The per-model `weight` then scales the whole turn by how expensive that
+ * model is relative to the reference. We anchor the reference at Sonnet
+ * (weight 1.0) — the default workhorse model — so Haiku turns weigh LESS than
+ * their raw count and Opus turns weigh MORE, exactly as they cost.
+ *
+ * ## Unknown models
+ *
+ * An unrecognized model id MUST NOT silently fall back to 0 (that would let a
+ * BYO-model or a newly-added model consume budget for free) nor to an
+ * arbitrarily punitive number. It falls back to {@link DEFAULT_WEIGHT} — the
+ * reference weight of 1.0 — so an unknown model is denominated exactly like the
+ * reference model: never free, never over-charged. The fallback is surfaced via
+ * `resolveModelWeight(...).known === false` so callers can log/alert if they
+ * care, without changing the math.
+ *
+ * ## Why a separate module from `../token-pricing.ts`
+ *
+ * `lib/token-pricing.ts` estimates *dollars* for an operator-facing demo signal and
+ * returns `null` for unknown models (the UI renders "—"). This module computes
+ * the *budget denominator* for billing enforcement, where "null" is not an
+ * option — every turn must denominate to a concrete, non-negative integer.
+ * They share the family-by-substring resolution idiom but answer different
+ * questions, so they stay separate.
+ */
+
+/** Known model families for weighting. Resolved from a model id by substring. */
+export type WeightedModelFamily = "haiku" | "sonnet" | "opus";
+
+/**
+ * The reference model family. Its weight is exactly 1.0 — every other family's
+ * weight is expressed relative to it, and an unknown model denominates as if it
+ * were this family (see {@link DEFAULT_WEIGHT}).
+ */
+export const REFERENCE_MODEL_FAMILY: WeightedModelFamily = "sonnet";
+
+/**
+ * Per-family weight relative to the reference (Sonnet = 1.0). These mirror the
+ * published Anthropic list-price ratios: Haiku is ~1/3 the cost of Sonnet and
+ * Opus is ~5× — so Haiku turns weigh less than their raw token count and Opus
+ * turns weigh more, making the budget genuinely model-aware.
+ *
+ * Same source of truth ballpark as `lib/token-pricing.ts`'s `FAMILY_RATES`
+ * (haiku 1/5, sonnet 3/15, opus 15/75 input/output per MTok) — the weight is
+ * the output-rate ratio: haiku 5/15 ≈ 0.33, sonnet 15/15 = 1.0, opus 75/15 = 5.
+ */
+export const MODEL_WEIGHTS = {
+  haiku: 1 / 3,
+  sonnet: 1.0,
+  opus: 5.0,
+} satisfies Record<WeightedModelFamily, number>;
+
+/**
+ * Weight applied to an unrecognized model. Equal to the reference weight (1.0):
+ * an unknown model is never free (would be a budget bypass) and never punished
+ * (would over-bill a legitimate new model) — it denominates exactly like the
+ * reference model until it's added to {@link MODEL_WEIGHTS}.
+ */
+export const DEFAULT_WEIGHT = MODEL_WEIGHTS[REFERENCE_MODEL_FAMILY];
+
+/**
+ * How much one input token weighs relative to one output token, for the SAME
+ * model. The published Anthropic list prices are a 1:5 input:output ratio
+ * across Haiku/Sonnet/Opus, so an input token is worth 1/5 of an output token
+ * before the per-model weight is applied.
+ */
+export const INPUT_WEIGHT = 1 / 5;
+
+/** Raw token counts for a turn (or aggregate), as recorded at agent-step time. */
+export interface RawTokenCounts {
+  /** Total input tokens for the turn (AI-SDK `inputTokens`). */
+  readonly inputTokens: number;
+  /** Total output/completion tokens for the turn (AI-SDK `outputTokens`). */
+  readonly outputTokens: number;
+}
+
+/** Result of resolving a model id to its weight. */
+export interface ResolvedModelWeight {
+  /** The numeric weight to scale the turn by. */
+  readonly weight: number;
+  /**
+   * `true` when the model id matched a known family; `false` when it fell back
+   * to {@link DEFAULT_WEIGHT}. Lets callers alert on unknown models without
+   * changing the math.
+   */
+  readonly known: boolean;
+  /** The resolved family, or `null` when unknown. */
+  readonly family: WeightedModelFamily | null;
+}
+
+/**
+ * Resolve a model id to its weight family. Substring match (case-insensitive)
+ * so it's robust to the gateway prefix (`anthropic/claude-opus-4.8`) and the
+ * direct/versioned form (`claude-opus-4-8-20251101`).
+ *
+ * An unknown or empty id resolves to {@link DEFAULT_WEIGHT} with
+ * `known: false` — never throws, never returns 0.
+ */
+export function resolveModelWeight(
+  model: string | null | undefined,
+): ResolvedModelWeight {
+  if (model) {
+    const id = model.toLowerCase();
+    // Order matters only for disjoint substrings; the three families never
+    // co-occur in a single id, so any order is correct. Listed cheap→dear.
+    if (id.includes("haiku")) return { weight: MODEL_WEIGHTS.haiku, known: true, family: "haiku" };
+    if (id.includes("sonnet")) return { weight: MODEL_WEIGHTS.sonnet, known: true, family: "sonnet" };
+    if (id.includes("opus")) return { weight: MODEL_WEIGHTS.opus, known: true, family: "opus" };
+  }
+  return { weight: DEFAULT_WEIGHT, known: false, family: null };
+}
+
+/**
+ * Normalize a turn's raw input/output tokens to output-equivalent tokens for
+ * the given model.
+ *
+ * Pure and total: negative inputs are clamped to 0, the result is a
+ * non-negative integer (rounded), and an unknown model uses
+ * {@link DEFAULT_WEIGHT} rather than throwing or returning 0.
+ *
+ *   output_equivalent = round((input * INPUT_WEIGHT + output) * weight)
+ *
+ * @param counts - The turn's raw `{ inputTokens, outputTokens }`.
+ * @param model  - The model id the turn ran on; unknown ids use the default weight.
+ */
+export function toOutputEquivalentTokens(
+  counts: RawTokenCounts,
+  model: string | null | undefined,
+): number {
+  const input = Math.max(0, counts.inputTokens);
+  const output = Math.max(0, counts.outputTokens);
+  const { weight } = resolveModelWeight(model);
+  const weighted = (input * INPUT_WEIGHT + output) * weight;
+  // Round to a whole token — the budget denominates in integer tokens and the
+  // `weighted_quantity` column is an integer. Clamp guards against a NaN/−0
+  // sneaking through (Math.round(NaN) is NaN → coalesced to 0).
+  const rounded = Math.round(weighted);
+  return Number.isFinite(rounded) ? Math.max(0, rounded) : 0;
+}

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -178,7 +178,9 @@ describe("runMigrations", () => {
     //   #3931) = 151.
     //   Plus 0151 (user pgcrypto sha256(lower(email)) functional index for the
     //   returning-user login front-door probe, ADR-0024 §3, #3973) = 152.
-    expect(count).toBe(152);
+    //   Plus 0152 (usage_events.weighted_quantity output-equivalent token
+    //   accounting, TokenWeighting WS2, #3989) = 153.
+    expect(count).toBe(153);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -359,6 +361,7 @@ describe("runMigrations", () => {
         "0149_conversation_group_reach.sql",
         "0150_token_usage_latency.sql",
         "0151_user_email_hash_index.sql",
+        "0152_usage_events_weighted_quantity.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0152_usage_events_weighted_quantity.sql
+++ b/packages/api/src/lib/db/migrations/0152_usage_events_weighted_quantity.sql
@@ -1,0 +1,29 @@
+-- Migration 0152: output-equivalent (weighted) token accounting (#3989, WS2).
+--
+-- The "model-aware budget" is denominated in output-equivalent tokens: a turn's
+-- raw input/output tokens are normalized by a per-model weight (reference model
+-- = 1.0) at agent-step accounting time. This column stores that weighted value
+-- ALONGSIDE the raw `quantity`, so period-usage summation and budget math can
+-- sum the weighted token spend without re-deriving it (the model id needed to
+-- weight a row is only in `metadata`, and back-deriving it per row at query
+-- time would be both slow and lossy).
+--
+-- Scope: populated only for `event_type = 'token'` rows written after this
+-- migration (the agent onFinish path supplies it). It is left NULL for:
+--   - rows predating this migration (no weight was computed), and
+--   - non-token events (`query`, `login`), which carry no token spend.
+-- Budget/period summation therefore reads `COALESCE(weighted_quantity, quantity)`
+-- so legacy token rows still contribute their raw count (a safe, slightly
+-- conservative under-weighting) until they age out of the billing window.
+--
+-- Nullable, no default: NULL is meaningful here ("not weighted"), distinct from
+-- 0 ("weighted to zero"). Mirrored in db/schema.ts (`usageEvents.weightedQuantity`)
+-- in the same PR per the schema-drift discipline.
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE usage_events
+  ADD COLUMN IF NOT EXISTS weighted_quantity integer;
+
+COMMENT ON COLUMN usage_events.weighted_quantity IS
+  'Output-equivalent (model-weighted) token count for token events (#3989). Raw tokens normalized by the per-model TokenWeighting table (reference model = 1.0). NULL for non-token events and for rows predating this migration; budget summation reads COALESCE(weighted_quantity, quantity).';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -798,6 +798,13 @@ export const usageEvents = pgTable(
     userId: text("user_id"),
     eventType: text("event_type").notNull(),
     quantity: integer("quantity").notNull().default(1),
+    // Output-equivalent (model-weighted) token count for `token` events (#3989,
+    // migration 0152). Raw tokens normalized by the per-model TokenWeighting
+    // table (reference model = 1.0). Nullable, no default: NULL means "not
+    // weighted" (non-token events, or token rows predating the migration) —
+    // distinct from 0 ("weighted to zero"). Budget/period summation reads
+    // COALESCE(weighted_quantity, quantity) so legacy token rows still count.
+    weightedQuantity: integer("weighted_quantity"),
     metadata: jsonb("metadata"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -36,6 +36,14 @@ export interface UsageEvent {
   userId: string | null;
   eventType: UsageEventType;
   quantity: number;
+  /**
+   * Output-equivalent (model-weighted) token count for `token` events (#3989).
+   * Computed at agent-step accounting time via the TokenWeighting module and
+   * persisted to `usage_events.weighted_quantity` alongside the raw `quantity`,
+   * so budget math can denominate in output-equivalent tokens. Omit (or pass
+   * `null`) for non-token events — the column is NULL for those.
+   */
+  weightedQuantity?: number | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -85,13 +93,14 @@ export function logUsageEvent(event: UsageEvent): void {
   // after 5 consecutive failures. No try/catch needed here — hasInternalDB()
   // guards against the only synchronous throw path (DATABASE_URL unset).
   internalExecute(
-    `INSERT INTO usage_events (workspace_id, user_id, event_type, quantity, metadata)
-     VALUES ($1, $2, $3, $4, $5)`,
+    `INSERT INTO usage_events (workspace_id, user_id, event_type, quantity, weighted_quantity, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
     [
       event.workspaceId ?? null,
       event.userId ?? null,
       event.eventType,
       event.quantity,
+      event.weightedQuantity ?? null,
       event.metadata ? JSON.stringify(event.metadata) : null,
     ],
   );
@@ -223,7 +232,17 @@ export interface UsageSummaryRow {
 
 export interface UsageCurrentPeriod {
   queryCount: number;
+  /** Raw token spend for the period (sum of `token` event `quantity`). */
   tokenCount: number;
+  /**
+   * Output-equivalent (model-weighted) token spend for the period (#3989): the
+   * sum of `COALESCE(weighted_quantity, quantity)` over `token` events. This is
+   * the budget denominator — a turn on a pricier model contributes more here
+   * than its raw `tokenCount`. Token rows predating migration 0152 have a NULL
+   * `weighted_quantity` and fall back to their raw `quantity`, so this is never
+   * less than it should be for un-backfilled history.
+   */
+  weightedTokenCount: number;
   activeUsers: number;
   /** Inclusive ISO start of the metering window. */
   periodStart: string;
@@ -260,6 +279,7 @@ export async function getCurrentPeriodUsage(
     return {
       queryCount: 0,
       tokenCount: 0,
+      weightedTokenCount: 0,
       activeUsers: 0,
       periodStart: "",
       periodEnd: "",
@@ -272,11 +292,13 @@ export async function getCurrentPeriodUsage(
   const rows = await internalQuery<{
     query_count: number;
     token_count: number;
+    weighted_token_count: number;
     active_users: number;
   }>(
     `SELECT
        COALESCE(SUM(CASE WHEN event_type = 'query' THEN quantity ELSE 0 END), 0)::int AS query_count,
        COALESCE(SUM(CASE WHEN event_type = 'token' THEN quantity ELSE 0 END), 0)::int AS token_count,
+       COALESCE(SUM(CASE WHEN event_type = 'token' THEN COALESCE(weighted_quantity, quantity) ELSE 0 END), 0)::int AS weighted_token_count,
        COALESCE(COUNT(DISTINCT CASE WHEN event_type = 'login' THEN user_id END), 0)::int AS active_users
      FROM usage_events
      WHERE workspace_id = $1
@@ -289,6 +311,7 @@ export async function getCurrentPeriodUsage(
   return {
     queryCount: row?.query_count ?? 0,
     tokenCount: row?.token_count ?? 0,
+    weightedTokenCount: row?.weighted_token_count ?? 0,
     activeUsers: row?.active_users ?? 0,
     periodStart: period.start.toISOString(),
     periodEnd: period.end.toISOString(),

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -95,7 +95,16 @@ export interface BillingLimits {
 /** Current-period usage counters. */
 export interface BillingUsage {
   queryCount: number;
+  /** Raw token spend for the period (input + output tokens). */
   tokenCount: number;
+  /**
+   * Output-equivalent (model-weighted) token spend for the period (#3989) —
+   * the denominator `tokenUsagePercent` and the enforced budget are computed
+   * from. A turn on a pricier model contributes more here than to the raw
+   * `tokenCount`, making the "model-aware budget" literally true. Optional for
+   * older-bundle tolerance; falls back to `tokenCount` when absent.
+   */
+  weightedTokenCount?: number;
   seatCount: number;
   tokenUsagePercent: number;
   tokenOverageStatus: OverageStatus;
@@ -212,6 +221,7 @@ export const BillingLimitsSchema = z.object({
 export const BillingUsageSchema = z.object({
   queryCount: z.number(),
   tokenCount: z.number(),
+  weightedTokenCount: z.number().optional(),
   seatCount: z.number(),
   tokenUsagePercent: z.number(),
   tokenOverageStatus: OverageStatusEnum,


### PR DESCRIPTION
## Summary

Introduces a pure **`TokenWeighting`** module that normalizes raw input/output tokens to **output-equivalent tokens** via a per-model weight table (reference model = 1.0, unknown model → safe default = the reference weight). Agent-step accounting now records the weighted value alongside raw tokens, and period-usage summation + budget enforcement denominate in output-equivalent tokens — making the advertised "model-aware budget" literally true. (WS2 of #3984.)

- **Pure module** `lib/billing/token-weighting.ts` — `MODEL_WEIGHTS` (haiku 1/3, sonnet 1.0 = reference, opus 5.0), `INPUT_WEIGHT` (1/5, the input:output list-price ratio), `resolveModelWeight()` (substring family match, `known` flag), `toOutputEquivalentTokens()` (clamped, total, integer). Unknown model → `DEFAULT_WEIGHT` (= reference, never free, never punitive). Exhaustive table-driven tests.
- **Migration 0152** adds `usage_events.weighted_quantity` (nullable integer); Drizzle schema mirror (`usageEvents.weightedQuantity`) in the **same PR** (schema-drift clean). NULL = "not weighted" (non-token / pre-migration rows), distinct from 0.
- **Accounting** — `UsageEvent.weightedQuantity` persisted at INSERT; `getCurrentPeriodUsage` sums `COALESCE(weighted_quantity, quantity)` as `weightedTokenCount`, so pre-0152 rows fall back to raw.
- **Budget math** — `enforcement.ts` and the `/billing` gauge denominate on `weightedTokenCount ?? tokenCount`, so the page percent can never diverge from the enforced 429.
- **Agent** — `agent.ts` onFinish computes the weighted value at emit time and records it.
- **Wire** — `BillingUsage.weightedTokenCount` (optional, additive) in `@useatlas/schemas` + regenerated `openapi.json`.

## Test plan

- [x] Table-driven unit tests for `toOutputEquivalentTokens` / `resolveModelWeight` (reference = 1.0, weighted up/down, zero/large, unknown → default, negative clamp, integer/non-negative invariants).
- [x] Enforcement tests proving the budget denominates on weighted ≠ raw (raw-under/weighted-over → blocked; raw-over/weighted-under → allowed; weighted-absent → `?? tokenCount` fallback).
- [x] Metering tests: INSERT persists `weighted_quantity`; aggregate uses `COALESCE(weighted_quantity, quantity)`.
- [x] Migration count + applied-list fixtures updated in both `migrate.test.ts` files.
- [x] `/ci`: lint, type, schema-drift, openapi-drift, all static gates pass; affected suite green. (Pre-existing `admin-model-config` gateway-catalog network test flakes in the sandbox — file identical to `origin/main`, unrelated to this diff.)

## Internal review panel

Converged in 2 rounds → CLEAN across silent-failure, type-design, test-coverage, comment-accuracy.

Closes #3989

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add output-equivalent token weighting to billing enforcement and metering
> - Introduces a new [token-weighting module](https://github.com/AtlasDevHQ/atlas/pull/4021/files#diff-188faf8a0899336eaddc7f6606abb7cba214ebb8d2e74167851edf5e57509037) that maps model IDs to per-family weights (haiku/sonnet/opus) and normalizes input/output token counts to a single integer output-equivalent total.
> - Token metering events now record a `weighted_quantity` column (via [migration 0152](https://github.com/AtlasDevHQ/atlas/pull/4021/files#diff-6965beeecf3107e01d047bdc7e4a3284c58ee39a4b43bf2ef7c76d832c5dca0a)) computed from the model and IO token mix at event time.
> - `getCurrentPeriodUsage` aggregates `weighted_quantity` with `COALESCE(weighted_quantity, quantity)` and returns `weightedTokenCount`; plan limit enforcement in `checkPlanLimits` and the billing status route now key off `weightedTokenCount`, falling back to raw `tokenCount` when absent.
> - Behavioral Change: plan enforcement decisions and token overage percentages now use weighted token counts rather than raw token counts for workspaces where weighted data is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36c051e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->