### PR TITLE
feat(api): move marketplace plan-gated veneer to /ee behind MarketplaceVeneer Tag (WS5)

### DIFF
--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -29,6 +29,7 @@ import type {
   SSOPolicy,
   SlaMetrics,
   AbuseResponse,
+  MarketplaceVeneer,
 } from "@atlas/api/lib/effect/services";
 import { ResidencyResolverLive } from "./platform/residency";
 import { ModelRouterLive } from "./platform/model-routing";
@@ -48,6 +49,7 @@ import { BrandingLive } from "./branding/white-label";
 import { DomainsLive } from "./platform/domains";
 import { ProactiveGateLive } from "./proactive-gate";
 import { DeployModeResolverLive } from "./deploy-mode";
+import { MarketplaceVeneerLive } from "./marketplace/veneer";
 import { SaasCrmLive } from "./saas-crm/index";
 
 /**
@@ -76,6 +78,7 @@ export const EELayer: Layer.Layer<
   | SSOPolicy
   | SlaMetrics
   | AbuseResponse
+  | MarketplaceVeneer
 > = Layer.mergeAll(
   ResidencyResolverLive,
   ModelRouterLive,
@@ -95,5 +98,6 @@ export const EELayer: Layer.Layer<
   DomainsLive,
   ProactiveGateLive,
   DeployModeResolverLive,
+  MarketplaceVeneerLive,
   SaasCrmLive,
 );

--- a/ee/src/marketplace/veneer.test.ts
+++ b/ee/src/marketplace/veneer.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Plugin-marketplace plan-gated veneer (EE) test — #4001 (WS5).
+ *
+ * `makeMarketplaceVeneerLive().isSaasIneligible` is the SaaS-eligibility gate
+ * the marketplace listing filter + install gate consult. It must gate a row
+ * iff the resolved deploy mode is `"saas"` AND the row is explicitly
+ * `saas_eligible === false`. Self-hosted (or an absent/null flag) is always
+ * eligible — that's the unchanged self-hosted behavior the Noop default
+ * mirrors in core.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Mutable deploy mode for the config mock ─────────────────────────
+let mockDeployMode: "saas" | "self-hosted" | undefined;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => (mockDeployMode ? { deployMode: mockDeployMode } : null),
+}));
+
+const { makeMarketplaceVeneerLive } = await import("./veneer");
+
+describe("MarketplaceVeneerLive — isSaasIneligible", () => {
+  beforeEach(() => {
+    mockDeployMode = undefined;
+  });
+
+  it("gates an explicit saas_eligible=false row on a SaaS deploy", () => {
+    mockDeployMode = "saas";
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({ saas_eligible: false })).toBe(true);
+  });
+
+  it("does NOT gate a saas_eligible=true row on a SaaS deploy", () => {
+    mockDeployMode = "saas";
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({ saas_eligible: true })).toBe(false);
+  });
+
+  it("does NOT gate a saas_eligible=false row on a self-hosted deploy", () => {
+    mockDeployMode = "self-hosted";
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({ saas_eligible: false })).toBe(false);
+  });
+
+  it("does NOT gate a saas_eligible=false row when deploy mode is unresolved", () => {
+    // getConfig() → null → deployMode undefined → treated as not-SaaS.
+    mockDeployMode = undefined;
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({ saas_eligible: false })).toBe(false);
+  });
+
+  it("treats an absent saas_eligible flag as eligible even on SaaS (only explicit false gates)", () => {
+    mockDeployMode = "saas";
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({})).toBe(false);
+  });
+
+  it("treats a null saas_eligible flag as eligible even on SaaS", () => {
+    mockDeployMode = "saas";
+    const veneer = makeMarketplaceVeneerLive();
+    expect(veneer.isSaasIneligible({ saas_eligible: null })).toBe(false);
+  });
+
+  it("re-reads the resolved deploy mode on every call (no cached config)", () => {
+    const veneer = makeMarketplaceVeneerLive();
+    mockDeployMode = "self-hosted";
+    expect(veneer.isSaasIneligible({ saas_eligible: false })).toBe(false);
+    mockDeployMode = "saas";
+    expect(veneer.isSaasIneligible({ saas_eligible: false })).toBe(true);
+  });
+});

--- a/ee/src/marketplace/veneer.ts
+++ b/ee/src/marketplace/veneer.ts
@@ -1,0 +1,42 @@
+/**
+ * Plugin-marketplace plan-gated veneer (enterprise) — #4001 (WS5).
+ *
+ * Inverts the inline `getConfig()?.deployMode === "saas" && saas_eligible ===
+ * false` checks that lived in `api/routes/admin-marketplace.ts`. The unified
+ * install pipeline (ADR-0007) stays in core; only the SaaS-eligibility gate —
+ * the plan-gated veneer — moves here behind the `MarketplaceVeneer`
+ * Context.Tag. The no-op default in `lib/effect/services.ts`
+ * (`NoopMarketplaceVeneerLayer`) makes every catalog row eligible, so
+ * self-hosted lists and installs the full catalog unchanged.
+ *
+ * `isSaasIneligible` is the single decision both the `/available` listing
+ * filter and the `POST /install` server-side gate consult. It returns `true`
+ * only when the deploy is SaaS AND the row is explicitly `saas_eligible =
+ * false` (e.g. DuckDB — file-path based, not multi-tenant safe, #3301). The
+ * resolved (not raw-env) deploy mode is read on every call so a config-file
+ * `deployMode: "saas"` that downgrades to self-hosted without `@atlas/ee`
+ * still lists everything (the env `ATLAS_DEPLOY_MODE=saas` path hard-fails
+ * boot instead). Because SaaS mode requires enterprise, this Live layer is the
+ * only place `deployMode === "saas"` is ever true — so the gate is correctly
+ * absent without EE. Mirrors the keyset gate in
+ * `lib/integrations/install/github-pat-form-handler.ts`.
+ */
+
+import { Layer } from "effect";
+import { getConfig } from "@atlas/api/lib/config";
+import {
+  MarketplaceVeneer,
+  type MarketplaceVeneerShape,
+  type CatalogEligibilityRow,
+} from "@atlas/api/lib/effect/services";
+
+export const makeMarketplaceVeneerLive = (): MarketplaceVeneerShape =>
+  ({
+    isSaasIneligible: (row: CatalogEligibilityRow): boolean =>
+      getConfig()?.deployMode === "saas" && row.saas_eligible === false,
+  }) satisfies MarketplaceVeneerShape;
+
+export const MarketplaceVeneerLive: Layer.Layer<MarketplaceVeneer> = Layer.sync(
+  MarketplaceVeneer,
+  makeMarketplaceVeneerLive,
+);

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -235,6 +235,22 @@ mock.module("@atlas/api/lib/effect/services", () => ({
   SSOPolicy: { _tag: "MockTag" },
   SCIMProvenance: { _tag: "MockTag" },
   RolesPolicy: { [Symbol.iterator]: function* (): Generator<unknown, unknown> { return yield {}; } },
+  // #4001 — the SaaS plan-gated veneer (`saas_eligible` gate) resolves
+  // through the `MarketplaceVeneer` Tag. Mirror the EE Live impl
+  // (`ee/src/marketplace/veneer.ts`): gate only on a resolved SaaS deploy
+  // with an explicit `saas_eligible === false`. Reading `mockDeployMode`
+  // directly keeps every `mockDeployMode = "saas"` test driving the gate
+  // exactly as it did when the check was inline in the route — and the Noop
+  // self-hosted behavior (`mockDeployMode` unset/`"self-hosted"` → never
+  // ineligible) falls out of the same predicate.
+  MarketplaceVeneer: {
+    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+      return yield {
+        isSaasIneligible: (row: { saas_eligible?: boolean | null }) =>
+          mockDeployMode === "saas" && row.saas_eligible === false,
+      };
+    },
+  },
 }));
 
 // Replace enterprise-layer's composition with an inert layer so the
@@ -1137,6 +1153,45 @@ describe("Workspace Plugin Marketplace", () => {
         body: JSON.stringify({ catalogId: "cat-1" }),
       });
       expect(res.status).toBe(201);
+    });
+
+    // #4001 — the install gate must fail OPEN for a row whose `saas_eligible`
+    // flag is absent, even on SaaS: only an explicit `false` is ineligible
+    // (`=== false`). Mirrors the listing-path "absent → visible on SaaS" test
+    // and pins the security-relevant edge at the install route, not just the
+    // EE-veneer unit.
+    it("allows installing a row whose saas_eligible is absent even on a SaaS deploy (#4001)", async () => {
+      mockDeployMode = "saas";
+      // sampleCatalogRow has no `saas_eligible` key → eligible.
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [
+        { ...sampleCatalogRow, slug: "obsidian" },
+      ]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setQueryResult("INSERT INTO workspace_plugins", [{
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "Obsidian",
+        slug: "obsidian",
+        type: "context",
+      }]);
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(201);
+      // No SaaS-ineligibility refusal audit on the happy path.
+      const refusal = mockLogAdminAction.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.actionType === "plugin.install" && e.status === "failure");
+      expect(refusal).toBeUndefined();
     });
   });
 

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -12,7 +12,7 @@
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { RequestContext } from "@atlas/api/lib/effect/services";
+import { RequestContext, MarketplaceVeneer } from "@atlas/api/lib/effect/services";
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -30,7 +30,6 @@ import {
   deleteDedicatedCredentialStore,
   tearDownWorkspaceInstall,
 } from "@atlas/api/lib/plugins/teardown";
-import { getConfig } from "@atlas/api/lib/config";
 import type { CatalogInstallModel } from "@useatlas/types";
 import { MIN_PLAN_TIERS, type PlanTier } from "@useatlas/types";
 import {
@@ -817,6 +816,12 @@ workspaceMarketplace.openapi(listAvailableRoute, async (c) => {
     Effect.gen(function* () {
       yield* RequestContext;
       const { orgId } = c.var.orgContext;
+      // #4001 — the SaaS plan-gated veneer moved to @atlas/ee behind the
+      // MarketplaceVeneer Tag. `isSaasIneligible` is the EE-resolved
+      // `deployMode === "saas" && saas_eligible === false` gate; the Noop
+      // default (self-hosted / non-EE) answers `false` for every row, so the
+      // full catalog lists — unchanged self-hosted behavior.
+      const veneer = yield* MarketplaceVeneer;
 
       // Independent queries — run in parallel
       const [plan, catalog, installations] = yield* Effect.promise(() =>
@@ -831,14 +836,12 @@ workspaceMarketplace.openapi(listAvailableRoute, async (c) => {
       );
       const installedMap = new Map(installations.map((i) => [i.catalog_id, { id: i.id, config: i.config }]));
 
-      // #3301 — on SaaS deploys, hide catalog rows flagged `saas_eligible =
-      // false` (DuckDB is file-path based and not multi-tenant safe). Resolved
-      // (not raw-env) deploy mode so a config-file `deployMode: "saas"` that
-      // silently downgrades to self-hosted without @atlas/ee still lists
-      // everything (the env `ATLAS_DEPLOY_MODE=saas` path hard-fails boot
-      // instead). Self-hosted is unaffected — every datasource type stays
-      // visible. The install path enforces the same flag (see POST /install).
-      const isSaasDeploy = getConfig()?.deployMode === "saas";
+      // #3301 / #4001 — on SaaS deploys, hide catalog rows flagged
+      // `saas_eligible = false` (DuckDB is file-path based and not multi-tenant
+      // safe). The decision lives in @atlas/ee (resolved, not raw-env, deploy
+      // mode — see MarketplaceVeneerLive); self-hosted is unaffected — the Noop
+      // veneer reports every row eligible, so each datasource type stays
+      // visible. The install path enforces the same gate (see POST /install).
 
       // Filter by plan eligibility, masking any installedConfig field marked
       // `secret: true` in the catalog's config_schema. A workspace admin
@@ -850,7 +853,7 @@ workspaceMarketplace.openapi(listAvailableRoute, async (c) => {
       // every string value and we log so operators see the drift.
       const available = catalog
         .filter((entry) => isPlanEligible(plan, entry.min_plan))
-        .filter((entry) => !isSaasDeploy || entry.saas_eligible !== false)
+        .filter((entry) => !veneer.isSaasIneligible(entry))
         .map((entry) => {
           const inst = installedMap.get(entry.id);
           const schema = parseConfigSchema(entry.config_schema);
@@ -882,6 +885,9 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       const { requestId } = yield* RequestContext;
       const { orgId } = c.var.orgContext;
       const body = c.req.valid("json");
+      // #4001 — SaaS-eligibility gate resolved through the EE veneer Tag (Noop
+      // on self-hosted answers `false`, so every row stays installable).
+      const veneer = yield* MarketplaceVeneer;
 
       // Fetch catalog entry. A lookup failure at this point means we cannot
       // know the slug, but we still want an audit row — a compromised admin
@@ -943,14 +949,15 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         }, 400);
       }
 
-      // #3301 defense-in-depth — the /available listing hides
+      // #3301 / #4001 defense-in-depth — the /available listing hides
       // `saas_eligible = false` rows on SaaS, but the install path must also
       // refuse them server-side: a workspace admin who already knows the
       // catalog id could otherwise POST it directly and bypass the hidden
       // card. DuckDB is file-path based and not multi-tenant safe. Mirrors the
-      // keyset gate in `integrations/install/github-pat-form-handler.ts`.
-      // Resolved (not raw-env) deploy mode, same as the listing filter.
-      if (getConfig()?.deployMode === "saas" && catalogEntry.saas_eligible === false) {
+      // keyset gate in `lib/integrations/install/github-pat-form-handler.ts`.
+      // Same EE-resolved veneer decision as the listing filter (Noop → never
+      // gated).
+      if (veneer.isSaasIneligible(catalogEntry)) {
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.install,
           targetType: "plugin",

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -36,6 +36,7 @@ import {
   type Domains,
   type ProactiveGate,
   type DeployModeResolver,
+  type MarketplaceVeneer,
   type SaasCrm,
 } from "./services";
 
@@ -185,6 +186,7 @@ export type EnterpriseSubsystem =
   | Domains
   | ProactiveGate
   | DeployModeResolver
+  | MarketplaceVeneer
   | SaasCrm;
 
 /**

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2847,6 +2847,63 @@ export const NoopDeployModeResolverLayer: Layer.Layer<DeployModeResolver> =
     resolve: () => "self-hosted",
   } satisfies DeployModeResolverShape);
 
+// ── MarketplaceVeneer (#4001 — WS5 plugin-marketplace veneer split) ──
+//
+// The plugin-marketplace **plan-gated veneer** — the deploy-mode-dependent
+// `saas_eligible` eligibility decision that hides catalog rows from the
+// workspace marketplace listing and refuses installing them — moved to
+// `@atlas/ee` (`ee/src/marketplace/veneer.ts`). The unified install pipeline
+// (ADR-0007: `WorkspaceInstaller`, `PillarCatalogQuery`, the platform catalog
+// CRUD routes, and the per-workspace install/uninstall/config handlers in
+// `api/routes/admin-marketplace.ts`) STAYS in core unchanged — only the
+// SaaS-eligibility gate routes through this Tag.
+//
+// `saas_eligible = false` marks a catalog row (e.g. DuckDB, which is
+// file-path based and not multi-tenant safe, #3301) that must never list or
+// install on a SaaS deploy. That gate is purely a multi-tenant/SaaS concern,
+// so it belongs in `/ee`: SaaS mode requires enterprise, so the Live layer is
+// the only place `deployMode === "saas"` is ever true. The no-op default
+// (self-hosted / non-EE) treats EVERY row as eligible — identical to today's
+// self-hosted behavior, where the filter was already inert because
+// `deployMode !== "saas"`. Per the `available`-flag convention above this Tag
+// omits `available`: no route branches on EE-loaded vs not — both listing and
+// install simply consult `isSaasIneligible`, which the Noop answers `false`.
+//
+// `CatalogEligibilityRow` is the minimal projection the gate reads — only the
+// `saas_eligible` column matters. Optional + `?? undefined`-tolerant because
+// the marketplace casts an unvalidated `SELECT *`; a stale pre-column row
+// (absent / null) defaults to eligible (`=== false` is the only ineligible
+// signal), matching the core comment on `CatalogRow.saas_eligible`.
+
+export interface CatalogEligibilityRow {
+  readonly saas_eligible?: boolean | null;
+}
+
+export interface MarketplaceVeneerShape {
+  /**
+   * Whether the SaaS plan-gated veneer makes this catalog row ineligible on
+   * the current deploy. `true` only when EE is loaded AND the deploy is SaaS
+   * AND the row is explicitly `saas_eligible = false`. The Noop default
+   * always returns `false` (self-hosted lists/installs everything), so the
+   * listing filter and the install gate are inert without EE — unchanged
+   * self-hosted behavior.
+   */
+  readonly isSaasIneligible: (row: CatalogEligibilityRow) => boolean;
+}
+export class MarketplaceVeneer extends Context.Tag("MarketplaceVeneer")<
+  MarketplaceVeneer,
+  MarketplaceVeneerShape
+>() {}
+// No-op default: no SaaS veneer. Every catalog row is eligible, so the
+// workspace marketplace lists and installs the full catalog — the exact
+// self-hosted behavior before the split, where `deployMode !== "saas"` made
+// the gate a no-op anyway. EE's `ee/src/marketplace/veneer.ts` overlays the
+// real `deployMode === "saas" && saas_eligible === false` gate.
+export const NoopMarketplaceVeneerLayer: Layer.Layer<MarketplaceVeneer> =
+  Layer.succeed(MarketplaceVeneer, {
+    isSaasIneligible: () => false,
+  } satisfies MarketplaceVeneerShape);
+
 // ── SaasCrm ──────────────────────────────────────────────────────────
 //
 // SaaS-only CRM dispatch (Twenty). Self-hosted gets the Noop layer.
@@ -3052,6 +3109,7 @@ export const NoopEnterpriseDefaultsLayer: Layer.Layer<
   | Domains
   | ProactiveGate
   | DeployModeResolver
+  | MarketplaceVeneer
   | SaasCrm
 > = Layer.mergeAll(
   NoopResidencyResolverLayer,
@@ -3072,6 +3130,7 @@ export const NoopEnterpriseDefaultsLayer: Layer.Layer<
   NoopDomainsLayer,
   NoopProactiveGateLayer,
   NoopDeployModeResolverLayer,
+  NoopMarketplaceVeneerLayer,
   NoopSaasCrmLayer,
 );
 


### PR DESCRIPTION
## What

Moves the plugin-marketplace **plan-gated veneer** — the `saas_eligible` deploy-mode eligibility gate — to `/ee` behind a new `MarketplaceVeneer` Context.Tag, following the #4027 (#4000) abuse-prevention split pattern (Context.Tag + Noop layer + `EELayer`/`EnterpriseSubsystem` wiring). The unified install pipeline (ADR-0007) stays in core unchanged.

The `saas_eligible` gate hides catalog rows from the workspace marketplace listing and refuses installing them on a SaaS deploy (#3301 — DuckDB is file-path based, not multi-tenant safe). That decision is purely a SaaS/multi-tenant concern, so it moves to `ee/src/marketplace/veneer.ts` (`MarketplaceVeneerLive`). Core keeps an inert `NoopMarketplaceVeneerLayer` that treats every row as eligible — identical to today's self-hosted behavior, where `deployMode !== "saas"` already made the filter a no-op.

## How

- **`MarketplaceVeneer` Tag** (`lib/effect/services.ts`) — single method `isSaasIneligible(row)`. Noop returns `false` (everything eligible); EE Live returns `getConfig()?.deployMode === "saas" && row.saas_eligible === false` (the exact pre-split inline predicate). `CatalogEligibilityRow` is the minimal `{ saas_eligible? }` projection the gate reads.
- **Route** (`api/routes/admin-marketplace.ts`) — the `/available` listing filter and the `POST /install` server-side gate now `yield* MarketplaceVeneer` and call `isSaasIneligible`, replacing the inline `getConfig()?.deployMode` checks. Per the `available`-flag convention the Tag omits `available` — no route branches on EE-loaded vs not.
- **Wiring** — added to `NoopEnterpriseDefaultsLayer`, the `EnterpriseSubsystem` union (`enterprise-layer.ts`), and `EELayer` (`ee/src/layers.ts`).

## Invariants

- Behavior on an enterprise deployment is **identical** — the EE Live predicate is byte-for-byte the old inline check. Self-hosted is unaffected (Noop is inert). `deployMode === "saas"` is only ever true when EE is loaded (env `ATLAS_DEPLOY_MODE=saas` without EE hard-fails boot; a config-file `deployMode: "saas"` downgrades to self-hosted).
- The unified install pipeline (`WorkspaceInstaller`, `PillarCatalogQuery`, platform catalog CRUD, per-workspace install/uninstall/config) is unchanged.
- Core→/ee inversion invariant holds — `check-ee-imports.sh` green.

## Tests

- `ee/src/marketplace/veneer.test.ts` (new) — unit tests for the EE Live `isSaasIneligible` gate across SaaS / self-hosted / unresolved deploy modes and explicit-false vs absent/null flag.
- `admin-marketplace.test.ts` — added a `MarketplaceVeneer` test layer so the existing `mockDeployMode = "saas"` SaaS-eligibility tests keep exercising the gate; added a new install-route test pinning the fail-open edge (absent `saas_eligible` on SaaS → 201).

Local gates: lint, type, syncpack, all drift/guard scripts (incl. `check-ee-imports.sh`, openapi-drift), and the full test suite pass. The sole full-suite failure is the pre-existing flaky `admin-model-config.test.ts` timeout (verified identical on clean `origin/main`), unrelated to this change.

Closes #4001

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move marketplace SaaS eligibility gating behind `MarketplaceVeneer` EE service
> - Introduces a `MarketplaceVeneer` Effect service with a `isSaasIneligible(entry)` method in [services.ts](https://github.com/AtlasDevHQ/atlas/pull/4030/files#diff-11b664638df1998c3ac26237ca0ec855ad834e2bff23c16399b010293d1355d3). The default `NoopMarketplaceVeneerLayer` always returns `false`, preserving existing self-hosted behavior.
> - Adds an EE implementation in [ee/src/marketplace/veneer.ts](https://github.com/AtlasDevHQ/atlas/pull/4030/files#diff-21028ab05c32c5263ed654188d31a5cced6268eb33442fecee2668b16289c201) that returns `true` only when `deployMode === "saas"` and the catalog row has `saas_eligible === false`.
> - Replaces direct `getConfig()` SaaS checks in the `listAvailableRoute` and `installRoute` handlers in [admin-marketplace.ts](https://github.com/AtlasDevHQ/atlas/pull/4030/files#diff-9e42dcfaff23f7823980ca772fccac02080d1c4e02e9ebedeb39e5ce97a49783) with `MarketplaceVeneer` resolution.
> - Behavioral Change: In EE on SaaS deploys, catalog rows with `saas_eligible === false` are now hidden from the listing and blocked at install time. Non-EE deploys are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13238db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->