### PR TITLE
chore(testing): pricing-parity enforcement-leg drift guard (WS1/WS4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Adversarial fixtures for the pricing-parity gate (#3996)
         run: bash scripts/__tests__/check-pricing-parity.test.sh
 
+      - name: Check entitlement SSOT ↔ route-layer enforcement drift (#3997)
+        run: bash scripts/check-enforcement-parity.sh
+
+      - name: Adversarial fixtures for the enforcement-parity gate (#3997)
+        run: bash scripts/__tests__/check-enforcement-parity.test.sh
+
       - name: Check Drizzle schema ↔ migration drift
         run: bash scripts/check-schema-drift.sh
 

--- a/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the enforcement-leg parity check (WS1/WS4 of #3984 / #3997).
+ *
+ * This is the third leg of the pricing-parity guard: that every gated feature
+ * in the entitlement SSOT is actually consulted by a route-layer
+ * `requireFeatureEntitlement` gate (or explicitly recorded as not-yet-wired in
+ * ENFORCEMENT_PENDING). #3996 covered SSOT ↔ marketing-artifact; these assert
+ * the SSOT ↔ enforcement leg at the module boundary.
+ *
+ * The acceptance criterion — "fails on an injected mismatch; passes when
+ * aligned (unit test proves both)" — is met by feeding the pure
+ * `checkEnforcementParity` synthetic inputs: an aligned triple returns no
+ * findings; each class of drift returns the matching finding. The live wiring
+ * (the source scan + the committed pending allowlist agreeing with the real
+ * tree) is exercised separately by the adversarial fixture
+ * `scripts/__tests__/check-enforcement-parity.test.sh`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  FEATURE_ENTITLEMENTS,
+  type GatedFeature,
+} from "../feature-entitlement";
+import {
+  ENFORCEMENT_PENDING,
+  checkEnforcementParity,
+  extractEnforcedFeatures,
+  type EnforcementParityFinding,
+} from "../enforcement-parity";
+
+const ALL_FEATURES = Object.keys(FEATURE_ENTITLEMENTS) as GatedFeature[];
+
+// A small synthetic SSOT + pending pair, independent of the live maps, so the
+// pure-function tests pin behavior without coupling to the current wiring
+// snapshot (which shifts as WS1 gates land).
+const SSOT = { sso: "business", scim: "business", masking: "business" } as const;
+
+function kinds(findings: EnforcementParityFinding[]): string[] {
+  return findings.map((f) => `${f.kind}:${f.feature}`).sort();
+}
+
+describe("checkEnforcementParity — aligned (passes)", () => {
+  it("returns no findings when every SSOT feature is enforced or pending", () => {
+    const findings = checkEnforcementParity(
+      ["sso"], // enforced
+      SSOT,
+      { scim: "#x", masking: "#y" }, // pending covers the rest
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("returns no findings when every SSOT feature is enforced (empty pending)", () => {
+    const findings = checkEnforcementParity(
+      ["sso", "scim", "masking"],
+      SSOT,
+      {},
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("checkEnforcementParity — injected mismatch (fails)", () => {
+  it("flags a SSOT feature that is neither enforced nor pending (the open ladder)", () => {
+    // `masking` is sold tier-gated by the SSOT but has no gate and no pending
+    // entry — the exact regression the guard exists to catch.
+    const findings = checkEnforcementParity(["sso"], SSOT, { scim: "#x" });
+    expect(kinds(findings)).toEqual(["ungated:masking"]);
+    expect(findings[0].message).toContain("no route consults");
+  });
+
+  it("flags every ungated, unacknowledged feature", () => {
+    const findings = checkEnforcementParity(["sso"], SSOT, {});
+    expect(kinds(findings)).toEqual(["ungated:masking", "ungated:scim"]);
+  });
+
+  it("flags a feature that is enforced but still listed pending (stale-pending)", () => {
+    // `scim` got its gate wired but the allowlist wasn't pruned — forces the
+    // list to shrink as gates land.
+    const findings = checkEnforcementParity(
+      ["sso", "scim"],
+      SSOT,
+      { scim: "#x", masking: "#y" },
+    );
+    expect(kinds(findings)).toEqual(["stale-pending:scim"]);
+  });
+
+  it("flags a pending entry for a feature not in the SSOT (phantom-pending)", () => {
+    const findings = checkEnforcementParity(
+      ["sso", "scim", "masking"],
+      SSOT,
+      { ghost_feature: "#x" },
+    );
+    expect(kinds(findings)).toEqual(["phantom-pending:ghost_feature"]);
+  });
+
+  it("reports multiple distinct drifts at once", () => {
+    const findings = checkEnforcementParity(
+      ["sso", "scim"], // scim enforced
+      SSOT,
+      { scim: "#x", ghost: "#y" }, // scim stale, ghost phantom, masking ungated
+    );
+    expect(kinds(findings)).toEqual([
+      "phantom-pending:ghost",
+      "stale-pending:scim",
+      "ungated:masking",
+    ]);
+  });
+});
+
+describe("extractEnforcedFeatures — the source scan parser", () => {
+  it("extracts the feature id from a requireFeatureEntitlement call", () => {
+    const src = `yield* requireFeatureEntitlement(orgId, "sso");`;
+    expect([...extractEnforcedFeatures(src)]).toEqual(["sso"]);
+  });
+
+  it("dedupes repeated call sites and finds multiple features", () => {
+    const src = `
+      requireFeatureEntitlement(orgId, "sso");
+      requireFeatureEntitlement(a, 'scim');
+      requireFeatureEntitlement(orgId, "sso");
+    `;
+    expect([...extractEnforcedFeatures(src)].sort()).toEqual(["scim", "sso"]);
+  });
+
+  it("matches underscore feature ids (white_label, audit_retention, …)", () => {
+    // The SSOT keys include snake_case ids; pin that the [a-z_]+ char class
+    // actually captures them, so a future narrowing to [a-z]+ fails here
+    // directly rather than only surfacing via the live-tree test below.
+    const src = `requireFeatureEntitlement(orgId, "white_label");`;
+    expect([...extractEnforcedFeatures(src)]).toEqual(["white_label"]);
+  });
+
+  it("ignores non-matching text", () => {
+    const src = `const x = "sso"; // not a gate call`;
+    expect([...extractEnforcedFeatures(src)]).toEqual([]);
+  });
+});
+
+describe("ENFORCEMENT_PENDING + live SSOT — the committed allowlist is honest", () => {
+  it("only lists real SSOT features (no phantom entries against the live map)", () => {
+    // Independent of the source scan: every committed pending key must be a
+    // real GatedFeature. (The full live-tree parity is the fixture script's
+    // job; this catches a typo'd key in the allowlist on its own.)
+    for (const key of Object.keys(ENFORCEMENT_PENDING)) {
+      expect(ALL_FEATURES).toContain(key as GatedFeature);
+    }
+  });
+
+  it("the live SSOT ∪ enforced(sso) ∪ pending leaves no ungated feature", () => {
+    // Treat sso as the known-wired feature (its call sites are in admin-sso.ts)
+    // and assert the committed ENFORCEMENT_PENDING covers every other SSOT
+    // feature — i.e. the committed allowlist is complete *today*. This is the
+    // assertion that breaks the moment someone adds a feature to the SSOT
+    // without either gating it or recording it pending.
+    //
+    // EXTEND THIS LIST as gates land: when a feature's route gate ships (e.g.
+    // scim under #3987) and is removed from ENFORCEMENT_PENDING, add its id
+    // here — otherwise this test goes red (the feature reads as ungated). That
+    // coupling is deliberate: the unit test tracks the real wiring snapshot,
+    // and the live-tree fixture (check-enforcement-parity.test.sh) covers the
+    // actual route scan.
+    const enforcedToday = ["sso"];
+    const findings = checkEnforcementParity(enforcedToday);
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/billing/enforcement-parity.ts
+++ b/packages/api/src/lib/billing/enforcement-parity.ts
@@ -1,0 +1,219 @@
+/**
+ * Enforcement-leg parity for the pricing-parity drift guard (WS1/WS4 of
+ * #3984 / #3997).
+ *
+ * #3996 shipped the SSOT ↔ marketing-artifact leg: it proves the pricing
+ * page's per-tier columns mirror {@link FEATURE_ENTITLEMENTS} exactly. This
+ * module adds the third leg the parent PRD asks for — **enforcement** — so the
+ * full triangle (page claims ↔ entitlement SSOT ↔ actual enforced gates) can't
+ * silently disagree:
+ *
+ *   - The page sells a feature as tier-gated (mirror leg, #3996).
+ *   - The SSOT maps that feature → its minimum tier ({@link FEATURE_ENTITLEMENTS}).
+ *   - **This leg:** the request-time guard `requireFeatureEntitlement(orgId,
+ *     "<feature>")` is actually wired into that feature's route handlers, so a
+ *     below-tier workspace is denied at the API boundary — not merely hidden in
+ *     the UI (PRD WS1 user story 29).
+ *
+ * The danger this catches is the *silently-ungated ladder*: a capability the
+ * SSOT/page advertises as a paid-tier feature, but which no route consults the
+ * SSOT for — so every workspace, regardless of tier, can reach it by calling
+ * the endpoint directly. That was the pre-#3984 status quo for all ten
+ * "Business-only" features, and it's exactly the drift the guard must make
+ * impossible to reintroduce.
+ *
+ * ## Why a pending allowlist
+ *
+ * Wiring the per-feature gates is itself incremental WS1 work (#3986 wired
+ * `sso`; #3987 and siblings wire SCIM, roles, IP allowlist, approvals, …). So
+ * at any given moment some SSOT features legitimately have no enforcement gate
+ * *yet*. {@link ENFORCEMENT_PENDING} is the explicit, reviewed record of those:
+ * a feature in the SSOT is acceptable-without-a-gate only while it's listed
+ * here with its tracking issue. The guard then fails on three distinct drifts:
+ *
+ *   1. **Ungated & unacknowledged** — a SSOT feature that is neither enforced
+ *      nor in {@link ENFORCEMENT_PENDING}. This is the real regression: someone
+ *      added/advertised a gated capability and forgot to gate it (or forgot to
+ *      record it as pending). Fails closed.
+ *   2. **Stale pending** — a feature that IS now enforced but is still listed
+ *      pending. Forces the allowlist to shrink as gates land, so it can't rot
+ *      into a permanent escape hatch.
+ *   3. **Phantom pending** — a {@link ENFORCEMENT_PENDING} entry that names a
+ *      feature not in the SSOT (typo, or a feature since removed). Keeps the
+ *      allowlist honest.
+ *
+ * The actual call-site scan over the route layer is done by the caller (the
+ * `scripts/check-enforcement-parity.sh` runner) and passed in as
+ * `enforcedFeatures`, so this module stays a pure, trivially table-testable
+ * function with no filesystem dependency — mirroring how
+ * `pricing-entitlement-artifact.ts` keeps the SSOT→mirror mapping pure and the
+ * generator script does the I/O.
+ *
+ * @module
+ */
+
+import {
+  FEATURE_ENTITLEMENTS,
+  type GatedFeature,
+} from "@atlas/api/lib/billing/feature-entitlement";
+
+/**
+ * A GitHub issue reference (`#1234`). Used as the {@link ENFORCEMENT_PENDING}
+ * value type so the "every pending entry names a tracking issue" invariant is
+ * compile-enforced — `scim: ""` or `scim: "soon"` is a type error.
+ */
+export type IssueRef = `#${number}`;
+
+/**
+ * Features in the SSOT that intentionally have **no** request-time
+ * `requireFeatureEntitlement` gate wired yet, each justified by the WS1 issue
+ * that will wire it. The guard treats a SSOT feature as acceptable-without-a-
+ * gate *only* while it appears here — so a newly-added gated capability with no
+ * gate and no pending entry fails the build.
+ *
+ * Remove an entry the moment its gate lands: {@link checkEnforcementParity}
+ * flags a still-pending feature that is already enforced (rule 2), so this set
+ * is forced to shrink to empty as WS1 completes. When it's empty, every SSOT
+ * feature is enforced — the ladder is fully real.
+ *
+ * Keyed by {@link GatedFeature}; the `Partial<Record<...>>` shape makes a typo'd
+ * key a compile error while {@link checkEnforcementParity} catches an entry for
+ * a feature no longer in the SSOT at runtime. The value is typed
+ * {@link IssueRef} (`#<number>`) so the documented "every pending entry carries
+ * a tracking issue" invariant is a compile-time guarantee, not a comment — an
+ * empty or prose value won't typecheck.
+ */
+export const ENFORCEMENT_PENDING: Partial<Record<GatedFeature, IssueRef>> = {
+  // #3987 — SCIM, custom roles, IP allowlist, approval workflows.
+  scim: "#3987",
+  custom_roles: "#3987",
+  ip_allowlist: "#3987",
+  approvals: "#3987",
+  // Remaining WS1 surfaces (audit-retention, masking, residency, backups,
+  // white-label, proactive) — gated in their own follow-up slices under #3984.
+  audit_retention: "#3984",
+  masking: "#3984",
+  residency: "#3984",
+  backups: "#3984",
+  white_label: "#3984",
+  proactive: "#3984",
+};
+
+/** A single enforcement-parity finding (one drift). */
+export interface EnforcementParityFinding {
+  readonly kind: "ungated" | "stale-pending" | "phantom-pending";
+  readonly feature: string;
+  readonly message: string;
+}
+
+/**
+ * Compare the SSOT's gated features against the set actually enforced at the
+ * route layer (call sites of `requireFeatureEntitlement(..., "<feature>")`)
+ * and the {@link ENFORCEMENT_PENDING} allowlist. Returns one finding per drift;
+ * an empty array means the three legs agree.
+ *
+ * Pure: the caller supplies the scanned `enforcedFeatures` set, so this is
+ * directly table-testable with synthetic inputs (the unit test feeds it an
+ * injected mismatch to prove the guard fires, and the aligned set to prove it
+ * passes — so the gate can never silently no-op). The live wiring of the scan
+ * is the script's job.
+ *
+ * @param enforcedFeatures feature ids found gated by a route-layer
+ *   `requireFeatureEntitlement` call. Strings (not narrowed to
+ *   {@link GatedFeature}) so a stray id from the scan is reported, not dropped.
+ * @param ssot the entitlement SSOT keys; defaults to the live
+ *   {@link FEATURE_ENTITLEMENTS}. Overridable for tests.
+ * @param pending the pending allowlist; defaults to the live
+ *   {@link ENFORCEMENT_PENDING}. Overridable for tests.
+ */
+export function checkEnforcementParity(
+  enforcedFeatures: Iterable<string>,
+  ssot: Readonly<Record<string, unknown>> = FEATURE_ENTITLEMENTS,
+  pending: Readonly<Record<string, string>> = ENFORCEMENT_PENDING,
+): EnforcementParityFinding[] {
+  const enforced = new Set(enforcedFeatures);
+  const ssotKeys = new Set(Object.keys(ssot));
+  const pendingKeys = new Set(Object.keys(pending));
+  const findings: EnforcementParityFinding[] = [];
+
+  // Rule 1 — every SSOT feature must be either enforced or explicitly pending.
+  // An ungated, unacknowledged feature is the silently-open ladder we guard
+  // against: the page sells it tier-gated but no route consults the SSOT.
+  for (const feature of [...ssotKeys].sort()) {
+    if (enforced.has(feature) || pendingKeys.has(feature)) continue;
+    findings.push({
+      kind: "ungated",
+      feature,
+      message:
+        `"${feature}" is in the entitlement SSOT but no route consults ` +
+        `requireFeatureEntitlement(orgId, "${feature}"). The pricing page ` +
+        `sells it as tier-gated while the API leaves it open to every tier. ` +
+        `Wire the guard into its route handlers, or — if it's not yet wired — ` +
+        `record it in ENFORCEMENT_PENDING with its tracking issue.`,
+    });
+  }
+
+  // Rule 2 — a feature that IS enforced must not still be listed pending, so
+  // the allowlist shrinks to empty as gates land and can't rot into a
+  // permanent escape hatch.
+  for (const feature of [...pendingKeys].sort()) {
+    if (!ssotKeys.has(feature)) continue; // handled by rule 3
+    if (enforced.has(feature)) {
+      findings.push({
+        kind: "stale-pending",
+        feature,
+        message:
+          `"${feature}" is now enforced by a route-layer ` +
+          `requireFeatureEntitlement call but is still listed in ` +
+          `ENFORCEMENT_PENDING. Remove it — the allowlist must only hold ` +
+          `features that are genuinely not yet gated.`,
+      });
+    }
+  }
+
+  // Rule 3 — a pending entry for a feature the SSOT no longer has (typo or a
+  // removed feature) is stale and must be cleaned up.
+  for (const feature of [...pendingKeys].sort()) {
+    if (ssotKeys.has(feature)) continue;
+    findings.push({
+      kind: "phantom-pending",
+      feature,
+      message:
+        `ENFORCEMENT_PENDING lists "${feature}", which is not a feature in ` +
+        `FEATURE_ENTITLEMENTS. Remove the stale entry.`,
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Regex that extracts the feature id from a route-layer enforcement call:
+ * `requireFeatureEntitlement(<anything>, "<feature>")`. The first argument is
+ * the orgId expression (ignored); the second is the stable feature id. Used by
+ * the script to scan the route layer. Exported so the unit test pins the exact
+ * shape the scan recognizes.
+ *
+ * Recognizes only a **string-literal** second argument (`"sso"`, `'scim'`) — a
+ * dynamic feature id (`requireFeatureEntitlement(orgId, feature)`) is not
+ * counted as enforced. That's the safe direction: an unrecognized call makes
+ * its feature look *un*-enforced, so the guard fails *closed* (demands a gate
+ * or a pending entry) rather than silently treating it as covered. If a route
+ * ever gates via a non-literal, add the feature to {@link ENFORCEMENT_PENDING}
+ * or switch the call to a literal.
+ */
+export const ENFORCEMENT_CALL_RE =
+  /requireFeatureEntitlement\s*\(\s*[^,]+,\s*["']([a-z_]+)["']\s*\)/g;
+
+/**
+ * Extract the set of enforced feature ids from a blob of TypeScript source
+ * (one or more concatenated route files), using {@link ENFORCEMENT_CALL_RE}.
+ * Pure string operation so the script and the test share one parser.
+ */
+export function extractEnforcedFeatures(source: string): Set<string> {
+  const found = new Set<string>();
+  for (const match of source.matchAll(ENFORCEMENT_CALL_RE)) {
+    found.add(match[1]);
+  }
+  return found;
+}

--- a/scripts/__tests__/check-enforcement-parity.test.sh
+++ b/scripts/__tests__/check-enforcement-parity.test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Adversarial fixture suite for scripts/check-enforcement-parity.sh (#3997).
+#
+# Locks in that the enforcement-leg drift guard can't silently no-op: it PASSES
+# on the committed tree (every SSOT feature gated or recorded pending) and FAILS
+# when the SSOT ↔ pending-allowlist ↔ route-gate triangle is tampered with. The
+# pure mapping correctness is covered by the unit test
+# packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts; this proves
+# the *gate wired into CI* actually fires on real on-disk drift.
+#
+# Each fixture mutates a single committed file, runs the gate, asserts the
+# expected status, then restores — so a failing case can't leave the tree dirty.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-enforcement-parity.sh"
+PENDING="$ROOT/packages/api/src/lib/billing/enforcement-parity.ts"
+SSO_ROUTE="$ROOT/packages/api/src/api/routes/admin-sso.ts"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+for f in "$PENDING" "$SSO_ROUTE"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::expected file not found at $f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+
+check() {
+  local expected="$1" name="$2"
+  local status=0
+  bash "$SCRIPT" > /dev/null 2>&1 || status=$?
+  if { [ "$expected" = "pass" ] && [ "$status" -eq 0 ]; } ||
+     { [ "$expected" = "fail" ] && [ "$status" -ne 0 ]; }; then
+    echo "  ok   $name (expected $expected)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $name — expected $expected, got status=$status" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Back the mutated files up so we always restore the committed versions, even
+# on error.
+PENDING_BAK="$(mktemp)"; cp "$PENDING" "$PENDING_BAK"
+SSO_BAK="$(mktemp)"; cp "$SSO_ROUTE" "$SSO_BAK"
+restore() {
+  cp "$PENDING_BAK" "$PENDING"; rm -f "$PENDING_BAK"
+  cp "$SSO_BAK" "$SSO_ROUTE"; rm -f "$SSO_BAK"
+}
+trap restore EXIT
+
+# --- committed tree passes --------------------------------------------------
+check pass "committed tree: every SSOT feature gated or pending"
+
+# --- rule 1: an ungated, unacknowledged feature fails -----------------------
+# Drop `scim` from ENFORCEMENT_PENDING. It's in the SSOT and has no route gate,
+# so the guard must catch the now-silently-open ladder.
+cp "$PENDING_BAK" "$PENDING"
+perl -0pi -e 's/^\s*scim:\s*"#3987",\n//m' "$PENDING"
+check fail "removing a pending entry for an ungated feature trips the gate"
+cp "$PENDING_BAK" "$PENDING"
+
+# --- rule 3: a phantom pending entry fails ----------------------------------
+# Add a pending entry for a feature that isn't in the SSOT.
+cp "$PENDING_BAK" "$PENDING"
+perl -0pi -e 's/(export const ENFORCEMENT_PENDING[^{]*\{)/$1\n  ghost_feature: "#0000",/' "$PENDING"
+check fail "a phantom pending entry (not in the SSOT) trips the gate"
+cp "$PENDING_BAK" "$PENDING"
+
+# --- rule 2: a stale pending entry (feature now enforced) fails -------------
+# Simulate `scim` getting wired: add a route-layer gate call for it AND leave
+# it in ENFORCEMENT_PENDING. The guard must flag the stale allowlist entry.
+cp "$SSO_BAK" "$SSO_ROUTE"
+perl -0pi -e 's/(yield\* requireFeatureEntitlement\(orgId, "sso"\);)/$1\n    yield* requireFeatureEntitlement(orgId, "scim");/' "$SSO_ROUTE"
+check fail "a feature that is enforced but still listed pending trips the gate"
+cp "$SSO_BAK" "$SSO_ROUTE"
+
+# --- restored tree passes again ---------------------------------------------
+check pass "restored tree is in sync again"
+
+echo ""
+echo "check-enforcement-parity.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/check-enforcement-parity.sh
+++ b/scripts/check-enforcement-parity.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# check-enforcement-parity.sh — the enforcement leg of the pricing-parity drift
+# guard (WS1/WS4 of #3984 / #3997).
+#
+# #3996 shipped check-pricing-parity.sh, which proves the marketing pricing
+# table mirrors the FEATURE_ENTITLEMENTS SSOT (the page-claims ↔ SSOT leg).
+# This sibling adds the third leg the parent PRD asks for: that every gated
+# capability in the SSOT is actually ENFORCED — i.e. a route handler consults
+# `requireFeatureEntitlement(orgId, "<feature>")` so a below-tier workspace is
+# denied at the API boundary, not just hidden in the UI.
+#
+# It fails (non-zero) when the SSOT, the reviewed not-yet-wired allowlist
+# (ENFORCEMENT_PENDING in packages/api/src/lib/billing/enforcement-parity.ts),
+# and the actual route-layer gates disagree — so the page can never advertise a
+# tier-gated feature that the API silently leaves open to every tier.
+#
+# Run locally: bash scripts/check-enforcement-parity.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+
+cd "$ROOT"
+
+echo ":: Verifying entitlement SSOT is enforced at the route layer..."
+# The runner scans packages/api/src/api/routes/** for requireFeatureEntitlement
+# call sites and exits non-zero (with an actionable message) on any drift;
+# `set -e` propagates that as the gate failure.
+bun scripts/check-enforcement-parity.ts
+
+echo "Pricing-parity enforcement check passed — the entitlement SSOT is enforced (or explicitly pending) at the route layer."

--- a/scripts/check-enforcement-parity.ts
+++ b/scripts/check-enforcement-parity.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env bun
+/**
+ * Enforcement-leg of the pricing-parity drift guard (WS1/WS4 of #3984 / #3997).
+ *
+ * #3996 shipped the SSOT ↔ marketing-artifact leg (`check-pricing-parity.sh`).
+ * This runner adds the third leg: it scans the API **route layer** for
+ * `requireFeatureEntitlement(orgId, "<feature>")` call sites — the request-time
+ * gate that denies a below-tier workspace at the API boundary — and verifies,
+ * via the pure `checkEnforcementParity`, that the set of enforced features plus
+ * the reviewed `ENFORCEMENT_PENDING` allowlist exactly covers the entitlement
+ * SSOT. It fails (non-zero, actionable message) on any of:
+ *
+ *   - a SSOT feature that is neither enforced nor pending (a silently-open
+ *     ladder: the page sells it tier-gated but no route consults the SSOT),
+ *   - a feature that is enforced yet still listed pending (stale allowlist),
+ *   - a pending entry for a feature no longer in the SSOT (phantom).
+ *
+ * The route-layer scan is the one impure piece, so it lives here in the script
+ * rather than in the unit-tested pure module — mirroring how
+ * `generate-pricing-entitlements.ts` does the file I/O while
+ * `pricing-entitlement-artifact.ts` stays pure. The pure parser
+ * (`extractEnforcedFeatures`) is shared so the script and the
+ * `enforcement-parity.test.ts` unit test recognize call sites identically.
+ *
+ * Run locally: bun scripts/check-enforcement-parity.ts
+ *
+ * @module
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+// Relative import: this script lives in repo-root scripts/, where the
+// @atlas/api workspace alias is not resolvable (root has no dep on it). Same
+// constraint as generate-pricing-entitlements.ts. The imported module pulls in
+// @atlas/api, so it runs only at check time in CI / a dev machine.
+import {
+  checkEnforcementParity,
+  extractEnforcedFeatures,
+} from "../packages/api/src/lib/billing/enforcement-parity";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SCRIPT_DIR, "..");
+
+// The route layer is where request-time gates are wired. The guard definition
+// and its unit test contain the literal `requireFeatureEntitlement(..., "sso")`
+// too, but those are the definition/test — not an enforced route — so the scan
+// is scoped to the routes dir and excludes test files.
+const SCAN_DIR = join(ROOT, "packages/api/src/api/routes");
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      // Skip test/fixture dirs — a literal in a test is not an enforced gate.
+      if (entry === "__tests__" || entry === "__fixtures__") continue;
+      out.push(...tsFilesUnder(full));
+      continue;
+    }
+    if (!entry.endsWith(".ts") && !entry.endsWith(".tsx")) continue;
+    if (entry.endsWith(".test.ts") || entry.endsWith(".test.tsx")) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+function main(): void {
+  const files = tsFilesUnder(SCAN_DIR);
+  if (files.length === 0) {
+    throw new Error(
+      `No route source files found under ${relative(ROOT, SCAN_DIR)} — the ` +
+        `enforcement scan would vacuously "pass". Check the SCAN_DIR path.`,
+    );
+  }
+
+  const blob = files.map((f) => readFileSync(f, "utf8")).join("\n");
+  const enforced = extractEnforcedFeatures(blob);
+
+  const findings = checkEnforcementParity(enforced);
+
+  process.stdout.write(
+    `check-enforcement-parity: scanned ${files.length} route file(s); ` +
+      `${enforced.size} feature(s) enforced at the route layer ` +
+      `(${[...enforced].sort().join(", ") || "none"}).\n`,
+  );
+
+  if (findings.length > 0) {
+    const lines = findings.map((f) => `  - [${f.kind}] ${f.message}`);
+    throw new Error(
+      `pricing-parity enforcement leg failed — the entitlement SSOT, the ` +
+        `pending allowlist, and the enforced route gates disagree:\n` +
+        lines.join("\n") +
+        `\n\nSSOT: packages/api/src/lib/billing/feature-entitlement.ts\n` +
+        `Pending allowlist: packages/api/src/lib/billing/enforcement-parity.ts ` +
+        `(ENFORCEMENT_PENDING)\n` +
+        `Route gates: packages/api/src/api/routes/** ` +
+        `(requireFeatureEntitlement call sites)`,
+    );
+  }
+
+  process.stdout.write(
+    `Pricing-parity enforcement leg passed — every SSOT feature is either ` +
+      `gated at the route layer or recorded as not-yet-wired in ` +
+      `ENFORCEMENT_PENDING.\n`,
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`check-enforcement-parity: ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What & why

Closes #3997 (WS1/WS4 of #3984).

#3996 shipped the **SSOT ↔ www-artifact** leg of the `pricing-parity` drift guard (`check-pricing-parity.sh` — the marketing comparison table mirrors `FEATURE_ENTITLEMENTS` exactly). This PR adds the third leg the parent PRD asks for — **enforcement** — so the full triangle (page claims ↔ entitlement SSOT ↔ actual enforced gates) can't silently disagree.

The danger it catches is the **silently-ungated ladder**: a capability the SSOT/page sells as a paid-tier feature, but which no route consults the SSOT for — so every workspace, regardless of tier, can reach it by calling the endpoint directly. That was the pre-#3984 status quo for all ten "Business-only" features, and this makes it impossible to reintroduce.

## How

- **`packages/api/src/lib/billing/enforcement-parity.ts`** — pure `checkEnforcementParity()` compares three sets: the SSOT (`FEATURE_ENTITLEMENTS`), the route-scan's *enforced* set (`requireFeatureEntitlement(orgId, "<feature>")` call sites), and a reviewed `ENFORCEMENT_PENDING` allowlist of not-yet-wired features. It fails on three distinct drifts:
  1. **ungated & unacknowledged** — a SSOT feature neither enforced nor pending (the real regression);
  2. **stale-pending** — a feature now enforced but still listed pending (forces the allowlist to shrink to empty as gates land);
  3. **phantom-pending** — a pending entry for a feature not in the SSOT.
  Each pending entry is keyed to its WS1 tracking issue via a compile-enforced `` `#${number}` `` `IssueRef` type. Today only `sso` is wired (#3986); the remaining 10 features sit in `ENFORCEMENT_PENDING` pointing at #3987 / #3984, and the allowlist shrinks as those slices land.
- **`scripts/check-enforcement-parity.ts` / `.sh`** — scans `packages/api/src/api/routes/**` for the call sites and runs the pure check. Fails **loud** (never vacuously) if the route dir is empty or missing.
- **CI** — both the gate and its adversarial fixture wired into the drift-gate block next to `check-pricing-parity`.

## Tests (acceptance: "fails on injected mismatch; passes when aligned")

- **`enforcement-parity.test.ts`** — feeds the pure function synthetic inputs: aligned → no findings; each drift class → its finding; multi-drift coexists; plus a live-tree assertion that breaks the moment a feature is added to the SSOT without gating-or-pending it.
- **`scripts/__tests__/check-enforcement-parity.test.sh`** — adversarial fixture proving the CI-wired gate fires on real on-disk drift (drops a pending entry, injects a phantom, simulates a stale gate) and restores the tree via `trap restore EXIT`.

## Scope note

This **extends** #3996 — it does not duplicate or rewrite the SSOT↔artifact leg. The enforcement leg is the part #3996 explicitly deferred. The `ENFORCEMENT_PENDING` allowlist is the seam that lets this gate ship now (while per-feature wiring is still in flight via #3987) without going red on main, while still catching a *new* unacknowledged ungated feature.

Internal review panel: CLEAN (no must-fix; applied the LOW/MEDIUM polish — compile-enforced `IssueRef`, underscore-id parser test, doc tightening).

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI enforcement-parity drift guard for pricing feature gating
> - Adds [`enforcement-parity.ts`](https://github.com/AtlasDevHQ/atlas/pull/4028/files#diff-668cbb78dbe26e8b26a609c6cc0a7dfc7671b2f0dd04d2ee2e67dbc18a73b171) with `checkEnforcementParity` and `extractEnforcedFeatures` to compare the feature entitlement SSOT against route-layer `requireFeatureEntitlement` calls, flagging ungated, stale-pending, and phantom-pending features.
> - Introduces `ENFORCEMENT_PENDING` to allowlist features intentionally not yet enforced at the route layer (e.g. `scim`, `custom_roles`, `ip_allowlist`), each referencing a tracking issue.
> - Adds [`scripts/check-enforcement-parity.sh`](https://github.com/AtlasDevHQ/atlas/pull/4028/files#diff-c4b69fa5b7962838a2a6f6036ade9165a251d5d753e9bc28eb4c0eddbd8c78de) and [`scripts/check-enforcement-parity.ts`](https://github.com/AtlasDevHQ/atlas/pull/4028/files#diff-16ba033eb85967ef4a7fe20ebda8b1e19b19b978a3363e5f95f2ae4c18d20db8) to scan route files and exit non-zero with diagnostics when drift is detected.
> - Wires both the parity check and its adversarial bash fixture into the CI `drift` job in [`.github/workflows/ci.yml`](https://github.com/AtlasDevHQ/atlas/pull/4028/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f), so the build fails on any enforcement drift.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1de71d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->