### PR TITLE
fix(web): durable post-signup session + cookie-only chat auth in managed mode

### DIFF
--- a/.claude/commands/verify-prod-signup.md
+++ b/.claude/commands/verify-prod-signup.md
@@ -124,6 +124,49 @@ for (const [r, host] of Object.entries(EDGES)) {
 
 ---
 
+## Post-signup session durability (the #4018 regression gate)
+
+The residency primitives prove the *region* is right. They do **not** prove the
+brand-new signup lands in a **working app**: #4018 was a separate session/auth
+defect where, straight after "Open Atlas", every authed call `401`'d and a reload
+bounced to `/login`, and even after a manual login the **first chat send** `401`'d
+"session expired". Run this **immediately after the signup completes (before any
+manual sign-out/login)**, from the authed app, against the workspace's **own**
+region edge. It asserts the app's own credential path — the **host-only session
+cookie**, with **no** `Authorization` header (exactly how the app's REST layer
+authenticates) — works for both the bootstrap GETs and a chat `POST`.
+
+```js
+// Home-region edge for the workspace under test (eu/apac use their own host).
+const API = { us: 'https://api.useatlas.dev', eu: 'https://api-eu.useatlas.dev', apac: 'https://api-apac.useatlas.dev' }[region];
+
+// 8a. BOOTSTRAP GETS — cookie-only (NO Authorization header), exactly like the
+//     app's REST path (useAdminFetch). Every one must 200 right after signup.
+for (const path of ['/api/v1/trial', '/api/v1/mode', '/api/v1/conversations',
+                    '/api/v1/tables', '/api/v1/me/preferences', '/api/v1/me/connection-groups']) {
+  const status = (await fetch(`${API}${path}`, { credentials: 'include' })).status;
+  // EVERY path → 200. Any 401 = the #4018 durable-session regression (the
+  // signup/OTP handoff isn't establishing the cookie the app reads).
+}
+
+// 8b. CHAT POST AUTHENTICATES VIA THE COOKIE. Send an empty body so the agent
+//     never runs — we're probing AUTH, not a turn. Crucially send NO bearer:
+//     the chat transport must ride the same cookie as REST (a stale in-memory
+//     `atlas-api-key` bearer used to override the cookie → 401 "session expired").
+const chatStatus = (await fetch(`${API}/api/v1/chat`, {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  credentials: 'include', body: '{}',
+})).status;
+// → 422 (body validation) or 2xx — auth PASSED. 401 = the #4018 chat-transport regression.
+```
+
+**Session-durability assertion (gates #4018):** straight after signup, every
+bootstrap GET in 8a `200`s and the chat `POST` in 8b is **not** `401` (a `422`
+validation is the pass — auth cleared, body didn't). A `401` from any 8a path, or
+a `401` from 8b, is the durable-session / chat-transport regression returning.
+
+---
+
 ## Per-region acceptance criteria
 
 - [ ] Signup completes end-to-end through the real OTP gate, no dead-end at any step
@@ -133,6 +176,7 @@ for (const [r, host] of Object.entries(EDGES)) {
 - [ ] **Returning-user login routes to the home region:** after sign-out, `resolve-region` for the workspace's email → `{ outcome: "single", region: <home> }`
 - [ ] **Raw probe is region-local:** the per-region `region-probe` reports `exists: true` only in the home region
 - [ ] **Multi-region chooser:** an email signed up in two regions → `resolve-region` → `{ outcome: "multiple", regions: [...] }`
+- [ ] **Post-signup session durable (#4018):** straight after "Open Atlas", the bootstrap GETs (primitive 8a) all `200` and the chat `POST` (8b) is not `401`; a reload stays authenticated (no bounce to `/login`)
 - [ ] Post-signup app loads and a **demo query returns an answer** in that region
 - [ ] Screenshot captured at each funnel step
 - [ ] Any defect filed as a follow-up issue (don't fix inline)
@@ -171,6 +215,7 @@ ATLAS_TEARDOWN_OK=1 bun run atlas -- ops teardown-verify-accounts \
 - **#3947** — demo first-answer dead-ends: `executeSQL` rejects whitelisted tables despite `/api/v1/tables` listing them (region-agnostic; **fails criterion 4**).
 - **#3948** — `staging` region leaks into the prod region picker.
 - **#3949** — demo-only signup gets a "connect your database" onboarding email (no demo-aware branch in the email sequence).
+- **#4018** — brand-new signup lands in a broken app: post-signup session not durable (every authed call `401`s, reload → `/login`) and the first chat send `401`s "session expired". **Regression gate is primitive 8** above — run it right after signup. Fixed by hydrating the session after OTP verify + a hard-nav "Open Atlas" (durable cookie) and making the chat transport cookie-only in managed mode (no stale bearer).
 
 ---
 

--- a/packages/web/src/app/signup/success/page.test.tsx
+++ b/packages/web/src/app/signup/success/page.test.tsx
@@ -18,10 +18,11 @@ import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-libra
 
 // ── Mocks ───────────────────────────────────────────────────────────────
 
-const routerPushMock = mock((_path: string) => {});
-const routerMock = { push: routerPushMock, replace: () => {}, back: () => {} };
-mock.module("next/navigation", () => ({
-  useRouter: () => routerMock,
+// #4018 — "Open Atlas" hands off with a HARD nav (navigatePostAuth), mirroring
+// the login front-door, so the app re-bootstraps from the durable cookie.
+const navigatePostAuthMock = mock((_path: string) => {});
+mock.module("@/lib/auth/post-auth-nav", () => ({
+  navigatePostAuth: navigatePostAuthMock,
 }));
 
 const getSessionMock = mock(async () => ({ data: null }));
@@ -56,7 +57,7 @@ mock.module("@/ui/components/signup/signup-shell", () => ({
 import SuccessPage from "./page";
 
 beforeEach(() => {
-  routerPushMock.mockReset();
+  navigatePostAuthMock.mockReset();
   getSessionMock.mockReset();
   getSessionMock.mockImplementation(async () => ({ data: null }));
 });
@@ -76,7 +77,7 @@ describe("SuccessPage — starter prompts (#3935)", () => {
     }
   });
 
-  test("clicking a prompt navigates to the chat with the ?prompt= payload", async () => {
+  test("clicking a prompt hands off to the chat with the ?prompt= payload (hard nav)", async () => {
     render(<SuccessPage />);
 
     const target = PROMPTS[0];
@@ -84,12 +85,30 @@ describe("SuccessPage — starter prompts (#3935)", () => {
       fireEvent.click(screen.getByRole("button", { name: new RegExp(target, "i") }));
     });
 
-    // openAtlas hydrates the session first, then pushes the encoded prompt.
+    // openAtlas hydrates the session first, then hard-navs (#4018) the encoded prompt.
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith(
+      expect(navigatePostAuthMock).toHaveBeenCalledWith(
         `/?prompt=${encodeURIComponent(target)}`,
       );
     });
     expect(getSessionMock).toHaveBeenCalled();
+  });
+
+  test("a getSession hiccup never strands the user — still hands off (#4018)", async () => {
+    // Best-effort hydration: if getSession throws, openAtlas must still navigate
+    // (the durable cookie re-bootstraps the app on the fresh load). A regression
+    // that moved the nav inside the try would dead-end the just-signed-up user.
+    getSessionMock.mockImplementation(async () => {
+      throw new Error("network");
+    });
+    render(<SuccessPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Open Atlas/i }));
+    });
+
+    await waitFor(() => {
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
+    });
   });
 });

--- a/packages/web/src/app/signup/success/page.tsx
+++ b/packages/web/src/app/signup/success/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -47,7 +47,6 @@ const NEXT_STEPS: NextStepDef[] = [
 ];
 
 export default function SuccessPage() {
-  const router = useRouter();
   // Starter prompts derive from the connected workspace's semantic layer via
   // the same adaptive resolver the in-chat empty state uses (#3935 §F4), with
   // a shared static fallback for a cold-start / not-yet-ready semantic layer.
@@ -56,6 +55,13 @@ export default function SuccessPage() {
   // #2487: hydrate the Better Auth session store before navigating to a
   // guarded route. Without this, AuthGuard can read the pre-signup `null`
   // snapshot and bounce the user back to /login.
+  //
+  // #4018: hand off to the app with a HARD nav (`navigatePostAuth`), matching
+  // the login front-door — this is the canonical "auth state just changed →
+  // guarded route" boundary the helper exists for. A soft `router.push` keeps
+  // the funnel's SPA client (and its session snapshot) alive across the
+  // boundary; a full reload re-bootstraps the app cleanly from the durable
+  // cookie instead of a carried-over store.
   async function openAtlas(destination: string) {
     try {
       await authClient.getSession();
@@ -65,7 +71,7 @@ export default function SuccessPage() {
         err instanceof Error ? err.message : String(err),
       );
     }
-    router.push(destination);
+    navigatePostAuth(destination);
   }
 
   return (

--- a/packages/web/src/ui/components/auth/verify-email-otp-form.test.tsx
+++ b/packages/web/src/ui/components/auth/verify-email-otp-form.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * #4018 — the OTP-verify step must hydrate the Better Auth session from the
+ * cookie `verifyEmail` establishes (`autoSignInAfterVerification`) BEFORE it
+ * hands off, mirroring the login front-door's post-signIn `getSession`. Without
+ * it the post-signup app carries no settled session into the cross-origin region
+ * API, so every bootstrap call 401s and a reload bounces the just-verified user
+ * to /login. These pin the ordering (verify → getSession → onVerified), that a
+ * FAILED verify neither hydrates nor advances, and that a hydration hiccup never
+ * traps the user (it still advances).
+ *
+ * `mock.module(...)` stubs every named export of the modules it touches (repo
+ * rule). The OTP input is mocked to a single controlled <input> so a full-length
+ * change deterministically fires the form's auto-submit without the real
+ * `input-otp` library's DOM-measurement quirks under happy-dom.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+mock.module("@/components/ui/input-otp", () => ({
+  InputOTP: ({
+    value,
+    onChange,
+    maxLength,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    maxLength: number;
+    children?: unknown;
+  }) => (
+    <input
+      aria-label="Verification code"
+      value={value}
+      maxLength={maxLength}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  InputOTPGroup: ({ children }: { children?: unknown }) => <div>{children as never}</div>,
+  InputOTPSlot: () => <span />,
+  InputOTPSeparator: () => <span />,
+}));
+
+const callOrder: string[] = [];
+const verifyEmailMock = mock(async (_opts: { email: string; otp: string }) => {
+  callOrder.push("verify");
+  return { data: {}, error: null } as { data: unknown; error: { code?: string } | null };
+});
+const sendVerificationOtpMock = mock(async () => ({ data: {}, error: null }));
+const getSessionMock = mock(async () => {
+  callOrder.push("getSession");
+  return { data: { user: { id: "u1" } } };
+});
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    emailOtp: { verifyEmail: verifyEmailMock, sendVerificationOtp: sendVerificationOtpMock },
+    getSession: getSessionMock,
+  },
+}));
+
+import { VerifyEmailOTPForm } from "./verify-email-otp-form";
+
+const CODE = "12345678";
+
+beforeEach(() => {
+  callOrder.length = 0;
+  verifyEmailMock.mockReset();
+  getSessionMock.mockReset();
+  verifyEmailMock.mockImplementation(async () => {
+    callOrder.push("verify");
+    return { data: {}, error: null };
+  });
+  getSessionMock.mockImplementation(async () => {
+    callOrder.push("getSession");
+    return { data: { user: { id: "u1" } } };
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("VerifyEmailOTPForm — session hydration (#4018)", () => {
+  test("hydrates the session after a successful verify, before onVerified", async () => {
+    const onVerified = mock(() => {
+      callOrder.push("onVerified");
+    });
+    render(<VerifyEmailOTPForm email="a@b.co" onVerified={onVerified} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Verification code"), {
+        target: { value: CODE },
+      });
+    });
+
+    await waitFor(() => expect(onVerified).toHaveBeenCalledTimes(1));
+    expect(verifyEmailMock).toHaveBeenCalledWith({ email: "a@b.co", otp: CODE });
+    expect(getSessionMock).toHaveBeenCalledTimes(1);
+    // Ordering is the invariant: the cookie is hydrated into the store before
+    // the caller navigates into the guarded app.
+    expect(callOrder).toEqual(["verify", "getSession", "onVerified"]);
+  });
+
+  test("a FAILED verify neither hydrates nor advances", async () => {
+    verifyEmailMock.mockImplementation(async () => {
+      callOrder.push("verify");
+      return { data: null, error: { code: "INVALID_OTP" } };
+    });
+    const onVerified = mock(() => {
+      callOrder.push("onVerified");
+    });
+    render(<VerifyEmailOTPForm email="a@b.co" onVerified={onVerified} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Verification code"), {
+        target: { value: CODE },
+      });
+    });
+
+    await waitFor(() => expect(verifyEmailMock).toHaveBeenCalled());
+    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(onVerified).not.toHaveBeenCalled();
+  });
+
+  test("a verify that THROWS (network) neither hydrates nor advances", async () => {
+    verifyEmailMock.mockImplementation(async () => {
+      callOrder.push("verify");
+      throw new Error("network");
+    });
+    const onVerified = mock(() => {
+      callOrder.push("onVerified");
+    });
+    render(<VerifyEmailOTPForm email="a@b.co" onVerified={onVerified} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Verification code"), {
+        target: { value: CODE },
+      });
+    });
+
+    await waitFor(() => expect(verifyEmailMock).toHaveBeenCalled());
+    // The outer catch surfaces actionable copy and must NOT hydrate or advance.
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toContain("Could not verify the code"),
+    );
+    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(onVerified).not.toHaveBeenCalled();
+  });
+
+  test("a hydration hiccup never traps the user — still advances after getSession throws", async () => {
+    getSessionMock.mockImplementation(async () => {
+      callOrder.push("getSession");
+      throw new Error("network");
+    });
+    const onVerified = mock(() => {
+      callOrder.push("onVerified");
+    });
+    render(<VerifyEmailOTPForm email="a@b.co" onVerified={onVerified} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Verification code"), {
+        target: { value: CODE },
+      });
+    });
+
+    await waitFor(() => expect(onVerified).toHaveBeenCalledTimes(1));
+    expect(callOrder).toEqual(["verify", "getSession", "onVerified"]);
+  });
+});

--- a/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
+++ b/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
@@ -15,9 +15,11 @@ interface VerifyEmailOTPFormProps {
   /** Address the OTP was dispatched to. Echoed in copy upstream of this form. */
   email: string;
   /**
-   * Called once the OTP has been verified successfully and Better Auth has
-   * marked the email verified + established a session. Callers typically
-   * `router.push` to the next step here.
+   * Called once the OTP has been verified successfully, Better Auth has marked
+   * the email verified + established a session, and this form has hydrated that
+   * session (see `verify` below, #4018). Callers hard-navigate into the guarded
+   * app here (`navigatePostAuth`) — a soft `router.push` would carry the funnel's
+   * stale session snapshot across the auth boundary and 401 / bounce to /login.
    */
   onVerified: () => void;
 }
@@ -54,6 +56,22 @@ export function VerifyEmailOTPForm({ email, onVerified }: VerifyEmailOTPFormProp
         setError(mapVerifyError(result.error));
         setCode("");
         return;
+      }
+      // #4018 / #2487 — hydrate the Better Auth session store from the durable
+      // cookie `verifyEmail` just established (`autoSignInAfterVerification`),
+      // mirroring the login front-door's post-signIn `getSession`. Without this
+      // the post-signup handoff carries no settled session into the app, so the
+      // cross-origin region API 401s every bootstrap call and a reload bounces
+      // the just-verified user to /login. Best-effort + read-only: a hydration
+      // hiccup must not trap the user on the code screen, so we still call
+      // `onVerified()` (the next nav re-reads the cookie on a fresh load).
+      try {
+        await authClient.getSession();
+      } catch (err) {
+        console.warn(
+          "[auth] getSession after OTP verify failed",
+          err instanceof Error ? err.message : String(err),
+        );
       }
       onVerified();
     } catch (err) {

--- a/packages/web/src/ui/hooks/__tests__/use-atlas-transport.test.ts
+++ b/packages/web/src/ui/hooks/__tests__/use-atlas-transport.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "bun:test";
 import {
   resolveResumeRequest,
   buildChatRequestBody,
+  buildAuthHeaders,
   nextCapturedId,
   ATLAS_RESUME_MARKER,
 } from "@/ui/hooks/use-atlas-transport";
@@ -121,6 +122,33 @@ describe("buildChatRequestBody (#3749)", () => {
   test("#3895 — omits groupReach when the getter is absent (SDK/API callers inherit the row)", () => {
     const body = buildChatRequestBody(MSGS, { groupReach: undefined });
     expect("groupReach" in body).toBe(false);
+  });
+});
+
+describe("buildAuthHeaders (#4018)", () => {
+  test("attaches the bearer in simple-key mode (the API key IS the credential)", () => {
+    expect(buildAuthHeaders("simple-key", "sk-123")).toEqual({
+      Authorization: "Bearer sk-123",
+    });
+  });
+
+  test("managed mode is cookie-only — NEVER attaches a key, even a stale one", () => {
+    // The regression guard: a leftover `atlas-api-key` must not ride as a bearer
+    // in managed mode. The bearer plugin validates it first, so a stale token
+    // 401s the chat ("session expired") while cookie-only REST calls succeed.
+    expect(buildAuthHeaders("managed", "sk-stale")).toEqual({});
+  });
+
+  test("byot / none / unresolved (null) are also cookie-only (no first-party key bearer)", () => {
+    // The `atlas-api-key` is written ONLY by the simple-key ApiKeyBar, so it's
+    // never the credential in these modes — stay cookie-only to match REST.
+    expect(buildAuthHeaders("byot", "sk-x")).toEqual({});
+    expect(buildAuthHeaders("none", "sk-x")).toEqual({});
+    expect(buildAuthHeaders(null, "sk-x")).toEqual({});
+  });
+
+  test("no bearer when the key is empty, even in simple-key mode", () => {
+    expect(buildAuthHeaders("simple-key", "")).toEqual({});
   });
 });
 

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -54,6 +54,31 @@ export function nextCapturedId(
   return null;
 }
 
+/**
+ * #4018 — decide which credential the chat transport attaches. The in-memory
+ * API key (sessionStorage `atlas-api-key`, written ONLY by the simple-key
+ * `ApiKeyBar`, which renders only in `simple-key` mode) is the credential in
+ * `simple-key` mode and must ride as an `Authorization: Bearer` there.
+ *
+ * In `managed` mode the durable credential is the host-only session COOKIE, sent
+ * via `credentials: "include"` exactly like the REST path (`useAdminFetch` sends
+ * NO Authorization header). A leftover/stale key must NOT be attached there: the
+ * server's bearer plugin validates the bearer FIRST, so a stale token 401s the
+ * request ("session expired") even though the cookie is valid — which is why the
+ * first chat send 401'd while cookie-only REST calls succeeded. `managed`/`byot`/
+ * `none`/unresolved (`null`) therefore stay cookie-only. Pure so the rule is
+ * unit-testable without rendering the hook.
+ */
+export function buildAuthHeaders(
+  authMode: AuthMode | null,
+  apiKey: string,
+): Record<string, string> {
+  if (authMode === "simple-key" && apiKey) {
+    return { Authorization: `Bearer ${apiKey}` };
+  }
+  return {};
+}
+
 /** The Atlas routing fields layered onto a normal `/chat` request body. */
 export interface ChatRoutingInputs {
   conversationId?: string | null;
@@ -281,11 +306,12 @@ export function useAtlasTransport(
   }, []);
 
   // --- Auth helpers ---
-  const getHeaders = useCallback(() => {
-    const headers: Record<string, string> = {};
-    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-    return headers;
-  }, [apiKey]);
+  // #4018 — credential decision lives in `buildAuthHeaders` (single-sourced with
+  // the transport memo): bearer only in simple-key mode, cookie-only otherwise.
+  const getHeaders = useCallback(
+    () => buildAuthHeaders(authMode, apiKey),
+    [authMode, apiKey],
+  );
 
   const getCredentials = useCallback(
     (): RequestCredentials => (isCrossOrigin ? "include" : "same-origin"),
@@ -385,12 +411,12 @@ export function useAtlasTransport(
   // conversationId is accessed via ref (not state) to avoid recreating the
   // transport mid-stream, which triggers an infinite re-render loop in useChat.
   // Callback refs (getConversationId, onNewConversationId) follow the same pattern.
-  // authMode: not read directly, but forces transport re-creation after auth resolves.
+  // authMode: read directly via `buildAuthHeaders` (and in deps) so the transport
+  // is rebuilt with the right credential once auth resolves (#4018).
   const transport = useMemo(() => {
-    const headers: Record<string, string> = {};
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
-    }
+    // #4018 — see `buildAuthHeaders`: managed mode rides the cookie (no bearer),
+    // so a stale `atlas-api-key` can't 401 the chat while REST stays authed.
+    const headers = buildAuthHeaders(authMode, apiKey);
     return new DefaultChatTransport({
       api: `${apiUrl}/api/v1/chat`,
       headers,


### PR DESCRIPTION
## Summary

A **brand-new signup landed in a broken app** (#4018): every authed call to the cross-origin region API `401`'d after "Open Atlas", a reload bounced to `/login`, and even after a manual login the **first chat send** `401`'d "session expired". Two distinct defects, both fixed by mirroring the **working login front-door**:

**1. Post-signup session not durable (REST + chat 401, reload → /login).**
The OTP-verify step never hydrated the session Better Auth establishes via `autoSignInAfterVerification`, and the success page's "Open Atlas" used a soft `router.push`.
- `verify-email-otp-form.tsx` now `await authClient.getSession()` after a successful verify, **before** `onVerified()` — exactly like login's post-`signIn` hydration (#2487). Benefits both consumers (signup funnel **and** the login `EMAIL_NOT_VERIFIED` path).
- `signup/success/page.tsx` "Open Atlas" now hands off with `navigatePostAuth` (hard nav) instead of `router.push`, so the app re-bootstraps cleanly from the durable cookie — this is the canonical "auth state just changed → guarded route" boundary that helper exists for.

**2. First chat send 401s "session expired" while REST works.**
The REST path (`useAdminFetch`) authenticates **cookie-only** (no `Authorization` header). The chat transport attached `Authorization: Bearer ${apiKey}` (from sessionStorage `atlas-api-key`) in **all** auth modes — but that key is written only by the `simple-key` `ApiKeyBar`. In `managed` mode the durable credential is the host-only cookie, and the server's bearer plugin validates a bearer **first**, so a stale/leftover key 401'd the chat while cookie-only REST succeeded.
- New pure `buildAuthHeaders(authMode, apiKey)` attaches the bearer **only** in `simple-key` mode; `managed`/`byot`/`none`/unresolved stay cookie-only, matching REST. Single-sourced across `getHeaders` + the transport memo.

## Regression guards (AC#4)

- `buildAuthHeaders` unit tests over the full `AuthMode` union (incl. `managed` + stale key → **no bearer**, the chat-401 root cause).
- OTP-form tests: verify → getSession → onVerified ordering; failed/throwing verify neither hydrates nor advances; a hydration hiccup never traps the user.
- Success-page test: a `getSession` hiccup still hands off (no dead-end).
- New **post-signup session-durability primitive** in `/verify-prod-signup` (bootstrap GETs `200` + chat `POST` authenticates via cookie) — the prod regression gate.

## Test plan

- [x] `bun run lint`, `bun run type` — clean
- [x] Full `bun run test` — only the 3 known WSL2 sandbox flakes (`lib/tools` explore/python) fail; unrelated to this web-only change
- [x] All CI drift/discipline gates pass (schema, openapi, template, security-headers, railway-watch, settings-readers, saas-env-doc, published-symbols, …)
- [ ] Prod verification deferred to `/verify-prod-signup` post-release (primitive 8) — the bug is prod-cross-origin-only and can only be confirmed against the multi-region SaaS deploy

## Notes

The exact cookie-durability mechanism is only fully observable against prod (cross-origin, multi-region); per the issue's guidance the signup/OTP path is changed to mirror the proven login session-establishment recipe, and the prod gate is wired into `/verify-prod-signup`. `main` deploys to staging only.

Closes #4018

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-signup session durability and restrict auth headers to simple-key mode in managed chat
> - After a successful OTP verification, [`VerifyEmailOTPForm`](https://github.com/AtlasDevHQ/atlas/pull/4023/files#diff-53d5c00df5a99e92ce8c5bccd9152c5570a7a4a2fb29c13ece1b98d698fa69f7) now calls `authClient.getSession()` to hydrate the Better Auth cookie session before invoking `onVerified`; hydration failures are warned but do not block progression.
> - The signup success page ([`page.tsx`](https://github.com/AtlasDevHQ/atlas/pull/4023/files#diff-412b473f977cc5278426c81070c3a061dfc9b9366a8aaf6ed65f39a694f328ec)) replaces `router.push()` with `navigatePostAuth()` to force a hard navigation after signup, ensuring the durable cookie session is picked up on the next page load.
> - [`buildAuthHeaders`](https://github.com/AtlasDevHQ/atlas/pull/4023/files#diff-b36c17d6b519759ed99516015666d6592610fad30034105b84cab929cbce6064) is extracted as a new exported helper that attaches an `Authorization: Bearer` header only when `authMode` is `'simple-key'` with a non-empty key; managed/byot/none modes send no bearer.
> - Behavioral Change: chat transport in managed mode no longer sends an `Authorization` header, relying solely on cookies for authentication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5d7353.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->