### PR TITLE
feat(billing): capture at-cost gateway.cost per turn (S1, Structure B #4036)

### DIFF
--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -56,6 +56,12 @@ mock.module("@atlas/api/lib/db/connection", () => createConnectionMock());
 const mockCurrentUsage = {
   queryCount: 42,
   tokenCount: 10000,
+  // Internal-only fields the rollup carries but the GET / wire contract must NOT
+  // expose: weightedTokenCount (#3989) and costUsd (#4036 — Atlas's per-period
+  // gateway COGS). Present here so a regression that spread `...usage` instead of
+  // picking explicit fields would leak them and trip the assertions below.
+  weightedTokenCount: 23000,
+  costUsd: 4.56,
   activeUsers: 3,
   periodStart: "2026-03-01T00:00:00.000Z",
   periodEnd: "2026-04-01T00:00:00.000Z",
@@ -314,6 +320,12 @@ describe("Admin Usage API", () => {
       expect(body.queryCount).toBe(42);
       expect(body.tokenCount).toBe(10000);
       expect(body.activeUsers).toBe(3);
+      // COGS non-leak (#4036): the at-cost costUsd (Atlas's per-period gateway
+      // margin) and the internal weightedTokenCount must NOT reach a workspace
+      // admin. The handler picks explicit fields rather than spreading the
+      // rollup; this pins that boundary so a revert to `...usage` fails here.
+      expect(body.costUsd).toBeUndefined();
+      expect(body.weightedTokenCount).toBeUndefined();
     });
 
     it("returns 404 when no internal DB", async () => {

--- a/packages/api/src/api/routes/admin-usage.ts
+++ b/packages/api/src/api/routes/admin-usage.ts
@@ -193,7 +193,23 @@ adminUsage.openapi(getCurrentUsageRoute, async (c) => {
     const { orgId } = yield* AuthContext;
 
     const usage = yield* Effect.promise(() => getCurrentPeriodUsage(orgId!));
-    return c.json({ workspaceId: orgId!, ...usage }, 200);
+    // Pick the response fields explicitly rather than spreading `usage`: the
+    // metering rollup now also carries the at-cost `costUsd` (Atlas's per-period
+    // gateway COGS, #4036) which must NOT leak to a workspace admin, and
+    // `weightedTokenCount`, which isn't part of this wire contract either. The
+    // response matches CurrentPeriodUsageResponseSchema exactly.
+    return c.json(
+      {
+        workspaceId: orgId!,
+        queryCount: usage.queryCount,
+        tokenCount: usage.tokenCount,
+        activeUsers: usage.activeUsers,
+        periodStart: usage.periodStart,
+        periodEnd: usage.periodEnd,
+        periodSource: usage.periodSource,
+      },
+      200,
+    );
   }), { label: "fetch current usage" });
 });
 

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -114,6 +114,36 @@ function textOnlyModel(usage: LanguageModelV3Usage): InstanceType<typeof MockLan
   });
 }
 
+/**
+ * Single text-only step whose finish part carries a Vercel-AI-Gateway cost
+ * annotation (`providerMetadata.gateway.cost`) — the shape the at-cost capture
+ * (#4036) reads off `step.providerMetadata` to record `gateway_cost_usd`.
+ */
+function gatewayCostModel(
+  usage: LanguageModelV3Usage,
+  cost: string,
+): InstanceType<typeof MockLanguageModelV3> {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "Done." },
+    {
+      type: "finish",
+      usage,
+      finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: { gateway: { cost } },
+    },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+}
+
+/** The `token` usage_events INSERT (event_type param === "token"). */
+function tokenUsageEvent() {
+  return internalCalls.find(
+    (c) => c.sql.includes("INSERT INTO usage_events") && (c.params as unknown[])?.[2] === "token",
+  );
+}
+
 /** Drain the data stream so the streamText onFinish callback runs. */
 async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
   mockModel = model;
@@ -160,6 +190,23 @@ describe("token_usage cache split write path (#3099)", () => {
     // carry no providerMetadata.gateway.cost, so the at-cost capture records NULL
     // ("no gateway cost recorded"), distinct from a recorded 0.
     expect(params[10]).toBeNull();
+  });
+
+  it("records the per-turn gateway cost on both writes for a gateway-routed turn (#4036)", async () => {
+    // Drives the REAL field path: sumStepGatewayCostUsd reads
+    // step.providerMetadata.gateway.cost off the AI-SDK StepResult. A regression
+    // that reads the wrong path (e.g. step.response.providerMetadata) would write
+    // NULL forever and the non-gateway test below would still pass — this pins it.
+    await drive(gatewayCostModel(CACHE_USAGE, "0.0123"));
+
+    // token_usage row: gateway_cost_usd is the last positional param ($11).
+    const insertParams = tokenUsageInsert()!.params as unknown[];
+    expect(insertParams[10]).toBe(0.0123);
+
+    // …and the `token` usage event carries the same at-cost dollars ($6 of 7).
+    const event = tokenUsageEvent();
+    expect(event).toBeDefined();
+    expect((event!.params as unknown[])[5]).toBe(0.0123);
   });
 
   it("writes 0 for the cache split when the provider reports no cache usage", async () => {

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -142,11 +142,12 @@ describe("token_usage cache split write path (#3099)", () => {
 
     // Columns: user_id, conversation_id, prompt_tokens, completion_tokens,
     //          cache_read_tokens, cache_write_tokens, model, provider, org_id,
-    //          latency_ms
+    //          latency_ms, gateway_cost_usd
     expect(insert!.sql).toContain("cache_read_tokens, cache_write_tokens");
     expect(insert!.sql).toContain("latency_ms");
+    expect(insert!.sql).toContain("gateway_cost_usd");
     const params = insert!.params as unknown[];
-    expect(params).toHaveLength(10);
+    expect(params).toHaveLength(11);
     expect(params[4]).toBe(7); // cache_read_tokens  ← inputTokenDetails.cacheReadTokens
     expect(params[5]).toBe(3); // cache_write_tokens ← inputTokenDetails.cacheWriteTokens
     // latency_ms (#3931) — agent-turn wall-clock, non-negative integer ms.
@@ -155,6 +156,10 @@ describe("token_usage cache split write path (#3099)", () => {
     // upper bound on a near-instant mock turn.
     expect(Number.isInteger(params[9])).toBe(true);
     expect(params[9] as number).toBeGreaterThanOrEqual(0);
+    // gateway_cost_usd (#4036) — NULL for this non-gateway mock turn: the steps
+    // carry no providerMetadata.gateway.cost, so the at-cost capture records NULL
+    // ("no gateway cost recorded"), distinct from a recorded 0.
+    expect(params[10]).toBeNull();
   });
 
   it("writes 0 for the cache split when the provider reports no cache usage", async () => {

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -193,7 +193,7 @@ describe("token_usage cache split write path (#3099)", () => {
   });
 
   it("records the per-turn gateway cost on both writes for a gateway-routed turn (#4036)", async () => {
-    // Drives the REAL field path: sumStepGatewayCostUsd reads
+    // Drives the REAL field path: the agent's summarizeStepGatewayCostUsd reads
     // step.providerMetadata.gateway.cost off the AI-SDK StepResult. A regression
     // that reads the wrong path (e.g. step.response.providerMetadata) would write
     // NULL forever and the non-gateway test below would still pass — this pins it.

--- a/packages/api/src/lib/__tests__/metering-cost-pg.test.ts
+++ b/packages/api/src/lib/__tests__/metering-cost-pg.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Real-Postgres coverage for the at-cost `costUsd` period aggregate (#4036).
+ * Mirrors the `overage-meter-pg.test.ts` harness: skips cleanly when
+ * `TEST_DATABASE_URL` is unset, runs every migration into a unique per-test
+ * schema, and exercises the ACTUAL SQL against the real schema.
+ *
+ * What this catches that the mock-based `metering.test.ts` can't — the runtime
+ * behavior of `getCurrentPeriodUsage`'s new
+ * `COALESCE(SUM(CASE WHEN event_type = 'token' THEN gateway_cost_usd ELSE 0 END), 0)::float8`:
+ *   - that `SUM(numeric)::float8` comes back from `pg` as a JS **number**, not a
+ *     numeric string (the class `platform-demo-pg` was built to catch);
+ *   - that NULL `gateway_cost_usd` rows (non-gateway turns) are SKIPPED by the
+ *     SUM rather than poisoning it to NULL;
+ *   - that non-`token` events never contribute to the cost basis;
+ *   - the all-NULL → 0 floor.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("getCurrentPeriodUsage costUsd aggregate (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `metering_cost_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`metering-cost-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // usage_events + subscription (the only tables getCurrentPeriodUsage touches)
+    // are created by regular migrations; no Better-Auth tables are needed —
+    // resolveBillingPeriod falls back to the UTC month when no subscription row
+    // exists, which is exactly what we want here.
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch(() => {});
+    await pool.end();
+  });
+
+  async function insertEvent(
+    workspaceId: string,
+    eventType: "token" | "query",
+    quantity: number,
+    gatewayCostUsd: number | null,
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO usage_events (workspace_id, event_type, quantity, weighted_quantity, gateway_cost_usd)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [workspaceId, eventType, quantity, eventType === "token" ? quantity : null, gatewayCostUsd],
+    );
+  }
+
+  it("sums gateway_cost_usd over token rows, skips NULL + non-token, returns a JS number", async () => {
+    const ws = `ws-cost-${Math.floor(Math.random() * 1e6)}`;
+    await insertEvent(ws, "token", 1000, 0.1);
+    await insertEvent(ws, "token", 2000, 0.2);
+    await insertEvent(ws, "token", 500, null); // non-gateway turn — must be skipped, not poison the SUM
+    await insertEvent(ws, "query", 1, 9.99); // non-token — must never contribute to cost
+
+    const usage = await getCurrentPeriodUsage(ws);
+
+    expect(typeof usage.costUsd).toBe("number"); // ::float8 → JS number, not a numeric string
+    expect(usage.costUsd).toBeCloseTo(0.3, 6); // 0.1 + 0.2; NULL skipped, query excluded
+    expect(usage.tokenCount).toBe(3500); // 1000 + 2000 + 500
+    expect(usage.queryCount).toBe(1);
+  });
+
+  it("returns costUsd 0 when every token row has a NULL gateway_cost_usd", async () => {
+    const ws = `ws-null-${Math.floor(Math.random() * 1e6)}`;
+    await insertEvent(ws, "token", 1000, null);
+    await insertEvent(ws, "token", 2000, null);
+
+    const usage = await getCurrentPeriodUsage(ws);
+
+    expect(usage.costUsd).toBe(0);
+    expect(usage.tokenCount).toBe(3000);
+  });
+});

--- a/packages/api/src/lib/__tests__/metering-cost-pg.test.ts
+++ b/packages/api/src/lib/__tests__/metering-cost-pg.test.ts
@@ -61,7 +61,10 @@ describeIfPg("getCurrentPeriodUsage costUsd aggregate (real Postgres)", () => {
     _resetPool(null, null);
     if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
-    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch(() => {});
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`metering-cost-pg: DROP SCHEMA cleanup failed: ${message}`);
+    });
     await pool.end();
   });
 

--- a/packages/api/src/lib/__tests__/metering.test.ts
+++ b/packages/api/src/lib/__tests__/metering.test.ts
@@ -130,6 +130,7 @@ describe("metering", () => {
         "query",
         1,
         null, // weighted_quantity — omitted for a non-token event
+        null, // gateway_cost_usd — omitted for a non-token event (#4036)
         JSON.stringify({ model: "gpt-4" }),
       ]);
     });
@@ -143,7 +144,7 @@ describe("metering", () => {
       });
 
       expect(queryCalls).toHaveLength(1);
-      expect(queryCalls[0].params).toEqual([null, null, "token", 500, null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "token", 500, null, null, null]);
     });
 
     it("persists the weighted (output-equivalent) quantity for a token event (#3989)", () => {
@@ -164,6 +165,31 @@ describe("metering", () => {
         "token",
         1500,
         4200,
+        null, // gateway_cost_usd — not supplied here
+        JSON.stringify({ input: 500, output: 1000, weighted: 4200 }),
+      ]);
+    });
+
+    it("persists the at-cost gateway dollars for a token event (#4036)", () => {
+      logUsageEvent({
+        workspaceId: "org-1",
+        userId: "user-1",
+        eventType: "token",
+        quantity: 1500,
+        weightedQuantity: 4200,
+        gatewayCostUsd: 0.2345,
+        metadata: { input: 500, output: 1000, weighted: 4200 },
+      });
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].sql).toContain("gateway_cost_usd");
+      expect(queryCalls[0].params).toEqual([
+        "org-1",
+        "user-1",
+        "token",
+        1500,
+        4200,
+        0.2345,
         JSON.stringify({ input: 500, output: 1000, weighted: 4200 }),
       ]);
     });
@@ -240,7 +266,7 @@ describe("metering", () => {
     it("returns current period aggregates (UTC-month fallback, no subscription)", async () => {
       queryResults = [
         [], // no active subscription row → UTC month
-        [{ query_count: 42, token_count: 10000, weighted_token_count: 23000, active_users: 3 }],
+        [{ query_count: 42, token_count: 10000, weighted_token_count: 23000, cost_usd: 1.23, active_users: 3 }],
       ];
 
       const result = await getCurrentPeriodUsage("org-1");
@@ -249,6 +275,8 @@ describe("metering", () => {
       expect(result.tokenCount).toBe(10000);
       // Output-equivalent (model-weighted) token spend — the budget denominator (#3989).
       expect(result.weightedTokenCount).toBe(23000);
+      // At-cost provider dollars for the period — the Structure B denominator (#4036).
+      expect(result.costUsd).toBe(1.23);
       expect(result.activeUsers).toBe(3);
       expect(result.periodStart).toBeTruthy();
       expect(result.periodEnd).toBeTruthy();
@@ -258,6 +286,8 @@ describe("metering", () => {
       // so token rows predating migration 0152 still contribute.
       const usageCall = queryCalls.find((c) => c.sql.includes("usage_events"));
       expect(usageCall?.sql).toContain("COALESCE(weighted_quantity, quantity)");
+      // …and sums the at-cost gateway dollars for the period (#4036).
+      expect(usageCall?.sql).toContain("gateway_cost_usd");
     });
 
     it("anchors on the Stripe period when an active subscription exists", async () => {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -63,6 +63,7 @@ import {
 import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
 import { toOutputEquivalentTokens } from "./billing/token-weighting";
+import { sumStepGatewayCostUsd } from "./billing/gateway-cost";
 import { buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
 import { resolveOrgKnowledgeSection } from "./learn/org-knowledge-section";
 import { dispatchMutableHook } from "./plugins/hooks";
@@ -1981,10 +1982,19 @@ export async function runAgent({
         // Persist token usage to internal DB (fire-and-forget).
         // Shares the internalExecute circuit breaker with audit writes.
         if (hasInternalDB() && totalUsage) {
+          // At-cost provider spend for the turn (#4036, Structure B): the Vercel
+          // AI Gateway annotates each step's actual charged cost on
+          // `providerMetadata.gateway.cost`, and the AI-SDK top-level metadata is
+          // final-step-only, so sum across `steps`. `null` when no step carried a
+          // gateway cost (non-gateway / BYOK-direct provider) → write NULL,
+          // distinct from a recorded 0. Recorded on BOTH the token_usage row and
+          // the `token` usage event so the cost basis is queryable per-turn and
+          // summable per-period.
+          const gatewayCostUsd = sumStepGatewayCostUsd(steps);
           try {
             internalExecute(
-              `INSERT INTO token_usage (user_id, conversation_id, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens, model, provider, org_id, latency_ms)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+              `INSERT INTO token_usage (user_id, conversation_id, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens, model, provider, org_id, latency_ms, gateway_cost_usd)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
               [
                 userId,
                 conversationId ?? null,
@@ -1999,6 +2009,7 @@ export async function runAgent({
                 // alongside the turn's usage so the demo tracking rollup reads
                 // tokens + cache + latency from one row.
                 Math.max(0, Date.now() - turnStartedAt),
+                gatewayCostUsd,
               ],
             );
           } catch (err) {
@@ -2034,6 +2045,9 @@ export async function runAgent({
                 eventType: "token",
                 quantity: totalTokens,
                 weightedQuantity: weightedTokens,
+                // At-cost dollars for the turn (#4036) — the Structure B billing
+                // denominator. NULL when the provider isn't the gateway.
+                gatewayCostUsd,
                 metadata: { input: inputTokens, output: outputTokens, weighted: weightedTokens },
               });
             }

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -63,7 +63,7 @@ import {
 import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
 import { toOutputEquivalentTokens } from "./billing/token-weighting";
-import { sumStepGatewayCostUsd } from "./billing/gateway-cost";
+import { summarizeStepGatewayCostUsd } from "./billing/gateway-cost";
 import { buildRetrievalQuery, getRetrievalTurns } from "./learn/pattern-cache";
 import { resolveOrgKnowledgeSection } from "./learn/org-knowledge-section";
 import { dispatchMutableHook } from "./plugins/hooks";
@@ -1982,15 +1982,45 @@ export async function runAgent({
         // Persist token usage to internal DB (fire-and-forget).
         // Shares the internalExecute circuit breaker with audit writes.
         if (hasInternalDB() && totalUsage) {
-          // At-cost provider spend for the turn (#4036, Structure B): the Vercel
-          // AI Gateway annotates each step's actual charged cost on
+          // At-cost provider spend for the turn (#4036): the Vercel AI Gateway
+          // annotates each step's actual charged cost on
           // `providerMetadata.gateway.cost`, and the AI-SDK top-level metadata is
           // final-step-only, so sum across `steps`. `null` when no step carried a
           // gateway cost (non-gateway / BYOK-direct provider) → write NULL,
           // distinct from a recorded 0. Recorded on BOTH the token_usage row and
           // the `token` usage event so the cost basis is queryable per-turn and
-          // summable per-period.
-          const gatewayCostUsd = sumStepGatewayCostUsd(steps);
+          // summable per-period. Captured-only here; the Structure B credit +
+          // overage meter will draw against it once #4038/#4039 land.
+          //
+          // Computed in its own guard so a (total, never-throwing) helper change
+          // can't break stream finalization, matching the metering block's
+          // "never disrupt finalization" contract below.
+          let gatewayCostUsd: number | null = null;
+          try {
+            const costSummary = summarizeStepGatewayCostUsd(steps);
+            gatewayCostUsd = costSummary.totalUsd;
+            // A present-but-unparseable per-step cost is dropped from the total
+            // (we never guess a number), so surface it loudly: this is the
+            // gateway-contract-drift signal — the period cost is under-captured
+            // until it's investigated. Should be 0 in normal operation.
+            if (costSummary.skippedSteps > 0) {
+              log.warn(
+                {
+                  skippedSteps: costSummary.skippedSteps,
+                  recordedSteps: costSummary.recordedSteps,
+                  totalSteps: steps.length,
+                  model: resolvedModelId,
+                  orgId: orgId ?? null,
+                },
+                "Gateway cost capture dropped unparseable provider cost annotation(s) — period at-cost is under-captured; check the gateway cost contract (#4036)",
+              );
+            }
+          } catch (err) {
+            log.warn(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Failed to compute gateway cost for the turn — recording NULL",
+            );
+          }
           try {
             internalExecute(
               `INSERT INTO token_usage (user_id, conversation_id, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens, model, provider, org_id, latency_ms, gateway_cost_usd)
@@ -2045,8 +2075,9 @@ export async function runAgent({
                 eventType: "token",
                 quantity: totalTokens,
                 weightedQuantity: weightedTokens,
-                // At-cost dollars for the turn (#4036) — the Structure B billing
-                // denominator. NULL when the provider isn't the gateway.
+                // At-cost dollars for the turn (#4036) — the future Structure B
+                // billing denominator (enforcement lands in #4038/#4039);
+                // captured now. NULL when the provider isn't the gateway.
                 gatewayCostUsd,
                 metadata: { input: inputTokens, output: outputTokens, weighted: weightedTokens },
               });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -427,6 +427,10 @@ describe("migrateAuthTables", () => {
             // ledger, #3992); no FK to a Better Auth table, so it is NOT in
             // MANAGED_AUTH_MIGRATIONS and runs in every auth mode — must be listed.
             { name: "0154_overage_meter_reports.sql" },
+            // 0155 adds usage_events/token_usage.gateway_cost_usd (at-cost
+            // capture, Structure B WS2, #4036); ALTERs Atlas-internal tables, no
+            // FK to a Better Auth table, so it runs in every auth mode — must be listed.
+            { name: "0155_usage_gateway_cost_usd.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/billing/__tests__/gateway-cost.test.ts
+++ b/packages/api/src/lib/billing/__tests__/gateway-cost.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import {
   parseGatewayCostUsd,
   sumStepGatewayCostUsd,
+  summarizeStepGatewayCostUsd,
   type StepProviderMetadata,
 } from "@atlas/api/lib/billing/gateway-cost";
 
@@ -30,6 +31,7 @@ describe("parseGatewayCostUsd", () => {
     expect(parseGatewayCostUsd(null)).toBeNull();
     expect(parseGatewayCostUsd(undefined)).toBeNull();
     expect(parseGatewayCostUsd("")).toBeNull(); // Number("") === 0, but empty is "not recorded"
+    expect(parseGatewayCostUsd("   ")).toBeNull(); // whitespace-only is "not recorded" too
     expect(parseGatewayCostUsd("not-a-number")).toBeNull();
     expect(parseGatewayCostUsd(-0.01)).toBeNull(); // never a negative cost
     expect(parseGatewayCostUsd(Number.NaN)).toBeNull();
@@ -73,5 +75,48 @@ describe("sumStepGatewayCostUsd", () => {
         { providerMetadata: { gateway: { cost: "0.04" } } },
       ]),
     ).toBeCloseTo(0.04, 10);
+  });
+
+  it("never credits usage back from a negative cost mixed with valid steps", () => {
+    // A negative cost is dropped (not subtracted) — the no-credit-back invariant
+    // enforced at the sum level, not just per-value.
+    const total = sumStepGatewayCostUsd([step("0.05"), step(-0.02), step("0.01")]);
+    expect(total).toBeCloseTo(0.06, 10);
+  });
+});
+
+describe("summarizeStepGatewayCostUsd", () => {
+  it("reports the total plus recorded/skipped step counts", () => {
+    const s = summarizeStepGatewayCostUsd([step("0.01"), step("0.02")]);
+    expect(s.totalUsd).toBeCloseTo(0.03, 10);
+    expect(s.recordedSteps).toBe(2);
+    expect(s.skippedSteps).toBe(0);
+  });
+
+  it("counts a PRESENT-but-unparseable cost as skipped (gateway contract drift)", () => {
+    // "garbage" (NaN) and an object are present but unparseable → skipped, not
+    // silently treated as a non-gateway no-op. The parseable steps still sum.
+    const s = summarizeStepGatewayCostUsd([
+      step("0.02"),
+      step("garbage"),
+      step({ amount: "0.03" }),
+      step(-0.01), // negative present value is also a drop-but-count anomaly
+      step("0.04"),
+    ]);
+    expect(s.totalUsd).toBeCloseTo(0.06, 10);
+    expect(s.recordedSteps).toBe(2);
+    expect(s.skippedSteps).toBe(3);
+  });
+
+  it("does NOT count absent / empty cost as skipped (legitimate non-gateway)", () => {
+    const s = summarizeStepGatewayCostUsd([step(), step(""), step("   ")]);
+    expect(s.totalUsd).toBeNull();
+    expect(s.recordedSteps).toBe(0);
+    expect(s.skippedSteps).toBe(0);
+  });
+
+  it("returns an all-zero summary for empty/absent steps", () => {
+    expect(summarizeStepGatewayCostUsd([])).toEqual({ totalUsd: null, recordedSteps: 0, skippedSteps: 0 });
+    expect(summarizeStepGatewayCostUsd(null)).toEqual({ totalUsd: null, recordedSteps: 0, skippedSteps: 0 });
   });
 });

--- a/packages/api/src/lib/billing/__tests__/gateway-cost.test.ts
+++ b/packages/api/src/lib/billing/__tests__/gateway-cost.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseGatewayCostUsd,
+  sumStepGatewayCostUsd,
+  type StepProviderMetadata,
+} from "@atlas/api/lib/billing/gateway-cost";
+
+/** Build a step carrying a gateway cost value (or none). */
+function step(cost?: unknown): StepProviderMetadata {
+  if (cost === undefined) return { providerMetadata: {} };
+  return { providerMetadata: { gateway: { cost } } };
+}
+
+describe("parseGatewayCostUsd", () => {
+  it("parses the gateway's decimal-string cost", () => {
+    expect(parseGatewayCostUsd("0.0234")).toBe(0.0234);
+    expect(parseGatewayCostUsd("1")).toBe(1);
+  });
+
+  it("tolerates a numeric cost", () => {
+    expect(parseGatewayCostUsd(0.5)).toBe(0.5);
+  });
+
+  it("treats a recorded zero as zero (not null)", () => {
+    expect(parseGatewayCostUsd("0")).toBe(0);
+    expect(parseGatewayCostUsd(0)).toBe(0);
+  });
+
+  it("returns null for absent / unparseable / negative / non-finite values", () => {
+    expect(parseGatewayCostUsd(null)).toBeNull();
+    expect(parseGatewayCostUsd(undefined)).toBeNull();
+    expect(parseGatewayCostUsd("")).toBeNull(); // Number("") === 0, but empty is "not recorded"
+    expect(parseGatewayCostUsd("not-a-number")).toBeNull();
+    expect(parseGatewayCostUsd(-0.01)).toBeNull(); // never a negative cost
+    expect(parseGatewayCostUsd(Number.NaN)).toBeNull();
+    expect(parseGatewayCostUsd(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(parseGatewayCostUsd({})).toBeNull();
+  });
+});
+
+describe("sumStepGatewayCostUsd", () => {
+  it("sums the per-step gateway cost across a multi-step turn", () => {
+    const total = sumStepGatewayCostUsd([step("0.01"), step("0.02"), step("0.005")]);
+    expect(total).toBeCloseTo(0.035, 10);
+  });
+
+  it("returns null when no step carried a gateway cost (non-gateway provider)", () => {
+    expect(sumStepGatewayCostUsd([step(), step()])).toBeNull();
+  });
+
+  it("returns null for an empty or absent steps array", () => {
+    expect(sumStepGatewayCostUsd([])).toBeNull();
+    expect(sumStepGatewayCostUsd(null)).toBeNull();
+    expect(sumStepGatewayCostUsd(undefined)).toBeNull();
+  });
+
+  it("includes recorded-zero steps and returns a number (not null)", () => {
+    expect(sumStepGatewayCostUsd([step("0"), step("0")])).toBe(0);
+  });
+
+  it("skips unparseable steps but keeps the parseable ones", () => {
+    const total = sumStepGatewayCostUsd([step("0.02"), step("garbage"), step(), step("0.03")]);
+    expect(total).toBeCloseTo(0.05, 10);
+  });
+
+  it("tolerates missing providerMetadata / gateway shapes", () => {
+    expect(
+      sumStepGatewayCostUsd([
+        { providerMetadata: null },
+        { providerMetadata: undefined },
+        {},
+        { providerMetadata: { gateway: undefined } },
+        { providerMetadata: { gateway: { cost: "0.04" } } },
+      ]),
+    ).toBeCloseTo(0.04, 10);
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
+++ b/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
@@ -114,6 +114,7 @@ function makeDeps(overrides: Partial<WorkspaceOverageDeps> = {}): {
       queryCount: 0,
       tokenCount: 0,
       weightedTokenCount: 0,
+      costUsd: 0,
       activeUsers: 0,
       periodStart: PERIOD_START,
       periodEnd: "2026-07-01T00:00:00.000Z",
@@ -306,6 +307,7 @@ describe("reportWorkspaceOverage", () => {
         tokenCount: STARTER_BUDGET + 500,
         // weighted field absent (un-backfilled / future shape change)
         weightedTokenCount: undefined as unknown as number,
+        costUsd: 0,
         activeUsers: 0,
         periodStart: PERIOD_START,
         periodEnd: "2026-07-01T00:00:00.000Z",
@@ -579,6 +581,7 @@ function usageWith(weighted: number): import("@atlas/api/lib/metering").UsageCur
     queryCount: 0,
     tokenCount: weighted,
     weightedTokenCount: weighted,
+    costUsd: 0,
     activeUsers: 0,
     periodStart: PERIOD_START,
     periodEnd: "2026-07-01T00:00:00.000Z",

--- a/packages/api/src/lib/billing/gateway-cost.ts
+++ b/packages/api/src/lib/billing/gateway-cost.ts
@@ -4,34 +4,41 @@
  *
  * Atlas resolves models through the Vercel AI Gateway, which is zero-markup and
  * returns the ACTUAL charged cost per generation inline as
- * `providerMetadata.gateway.cost` (a USD decimal). The Structure B billing model
- * draws the included usage credit and the overage meter against the SUM of this
- * real dollar cost, so each agent turn records its gateway cost alongside its
- * token usage.
+ * `providerMetadata.gateway.cost` (a USD decimal). This slice CAPTURES that cost
+ * per turn (#4036); the Structure B credit + overage meter will draw against the
+ * summed real dollars once the re-denomination lands (#4038/#4039). Until then
+ * nothing enforces against it — it is recorded only.
+ *
+ * Float summation here (`total += cost`) is fine for the captured/displayed
+ * value; the period rollup re-sums in Postgres `numeric` (exact) and the
+ * exact-decimal handling for *enforcement* is the enforcement slice's concern.
  *
  * ## Why sum across steps
  *
  * A turn is multi-step (the agent loops tool calls). In the AI SDK the
  * **top-level** `onFinish` `providerMetadata` reflects the FINAL step only, so
  * the turn's true cost is the sum of each step's `providerMetadata.gateway.cost`.
- * {@link sumStepGatewayCostUsd} does exactly that, defensively.
+ * {@link summarizeStepGatewayCostUsd} does exactly that, defensively.
  *
- * ## NULL vs 0
+ * ## NULL vs 0, and present-but-unparseable
  *
  * The capture distinguishes "no gateway cost was recorded for this turn" (NULL —
  * a non-gateway / BYOK-direct provider, where the gateway never annotated a cost)
  * from "the recorded cost was zero" (0 — e.g. a fully-cached/free generation).
- * {@link sumStepGatewayCostUsd} returns `null` only when NO step carried a
- * parseable cost, and a number (possibly 0) otherwise — mirroring the nullable
- * `gateway_cost_usd` column semantics (migration 0155).
+ * A THIRD case — a step whose cost is PRESENT but unparseable (a gateway
+ * contract drift: renamed field, object shape, locale-formatted number, a
+ * negative credit) — is dropped from the sum but COUNTED, so the caller can log
+ * it rather than silently under-capturing. {@link summarizeStepGatewayCostUsd}
+ * returns the total (`null` only when NO step carried a parseable cost — mirrors
+ * the nullable `gateway_cost_usd` column, migration 0155) plus the skipped count.
  */
 
 /**
  * Coerce a raw gateway cost value to a non-negative USD number, or `null` when
- * it's absent / unparseable. The gateway returns the cost as a decimal STRING;
- * a numeric form is tolerated defensively. Negative or non-finite values are
- * rejected as `null` (never a negative cost) so a malformed annotation can't
- * credit usage back.
+ * it's absent / unparseable. The gateway typically returns the cost as a decimal
+ * string; a numeric form is tolerated defensively (the SDK types the value as
+ * `unknown`). Negative or non-finite values are rejected as `null` (never a
+ * negative cost) so a malformed annotation can't credit usage back.
  */
 export function parseGatewayCostUsd(raw: unknown): number | null {
   if (raw == null) return null;
@@ -56,27 +63,71 @@ export interface StepProviderMetadata {
   readonly providerMetadata?: Record<string, Record<string, unknown> | undefined> | null;
 }
 
+/** Whether a raw cost value is PRESENT (not absent / empty-string) regardless of parseability. */
+function isPresentCost(raw: unknown): boolean {
+  if (raw == null) return false;
+  if (typeof raw === "string" && raw.trim() === "") return false;
+  return true;
+}
+
+/** Outcome of summing a turn's per-step gateway cost. */
+export interface GatewayCostSummary {
+  /**
+   * Total at-cost USD for the turn — `null` only when NO step carried a
+   * parseable cost (→ write NULL, "no gateway cost recorded"). A number
+   * (possibly 0) when at least one step did.
+   */
+  readonly totalUsd: number | null;
+  /** Steps that contributed a parseable cost to {@link totalUsd}. */
+  readonly recordedSteps: number;
+  /**
+   * Steps whose `gateway.cost` was PRESENT but unparseable (NaN / object /
+   * negative / non-finite) — dropped from the total but counted so the caller
+   * can surface a gateway-contract-drift warning instead of silently
+   * under-capturing. Should be 0 in normal operation.
+   */
+  readonly skippedSteps: number;
+}
+
 /**
- * Sum the per-step Vercel AI Gateway cost over a turn's steps, in USD.
+ * Sum the per-step Vercel AI Gateway cost over a turn's steps, in USD, and
+ * report how many present-but-unparseable steps were dropped.
  *
- * Returns `null` when the steps array is empty/absent OR no step carried a
- * parseable `providerMetadata.gateway.cost` (→ write NULL: "no gateway cost
- * recorded", e.g. a non-gateway provider). Returns a non-negative number
- * (possibly 0) when at least one step carried a cost. Pure and total — never
- * throws, never returns NaN/negative.
+ * Pure and total — never throws, never returns NaN/negative. See the module doc
+ * for the NULL-vs-0-vs-skipped semantics.
+ */
+export function summarizeStepGatewayCostUsd(
+  steps: ReadonlyArray<StepProviderMetadata> | null | undefined,
+): GatewayCostSummary {
+  if (!steps || steps.length === 0) {
+    return { totalUsd: null, recordedSteps: 0, skippedSteps: 0 };
+  }
+  let total = 0;
+  let recordedSteps = 0;
+  let skippedSteps = 0;
+  for (const step of steps) {
+    const raw = step?.providerMetadata?.gateway?.cost;
+    const cost = parseGatewayCostUsd(raw);
+    if (cost !== null) {
+      total += cost;
+      recordedSteps += 1;
+    } else if (isPresentCost(raw)) {
+      // Present but unparseable — a gateway contract drift. Drop it from the
+      // total (never guess) but count it so the caller logs the under-capture.
+      skippedSteps += 1;
+    }
+  }
+  return { totalUsd: recordedSteps > 0 ? total : null, recordedSteps, skippedSteps };
+}
+
+/**
+ * Convenience: the at-cost USD total for a turn, discarding the skipped-step
+ * detail. `null` when no step carried a parseable cost. Prefer
+ * {@link summarizeStepGatewayCostUsd} where the skipped count matters (the agent
+ * write path logs it).
  */
 export function sumStepGatewayCostUsd(
   steps: ReadonlyArray<StepProviderMetadata> | null | undefined,
 ): number | null {
-  if (!steps || steps.length === 0) return null;
-  let total = 0;
-  let recorded = false;
-  for (const step of steps) {
-    const cost = parseGatewayCostUsd(step?.providerMetadata?.gateway?.cost);
-    if (cost !== null) {
-      total += cost;
-      recorded = true;
-    }
-  }
-  return recorded ? total : null;
+  return summarizeStepGatewayCostUsd(steps).totalUsd;
 }

--- a/packages/api/src/lib/billing/gateway-cost.ts
+++ b/packages/api/src/lib/billing/gateway-cost.ts
@@ -1,0 +1,82 @@
+/**
+ * Gateway at-cost capture — per-turn provider cost from the Vercel AI Gateway
+ * (#4036, Structure B WS2).
+ *
+ * Atlas resolves models through the Vercel AI Gateway, which is zero-markup and
+ * returns the ACTUAL charged cost per generation inline as
+ * `providerMetadata.gateway.cost` (a USD decimal). The Structure B billing model
+ * draws the included usage credit and the overage meter against the SUM of this
+ * real dollar cost, so each agent turn records its gateway cost alongside its
+ * token usage.
+ *
+ * ## Why sum across steps
+ *
+ * A turn is multi-step (the agent loops tool calls). In the AI SDK the
+ * **top-level** `onFinish` `providerMetadata` reflects the FINAL step only, so
+ * the turn's true cost is the sum of each step's `providerMetadata.gateway.cost`.
+ * {@link sumStepGatewayCostUsd} does exactly that, defensively.
+ *
+ * ## NULL vs 0
+ *
+ * The capture distinguishes "no gateway cost was recorded for this turn" (NULL —
+ * a non-gateway / BYOK-direct provider, where the gateway never annotated a cost)
+ * from "the recorded cost was zero" (0 — e.g. a fully-cached/free generation).
+ * {@link sumStepGatewayCostUsd} returns `null` only when NO step carried a
+ * parseable cost, and a number (possibly 0) otherwise — mirroring the nullable
+ * `gateway_cost_usd` column semantics (migration 0155).
+ */
+
+/**
+ * Coerce a raw gateway cost value to a non-negative USD number, or `null` when
+ * it's absent / unparseable. The gateway returns the cost as a decimal STRING;
+ * a numeric form is tolerated defensively. Negative or non-finite values are
+ * rejected as `null` (never a negative cost) so a malformed annotation can't
+ * credit usage back.
+ */
+export function parseGatewayCostUsd(raw: unknown): number | null {
+  if (raw == null) return null;
+  let n: number;
+  if (typeof raw === "number") {
+    n = raw;
+  } else if (typeof raw === "string") {
+    // An empty / whitespace-only string is "not recorded", NOT zero — guard it
+    // before `Number("")` coerces it to 0 (which would mark a turn as a recorded
+    // $0 spend rather than a non-gateway no-op).
+    if (raw.trim() === "") return null;
+    n = Number(raw);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/** A turn step, narrowed to the provider-metadata shape this module reads. */
+export interface StepProviderMetadata {
+  readonly providerMetadata?: Record<string, Record<string, unknown> | undefined> | null;
+}
+
+/**
+ * Sum the per-step Vercel AI Gateway cost over a turn's steps, in USD.
+ *
+ * Returns `null` when the steps array is empty/absent OR no step carried a
+ * parseable `providerMetadata.gateway.cost` (→ write NULL: "no gateway cost
+ * recorded", e.g. a non-gateway provider). Returns a non-negative number
+ * (possibly 0) when at least one step carried a cost. Pure and total — never
+ * throws, never returns NaN/negative.
+ */
+export function sumStepGatewayCostUsd(
+  steps: ReadonlyArray<StepProviderMetadata> | null | undefined,
+): number | null {
+  if (!steps || steps.length === 0) return null;
+  let total = 0;
+  let recorded = false;
+  for (const step of steps) {
+    const cost = parseGatewayCostUsd(step?.providerMetadata?.gateway?.cost);
+    if (cost !== null) {
+      total += cost;
+      recorded = true;
+    }
+  }
+  return recorded ? total : null;
+}

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -184,7 +184,9 @@ describe("runMigrations", () => {
     //   GDPR purge completes in passive EU/APAC regions, #4019) = 154.
     //   Plus 0154 (overage_meter_reports ledger for the idempotent Stripe
     //   Billing Meters overage reporter, WS2, #3992) = 155.
-    expect(count).toBe(155);
+    //   Plus 0155 (usage_events/token_usage.gateway_cost_usd at-cost capture,
+    //   Structure B WS2, #4036) = 156.
+    expect(count).toBe(156);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -368,6 +370,7 @@ describe("runMigrations", () => {
         "0152_usage_events_weighted_quantity.sql",
         "0153_region_db_subscription_scim_parity.sql",
         "0154_overage_meter_reports.sql",
+        "0155_usage_gateway_cost_usd.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
+++ b/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
@@ -21,9 +21,10 @@
 -- COALESCE(SUM(gateway_cost_usd), 0) so NULL rows simply don't contribute.
 --
 -- Mirrored in db/schema.ts (usageEvents.gatewayCostUsd, tokenUsage.gatewayCostUsd)
--- in the same PR per the schema-drift discipline. Pure-additive: nothing reads
--- this column for billing yet (the enforcement/meter re-denomination lands in
--- later Structure B slices, #4038/#4039).
+-- in the same PR per the schema-drift discipline. Pure-additive: the column is
+-- summed into the period usage rollup for display, but no meter/enforcement
+-- draws against it yet — the enforcement/meter re-denomination lands in later
+-- Structure B slices (#4038/#4039).
 --
 -- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
 

--- a/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
+++ b/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
@@ -2,9 +2,10 @@
 --
 -- Atlas resolves models through the Vercel AI Gateway, which returns the ACTUAL
 -- charged cost per generation as providerMetadata.gateway.cost (USD decimal,
--- zero-markup). The Structure B billing model (2026-06-27) draws the included
--- usage credit and the overage meter against the SUM of this real dollar cost,
--- so each agent turn records its gateway cost alongside its token usage.
+-- zero-markup). The Structure B billing model (2026-06-27) is designed to draw
+-- the included usage credit and the overage meter against the SUM of this real
+-- dollar cost (once #4038/#4039 land), so each agent turn records its gateway
+-- cost alongside its token usage now.
 --
 -- This column stores the turn's total gateway cost in USD (summed across the
 -- turn's steps[], since the AI-SDK top-level providerMetadata is final-step

--- a/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
+++ b/packages/api/src/lib/db/migrations/0155_usage_gateway_cost_usd.sql
@@ -1,0 +1,40 @@
+-- Migration 0155: at-cost gateway.cost capture (#4036, Structure B WS2).
+--
+-- Atlas resolves models through the Vercel AI Gateway, which returns the ACTUAL
+-- charged cost per generation as providerMetadata.gateway.cost (USD decimal,
+-- zero-markup). The Structure B billing model (2026-06-27) draws the included
+-- usage credit and the overage meter against the SUM of this real dollar cost,
+-- so each agent turn records its gateway cost alongside its token usage.
+--
+-- This column stores the turn's total gateway cost in USD (summed across the
+-- turn's steps[], since the AI-SDK top-level providerMetadata is final-step
+-- only). It is added to BOTH usage tables:
+--   - usage_events   — the billing/metering aggregate sums this per period.
+--   - token_usage    — the per-turn record, kept in lockstep with usage_events
+--                      so the demo/cost rollup reads cost from one row.
+--
+-- numeric(12, 6): up to 999,999.999999 USD with micro-dollar precision — a
+-- single turn's cost is fractions of a dollar; a workspace's period sum stays
+-- well under the ceiling. Nullable, no default: NULL means "no gateway cost
+-- recorded" (non-gateway / BYOK-direct providers, or rows predating this
+-- migration) — distinct from 0 ("cost was zero"). Aggregation reads
+-- COALESCE(SUM(gateway_cost_usd), 0) so NULL rows simply don't contribute.
+--
+-- Mirrored in db/schema.ts (usageEvents.gatewayCostUsd, tokenUsage.gatewayCostUsd)
+-- in the same PR per the schema-drift discipline. Pure-additive: nothing reads
+-- this column for billing yet (the enforcement/meter re-denomination lands in
+-- later Structure B slices, #4038/#4039).
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE usage_events
+  ADD COLUMN IF NOT EXISTS gateway_cost_usd numeric(12, 6);
+
+ALTER TABLE token_usage
+  ADD COLUMN IF NOT EXISTS gateway_cost_usd numeric(12, 6);
+
+COMMENT ON COLUMN usage_events.gateway_cost_usd IS
+  'Provider-cost USD for the turn from Vercel AI Gateway providerMetadata.gateway.cost, summed across steps (#4036, Structure B). NULL for non-gateway providers and rows predating this migration; billing aggregation reads COALESCE(SUM(gateway_cost_usd), 0).';
+
+COMMENT ON COLUMN token_usage.gateway_cost_usd IS
+  'Provider-cost USD for the turn from Vercel AI Gateway providerMetadata.gateway.cost, summed across steps (#4036, Structure B). NULL for non-gateway providers and rows predating this migration.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -415,6 +415,13 @@ export const tokenUsage = pgTable(
     // path supplies a value for every turn after. Powers the /platform/demo
     // latency rollup (aggregates skip NULLs).
     latencyMs: integer("latency_ms"),
+    // Provider-cost USD for the turn from the Vercel AI Gateway
+    // (providerMetadata.gateway.cost, summed across steps), #4036 / migration
+    // 0155 (Structure B). Zero-markup actual cost — the basis the included usage
+    // credit + overage meter draw against. Nullable, no default: NULL for
+    // non-gateway / BYOK-direct providers and rows predating the migration,
+    // distinct from 0 ("cost was zero").
+    gatewayCostUsd: numeric("gateway_cost_usd", { precision: 12, scale: 6 }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     // Org scoping
     orgId: text("org_id"),
@@ -805,6 +812,13 @@ export const usageEvents = pgTable(
     // distinct from 0 ("weighted to zero"). Budget/period summation reads
     // COALESCE(weighted_quantity, quantity) so legacy token rows still count.
     weightedQuantity: integer("weighted_quantity"),
+    // Provider-cost USD for a `token` event's turn from the Vercel AI Gateway
+    // (providerMetadata.gateway.cost, summed across steps), #4036 / migration
+    // 0155 (Structure B). The billing/period aggregate sums this as the at-cost
+    // dollar spend the included credit + overage meter draw against. Nullable,
+    // no default: NULL for non-token events, non-gateway providers, and rows
+    // predating the migration; aggregation reads COALESCE(SUM(...), 0).
+    gatewayCostUsd: numeric("gateway_cost_usd", { precision: 12, scale: 6 }),
     metadata: jsonb("metadata"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -417,10 +417,10 @@ export const tokenUsage = pgTable(
     latencyMs: integer("latency_ms"),
     // Provider-cost USD for the turn from the Vercel AI Gateway
     // (providerMetadata.gateway.cost, summed across steps), #4036 / migration
-    // 0155 (Structure B). Zero-markup actual cost — the basis the included usage
-    // credit + overage meter draw against. Nullable, no default: NULL for
-    // non-gateway / BYOK-direct providers and rows predating the migration,
-    // distinct from 0 ("cost was zero").
+    // 0155. Zero-markup actual cost — captured now; the basis the included usage
+    // credit + overage meter will draw against once #4038/#4039 land. Nullable,
+    // no default: NULL for non-gateway / BYOK-direct providers and rows predating
+    // the migration, distinct from 0 ("cost was zero").
     gatewayCostUsd: numeric("gateway_cost_usd", { precision: 12, scale: 6 }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     // Org scoping
@@ -814,10 +814,11 @@ export const usageEvents = pgTable(
     weightedQuantity: integer("weighted_quantity"),
     // Provider-cost USD for a `token` event's turn from the Vercel AI Gateway
     // (providerMetadata.gateway.cost, summed across steps), #4036 / migration
-    // 0155 (Structure B). The billing/period aggregate sums this as the at-cost
-    // dollar spend the included credit + overage meter draw against. Nullable,
-    // no default: NULL for non-token events, non-gateway providers, and rows
-    // predating the migration; aggregation reads COALESCE(SUM(...), 0).
+    // 0155. The billing/period aggregate sums this into the at-cost dollar spend
+    // the included credit + overage meter WILL draw against once #4038/#4039
+    // land (captured-only today). Nullable, no default: NULL for non-token
+    // events, non-gateway providers, and rows predating the migration;
+    // aggregation reads COALESCE(SUM(...), 0).
     gatewayCostUsd: numeric("gateway_cost_usd", { precision: 12, scale: 6 }),
     metadata: jsonb("metadata"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -253,13 +253,14 @@ export interface UsageCurrentPeriod {
    */
   weightedTokenCount: number;
   /**
-   * At-cost provider spend in USD for the period (#4036, Structure B): the sum
-   * of `gateway_cost_usd` over `token` events — the EXACT zero-markup dollars
-   * Atlas paid the Vercel AI Gateway. This is the billing denominator the
-   * Structure B included credit ($20/seat) and the overage meter draw against
-   * (the token-weighted count above is retained for display / budget fallback).
-   * Rows with a NULL `gateway_cost_usd` (non-gateway providers, or token rows
-   * predating migration 0155) simply don't contribute.
+   * At-cost provider spend in USD for the period (#4036): the sum of
+   * `gateway_cost_usd` over `token` events — the EXACT zero-markup dollars Atlas
+   * paid the Vercel AI Gateway. Captured now; the Structure B included credit
+   * ($20/seat) + overage meter will draw against this once the re-denomination
+   * lands (#4038/#4039) — until then `weightedTokenCount` above remains the
+   * active budget denominator and this is for display only. Rows with a NULL
+   * `gateway_cost_usd` (non-gateway providers, or token rows predating migration
+   * 0155) simply don't contribute.
    */
   costUsd: number;
   activeUsers: number;

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -44,6 +44,14 @@ export interface UsageEvent {
    * `null`) for non-token events — the column is NULL for those.
    */
   weightedQuantity?: number | null;
+  /**
+   * Provider-cost USD for a `token` event's turn, from the Vercel AI Gateway
+   * (`providerMetadata.gateway.cost`, summed across the turn's steps), #4036.
+   * Persisted to `usage_events.gateway_cost_usd` as the at-cost dollar basis the
+   * Structure B credit + overage meter draw against. Omit (or pass `null`) for
+   * non-token events and for non-gateway providers — the column is NULL there.
+   */
+  gatewayCostUsd?: number | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -93,14 +101,15 @@ export function logUsageEvent(event: UsageEvent): void {
   // after 5 consecutive failures. No try/catch needed here — hasInternalDB()
   // guards against the only synchronous throw path (DATABASE_URL unset).
   internalExecute(
-    `INSERT INTO usage_events (workspace_id, user_id, event_type, quantity, weighted_quantity, metadata)
-     VALUES ($1, $2, $3, $4, $5, $6)`,
+    `INSERT INTO usage_events (workspace_id, user_id, event_type, quantity, weighted_quantity, gateway_cost_usd, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
     [
       event.workspaceId ?? null,
       event.userId ?? null,
       event.eventType,
       event.quantity,
       event.weightedQuantity ?? null,
+      event.gatewayCostUsd ?? null,
       event.metadata ? JSON.stringify(event.metadata) : null,
     ],
   );
@@ -243,6 +252,16 @@ export interface UsageCurrentPeriod {
    * less than it should be for un-backfilled history.
    */
   weightedTokenCount: number;
+  /**
+   * At-cost provider spend in USD for the period (#4036, Structure B): the sum
+   * of `gateway_cost_usd` over `token` events — the EXACT zero-markup dollars
+   * Atlas paid the Vercel AI Gateway. This is the billing denominator the
+   * Structure B included credit ($20/seat) and the overage meter draw against
+   * (the token-weighted count above is retained for display / budget fallback).
+   * Rows with a NULL `gateway_cost_usd` (non-gateway providers, or token rows
+   * predating migration 0155) simply don't contribute.
+   */
+  costUsd: number;
   activeUsers: number;
   /** Inclusive ISO start of the metering window. */
   periodStart: string;
@@ -280,6 +299,7 @@ export async function getCurrentPeriodUsage(
       queryCount: 0,
       tokenCount: 0,
       weightedTokenCount: 0,
+      costUsd: 0,
       activeUsers: 0,
       periodStart: "",
       periodEnd: "",
@@ -293,12 +313,14 @@ export async function getCurrentPeriodUsage(
     query_count: number;
     token_count: number;
     weighted_token_count: number;
+    cost_usd: number;
     active_users: number;
   }>(
     `SELECT
        COALESCE(SUM(CASE WHEN event_type = 'query' THEN quantity ELSE 0 END), 0)::int AS query_count,
        COALESCE(SUM(CASE WHEN event_type = 'token' THEN quantity ELSE 0 END), 0)::int AS token_count,
        COALESCE(SUM(CASE WHEN event_type = 'token' THEN COALESCE(weighted_quantity, quantity) ELSE 0 END), 0)::int AS weighted_token_count,
+       COALESCE(SUM(CASE WHEN event_type = 'token' THEN gateway_cost_usd ELSE 0 END), 0)::float8 AS cost_usd,
        COALESCE(COUNT(DISTINCT CASE WHEN event_type = 'login' THEN user_id END), 0)::int AS active_users
      FROM usage_events
      WHERE workspace_id = $1
@@ -312,6 +334,9 @@ export async function getCurrentPeriodUsage(
     queryCount: row?.query_count ?? 0,
     tokenCount: row?.token_count ?? 0,
     weightedTokenCount: row?.weighted_token_count ?? 0,
+    // `::float8` so `pg` returns a JS number (not a numeric string). Dollar sums
+    // stay well within float8's ~15 significant digits, so no meaningful drift.
+    costUsd: row?.cost_usd ?? 0,
     activeUsers: row?.active_users ?? 0,
     periodStart: period.start.toISOString(),
     periodEnd: period.end.toISOString(),

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -48,8 +48,9 @@ export interface UsageEvent {
    * Provider-cost USD for a `token` event's turn, from the Vercel AI Gateway
    * (`providerMetadata.gateway.cost`, summed across the turn's steps), #4036.
    * Persisted to `usage_events.gateway_cost_usd` as the at-cost dollar basis the
-   * Structure B credit + overage meter draw against. Omit (or pass `null`) for
-   * non-token events and for non-gateway providers — the column is NULL there.
+   * Structure B credit + overage meter will draw against once #4038/#4039 land
+   * (captured-only today). Omit (or pass `null`) for non-token events and for
+   * non-gateway providers — the column is NULL there.
    */
   gatewayCostUsd?: number | null;
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Structure B foundation slice (WS2 of #3984 / re-denomination #4034). Atlas resolves models through the **Vercel AI Gateway**, which returns the actual zero-markup charged cost per generation as `providerMetadata.gateway.cost`. This slice **captures** that real per-turn dollar cost alongside token usage so the later Structure B slices can draw the included credit + overage meter against summed real dollars. **Pure-additive — nothing enforces against it yet.**

- **Migration 0155** adds a nullable `gateway_cost_usd numeric(12,6)` to `usage_events` and `token_usage` (schema.ts mirrored same PR). NULL = "no gateway cost recorded" (non-gateway provider), distinct from a recorded 0.
- **agent.ts `onFinish`** sums `steps[].providerMetadata.gateway.cost` (the AI-SDK top-level metadata is final-step-only, so summed across steps) via a pure, null-safe `gateway-cost` module, and writes it to both tables. A present-but-unparseable per-step cost is dropped **and counted** → `log.warn` (gateway-contract-drift signal, no silent under-capture).
- **metering.ts** exposes `costUsd` on `UsageCurrentPeriod` via `SUM(gateway_cost_usd)::float8`.
- The at-cost `costUsd` (Atlas's per-period gateway COGS) is kept **internal** — the `GET /api/v1/admin/usage` handler picks explicit fields so it never leaks to a workspace admin.

## Test plan

- [x] `bun run type` — 0 errors
- [x] `bun run lint` — clean
- [x] Unit: `gateway-cost.test.ts` (multi-step sum, NULL/0/present-but-unparseable tri-state, negative-no-credit-back, whitespace), `metering.test.ts` (write param + `costUsd` aggregate), `agent-token-usage.test.ts` (gateway-routed turn pins the real `step.providerMetadata.gateway.cost` field path on both writes; non-gateway → NULL)
- [x] Real-Postgres: `metering-cost-pg.test.ts` (`SUM(gateway_cost_usd)::float8` returns a JS number, NULL-skip, non-token exclusion, all-NULL → 0); `migrate-pg` smoke applies 0155
- [x] Regression net: `admin-usage.test.ts` asserts `costUsd` + `weightedTokenCount` are **not** in the wire response (COGS non-leak)
- [x] All drift/parity gates green (schema-drift, pricing-parity, openapi-drift, settings-readers, …)
- [x] Affected isolated suite 86/86 (full-suite WSL2 collisions verified passing in isolation)

Part of #4034 · Internal review panel: 2 rounds to CLEAN.

Closes #4036

https://claude.ai/code/session_017AjYJfsEshwZhc3GFGpJci


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture at-cost gateway spend per agent turn in `token_usage` and `usage_events`
> - Adds a `gateway_cost_usd` column (nullable `numeric(12,6)`) to `token_usage` and `usage_events` via migration [0155_usage_gateway_cost_usd.sql](https://github.com/AtlasDevHQ/atlas/pull/4041/files#diff-a0e9553d2d271a67e7d9546df93b0ae1f20dfc85e582bfb39ee9294513cb2f92).
> - Introduces [gateway-cost.ts](https://github.com/AtlasDevHQ/atlas/pull/4041/files#diff-feb14cec30d831b40c01de74e209cd8b6abf7b1a1fa211e2a6e9980bf1df4b62) with `parseGatewayCostUsd`, `sumStepGatewayCostUsd`, and `summarizeStepGatewayCostUsd` to extract and sum `providerMetadata.gateway.cost` across steps; non-gateway turns record `NULL`.
> - `runAgent` in [agent.ts](https://github.com/AtlasDevHQ/atlas/pull/4041/files#diff-3e03d12ba1cff0d76d15506a217b68932d6fe7f701dc8048816a1095cd0f5c98) computes `gatewayCostUsd` on finish and writes it to both `token_usage` and the logged `token` usage event.
> - `getCurrentPeriodUsage` in [metering.ts](https://github.com/AtlasDevHQ/atlas/pull/4041/files#diff-8dd6f396380391f4dfc37c20cd8f1cbfb168e32030d6c9b78518238139714e49) now aggregates `costUsd` by summing `gateway_cost_usd` over token events and returns it in `UsageCurrentPeriod`.
> - `GET /api/v1/admin/usage` in [admin-usage.ts](https://github.com/AtlasDevHQ/atlas/pull/4041/files#diff-0c82660a849053ff3092026d891649d509b894ddc9437dc25eb0611ac00e2a10) is updated to explicitly list returned fields, excluding `costUsd` and `weightedTokenCount` from the wire response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a432f39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->