### PR TITLE
feat(api): OverageMeter — idempotent Stripe Billing Meters reporter + metered subscription item (WS2)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -423,6 +423,10 @@ describe("migrateAuthTables", () => {
             // #4019); neither FKs a Better Auth table, so it is NOT in
             // MANAGED_AUTH_MIGRATIONS and runs in every auth mode — must be listed.
             { name: "0153_region_db_subscription_scim_parity.sql" },
+            // 0154 creates overage_meter_reports (the Stripe overage-reporter
+            // ledger, #3992); no FK to a Better Auth table, so it is NOT in
+            // MANAGED_AUTH_MIGRATIONS and runs in every auth mode — must be listed.
+            { name: "0154_overage_meter_reports.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
@@ -42,6 +42,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   internalExecute: mock(() => {}),
+  // Required by metering.ts (loaded transitively via server.ts → enforcement /
+  // overage-meter). Mirrors buildInternalDbMockDefaults; omitting it surfaces as
+  // "Export named 'isInternalCircuitOpen' not found" once a new import path
+  // forces metering to link against this hand-rolled partial mock (#3992).
+  isInternalCircuitOpen: () => false,
   getInternalDB: () => ({ query: mockDbQuery }),
   closeInternalDB: async () => {},
   migrateInternalDB: async () => {},
@@ -98,6 +103,11 @@ mock.module("@atlas/api/lib/billing/enforcement", () => ({
   invalidatePlanCache: () => {},
   buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 2_000_000, usagePercent: 0, status: "ok" }),
   severityOf: () => 0,
+  // Imported by overage-meter.ts (loaded transitively via server.ts → the
+  // ensureOverageSubscriptionItem seam). Omitting it surfaces as "Export named
+  // 'computeOverageTokens' not found" once that import forces enforcement to
+  // link against this partial mock (#3992). Real trivial impl — never called here.
+  computeOverageTokens: (usage: number, limit: number) => Math.max(0, usage - limit),
 }));
 
 const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});

--- a/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-webhook-lifecycle.test.ts
@@ -195,10 +195,18 @@ function ledgerAwareQuery(
 
 const STARTER_PRICE = "price_starter_test";
 const PRO_PRICE = "price_pro_test";
+const STARTER_OVERAGE_PRICE = "price_starter_overage_test"; // #3992 metered item
 const EPOCH = Math.floor(Date.now() / 1000);
 
 const subscriptionsRetrieve: Mock<(id: string) => Promise<unknown>> = mock(() =>
   Promise.resolve(stripeSubscription()),
+);
+
+// #3992 — the metered-overage subscription-item create the onEvent seam calls
+// via ensureOverageSubscriptionItem. Recorded so the wiring test can assert it
+// fires on customer.subscription.{created,updated}.
+const subscriptionItemsCreate: Mock<(params: unknown) => Promise<unknown>> = mock(() =>
+  Promise.resolve({ id: "si_overage" }),
 );
 
 function makeStripeClient() {
@@ -209,6 +217,9 @@ function makeStripeClient() {
     subscriptions: {
       retrieve: subscriptionsRetrieve,
       list: mock(() => Promise.resolve({ data: [] })),
+    },
+    subscriptionItems: {
+      create: subscriptionItemsCreate,
     },
     customers: {
       retrieve: mock(() => Promise.resolve({ id: "cus_1", email: "buyer@example.com" })),
@@ -310,13 +321,18 @@ function checkoutCompletedEvent(id = "evt_checkout_1", created = EPOCH) {
   };
 }
 
-const ENV_KEYS = ["STRIPE_STARTER_PRICE_ID", "STRIPE_PRO_PRICE_ID"] as const;
+const ENV_KEYS = [
+  "STRIPE_STARTER_PRICE_ID",
+  "STRIPE_PRO_PRICE_ID",
+  "STRIPE_STARTER_OVERAGE_PRICE_ID",
+] as const;
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeAll(() => {
   for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
   process.env.STRIPE_STARTER_PRICE_ID = STARTER_PRICE;
   process.env.STRIPE_PRO_PRICE_ID = PRO_PRICE;
+  process.env.STRIPE_STARTER_OVERAGE_PRICE_ID = STARTER_OVERAGE_PRICE;
 });
 
 afterAll(() => {
@@ -338,6 +354,8 @@ beforeEach(() => {
   mockInternalQuery.mockImplementation(ledgerAwareQuery());
   subscriptionsRetrieve.mockClear();
   subscriptionsRetrieve.mockImplementation(() => Promise.resolve(stripeSubscription()));
+  subscriptionItemsCreate.mockClear();
+  subscriptionItemsCreate.mockImplementation(() => Promise.resolve({ id: "si_overage" }));
   lockTails.clear();
   lockCalls.length = 0;
 });
@@ -1436,5 +1454,46 @@ describe("subscription status policy (#3424)", () => {
 
     expect(res.status).toBe(200);
     expect(mockUpdateWorkspaceStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ── customer.subscription.{created,updated} → metered overage item (#3992) ──
+//
+// End-to-end wiring guard for the AC "metered item added as a second
+// subscription item per tier": a real webhook drives the real onEvent seam,
+// which calls the real ensureOverageSubscriptionItem. With the seat + overage
+// price IDs set (beforeAll) and the subscription's first item priced at
+// STARTER_PRICE, the tier resolves to starter and the metered item is added.
+// If the 2-line wiring in onEvent's switch were dropped, overage would meter
+// but never invoice — these tests fail loudly instead.
+describe("metered-overage subscription item wiring (#3992)", () => {
+  function subscriptionEvent(type: string, id: string) {
+    return { id, type, created: EPOCH, data: { object: stripeSubscription() } };
+  }
+
+  it("adds the tier's metered-overage item on customer.subscription.created", async () => {
+    const auth = makeAuth(emptyDB());
+    const res = await postWebhook(
+      auth,
+      subscriptionEvent("customer.subscription.created", "evt_ovg_created"),
+    );
+    expect(res.status).toBe(200);
+    expect(subscriptionItemsCreate).toHaveBeenCalledWith({
+      subscription: "sub_stripe_1",
+      price: STARTER_OVERAGE_PRICE,
+    });
+  });
+
+  it("ensures the metered-overage item on customer.subscription.updated (upgrade/downgrade path)", async () => {
+    const auth = makeAuth(emptyDB());
+    const res = await postWebhook(
+      auth,
+      subscriptionEvent("customer.subscription.updated", "evt_ovg_updated"),
+    );
+    expect(res.status).toBe(200);
+    expect(subscriptionItemsCreate).toHaveBeenCalledWith({
+      subscription: "sub_stripe_1",
+      price: STARTER_OVERAGE_PRICE,
+    });
   });
 });

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -73,6 +73,7 @@ import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/a
 import { userHasConsumedTrial, claimTrialGrant, extendTrialOnClaim } from "@atlas/api/lib/billing/trial-eligibility";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
+import { ensureOverageSubscriptionItem } from "@atlas/api/lib/billing/overage-meter";
 import {
   classifyStripeEvent,
   recordStripeEvent,
@@ -2266,8 +2267,18 @@ export function buildStripePluginOptions(deps: {
               case "invoice.paid":
                 await handleInvoicePaid(event.data.object as Stripe.Invoice);
                 break;
+              case "customer.subscription.created":
+                // #3992 — add the tier's metered-overage price as a second
+                // subscription item. Best-effort (ensureOverageSubscriptionItem
+                // swallows + logs Stripe errors), so it can't force a redelivery
+                // of the already-applied tier write above.
+                await ensureOverageSubscriptionItem(event.data.object as Stripe.Subscription, stripeClient);
+                break;
               case "customer.subscription.updated":
                 await handleSubscriptionStatusPolicy(event.data.object as Stripe.Subscription);
+                // #3992 — idempotent: a no-op once the metered item is present;
+                // covers the upgrade/downgrade paths that don't fire `created`.
+                await ensureOverageSubscriptionItem(event.data.object as Stripe.Subscription, stripeClient);
                 break;
               default:
                 break;

--- a/packages/api/src/lib/billing/__tests__/config-validation.test.ts
+++ b/packages/api/src/lib/billing/__tests__/config-validation.test.ts
@@ -11,8 +11,12 @@ import { describe, it, expect } from "bun:test";
 import {
   MONTHLY_PRICE_ID_ENV_VARS,
   ANNUAL_PRICE_ID_ENV_VARS,
+  OVERAGE_PRICE_ID_ENV_VARS,
+  OVERAGE_PRICE_ID_ENV_VAR_BY_TIER,
   findMissingMonthlyPriceIdEnvVars,
   findMissingMonthlyPriceIds,
+  findMissingOveragePriceIds,
+  findMissingOveragePriceIdEnvVars,
   detectStripeKeyMode,
   isPriceModeConsistent,
 } from "@atlas/api/lib/billing/config-validation";
@@ -117,6 +121,87 @@ describe("billing/config-validation", () => {
         STRIPE_BUSINESS_PRICE_ID: "price_c",
       };
       expect(findMissingMonthlyPriceIds((k) => store[k])).toEqual(["STRIPE_STARTER_PRICE_ID"]);
+    });
+  });
+
+  describe("OVERAGE_PRICE_ID_ENV_VARS (#3992)", () => {
+    it("enumerates the three paid-tier metered-overage price vars", () => {
+      expect([...OVERAGE_PRICE_ID_ENV_VARS]).toEqual([
+        "STRIPE_STARTER_OVERAGE_PRICE_ID",
+        "STRIPE_PRO_OVERAGE_PRICE_ID",
+        "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+      ]);
+    });
+
+    it("is disjoint from the monthly + annual seat-price vars", () => {
+      for (const overage of OVERAGE_PRICE_ID_ENV_VARS) {
+        expect(MONTHLY_PRICE_ID_ENV_VARS).not.toContain(overage);
+        expect(ANNUAL_PRICE_ID_ENV_VARS).not.toContain(overage);
+      }
+    });
+
+    it("maps each paid tier to its overage price var", () => {
+      expect(OVERAGE_PRICE_ID_ENV_VAR_BY_TIER).toEqual({
+        starter: "STRIPE_STARTER_OVERAGE_PRICE_ID",
+        pro: "STRIPE_PRO_OVERAGE_PRICE_ID",
+        business: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+      });
+    });
+  });
+
+  describe("findMissingOveragePriceIds (settings-aware, #3992)", () => {
+    it("returns all three when the resolver finds nothing", () => {
+      expect(findMissingOveragePriceIds(() => undefined)).toEqual([
+        "STRIPE_STARTER_OVERAGE_PRICE_ID",
+        "STRIPE_PRO_OVERAGE_PRICE_ID",
+        "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+      ]);
+    });
+
+    it("returns empty when the resolver supplies all three", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_OVERAGE_PRICE_ID: "price_so",
+        STRIPE_PRO_OVERAGE_PRICE_ID: "price_po",
+        STRIPE_BUSINESS_OVERAGE_PRICE_ID: "price_bo",
+      };
+      expect(findMissingOveragePriceIds((k) => store[k])).toEqual([]);
+    });
+
+    it("flags only the tier the resolver leaves unset", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_OVERAGE_PRICE_ID: "price_so",
+        STRIPE_BUSINESS_OVERAGE_PRICE_ID: "price_bo",
+      };
+      expect(findMissingOveragePriceIds((k) => store[k])).toEqual(["STRIPE_PRO_OVERAGE_PRICE_ID"]);
+    });
+
+    it("treats an empty string from the resolver as missing", () => {
+      const store: Record<string, string> = {
+        STRIPE_STARTER_OVERAGE_PRICE_ID: "",
+        STRIPE_PRO_OVERAGE_PRICE_ID: "price_po",
+        STRIPE_BUSINESS_OVERAGE_PRICE_ID: "price_bo",
+      };
+      expect(findMissingOveragePriceIds((k) => store[k])).toEqual(["STRIPE_STARTER_OVERAGE_PRICE_ID"]);
+    });
+  });
+
+  describe("findMissingOveragePriceIdEnvVars (pure env, #3992)", () => {
+    it("returns all three when env is empty", () => {
+      expect(findMissingOveragePriceIdEnvVars({})).toEqual([
+        "STRIPE_STARTER_OVERAGE_PRICE_ID",
+        "STRIPE_PRO_OVERAGE_PRICE_ID",
+        "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+      ]);
+    });
+
+    it("returns empty when all three are set", () => {
+      expect(
+        findMissingOveragePriceIdEnvVars({
+          STRIPE_STARTER_OVERAGE_PRICE_ID: "price_so",
+          STRIPE_PRO_OVERAGE_PRICE_ID: "price_po",
+          STRIPE_BUSINESS_OVERAGE_PRICE_ID: "price_bo",
+        }),
+      ).toEqual([]);
     });
   });
 

--- a/packages/api/src/lib/billing/__tests__/overage-meter-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/overage-meter-pg.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Real-Postgres coverage for the OverageMeter ledger + sweep (#3992).
+ * Mirrors the `reconcile-plan-tiers-pg.test.ts` harness: skips cleanly when
+ * `TEST_DATABASE_URL` is unset, runs every migration into a unique per-test
+ * schema, and exercises the ACTUAL SQL against the real schema.
+ *
+ * What this catches that the mock-based `overage-meter.test.ts` can't:
+ *   - The `recordOverageReport` upsert's `GREATEST(...)` MONOTONICITY — the
+ *     property that makes a late/retried tick unable to regress the cumulative
+ *     (and so unable to re-bill). The unit test only string-matches the SQL.
+ *   - The `chk_overage_meter_reports_tokens_nonneg` CHECK actually rejecting a
+ *     negative cumulative.
+ *   - The `reportPeriodOverages` scan SELECT, which reads `organization.byot`,
+ *     `.plan_tier`, `."stripeCustomerId"` and joins `subscription` — exactly
+ *     the `column "X" does not exist` class that broke the plan-tier reconcile
+ *     in prod and passes every mock test. `organization` is Better-Auth-owned
+ *     and skipped in this run (MANAGED_AUTH_MIGRATIONS), so the fixture builds
+ *     the minimal columns the scan reads; `subscription` is created by 0153.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import {
+  getReportedOverageTokens,
+  recordOverageReport,
+  reportPeriodOverages,
+  type OverageWorkspaceRow,
+} from "@atlas/api/lib/billing/overage-meter";
+import { _resetStripeClientCache } from "@atlas/api/lib/billing/stripe-client";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+const PERIOD = "2026-06-01T00:00:00.000Z";
+
+describeIfPg("OverageMeter ledger + sweep (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `overage_meter_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+  const ORIGINAL_STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`overage-meter-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // Minimal Better-Auth-owned `organization` — only the columns the sweep
+    // scan reads (`plan_tier`, `byot`, `"stripeCustomerId"`). `subscription` is
+    // created by migration 0153 during runMigrations; `overage_meter_reports`
+    // by our migration 0154 (a regular migration, not BA-managed).
+    await pool.query(
+      `CREATE TABLE organization (
+         id text PRIMARY KEY,
+         name text,
+         slug text,
+         plan_tier text NOT NULL DEFAULT 'free',
+         byot boolean,
+         "stripeCustomerId" text
+       )`,
+    );
+
+    process.env.DATABASE_URL = TEST_DB_URL;
+    // A dummy test key makes getStripeClient() return a client (no network at
+    // construction) so reportPeriodOverages reaches the scan; the injected
+    // reportOne never touches Stripe.
+    process.env.STRIPE_SECRET_KEY = "sk_test_overage_pg_dummy";
+    _resetStripeClientCache();
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    if (ORIGINAL_STRIPE_KEY === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = ORIGINAL_STRIPE_KEY;
+    _resetStripeClientCache();
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query(`DELETE FROM overage_meter_reports`);
+    await pool.query(`DELETE FROM subscription`);
+    await pool.query(`DELETE FROM organization`);
+  });
+
+  async function seedOrg(opts: {
+    id: string;
+    planTier: string;
+    byot?: boolean | null;
+    stripeCustomerId?: string | null;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO organization (id, name, slug, plan_tier, byot, "stripeCustomerId")
+       VALUES ($1, $1, $1, $2, $3, $4)`,
+      [opts.id, opts.planTier, opts.byot ?? null, opts.stripeCustomerId ?? null],
+    );
+  }
+
+  async function seedSubscription(opts: {
+    org: string;
+    status: string;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO subscription (id, plan, "referenceId", "stripeSubscriptionId", status, "periodStart")
+       VALUES ($1, 'starter', $2, $1, $3, now())`,
+      [`sub-${opts.org}`, opts.org, opts.status],
+    );
+  }
+
+  it(
+    "advances the cumulative monotonically — GREATEST keeps a late/retried lower tick from regressing it",
+    async () => {
+      const base = {
+        orgId: "org_mono",
+        periodStartISO: PERIOD,
+        stripeCustomerId: "cus_mono",
+      };
+      await recordOverageReport({ ...base, reportedTokens: 500, eventIdentifier: "id_0" });
+      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(500);
+
+      // A stale/retried tick carrying a LOWER cumulative must not regress it.
+      await recordOverageReport({ ...base, reportedTokens: 300, eventIdentifier: "id_stale" });
+      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(500);
+
+      // A genuine advance moves it forward.
+      await recordOverageReport({ ...base, reportedTokens: 700, eventIdentifier: "id_1" });
+      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(700);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "enforces the non-negative CHECK on reported_tokens",
+    async () => {
+      // Assert the SPECIFIC non-negative CHECK fired (not just any SQL error).
+      await expect(
+        pool.query(
+          `INSERT INTO overage_meter_reports (org_id, period_start, stripe_customer_id, reported_tokens)
+           VALUES ('org_neg', $1, 'cus', -1)`,
+          [PERIOD],
+        ),
+      ).rejects.toThrow("chk_overage_meter_reports_tokens_nonneg");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "scans only paid, non-BYOT workspaces with a Stripe customer and an active subscription",
+    async () => {
+      // Included.
+      await seedOrg({ id: "inc_starter", planTier: "starter", byot: false, stripeCustomerId: "cus_a" });
+      await seedSubscription({ org: "inc_starter", status: "active" });
+      await seedOrg({ id: "inc_pro_nullbyot", planTier: "pro", byot: null, stripeCustomerId: "cus_b" });
+      await seedSubscription({ org: "inc_pro_nullbyot", status: "active" });
+      // Excluded — BYOT.
+      await seedOrg({ id: "exc_byot", planTier: "business", byot: true, stripeCustomerId: "cus_c" });
+      await seedSubscription({ org: "exc_byot", status: "active" });
+      // Excluded — no Stripe customer.
+      await seedOrg({ id: "exc_nocus", planTier: "starter", byot: false, stripeCustomerId: null });
+      await seedSubscription({ org: "exc_nocus", status: "active" });
+      // Excluded — subscription not active.
+      await seedOrg({ id: "exc_trialing", planTier: "starter", byot: false, stripeCustomerId: "cus_e" });
+      await seedSubscription({ org: "exc_trialing", status: "trialing" });
+      // Excluded — non-paid tier.
+      await seedOrg({ id: "exc_trial_tier", planTier: "trial", byot: false, stripeCustomerId: "cus_f" });
+      await seedSubscription({ org: "exc_trial_tier", status: "active" });
+      // Excluded — no subscription row at all.
+      await seedOrg({ id: "exc_nosub", planTier: "starter", byot: false, stripeCustomerId: "cus_g" });
+
+      const seen: string[] = [];
+      const result = await reportPeriodOverages(new Date(), async (_s, row: OverageWorkspaceRow) => {
+        seen.push(row.org_id);
+        return "skipped";
+      });
+
+      expect(seen.toSorted()).toEqual(["inc_pro_nullbyot", "inc_starter"]);
+      expect(result.scanned).toBe(2);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
+++ b/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Unit tests for the OverageMeter reporter (#3992).
+ *
+ * Covers the four acceptance criteria at the module boundary:
+ *   - period overage reported idempotently + reconcilably (ledger-backed):
+ *     the same delta reported twice bills once;
+ *   - the metered item is added as a second subscription item per tier;
+ *   - delta math / identifier determinism (the idempotency primitives);
+ *   - BYOT workspaces are NEVER reported.
+ *
+ * The meaty per-workspace path takes its I/O as injected deps (CLAUDE.md:
+ * prefer dependency injection over `mock.module`), so most tests need only a
+ * Stripe double. The ledger SQL-shape + the sweep scan are pinned against a
+ * mocked `internalQuery`, mirroring `stripe-event-ledger.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type Stripe from "stripe";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type {
+  OverageWorkspaceRow,
+  WorkspaceOverageDeps,
+  OverageReportRecord,
+} from "@atlas/api/lib/billing/overage-meter";
+
+// ── Mocked internal DB (drives the ledger reads/writes + the sweep scan) ──
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  () => Promise.resolve([]),
+);
+let hasDb = true;
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({
+    internalQuery: mockInternalQuery,
+    hasInternalDB: () => hasDb,
+  }),
+}));
+
+// ── Mocked Stripe client (only the period sweep resolves it) ──────────────
+let stripeForSweep: Stripe | null = null;
+mock.module("@atlas/api/lib/billing/stripe-client", () => ({
+  getStripeClient: () => stripeForSweep,
+  _resetStripeClientCache: () => {},
+}));
+
+// ── Quiet logger ──────────────────────────────────────────────────────────
+const stubLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  setLogLevel: () => false,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [] as string[],
+  hashShareToken: (token: string) => token,
+}));
+
+const {
+  OVERAGE_METER_EVENT_NAME,
+  OVERAGE_REPORT_INTERVAL_MS,
+  getOveragePriceIdForTier,
+  computeReportableDelta,
+  buildOverageEventIdentifier,
+  getReportedOverageTokens,
+  recordOverageReport,
+  reportWorkspaceOverage,
+  reportPeriodOverages,
+  ensureOverageSubscriptionItem,
+} = await import("../overage-meter");
+
+const NOW = new Date("2026-06-15T12:00:00.000Z");
+const PERIOD_START = "2026-06-01T00:00:00.000Z";
+
+// ── Stripe doubles ──────────────────────────────────────────────────────
+interface MeterDouble {
+  stripe: Stripe;
+  meterCreate: Mock<(params: unknown) => Promise<unknown>>;
+}
+function makeMeterStripe(impl?: (params: unknown) => Promise<unknown>): MeterDouble {
+  const meterCreate = mock(impl ?? (async () => ({ identifier: "ok" })));
+  const stripe = {
+    billing: { meterEvents: { create: meterCreate } },
+  } as unknown as Stripe;
+  return { stripe, meterCreate };
+}
+
+interface ItemDouble {
+  stripe: Stripe;
+  itemCreate: Mock<(params: unknown) => Promise<unknown>>;
+}
+function makeItemStripe(impl?: (params: unknown) => Promise<unknown>): ItemDouble {
+  const itemCreate = mock(impl ?? (async () => ({ id: "si_new" })));
+  const stripe = {
+    subscriptionItems: { create: itemCreate },
+  } as unknown as Stripe;
+  return { stripe, itemCreate };
+}
+
+// ── Injectable per-workspace deps ────────────────────────────────────────
+function makeDeps(overrides: Partial<WorkspaceOverageDeps> = {}): {
+  deps: WorkspaceOverageDeps;
+  recordCalls: OverageReportRecord[];
+} {
+  const recordCalls: OverageReportRecord[] = [];
+  const deps: WorkspaceOverageDeps = {
+    getSeatCount: async () => 1,
+    getCurrentPeriodUsage: async () => ({
+      queryCount: 0,
+      tokenCount: 0,
+      weightedTokenCount: 0,
+      activeUsers: 0,
+      periodStart: PERIOD_START,
+      periodEnd: "2026-07-01T00:00:00.000Z",
+      periodSource: "utc-month",
+    }),
+    getReportedOverageTokens: async () => 0,
+    recordOverageReport: async (r) => {
+      recordCalls.push(r);
+    },
+    ...overrides,
+  };
+  return { deps, recordCalls };
+}
+
+const STARTER_BUDGET = 2_000_000; // plans.ts starter tokenBudgetPerSeat × 1 seat
+
+function starterRow(overrides: Partial<OverageWorkspaceRow> = {}): OverageWorkspaceRow {
+  return {
+    org_id: "org_1",
+    plan_tier: "starter",
+    byot: false,
+    stripe_customer_id: "cus_1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  hasDb = true;
+  stripeForSweep = null;
+  mockInternalQuery.mockReset();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+});
+
+// ───────────────────────────────────────────────────────────────────────
+describe("computeReportableDelta", () => {
+  it("reports the gap when current overage exceeds what's already reported", () => {
+    expect(computeReportableDelta(500, 0)).toBe(500);
+    expect(computeReportableDelta(500, 200)).toBe(300);
+  });
+
+  it("is zero when nothing new has accrued (same delta reported twice → bill once)", () => {
+    expect(computeReportableDelta(500, 500)).toBe(0);
+  });
+
+  it("never goes negative when the ledger is ahead (downward correction)", () => {
+    expect(computeReportableDelta(300, 500)).toBe(0);
+  });
+
+  it("returns 0 for non-finite inputs", () => {
+    expect(computeReportableDelta(Number.NaN, 0)).toBe(0);
+    expect(computeReportableDelta(500, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("buildOverageEventIdentifier", () => {
+  it("is deterministic on the baseline (re-report after crash → same id)", () => {
+    const a = buildOverageEventIdentifier("org_1", PERIOD_START, 500);
+    const b = buildOverageEventIdentifier("org_1", PERIOD_START, 500);
+    expect(a).toBe(b);
+  });
+
+  it("differs when the baseline advances (distinct, non-overlapping ranges)", () => {
+    expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).not.toBe(
+      buildOverageEventIdentifier("org_1", PERIOD_START, 650),
+    );
+  });
+
+  it("scopes by org and period", () => {
+    expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).toContain("org_1");
+    expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).not.toBe(
+      buildOverageEventIdentifier("org_2", PERIOD_START, 500),
+    );
+  });
+});
+
+describe("getOveragePriceIdForTier", () => {
+  it("resolves each tier's metered-overage price via the injected resolver", () => {
+    const store: Record<string, string> = {
+      STRIPE_STARTER_OVERAGE_PRICE_ID: "price_so",
+      STRIPE_PRO_OVERAGE_PRICE_ID: "price_po",
+      STRIPE_BUSINESS_OVERAGE_PRICE_ID: "price_bo",
+    };
+    const resolve = (k: string) => store[k];
+    expect(getOveragePriceIdForTier("starter", resolve)).toBe("price_so");
+    expect(getOveragePriceIdForTier("pro", resolve)).toBe("price_po");
+    expect(getOveragePriceIdForTier("business", resolve)).toBe("price_bo");
+  });
+
+  it("returns undefined for an unset or empty value", () => {
+    expect(getOveragePriceIdForTier("starter", () => undefined)).toBeUndefined();
+    expect(getOveragePriceIdForTier("starter", () => "")).toBeUndefined();
+  });
+});
+
+describe("getReportedOverageTokens", () => {
+  it("returns 0 when no ledger row exists", async () => {
+    mockInternalQuery.mockResolvedValueOnce([]);
+    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(0);
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("FROM overage_meter_reports");
+    expect(sql).toContain("org_id = $1");
+    expect(sql).toContain("period_start = $2");
+    expect(params).toEqual(["org_1", PERIOD_START]);
+  });
+
+  it("coerces the pg BIGINT string back to a number", async () => {
+    mockInternalQuery.mockResolvedValueOnce([{ reported_tokens: "12345" }]);
+    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(12345);
+  });
+
+  it("THROWS on a present-but-uncoercible value (fail closed, never silently 0 → no double-bill)", async () => {
+    mockInternalQuery.mockResolvedValueOnce([{ reported_tokens: "not-a-number" }]);
+    // Returning 0 here would re-key the identifier on baseline 0 and re-report
+    // the whole cumulative; throwing routes to the safe per-workspace skip+retry.
+    await expect(getReportedOverageTokens("org_1", PERIOD_START)).rejects.toThrow();
+  });
+
+  it("no-ops to 0 without an internal DB", async () => {
+    hasDb = false;
+    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(0);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("recordOverageReport", () => {
+  it("upserts the cumulative with GREATEST + composite-PK conflict", async () => {
+    await recordOverageReport({
+      orgId: "org_1",
+      periodStartISO: PERIOD_START,
+      stripeCustomerId: "cus_1",
+      reportedTokens: 500,
+      eventIdentifier: "id_1",
+    });
+    const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO overage_meter_reports");
+    expect(sql).toContain("ON CONFLICT (org_id, period_start) DO UPDATE");
+    // Monotonic: never regress the cumulative (would re-bill).
+    expect(sql).toContain("GREATEST(overage_meter_reports.reported_tokens, EXCLUDED.reported_tokens)");
+    expect(params).toEqual(["org_1", PERIOD_START, "cus_1", 500, "id_1"]);
+  });
+
+  it("no-ops without an internal DB", async () => {
+    hasDb = false;
+    await recordOverageReport({
+      orgId: "org_1",
+      periodStartISO: PERIOD_START,
+      stripeCustomerId: "cus_1",
+      reportedTokens: 500,
+      eventIdentifier: "id_1",
+    });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportWorkspaceOverage", () => {
+  it("reports the period overage delta to the meter and advances the ledger", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps, recordCalls } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
+      getReportedOverageTokens: async () => 0,
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
+
+    expect(meterCreate).toHaveBeenCalledTimes(1);
+    const params = meterCreate.mock.calls[0][0] as {
+      event_name: string;
+      payload: { stripe_customer_id: string; value: string };
+      identifier: string;
+    };
+    expect(params.event_name).toBe(OVERAGE_METER_EVENT_NAME);
+    expect(params.payload.stripe_customer_id).toBe("cus_1");
+    expect(params.payload.value).toBe("500"); // delta, as a string
+    // Identifier is keyed on the BASELINE (reportedSoFar = 0 here), not the
+    // new cumulative — so a crash-retry from the un-advanced ledger reuses it.
+    expect(params.identifier).toBe(buildOverageEventIdentifier("org_1", PERIOD_START, 0));
+
+    expect(recordCalls).toHaveLength(1);
+    expect(recordCalls[0].reportedTokens).toBe(500); // cumulative, not delta
+    // The recorded identifier MUST equal the one sent — the crash-window dedup
+    // relies on the retry reproducing it.
+    expect(recordCalls[0].eventIdentifier).toBe(params.identifier);
+  });
+
+  it("falls back to raw token count when the weighted field is absent", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => ({
+        queryCount: 0,
+        tokenCount: STARTER_BUDGET + 500,
+        // weighted field absent (un-backfilled / future shape change)
+        weightedTokenCount: undefined as unknown as number,
+        activeUsers: 0,
+        periodStart: PERIOD_START,
+        periodEnd: "2026-07-01T00:00:00.000Z",
+        periodSource: "utc-month",
+      }),
+      getReportedOverageTokens: async () => 0,
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
+    const params = meterCreate.mock.calls[0][0] as { payload: { value: string } };
+    expect(params.payload.value).toBe("500"); // billed on raw, not silently zero
+  });
+
+  it("reports only the DELTA past what's already reported, recording the new cumulative", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps, recordCalls } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 250),
+      getReportedOverageTokens: async () => 100,
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
+
+    const params = meterCreate.mock.calls[0][0] as { payload: { value: string }; identifier: string };
+    expect(params.payload.value).toBe("150"); // 250 current − 100 reported
+    expect(recordCalls[0].reportedTokens).toBe(250);
+    // Identifier is keyed on the BASELINE (100), not the delta or the cumulative
+    // — pins the baseline-keying for a non-zero baseline.
+    expect(params.identifier).toBe(buildOverageEventIdentifier("org_1", PERIOD_START, 100));
+  });
+
+  it("is idempotent — the same overage reported twice bills once", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    // Second tick: the ledger already holds the full cumulative.
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
+      getReportedOverageTokens: async () => 500,
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a downward correction without a negative meter event", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 300),
+      getReportedOverageTokens: async () => 500, // ledger ahead of current
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+  });
+
+  it("never reports a BYOT workspace", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const getSeatCount = mock(async () => 1);
+    const { deps, recordCalls } = makeDeps({
+      getSeatCount,
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
+      getReportedOverageTokens: async () => 0,
+    });
+
+    await expect(
+      reportWorkspaceOverage(stripe, starterRow({ byot: true }), NOW, deps),
+    ).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+    expect(recordCalls).toHaveLength(0);
+    // Bailed before doing any work.
+    expect(getSeatCount).not.toHaveBeenCalled();
+  });
+
+  it("skips non-paid tiers (trial / free / locked)", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
+    });
+    for (const tier of ["trial", "free", "locked"]) {
+      await expect(
+        reportWorkspaceOverage(stripe, starterRow({ plan_tier: tier }), NOW, deps),
+      ).resolves.toBe("skipped");
+    }
+    expect(meterCreate).not.toHaveBeenCalled();
+  });
+
+  it("skips a workspace with no Stripe customer id", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
+    });
+    await expect(
+      reportWorkspaceOverage(stripe, starterRow({ stripe_customer_id: null }), NOW, deps),
+    ).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+  });
+
+  it("skips when usage is within budget (no overage)", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET - 1),
+    });
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT advance the ledger when the meter report fails (report-before-record)", async () => {
+    const { stripe, meterCreate } = makeMeterStripe(async () => {
+      throw new Error("stripe 503");
+    });
+    const { deps, recordCalls } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
+      getReportedOverageTokens: async () => 0,
+    });
+
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).rejects.toThrow("stripe 503");
+    expect(meterCreate).toHaveBeenCalledTimes(1);
+    expect(recordCalls).toHaveLength(0); // ledger untouched → delta retried next tick
+  });
+
+  it("re-throws (so the tick retries) when Stripe billed but the ledger record fails", async () => {
+    const { stripe, meterCreate } = makeMeterStripe(); // Stripe succeeds
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
+      getReportedOverageTokens: async () => 0,
+      recordOverageReport: async () => {
+        throw new Error("pg down");
+      },
+    });
+
+    // Stripe was billed; the ledger lagged. Re-throw → sweep counts it failed +
+    // retries. The baseline-keyed identifier (baseline 0, unchanged on the
+    // un-advanced ledger) makes the retry dedupe-safe rather than a double-bill.
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).rejects.toThrow("pg down");
+    expect(meterCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ensureOverageSubscriptionItem", () => {
+  function subWith(items: Array<{ price: { id: string } }>): Stripe.Subscription {
+    return { id: "sub_1", items: { data: items } } as unknown as Stripe.Subscription;
+  }
+  const deps = {
+    resolveTier: (priceId: string) => (priceId === "price_seat_starter" ? "starter" : null),
+    getOveragePriceId: () => "price_starter_overage",
+  } as const;
+
+  it("adds the tier's metered price as a second item when absent", async () => {
+    const { stripe, itemCreate } = makeItemStripe();
+    const out = await ensureOverageSubscriptionItem(
+      subWith([{ price: { id: "price_seat_starter" } }]),
+      stripe,
+      deps,
+    );
+    expect(out).toBe("added");
+    expect(itemCreate).toHaveBeenCalledWith({ subscription: "sub_1", price: "price_starter_overage" });
+  });
+
+  it("is a no-op when the metered item is already present (idempotent)", async () => {
+    const { stripe, itemCreate } = makeItemStripe();
+    const out = await ensureOverageSubscriptionItem(
+      subWith([{ price: { id: "price_seat_starter" } }, { price: { id: "price_starter_overage" } }]),
+      stripe,
+      deps,
+    );
+    expect(out).toBe("present");
+    expect(itemCreate).not.toHaveBeenCalled();
+  });
+
+  it("skips a non-paid / unrecognized first item", async () => {
+    const { stripe, itemCreate } = makeItemStripe();
+    const out = await ensureOverageSubscriptionItem(
+      subWith([{ price: { id: "price_unknown" } }]),
+      stripe,
+      deps,
+    );
+    expect(out).toBe("skipped");
+    expect(itemCreate).not.toHaveBeenCalled();
+  });
+
+  it("skips when no overage price is configured for the tier", async () => {
+    const { stripe, itemCreate } = makeItemStripe();
+    const out = await ensureOverageSubscriptionItem(
+      subWith([{ price: { id: "price_seat_starter" } }]),
+      stripe,
+      { ...deps, getOveragePriceId: () => undefined },
+    );
+    expect(out).toBe("skipped");
+    expect(itemCreate).not.toHaveBeenCalled();
+  });
+
+  it("is best-effort — a Stripe failure is swallowed (never throws into the durable sync)", async () => {
+    const { stripe } = makeItemStripe(async () => {
+      throw new Error("stripe 500");
+    });
+    const out = await ensureOverageSubscriptionItem(
+      subWith([{ price: { id: "price_seat_starter" } }]),
+      stripe,
+      deps,
+    );
+    expect(out).toBe("skipped");
+  });
+});
+
+describe("reportPeriodOverages", () => {
+  it("no-ops without an internal DB", async () => {
+    hasDb = false;
+    await expect(reportPeriodOverages(NOW)).resolves.toEqual({
+      scanned: 0,
+      reported: 0,
+      skipped: 0,
+      failed: 0,
+    });
+  });
+
+  it("no-ops when Stripe is not configured", async () => {
+    hasDb = true;
+    stripeForSweep = null;
+    await expect(reportPeriodOverages(NOW)).resolves.toEqual({
+      scanned: 0,
+      reported: 0,
+      skipped: 0,
+      failed: 0,
+    });
+  });
+
+  it("scans only paid, non-BYOT, subscribed workspaces with a Stripe customer", async () => {
+    stripeForSweep = makeMeterStripe().stripe;
+    mockInternalQuery.mockResolvedValueOnce([]); // scan returns nothing
+    await reportPeriodOverages(NOW, async () => "skipped");
+    const [sql] = mockInternalQuery.mock.calls[0] as [string];
+    expect(sql).toContain("plan_tier IN ('starter', 'pro', 'business')");
+    expect(sql).toContain("byot IS NOT TRUE");
+    expect(sql).toContain('"stripeCustomerId" IS NOT NULL');
+    expect(sql).toContain("FROM subscription s");
+    expect(sql).toContain("s.status = 'active'");
+  });
+
+  it("fans out to the per-workspace reporter and tallies outcomes", async () => {
+    stripeForSweep = makeMeterStripe().stripe;
+    mockInternalQuery.mockResolvedValueOnce([
+      starterRow({ org_id: "org_a" }),
+      starterRow({ org_id: "org_b" }),
+      starterRow({ org_id: "org_c" }),
+    ]);
+    const seen: string[] = [];
+    const reportOne = mock(async (_s: Stripe, row: OverageWorkspaceRow) => {
+      seen.push(row.org_id);
+      if (row.org_id === "org_a") return "reported" as const;
+      if (row.org_id === "org_b") throw new Error("boom");
+      return "skipped" as const;
+    });
+
+    const result = await reportPeriodOverages(NOW, reportOne);
+    expect(seen).toEqual(["org_a", "org_b", "org_c"]);
+    expect(result).toEqual({ scanned: 3, reported: 1, skipped: 1, failed: 1 });
+  });
+});
+
+describe("constants", () => {
+  it("uses the configured Stripe meter event name", () => {
+    expect(OVERAGE_METER_EVENT_NAME).toBe("atlas_token_overage");
+  });
+
+  it("ticks on a positive interval", () => {
+    expect(OVERAGE_REPORT_INTERVAL_MS).toBeGreaterThan(0);
+  });
+});
+
+// ── helpers ────────────────────────────────────────────────────────────
+function usageWith(weighted: number): import("@atlas/api/lib/metering").UsageCurrentPeriod {
+  return {
+    queryCount: 0,
+    tokenCount: weighted,
+    weightedTokenCount: weighted,
+    activeUsers: 0,
+    periodStart: PERIOD_START,
+    periodEnd: "2026-07-01T00:00:00.000Z",
+    periodSource: "utc-month",
+  };
+}

--- a/packages/api/src/lib/billing/config-validation.ts
+++ b/packages/api/src/lib/billing/config-validation.ts
@@ -31,6 +31,8 @@
  * outage must not wedge boot). It is NOT here because it isn't pure.
  */
 
+import type { PaidPlanTier } from "./plans";
+
 /** Monthly price-ID env var for each paid tier — the SSOT `getStripePlans()` reads. */
 export const MONTHLY_PRICE_ID_ENV_VARS = [
   "STRIPE_STARTER_PRICE_ID",
@@ -46,6 +48,73 @@ export const ANNUAL_PRICE_ID_ENV_VARS = [
 ] as const;
 
 export type MonthlyPriceIdEnvVar = (typeof MONTHLY_PRICE_ID_ENV_VARS)[number];
+
+/**
+ * Per-tier metered-overage price-ID setting keys (#3992). One Stripe Price per
+ * paid tier, each metered (`usage_type=metered`) and pointing at the single
+ * shared `atlas_token_overage` Billing Meter (#3991). Required for a paid
+ * tier's token overage to be billed: the `OverageMeter` reporter maps a
+ * workspace's tier → overage price when adding the metered subscription item,
+ * and reports the period's output-equivalent overage delta to the meter.
+ *
+ * A missing one is an operator-actionable boot WARNING (not a crash), the same
+ * posture as the monthly price IDs (#3703): the overage price IDs are likewise
+ * runtime-editable platform settings, so a boot crash would prevent an operator
+ * from ever fixing pricing without a redeploy.
+ */
+export const OVERAGE_PRICE_ID_ENV_VARS = [
+  "STRIPE_STARTER_OVERAGE_PRICE_ID",
+  "STRIPE_PRO_OVERAGE_PRICE_ID",
+  "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+] as const;
+
+export type OveragePriceIdEnvVar = (typeof OVERAGE_PRICE_ID_ENV_VARS)[number];
+
+/**
+ * Paid tier → its metered-overage price-ID setting key. The SSOT both the
+ * `OverageMeter` reporter (mapping a workspace's tier → overage price when
+ * adding the metered subscription item) and boot validation read, so the
+ * mapping can never drift between "validated at boot" and "used at runtime". A
+ * compile error here if a new {@link PaidPlanTier} is added without a key.
+ */
+export const OVERAGE_PRICE_ID_ENV_VAR_BY_TIER = {
+  starter: "STRIPE_STARTER_OVERAGE_PRICE_ID",
+  pro: "STRIPE_PRO_OVERAGE_PRICE_ID",
+  business: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+} as const satisfies Record<PaidPlanTier, OveragePriceIdEnvVar>;
+
+/**
+ * Return the subset of {@link OVERAGE_PRICE_ID_ENV_VARS} that resolve to a
+ * missing (undefined or empty-string) value through `resolve` (#3992).
+ *
+ * Settings-aware sibling of {@link findMissingOveragePriceIdEnvVars}: the
+ * overage price IDs are platform-scoped settings (registry-backed, env
+ * fallback), so the boot guard resolves them via `getSettingAuto` — an overage
+ * price set only in the Admin console must NOT register as missing. The lookup
+ * is injected so the function stays pure and unit-testable with a stub resolver.
+ */
+export function findMissingOveragePriceIds(
+  resolve: (settingKey: OveragePriceIdEnvVar) => string | undefined,
+): OveragePriceIdEnvVar[] {
+  return OVERAGE_PRICE_ID_ENV_VARS.filter((key) => {
+    const value = resolve(key);
+    return value === undefined || value === "";
+  });
+}
+
+/**
+ * Return the subset of {@link OVERAGE_PRICE_ID_ENV_VARS} that are unset or
+ * empty in `env`. Pure env sibling of {@link findMissingOveragePriceIds}; an
+ * empty string counts as missing (Stripe never issues an empty price ID).
+ */
+export function findMissingOveragePriceIdEnvVars(
+  env: Record<string, string | undefined> = process.env,
+): OveragePriceIdEnvVar[] {
+  return OVERAGE_PRICE_ID_ENV_VARS.filter((key) => {
+    const value = env[key];
+    return value === undefined || value === "";
+  });
+}
 
 /**
  * Return the subset of {@link MONTHLY_PRICE_ID_ENV_VARS} that resolve to a

--- a/packages/api/src/lib/billing/overage-meter.ts
+++ b/packages/api/src/lib/billing/overage-meter.ts
@@ -1,0 +1,567 @@
+/**
+ * OverageMeter — idempotent, reconcilable Stripe Billing Meters reporter (#3992).
+ *
+ * Each billing period a paid workspace can run past its included token budget
+ * (the metered soft-cap band in `enforcement.ts`, #3990). This module flushes
+ * that overage to Stripe's Billing Meters API (`meter_events`) on a scheduler
+ * tick so the customer is actually invoiced for it, and adds the per-tier
+ * metered price as a SECOND subscription item so the meter has a price to bill
+ * against.
+ *
+ * ## What is reported
+ *
+ * Overage is denominated in **output-equivalent tokens** (#3989) — the same
+ * weighted unit `enforcement.ts` meters the budget in, so the value reported is
+ * the real billed quantity. The shared `atlas_token_overage` meter (#3991) is
+ * priced at $1 / 1M output-equivalent tokens (`plans.ts`
+ * `overagePerMillionTokens = 1.0`).
+ *
+ * ## Idempotency + reconciliation (ledger-backed)
+ *
+ * `overage_meter_reports` records, per (org, billing period), the CUMULATIVE
+ * overage already reported to Stripe (`reported_tokens`). Each tick:
+ *
+ *   1. compute the period's current overage (weighted usage − budget),
+ *   2. delta = currentOverage − reported_tokens (floored at 0),
+ *   3. if delta > 0, send ONE `meter_event` carrying `payload.value = delta`
+ *      and `payload.stripe_customer_id`, then advance `reported_tokens` to the
+ *      new cumulative.
+ *
+ * So the **same delta reported twice bills once**: the second tick sees the
+ * advanced cumulative and computes a zero delta. The ledger is the primary
+ * idempotency mechanism.
+ *
+ * Report-BEFORE-record is deliberate: a Stripe failure (the common case — a
+ * transient 429 / timeout) leaves the ledger un-advanced and the delta is
+ * retried next tick, so overage is never silently lost. The remaining hazard is
+ * a crash in the sub-second window AFTER Stripe accepts the event but BEFORE the
+ * ledger advances. The deterministic `meter_event` identifier closes it: it is
+ * keyed on the **baseline** (`reported_tokens` BEFORE this report), NOT the new
+ * cumulative — so a retry from the same un-advanced ledger reuses the SAME
+ * identifier even if usage grew in between, and Stripe (which keeps the first
+ * value per identifier within its rolling 24h window) never double-counts the
+ * overlap. A baseline key fails toward a bounded, safe-direction under-bill in
+ * that rare window — never a double-bill. (Keying on the cumulative would change
+ * the identifier whenever usage grew between ticks and double-bill the overlap.)
+ * Successive reports advance the baseline monotonically (the cumulative is
+ * upserted with GREATEST, so a late/retried tick can never regress it), so each
+ * identifier covers a distinct `[baseline, …)` range.
+ *
+ * ## Never reported
+ *
+ * BYOT workspaces accrue no metered usage (they bring their own keys and bypass
+ * token enforcement entirely) and are excluded by the sweep scan; non-paid tiers
+ * (free / trial / locked) are excluded by tier membership; and an unlimited- or
+ * zero-budget workspace is skipped by the per-workspace budget check. All bail
+ * before any meter event.
+ *
+ * ## Gating
+ *
+ * Needs `STRIPE_SECRET_KEY` (to call Stripe) + an internal DB (to hold the
+ * ledger + read usage). No-ops cleanly otherwise (self-hosted never accrues
+ * rows). Forked as a periodic fiber in `lib/effect/layers.ts`; the metered-item
+ * seam runs on the Stripe webhook path in `lib/auth/server.ts`.
+ */
+
+import type Stripe from "stripe";
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
+import { getCurrentPeriodUsage, type UsageCurrentPeriod } from "@atlas/api/lib/metering";
+import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
+import {
+  computeTokenBudget,
+  isUnlimited,
+  resolvePlanTierFromPriceId,
+  type PaidPlanTier,
+} from "@atlas/api/lib/billing/plans";
+import { computeOverageTokens } from "@atlas/api/lib/billing/enforcement";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import {
+  OVERAGE_PRICE_ID_ENV_VAR_BY_TIER,
+  type OveragePriceIdEnvVar,
+} from "@atlas/api/lib/billing/config-validation";
+import { createLogger } from "@atlas/api/lib/logger";
+import { PLAN_TIERS, type PlanTier } from "@useatlas/types";
+
+const log = createLogger("billing:overage-meter");
+
+/** Stripe Billing Meter `event_name` for token overage (#3991). */
+export const OVERAGE_METER_EVENT_NAME = "atlas_token_overage";
+
+/**
+ * The paid tiers that accrue billable token overage — DERIVED from the
+ * drift-proof tier→price map so a new {@link PaidPlanTier} (which the map's
+ * `satisfies` forces to be added there) automatically appears here too, rather
+ * than being silently never-billed by a hand-maintained parallel list.
+ */
+const PAID_TIERS: readonly PaidPlanTier[] = Object.keys(
+  OVERAGE_PRICE_ID_ENV_VAR_BY_TIER,
+) as PaidPlanTier[];
+
+/** `'starter', 'pro', 'business'` for the sweep scan's `IN (...)` — same SSOT. */
+const PAID_TIERS_SQL_LIST = PAID_TIERS.map((t) => `'${t}'`).join(", ");
+
+function isPaidTier(tier: PlanTier): tier is PaidPlanTier {
+  return (PAID_TIERS as readonly string[]).includes(tier);
+}
+
+/**
+ * How often the overage reporter ticks. Hourly: frequent enough that metered
+ * usage lands well inside the period and Stripe's 35-day `meter_event`
+ * acceptance window, infrequent enough to add no meaningful load (one indexed
+ * org scan + a meter event only for workspaces actually in overage). Exported
+ * so `layers.ts` references the same value the fiber is documented around;
+ * `Effect.repeat(Schedule.spaced)` runs the tick once eagerly on boot.
+ */
+export const OVERAGE_REPORT_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Resolve a paid tier's metered-overage Stripe Price ID. Reads the
+ * platform-scoped setting (registry → env), hot-reloadable like the seat price
+ * IDs. `resolve` is injected (defaulting to `getSettingAuto`) so the mapping is
+ * unit-testable with a stub, mirroring `findMissingOveragePriceIds`.
+ */
+export function getOveragePriceIdForTier(
+  tier: PaidPlanTier,
+  resolve: (key: OveragePriceIdEnvVar) => string | undefined = getSettingAuto,
+): string | undefined {
+  const value = resolve(OVERAGE_PRICE_ID_ENV_VAR_BY_TIER[tier]);
+  return value && value.length > 0 ? value : undefined;
+}
+
+/**
+ * The reportable overage delta: how many output-equivalent tokens past what's
+ * already been reported the workspace has now consumed. Floored at 0 — a
+ * downward correction (usage re-counted lower, or a stale ledger ahead of
+ * current) must never produce a NEGATIVE meter event (which would credit the
+ * customer for usage they actually had). Pure.
+ */
+export function computeReportableDelta(
+  currentOverageTokens: number,
+  alreadyReportedTokens: number,
+): number {
+  if (!Number.isFinite(currentOverageTokens) || !Number.isFinite(alreadyReportedTokens)) {
+    return 0;
+  }
+  return Math.max(0, Math.trunc(currentOverageTokens) - Math.trunc(alreadyReportedTokens));
+}
+
+/**
+ * Deterministic Stripe `meter_event` identifier for a report. Keyed on the
+ * BASELINE — the `reported_tokens` cumulative BEFORE this report — NOT the new
+ * cumulative or the delta. The baseline is read from the ledger, which only
+ * advances on a successful record, so a crash-before-record (or a concurrent
+ * pod) retries from the SAME baseline and reuses the SAME identifier even if
+ * usage grew in between. Stripe keeps the first value per identifier within its
+ * rolling 24h window, so the overlap is never double-counted (it fails toward a
+ * bounded under-bill, the safe direction — see the module doc). Successive
+ * reports use strictly increasing baselines, so each identifier covers a
+ * distinct `[baseline, …)` range.
+ */
+export function buildOverageEventIdentifier(
+  orgId: string,
+  periodStartISO: string,
+  baselineTokens: number,
+): string {
+  const periodKey = Date.parse(periodStartISO);
+  const period = Number.isFinite(periodKey) ? periodKey : periodStartISO;
+  return `atlas-overage-${orgId}-${period}-${baselineTokens}`;
+}
+
+// ---------------------------------------------------------------------------
+// Ledger access
+// ---------------------------------------------------------------------------
+
+/**
+ * The cumulative overage tokens already reported to Stripe for `(orgId,
+ * periodStart)`, or 0 when no row exists yet. Postgres returns `BIGINT` as a
+ * string via `pg`, so coerce + validate rather than trust the wire type.
+ */
+export async function getReportedOverageTokens(
+  orgId: string,
+  periodStartISO: string,
+): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  const rows = await internalQuery<{ reported_tokens: number | string | null }>(
+    `SELECT reported_tokens FROM overage_meter_reports
+      WHERE org_id = $1 AND period_start = $2
+      LIMIT 1`,
+    [orgId, periodStartISO],
+  );
+  const raw = rows[0]?.reported_tokens;
+  if (raw == null) return 0; // no row / NULL — fresh period
+  const parsed = typeof raw === "string" ? Number(raw) : raw;
+  if (typeof parsed !== "number" || !Number.isFinite(parsed) || parsed < 0) {
+    // Fail CLOSED (throw, never return 0). The NOT NULL + CHECK(>= 0) column
+    // makes this unreachable, but a present-yet-uncoercible cumulative read as 0
+    // would re-key the identifier on baseline 0 and re-report (double-bill) the
+    // whole cumulative — the exact direction this module is built to avoid.
+    // Throwing routes to the per-workspace sweep guard (warn + count failed +
+    // skip + retry next tick): loud AND a safe under-bill, never a double-bill.
+    throw new Error(
+      `overage_meter_reports.reported_tokens is not a non-negative number for org ${orgId} period ${periodStartISO}: ${String(raw)}`,
+    );
+  }
+  return parsed;
+}
+
+export interface OverageReportRecord {
+  readonly orgId: string;
+  readonly periodStartISO: string;
+  readonly stripeCustomerId: string;
+  /** New cumulative reported total for the period (NOT the delta). */
+  readonly reportedTokens: number;
+  readonly eventIdentifier: string;
+}
+
+/**
+ * Upsert the ledger to the new cumulative reported total. `GREATEST` keeps
+ * `reported_tokens` monotonic within a period — a late/retried tick carrying an
+ * older cumulative can never regress it, which would re-report already-billed
+ * tokens. `ON CONFLICT` keys on the composite PK `(org_id, period_start)`.
+ */
+export async function recordOverageReport(record: OverageReportRecord): Promise<void> {
+  if (!hasInternalDB()) return;
+  await internalQuery(
+    `INSERT INTO overage_meter_reports
+       (org_id, period_start, stripe_customer_id, reported_tokens, last_event_identifier, updated_at)
+     VALUES ($1, $2, $3, $4, $5, now())
+     ON CONFLICT (org_id, period_start) DO UPDATE SET
+       reported_tokens = GREATEST(overage_meter_reports.reported_tokens, EXCLUDED.reported_tokens),
+       stripe_customer_id = EXCLUDED.stripe_customer_id,
+       last_event_identifier = EXCLUDED.last_event_identifier,
+       updated_at = now()`,
+    [
+      record.orgId,
+      record.periodStartISO,
+      record.stripeCustomerId,
+      record.reportedTokens,
+      record.eventIdentifier,
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-workspace reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * A workspace row the period-overage sweep iterates over. Type alias (not
+ * interface) so it satisfies `internalQuery`'s `Record<string, unknown>`
+ * generic constraint via the implicit index signature (same reason the
+ * reconcile/teardown row types are aliases).
+ */
+export type OverageWorkspaceRow = {
+  readonly org_id: string;
+  readonly plan_tier: string | null;
+  readonly byot: boolean | null;
+  readonly stripe_customer_id: string | null;
+};
+
+export type OverageReportOutcome = "reported" | "skipped";
+
+/**
+ * I/O dependencies of {@link reportWorkspaceOverage}, injected so the
+ * orchestration (delta math, BYOT/unlimited skips, report-then-record ordering)
+ * is unit-testable without `mock.module` — the Effect-style preference over
+ * module mocking (CLAUDE.md). Defaults wire the real functions.
+ */
+export interface WorkspaceOverageDeps {
+  readonly getSeatCount: (orgId: string) => Promise<number>;
+  readonly getCurrentPeriodUsage: (orgId: string, now: Date) => Promise<UsageCurrentPeriod>;
+  readonly getReportedOverageTokens: (orgId: string, periodStartISO: string) => Promise<number>;
+  readonly recordOverageReport: (record: OverageReportRecord) => Promise<void>;
+}
+
+const defaultWorkspaceOverageDeps: WorkspaceOverageDeps = {
+  getSeatCount,
+  getCurrentPeriodUsage,
+  getReportedOverageTokens,
+  recordOverageReport,
+};
+
+/**
+ * Report one workspace's current-period overage delta to the Stripe meter,
+ * idempotently. Returns `"reported"` when a positive delta was sent, else
+ * `"skipped"` (BYOT, non-paid/unlimited tier, no Stripe customer, or zero
+ * delta). THROWS on a Stripe / DB failure so the caller's per-org guard logs it
+ * and the un-advanced ledger retries next tick — overage is never silently lost.
+ */
+export async function reportWorkspaceOverage(
+  stripe: Stripe,
+  row: OverageWorkspaceRow,
+  now: Date = new Date(),
+  deps: WorkspaceOverageDeps = defaultWorkspaceOverageDeps,
+): Promise<OverageReportOutcome> {
+  // BYOT never accrues metered usage — they bring their own keys and bypass
+  // token enforcement entirely (#3990). Checked first, defensively: the sweep's
+  // scan already excludes BYOT, but this keeps the function boundary honest so
+  // a direct caller can never report a BYOT workspace.
+  if (row.byot === true) return "skipped";
+
+  const tier = parseTier(row.plan_tier);
+  if (!tier || !isPaidTier(tier)) return "skipped";
+  if (!row.stripe_customer_id) return "skipped";
+
+  const seatCount = await deps.getSeatCount(row.org_id);
+  const budget = computeTokenBudget(tier, seatCount);
+  // Unlimited budget → there is no "over budget", so nothing to meter.
+  if (isUnlimited(budget) || budget <= 0) return "skipped";
+
+  const usage = await deps.getCurrentPeriodUsage(row.org_id, now);
+  // Denominate in output-equivalent tokens (#3989) — the same weighted unit the
+  // budget is enforced in. `getCurrentPeriodUsage` already COALESCEs
+  // `weighted_quantity` to the raw `quantity` for token rows predating
+  // migration 0152 in its SQL aggregate, so `weightedTokenCount` is never under
+  // raw for un-backfilled history. The `?? tokenCount` is a defensive belt
+  // (matching `enforcement.ts`): if a future shape change made the field arrive
+  // undefined, denominate on raw rather than silently treat usage as zero.
+  const weightedUsage = usage.weightedTokenCount ?? usage.tokenCount;
+  const currentOverage = computeOverageTokens(weightedUsage, budget);
+  if (currentOverage <= 0) return "skipped";
+
+  const reportedSoFar = await deps.getReportedOverageTokens(row.org_id, usage.periodStart);
+  const delta = computeReportableDelta(currentOverage, reportedSoFar);
+  if (delta <= 0) return "skipped";
+
+  // Identifier is keyed on the BASELINE (reportedSoFar) — see
+  // buildOverageEventIdentifier + the module doc for why this (not the new
+  // cumulative) is what makes the crash-window backstop never double-bill.
+  const identifier = buildOverageEventIdentifier(row.org_id, usage.periodStart, reportedSoFar);
+
+  // Report to Stripe FIRST, then advance the ledger — see the module doc for
+  // why this ordering (with the baseline-keyed identifier) never double-bills
+  // and never silently loses overage on a transient Stripe failure.
+  await stripe.billing.meterEvents.create({
+    event_name: OVERAGE_METER_EVENT_NAME,
+    payload: {
+      stripe_customer_id: row.stripe_customer_id,
+      value: String(delta),
+    },
+    identifier,
+  });
+
+  try {
+    await deps.recordOverageReport({
+      orgId: row.org_id,
+      periodStartISO: usage.periodStart,
+      stripeCustomerId: row.stripe_customer_id,
+      reportedTokens: currentOverage,
+      eventIdentifier: identifier,
+    });
+  } catch (err) {
+    // Stripe HAS been billed by this point; only the ledger write failed. This
+    // is a reconciliation hazard (the ledger lags what Stripe was told), NOT a
+    // lost report — surface it distinctly so it isn't masked by the generic
+    // "report failed" line in reportPeriodOverages, then re-throw so the tick
+    // retries. The baseline-keyed identifier makes the retry safe: it reuses
+    // the same identifier from the un-advanced ledger, so Stripe dedupes the
+    // overlap rather than double-billing.
+    log.error(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        orgId: row.org_id,
+        periodStart: usage.periodStart,
+        cumulative: currentOverage,
+        identifier,
+      },
+      "Stripe meter billed but ledger record failed — reconciliation required (will retry; dedup prevents double-bill)",
+    );
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  log.info(
+    {
+      orgId: row.org_id,
+      tier,
+      periodStart: usage.periodStart,
+      delta,
+      cumulative: currentOverage,
+    },
+    "Reported token overage delta to Stripe meter",
+  );
+  return "reported";
+}
+
+// ---------------------------------------------------------------------------
+// Period sweep (scheduler tick)
+// ---------------------------------------------------------------------------
+
+export interface OverageReportSweepResult {
+  /** Paid, non-BYOT, Stripe-customer workspaces examined this tick. */
+  readonly scanned: number;
+  /** Workspaces for which a positive overage delta was reported. */
+  readonly reported: number;
+  /** Workspaces with no reportable delta (no overage / already reported). */
+  readonly skipped: number;
+  /** Workspaces whose report failed — logged, left for the next tick. */
+  readonly failed: number;
+}
+
+const EMPTY_SWEEP: OverageReportSweepResult = { scanned: 0, reported: 0, skipped: 0, failed: 0 };
+
+/** The per-workspace reporter the sweep fans out to. Injectable for tests. */
+export type ReportOneWorkspace = (
+  stripe: Stripe,
+  row: OverageWorkspaceRow,
+  now: Date,
+) => Promise<OverageReportOutcome>;
+
+/**
+ * One overage-reporting pass over every paid, non-BYOT workspace with a Stripe
+ * customer and an active subscription. Idempotent and safe to run concurrently
+ * across pods — each report is ledger-gated by the per-(org, period) cumulative
+ * and a deterministic meter identifier. No-ops without Stripe or an internal DB.
+ * Throws on the org-scan failure so the scheduler tick logs it and retries;
+ * per-workspace failures are caught and counted, never abort the sweep.
+ *
+ * `reportOne` is injected (defaulting to {@link reportWorkspaceOverage}) so the
+ * scan + fan-out is unit-testable without driving real usage/seat-count I/O.
+ */
+export async function reportPeriodOverages(
+  now: Date = new Date(),
+  reportOne: ReportOneWorkspace = reportWorkspaceOverage,
+): Promise<OverageReportSweepResult> {
+  if (!hasInternalDB()) return EMPTY_SWEEP;
+  const stripe = getStripeClient();
+  if (!stripe) return EMPTY_SWEEP;
+
+  // Paid, non-BYOT, has a Stripe customer, and currently subscribed. BYOT is
+  // excluded here (and re-checked in reportWorkspaceOverage); `byot IS NOT TRUE`
+  // also covers a NULL byot (not BYOT). Only `status = 'active'` subscriptions
+  // are metered — trialing/past_due/canceled don't invoice overage.
+  const rows = await internalQuery<OverageWorkspaceRow>(
+    `SELECT o.id AS org_id, o.plan_tier, o.byot, o."stripeCustomerId" AS stripe_customer_id
+       FROM organization o
+      WHERE o.plan_tier IN (${PAID_TIERS_SQL_LIST})
+        AND o.byot IS NOT TRUE
+        AND o."stripeCustomerId" IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM subscription s
+           WHERE s."referenceId" = o.id AND s.status = 'active'
+        )`,
+  );
+
+  let reported = 0;
+  let skipped = 0;
+  let failed = 0;
+  // Sequential, not Promise.all: a background sweep over a normally-small set —
+  // serializing the per-org Stripe calls keeps the sweep from bursting the
+  // Stripe rate limit or the internal pool alongside live traffic.
+  for (const row of rows) {
+    try {
+      const outcome = await reportOne(stripe, row, now);
+      if (outcome === "reported") reported += 1;
+      else skipped += 1;
+    } catch (err) {
+      failed += 1;
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), orgId: row.org_id },
+        "Overage report failed for workspace — will retry next tick",
+      );
+    }
+  }
+
+  if (reported > 0 || failed > 0) {
+    log.info(
+      { scanned: rows.length, reported, skipped, failed },
+      "Overage-meter reporting pass complete",
+    );
+  }
+  return { scanned: rows.length, reported, skipped, failed };
+}
+
+// ---------------------------------------------------------------------------
+// Metered subscription item (billing-plugin seam)
+// ---------------------------------------------------------------------------
+
+export type EnsureOverageItemOutcome = "added" | "present" | "skipped";
+
+/**
+ * Dependencies of {@link ensureOverageSubscriptionItem}, injected so the seam
+ * is testable without mocking the settings/plans modules. Defaults wire the
+ * real resolvers.
+ */
+export interface EnsureOverageItemDeps {
+  readonly resolveTier: (priceId: string) => PlanTier | null;
+  readonly getOveragePriceId: (tier: PaidPlanTier) => string | undefined;
+}
+
+const defaultEnsureOverageItemDeps: EnsureOverageItemDeps = {
+  resolveTier: resolvePlanTierFromPriceId,
+  getOveragePriceId: (tier) => getOveragePriceIdForTier(tier),
+};
+
+/**
+ * Ensure a paid subscription carries its tier's metered-overage price as a
+ * SECOND subscription item (#3992) — the price the `atlas_token_overage` meter
+ * bills against. Idempotent: a no-op when the item is already present, and
+ * runs on every `customer.subscription.{created,updated}` webhook so it is
+ * path-agnostic (checkout, upgrade, downgrade all converge here).
+ *
+ * BEST-EFFORT by construction: it runs as a side branch of the durable Stripe
+ * sync (`onEvent` in `lib/auth/server.ts`), so a transient Stripe failure here
+ * must NOT throw and force a redelivery of the already-applied tier write. The
+ * Stripe call is caught + logged; the scheduler's overage reporter will still
+ * record meter events (customer-scoped) which Stripe bills once the item lands
+ * on a later sync. Returns the outcome for observability/testing.
+ */
+export async function ensureOverageSubscriptionItem(
+  subscription: Stripe.Subscription,
+  stripe: Stripe,
+  deps: EnsureOverageItemDeps = defaultEnsureOverageItemDeps,
+): Promise<EnsureOverageItemOutcome> {
+  const items = subscription.items?.data ?? [];
+  const seatPriceId = items[0]?.price?.id;
+  const tier = seatPriceId ? deps.resolveTier(seatPriceId) : null;
+  if (!tier || !isPaidTier(tier)) return "skipped";
+
+  const overagePriceId = deps.getOveragePriceId(tier);
+  if (!overagePriceId) {
+    log.warn(
+      { subscriptionId: subscription.id, tier },
+      "No metered-overage price ID configured for tier — skipping metered subscription item",
+    );
+    return "skipped";
+  }
+
+  if (items.some((item) => item.price?.id === overagePriceId)) {
+    return "present";
+  }
+
+  try {
+    await stripe.subscriptionItems.create({
+      subscription: subscription.id,
+      price: overagePriceId,
+    });
+  } catch (err) {
+    // Best-effort: log, never throw (would force a webhook redelivery of the
+    // durable tier sync). The next subscription.updated sync re-attempts.
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        subscriptionId: subscription.id,
+        tier,
+      },
+      "Failed to add metered-overage subscription item — will retry on next subscription sync",
+    );
+    return "skipped";
+  }
+
+  log.info(
+    { subscriptionId: subscription.id, tier, overagePriceId },
+    "Added metered-overage subscription item",
+  );
+  return "added";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Narrow a raw `plan_tier` string to a known {@link PlanTier}, or null. */
+function parseTier(raw: string | null | undefined): PlanTier | null {
+  if (!raw) return null;
+  return (PLAN_TIERS as readonly string[]).includes(raw) ? (raw as PlanTier) : null;
+}

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -182,7 +182,9 @@ describe("runMigrations", () => {
     //   accounting, TokenWeighting WS2, #3989) = 153.
     //   Plus 0153 (subscription + scim_group_mappings region-DB parity so the
     //   GDPR purge completes in passive EU/APAC regions, #4019) = 154.
-    expect(count).toBe(154);
+    //   Plus 0154 (overage_meter_reports ledger for the idempotent Stripe
+    //   Billing Meters overage reporter, WS2, #3992) = 155.
+    expect(count).toBe(155);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -365,6 +367,7 @@ describe("runMigrations", () => {
         "0151_user_email_hash_index.sql",
         "0152_usage_events_weighted_quantity.sql",
         "0153_region_db_subscription_scim_parity.sql",
+        "0154_overage_meter_reports.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0154_overage_meter_reports.sql
+++ b/packages/api/src/lib/db/migrations/0154_overage_meter_reports.sql
@@ -1,0 +1,48 @@
+-- 0154: Overage-meter report ledger (#3992).
+--
+-- Idempotency + reconciliation for the `OverageMeter` reporter
+-- (lib/billing/overage-meter.ts), which flushes each billing period's token
+-- overage to Stripe Billing Meters (`meter_events`) on a scheduler tick.
+--
+-- One row per (org, billing period). `reported_tokens` is the CUMULATIVE
+-- output-equivalent overage already reported to Stripe for that period. Each
+-- tick computes `currentOverage - reported_tokens` (the delta), reports ONLY
+-- that delta to the meter, then advances `reported_tokens` to the new
+-- cumulative — so:
+--   • idempotency  — the same delta reported twice bills once (the second tick
+--     sees the advanced cumulative and computes a zero delta), backstopped by a
+--     deterministic Stripe `meter_event` identifier within Stripe's 24h dedup
+--     window for the crash-between-report-and-record gap.
+--   • reconciliation — `reported_tokens` per (org, period) is the ledgered
+--     record of what Stripe was told, cross-checkable against the meter sum.
+--
+-- The reporter advances the cumulative with GREATEST(existing, new) so a
+-- late/retried tick can never REGRESS it (which would re-report — and so
+-- double-bill — already-reported tokens). The CHECK keeps it non-negative.
+--
+-- NOT Better-Auth-dependent: no FK to the `organization`/`subscription`
+-- tables (it holds only an org id + period + Stripe customer id), so it is
+-- created in every auth mode, exactly like `stripe_webhook_events` (0128).
+CREATE TABLE IF NOT EXISTS overage_meter_reports (
+  org_id TEXT NOT NULL,
+  -- Inclusive start of the billing period this row meters (the Stripe
+  -- subscription period when active, else the UTC calendar month) — the same
+  -- window `getCurrentPeriodUsage` returns. A new period gets a fresh row, so
+  -- its cumulative resets to 0 and overage re-accrues from the new anchor.
+  period_start TIMESTAMPTZ NOT NULL,
+  stripe_customer_id TEXT NOT NULL,
+  -- Cumulative output-equivalent overage tokens reported to Stripe for this
+  -- (org, period). Monotonic within a period (advanced via GREATEST).
+  reported_tokens BIGINT NOT NULL DEFAULT 0,
+  -- The last Stripe `meter_event` identifier sent for this row — observability
+  -- + a breadcrumb for reconciliation against the meter.
+  last_event_identifier TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, period_start),
+  CONSTRAINT chk_overage_meter_reports_tokens_nonneg CHECK (reported_tokens >= 0)
+);
+
+-- Operational scans (recent reports / reconciliation sweeps).
+CREATE INDEX IF NOT EXISTS idx_overage_meter_reports_updated
+  ON overage_meter_reports (updated_at);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2536,6 +2536,36 @@ export const stripePurgedSubscriptions = pgTable(
 );
 
 /**
+ * Overage-meter report ledger (#3992) — idempotency + reconciliation for the
+ * `OverageMeter` reporter that flushes each billing period's token overage to
+ * Stripe Billing Meters on a scheduler tick. One row per (org, billing period):
+ * `reported_tokens` is the CUMULATIVE output-equivalent overage already reported
+ * to Stripe for that period. Each tick reports only `currentOverage -
+ * reported_tokens` (the delta) and advances `reported_tokens`, so the same delta
+ * reported twice bills once (the second tick computes a zero delta). The CHECK
+ * keeps the cumulative non-negative; the upsert uses GREATEST so a late/retried
+ * tick can never regress it (which would re-report already-billed tokens).
+ * Mirrors `migrations/0154_overage_meter_reports.sql`.
+ */
+export const overageMeterReports = pgTable(
+  "overage_meter_reports",
+  {
+    orgId: text("org_id").notNull(),
+    periodStart: timestamp("period_start", { withTimezone: true }).notNull(),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    reportedTokens: bigint("reported_tokens", { mode: "number" }).notNull().default(0),
+    lastEventIdentifier: text("last_event_identifier"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.orgId, t.periodStart] }),
+    check("chk_overage_meter_reports_tokens_nonneg", sql`reported_tokens >= 0`),
+    index("idx_overage_meter_reports_updated").on(t.updatedAt),
+  ],
+);
+
+/**
  * Durable Stripe teardown outbox (#3679) — the symmetric counterpart to the
  * plan-tier reconcile sweep. Workspace delete/purge cancels Stripe
  * subscriptions (and deletes the customer on GDPR purge) BEFORE the DB

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -450,6 +450,7 @@ describe("makeSchedulerLive", () => {
         "billing_reconcile",
         "stripe_teardown_sweep",
         "unclaimed_grace_reap",
+        "overage_report",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -188,13 +188,15 @@ function withFiberDeathLog<A, E, R>(
 //     `region_probe_rate_sweep` (#3973, ADR-0024 §3), evicts expired per-IP
 //     buckets from the login front-door's hashed-email existence-probe limiter.
 //
-//   • SCHEDULER_WORK_SPAN_NAMES — 5 background-work fibers (they perform
+//   • SCHEDULER_WORK_SPAN_NAMES — background-work fibers (they perform
 //     recurring side-effecting work rather than evicting state):
 //     `sub_processor_publisher`, `settings_refresh`, `onboarding_email`,
-//     `expert_scheduler`, `billing_reconcile`. Spanned by #2987 (+#3423
-//     for billing_reconcile) — identical rationale and wrap shape, no
-//     result attributes (each tick returns void, matching the 8
-//     attribute-less cleanup fibers).
+//     `expert_scheduler`, `promote_decay`, `billing_reconcile`,
+//     `stripe_teardown_sweep`, `unclaimed_grace_reap`, `overage_report`.
+//     Spanned by #2987 (+#3423 for billing_reconcile, #3992 for
+//     overage_report) — identical rationale and wrap shape, no result
+//     attributes (each tick returns void, matching the attribute-less
+//     cleanup fibers).
 //
 // Two records, not one: "cleanup sweep" vs "background work" is a real
 // distinction (it drives the log wording and the operator's mental model),
@@ -252,6 +254,7 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   billing_reconcile: "atlas.scheduler.billing_reconcile",
   stripe_teardown_sweep: "atlas.scheduler.stripe_teardown_sweep",
   unclaimed_grace_reap: "atlas.scheduler.unclaimed_grace_reap",
+  overage_report: "atlas.scheduler.overage_report",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1821,6 +1824,78 @@ export function makeSchedulerLive(
       } else {
         log.debug(
           "Stripe teardown outbox sweep not started — Stripe or internal DB not configured",
+        );
+      }
+
+      // ── Periodic fiber: token-overage meter reporter (#3992) ─────────────
+      // Flushes each paid workspace's current-period token overage to Stripe
+      // Billing Meters (`meter_events`), idempotently (ledger-backed: same delta
+      // reported twice bills once). Like the teardown sweep it needs only
+      // `STRIPE_SECRET_KEY` (to call Stripe) + an internal DB (to hold the
+      // ledger + read usage) — NOT the webhook secret. The sweep query excludes
+      // BYOT and non-paid tiers (free/trial/locked); an unlimited-/zero-budget
+      // workspace is skipped by the per-workspace budget check.
+      // The `yield* Migration` barrier above already sequences this after
+      // `MigrationLive`, so the eager boot tick can't race migration 0154
+      // creating `overage_meter_reports`.
+      const overageReportEnabled = yield* Effect.try({
+        try: () => {
+          if (!process.env.STRIPE_SECRET_KEY) return false;
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+          const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+            hasInternalDB: () => boolean;
+          };
+          return hasInternalDB();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.debug({ err: errorMessage(err) }, "Overage reporter gate check failed — skipping");
+            return false;
+          }),
+        ),
+      );
+
+      if (overageReportEnabled) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- read the interval constant synchronously at build time (same pattern as stripe_teardown_sweep)
+        const { OVERAGE_REPORT_INTERVAL_MS } = require("@atlas/api/lib/billing/overage-meter") as {
+          OVERAGE_REPORT_INTERVAL_MS: number;
+        };
+        const overageReportTick = Effect.tryPromise({
+          try: async () => {
+            const { reportPeriodOverages } = await import(
+              "@atlas/api/lib/billing/overage-meter"
+            );
+            await reportPeriodOverages();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn(
+                { err: errorMessage(err) },
+                "Overage-meter reporting tick failed — will retry next interval",
+              );
+            }),
+          ),
+        );
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
+          withFiberDeathLog(
+            "overage_report",
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.overage_report, {}, overageReportTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(OVERAGE_REPORT_INTERVAL_MS))),
+            ),
+          ),
+        );
+        log.info(
+          { intervalMs: OVERAGE_REPORT_INTERVAL_MS },
+          "Token-overage meter reporter started",
+        );
+      } else {
+        log.debug(
+          "Token-overage meter reporter not started — Stripe or internal DB not configured",
         );
       }
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -1375,10 +1375,12 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
 
     const {
       findMissingMonthlyPriceIds,
+      findMissingOveragePriceIds,
       detectStripeKeyMode,
       isPriceModeConsistent,
       MONTHLY_PRICE_ID_ENV_VARS,
       ANNUAL_PRICE_ID_ENV_VARS,
+      OVERAGE_PRICE_ID_ENV_VARS,
     } = yield* Effect.tryPromise({
       try: () => import("@atlas/api/lib/billing/config-validation"),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
@@ -1443,14 +1445,37 @@ export const BillingConfigGuardLive: Layer.Layer<never, BillingConfigInvalidErro
       );
     }
 
+    // ── Settings-presence WARN: metered-overage price IDs (#3992) ────────
+    // Same posture as the monthly IDs: a missing per-tier overage price means
+    // `ensureOverageSubscriptionItem` (the webhook seam) can't attach that
+    // tier's metered subscription item, so Stripe still records the reporter's
+    // meter events but has no metered price to invoice them against — usage is
+    // metered, not billed. The fix is a runtime Admin → Settings edit, so WARN
+    // (never crash boot).
+    const missingOveragePriceIds = findMissingOveragePriceIds((key) => getSettingAuto(key));
+    if (missingOveragePriceIds.length > 0) {
+      log.error(
+        {
+          missingOveragePriceIds,
+          event: "billing_config.overage_price_missing",
+        },
+        `Stripe billing is enabled but ${missingOveragePriceIds.length} metered-overage price ID(s) ` +
+          `are unset after settings resolution: [${missingOveragePriceIds.join(", ")}]. ` +
+          `ensureOverageSubscriptionItem won't attach the metered subscription item for the affected ` +
+          `tier(s), so their token overage is metered in Stripe but never invoiced. Set the price ` +
+          `ID(s) in Admin → Settings (Billing) — no redeploy needed. See ${BILLING_CONFIG_ISSUE_REF}.`,
+      );
+    }
+
     // ── Network check: price existence + livemode↔key-mode (loud WARN) ───
     // A transient Stripe error here must NOT crash boot, so everything below
     // resolves to a logged warning. We resolve every CONFIGURED price ID
-    // (monthly + annual) through settings and check each price's livemode
-    // against keyMode.
+    // (monthly + annual + overage) through settings and check each price's
+    // livemode against keyMode.
     const configuredPriceVars = [
       ...MONTHLY_PRICE_ID_ENV_VARS,
       ...ANNUAL_PRICE_ID_ENV_VARS,
+      ...OVERAGE_PRICE_ID_ENV_VARS,
     ]
       .map((envVar): { envVar: string; priceId: string | undefined } => ({
         envVar,

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -868,6 +868,48 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     saasVisible: false,
   },
 
+  // Stripe Billing — per-tier metered-overage price IDs (#3992). One metered
+  // (usage_type=metered) Stripe Price per paid tier, each pointing at the single
+  // shared `atlas_token_overage` Billing Meter (#3991). The `OverageMeter`
+  // reporter maps a workspace's tier → overage price (added as a SECOND
+  // subscription item) and reports the period's output-equivalent overage delta
+  // to the meter. Platform-scoped + hot-reloadable (same as the monthly IDs):
+  // `getOveragePriceIdForTier()` reads them per-operation via `getSettingAuto`,
+  // so an operator can change the metered price from Admin → Settings without a
+  // redeploy. `saasVisible: false` keeps them off the per-tenant settings page.
+  // A missing one surfaces as an operator-actionable boot WARNING (not a crash;
+  // see `BillingConfigGuardLive`) — its tier's overage simply won't be billed.
+  {
+    key: "STRIPE_STARTER_OVERAGE_PRICE_ID",
+    section: "Billing",
+    label: "Starter Overage Price ID (metered)",
+    description: "Stripe Price ID for the Starter plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Starter overage to be billed.",
+    type: "string",
+    envVar: "STRIPE_STARTER_OVERAGE_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_PRO_OVERAGE_PRICE_ID",
+    section: "Billing",
+    label: "Pro Overage Price ID (metered)",
+    description: "Stripe Price ID for the Pro plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Pro overage to be billed.",
+    type: "string",
+    envVar: "STRIPE_PRO_OVERAGE_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+    section: "Billing",
+    label: "Business Overage Price ID (metered)",
+    description: "Stripe Price ID for the Business plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Business overage to be billed.",
+    type: "string",
+    envVar: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
+    scope: "platform",
+    saasVisible: false,
+  },
+
   // Dynamic Learning — retrieval-time tuning for learned query patterns.
   // Workspace-scoped + hot-reloaded (read per-request via getSettingAuto), so
   // a tenant can tune them from Admin → Settings with no redeploy. The env var

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -79,8 +79,16 @@ GENERIC_SETTINGS_ROUTES_FILE="packages/api/src/api/routes/admin.ts"
 # or remove the setting.
 # ---------------------------------------------------------------------------
 ALLOWLIST=(
-  # (empty — the four Semantic Expert keys were removed by #3392 when their
-  # readers moved to getSetting; new entries need a justification comment.)
+  # The three metered-overage price IDs (#3992) ARE read at runtime — by
+  # getOveragePriceIdForTier() in lib/billing/overage-meter.ts, which calls
+  # getSettingAuto(OVERAGE_PRICE_ID_ENV_VAR_BY_TIER[tier]), and by the boot
+  # guard findMissingOveragePriceIds() in saas-guards.ts. The lookup key is the
+  # tier→key map indexed by tier, not a static string literal, so the
+  # literal/const-indirected grep below can't see it. They are NOT runtime-inert
+  # (drift class 1) — allowlisted because the reader is a dynamic map lookup.
+  "STRIPE_STARTER_OVERAGE_PRICE_ID"
+  "STRIPE_PRO_OVERAGE_PRICE_ID"
+  "STRIPE_BUSINESS_OVERAGE_PRICE_ID"
 )
 
 if [ ! -f "$SETTINGS_FILE" ]; then


### PR DESCRIPTION
## Summary

Builds the **`OverageMeter`** — an idempotent, reconcilable reporter that flushes each billing period's token overage to Stripe Billing Meters (`meter_events`) on a scheduler tick, plus the per-tier metered subscription item and boot-time validation of the overage price IDs.

- **Idempotent + reconcilable (ledger-backed).** New `overage_meter_reports` table (migration 0154 + drizzle mirror) records the cumulative output-equivalent overage already reported per `(org, period)`. Each tick reports only `currentOverage − reported_tokens` (the delta) and advances the cumulative with `GREATEST` (monotonic — a late/retried tick can't regress it). **Same delta reported twice bills once.** The `meter_event` identifier is keyed on the **baseline** so a crash-between-report-and-record retry reuses it (Stripe dedupes within 24h) — fails toward a bounded, safe-direction under-bill, never a double-bill. Report-before-record means a transient Stripe failure leaves the ledger un-advanced and the delta is retried, never lost.
- **Overage in output-equivalent tokens** (#3989 weighted unit, `$1 / 1M` = `plans.ts overagePerMillionTokens = 1.0`). **BYOT, non-paid tiers, and within-budget / unlimited-budget workspaces are never reported.**
- **Metered subscription item** added as a second item per tier via the Stripe webhook seam (`onEvent` → `ensureOverageSubscriptionItem`, idempotent + best-effort, path-agnostic across checkout/upgrade/downgrade).
- **Boot validation** of the 3 new `STRIPE_*_OVERAGE_PRICE_ID` platform settings (`findMissingOveragePriceIds` in `BillingConfigGuardLive`) — a missing one is an operator-actionable WARNING, not a boot crash (#3703 posture).
- Reporter runs as a periodic scheduler fiber (gated on `STRIPE_SECRET_KEY` + internal DB), alongside the existing billing sweeps.

Interim: lands the token-overage (markup) model matching the already-merged #3989/#3990; Structure B at-cost re-denomination + spend-policy is tracked separately in #4034.

## Test plan
- [x] Unit: same delta reported twice → billed once; reports only the delta past the ledger; reconciliation/downward-correction → no negative event; report-before-record + record-failure-after-Stripe ordering; BYOT/non-paid/no-customer/within-budget skips; baseline-keyed identifier; weighted→raw fallback.
- [x] Real-Postgres (`overage-meter-pg.test.ts`): `GREATEST` upsert monotonicity, non-negative `CHECK`, and the sweep scan filter (paid + non-BYOT + has-customer + active-subscription) against real `organization`/`subscription` tables.
- [x] Boot validation: `findMissingOveragePriceIds` / env-var SSOT.
- [x] Webhook wiring: `customer.subscription.{created,updated}` → metered item added end-to-end.
- [x] `/ci` local gates: lint, type, syncpack, schema-drift, settings-readers, test-discipline, saas-env-doc, pricing-parity, template/security/railway/openapi/oauth-helper/twenty/published-symbols — all pass. Migration count + lists updated (0154).

Closes #3992

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add idempotent Stripe Billing Meters overage reporter and metered subscription item enforcement
> - Introduces [`overage-meter.ts`](https://github.com/AtlasDevHQ/atlas/pull/4035/files#diff-c1228e5ad09fc7a10bd289577364bcdfd9c4853d4ce7ae3c83b106656da1dee4) with a ledger-backed, delta-based reporter that posts `atlas_token_overage` Stripe meter events using deterministic identifiers for safe deduplication on retries.
> - Adds a new `overage_meter_reports` table (migration [`0154_overage_meter_reports.sql`](https://github.com/AtlasDevHQ/atlas/pull/4035/files#diff-66cc6954d5c71e11c3e276ee9de0339a726685c582b19e1935be41fac2fc175c)) to track cumulative reported tokens per org/period using `GREATEST`-based upserts for monotonicity.
> - Registers a new hourly `overage_report` background fiber in the scheduler ([`layers.ts`](https://github.com/AtlasDevHQ/atlas/pull/4035/files#diff-5ad84a2ea26a190f9b35b153e10849be5e0c9feb4622b1587b7ecdb74715a12c)) that calls `reportPeriodOverages()` when Stripe and the internal DB are available.
> - Adds `ensureOverageSubscriptionItem` called on `customer.subscription.created` and `customer.subscription.updated` webhooks to attach the metered overage price item to paid subscriptions.
> - Adds three new settings (`STRIPE_STARTER_OVERAGE_PRICE_ID`, `STRIPE_PRO_OVERAGE_PRICE_ID`, `STRIPE_BUSINESS_OVERAGE_PRICE_ID`) and extends the boot-time `StripeBillingConfigGuard` to validate and warn on missing overage price IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da698c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->