### PR TITLE
feat(api): metered soft-cap + AbuseCeiling replacing the 110% hard block (WS2)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -77178,8 +77178,15 @@
                             "ok",
                             "warning",
                             "soft_limit",
+                            "metered",
                             "hard_limit"
                           ]
+                        },
+                        "overageTokens": {
+                          "type": "number"
+                        },
+                        "overageCost": {
+                          "type": "number"
                         },
                         "periodStart": {
                           "type": "string"

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -265,6 +265,79 @@ describe("billing routes", () => {
       expect(body.plan.trialDays).toBeNull();
     });
 
+    it("surfaces metered overage + accrued cost when over budget (#3990)", async () => {
+      // Starter: 2M/seat. 3 seats → 6M budget. Spend 7M (≈117%) — over budget
+      // but, with the ceiling disabled in this test's settings mock, metered
+      // (served + billed), never hard-blocked. 1M overage at $1.00/M = $1.00.
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 3 }]);
+        }
+        return Promise.resolve([]);
+      });
+      const meteringMod = await import("@atlas/api/lib/metering");
+      (meteringMod.getCurrentPeriodUsage as ReturnType<typeof mock>).mockImplementationOnce(() =>
+        Promise.resolve({ ...mockUsage, tokenCount: 7_000_000, weightedTokenCount: 7_000_000 }),
+      );
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.usage.tokenOverageStatus).toBe("metered");
+      expect(body.usage.overageTokens).toBe(1_000_000);
+      expect(body.usage.overageCost).toBeCloseTo(1.0, 6);
+    });
+
+    it("never reports overage for a BYOT workspace, even over budget (#3990)", async () => {
+      // BYOT bypasses token enforcement entirely, so the page must never show
+      // metered status or accrued overage for a BYOT workspace — "BYOT never
+      // accrues overage". Paid tier + byot, usage way over the 6M budget.
+      mockGetWorkspaceDetails.mockImplementation(() =>
+        Promise.resolve({ ...mockWorkspace, plan_tier: "starter", byot: true }),
+      );
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 3 }]);
+        }
+        return Promise.resolve([]);
+      });
+      const meteringMod = await import("@atlas/api/lib/metering");
+      (meteringMod.getCurrentPeriodUsage as ReturnType<typeof mock>).mockImplementationOnce(() =>
+        Promise.resolve({ ...mockUsage, tokenCount: 50_000_000, weightedTokenCount: 50_000_000 }),
+      );
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.plan.byot).toBe(true);
+      expect(body.usage.tokenOverageStatus).toBe("ok");
+      expect(body.usage.overageTokens).toBe(0);
+      expect(body.usage.overageCost).toBe(0);
+    });
+
+    it("reports zero overage when under budget (#3990)", async () => {
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 3 }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      // Default mockUsage (25k tokens) is far under the 6M budget.
+      expect(body.usage.tokenOverageStatus).toBe("ok");
+      expect(body.usage.overageTokens).toBe(0);
+      expect(body.usage.overageCost).toBe(0);
+    });
+
     it("computes trialEndsAtEffective from trial_ends_at for trial workspaces (#3434)", async () => {
       const trialEnds = "2026-06-20T00:00:00.000Z";
       mockGetWorkspaceDetails.mockImplementation(() =>

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -32,7 +32,7 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, getStripePlans, computeTokenBudget, isUnlimited, type PaidPlanTier } from "@atlas/api/lib/billing/plans";
-import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
+import { buildMetricStatus, resolveAbuseCeilingPercent, computeOverageTokens, computeOverageCost } from "@atlas/api/lib/billing/enforcement";
 import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import { effectiveTrialEndsAt } from "@atlas/api/lib/billing/trial-expiry";
 import { getSettingLive } from "@atlas/api/lib/settings";
@@ -374,14 +374,48 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     const totalTokenBudget = computeTokenBudget(workspace.plan_tier, seatCount);
     const tokenLimit = isUnlimited(totalTokenBudget) ? null : totalTokenBudget;
 
+    // Whether a real budget is enforced for this workspace. BYOT workspaces
+    // bypass token enforcement entirely (checkPlanLimits returns early before
+    // any usage evaluation), so they must NEVER show metered status or accrued
+    // overage on the page — "BYOT never accrues overage" (#3990). Treating BYOT
+    // like the unlimited case (null limit) keeps the page surface in lockstep
+    // with what enforcement actually charges: nothing.
+    const enforcesBudget = tokenLimit !== null && !workspace.byot;
+
     // The budget gauge denominates in output-equivalent (model-weighted)
     // tokens (#3989) — the SAME denominator enforcement uses — so the page's
     // usage percent can never diverge from the 429 the workspace actually hits.
     // `?? tokenCount` mirrors the enforcement consumer: if the weighted field is
     // ever absent, the gauge degrades to raw rather than showing a false 0%.
-    const tokenOverage = tokenLimit !== null
-      ? buildMetricStatus("tokens", usage.weightedTokenCount ?? usage.tokenCount, tokenLimit)
+    //
+    // Resolve the workspace's abuse ceiling so the page's `metered` vs
+    // `hard_limit` classification matches enforcement exactly (#3990), then
+    // surface the accrued overage so the UI can render "in overage, $X.XX so
+    // far". `overagePerMillionTokens` comes from the plan definition (0 ⇒ no
+    // billable overage ⇒ $0 cost even while metered).
+    const weightedUsage = usage.weightedTokenCount ?? usage.tokenCount;
+    const ceilingPercent = enforcesBudget
+      ? yield* Effect.promise(() => resolveAbuseCeilingPercent(orgId).catch((err) => {
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err), orgId },
+            "Failed to resolve abuse ceiling for billing page — using default classification",
+          );
+          return undefined;
+        }))
+      : null;
+    // Forward `undefined` (resolution failed → route `.catch` returned it) so
+    // buildMetricStatus falls to its conservative default-ceiling param,
+    // matching enforcement's own failure fallback (500). A resolved `null`
+    // (operator-disabled ceiling) is passed through verbatim to disable the
+    // cutoff on the page too — hence the explicit undefined-vs-null distinction
+    // rather than a `?? default` coalesce.
+    const tokenOverage = enforcesBudget && tokenLimit !== null
+      ? buildMetricStatus("tokens", weightedUsage, tokenLimit, ceilingPercent === undefined ? undefined : ceilingPercent)
       : { usagePercent: 0, status: "ok" as const };
+    const overageTokens = enforcesBudget && tokenLimit !== null ? computeOverageTokens(weightedUsage, tokenLimit) : 0;
+    const overageCost = enforcesBudget && tokenLimit !== null
+      ? computeOverageCost(weightedUsage, tokenLimit, plan.overagePerMillionTokens)
+      : 0;
 
     return c.json({
       workspaceId: orgId,
@@ -417,6 +451,8 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         seatCount,
         tokenUsagePercent: tokenOverage.usagePercent,
         tokenOverageStatus: tokenOverage.status,
+        overageTokens,
+        overageCost,
         periodStart: usage.periodStart,
         periodEnd: usage.periodEnd,
         periodSource: usage.periodSource,

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -155,6 +155,11 @@ let CHAT_INTEGRATION_COUNT_SQL: typeof import("@atlas/api/lib/billing/enforcemen
 let checkPlanLimits: typeof import("@atlas/api/lib/billing/enforcement").checkPlanLimits;
 let checkResourceLimit: typeof import("@atlas/api/lib/billing/enforcement").checkResourceLimit;
 let invalidatePlanCache: typeof import("@atlas/api/lib/billing/enforcement").invalidatePlanCache;
+let buildMetricStatus: typeof import("@atlas/api/lib/billing/enforcement").buildMetricStatus;
+let computeOverageTokens: typeof import("@atlas/api/lib/billing/enforcement").computeOverageTokens;
+let computeOverageCost: typeof import("@atlas/api/lib/billing/enforcement").computeOverageCost;
+let resolveAbuseCeilingPercent: typeof import("@atlas/api/lib/billing/enforcement").resolveAbuseCeilingPercent;
+let _resetSettingsCache: typeof import("@atlas/api/lib/settings")._resetSettingsCache;
 
 beforeAll(async () => {
   ({
@@ -164,7 +169,12 @@ beforeAll(async () => {
     checkPlanLimits,
     checkResourceLimit,
     invalidatePlanCache,
+    buildMetricStatus,
+    computeOverageTokens,
+    computeOverageCost,
+    resolveAbuseCeilingPercent,
   } = await import("@atlas/api/lib/billing/enforcement"));
+  ({ _resetSettingsCache } = await import("@atlas/api/lib/settings"));
 });
 
 /** Narrow a denied result for type-safe assertion access. */
@@ -350,11 +360,16 @@ describe("billing/enforcement", () => {
 
   // ── BYOT ──────────────────────────────────────────────────────────
 
-  it("allows BYOT workspaces unconditionally", async () => {
+  it("allows BYOT workspaces unconditionally — and NEVER accrues overage (#3990)", async () => {
+    // Paid tier + BYOT, usage massively over budget (far past any abuse
+    // ceiling). BYOT bypasses enforcement before any usage evaluation, so the
+    // request is allowed AND carries no overage warning — the "BYOT never
+    // accrues overage" acceptance criterion. A regression that attached a
+    // metered warning to BYOT would flip the warning assertion.
     mockWorkspace = makeWorkspace({ plan_tier: "starter", byot: true });
     mockUsage = { queryCount: 999_999, tokenCount: 999_999_999, activeUsers: 0, periodStart: "", periodEnd: "" };
-    const result = await checkPlanLimits("org-1", SEATS);
-    expect(result.allowed).toBe(true);
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    expect(result.warning).toBeUndefined();
   });
 
   // ── Trial tier ────────────────────────────────────────────────────
@@ -436,61 +451,149 @@ describe("billing/enforcement", () => {
     expect(tokenMetric!.usagePercent).toBe(95);
   });
 
-  // ── Starter tier — Soft limit (100-109%) ──────────────────────────
+  // ── Starter tier — Metered overage (100% → AbuseCeiling) (#3990) ──
+  // The 110% hard block is gone: usage past 100% is METERED (served, billed),
+  // not cut off, until the abuse ceiling (default 500%). Starter overage rate
+  // is $1.00 / 1M output-equivalent tokens.
 
-  it("allows with soft limit warning at 100% token usage", async () => {
+  it("meters (does not block) at exactly 100% token usage", async () => {
     mockWorkspace = makeWorkspace();
     mockUsage = { queryCount: 0, tokenCount: 2_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
     expect(result.warning).toBeDefined();
-    expect(result.warning!.message).toContain("grace period");
+    expect(result.warning!.message).toContain("exceeded");
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
-    expect(tokenMetric!.status).toBe("soft_limit");
+    expect(tokenMetric!.status).toBe("metered");
     expect(tokenMetric!.usagePercent).toBe(100);
+    // Exactly at budget → zero overage tokens → $0.00 so far.
+    expect(result.warning!.message).toContain("$0.00 so far");
   });
 
-  it("allows with soft limit warning at 105% token usage", async () => {
+  it("meters at 105% and surfaces the accrued overage cost", async () => {
     mockWorkspace = makeWorkspace();
-    // 105% of 2,000,000 = 2,100,000
+    // 105% of 2,000,000 = 2,100,000 → 100,000 tokens of overage.
+    // 100,000 / 1,000,000 * $1.00 = $0.10.
     mockUsage = { queryCount: 0, tokenCount: 2_100_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
     expect(result.warning).toBeDefined();
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
-    expect(tokenMetric!.status).toBe("soft_limit");
+    expect(tokenMetric!.status).toBe("metered");
+    expect(result.warning!.message).toContain("$0.10 so far");
   });
 
-  it("allows with soft limit at 109% token usage", async () => {
+  it("meters at 150% (well past the old 110% block) without cutting off", async () => {
     mockWorkspace = makeWorkspace();
-    // 109% of 2,000,000 = 2,180,000
+    // 150% of 2,000,000 = 3,000,000 → 1,000,000 overage → $1.00.
+    mockUsage = { queryCount: 0, tokenCount: 3_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric!.status).toBe("metered");
+    expect(result.warning!.message).toContain("$1.00 so far");
+  });
+
+  it("meters at 109% (the old grace-buffer top) instead of blocking", async () => {
+    mockWorkspace = makeWorkspace();
+    // 109% of 2,000,000 = 2,180,000.
     mockUsage = { queryCount: 0, tokenCount: 2_180_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
-    expect(result.warning).toBeDefined();
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
-    expect(tokenMetric!.status).toBe("soft_limit");
+    expect(tokenMetric!.status).toBe("metered");
   });
 
-  // ── Starter tier — Hard limit (110%+) ─────────────────────────────
+  // ── Starter tier — Abuse ceiling cutoff (≥ AbuseCeiling) (#3990) ──
+  // The hard 429 fires ONLY at the abuse ceiling (default 500% of budget),
+  // not at the old 110%.
 
-  it("blocks at 110% token usage", async () => {
+  it("does NOT block at 110% (the old hard-limit threshold)", async () => {
     mockWorkspace = makeWorkspace();
-    // 110% of 2,000,000 = 2,200,000
     mockUsage = { queryCount: 0, tokenCount: 2_200_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric!.status).toBe("metered");
+  });
+
+  it("blocks at the abuse ceiling (500% = 10,000,000 tokens) with 429", async () => {
+    mockWorkspace = makeWorkspace();
+    // 500% of 2,000,000 = 10,000,000 → at the default ceiling → cutoff.
+    mockUsage = { queryCount: 0, tokenCount: 10_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
     expect(exceeded.httpStatus).toBe(429);
-    expect(exceeded.errorMessage).toContain("token budget");
-    expect(exceeded.errorMessage).toContain("grace buffer");
-    expect(exceeded.usage.currentUsage).toBe(2_200_000);
+    expect(exceeded.errorMessage).toContain("ceiling");
+    expect(exceeded.usage.currentUsage).toBe(10_000_000);
     expect(exceeded.usage.limit).toBe(2_000_000);
     expect(exceeded.usage.metric).toBe("tokens");
   });
 
-  it("blocks at 150% token usage", async () => {
+  it("blocks above the abuse ceiling (600%) with 429", async () => {
     mockWorkspace = makeWorkspace();
-    // 150% of 2,000,000 = 3,000,000
-    mockUsage = { queryCount: 0, tokenCount: 3_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    // 600% of 2,000,000 = 12,000,000 → above ceiling → cutoff.
+    mockUsage = { queryCount: 0, tokenCount: 12_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
     expect(exceeded.httpStatus).toBe(429);
-    expect(exceeded.usage.metric).toBe("tokens");
+  });
+
+  it("just under the abuse ceiling (499%) still meters, not blocks", async () => {
+    mockWorkspace = makeWorkspace();
+    // 499% of 2,000,000 = 9,980,000 → just under ceiling → metered.
+    mockUsage = { queryCount: 0, tokenCount: 9_980_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric!.status).toBe("metered");
+  });
+
+  // ── Configurable ceiling end-to-end through checkPlanLimits (#3990) ──
+  // The above cases ride the registry default (500). These drive a NON-default
+  // ceiling and the disabled ceiling all the way through enforcement by setting
+  // ATLAS_ABUSE_CEILING in env (the settings module reads it through the mocked
+  // internalQuery → no override → env), with set/restore + cache reset so they
+  // stay self-contained.
+  async function withCeilingEnvE2E<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+    const prev = process.env.ATLAS_ABUSE_CEILING;
+    if (value === undefined) delete process.env.ATLAS_ABUSE_CEILING;
+    else process.env.ATLAS_ABUSE_CEILING = value;
+    _resetSettingsCache();
+    invalidatePlanCache();
+    try {
+      return await fn();
+    } finally {
+      if (prev === undefined) delete process.env.ATLAS_ABUSE_CEILING;
+      else process.env.ATLAS_ABUSE_CEILING = prev;
+      _resetSettingsCache();
+    }
+  }
+
+  it("blocks at a custom (lower) ceiling set via ATLAS_ABUSE_CEILING", async () => {
+    mockWorkspace = makeWorkspace({ id: "org-custom-ceiling" });
+    // Custom ceiling 200%. 200% of 2M = 4M → at the custom ceiling → cutoff,
+    // even though it's far under the default 500% (10M).
+    mockUsage = { queryCount: 0, tokenCount: 4_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    await withCeilingEnvE2E("200", async () => {
+      const exceeded = expectLimitExceeded(await checkPlanLimits("org-custom-ceiling", SEATS));
+      expect(exceeded.httpStatus).toBe(429);
+    });
+  });
+
+  it("meters just under a custom ceiling set via ATLAS_ABUSE_CEILING", async () => {
+    mockWorkspace = makeWorkspace({ id: "org-custom-ceiling-2" });
+    // Custom ceiling 200%. 150% (3M) is under it → metered, not blocked.
+    mockUsage = { queryCount: 0, tokenCount: 3_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    await withCeilingEnvE2E("200", async () => {
+      const result = expectAllowed(await checkPlanLimits("org-custom-ceiling-2", SEATS));
+      const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+      expect(tokenMetric!.status).toBe("metered");
+    });
+  });
+
+  it("never blocks at extreme usage when the ceiling is disabled (0) — pure metering", async () => {
+    mockWorkspace = makeWorkspace({ id: "org-disabled-ceiling" });
+    // 2000% of budget (40M) with the ceiling disabled → still metered, never a
+    // 429. Proves the disabled-ceiling pure-metering path end-to-end.
+    mockUsage = { queryCount: 0, tokenCount: 40_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    await withCeilingEnvE2E("0", async () => {
+      const result = expectAllowed(await checkPlanLimits("org-disabled-ceiling", SEATS));
+      const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+      expect(tokenMetric!.status).toBe("metered");
+    });
   });
 
   // ── Output-equivalent (model-weighted) denomination (#3989) ───────
@@ -499,11 +602,30 @@ describe("billing/enforcement", () => {
   // `tokenCount` — so reverting enforcement.ts back to `usage.tokenCount`
   // would flip every assertion here. Starter budget = 2M (1 seat).
 
-  it("blocks when WEIGHTED usage exceeds the hard limit even though RAW usage is under budget", async () => {
-    mockWorkspace = makeWorkspace(); // starter: 2M/seat, hard limit 110% = 2.2M
+  it("blocks when WEIGHTED usage reaches the abuse ceiling even though RAW usage is under budget", async () => {
+    mockWorkspace = makeWorkspace(); // starter: 2M/seat, ceiling 500% = 10M
     // Raw usage 1.5M (75%, well under budget) but a pricier model weighted it
-    // up to 2.3M (115%, over the hard limit). Enforcement must block on the
+    // up to 10M (500%, at the abuse ceiling). Enforcement must block on the
     // weighted figure — if it read raw, this would be allowed with no warning.
+    mockUsage = {
+      queryCount: 0,
+      tokenCount: 1_500_000,
+      weightedTokenCount: 10_000_000,
+      activeUsers: 0,
+      periodStart: "",
+      periodEnd: "",
+    };
+    const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
+    expect(exceeded.httpStatus).toBe(429);
+    // The reported usage is the WEIGHTED count, not the raw 1.5M.
+    expect(exceeded.usage.currentUsage).toBe(10_000_000);
+    expect(exceeded.usage.limit).toBe(2_000_000);
+  });
+
+  it("meters on WEIGHTED usage in the 100%→ceiling band even though RAW usage is under budget", async () => {
+    mockWorkspace = makeWorkspace(); // starter: 2M/seat
+    // Raw 1.5M (75%) but weighted up to 2.3M (115%) — over budget but well
+    // under the 500% ceiling, so metered (served + billed), not blocked.
     mockUsage = {
       queryCount: 0,
       tokenCount: 1_500_000,
@@ -512,18 +634,17 @@ describe("billing/enforcement", () => {
       periodStart: "",
       periodEnd: "",
     };
-    const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
-    expect(exceeded.httpStatus).toBe(429);
-    // The reported usage is the WEIGHTED count, not the raw 1.5M.
-    expect(exceeded.usage.currentUsage).toBe(2_300_000);
-    expect(exceeded.usage.limit).toBe(2_000_000);
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric!.status).toBe("metered");
+    expect(tokenMetric!.currentUsage).toBe(2_300_000);
   });
 
-  it("allows when WEIGHTED usage is under budget even though RAW usage is over the hard limit", async () => {
+  it("allows when WEIGHTED usage is under budget even though RAW usage is over the old hard limit", async () => {
     mockWorkspace = makeWorkspace(); // starter: 2M/seat
-    // Raw usage 2.4M (120%, would hard-block on raw) but a cheap model (e.g.
-    // Haiku) weighted it down to 800k (40%). Enforcement must allow on the
-    // weighted figure with no warning — proving it does not read raw.
+    // Raw usage 2.4M (120%, would hard-block on raw under the OLD rule) but a
+    // cheap model (e.g. Haiku) weighted it down to 800k (40%). Enforcement must
+    // allow on the weighted figure with no warning — proving it does not read raw.
     mockUsage = {
       queryCount: 0,
       tokenCount: 2_400_000,
@@ -540,12 +661,12 @@ describe("billing/enforcement", () => {
     mockWorkspace = makeWorkspace();
     // No `weightedTokenCount` on the usage shape (e.g. an older code path). The
     // `?? tokenCount` fallback denominates on raw rather than treating usage as
-    // an unenforced zero. 2.2M raw = 110% → hard block.
+    // an unenforced zero. 10M raw = 500% = abuse ceiling → hard block.
     mockOmitWeighted = true;
-    mockUsage = { queryCount: 0, tokenCount: 2_200_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    mockUsage = { queryCount: 0, tokenCount: 10_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const exceeded = expectLimitExceeded(await checkPlanLimits("org-1", SEATS));
     expect(exceeded.httpStatus).toBe(429);
-    expect(exceeded.usage.currentUsage).toBe(2_200_000);
+    expect(exceeded.usage.currentUsage).toBe(10_000_000);
   });
 
   // ── Per-seat scaling ──────────────────────────────────────────────
@@ -591,11 +712,24 @@ describe("billing/enforcement", () => {
 
   // ── Trial tier — usage limits ────────────────────────────────────
 
-  it("blocks trial tier at hard limit", async () => {
+  it("meters trial tier in the 100%→ceiling band (no overage cost — trial rate is $0)", async () => {
     const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
     mockWorkspace = makeWorkspace({ plan_tier: "trial", trial_ends_at: futureDate, createdAt: new Date().toISOString() });
-    // Trial = starter limits (2M/seat). 110% of 2M = 2.2M
+    // Trial = starter limits (2M/seat). 110% of 2M = 2.2M — over budget but well
+    // under the 500% ceiling → metered. Trial overagePerMillionTokens is 0, so
+    // no "$X.XX so far" cost line is appended.
     mockUsage = { queryCount: 0, tokenCount: 2_200_000, activeUsers: 0, periodStart: "", periodEnd: "" };
+    const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
+    const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric!.status).toBe("metered");
+    expect(result.warning!.message).not.toContain("$");
+  });
+
+  it("blocks trial tier at the abuse ceiling (500% = 10M) with 429", async () => {
+    const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    mockWorkspace = makeWorkspace({ plan_tier: "trial", trial_ends_at: futureDate, createdAt: new Date().toISOString() });
+    // 500% of 2M = 10M → abuse ceiling cutoff.
+    mockUsage = { queryCount: 0, tokenCount: 10_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const denied = expectDenied(await checkPlanLimits("org-1", SEATS));
     expect(denied.errorCode).toBe("plan_limit_exceeded");
     expect(denied.httpStatus).toBe(429);
@@ -737,6 +871,146 @@ describe("billing/enforcement", () => {
     expect(mockWorkspaceReadCount).toBe(3);
     await checkPlanLimits("org-2", SEATS);
     expect(mockWorkspaceReadCount).toBe(3);
+  });
+});
+
+// ===========================================================================
+// Metered soft-cap classification + overage accounting (#3990)
+//
+// Unit tests on the pure helpers — `buildMetricStatus` takes the abuse-ceiling
+// percent directly, so the metered/hard_limit boundary and the disabled-ceiling
+// (pure-metering) case are exercised without going through the settings read.
+// ===========================================================================
+
+describe("buildMetricStatus — metered soft-cap classification (#3990)", () => {
+  const LIMIT = 2_000_000; // starter, 1 seat
+
+  it("classifies under 80% as ok", () => {
+    expect(buildMetricStatus("tokens", 1_000_000, LIMIT, 500).status).toBe("ok");
+  });
+
+  it("classifies 80-99% as warning", () => {
+    expect(buildMetricStatus("tokens", 1_700_000, LIMIT, 500).status).toBe("warning");
+    expect(buildMetricStatus("tokens", 1_980_000, LIMIT, 500).status).toBe("warning");
+  });
+
+  it("classifies exactly 100% as metered", () => {
+    expect(buildMetricStatus("tokens", 2_000_000, LIMIT, 500).status).toBe("metered");
+  });
+
+  it("classifies the 100%→ceiling band as metered (110%, 150%, 499%)", () => {
+    expect(buildMetricStatus("tokens", 2_200_000, LIMIT, 500).status).toBe("metered"); // 110%
+    expect(buildMetricStatus("tokens", 3_000_000, LIMIT, 500).status).toBe("metered"); // 150%
+    expect(buildMetricStatus("tokens", 9_980_000, LIMIT, 500).status).toBe("metered"); // 499%
+  });
+
+  it("classifies at/above the ceiling as hard_limit", () => {
+    expect(buildMetricStatus("tokens", 10_000_000, LIMIT, 500).status).toBe("hard_limit"); // 500%
+    expect(buildMetricStatus("tokens", 12_000_000, LIMIT, 500).status).toBe("hard_limit"); // 600%
+  });
+
+  it("honours a custom (lower) ceiling", () => {
+    // Ceiling 200%: 150% meters, 200% cuts off.
+    expect(buildMetricStatus("tokens", 3_000_000, LIMIT, 200).status).toBe("metered"); // 150%
+    expect(buildMetricStatus("tokens", 4_000_000, LIMIT, 200).status).toBe("hard_limit"); // 200%
+  });
+
+  it("never hard-limits when the ceiling is disabled (null) — pure metering", () => {
+    // Even at 1000% of budget, a disabled ceiling keeps the status metered.
+    expect(buildMetricStatus("tokens", 20_000_000, LIMIT, null).status).toBe("metered");
+  });
+
+  it("defaults to the conservative ceiling when none is passed", () => {
+    // Default param = 500%. 499% meters, 500% cuts off.
+    expect(buildMetricStatus("tokens", 9_980_000, LIMIT).status).toBe("metered");
+    expect(buildMetricStatus("tokens", 10_000_000, LIMIT).status).toBe("hard_limit");
+  });
+
+  it("treats an invalid (<=0) limit as hard_limit regardless of ceiling", () => {
+    expect(buildMetricStatus("tokens", 100, 0, 500).status).toBe("hard_limit");
+    expect(buildMetricStatus("tokens", 100, 0, null).status).toBe("hard_limit");
+  });
+});
+
+describe("computeOverageTokens / computeOverageCost (#3990)", () => {
+  it("reports zero overage at or under budget", () => {
+    expect(computeOverageTokens(1_000_000, 2_000_000)).toBe(0);
+    expect(computeOverageTokens(2_000_000, 2_000_000)).toBe(0);
+  });
+
+  it("reports the excess over budget as overage tokens", () => {
+    expect(computeOverageTokens(2_100_000, 2_000_000)).toBe(100_000);
+    expect(computeOverageTokens(3_000_000, 2_000_000)).toBe(1_000_000);
+  });
+
+  it("computes cost as (overageTokens / 1M) * rate", () => {
+    // 100k overage at $1.00/M = $0.10
+    expect(computeOverageCost(2_100_000, 2_000_000, 1.0)).toBeCloseTo(0.1, 6);
+    // 1M overage at $1.00/M = $1.00
+    expect(computeOverageCost(3_000_000, 2_000_000, 1.0)).toBeCloseTo(1.0, 6);
+  });
+
+  it("is zero when the plan has no overage rate (e.g. trial)", () => {
+    expect(computeOverageCost(3_000_000, 2_000_000, 0)).toBe(0);
+  });
+
+  it("is zero (never negative) when under budget", () => {
+    expect(computeOverageCost(1_000_000, 2_000_000, 1.0)).toBe(0);
+  });
+
+  it("guards an invalid (<=0) limit — no overage from a misconfigured budget", () => {
+    expect(computeOverageTokens(1_000_000, 0)).toBe(0);
+    expect(computeOverageCost(1_000_000, 0, 1.0)).toBe(0);
+  });
+});
+
+describe("resolveAbuseCeilingPercent — settings parsing (#3990)", () => {
+  // The setting resolves through the REAL settings module (internalQuery is
+  // mocked to return no rows, so reads fall to the env var → registry default).
+  // Each case sets ATLAS_ABUSE_CEILING in env, clears the settings live cache,
+  // then restores env — self-contained, no top-level env mutation.
+  async function withCeilingEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+    const prev = process.env.ATLAS_ABUSE_CEILING;
+    if (value === undefined) delete process.env.ATLAS_ABUSE_CEILING;
+    else process.env.ATLAS_ABUSE_CEILING = value;
+    _resetSettingsCache();
+    try {
+      return await fn();
+    } finally {
+      if (prev === undefined) delete process.env.ATLAS_ABUSE_CEILING;
+      else process.env.ATLAS_ABUSE_CEILING = prev;
+      _resetSettingsCache();
+    }
+  }
+
+  it("returns the registry default (500) when unset", async () => {
+    const ceiling = await withCeilingEnv(undefined, () => resolveAbuseCeilingPercent("org-ceiling-default"));
+    expect(ceiling).toBe(500);
+  });
+
+  it("returns a custom numeric ceiling", async () => {
+    const ceiling = await withCeilingEnv("250", () => resolveAbuseCeilingPercent("org-ceiling-custom"));
+    expect(ceiling).toBe(250);
+  });
+
+  it("returns null (disabled) for '0'", async () => {
+    const ceiling = await withCeilingEnv("0", () => resolveAbuseCeilingPercent("org-ceiling-zero"));
+    expect(ceiling).toBeNull();
+  });
+
+  it("returns null (disabled) for an empty/whitespace value", async () => {
+    const ceiling = await withCeilingEnv("  ", () => resolveAbuseCeilingPercent("org-ceiling-blank"));
+    expect(ceiling).toBeNull();
+  });
+
+  it("floors a self-defeating ceiling (<=100%) at the default", async () => {
+    const ceiling = await withCeilingEnv("90", () => resolveAbuseCeilingPercent("org-ceiling-low"));
+    expect(ceiling).toBe(500);
+  });
+
+  it("falls back to the default for a non-numeric value", async () => {
+    const ceiling = await withCeilingEnv("not-a-number", () => resolveAbuseCeilingPercent("org-ceiling-garbage"));
+    expect(ceiling).toBe(500);
   });
 });
 

--- a/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/seat-count-parity.test.ts
@@ -43,9 +43,12 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     end: mock(() => {}),
     on: mock(() => {}),
   }),
-  // Both the seat-count query (member COUNT) and any other internalQuery
-  // consumer route through here; the parity test only triggers the seat-count
-  // path, so returning the member rows is sufficient.
+  // Both the seat-count query (member COUNT) and the settings-load query
+  // (checkPlanLimits → resolveAbuseCeilingPercent → getSettingLive →
+  // loadSettings) route through here. Returning the member rows is sufficient:
+  // loadSettings maps a `{count}` row to a `key: undefined` cache entry, so the
+  // ATLAS_ABUSE_CEILING lookup finds no override and falls to the registry
+  // default (500) — exactly the ceiling the 100M/110M math below assumes.
   internalQuery: async () => mockSeatRows,
   internalExecute: () => {},
   updateWorkspacePlanTier: async () => true,
@@ -131,9 +134,10 @@ describe("token budget parity across surfaces (#3430)", () => {
   });
 
   it("enforcement uses the same member-derived budget as the pages", async () => {
-    // Usage just under the 10-seat hard limit (110% of 20M = 22M) but FAR over
-    // the old 1-seat budget's hard limit (110% of 2M = 2.2M). If enforcement
-    // were still keyed off a smaller seat count, this would 429.
+    // 19M = 95% of the 10-seat budget (20M) → a warning, allowed. The point is
+    // that it's read against the 10-seat budget at all: 19M is 950% of the
+    // 1-seat budget (2M), which under the 500% abuse ceiling would be a hard
+    // 429 if enforcement had collapsed to a smaller seat count.
     mockUsage.tokenCount = 19_000_000;
 
     const result = await checkPlanLimits("org-1"); // seatCount omitted → shared source
@@ -144,14 +148,35 @@ describe("token budget parity across surfaces (#3430)", () => {
     expect(pageLimit).toBe(TEN_SEAT_BUDGET);
   });
 
-  it("blocks only when usage exceeds the member-derived budget, not the 1-seat budget", async () => {
-    // Over the 10-seat hard limit (> 22M).
-    mockUsage.tokenCount = 23_000_000;
+  it("meters past the member-derived budget without collapsing to the 1-seat budget (#3990)", async () => {
+    // 30M usage = 150% of the 10-seat budget (20M) — over budget, so metered
+    // (served + billed), NOT blocked. Crucially it is also 1500% of the 1-seat
+    // budget (2M), which under the default 500% ceiling WOULD have been a hard
+    // cutoff if enforcement had collapsed to 1 seat. That it's merely metered
+    // proves the threshold keys off the 10-seat budget.
+    mockUsage.tokenCount = 30_000_000;
+
+    const result = await checkPlanLimits("org-1");
+    expect(result.allowed).toBe(true);
+    if (!result.allowed) {
+      throw new Error(`expected metered allow, got ${JSON.stringify(result)}`);
+    }
+    const tokenMetric = result.warning?.metrics.find((m) => m.metric === "tokens");
+    expect(tokenMetric?.status).toBe("metered");
+    // The reported limit is the full 10-seat budget, not the collapsed 1-seat one.
+    expect(tokenMetric?.limit).toBe(TEN_SEAT_BUDGET);
+    expect(tokenMetric?.limit).not.toBe(ONE_SEAT_BUDGET);
+  });
+
+  it("blocks at the member-derived abuse ceiling, not the 1-seat ceiling (#3990)", async () => {
+    // Abuse ceiling = 500% of budget. 10-seat budget 20M → ceiling 100M;
+    // 1-seat budget 2M → ceiling 10M. 110M usage clears the 10-seat ceiling and
+    // hard-blocks; the reported limit proves it's the 10-seat budget.
+    mockUsage.tokenCount = 110_000_000;
 
     const result = await checkPlanLimits("org-1");
     expect(result.allowed).toBe(false);
     if (!result.allowed && result.errorCode === "plan_limit_exceeded") {
-      // The reported limit is the full 10-seat budget, not the collapsed 1-seat one.
       expect(result.usage.limit).toBe(TEN_SEAT_BUDGET);
       expect(result.usage.limit).not.toBe(ONE_SEAT_BUDGET);
     } else {

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -1,5 +1,5 @@
 /**
- * Plan limit enforcement with graceful degradation.
+ * Plan limit enforcement with a metered soft-cap.
  *
  * Called before agent execution in chat and query routes.
  * Returns { allowed: true } (with optional warning) when the request
@@ -7,12 +7,18 @@
  *
  * Token budgets are per-seat: total budget = tokenBudgetPerSeat * seatCount.
  *
- * Degradation tiers:
+ * Metered soft-cap tiers (#3990 — replaces the old 110% hard block):
  * - **OK (0-79%):** No warning, request proceeds normally.
  * - **Warning (80-99%):** Request proceeds, warning metadata attached.
- * - **Soft limit (100-109%):** 10% grace buffer. Request proceeds with
- *   overage warning. Structured log emitted.
- * - **Hard limit (110%+):** Request blocked with 429, upgrade CTA.
+ * - **Metered (100% → AbuseCeiling):** Request proceeds and every token past
+ *   100% accrues billable overage at the plan's `overagePerMillionTokens`
+ *   rate. A warning carrying the accrued "in overage, $X.XX so far" surface is
+ *   attached. This is the heart of the metered soft-cap: a paying workspace is
+ *   metered, not cut off, for ordinary overage.
+ * - **Hard limit (≥ AbuseCeiling):** the ABUSE ceiling, not the budget limit.
+ *   A configurable, conservative multiple of the budget (default 500% via the
+ *   `ATLAS_ABUSE_CEILING` settings knob) that bounds runaway / abusive spend.
+ *   Requests are blocked with 429 here and ONLY here.
  *
  * Enforcement is skipped entirely when:
  * - No internal DB is configured (self-hosted without managed auth)
@@ -31,8 +37,9 @@ import {
   type WorkspaceRow,
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
+import { getSettingLive } from "@atlas/api/lib/settings";
 import { getSeatCount, SeatCountUnavailableError } from "./seat-count";
-import { computeTokenBudget, getPlanLimits, isUnlimited, TRIAL_DAYS } from "./plans";
+import { computeTokenBudget, getPlanDefinition, getPlanLimits, isUnlimited, TRIAL_DAYS } from "./plans";
 import type { OverageStatus, PlanLimitStatus } from "@useatlas/types";
 
 const log = createLogger("billing:enforcement");
@@ -44,8 +51,82 @@ const log = createLogger("billing:enforcement");
 /** Usage percent at which a warning is included in the response. */
 const WARNING_THRESHOLD = 80;
 
-/** Usage percent at which the hard block kicks in (grace buffer ends). */
-const HARD_LIMIT_THRESHOLD = 110;
+/** Usage percent at which billable overage begins to accrue (metered band). */
+const METERED_THRESHOLD = 100;
+
+/**
+ * Settings key for the abuse ceiling — the metered soft-cap cutoff, expressed
+ * as a percent of the plan budget. See the registry entry in `lib/settings.ts`.
+ */
+const ABUSE_CEILING_KEY = "ATLAS_ABUSE_CEILING";
+
+/**
+ * Conservative fallback abuse ceiling (percent of budget) when the setting is
+ * unreadable or malformed. Mirrors the registry default (500% = 5× budget):
+ * high enough that ordinary metered overage never trips it, low enough to cap
+ * runaway / abusive spend at a bounded multiple of the plan budget. Used only
+ * as the in-code belt — the registry default is the real source.
+ */
+const DEFAULT_ABUSE_CEILING_PERCENT = 500;
+
+/**
+ * Resolve the abuse ceiling (percent of plan budget) for a workspace.
+ *
+ * Read live (per request, hot-reloadable) from the workspace-scoped
+ * `ATLAS_ABUSE_CEILING` setting so an operator can lift it for a known heavy
+ * customer without a redeploy. Returns `null` when the ceiling is DISABLED
+ * (value 0 or empty) — pure metering with no cutoff — and the conservative
+ * {@link DEFAULT_ABUSE_CEILING_PERCENT} when the value is unreadable or
+ * non-numeric (fail-safe: a typo must not silently remove the abuse cap).
+ *
+ * The ceiling is clamped to be strictly above the metered threshold: a value
+ * at or below 100% would make EVERY overage an instant hard block, re-creating
+ * the very behaviour #3990 removes, so such a misconfiguration is floored at
+ * the default rather than honoured.
+ */
+export async function resolveAbuseCeilingPercent(orgId: string): Promise<number | null> {
+  let raw: string | undefined;
+  try {
+    raw = await getSettingLive(ABUSE_CEILING_KEY, orgId);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to read abuse-ceiling setting — falling back to conservative default",
+    );
+    return DEFAULT_ABUSE_CEILING_PERCENT;
+  }
+
+  const trimmed = raw?.trim() ?? "";
+  // Empty → explicit disable (no cutoff, pure metering).
+  if (trimmed === "") return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    log.warn(
+      { orgId, value: raw },
+      "Abuse-ceiling setting is not a non-negative number — using conservative default",
+    );
+    return DEFAULT_ABUSE_CEILING_PERCENT;
+  }
+  // Numeric zero (any spelling: "0", "0.0", "00") → explicit disable. Owning
+  // every zero spelling in ONE post-parse branch keeps the security-relevant
+  // disable path single — a future "simplify" can't accidentally flip "0.0"
+  // from disabled to default.
+  if (parsed === 0) return null;
+
+  // A ceiling at or below the metered threshold would hard-block all overage,
+  // defeating the metered soft-cap. Floor it at the default rather than honour
+  // a self-defeating misconfiguration.
+  if (parsed <= METERED_THRESHOLD) {
+    log.warn(
+      { orgId, value: parsed, floor: DEFAULT_ABUSE_CEILING_PERCENT },
+      "Abuse-ceiling setting is at or below 100% (would block all overage) — flooring at default",
+    );
+    return DEFAULT_ABUSE_CEILING_PERCENT;
+  }
+
+  return parsed;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -277,6 +358,12 @@ export async function checkPlanLimits(
   const totalBudget = computeTokenBudget(tier, seatCount);
   if (!isUnlimited(totalBudget)) {
     try {
+      // Resolve the abuse ceiling (metered soft-cap cutoff) and the plan's
+      // overage rate up front so evaluateUsage can both decide the cutoff and
+      // surface the accrued overage cost. The ceiling is read live per request
+      // so an operator lift takes effect without a redeploy.
+      const ceilingPercent = await resolveAbuseCeilingPercent(orgId);
+      const overagePerMillion = getPlanDefinition(tier).overagePerMillionTokens;
       const usage = await getCurrentPeriodUsage(orgId);
       // Denominate the budget in output-equivalent tokens (#3989): a turn on a
       // pricier model consumes more of the budget per raw token, making the
@@ -287,7 +374,13 @@ export async function checkPlanLimits(
       // second belt: if a future shape change ever made the weighted field
       // arrive undefined, we denominate on raw rather than silently treating
       // usage as zero and never enforcing (a false-negative on the budget path).
-      return evaluateUsage(orgId, usage.weightedTokenCount ?? usage.tokenCount, totalBudget);
+      return evaluateUsage(
+        orgId,
+        usage.weightedTokenCount ?? usage.tokenCount,
+        totalBudget,
+        ceilingPercent,
+        overagePerMillion,
+      );
     } catch (err) {
       // DELIBERATE FAIL-OPEN (#3428): if we can't read usage, ALLOW the request
       // — metering is best-effort and we prioritise availability over revenue
@@ -324,19 +417,48 @@ export async function checkPlanLimits(
 }
 
 // ---------------------------------------------------------------------------
-// Usage evaluation (3-tier degradation)
+// Overage accounting (#3990)
+// ---------------------------------------------------------------------------
+
+/**
+ * Output-equivalent tokens consumed BEYOND the included budget. 0 when usage
+ * is at or under budget. Denominated in the SAME weighted tokens enforcement
+ * meters, so the dollar figure derived from it is the real billed amount.
+ */
+export function computeOverageTokens(currentUsage: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.max(0, currentUsage - limit);
+}
+
+/**
+ * Accrued billable overage cost in USD: `(overageTokens / 1e6) * rate`. 0 when
+ * not in overage or when the plan carries no overage rate. Never negative.
+ */
+export function computeOverageCost(
+  currentUsage: number,
+  limit: number,
+  overagePerMillionTokens: number,
+): number {
+  if (overagePerMillionTokens <= 0) return 0;
+  const overageTokens = computeOverageTokens(currentUsage, limit);
+  return (overageTokens / 1_000_000) * overagePerMillionTokens;
+}
+
+// ---------------------------------------------------------------------------
+// Usage evaluation (metered soft-cap: ok → warning → metered → ceiling cutoff)
 // ---------------------------------------------------------------------------
 
 function evaluateUsage(
   orgId: string,
   tokenCount: number,
   tokenBudget: number,
+  ceilingPercent: number | null,
+  overagePerMillionTokens: number,
 ): PlanCheckResult {
-  const metric = buildMetricStatus("tokens", tokenCount, tokenBudget);
+  const metric = buildMetricStatus("tokens", tokenCount, tokenBudget, ceilingPercent);
 
-  // Hard limit — block the request
+  // Hard limit — the abuse ceiling, not the budget. Block the request.
   if (metric.status === "hard_limit") {
-    const graceUsed = metric.usagePercent - 100;
     log.warn(
       {
         orgId,
@@ -344,19 +466,22 @@ function evaluateUsage(
         currentUsage: metric.currentUsage,
         limit: metric.limit,
         usagePercent: metric.usagePercent,
-        threshold: "hard_limit",
+        ceilingPercent,
+        threshold: "abuse_ceiling",
       },
-      "Workspace exceeded hard limit (%d%% of token budget) — blocking request",
+      "Workspace reached abuse ceiling (%d%% of token budget, ceiling %d%%) — blocking request",
       metric.usagePercent,
+      ceilingPercent ?? 0,
     );
     return {
       allowed: false,
       errorCode: "plan_limit_exceeded",
       errorMessage:
-        `You have exceeded your plan's token budget ` +
-        `(${metric.currentUsage.toLocaleString()} / ${metric.limit.toLocaleString()} tokens). ` +
-        `The 10% grace buffer has been used (${graceUsed.toFixed(0)}% over). ` +
-        `Upgrade your plan, add seats, or wait until the next billing period.`,
+        `You have reached your workspace's usage ceiling ` +
+        `(${metric.currentUsage.toLocaleString()} / ${metric.limit.toLocaleString()} tokens, ` +
+        `${metric.usagePercent}% of budget). ` +
+        `Requests are paused to prevent runaway spend. ` +
+        `Upgrade your plan, add seats, or contact support to raise the ceiling.`,
       httpStatus: 429,
       usage: {
         currentUsage: metric.currentUsage,
@@ -366,8 +491,34 @@ function evaluateUsage(
     };
   }
 
-  // Soft limit (100-109%) — allow with overage warning
-  if (metric.status === "soft_limit") {
+  // Metered (100% → ceiling) — allow, accruing billable overage.
+  if (metric.status === "metered") {
+    const overageCost = computeOverageCost(metric.currentUsage, metric.limit, overagePerMillionTokens);
+    const overageTokens = computeOverageTokens(metric.currentUsage, metric.limit);
+    // OPERATOR ALERT: a workspace metering past the would-be default ceiling
+    // WITH its abuse ceiling disabled (null) is accruing unbounded overage with
+    // no cutoff — exactly the runaway-loop / compromised-key case the ceiling
+    // exists to bound. Elevate to log.error (matching the #3428 fail-open alert
+    // pattern) so it's distinguishable from an ordinary 101% metered warning and
+    // an operator can scope the uncapped exposure. Capped-ceiling workspaces
+    // hard-block before reaching this depth, so this only fires for a
+    // deliberately-uncapped one.
+    if (ceilingPercent === null && metric.usagePercent >= DEFAULT_ABUSE_CEILING_PERCENT) {
+      log.error(
+        {
+          orgId,
+          metric: metric.metric,
+          currentUsage: metric.currentUsage,
+          limit: metric.limit,
+          usagePercent: metric.usagePercent,
+          overageTokens,
+          overageCost,
+          reason: "abuse_ceiling_disabled_extreme_overage",
+        },
+        "Workspace at %d%% of budget with abuse ceiling DISABLED — unbounded overage accruing, no cutoff (review ATLAS_ABUSE_CEILING)",
+        metric.usagePercent,
+      );
+    }
     log.warn(
       {
         orgId,
@@ -375,19 +526,27 @@ function evaluateUsage(
         currentUsage: metric.currentUsage,
         limit: metric.limit,
         usagePercent: metric.usagePercent,
-        threshold: "soft_limit",
+        overageTokens,
+        overageCost,
+        threshold: "metered",
       },
-      "Workspace in grace buffer (%d%% of token budget) — allowing with warning",
+      "Workspace in metered overage (%d%% of token budget, $%s so far) — allowing and billing overage",
       metric.usagePercent,
+      overageCost.toFixed(2),
     );
+    const costSuffix =
+      overagePerMillionTokens > 0
+        ? ` You are in overage: $${overageCost.toFixed(2)} so far this period.`
+        : "";
     return {
       allowed: true,
       warning: {
         code: "plan_limit_warning",
         message:
-          `You have exceeded your plan's token budget ` +
-          `(${metric.currentUsage.toLocaleString()} / ${metric.limit.toLocaleString()} tokens). ` +
-          `You are in a 10% grace period. Upgrade or add seats to avoid service interruption.`,
+          `You have exceeded your plan's included token budget ` +
+          `(${metric.currentUsage.toLocaleString()} / ${metric.limit.toLocaleString()} tokens).` +
+          costSuffix +
+          ` Upgrade or add seats to lower your per-token cost.`,
         metrics: [metric],
       },
     };
@@ -425,10 +584,22 @@ function evaluateUsage(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a per-metric usage status.
+ *
+ * `ceilingPercent` is the abuse-ceiling cutoff (percent of budget): usage at or
+ * above it classifies as `hard_limit` (429 cutoff), the 100%→ceiling band is
+ * `metered` (served + billed). When `null` (ceiling disabled) there is no
+ * cutoff — usage past 100% stays `metered` no matter how high. When omitted
+ * (billing-page / display callers that don't resolve the per-workspace
+ * setting) it defaults to the conservative {@link DEFAULT_ABUSE_CEILING_PERCENT}
+ * so a display surface and enforcement agree on the common case.
+ */
 export function buildMetricStatus(
   metric: "tokens",
   currentUsage: number,
   limit: number,
+  ceilingPercent: number | null = DEFAULT_ABUSE_CEILING_PERCENT,
 ): PlanLimitStatus {
   if (limit <= 0) {
     // Invalid limit (not the -1 unlimited sentinel, which is filtered upstream).
@@ -442,13 +613,27 @@ export function buildMetricStatus(
     currentUsage,
     limit,
     usagePercent,
-    status: classifyUsage(usagePercent),
+    status: classifyUsage(usagePercent, ceilingPercent),
   };
 }
 
-function classifyUsage(usagePercent: number): OverageStatus {
-  if (usagePercent >= HARD_LIMIT_THRESHOLD) return "hard_limit";
-  if (usagePercent >= 100) return "soft_limit";
+/**
+ * Classify usage into the metered soft-cap bands (#3990).
+ *
+ * - `>= ceilingPercent` → `hard_limit` (abuse ceiling cutoff). Skipped when
+ *   `ceilingPercent` is null (ceiling disabled — pure metering, no cutoff).
+ * - `>= 100%` → `metered` (over budget, served + billed).
+ * - `>= 80%` → `warning`.
+ * - otherwise `ok`.
+ *
+ * The ceiling is checked first so it always wins over `metered`. A non-positive
+ * ceiling is treated as disabled (defensive — `resolveAbuseCeilingPercent`
+ * already maps 0 → null, but guarding here means a ceiling of 0 can never
+ * classify EVERY usage, including 0%, as `hard_limit`).
+ */
+function classifyUsage(usagePercent: number, ceilingPercent: number | null): OverageStatus {
+  if (ceilingPercent !== null && ceilingPercent > 0 && usagePercent >= ceilingPercent) return "hard_limit";
+  if (usagePercent >= METERED_THRESHOLD) return "metered";
   if (usagePercent >= WARNING_THRESHOLD) return "warning";
   return "ok";
 }
@@ -456,8 +641,12 @@ function classifyUsage(usagePercent: number): OverageStatus {
 const SEVERITY_ORDER: Record<OverageStatus, number> = {
   ok: 0,
   warning: 1,
+  // `soft_limit` is retained in the wire union for back-compat; the current
+  // classifier never returns it, but ordering it between warning and metered
+  // keeps any legacy value sortable.
   soft_limit: 2,
-  hard_limit: 3,
+  metered: 3,
+  hard_limit: 4,
 };
 
 /** Exported for tests. */

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -770,6 +770,30 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     saasVisible: false,
   },
 
+  // Abuse ceiling (#3990) — the metered soft-cap cutoff. Usage past 100% of
+  // the included budget is METERED (served, accruing billable overage), NOT
+  // blocked; the hard 429 cutoff fires only at this ceiling, expressed as a
+  // percent of the plan budget. It bounds runaway / abusive spend, not normal
+  // paying overage. Workspace-scoped so an operator can lift it per tenant
+  // (e.g. a known heavy customer) from Admin → Settings without a redeploy;
+  // hot-reloadable (no requiresRestart — checkPlanLimits reads it live per
+  // request). Conservative default 500% = 5× the included budget: high enough
+  // that ordinary metered overage never trips it, low enough to cap a runaway
+  // loop or compromised key at a bounded multiple of the plan. 0 or empty
+  // disables the ceiling entirely (pure metering, no cutoff) — only set that
+  // for a trusted workspace.
+  {
+    key: "ATLAS_ABUSE_CEILING",
+    section: "Billing",
+    label: "Abuse Ceiling (% of budget)",
+    description:
+      "Hard cutoff for metered overage, as a percent of the plan's token budget (default 500 = 5× budget). Usage between 100% and this ceiling is served and billed as overage; at or above it, requests are blocked with a 429. 0 or empty disables the cutoff (pure metering).",
+    type: "number",
+    default: "500",
+    envVar: "ATLAS_ABUSE_CEILING",
+    scope: "workspace",
+  },
+
   // Stripe Billing — the six paid-tier price IDs (#3703). These are
   // NON-SECRET Stripe constants (the genuine secrets — STRIPE_SECRET_KEY,
   // STRIPE_WEBHOOK_SECRET — stay env-only and are never registry-backed).

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -5,7 +5,7 @@ import { PLAN_TIERS } from "@useatlas/types";
 // Mirrors the private `OVERAGE_STATUSES` tuple in ../billing — kept in sync
 // by the "canonical tuples match expected values" assertion below so a
 // reorder or addition fails loud.
-const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
+const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "metered", "hard_limit"] as const;
 
 const validStatus = {
   workspaceId: "org_1",
@@ -150,7 +150,7 @@ describe("enum strict rejection", () => {
   });
 
   test("canonical tuples match expected values", () => {
-    expect(OVERAGE_STATUSES).toEqual(["ok", "warning", "soft_limit", "hard_limit"]);
+    expect(OVERAGE_STATUSES).toEqual(["ok", "warning", "soft_limit", "metered", "hard_limit"]);
   });
 });
 

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -41,7 +41,7 @@
 import { z } from "zod";
 import { PLAN_TIERS, type PlanTier, type OverageStatus } from "@useatlas/types";
 
-const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
+const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "metered", "hard_limit"] as const;
 const OverageStatusEnum = z.enum(OVERAGE_STATUSES) satisfies z.ZodType<OverageStatus>;
 const PlanTierEnum = z.enum(PLAN_TIERS);
 
@@ -108,6 +108,24 @@ export interface BillingUsage {
   seatCount: number;
   tokenUsagePercent: number;
   tokenOverageStatus: OverageStatus;
+  /**
+   * #3990 — output-equivalent tokens consumed BEYOND the included budget this
+   * period (max(0, weighted usage − budget)). 0 when at or under the included
+   * budget; positive once usage exceeds it (i.e. within the `metered` /
+   * `hard_limit` bands — note it is still 0 at exactly 100%, where the status
+   * is already `metered`). Denominated in the SAME output-equivalent tokens
+   * enforcement meters, so the accrued cost below is the real one. Optional for
+   * older-bundle tolerance; absent ⇒ render as 0.
+   */
+  overageTokens?: number;
+  /**
+   * #3990 — accrued billable overage cost in USD this period, i.e.
+   * `(overageTokens / 1_000_000) * overagePerMillionTokens`. Drives the
+   * billing page's "in overage, $X.XX so far" surface. 0 when not in overage
+   * or when the plan has no overage rate (`overagePerMillionTokens === 0`).
+   * Optional for older-bundle tolerance; absent ⇒ render as 0.
+   */
+  overageCost?: number;
   periodStart: string;
   periodEnd: string;
   /**
@@ -225,6 +243,8 @@ export const BillingUsageSchema = z.object({
   seatCount: z.number(),
   tokenUsagePercent: z.number(),
   tokenOverageStatus: OverageStatusEnum,
+  overageTokens: z.number().optional(),
+  overageCost: z.number().optional(),
   periodStart: z.string(),
   periodEnd: z.string(),
   periodSource: z.enum(["stripe", "utc-month"]).optional(),

--- a/packages/types/src/billing.ts
+++ b/packages/types/src/billing.ts
@@ -2,8 +2,31 @@
 // Plan limit status — returned by enforcement and billing endpoints
 // ---------------------------------------------------------------------------
 
-/** Overage status levels for a workspace's usage against its plan limits. */
-export type OverageStatus = "ok" | "warning" | "soft_limit" | "hard_limit";
+/**
+ * Overage status levels for a workspace's usage against its plan limits.
+ *
+ * Metered soft-cap progression (#3990):
+ * - `ok` (0–79%): within budget, no signal.
+ * - `warning` (80–99%): approaching the included budget.
+ * - `metered` (100% → `AbuseCeiling`): over the included budget but still
+ *   served — every token past 100% accrues billable overage at the plan's
+ *   `overagePerMillionTokens` rate. The billing page surfaces the accrued
+ *   "in overage, $X.XX so far" figure. This REPLACES the old 110% hard block:
+ *   a paying workspace is metered, not cut off, for ordinary overage.
+ * - `hard_limit` (≥ `AbuseCeiling`): the abuse ceiling, NOT the budget limit.
+ *   A configurable, conservative multiple of the budget that bounds runaway /
+ *   abusive spend; the request is cut off with a 429 here and only here.
+ *
+ * `soft_limit` is retained in the union for wire/back-compat (older API or web
+ * bundles may still emit or parse it) but the current classifier never returns
+ * it — the 100%+ band is `metered`.
+ */
+export type OverageStatus =
+  | "ok"
+  | "warning"
+  | "soft_limit"
+  | "metered"
+  | "hard_limit";
 
 /**
  * Usage status for a single metered dimension (queries or tokens).

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -117,12 +117,21 @@ function overageColor(status: BillingStatus["usage"]["tokenOverageStatus"]): str
   switch (status) {
     case "hard_limit":
       return "text-destructive";
+    // #3990 — `metered` (over budget, accruing billable overage) shares the
+    // amber "still served, not cut off" treatment with the approaching-budget
+    // states; only `hard_limit` (the abuse ceiling) goes destructive.
     case "warning":
     case "soft_limit":
+    case "metered":
       return "text-amber-600 dark:text-amber-400";
     default:
       return "text-muted-foreground";
   }
+}
+
+/** Format an accrued overage cost as a "$X.XX" string. */
+function formatOverageCost(cost: number): string {
+  return `$${cost.toFixed(2)}`;
 }
 
 // Values are Vercel AI Gateway model IDs (slash+dot) — SaaS resolves
@@ -829,6 +838,18 @@ function UsageShell({ data }: { data: BillingStatus }) {
             value={Math.min(usage.tokenUsagePercent, 100)}
             className="h-1.5"
           />
+          {/* #3990 — metered overage surface. When the workspace is over its
+              included budget (metered) or at the abuse ceiling (hard_limit),
+              show the accrued billable overage so "in overage, $X.XX so far"
+              is visible. `overageCost` is server-computed from the same
+              weighted usage enforcement meters; absent on older bundles ⇒ 0. */}
+          {(usage.tokenOverageStatus === "metered" ||
+            usage.tokenOverageStatus === "hard_limit") &&
+            (usage.overageCost ?? 0) > 0 && (
+              <p className="text-[11px] font-medium text-amber-600 dark:text-amber-400">
+                In overage: {formatOverageCost(usage.overageCost ?? 0)} so far this period
+              </p>
+            )}
           {limits.tokenBudgetPerSeat !== null && (
             <p className="text-[11px] text-muted-foreground">
               {formatNumber(limits.tokenBudgetPerSeat)} tokens/seat ×{" "}


### PR DESCRIPTION
## Summary

Replaces the 110% hard block in usage evaluation with **metered soft-cap** semantics (#3990, builds on #3989 output-equivalent token denomination):

- **warn (~80–99%)** → **metered (100% → AbuseCeiling)** → **hard cutoff (≥ AbuseCeiling)**. Past 100% a paying workspace is *metered*, not cut off: every output-equivalent token over budget accrues billable overage at the plan's `overagePerMillionTokens` rate.
- New **`ATLAS_ABUSE_CEILING`** settings-registry knob (workspace-scoped, hot-reloadable, conservative **500% = 5× budget** default; `0`/empty disables the cutoff for a trusted workspace). It bounds runaway/abusive spend — the 429 fires here and only here. Fail-safe: an unreadable/malformed value floors at the default so a typo can't silently remove the abuse cap.
- `OverageStatus` gains **`metered`** (`soft_limit` retained for wire back-compat, never emitted). The billing page renders the metered state and an **"In overage: $X.XX so far this period"** surface; new wire fields `usage.overageTokens` / `usage.overageCost`.
- **BYOT/BYOK never accrues overage** — bypassed in enforcement (returns before any usage evaluation) *and* gated off on the billing-page surface (`enforcesBudget = tokenLimit !== null && !workspace.byot`), so the page can never show metered/overage for a BYOT workspace.
- Operator-visible `log.error` when a workspace meters past the default ceiling *with the ceiling disabled* (unbounded overage, no cutoff).

Denominates everything in the output-equivalent (model-weighted) tokens from #3989 — page and enforcement use the same denominator, so the page can't diverge from the actual 429 threshold.

## Test plan

- [x] `bun run lint` / `bun run type` — clean
- [x] Threshold transitions (79→80→100→ceiling) + ceiling cutoff (500%/600%, custom 200%, disabled-0 extreme) covered end-to-end via `checkPlanLimits` and at the `buildMetricStatus` unit level
- [x] `computeOverageTokens` / `computeOverageCost` (zero-rate trial, under-budget, invalid-limit) + `resolveAbuseCeilingPercent` parsing (default/custom/disabled/floor/garbage)
- [x] BYOT-never-accrues asserted on **both** surfaces (enforcement: no warning; billing route: ok/0/0 while over budget)
- [x] Internal review panel — 2 rounds, converged clean (round 1 flagged the BYOT page gap → fixed + tested)
- [x] OpenAPI spec regenerated (`apps/docs/openapi.json`); all drift/parity gates green
- [x] Full `bun run test` — billing suites green (2 unrelated pre-existing flakes: `admin-model-config` gateway-catalog 5s timeout, `teams-discord-always-mount` — both fail on clean base / pass in isolation)

Closes #3990

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace 110% hard block with metered soft-cap and configurable `AbuseCeiling` in billing enforcement
> - Requests between 100% and a configurable abuse ceiling (default 500% of budget) now return status `metered` instead of being blocked; requests are only hard-blocked at or above the ceiling.
> - Adds `resolveAbuseCeilingPercent` to read the per-workspace `ATLAS_ABUSE_CEILING` live setting, with 0/blank disabling the ceiling entirely.
> - Adds `computeOverageTokens` and `computeOverageCost` helpers and surfaces `overageTokens` and `overageCost` in `GET /api/v1/billing` responses.
> - The admin billing UI displays an accrued overage cost notice (amber styling) when status is `metered` or `hard_limit` and cost is positive.
> - BYOT workspaces are exempt from overage accounting and always return `ok` with zero overage.
> - Risk: workspaces previously blocked at 110% will now continue to accrue usage (and cost) up to 500% of their budget by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d6ea8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->