### PR TITLE
feat(api): FeatureEntitlement SSOT + shared workspace-entitlement + SSO gated per-tier (WS1)

### DIFF
--- a/packages/api/src/api/__tests__/admin-sso-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-sso-audit.test.ts
@@ -191,6 +191,17 @@ function lastAuditCall(): AuditEntry {
 
 beforeEach(() => {
   mocks.hasInternalDB = true;
+  // The per-tier SSO entitlement gate (WS1 #3986) resolves the workspace's
+  // plan_tier before the audit-emitting handler runs. SSO gates to Business,
+  // so the test workspace must read back as `business` or every route 403s.
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? [{ plan_tier: "business", is_operator_workspace: false }]
+      : [],
+  );
   mockLogAdminAction.mockClear();
   mockVerifyDomain.mockClear();
   mockVerifyDomain.mockImplementation(() =>

--- a/packages/api/src/api/__tests__/admin-sso.test.ts
+++ b/packages/api/src/api/__tests__/admin-sso.test.ts
@@ -181,6 +181,10 @@ mock.module("@atlas/ee/layers", () => {
 // overwrites. Files that need to restore env do so in their own
 // afterAll; the `??=` here is the module-load contract, not teardown.
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
+// The per-tier SSO entitlement gate (WS1 #3986) only fires in SaaS deploy mode.
+// Pin it so the gate-enforcement tests below are deterministic regardless of the
+// ambient ATLAS_DEPLOY_MODE / DATABASE_URL.
+process.env.ATLAS_DEPLOY_MODE ??= "saas";
 
 // --- Import app after mocks ---
 
@@ -680,5 +684,27 @@ describe("admin SSO — per-tier entitlement gate", () => {
       adminRequest("/api/v1/admin/sso/providers"),
     );
     expect(res.status).toBe(200);
+  });
+
+  it("fails closed with 503 billing_check_failed when the tier lookup throws", async () => {
+    // A transient internal-DB fault must NOT silently widen access to a
+    // Business feature — the per-tier guard fails closed end-to-end.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (
+        /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+          sql,
+        )
+      ) {
+        throw new Error("db unavailable");
+      }
+      return [];
+    });
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/sso/providers"),
+    );
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "billing_check_failed",
+    );
   });
 });

--- a/packages/api/src/api/__tests__/admin-sso.test.ts
+++ b/packages/api/src/api/__tests__/admin-sso.test.ts
@@ -231,7 +231,17 @@ describe("admin SSO — domain verification", () => {
   beforeEach(() => {
     mocks.hasInternalDB = true;
     mocks.mockInternalQuery.mockReset();
-    mocks.mockInternalQuery.mockResolvedValue([]);
+    // The per-tier feature-entitlement guard (WS1 #3986) resolves the
+    // workspace's plan_tier before every SSO route runs. SSO gates to Business,
+    // so the test workspace must read back as `business` or every route 403s
+    // with `plan_upgrade_required`. Other queries keep returning [].
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+      /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+        sql,
+      )
+        ? [{ plan_tier: "business", is_operator_workspace: false }]
+        : [],
+    );
     mockVerifyDomain.mockReset();
     mockCheckDomainAvailability.mockReset();
     mockCreateSSOProvider.mockReset();
@@ -492,6 +502,15 @@ describe("Admin SSO Test Connection API", () => {
   beforeEach(() => {
     mockTestSSOProvider.mockReset();
     mocks.setOrgAdmin("org-1");
+    // Business-tier workspace so the per-tier SSO gate (WS1 #3986) admits.
+    mocks.mockInternalQuery.mockReset();
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+      /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+        sql,
+      )
+        ? [{ plan_tier: "business", is_operator_workspace: false }]
+        : [],
+    );
   });
 
   describe("POST /api/v1/admin/sso/providers/:id/test", () => {
@@ -587,5 +606,79 @@ describe("Admin SSO Test Connection API", () => {
       );
       expect(res.status).toBe(403);
     });
+  });
+});
+
+// ── Per-tier feature-entitlement gating (WS1 #3986) ────────────────
+//
+// Proves the SSO surface is gated at the route/handler layer (not UI-only):
+// an enterprise-enabled deployment still denies a below-Business workspace,
+// and a Business workspace is admitted. The enterprise-license Tag is real
+// (EELayer mock provides SSOPolicy); only the per-tier ladder changes the
+// outcome here.
+describe("admin SSO — per-tier entitlement gate", () => {
+  beforeEach(() => {
+    mocks.setOrgAdmin("org-1");
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+  });
+
+  /** Make the entitlement lookup read back a specific tier. */
+  function setWorkspaceTier(tier: string, isOperator = false): void {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+      /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+        sql,
+      )
+        ? [{ plan_tier: tier, is_operator_workspace: isOperator }]
+        : [],
+    );
+  }
+
+  it("denies a Pro workspace with 403 plan_upgrade_required", async () => {
+    setWorkspaceTier("pro");
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/sso/providers"),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as {
+      error: string;
+      required_plan: string;
+      current_plan: string;
+    };
+    expect(body.error).toBe("plan_upgrade_required");
+    expect(body.required_plan).toBe("business");
+    expect(body.current_plan).toBe("pro");
+  });
+
+  it("denies a Starter workspace creating a provider", async () => {
+    setWorkspaceTier("starter");
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/sso/providers", "POST", {
+        type: "oidc",
+        issuer: "https://idp.acme.com",
+        domain: "acme.com",
+        config: { clientId: "x", clientSecret: "y", discoveryUrl: "https://idp.acme.com/.well-known/openid-configuration" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "plan_upgrade_required",
+    );
+  });
+
+  it("allows a Business workspace (gate passes through to the SSO service)", async () => {
+    setWorkspaceTier("business");
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/sso/providers"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows an operator workspace regardless of tier", async () => {
+    setWorkspaceTier("free", true);
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/sso/providers"),
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/api/src/api/routes/admin-sso.ts
+++ b/packages/api/src/api/routes/admin-sso.ts
@@ -14,6 +14,7 @@ import {
   SSOPolicy,
 } from "@atlas/api/lib/effect/services";
 import { SSOError, SSOEnforcementError } from "@atlas/api/lib/auth/auth-errors";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import type {
   CreateSSOProviderRequest,
   UpdateSSOProviderRequest,
@@ -627,6 +628,7 @@ adminSso.use(requireOrgContext());
 adminSso.openapi(listProvidersRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const sso = yield* SSOPolicy;
 
     const providers = yield* sso.listSSOProviders(orgId!);
@@ -638,6 +640,7 @@ adminSso.openapi(listProvidersRoute, async (c) => {
 adminSso.openapi(getProviderRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const sso = yield* SSOPolicy;
     const { id: providerId } = c.req.valid("param");
 
@@ -657,6 +660,7 @@ adminSso.openapi(getProviderRoute, async (c) => {
 adminSso.openapi(createProviderRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const body = c.req.valid("json");
 
     // Structural check only — business validation is in createSSOProvider
@@ -683,6 +687,7 @@ adminSso.openapi(createProviderRoute, async (c) => {
 adminSso.openapi(updateProviderRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { id: providerId } = c.req.valid("param");
 
     if (!isValidId(providerId)) {
@@ -710,6 +715,7 @@ adminSso.openapi(updateProviderRoute, async (c) => {
 adminSso.openapi(deleteProviderRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { id: providerId } = c.req.valid("param");
 
     if (!isValidId(providerId)) {
@@ -736,6 +742,7 @@ adminSso.openapi(deleteProviderRoute, async (c) => {
 adminSso.openapi(testProviderRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { id: providerId } = c.req.valid("param");
 
     if (!isValidId(providerId)) {
@@ -760,6 +767,7 @@ adminSso.openapi(testProviderRoute, async (c) => {
 adminSso.openapi(getEnforcementRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
 
     const result = yield* (yield* SSOPolicy).isSSOEnforced(orgId!);
     return c.json({ enforced: result?.enforced ?? false, orgId: orgId! }, 200);
@@ -770,6 +778,7 @@ adminSso.openapi(getEnforcementRoute, async (c) => {
 adminSso.openapi(setEnforcementRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { enforced } = c.req.valid("json");
 
     const result = yield* (yield* SSOPolicy).setSSOEnforcement(orgId!, enforced);
@@ -794,6 +803,7 @@ adminSso.openapi(setEnforcementRoute, async (c) => {
 adminSso.openapi(verifyDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { id: providerId } = c.req.valid("param");
 
     if (!isValidId(providerId)) {
@@ -827,6 +837,7 @@ adminSso.openapi(verifyDomainRoute, async (c) => {
 adminSso.openapi(domainCheckRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "sso");
     const { domain } = c.req.valid("query");
 
     if (!domain) {

--- a/packages/api/src/api/routes/integrations-discord.ts
+++ b/packages/api/src/api/routes/integrations-discord.ts
@@ -61,12 +61,12 @@ import {
   isPlanEligible,
   parsePlanTier,
 } from "@atlas/api/lib/integrations/install/plan-rank";
+import { getWorkspaceEntitlement } from "@atlas/api/lib/integrations/install/workspace-entitlement";
 import { adminAuthPreamble } from "./admin-auth";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { PLAN_TIERS } from "@useatlas/types";
 import type {
-  PlanTier,
   PlanUpgradeRequiredBody,
   WorkspaceId,
 } from "@useatlas/types";
@@ -244,28 +244,6 @@ async function loadDiscordCatalogRow(): Promise<CatalogRow | null> {
   );
   if (rows.length === 0) return null;
   return rows[0];
-}
-
-async function getWorkspaceEntitlement(orgId: string): Promise<{
-  planTier: PlanTier | null;
-  isOperator: boolean;
-}> {
-  if (orgId === "self-hosted") return { planTier: null, isOperator: false };
-  const rows = await internalQuery<{
-    plan_tier: string | null;
-    is_operator_workspace: boolean | null;
-  }>(
-    `SELECT plan_tier, is_operator_workspace
-       FROM organization
-      WHERE id = $1
-      LIMIT 1`,
-    [orgId],
-  );
-  if (rows.length === 0) return { planTier: null, isOperator: false };
-  return {
-    planTier: parsePlanTier(rows[0]?.plan_tier),
-    isOperator: rows[0]?.is_operator_workspace === true,
-  };
 }
 
 function prefersHtml(req: Request): boolean {

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -56,6 +56,7 @@ import {
   isPlanEligible,
   parsePlanTier,
 } from "@atlas/api/lib/integrations/install/plan-rank";
+import { getWorkspaceEntitlement } from "@atlas/api/lib/integrations/install/workspace-entitlement";
 import { verifyOAuthStateToken } from "@atlas/api/lib/integrations/install/oauth-state-token";
 import { findDataCandidateBySlug } from "@atlas/api/lib/openapi/data-candidates";
 import {
@@ -599,43 +600,6 @@ async function getInstallableCatalogRowBySlug(slug: string): Promise<{
     config_schema: row.config_schema ?? null,
     implementation_status: row.implementation_status ?? null,
     saas_eligible: row.saas_eligible ?? null,
-  };
-}
-
-/**
- * Resolve `{ planTier, isOperator }` for a workspace from the
- * `organization` table. `planTier` is narrowed via {@link parsePlanTier}
- * at the SQL boundary so downstream gates see `PlanTier | null` rather
- * than a raw string — a legacy / unknown value maps to `null` and
- * callers treat `null` as "no plan / not an operator", which by
- * construction denies any `min_plan != 'free'` install attempt without
- * admitting the operator bypass.
- *
- * On a self-hosted no-auth deploy (sentinel `workspaceId =
- * "self-hosted"`), there's no organization row at all. The function
- * returns `{ planTier: null, isOperator: false }` and the same fail-
- * closed default applies — `null` collapses to `"free"` in the
- * response body only when the caller builds an upgrade prompt.
- */
-async function getWorkspaceEntitlement(orgId: string): Promise<{
-  planTier: PlanTier | null;
-  isOperator: boolean;
-}> {
-  if (orgId === "self-hosted") return { planTier: null, isOperator: false };
-  const rows = await internalQuery<{
-    plan_tier: string | null;
-    is_operator_workspace: boolean | null;
-  }>(
-    `SELECT plan_tier, is_operator_workspace
-       FROM organization
-      WHERE id = $1
-      LIMIT 1`,
-    [orgId],
-  );
-  if (rows.length === 0) return { planTier: null, isOperator: false };
-  return {
-    planTier: parsePlanTier(rows[0]?.plan_tier),
-    isOperator: rows[0]?.is_operator_workspace === true,
   };
 }
 

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement-guard.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement-guard.test.ts
@@ -14,6 +14,7 @@ import type { PlanTier } from "@useatlas/types";
 // --- Mocks ---
 
 let mockHasInternalDB = true;
+let mockDeployMode: "saas" | "self-hosted" = "saas";
 let mockEntitlement: { planTier: PlanTier | null; isOperator: boolean } = {
   planTier: "business",
   isOperator: false,
@@ -25,6 +26,12 @@ const actualInternal = await import("@atlas/api/lib/db/internal");
 mock.module("@atlas/api/lib/db/internal", () => ({
   ...actualInternal,
   hasInternalDB: () => mockHasInternalDB,
+}));
+
+const actualDeployMode = await import("@atlas/api/lib/effect/deploy-mode");
+mock.module("@atlas/api/lib/effect/deploy-mode", () => ({
+  ...actualDeployMode,
+  resolveDeployMode: () => mockDeployMode,
 }));
 
 mock.module(
@@ -44,6 +51,7 @@ const { requireFeatureEntitlement } = await import(
 
 beforeEach(() => {
   mockHasInternalDB = true;
+  mockDeployMode = "saas";
   mockEntitlement = { planTier: "business", isOperator: false };
   mockEntitlementShouldThrow = false;
   mockEntitlementCallCount = 0;
@@ -62,6 +70,20 @@ function failureOf(exit: Exit.Exit<void, unknown>): unknown {
   }
   return undefined;
 }
+
+describe("requireFeatureEntitlement — non-SaaS deploy mode", () => {
+  it("passes (no-op) on a self-hosted deploy even with a below-tier org", async () => {
+    // A self-hosted enterprise build has its workspaces on `free`; the per-tier
+    // ladder must not fire there or SSO would be wrongly denied. The enterprise
+    // license Tag is what gates the feature in that topology.
+    mockDeployMode = "self-hosted";
+    mockEntitlement = { planTier: "free", isOperator: false };
+    const exit = await runGuard("org_selfhosted");
+    expect(Exit.isSuccess(exit)).toBe(true);
+    // Must not even attempt a workspace lookup off the SaaS path.
+    expect(mockEntitlementCallCount).toBe(0);
+  });
+});
 
 describe("requireFeatureEntitlement — self-hosted / no billing context", () => {
   it("passes when no internal DB is configured (self-hosted)", async () => {

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement-guard.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement-guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the request-time feature-entitlement guard (WS1 of #3986).
+ *
+ * Asserts the external enforcement behavior at the guard boundary: given a
+ * workspace's resolved tier, does the guard pass, deny with the upgrade error,
+ * or fail closed. Mirrors the enforcement-posture cases in `enforcement.test.ts`
+ * (self-hosted pass, lookup-error fail-closed, operator bypass).
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Cause, Effect, Exit, Option } from "effect";
+import type { PlanTier } from "@useatlas/types";
+
+// --- Mocks ---
+
+let mockHasInternalDB = true;
+let mockEntitlement: { planTier: PlanTier | null; isOperator: boolean } = {
+  planTier: "business",
+  isOperator: false,
+};
+let mockEntitlementShouldThrow = false;
+let mockEntitlementCallCount = 0;
+
+const actualInternal = await import("@atlas/api/lib/db/internal");
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...actualInternal,
+  hasInternalDB: () => mockHasInternalDB,
+}));
+
+mock.module(
+  "@atlas/api/lib/integrations/install/workspace-entitlement",
+  () => ({
+    getWorkspaceEntitlement: async () => {
+      mockEntitlementCallCount++;
+      if (mockEntitlementShouldThrow) throw new Error("internal db error");
+      return mockEntitlement;
+    },
+  }),
+);
+
+const { requireFeatureEntitlement } = await import(
+  "../feature-entitlement-guard"
+);
+
+beforeEach(() => {
+  mockHasInternalDB = true;
+  mockEntitlement = { planTier: "business", isOperator: false };
+  mockEntitlementShouldThrow = false;
+  mockEntitlementCallCount = 0;
+});
+
+/** Run the guard and return its Exit for inspection. */
+async function runGuard(orgId: string | undefined) {
+  return Effect.runPromiseExit(requireFeatureEntitlement(orgId, "sso"));
+}
+
+/** Extract the failure value from a failed Exit, or undefined. */
+function failureOf(exit: Exit.Exit<void, unknown>): unknown {
+  if (Exit.isFailure(exit)) {
+    const opt = Cause.failureOption(exit.cause);
+    return Option.isSome(opt) ? opt.value : undefined;
+  }
+  return undefined;
+}
+
+describe("requireFeatureEntitlement — self-hosted / no billing context", () => {
+  it("passes when no internal DB is configured (self-hosted)", async () => {
+    mockHasInternalDB = false;
+    const exit = await runGuard("org_123");
+    expect(Exit.isSuccess(exit)).toBe(true);
+    // Must not even attempt a workspace lookup on self-hosted.
+    expect(mockEntitlementCallCount).toBe(0);
+  });
+
+  it("passes for the `self-hosted` sentinel orgId", async () => {
+    const exit = await runGuard("self-hosted");
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(mockEntitlementCallCount).toBe(0);
+  });
+
+  it("passes when orgId is undefined", async () => {
+    const exit = await runGuard(undefined);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(mockEntitlementCallCount).toBe(0);
+  });
+});
+
+describe("requireFeatureEntitlement — tier gating", () => {
+  it("allows a Business workspace (SSO unlocked)", async () => {
+    mockEntitlement = { planTier: "business", isOperator: false };
+    const exit = await runGuard("org_biz");
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+
+  it("denies a below-tier workspace with FeatureEntitlementError (403 upgrade)", async () => {
+    mockEntitlement = { planTier: "pro", isOperator: false };
+    const exit = await runGuard("org_pro");
+    expect(Exit.isFailure(exit)).toBe(true);
+    const err = failureOf(exit) as {
+      _tag: string;
+      requiredPlan: string;
+      currentPlan: string;
+      feature: string;
+    };
+    expect(err._tag).toBe("FeatureEntitlementError");
+    expect(err.requiredPlan).toBe("business");
+    expect(err.currentPlan).toBe("pro");
+    expect(err.feature).toBe("sso");
+  });
+
+  it("denies a Starter workspace", async () => {
+    mockEntitlement = { planTier: "starter", isOperator: false };
+    const exit = await runGuard("org_starter");
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect((failureOf(exit) as { _tag: string })._tag).toBe(
+      "FeatureEntitlementError",
+    );
+  });
+
+  it("collapses a null tier (row not found / legacy) to `free` in the upgrade body", async () => {
+    mockEntitlement = { planTier: null, isOperator: false };
+    const exit = await runGuard("org_unknown");
+    const err = failureOf(exit) as { _tag: string; currentPlan: string };
+    expect(err._tag).toBe("FeatureEntitlementError");
+    expect(err.currentPlan).toBe("free");
+  });
+
+  it("denies the `locked` churn tier (fails closed)", async () => {
+    mockEntitlement = { planTier: "locked", isOperator: false };
+    const exit = await runGuard("org_locked");
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect((failureOf(exit) as { _tag: string })._tag).toBe(
+      "FeatureEntitlementError",
+    );
+  });
+});
+
+describe("requireFeatureEntitlement — operator bypass", () => {
+  it("allows an operator workspace regardless of tier", async () => {
+    mockEntitlement = { planTier: "free", isOperator: true };
+    const exit = await runGuard("org_operator");
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+});
+
+describe("requireFeatureEntitlement — fail-closed on lookup error", () => {
+  it("fails closed with BillingCheckFailedError (503) when the lookup throws", async () => {
+    mockEntitlementShouldThrow = true;
+    const exit = await runGuard("org_err");
+    expect(Exit.isFailure(exit)).toBe(true);
+    const err = failureOf(exit) as { _tag: string; message: string };
+    expect(err._tag).toBe("BillingCheckFailedError");
+    // Must NOT tell the user to upgrade — this is a transient fault, so the
+    // message says "try again", not "upgrade to <tier>".
+    expect(err.message.toLowerCase()).toContain("try again");
+    expect(err.message.toLowerCase()).not.toContain("upgrade");
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the FeatureEntitlement SSOT + pure predicate (WS1 of #3986).
+ *
+ * The tier × feature matrix is the correctness boundary for the entire feature
+ * ladder: every gated feature must be denied below its minimum tier and allowed
+ * at/above it, and `locked`/unknown tiers must fail closed. These assert
+ * external behavior at the module boundary (given a tier and a feature, is it
+ * entitled), not internal wiring — prior art: `plan-rank.test.ts`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { PlanTier } from "@useatlas/types";
+import {
+  FEATURE_ENTITLEMENTS,
+  isFeatureEntitled,
+  type GatedFeature,
+} from "../feature-entitlement";
+
+const ALL_FEATURES = Object.keys(FEATURE_ENTITLEMENTS) as GatedFeature[];
+
+// Tiers in ascending rank order. `locked` (rank -1) is below `free`.
+const RANKED_TIERS: PlanTier[] = [
+  "locked",
+  "free",
+  "trial",
+  "starter",
+  "pro",
+  "business",
+];
+
+const TIER_RANK: Record<PlanTier, number> = {
+  locked: -1,
+  free: 0,
+  trial: 1,
+  starter: 2,
+  pro: 3,
+  business: 4,
+};
+
+describe("FEATURE_ENTITLEMENTS map", () => {
+  it("defaults every gated feature to the Business tier (current pricing page)", () => {
+    // The PRD locks the default tier line at Business for all ten EE features
+    // plus proactive. A Pro+ override would be an intentional single-line
+    // change here; until then the map must be uniformly Business.
+    for (const feature of ALL_FEATURES) {
+      expect(FEATURE_ENTITLEMENTS[feature]).toBe("business");
+    }
+  });
+
+  it("enumerates the full advertised gated-feature set (not an ad-hoc subset)", () => {
+    // The plan model must enumerate every advertised gated capability so a new
+    // premium feature is gated by construction. This pins the membership so a
+    // dropped feature is caught.
+    const expected: GatedFeature[] = [
+      "sso",
+      "scim",
+      "custom_roles",
+      "ip_allowlist",
+      "approvals",
+      "audit_retention",
+      "masking",
+      "residency",
+      "backups",
+      "white_label",
+      "proactive",
+    ];
+    expect(ALL_FEATURES.toSorted()).toEqual(expected.toSorted());
+  });
+});
+
+describe("isFeatureEntitled — tier × feature matrix", () => {
+  it("denies below the minimum tier and allows at/above it, for every feature", () => {
+    for (const feature of ALL_FEATURES) {
+      const requiredRank = TIER_RANK[FEATURE_ENTITLEMENTS[feature]];
+      for (const tier of RANKED_TIERS) {
+        const expected = TIER_RANK[tier] >= requiredRank;
+        expect(isFeatureEntitled(tier, feature)).toBe(expected);
+      }
+    }
+  });
+
+  it("allows Business for every gated feature", () => {
+    for (const feature of ALL_FEATURES) {
+      expect(isFeatureEntitled("business", feature)).toBe(true);
+    }
+  });
+
+  it("denies Starter and Pro every Business-gated feature", () => {
+    for (const feature of ALL_FEATURES) {
+      expect(isFeatureEntitled("starter", feature)).toBe(false);
+      expect(isFeatureEntitled("pro", feature)).toBe(false);
+    }
+  });
+
+  it("fails closed for the `locked` churn tier on every feature", () => {
+    for (const feature of ALL_FEATURES) {
+      expect(isFeatureEntitled("locked", feature)).toBe(false);
+    }
+  });
+
+  it("fails closed for null / undefined tier (no billing context / legacy row)", () => {
+    for (const feature of ALL_FEATURES) {
+      expect(isFeatureEntitled(null, feature)).toBe(false);
+      expect(isFeatureEntitled(undefined, feature)).toBe(false);
+    }
+  });
+
+  it("treats SSO specifically as Business-gated (the WS1 proof feature)", () => {
+    expect(isFeatureEntitled("free", "sso")).toBe(false);
+    expect(isFeatureEntitled("trial", "sso")).toBe(false);
+    expect(isFeatureEntitled("starter", "sso")).toBe(false);
+    expect(isFeatureEntitled("pro", "sso")).toBe(false);
+    expect(isFeatureEntitled("business", "sso")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/billing/feature-entitlement-guard.ts
+++ b/packages/api/src/lib/billing/feature-entitlement-guard.ts
@@ -7,14 +7,21 @@
  * 403 `plan_upgrade_required` carrying the same `PlanUpgradeRequiredBody`
  * envelope the integration install endpoints emit.
  *
- * Enforcement posture mirrors `billing/enforcement.ts` exactly so the per-tier
- * ladder and the token-budget gate behave consistently:
+ * The per-tier ladder is a **SaaS** concept: only the hosted multi-tenant
+ * deployment sells and bills tiers. So the guard is scoped to `saas` deploy
+ * mode and is a no-op everywhere else — the enforcement posture then mirrors
+ * `billing/enforcement.ts`:
  *
- *   - **Self-hosted / no internal DB / no orgId** → pass. There is no billing
- *     context, so per-tier gating doesn't apply. On a self-hosted *enterprise*
- *     deploy the feature itself is still gated — by the enterprise-license Tag
- *     (`SSOPolicy` et al. fail with `EnterpriseError`), not by plan tier. This
- *     guard is the SaaS per-tier layer that sits *in addition to* that Tag.
+ *   - **Not SaaS deploy mode** → pass. A self-hosted deployment (including a
+ *     self-hosted *enterprise* build) has no per-tier billing ladder; its
+ *     workspaces sit on the unlimited `free` tier (see `plans.ts`). The feature
+ *     is gated there by the enterprise-license Tag, NOT by plan tier: when
+ *     enterprise is disabled the `SSOPolicy` *Noop* layer fails its methods
+ *     with `EnterpriseError` (403); when enterprise is enabled the EE layer is
+ *     active and SSO is unlocked. Either way this per-tier guard must not fire,
+ *     or a self-hosted enterprise customer would be wrongly denied SSO because
+ *     their tier is `free`.
+ *   - **No orgId / no internal DB** → pass (no workspace to resolve a tier for).
  *   - **Lookup error** → fail closed with {@link BillingCheckFailedError}
  *     (503 "try again"), matching `checkPlanLimits`' workspace-lookup fail-
  *     closed arm. A transient internal-DB fault must not silently widen access.
@@ -32,6 +39,7 @@
 
 import { Effect } from "effect";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import {
   BillingCheckFailedError,
   FeatureEntitlementError,
@@ -50,28 +58,38 @@ const log = createLogger("billing:feature-entitlement");
  * Effect guard: require that the workspace identified by `orgId` is entitled to
  * `feature`, or fail with the appropriate tier/upgrade error.
  *
- * Succeeds (`void`) when entitled, self-hosted, or operator-bypassed. Fails
- * with {@link FeatureEntitlementError} (→ 403 `plan_upgrade_required`) when the
- * tier ranks below the feature's minimum, or {@link BillingCheckFailedError}
- * (→ 503 `billing_check_failed`) when the workspace lookup throws.
+ * Succeeds (`void`) when entitled, not in SaaS deploy mode, self-hosted, or
+ * operator-bypassed. Fails with {@link FeatureEntitlementError}
+ * (→ 403 `plan_upgrade_required`) when the SaaS tier ranks below the feature's
+ * minimum, or {@link BillingCheckFailedError} (→ 503 `billing_check_failed`)
+ * when the workspace lookup throws.
  *
- * Intended to be yielded at the top of an EE feature route handler, after the
- * enterprise-license Tag is resolved — so a SaaS workspace below tier is denied
- * even when the deployment is enterprise-enabled:
+ * Intended to be yielded near the top of an EE feature route handler, alongside
+ * the enterprise-license Tag — so on SaaS a below-tier workspace is denied even
+ * though the deployment is enterprise-enabled. Resolving the Tag itself never
+ * fails (it returns the EE or Noop shape); the enterprise denial fires only
+ * when a Noop *method* is invoked, so this guard's order relative to
+ * `yield* SSOPolicy` is immaterial:
  *
  * ```ts
  * const { orgId } = yield* AuthContext;
- * const sso = yield* SSOPolicy;            // deployment-level enterprise gate
- * yield* requireFeatureEntitlement(orgId, "sso"); // per-tier ladder gate
+ * yield* requireFeatureEntitlement(orgId, "sso"); // SaaS per-tier ladder gate
+ * const sso = yield* SSOPolicy;                    // EE methods enforce license
  * ```
  */
 export function requireFeatureEntitlement(
   orgId: string | undefined,
   feature: GatedFeature,
 ): Effect.Effect<void, FeatureEntitlementError | BillingCheckFailedError> {
-  // Self-hosted / no org / no internal DB — no per-tier billing context. The
-  // enterprise-license Tag is what gates the feature on self-hosted enterprise
-  // deploys; this per-tier layer is a no-op there.
+  // The per-tier ladder only exists on the hosted SaaS. On any self-hosted
+  // deploy — including a self-hosted *enterprise* build, whose workspaces sit
+  // on the unlimited `free` tier — feature access is gated by the
+  // enterprise-license Tag, not by plan tier. Gating here would wrongly deny a
+  // self-hosted enterprise customer SSO (tier `free` < `business`). The
+  // remaining short-circuits (no org / no internal DB) only matter inside SaaS.
+  if (resolveDeployMode() !== "saas") {
+    return Effect.void;
+  }
   if (!orgId || orgId === "self-hosted" || !hasInternalDB()) {
     return Effect.void;
   }

--- a/packages/api/src/lib/billing/feature-entitlement-guard.ts
+++ b/packages/api/src/lib/billing/feature-entitlement-guard.ts
@@ -1,0 +1,123 @@
+/**
+ * Request-time feature-entitlement guard (WS1 of #3984 / #3986).
+ *
+ * {@link requireFeatureEntitlement} resolves a workspace's plan tier and, when
+ * it ranks below the feature's minimum tier in the {@link FEATURE_ENTITLEMENTS}
+ * SSOT, fails with {@link FeatureEntitlementError} — the bridge maps that to a
+ * 403 `plan_upgrade_required` carrying the same `PlanUpgradeRequiredBody`
+ * envelope the integration install endpoints emit.
+ *
+ * Enforcement posture mirrors `billing/enforcement.ts` exactly so the per-tier
+ * ladder and the token-budget gate behave consistently:
+ *
+ *   - **Self-hosted / no internal DB / no orgId** → pass. There is no billing
+ *     context, so per-tier gating doesn't apply. On a self-hosted *enterprise*
+ *     deploy the feature itself is still gated — by the enterprise-license Tag
+ *     (`SSOPolicy` et al. fail with `EnterpriseError`), not by plan tier. This
+ *     guard is the SaaS per-tier layer that sits *in addition to* that Tag.
+ *   - **Lookup error** → fail closed with {@link BillingCheckFailedError}
+ *     (503 "try again"), matching `checkPlanLimits`' workspace-lookup fail-
+ *     closed arm. A transient internal-DB fault must not silently widen access.
+ *   - **Operator workspace** → pass (the same admin bypass the install gate
+ *     honors via {@link WorkspaceEntitlement.isOperator}).
+ *   - **Tier below minimum** → fail with {@link FeatureEntitlementError} (403
+ *     upgrade). `null` tier (row not found / legacy value) collapses to `free`
+ *     for the upgrade-prompt body, exactly as the install gate does.
+ *
+ * The guard is split out from the pure `feature-entitlement.ts` predicate so
+ * that module stays free of Effect / DB imports and trivially table-testable.
+ *
+ * @module
+ */
+
+import { Effect } from "effect";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import {
+  BillingCheckFailedError,
+  FeatureEntitlementError,
+} from "@atlas/api/lib/effect/errors";
+import { getWorkspaceEntitlement } from "@atlas/api/lib/integrations/install/workspace-entitlement";
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  FEATURE_ENTITLEMENTS,
+  isFeatureEntitled,
+  type GatedFeature,
+} from "./feature-entitlement";
+
+const log = createLogger("billing:feature-entitlement");
+
+/**
+ * Effect guard: require that the workspace identified by `orgId` is entitled to
+ * `feature`, or fail with the appropriate tier/upgrade error.
+ *
+ * Succeeds (`void`) when entitled, self-hosted, or operator-bypassed. Fails
+ * with {@link FeatureEntitlementError} (→ 403 `plan_upgrade_required`) when the
+ * tier ranks below the feature's minimum, or {@link BillingCheckFailedError}
+ * (→ 503 `billing_check_failed`) when the workspace lookup throws.
+ *
+ * Intended to be yielded at the top of an EE feature route handler, after the
+ * enterprise-license Tag is resolved — so a SaaS workspace below tier is denied
+ * even when the deployment is enterprise-enabled:
+ *
+ * ```ts
+ * const { orgId } = yield* AuthContext;
+ * const sso = yield* SSOPolicy;            // deployment-level enterprise gate
+ * yield* requireFeatureEntitlement(orgId, "sso"); // per-tier ladder gate
+ * ```
+ */
+export function requireFeatureEntitlement(
+  orgId: string | undefined,
+  feature: GatedFeature,
+): Effect.Effect<void, FeatureEntitlementError | BillingCheckFailedError> {
+  // Self-hosted / no org / no internal DB — no per-tier billing context. The
+  // enterprise-license Tag is what gates the feature on self-hosted enterprise
+  // deploys; this per-tier layer is a no-op there.
+  if (!orgId || orgId === "self-hosted" || !hasInternalDB()) {
+    return Effect.void;
+  }
+
+  return Effect.tryPromise({
+    try: () => getWorkspaceEntitlement(orgId),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(
+    // Lookup fault → fail closed (503), never silently widen access.
+    Effect.catchAll((err) => {
+      log.error(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          orgId,
+          feature,
+        },
+        "Failed to resolve workspace entitlement for feature gate — blocking as precaution",
+      );
+      return Effect.fail(
+        new BillingCheckFailedError({
+          message: "Unable to verify your plan. Please try again.",
+          workspaceId: orgId,
+        }),
+      );
+    }),
+    Effect.flatMap((entitlement) => {
+      // Operator-workspace admin bypass (parity with the install gate).
+      if (entitlement.isOperator) return Effect.void;
+      if (isFeatureEntitled(entitlement.planTier, feature)) return Effect.void;
+
+      const requiredPlan = FEATURE_ENTITLEMENTS[feature];
+      // `null` tier (row not found / legacy value) collapses to "free" for the
+      // upgrade-prompt body, matching the install gate's current_plan handling.
+      const currentPlan = entitlement.planTier ?? "free";
+      log.info(
+        { orgId, feature, requiredPlan, currentPlan },
+        "Feature denied: workspace plan ranks below the feature's minimum tier",
+      );
+      return Effect.fail(
+        new FeatureEntitlementError({
+          message: `This feature requires the "${requiredPlan}" plan. Your workspace is on the "${currentPlan}" plan.`,
+          feature,
+          requiredPlan,
+          currentPlan,
+        }),
+      );
+    }),
+  );
+}

--- a/packages/api/src/lib/billing/feature-entitlement-guard.ts
+++ b/packages/api/src/lib/billing/feature-entitlement-guard.ts
@@ -16,8 +16,8 @@
  *     self-hosted *enterprise* build) has no per-tier billing ladder; its
  *     workspaces sit on the unlimited `free` tier (see `plans.ts`). The feature
  *     is gated there by the enterprise-license Tag, NOT by plan tier: when
- *     enterprise is disabled the `SSOPolicy` *Noop* layer fails its methods
- *     with `EnterpriseError` (403); when enterprise is enabled the EE layer is
+ *     enterprise is disabled the `SSOPolicy` *Noop* layer fails its
+ *     enforcement/mutation methods with `EnterpriseError` (403); when enterprise is enabled the EE layer is
  *     active and SSO is unlocked. Either way this per-tier guard must not fire,
  *     or a self-hosted enterprise customer would be wrongly denied SSO because
  *     their tier is `free`.

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -28,7 +28,7 @@
  * @module
  */
 
-import type { PlanTier } from "@useatlas/types";
+import type { MinPlanTier, PlanTier } from "@useatlas/types";
 import { isPlanEligible } from "@atlas/api/lib/integrations/install/plan-rank";
 
 /**
@@ -62,9 +62,13 @@ export type GatedFeature =
  * both enforcement and the SSOT-rendered page in lockstep.
  *
  * Keyed by {@link GatedFeature} so adding a feature without assigning a tier
- * is a compile error — the ladder can't drift open.
+ * is a compile error — the ladder can't drift open. Values are typed
+ * {@link MinPlanTier} (the tier union excluding `locked`) so a `locked`
+ * minimum — an illegal state that would make the feature ungateable to every
+ * workspace ({@link isPlanEligible} returns `false` for a `locked` requirement)
+ * — is unrepresentable.
  */
-export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, PlanTier>> = {
+export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, MinPlanTier>> = {
   sso: "business",
   scim: "business",
   custom_roles: "business",
@@ -91,9 +95,12 @@ export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, PlanTier>> = {
  *     self-hosted no-billing sentinel) resolves to the rank of `free`, so it
  *     satisfies only a `free`-min feature. No gated feature is `free`-min, so
  *     `null` fails closed for every member of {@link FEATURE_ENTITLEMENTS}.
- *     (Self-hosted enterprise SSO is unaffected because the request-time guard
- *     short-circuits self-hosted before consulting this predicate — the
- *     enterprise-license Tag, not the plan tier, is what gates there.)
+ *
+ * This predicate is the SaaS per-tier decision only. Self-hosted deployments
+ * (including self-hosted enterprise, whose workspaces are on `free`) never reach
+ * it: the request-time guard short-circuits non-SaaS deploy mode before
+ * consulting this predicate, so the enterprise-license Tag — not the plan tier —
+ * is what gates features there. See `feature-entitlement-guard.ts`.
  *
  * Exhaustive over the tier union by construction: every recognized tier has a
  * `plan-rank` entry, and the lookup of `feature` in {@link FEATURE_ENTITLEMENTS}

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -1,0 +1,108 @@
+/**
+ * Feature entitlement — the single source of truth mapping every gated
+ * capability to the minimum plan tier that unlocks it (WS1 of #3984 / #3986).
+ *
+ * Before this module the per-tier feature ladder the /pricing page sells was
+ * fictional on the hosted SaaS: the ten "Business-only" capabilities (SSO,
+ * SCIM, custom roles, IP allowlist, approvals, audit-retention, masking,
+ * residency, backups, white-label) plus proactive monitoring gated only on
+ * whether the *deployment* was enterprise-enabled — never on the workspace's
+ * plan tier. The four `PlanFeatures` booleans in `plans.ts` were read for
+ * display, never to gate. This module makes the ladder real:
+ *
+ *   - {@link FEATURE_ENTITLEMENTS} enumerates every gated feature → minimum
+ *     tier. It is the authoritative map both enforcement and (eventually,
+ *     via the WS4 drift guard) the pricing page read from.
+ *   - {@link isFeatureEntitled} is a pure predicate over `(tier, feature)`,
+ *     reusing the `plan-rank` ordering vocabulary
+ *     (`free < trial < starter < pro < business`, `locked` = no entitlement).
+ *
+ * The default tier line is **Business** for every feature; a feature that
+ * should sit at Pro+ instead is a single-line override in the map below.
+ *
+ * The request-time guard (`requireFeatureEntitlement`) that resolves a
+ * workspace's tier and returns the standard upgrade/403 lives in
+ * `feature-entitlement-guard.ts` so the pure predicate here stays free of
+ * Effect / DB dependencies and remains trivially table-testable.
+ *
+ * @module
+ */
+
+import type { PlanTier } from "@useatlas/types";
+import { isPlanEligible } from "@atlas/api/lib/integrations/install/plan-rank";
+
+/**
+ * The set of gated capabilities the feature ladder enforces. Each maps to a
+ * minimum {@link PlanTier} in {@link FEATURE_ENTITLEMENTS}. Adding a member
+ * here forces a corresponding entry in that map (the `Record<GatedFeature,
+ * PlanTier>` annotation makes the omission a compile error), so a new premium
+ * feature is correct-by-construction gated rather than silently ungated.
+ *
+ * The string values are stable wire/log identifiers (snake_case) — they appear
+ * in structured logs and may surface in the WS4 drift guard, so they are not
+ * cosmetic.
+ */
+export type GatedFeature =
+  | "sso"
+  | "scim"
+  | "custom_roles"
+  | "ip_allowlist"
+  | "approvals"
+  | "audit_retention"
+  | "masking"
+  | "residency"
+  | "backups"
+  | "white_label"
+  | "proactive";
+
+/**
+ * Feature → minimum plan tier. The default line is **Business** for every
+ * gated capability, matching the current /pricing page. Where a feature
+ * should unlock earlier (Pro+), change its value here — that single edit moves
+ * both enforcement and the SSOT-rendered page in lockstep.
+ *
+ * Keyed by {@link GatedFeature} so adding a feature without assigning a tier
+ * is a compile error — the ladder can't drift open.
+ */
+export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, PlanTier>> = {
+  sso: "business",
+  scim: "business",
+  custom_roles: "business",
+  ip_allowlist: "business",
+  approvals: "business",
+  audit_retention: "business",
+  masking: "business",
+  residency: "business",
+  backups: "business",
+  white_label: "business",
+  proactive: "business",
+};
+
+/**
+ * Pure predicate: is a workspace on `tier` entitled to `feature`?
+ *
+ * Returns `true` iff the workspace's tier ranks at or above the feature's
+ * minimum tier in the `plan-rank` ordering. Delegates the rank comparison to
+ * {@link isPlanEligible} so the fail-closed semantics are shared with the
+ * install gate and can't drift:
+ *
+ *   - `locked` (rank -1) is entitled to nothing — fails closed.
+ *   - An unknown / `null` tier (a legacy `plan_tier`, a row not found, or the
+ *     self-hosted no-billing sentinel) resolves to the rank of `free`, so it
+ *     satisfies only a `free`-min feature. No gated feature is `free`-min, so
+ *     `null` fails closed for every member of {@link FEATURE_ENTITLEMENTS}.
+ *     (Self-hosted enterprise SSO is unaffected because the request-time guard
+ *     short-circuits self-hosted before consulting this predicate — the
+ *     enterprise-license Tag, not the plan tier, is what gates there.)
+ *
+ * Exhaustive over the tier union by construction: every recognized tier has a
+ * `plan-rank` entry, and the lookup of `feature` in {@link FEATURE_ENTITLEMENTS}
+ * is total over {@link GatedFeature}.
+ */
+export function isFeatureEntitled(
+  tier: PlanTier | null | undefined,
+  feature: GatedFeature,
+): boolean {
+  const requiredTier = FEATURE_ENTITLEMENTS[feature];
+  return isPlanEligible(tier ?? null, requiredTier);
+}

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -17,6 +17,7 @@
  */
 
 import { Data } from "effect";
+import type { PlanTier } from "@useatlas/types";
 
 // Content-mode errors live in `lib/content-mode/port.ts` so that module
 // stays self-contained and pure. They are folded into the `AtlasError`
@@ -842,8 +843,12 @@ export class BillingCheckFailedError extends Data.TaggedError("BillingCheckFaile
 export class FeatureEntitlementError extends Data.TaggedError("FeatureEntitlementError")<{
   readonly message: string;
   readonly feature: string;
-  readonly requiredPlan: string;
-  readonly currentPlan: string;
+  // Typed `PlanTier` (not `string`) so this producer of the
+  // `plan_upgrade_required` envelope agrees at compile time with the wire SSOT
+  // (`PlanUpgradeRequiredBody.required_plan` / `current_plan`, both `PlanTier`)
+  // and the install endpoints' OpenAPI schema (`z.enum(PLAN_TIERS)`).
+  readonly requiredPlan: PlanTier;
+  readonly currentPlan: PlanTier;
 }> {}
 
 // ── Backups (#2989 — verify/restore structural error mapping) ──────

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -817,6 +817,35 @@ export class BillingCheckFailedError extends Data.TaggedError("BillingCheckFaile
   readonly workspaceId: string;
 }> {}
 
+/**
+ * A request hit a tier-gated feature its workspace's plan does not unlock
+ * (WS1 of #3984 / #3986). Thrown by `requireFeatureEntitlement` when the
+ * resolved tier ranks below the feature's minimum tier in the
+ * `FeatureEntitlement` SSOT.
+ *
+ * Maps to HTTP 403 `plan_upgrade_required` — the SAME envelope the
+ * integration install endpoints already emit
+ * ({@link import("@useatlas/types").PlanUpgradeRequiredBody}), so the admin
+ * UI's upgrade toast renders identically whether the gate fired on an
+ * integration install or a Business-only feature. `mapTaggedError` surfaces
+ * `requiredPlan` / `currentPlan` as the body's `required_plan` /
+ * `current_plan` fields.
+ *
+ * Distinct from {@link BillingCheckFailedError} (503 "try again", a transient
+ * lookup fault) and {@link EnterpriseError} (the deployment-level enterprise
+ * license gate, 403 `enterprise_required`). This is the per-tier ladder: the
+ * deployment is enterprise-enabled, but the workspace's plan tier is too low.
+ *
+ * `feature` is the {@link import("@atlas/api/lib/billing/feature-entitlement").GatedFeature}
+ * identifier — forensic/log context, not read by `mapTaggedError`.
+ */
+export class FeatureEntitlementError extends Data.TaggedError("FeatureEntitlementError")<{
+  readonly message: string;
+  readonly feature: string;
+  readonly requiredPlan: string;
+  readonly currentPlan: string;
+}> {}
+
 // ── Backups (#2989 — verify/restore structural error mapping) ──────
 
 /**
@@ -958,6 +987,7 @@ export type AtlasError =
   | InvalidInstallIdError
   | ChatIntegrationLimitError
   | BillingCheckFailedError
+  | FeatureEntitlementError
   | BackupNotFoundError
   | BackupInvalidStateError
   | BackupRestoreTokenError
@@ -1037,6 +1067,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "InvalidInstallIdError",
   "ChatIntegrationLimitError",
   "BillingCheckFailedError",
+  "FeatureEntitlementError",
   "BackupNotFoundError",
   "BackupInvalidStateError",
   "BackupRestoreTokenError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -87,6 +87,7 @@ type HttpErrorCode =
   | "rate_limited"
   | "conversation_budget_exceeded"
   | "plan_limit_exceeded"
+  | "plan_upgrade_required"
   | "billing_check_failed"
   | "upstream_error"
   | "service_unavailable"
@@ -385,6 +386,23 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         status: 503,
         code: "billing_check_failed",
         message: error.message,
+      };
+    // WS1 (#3986) — a tier-gated feature whose minimum plan ranks above the
+    // workspace's current tier. 403 + `plan_upgrade_required` matches the
+    // integration install endpoints' upgrade envelope
+    // (`PlanUpgradeRequiredBody`) so the admin UI's upgrade toast renders
+    // identically. Body carries both plan fields. Distinct from the 503
+    // above (a lookup fault) and from `EnterpriseError`'s 403
+    // `enterprise_required` (the deployment-level license gate).
+    case "FeatureEntitlementError":
+      return {
+        status: 403,
+        code: "plan_upgrade_required",
+        message: error.message,
+        body: {
+          required_plan: error.requiredPlan,
+          current_plan: error.currentPlan,
+        },
       };
 
     // ── 502 Bad Gateway — upstream DB error ──────────────────────

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -387,7 +387,7 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         code: "billing_check_failed",
         message: error.message,
       };
-    // WS1 (#3986) — a tier-gated feature whose minimum plan ranks above the
+    // WS1 (#3984 / #3986) — a tier-gated feature whose minimum plan ranks above the
     // workspace's current tier. 403 + `plan_upgrade_required` matches the
     // integration install endpoints' upgrade envelope
     // (`PlanUpgradeRequiredBody`) so the admin UI's upgrade toast renders

--- a/packages/api/src/lib/integrations/install/__tests__/workspace-entitlement.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/workspace-entitlement.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the unified workspace-entitlement resolver (WS1 of #3986).
+ *
+ * This module is the SSOT for "what plan tier is this workspace on, and is it an
+ * operator?" — extracted from two byte-identical copies in the integration
+ * route files. Every other test that touches the resolver mocks it out, so its
+ * own branches (self-hosted short-circuit, row-not-found, tier narrowing,
+ * operator coercion) are pinned here directly against a stubbed `internalQuery`.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// --- Mocks ---
+
+let mockRows: unknown[] = [];
+let mockInternalQueryShouldThrow = false;
+let mockQueryCallCount = 0;
+let lastSql: string | undefined;
+
+const actualInternal = await import("@atlas/api/lib/db/internal");
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...actualInternal,
+  internalQuery: async (sql: string) => {
+    mockQueryCallCount++;
+    lastSql = sql;
+    if (mockInternalQueryShouldThrow) throw new Error("internal db error");
+    return mockRows;
+  },
+}));
+
+const { getWorkspaceEntitlement } = await import("../workspace-entitlement");
+
+beforeEach(() => {
+  mockRows = [];
+  mockInternalQueryShouldThrow = false;
+  mockQueryCallCount = 0;
+  lastSql = undefined;
+});
+
+describe("getWorkspaceEntitlement", () => {
+  it("short-circuits the `self-hosted` sentinel WITHOUT querying", async () => {
+    const result = await getWorkspaceEntitlement("self-hosted");
+    expect(result).toEqual({ planTier: null, isOperator: false });
+    expect(mockQueryCallCount).toBe(0);
+  });
+
+  it("returns the safe default when no organization row is found", async () => {
+    mockRows = [];
+    const result = await getWorkspaceEntitlement("org_missing");
+    expect(result).toEqual({ planTier: null, isOperator: false });
+    expect(mockQueryCallCount).toBe(1);
+  });
+
+  it("narrows a known plan_tier and reads the operator flag", async () => {
+    mockRows = [{ plan_tier: "business", is_operator_workspace: true }];
+    const result = await getWorkspaceEntitlement("org_biz");
+    expect(result).toEqual({ planTier: "business", isOperator: true });
+  });
+
+  it("narrows a legacy / unknown plan_tier string to null (fails closed)", async () => {
+    mockRows = [{ plan_tier: "enterprise", is_operator_workspace: false }];
+    const result = await getWorkspaceEntitlement("org_legacy");
+    expect(result.planTier).toBeNull();
+  });
+
+  it("coerces a non-`true` is_operator_workspace (null) to false", async () => {
+    // Defends the `=== true` strictness: a NULL column must NOT admit the
+    // operator bypass. A truthy check would be a privilege-escalation bug.
+    mockRows = [{ plan_tier: "pro", is_operator_workspace: null }];
+    const result = await getWorkspaceEntitlement("org_null_op");
+    expect(result).toEqual({ planTier: "pro", isOperator: false });
+  });
+
+  it("queries the organization table by id", async () => {
+    mockRows = [{ plan_tier: "starter", is_operator_workspace: false }];
+    await getWorkspaceEntitlement("org_x");
+    expect(lastSql).toContain("FROM organization");
+    expect(lastSql).toContain("plan_tier");
+    expect(lastSql).toContain("is_operator_workspace");
+  });
+
+  it("propagates a lookup error (callers fail closed on the rejection)", async () => {
+    mockInternalQueryShouldThrow = true;
+    await expect(getWorkspaceEntitlement("org_err")).rejects.toThrow(
+      "internal db error",
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/workspace-entitlement.ts
+++ b/packages/api/src/lib/integrations/install/workspace-entitlement.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared workspace-entitlement resolution — single source of truth for
+ * "what plan tier is this workspace on, and is it an operator?" reads.
+ *
+ * Before this module the same `getWorkspaceEntitlement` body was duplicated
+ * byte-for-byte across two integration route files
+ * (`routes/integrations.ts` and `routes/integrations-discord.ts`). Both copies
+ * resolved the workspace's `plan_tier` + `is_operator_workspace` from the
+ * `organization` table and narrowed the tier via {@link parsePlanTier} at the
+ * SQL boundary. Centralizing here means the install plan-gates and the new
+ * per-tier feature-entitlement guard ({@link import("@atlas/api/lib/billing/feature-entitlement").requireFeatureEntitlement})
+ * resolve entitlement identically — one edit moves every consumer in lockstep
+ * (WS1 of #3984 / #3986).
+ *
+ * @module
+ */
+
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { PlanTier } from "@useatlas/types";
+import { parsePlanTier } from "./plan-rank";
+
+/**
+ * Resolved entitlement for a workspace: its plan tier (narrowed to
+ * {@link PlanTier} or `null`) and whether it is an operator workspace
+ * (the admin bypass that admits any install / feature regardless of tier).
+ */
+export interface WorkspaceEntitlement {
+  /**
+   * The workspace's plan tier, narrowed at the SQL boundary. `null` means
+   * "no plan / no billing context" — the self-hosted no-auth sentinel, a
+   * workspace row not found, or a legacy/unknown `plan_tier` string. Callers
+   * treat `null` as the most restrictive default (rank of `free` via
+   * {@link import("./plan-rank").isPlanEligible}) for install gates; the
+   * feature-entitlement guard additionally short-circuits self-hosted (no
+   * internal DB) before reaching this resolver, so a `null` here on SaaS
+   * collapses to `free` for the upgrade-prompt body.
+   */
+  planTier: PlanTier | null;
+  /** Operator-workspace bypass — admits any install / gated feature. */
+  isOperator: boolean;
+}
+
+/**
+ * Resolve `{ planTier, isOperator }` for a workspace from the `organization`
+ * table. `planTier` is narrowed via {@link parsePlanTier} at the SQL boundary
+ * so downstream gates see `PlanTier | null` rather than a raw string — a
+ * legacy / unknown value maps to `null` and callers treat `null` as "no plan /
+ * not an operator", which by construction denies any `min_plan != 'free'`
+ * install attempt without admitting the operator bypass.
+ *
+ * On a self-hosted no-auth deploy (sentinel `workspaceId = "self-hosted"`),
+ * there's no organization row at all. The function returns
+ * `{ planTier: null, isOperator: false }` and the same fail-closed default
+ * applies — `null` collapses to `"free"` in the response body only when the
+ * caller builds an upgrade prompt.
+ */
+export async function getWorkspaceEntitlement(
+  orgId: string,
+): Promise<WorkspaceEntitlement> {
+  if (orgId === "self-hosted") return { planTier: null, isOperator: false };
+  const rows = await internalQuery<{
+    plan_tier: string | null;
+    is_operator_workspace: boolean | null;
+  }>(
+    `SELECT plan_tier, is_operator_workspace
+       FROM organization
+      WHERE id = $1
+      LIMIT 1`,
+    [orgId],
+  );
+  if (rows.length === 0) return { planTier: null, isOperator: false };
+  return {
+    planTier: parsePlanTier(rows[0]?.plan_tier),
+    isOperator: rows[0]?.is_operator_workspace === true,
+  };
+}

--- a/packages/api/src/lib/integrations/install/workspace-entitlement.ts
+++ b/packages/api/src/lib/integrations/install/workspace-entitlement.ts
@@ -35,9 +35,9 @@ export interface WorkspaceEntitlement {
    * internal DB) before reaching this resolver, so a `null` here on SaaS
    * collapses to `free` for the upgrade-prompt body.
    */
-  planTier: PlanTier | null;
+  readonly planTier: PlanTier | null;
   /** Operator-workspace bypass — admits any install / gated feature. */
-  isOperator: boolean;
+  readonly isOperator: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

WS1 keystone of #3984 — the per-tier feature-entitlement layer the rest of the milestone (other gates, SSOT-rendered pricing, drift guard) builds on.

- **`FeatureEntitlement` SSOT** (`lib/billing/feature-entitlement.ts`) — one map (`FEATURE_ENTITLEMENTS`) of every gated capability → minimum tier (all default Business), plus a pure `isFeatureEntitled(tier, feature)` predicate that reuses the `plan-rank` ordering. `Record<GatedFeature, MinPlanTier>` makes a dropped feature a compile error and a `locked` minimum unrepresentable; `locked`/unknown/`null` tiers fail closed.
- **Request-time guard** (`lib/billing/feature-entitlement-guard.ts`) — `requireFeatureEntitlement(orgId, feature)` Effect. The per-tier ladder is a SaaS concept, so it scopes to `saas` deploy mode and is a no-op on self-hosted (incl. self-hosted enterprise, whose workspaces are on `free`) — there the enterprise-license Tag gates, not plan tier. On SaaS: operator bypass passes; below-tier fails with `FeatureEntitlementError` → 403 `plan_upgrade_required` (same `PlanUpgradeRequiredBody` envelope the install gates emit); a lookup fault fails closed with `BillingCheckFailedError` → 503, mirroring `enforcement.ts`.
- **Unified workspace-entitlement helper** (`lib/integrations/install/workspace-entitlement.ts`) — extracts the byte-identical `getWorkspaceEntitlement` that was duplicated across `routes/integrations.ts` and `routes/integrations-discord.ts`; both now import the one shared module.
- **SSO gated end-to-end** — all 10 `admin-sso` handlers gate via `requireFeatureEntitlement(orgId, "sso")` at the handler layer (not UI-only): below-Business denied, Business allowed.
- New tagged error `FeatureEntitlementError` registered in the `AtlasError` union + `ATLAS_ERROR_TAG_LIST` + `mapTaggedError`; new `plan_upgrade_required` HttpErrorCode.

## Test plan

- [x] Table-driven tier × feature matrix — every feature denied below its min tier, allowed at/above; `locked`/`null`/unknown fail closed; Business default
- [x] Guard posture — non-SaaS no-op, self-hosted/no-DB pass, operator bypass, below-tier 403, `null`→`free` body, lookup-error 503 fail-closed
- [x] Direct unit tests for the extracted `getWorkspaceEntitlement` (self-hosted short-circuit, row-not-found, tier narrowing, operator coercion, lookup throw)
- [x] Route-level SSO enforcement — Pro/Starter denied with `plan_upgrade_required`, Business + operator allowed, lookup-fault → 503 `billing_check_failed`
- [x] Local CI: lint, type, full test suite (one pre-existing network-timeout failure in `admin-model-config.test.ts`, reproduces on clean `main`), syncpack, all drift + discipline checks

## Notes

- Respects CLAUDE.md enterprise-gating (core never imports `@atlas/ee`; gate reachable via the existing license Tag) and SaaS-first config (no new env var — deploy mode resolved via the existing `resolveDeployMode`).
- Internal review panel ran 2 rounds → CLEAN.

Closes #3986

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate all SSO admin routes behind a per-tier feature entitlement check
> - Introduces `FEATURE_ENTITLEMENTS` as a SSOT map of features to minimum plan tiers, with `isFeatureEntitled` and a reusable `requireFeatureEntitlement` Effect guard in [`feature-entitlement-guard.ts`](https://github.com/AtlasDevHQ/atlas/pull/4022/files#diff-98ae38cce1ad241819c39dcbde381093c199e88cab097756294e780bf5430e7e).
> - Applies `requireFeatureEntitlement(orgId, 'sso')` to all 10 SSO admin route handlers in [`admin-sso.ts`](https://github.com/AtlasDevHQ/atlas/pull/4022/files#diff-5dbbe5c4afe5147b6de31516bda92a3727249134dbdf6f6f63282cd5f2394cac); SSO is gated at the `business` tier.
> - Operator workspaces bypass the gate; non-SaaS and self-hosted deployments short-circuit to allow.
> - Extracts `getWorkspaceEntitlement` into a shared utility at [`workspace-entitlement.ts`](https://github.com/AtlasDevHQ/atlas/pull/4022/files#diff-0bb68555ac3258ecd4804c88bdeae1e10b658f9ff6bcd9ae90cbefa7aeadd653), replacing duplicate implementations in the integrations routes.
> - Behavioral Change: Pro and Starter workspaces now receive `403 plan_upgrade_required` on all SSO endpoints; lookup failures return `503 billing_check_failed` (fail-closed).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea3735e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->