### PR TITLE
feat(api): per-tier gates for audit-retention, masking, white-label, custom-domain, residency (WS1)

### DIFF
--- a/apps/www/src/app/pricing/entitlements.generated.ts
+++ b/apps/www/src/app/pricing/entitlements.generated.ts
@@ -29,7 +29,7 @@ export const ENTITLEMENT_SECTION_ORDER: readonly EntitlementSection[] = [
 ];
 
 /** Stable wire id of a gated feature (matches the SSOT key). */
-export type FeatureId = "residency" | "backups" | "white_label" | "sso" | "scim" | "custom_roles" | "ip_allowlist" | "approvals" | "audit_retention" | "masking" | "proactive";
+export type FeatureId = "residency" | "backups" | "white_label" | "custom_domain" | "sso" | "scim" | "custom_roles" | "ip_allowlist" | "approvals" | "audit_retention" | "masking" | "proactive";
 
 /** One per-tier entitlement row mirrored from the SSOT. */
 export interface EntitlementRow {
@@ -67,6 +67,12 @@ export const ENTITLEMENT_ROWS: readonly EntitlementRow[] = [
     label: "White-label branding",
     section: "hosting",
     cells: { selfHosted: false, starter: false, pro: false, business: true },
+  },
+  {
+    feature: "custom_domain",
+    label: "Custom domain",
+    section: "hosting",
+    cells: { selfHosted: false, starter: false, pro: true, business: true },
   },
   {
     feature: "sso",

--- a/packages/api/src/api/__tests__/admin-audit-retention.test.ts
+++ b/packages/api/src/api/__tests__/admin-audit-retention.test.ts
@@ -55,7 +55,18 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     end: async () => {},
     on: () => {},
   }),
-  internalQuery: () => Promise.resolve([]),
+  // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
+  // plan_tier before every audit-retention route in SaaS deploy mode (which this
+  // monorepo's test env resolves to: enterprise enabled + internal DB present).
+  // audit-retention gates to Business, so the entitlement read must return
+  // `business` or every route 403s with `plan_upgrade_required`. All other
+  // queries keep returning [].
+  internalQuery: (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? Promise.resolve([{ plan_tier: "business", is_operator_workspace: false }])
+      : Promise.resolve([]),
   internalExecute: mock(() => {}),
 }));
 

--- a/packages/api/src/api/__tests__/admin-branding.test.ts
+++ b/packages/api/src/api/__tests__/admin-branding.test.ts
@@ -43,7 +43,17 @@ let mockHasInternalDB = true;
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   getInternalDB: () => ({ query: () => Promise.resolve({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: () => Promise.resolve([]),
+  // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
+  // plan_tier before every branding route in SaaS deploy mode (which this
+  // monorepo's test env resolves to). White-label gates to Business, so the
+  // entitlement read must return `business` or every route 403s with
+  // `plan_upgrade_required`. All other queries keep returning [].
+  internalQuery: (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? Promise.resolve([{ plan_tier: "business", is_operator_workspace: false }])
+      : Promise.resolve([]),
   internalExecute: () => {},
   setWorkspaceRegion: mock(async () => {}),
   insertSemanticAmendment: mock(async () => "mock-amendment-id"),

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -72,7 +72,17 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     end: async () => {},
     on: () => {},
   }),
-  internalQuery: () => Promise.resolve([]),
+  // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
+  // plan_tier before every compliance/masking route in SaaS deploy mode (which
+  // this monorepo's test env resolves to). Masking gates to Business, so the
+  // entitlement read must return `business` or every route 403s with
+  // `plan_upgrade_required`. All other queries keep returning [].
+  internalQuery: (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? Promise.resolve([{ plan_tier: "business", is_operator_workspace: false }])
+      : Promise.resolve([]),
   internalExecute: mock(() => {}),
 }));
 

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -46,7 +46,17 @@ mock.module("@atlas/api/lib/auth/detect", () => ({
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   getInternalDB: () => ({ query: () => Promise.resolve({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: () => Promise.resolve([]),
+  // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
+  // plan_tier before every custom-domain route in SaaS deploy mode (which this
+  // monorepo's test env resolves to). custom_domain gates to Pro+, so the
+  // entitlement read returns `business` (≥ Pro) so the gate passes and these
+  // tests exercise the route body. All other queries keep returning [].
+  internalQuery: (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? Promise.resolve([{ plan_tier: "business", is_operator_workspace: false }])
+      : Promise.resolve([]),
   internalExecute: () => {},
   getWorkspaceDetails: mock(async () => ({ plan_tier: "free" })),
 }));

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -489,7 +489,23 @@ let mockHasInternalDB = true;
 // internalQuery and queryEffect mocks so tests can exercise DB rejection paths.
 let mockInternalQueryResult: unknown[] | Error = [];
 
-function invokeInternalQueryMock(): Promise<unknown[]> {
+function invokeInternalQueryMock(sql?: string): Promise<unknown[]> {
+  // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
+  // plan_tier before every residency route in SaaS deploy mode (which this
+  // monorepo's test env resolves to). Residency gates to Business, so the
+  // entitlement read returns `business` independent of `mockInternalQueryResult`
+  // (which drives the residency migration-row queries / rejection paths) — so a
+  // test exercising a DB-rejection migration path still passes the gate first.
+  if (
+    sql &&
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+  ) {
+    return Promise.resolve([
+      { plan_tier: "business", is_operator_workspace: false },
+    ]);
+  }
   return mockInternalQueryResult instanceof Error
     ? Promise.reject(mockInternalQueryResult)
     : Promise.resolve(mockInternalQueryResult);

--- a/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
+++ b/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Per-tier feature-entitlement route gates (WS1 of #3984 / #3988).
+ *
+ * #3986 wired `requireFeatureEntitlement` into the SSO routes and proved the
+ * gate end-to-end. #3988 extends the same gate to the remaining compliance /
+ * hosting tenant surfaces:
+ *
+ *   - audit-retention  (`audit_retention`, Business)
+ *   - PII masking + compliance reports (`masking`, Business)
+ *   - white-label branding (`white_label`, Business)
+ *   - custom domain (`custom_domain`, Pro+)
+ *   - data residency (`residency`, Business)
+ *
+ * These assert the gate's external behavior at the API boundary: a below-tier
+ * workspace is denied with the `plan_upgrade_required` upgrade envelope BEFORE
+ * the route ever reaches the EE service; an at/above-tier workspace passes the
+ * gate (so it never sees `plan_upgrade_required`); an operator workspace
+ * bypasses the ladder; and a tier-lookup fault fails closed with 503. This is
+ * the per-feature deny/allow proof the acceptance criteria require — modeled on
+ * `admin-sso.test.ts`'s "per-tier entitlement gate" block.
+ *
+ * The gate fires before the EE Policy Tag is yielded, so the *deny* path is
+ * fully observable without mocking each feature's EE service: a denied request
+ * 403s with `plan_upgrade_required` regardless of the (Noop) EE layer. The
+ * *allow* path is asserted as "not denied by the ladder" (status is not 403
+ * `plan_upgrade_required`) — the downstream EE service is Noop here so it may
+ * 404/403-enterprise, but crucially it is NOT the per-tier upgrade denial,
+ * which proves the gate let the request through.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks();
+
+// Module-top env setup — must be set before the dynamic app import below.
+// `??=` keeps the assignment hoisted; cross-file leakage under bun's parallel
+// runner is bounded (the first file to load wins). The per-tier ladder only
+// fires in SaaS deploy mode, so pin it so these gate tests are deterministic
+// regardless of the ambient ATLAS_DEPLOY_MODE / DATABASE_URL.
+process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
+process.env.ATLAS_DEPLOY_MODE ??= "saas";
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+function adminRequest(urlPath: string, method = "GET", body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+    },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${urlPath}`, opts);
+}
+
+/** Make the entitlement lookup read back a specific tier for the workspace. */
+function setWorkspaceTier(tier: string, isOperator = false): void {
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+    /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+      sql,
+    )
+      ? [{ plan_tier: tier, is_operator_workspace: isOperator }]
+      : [],
+  );
+}
+
+/** Make the tier lookup throw — the fail-closed (503) arm. */
+function failWorkspaceLookup(): void {
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+    if (
+      /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(
+        sql,
+      )
+    ) {
+      throw new Error("db unavailable");
+    }
+    return [];
+  });
+}
+
+async function errorOf(res: Response): Promise<string> {
+  return ((await res.json()) as { error?: string }).error ?? "";
+}
+
+/**
+ * Each Business-gated tenant surface, with a side-effect-free GET probe and a
+ * representative MUTATING route. The gate is wired identically across every
+ * handler in the file (asserted structurally by the enforcement-parity guard);
+ * probing both a read and a write per feature additionally pins that the gate
+ * sits *before* the mutating handler's side effect — a below-tier write must be
+ * denied (403) rather than mutating-then-403, which a GET-only probe + a
+ * presence-only structural scan would both miss.
+ */
+const BUSINESS_FEATURES: Array<{
+  feature: string;
+  label: string;
+  path: string;
+  mutate: { method: string; path: string; body?: unknown };
+}> = [
+  {
+    feature: "audit_retention",
+    label: "audit-retention",
+    path: "/api/v1/admin/audit/retention",
+    mutate: { method: "POST", path: "/api/v1/admin/audit/retention/purge" },
+  },
+  {
+    feature: "masking",
+    label: "masking / compliance",
+    path: "/api/v1/admin/compliance/classifications",
+    mutate: {
+      method: "DELETE",
+      path: "/api/v1/admin/compliance/classifications/cls_1",
+    },
+  },
+  {
+    feature: "white_label",
+    label: "white-label branding",
+    path: "/api/v1/admin/branding",
+    mutate: { method: "PUT", path: "/api/v1/admin/branding", body: { logoText: "Acme" } },
+  },
+  {
+    feature: "residency",
+    label: "data residency",
+    path: "/api/v1/admin/residency",
+    mutate: { method: "PUT", path: "/api/v1/admin/residency", body: { region: "us-east" } },
+  },
+];
+
+describe("per-tier feature-entitlement route gates (#3988)", () => {
+  beforeEach(() => {
+    mocks.setOrgAdmin("org-1");
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+  });
+
+  describe.each(BUSINESS_FEATURES)(
+    "$label — Business-gated",
+    ({ feature, path, mutate }) => {
+      it(`denies a Pro workspace with 403 plan_upgrade_required (${feature})`, async () => {
+        setWorkspaceTier("pro");
+        const res = await app.fetch(adminRequest(path));
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as {
+          error: string;
+          required_plan: string;
+          current_plan: string;
+        };
+        expect(body.error).toBe("plan_upgrade_required");
+        expect(body.required_plan).toBe("business");
+        expect(body.current_plan).toBe("pro");
+      });
+
+      it(`denies a Starter workspace (${feature})`, async () => {
+        setWorkspaceTier("starter");
+        const res = await app.fetch(adminRequest(path));
+        expect(res.status).toBe(403);
+        expect(await errorOf(res)).toBe("plan_upgrade_required");
+      });
+
+      it(`denies a below-tier workspace on the mutating ${mutate.method} route before any side effect (${feature})`, async () => {
+        // The gate must sit ABOVE the mutating handler's side effect: a
+        // below-tier write is denied with the ladder 403, never
+        // mutate-then-403. A GET-only probe plus the presence-only
+        // enforcement-parity scan would both miss a gate that ran after the
+        // destructive call, so probe a real write per feature.
+        setWorkspaceTier("pro");
+        const res = await app.fetch(
+          adminRequest(mutate.path, mutate.method, mutate.body),
+        );
+        expect(res.status).toBe(403);
+        expect(await errorOf(res)).toBe("plan_upgrade_required");
+      });
+
+      it(`allows a Business workspace past the ladder (${feature})`, async () => {
+        setWorkspaceTier("business");
+        const res = await app.fetch(adminRequest(path));
+        // The gate passed: the request is NOT denied with the per-tier upgrade
+        // envelope. (Downstream the EE layer is Noop here, so the final status
+        // may be a 404/enterprise response — but never the ladder's 403.)
+        expect(await errorOf(res)).not.toBe("plan_upgrade_required");
+      });
+
+      it(`bypasses the ladder for an operator workspace (${feature})`, async () => {
+        setWorkspaceTier("free", true);
+        const res = await app.fetch(adminRequest(path));
+        expect(await errorOf(res)).not.toBe("plan_upgrade_required");
+      });
+
+      it(`fails closed with 503 billing_check_failed when the tier lookup throws (${feature})`, async () => {
+        // A transient internal-DB fault must NOT silently widen access to a
+        // Business feature — the per-tier guard fails closed end-to-end.
+        failWorkspaceLookup();
+        const res = await app.fetch(adminRequest(path));
+        expect(res.status).toBe(503);
+        expect(await errorOf(res)).toBe("billing_check_failed");
+      });
+    },
+  );
+
+  // Custom domain is the one Pro+ override (#3988): denied below Pro, allowed at
+  // Pro and Business. This proves the SSOT's non-Business minimum is enforced.
+  describe("custom domain — Pro+ gated", () => {
+    const path = "/api/v1/admin/domain";
+
+    it("denies a Starter workspace with 403 plan_upgrade_required", async () => {
+      setWorkspaceTier("starter");
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: string;
+        required_plan: string;
+        current_plan: string;
+      };
+      expect(body.error).toBe("plan_upgrade_required");
+      expect(body.required_plan).toBe("pro");
+      expect(body.current_plan).toBe("starter");
+    });
+
+    it("denies a Free workspace", async () => {
+      setWorkspaceTier("free");
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(403);
+      expect(await errorOf(res)).toBe("plan_upgrade_required");
+    });
+
+    it("allows a Pro workspace past the ladder (the override)", async () => {
+      setWorkspaceTier("pro");
+      const res = await app.fetch(adminRequest(path));
+      expect(await errorOf(res)).not.toBe("plan_upgrade_required");
+    });
+
+    it("allows a Business workspace past the ladder", async () => {
+      setWorkspaceTier("business");
+      const res = await app.fetch(adminRequest(path));
+      expect(await errorOf(res)).not.toBe("plan_upgrade_required");
+    });
+
+    it("fails closed with 503 when the tier lookup throws", async () => {
+      failWorkspaceLookup();
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(503);
+      expect(await errorOf(res)).toBe("billing_check_failed");
+    });
+  });
+});

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -20,6 +20,7 @@ import { AuthContext } from "@atlas/api/lib/effect/services";
 import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
 import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
@@ -403,6 +404,7 @@ adminAuditRetention.use(requirePermission("admin:audit"));
 adminAuditRetention.openapi(getRetentionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "audit_retention");
 
     const retention = yield* yieldAuditRetentionFailClosed();
     const policy = yield* retention.getRetentionPolicy(orgId!);
@@ -415,6 +417,7 @@ adminAuditRetention.openapi(updateRetentionRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const { orgId, user } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "audit_retention");
 
     const body = c.req.valid("json");
 
@@ -492,6 +495,7 @@ adminAuditRetention.openapi(exportRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "audit_retention");
 
     const body = c.req.valid("json");
 
@@ -567,6 +571,7 @@ adminAuditRetention.openapi(purgeRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "audit_retention");
 
     const retention = yield* yieldAuditRetentionFailClosed();
     const { purgeExpiredEntries, getRetentionPolicy } = retention;
@@ -623,6 +628,7 @@ adminAuditRetention.openapi(hardDeleteRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "audit_retention");
 
     const retention = yield* yieldAuditRetentionFailClosed();
 

--- a/packages/api/src/api/routes/admin-branding.ts
+++ b/packages/api/src/api/routes/admin-branding.ts
@@ -11,6 +11,7 @@ import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext, Branding } from "@atlas/api/lib/effect/services";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { BrandingError } from "@atlas/api/lib/branding/branding-errors";
 import { WorkspaceBrandingSchema as BrandingSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -214,6 +215,7 @@ adminBranding.use(requirePermission("admin:settings"));
 adminBranding.openapi(getBrandingRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "white_label");
     const branding = yield* Branding;
 
     const result = yield* branding.getWorkspaceBranding(orgId!);
@@ -228,6 +230,7 @@ adminBranding.openapi(setBrandingRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "white_label");
     const brandingSvc = yield* Branding;
 
     const branding = yield* brandingSvc.setWorkspaceBranding(orgId!, {
@@ -265,6 +268,7 @@ adminBranding.openapi(deleteBrandingRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "white_label");
     const brandingSvc = yield* Branding;
 
     const deleted = yield* brandingSvc.deleteWorkspaceBranding(orgId!);

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -23,6 +23,7 @@ import {
   MaskingPolicy,
 } from "@atlas/api/lib/effect/services";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { ComplianceError, ReportError } from "@atlas/api/lib/compliance/errors";
 import type { PIICategory, MaskingStrategy } from "@useatlas/types";
 import { PIIColumnClassificationSchema as PIIClassificationSchema } from "@useatlas/schemas";
@@ -126,6 +127,7 @@ adminCompliance.use(requireOrgContext());
 adminCompliance.openapi(listRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "masking");
     const masking = yield* MaskingPolicy;
     const { connectionGroupId } = c.req.valid("query");
 
@@ -142,6 +144,7 @@ adminCompliance.openapi(updateRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "masking");
     const masking = yield* MaskingPolicy;
 
     const updated = yield* masking.updatePIIClassification(orgId!, id, {
@@ -178,6 +181,7 @@ adminCompliance.openapi(deleteRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "masking");
     const masking = yield* MaskingPolicy;
 
     yield* masking.deletePIIClassification(orgId!, id);
@@ -304,6 +308,7 @@ const userActivityReportRoute = createRoute({
 adminCompliance.openapi(dataAccessReportRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "masking");
     const reports = yield* ComplianceReports;
     const query = c.req.valid("query");
 
@@ -339,6 +344,7 @@ adminCompliance.openapi(dataAccessReportRoute, async (c) => {
 adminCompliance.openapi(userActivityReportRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "masking");
     const reports = yield* ComplianceReports;
     const query = c.req.valid("query");
 

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -20,6 +20,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import type { Context } from "hono";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext, Domains, RequestContext } from "@atlas/api/lib/effect/services";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
@@ -273,6 +274,7 @@ adminDomains.use(requirePermission("admin:settings"));
 adminDomains.openapi(getDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 
@@ -293,6 +295,7 @@ adminDomains.openapi(getDomainRoute, async (c) => {
 adminDomains.openapi(addDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 
@@ -343,6 +346,7 @@ adminDomains.openapi(addDomainRoute, async (c) => {
 adminDomains.openapi(verifyDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 
@@ -376,6 +380,7 @@ adminDomains.openapi(verifyDomainRoute, async (c) => {
 adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 
@@ -408,6 +413,7 @@ adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
 adminDomains.openapi(domainCheckRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 
@@ -433,6 +439,7 @@ adminDomains.openapi(domainCheckRoute, async (c) => {
 adminDomains.openapi(removeDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    yield* requireFeatureEntitlement(orgId, "custom_domain");
     const { requestId } = yield* RequestContext;
     const mod = yield* Domains;
 

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -16,6 +16,7 @@ import { RequestContext, AuthContext, ResidencyResolver } from "@atlas/api/lib/e
 import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import {
   triggerMigrationExecution,
@@ -482,6 +483,7 @@ adminResidency.openapi(getStatusRoute, async (c) => {
     c,
     Effect.gen(function* () {
       const { orgId } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
       const mod = yield* ResidencyResolver;
 
       if (!mod.available) {
@@ -560,6 +562,7 @@ adminResidency.openapi(assignRegionRoute, async (c) => {
     c,
     Effect.gen(function* () {
       const { orgId } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
       const mod = yield* ResidencyResolver;
 
       if (!mod.available) {
@@ -620,6 +623,7 @@ adminResidency.openapi(getMigrationStatusRoute, async (c) => {
     Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
 
       if (!hasInternalDB()) {
         return c.json({ error: "not_available", message: "Migration tracking requires an internal database.", requestId }, 404);
@@ -655,6 +659,7 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
     Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
       const { orgId, user } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
       const { targetRegion } = c.req.valid("json");
 
       if (!orgId) {
@@ -787,6 +792,7 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
     Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
       const { id } = c.req.valid("param");
 
       if (!hasInternalDB()) {
@@ -882,6 +888,7 @@ adminResidency.openapi(cancelMigrationRoute, async (c) => {
     Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
+      yield* requireFeatureEntitlement(orgId, "residency");
       const { id } = c.req.valid("param");
 
       if (!hasInternalDB()) {

--- a/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
@@ -159,14 +159,21 @@ describe("ENFORCEMENT_PENDING + live SSOT — the committed allowlist is honest"
     // coupling is deliberate: the unit test tracks the real wiring snapshot,
     // and the live-tree fixture (check-enforcement-parity.test.sh) covers the
     // actual route scan.
-    // #3987 wired SCIM, custom roles, IP allowlist, and approval workflows and
-    // removed them from ENFORCEMENT_PENDING — so they read as enforced now.
+    // sso (#3986); scim, custom_roles, ip_allowlist, approvals (#3987); and the
+    // #3988 tenant-route gates (audit_retention, masking, residency, white_label,
+    // custom_domain). Only backups + proactive (#3984) remain in
+    // ENFORCEMENT_PENDING and so are not listed here.
     const enforcedToday = [
       "sso",
       "scim",
       "custom_roles",
       "ip_allowlist",
       "approvals",
+      "audit_retention",
+      "masking",
+      "residency",
+      "white_label",
+      "custom_domain",
     ];
     const findings = checkEnforcementParity(enforcedToday);
     expect(findings).toEqual([]);

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import type { PlanTier } from "@useatlas/types";
+import type { MinPlanTier, PlanTier } from "@useatlas/types";
 import {
   FEATURE_ENTITLEMENTS,
   isFeatureEntitled,
@@ -37,14 +37,27 @@ const TIER_RANK: Record<PlanTier, number> = {
   business: 4,
 };
 
+// Features whose minimum tier intentionally overrides the Business default.
+// `custom_domain` sits at Pro+ (#3988): the custom-domain route has always
+// documented "Pro or Business plan … required to create a domain". Every other
+// gated feature must remain at the Business default.
+const TIER_OVERRIDES: Partial<Record<GatedFeature, MinPlanTier>> = {
+  custom_domain: "pro",
+};
+
 describe("FEATURE_ENTITLEMENTS map", () => {
-  it("defaults every gated feature to the Business tier (current pricing page)", () => {
-    // The PRD locks the default tier line at Business for all ten EE features
-    // plus proactive. A Pro+ override would be an intentional single-line
-    // change here; until then the map must be uniformly Business.
+  it("defaults every gated feature to Business except the recorded Pro+ overrides", () => {
+    // The PRD locks the default tier line at Business. A Pro+ override is an
+    // intentional single-line change in the SSOT; this pins the exact override
+    // set so a stray re-tier is caught.
     for (const feature of ALL_FEATURES) {
-      expect(FEATURE_ENTITLEMENTS[feature]).toBe("business");
+      const expected = TIER_OVERRIDES[feature] ?? "business";
+      expect(FEATURE_ENTITLEMENTS[feature]).toBe(expected);
     }
+  });
+
+  it("pins custom_domain to Pro (the one Pro+ override)", () => {
+    expect(FEATURE_ENTITLEMENTS.custom_domain).toBe("pro");
   });
 
   it("enumerates the full advertised gated-feature set (not an ad-hoc subset)", () => {
@@ -62,6 +75,7 @@ describe("FEATURE_ENTITLEMENTS map", () => {
       "residency",
       "backups",
       "white_label",
+      "custom_domain",
       "proactive",
     ];
     expect(ALL_FEATURES.toSorted()).toEqual(expected.toSorted());
@@ -87,9 +101,18 @@ describe("isFeatureEntitled — tier × feature matrix", () => {
 
   it("denies Starter and Pro every Business-gated feature", () => {
     for (const feature of ALL_FEATURES) {
+      if (FEATURE_ENTITLEMENTS[feature] !== "business") continue;
       expect(isFeatureEntitled("starter", feature)).toBe(false);
       expect(isFeatureEntitled("pro", feature)).toBe(false);
     }
+  });
+
+  it("treats custom_domain as Pro-gated: denied below Pro, allowed at Pro and Business", () => {
+    expect(isFeatureEntitled("free", "custom_domain")).toBe(false);
+    expect(isFeatureEntitled("trial", "custom_domain")).toBe(false);
+    expect(isFeatureEntitled("starter", "custom_domain")).toBe(false);
+    expect(isFeatureEntitled("pro", "custom_domain")).toBe(true);
+    expect(isFeatureEntitled("business", "custom_domain")).toBe(true);
   });
 
   it("fails closed for the `locked` churn tier on every feature", () => {

--- a/packages/api/src/lib/billing/enforcement-parity.ts
+++ b/packages/api/src/lib/billing/enforcement-parity.ts
@@ -84,16 +84,20 @@ export type IssueRef = `#${number}`;
  * empty or prose value won't typecheck.
  */
 export const ENFORCEMENT_PENDING: Partial<Record<GatedFeature, IssueRef>> = {
-  // #3987 gated SCIM, custom roles, IP allowlist, and approval workflows — those
-  // four now have route-layer requireFeatureEntitlement gates and were removed
-  // from this allowlist when that slice landed (rule 2 forces the shrink).
-  // Remaining WS1 surfaces (audit-retention, masking, residency, backups,
-  // white-label, proactive) — gated in their own follow-up slices under #3984.
-  audit_retention: "#3984",
-  masking: "#3984",
-  residency: "#3984",
+  // #3987 gated SCIM, custom roles, IP allowlist, and approval workflows, and
+  // #3988 gated audit-retention, masking (incl. compliance reports), residency,
+  // white-label, and custom-domain at their tenant (`admin-*`) routes — all
+  // removed from this allowlist as their gates landed (rule 2 forces the shrink).
+  //
+  // `backups` stays pending: its only route surface is operator/platform-scoped
+  // (`platform-backups.ts`, `createPlatformRouter`, no workspace `orgId`), so a
+  // per-tenant `requireFeatureEntitlement(orgId, "backups")` gate is structurally
+  // inapplicable there. It is gated by the enterprise-license Tag
+  // (`backups.available`) today; a tenant-facing backups surface is needed before
+  // the per-tier ladder can apply, tracked under #3984.
   backups: "#3984",
-  white_label: "#3984",
+  // `proactive` is gated in its own follow-up slice under #3984 (it also needs
+  // the WS5 relocation into `/ee`).
   proactive: "#3984",
 };
 

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -53,6 +53,7 @@ export type GatedFeature =
   | "residency"
   | "backups"
   | "white_label"
+  | "custom_domain"
   | "proactive";
 
 /**
@@ -79,6 +80,12 @@ export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, MinPlanTier>> =
   residency: "business",
   backups: "business",
   white_label: "business",
+  // Pro+ override (not the Business default): the custom-domain route has always
+  // documented "Pro or Business plan … required to create a domain" (see
+  // admin-domains.ts), so the SSOT pins its minimum at `pro` to match the
+  // product's established intent. #3988 / #3984 acceptance criteria explicitly
+  // permit custom domain to sit at Pro+ where the SSOT says so.
+  custom_domain: "pro",
   proactive: "business",
 };
 

--- a/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
+++ b/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
@@ -75,6 +75,7 @@ export const FEATURE_DISPLAY: Record<GatedFeature, FeatureDisplay> = {
   white_label: { label: "White-label branding", section: "hosting" },
   residency: { label: "Data residency", section: "hosting" },
   backups: { label: "Automated backups", section: "hosting" },
+  custom_domain: { label: "Custom domain", section: "hosting" },
   // security & compliance
   sso: { label: "SSO (SAML + OIDC)", section: "security & compliance" },
   scim: { label: "SCIM directory sync", section: "security & compliance" },

--- a/scripts/__tests__/check-enforcement-parity.test.sh
+++ b/scripts/__tests__/check-enforcement-parity.test.sh
@@ -61,12 +61,14 @@ trap restore EXIT
 check pass "committed tree: every SSOT feature gated or pending"
 
 # --- rule 1: an ungated, unacknowledged feature fails -----------------------
-# Drop `masking` from ENFORCEMENT_PENDING. It's in the SSOT and has no route
-# gate yet (#3984), so the guard must catch the now-silently-open ladder.
-# (`scim`/`custom_roles`/`ip_allowlist`/`approvals` are no longer usable here —
-# #3987 gated them, so dropping their pending entry creates no drift.)
+# Drop `backups` from ENFORCEMENT_PENDING. It's in the SSOT and has no route
+# gate (its only surface is the operator-scoped platform-backups router, #3984),
+# so the guard must catch the now-silently-open ladder.
+# (`scim`/`custom_roles`/`ip_allowlist`/`approvals` (#3987) and audit_retention/
+# masking/residency/white_label/custom_domain (#3988) are no longer usable here —
+# they're gated + removed from pending, so dropping their entry creates no drift.)
 cp "$PENDING_BAK" "$PENDING"
-perl -0pi -e 's/^\s*masking:\s*"#3984",\n//m' "$PENDING"
+perl -0pi -e 's/^\s*backups:\s*"#3984",\n//m' "$PENDING"
 check fail "removing a pending entry for an ungated feature trips the gate"
 cp "$PENDING_BAK" "$PENDING"
 
@@ -78,12 +80,12 @@ check fail "a phantom pending entry (not in the SSOT) trips the gate"
 cp "$PENDING_BAK" "$PENDING"
 
 # --- rule 2: a stale pending entry (feature now enforced) fails -------------
-# Simulate `masking` getting wired: add a route-layer gate call for it AND leave
+# Simulate `backups` getting wired: add a route-layer gate call for it AND leave
 # it in ENFORCEMENT_PENDING. The guard must flag the stale allowlist entry.
-# (Use a still-pending feature — `scim` et al. are already enforced + removed
-# from pending by #3987, so they can't fake a stale-pending state.)
+# (Use a still-pending feature — the #3987/#3988 features are already enforced +
+# removed from pending, so they can't fake a stale-pending state.)
 cp "$SSO_BAK" "$SSO_ROUTE"
-perl -0pi -e 's/(yield\* requireFeatureEntitlement\(orgId, "sso"\);)/$1\n    yield* requireFeatureEntitlement(orgId, "masking");/' "$SSO_ROUTE"
+perl -0pi -e 's/(yield\* requireFeatureEntitlement\(orgId, "sso"\);)/$1\n    yield* requireFeatureEntitlement(orgId, "backups");/' "$SSO_ROUTE"
 check fail "a feature that is enforced but still listed pending trips the gate"
 cp "$SSO_BAK" "$SSO_ROUTE"
 


### PR DESCRIPTION
## What

Applies the `requireFeatureEntitlement(orgId, "<feature>")` guard (from #3986) to the remaining compliance/hosting **tenant** feature routes, each gated to its minimum tier at the route/handler layer and registered in the `FEATURE_ENTITLEMENTS` SSOT. WS1 of #3984; sibling to #3987 (which gated SCIM/roles/IP-allowlist/approvals).

| Feature | SSOT key | Min tier | Route file |
|---|---|---|---|
| Audit-retention policies | `audit_retention` | Business | `admin-audit-retention.ts` (5 handlers) |
| PII masking + compliance reports | `masking` | Business | `admin-compliance.ts` (5 handlers) |
| White-label branding | `white_label` | Business | `admin-branding.ts` (3 handlers) |
| Custom domain | `custom_domain` *(new key)* | **Pro+** | `admin-domains.ts` (6 handlers) |
| Data residency | `residency` | Business | `admin-residency.ts` (6 handlers) |

Below-tier workspaces are denied with the standard `403 plan_upgrade_required` upgrade envelope; at/above-tier workspaces pass; operator workspaces bypass; a tier-lookup fault fails closed with `503 billing_check_failed`.

### Key decisions

- **`compliance reports` folds into `masking`.** The parent PRD lists this surface as "compliance/masking" (one feature); `admin-compliance.ts` holds both the PII-classification (masking) and report-generation handlers, all gated with `masking`.
- **`custom_domain` is a new SSOT key at Pro+** (the one non-Business override). The custom-domain route has always documented "Pro or Business plan … required to create a domain" — the SSOT now pins that intent. A `FEATURE_DISPLAY` row is added and the pricing mirror artifact regenerated; pricing-parity stays green.
- **`backups` stays in `ENFORCEMENT_PENDING`.** Its only route surface is the operator-scoped `platform-backups.ts` (`createPlatformRouter`, no workspace `orgId`), so a per-tenant gate is structurally inapplicable. It remains gated by the enterprise-license Tag (`backups.available`); a tenant-facing surface is the precondition for the per-tier ladder (tracked under #3984). `proactive` also stays pending (#3984).
- The newly-gated features are removed from `ENFORCEMENT_PENDING`, and the adversarial fixture (`check-enforcement-parity.test.sh`) is retargeted to `backups` (the still-pending feature) so all five fixture cases stay valid.

## Tests

`packages/api/src/api/__tests__/feature-entitlement-routes.test.ts` — per feature: deny below-tier (`403 plan_upgrade_required`), allow at/above-tier (passes the ladder), operator bypass, fail-closed `503`, **and a mutating-route (POST/DELETE/PUT) deny probe** that pins the gate sits *before* the handler's side effect. `custom_domain`'s Pro+ override is proven specifically (Pro allowed, Starter/Free denied) at both the route boundary and the predicate level. The five existing route test files now seed a Business tier so the now-active SaaS-mode gate passes; `feature-entitlement.test.ts` / `enforcement-parity.test.ts` track the new SSOT key + override.

## Gates

Local: lint, type, syncpack, enforcement-parity, pricing-parity, the parity fixture (5/5), schema/openapi/template/all drift checks — green. `@atlas/api` suite: 741/742 (the single failure, `admin-model-config.test.ts`, is a pre-existing environment-only timeout, byte-identical to `main` and green on `main`'s CI — unrelated to this change).

Internal review panel (silent-failure, type-design, test-coverage, comment) — CLEAN after addressing the one finding (mutating-route ordering probe).

Closes #3988

https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb

---
_Generated by [Claude Code](https://claude.ai/code/session_019iMJ2M4grE94HdNo9pmBSb)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate audit-retention, masking, white-label, custom-domain, and residency routes by plan tier
> - Adds `requireFeatureEntitlement` checks to all admin routes for audit retention, branding (white-label), compliance/masking, custom domains, and residency — returning `403 plan_upgrade_required` for below-tier requests in SaaS mode.
> - `custom_domain` is gated at Pro+; all other new features (`audit_retention`, `masking`, `white_label`, `residency`) require Business tier.
> - Removes these five features from the `ENFORCEMENT_PENDING` map in [enforcement-parity.ts](https://github.com/AtlasDevHQ/atlas/pull/4031/files#diff-668cbb78dbe26e8b26a609c6cc0a7dfc7671b2f0dd04d2ee2e67dbc18a73b171) now that their gates are wired.
> - Updates test mocks across all affected route test files to simulate Business-tier workspaces so existing tests continue to pass the new gates.
> - Adds a new [feature-entitlement-routes.test.ts](https://github.com/AtlasDevHQ/atlas/pull/4031/files#diff-ca91c040ec4275fad9ee34283db7d113436ce7959e3b2660359fee7ee5001688) suite asserting `403`/`503` behavior for below-tier, operator bypass, and lookup failure cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78c3ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->