### PR TITLE
fix(api,cli): region-DB migration parity for subscription + scim_group_mappings (#4019)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -419,6 +419,10 @@ describe("migrateAuthTables", () => {
             // output-equivalent token accounting, TokenWeighting WS2, #3989) —
             // runs in every auth mode, so it must be pre-applied here.
             { name: "0152_usage_events_weighted_quantity.sql" },
+            // 0153 creates subscription + scim_group_mappings (region-DB parity,
+            // #4019); neither FKs a Better Auth table, so it is NOT in
+            // MANAGED_AUTH_MIGRATIONS and runs in every auth mode — must be listed.
+            { name: "0153_region_db_subscription_scim_parity.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/reconcile-plan-tiers-pg.test.ts
@@ -14,11 +14,13 @@
  *     throws here against the real table. The `subscription` table has no
  *     creation timestamp; `periodStart` is the newest-subscription proxy.
  *
- * `organization` and `subscription` are owned by Better Auth in production, so
- * they are not in our migration set — the fixture creates the minimal columns
- * the sweep's query and heal-write read (mirrors chat-cap-pg's `organization`
- * fixture). `stripe_webhook_events` (0128) + `stripe_purged_subscriptions`
- * (0129) ARE regular migrations, so `runMigrations` creates them.
+ * `organization` is owned by Better Auth in production, so it is not in our
+ * migration set — the fixture creates the minimal columns the sweep's query and
+ * heal-write read (mirrors chat-cap-pg's `organization` fixture). `subscription`
+ * IS now created by `runMigrations` (migration 0152, #4019 region-DB parity), so
+ * this suite no longer hand-builds it: 0152's shape already has every column the
+ * sweep reads and, crucially, still no `createdAt`. `stripe_webhook_events`
+ * (0128) + `stripe_purged_subscriptions` (0129) are likewise regular migrations.
  *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
@@ -69,19 +71,10 @@ describeIfPg("reconcilePlanTiers (real Postgres)", () => {
          plan_override_until timestamptz
        )`,
     );
-    // Minimal Better-Auth-stripe `subscription` — only the columns the sweep's
-    // LATERAL subquery reads. Crucially there is NO `createdAt` column (the bug):
-    // the real table's newest-period proxy is `periodStart`.
-    await pool.query(
-      `CREATE TABLE subscription (
-         id text PRIMARY KEY,
-         plan text,
-         "referenceId" text,
-         "stripeSubscriptionId" text,
-         status text,
-         "periodStart" timestamptz
-       )`,
-    );
+    // `subscription` is created by migration 0152 (#4019 region-DB parity)
+    // during `runMigrations` above — the full @better-auth/stripe shape, and
+    // (the property this suite guards) still NO `createdAt` column, so the
+    // sweep's newest-period proxy remains `periodStart`. No hand-built fixture.
 
     // Point the sweep's module pool (`internalQuery`/`updateWorkspacePlanTier`)
     // at this scratch-schema pool, and make `hasInternalDB()` true.

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -1267,6 +1267,55 @@ describe("hardDeleteWorkspace()", () => {
     expect(result.subscriptions).toBe(0);
     expect(result.stripeWebhookEvents).toBe(0);
   });
+
+  it("completes the GDPR purge when scim_group_mappings is absent (region-DB drift, #4019)", async () => {
+    // The EU/APAC prod region DBs were missing scim_group_mappings, so the
+    // (previously unconditional) DELETE threw `relation does not exist` and
+    // rolled the WHOLE purge back — a workspace stuck soft-deleted, never
+    // GDPR-purged. The to_regclass probe must let the cascade skip the absent
+    // table and complete. Migration 0152 repairs the drift; this proves the
+    // purge no longer aborts when `scim_group_mappings` specifically is absent
+    // (the #4019 region-DB drift).
+    const { pool: basePool } = createMockPool();
+    const queries: string[] = [];
+    const client = {
+      async query(sql: string) {
+        queries.push(sql);
+        const upper = sql.trim().toUpperCase();
+        if (upper.startsWith("SELECT WORKSPACE_STATUS")) {
+          return { rows: [{ workspace_status: "deleted" }] };
+        }
+        // Only scim_group_mappings is absent; `subscription` still exists.
+        if (sql.includes("to_regclass")) {
+          return { rows: [{ table_exists: !sql.includes("scim_group_mappings") }] };
+        }
+        if (sql.includes("FROM member m")) return { rows: [] };
+        // A real Postgres throws here if the cascade ever issues the DELETE —
+        // the probe must keep it from being reached.
+        if (sql.includes("DELETE FROM scim_group_mappings")) {
+          throw new Error('relation "scim_group_mappings" does not exist');
+        }
+        if (upper.startsWith("DELETE")) return { rows: [{ ok: 1 }] };
+        return { rows: [] };
+      },
+      release() {},
+    };
+    const pool = {
+      ...basePool,
+      async connect() {
+        return client;
+      },
+    };
+    _resetPool(pool);
+
+    // Resolves (no throw, no rollback) and skips the absent table.
+    const result = await hardDeleteWorkspace("org-1");
+
+    expect(result.scimGroupMappings).toBe(0);
+    expect(queries.some((q) => q.includes("DELETE FROM scim_group_mappings"))).toBe(false);
+    // The rest of the cascade still ran — proof the purge completed, not aborted.
+    expect(result.subscriptions).toBe(1);
+  });
 });
 
 describe("connection URL encryption", () => {

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -101,6 +101,38 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(count).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
+  // #4019 — region-DB schema parity. The EU/APAC prod region DBs were missing
+  // `subscription` (the @better-auth/stripe plugin table, created by Better
+  // Auth's runMigrations only where the stripe plugin is registered — US-only
+  // per STRIPE_SECRET_KEY) and `scim_group_mappings`. This suite runs with
+  // `skip: MANAGED_AUTH_MIGRATIONS` (the non-managed path, where Better Auth has
+  // NOT pre-created `subscription`) — a strict superset of the passive EU/APAC
+  // region where it is likewise absent. So `subscription` exists here ONLY if
+  // 0152 created it: that assertion (+ its column check) is what locks the fix.
+  // `scim_group_mappings` also ships in 0000_baseline.sql, so its presence here
+  // is a parity sanity check rather than a unique 0152 lock — the real scim
+  // regression (an absent table must NOT abort the purge) lives in
+  // internal.test.ts's hardDeleteWorkspace probe test.
+  it("0152: subscription + scim_group_mappings exist after migrations (region parity, #4019)", async () => {
+    const { rows } = await pool.query<{ subscription: string | null; scim: string | null }>(
+      `SELECT to_regclass('subscription') AS subscription,
+              to_regclass('scim_group_mappings') AS scim`,
+    );
+    expect(rows[0]?.subscription).not.toBeNull();
+    expect(rows[0]?.scim).not.toBeNull();
+
+    // Parity, not just presence: the `subscription` columns hardDeleteWorkspace
+    // and the Stripe teardown read (`referenceId`, `stripeSubscriptionId`) must
+    // be there, or the purge would still throw a column error in EU/APAC.
+    const { rows: cols } = await pool.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+        WHERE table_schema = current_schema() AND table_name = 'subscription'`,
+    );
+    const names = new Set(cols.map((c) => c.column_name));
+    expect(names.has("referenceId")).toBe(true);
+    expect(names.has("stripeSubscriptionId")).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
   // #2184 — audit_log.auth_mode CHECK constraint. Inserts that pass
   // the canonical AuthMode tuple succeed; an insert with an unknown
   // mode rejects with PostgreSQL error code 23514 (check_violation),

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -180,7 +180,9 @@ describe("runMigrations", () => {
     //   returning-user login front-door probe, ADR-0024 §3, #3973) = 152.
     //   Plus 0152 (usage_events.weighted_quantity output-equivalent token
     //   accounting, TokenWeighting WS2, #3989) = 153.
-    expect(count).toBe(153);
+    //   Plus 0153 (subscription + scim_group_mappings region-DB parity so the
+    //   GDPR purge completes in passive EU/APAC regions, #4019) = 154.
+    expect(count).toBe(154);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -362,6 +364,7 @@ describe("runMigrations", () => {
         "0150_token_usage_latency.sql",
         "0151_user_email_hash_index.sql",
         "0152_usage_events_weighted_quantity.sql",
+        "0153_region_db_subscription_scim_parity.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -3165,7 +3165,29 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const workspaceBranding = await del(`DELETE FROM workspace_branding WHERE org_id = $1`);
     const onboardingEmails = await del(`DELETE FROM onboarding_emails WHERE org_id = $1`);
     const piiColumnClassifications = await del(`DELETE FROM pii_column_classifications WHERE org_id = $1`);
-    const scimGroupMappings = await del(`DELETE FROM scim_group_mappings WHERE org_id = $1`);
+    // scim_group_mappings ships in 0000_baseline.sql + migration 0152 (#4019),
+    // but the EU/APAC prod region DBs were observed missing it — and unlike the
+    // `subscription` deletes below, this DELETE had NO existence probe, so its
+    // `relation "scim_group_mappings" does not exist` aborted the ENTIRE purge
+    // transaction: a workspace could be soft-deleted but never GDPR-purged.
+    // Probe with to_regclass so a region with residual drift skips this one
+    // table instead of rolling the whole cascade back. The `subscription` probe
+    // below stays silent on a miss (a historically Better-Auth-only table whose
+    // probe predates 0152), but scim_group_mappings has always shipped in the
+    // baseline, so post-0152 an absent table here is pure drift — log it rather
+    // than skip silently.
+    let scimGroupMappings = 0;
+    const scimTableProbe = await client.query(
+      `SELECT to_regclass('public.scim_group_mappings') IS NOT NULL AS table_exists`,
+    );
+    if ((scimTableProbe.rows[0] as { table_exists?: boolean } | undefined)?.table_exists === true) {
+      scimGroupMappings = await del(`DELETE FROM scim_group_mappings WHERE org_id = $1`);
+    } else {
+      log.warn(
+        { orgId },
+        "scim_group_mappings absent during hardDeleteWorkspace — skipping its DELETE (region-DB drift; migration 0152 should have repaired this)",
+      );
+    }
     const sandboxCredentials = await del(`DELETE FROM sandbox_credentials WHERE org_id = $1`);
     const dashboards = await del(`DELETE FROM dashboards WHERE org_id = $1`);
     const oauthState = await del(`DELETE FROM oauth_state WHERE org_id = $1`);
@@ -3198,15 +3220,16 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const twentyIntegrations = await del(`DELETE FROM twenty_integrations WHERE workspace_id = $1`);
 
     // ── Phase 3b: Stripe billing linkage rows (#3425) ──
-    // The @better-auth/stripe plugin's `subscription` table only exists when
-    // the plugin has run its migrations (STRIPE_SECRET_KEY deployments) —
-    // probe with to_regclass so non-Stripe deployments don't abort the purge
-    // transaction. The REMOTE teardown (cancel subscription, delete the
-    // Stripe customer) runs in lib/billing/workspace-teardown.ts BEFORE this
-    // cascade; these deletes remove the local billable linkage for GDPR
-    // completeness. The stripe_webhook_events dedupe ledger rows are matched
-    // via the org's subscription ids, so they must go before the
-    // subscription rows.
+    // Better Auth creates the @better-auth/stripe `subscription` table only on
+    // Stripe deployments (STRIPE_SECRET_KEY), but migration 0152 (#4019) now also
+    // CREATEs it IF NOT EXISTS in every mode for region parity, so post-0152 it
+    // exists everywhere. Probe with to_regclass anyway so a DB that pre-dates
+    // 0152 (or carries residual drift) doesn't abort the purge transaction. The
+    // REMOTE teardown (cancel subscription, delete the Stripe customer) runs in
+    // lib/billing/workspace-teardown.ts BEFORE this cascade; these deletes remove
+    // the local billable linkage for GDPR completeness. The stripe_webhook_events
+    // dedupe ledger rows are matched via the org's subscription ids, so they must
+    // go before the subscription rows.
     let subscriptions = 0;
     let stripeWebhookEvents = 0;
     const subscriptionTableProbe = await client.query(

--- a/packages/api/src/lib/db/migrations/0153_region_db_subscription_scim_parity.sql
+++ b/packages/api/src/lib/db/migrations/0153_region_db_subscription_scim_parity.sql
@@ -1,0 +1,87 @@
+-- 0153 — region-DB schema parity: subscription + scim_group_mappings (#4019).
+--
+-- The EU/APAC prod region internal DBs were missing two tables the US DB has —
+-- `subscription` and `scim_group_mappings`. `hardDeleteWorkspace` (the
+-- GDPR-grade workspace purge SSOT in db/internal.ts) DELETEs from both inside a
+-- single transaction. The `subscription` deletes are already to_regclass-probed
+-- (the table only exists on Stripe deployments), so a MISSING `subscription` was
+-- tolerated. But the `scim_group_mappings` DELETE was UNCONDITIONAL, so in
+-- EU/APAC it hit `relation "scim_group_mappings" does not exist` and rolled the
+-- whole purge back — a workspace stuck soft-deleted, never hard-purged. That is
+-- a data-residency / GDPR-erasure failure for EU/APAC workspaces. (This PR also
+-- adds a matching to_regclass probe to that scim DELETE in hardDeleteWorkspace,
+-- so a region still missing `scim_group_mappings` skips it instead of aborting —
+-- the same guard `subscription` already had.)
+--
+-- Why these two drifted (same root cause, two paths):
+--   * `subscription` is the @better-auth/stripe plugin's table. Better Auth only
+--     creates it in `ctx.runMigrations()` when the stripe plugin is registered,
+--     and the plugin is registered only when STRIPE_SECRET_KEY is set
+--     (auth/server.ts buildPlugins). Billing runs in US only per the
+--     per-service env, so the passive EU/APAC Better Auth instances never
+--     register the plugin and never create the table.
+--   * `scim_group_mappings` ships in 0000_baseline.sql, but the already-
+--     provisioned EU/APAC region DBs recorded the baseline as applied before it
+--     materialized there, so it never landed. A forward `IF NOT EXISTS` re-
+--     assert closes that drift the normal migration way (acceptance criterion:
+--     "applied via the normal migration path, not ad-hoc DDL").
+--
+-- Ordering / idempotency: this migration is a no-op wherever the tables already
+-- exist. On US, Better Auth's `runMigrations()` (boot step 1) creates
+-- `subscription` BEFORE Atlas migrations (step 2) run, so the `IF NOT EXISTS`
+-- here simply confirms it; the migration only *materializes* the tables on the
+-- passive regions (and on self-hosted non-managed installs, where they are
+-- harmless empty tables the existing `subscription` probe in hardDeleteWorkspace
+-- already tolerated).
+--
+-- The `subscription` DDL below MUST mirror what @better-auth/stripe v1.6.x makes
+-- on US, so the BA-created (US) and migration-created (EU/APAC) tables converge
+-- to one shape. Better Auth's Postgres migrator (better-auth/db/get-migration)
+-- maps field types: string→text, date→timestamptz, number→integer,
+-- boolean→boolean, the `id` primary key→text, `required: false`→nullable, and
+-- does NOT emit a SQL DEFAULT for non-date `defaultValue`s (those are applied in
+-- app code). Column names stay camelCase, so they are quoted here.
+--
+-- NOT in MANAGED_AUTH_MIGRATIONS (db/internal.ts): neither table has a foreign
+-- key to a Better Auth table, so both CREATEs succeed without the `user` /
+-- `organization` tables present. Keeping it out of the skip set means it runs in
+-- every mode — `scim_group_mappings` keeps its baseline always-create behavior,
+-- and `subscription` materializes everywhere. migrate-pg.test.ts runs the set
+-- with `skip: MANAGED_AUTH_MIGRATIONS` (the non-managed path, where Better Auth
+-- has NOT pre-created `subscription`) — a strict superset of the passive EU/APAC
+-- region where `subscription` is likewise absent, so the parity assertion there
+-- proves 0153 alone supplies the table. `subscription` gets a Drizzle mirror in
+-- db/schema.ts so scripts/check-schema-drift.sh stays green.
+
+-- @better-auth/stripe `subscription` table — see header for the field→column
+-- type mapping this mirrors.
+CREATE TABLE IF NOT EXISTS subscription (
+  "id" TEXT PRIMARY KEY,
+  "plan" TEXT NOT NULL,
+  "referenceId" TEXT NOT NULL,
+  "stripeCustomerId" TEXT,
+  "stripeSubscriptionId" TEXT,
+  "status" TEXT NOT NULL,
+  "periodStart" TIMESTAMPTZ,
+  "periodEnd" TIMESTAMPTZ,
+  "trialStart" TIMESTAMPTZ,
+  "trialEnd" TIMESTAMPTZ,
+  "cancelAtPeriodEnd" BOOLEAN,
+  "cancelAt" TIMESTAMPTZ,
+  "canceledAt" TIMESTAMPTZ,
+  "endedAt" TIMESTAMPTZ,
+  "seats" INTEGER,
+  "billingInterval" TEXT,
+  "stripeScheduleId" TEXT
+);
+
+-- EE SCIM group mappings — re-asserts the 0000_baseline.sql definition verbatim
+-- so the passive regions converge to the same shape (inline UNIQUE constraint).
+CREATE TABLE IF NOT EXISTS scim_group_mappings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL,
+  scim_group_name TEXT NOT NULL,
+  role_name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(org_id, scim_group_name)
+);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1342,6 +1342,47 @@ export const scimGroupMappings = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Billing: @better-auth/stripe `subscription` table
+// ---------------------------------------------------------------------------
+
+/**
+ * The @better-auth/stripe plugin's `subscription` table. Better Auth owns its
+ * creation on US (the stripe plugin is registered only when STRIPE_SECRET_KEY
+ * is set — US-only per the per-service env), so this is NOT a table Atlas
+ * historically created. Migration 0152 (#4019) adds a forward `CREATE TABLE IF
+ * NOT EXISTS subscription` so the passive EU/APAC region DBs — which never
+ * register the stripe plugin — reach full schema parity with US. (The purge's
+ * `subscription` deletes are to_regclass-probed, so an absent table was already
+ * tolerated; the unconditional `scim_group_mappings` delete is what actually
+ * aborted the EU/APAC purge — fixed by the same migration + a new probe.)
+ *
+ * This mirror exists so scripts/check-schema-drift.sh sees a pgTable for the
+ * table 0152 now creates. The column names stay camelCase to match what Better
+ * Auth generates (string→text, date→timestamptz, number→integer, boolean,
+ * id→text PK, `required: false`→nullable). Mirrors
+ * `migrations/0152_region_db_subscription_scim_parity.sql`.
+ */
+export const subscription = pgTable("subscription", {
+  id: text("id").primaryKey(),
+  plan: text("plan").notNull(),
+  referenceId: text("referenceId").notNull(),
+  stripeCustomerId: text("stripeCustomerId"),
+  stripeSubscriptionId: text("stripeSubscriptionId"),
+  status: text("status").notNull(),
+  periodStart: timestamp("periodStart", { withTimezone: true }),
+  periodEnd: timestamp("periodEnd", { withTimezone: true }),
+  trialStart: timestamp("trialStart", { withTimezone: true }),
+  trialEnd: timestamp("trialEnd", { withTimezone: true }),
+  cancelAtPeriodEnd: boolean("cancelAtPeriodEnd"),
+  cancelAt: timestamp("cancelAt", { withTimezone: true }),
+  canceledAt: timestamp("canceledAt", { withTimezone: true }),
+  endedAt: timestamp("endedAt", { withTimezone: true }),
+  seats: integer("seats"),
+  billingInterval: text("billingInterval"),
+  stripeScheduleId: text("stripeScheduleId"),
+});
+
+// ---------------------------------------------------------------------------
 // EE: SLA metrics
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -220,7 +220,6 @@ interface FakeRow extends Record<string, unknown> {
   userId: string;
   email: string;
   userName: string | null;
-  userStripeCustomerId: string | null;
   memberRole: string | null;
   orgId: string | null;
   orgName: string | null;
@@ -243,7 +242,6 @@ function row(over: Partial<FakeRow>): FakeRow {
     userId: "user_1",
     email: "matt+us@useatlas.dev",
     userName: "Matt US",
-    userStripeCustomerId: null,
     memberRole: "owner",
     orgId: "org_1",
     orgName: "Atlas us Verify",
@@ -271,19 +269,20 @@ describe("resolveVerifyTargets", () => {
       email: "ghost+us@useatlas.dev",
       userId: null,
       found: false,
-      userStripeCustomerId: null,
       orgs: [],
     });
   });
 
-  it("carries user.stripeCustomerId onto the target (the #4011 user-level customer)", async () => {
+  it("carries the org-level stripeCustomerId onto the org (no user-level customer, #4019)", async () => {
     const q = fakeQuery({
-      "matt+us@useatlas.dev": [row({ userStripeCustomerId: "cus_user", stripeCustomerId: null })],
+      "matt+us@useatlas.dev": [row({ stripeCustomerId: "cus_org" })],
     });
     const [t] = await resolveVerifyTargets(q, ["matt+us@useatlas.dev"]);
-    expect(t!.userStripeCustomerId).toBe("cus_user");
-    // The org column is null in the #4011 shape — the customer lives only on the user.
-    expect(t!.orgs[0]!.stripeCustomerId).toBeNull();
+    // Org-scoped billing only — the customer lives on the org row. The resolved
+    // target has no user-level customer field at all (the crashing
+    // `u."stripeCustomerId"` select is gone, #4019).
+    expect(t!.orgs[0]!.stripeCustomerId).toBe("cus_org");
+    expect(t).not.toHaveProperty("userStripeCustomerId");
   });
 
   it("treats a user with no membership (LEFT JOIN null org) as found with zero orgs", async () => {
@@ -335,14 +334,14 @@ describe("resolveVerifyTargets", () => {
 describe("countOwnedOrgs", () => {
   it("counts only owned orgs across targets, ignoring non-owner memberships", () => {
     const targets: VerifyTarget[] = [
-      { email: "a", userId: "u1", found: true, userStripeCustomerId: null, orgs: [
+      { email: "a", userId: "u1", found: true, orgs: [
         { orgId: "o1", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
         { orgId: "o2", orgName: null, orgSlug: null, region: "us", workspaceStatus: "active", stripeCustomerId: null, isOwner: false },
       ] },
-      { email: "b", userId: "u2", found: true, userStripeCustomerId: null, orgs: [
+      { email: "b", userId: "u2", found: true, orgs: [
         { orgId: "o3", orgName: null, orgSlug: null, region: "eu", workspaceStatus: "active", stripeCustomerId: null, isOwner: true },
       ] },
-      { email: "c", userId: null, found: false, userStripeCustomerId: null, orgs: [] },
+      { email: "c", userId: null, found: false, orgs: [] },
     ];
     expect(countOwnedOrgs(targets)).toBe(2);
     expect(countOwnedOrgs(targets)).toBeLessThanOrEqual(MAX_TEARDOWN_TARGETS);
@@ -364,7 +363,6 @@ function target(over: Partial<VerifyTarget> & { orgs?: VerifyTarget["orgs"] }): 
     email: "matt+us@useatlas.dev",
     userId: "user_1",
     found: true,
-    userStripeCustomerId: null,
     orgs: [],
     ...over,
   };
@@ -392,16 +390,13 @@ describe("teardownTargets", () => {
       hardDelete: async () => { calls.push("hard"); return 0; },
     };
     const report = await teardownTargets(
-      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg()] })],
+      [target({ orgs: [ownedOrg()] })],
       deps,
       true,
     );
     expect(calls).toEqual([]);
     expect(report.dryRun).toBe(true);
     expect(report.targets[0]!.orgs[0]!.status).toBe("would-tear-down");
-    // Preview must still report the user-level customer that the live run will
-    // delete — a dropped carry-through here would make the dry run lie (#4011).
-    expect(report.targets[0]!.userStripeCustomerId).toBe("cus_user");
     expect(report.totals).toMatchObject({ orgsWouldTearDown: 1, orgsTornDown: 0 });
   });
 
@@ -425,119 +420,26 @@ describe("teardownTargets", () => {
     expect(report.totals).toMatchObject({ orgsTornDown: 1, rowsPurged: 42, errors: 0 });
   });
 
-  it("unions the user-level customer into the purge call (#4011 — org column null)", async () => {
-    // The #4011 shape: customer parked on user.stripeCustomerId, org column null.
-    const purgeCalls: Array<[string, string | null, readonly string[]]> = [];
+  it("purges only the org-level customer — no user-level union (#4019)", async () => {
+    // Org-scoped billing (#4014) + the user.stripeCustomerId column being absent
+    // in EU/APAC (#4019) mean the only customer to purge is the org's. The purge
+    // is called with exactly (orgId, org.stripeCustomerId) and nothing else.
+    const purgeCalls: Array<[string, string | null]> = [];
     const deps: TeardownDeps = {
-      purgeStripe: async (orgId, stripeCustomerId, extraCustomerIds) => {
-        purgeCalls.push([orgId, stripeCustomerId, extraCustomerIds]);
-        return okStripe({ actions: ["deleted Stripe customer cus_user"] });
+      purgeStripe: async (orgId, stripeCustomerId) => {
+        purgeCalls.push([orgId, stripeCustomerId]);
+        return okStripe({ actions: ["deleted Stripe customer cus_org"] });
       },
       softDelete: async () => true,
       hardDelete: async () => 1,
     };
     const report = await teardownTargets(
-      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg({ stripeCustomerId: null })] })],
+      [target({ orgs: [ownedOrg({ stripeCustomerId: "cus_org" })] })],
       deps,
       false,
     );
-    expect(purgeCalls).toEqual([["org_1", null, ["cus_user"]]]);
-    expect(report.targets[0]!.userStripeCustomerId).toBe("cus_user");
-    expect(report.targets[0]!.orgs[0]!.stripeActions).toContain("deleted Stripe customer cus_user");
-  });
-
-  it("passes an empty extra-ids array when the user has no user-level customer", async () => {
-    const purgeCalls: Array<readonly string[]> = [];
-    const deps: TeardownDeps = {
-      purgeStripe: async (_o, _c, extraCustomerIds) => { purgeCalls.push(extraCustomerIds); return okStripe(); },
-      softDelete: async () => true,
-      hardDelete: async () => 1,
-    };
-    await teardownTargets(
-      [target({ userStripeCustomerId: null, orgs: [ownedOrg({ stripeCustomerId: "cus_org" })] })],
-      deps,
-      false,
-    );
-    expect(purgeCalls).toEqual([[]]);
-  });
-
-  it("warns when an orphan user (no owned org) carries a user-level customer the purge can't reach", async () => {
-    const deps: TeardownDeps = {
-      purgeStripe: async () => okStripe(),
-      softDelete: async () => true,
-      hardDelete: async () => 0,
-    };
-    const report = await teardownTargets(
-      [target({ email: "orphan+us@useatlas.dev", userStripeCustomerId: "cus_orphan", orgs: [] })],
-      deps,
-      false,
-    );
-    expect(report.targets[0]!.warnings.some((w) => w.includes("cus_orphan"))).toBe(true);
-    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
-    // Counted so the handler exits non-zero — a surviving billable customer
-    // must not be reported as a clean teardown.
-    expect(report.totals.orphanedUserCustomers).toBe(1);
-  });
-
-  it("warns when a user owns NO workspace (only non-owner memberships) but carries a customer", async () => {
-    // The org-loop skips every non-owner membership, so the user-level customer
-    // is never unioned into a purge — it must still be surfaced loudly (#4011),
-    // not just in the zero-membership case.
-    const calls: string[] = [];
-    const deps: TeardownDeps = {
-      purgeStripe: async () => { calls.push("purge"); return okStripe(); },
-      softDelete: async () => true,
-      hardDelete: async () => 0,
-    };
-    const report = await teardownTargets(
-      [target({
-        userStripeCustomerId: "cus_nonowner",
-        orgs: [ownedOrg({ orgId: "org_shared", isOwner: false })],
-      })],
-      deps,
-      false,
-    );
-    expect(calls).toEqual([]); // no purge ran — every membership is non-owner
-    expect(report.targets[0]!.warnings.some((w) => w.includes("cus_nonowner"))).toBe(true);
-    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(true);
-    expect(report.totals.orphanedUserCustomers).toBe(1);
-  });
-
-  it("does NOT warn (customer is reached) when the user owns at least one workspace", async () => {
-    const deps: TeardownDeps = {
-      purgeStripe: async () => okStripe({ actions: ["deleted Stripe customer cus_user"] }),
-      softDelete: async () => true,
-      hardDelete: async () => 1,
-    };
-    const report = await teardownTargets(
-      [target({ userStripeCustomerId: "cus_user", orgs: [ownedOrg()] })],
-      deps,
-      false,
-    );
-    // An owned org's purge unions the customer in, so no manual-cleanup warning fires.
-    expect(report.targets[0]!.warnings.some((w) => w.includes("manually"))).toBe(false);
-    expect(report.totals.orphanedUserCustomers).toBe(0);
-  });
-
-  it("unions the user customer into EVERY owned org's purge (multi-org fan-out)", async () => {
-    // A user owning 2 workspaces: the same user-level customer is passed to each
-    // owned org's purge. The first deletes it, the rest hit resource_missing (a
-    // no-op success) — proven safe, never orphaned, never double-counted.
-    const extraArgs: Array<readonly string[]> = [];
-    const deps: TeardownDeps = {
-      purgeStripe: async (_o, _c, extraCustomerIds) => { extraArgs.push(extraCustomerIds); return okStripe(); },
-      softDelete: async () => true,
-      hardDelete: async () => 1,
-    };
-    await teardownTargets(
-      [target({
-        userStripeCustomerId: "cus_user",
-        orgs: [ownedOrg({ orgId: "org_a" }), ownedOrg({ orgId: "org_b" })],
-      })],
-      deps,
-      false,
-    );
-    expect(extraArgs).toEqual([["cus_user"], ["cus_user"]]);
+    expect(purgeCalls).toEqual([["org_1", "cus_org"]]);
+    expect(report.targets[0]!.orgs[0]!.stripeActions).toContain("deleted Stripe customer cus_org");
   });
 
   it("skips a non-owner membership without calling any dep", async () => {

--- a/packages/cli/src/commands/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/ops-teardown-verify.ts
@@ -16,12 +16,14 @@
  * three SSOT functions the platform-admin purge uses:
  *   1. `purgeStripeBillingForWorkspace` — cancel subs + delete the Stripe
  *      customer (a torn-down account must leave no billable Stripe linkage).
- *      The org's `organization."stripeCustomerId"` AND the user's
- *      `user.stripeCustomerId` are both unioned into the delete set: the
- *      @better-auth/stripe plugin's `createCustomerOnSignUp` parks a customer
- *      on the USER row at signup, so a trial verify account's only `cus_…`
- *      lives there while the org column is null — passing only the org id would
- *      tear the workspace down but orphan that customer (#4011).
+ *      Only the org's `organization."stripeCustomerId"` is purged. Org-scoped
+ *      billing (#4014) stopped minting the user-level `createCustomerOnSignUp`
+ *      customer, and that `user.stripeCustomerId` column doesn't even exist in
+ *      the passive EU/APAC region DBs — the @better-auth/stripe plugin that adds
+ *      it is registered US-only (STRIPE_SECRET_KEY) — so selecting it crashed
+ *      the teardown against those regions (`column u.stripeCustomerId does not
+ *      exist`, #4019). The legacy user-level customer union (#4011) is removed
+ *      with it: there is no user-level `cus_…` left to orphan.
  *   2. `updateWorkspaceStatus(orgId, "deleted")` — the soft-delete precondition
  *      `hardDeleteWorkspace` enforces (it aborts unless the org is "deleted").
  *   3. `hardDeleteWorkspace` — the exhaustive GDPR-grade row purge, which also
@@ -223,16 +225,6 @@ export interface VerifyTarget {
   email: string;
   userId: string | null;
   found: boolean;
-  /**
-   * The customer id on the USER row (`user.stripeCustomerId`). The
-   * @better-auth/stripe plugin's `createCustomerOnSignUp` parks a customer here
-   * at signup before any org subscription exists, so for a trial verify account
-   * this is populated while every owned org's `stripeCustomerId` is null (#4011).
-   * Unioned into each *owned* org's Stripe purge; a user who owns no workspace
-   * (zero or only non-owner memberships) is surfaced as a manual-cleanup warning
-   * instead, since no purge can reach it.
-   */
-  userStripeCustomerId: string | null;
   orgs: VerifyOrg[];
 }
 
@@ -272,7 +264,6 @@ interface TargetRow extends Record<string, unknown> {
   userId: string;
   email: string;
   userName: string | null;
-  userStripeCustomerId: string | null;
   memberRole: string | null;
   orgId: string | null;
   orgName: string | null;
@@ -296,11 +287,16 @@ export async function resolveVerifyTargets(
   const targets: VerifyTarget[] = [];
   for (const email of emails) {
     const rows = await query<TargetRow>(
+      // NOTE: deliberately no `u."stripeCustomerId"` — that column is added by
+      // the @better-auth/stripe plugin's user-row field, which is registered
+      // US-only, so it doesn't exist in the EU/APAC region DBs and selecting it
+      // crashed the teardown there (#4019). Org-scoped billing (#4014) no longer
+      // mints a user-level customer anyway, so only `o."stripeCustomerId"` is
+      // purged.
       `SELECT
          u.id                  AS "userId",
          u.email               AS "email",
          u.name                AS "userName",
-         u."stripeCustomerId"  AS "userStripeCustomerId",
          m.role                AS "memberRole",
          o.id                  AS "orgId",
          o.name                AS "orgName",
@@ -316,12 +312,11 @@ export async function resolveVerifyTargets(
     );
 
     if (rows.length === 0) {
-      targets.push({ email, userId: null, found: false, userStripeCustomerId: null, orgs: [] });
+      targets.push({ email, userId: null, found: false, orgs: [] });
       continue;
     }
 
     const userId = rows[0]!.userId;
-    const userStripeCustomerId = rows[0]!.userStripeCustomerId;
     const orgs: VerifyOrg[] = [];
     for (const r of rows) {
       if (!r.orgId) continue; // user with no membership (LEFT JOIN null row)
@@ -335,7 +330,7 @@ export async function resolveVerifyTargets(
         isOwner: r.memberRole === "owner",
       });
     }
-    targets.push({ email, userId, found: true, userStripeCustomerId, orgs });
+    targets.push({ email, userId, found: true, orgs });
   }
   return targets;
 }
@@ -357,9 +352,6 @@ export interface TargetTeardownResult {
   email: string;
   userId: string | null;
   found: boolean;
-  /** The user-row Stripe customer unioned into the org purges (#4011) — surfaced
-   *  so a dry-run preview shows it will be deleted, not just the org-level id. */
-  userStripeCustomerId: string | null;
   orgs: OrgTeardownResult[];
   warnings: string[];
 }
@@ -376,12 +368,6 @@ export interface TeardownReport {
      *  warning (e.g. a customer that couldn't be deleted) — a non-clean
      *  outcome the handler exits non-zero on, even though the row purge ran. */
     stripeWarnings: number;
-    /** Users carrying a `user.stripeCustomerId` who own no workspace, so no
-     *  purge could reach it (#4011) — a live billable customer the run can't
-     *  delete. Counted so the handler exits non-zero rather than reporting a
-     *  clean teardown while an orphan `cus_…` survives (a scripted/CI cleanup
-     *  must fail loudly). The customer id is in the per-target warning. */
-    orphanedUserCustomers: number;
   };
 }
 
@@ -392,7 +378,6 @@ export interface TeardownDeps {
   purgeStripe: (
     orgId: string,
     stripeCustomerId: string | null,
-    extraCustomerIds: readonly string[],
   ) => Promise<StripeTeardownOutcome>;
   softDelete: (orgId: string) => Promise<boolean>;
   hardDelete: (orgId: string) => Promise<number>;
@@ -408,13 +393,10 @@ export interface TeardownDeps {
  * recorded and the run continues — one stuck account never strands the rest.
  * Non-owner memberships and orphan users become warnings, never deletions.
  *
- * The user's `user.stripeCustomerId` is unioned into each owned org's Stripe
- * purge (#4011): the @better-auth/stripe plugin's `createCustomerOnSignUp`
- * parks a customer on the user row at signup, so a trial verify account carries
- * a live `cus_…` there while every org column is null — passing only the org id
- * would tear the workspace down but orphan that customer. The purge de-dupes
- * and treats `resource_missing` as success, so attaching it to each owned org
- * (rather than guessing one) can't double-delete or strand it.
+ * Only the org's `stripeCustomerId` is purged. The legacy user-level customer
+ * union (#4011) is gone: org-scoped billing (#4014) stopped minting the
+ * `createCustomerOnSignUp` user customer, and the `user.stripeCustomerId` column
+ * doesn't exist in the passive EU/APAC region DBs at all (#4019).
  */
 export async function teardownTargets(
   targets: VerifyTarget[],
@@ -428,7 +410,6 @@ export async function teardownTargets(
     rowsPurged: 0,
     errors: 0,
     stripeWarnings: 0,
-    orphanedUserCustomers: 0,
   };
 
   for (const target of targets) {
@@ -442,22 +423,6 @@ export async function teardownTargets(
         `User ${target.email} (${target.userId}) has no workspace membership — ` +
           "orphan user row left untouched; remove it manually if it is a verification artifact.",
       );
-    }
-
-    // The user-level customer is unioned into the purge of every OWNED org (see
-    // the loop below). When the user owns NO workspace — whether they have zero
-    // memberships or only non-owner ones — no purge reaches it, so a live `cus_…`
-    // would be silently left behind (the exact #4011 orphaning, via a different
-    // topology). Warn loudly in that case rather than reporting a clean teardown.
-    const ownsAnyWorkspace = target.orgs.some((o) => o.isOwner);
-    if (target.found && target.userStripeCustomerId && !ownsAnyWorkspace) {
-      targetWarnings.push(
-        `User ${target.email} carries a Stripe customer ${target.userStripeCustomerId} but owns no ` +
-          "workspace to purge — delete it manually in the Stripe dashboard so it isn't orphaned.",
-      );
-      // Counted into totals so the handler exits non-zero: a surviving billable
-      // customer is a non-clean outcome a scripted/CI cleanup must not pass over.
-      totals.orphanedUserCustomers += 1;
     }
 
     for (const org of target.orgs) {
@@ -493,11 +458,7 @@ export async function teardownTargets(
       }
 
       try {
-        const stripe = await deps.purgeStripe(
-          org.orgId,
-          org.stripeCustomerId,
-          target.userStripeCustomerId ? [target.userStripeCustomerId] : [],
-        );
+        const stripe = await deps.purgeStripe(org.orgId, org.stripeCustomerId);
         // softDelete returns false when no row matched (e.g. the org was
         // concurrently reactivated/removed between resolve and execute). Surface
         // that as the cause rather than letting hardDelete throw the downstream
@@ -544,7 +505,6 @@ export async function teardownTargets(
       email: target.email,
       userId: target.userId,
       found: target.found,
-      userStripeCustomerId: target.userStripeCustomerId,
       orgs: orgResults,
       warnings: targetWarnings,
     });
@@ -562,17 +522,6 @@ export function printTeardownReport(report: TeardownReport): void {
 
   for (const target of report.targets) {
     console.log(`\n• ${target.email}${target.userId ? ` (user ${target.userId})` : ""}`);
-    if (target.userStripeCustomerId) {
-      // The customer is unioned into a purge only when the user owns a workspace;
-      // an owner-less user gets the manual-cleanup warning below instead, so the
-      // parenthetical must reflect which case this is (a "skipped-not-owner" or
-      // empty org list means no purge reached it).
-      const reached = target.orgs.some((o) => o.status !== "skipped-not-owner");
-      const note = reached
-        ? "(unioned into owned-org purge)"
-        : "(NOT reached by any purge — see warning below)";
-      console.log(`  user stripe customer: ${target.userStripeCustomerId} ${note}`);
-    }
     for (const w of target.warnings) console.log(`  ⚠ ${w}`);
     for (const org of target.orgs) {
       const tag = {
@@ -596,9 +545,6 @@ export function printTeardownReport(report: TeardownReport): void {
       `${report.dryRun ? t.orgsWouldTearDown : t.orgsTornDown} workspace(s)` +
       (report.dryRun ? "" : `, ${t.rowsPurged} rows purged`) +
       (t.stripeWarnings > 0 ? `, ${t.stripeWarnings} workspace(s) with Stripe warnings` : "") +
-      (t.orphanedUserCustomers > 0
-        ? `, ${t.orphanedUserCustomers} orphaned user-level Stripe customer(s) needing manual deletion`
-        : "") +
       (t.errors > 0 ? `, ${t.errors} error(s)` : ""),
   );
 }
@@ -672,19 +618,13 @@ export async function handleTeardownVerifyAccounts(args: string[]): Promise<void
     }, dryRun);
 
     printTeardownReport(report);
-    // Exit non-zero on a row-purge error, a left-behind Stripe linkage, OR an
-    // orphaned user-level customer that no purge could reach — a scripted
-    // cleanup must fail loudly rather than report a clean "success" while a
-    // billable Stripe customer survives. A failed customer-delete /
+    // Exit non-zero on a row-purge error OR a left-behind Stripe linkage — a
+    // scripted cleanup must fail loudly rather than report a clean "success"
+    // while a billable Stripe customer survives. A failed customer-delete /
     // subscription-cancel is enqueued in `stripe_teardown_pending` for durable
-    // retry; some warnings (a subscription-read or outbox-write failure, or an
-    // owner-less user-level customer) are manual-follow-up only — either way the
-    // operator/CI should know it didn't fully complete.
-    if (
-      report.totals.errors > 0 ||
-      report.totals.stripeWarnings > 0 ||
-      report.totals.orphanedUserCustomers > 0
-    ) {
+    // retry; a subscription-read or outbox-write warning is manual-follow-up
+    // only — either way the operator/CI should know it didn't fully complete.
+    if (report.totals.errors > 0 || report.totals.stripeWarnings > 0) {
       process.exitCode = 1;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

The EU/APAC prod region internal DBs were missing two tables the US DB has — the `@better-auth/stripe` `subscription` table (Better Auth creates it only where the stripe plugin is registered, which is **US-only** via `STRIPE_SECRET_KEY`) and `scim_group_mappings`. `hardDeleteWorkspace` (the GDPR-grade purge SSOT) DELETEs from both. The `subscription` deletes were already `to_regclass`-probed (tolerated), but the **`scim_group_mappings` DELETE was unconditional**, so in EU/APAC it threw `relation "scim_group_mappings" does not exist` and rolled the whole purge back — a workspace could be soft-deleted but never GDPR-purged. (Prod probe: `present=55/57 missing=[scim_group_mappings, subscription]`.)

- **New migration `0153`** creates both tables `IF NOT EXISTS` via the normal migration path (kept out of `MANAGED_AUTH_MIGRATIONS` — neither FKs a Better Auth table, so both run in every mode and `scim_group_mappings` keeps its baseline always-create behavior). The `subscription` DDL mirrors `@better-auth/stripe` v1.6.x's generated Postgres schema exactly (verified against the package source), so the US (BA-created) and EU/APAC (migration-created) tables converge. A Drizzle mirror is added to `schema.ts` for the drift checker.
- **`hardDeleteWorkspace` now `to_regclass`-probes the scim DELETE too** (mirrors the subscription probe) so any residual region drift skips that one table — and **logs** it (post-0153 the table should exist everywhere, so absence is anomalous) — instead of aborting the cascade.
- **`ops teardown-verify-accounts` CLI** drops the `user.stripeCustomerId` union: that column is absent in the passive EU/APAC region DBs (the stripe plugin that adds it is US-only) and is no longer minted post-#4014, so selecting it crashed the teardown against current prod. Org-scoped billing means only `organization."stripeCustomerId"` is purged now.

## Test plan
- [x] `migrate-pg.test.ts` — new region-parity assertion: after migrations run with `skip: MANAGED_AUTH_MIGRATIONS` (the passive-region shape, no BA-created `subscription`), `subscription` exists (uniquely 0153-locked) with the columns the purge reads.
- [x] `internal.test.ts` — new regression: `hardDeleteWorkspace` **completes** (no rollback) when `scim_group_mappings` is absent.
- [x] `reconcile-plan-tiers-pg.test.ts` — dropped its hand-built `subscription` fixture that now collides with 0153.
- [x] `migrate.test.ts` / `auth/migrate.test.ts` — count 154 + applied-lists updated.
- [x] `ops-teardown-verify.test.ts` — org-only purge path (no user-level union).
- [x] Internal review panel: CLEAN over 3 rounds. Local CI: lint, type, schema-drift + all drift/check scripts, syncpack, affected tests — green.

## Follow-up (operator action — needs the user)
The **3 EU/APAC verify orgs left soft-deleted** by the #4007 teardown run get their final purge once 0153 deploys and creates the tables. This is a destructive prod-DB operation against the live region DBs (`railway ssh --service api`), not done here:
- EU: `Atlas EU Verify` [`JgCggC3Hap1UXvZiu8SRvSVXOEUq5xh6`], `Atlas Multi EU` [`7zupvbINGs8FVvl7E24aJ8Vnx0q6wuZS`]
- APAC: `Atlas APAC Verify` [`2lfa0sIdoqkhVx2D6RrzpTMpQYHy5qOv`]

Closes #4019

https://claude.ai/code/session_01Qu3NZLYPwp3Bs3J5qJmJzG

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix region-DB parity for subscription and scim_group_mappings tables
> - Adds migration [0153_region_db_subscription_scim_parity.sql](https://github.com/AtlasDevHQ/atlas/pull/4024/files#diff-e1ad18de04108847892ad8e6198e9a93ee9b3bb1128d3aef3359bfbb04851681) that creates `subscription` and `scim_group_mappings` tables where they don't exist, ensuring schema parity across regions.
> - `hardDeleteWorkspace` in [internal.ts](https://github.com/AtlasDevHQ/atlas/pull/4024/files#diff-529cda9356c35645b01b8c05f4e2bac08aba6126b0369625803abe23644e8034) now probes for `scim_group_mappings` via `to_regclass` before deleting, skipping the DELETE with a warning if the table is absent rather than aborting the transaction.
> - `ops-teardown-verify` no longer queries `user.stripeCustomerId` (which doesn't exist in non-US regions) and removes user-level Stripe customer purging, reporting, and failure conditions entirely.
> - Behavioral Change: `teardownTargets` now purges only org-level Stripe customers; user-level customer orphan counts no longer appear in reports or trigger non-zero exit codes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 147c021.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->